### PR TITLE
[NA] [CI] fix: add fallback matrix versions for forked PRs

### DIFF
--- a/.github/workflows/opik-optimizer-unit-tests.yaml
+++ b/.github/workflows/opik-optimizer-unit-tests.yaml
@@ -38,7 +38,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python_version: ${{ fromJSON(vars.PYTHON_VERSIONS) }}
+                python_version: ${{ fromJSON(vars.PYTHON_VERSIONS || '["3.10","3.11","3.12","3.13","3.14"]') }}
 
         steps:
         - name: Check out code

--- a/.github/workflows/python_sdk_unit_tests.yml
+++ b/.github/workflows/python_sdk_unit_tests.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ${{ fromJSON(vars.PYTHON_VERSIONS) }}
+        python_version: ${{ fromJSON(vars.PYTHON_VERSIONS || '["3.10","3.11","3.12","3.13","3.14"]') }}
 
     steps:
       - name: Check out code

--- a/.github/workflows/typescript_sdk_unit_tests.yml
+++ b/.github/workflows/typescript_sdk_unit_tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ${{ fromJSON(vars.NODE_VERSIONS) }}
+        node-version: ${{ fromJSON(vars.NODE_VERSIONS || '[18,20,22]') }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Details

Forked PRs don't have access to repository variables (`vars.*`), causing `fromJSON()` to fail and the CI matrix to be empty — no unit test jobs run for fork contributions.

Added fallback defaults so unit test workflows work for forks: Python `["3.10","3.11","3.12","3.13","3.14"]`, Node `[18,20,22]`. When the repo variable is set (non-fork PRs), it still takes precedence.

- `python_sdk_unit_tests.yml`
- `typescript_sdk_unit_tests.yml`
- `opik-optimizer-unit-tests.yaml`

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Full implementation
  - Human verification: Reviewed changes

## Testing

Verified that the `||` fallback syntax is valid GitHub Actions expression syntax. Non-fork PRs will continue using `vars.PYTHON_VERSIONS` / `vars.NODE_VERSIONS` as before.

- Open a PR from a fork and verify Python SDK, TypeScript SDK, and Opik Optimizer unit tests run
- Verify non-fork PRs still use the repo variable values

## Documentation

N/A