### PR TITLE
[OPIK-4509] [FE] fix: annotation queue reason persistence and navigation order

### DIFF
--- a/apps/opik-frontend/src/hooks/useDebouncedValue.ts
+++ b/apps/opik-frontend/src/hooks/useDebouncedValue.ts
@@ -1,5 +1,5 @@
 import { debounce } from "lodash";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 type UseDebouncedValueArgs = {
   initialValue?: string;
@@ -8,16 +8,37 @@ type UseDebouncedValueArgs = {
   onChange?: () => void;
 };
 export const useDebouncedValue = ({
+  initialValue,
   onDebouncedChange,
   delay = 300,
   onChange,
 }: UseDebouncedValueArgs) => {
-  const [inputValue, setInputValue] = useState<string | undefined>();
+  const [inputValue, setInputValue] = useState<string | undefined>(
+    initialValue,
+  );
+
+  const isFocusedRef = useRef(false);
+  const pendingValueRef = useRef<string | undefined>(undefined);
 
   const debouncedCallback = useMemo(
     () => debounce(onDebouncedChange, delay),
     [delay, onDebouncedChange],
   );
+
+  useEffect(() => {
+    if (!isFocusedRef.current) {
+      setInputValue(initialValue);
+      pendingValueRef.current = undefined;
+    } else {
+      pendingValueRef.current = initialValue;
+    }
+  }, [initialValue]);
+
+  useEffect(() => {
+    return () => {
+      debouncedCallback.cancel();
+    };
+  }, [debouncedCallback]);
 
   const handleInputChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -29,6 +50,19 @@ export const useDebouncedValue = ({
     [debouncedCallback, onChange],
   );
 
+  const handleFocus = useCallback(() => {
+    isFocusedRef.current = true;
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    isFocusedRef.current = false;
+    debouncedCallback.flush();
+    if (pendingValueRef.current !== undefined) {
+      setInputValue(pendingValueRef.current);
+      pendingValueRef.current = undefined;
+    }
+  }, [debouncedCallback]);
+
   const onReset = useCallback(() => {
     setInputValue("");
     debouncedCallback("");
@@ -38,6 +72,8 @@ export const useDebouncedValue = ({
     value: inputValue,
     setInputValue,
     onChange: handleInputChange,
+    onFocus: handleFocus,
+    onBlur: handleBlur,
     onReset,
   };
 };

--- a/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow.tsx
@@ -105,16 +105,9 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [feedbackScoreData.value]);
 
-  const handleChangeValue = useCallback(
-    (value: number, categoryName?: string) => {
-      onUpdateFeedbackScore({
-        categoryName,
-        name,
-        value,
-      });
-    },
-    [name, onUpdateFeedbackScore],
-  );
+  const onChangeTextAreaTriggered = useCallback(() => {
+    updateTextAreaHeight(textAreaRef.current);
+  }, []);
 
   const handleChangeReason = useCallback(
     (reason?: string) => {
@@ -128,13 +121,11 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
     [name, value, categoryName, onUpdateFeedbackScore],
   );
 
-  const onChangeTextAreaTriggered = useCallback(() => {
-    updateTextAreaHeight(textAreaRef.current);
-  }, []);
-
   const {
     value: reasonValue,
     onChange: onReasonChange,
+    onFocus: onReasonFocus,
+    onBlur: onReasonBlur,
     onReset: onReasonReset,
     setInputValue: setReasonValue,
   } = useDebouncedValue({
@@ -143,6 +134,18 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
     delay: SET_VALUE_DEBOUNCE_DELAY,
     onChange: onChangeTextAreaTriggered,
   });
+
+  const handleChangeValue = useCallback(
+    (value: number, categoryName?: string) => {
+      onUpdateFeedbackScore({
+        categoryName,
+        name,
+        value,
+        reason: reasonValue,
+      });
+    },
+    [name, reasonValue, onUpdateFeedbackScore],
+  );
 
   const deleteFeedbackScore = useCallback(() => {
     onDeleteFeedbackScore(name);
@@ -364,6 +367,8 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
           placeholder="Add a reason..."
           value={reasonValue}
           onChange={onReasonChange}
+          onFocus={onReasonFocus}
+          onBlur={onReasonBlur}
           disabled={value === ""}
           className="min-h-6 resize-none overflow-hidden py-1 pt-[4px]"
           ref={(e) => {

--- a/apps/opik-frontend/src/v1/pages/SMEFlowPage/SMEFlowContext.tsx
+++ b/apps/opik-frontend/src/v1/pages/SMEFlowPage/SMEFlowContext.tsx
@@ -699,6 +699,10 @@ export const SMEFlowProvider: React.FunctionComponent<SMEFlowProviderProps> = ({
 
     if (wasLastUnprocessed) {
       setCurrentView(WORKFLOW_STATUS.COMPLETED);
+    } else if (isCurrentItemProcessed) {
+      if (currentIndex < queueItems.length - 1) {
+        setCurrentIndex(currentIndex + 1);
+      }
     } else {
       handleNextUnprocessed();
     }
@@ -714,6 +718,9 @@ export const SMEFlowProvider: React.FunctionComponent<SMEFlowProviderProps> = ({
     handleNextUnprocessed,
     unprocessedIds,
     setCurrentView,
+    isCurrentItemProcessed,
+    currentIndex,
+    queueItems.length,
   ]);
 
   useEffect(() => {

--- a/apps/opik-frontend/src/v1/pages/SMEFlowPage/SMEFlowContext.tsx
+++ b/apps/opik-frontend/src/v1/pages/SMEFlowPage/SMEFlowContext.tsx
@@ -699,10 +699,8 @@ export const SMEFlowProvider: React.FunctionComponent<SMEFlowProviderProps> = ({
 
     if (wasLastUnprocessed) {
       setCurrentView(WORKFLOW_STATUS.COMPLETED);
-    } else if (isCurrentItemProcessed) {
-      if (currentIndex < queueItems.length - 1) {
-        setCurrentIndex(currentIndex + 1);
-      }
+    } else if (isCurrentItemProcessed && currentIndex < queueItems.length - 1) {
+      setCurrentIndex(currentIndex + 1);
     } else {
       handleNextUnprocessed();
     }

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow.tsx
@@ -105,16 +105,9 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [feedbackScoreData.value]);
 
-  const handleChangeValue = useCallback(
-    (value: number, categoryName?: string) => {
-      onUpdateFeedbackScore({
-        categoryName,
-        name,
-        value,
-      });
-    },
-    [name, onUpdateFeedbackScore],
-  );
+  const onChangeTextAreaTriggered = useCallback(() => {
+    updateTextAreaHeight(textAreaRef.current);
+  }, []);
 
   const handleChangeReason = useCallback(
     (reason?: string) => {
@@ -128,13 +121,11 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
     [name, value, categoryName, onUpdateFeedbackScore],
   );
 
-  const onChangeTextAreaTriggered = useCallback(() => {
-    updateTextAreaHeight(textAreaRef.current);
-  }, []);
-
   const {
     value: reasonValue,
     onChange: onReasonChange,
+    onFocus: onReasonFocus,
+    onBlur: onReasonBlur,
     onReset: onReasonReset,
     setInputValue: setReasonValue,
   } = useDebouncedValue({
@@ -143,6 +134,18 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
     delay: SET_VALUE_DEBOUNCE_DELAY,
     onChange: onChangeTextAreaTriggered,
   });
+
+  const handleChangeValue = useCallback(
+    (value: number, categoryName?: string) => {
+      onUpdateFeedbackScore({
+        categoryName,
+        name,
+        value,
+        reason: reasonValue,
+      });
+    },
+    [name, reasonValue, onUpdateFeedbackScore],
+  );
 
   const deleteFeedbackScore = useCallback(() => {
     onDeleteFeedbackScore(name);
@@ -364,6 +367,8 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
           placeholder="Add a reason..."
           value={reasonValue}
           onChange={onReasonChange}
+          onFocus={onReasonFocus}
+          onBlur={onReasonBlur}
           disabled={value === ""}
           className="min-h-6 resize-none overflow-hidden py-1 pt-[4px]"
           ref={(e) => {

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/SMEFlowContext.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/SMEFlowContext.tsx
@@ -699,6 +699,10 @@ export const SMEFlowProvider: React.FunctionComponent<SMEFlowProviderProps> = ({
 
     if (wasLastUnprocessed) {
       setCurrentView(WORKFLOW_STATUS.COMPLETED);
+    } else if (isCurrentItemProcessed) {
+      if (currentIndex < queueItems.length - 1) {
+        setCurrentIndex(currentIndex + 1);
+      }
     } else {
       handleNextUnprocessed();
     }
@@ -714,6 +718,9 @@ export const SMEFlowProvider: React.FunctionComponent<SMEFlowProviderProps> = ({
     handleNextUnprocessed,
     unprocessedIds,
     setCurrentView,
+    isCurrentItemProcessed,
+    currentIndex,
+    queueItems.length,
   ]);
 
   useEffect(() => {

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/SMEFlowContext.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/SMEFlowContext.tsx
@@ -699,10 +699,8 @@ export const SMEFlowProvider: React.FunctionComponent<SMEFlowProviderProps> = ({
 
     if (wasLastUnprocessed) {
       setCurrentView(WORKFLOW_STATUS.COMPLETED);
-    } else if (isCurrentItemProcessed) {
-      if (currentIndex < queueItems.length - 1) {
-        setCurrentIndex(currentIndex + 1);
-      }
+    } else if (isCurrentItemProcessed && currentIndex < queueItems.length - 1) {
+      setCurrentIndex(currentIndex + 1);
     } else {
       handleNextUnprocessed();
     }


### PR DESCRIPTION
## Details

Fixes two customer-reported bugs in the annotation queue flow:

- **Reason field disappears when navigating between items.** `useDebouncedValue` declared an `initialValue` prop but never passed it to `useState`, and ignored prop changes after mount. The hook now adopts the focus-based sync pattern already used by `DebounceInput`: while the textarea is focused, prop changes are stashed; on blur the debounced callback is flushed and the stashed value is applied. This also fixes a latent bug where typed-but-not-yet-debounced reasons were lost if the reviewer clicked "Next" within the 500ms debounce window.
- **`handleChangeValue` was wiping the saved reason** from parent state by calling `onUpdateFeedbackScore` without a reason field. Now passes the current `reasonValue` so changing a score value preserves the reason.
- **"Update + Next" jumped to the first unprocessed item** instead of advancing sequentially. `handleSubmit` now branches on `isCurrentItemProcessed`: Update flow goes to `currentIndex + 1` (sequential); Submit flow keeps the existing next-unprocessed behavior.
- Applied to both v1 and v2 since both share the hook and exhibit the same bugs.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-4509

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Haiku 4.5, Claude Opus 4.7
- Scope: assisted (analysis, implementation, iteration on hook design)
- Human verification: code review + manual testing in annotation queue flow

## Testing

- `npx eslint` and `npx tsc --noEmit` clean for all touched files
- Manual repro and verification of both customer scenarios:
  - Submit reason on an item → navigate to next → navigate back → reason populates in the textarea
  - At a processed item with an unprocessed earlier item, click "Update + next" → advances sequentially instead of jumping back
- Bonus: typing a reason then immediately clicking "Submit + next" (< 500ms) no longer drops the typed value — blur flushes the debounce before navigation
- No automated tests added; affected logic is in shared hook + SME flow context that lack existing test coverage. Existing `AnnotationView.test.tsx` (button-label logic, mocked context) still passes.

## Documentation

N/A