### PR TITLE
[NA] [BE] fix: release ExperimentProjectMigrationJob lock on completion

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/ExperimentProjectMigrationJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/ExperimentProjectMigrationJob.java
@@ -96,7 +96,7 @@ public class ExperimentProjectMigrationJob extends Job implements InterruptableJ
                 }),
                 config.lockTimeout().toJavaDuration(),
                 config.lockWaitTime().toJavaDuration(),
-                true)
+                false)
                 // Resume on errors so the recurring job stays alive
                 .onErrorResume(throwable -> {
                     cycleDuration.record(System.currentTimeMillis() - startMillis, RESULT_ERROR);


### PR DESCRIPTION
## Details

Switches `ExperimentProjectMigrationJob` to `holdUntilExpiry=false` so the distributed lock is released as soon as a migration cycle finishes, instead of being held for the full `lockTimeout` TTL.

- Before: even though the job interval is `30s`, the lock was held for the full `lockTimeout` (5m default) after each cycle, throttling real cycles to ~12/hour and recording the rest as `result=lock_skipped` on the `opik.migration.experiment_project.cycle.duration` histogram. Confirmed against prod metrics.
- After: the lock is released on normal completion, so the next scheduled tick (`30s` later by default) can acquire it. The lock TTL keeps its role as a safety net if the JVM dies mid-cycle; cross-replica overlap remains safe because the migration is idempotent (`WHERE project_id = ''` skips already-migrated rows).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: assisted (analysis + draft change; human reviewed and trimmed before commit)
- Human verification: code review + production metric verification (`result=success` vs `result=lock_skipped` ratio on the cycle-duration histogram)

## Testing

- `mvn -o compile` on `apps/opik-backend` (passes)
- No new tests added: the change is a single boolean flip in the lock call; existing `ExperimentProjectMigrationJobTest` cases all complete in the first cycle and are unaffected by lock-release timing.
- Production validation will be observing the `cycle.duration` histogram after rollout: `result=success` count should rise to roughly match the firing rate, and `result=lock_skipped` should drop to near zero on a single-replica deploy.

## Documentation

N/A — internal job behavior change, no user-facing or developer-facing docs affected.