### PR TITLE
[OPIK-6478] docs: Document programmatic dataset/version tagging

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/manage_datasets.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/manage_datasets.mdx
@@ -123,6 +123,45 @@ From this view you can:
   No history is lost or overwritten.
 </Note>
 
+### Managing dataset and version tags from the SDK
+
+The `Dataset` object exposes `get_tags()` to read the current tags, but does not yet provide a dedicated setter. To write tags programmatically — for example to drive an `env:prod` / `env:stage` promotion workflow — use the REST client exposed on the Opik client.
+
+There are two tag surfaces, depending on what you want to scope the tag to:
+
+- **Dataset-level tags** apply to the dataset as a whole and persist across versions. Use `update_dataset` — this **replaces** the existing tag list.
+- **Version-level tags** apply to a specific dataset version. Use `update_dataset_version` — this is **additive** (it adds to the version's existing tags).
+
+```python {pytest_codeblocks_skip=true}
+import opik
+
+client = opik.Opik()
+dataset = client.get_or_create_dataset(name="my-eval", project_name="my-project")
+
+# Read current dataset-level tags
+print(dataset.get_tags())
+
+# Set dataset-level tags (replaces the existing list)
+client.rest_client.datasets.update_dataset(
+    id=dataset.id,
+    name=dataset.name,
+    tags=["env:prod"],
+)
+
+# Add tags to a specific version (additive)
+client.rest_client.datasets.update_dataset_version(
+    id=dataset.id,
+    version_hash=dataset.version_hash,
+    tags_to_add=["env:prod"],
+)
+```
+
+<Note>
+  `client.rest_client` is a thin wrapper around the public REST API. The underlying endpoints are stable, but the Python wrapper itself is not guaranteed to be backward-compatible across SDK versions. A first-class `Dataset.set_tags()` / `Dataset.add_version_tags()` helper is on the roadmap — this snippet is the supported interim path.
+</Note>
+
+You can then filter dataset items by these tags via [`get_items(filter_string=...)`](#querying-dataset-items) using the `tags contains` operator.
+
 ## Adding traces to a dataset
 
 One of the most powerful ways to build evaluation datasets is by converting production traces into dataset items. This allows you to leverage real-world interactions from your LLM application to create test cases for evaluation.

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/manage_datasets.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/manage_datasets.mdx
@@ -123,6 +123,45 @@ From this view you can:
   No history is lost or overwritten.
 </Note>
 
+### Managing dataset and version tags from the SDK
+
+The `Dataset` object exposes `get_tags()` to read the current tags, but does not yet provide a dedicated setter. To write tags programmatically — for example to drive an `env:prod` / `env:stage` promotion workflow — use the REST client exposed on the Opik client.
+
+There are two tag surfaces, depending on what you want to scope the tag to:
+
+- **Dataset-level tags** apply to the dataset as a whole and persist across versions. Use `update_dataset` — this **replaces** the existing tag list.
+- **Version-level tags** apply to a specific dataset version. Use `update_dataset_version` — this is **additive** (it adds to the version's existing tags).
+
+```python {pytest_codeblocks_skip=true}
+import opik
+
+client = opik.Opik()
+dataset = client.get_or_create_dataset(name="my-eval", project_name="my-project")
+
+# Read current dataset-level tags
+print(dataset.get_tags())
+
+# Set dataset-level tags (replaces the existing list)
+client.rest_client.datasets.update_dataset(
+    id=dataset.id,
+    name=dataset.name,
+    tags=["env:prod"],
+)
+
+# Add tags to a specific version (additive)
+client.rest_client.datasets.update_dataset_version(
+    id=dataset.id,
+    version_hash=dataset.version_hash,
+    tags_to_add=["env:prod"],
+)
+```
+
+<Note>
+  `client.rest_client` is a thin wrapper around the public REST API. The underlying endpoints are stable, but the Python wrapper itself is not guaranteed to be backward-compatible across SDK versions. A first-class `Dataset.set_tags()` / `Dataset.add_version_tags()` helper is on the roadmap — this snippet is the supported interim path.
+</Note>
+
+You can then filter dataset items by these tags via [`get_items(filter_string=...)`](#querying-dataset-items) using the `tags contains` operator.
+
 ## Adding traces to a dataset
 
 One of the most powerful ways to build evaluation datasets is by converting production traces into dataset items. This allows you to leverage real-world interactions from your LLM application to create test cases for evaluation.


### PR DESCRIPTION
## Summary

- Adds a new SDK section to `manage_datasets.mdx` (v1 + v2 docs trees) covering how to set tags on a dataset and on a specific dataset version from Python.
- The `Dataset` SDK object today only exposes `get_tags()`. The supported write path is `client.rest_client.datasets.update_dataset` (dataset-level, replaces) and `update_dataset_version` (version-level, additive). This documents both — including the `env:prod` / `env:stage` promotion workflow customers ask about.
- Interim fix until [OPIK-6478](https://comet-ml.atlassian.net/browse/OPIK-6478) lands first-class `Dataset.set_tags()` / `Dataset.add_version_tags()` helpers.

## Why

Customer in `#ext-comet-pattern` was sent the (non-existent) `dataset.set_tags([...])` snippet. They reasonably came back with "this method doesn't exist." The REST workaround is the supported path today and needs to live in the docs while the helper RFE is pending.

Verified live against `comet.com` workspace (Opik SDK 2.0.21) — both endpoints return the expected `get_tags()` / version-tag state.

## Test plan

- [ ] `cd apps/opik-documentation/documentation && npm run lint` (or whatever Fern uses locally)
- [ ] Preview docs locally and confirm the new "Managing dataset and version tags from the SDK" subsection renders under "Version history" in both the v1 and v2 builds.
- [ ] Spot-check the in-page anchor link to `#querying-dataset-items` still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OPIK-6478]: https://comet-ml.atlassian.net/browse/OPIK-6478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ