### PR TITLE
[OPIK-6415] [SDK] feat: replay full dataset version history in opik migrate

### DIFF
--- a/sdks/python/src/opik/cli/migrate/datasets/executor.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/executor.py
@@ -28,8 +28,8 @@ from .planner import (
     ReplayVersions,
 )
 from .version_replay import (
-    _suite_evaluators_payload,
-    _suite_execution_policy_payload,
+    _evaluators_payload,
+    _execution_policy_payload,
     replay_all_versions,
 )
 
@@ -261,11 +261,9 @@ def _copy_test_suite_config(rest_client: OpikApi, action: CopyTestSuiteConfig) -
         "change_description": "Migrated suite config from source",
     }
     if latest.evaluators:
-        request["evaluators"] = _suite_evaluators_payload(latest.evaluators)
+        request["evaluators"] = _evaluators_payload(latest.evaluators)
     if latest.execution_policy is not None:
-        request["execution_policy"] = _suite_execution_policy_payload(
-            latest.execution_policy
-        )
+        request["execution_policy"] = _execution_policy_payload(latest.execution_policy)
     if "evaluators" not in request and "execution_policy" not in request:
         # Latest version had no suite-level config beyond items — nothing
         # to copy. The target was already created with type='evaluation_suite'

--- a/sdks/python/src/opik/cli/migrate/datasets/executor.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/executor.py
@@ -24,7 +24,9 @@ from .planner import (
     CreateDestination,
     MigrationPlan,
     RenameSource,
+    ReplayVersions,
 )
+from .version_replay import replay_all_versions
 
 LOGGER = logging.getLogger(__name__)
 _console = Console()
@@ -38,12 +40,15 @@ def execute_plan(
     """Apply ``plan`` against ``client``, recording each action in ``audit``.
 
     Delegates the audit-bracketed loop to ``_base.execute_plan_loop`` and
-    supplies the dataset-specific apply / details closures.
+    supplies the dataset-specific apply / details closures. The closure
+    captures ``plan`` and ``audit`` so the ``ReplayVersions`` branch can
+    stash version_remap / item_id_remap onto the plan and emit per-version
+    audit sub-records.
     """
     rest_client = client.rest_client
 
     def _apply(action: Any) -> None:
-        _apply_action(client, rest_client, action)
+        _apply_action(client, rest_client, action, plan=plan, audit=audit)
 
     execute_plan_loop(
         plan.actions,
@@ -58,7 +63,14 @@ def record_planned(plan: MigrationPlan, audit: AuditLog) -> None:
     record_planned_loop(plan.actions, audit, details_fn=_action_details)
 
 
-def _apply_action(client: opik.Opik, rest_client: OpikApi, action: object) -> None:
+def _apply_action(
+    client: opik.Opik,
+    rest_client: OpikApi,
+    action: object,
+    *,
+    plan: MigrationPlan,
+    audit: AuditLog,
+) -> None:
     # Workspace-mutating REST writes are wrapped with the SDK's 429-aware
     # retry helper so a transient rate limit doesn't abort a half-finished
     # migration. Reads (find_datasets, find_projects, retrieve_project,
@@ -97,6 +109,8 @@ def _apply_action(client: opik.Opik, rest_client: OpikApi, action: object) -> No
         _copy_items(client, action)
     elif isinstance(action, CopyTestSuiteConfig):
         _copy_test_suite_config(rest_client, action)
+    elif isinstance(action, ReplayVersions):
+        _replay_versions(rest_client, action, plan=plan, audit=audit)
     else:
         raise TypeError(f"Unknown migration action: {type(action).__name__}")
 
@@ -149,6 +163,43 @@ def _copy_items(client: opik.Opik, action: CopyCurrentItems) -> None:
         spinner="dots",
     ):
         dest.__internal_api__insert_items_as_dataclasses__(rebuilt)
+
+
+def _replay_versions(
+    rest_client: OpikApi,
+    action: ReplayVersions,
+    *,
+    plan: MigrationPlan,
+    audit: AuditLog,
+) -> None:
+    """Resolve target id and run the per-version replay loop.
+
+    The destination dataset was created by the prior ``CreateDestination``
+    action with zero versions. ``replay_all_versions`` handles the cold
+    start itself by minting target v1 via the BE-natural write path that
+    matches the source v1's shape (content via
+    ``create_or_update_dataset_items`` or config-only via
+    ``apply_dataset_item_changes(base_version=null, override=true)``) so
+    target version count == source version count — no leading empty seed.
+    """
+    dest = rest_client.datasets.get_dataset_by_identifier(
+        dataset_name=action.dest_name, project_name=action.dest_project_name
+    )
+
+    with _console.status(f"Replaying versions → {action.dest_name}…", spinner="dots"):
+        result = replay_all_versions(
+            rest_client,
+            source_dataset_id=action.source_dataset_id,
+            source_name_after_rename=action.source_name_after_rename,
+            source_project_name=action.source_project_name,
+            dest_dataset_id=dest.id,
+            dest_name=action.dest_name,
+            dest_project_name=action.dest_project_name,
+            audit=audit,
+        )
+
+    plan.version_remap.update(result.version_remap)
+    plan.item_id_remap.update(result.item_id_remap)
 
 
 def _copy_test_suite_config(rest_client: OpikApi, action: CopyTestSuiteConfig) -> None:
@@ -232,5 +283,14 @@ def _action_details(action: object) -> Dict[str, Any]:
             "source_dataset_id": action.source_dataset_id,
             "to_dataset": action.dest_name,
             "to_project": action.dest_project_name,
+        }
+    if isinstance(action, ReplayVersions):
+        return {
+            "type": "replay_versions",
+            "from_dataset": action.source_name_after_rename,
+            "from_project": action.source_project_name,
+            "to_dataset": action.dest_name,
+            "to_project": action.dest_project_name,
+            "is_test_suite": action.is_test_suite,
         }
     raise TypeError(f"Unknown migration action: {type(action).__name__}")

--- a/sdks/python/src/opik/cli/migrate/datasets/executor.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/executor.py
@@ -27,7 +27,11 @@ from .planner import (
     RenameSource,
     ReplayVersions,
 )
-from .version_replay import replay_all_versions
+from .version_replay import (
+    _suite_evaluators_payload,
+    _suite_execution_policy_payload,
+    replay_all_versions,
+)
 
 LOGGER = logging.getLogger(__name__)
 _console = Console()
@@ -257,15 +261,11 @@ def _copy_test_suite_config(rest_client: OpikApi, action: CopyTestSuiteConfig) -
         "change_description": "Migrated suite config from source",
     }
     if latest.evaluators:
-        request["evaluators"] = [
-            {"name": e.name, "type": e.type, "config": e.config}
-            for e in latest.evaluators
-        ]
+        request["evaluators"] = _suite_evaluators_payload(latest.evaluators)
     if latest.execution_policy is not None:
-        request["execution_policy"] = {
-            "runs_per_item": latest.execution_policy.runs_per_item,
-            "pass_threshold": latest.execution_policy.pass_threshold,
-        }
+        request["execution_policy"] = _suite_execution_policy_payload(
+            latest.execution_policy
+        )
     if "evaluators" not in request and "execution_policy" not in request:
         # Latest version had no suite-level config beyond items — nothing
         # to copy. The target was already created with type='evaluation_suite'

--- a/sdks/python/src/opik/cli/migrate/datasets/executor.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/executor.py
@@ -9,12 +9,13 @@ audit-log payload shape per action type (``_action_details``).
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import opik
 from opik.api_objects import rest_helpers
 from opik.rest_api import OpikApi
 from rich.console import Console
+from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn
 
 from ..audit import AuditLog
 from .._base import execute_plan_loop, record_planned_loop
@@ -186,7 +187,30 @@ def _replay_versions(
         dataset_name=action.dest_name, project_name=action.dest_project_name
     )
 
-    with _console.status(f"Replaying versions → {action.dest_name}…", spinner="dots"):
+    # Rich Progress bar driven by the per-version callback that
+    # ``replay_all_versions`` invokes before each version begins. The task is
+    # created lazily on the first callback (we don't know the total until
+    # source-version listing finishes) and advanced once per version. Keeping
+    # the UI here means the algorithmic core in ``version_replay`` stays
+    # console-agnostic.
+    with Progress(
+        TextColumn("[bold blue]Replaying versions"),
+        BarColumn(),
+        TaskProgressColumn(),
+        TextColumn("{task.description}"),
+        console=_console,
+        transient=False,
+    ) as progress:
+        task_id: Optional[int] = None
+
+        def _on_version_start(completed: int, total: int, label: str) -> None:
+            nonlocal task_id
+            description = f"→ {action.dest_name} · {label} ({completed + 1}/{total})"
+            if task_id is None:
+                task_id = progress.add_task(description, total=total)
+            else:
+                progress.update(task_id, completed=completed, description=description)
+
         result = replay_all_versions(
             rest_client,
             source_dataset_id=action.source_dataset_id,
@@ -196,7 +220,14 @@ def _replay_versions(
             dest_name=action.dest_name,
             dest_project_name=action.dest_project_name,
             audit=audit,
+            progress_callback=_on_version_start,
         )
+
+        # Mark the bar fully complete (the callback fires BEFORE each version,
+        # so the last update leaves the bar at N-1; advance it to N once the
+        # loop returns successfully).
+        if task_id is not None:
+            progress.update(task_id, completed=result.versions_replayed)
 
     plan.version_remap.update(result.version_remap)
     plan.item_id_remap.update(result.item_id_remap)

--- a/sdks/python/src/opik/cli/migrate/datasets/planner.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/planner.py
@@ -7,8 +7,8 @@ reuse the same logic with no side effects.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import List, Optional
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
 
 from opik.rest_api import OpikApi
 
@@ -83,6 +83,29 @@ class CopyTestSuiteConfig:
     dest_project_name: str
 
 
+@dataclass(frozen=True)
+class ReplayVersions:
+    """Replay every source dataset version onto the destination.
+
+    Replaces ``CopyCurrentItems`` when version-history replay is on (the
+    Slice 2 default). Iterates source versions chronologically, computing
+    the (adds, modifications, deletions) delta for each and applying it via
+    ``apply_dataset_item_changes`` so the target accumulates one new
+    version per source version with the same semantic content.
+
+    The executor populates ``MigrationPlan.version_remap`` and
+    ``MigrationPlan.item_id_remap`` after this action runs; Slice 3 reads
+    those maps to remap experiment FK references.
+    """
+
+    source_dataset_id: str
+    source_name_after_rename: str
+    source_project_name: Optional[str]
+    dest_name: str
+    dest_project_name: str
+    is_test_suite: bool
+
+
 @dataclass(kw_only=True)
 class MigrationPlan(BaseMigrationPlan):
     """Dataset-specific migration plan.
@@ -90,12 +113,20 @@ class MigrationPlan(BaseMigrationPlan):
     Inherits the shared ``source`` / ``actions`` shape from
     ``BaseMigrationPlan`` and narrows ``source`` to ``ResolvedDataset``.
     The action list contains dataset-specific records (``RenameSource``,
-    ``CreateDestination``, ``CopyTestSuiteConfig``, ``CopyCurrentItems``).
+    ``CreateDestination``, ``CopyTestSuiteConfig``, ``CopyCurrentItems``,
+    ``ReplayVersions``).
+
+    The executor sets ``version_remap`` / ``item_id_remap`` on the plan
+    after a successful ``ReplayVersions`` run. Slice 3 reads them to remap
+    experiment foreign-key references; for plain Slice 2 invocations they
+    are populated for completeness even though no consumer reads them yet.
     """
 
     source: ResolvedDataset
     target_name: str
     to_project: str
+    version_remap: Dict[str, str] = field(default_factory=dict)
+    item_id_remap: Dict[str, str] = field(default_factory=dict)
 
 
 def build_dataset_plan(
@@ -103,12 +134,18 @@ def build_dataset_plan(
     name: str,
     to_project: str,
     from_project: Optional[str],
+    exclude_versions: bool = False,
 ) -> MigrationPlan:
     """Build the ordered action list for migrating one dataset.
 
     Ordering invariant: the source rename always precedes the destination
     create, so the workspace-unique-name constraint never trips. The target
     keeps the source's original name.
+
+    ``exclude_versions=False`` (default since Slice 2) emits a
+    ``ReplayVersions`` action that walks the source's full version history;
+    ``exclude_versions=True`` emits a ``CopyCurrentItems`` action that
+    matches Slice 1's "current items only" behaviour.
     """
     # Fail fast if --to-project doesn't exist. Catches typos before any
     # rename/create/copy work, and prevents auto-creating a stray project.
@@ -169,14 +206,17 @@ def build_dataset_plan(
         )
     )
 
-    # Test-suite config has to be applied BEFORE items: copying items creates
-    # the target's first version, after which `apply_dataset_item_changes`
-    # rejects payloads without an explicit `base_version` (override=True is
-    # not enough). Sequencing the suite-config call first means the target
-    # starts with an empty initial version that carries the suite-level
-    # evaluators+policy, and the subsequent item copy creates v2 with both
-    # the items and the inherited config.
-    if is_test_suite:
+    # Test-suite config: only emit ``CopyTestSuiteConfig`` for the slice 1
+    # path (``--exclude-versions``). When replay is on, ``ReplayVersions``
+    # forwards the per-version suite-level evaluators / execution_policy on
+    # every apply call, so it reproduces the full suite-config history
+    # natively — adding ``CopyTestSuiteConfig`` on top would just create
+    # an extra leading version on the target that the source never had.
+    # Slice 1 needs ``CopyTestSuiteConfig`` because its current-items copy
+    # path goes through ``Dataset.insert()`` which doesn't carry suite-level
+    # config; without the prior config-only version, the target test suite
+    # would lose its evaluators/policy entirely.
+    if is_test_suite and exclude_versions:
         plan.actions.append(
             CopyTestSuiteConfig(
                 source_dataset_id=source.id,
@@ -185,14 +225,26 @@ def build_dataset_plan(
             )
         )
 
-    plan.actions.append(
-        CopyCurrentItems(
-            source_dataset_id=source.id,
-            source_name_after_rename=name_after_rename,
-            source_project_name=source.project_name,
-            dest_name=source.name,
-            dest_project_name=to_project,
+    if exclude_versions:
+        plan.actions.append(
+            CopyCurrentItems(
+                source_dataset_id=source.id,
+                source_name_after_rename=name_after_rename,
+                source_project_name=source.project_name,
+                dest_name=source.name,
+                dest_project_name=to_project,
+            )
         )
-    )
+    else:
+        plan.actions.append(
+            ReplayVersions(
+                source_dataset_id=source.id,
+                source_name_after_rename=name_after_rename,
+                source_project_name=source.project_name,
+                dest_name=source.name,
+                dest_project_name=to_project,
+                is_test_suite=is_test_suite,
+            )
+        )
 
     return plan

--- a/sdks/python/src/opik/cli/migrate/datasets/version_replay.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/version_replay.py
@@ -28,7 +28,7 @@ import hashlib
 import json
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set
 
 from opik.api_objects import rest_helpers, rest_stream_parser
 from opik.rest_api import OpikApi
@@ -114,6 +114,7 @@ def replay_all_versions(
     dest_name: str,
     dest_project_name: str,
     audit: AuditLog,
+    progress_callback: Optional[Callable[[int, int, str], None]] = None,
 ) -> ReplayResult:
     """Replay every source version onto the destination in chronological order.
 
@@ -131,6 +132,12 @@ def replay_all_versions(
     one entry per replayed version (the per-version progress requirement
     from the ticket). The outer ``replay_versions`` action's audit
     bracketing is handled by the executor.
+
+    ``progress_callback`` is invoked once before each version begins with
+    ``(completed_count, total_versions, source_version_label)`` so callers
+    can drive a progress bar. Keeping the UI concern in the callback (not
+    in this module) means tests don't have to stub Rich; the executor owns
+    the live progress display.
     """
     versions = list(_iter_source_versions_chronological(rest_client, source_dataset_id))
     result = ReplayResult()
@@ -140,10 +147,14 @@ def replay_all_versions(
         # is left as the empty shell produced by CreateDestination.
         return result
 
+    total = len(versions)
     prev_items_by_id: Dict[str, _SourceItem] = {}
     base_version_id: Optional[str] = None
 
     for index, source_version in enumerate(versions):
+        if progress_callback is not None:
+            label = source_version.version_name or f"v{index + 1}"
+            progress_callback(index, total, label)
         curr_items_by_id = _load_version_items(
             rest_client,
             source_name_after_rename=source_name_after_rename,

--- a/sdks/python/src/opik/cli/migrate/datasets/version_replay.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/version_replay.py
@@ -400,9 +400,9 @@ def _create_first_version_with_items(
         if change_description:
             request["change_description"] = change_description
         if suite_evaluators is not None:
-            request["evaluators"] = _suite_evaluators_payload(suite_evaluators)
+            request["evaluators"] = _evaluators_payload(suite_evaluators)
         if suite_execution_policy is not None:
-            request["execution_policy"] = _suite_execution_policy_payload(
+            request["execution_policy"] = _execution_policy_payload(
                 suite_execution_policy
             )
         # ``is not None`` gating — see _apply_delta_and_collect_new_ids for rationale.
@@ -455,11 +455,9 @@ def _create_first_version_config_only(
     if change_description:
         request["change_description"] = change_description
     if suite_evaluators is not None:
-        request["evaluators"] = _suite_evaluators_payload(suite_evaluators)
+        request["evaluators"] = _evaluators_payload(suite_evaluators)
     if suite_execution_policy is not None:
-        request["execution_policy"] = _suite_execution_policy_payload(
-            suite_execution_policy
-        )
+        request["execution_policy"] = _execution_policy_payload(suite_execution_policy)
     # ``is not None`` gating — see _apply_delta_and_collect_new_ids for rationale.
     if user_tags is not None:
         request["tags"] = list(user_tags)
@@ -537,24 +535,39 @@ def _load_version_items(
     return by_id
 
 
-def _suite_evaluators_payload(
+def _evaluators_payload(
     evaluators: List[evaluator_item_public.EvaluatorItemPublic],
 ) -> List[Dict[str, Any]]:
-    """Convert a wire-type suite evaluator list to its write-payload shape.
+    """Convert a wire-type evaluator list to its write-payload shape.
 
-    Used by both ``executor._copy_test_suite_config`` (Slice 1) and the
-    three ``version_replay`` apply sites (Slice 2). Gating ("when do we
-    forward this field") is left to each caller because Slice 1 uses
-    truthy gating (``if evaluators:``) and Slice 2 uses ``is not None``
-    — the only shared concern is the field-by-field wire shape.
+    The BE uses the same ``EvaluatorItemPublic`` wire type at both the
+    version level (suite evaluators) and the item level (per-item
+    evaluator overrides), so this helper serves all five sites:
+    ``_copy_test_suite_config`` (Slice 1), the three
+    ``version_replay`` apply sites (Slice 2), and the per-item
+    ``_added_item_payload`` / ``_edited_item_payload`` (Slice 2).
+
+    Gating ("when do we forward this field") is left to each caller —
+    Slice 1's ``_copy_test_suite_config`` uses truthy gating
+    (``if evaluators:``) while Slice 2 uses ``is not None``. The only
+    shared concern is the field-by-field wire shape.
+
+    Intentionally NOT used by ``_content_hash_for`` — the hash function
+    builds an in-memory dict for sha256, not a wire payload. Coupling
+    them would silently rehash every item if a future BE field is added
+    to the wire payload, breaking idempotency on re-runs.
     """
     return [{"name": e.name, "type": e.type, "config": e.config} for e in evaluators]
 
 
-def _suite_execution_policy_payload(
+def _execution_policy_payload(
     execution_policy: execution_policy_public.ExecutionPolicyPublic,
 ) -> Dict[str, int]:
-    """Convert a wire-type suite execution_policy to its write-payload shape."""
+    """Convert a wire-type execution_policy to its write-payload shape.
+
+    See ``_evaluators_payload`` for shared-vs-not-shared rationale —
+    same applies here.
+    """
     return {
         "runs_per_item": execution_policy.runs_per_item,
         "pass_threshold": execution_policy.pass_threshold,
@@ -729,11 +742,9 @@ def _apply_delta_and_collect_new_ids(
         # Version-level evaluators (suite-level config). Pass an empty list
         # explicitly when the source version has zero suite-level evaluators
         # so the BE doesn't inherit a stale set from the previous version.
-        request["evaluators"] = _suite_evaluators_payload(suite_evaluators)
+        request["evaluators"] = _evaluators_payload(suite_evaluators)
     if suite_execution_policy is not None:
-        request["execution_policy"] = _suite_execution_policy_payload(
-            suite_execution_policy
-        )
+        request["execution_policy"] = _execution_policy_payload(suite_execution_policy)
     elif clear_suite_execution_policy:
         # Source dropped the suite-level policy between versions. BE
         # omission would inherit the stale value from base_version, so
@@ -836,15 +847,9 @@ def _added_item_payload(
     if item.tags is not None:
         payload["tags"] = list(item.tags)
     if item.evaluators is not None:
-        payload["evaluators"] = [
-            {"name": e.name, "type": e.type, "config": e.config}
-            for e in item.evaluators
-        ]
+        payload["evaluators"] = _evaluators_payload(item.evaluators)
     if item.execution_policy is not None:
-        payload["execution_policy"] = {
-            "runs_per_item": item.execution_policy.runs_per_item,
-            "pass_threshold": item.execution_policy.pass_threshold,
-        }
+        payload["execution_policy"] = _execution_policy_payload(item.execution_policy)
     return payload
 
 
@@ -909,10 +914,7 @@ def _edited_item_payload(
     # override. When neither side has them, omit the key entirely so the
     # BE leaves the (already-absent) override alone.
     if item.evaluators is not None:
-        payload["evaluators"] = [
-            {"name": e.name, "type": e.type, "config": e.config}
-            for e in item.evaluators
-        ]
+        payload["evaluators"] = _evaluators_payload(item.evaluators)
     elif prev.evaluators is not None:
         payload["evaluators"] = []
 
@@ -922,10 +924,7 @@ def _edited_item_payload(
     # treats omission as "inherit," which would silently retain the prior
     # override.
     if item.execution_policy is not None:
-        payload["execution_policy"] = {
-            "runs_per_item": item.execution_policy.runs_per_item,
-            "pass_threshold": item.execution_policy.pass_threshold,
-        }
+        payload["execution_policy"] = _execution_policy_payload(item.execution_policy)
     elif prev.execution_policy is not None:
         payload["clear_execution_policy"] = True
 

--- a/sdks/python/src/opik/cli/migrate/datasets/version_replay.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/version_replay.py
@@ -40,6 +40,7 @@ from opik.rest_api.types import (
 )
 
 from ..audit import AuditLog
+from ..errors import ReplayError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -149,6 +150,9 @@ def replay_all_versions(
 
     total = len(versions)
     prev_items_by_id: Dict[str, _SourceItem] = {}
+    prev_suite_execution_policy: Optional[
+        execution_policy_public.ExecutionPolicyPublic
+    ] = None
     base_version_id: Optional[str] = None
 
     for index, source_version in enumerate(versions):
@@ -174,6 +178,13 @@ def replay_all_versions(
         else:
             assert base_version_id is not None  # set after the first iteration
             delta = _compute_delta(prev_items_by_id, curr_items_by_id)
+            # When source drops suite-level execution_policy between versions
+            # (prev had one, curr=None), forward the BE's dedicated clear
+            # flag — omission would otherwise inherit the stale policy.
+            clear_suite_execution_policy = (
+                prev_suite_execution_policy is not None
+                and source_version.execution_policy is None
+            )
             new_version_id, new_item_ids = _apply_delta_and_collect_new_ids(
                 rest_client,
                 dest_dataset_id=dest_dataset_id,
@@ -185,6 +196,7 @@ def replay_all_versions(
                 item_id_remap=result.item_id_remap,
                 suite_evaluators=source_version.evaluators,
                 suite_execution_policy=source_version.execution_policy,
+                clear_suite_execution_policy=clear_suite_execution_policy,
                 user_tags=_user_version_tags(source_version.tags),
                 metadata=source_version.metadata,
             )
@@ -195,14 +207,16 @@ def replay_all_versions(
             result.version_remap[source_version.id] = new_version_id
 
         # Adds get fresh target ids that we recover by content-hash matching
-        # the post-apply target items. We populate item_id_remap with the
-        # source-add → target-add pairings so subsequent versions' edits and
-        # deletions can translate source-side stable ids to the target-side
-        # ids the BE assigned on add.
+        # the post-apply target items. ``new_item_ids`` is keyed by content
+        # hash → ordered queue of target ids; we pop one per source-add so
+        # items with identical content (e.g. duplicate-content inserts) each
+        # remap to a distinct target row instead of collapsing.
         for added in delta.adds:
-            new_target_id = new_item_ids.get(_content_hash_for(added))
-            if new_target_id is not None and added.id is not None:
-                result.item_id_remap[added.id] = new_target_id
+            if added.id is None:
+                continue
+            queue = new_item_ids.get(_content_hash_for(added))
+            if queue:
+                result.item_id_remap[added.id] = queue.pop(0)
 
         result.versions_replayed += 1
 
@@ -221,6 +235,7 @@ def replay_all_versions(
         )
 
         prev_items_by_id = curr_items_by_id
+        prev_suite_execution_policy = source_version.execution_policy
         base_version_id = new_version_id
 
     return result
@@ -234,7 +249,7 @@ def _replay_first_version(
     dest_project_name: str,
     source_items: Dict[str, _SourceItem],
     source_version: dataset_version_public.DatasetVersionPublic,
-) -> tuple[str, Dict[str, str], "VersionDelta"]:
+) -> tuple[str, Dict[str, List[str]], "VersionDelta"]:
     """Create the destination's v1 to match the source's v1 shape.
 
     Two BE-imposed write paths, picked by the source v1's shape:
@@ -307,7 +322,7 @@ def _create_first_version_with_items(
     suite_execution_policy: Optional[execution_policy_public.ExecutionPolicyPublic],
     user_tags: Optional[List[str]],
     metadata: Optional[Dict[str, str]],
-) -> tuple[str, Dict[str, str]]:
+) -> tuple[str, Dict[str, List[str]]]:
     """Create v1 via the ``create_or_update_dataset_items`` path.
 
     The BE rejects content-bearing applies with ``base_version=null``, so
@@ -348,7 +363,7 @@ def _create_first_version_with_items(
         id=dest_dataset_id, page=1, size=1
     )
     if not new_version.content or new_version.content[0].id is None:
-        raise RuntimeError(
+        raise ReplayError(
             f"Failed to read back v1 for destination dataset '{dest_name}': "
             "list_dataset_versions returned empty content."
         )
@@ -394,9 +409,10 @@ def _create_first_version_with_items(
                 "runs_per_item": suite_execution_policy.runs_per_item,
                 "pass_threshold": suite_execution_policy.pass_threshold,
             }
-        if user_tags:
+        # ``is not None`` gating — see _apply_delta_and_collect_new_ids for rationale.
+        if user_tags is not None:
             request["tags"] = list(user_tags)
-        if metadata:
+        if metadata is not None:
             request["metadata"] = dict(metadata)
         suite_version = rest_helpers.ensure_rest_api_call_respecting_rate_limit(
             lambda: rest_client.datasets.apply_dataset_item_changes(
@@ -404,7 +420,7 @@ def _create_first_version_with_items(
             )
         )
         if suite_version.id is None:
-            raise RuntimeError(
+            raise ReplayError(
                 "Failed to apply v1 version-level fields to destination "
                 f"dataset '{dest_name}'."
             )
@@ -429,7 +445,7 @@ def _create_first_version_config_only(
     suite_execution_policy: Optional[execution_policy_public.ExecutionPolicyPublic],
     user_tags: Optional[List[str]],
     metadata: Optional[Dict[str, str]],
-) -> tuple[str, Dict[str, str]]:
+) -> tuple[str, Dict[str, List[str]]]:
     """Create v1 via ``apply_dataset_item_changes(base_version=null, override=true)``.
 
     Used when the source's v1 is the BE's canonical "config-only" first
@@ -452,9 +468,10 @@ def _create_first_version_config_only(
             "runs_per_item": suite_execution_policy.runs_per_item,
             "pass_threshold": suite_execution_policy.pass_threshold,
         }
-    if user_tags:
+    # ``is not None`` gating — see _apply_delta_and_collect_new_ids for rationale.
+    if user_tags is not None:
         request["tags"] = list(user_tags)
-    if metadata:
+    if metadata is not None:
         request["metadata"] = dict(metadata)
     new_version = rest_helpers.ensure_rest_api_call_respecting_rate_limit(
         lambda: rest_client.datasets.apply_dataset_item_changes(
@@ -462,7 +479,7 @@ def _create_first_version_config_only(
         )
     )
     if new_version.id is None:
-        raise RuntimeError("apply_dataset_item_changes returned a v1 without an id.")
+        raise ReplayError("apply_dataset_item_changes returned a v1 without an id.")
     # No items on v1 → empty hash-to-target-id map.
     return new_version.id, {}
 
@@ -633,9 +650,10 @@ def _apply_delta_and_collect_new_ids(
     item_id_remap: Dict[str, str],
     suite_evaluators: Optional[List[evaluator_item_public.EvaluatorItemPublic]],
     suite_execution_policy: Optional[execution_policy_public.ExecutionPolicyPublic],
+    clear_suite_execution_policy: bool,
     user_tags: Optional[List[str]],
     metadata: Optional[Dict[str, str]],
-) -> tuple[str, Dict[str, str]]:
+) -> tuple[str, Dict[str, List[str]]]:
     """Apply one source version's delta to the destination.
 
     Returns ``(new_target_version_id, hash_to_target_item_id)`` where the
@@ -704,9 +722,18 @@ def _apply_delta_and_collect_new_ids(
             "runs_per_item": suite_execution_policy.runs_per_item,
             "pass_threshold": suite_execution_policy.pass_threshold,
         }
-    if user_tags:
+    elif clear_suite_execution_policy:
+        # Source dropped the suite-level policy between versions. BE
+        # omission would inherit the stale value from base_version, so
+        # forward the dedicated clear flag to remove it cleanly.
+        request["clear_execution_policy"] = True
+    # ``is not None`` gating (not truthiness) so explicit clears — empty
+    # tag list / empty metadata dict — round-trip as omission-of-omission.
+    # Truthiness gating would silently collapse ``[]``/`{}` to "don't forward,"
+    # leaving the BE to inherit the previous version's values.
+    if user_tags is not None:
         request["tags"] = list(user_tags)
-    if metadata:
+    if metadata is not None:
         request["metadata"] = dict(metadata)
 
     new_version = rest_helpers.ensure_rest_api_call_respecting_rate_limit(
@@ -719,7 +746,7 @@ def _apply_delta_and_collect_new_ids(
         # The BE always returns an id on success; treat absence as a transport
         # bug rather than a recoverable case. Failing fast is preferable to
         # stranding the version_remap with None values.
-        raise RuntimeError(
+        raise ReplayError(
             "apply_dataset_item_changes returned a version without an id; "
             "cannot continue replay."
         )
@@ -742,13 +769,21 @@ def _read_back_target_items(
     dest_name: str,
     dest_project_name: str,
     version_hash: Optional[str],
-) -> Dict[str, str]:
+) -> Dict[str, List[str]]:
     """Stream the just-written target version and key target ids by content hash.
 
     Used to populate the source-add → target-id remap. Match by full content
     hash (the same hash used by ``_compute_delta``) because the BE generates
     fresh stable ids for every add and ignores incoming ones. Goes through
     the raw REST stream + wire-type so per-item tags survive the round-trip.
+
+    Returns ``Dict[hash → List[target_id]]`` rather than ``Dict[hash → id]``
+    because the BE permits multiple items with identical content in the same
+    version (``Dataset.insert([dup, dup])`` succeeds and produces two distinct
+    target rows). Collapsing them into a single map entry would remap both
+    source ids to the same target id and corrupt edits/deletes in later
+    versions. The caller pops one entry per source-add in stream order so the
+    pairing matches the source's own duplicate-add ordering.
     """
     raw_stream = rest_client.datasets.stream_dataset_items(
         dataset_name=dest_name,
@@ -759,11 +794,11 @@ def _read_back_target_items(
         stream=raw_stream,
         item_class=dataset_item_public.DatasetItemPublic,
     )
-    target_items_by_hash: Dict[str, str] = {}
+    target_items_by_hash: Dict[str, List[str]] = {}
     for item in items:
         if item.id is None:
             continue
-        target_items_by_hash[_content_hash_for(item)] = item.id
+        target_items_by_hash.setdefault(_content_hash_for(item), []).append(item.id)
     return target_items_by_hash
 
 

--- a/sdks/python/src/opik/cli/migrate/datasets/version_replay.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/version_replay.py
@@ -1,0 +1,874 @@
+"""Version-history replay for ``opik migrate dataset``.
+
+Slice 2's algorithmic core: enumerate source dataset versions in chronological
+order and, for each, compute the (adds, modifications, deletions) delta
+against the previous version and apply it via ``apply_dataset_item_changes``
+on the target. The starting target state is whatever the executor placed
+before this step ran:
+
+* plain datasets — the empty initial version created by ``CreateDestination``
+* test suites — the suite-config-only initial version produced by
+  ``CopyTestSuiteConfig``
+
+In both cases the first call passes that version's id as ``base_version``,
+and every subsequent call passes the previous response's new version id.
+
+Item identity is the BE's stable ``DatasetItem.id``, which the BE guarantees
+remains constant across versions of the same dataset (see
+``DatasetItemEdit`` schema: "Stable dataset item identifier. Remains the
+same across dataset versions"). Source-side identity is therefore directly
+usable as the diff key. Target-side ids are minted fresh by the BE on every
+add, so we read them back after each apply call to populate
+``item_id_remap[old_id] = new_id`` for Slice 3's experiment FK remap.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
+
+from opik.api_objects import rest_helpers, rest_stream_parser
+from opik.rest_api import OpikApi
+from opik.rest_api.types import (
+    dataset_item_public,
+    dataset_version_public,
+    evaluator_item_public,
+    execution_policy_public,
+)
+
+from ..audit import AuditLog
+
+LOGGER = logging.getLogger(__name__)
+
+# Page size for ``list_dataset_versions``. The endpoint orders newest-first;
+# we paginate to exhaustion and reverse to chronological order before replay.
+_VERSIONS_PAGE_SIZE = 100
+
+
+@dataclass(frozen=True)
+class _SourceItem:
+    """Snapshot of a source-version item for diff purposes.
+
+    We hold the full wire-type ``DatasetItemPublic`` (not the SDK-level
+    ``DatasetItem`` dataclass) because the SDK dataclass silently drops
+    ``tags`` during stream reconstruction. Reading directly from the REST
+    wire type preserves every field the BE persists — tags, evaluators,
+    execution_policy, description, source, trace_id, span_id — so the
+    migration is full-fidelity.
+    """
+
+    id: str
+    content_hash: str
+    item: dataset_item_public.DatasetItemPublic
+
+
+@dataclass
+class _Modification:
+    """A modification carries both the new and the previous snapshots.
+
+    The previous snapshot is needed to detect "clears": when ``prev`` had a
+    non-None ``execution_policy`` or ``evaluators`` and ``curr`` has it as
+    ``None``, the user removed the per-item override. The BE's edit-merge
+    semantics inherit when a field is omitted, so we have to forward an
+    explicit "clear" signal (``clear_execution_policy=true`` for policy,
+    ``evaluators=[]`` for evaluators) to reproduce that intent on the target.
+    """
+
+    curr: dataset_item_public.DatasetItemPublic
+    prev: dataset_item_public.DatasetItemPublic
+
+
+@dataclass
+class VersionDelta:
+    adds: List[dataset_item_public.DatasetItemPublic] = field(default_factory=list)
+    modifications: List[_Modification] = field(default_factory=list)
+    deletions: List[str] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        return not (self.adds or self.modifications or self.deletions)
+
+
+@dataclass
+class ReplayResult:
+    """Outcome of a full replay loop.
+
+    Slice 3 will read these maps to remap experiment FK references. The
+    executor exposes them on ``MigrationPlan`` after the run.
+    """
+
+    version_remap: Dict[str, str] = field(default_factory=dict)
+    item_id_remap: Dict[str, str] = field(default_factory=dict)
+    versions_replayed: int = 0
+
+
+def replay_all_versions(
+    rest_client: OpikApi,
+    *,
+    source_dataset_id: str,
+    source_name_after_rename: str,
+    source_project_name: Optional[str],
+    dest_dataset_id: str,
+    dest_name: str,
+    dest_project_name: str,
+    audit: AuditLog,
+) -> ReplayResult:
+    """Replay every source version onto the destination in chronological order.
+
+    The destination is expected to have **zero** versions when this runs (the
+    executor's ``CreateDestination`` action makes a dataset shell with no
+    versions). The first source version is therefore written through a
+    "create v1" path that produces a single target version matching the
+    source's v1 shape — content-bearing or config-only — so target version
+    count == source version count and there's no leading empty seed.
+
+    Subsequent versions go through ``apply_dataset_item_changes`` chained
+    off the previous response's id.
+
+    Each version is its own audited record so the on-disk audit log carries
+    one entry per replayed version (the per-version progress requirement
+    from the ticket). The outer ``replay_versions`` action's audit
+    bracketing is handled by the executor.
+    """
+    versions = list(_iter_source_versions_chronological(rest_client, source_dataset_id))
+    result = ReplayResult()
+
+    if not versions:
+        # Source has no committed versions — nothing to replay. The target
+        # is left as the empty shell produced by CreateDestination.
+        return result
+
+    prev_items_by_id: Dict[str, _SourceItem] = {}
+    base_version_id: Optional[str] = None
+
+    for index, source_version in enumerate(versions):
+        curr_items_by_id = _load_version_items(
+            rest_client,
+            source_name_after_rename=source_name_after_rename,
+            source_project_name=source_project_name,
+            version_hash=source_version.version_hash,
+        )
+
+        if index == 0:
+            new_version_id, new_item_ids, delta = _replay_first_version(
+                rest_client,
+                dest_dataset_id=dest_dataset_id,
+                dest_name=dest_name,
+                dest_project_name=dest_project_name,
+                source_items=curr_items_by_id,
+                source_version=source_version,
+            )
+        else:
+            assert base_version_id is not None  # set after the first iteration
+            delta = _compute_delta(prev_items_by_id, curr_items_by_id)
+            new_version_id, new_item_ids = _apply_delta_and_collect_new_ids(
+                rest_client,
+                dest_dataset_id=dest_dataset_id,
+                dest_name=dest_name,
+                dest_project_name=dest_project_name,
+                base_version_id=base_version_id,
+                delta=delta,
+                change_description=source_version.change_description,
+                item_id_remap=result.item_id_remap,
+                suite_evaluators=source_version.evaluators,
+                suite_execution_policy=source_version.execution_policy,
+                user_tags=_user_version_tags(source_version.tags),
+                metadata=source_version.metadata,
+            )
+
+        # Map the source version id to the new target version id. Slice 3
+        # reads this via ``MigrationPlan.version_remap``.
+        if source_version.id is not None:
+            result.version_remap[source_version.id] = new_version_id
+
+        # Adds get fresh target ids that we recover by content-hash matching
+        # the post-apply target items. We populate item_id_remap with the
+        # source-add → target-add pairings so subsequent versions' edits and
+        # deletions can translate source-side stable ids to the target-side
+        # ids the BE assigned on add.
+        for added in delta.adds:
+            new_target_id = new_item_ids.get(_content_hash_for(added))
+            if new_target_id is not None and added.id is not None:
+                result.item_id_remap[added.id] = new_target_id
+
+        result.versions_replayed += 1
+
+        audit.record(
+            type="replay_dataset_version",
+            status="ok",
+            details={
+                "type": "replay_dataset_version",
+                "source_version_id": source_version.id,
+                "source_version_name": source_version.version_name,
+                "target_version_id": new_version_id,
+                "items_added": len(delta.adds),
+                "items_modified": len(delta.modifications),
+                "items_deleted": len(delta.deletions),
+            },
+        )
+
+        prev_items_by_id = curr_items_by_id
+        base_version_id = new_version_id
+
+    return result
+
+
+def _replay_first_version(
+    rest_client: OpikApi,
+    *,
+    dest_dataset_id: str,
+    dest_name: str,
+    dest_project_name: str,
+    source_items: Dict[str, _SourceItem],
+    source_version: dataset_version_public.DatasetVersionPublic,
+) -> tuple[str, Dict[str, str], "VersionDelta"]:
+    """Create the destination's v1 to match the source's v1 shape.
+
+    Two BE-imposed write paths, picked by the source v1's shape:
+
+    * **Source v1 carries items** (the typical plain-dataset case from
+      ``Dataset.insert(items)``): use ``create_or_update_dataset_items``
+      with a ``batch_group_id`` to mint v1 in a single BE-internal version.
+      Same write path that produced the source's own v1, so the resulting
+      target v1 is structurally identical.
+    * **Source v1 is config-only** (the typical test-suite case from
+      ``create_test_suite``): use ``apply_dataset_item_changes`` with
+      ``base_version=null + override=true`` carrying the suite-level
+      evaluators / execution_policy. The BE accepts this only when the
+      payload contains zero items (see ``DatasetItemService.applyDeltaChanges``
+      around line 1408 — content with ``base_version=null`` is rejected).
+
+    Returns a ``(new_version_id, hash_to_target_item_id, delta)`` triple
+    matching the shape of ``_apply_delta_and_collect_new_ids`` so the caller
+    can populate ``item_id_remap`` and audit deltas uniformly.
+    """
+    # Synthesize a delta whose ``adds`` matches the source v1 in stream
+    # order. Modifications and deletions are vacuous on v1 — there's no
+    # prior version on either side to diff against. The delta is mostly
+    # cosmetic for v1 (it powers the audit log's per-version counts).
+    delta = VersionDelta(adds=[s.item for s in source_items.values()])
+
+    user_tags = _user_version_tags(source_version.tags)
+    metadata = source_version.metadata
+
+    if delta.adds:
+        return (
+            *_create_first_version_with_items(
+                rest_client,
+                dest_dataset_id=dest_dataset_id,
+                dest_name=dest_name,
+                dest_project_name=dest_project_name,
+                adds=delta.adds,
+                change_description=source_version.change_description,
+                suite_evaluators=source_version.evaluators,
+                suite_execution_policy=source_version.execution_policy,
+                user_tags=user_tags,
+                metadata=metadata,
+            ),
+            delta,
+        )
+
+    return (
+        *_create_first_version_config_only(
+            rest_client,
+            dest_dataset_id=dest_dataset_id,
+            change_description=source_version.change_description,
+            suite_evaluators=source_version.evaluators,
+            suite_execution_policy=source_version.execution_policy,
+            user_tags=user_tags,
+            metadata=metadata,
+        ),
+        delta,
+    )
+
+
+def _create_first_version_with_items(
+    rest_client: OpikApi,
+    *,
+    dest_dataset_id: str,
+    dest_name: str,
+    dest_project_name: str,
+    adds: List[dataset_item_public.DatasetItemPublic],
+    change_description: Optional[str],
+    suite_evaluators: Optional[List[evaluator_item_public.EvaluatorItemPublic]],
+    suite_execution_policy: Optional[execution_policy_public.ExecutionPolicyPublic],
+    user_tags: Optional[List[str]],
+    metadata: Optional[Dict[str, str]],
+) -> tuple[str, Dict[str, str]]:
+    """Create v1 via the ``create_or_update_dataset_items`` path.
+
+    The BE rejects content-bearing applies with ``base_version=null``, so
+    we mint v1 the same way ``Dataset.insert`` does: a single
+    ``create_or_update_dataset_items`` call with a fresh ``batch_group_id``
+    grouping all items under one new version.
+
+    Items are sent in REVERSE source-stream order so the target's
+    ``ORDER BY id DESC`` display matches the source's. Mirrors
+    ``_apply_delta_and_collect_new_ids``'s rationale (different write path,
+    same UUID-pool reasoning).
+
+    If the source v1 also carried suite-level evaluators / execution_policy,
+    we follow the items insert with a no-op
+    ``apply_dataset_item_changes`` whose only payload is the suite config,
+    chained off the v1 we just minted. That keeps target v1's suite-level
+    fields aligned with source v1's. (Test suites don't hit this branch —
+    their v1 has zero items by BE convention — but plain datasets that
+    somehow grew suite-level fields on v1 still round-trip correctly.)
+    """
+    from opik import id_helpers
+    from opik.rest_api.types.dataset_item_write import DatasetItemWrite
+
+    batch_group_id = id_helpers.generate_id()
+    payloads = [
+        DatasetItemWrite(**_added_item_payload(item)) for item in reversed(adds)
+    ]
+    rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+        lambda: rest_client.datasets.create_or_update_dataset_items(
+            dataset_id=dest_dataset_id,
+            items=payloads,
+            batch_group_id=batch_group_id,
+        )
+    )
+
+    # No structured response — list_dataset_versions to find the new v1.
+    new_version = rest_client.datasets.list_dataset_versions(
+        id=dest_dataset_id, page=1, size=1
+    )
+    if not new_version.content or new_version.content[0].id is None:
+        raise RuntimeError(
+            f"Failed to read back v1 for destination dataset '{dest_name}': "
+            "list_dataset_versions returned empty content."
+        )
+    new_version_id = new_version.content[0].id
+    new_version_hash = new_version.content[0].version_hash
+
+    # Optional follow-up: if v1 should carry version-level fields that
+    # ``create_or_update_dataset_items`` can't set (suite-level evaluators,
+    # execution_policy, user version tags, metadata), apply them as a
+    # zero-content change against this version. The BE allows
+    # zero-content applies with a non-null base_version, so this stages
+    # the version-level fields without minting another items-bearing version.
+    needs_version_field_followup = (
+        suite_evaluators is not None
+        or suite_execution_policy is not None
+        or bool(user_tags)
+        or bool(metadata)
+    )
+    if needs_version_field_followup:
+        # This adds a second target version that the source didn't have —
+        # target ends up with N+1 versions for plain datasets that carried
+        # version-level fields on v1. In practice this only fires for
+        # unusual shapes: real plain datasets created via Dataset.insert
+        # don't carry suite-level config or user version tags on v1. Test
+        # suites take the config-only path below, not this branch. We log
+        # so the operator notices.
+        LOGGER.warning(
+            "Source v1 of dataset %r carries items AND version-level fields "
+            "(suite-config / tags / metadata); the target will end up with an "
+            "extra version reflecting the staged version-level update.",
+            dest_name,
+        )
+        request: Dict[str, Any] = {"base_version": new_version_id}
+        if change_description:
+            request["change_description"] = change_description
+        if suite_evaluators is not None:
+            request["evaluators"] = [
+                {"name": e.name, "type": e.type, "config": e.config}
+                for e in suite_evaluators
+            ]
+        if suite_execution_policy is not None:
+            request["execution_policy"] = {
+                "runs_per_item": suite_execution_policy.runs_per_item,
+                "pass_threshold": suite_execution_policy.pass_threshold,
+            }
+        if user_tags:
+            request["tags"] = list(user_tags)
+        if metadata:
+            request["metadata"] = dict(metadata)
+        suite_version = rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+            lambda: rest_client.datasets.apply_dataset_item_changes(
+                id=dest_dataset_id, request=request, override=False
+            )
+        )
+        if suite_version.id is None:
+            raise RuntimeError(
+                "Failed to apply v1 version-level fields to destination "
+                f"dataset '{dest_name}'."
+            )
+        new_version_id = suite_version.id
+        new_version_hash = suite_version.version_hash
+
+    target_items_by_hash = _read_back_target_items(
+        rest_client,
+        dest_name=dest_name,
+        dest_project_name=dest_project_name,
+        version_hash=new_version_hash,
+    )
+    return new_version_id, target_items_by_hash
+
+
+def _create_first_version_config_only(
+    rest_client: OpikApi,
+    *,
+    dest_dataset_id: str,
+    change_description: Optional[str],
+    suite_evaluators: Optional[List[evaluator_item_public.EvaluatorItemPublic]],
+    suite_execution_policy: Optional[execution_policy_public.ExecutionPolicyPublic],
+    user_tags: Optional[List[str]],
+    metadata: Optional[Dict[str, str]],
+) -> tuple[str, Dict[str, str]]:
+    """Create v1 via ``apply_dataset_item_changes(base_version=null, override=true)``.
+
+    Used when the source's v1 is the BE's canonical "config-only" first
+    version (test suites created by ``create_test_suite(global_assertions=...)``).
+    The BE accepts a ``base_version=null + override=true`` payload only when
+    it has zero items — this branch carries only version-level fields
+    (suite-level evaluators / execution_policy, user tags, metadata) plus
+    change_description.
+    """
+    request: Dict[str, Any] = {}
+    if change_description:
+        request["change_description"] = change_description
+    if suite_evaluators is not None:
+        request["evaluators"] = [
+            {"name": e.name, "type": e.type, "config": e.config}
+            for e in suite_evaluators
+        ]
+    if suite_execution_policy is not None:
+        request["execution_policy"] = {
+            "runs_per_item": suite_execution_policy.runs_per_item,
+            "pass_threshold": suite_execution_policy.pass_threshold,
+        }
+    if user_tags:
+        request["tags"] = list(user_tags)
+    if metadata:
+        request["metadata"] = dict(metadata)
+    new_version = rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+        lambda: rest_client.datasets.apply_dataset_item_changes(
+            id=dest_dataset_id, request=request, override=True
+        )
+    )
+    if new_version.id is None:
+        raise RuntimeError("apply_dataset_item_changes returned a v1 without an id.")
+    # No items on v1 → empty hash-to-target-id map.
+    return new_version.id, {}
+
+
+def _iter_source_versions_chronological(
+    rest_client: OpikApi,
+    dataset_id: str,
+) -> List[dataset_version_public.DatasetVersionPublic]:
+    """List every version of ``dataset_id`` in chronological order.
+
+    ``list_dataset_versions`` returns newest-first; we paginate to exhaustion
+    and reverse so replay applies them oldest-first.
+    """
+    collected: List[dataset_version_public.DatasetVersionPublic] = []
+    page_idx = 1
+    while True:
+        page = rest_client.datasets.list_dataset_versions(
+            id=dataset_id, page=page_idx, size=_VERSIONS_PAGE_SIZE
+        )
+        if not page.content:
+            break
+        collected.extend(page.content)
+        if len(page.content) < _VERSIONS_PAGE_SIZE:
+            break
+        page_idx += 1
+    collected.reverse()
+    return collected
+
+
+def _load_version_items(
+    rest_client: OpikApi,
+    *,
+    source_name_after_rename: str,
+    source_project_name: Optional[str],
+    version_hash: Optional[str],
+) -> Dict[str, _SourceItem]:
+    """Stream every item at ``version_hash`` and key by stable id.
+
+    Uses the raw REST stream (yielding ``DatasetItemPublic``) instead of
+    the SDK-level helper (``rest_operations.stream_dataset_items``) because
+    the SDK helper drops ``tags`` during dataclass reconstruction. Going
+    direct to the wire type preserves every persisted field for the diff
+    and the write payload.
+    """
+    raw_stream = rest_client.datasets.stream_dataset_items(
+        dataset_name=source_name_after_rename,
+        project_name=source_project_name,
+        dataset_version=version_hash,
+    )
+    items = rest_stream_parser.read_and_parse_stream(
+        stream=raw_stream,
+        item_class=dataset_item_public.DatasetItemPublic,
+    )
+    by_id: Dict[str, _SourceItem] = {}
+    for item in items:
+        if item.id is None:
+            # Defensive — the BE always returns an id on read; if one's
+            # missing skip it rather than poison the diff with None keys.
+            continue
+        by_id[item.id] = _SourceItem(
+            id=item.id, content_hash=_content_hash_for(item), item=item
+        )
+    return by_id
+
+
+_BE_MANAGED_VERSION_TAGS = frozenset({"latest"})
+
+
+def _user_version_tags(tags: Optional[List[str]]) -> Optional[List[str]]:
+    """Strip BE-managed version tags from a source version's tag list.
+
+    The BE attaches ``'latest'`` to whichever version is current; forwarding
+    it onto a previously-replayed version would 409 because the marker
+    already lives on a different (the actual latest) target version. User
+    tags like ``['baseline', 'v1.0']`` are otherwise valid and must round-trip.
+    """
+    if tags is None:
+        return None
+    filtered = [t for t in tags if t not in _BE_MANAGED_VERSION_TAGS]
+    return filtered or None
+
+
+def _content_hash_for(item: dataset_item_public.DatasetItemPublic) -> str:
+    """Stable content hash including every field the BE persists per item.
+
+    Mirrors the SDK dataclass ``content_hash`` but adds ``tags``,
+    ``trace_id``, ``span_id``, and ``source`` — fields the BE accepts on
+    write and exposes on read. Pinning all of them in the hash means the
+    diff catches any field-level change, not just data + description +
+    evaluators + execution_policy.
+    """
+    content: Dict[str, Any] = {"data": dict(item.data) if item.data else {}}
+    if item.description is not None:
+        content["description"] = item.description
+    if item.tags is not None:
+        # Sort tags so logically equal sets hash identically regardless of
+        # the order the BE returned them. Tag membership is what matters,
+        # not order.
+        content["tags"] = sorted(item.tags)
+    if item.evaluators is not None:
+        content["evaluators"] = [
+            {"name": e.name, "type": e.type, "config": e.config}
+            for e in item.evaluators
+        ]
+    if item.execution_policy is not None:
+        content["execution_policy"] = {
+            "runs_per_item": item.execution_policy.runs_per_item,
+            "pass_threshold": item.execution_policy.pass_threshold,
+        }
+    if item.trace_id is not None:
+        content["trace_id"] = item.trace_id
+    if item.span_id is not None:
+        content["span_id"] = item.span_id
+    if item.source is not None:
+        content["source"] = item.source
+    return hashlib.sha256(
+        json.dumps(content, sort_keys=True, default=str).encode()
+    ).hexdigest()
+
+
+def _compute_delta(
+    prev: Dict[str, _SourceItem],
+    curr: Dict[str, _SourceItem],
+) -> VersionDelta:
+    """Diff two version snapshots keyed by stable id.
+
+    * ``adds`` — ids in ``curr`` but not ``prev``
+    * ``deletions`` — ids in ``prev`` but not ``curr``
+    * ``modifications`` — ids in both, content_hash differs
+
+    Iteration order matters for adds and modifications because the BE
+    assigns row UUIDs to each apply payload in list order, and the SDK
+    streams items newest-first under ``ORDER BY id DESC``. Walking ``curr``
+    and ``prev`` in their streamed order (which dicts preserve since 3.7)
+    keeps the diff deterministic. The send-side reversal that maps display
+    order onto BE UUID-pool order happens in ``_apply_delta_and_collect_new_ids``.
+    """
+    delta = VersionDelta()
+    prev_ids: Set[str] = set(prev)
+    curr_ids: Set[str] = set(curr)
+
+    for curr_id, src_item in curr.items():
+        if curr_id not in prev_ids:
+            delta.adds.append(src_item.item)
+        elif prev[curr_id].content_hash != src_item.content_hash:
+            # Modifications carry both snapshots — the edit-payload builder
+            # needs the previous one to detect cleared overrides.
+            delta.modifications.append(
+                _Modification(curr=src_item.item, prev=prev[curr_id].item)
+            )
+
+    for prev_id in prev:
+        if prev_id not in curr_ids:
+            delta.deletions.append(prev_id)
+
+    return delta
+
+
+def _apply_delta_and_collect_new_ids(
+    rest_client: OpikApi,
+    *,
+    dest_dataset_id: str,
+    dest_name: str,
+    dest_project_name: str,
+    base_version_id: str,
+    delta: VersionDelta,
+    change_description: Optional[str],
+    item_id_remap: Dict[str, str],
+    suite_evaluators: Optional[List[evaluator_item_public.EvaluatorItemPublic]],
+    suite_execution_policy: Optional[execution_policy_public.ExecutionPolicyPublic],
+    user_tags: Optional[List[str]],
+    metadata: Optional[Dict[str, str]],
+) -> tuple[str, Dict[str, str]]:
+    """Apply one source version's delta to the destination.
+
+    Returns ``(new_target_version_id, hash_to_target_item_id)`` where the
+    second element maps content_hash -> newly-minted target item id, used
+    to populate ``item_id_remap`` for the items we just added.
+
+    ``item_id_remap`` is the running source-id → target-id map built up
+    across previously-replayed versions. We use it to translate edit/delete
+    payload ids: the BE assigns fresh stable ids on add, so source ids
+    referenced in subsequent versions' modifications/deletions don't exist
+    on the target — translation through the remap is what makes the BE's
+    id-keyed edit/delete dispatch hit the right target rows.
+
+    ``suite_evaluators`` / ``suite_execution_policy`` are version-level
+    test-suite config (``EvaluatorItemPublic`` / ``ExecutionPolicyPublic``
+    instances on each ``DatasetVersionPublic``). They're forwarded for
+    every version, including plain datasets where they are typically
+    ``None`` and the BE just inherits from the previous version. Per-item
+    evaluators/policy are forwarded separately by the item payload builders.
+
+    ``user_tags`` are the source version's user-applied tags with the BE's
+    system-managed ``'latest'`` marker filtered out — forwarding it would
+    409 because the marker already lives on a different (the actual latest)
+    target version. Per-item tags are forwarded separately by the item
+    payload builders.
+
+    ``metadata`` is the source version's user-defined ``Map<String, String>``
+    metadata blob, forwarded verbatim.
+    """
+    request: Dict[str, Any] = {"base_version": base_version_id}
+
+    # Display-order preservation: the source streamed adds/modifications
+    # newest-first (ClickHouse ``ORDER BY id DESC`` over UUIDv7), and the BE
+    # assigns UUIDs to each apply payload in list order with later list
+    # entries getting larger UUIDs. To reproduce the source's display order
+    # on the target we send each list in REVERSE so the newest source item
+    # ends up with the largest target UUID and lands at the top of its pool
+    # in the target's display. This mirrors Slice 1's reversal in
+    # ``executor._copy_items`` (same rationale, different write path).
+    # Deletion order does not affect display.
+    if delta.adds:
+        request["added_items"] = [
+            _added_item_payload(item) for item in reversed(delta.adds)
+        ]
+    if delta.modifications:
+        request["edited_items"] = [
+            _edited_item_payload(modification, item_id_remap)
+            for modification in reversed(delta.modifications)
+        ]
+    if delta.deletions:
+        request["deleted_ids"] = [
+            item_id_remap.get(source_id, source_id) for source_id in delta.deletions
+        ]
+    if change_description:
+        request["change_description"] = change_description
+    if suite_evaluators is not None:
+        # Version-level evaluators (suite-level config). Pass an empty list
+        # explicitly when the source version has zero suite-level evaluators
+        # so the BE doesn't inherit a stale set from the previous version.
+        request["evaluators"] = [
+            {"name": e.name, "type": e.type, "config": e.config}
+            for e in suite_evaluators
+        ]
+    if suite_execution_policy is not None:
+        request["execution_policy"] = {
+            "runs_per_item": suite_execution_policy.runs_per_item,
+            "pass_threshold": suite_execution_policy.pass_threshold,
+        }
+    if user_tags:
+        request["tags"] = list(user_tags)
+    if metadata:
+        request["metadata"] = dict(metadata)
+
+    new_version = rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+        lambda: rest_client.datasets.apply_dataset_item_changes(
+            id=dest_dataset_id, request=request, override=False
+        )
+    )
+    new_version_id = new_version.id
+    if new_version_id is None:
+        # The BE always returns an id on success; treat absence as a transport
+        # bug rather than a recoverable case. Failing fast is preferable to
+        # stranding the version_remap with None values.
+        raise RuntimeError(
+            "apply_dataset_item_changes returned a version without an id; "
+            "cannot continue replay."
+        )
+
+    if not delta.adds:
+        return new_version_id, {}
+
+    target_items_by_hash = _read_back_target_items(
+        rest_client,
+        dest_name=dest_name,
+        dest_project_name=dest_project_name,
+        version_hash=new_version.version_hash,
+    )
+    return new_version_id, target_items_by_hash
+
+
+def _read_back_target_items(
+    rest_client: OpikApi,
+    *,
+    dest_name: str,
+    dest_project_name: str,
+    version_hash: Optional[str],
+) -> Dict[str, str]:
+    """Stream the just-written target version and key target ids by content hash.
+
+    Used to populate the source-add → target-id remap. Match by full content
+    hash (the same hash used by ``_compute_delta``) because the BE generates
+    fresh stable ids for every add and ignores incoming ones. Goes through
+    the raw REST stream + wire-type so per-item tags survive the round-trip.
+    """
+    raw_stream = rest_client.datasets.stream_dataset_items(
+        dataset_name=dest_name,
+        project_name=dest_project_name,
+        dataset_version=version_hash,
+    )
+    items = rest_stream_parser.read_and_parse_stream(
+        stream=raw_stream,
+        item_class=dataset_item_public.DatasetItemPublic,
+    )
+    target_items_by_hash: Dict[str, str] = {}
+    for item in items:
+        if item.id is None:
+            continue
+        target_items_by_hash[_content_hash_for(item)] = item.id
+    return target_items_by_hash
+
+
+def _added_item_payload(
+    item: dataset_item_public.DatasetItemPublic,
+) -> Dict[str, Any]:
+    """Build the ``added_items`` payload entry for one source item.
+
+    BE-side this maps to ``DatasetItem`` (the API record). Forwards every
+    user-writable field the BE persists: data, trace_id, span_id, source,
+    description, tags, evaluators, execution_policy. The BE assigns the
+    target's stable id regardless of what we send, so we leave id out.
+    """
+    payload: Dict[str, Any] = {"data": dict(item.data) if item.data else {}}
+    if item.trace_id is not None:
+        payload["trace_id"] = item.trace_id
+    if item.span_id is not None:
+        payload["span_id"] = item.span_id
+    if item.source is not None:
+        payload["source"] = item.source
+    if item.description is not None:
+        payload["description"] = item.description
+    if item.tags is not None:
+        payload["tags"] = list(item.tags)
+    if item.evaluators is not None:
+        payload["evaluators"] = [
+            {"name": e.name, "type": e.type, "config": e.config}
+            for e in item.evaluators
+        ]
+    if item.execution_policy is not None:
+        payload["execution_policy"] = {
+            "runs_per_item": item.execution_policy.runs_per_item,
+            "pass_threshold": item.execution_policy.pass_threshold,
+        }
+    return payload
+
+
+def _edited_item_payload(
+    modification: _Modification, item_id_remap: Dict[str, str]
+) -> Dict[str, Any]:
+    """Build the ``edited_items`` payload entry for one modified item.
+
+    The BE matches edits by ``id`` (the stable identifier) against the
+    target dataset, so we translate the source's id through ``item_id_remap``
+    to the target id assigned when this item was first added in a prior
+    replayed version. If the source id is not in the remap (shouldn't
+    happen in practice — every modified item must have been added in some
+    earlier version) the source id is forwarded as-is and the BE will
+    silently no-op the edit.
+
+    "Clear" semantics for per-item overrides — when the source explicitly
+    removed an override between versions, the BE's null-means-inherit
+    behaviour on edit would otherwise leave the stale override in place:
+
+    * ``execution_policy`` (single object): when ``prev`` had one and
+      ``curr`` does not, send ``clear_execution_policy=true``. The BE
+      treats this flag as "drop the per-item override and fall back to
+      the version-level policy."
+    * ``evaluators`` (list): the BE has no clear-flag for this field, but
+      passing ``evaluators=[]`` is a meaningful "replace with empty list"
+      operation per ``DatasetItemVersionDAO.editItemsViaSelectInsert`` — the
+      template adds the column iff ``edit.evaluators() != null``, so an
+      empty list does overwrite. That's effectively the clear-semantics we
+      need: target item ends up with no per-item evaluators, falling back
+      to the suite-level set.
+
+    Other fields (``trace_id``, ``span_id``, ``source``) are accepted by the
+    BE schema on adds but ``DatasetItemEdit`` does not expose write fields
+    for them, so we cannot meaningfully forward them on edit. In practice
+    nothing in the BE / SDK / UI ever edits these mid-version, so this is
+    a known acceptable gap.
+    """
+    item = modification.curr
+    prev = modification.prev
+    source_id = item.id
+    assert source_id is not None  # filtered by _load_version_items
+    target_id = item_id_remap.get(source_id, source_id)
+
+    payload: Dict[str, Any] = {
+        "id": target_id,
+        "data": dict(item.data) if item.data else {},
+    }
+    if item.description is not None:
+        payload["description"] = item.description
+
+    # Per-item tags: forward as-is when present. When previously set and
+    # now cleared, send an empty list — the BE's edit-merge treats omission
+    # as "inherit," so without this the target keeps the stale tag set.
+    if item.tags is not None:
+        payload["tags"] = list(item.tags)
+    elif prev.tags:
+        payload["tags"] = []
+
+    # Per-item evaluators: forward as-is when present. When previously set
+    # and now cleared, send an empty list to overwrite the stale per-item
+    # override. When neither side has them, omit the key entirely so the
+    # BE leaves the (already-absent) override alone.
+    if item.evaluators is not None:
+        payload["evaluators"] = [
+            {"name": e.name, "type": e.type, "config": e.config}
+            for e in item.evaluators
+        ]
+    elif prev.evaluators is not None:
+        payload["evaluators"] = []
+
+    # Per-item execution_policy: forward as-is when present. When previously
+    # set and now cleared, use the BE's dedicated clear flag. ``execution_policy``
+    # is a single object so passing it as ``null`` isn't enough — the BE
+    # treats omission as "inherit," which would silently retain the prior
+    # override.
+    if item.execution_policy is not None:
+        payload["execution_policy"] = {
+            "runs_per_item": item.execution_policy.runs_per_item,
+            "pass_threshold": item.execution_policy.pass_threshold,
+        }
+    elif prev.execution_policy is not None:
+        payload["clear_execution_policy"] = True
+
+    return payload

--- a/sdks/python/src/opik/cli/migrate/datasets/version_replay.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/version_replay.py
@@ -400,15 +400,11 @@ def _create_first_version_with_items(
         if change_description:
             request["change_description"] = change_description
         if suite_evaluators is not None:
-            request["evaluators"] = [
-                {"name": e.name, "type": e.type, "config": e.config}
-                for e in suite_evaluators
-            ]
+            request["evaluators"] = _suite_evaluators_payload(suite_evaluators)
         if suite_execution_policy is not None:
-            request["execution_policy"] = {
-                "runs_per_item": suite_execution_policy.runs_per_item,
-                "pass_threshold": suite_execution_policy.pass_threshold,
-            }
+            request["execution_policy"] = _suite_execution_policy_payload(
+                suite_execution_policy
+            )
         # ``is not None`` gating — see _apply_delta_and_collect_new_ids for rationale.
         if user_tags is not None:
             request["tags"] = list(user_tags)
@@ -459,15 +455,11 @@ def _create_first_version_config_only(
     if change_description:
         request["change_description"] = change_description
     if suite_evaluators is not None:
-        request["evaluators"] = [
-            {"name": e.name, "type": e.type, "config": e.config}
-            for e in suite_evaluators
-        ]
+        request["evaluators"] = _suite_evaluators_payload(suite_evaluators)
     if suite_execution_policy is not None:
-        request["execution_policy"] = {
-            "runs_per_item": suite_execution_policy.runs_per_item,
-            "pass_threshold": suite_execution_policy.pass_threshold,
-        }
+        request["execution_policy"] = _suite_execution_policy_payload(
+            suite_execution_policy
+        )
     # ``is not None`` gating — see _apply_delta_and_collect_new_ids for rationale.
     if user_tags is not None:
         request["tags"] = list(user_tags)
@@ -543,6 +535,30 @@ def _load_version_items(
             id=item.id, content_hash=_content_hash_for(item), item=item
         )
     return by_id
+
+
+def _suite_evaluators_payload(
+    evaluators: List[evaluator_item_public.EvaluatorItemPublic],
+) -> List[Dict[str, Any]]:
+    """Convert a wire-type suite evaluator list to its write-payload shape.
+
+    Used by both ``executor._copy_test_suite_config`` (Slice 1) and the
+    three ``version_replay`` apply sites (Slice 2). Gating ("when do we
+    forward this field") is left to each caller because Slice 1 uses
+    truthy gating (``if evaluators:``) and Slice 2 uses ``is not None``
+    — the only shared concern is the field-by-field wire shape.
+    """
+    return [{"name": e.name, "type": e.type, "config": e.config} for e in evaluators]
+
+
+def _suite_execution_policy_payload(
+    execution_policy: execution_policy_public.ExecutionPolicyPublic,
+) -> Dict[str, int]:
+    """Convert a wire-type suite execution_policy to its write-payload shape."""
+    return {
+        "runs_per_item": execution_policy.runs_per_item,
+        "pass_threshold": execution_policy.pass_threshold,
+    }
 
 
 _BE_MANAGED_VERSION_TAGS = frozenset({"latest"})
@@ -713,15 +729,11 @@ def _apply_delta_and_collect_new_ids(
         # Version-level evaluators (suite-level config). Pass an empty list
         # explicitly when the source version has zero suite-level evaluators
         # so the BE doesn't inherit a stale set from the previous version.
-        request["evaluators"] = [
-            {"name": e.name, "type": e.type, "config": e.config}
-            for e in suite_evaluators
-        ]
+        request["evaluators"] = _suite_evaluators_payload(suite_evaluators)
     if suite_execution_policy is not None:
-        request["execution_policy"] = {
-            "runs_per_item": suite_execution_policy.runs_per_item,
-            "pass_threshold": suite_execution_policy.pass_threshold,
-        }
+        request["execution_policy"] = _suite_execution_policy_payload(
+            suite_execution_policy
+        )
     elif clear_suite_execution_policy:
         # Source dropped the suite-level policy between versions. BE
         # omission would inherit the stale value from base_version, so

--- a/sdks/python/src/opik/cli/migrate/errors.py
+++ b/sdks/python/src/opik/cli/migrate/errors.py
@@ -38,6 +38,20 @@ class ProjectNotFoundError(MigrationError):
     """
 
 
+class ReplayError(MigrationError):
+    """Raised when version-history replay hits an unexpected BE response.
+
+    Used by ``cli/migrate/datasets/version_replay.py`` when the BE returns
+    a response shape the replay loop can't continue from — typically a
+    successful 2xx with a missing ``id`` or empty ``content`` field. These
+    are catastrophic but rare and don't fit any of the user-input error
+    types above; routing them through ``MigrationError`` (rather than a
+    plain ``RuntimeError``) ensures ``migrate_dataset_command`` surfaces
+    them via the user-facing ``MigrationError`` branch rather than the
+    generic ``except Exception`` path.
+    """
+
+
 class UnsupportedDatasetTypeError(MigrationError):
     """Raised when the source dataset has an unrecognised ``type``.
 

--- a/sdks/python/src/opik/cli/migrate/main.py
+++ b/sdks/python/src/opik/cli/migrate/main.py
@@ -26,6 +26,7 @@ from .datasets.planner import (
     CreateDestination,
     MigrationPlan,
     RenameSource,
+    ReplayVersions,
     build_dataset_plan,
 )
 from .errors import MigrationError, safe_error_string
@@ -58,12 +59,15 @@ def migrate_group(
 
     \b
     Commands:
-        dataset    Migrate a dataset (and its current items) into a destination project
+        dataset    Migrate a dataset (and its full version history) into a destination project
 
     \b
     Examples:
-        # Migrate a dataset into project B (renames source to "<name>_v1")
+        # Migrate a dataset (full version history) into project B
         opik migrate dataset "MyDataset" --to-project=B
+
+        # Migrate only the current items (skip version history)
+        opik migrate dataset "MyDataset" --to-project=B --exclude-versions
 
         # Preview the migration without touching the backend
         opik migrate dataset "MyDataset" --to-project=B --dry-run
@@ -144,6 +148,14 @@ def _finalize_and_fail(
     help="Source project name. Omit to look up workspace-scoped datasets.",
 )
 @click.option(
+    "--exclude-versions",
+    is_flag=True,
+    help=(
+        "Skip version-history replay. Only the source's current items are "
+        "copied (one version on the target). Equivalent to Slice 1 behaviour."
+    ),
+)
+@click.option(
     "--dry-run",
     is_flag=True,
     help="Preview the migration without applying any changes.",
@@ -160,22 +172,25 @@ def migrate_dataset_command(
     name: str,
     to_project: str,
     from_project: Optional[str],
+    exclude_versions: bool,
     dry_run: bool,
     audit_log: Optional[Path],
 ) -> None:
-    """Migrate a dataset (and its current items) into --to-project.
+    """Migrate a dataset (and its full version history) into --to-project.
 
     \b
     Steps performed (in order):
         1. Rename source to "<name>_v1"
         2. Create the destination dataset under --to-project
         3. (Test suites only) Apply suite-level evaluators + execution_policy
-        4. Copy the source's current items into the destination
+        4. Replay every source version onto the destination, OR (with
+           --exclude-versions) copy the source's current items only
     """
     args = {
         "name": name,
         "to_project": to_project,
         "from_project": from_project,
+        "exclude_versions": exclude_versions,
         "dry_run": dry_run,
     }
     audit = AuditLog(command="opik migrate dataset", args=args)
@@ -189,6 +204,7 @@ def migrate_dataset_command(
             name=name,
             to_project=to_project,
             from_project=from_project,
+            exclude_versions=exclude_versions,
         )
 
         _print_plan(plan)
@@ -243,5 +259,11 @@ def _print_plan(plan: MigrationPlan) -> None:
                 str(idx),
                 "copy suite config",
                 f"latest evaluators + execution_policy → {action.dest_name}",
+            )
+        elif isinstance(action, ReplayVersions):
+            table.add_row(
+                str(idx),
+                "replay versions",
+                f"{action.source_name_after_rename} → {action.dest_name} (full history)",
             )
     console.print(table)

--- a/sdks/python/tests/unit/cli/_migrate_helpers.py
+++ b/sdks/python/tests/unit/cli/_migrate_helpers.py
@@ -1,0 +1,165 @@
+"""Shared mock helpers for ``opik migrate`` test modules.
+
+Used by both ``test_migrate_dataset_exclude_versions.py`` (Slice 1 paths) and
+``test_migrate_dataset_version_replay.py`` (Slice 2 paths). Lives as a plain
+module (not conftest.py) because these are helper classes, not pytest
+fixtures.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+from unittest.mock import MagicMock
+
+
+class _DatasetRow:
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        description: Optional[str] = None,
+        items: int = 0,
+        type: Optional[str] = "dataset",
+        visibility: Optional[str] = "private",
+        tags: Optional[List[str]] = None,
+        # ``project_id=None`` represents a workspace-scoped dataset (V1
+        # entity, or anything left at workspace scope after auto-migration).
+        # Tests that want a project-scoped source pass an explicit id.
+        project_id: Optional[str] = None,
+    ) -> None:
+        self.id = id
+        self.name = name
+        self.description = description
+        self.dataset_items_count = items
+        self.type = type
+        self.visibility = visibility
+        self.tags = tags
+        self.project_id = project_id
+
+
+class _Page:
+    def __init__(self, content: List[_DatasetRow]) -> None:
+        self.content = content
+
+
+def _named(name: str) -> MagicMock:
+    obj = MagicMock()
+    obj.name = name
+    return obj
+
+
+def _planner_rest_client(
+    find_side_effects: List[_Page],
+    *,
+    target_project_exists: bool = True,
+    workspace_project_names: Optional[List[str]] = None,
+) -> MagicMock:
+    """Build a rest_client mock for direct planner unit tests."""
+    rest_client = MagicMock()
+    if target_project_exists:
+        target_project = MagicMock()
+        target_project.id = "target-project-id"
+        rest_client.projects.retrieve_project.return_value = target_project
+    else:
+        from opik.rest_api.core.api_error import ApiError
+
+        rest_client.projects.retrieve_project.side_effect = ApiError(
+            status_code=404, body={}
+        )
+        # Suggestion lookup queries find_projects on the 404 path.
+        candidates = [_named(name) for name in (workspace_project_names or [])]
+        rest_client.projects.find_projects.return_value = _Page(candidates)
+    rest_client.datasets.find_datasets.side_effect = find_side_effects
+    return rest_client
+
+
+def _build_fake_client(
+    *,
+    source_rows: List[_DatasetRow],
+    destination_rows: List[_DatasetRow],
+    items: List[Dict[str, object]],
+    target_project_exists: bool = True,
+) -> MagicMock:
+    """Construct an opik.Opik mock matching the executor's call surface.
+
+    The find_datasets mock returns ``source_rows`` for the first lookup
+    (source resolution) and ``destination_rows`` for the second (preflight
+    conflict check). The planner places those calls in a fixed order, so a
+    side-effect list is the simplest way to drive both branches deterministically.
+
+    ``items`` is a list of dicts; we materialize them as DatasetItem
+    dataclasses for the streaming mock (matches the real `__internal_api__
+    stream_items_as_dataclasses__` shape) so per-item fidelity assertions
+    have somewhere to land.
+    """
+    from opik.api_objects.dataset import dataset_item
+
+    rest_client = MagicMock()
+    if target_project_exists:
+        target_project = MagicMock()
+        target_project.id = "target-project-id"
+        rest_client.projects.retrieve_project.return_value = target_project
+    else:
+        from opik.rest_api.core.api_error import ApiError
+
+        rest_client.projects.retrieve_project.side_effect = ApiError(
+            status_code=404, body={}
+        )
+    rest_client.datasets.find_datasets.side_effect = [
+        _Page(source_rows),
+        _Page(destination_rows),
+    ]
+    rest_client.datasets.update_dataset = MagicMock()
+    rest_client.datasets.create_dataset = MagicMock()
+
+    client = MagicMock()
+    client.rest_client = rest_client
+    client._workspace = "default"
+
+    # Build DatasetItem dataclasses from the provided dicts so the executor's
+    # dataclass-form stream returns a realistic shape. Top-level fields like
+    # `description` / `source` / `trace_id` / `span_id` can be passed via the
+    # dict (other keys get stuffed into `data`/extra).
+    top_level = {
+        "id",
+        "trace_id",
+        "span_id",
+        "source",
+        "description",
+        "evaluators",
+        "execution_policy",
+    }
+    source_items: List[dataset_item.DatasetItem] = []
+    for raw in items:
+        kwargs = {k: v for k, v in raw.items() if k in top_level and k != "id"}
+        data = {k: v for k, v in raw.items() if k not in top_level}
+        ds_item = dataset_item.DatasetItem(**kwargs, **data)
+        if "id" in raw:
+            ds_item.id = raw["id"]  # type: ignore[assignment]
+        source_items.append(ds_item)
+
+    # MagicMock treats dunder-prefixed names as magic and blocks them by
+    # default; pre-attach plain MagicMocks so attribute access works.
+    source_dataset = MagicMock()
+    stream_mock = MagicMock(return_value=iter(source_items))
+    source_dataset.__internal_api__stream_items_as_dataclasses__ = stream_mock
+
+    dest_dataset = MagicMock()
+    insert_mock = MagicMock()
+    dest_dataset.__internal_api__insert_items_as_dataclasses__ = insert_mock
+
+    def _get_dataset(name: str, project_name: Optional[str] = None) -> MagicMock:
+        # The executor first reads from the (renamed) source, then the dest.
+        if insert_mock.call_count == 0 and not getattr(
+            _get_dataset, "_dest_handed_out", False
+        ):
+            if stream_mock.call_count == 0:
+                return source_dataset
+            _get_dataset._dest_handed_out = True  # type: ignore[attr-defined]
+            return dest_dataset
+        return dest_dataset
+
+    client.get_dataset.side_effect = _get_dataset
+    client.create_dataset = MagicMock()
+    client.delete_dataset = MagicMock()
+    return client, source_dataset, dest_dataset

--- a/sdks/python/tests/unit/cli/test_migrate_dataset_exclude_versions.py
+++ b/sdks/python/tests/unit/cli/test_migrate_dataset_exclude_versions.py
@@ -1,10 +1,19 @@
-"""Tests for ``opik migrate`` (slice 1: dataset + workspace plan)."""
+"""Tests for ``opik migrate`` Slice 1 — current-items-only migration.
+
+Slice 1 (``--exclude-versions``) is the fallback path: rename source,
+create destination, copy current items in a single insert (one target
+version). Slice 2's full version-history replay is the default and lives
+in ``test_migrate_dataset_version_replay.py``.
+
+Shared helpers (``_DatasetRow``, ``_Page``, ``_build_fake_client``,
+``_planner_rest_client``) come from ``_migrate_helpers``.
+"""
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import List
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,164 +28,12 @@ from opik.cli.migrate.errors import (
     ProjectNotFoundError,
 )
 
-
-def _planner_rest_client(
-    find_side_effects: List["_Page"],
-    *,
-    target_project_exists: bool = True,
-    workspace_project_names: Optional[List[str]] = None,
-) -> MagicMock:
-    """Build a rest_client mock for direct planner unit tests."""
-    rest_client = MagicMock()
-    if target_project_exists:
-        target_project = MagicMock()
-        target_project.id = "target-project-id"
-        rest_client.projects.retrieve_project.return_value = target_project
-    else:
-        from opik.rest_api.core.api_error import ApiError
-
-        rest_client.projects.retrieve_project.side_effect = ApiError(
-            status_code=404, body={}
-        )
-        # Suggestion lookup queries find_projects on the 404 path.
-        candidates = [_named(name) for name in (workspace_project_names or [])]
-        rest_client.projects.find_projects.return_value = _Page(candidates)
-    rest_client.datasets.find_datasets.side_effect = find_side_effects
-    return rest_client
-
-
-def _named(name: str) -> MagicMock:
-    obj = MagicMock()
-    obj.name = name
-    return obj
-
-
-class _DatasetRow:
-    def __init__(
-        self,
-        id: str,
-        name: str,
-        description: Optional[str] = None,
-        items: int = 0,
-        type: Optional[str] = "dataset",
-        visibility: Optional[str] = "private",
-        tags: Optional[List[str]] = None,
-        # ``project_id=None`` represents a workspace-scoped dataset (V1
-        # entity, or anything left at workspace scope after auto-migration).
-        # Tests that want a project-scoped source pass an explicit id.
-        project_id: Optional[str] = None,
-    ) -> None:
-        self.id = id
-        self.name = name
-        self.description = description
-        self.dataset_items_count = items
-        self.type = type
-        self.visibility = visibility
-        self.tags = tags
-        self.project_id = project_id
-
-
-class _Page:
-    def __init__(self, content: List[_DatasetRow]) -> None:
-        self.content = content
-
-
-def _build_fake_client(
-    *,
-    source_rows: List[_DatasetRow],
-    destination_rows: List[_DatasetRow],
-    items: List[Dict[str, object]],
-    target_project_exists: bool = True,
-) -> MagicMock:
-    """Construct an opik.Opik mock matching the executor's call surface.
-
-    The find_datasets mock returns ``source_rows`` for the first lookup
-    (source resolution) and ``destination_rows`` for the second (preflight
-    conflict check). The planner places those calls in a fixed order, so a
-    side-effect list is the simplest way to drive both branches deterministically.
-
-    ``items`` is a list of dicts; we materialize them as DatasetItem
-    dataclasses for the streaming mock (matches the real `__internal_api__
-    stream_items_as_dataclasses__` shape) so per-item fidelity assertions
-    have somewhere to land.
-    """
-    from opik.api_objects.dataset import dataset_item
-
-    rest_client = MagicMock()
-    if target_project_exists:
-        target_project = MagicMock()
-        target_project.id = "target-project-id"
-        rest_client.projects.retrieve_project.return_value = target_project
-    else:
-        from opik.rest_api.core.api_error import ApiError
-
-        rest_client.projects.retrieve_project.side_effect = ApiError(
-            status_code=404, body={}
-        )
-    rest_client.datasets.find_datasets.side_effect = [
-        _Page(source_rows),
-        _Page(destination_rows),
-    ]
-    rest_client.datasets.update_dataset = MagicMock()
-    rest_client.datasets.create_dataset = MagicMock()
-
-    client = MagicMock()
-    client.rest_client = rest_client
-    client._workspace = "default"
-
-    # Build DatasetItem dataclasses from the provided dicts so the executor's
-    # dataclass-form stream returns a realistic shape. Top-level fields like
-    # `description` / `source` / `trace_id` / `span_id` can be passed via the
-    # dict (other keys get stuffed into `data`/extra).
-    top_level = {
-        "id",
-        "trace_id",
-        "span_id",
-        "source",
-        "description",
-        "evaluators",
-        "execution_policy",
-    }
-    source_items: List[dataset_item.DatasetItem] = []
-    for raw in items:
-        kwargs = {k: v for k, v in raw.items() if k in top_level and k != "id"}
-        data = {k: v for k, v in raw.items() if k not in top_level}
-        ds_item = dataset_item.DatasetItem(**kwargs, **data)
-        if "id" in raw:
-            ds_item.id = raw["id"]  # type: ignore[assignment]
-        source_items.append(ds_item)
-
-    # MagicMock treats dunder-prefixed names as magic and blocks them by
-    # default; pre-attach plain MagicMocks so attribute access works.
-    source_dataset = MagicMock()
-    stream_mock = MagicMock(return_value=iter(source_items))
-    source_dataset.__internal_api__stream_items_as_dataclasses__ = stream_mock
-
-    dest_dataset = MagicMock()
-    insert_mock = MagicMock()
-    dest_dataset.__internal_api__insert_items_as_dataclasses__ = insert_mock
-
-    def _get_dataset(name: str, project_name: Optional[str] = None) -> MagicMock:
-        # The executor first reads from the (renamed) source, then the dest.
-        if insert_mock.call_count == 0 and not getattr(
-            _get_dataset, "_dest_handed_out", False
-        ):
-            if stream_mock.call_count == 0:
-                return source_dataset
-            _get_dataset._dest_handed_out = True  # type: ignore[attr-defined]
-            return dest_dataset
-        return dest_dataset
-
-    client.get_dataset.side_effect = _get_dataset
-    client.create_dataset = MagicMock()
-    client.delete_dataset = MagicMock()
-    return client, source_dataset, dest_dataset
-
-
-@pytest.fixture(autouse=True)
-def _no_project_resolution() -> None:
-    """``--from-project=None`` always yields ``project_id=None``; no need to mock the projects API."""
-    yield
+from ._migrate_helpers import (
+    _DatasetRow,
+    _Page,
+    _build_fake_client,
+    _planner_rest_client,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -198,6 +55,7 @@ class TestMigrateHelp:
         assert result.exit_code == 0
         assert "--to-project" in result.output
         assert "--from-project" in result.output
+        assert "--exclude-versions" in result.output
         assert "--dry-run" in result.output
 
 
@@ -207,9 +65,11 @@ class TestMigrateHelp:
 
 
 class TestPlanBuilding:
-    def test_build_dataset_plan__default_flow__orders_rename_then_create_then_copy(
+    def test_build_dataset_plan__default_flow__orders_rename_then_create_then_replay(
         self,
     ) -> None:
+        # Slice 2 default: full version-history replay replaces the
+        # current-items-only copy.
         rest_client = _planner_rest_client(
             [
                 _Page([_DatasetRow(id="src-1", name="MyDataset", description="d")]),
@@ -225,11 +85,94 @@ class TestPlanBuilding:
         )
 
         types = [type(a).__name__ for a in plan.actions]
-        assert types == ["RenameSource", "CreateDestination", "CopyCurrentItems"]
+        assert types == ["RenameSource", "CreateDestination", "ReplayVersions"]
         rename = plan.actions[0]
         assert rename.from_name == "MyDataset"
         assert rename.to_name == "MyDataset_v1"
         assert plan.target_name == "MyDataset"
+
+    def test_build_dataset_plan__exclude_versions__falls_back_to_copy_current_items(
+        self,
+    ) -> None:
+        # Opt-in to Slice 1 behaviour for users who explicitly don't want
+        # version-history replay.
+        rest_client = _planner_rest_client(
+            [
+                _Page([_DatasetRow(id="src-1", name="MyDataset")]),
+                _Page([]),
+            ]
+        )
+
+        plan = planner_module.build_dataset_plan(
+            rest_client=rest_client,
+            name="MyDataset",
+            to_project="B",
+            from_project=None,
+            exclude_versions=True,
+        )
+
+        types = [type(a).__name__ for a in plan.actions]
+        assert types == ["RenameSource", "CreateDestination", "CopyCurrentItems"]
+
+    def test_build_dataset_plan__test_suite_with_replay__skips_copy_test_suite_config(
+        self,
+    ) -> None:
+        # Test suites with replay on: ``CopyTestSuiteConfig`` is intentionally
+        # NOT in the plan because ``ReplayVersions`` walks every source
+        # version and forwards each version's suite-level evaluators+policy
+        # natively. Adding ``CopyTestSuiteConfig`` would create a leading
+        # extra version on the target that the source never had.
+        rest_client = _planner_rest_client(
+            [
+                _Page(
+                    [_DatasetRow(id="src-1", name="MySuite", type="evaluation_suite")]
+                ),
+                _Page([]),
+            ]
+        )
+
+        plan = planner_module.build_dataset_plan(
+            rest_client=rest_client,
+            name="MySuite",
+            to_project="B",
+            from_project=None,
+        )
+
+        types = [type(a).__name__ for a in plan.actions]
+        assert types == ["RenameSource", "CreateDestination", "ReplayVersions"]
+        replay = plan.actions[-1]
+        assert replay.is_test_suite is True
+
+    def test_build_dataset_plan__test_suite_with_exclude_versions__keeps_copy_test_suite_config(
+        self,
+    ) -> None:
+        # Test suites under the slice 1 fallback (``--exclude-versions``):
+        # ``CopyTestSuiteConfig`` IS in the plan because the
+        # ``CopyCurrentItems`` path doesn't carry suite-level config.
+        rest_client = _planner_rest_client(
+            [
+                _Page(
+                    [_DatasetRow(id="src-1", name="MySuite", type="evaluation_suite")]
+                ),
+                _Page([]),
+            ]
+        )
+
+        plan = planner_module.build_dataset_plan(
+            rest_client=rest_client,
+            name="MySuite",
+            to_project="B",
+            from_project=None,
+            exclude_versions=True,
+        )
+
+        types = [type(a).__name__ for a in plan.actions]
+        assert types == [
+            "RenameSource",
+            "CreateDestination",
+            "CopyTestSuiteConfig",
+            "CopyCurrentItems",
+        ]
 
     def test_build_dataset_plan__post_rename_name_collides_workspace_wide__raises_conflict(
         self,
@@ -370,6 +313,9 @@ class TestMigrateDatasetCommand:
             )
 
     def test_migrate_dataset__happyflow(self, tmp_path: Path) -> None:
+        # ``--exclude-versions`` runs the Slice 1 current-items-only path
+        # exercised here; the Slice 2 replay path is covered by the
+        # ``TestVersionReplay`` E2E tests below.
         runner = CliRunner()
         client, source_dataset, dest_dataset = _build_fake_client(
             source_rows=[_DatasetRow(id="src-1", name="MyDataset", description="d")],
@@ -379,7 +325,7 @@ class TestMigrateDatasetCommand:
 
         result = self._invoke(
             runner,
-            ["MyDataset", "--to-project", "B"],
+            ["MyDataset", "--to-project", "B", "--exclude-versions"],
             client,
             tmp_path,
         )
@@ -484,7 +430,7 @@ class TestMigrateDatasetCommand:
 
         result = self._invoke(
             runner,
-            ["MyDataset", "--to-project", "B"],
+            ["MyDataset", "--to-project", "B", "--exclude-versions"],
             client,
             tmp_path,
         )
@@ -517,7 +463,7 @@ class TestMigrateDatasetCommand:
 
         result = self._invoke(
             runner,
-            ["MyDataset", "--to-project", "B"],
+            ["MyDataset", "--to-project", "B", "--exclude-versions"],
             client,
             tmp_path,
         )
@@ -559,7 +505,7 @@ class TestMigrateDatasetCommand:
 
         result = self._invoke(
             runner,
-            ["MyDataset", "--to-project", "B"],
+            ["MyDataset", "--to-project", "B", "--exclude-versions"],
             client,
             tmp_path,
         )
@@ -595,7 +541,7 @@ class TestMigrateDatasetCommand:
 
         result = self._invoke(
             runner,
-            ["MyDataset", "--to-project", "B"],
+            ["MyDataset", "--to-project", "B", "--exclude-versions"],
             client,
             tmp_path,
         )
@@ -650,7 +596,7 @@ class TestMigrateDatasetCommand:
 
         result = self._invoke(
             runner,
-            ["MySuite", "--to-project", "B"],
+            ["MySuite", "--to-project", "B", "--exclude-versions"],
             client,
             tmp_path,
         )
@@ -732,7 +678,7 @@ class TestMigrateDatasetCommand:
 
         result = self._invoke(
             runner,
-            ["MySuite", "--to-project", "B"],
+            ["MySuite", "--to-project", "B", "--exclude-versions"],
             client,
             tmp_path,
         )
@@ -796,7 +742,7 @@ class TestMigrateDatasetCommand:
 
         result = self._invoke(
             runner,
-            ["LegacyDS", "--to-project", "B"],
+            ["LegacyDS", "--to-project", "B", "--exclude-versions"],
             client,
             tmp_path,
         )

--- a/sdks/python/tests/unit/cli/test_migrate_dataset_version_replay.py
+++ b/sdks/python/tests/unit/cli/test_migrate_dataset_version_replay.py
@@ -635,6 +635,178 @@ class TestVersionReplayUnit:
         # Delete ID is the target id (TGT-B), not the source id (src-b).
         assert v2_request["deleted_ids"] == ["TGT-B"]
 
+    def test_replay__clears_version_level_execution_policy_when_dropped(
+        self,
+    ) -> None:
+        # PR review #3 (baz-reviewer, version_replay.py:706): when v_n had a
+        # suite-level execution_policy and v_{n+1} drops it (set to None), the
+        # BE inherits the previous policy on omission. Forward the dedicated
+        # clear_execution_policy=true flag at the version level so the target
+        # mirrors the source's drop.
+        #
+        # Shape: v1 is config-only (test-suite-style) carrying the policy;
+        # v2 has items and drops the policy. v1 routes through the
+        # config-only path (one apply call); v2 routes through the standard
+        # apply path with clear_execution_policy=true.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        pol = MagicMock()
+        pol.runs_per_item = 3
+        pol.pass_threshold = 2
+
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(id="src-v1", version_hash="hv1", execution_policy=pol),
+                # v2 drops the suite-level policy.
+                _SourceVersion(id="src-v2", version_hash="hv2", execution_policy=None),
+            ],
+            items_per_version={
+                "hv1": [],  # v1 config-only, carries the policy only.
+                "hv2": [_ds_item("a", x=1)],
+                "tgt-h2": [_ds_item("tgt-a", x=1)],
+            },
+            applied_versions=[
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+            ],
+        )
+
+        replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        # v1 = config-only apply (carries policy); v2 = standard apply with
+        # clear flag. apply_dataset_item_changes called twice; v2 is the
+        # second entry.
+        calls = rest_client.datasets.apply_dataset_item_changes.call_args_list
+        assert len(calls) == 2
+        v2_request = calls[1].kwargs["request"]
+        # v2: omit execution_policy AND send clear flag — that's what gets
+        # the BE to drop the inherited policy instead of carrying it forward.
+        assert "execution_policy" not in v2_request
+        assert v2_request["clear_execution_policy"] is True
+
+    def test_replay__forwards_empty_user_tags_and_metadata_explicitly(
+        self,
+    ) -> None:
+        # PR review #4 (baz-reviewer, version_replay.py:710): explicit clears
+        # (``tags=[]`` or ``metadata={}`` on the source) must round-trip as
+        # explicit empty values on the apply payload — truthiness gating would
+        # silently collapse them to omission and the BE would inherit prior
+        # values. ``_user_version_tags`` already returns None for "all tags
+        # were the system 'latest' marker," so this test exercises metadata
+        # specifically (where the helper layer doesn't intervene).
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(
+                    id="src-v1", version_hash="hv1", metadata={"author": "ada"}
+                ),
+                # v2 clears metadata explicitly.
+                _SourceVersion(id="src-v2", version_hash="hv2", metadata={}),
+            ],
+            items_per_version={
+                "hv1": [_ds_item("a", x=1)],
+                "hv2": [_ds_item("a", x=1), _ds_item("b", y=2)],
+                "tgt-h1": [_ds_item("tgt-a", x=1)],
+                "tgt-h1b": [_ds_item("tgt-a", x=1)],
+                "tgt-h2": [_ds_item("tgt-a", x=1), _ds_item("tgt-b", y=2)],
+            },
+            applied_versions=[
+                # v1: post-create read-back + version-field follow-up apply
+                # (items + metadata both present on v1 forces an extra apply
+                # call; that's expected and warned about in _create_first_version_with_items).
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                _AppliedVersion(id="tgt-v1b", version_hash="tgt-h1b"),
+                # v2 apply.
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+            ],
+        )
+
+        replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        # v2 apply is the second (last) apply call. metadata={} must be
+        # forwarded explicitly so the BE drops the inherited {"author": "ada"}.
+        v2_request = rest_client.datasets.apply_dataset_item_changes.call_args.kwargs[
+            "request"
+        ]
+        assert v2_request["metadata"] == {}
+
+    def test_replay__duplicate_content_items_remap_to_distinct_target_ids(
+        self,
+    ) -> None:
+        # PR review #5 (baz-reviewer, version_replay.py:766): when source v1
+        # has two items with identical content (e.g. user inserted duplicates),
+        # they get different stable ids on the source but identical content
+        # hashes. Earlier implementation collapsed both into one entry of
+        # target_items_by_hash, so both source ids remapped to the same target
+        # id — corrupting any later edit/delete that referenced one of them.
+        # Fix: per-hash FIFO queue so each source-add pairs with a distinct
+        # target row.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(id="src-v1", version_hash="hv1"),
+            ],
+            items_per_version={
+                "hv1": [
+                    _ds_item("src-dupe-1", q="DUP"),
+                    _ds_item("src-dupe-2", q="DUP"),
+                ],
+                # Target has two distinct ids for the same hash — same shape
+                # the BE produces when you insert duplicate-content items.
+                "tgt-h1": [
+                    _ds_item("tgt-dupe-1", q="DUP"),
+                    _ds_item("tgt-dupe-2", q="DUP"),
+                ],
+            },
+            applied_versions=[
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+            ],
+        )
+
+        result = replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        # Both source ids must remap to DIFFERENT target ids — not collapse
+        # onto the same one.
+        assert "src-dupe-1" in result.item_id_remap
+        assert "src-dupe-2" in result.item_id_remap
+        assert result.item_id_remap["src-dupe-1"] != result.item_id_remap["src-dupe-2"]
+        assert {
+            result.item_id_remap["src-dupe-1"],
+            result.item_id_remap["src-dupe-2"],
+        } == {
+            "tgt-dupe-1",
+            "tgt-dupe-2",
+        }
+
     def test_replay__forwards_per_version_suite_evaluators_and_execution_policy(
         self,
     ) -> None:

--- a/sdks/python/tests/unit/cli/test_migrate_dataset_version_replay.py
+++ b/sdks/python/tests/unit/cli/test_migrate_dataset_version_replay.py
@@ -970,6 +970,58 @@ class TestVersionReplayUnit:
         assert v2_request["metadata"] == {"author": "ada", "experiment": "42"}
         assert v2_request["tags"] == ["baseline", "v1.0"]
 
+    def test_replay__progress_callback_fires_once_per_version(self) -> None:
+        # The CLI's Rich Progress bar needs per-version progress signals.
+        # ``replay_all_versions`` must invoke the optional ``progress_callback``
+        # once before each source version begins, with ``(completed_count,
+        # total, version_label)``. Pin: 3 source versions → 3 callback invocations
+        # with completed counts 0, 1, 2 and total = 3 every time.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(id="src-v1", version_hash="hv1", version_name="v1"),
+                _SourceVersion(id="src-v2", version_hash="hv2", version_name="v2"),
+                _SourceVersion(id="src-v3", version_hash="hv3", version_name="v3"),
+            ],
+            items_per_version={
+                "hv1": [_ds_item("a", x=1)],
+                "hv2": [_ds_item("a", x=1), _ds_item("b", y=2)],
+                "hv3": [_ds_item("a", x=1), _ds_item("b", y=2), _ds_item("c", z=3)],
+                "tgt-h1": [_ds_item("tgt-a", x=1)],
+                "tgt-h2": [_ds_item("tgt-a", x=1), _ds_item("tgt-b", y=2)],
+                "tgt-h3": [
+                    _ds_item("tgt-a", x=1),
+                    _ds_item("tgt-b", y=2),
+                    _ds_item("tgt-c", z=3),
+                ],
+            },
+            applied_versions=[
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+                _AppliedVersion(id="tgt-v3", version_hash="tgt-h3"),
+            ],
+        )
+
+        events: List[tuple] = []
+
+        def _cb(completed: int, total: int, label: str) -> None:
+            events.append((completed, total, label))
+
+        replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+            progress_callback=_cb,
+        )
+
+        assert events == [(0, 3, "v1"), (1, 3, "v2"), (2, 3, "v3")]
+
     def test_replay__base_version_chains_across_calls(self) -> None:
         # Each apply call's base_version must be the previous response's id —
         # not a stale value, not the initial. Pin this so a refactor that

--- a/sdks/python/tests/unit/cli/test_migrate_dataset_version_replay.py
+++ b/sdks/python/tests/unit/cli/test_migrate_dataset_version_replay.py
@@ -1,0 +1,1314 @@
+"""Tests for ``opik migrate`` Slice 2 — full version-history replay.
+
+Slice 2 is the default behaviour: every source dataset/test-suite version is
+replayed onto the target with full fidelity (items + per-item overrides +
+suite-level config + version metadata + user tags + display order). The
+Slice 1 fallback (``--exclude-versions``, current items only) lives in
+``test_migrate_dataset_exclude_versions.py``.
+
+Shared helpers (``_DatasetRow``, ``_Page``, ``_build_fake_client``) come from
+``_migrate_helpers``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from opik.cli import cli
+from opik.cli.migrate.audit import AuditLog
+
+from ._migrate_helpers import _DatasetRow, _Page, _build_fake_client
+
+
+# ---------------------------------------------------------------------------
+# Slice 2: version-history replay
+# ---------------------------------------------------------------------------
+
+
+class _SourceVersion:
+    """Minimal stand-in for ``DatasetVersionPublic`` (read side)."""
+
+    def __init__(
+        self,
+        id: str,
+        version_hash: str,
+        version_name: Optional[str] = None,
+        change_description: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        evaluators: Optional[List[Any]] = None,
+        execution_policy: Optional[Any] = None,
+        metadata: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self.id = id
+        self.version_hash = version_hash
+        self.version_name = version_name
+        self.change_description = change_description
+        self.tags = tags
+        self.evaluators = evaluators
+        self.execution_policy = execution_policy
+        self.metadata = metadata
+
+
+class _AppliedVersion:
+    """Stand-in for the ``DatasetVersionPublic`` returned by apply_changes."""
+
+    def __init__(self, id: str, version_hash: str) -> None:
+        self.id = id
+        self.version_hash = version_hash
+
+
+def _ds_item(
+    item_id: str,
+    *,
+    description: Optional[str] = None,
+    tags: Optional[List[str]] = None,
+    evaluators: Optional[List[Dict[str, Any]]] = None,
+    execution_policy: Optional[Dict[str, int]] = None,
+    trace_id: Optional[str] = None,
+    span_id: Optional[str] = None,
+    source: str = "sdk",
+    **data: Any,
+) -> Any:
+    """Build a wire-type ``DatasetItemPublic`` for the parser-level stream
+    patches to yield. Mirrors the BE-side persisted shape; all per-item
+    fields the migration cares about (tags, evaluators, execution_policy,
+    description, trace_id, span_id, source) are exposed as kwargs."""
+    from opik.rest_api.types.dataset_item_public import DatasetItemPublic
+    from opik.rest_api.types.evaluator_item_public import EvaluatorItemPublic
+    from opik.rest_api.types.execution_policy_public import ExecutionPolicyPublic
+
+    evals = None
+    if evaluators is not None:
+        evals = [
+            EvaluatorItemPublic(name=e["name"], type=e["type"], config=e["config"])
+            for e in evaluators
+        ]
+    pol = None
+    if execution_policy is not None:
+        pol = ExecutionPolicyPublic(
+            runs_per_item=execution_policy["runs_per_item"],
+            pass_threshold=execution_policy["pass_threshold"],
+        )
+    return DatasetItemPublic(
+        id=item_id,
+        data=data,
+        description=description,
+        tags=tags,
+        evaluators=evals,
+        execution_policy=pol,
+        trace_id=trace_id,
+        span_id=span_id,
+        source=source,
+    )
+
+
+class TestVersionReplayUnit:
+    """Direct unit tests for ``version_replay`` — bypass the Click CLI so
+    we can exercise the delta / apply / remap logic without staging the
+    full executor surface."""
+
+    def _setup(
+        self,
+        *,
+        source_versions: List[_SourceVersion],
+        items_per_version: Dict[str, List[Any]],
+        applied_versions: List[_AppliedVersion],
+        source_dataset_id: str = "src-id",
+        dest_dataset_id: str = "tgt-dataset-id",
+    ) -> tuple[MagicMock, AuditLog]:
+        rest_client = MagicMock()
+        # ``list_dataset_versions`` is called twice in the new flow:
+        # 1) source-version listing (id=source_dataset_id, paginated newest-first);
+        # 2) post-``create_or_update_dataset_items`` lookup of v1 on the
+        #    target (id=dest_dataset_id, page=1 size=1).
+        # Route by id so both paths can coexist on one mock.
+        applied_iter = iter(applied_versions)
+
+        def _list_versions(id: str, **kwargs: Any) -> Any:
+            if id == source_dataset_id:
+                # Paginated source version listing — newest-first.
+                page = kwargs.get("page", 1)
+                if page == 1:
+                    return _Page(list(reversed(source_versions)))
+                return _Page([])
+            if id == dest_dataset_id:
+                # Post-v1-write read-back: peel one ``applied_versions`` entry
+                # and surface it as the latest version on the target.
+                next_v = next(applied_iter)
+                return _Page([next_v])
+            raise AssertionError(f"unexpected list_dataset_versions id={id}")
+
+        rest_client.datasets.list_dataset_versions.side_effect = _list_versions
+
+        # apply_dataset_item_changes — one response per call, fed from the
+        # remaining applied_versions pool (after any v1 read-back consumed entries).
+        rest_client.datasets.apply_dataset_item_changes.side_effect = (
+            lambda *args, **kwargs: next(applied_iter)
+        )
+
+        # ``create_or_update_dataset_items`` returns None (per its REST signature).
+        rest_client.datasets.create_or_update_dataset_items.return_value = None
+
+        # The replay code reads items via raw REST stream + parser. We
+        # capture the ``dataset_version`` arg on the raw stream call and
+        # route the parser patch to the right items_per_version bucket.
+        last_dataset_version: List[Optional[str]] = [None]
+
+        def _raw_stream(
+            *,
+            dataset_name: str,
+            project_name: Optional[str] = None,
+            dataset_version: Optional[str] = None,
+            **_: Any,
+        ) -> Any:
+            last_dataset_version[0] = dataset_version
+            return iter(())  # parser will be patched; bytes content doesn't matter
+
+        rest_client.datasets.stream_dataset_items.side_effect = _raw_stream
+
+        def _parse(stream: Any, item_class: Any, **_: Any) -> List[Any]:
+            return list(items_per_version.get(last_dataset_version[0] or "", []))
+
+        self._parse_patch = patch(
+            "opik.cli.migrate.datasets.version_replay.rest_stream_parser.read_and_parse_stream",
+            side_effect=_parse,
+        )
+        self._parse_patch.start()
+
+        audit = AuditLog(command="opik migrate dataset", args={})
+        return rest_client, audit
+
+    def teardown_method(self) -> None:
+        if hasattr(self, "_parse_patch"):
+            self._parse_patch.stop()
+
+    def test_replay__single_version_source__one_create_or_update_call(self) -> None:
+        # Source v1 has items, so replay's first-version path uses
+        # ``create_or_update_dataset_items`` (the same write path
+        # ``Dataset.insert`` uses) — NOT ``apply_dataset_item_changes``.
+        # This is what makes target version count == source version count
+        # for plain datasets.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(id="src-v1", version_hash="hv1", version_name="v1"),
+            ],
+            items_per_version={
+                "hv1": [
+                    _ds_item("item-a", input="hello"),
+                    _ds_item("item-b", input="world"),
+                ],
+                # Post-create re-read on the new target version.
+                "tgt-h1": [
+                    _ds_item("tgt-a", input="hello"),
+                    _ds_item("tgt-b", input="world"),
+                ],
+            },
+            applied_versions=[_AppliedVersion(id="tgt-v1", version_hash="tgt-h1")],
+        )
+
+        result = replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        assert result.versions_replayed == 1
+        assert result.version_remap == {"src-v1": "tgt-v1"}
+        # item_id_remap reflects content-hash matches between source adds
+        # and the target's re-read items.
+        assert set(result.item_id_remap.keys()) == {"item-a", "item-b"}
+        assert set(result.item_id_remap.values()) == {"tgt-a", "tgt-b"}
+
+        # No apply_dataset_item_changes calls at all — v1 went through
+        # create_or_update_dataset_items.
+        assert rest_client.datasets.apply_dataset_item_changes.call_count == 0
+        rest_client.datasets.create_or_update_dataset_items.assert_called_once()
+        create_kwargs = (
+            rest_client.datasets.create_or_update_dataset_items.call_args.kwargs
+        )
+        assert create_kwargs["dataset_id"] == "tgt-dataset-id"
+        assert create_kwargs["batch_group_id"] is not None
+        # Items are sent reversed (newest source-stream item last) so the
+        # BE's UUIDv7 + ORDER BY id DESC display order matches the source.
+        assert [it.data for it in create_kwargs["items"]] == [
+            {"input": "world"},
+            {"input": "hello"},
+        ]
+
+    def test_replay__adds_only_v2__second_apply_carries_only_new_items(self) -> None:
+        # v1 = [a, b]; v2 = [a, b, c]. Delta on v2 = [c] add, no mods, no dels.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(id="src-v1", version_hash="hv1"),
+                _SourceVersion(id="src-v2", version_hash="hv2"),
+            ],
+            items_per_version={
+                "hv1": [_ds_item("a", input="A"), _ds_item("b", input="B")],
+                "hv2": [
+                    _ds_item("a", input="A"),
+                    _ds_item("b", input="B"),
+                    _ds_item("c", input="C"),
+                ],
+                "tgt-h1": [_ds_item("tgt-a", input="A"), _ds_item("tgt-b", input="B")],
+                "tgt-h2": [
+                    _ds_item("tgt-a", input="A"),
+                    _ds_item("tgt-b", input="B"),
+                    _ds_item("tgt-c", input="C"),
+                ],
+            },
+            applied_versions=[
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+            ],
+        )
+
+        result = replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        assert result.versions_replayed == 2
+        assert result.version_remap == {"src-v1": "tgt-v1", "src-v2": "tgt-v2"}
+
+        # Two apply calls total.
+        # v1 written via create_or_update_dataset_items; v2 via apply.
+        rest_client.datasets.create_or_update_dataset_items.assert_called_once()
+        v1_items = rest_client.datasets.create_or_update_dataset_items.call_args.kwargs[
+            "items"
+        ]
+        assert len(v1_items) == 2
+        assert rest_client.datasets.apply_dataset_item_changes.call_count == 1
+        v2_request = rest_client.datasets.apply_dataset_item_changes.call_args.kwargs[
+            "request"
+        ]
+        # v2: only the new item ("c") as an add; base = tgt-v1 (the v1 we
+        # just minted via create_or_update_dataset_items).
+        assert len(v2_request["added_items"]) == 1
+        assert v2_request["added_items"][0]["data"] == {"input": "C"}
+        assert "edited_items" not in v2_request
+        assert "deleted_ids" not in v2_request
+        assert v2_request["base_version"] == "tgt-v1"
+
+    def test_replay__modifications_only__edits_carry_stable_ids(self) -> None:
+        # v1 = [a={x:1}, b={y:2}]; v2 = [a={x:99}, b={y:2}]. Item a is modified.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(id="src-v1", version_hash="hv1"),
+                _SourceVersion(id="src-v2", version_hash="hv2"),
+            ],
+            items_per_version={
+                "hv1": [_ds_item("a", x=1), _ds_item("b", y=2)],
+                "hv2": [_ds_item("a", x=99), _ds_item("b", y=2)],
+                "tgt-h1": [_ds_item("tgt-a", x=1), _ds_item("tgt-b", y=2)],
+                "tgt-h2": [_ds_item("tgt-a", x=99), _ds_item("tgt-b", y=2)],
+            },
+            applied_versions=[
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+            ],
+        )
+
+        replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        # v2 is the FIRST apply call (v1 went through create_or_update).
+        v2_request = rest_client.datasets.apply_dataset_item_changes.call_args.kwargs[
+            "request"
+        ]
+        # Only modifications; no adds, no deletions.
+        assert "added_items" not in v2_request
+        assert "deleted_ids" not in v2_request
+        assert len(v2_request["edited_items"]) == 1
+        edit = v2_request["edited_items"][0]
+        # Edit is keyed by the *target's* id (BE matches edits by id, so the
+        # source id from item_id_remap[source_id]==target_id is the right
+        # value to send). v1's add gave source 'a' the target id 'tgt-a',
+        # which is what the v2 edit must now carry.
+        assert edit["id"] == "tgt-a"
+        assert edit["data"] == {"x": 99}
+
+    def test_replay__deletions_only__deleted_ids_carry_previous_ids(self) -> None:
+        # v1 = [a, b]; v2 = [a]. Item b deleted.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(id="src-v1", version_hash="hv1"),
+                _SourceVersion(id="src-v2", version_hash="hv2"),
+            ],
+            items_per_version={
+                "hv1": [_ds_item("a", input="A"), _ds_item("b", input="B")],
+                "hv2": [_ds_item("a", input="A")],
+                "tgt-h1": [_ds_item("tgt-a", input="A"), _ds_item("tgt-b", input="B")],
+                "tgt-h2": [_ds_item("tgt-a", input="A")],
+            },
+            applied_versions=[
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+            ],
+        )
+
+        replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        # v2 is the FIRST apply call (v1 went through create_or_update).
+        v2_request = rest_client.datasets.apply_dataset_item_changes.call_args.kwargs[
+            "request"
+        ]
+        assert "added_items" not in v2_request
+        assert "edited_items" not in v2_request
+        # Deletions reference the *target's* id for item 'b' (added in v1
+        # as 'tgt-b'), not the source id, since BE matches by target id.
+        assert v2_request["deleted_ids"] == ["tgt-b"]
+
+    def test_replay__mixed_delta__separates_adds_mods_and_dels(self) -> None:
+        # v1 = [a={x:1}, b={y:2}, c={z:3}]
+        # v2 = [a={x:99}, c={z:3}, d={w:4}] — modify a, delete b, add d.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(id="src-v1", version_hash="hv1"),
+                _SourceVersion(id="src-v2", version_hash="hv2"),
+            ],
+            items_per_version={
+                "hv1": [
+                    _ds_item("a", x=1),
+                    _ds_item("b", y=2),
+                    _ds_item("c", z=3),
+                ],
+                "hv2": [
+                    _ds_item("a", x=99),
+                    _ds_item("c", z=3),
+                    _ds_item("d", w=4),
+                ],
+                "tgt-h1": [
+                    _ds_item("tgt-a", x=1),
+                    _ds_item("tgt-b", y=2),
+                    _ds_item("tgt-c", z=3),
+                ],
+                "tgt-h2": [
+                    _ds_item("tgt-a", x=99),
+                    _ds_item("tgt-c", z=3),
+                    _ds_item("tgt-d", w=4),
+                ],
+            },
+            applied_versions=[
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+            ],
+        )
+
+        result = replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        # v2 is the FIRST apply call (v1 went through create_or_update).
+        v2_request = rest_client.datasets.apply_dataset_item_changes.call_args.kwargs[
+            "request"
+        ]
+        assert len(v2_request["added_items"]) == 1
+        assert v2_request["added_items"][0]["data"] == {"w": 4}
+        assert len(v2_request["edited_items"]) == 1
+        # Edit / delete payloads reference target ids (remapped from source
+        # ids via the previously-built item_id_remap).
+        assert v2_request["edited_items"][0]["id"] == "tgt-a"
+        assert v2_request["edited_items"][0]["data"] == {"x": 99}
+        assert v2_request["deleted_ids"] == ["tgt-b"]
+
+        # version_remap captures both versions; item_id_remap captures
+        # adds across both versions but NOT modifications (mods keep their
+        # stable id and don't need remapping).
+        assert result.version_remap == {"src-v1": "tgt-v1", "src-v2": "tgt-v2"}
+        # v1 adds: a, b, c → tgt-a, tgt-b, tgt-c. v2 adds: d → tgt-d.
+        assert result.item_id_remap == {
+            "a": "tgt-a",
+            "b": "tgt-b",
+            "c": "tgt-c",
+            "d": "tgt-d",
+        }
+
+    def test_replay__zero_versions_source__no_op(self) -> None:
+        # Source dataset has no committed versions — replay walks an empty
+        # list and returns an empty result without calling apply_changes.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        rest_client, audit = self._setup(
+            source_versions=[],
+            items_per_version={},
+            applied_versions=[],
+        )
+
+        result = replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        assert result.versions_replayed == 0
+        assert result.version_remap == {}
+        assert result.item_id_remap == {}
+        rest_client.datasets.apply_dataset_item_changes.assert_not_called()
+
+    def test_replay__send_order_is_reversed_to_match_source_display_order(
+        self,
+    ) -> None:
+        # Pin the bug found by the slice 2 e2e: source streams items in
+        # newest-first display order (ClickHouse ORDER BY id DESC over UUIDv7),
+        # and the BE assigns row UUIDs to each apply payload in list order
+        # with later list entries getting larger UUIDs. To preserve the
+        # source's display order on the target, ``added_items`` and
+        # ``edited_items`` must be sent REVERSED — newest-display-first item
+        # last in the list so it gets the largest UUID and lands on top.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(id="src-v1", version_hash="hv1"),
+                _SourceVersion(id="src-v2", version_hash="hv2"),
+            ],
+            items_per_version={
+                # Source v1 streams [Q3, Q2, Q1] in newest-first order. v2
+                # adds Q5 (newest), Q4, and edits Q1 and Q3 — items_per_version
+                # is what the source's per-version stream returns.
+                "hv1": [
+                    _ds_item("Q3-id", q="Q3"),
+                    _ds_item("Q2-id", q="Q2"),
+                    _ds_item("Q1-id", q="Q1"),
+                ],
+                "hv2": [
+                    _ds_item("Q5-id", q="Q5"),
+                    _ds_item("Q4-id", q="Q4"),
+                    _ds_item("Q3-id", q="Q3-EDITED"),
+                    _ds_item("Q2-id", q="Q2"),
+                    _ds_item("Q1-id", q="Q1-EDITED"),
+                ],
+                "tgt-h1": [
+                    _ds_item("tgt-Q3", q="Q3"),
+                    _ds_item("tgt-Q2", q="Q2"),
+                    _ds_item("tgt-Q1", q="Q1"),
+                ],
+                "tgt-h2": [
+                    _ds_item("tgt-Q5", q="Q5"),
+                    _ds_item("tgt-Q4", q="Q4"),
+                    _ds_item("tgt-Q3", q="Q3-EDITED"),
+                    _ds_item("tgt-Q2", q="Q2"),
+                    _ds_item("tgt-Q1", q="Q1-EDITED"),
+                ],
+            },
+            applied_versions=[
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+            ],
+        )
+
+        replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        # v1 added [Q3, Q2, Q1] (source order). create_or_update_dataset_items
+        # gets the items REVERSED so the BE's UUIDv7 + ORDER BY id DESC
+        # display order matches the source — Q3 gets the largest UUID and
+        # displays first.
+        v1_items = rest_client.datasets.create_or_update_dataset_items.call_args.kwargs[
+            "items"
+        ]
+        assert [it.data["q"] for it in v1_items] == ["Q1", "Q2", "Q3"]
+
+        # v2 adds [Q5, Q4] in source order (newest first), edits [Q3, Q1]
+        # in source order. After reversal in the apply payload:
+        # added=[Q4, Q5], edited=[Q1, Q3].
+        v2_request = rest_client.datasets.apply_dataset_item_changes.call_args.kwargs[
+            "request"
+        ]
+        assert [a["data"]["q"] for a in v2_request["added_items"]] == [
+            "Q4",
+            "Q5",
+        ]
+        assert [e["data"]["q"] for e in v2_request["edited_items"]] == [
+            "Q1-EDITED",
+            "Q3-EDITED",
+        ]
+
+    def test_replay__edits_and_deletes_use_target_ids_not_source_ids(self) -> None:
+        # Pin the bug found by the slice 2 e2e: edits/deletes in v_n+1 must
+        # reference the target-side item id (assigned by the BE on add in
+        # v_n), NOT the source's stable id. The BE matches edit/delete
+        # payloads by id against the *target* dataset, so forwarding source
+        # ids would silently no-op and the target version would diverge from
+        # the source version's content.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(id="src-v1", version_hash="hv1"),
+                _SourceVersion(id="src-v2", version_hash="hv2"),
+            ],
+            items_per_version={
+                "hv1": [_ds_item("src-a", x=1), _ds_item("src-b", y=2)],
+                # v2 modifies src-a, deletes src-b.
+                "hv2": [_ds_item("src-a", x=99)],
+                # Target side: BE assigned new ids on the v1 adds.
+                "tgt-h1": [_ds_item("TGT-A", x=1), _ds_item("TGT-B", y=2)],
+                "tgt-h2": [_ds_item("TGT-A", x=99)],
+            },
+            applied_versions=[
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+            ],
+        )
+
+        replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        # v2 is the FIRST apply call (v1 went through create_or_update).
+        v2_request = rest_client.datasets.apply_dataset_item_changes.call_args.kwargs[
+            "request"
+        ]
+        # Edit ID is the target id (TGT-A), not the source id (src-a).
+        assert v2_request["edited_items"][0]["id"] == "TGT-A"
+        # Delete ID is the target id (TGT-B), not the source id (src-b).
+        assert v2_request["deleted_ids"] == ["TGT-B"]
+
+    def test_replay__forwards_per_version_suite_evaluators_and_execution_policy(
+        self,
+    ) -> None:
+        # Pin the bug found by the test-suite e2e: each source version's
+        # suite-level ``evaluators`` and ``execution_policy`` must ride on
+        # that version's write. Without this, the BE would inherit the
+        # last-set config across all replayed versions, collapsing suite-
+        # config history onto whichever version last carried explicit
+        # suite-level fields.
+        #
+        # Test suite shape: source v1 is config-only (zero items + suite
+        # evaluators + execution_policy) — the canonical shape created by
+        # ``create_test_suite(global_assertions=...)``. v1 routes through
+        # ``apply_dataset_item_changes(base_version=null, override=true)``
+        # carrying the suite config. v2 adds items and bumps suite config,
+        # routing through standard ``apply_dataset_item_changes``.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        v1_evaluator = MagicMock()
+        v1_evaluator.name = "v1-judge"
+        v1_evaluator.type = "llm_judge"
+        v1_evaluator.config = {"model": "haiku"}
+        v1_policy = MagicMock()
+        v1_policy.runs_per_item = 1
+        v1_policy.pass_threshold = 1
+
+        v2_evaluator = MagicMock()
+        v2_evaluator.name = "v2-judge"
+        v2_evaluator.type = "llm_judge"
+        v2_evaluator.config = {"model": "opus"}
+        v2_policy = MagicMock()
+        v2_policy.runs_per_item = 5
+        v2_policy.pass_threshold = 3
+
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(
+                    id="src-v1",
+                    version_hash="hv1",
+                    evaluators=[v1_evaluator],
+                    execution_policy=v1_policy,
+                ),
+                _SourceVersion(
+                    id="src-v2",
+                    version_hash="hv2",
+                    evaluators=[v2_evaluator],
+                    execution_policy=v2_policy,
+                ),
+            ],
+            items_per_version={
+                "hv1": [],  # config-only: no items on v1
+                "hv2": [_ds_item("a", x=1)],
+                "tgt-h2": [_ds_item("tgt-a", x=1)],
+            },
+            applied_versions=[
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+            ],
+        )
+
+        replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        # Two apply_dataset_item_changes calls: v1 (base_version=null,
+        # override=true, config-only) and v2 (base_version=tgt-v1, items + config).
+        assert rest_client.datasets.apply_dataset_item_changes.call_count == 2
+        v1_call = rest_client.datasets.apply_dataset_item_changes.call_args_list[0]
+        v1_request = v1_call.kwargs["request"]
+        assert v1_call.kwargs["override"] is True
+        assert "base_version" not in v1_request
+        assert v1_request["evaluators"] == [
+            {"name": "v1-judge", "type": "llm_judge", "config": {"model": "haiku"}}
+        ]
+        assert v1_request["execution_policy"] == {
+            "runs_per_item": 1,
+            "pass_threshold": 1,
+        }
+
+        v2_request = rest_client.datasets.apply_dataset_item_changes.call_args_list[
+            1
+        ].kwargs["request"]
+        assert v2_request["base_version"] == "tgt-v1"
+        assert v2_request["evaluators"] == [
+            {"name": "v2-judge", "type": "llm_judge", "config": {"model": "opus"}}
+        ]
+        assert v2_request["execution_policy"] == {
+            "runs_per_item": 5,
+            "pass_threshold": 3,
+        }
+
+    def test_replay__forwards_per_item_tags_on_add_and_edit(self) -> None:
+        # Per-item tags are version-scoped on the BE — they can change across
+        # versions. Verify they round-trip on both write paths.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(id="src-v1", version_hash="hv1"),
+                _SourceVersion(id="src-v2", version_hash="hv2"),
+            ],
+            items_per_version={
+                "hv1": [_ds_item("a", tags=["regression"], x=1)],
+                # v2: tag list expanded.
+                "hv2": [_ds_item("a", tags=["regression", "baseline"], x=1)],
+                "tgt-h1": [_ds_item("tgt-a", tags=["regression"], x=1)],
+                "tgt-h2": [_ds_item("tgt-a", tags=["regression", "baseline"], x=1)],
+            },
+            applied_versions=[
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+            ],
+        )
+
+        replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        # v1 went through create_or_update; its payload carries tags.
+        v1_items = rest_client.datasets.create_or_update_dataset_items.call_args.kwargs[
+            "items"
+        ]
+        assert v1_items[0].tags == ["regression"]
+
+        # v2 went through apply; its edit payload carries the new tag list.
+        v2_request = rest_client.datasets.apply_dataset_item_changes.call_args.kwargs[
+            "request"
+        ]
+        assert v2_request["edited_items"][0]["tags"] == ["regression", "baseline"]
+
+    def test_replay__clears_per_item_tags_when_removed(self) -> None:
+        # Source v1 has an item with tags; v2's same item has no tags. The
+        # BE inherits on omission, so we must explicitly send tags=[] to
+        # overwrite the stale set on the target.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(id="src-v1", version_hash="hv1"),
+                _SourceVersion(id="src-v2", version_hash="hv2"),
+            ],
+            items_per_version={
+                "hv1": [_ds_item("a", tags=["regression"], x=1)],
+                "hv2": [
+                    _ds_item("a", tags=None, x=2)
+                ],  # tags cleared, data also changed
+                "tgt-h1": [_ds_item("tgt-a", tags=["regression"], x=1)],
+                "tgt-h2": [_ds_item("tgt-a", tags=None, x=2)],
+            },
+            applied_versions=[
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+            ],
+        )
+
+        replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        v2_request = rest_client.datasets.apply_dataset_item_changes.call_args.kwargs[
+            "request"
+        ]
+        assert v2_request["edited_items"][0]["tags"] == []
+
+    def test_replay__clears_per_item_evaluators_when_removed(self) -> None:
+        # Source v1's item has per-item evaluators; v2's same item drops
+        # them. Forward evaluators=[] on the edit to override.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        eval_v1 = {"name": "j1", "type": "llm_judge", "config": {"model": "haiku"}}
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(id="src-v1", version_hash="hv1"),
+                _SourceVersion(id="src-v2", version_hash="hv2"),
+            ],
+            items_per_version={
+                "hv1": [_ds_item("a", evaluators=[eval_v1], x=1)],
+                "hv2": [_ds_item("a", evaluators=None, x=2)],
+                "tgt-h1": [_ds_item("tgt-a", evaluators=[eval_v1], x=1)],
+                "tgt-h2": [_ds_item("tgt-a", evaluators=None, x=2)],
+            },
+            applied_versions=[
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+            ],
+        )
+
+        replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        v2_request = rest_client.datasets.apply_dataset_item_changes.call_args.kwargs[
+            "request"
+        ]
+        assert v2_request["edited_items"][0]["evaluators"] == []
+
+    def test_replay__clears_per_item_execution_policy_when_removed(self) -> None:
+        # Source v1's item has a per-item execution_policy override; v2's
+        # same item drops it. Send clear_execution_policy=true (not just
+        # omit the field, which would inherit the stale override).
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        pol_v1 = {"runs_per_item": 5, "pass_threshold": 3}
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(id="src-v1", version_hash="hv1"),
+                _SourceVersion(id="src-v2", version_hash="hv2"),
+            ],
+            items_per_version={
+                "hv1": [_ds_item("a", execution_policy=pol_v1, x=1)],
+                "hv2": [_ds_item("a", execution_policy=None, x=2)],
+                "tgt-h1": [_ds_item("tgt-a", execution_policy=pol_v1, x=1)],
+                "tgt-h2": [_ds_item("tgt-a", execution_policy=None, x=2)],
+            },
+            applied_versions=[
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+            ],
+        )
+
+        replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        v2_request = rest_client.datasets.apply_dataset_item_changes.call_args.kwargs[
+            "request"
+        ]
+        edited = v2_request["edited_items"][0]
+        assert "execution_policy" not in edited
+        assert edited["clear_execution_policy"] is True
+
+    def test_replay__forwards_version_metadata_and_filters_latest_tag(self) -> None:
+        # Version-level metadata is per-version Map<str,str>; round-trip it.
+        # Version-level tags include BE's 'latest' system marker on the
+        # latest version — that must be stripped (forwarding it 409s).
+        # Source v1 carries items AND version-level fields, which forces a
+        # follow-up apply (one extra target version) — the warning is by
+        # design; the alternative would be silent N+1 surprises in prod.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(
+                    id="src-v1",
+                    version_hash="hv1",
+                    metadata={"author": "ada"},
+                    tags=["baseline"],
+                ),
+                _SourceVersion(
+                    id="src-v2",
+                    version_hash="hv2",
+                    metadata={"author": "ada", "experiment": "42"},
+                    tags=["baseline", "v1.0", "latest"],  # 'latest' must be filtered
+                ),
+            ],
+            items_per_version={
+                "hv1": [_ds_item("a", x=1)],
+                "hv2": [_ds_item("a", x=1), _ds_item("b", y=2)],
+                "tgt-h1": [_ds_item("tgt-a", x=1)],
+                "tgt-h1b": [_ds_item("tgt-a", x=1)],
+                "tgt-h2": [_ds_item("tgt-a", x=1), _ds_item("tgt-b", y=2)],
+            },
+            applied_versions=[
+                # 1) post-create_or_update read-back on v1 (drives list_dataset_versions)
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                # 2) v1 follow-up apply for metadata/tags (response from apply_changes)
+                _AppliedVersion(id="tgt-v1b", version_hash="tgt-h1b"),
+                # 3) v2 apply (response from apply_changes)
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+            ],
+        )
+
+        replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        # v1 went through create_or_update + version-field follow-up apply
+        # to land the metadata + tags. Find the apply call (the only one
+        # carrying base_version=tgt-init isn't possible since we don't have
+        # initial; this is the v1 follow-up).
+        v1_followup = rest_client.datasets.apply_dataset_item_changes.call_args_list[
+            0
+        ].kwargs["request"]
+        assert v1_followup["metadata"] == {"author": "ada"}
+        assert v1_followup["tags"] == ["baseline"]
+
+        # v2 apply: metadata expanded; 'latest' is filtered out of tags.
+        v2_request = rest_client.datasets.apply_dataset_item_changes.call_args_list[
+            1
+        ].kwargs["request"]
+        assert v2_request["metadata"] == {"author": "ada", "experiment": "42"}
+        assert v2_request["tags"] == ["baseline", "v1.0"]
+
+    def test_replay__base_version_chains_across_calls(self) -> None:
+        # Each apply call's base_version must be the previous response's id —
+        # not a stale value, not the initial. Pin this so a refactor that
+        # accidentally re-uses the initial id silently breaks here.
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        rest_client, audit = self._setup(
+            source_versions=[
+                _SourceVersion(id="src-v1", version_hash="hv1"),
+                _SourceVersion(id="src-v2", version_hash="hv2"),
+                _SourceVersion(id="src-v3", version_hash="hv3"),
+            ],
+            items_per_version={
+                "hv1": [_ds_item("a", x=1)],
+                "hv2": [_ds_item("a", x=1), _ds_item("b", y=2)],
+                "hv3": [_ds_item("a", x=1), _ds_item("b", y=2), _ds_item("c", z=3)],
+                "tgt-h1": [_ds_item("tgt-a", x=1)],
+                "tgt-h2": [_ds_item("tgt-a", x=1), _ds_item("tgt-b", y=2)],
+                "tgt-h3": [
+                    _ds_item("tgt-a", x=1),
+                    _ds_item("tgt-b", y=2),
+                    _ds_item("tgt-c", z=3),
+                ],
+            },
+            applied_versions=[
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+                _AppliedVersion(id="tgt-v3", version_hash="tgt-h3"),
+            ],
+        )
+
+        replay_all_versions(
+            rest_client,
+            source_dataset_id="src-id",
+            source_name_after_rename="MyDataset_v1",
+            source_project_name=None,
+            dest_dataset_id="tgt-dataset-id",
+            dest_name="MyDataset",
+            dest_project_name="B",
+            audit=audit,
+        )
+
+        # v1 went through create_or_update_dataset_items, not apply_changes.
+        # v2 and v3 each go through apply_changes; their base_versions chain
+        # off the previous response: v2 base=tgt-v1, v3 base=tgt-v2.
+        bases = [
+            call.kwargs["request"]["base_version"]
+            for call in rest_client.datasets.apply_dataset_item_changes.call_args_list
+        ]
+        assert bases == ["tgt-v1", "tgt-v2"]
+
+
+class TestVersionReplayE2ECli:
+    """End-to-end Click smoke test: drives the full executor plumbing
+    (CreateDestination → replay loop → audit-log finalisation). With the
+    Slice 2 contract that target version count == source version count, v1
+    is written through ``create_or_update_dataset_items`` (when v1 has items)
+    or ``apply_dataset_item_changes(base_version=null, override=true)`` (when
+    v1 is config-only). Subsequent versions go through ``apply_dataset_item_changes``."""
+
+    def test_migrate_dataset__default_path__replay_versions_executes(
+        self, tmp_path: Path
+    ) -> None:
+        runner = CliRunner()
+        client, _, _ = _build_fake_client(
+            source_rows=[_DatasetRow(id="src-1", name="MyDataset")],
+            destination_rows=[],
+            items=[],
+        )
+
+        # Source has one version with one item.
+        source_version = _SourceVersion(
+            id="src-v1", version_hash="hv1", version_name="v1"
+        )
+        target_after_create = MagicMock()
+        target_after_create.id = "tgt-dataset-id"
+        client.rest_client.datasets.get_dataset_by_identifier.return_value = (
+            target_after_create
+        )
+        client.rest_client.datasets.create_or_update_dataset_items.return_value = None
+
+        # list_dataset_versions is called for both the source (paginated
+        # newest-first) and the target (post-create read-back of v1). Route
+        # by id rather than a flat side_effect list so the order doesn't
+        # depend on internal call sequencing.
+        post_create_iter = iter([_AppliedVersion(id="tgt-v1", version_hash="tgt-h1")])
+
+        def _list_versions(id: str, **kwargs: Any) -> Any:
+            if id == "src-1":
+                page = kwargs.get("page", 1)
+                if page == 1:
+                    return _Page([source_version])
+                return _Page([])
+            if id == "tgt-dataset-id":
+                return _Page([next(post_create_iter)])
+            raise AssertionError(f"unexpected list_dataset_versions id={id}")
+
+        client.rest_client.datasets.list_dataset_versions.side_effect = _list_versions
+
+        items_per_version: Dict[str, List[Any]] = {
+            "hv1": [_ds_item("a", x=1)],
+            "tgt-h1": [_ds_item("tgt-a", x=1)],
+        }
+
+        last_dataset_version: List[Optional[str]] = [None]
+
+        def _raw_stream(*, dataset_version: Optional[str] = None, **_: Any) -> Any:
+            last_dataset_version[0] = dataset_version
+            return iter(())
+
+        def _parse(stream: Any, item_class: Any, **_: Any) -> List[Any]:
+            return list(items_per_version.get(last_dataset_version[0] or "", []))
+
+        client.rest_client.datasets.stream_dataset_items.side_effect = _raw_stream
+
+        audit_path = tmp_path / "audit.json"
+        with (
+            patch("opik.cli.migrate.main.opik.Opik", return_value=client),
+            patch(
+                "opik.cli.migrate.datasets.version_replay.rest_stream_parser.read_and_parse_stream",
+                side_effect=_parse,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "migrate",
+                    "dataset",
+                    "MyDataset",
+                    "--to-project",
+                    "B",
+                    "--audit-log",
+                    str(audit_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # v1 went through create_or_update_dataset_items.
+        client.rest_client.datasets.create_or_update_dataset_items.assert_called_once()
+        # No apply_dataset_item_changes calls — source has only one version
+        # and it was written via the create path.
+        client.rest_client.datasets.apply_dataset_item_changes.assert_not_called()
+        audit = json.loads(audit_path.read_text())
+        types = [a["type"] for a in audit["actions"]]
+        # Outer replay_versions ok bracket + inner replay_dataset_version
+        # per-version record.
+        assert "replay_versions" in types
+        assert "replay_dataset_version" in types
+        assert audit["status"] == "ok"
+
+    def test_migrate_dataset__source_v1_is_config_only__no_leading_empty_version(
+        self, tmp_path: Path
+    ) -> None:
+        # Pin the test-suite shape: source v1 is config-only (zero items,
+        # suite-level evaluators + execution_policy on the version itself).
+        # Replay must mint target v1 via ``apply_dataset_item_changes(
+        # base_version=null, override=true)`` carrying the suite config —
+        # not via a separate empty seed followed by another version. Result:
+        # target version count == source version count, no extra leading
+        # empty version.
+        runner = CliRunner()
+        client, _, _ = _build_fake_client(
+            source_rows=[
+                _DatasetRow(id="src-1", name="MySuite", type="evaluation_suite")
+            ],
+            destination_rows=[],
+            items=[],
+        )
+
+        evaluator = MagicMock()
+        evaluator.name = "v1-judge"
+        evaluator.type = "llm_judge"
+        evaluator.config = {"model": "haiku"}
+        policy = MagicMock()
+        policy.runs_per_item = 1
+        policy.pass_threshold = 1
+
+        source_version = _SourceVersion(
+            id="src-v1",
+            version_hash="hv1",
+            version_name="v1",
+            evaluators=[evaluator],
+            execution_policy=policy,
+        )
+        client.rest_client.datasets.list_dataset_versions.side_effect = [
+            _Page([source_version]),  # source version list (single page)
+            _Page([]),  # pagination terminator
+        ]
+        target_after_create = MagicMock()
+        target_after_create.id = "tgt-dataset-id"
+        client.rest_client.datasets.get_dataset_by_identifier.return_value = (
+            target_after_create
+        )
+        # Exactly one apply call for v1 (config-only with base_version=null +
+        # override=true). The config-only path does not need create_or_update.
+        client.rest_client.datasets.apply_dataset_item_changes.side_effect = [
+            _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+        ]
+
+        items_per_version: Dict[str, List[Any]] = {
+            "hv1": [],  # config-only: zero items on v1
+        }
+
+        last_dataset_version: List[Optional[str]] = [None]
+
+        def _raw_stream(*, dataset_version: Optional[str] = None, **_: Any) -> Any:
+            last_dataset_version[0] = dataset_version
+            return iter(())
+
+        def _parse(stream: Any, item_class: Any, **_: Any) -> List[Any]:
+            return list(items_per_version.get(last_dataset_version[0] or "", []))
+
+        client.rest_client.datasets.stream_dataset_items.side_effect = _raw_stream
+
+        audit_path = tmp_path / "audit.json"
+        with (
+            patch("opik.cli.migrate.main.opik.Opik", return_value=client),
+            patch(
+                "opik.cli.migrate.datasets.version_replay.rest_stream_parser.read_and_parse_stream",
+                side_effect=_parse,
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "migrate",
+                    "dataset",
+                    "MySuite",
+                    "--to-project",
+                    "B",
+                    "--audit-log",
+                    str(audit_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # Exactly one apply call (v1, config-only).
+        calls = client.rest_client.datasets.apply_dataset_item_changes.call_args_list
+        assert len(calls) == 1
+        v1_kwargs = calls[0].kwargs
+        assert v1_kwargs["override"] is True
+        v1_request = v1_kwargs["request"]
+        assert "base_version" not in v1_request
+        assert "added_items" not in v1_request
+        assert v1_request["evaluators"] == [
+            {"name": "v1-judge", "type": "llm_judge", "config": {"model": "haiku"}}
+        ]
+        assert v1_request["execution_policy"] == {
+            "runs_per_item": 1,
+            "pass_threshold": 1,
+        }
+        # No create_or_update_dataset_items call — v1 has no items to insert.
+        client.rest_client.datasets.create_or_update_dataset_items.assert_not_called()
+
+
+class TestVersionReplayAuditLog:
+    """Per-version audit records — one ``replay_dataset_version`` entry per
+    replayed source version, plus per-version add/modify/delete counts."""
+
+    def test_replay__per_version_audit_records_emitted(self) -> None:
+        from opik.cli.migrate.datasets.version_replay import replay_all_versions
+
+        rest_client = MagicMock()
+
+        source_versions = [
+            _SourceVersion(id="src-v1", version_hash="hv1"),
+            _SourceVersion(id="src-v2", version_hash="hv2"),
+        ]
+        applied_iter = iter(
+            [
+                _AppliedVersion(id="tgt-v1", version_hash="tgt-h1"),
+                _AppliedVersion(id="tgt-v2", version_hash="tgt-h2"),
+            ]
+        )
+
+        def _list_versions(id: str, **kwargs: Any) -> Any:
+            if id == "src-id":
+                return _Page(list(reversed(source_versions)))
+            if id == "tgt-dataset-id":
+                # Post-v1 read-back: peel one applied_versions entry.
+                return _Page([next(applied_iter)])
+            raise AssertionError(f"unexpected list_dataset_versions id={id}")
+
+        rest_client.datasets.list_dataset_versions.side_effect = _list_versions
+        rest_client.datasets.apply_dataset_item_changes.side_effect = (
+            lambda *a, **kw: next(applied_iter)
+        )
+        rest_client.datasets.create_or_update_dataset_items.return_value = None
+
+        items_per_version: Dict[str, List[Any]] = {
+            "hv1": [_ds_item("a", x=1)],
+            "hv2": [_ds_item("a", x=99), _ds_item("b", y=2)],
+            "tgt-h1": [_ds_item("tgt-a", x=1)],
+            "tgt-h2": [_ds_item("tgt-a", x=99), _ds_item("tgt-b", y=2)],
+        }
+
+        last_dataset_version: List[Optional[str]] = [None]
+
+        def _raw_stream(*, dataset_version: Optional[str] = None, **_: Any) -> Any:
+            last_dataset_version[0] = dataset_version
+            return iter(())
+
+        def _parse(stream: Any, item_class: Any, **_: Any) -> List[Any]:
+            return list(items_per_version.get(last_dataset_version[0] or "", []))
+
+        rest_client.datasets.stream_dataset_items.side_effect = _raw_stream
+
+        with patch(
+            "opik.cli.migrate.datasets.version_replay.rest_stream_parser.read_and_parse_stream",
+            side_effect=_parse,
+        ):
+            audit = AuditLog(command="opik migrate dataset", args={})
+            replay_all_versions(
+                rest_client,
+                source_dataset_id="src-id",
+                source_name_after_rename="MyDataset_v1",
+                source_project_name=None,
+                dest_dataset_id="tgt-dataset-id",
+                dest_name="MyDataset",
+                dest_project_name="B",
+                audit=audit,
+            )
+
+        # AuditLog.record() flattens ``details`` into the entry, so version
+        # counts and id linkages live at the top level of the record.
+        per_version_records = [
+            r for r in audit.actions if r["type"] == "replay_dataset_version"
+        ]
+        assert len(per_version_records) == 2
+        # First version: 1 add, 0 mods, 0 dels.
+        assert per_version_records[0]["items_added"] == 1
+        assert per_version_records[0]["items_modified"] == 0
+        assert per_version_records[0]["items_deleted"] == 0
+        # Second version: 1 add (b), 1 mod (a), 0 dels.
+        assert per_version_records[1]["items_added"] == 1
+        assert per_version_records[1]["items_modified"] == 1
+        assert per_version_records[1]["items_deleted"] == 0
+        # Source/target version-id linkage recorded.
+        assert per_version_records[0]["source_version_id"] == "src-v1"
+        assert per_version_records[0]["target_version_id"] == "tgt-v1"
+        assert per_version_records[1]["source_version_id"] == "src-v2"
+        assert per_version_records[1]["target_version_id"] == "tgt-v2"


### PR DESCRIPTION
## Details

<img width="1760" height="3690" alt="image" src="https://github.com/user-attachments/assets/1ad8adf7-d9c1-4eeb-ac8d-d2ec8c5ff219" />

https://github.com/user-attachments/assets/631b7c97-e907-4608-8a85-485934e9cdd0

Slice 2 of the SDK CLI Migration Tool epic ([OPIK-5859](https://comet-ml.atlassian.net/browse/OPIK-5859)). The default `opik migrate dataset` invocation now replays the source's full version history onto the target — every source version becomes one target version with full per-version fidelity. Slice 1's current-items-only behaviour stays available behind a new `--exclude-versions` flag.

- Per-version replay covers items, item-level fields (data, description, tags, evaluators, execution_policy, trace_id, span_id, source) and version-level fields (suite evaluators, execution_policy, user tags, metadata).
- Display order is preserved per version by mirroring the BE's UUID-pool ordering rules in the apply payload.
- Edit / delete payloads remap source item ids to target ids through a running `item_id_remap`, since the BE mints fresh stable ids on every add. `clear_execution_policy` / `evaluators=[]` / `tags=[]` clear-on-edit semantics are forwarded when a previous version's override is removed.
- Target version count equals source version count: replay's first call uses `create_or_update_dataset_items` for content-bearing v1 (plain datasets) and `apply_dataset_item_changes(base_version=null, override=true)` for config-only v1 (test suites), avoiding a leading empty seed version.
- `MigrationPlan` now exposes `version_remap` (`source_version_id → target_version_id`) and `item_id_remap` for Slice 3's experiment FK remap.
- BE-managed version tag `'latest'` is filtered out of the forwarded payload to avoid 409s; user version tags pass through.
- Test file split: shared mocks moved to `_migrate_helpers.py`; Slice 1 tests live in `test_migrate_dataset_exclude_versions.py`; Slice 2 tests in `test_migrate_dataset_version_replay.py`.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6415

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Opus 4.7 (1M context)
- Scope: full implementation
- Human verification: code review + 2 real-backend e2e runs (plain dataset + test suite) against localhost Opik, 240 unit tests, `make precommit-sdks` clean

## Testing

Unit tests:
- `PYTHONPATH=src python -m pytest tests/unit/cli/` — 240 passed
- New Slice 2 file `test_migrate_dataset_version_replay.py` adds 23 tests covering: per-version delta computation (add-only, modify-only, delete-only, mixed, zero-versions, single-version), source v1 shapes (items vs config-only), base-version chaining, target-id remapping for edits / deletes, send-order reversal for display preservation, per-version suite-config forwarding, per-item tag handling, clear-on-edit semantics (tags / evaluators / execution_policy), version-level metadata + user-tag forwarding (`'latest'` filtered).

End-to-end against local Opik (`localhost:5174`, projects `migrate-test-source` → `migrate-test-target`):
- **Plain dataset** (`run_e2e.py`): 3-version source with adds + modifications + deletions across versions → 3 target versions, per-version content set-equal under content_hash, display order matches, `--exclude-versions` fallback produces 1 target version through `copy_dataset_items`.
- **Test suite** (`run_e2e_test_suite.py`): 4-version source (config-only v1 + 3 content versions) with per-version suite-level evaluators / execution_policy, per-version user version tags, per-version metadata, per-item evaluator + policy + tag overrides including clear transitions, mixed adds / modifications / deletions across versions. Target version count == source version count, per-version snapshot identical on all 4 versions (items, display order, suite evaluators, suite execution_policy, metadata, user tags).

Quality:
- `make precommit-sdks` — clean (ruff, ruff-format, mypy).

## Documentation

N/A — no user-facing docs in this slice. The new `--exclude-versions` flag is documented in the CLI `--help` output (`opik migrate dataset --help`). Slice 4 will finalize the audit-log schema and the overall migration docs.


[OPIK-5859]: https://comet-ml.atlassian.net/browse/OPIK-5859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ