### PR TITLE
[OPIK-6495] [BE] fix: add demo test-suite experiment names to DemoData exclusion list

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DemoData.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DemoData.java
@@ -43,7 +43,9 @@ public class DemoData {
             "Demo-major_fruit_6938",
             "Demo-flat_bulb_3765",
             "Demo-horizontal_shrimp_833",
-            "Demo-continuous_milk_2919");
+            "Demo-continuous_milk_2919",
+            "Support agent — prod candidate",
+            "Support agent — staging candidate");
 
     /** MySQL (utf8mb4_unicode_ci) — matching is case-insensitive, no need for case variants. */
     public static final List<String> PROMPTS = List.of(


### PR DESCRIPTION
## What

Adds `"Support agent — prod candidate"` and `"Support agent — staging candidate"` to `DemoData.EXPERIMENTS`.

## Why

PR #6426 introduced `create_demo_test_suite_and_experiments`, which seeds these two experiments into every new workspace as part of the post-signup demo hook. They were never added to the `DemoData.EXPERIMENTS` exclusion list.

`ExperimentDAO.getDailyCreatedCount()` uses:

```sql
AND name NOT IN :excluded_names   -- bound to DemoData.EXPERIMENTS
```

Because both names were absent, the `daily_experiments` field in the `opik_os_statistics_be` BI event has been counting demo experiments as real user activity since ~Apr 22 — making it appear that 100% of users use the experiments feature.

The follow-up in PR #6457 caught the `opik_eval_suite_created` / `opik_eval_suite_run` leaks but only patched `DemoData.DATASETS`; this PR fixes the remaining gap in `DemoData.EXPERIMENTS`.

## Test plan

- [ ] Verify `ExperimentDAO.getDailyCreatedCount()` no longer counts experiments named `"Support agent — prod candidate"` or `"Support agent — staging candidate"`
- [ ] Confirm existing unit/integration tests for `DailyUsageReportJob` still pass

Fixes [OPIK-6495](https://comet-ml.atlassian.net/browse/OPIK-6495)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OPIK-6495]: https://comet-ml.atlassian.net/browse/OPIK-6495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ