### PR TITLE
[OPIK-6266][FE] environments bug fixes

### DIFF
--- a/apps/opik-frontend/src/api/datasets/useDatasetItemBatchUpdateMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useDatasetItemBatchUpdateMutation.ts
@@ -9,11 +9,8 @@ import {
   generateSearchByFieldFilters,
   processFiltersArray,
 } from "@/lib/filters";
-import {
-  TagUpdateFields,
-  buildTagUpdatePayload,
-  extractErrorMessage,
-} from "@/lib/tags";
+import { TagUpdateFields, buildTagUpdatePayload } from "@/lib/tags";
+import { extractErrorMessage } from "@/lib/errors";
 
 type UseDatasetItemBatchUpdateMutationParams = {
   datasetId: string;

--- a/apps/opik-frontend/src/api/datasets/useDatasetItemChangesMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useDatasetItemChangesMutation.ts
@@ -5,7 +5,7 @@ import api, { DATASETS_REST_ENDPOINT } from "@/api/api";
 import { DatasetItem, Evaluator } from "@/types/datasets";
 import { ExecutionPolicy } from "@/types/test-suites";
 import { useToast } from "@/ui/use-toast";
-import { extractErrorMessage } from "@/lib/tags";
+import { extractErrorMessage } from "@/lib/errors";
 
 interface DatasetItemChangesPayload {
   added_items: DatasetItem[];

--- a/apps/opik-frontend/src/api/datasets/useExperimentBatchUpdateMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useExperimentBatchUpdateMutation.ts
@@ -4,11 +4,8 @@ import { AxiosError } from "axios";
 import api, { EXPERIMENTS_REST_ENDPOINT } from "@/api/api";
 import { Experiment } from "@/types/datasets";
 import { useToast } from "@/ui/use-toast";
-import {
-  TagUpdateFields,
-  buildTagUpdatePayload,
-  extractErrorMessage,
-} from "@/lib/tags";
+import { TagUpdateFields, buildTagUpdatePayload } from "@/lib/tags";
+import { extractErrorMessage } from "@/lib/errors";
 
 type UseExperimentBatchUpdateMutationParams = {
   ids: string[];

--- a/apps/opik-frontend/src/api/environments/useEnvironmentCreateMutation.ts
+++ b/apps/opik-frontend/src/api/environments/useEnvironmentCreateMutation.ts
@@ -1,10 +1,10 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
-import get from "lodash/get";
 import api, { ENVIRONMENTS_KEY, ENVIRONMENTS_REST_ENDPOINT } from "@/api/api";
 import { Environment } from "@/types/environments";
 import { useToast } from "@/ui/use-toast";
 import { extractIdFromLocation } from "@/lib/utils";
+import { extractErrorMessage } from "@/lib/tags";
 
 type EnvironmentCreatePayload = Pick<Environment, "name"> &
   Partial<Pick<Environment, "description" | "color" | "position">>;
@@ -36,15 +36,9 @@ const useEnvironmentCreateMutation = ({
     onError: (error: AxiosError) => {
       if (!showErrorToast) return;
 
-      const errors = get(error, ["response", "data", "errors"]);
-      const message =
-        (Array.isArray(errors) && errors[0]) ||
-        get(error, ["response", "data", "message"]) ||
-        error.message;
-
       toast({
         title: "Error",
-        description: message,
+        description: extractErrorMessage(error),
         variant: "destructive",
       });
     },

--- a/apps/opik-frontend/src/api/environments/useEnvironmentCreateMutation.ts
+++ b/apps/opik-frontend/src/api/environments/useEnvironmentCreateMutation.ts
@@ -4,7 +4,7 @@ import api, { ENVIRONMENTS_KEY, ENVIRONMENTS_REST_ENDPOINT } from "@/api/api";
 import { Environment } from "@/types/environments";
 import { useToast } from "@/ui/use-toast";
 import { extractIdFromLocation } from "@/lib/utils";
-import { extractErrorMessage } from "@/lib/tags";
+import { extractErrorMessage } from "@/lib/errors";
 
 type EnvironmentCreatePayload = Pick<Environment, "name"> &
   Partial<Pick<Environment, "description" | "color" | "position">>;

--- a/apps/opik-frontend/src/api/environments/useEnvironmentCreateMutation.ts
+++ b/apps/opik-frontend/src/api/environments/useEnvironmentCreateMutation.ts
@@ -36,11 +36,11 @@ const useEnvironmentCreateMutation = ({
     onError: (error: AxiosError) => {
       if (!showErrorToast) return;
 
-      const message = get(
-        error,
-        ["response", "data", "message"],
-        error.message,
-      );
+      const errors = get(error, ["response", "data", "errors"]);
+      const message =
+        (Array.isArray(errors) && errors[0]) ||
+        get(error, ["response", "data", "message"]) ||
+        error.message;
 
       toast({
         title: "Error",

--- a/apps/opik-frontend/src/api/environments/useEnvironmentUpdateMutation.ts
+++ b/apps/opik-frontend/src/api/environments/useEnvironmentUpdateMutation.ts
@@ -7,7 +7,7 @@ import api, {
 } from "@/api/api";
 import { Environment } from "@/types/environments";
 import { useToast } from "@/ui/use-toast";
-import { extractErrorMessage } from "@/lib/tags";
+import { extractErrorMessage } from "@/lib/errors";
 
 type EnvironmentUpdatePayload = Partial<
   Pick<Environment, "name" | "description" | "color" | "position">

--- a/apps/opik-frontend/src/api/environments/useEnvironmentUpdateMutation.ts
+++ b/apps/opik-frontend/src/api/environments/useEnvironmentUpdateMutation.ts
@@ -1,6 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
-import get from "lodash/get";
 import api, {
   ENVIRONMENT_KEY,
   ENVIRONMENTS_KEY,
@@ -8,6 +7,7 @@ import api, {
 } from "@/api/api";
 import { Environment } from "@/types/environments";
 import { useToast } from "@/ui/use-toast";
+import { extractErrorMessage } from "@/lib/tags";
 
 type EnvironmentUpdatePayload = Partial<
   Pick<Environment, "name" | "description" | "color" | "position">
@@ -42,15 +42,9 @@ const useEnvironmentUpdateMutation = ({
     onError: (error: AxiosError) => {
       if (!showErrorToast) return;
 
-      const errors = get(error, ["response", "data", "errors"]);
-      const message =
-        (Array.isArray(errors) && errors[0]) ||
-        get(error, ["response", "data", "message"]) ||
-        error.message;
-
       toast({
         title: "Error",
-        description: message,
+        description: extractErrorMessage(error),
         variant: "destructive",
       });
     },

--- a/apps/opik-frontend/src/api/environments/useEnvironmentUpdateMutation.ts
+++ b/apps/opik-frontend/src/api/environments/useEnvironmentUpdateMutation.ts
@@ -18,7 +18,13 @@ type UseEnvironmentUpdateMutationParams = {
   environment: EnvironmentUpdatePayload;
 };
 
-const useEnvironmentUpdateMutation = () => {
+type UseEnvironmentUpdateMutationOptions = {
+  showErrorToast?: boolean;
+};
+
+const useEnvironmentUpdateMutation = ({
+  showErrorToast = true,
+}: UseEnvironmentUpdateMutationOptions = {}) => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
@@ -34,11 +40,13 @@ const useEnvironmentUpdateMutation = () => {
       return data;
     },
     onError: (error: AxiosError) => {
-      const message = get(
-        error,
-        ["response", "data", "message"],
-        error.message,
-      );
+      if (!showErrorToast) return;
+
+      const errors = get(error, ["response", "data", "errors"]);
+      const message =
+        (Array.isArray(errors) && errors[0]) ||
+        get(error, ["response", "data", "message"]) ||
+        error.message;
 
       toast({
         title: "Error",

--- a/apps/opik-frontend/src/api/traces/useSpanBatchUpdateMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useSpanBatchUpdateMutation.ts
@@ -4,11 +4,8 @@ import { AxiosError } from "axios";
 import api, { SPANS_KEY, SPANS_REST_ENDPOINT } from "@/api/api";
 import { Span } from "@/types/traces";
 import { useToast } from "@/ui/use-toast";
-import {
-  TagUpdateFields,
-  buildTagUpdatePayload,
-  extractErrorMessage,
-} from "@/lib/tags";
+import { TagUpdateFields, buildTagUpdatePayload } from "@/lib/tags";
+import { extractErrorMessage } from "@/lib/errors";
 
 type UseSpanBatchUpdateMutationParams = {
   projectId: string;

--- a/apps/opik-frontend/src/api/traces/useThreadBatchUpdateMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useThreadBatchUpdateMutation.ts
@@ -3,11 +3,8 @@ import { AxiosError } from "axios";
 
 import api, { THREADS_KEY, TRACES_REST_ENDPOINT } from "@/api/api";
 import { useToast } from "@/ui/use-toast";
-import {
-  TagUpdateFields,
-  buildTagUpdatePayload,
-  extractErrorMessage,
-} from "@/lib/tags";
+import { TagUpdateFields, buildTagUpdatePayload } from "@/lib/tags";
+import { extractErrorMessage } from "@/lib/errors";
 
 type UseThreadBatchUpdateMutationParams = {
   projectId: string;

--- a/apps/opik-frontend/src/api/traces/useTraceBatchUpdateMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTraceBatchUpdateMutation.ts
@@ -4,11 +4,8 @@ import { AxiosError } from "axios";
 import api, { TRACES_KEY, TRACES_REST_ENDPOINT } from "@/api/api";
 import { Trace } from "@/types/traces";
 import { useToast } from "@/ui/use-toast";
-import {
-  TagUpdateFields,
-  buildTagUpdatePayload,
-  extractErrorMessage,
-} from "@/lib/tags";
+import { TagUpdateFields, buildTagUpdatePayload } from "@/lib/tags";
+import { extractErrorMessage } from "@/lib/errors";
 
 type UseTraceBatchUpdateMutationParams = {
   projectId: string;

--- a/apps/opik-frontend/src/hooks/useQueryErrorToast.ts
+++ b/apps/opik-frontend/src/hooks/useQueryErrorToast.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 import axios, { AxiosError } from "axios";
 
 import { useToast } from "@/ui/use-toast";
-import { extractErrorMessage } from "@/lib/tags";
+import { extractErrorMessage } from "@/lib/errors";
 
 interface UseQueryErrorToastParams {
   isError: boolean;

--- a/apps/opik-frontend/src/lib/errors.ts
+++ b/apps/opik-frontend/src/lib/errors.ts
@@ -1,0 +1,14 @@
+import { AxiosError } from "axios";
+import get from "lodash/get";
+
+export const extractErrorMessage = (error: AxiosError): string => {
+  const errors = get(error, ["response", "data", "errors"]);
+  return (
+    (Array.isArray(errors) && errors.length > 0
+      ? errors.join(", ")
+      : undefined) ??
+    get(error, ["response", "data", "message"]) ??
+    error.message ??
+    "An unknown error occurred. Please try again later."
+  );
+};

--- a/apps/opik-frontend/src/lib/tags.ts
+++ b/apps/opik-frontend/src/lib/tags.ts
@@ -1,6 +1,3 @@
-import { AxiosError } from "axios";
-import get from "lodash/get";
-
 export type TagUpdateFields = {
   tagsToAdd?: string[];
   tagsToRemove?: string[];
@@ -14,16 +11,4 @@ export const buildTagUpdatePayload = <T extends TagUpdateFields>(
   if (tagsToAdd !== undefined) payload.tags_to_add = tagsToAdd;
   if (tagsToRemove !== undefined) payload.tags_to_remove = tagsToRemove;
   return payload;
-};
-
-export const extractErrorMessage = (error: AxiosError): string => {
-  const errors = get(error, ["response", "data", "errors"]);
-  return (
-    (Array.isArray(errors) && errors.length > 0
-      ? errors.join(", ")
-      : undefined) ??
-    get(error, ["response", "data", "message"]) ??
-    error.message ??
-    "An unknown error occurred. Please try again later."
-  );
 };

--- a/apps/opik-frontend/src/v2/pages-shared/environments/AddEditEnvironmentDialog/AddEditEnvironmentDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/environments/AddEditEnvironmentDialog/AddEditEnvironmentDialog.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { AxiosError } from "axios";
-import get from "lodash/get";
 
 import useEnvironmentCreateMutation from "@/api/environments/useEnvironmentCreateMutation";
 import useEnvironmentUpdateMutation from "@/api/environments/useEnvironmentUpdateMutation";
@@ -26,6 +25,7 @@ import {
   ENVIRONMENT_NAME_REGEX,
   Environment,
 } from "@/types/environments";
+import { extractErrorMessage } from "@/lib/tags";
 
 type EnvironmentDialogMode = "create" | "edit" | "clone";
 
@@ -36,25 +36,9 @@ type AddEditEnvironmentDialogProps = {
   mode?: EnvironmentDialogMode;
 };
 
-const extractBackendErrorMessage = (error: AxiosError): string => {
-  const errors = get(error, ["response", "data", "errors"]);
-  const firstError = Array.isArray(errors) ? errors[0] : undefined;
-  if (typeof firstError === "string" && firstError) return firstError;
-  const message = get(error, ["response", "data", "message"]);
-  if (typeof message === "string" && message) return message;
-  return error.message;
-};
-
 const AddEditEnvironmentDialog: React.FunctionComponent<
   AddEditEnvironmentDialogProps
 > = ({ open, setOpen, environment, mode = "create" }) => {
-  const { mutate: createMutation } = useEnvironmentCreateMutation({
-    showErrorToast: false,
-  });
-  const { mutate: updateMutation } = useEnvironmentUpdateMutation({
-    showErrorToast: false,
-  });
-
   const [name, setName] = useState<string>(
     mode === "clone" && environment
       ? `${environment.name}-copy`
@@ -70,6 +54,13 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
   );
   const [submitError, setSubmitError] = useState<string>("");
 
+  const { mutate: createMutation } = useEnvironmentCreateMutation({
+    showErrorToast: false,
+  });
+  const { mutate: updateMutation } = useEnvironmentUpdateMutation({
+    showErrorToast: false,
+  });
+
   const trimmedName = name.trim();
   const nameError = useMemo(() => {
     if (!trimmedName) return "";
@@ -82,11 +73,6 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
     return "";
   }, [trimmedName]);
 
-  const handleNameChange = useCallback((value: string) => {
-    setName(value);
-    setSubmitError("");
-  }, []);
-
   const isEdit = mode === "edit";
   const title =
     mode === "clone"
@@ -97,6 +83,21 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
   const submitText = isEdit ? "Update environment" : "Create environment";
 
   const isValid = trimmedName.length > 0 && !nameError;
+
+  const handleNameChange = useCallback((value: string) => {
+    setName(value);
+    setSubmitError("");
+  }, []);
+
+  const handleDescriptionChange = useCallback((value: string) => {
+    setDescription(value);
+    setSubmitError("");
+  }, []);
+
+  const handleColorChange = useCallback((value: string) => {
+    setColor(value);
+    setSubmitError("");
+  }, []);
 
   const submitHandler = useCallback(() => {
     if (!isValid) return;
@@ -110,7 +111,7 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
     const mutationOptions = {
       onSuccess: () => setOpen(false),
       onError: (error: AxiosError) => {
-        setSubmitError(extractBackendErrorMessage(error));
+        setSubmitError(extractErrorMessage(error));
       },
     };
 
@@ -154,7 +155,7 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
                   />
                 </PopoverTrigger>
                 <PopoverContent className="w-auto" align="start">
-                  <ColorPicker value={color} onChange={setColor} />
+                  <ColorPicker value={color} onChange={handleColorChange} />
                 </PopoverContent>
               </Popover>
               <Input
@@ -184,7 +185,7 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
               placeholder="Optional description"
               className="min-h-20"
               value={description}
-              onChange={(event) => setDescription(event.target.value)}
+              onChange={(event) => handleDescriptionChange(event.target.value)}
               maxLength={ENVIRONMENT_DESCRIPTION_MAX_LENGTH}
             />
           </div>

--- a/apps/opik-frontend/src/v2/pages-shared/environments/AddEditEnvironmentDialog/AddEditEnvironmentDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/environments/AddEditEnvironmentDialog/AddEditEnvironmentDialog.tsx
@@ -25,7 +25,7 @@ import {
   ENVIRONMENT_NAME_REGEX,
   Environment,
 } from "@/types/environments";
-import { extractErrorMessage } from "@/lib/tags";
+import { extractErrorMessage } from "@/lib/errors";
 
 type EnvironmentDialogMode = "create" | "edit" | "clone";
 

--- a/apps/opik-frontend/src/v2/pages-shared/environments/AddEditEnvironmentDialog/AddEditEnvironmentDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/environments/AddEditEnvironmentDialog/AddEditEnvironmentDialog.tsx
@@ -1,4 +1,6 @@
 import React, { useCallback, useMemo, useState } from "react";
+import { AxiosError } from "axios";
+import get from "lodash/get";
 
 import useEnvironmentCreateMutation from "@/api/environments/useEnvironmentCreateMutation";
 import useEnvironmentUpdateMutation from "@/api/environments/useEnvironmentUpdateMutation";
@@ -34,11 +36,24 @@ type AddEditEnvironmentDialogProps = {
   mode?: EnvironmentDialogMode;
 };
 
+const extractBackendErrorMessage = (error: AxiosError): string => {
+  const errors = get(error, ["response", "data", "errors"]);
+  const firstError = Array.isArray(errors) ? errors[0] : undefined;
+  if (typeof firstError === "string" && firstError) return firstError;
+  const message = get(error, ["response", "data", "message"]);
+  if (typeof message === "string" && message) return message;
+  return error.message;
+};
+
 const AddEditEnvironmentDialog: React.FunctionComponent<
   AddEditEnvironmentDialogProps
 > = ({ open, setOpen, environment, mode = "create" }) => {
-  const { mutate: createMutation } = useEnvironmentCreateMutation();
-  const { mutate: updateMutation } = useEnvironmentUpdateMutation();
+  const { mutate: createMutation } = useEnvironmentCreateMutation({
+    showErrorToast: false,
+  });
+  const { mutate: updateMutation } = useEnvironmentUpdateMutation({
+    showErrorToast: false,
+  });
 
   const [name, setName] = useState<string>(
     mode === "clone" && environment
@@ -53,6 +68,7 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
       ? environment.color
       : DEFAULT_HEX_COLOR,
   );
+  const [submitError, setSubmitError] = useState<string>("");
 
   const trimmedName = name.trim();
   const nameError = useMemo(() => {
@@ -65,6 +81,11 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
     }
     return "";
   }, [trimmedName]);
+
+  const handleNameChange = useCallback((value: string) => {
+    setName(value);
+    setSubmitError("");
+  }, []);
 
   const isEdit = mode === "edit";
   const title =
@@ -86,16 +107,21 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
       color,
     };
 
-    if (isEdit && environment) {
-      updateMutation({
-        environmentId: environment.id,
-        environment: payload,
-      });
-    } else {
-      createMutation({ environment: payload });
-    }
+    const mutationOptions = {
+      onSuccess: () => setOpen(false),
+      onError: (error: AxiosError) => {
+        setSubmitError(extractBackendErrorMessage(error));
+      },
+    };
 
-    setOpen(false);
+    if (isEdit && environment) {
+      updateMutation(
+        { environmentId: environment.id, environment: payload },
+        mutationOptions,
+      );
+    } else {
+      createMutation({ environment: payload }, mutationOptions);
+    }
   }, [
     isValid,
     trimmedName,
@@ -136,12 +162,14 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
                 className="flex-1 rounded-l-none"
                 placeholder="e.g. staging"
                 value={name}
-                onChange={(event) => setName(event.target.value)}
+                onChange={(event) => handleNameChange(event.target.value)}
                 maxLength={ENVIRONMENT_NAME_MAX_LENGTH}
               />
             </div>
-            {nameError ? (
-              <p className="comet-body-xs text-destructive">{nameError}</p>
+            {nameError || submitError ? (
+              <p className="comet-body-xs text-destructive">
+                {nameError || submitError}
+              </p>
             ) : (
               <p className="comet-body-xs text-light-slate">
                 Use letters, numbers, dashes, or underscores. Must be unique

--- a/apps/opik-frontend/src/v2/pages/ConfigurationPage/EnvironmentsTab/EnvironmentNameCell.tsx
+++ b/apps/opik-frontend/src/v2/pages/ConfigurationPage/EnvironmentsTab/EnvironmentNameCell.tsx
@@ -17,14 +17,14 @@ const EnvironmentNameCell: React.FunctionComponent<
       tableMetadata={context.table.options.meta}
       className="gap-1.5"
     >
-      <div className="flex max-w-full items-center gap-1.5 rounded-md border border-transparent px-2">
-        <EnvironmentSquare color={color} />
-        <TooltipWrapper content={name} stopClickPropagation>
+      <TooltipWrapper content={name} stopClickPropagation>
+        <div className="flex max-w-full items-center gap-1.5 rounded-md border border-transparent px-2">
+          <EnvironmentSquare color={color} />
           <div className="comet-body-xs-accented min-w-0 flex-1 truncate text-muted-slate">
             {name}
           </div>
-        </TooltipWrapper>
-      </div>
+        </div>
+      </TooltipWrapper>
     </CellWrapper>
   );
 };

--- a/apps/opik-frontend/src/v2/pages/ConfigurationPage/EnvironmentsTab/EnvironmentsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/ConfigurationPage/EnvironmentsTab/EnvironmentsActionsPanel.tsx
@@ -32,7 +32,7 @@ const EnvironmentsActionsPanel: React.FunctionComponent<
         setOpen={setOpen}
         onConfirm={deleteEnvironmentsHandler}
         title="Delete environments"
-        description="This action can’t be undone. Existing traces and spans will keep their environment values and surface under “Unrecognized environments”. Are you sure you want to continue?"
+        description="This action can’t be undone. Existing traces and spans will keep their environment values. Are you sure you want to continue?"
         confirmText="Delete environments"
         confirmButtonVariant="destructive"
       />

--- a/apps/opik-frontend/src/v2/pages/ConfigurationPage/EnvironmentsTab/EnvironmentsRowActionsCell.tsx
+++ b/apps/opik-frontend/src/v2/pages/ConfigurationPage/EnvironmentsTab/EnvironmentsRowActionsCell.tsx
@@ -60,7 +60,7 @@ const EnvironmentsRowActionsCell: React.FunctionComponent<
         setOpen={handleClose}
         onConfirm={deleteHandler}
         title="Delete environment"
-        description="This action can’t be undone. Existing traces and spans will keep their environment value and surface under “Unrecognized environments”. Are you sure you want to continue?"
+        description="This action can’t be undone. Existing traces and spans will keep their environment value. Are you sure you want to continue?"
         confirmText="Delete environment"
         confirmButtonVariant="destructive"
       />


### PR DESCRIPTION

## Details
### Summary

Three bug fixes for the Environments feature ([OPIK-6266](https://comet-ml.atlassian.net/browse/OPIK-6266)):

1. **Surface the backend error inline when creating/editing an environment.** Previously, a duplicate-name attempt closed the dialog and showed a generic toast ("Request failed with status code 409") with the user's input lost. Now the dialog stays open on error and renders the backend message (e.g. `"Environment with name 'development' already exists in the workspace"`) directly beneath the name input. The error clears as soon as the user edits the name.
2. **Remove "Unrecognized environments" mention** from the single and batch delete confirmation copy — that surface no longer exists.
3. **Show the full environment name on hover** across the entire name pill (color square + label) in Configuration → Environments. The tooltip previously only triggered on the text portion, which was easy to miss when names were truncated.

### Changes

- `useEnvironmentCreateMutation` / `useEnvironmentUpdateMutation`: extract error message from `response.data.errors[0]` (with fallbacks to `data.message` and `error.message`); add `showErrorToast: false` opt-out so callers can render the error inline.
- `AddEditEnvironmentDialog`: opts out of the toast, uses `mutate(payload, { onSuccess, onError })` to drive `setOpen(false)` only on success and capture the error into a `submitError` state shown under the name input.
- `EnvironmentsActionsPanel` / `EnvironmentsRowActionsCell`: drop "and surface under 'Unrecognized environments'" from the delete confirm description.
- `EnvironmentNameCell`: move the `TooltipWrapper` to wrap the full pill (`EnvironmentSquare` + name) instead of just the text node.

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6266

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Opus 4.7
  - Scope: Development and testing
  - Human verification: Yep

## Testing
- Tested manually

## Documentation
NA

[OPIK-6266]: https://comet-ml.atlassian.net/browse/OPIK-6266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ