### PR TITLE
[OPIK-6373] [FE] feat: consume lite workspace endpoint with safe fallback

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/WorkspaceMenuContent.tsx
+++ b/apps/opik-frontend/src/plugins/comet/WorkspaceMenuContent.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useRef } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { Settings2 } from "lucide-react";
 
 import { Button } from "@/ui/button";
@@ -21,6 +22,10 @@ import {
   Workspace,
 } from "@/plugins/comet/types";
 import { buildUrl } from "@/plugins/comet/utils";
+
+const WORKSPACE_ITEM_HEIGHT = 32;
+const WORKSPACE_VIRTUALIZATION_THRESHOLD = 50;
+const WORKSPACE_VIRTUAL_OVERSCAN = 8;
 
 const canManageOrg = (org: Organization) =>
   org.role === ORGANIZATION_ROLE_TYPE.admin;
@@ -56,167 +61,205 @@ const WorkspaceMenuContent: React.FC<WorkspaceMenuContentProps> = ({
   handleChangeOrganization,
   search,
   setSearch,
-}) => (
-  <>
-    {hasMultipleOrganizations ? (
-      <DropdownMenuSub
-        open={isOrgSubmenuOpen}
-        onOpenChange={setIsOrgSubmenuOpen}
+}) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const shouldVirtualize =
+    sortedWorkspaces.length > WORKSPACE_VIRTUALIZATION_THRESHOLD;
+
+  const virtualizer = useVirtualizer({
+    count: shouldVirtualize ? sortedWorkspaces.length : 0,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => WORKSPACE_ITEM_HEIGHT,
+    overscan: WORKSPACE_VIRTUAL_OVERSCAN,
+  });
+
+  const renderWorkspaceItem = (workspace: Workspace) => {
+    const wsDisplayName = calculateWorkspaceName(workspace.workspaceName);
+    const isSelected = workspace.workspaceName === workspaceName;
+
+    return (
+      <DropdownMenuItem
+        key={workspace.workspaceName}
+        size="sm"
+        selected={isSelected}
+        onSelect={(e) => {
+          e.preventDefault();
+          handleChangeWorkspace(workspace);
+          setIsDropdownOpen(false);
+          setSearch("");
+        }}
       >
-        <DropdownMenuSubTrigger
-          variant="menu"
-          size="sm"
-          className="cursor-pointer"
+        <TooltipWrapper content={wsDisplayName}>
+          <span className="comet-body-s min-w-0 flex-1 truncate text-left">
+            {wsDisplayName}
+          </span>
+        </TooltipWrapper>
+      </DropdownMenuItem>
+    );
+  };
+
+  return (
+    <>
+      {hasMultipleOrganizations ? (
+        <DropdownMenuSub
+          open={isOrgSubmenuOpen}
+          onOpenChange={setIsOrgSubmenuOpen}
         >
+          <DropdownMenuSubTrigger
+            variant="menu"
+            size="sm"
+            className="cursor-pointer"
+          >
+            <TooltipWrapper content={currentOrganization.name}>
+              <span className="min-w-0 flex-1 truncate text-left">
+                {currentOrganization.name}
+              </span>
+            </TooltipWrapper>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuSubContent className="w-[280px] p-1" sideOffset={8}>
+              <DropdownMenuLabel size="sm">Organizations</DropdownMenuLabel>
+              <DropdownMenuSeparator className="my-1" />
+              <div className="max-h-[60vh] overflow-auto">
+                {sortedOrganizations.length > 0 ? (
+                  sortedOrganizations.map((org) => {
+                    const isActive = currentOrganization.id === org.id;
+                    return (
+                      <DropdownMenuItem
+                        key={org.id}
+                        size="sm"
+                        selected={isActive}
+                        onSelect={(e) => {
+                          e.preventDefault();
+                          handleChangeOrganization(org);
+                          setIsOrgSubmenuOpen(false);
+                        }}
+                        className="group pr-1.5"
+                      >
+                        <TooltipWrapper content={org.name}>
+                          <span className="comet-body-s min-w-0 flex-1 truncate text-left">
+                            {org.name}
+                          </span>
+                        </TooltipWrapper>
+                        {canManageOrg(org) && (
+                          <Button
+                            variant="minimal"
+                            size="icon-2xs"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              window.location.href = orgSettingsUrl(
+                                org.id,
+                                workspaceName,
+                              );
+                            }}
+                            aria-label={`Open ${org.name} settings`}
+                            className={cn(
+                              "shrink-0 text-light-slate hover:text-foreground",
+                              !isActive && "invisible group-hover:visible",
+                            )}
+                          >
+                            <Settings2 className="size-3.5" />
+                          </Button>
+                        )}
+                      </DropdownMenuItem>
+                    );
+                  })
+                ) : (
+                  <div className="flex min-h-[120px] flex-col items-center justify-center px-4 py-2 text-center">
+                    <span className="comet-body-s text-muted-slate">
+                      No organizations found
+                    </span>
+                  </div>
+                )}
+              </div>
+            </DropdownMenuSubContent>
+          </DropdownMenuPortal>
+        </DropdownMenuSub>
+      ) : (
+        <div className="flex h-8 items-center gap-1.5 px-3 pr-1.5">
           <TooltipWrapper content={currentOrganization.name}>
-            <span className="min-w-0 flex-1 truncate text-left">
+            <span className="comet-body-s-accented min-w-0 flex-1 truncate text-foreground">
               {currentOrganization.name}
             </span>
           </TooltipWrapper>
-        </DropdownMenuSubTrigger>
-        <DropdownMenuPortal>
-          <DropdownMenuSubContent className="w-[280px] p-1" sideOffset={8}>
-            <DropdownMenuLabel size="sm">Organizations</DropdownMenuLabel>
-            <DropdownMenuSeparator className="my-1" />
-            <div className="max-h-[60vh] overflow-auto">
-              {sortedOrganizations.length > 0 ? (
-                sortedOrganizations.map((org) => {
-                  const isActive = currentOrganization.id === org.id;
-                  return (
-                    <DropdownMenuItem
-                      key={org.id}
-                      size="sm"
-                      selected={isActive}
-                      onSelect={(e) => {
-                        e.preventDefault();
-                        handleChangeOrganization(org);
-                        setIsOrgSubmenuOpen(false);
-                      }}
-                      className="group pr-1.5"
-                    >
-                      <TooltipWrapper content={org.name}>
-                        <span className="comet-body-s min-w-0 flex-1 truncate text-left">
-                          {org.name}
-                        </span>
-                      </TooltipWrapper>
-                      {canManageOrg(org) && (
-                        <Button
-                          variant="minimal"
-                          size="icon-2xs"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            window.location.href = orgSettingsUrl(
-                              org.id,
-                              workspaceName,
-                            );
-                          }}
-                          aria-label={`Open ${org.name} settings`}
-                          className={cn(
-                            "shrink-0 text-light-slate hover:text-foreground",
-                            !isActive && "invisible group-hover:visible",
-                          )}
-                        >
-                          <Settings2 className="size-3.5" />
-                        </Button>
-                      )}
-                    </DropdownMenuItem>
-                  );
-                })
-              ) : (
-                <div className="flex min-h-[120px] flex-col items-center justify-center px-4 py-2 text-center">
-                  <span className="comet-body-s text-muted-slate">
-                    No organizations found
-                  </span>
-                </div>
-              )}
-            </div>
-          </DropdownMenuSubContent>
-        </DropdownMenuPortal>
-      </DropdownMenuSub>
-    ) : (
-      <div className="flex h-8 items-center gap-1.5 px-3 pr-1.5">
-        <TooltipWrapper content={currentOrganization.name}>
-          <span className="comet-body-s-accented min-w-0 flex-1 truncate text-foreground">
-            {currentOrganization.name}
-          </span>
-        </TooltipWrapper>
-        {canManageOrg(currentOrganization) && (
-          <Button
-            variant="minimal"
-            size="icon-2xs"
-            onClick={() => {
-              window.location.href = orgSettingsUrl(
-                currentOrganization.id,
-                workspaceName,
-              );
-            }}
-            aria-label={`Open ${currentOrganization.name} settings`}
-            className="shrink-0 text-light-slate hover:text-foreground"
-          >
-            <Settings2 className="size-3.5" />
-          </Button>
-        )}
-      </div>
-    )}
-
-    <DropdownMenuSeparator className="my-1" />
-
-    <div className="px-0.5" onKeyDown={(e) => e.stopPropagation()}>
-      <SearchInput
-        searchText={search}
-        setSearchText={setSearch}
-        placeholder="Search"
-        variant="ghost"
-        size="sm"
-      />
-    </div>
-
-    <DropdownMenuSeparator className="my-1" />
-
-    <div className="max-h-[50vh] overflow-auto">
-      {sortedWorkspaces.length > 0 ? (
-        sortedWorkspaces.map((workspace) => {
-          const wsDisplayName = calculateWorkspaceName(workspace.workspaceName);
-          const isSelected = workspace.workspaceName === workspaceName;
-
-          return (
-            <DropdownMenuItem
-              key={workspace.workspaceName}
-              size="sm"
-              selected={isSelected}
-              onSelect={(e) => {
-                e.preventDefault();
-                handleChangeWorkspace(workspace);
-                setIsDropdownOpen(false);
-                setSearch("");
+          {canManageOrg(currentOrganization) && (
+            <Button
+              variant="minimal"
+              size="icon-2xs"
+              onClick={() => {
+                window.location.href = orgSettingsUrl(
+                  currentOrganization.id,
+                  workspaceName,
+                );
               }}
+              aria-label={`Open ${currentOrganization.name} settings`}
+              className="shrink-0 text-light-slate hover:text-foreground"
             >
-              <TooltipWrapper content={wsDisplayName}>
-                <span className="comet-body-s min-w-0 flex-1 truncate text-left">
-                  {wsDisplayName}
-                </span>
-              </TooltipWrapper>
-            </DropdownMenuItem>
-          );
-        })
-      ) : (
-        <div className="flex min-h-[120px] flex-col items-center justify-center px-4 py-2 text-center">
-          <span className="comet-body-s text-muted-slate">
-            No workspaces found
-          </span>
+              <Settings2 className="size-3.5" />
+            </Button>
+          )}
         </div>
       )}
-    </div>
 
-    <DropdownMenuSeparator className="my-1" />
+      <DropdownMenuSeparator className="my-1" />
 
-    <ListAction variant="default" size="sm" asChild>
-      <a href={buildUrl("account-settings/workspaces", workspaceName)}>
-        <Settings2 className="size-3.5 text-light-slate" />
-        <span>Manage workspaces</span>
-      </a>
-    </ListAction>
-  </>
-);
+      <div className="px-0.5" onKeyDown={(e) => e.stopPropagation()}>
+        <SearchInput
+          searchText={search}
+          setSearchText={setSearch}
+          placeholder="Search"
+          variant="ghost"
+          size="sm"
+        />
+      </div>
+
+      <DropdownMenuSeparator className="my-1" />
+
+      <div ref={scrollRef} className="max-h-[50vh] overflow-auto">
+        {sortedWorkspaces.length === 0 ? (
+          <div className="flex min-h-[120px] flex-col items-center justify-center px-4 py-2 text-center">
+            <span className="comet-body-s text-muted-slate">
+              No workspaces found
+            </span>
+          </div>
+        ) : shouldVirtualize ? (
+          <div
+            style={{
+              height: `${virtualizer.getTotalSize()}px`,
+              position: "relative",
+            }}
+          >
+            {virtualizer.getVirtualItems().map((virtualRow) => (
+              <div
+                key={virtualRow.key}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  height: `${virtualRow.size}px`,
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              >
+                {renderWorkspaceItem(sortedWorkspaces[virtualRow.index])}
+              </div>
+            ))}
+          </div>
+        ) : (
+          sortedWorkspaces.map(renderWorkspaceItem)
+        )}
+      </div>
+
+      <DropdownMenuSeparator className="my-1" />
+
+      <ListAction variant="default" size="sm" asChild>
+        <a href={buildUrl("account-settings/workspaces", workspaceName)}>
+          <Settings2 className="size-3.5 text-light-slate" />
+          <span>Manage workspaces</span>
+        </a>
+      </ListAction>
+    </>
+  );
+};
 
 export default WorkspaceMenuContent;

--- a/apps/opik-frontend/src/plugins/comet/types.ts
+++ b/apps/opik-frontend/src/plugins/comet/types.ts
@@ -97,14 +97,14 @@ export interface UserPermission {
 }
 
 export interface Workspace {
-  createdAt: number;
   workspaceId: string;
   workspaceName: string;
-  workspaceOwner: string;
-  workspaceCreator: string;
   organizationId: string;
-  collaborationFeaturesDisabled: boolean;
   default: boolean;
+  createdAt?: number;
+  workspaceOwner?: string;
+  workspaceCreator?: string;
+  collaborationFeaturesDisabled?: boolean;
 }
 
 export interface OrganizationMember {

--- a/apps/opik-frontend/src/plugins/comet/useAllWorkspaces.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAllWorkspaces.ts
@@ -1,12 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import uniqBy from "lodash/uniqBy";
-import { QueryConfig } from "./api";
-import { Workspace } from "./types";
 import useUserWorkspacesLite from "@/plugins/comet/useUserWorkspacesLite";
 import useUserInvitedWorkspaces from "@/plugins/comet/useUserInvitedWorkspaces";
 import useAdminOrganizationWorkspaces from "@/plugins/comet/useAdminOrganizationWorkspaces";
 
-export default function useAllWorkspaces(options?: QueryConfig<Workspace[]>) {
+type UseAllWorkspacesOptions = {
+  enabled?: boolean;
+};
+
+export default function useAllWorkspaces(options?: UseAllWorkspacesOptions) {
   const enabled = Boolean(options?.enabled);
   const lite = useUserWorkspacesLite({ enabled });
 

--- a/apps/opik-frontend/src/plugins/comet/useAllWorkspaces.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAllWorkspaces.ts
@@ -1,25 +1,43 @@
 import { useQuery } from "@tanstack/react-query";
+import uniqBy from "lodash/uniqBy";
 import { QueryConfig } from "./api";
 import { Workspace } from "./types";
-import { uniqBy } from "lodash";
+import useUserWorkspacesLite from "@/plugins/comet/useUserWorkspacesLite";
 import useUserInvitedWorkspaces from "@/plugins/comet/useUserInvitedWorkspaces";
 import useAdminOrganizationWorkspaces from "@/plugins/comet/useAdminOrganizationWorkspaces";
 
-// all workspaces of organizations
 export default function useAllWorkspaces(options?: QueryConfig<Workspace[]>) {
-  const { data: userInvitedWorkspaces } = useUserInvitedWorkspaces(options);
-  const { data: allUserWorkspaces } = useAdminOrganizationWorkspaces(options);
+  const enabled = Boolean(options?.enabled);
+  const { data: liteResult } = useUserWorkspacesLite({ enabled });
+
+  const isUnsupported = liteResult?.kind === "unsupported";
+  const liteData = liteResult?.kind === "data" ? liteResult.data : undefined;
+
+  const fallbackEnabled = enabled && isUnsupported;
+
+  const { data: userInvitedWorkspaces } = useUserInvitedWorkspaces({
+    enabled: fallbackEnabled,
+  });
+  const { data: adminOrgWorkspaces } = useAdminOrganizationWorkspaces({
+    enabled: fallbackEnabled,
+  });
+
+  const hasLite = liteData !== undefined;
+  const hasFallback =
+    isUnsupported && !!userInvitedWorkspaces && !!adminOrgWorkspaces;
 
   return useQuery({
     queryKey: ["all-user-workspaces", { enabled: true }],
     queryFn: async () => {
-      return !allUserWorkspaces || !userInvitedWorkspaces
-        ? undefined
-        : uniqBy(
-            [...allUserWorkspaces, ...userInvitedWorkspaces],
-            "workspaceId",
-          );
+      if (hasLite) return liteData;
+      if (hasFallback) {
+        return uniqBy(
+          [...adminOrgWorkspaces, ...userInvitedWorkspaces],
+          "workspaceId",
+        );
+      }
+      return undefined;
     },
-    enabled: !!allUserWorkspaces && !!userInvitedWorkspaces,
+    enabled: hasLite || hasFallback,
   });
 }

--- a/apps/opik-frontend/src/plugins/comet/useAllWorkspaces.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAllWorkspaces.ts
@@ -8,12 +8,9 @@ import useAdminOrganizationWorkspaces from "@/plugins/comet/useAdminOrganization
 
 export default function useAllWorkspaces(options?: QueryConfig<Workspace[]>) {
   const enabled = Boolean(options?.enabled);
-  const { data: liteResult } = useUserWorkspacesLite({ enabled });
+  const lite = useUserWorkspacesLite({ enabled });
 
-  const isUnsupported = liteResult?.kind === "unsupported";
-  const liteData = liteResult?.kind === "data" ? liteResult.data : undefined;
-
-  const fallbackEnabled = enabled && isUnsupported;
+  const fallbackEnabled = enabled && lite.isError;
 
   const { data: userInvitedWorkspaces } = useUserInvitedWorkspaces({
     enabled: fallbackEnabled,
@@ -22,14 +19,14 @@ export default function useAllWorkspaces(options?: QueryConfig<Workspace[]>) {
     enabled: fallbackEnabled,
   });
 
-  const hasLite = liteData !== undefined;
+  const hasLite = lite.data !== undefined;
   const hasFallback =
-    isUnsupported && !!userInvitedWorkspaces && !!adminOrgWorkspaces;
+    lite.isError && !!userInvitedWorkspaces && !!adminOrgWorkspaces;
 
   return useQuery({
     queryKey: ["all-user-workspaces", { enabled: true }],
     queryFn: async () => {
-      if (hasLite) return liteData;
+      if (hasLite) return lite.data;
       if (hasFallback) {
         return uniqBy(
           [...adminOrgWorkspaces, ...userInvitedWorkspaces],

--- a/apps/opik-frontend/src/plugins/comet/useUserWorkspacesLite.ts
+++ b/apps/opik-frontend/src/plugins/comet/useUserWorkspacesLite.ts
@@ -1,0 +1,34 @@
+import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import api, { QueryConfig } from "./api";
+import { Workspace } from "./types";
+
+export type LiteWorkspacesResult =
+  | { kind: "data"; data: Workspace[] }
+  | { kind: "unsupported" };
+
+const getUserWorkspacesLite = async ({
+  signal,
+}: QueryFunctionContext): Promise<LiteWorkspacesResult> => {
+  try {
+    const response = await api.get<Workspace[]>(`/workspaces/lite`, { signal });
+    return { kind: "data", data: response.data };
+  } catch (error) {
+    if ((error as AxiosError)?.response?.status === 404) {
+      return { kind: "unsupported" };
+    }
+    throw error;
+  }
+};
+
+export default function useUserWorkspacesLite(
+  options?: QueryConfig<LiteWorkspacesResult>,
+) {
+  return useQuery({
+    queryKey: ["user-workspaces-lite", { enabled: true }],
+    queryFn: getUserWorkspacesLite,
+    staleTime: Infinity,
+    ...options,
+    enabled: Boolean(options?.enabled),
+  });
+}

--- a/apps/opik-frontend/src/plugins/comet/useUserWorkspacesLite.ts
+++ b/apps/opik-frontend/src/plugins/comet/useUserWorkspacesLite.ts
@@ -1,32 +1,23 @@
 import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
-import { AxiosError } from "axios";
 import api, { QueryConfig } from "./api";
 import { Workspace } from "./types";
 
-export type LiteWorkspacesResult =
-  | { kind: "data"; data: Workspace[] }
-  | { kind: "unsupported" };
-
-const getUserWorkspacesLite = async ({
-  signal,
-}: QueryFunctionContext): Promise<LiteWorkspacesResult> => {
-  try {
-    const response = await api.get<Workspace[]>(`/workspaces/lite`, { signal });
-    return { kind: "data", data: response.data };
-  } catch (error) {
-    if ((error as AxiosError)?.response?.status === 404) {
-      return { kind: "unsupported" };
-    }
-    throw error;
-  }
+const getUserWorkspacesLite = async ({ signal }: QueryFunctionContext) => {
+  const { data } = await api.get<Workspace[]>(`/workspaces/lite`, { signal });
+  return data;
 };
 
 export default function useUserWorkspacesLite(
-  options?: QueryConfig<LiteWorkspacesResult>,
+  options?: QueryConfig<Workspace[]>,
 ) {
   return useQuery({
     queryKey: ["user-workspaces-lite", { enabled: true }],
     queryFn: getUserWorkspacesLite,
+    // Any failure (404, 405, 5xx, network, etc.) falls back to legacy
+    // /api/workspaces hooks via the orchestrator in useAllWorkspaces.
+    // Disable retries so the fallback kicks in immediately instead of
+    // burning ~10s on exponential-backoff retries.
+    retry: false,
     staleTime: Infinity,
     ...options,
     enabled: Boolean(options?.enabled),

--- a/apps/opik-frontend/src/plugins/comet/useWorkspaceSelectorData.ts
+++ b/apps/opik-frontend/src/plugins/comet/useWorkspaceSelectorData.ts
@@ -8,7 +8,7 @@ import { calculateWorkspaceName } from "@/lib/utils";
 import useCurrentOrganization from "@/plugins/comet/useCurrentOrganization";
 import useOrganizations from "@/plugins/comet/useOrganizations";
 import useUser from "@/plugins/comet/useUser";
-import useUserInvitedWorkspaces from "@/plugins/comet/useUserInvitedWorkspaces";
+import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
 import useAppStore from "@/store/AppStore";
 import {
   Workspace,
@@ -26,7 +26,7 @@ const useWorkspaceSelectorData = () => {
   const [isOrgSubmenuOpen, setIsOrgSubmenuOpen] = useState(false);
 
   const { data: user } = useUser();
-  const { data: userInvitedWorkspaces, isLoading } = useUserInvitedWorkspaces({
+  const { data: allWorkspaces, isLoading } = useAllWorkspaces({
     enabled: !!user?.loggedIn,
   });
   const { data: organizations } = useOrganizations({
@@ -63,7 +63,7 @@ const useWorkspaceSelectorData = () => {
   const handleChangeOrganization = useCallback(
     (newOrganization: Organization) => {
       const newOrganizationWorkspaces =
-        userInvitedWorkspaces?.filter(
+        allWorkspaces?.filter(
           (workspace) => workspace.organizationId === newOrganization.id,
         ) || [];
 
@@ -86,7 +86,7 @@ const useWorkspaceSelectorData = () => {
         });
       }
     },
-    [navigate, userInvitedWorkspaces, toast],
+    [navigate, allWorkspaces, toast],
   );
 
   const handleOrgSettingsClick = useCallback(() => {
@@ -99,13 +99,13 @@ const useWorkspaceSelectorData = () => {
   }, [currentOrganization, workspaceName]);
 
   const memberWorkspaces = useMemo(() => {
-    if (!userInvitedWorkspaces || !currentOrganization) return [];
-    return userInvitedWorkspaces.filter(
+    if (!allWorkspaces || !currentOrganization) return [];
+    return allWorkspaces.filter(
       (workspace) =>
         workspace.organizationId === currentOrganization.id &&
         workspace.workspaceName !== DEFAULT_WORKSPACE_NAME,
     );
-  }, [userInvitedWorkspaces, currentOrganization]);
+  }, [allWorkspaces, currentOrganization]);
 
   const filteredWorkspaces = useMemo(() => {
     if (!search) return memberWorkspaces;


### PR DESCRIPTION
## Details

Consumes the new `GET /api/workspaces/lite` endpoint (added in [comet-ml/comet-backend#5543](https://github.com/comet-ml/comet-backend/pull/5543), already deployed on dev) to eliminate the workspace-list N+1 from Opik's bootstrap. With many workspaces under one user (~2,790 measured on dev), the legacy `/api/workspaces?withoutExtendedData=true` + per-admin-org calls take ~30s each. The new `/lite` endpoint returns in ~200ms because it skips `addWorkspaceData()` and uses a single UNION SQL query.

- `useUserWorkspacesLite` calls `/workspaces/lite`; on **any** failure (4xx, 5xx, network, CORS, proxy 405) the orchestrator falls back to today's `useUserInvitedWorkspaces` + `useAdminOrganizationWorkspaces` hooks, so the page keeps working against older self-hosted BEs or partial outages.
- `useAllWorkspaces` becomes a lite-first orchestrator; the legacy hooks stay as fallback only.
- `WorkspaceMenuContent` switcher list is virtualized with `@tanstack/react-virtual` above 50 items — opening the dropdown with ~2,800 workspaces is near-instant instead of laggy.
- `useWorkspaceSelectorData` swapped from `useUserInvitedWorkspaces` directly to `useAllWorkspaces` so the selector also benefits from the unioned list (intended UX shift: admin-of-org workspaces now appear in the switcher; access was already granted server-side).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6373

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: full implementation
- Human verification: manual test on dev with 2,790 workspaces (lite path, 404 fallback, 405/non-404 fallback all verified); code review by engineer; lint + tsc clean

## Testing

- `bash scripts/dev-runner.sh --lint-fe` — lint, tsc, depcruise all clean
- Manual on dev.comet.com with 2,790 workspaces under one user (instrumented via Chrome DevTools MCP, 3 reloads per branch):
  - main branch wave-1 average: **67.6s**
  - this PR wave-1 average: **45.6s** (−32% / −22s saved per page load)
  - `/api/workspaces*` time avg: ~49s → ~0.2s (lite endpoint replaces both legacy calls)
  - Wave-1 critical path is now bounded by `/api/auth/test`'s separate N+1 — tracked in OPIK-6494
- 404 fallback verified: forced `/lite` 404 via Chrome DevTools — both legacy hooks fire, page loads normally with bit-for-bit equivalent behavior to today's main
- Virtualized switcher verified: opens instantly with ~2,800 items, search filter responsive

## Documentation

N/A — purely internal FE plumbing under `apps/opik-frontend/src/plugins/comet/`. No public API or user-facing copy changes.