### PR TITLE
fix(python-backend): stamp unique service.instance.id on each RQ forked child

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/workers/metrics_worker.py
+++ b/apps/opik-python-backend/src/opik_backend/workers/metrics_worker.py
@@ -1,9 +1,12 @@
 import logging
+import uuid
 
 from rq import Worker
 from rq.job import Job
 from rq.queue import Queue
+from opentelemetry import metrics, trace
 from opentelemetry.metrics import get_meter
+from opentelemetry.sdk.resources import Resource
 
 from .death_penalty import NoOpDeathPenalty
 from opik_backend.utils.env_utils import get_env_int
@@ -76,6 +79,51 @@ class MetricsWorker(Worker):
         super().__init__(*args, **kwargs)
         self._failure_ttl = RQ_FAILURE_TTL
         logger.info(f"MetricsWorker initialized with failure_ttl={self._failure_ttl}s")
+
+    def main_work_horse(self, job: Job, queue: Queue):
+        """RQ post-fork entry point (runs in the forked child process).
+
+        Stamps a fresh `service.instance.id` onto the OTel Resource of the
+        already-installed MeterProvider and TracerProvider before any metrics
+        fire in the child. Without this, every forked optimizer child inherits
+        the parent's identical resource attributes and emits per-process
+        runtime metrics (`system_cpu_time_seconds_total`, `system_memory_*`,
+        ...) under the same label set as the parent and its siblings.
+        Prometheus rejects those batches with HTTP 400
+        `duplicate sample for timestamp ... overrides not allowed` the moment
+        two children's emit timestamps land in the same millisecond.
+
+        Mutating `_sdk_config.resource` (metrics) and `_resource` (traces) in
+        place is deliberately surgical: existing observable instruments
+        registered before fork — including `SystemMetricsInstrumentor`'s
+        `system.cpu.time`, registered by `opentelemetry-instrument` at process
+        start — start emitting under the new resource on the next export tick,
+        because the SDK reads the resource at export time rather than at
+        instrument-creation time.
+        """
+        self._stamp_unique_otel_instance_id(job)
+        return super().main_work_horse(job, queue)
+
+    @staticmethod
+    def _stamp_unique_otel_instance_id(job: Job) -> None:
+        instance_id = str(uuid.uuid4())
+        addition = Resource.create({"service.instance.id": instance_id})
+
+        meter_provider = metrics.get_meter_provider()
+        sdk_cfg = getattr(meter_provider, "_sdk_config", None)
+        if sdk_cfg is not None and getattr(sdk_cfg, "resource", None) is not None:
+            sdk_cfg.resource = sdk_cfg.resource.merge(addition)
+
+        tracer_provider = trace.get_tracer_provider()
+        existing_trace_resource = getattr(tracer_provider, "_resource", None)
+        if existing_trace_resource is not None:
+            tracer_provider._resource = existing_trace_resource.merge(addition)
+
+        logger.info(
+            "Stamped service.instance.id=%s on forked RQ child for job %s",
+            instance_id,
+            getattr(job, "id", "unknown"),
+        )
 
     def handle_job_failure(self, job: Job, queue: Queue, started_job_registry=None, exc_string=''):
         """Handle job failure with custom failure TTL.


### PR DESCRIPTION
## Summary
Override `MetricsWorker.main_work_horse` (RQ's post-fork entry point in the child) to stamp a fresh UUID `service.instance.id` onto the OTel Resource of the already-installed MeterProvider and TracerProvider, before any metrics fire in the child.

## Problem

RQ's default `Worker` forks a child process per job. The child inherits the parent's already-initialized OTel SDK state — including a Resource whose attributes contain only `service.name`, `service.version`, and `telemetry.sdk.*`. The Python OTel SDK doesn't auto-generate `service.instance.id`, and our entrypoint doesn't add one to `OTEL_RESOURCE_ATTRIBUTES`.

Every forked child then emits its own per-process runtime metrics (`system_cpu_time_seconds_total`, `system_memory_usage_bytes`, `process_runtime_cpython_*`, ...) via the inherited SDK. Because all children share the parent's identical resource attribute set, the emitted series collide on the way to Prometheus remote-write. The collector forwards each cycle faithfully, and Prometheus rejects the batch with HTTP 400:

```
duplicate sample for timestamp <ts>; overrides not allowed:
  existing X, new value Y for series {
    __name__="system_cpu_time_seconds_total", cpu="3",
    job="opik-python-backend",
    k8s_pod_name="opik-python-backend-<...>",
    service_name="opik-python-backend",
    state="user",
    telemetry_sdk_language="python", telemetry_sdk_name="opentelemetry", telemetry_sdk_version="1.36.0"
  }
```

dropping ~1000+ metric points per export cycle on a busy pod. Observed in `self-hosted-eks` with ~17 concurrent optimizer jobs against `dev-monitoring-opentelemetry-collector`. A direct Prometheus query confirmed the *same series* receives **18 samples/minute** from the affected pod versus **1/minute** from sibling pods on the same image (`2.0.31`) in other namespaces.

## How the fix works

Mutate `_sdk_config.resource` (metrics) and `_resource` (traces) in place on the providers that are already installed by the parent's `setup_telemetry` flow. Because the OTel SDK reads the resource at export time — not at instrument-creation time — observable instruments registered before fork (including `SystemMetricsInstrumentor`'s `system.cpu.time`, registered at process start by `opentelemetry-instrument`) start emitting under the new resource on the next export tick. Each forked child therefore reaches Prometheus with a distinct `service_instance_id` label, so sibling series no longer collide.

The mutation uses `_sdk_config.resource = sdk_cfg.resource.merge(...)`, leveraging the fact that `SdkConfiguration` is a regular `@dataclass` (mutable) and `Resource.merge()` returns a new Resource that overlays the new attributes on the old.

## Test plan

- [ ] Build the python-backend image, deploy to a test env where multiple RQ optimizer jobs run.
- [ ] In `dev-monitoring-opentelemetry-collector` logs, confirm the `duplicate sample for timestamp ... opik-python-backend ...` errors stop.
- [ ] Query Prometheus: `count by (service_instance_id) (system_cpu_time_seconds_total{service_name="opik-python-backend"})` — expect multiple distinct `service_instance_id` values per active pod (parent + one per active job).
- [ ] `count_over_time(system_cpu_time_seconds_total{service_name="opik-python-backend",k8s_pod_name="<busy-pod>"}[5m])` returns ~5 per series (one per minute) rather than ~90.
- [ ] Confirm RQ job lifecycle metrics (`rq_worker.jobs.*`) still emit correctly from within the forked child.

## Operational note for the devops team

This fix relies on `service.instance.id` reaching Prometheus. The OTel Collector's `resource/strip-instance-id` processor (in `comet-monitoring/values-dev.yaml`) currently deletes that attribute on every push. A coordinated change is being prepared to exempt `opik-python-backend` from the strip once this PR is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)