### PR TITLE
[OPIK-6472] [SDK] fix: preserve environment field in span/trace update messages

### DIFF
--- a/sdks/python/src/opik/api_objects/span/span_client.py
+++ b/sdks/python/src/opik/api_objects/span/span_client.py
@@ -211,6 +211,7 @@ class Span:
             error_info=error_info,
             total_cost=total_cost,
             source=self.source,
+            environment=self._environment,
         )
 
     def span(
@@ -434,6 +435,7 @@ def update_span(
     error_info: Optional[ErrorInfoDict] = None,
     total_cost: Optional[float] = None,
     attachments: Optional[List[attachment.Attachment]] = None,
+    environment: Optional[str] = None,
 ) -> None:
     backend_compatible_usage = validation_helpers.validate_and_parse_usage(
         usage=usage,
@@ -460,6 +462,7 @@ def update_span(
         error_info=error_info,
         total_cost=total_cost,
         source=source,
+        environment=environment,
     )
 
     if attachments is not None:

--- a/sdks/python/src/opik/api_objects/trace/trace_client.py
+++ b/sdks/python/src/opik/api_objects/trace/trace_client.py
@@ -158,6 +158,7 @@ class Trace:
             error_info=error_info,
             thread_id=thread_id,
             source=self.source,
+            environment=self._environment,
         )
 
     def span(
@@ -282,6 +283,7 @@ def update_trace(
     tags: Optional[List[Any]] = None,
     error_info: Optional[ErrorInfoDict] = None,
     thread_id: Optional[str] = None,
+    environment: Optional[str] = None,
 ) -> None:
     """
     Update an existing trace with new information.
@@ -319,5 +321,6 @@ def update_trace(
         error_info=error_info,
         thread_id=thread_id,
         source=source,
+        environment=environment,
     )
     message_streamer.put(update_trace_message)

--- a/sdks/python/src/opik/message_processing/emulation/emulator_message_processor.py
+++ b/sdks/python/src/opik/message_processing/emulation/emulator_message_processor.py
@@ -546,6 +546,7 @@ class EmulatorMessageProcessor(message_processors.BaseMessageProcessor, abc.ABC)
                 "tags": message.tags,
                 "input": message.input,
                 "total_cost": message.total_cost,
+                "environment": message.environment,
             }
         )
         span = self._span_observations.get(message.span_id)
@@ -568,6 +569,7 @@ class EmulatorMessageProcessor(message_processors.BaseMessageProcessor, abc.ABC)
                 "tags": message.tags,
                 "input": message.input,
                 "thread_id": message.thread_id,
+                "environment": message.environment,
             }
         )
         current_trace = self._trace_observations.get(message.trace_id)

--- a/sdks/python/tests/unit/api_objects/test_environment.py
+++ b/sdks/python/tests/unit/api_objects/test_environment.py
@@ -203,3 +203,69 @@ def test_create_span_message__environment_field_default_is_none_for_backwards_co
         source="sdk",
     )
     assert msg.environment is None
+
+
+def _update_span_messages(streamer: MagicMock):
+    return [
+        c.args[0]
+        for c in streamer.put.call_args_list
+        if isinstance(c.args[0], messages.UpdateSpanMessage)
+    ]
+
+
+def _update_trace_messages(streamer: MagicMock):
+    return [
+        c.args[0]
+        for c in streamer.put.call_args_list
+        if isinstance(c.args[0], messages.UpdateTraceMessage)
+    ]
+
+
+def test_span_end__preserves_environment_in_update_message():
+    client = opik_client.Opik(project_name="test-project")
+    streamer = _capture_messages(client)
+
+    trace = client.trace(name="t", environment="staging")
+    span = trace.span(name="s")
+    span.end()
+
+    update_msgs = _update_span_messages(streamer)
+    assert len(update_msgs) == 1
+    assert update_msgs[0].environment == "staging"
+
+
+def test_span_update__preserves_environment_in_update_message():
+    client = opik_client.Opik(project_name="test-project")
+    streamer = _capture_messages(client)
+
+    trace = client.trace(name="t", environment="production")
+    span = trace.span(name="s")
+    span.update(output={"result": "ok"})
+
+    update_msgs = _update_span_messages(streamer)
+    assert len(update_msgs) == 1
+    assert update_msgs[0].environment == "production"
+
+
+def test_trace_end__preserves_environment_in_update_message():
+    client = opik_client.Opik(project_name="test-project")
+    streamer = _capture_messages(client)
+
+    trace = client.trace(name="t", environment="staging")
+    trace.end()
+
+    update_msgs = _update_trace_messages(streamer)
+    assert len(update_msgs) == 1
+    assert update_msgs[0].environment == "staging"
+
+
+def test_trace_update__preserves_environment_in_update_message():
+    client = opik_client.Opik(project_name="test-project")
+    streamer = _capture_messages(client)
+
+    trace = client.trace(name="t", environment="production")
+    trace.update(output={"result": "ok"})
+
+    update_msgs = _update_trace_messages(streamer)
+    assert len(update_msgs) == 1
+    assert update_msgs[0].environment == "production"


### PR DESCRIPTION
## Details

`span.end()`, `span.update()`, `trace.end()`, and `trace.update()` were creating `UpdateSpanMessage`/`UpdateTraceMessage` without forwarding the `environment` field stored on the Span/Trace object. This caused the environment set during creation to be lost when the update was processed by the backend.

The fix passes `self._environment` through the update path so the field is preserved in update messages.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6472

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review + unit test verification

## Testing

- Ran `python -m pytest tests/unit/api_objects/test_environment.py -v` — all 13 tests pass (9 existing + 4 new)
- New tests verify that `UpdateSpanMessage.environment` and `UpdateTraceMessage.environment` carry the correct value after `span.end()`, `span.update()`, `trace.end()`, and `trace.update()`
- Pre-commit hooks pass (ruff, ruff-format, mypy)

## Documentation

N/A