### PR TITLE
[OPIK-6376][BE] `ExperimentItemProcessor.process` silently masks agent LLM failures as empty-output traces

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemProcessor.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemProcessor.java
@@ -47,10 +47,13 @@ public class ExperimentItemProcessor {
                             var response = chatCompletionService.create(chatRequest, message.workspaceId());
                             return new LlmCallResult(response, null, null, startTime, Instant.now());
                         } catch (Exception e) {
+                            // Do not include e.getMessage() in the log: provider exceptions can echo
+                            // request/response bodies (tokens, API keys, raw user input). The full
+                            // message is still persisted to the trace's errorInfo for in-product
+                            // debugging where workspace ACLs apply.
                             log.error(
-                                    "LLM call failed for experiment '{}', dataset item '{}' ('{}: {}'); persisting trace with error info",
-                                    message.experimentId(), datasetItem.id(), e.getClass().getSimpleName(),
-                                    e.getMessage(), e);
+                                    "LLM call failed for experiment '{}', dataset item '{}' (exception '{}'); persisting trace with error info",
+                                    message.experimentId(), datasetItem.id(), e.getClass().getName(), e);
                             return new LlmCallResult(null, e.getClass().getSimpleName(), e.getMessage(),
                                     startTime, Instant.now());
                         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemProcessor.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemProcessor.java
@@ -47,8 +47,10 @@ public class ExperimentItemProcessor {
                             var response = chatCompletionService.create(chatRequest, message.workspaceId());
                             return new LlmCallResult(response, null, null, startTime, Instant.now());
                         } catch (Exception e) {
-                            log.warn("LLM call failed for experiment '{}', dataset item '{}'",
-                                    message.experimentId(), datasetItem.id(), e);
+                            log.error(
+                                    "LLM call failed for experiment '{}', dataset item '{}' ('{}: {}'); persisting trace with error info",
+                                    message.experimentId(), datasetItem.id(), e.getClass().getSimpleName(),
+                                    e.getMessage(), e);
                             return new LlmCallResult(null, e.getClass().getSimpleName(), e.getMessage(),
                                     startTime, Instant.now());
                         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentTracePersistence.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentTracePersistence.java
@@ -56,7 +56,7 @@ class ExperimentTracePersistence {
     Mono<Void> persistTraceSpanAndItem(@NonNull PersistenceContext ctx) {
 
         ObjectNode input = buildMessagesInput(ctx.renderedMessages());
-        ObjectNode output = buildLlmOutput(ctx.llmResponse());
+        ObjectNode output = buildLlmOutput(ctx.llmResponse(), ctx.errorType(), ctx.errorMessage());
 
         return Mono.when(createTrace(ctx, input, output), createSpan(ctx, input, output))
                 .then(createExperimentItem(ctx.experimentId(), ctx.datasetItemId(), ctx.traceId(),
@@ -177,13 +177,25 @@ class ExperimentTracePersistence {
         return input;
     }
 
-    private ObjectNode buildLlmOutput(ChatCompletionResponse llmResponse) {
+    private ObjectNode buildLlmOutput(ChatCompletionResponse llmResponse, String errorType, String errorMessage) {
         ObjectNode output = JsonUtils.createObjectNode();
         if (llmResponse != null && llmResponse.choices() != null && !llmResponse.choices().isEmpty()) {
             var choice = llmResponse.choices().getFirst();
             if (choice.message() != null && choice.message().content() != null) {
                 output.put("output", choice.message().content());
             }
+        }
+        // When the agent LLM call failed, surface the error inside the persisted output so the
+        // assertion judge (which reads trace.output) can recognise the fault state instead of
+        // fabricating verdicts against an empty `{}`. The structured ErrorInfo on the trace itself
+        // is set separately in createTrace; the assertion path doesn't consume that field today.
+        if (errorMessage != null) {
+            ObjectNode errorNode = JsonUtils.createObjectNode();
+            if (errorType != null) {
+                errorNode.put("type", errorType);
+            }
+            errorNode.put("message", errorMessage);
+            output.set("error", errorNode);
         }
         return output;
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentItemProcessorTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentItemProcessorTest.java
@@ -446,7 +446,7 @@ class ExperimentItemProcessorTest {
         }
 
         @Test
-        void processCreatesTraceWithEmptyOutputOnLlmFailure() {
+        void processCreatesTraceWithoutLlmOutputOnLlmFailure() {
             var prompt = buildPrompt("gpt-4", "user", "Hello");
             var datasetItem = buildDatasetItem(UUID.randomUUID(), Map.of());
             var experimentId = UUID.randomUUID();
@@ -464,6 +464,35 @@ class ExperimentItemProcessorTest {
 
             var output = captor.getValue().output();
             assertThat(output.has("output")).isFalse();
+        }
+
+        @Test
+        void processSurfacesAgentErrorInTraceOutputOnLlmFailure() {
+            var prompt = buildPrompt("gpt-4", "user", "Hello");
+            var datasetItem = buildDatasetItem(UUID.randomUUID(), Map.of());
+            var experimentId = UUID.randomUUID();
+            var datasetId = UUID.randomUUID();
+
+            stubCommonMocks();
+            when(chatCompletionService.create(any(ChatCompletionRequest.class), eq(WORKSPACE_ID)))
+                    .thenThrow(new RuntimeException("rate limit exceeded"));
+
+            processor.process(buildMessage(prompt, datasetItem, experimentId, datasetId, null,
+                    PROJECT_NAME, WORKSPACE_ID, USER_NAME)).block();
+
+            var traceCaptor = ArgumentCaptor.forClass(Trace.class);
+            verify(traceService).create(traceCaptor.capture());
+
+            var output = traceCaptor.getValue().output();
+            assertThat(output.has("error")).isTrue();
+            assertThat(output.get("error").get("type").asText()).isEqualTo("RuntimeException");
+            assertThat(output.get("error").get("message").asText()).isEqualTo("rate limit exceeded");
+
+            var spanCaptor = ArgumentCaptor.forClass(Span.class);
+            verify(spanService).create(spanCaptor.capture());
+            var spanOutput = spanCaptor.getValue().output();
+            assertThat(spanOutput.has("error")).isTrue();
+            assertThat(spanOutput.get("error").get("message").asText()).isEqualTo("rate limit exceeded");
         }
     }
 


### PR DESCRIPTION
## Details
When the agent LLM call inside `ExperimentItemProcessor.process` throws (timeout, validation error, rate limit, network failure, etc.), the exception is caught and the trace is persisted with an empty output. Downstream consumers — most notably the test-suite assertion judge — then run as if the agent had succeeded with an empty `{}` response, producing confidently-wrong scores ("all assertions failed because the response is empty") that are stored alongside legitimate scores in `assertion_results` with no error indication anywhere.

End users see the experiment status flip to "completed" and a row of red Xs in the assertion grid. There is no signal that the agent actually broke; the fault is invisible to anyone who isn't grepping the backend log.

## Summary

Stops experiment runs from silently masking agent LLM failures as empty-output traces. When the chat completion call inside `ExperimentItemProcessor` throws, the persisted trace/span output now carries a structured `error` block so the downstream assertion judge sees the fault state instead of fabricating verdicts against `{}`, and the application log emits the failure at `error` level (without echoing sensitive provider message bodies).

## Changes by Component

### Backend

- `ExperimentItemProcessor.process` upgraded the agent-failure log from `warn` to `error` and trimmed it to safe structured fields (`experimentId`, `datasetItem.id`, exception FQN, plus the throwable for the stack trace). Raw `e.getMessage()` is no longer logged — provider exceptions can echo tokens / API keys / raw user input — but the full message still flows into the trace's `errorInfo` and persisted output where workspace ACLs apply.
- `ExperimentTracePersistence.buildLlmOutput` now accepts `errorType` / `errorMessage` and embeds `{"error": {"type": ..., "message": ...}}` in the persisted trace and span `output` when the LLM call failed. The existing `errorInfo` on the trace/span is unchanged; the new `output.error` field is what the assertion judge actually consumes today.
- `ExperimentItemProcessorTest` renamed the prior empty-output failure test for clarity and added `processSurfacesAgentErrorInTraceOutputOnLlmFailure`, asserting that both the trace and the span carry the structured error block when the agent throws.

## Files Changed

```
 .../comet/opik/domain/ExperimentItemProcessor.java |  9 +++++--
 .../opik/domain/ExperimentTracePersistence.java    | 16 +++++++++--
 .../opik/domain/ExperimentItemProcessorTest.java   | 31 +++++++++++++++++++++-
 3 files changed, 51 insertions(+), 5 deletions(-)
```


## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6376

## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
Added new tests

## Documentation
NA