### PR TITLE
[OPIK-6448] [FE] refactor: remove TOGGLE_ALERTS_ENABLED feature flag

### DIFF
--- a/apps/opik-frontend/src/contexts/feature-toggles-provider.tsx
+++ b/apps/opik-frontend/src/contexts/feature-toggles-provider.tsx
@@ -21,7 +21,6 @@ const DEFAULT_STATE: FeatureToggles = {
   [FeatureToggleKeys.PYTHON_EVALUATOR_ENABLED]: false,
   [FeatureToggleKeys.GUARDRAILS_ENABLED]: false,
   [FeatureToggleKeys.TOGGLE_OPIK_AI_ENABLED]: false,
-  [FeatureToggleKeys.TOGGLE_ALERTS_ENABLED]: false,
   [FeatureToggleKeys.WELCOME_WIZARD_ENABLED]: false,
   [FeatureToggleKeys.CSV_UPLOAD_ENABLED]: false,
   [FeatureToggleKeys.EXPORT_ENABLED]: true,

--- a/apps/opik-frontend/src/types/feature-toggles.ts
+++ b/apps/opik-frontend/src/types/feature-toggles.ts
@@ -6,7 +6,6 @@ export enum FeatureToggleKeys {
   PYTHON_EVALUATOR_ENABLED = "python_evaluator_enabled",
   GUARDRAILS_ENABLED = "guardrails_enabled",
   TOGGLE_OPIK_AI_ENABLED = "opik_aienabled",
-  TOGGLE_ALERTS_ENABLED = "alerts_enabled",
   WELCOME_WIZARD_ENABLED = "welcome_wizard_enabled",
   CSV_UPLOAD_ENABLED = "csv_upload_enabled",
   EXPORT_ENABLED = "export_enabled",

--- a/apps/opik-frontend/src/v1/layout/SideBar/helpers/getMenuItems.ts
+++ b/apps/opik-frontend/src/v1/layout/SideBar/helpers/getMenuItems.ts
@@ -170,7 +170,6 @@ const getMenuItems = ({
           icon: Bell,
           label: "Alerts",
           count: "alerts",
-          featureFlag: FeatureToggleKeys.TOGGLE_ALERTS_ENABLED,
         },
       ],
     },

--- a/apps/opik-frontend/src/v1/layout/SideBar/helpers/getMenuItems.ts
+++ b/apps/opik-frontend/src/v1/layout/SideBar/helpers/getMenuItems.ts
@@ -15,7 +15,6 @@ import {
   MENU_ITEM_TYPE,
   MenuItemGroup,
 } from "@/v1/layout/SideBar/MenuItem/SidebarMenuItem";
-import { FeatureToggleKeys } from "@/types/feature-toggles";
 
 const getMenuItems = ({
   canViewExperiments,

--- a/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
+++ b/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
@@ -202,7 +202,6 @@ const getMenuItems = ({
           icon: Bell,
           label: "Alerts",
           disabled: !projectPrefix,
-          featureFlag: FeatureToggleKeys.TOGGLE_ALERTS_ENABLED,
         },
       ],
     },

--- a/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
+++ b/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
@@ -20,7 +20,6 @@ import {
   MENU_ITEM_TYPE,
   MenuItemGroup,
 } from "@/v2/layout/SideBar/MenuItem/SidebarMenuItem";
-import { FeatureToggleKeys } from "@/types/feature-toggles";
 
 const getMenuItems = ({
   projectId,


### PR DESCRIPTION
## Details

Removed the `TOGGLE_ALERTS_ENABLED` feature flag completely from the frontend codebase. The alerts functionality is now always enabled without requiring a feature toggle check. This simplifies the codebase and ensures alerts are accessible to all users.

Changes made:
- Removed enum value from `FeatureToggleKeys`
- Removed default state entry from feature toggles provider
- Removed `featureFlag` property from alerts menu items in both v1 and v2 sidebars
- Cleaned up unused imports

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-6448

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: Full implementation
- Human verification: Code review and manual testing of alerts tab visibility

## Testing

To test this change:
1. Start the dev server: `npm run dev` (frontend) and backend
2. Navigate to a project in the sidebar
3. Verify that the "Alerts" menu item appears in the "Production" section under "Online evaluation"
4. Click on "Alerts" and verify the page loads correctly
5. Check that no console errors occur related to feature toggles

Tested scenarios:
- v1 sidebar: Alerts menu item displays correctly
- v2 sidebar: Alerts menu item displays correctly
- No TypeScript or linting errors

## Documentation

N/A