### PR TITLE
[NA] [BE] fix(python-backend): one metric exporter per pod (move rq_worker metrics to parent)

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/workers/metrics_worker.py
+++ b/apps/opik-python-backend/src/opik_backend/workers/metrics_worker.py
@@ -1,5 +1,6 @@
 import logging
-from datetime import datetime, timezone
+import re
+from typing import Mapping
 
 from rq import Worker
 from rq.job import Job
@@ -141,58 +142,49 @@ class MetricsWorker(Worker):
         `perform_job` (child) so the pod has exactly one MeterProvider+Reader
         chain. Sequence:
 
-          1. Record queue wait time (`now - job.created_at`) before forking.
-          2. Bump `concurrent_jobs_counter`.
-          3. Call `super().execute_job` which forks and waits for the child.
-          4. Refresh the job from Redis to read the final timestamps and
+          1. Bump `concurrent_jobs_counter`.
+          2. Call `super().execute_job` which forks and waits for the child.
+          3. Refresh the job from Redis to read the final timestamps and
              status the child wrote.
-          5. Record `jobs_processed`, `jobs_succeeded`/`jobs_failed`,
-             `processing_time`, `total_time`.
+          4. Record `jobs_processed`, `jobs_succeeded`/`jobs_failed`,
+             `processing_time`, `total_time`, and `queue_wait_time` (from
+             `job.started_at - job.created_at` after refresh, preserving the
+             pre-refactor SLI definition).
         """
         func_name = getattr(job, "func_name", None) or "unknown"
         queue_name = queue.name
         metric_attributes = {"queue": queue_name, "function": func_name}
 
-        queue_wait_ms = None
-        if job.created_at:
-            now = datetime.now(tz=timezone.utc)
+        result: bool = False
+        execute_exc: "BaseException | None" = None
+
+        # Pair concurrent_jobs_counter +1/-1 via a try/finally that brackets
+        # everything below — if the inner block raises (including a metric
+        # call), the matching decrement still runs.
+        concurrent_jobs_counter.add(1, metric_attributes)
+        try:
             try:
-                queue_wait_ms = (now - job.created_at).total_seconds() * 1000
-                queue_wait_time_histogram.record(queue_wait_ms, metric_attributes)
-            except (TypeError, ValueError):
-                logger.debug(
-                    "Could not compute queue wait time for job %s",
-                    job.id,
+                logger.debug(f"execute_job called for job {job.id}, status: {job.get_status()}")
+                result = super().execute_job(job, queue)
+                logger.debug(f"execute_job completed for job {job.id}")
+            except Exception as e:
+                execute_exc = e
+                logger.error(
+                    f"execute_job FAILED for job {job.id}: {type(e).__name__}: {e}",
                     exc_info=True,
                 )
-
-        concurrent_jobs_counter.add(1, metric_attributes)
-
-        result: bool = False
-        execute_exc: BaseException | None = None
-        try:
-            logger.debug(f"execute_job called for job {job.id}, status: {job.get_status()}")
-            result = super().execute_job(job, queue)
-            logger.debug(f"execute_job completed for job {job.id}")
-        except Exception as e:
-            execute_exc = e
-            logger.error(
-                f"execute_job FAILED for job {job.id}: {type(e).__name__}: {e}",
-                exc_info=True,
-            )
-            raise
-        finally:
-            try:
-                self._record_job_completion_metrics(job, metric_attributes, execute_exc)
+                raise
             finally:
-                concurrent_jobs_counter.add(-1, metric_attributes)
+                self._record_job_completion_metrics(job, metric_attributes, execute_exc)
+        finally:
+            concurrent_jobs_counter.add(-1, metric_attributes)
 
         return result
 
     @staticmethod
     def _record_job_completion_metrics(
         job: Job,
-        metric_attributes: dict,
+        metric_attributes: "Mapping[str, str]",
         execute_exc: "BaseException | None",
     ) -> None:
         """Read the final job state from Redis and emit the per-job metrics.
@@ -200,7 +192,7 @@ class MetricsWorker(Worker):
         Runs from the parent process after the forked child has exited. The
         child writes `started_at`, `ended_at`, status, and `exc_info` to Redis
         before exiting; `job.refresh()` here pulls those values into the local
-        Job object so we can record processing/total time and success/failure
+        Job object so we can record durations, queue wait, and success/failure
         counters from the parent.
         """
         try:
@@ -230,6 +222,13 @@ class MetricsWorker(Worker):
         started_at = getattr(job, "started_at", None)
         ended_at = getattr(job, "ended_at", None)
         created_at = getattr(job, "created_at", None)
+
+        # queue_wait_time: time the job spent in Redis before the child started
+        # executing. Preserved from the pre-refactor SLI definition so existing
+        # dashboards/alerts keyed on this histogram see no semantic change.
+        if started_at and created_at:
+            queue_wait_ms = (started_at - created_at).total_seconds() * 1000
+            queue_wait_time_histogram.record(queue_wait_ms, metric_attributes)
 
         if started_at and ended_at:
             processing_time_ms = (ended_at - started_at).total_seconds() * 1000
@@ -265,20 +264,30 @@ class MetricsWorker(Worker):
             raise
 
 
+_EXCEPTION_LINE = re.compile(r"^([A-Za-z_][A-Za-z0-9_.]*)\s*:")
+
+
 def _error_type_from_job(job: Job) -> str:
     """Best-effort extraction of the exception class name from `job.exc_info`.
 
-    RQ stores the child's traceback as a string; we read the last non-empty
-    line ("ExceptionClass: message") and take the part before the colon. Falls
-    back to "UnknownError" if the format isn't what we expect.
+    RQ stores the child's traceback as a string. Python's traceback format
+    places the exception line at column 0 ("ExceptionClass: message"), with
+    any continuation of a multi-line message and stack frames indented. We
+    scan lines from the end, skip indented continuations, and match the first
+    unindented `Name:` line — that's the outermost exception that propagated
+    out (correct under chained-exception traceback printing too).
+
+    Falls back to "UnknownError" if no such line is found.
     """
     exc_info = getattr(job, "exc_info", None)
     if not exc_info:
         return "UnknownError"
-    lines = [line for line in exc_info.strip().splitlines() if line.strip()]
-    if not lines:
-        return "UnknownError"
-    last = lines[-1].strip()
-    head = last.split(":", 1)[0].strip()
-    # Strip dotted module prefix: `module.Klass` -> `Klass`
-    return head.rsplit(".", 1)[-1] or "UnknownError"
+    for line in reversed(exc_info.splitlines()):
+        if not line or line[0].isspace():
+            continue
+        m = _EXCEPTION_LINE.match(line)
+        if m:
+            # Strip dotted module prefix: `requests.exceptions.ConnectionError`
+            # -> `ConnectionError`.
+            return m.group(1).rsplit(".", 1)[-1] or "UnknownError"
+    return "UnknownError"

--- a/apps/opik-python-backend/src/opik_backend/workers/metrics_worker.py
+++ b/apps/opik-python-backend/src/opik_backend/workers/metrics_worker.py
@@ -197,27 +197,45 @@ class MetricsWorker(Worker):
         """
         try:
             job.refresh()
+            refresh_ok = True
         except Exception:
             logger.debug(
-                "job.refresh() failed for job %s — per-job metrics may be incomplete",
+                "job.refresh() failed for job %s — terminal state unavailable",
                 getattr(job, "id", "unknown"),
                 exc_info=True,
             )
+            refresh_ok = False
 
         jobs_processed_counter.add(1, metric_attributes)
 
+        # Decide success vs failure. `job.is_failed` in RQ triggers another
+        # Redis round-trip (`get_status()`), so we only consult it when the
+        # earlier refresh succeeded; otherwise we'd risk raising from this
+        # finally-block and surfacing a completed job as a worker error.
         if execute_exc is not None:
-            error_type = type(execute_exc).__name__
+            # Parent-side exception is locally reliable; doesn't need Redis.
             jobs_failed_counter.add(
-                1, {**metric_attributes, "error_type": error_type}
+                1, {**metric_attributes, "error_type": type(execute_exc).__name__}
+            )
+        elif not refresh_ok:
+            # We can't tell whether the child succeeded or failed without
+            # Redis. Emit an explicit outcome with `error_type="RefreshFailed"`
+            # rather than silently dropping the terminal metric.
+            jobs_failed_counter.add(
+                1, {**metric_attributes, "error_type": "RefreshFailed"}
             )
         elif getattr(job, "is_failed", False):
-            error_type = _error_type_from_job(job)
             jobs_failed_counter.add(
-                1, {**metric_attributes, "error_type": error_type}
+                1, {**metric_attributes, "error_type": _error_type_from_job(job)}
             )
         else:
             jobs_succeeded_counter.add(1, metric_attributes)
+
+        # Duration histograms depend on timestamps written by the child to
+        # Redis. After a failed refresh those values are stale or absent, so
+        # skip rather than record bogus durations.
+        if not refresh_ok:
+            return
 
         started_at = getattr(job, "started_at", None)
         ended_at = getattr(job, "ended_at", None)

--- a/apps/opik-python-backend/src/opik_backend/workers/metrics_worker.py
+++ b/apps/opik-python-backend/src/opik_backend/workers/metrics_worker.py
@@ -1,8 +1,10 @@
 import logging
+from datetime import datetime, timezone
 
 from rq import Worker
 from rq.job import Job
 from rq.queue import Queue
+from opentelemetry import metrics
 from opentelemetry.metrics import get_meter
 
 from .death_penalty import NoOpDeathPenalty
@@ -66,6 +68,32 @@ class MetricsWorker(Worker):
     """
     Custom RQ Worker that emits OpenTelemetry metrics.
 
+    Architecture: single MeterProvider/Exporter per pod.
+
+    The pod runs gunicorn (--workers 1 --threads N) plus N RQ worker threads
+    in that same process. The parent's OTel SDK is initialized once and is the
+    only metric exporter for the pod. RQ's default Worker.execute_job forks a
+    child per job; without intervention each forked child would carry an
+    inherited MeterProvider + PeriodicExportingMetricReader and emit its own
+    `system_cpu_time`/`system_memory_*` series. Because the Python SDK's
+    default Resource has no per-process identifier, every child's series
+    collides with the parent and siblings on the same labels, and Prometheus
+    rejects the remote-write batch with HTTP 400 "duplicate sample for
+    timestamp".
+
+    Two coordinated changes keep the pod to a single metric exporter:
+
+    1. `main_work_horse` (runs post-fork in the child) shuts down the
+       inherited MeterProvider so the child contributes no metrics. The
+       TracerProvider is intentionally left alone -- span IDs are unique per
+       span, so traces produced by auto-instrumentation inside a job (Flask,
+       Requests, ...) remain useful and don't suffer the same dedup issue.
+
+    2. `execute_job` (runs in the parent) wraps the call to RQ's
+       `super().execute_job()` and records the per-job counters/histograms
+       there, reading the final timestamps and status from Redis via
+       `job.refresh()` after the child exits.
+
     Configuration:
         RQ_FAILURE_TTL: TTL for failed jobs in seconds (default: 86400 = 1 day)
     """
@@ -89,83 +117,168 @@ class MetricsWorker(Worker):
 
         return super().handle_job_failure(job, queue, started_job_registry, exc_string)
 
-    def execute_job(self, job: Job, queue: Queue) -> bool:
-        """Execute a job and return success status."""
-        logger.debug(f"execute_job called for job {job.id}, status: {job.get_status()}")
+    def main_work_horse(self, job: Job, queue: Queue):
+        """RQ post-fork entry point — runs in the forked child process.
+
+        Silence the MeterProvider the child inherited from the parent so the
+        pod ends up with a single metric exporter. See the class docstring for
+        the full rationale.
+        """
         try:
+            metrics.get_meter_provider().shutdown()
+        except Exception:
+            logger.debug(
+                "Failed to shut down MeterProvider in forked child; "
+                "duplicate-sample errors may resume",
+                exc_info=True,
+            )
+        return super().main_work_horse(job, queue)
+
+    def execute_job(self, job: Job, queue: Queue) -> bool:
+        """Execute a job and record OTel metrics from the parent process.
+
+        Per-job metric emission lives here (parent) rather than in
+        `perform_job` (child) so the pod has exactly one MeterProvider+Reader
+        chain. Sequence:
+
+          1. Record queue wait time (`now - job.created_at`) before forking.
+          2. Bump `concurrent_jobs_counter`.
+          3. Call `super().execute_job` which forks and waits for the child.
+          4. Refresh the job from Redis to read the final timestamps and
+             status the child wrote.
+          5. Record `jobs_processed`, `jobs_succeeded`/`jobs_failed`,
+             `processing_time`, `total_time`.
+        """
+        func_name = getattr(job, "func_name", None) or "unknown"
+        queue_name = queue.name
+        metric_attributes = {"queue": queue_name, "function": func_name}
+
+        queue_wait_ms = None
+        if job.created_at:
+            now = datetime.now(tz=timezone.utc)
+            try:
+                queue_wait_ms = (now - job.created_at).total_seconds() * 1000
+                queue_wait_time_histogram.record(queue_wait_ms, metric_attributes)
+            except (TypeError, ValueError):
+                logger.debug(
+                    "Could not compute queue wait time for job %s",
+                    job.id,
+                    exc_info=True,
+                )
+
+        concurrent_jobs_counter.add(1, metric_attributes)
+
+        result: bool = False
+        execute_exc: BaseException | None = None
+        try:
+            logger.debug(f"execute_job called for job {job.id}, status: {job.get_status()}")
             result = super().execute_job(job, queue)
             logger.debug(f"execute_job completed for job {job.id}")
-            return result
         except Exception as e:
+            execute_exc = e
             logger.error(
                 f"execute_job FAILED for job {job.id}: {type(e).__name__}: {e}",
                 exc_info=True,
             )
             raise
+        finally:
+            try:
+                self._record_job_completion_metrics(job, metric_attributes, execute_exc)
+            finally:
+                concurrent_jobs_counter.add(-1, metric_attributes)
 
-    def perform_job(self, job: Job, queue: Queue) -> bool:
-        logger.debug(
-            f"Starting perform_job for job {job.id}, func: {getattr(job, 'func_name', 'unknown')}"
-        )
+        return result
 
-        func_name = job.func_name if hasattr(job, "func_name") else "unknown"
-        queue_name = queue.name
+    @staticmethod
+    def _record_job_completion_metrics(
+        job: Job,
+        metric_attributes: dict,
+        execute_exc: "BaseException | None",
+    ) -> None:
+        """Read the final job state from Redis and emit the per-job metrics.
 
-        queue_wait_ms = None
-        if job.created_at and job.started_at:
-            queue_wait_seconds = (job.started_at - job.created_at).total_seconds()
-            queue_wait_ms = queue_wait_seconds * 1000
-            queue_wait_time_histogram.record(
-                queue_wait_ms, {"queue": queue_name, "function": func_name}
+        Runs from the parent process after the forked child has exited. The
+        child writes `started_at`, `ended_at`, status, and `exc_info` to Redis
+        before exiting; `job.refresh()` here pulls those values into the local
+        Job object so we can record processing/total time and success/failure
+        counters from the parent.
+        """
+        try:
+            job.refresh()
+        except Exception:
+            logger.debug(
+                "job.refresh() failed for job %s — per-job metrics may be incomplete",
+                getattr(job, "id", "unknown"),
+                exc_info=True,
             )
 
-        metric_attributes = {"queue": queue_name, "function": func_name}
+        jobs_processed_counter.add(1, metric_attributes)
 
-        # Track concurrent jobs (UpDownCounter is thread-safe)
-        concurrent_jobs_counter.add(1, metric_attributes)
+        if execute_exc is not None:
+            error_type = type(execute_exc).__name__
+            jobs_failed_counter.add(
+                1, {**metric_attributes, "error_type": error_type}
+            )
+        elif getattr(job, "is_failed", False):
+            error_type = _error_type_from_job(job)
+            jobs_failed_counter.add(
+                1, {**metric_attributes, "error_type": error_type}
+            )
+        else:
+            jobs_succeeded_counter.add(1, metric_attributes)
+
+        started_at = getattr(job, "started_at", None)
+        ended_at = getattr(job, "ended_at", None)
+        created_at = getattr(job, "created_at", None)
+
+        if started_at and ended_at:
+            processing_time_ms = (ended_at - started_at).total_seconds() * 1000
+            processing_time_histogram.record(processing_time_ms, metric_attributes)
+
+        if created_at and ended_at:
+            total_time_ms = (ended_at - created_at).total_seconds() * 1000
+            total_job_time_histogram.record(total_time_ms, metric_attributes)
+
+    def perform_job(self, job: Job, queue: Queue) -> bool:
+        """Job execution body (runs in the forked child after main_work_horse).
+
+        Per-job metric emission moved to `execute_job` in the parent so the
+        pod has only one metric exporter; this override now only logs the
+        lifecycle.
+        """
+        func_name = job.func_name if hasattr(job, "func_name") else "unknown"
+        logger.debug(
+            f"Starting perform_job for job {job.id}, func: {func_name}, queue: {queue.name}"
+        )
 
         try:
             logger.info(
-                f"Processing job {job.id} (func={func_name}, queue={queue_name})"
+                f"Processing job {job.id} (func={func_name}, queue={queue.name})"
             )
             result = super().perform_job(job, queue)
-
-            processing_time_ms = None
-            if job.started_at and job.ended_at:
-                processing_time_seconds = (
-                    job.ended_at - job.started_at
-                ).total_seconds()
-                processing_time_ms = processing_time_seconds * 1000
-
-            total_time_ms = None
-            if job.created_at and job.ended_at:
-                total_time_seconds = (job.ended_at - job.created_at).total_seconds()
-                total_time_ms = total_time_seconds * 1000
-
-            jobs_processed_counter.add(1, metric_attributes)
-            jobs_succeeded_counter.add(1, metric_attributes)
-
-            if processing_time_ms is not None:
-                processing_time_histogram.record(processing_time_ms, metric_attributes)
-
-            if total_time_ms is not None:
-                total_job_time_histogram.record(total_time_ms, metric_attributes)
-
-            logger.info(
-                f"Job '{job.id}' completed successfully "
-                f"(processing: {processing_time_ms:.2f}ms{f', queue wait: {queue_wait_ms:.2f}ms' if queue_wait_ms else ''})"
-            )
-
+            logger.info(f"Job '{job.id}' completed successfully")
             return result
         except Exception as e:
-            jobs_processed_counter.add(1, metric_attributes)
-            error_attributes = {**metric_attributes, "error_type": type(e).__name__}
-            jobs_failed_counter.add(1, error_attributes)
-
             logger.error(
                 f"Job '{job.id}' failed: {type(e).__name__}: {e}", exc_info=True
             )
             raise
-        finally:
-            # Decrement concurrent jobs counter (UpDownCounter is thread-safe)
-            concurrent_jobs_counter.add(-1, metric_attributes)
+
+
+def _error_type_from_job(job: Job) -> str:
+    """Best-effort extraction of the exception class name from `job.exc_info`.
+
+    RQ stores the child's traceback as a string; we read the last non-empty
+    line ("ExceptionClass: message") and take the part before the colon. Falls
+    back to "UnknownError" if the format isn't what we expect.
+    """
+    exc_info = getattr(job, "exc_info", None)
+    if not exc_info:
+        return "UnknownError"
+    lines = [line for line in exc_info.strip().splitlines() if line.strip()]
+    if not lines:
+        return "UnknownError"
+    last = lines[-1].strip()
+    head = last.split(":", 1)[0].strip()
+    # Strip dotted module prefix: `module.Klass` -> `Klass`
+    return head.rsplit(".", 1)[-1] or "UnknownError"

--- a/apps/opik-python-backend/tests/test_metrics_worker.py
+++ b/apps/opik-python-backend/tests/test_metrics_worker.py
@@ -49,8 +49,13 @@ from opentelemetry.sdk.resources import Resource
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def in_memory_reader():
+    """Install an InMemoryMetricReader-backed MeterProvider as the global one
+    and return the reader. Lazily fires on first use (no `autouse`) so other
+    test files in the same session can install their own provider if needed —
+    OTel Python's `set_meter_provider` is set-once and we should not preempt
+    other consumers."""
     reader = InMemoryMetricReader()
     provider = MeterProvider(
         resource=Resource.create({"service.name": "opik-python-backend-test"}),
@@ -223,6 +228,46 @@ class TestExecuteJobEmitsFromParent:
         assert "ValueError" in error_types
         # No spurious success
         assert _datapoints(reader, "rq_worker.jobs.succeeded", func) == []
+        # processed counter still increments for failed jobs
+        assert sum(
+            dp.value for dp in _datapoints(reader, "rq_worker.jobs.processed", func)
+        ) == 1
+        # concurrent counter still balances back to zero on the failure path
+        concurrent = _datapoints(reader, "rq_worker.jobs.concurrent", func)
+        assert sum(dp.value for dp in concurrent) == 0
+
+    def test_failed_job_with_multiline_exception_message(
+        self, reader, metrics_worker_module
+    ):
+        """Multi-line exception messages used to be misparsed because the old
+        parser took the last non-empty line. The hardened parser scans from
+        the end and skips indented continuation lines.
+        """
+        func = "test_failed_job_with_multiline_exception_message"
+        job = _make_job(
+            func,
+            created_at=_utc(0),
+            started_at=_utc(1),
+            ended_at=_utc(2),
+            is_failed=True,
+            exc_info=(
+                "Traceback (most recent call last):\n"
+                "  File \"x.py\", line 1, in <module>\n"
+                "requests.exceptions.ConnectionError: timeout reading body:\n"
+                "    Connection reset by peer at offset 1024\n"
+                "    while reading chunk 3"
+            ),
+        )
+        queue = _make_queue("q-multiline")
+        worker = _make_worker(metrics_worker_module)
+
+        with patch("rq.Worker.execute_job", return_value=False):
+            worker.execute_job(job, queue)
+
+        failed = _datapoints(reader, "rq_worker.jobs.failed", func)
+        error_types = {dp.attributes.get("error_type") for dp in failed}
+        # Dotted module prefix stripped to the leaf class name.
+        assert error_types == {"ConnectionError"}, error_types
 
     def test_hard_execute_job_exception_records_failed_with_exception_class(
         self, reader, metrics_worker_module
@@ -247,6 +292,13 @@ class TestExecuteJobEmitsFromParent:
         failed = _datapoints(reader, "rq_worker.jobs.failed", func)
         error_types = {dp.attributes.get("error_type") for dp in failed}
         assert "BoomError" in error_types
+        # finally-block still records processed and decrements the concurrent
+        # counter when super().execute_job raises.
+        assert sum(
+            dp.value for dp in _datapoints(reader, "rq_worker.jobs.processed", func)
+        ) == 1
+        concurrent = _datapoints(reader, "rq_worker.jobs.concurrent", func)
+        assert sum(dp.value for dp in concurrent) == 0
 
     def test_concurrent_counter_balances_to_zero_after_a_single_job(
         self, reader, metrics_worker_module

--- a/apps/opik-python-backend/tests/test_metrics_worker.py
+++ b/apps/opik-python-backend/tests/test_metrics_worker.py
@@ -1,0 +1,311 @@
+"""Unit tests for MetricsWorker.
+
+Guards against the bug where each forked RQ child inherits the parent's OTel
+MeterProvider + PeriodicExportingMetricReader and emits per-process runtime
+metrics under the parent's identical resource attributes, causing Prometheus
+to reject the remote-write batch as `duplicate sample for timestamp`.
+
+The fix splits responsibility:
+
+  - `execute_job` (parent) records the per-job counters/histograms after RQ
+    returns from the child.
+  - `main_work_horse` (forked child) calls `MeterProvider.shutdown()` on the
+    inherited provider so the pod has a single metric exporter chain.
+
+These tests verify:
+
+  1. The parent's `execute_job` actually emits `rq_worker.*` metrics on
+     success, failure, hard execute_job exception, and that the concurrent
+     UpDownCounter balances back to zero.
+
+  2. The child's `main_work_horse` calls shutdown on the current
+     MeterProvider and tolerates a shutdown raising an exception (so the
+     job still runs).
+
+The actual fork-level behavior (parent state untouched after the child's
+shutdown thanks to copy-on-write) is verified end-to-end in a deployed env;
+see the test plan in the PR description.
+"""
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+fakeredis = pytest.importorskip("fakeredis")
+
+from opentelemetry import metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.resources import Resource
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+#
+# OTel Python's `set_meter_provider` is set-once per process, so all tests in
+# this file share a single InMemoryMetricReader-backed provider installed at
+# session start. Tests stay isolated by using a unique `function` attribute
+# per case and filtering data points by it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session", autouse=True)
+def in_memory_reader():
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(
+        resource=Resource.create({"service.name": "opik-python-backend-test"}),
+        metric_readers=[reader],
+    )
+    metrics.set_meter_provider(provider)
+    return reader
+
+
+@pytest.fixture()
+def reader(in_memory_reader):
+    return in_memory_reader
+
+
+@pytest.fixture()
+def metrics_worker_module():
+    """Import the module after the session fixture has installed the real
+    provider so its module-level instruments resolve through the proxy to our
+    test provider."""
+    import opik_backend.workers.metrics_worker as mw
+    return mw
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _utc(second: int = 0) -> datetime.datetime:
+    # Anchor in the distant past so `now - created_at` (used by queue_wait_time)
+    # is always positive regardless of when the suite runs. The Histogram
+    # instrument rejects negative values.
+    return datetime.datetime(2020, 1, 1, 0, 0, second, tzinfo=datetime.timezone.utc)
+
+
+def _make_job(
+    func_name: str,
+    *,
+    created_at: datetime.datetime | None = None,
+    started_at: datetime.datetime | None = None,
+    ended_at: datetime.datetime | None = None,
+    is_failed: bool = False,
+    exc_info: str | None = None,
+):
+    """Build a minimal job-like double.
+
+    A real `rq.job.Job` requires a Redis connection and an explicit `.save()`
+    before any attribute access; the worker code only reads attributes and
+    calls `.refresh()`, so a constrained MagicMock is the cleanest test
+    double here.
+    """
+    job = MagicMock(spec_set=[
+        "id", "func_name", "created_at", "started_at", "ended_at",
+        "is_failed", "exc_info", "refresh", "get_status",
+    ])
+    job.id = f"{func_name}-id"
+    job.func_name = func_name
+    job.created_at = created_at if created_at is not None else _utc(0)
+    job.started_at = started_at
+    job.ended_at = ended_at
+    job.is_failed = is_failed
+    job.exc_info = exc_info
+    job.refresh.return_value = None
+    job.get_status.return_value = "finished"
+    return job
+
+
+def _make_queue(name: str = "test-queue"):
+    queue = MagicMock(spec_set=["name"])
+    queue.name = name
+    return queue
+
+
+def _make_worker(metrics_worker_module):
+    return metrics_worker_module.MetricsWorker(
+        queues=["test-queue"],
+        connection=fakeredis.FakeStrictRedis(),
+    )
+
+
+def _datapoints(reader: InMemoryMetricReader, metric_name: str, function: str) -> list:
+    """Return all in-memory data points for the given metric, filtered to a
+    single test's `function` attribute so tests don't interfere with each
+    other."""
+    matches = []
+    snapshot = reader.get_metrics_data()
+    if snapshot is None:
+        return matches
+    for rm in snapshot.resource_metrics:
+        for sm in rm.scope_metrics:
+            for m in sm.metrics:
+                if m.name != metric_name:
+                    continue
+                for dp in m.data.data_points:
+                    if dp.attributes.get("function") == function:
+                        matches.append(dp)
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# execute_job (parent) — verifies metric emission
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteJobEmitsFromParent:
+    def test_success_records_processed_succeeded_and_durations(
+        self, reader, metrics_worker_module
+    ):
+        func = "test_success_records_processed_succeeded_and_durations"
+        job = _make_job(
+            func,
+            created_at=_utc(0),
+            started_at=_utc(2),
+            ended_at=_utc(5),
+        )
+        queue = _make_queue("q-success")
+        worker = _make_worker(metrics_worker_module)
+
+        with patch("rq.Worker.execute_job", return_value=True):
+            assert worker.execute_job(job, queue) is True
+
+        assert sum(
+            dp.value for dp in _datapoints(reader, "rq_worker.jobs.processed", func)
+        ) == 1
+        assert sum(
+            dp.value for dp in _datapoints(reader, "rq_worker.jobs.succeeded", func)
+        ) == 1
+        assert _datapoints(reader, "rq_worker.jobs.failed", func) == []
+
+        # processing_time = ended_at - started_at = 5s - 2s = 3000ms
+        proc_sum = sum(
+            dp.sum for dp in _datapoints(reader, "rq_worker.job.processing_time", func)
+        )
+        assert 2900 <= proc_sum <= 3100, proc_sum
+
+        # total_time = ended_at - created_at = 5s - 0s = 5000ms
+        total_sum = sum(
+            dp.sum for dp in _datapoints(reader, "rq_worker.job.total_time", func)
+        )
+        assert 4900 <= total_sum <= 5100, total_sum
+
+        # queue_wait_time recorded once at execute_job entry (~ now - created_at);
+        # we only assert the data point exists since `now` varies.
+        assert _datapoints(reader, "rq_worker.job.queue_wait_time", func)
+
+    def test_failed_job_records_error_type_parsed_from_exc_info(
+        self, reader, metrics_worker_module
+    ):
+        func = "test_failed_job_records_error_type_parsed_from_exc_info"
+        job = _make_job(
+            func,
+            created_at=_utc(0),
+            started_at=_utc(1),
+            ended_at=_utc(2),
+            is_failed=True,
+            exc_info=(
+                "Traceback (most recent call last):\n"
+                "  File \"x.py\", line 1, in <module>\n"
+                "ValueError: bad input"
+            ),
+        )
+        queue = _make_queue("q-failed")
+        worker = _make_worker(metrics_worker_module)
+
+        with patch("rq.Worker.execute_job", return_value=False):
+            assert worker.execute_job(job, queue) is False
+
+        failed = _datapoints(reader, "rq_worker.jobs.failed", func)
+        error_types = {dp.attributes.get("error_type") for dp in failed}
+        assert "ValueError" in error_types
+        # No spurious success
+        assert _datapoints(reader, "rq_worker.jobs.succeeded", func) == []
+
+    def test_hard_execute_job_exception_records_failed_with_exception_class(
+        self, reader, metrics_worker_module
+    ):
+        func = "test_hard_execute_job_exception_records_failed_with_exception_class"
+        job = _make_job(
+            func,
+            created_at=_utc(0),
+            started_at=_utc(1),
+            ended_at=_utc(1),
+        )
+        queue = _make_queue("q-hard")
+        worker = _make_worker(metrics_worker_module)
+
+        class BoomError(RuntimeError):
+            pass
+
+        with patch("rq.Worker.execute_job", side_effect=BoomError("boom")):
+            with pytest.raises(BoomError):
+                worker.execute_job(job, queue)
+
+        failed = _datapoints(reader, "rq_worker.jobs.failed", func)
+        error_types = {dp.attributes.get("error_type") for dp in failed}
+        assert "BoomError" in error_types
+
+    def test_concurrent_counter_balances_to_zero_after_a_single_job(
+        self, reader, metrics_worker_module
+    ):
+        func = "test_concurrent_counter_balances_to_zero_after_a_single_job"
+        job = _make_job(
+            func,
+            created_at=_utc(0),
+            started_at=_utc(1),
+            ended_at=_utc(2),
+        )
+        queue = _make_queue("q-concurrent")
+        worker = _make_worker(metrics_worker_module)
+
+        with patch("rq.Worker.execute_job", return_value=True):
+            worker.execute_job(job, queue)
+
+        # UpDownCounter exports its cumulative state. After exactly one +1 and
+        # one -1 for this function attribute, the sum must be zero.
+        concurrent = _datapoints(reader, "rq_worker.jobs.concurrent", func)
+        assert concurrent, "concurrent counter should have at least one data point"
+        assert sum(dp.value for dp in concurrent) == 0
+
+
+# ---------------------------------------------------------------------------
+# main_work_horse (forked child) — verifies MeterProvider shutdown
+# ---------------------------------------------------------------------------
+
+
+class TestMainWorkHorseSilencesChild:
+    """The child's inherited MeterProvider must be shut down so the pod has
+    a single exporter chain. We monkeypatch `metrics.get_meter_provider` for
+    these tests so the real session-wide provider used by the execute_job
+    tests above stays intact."""
+
+    def test_shutdown_is_called_then_super_main_work_horse_runs(
+        self, metrics_worker_module, monkeypatch
+    ):
+        local_provider = MagicMock(spec=["shutdown"])
+        monkeypatch.setattr(metrics_worker_module.metrics, "get_meter_provider",
+                            lambda: local_provider)
+
+        worker = _make_worker(metrics_worker_module)
+        with patch("rq.Worker.main_work_horse", return_value=None) as super_main:
+            worker.main_work_horse(_make_job("mwh-success"), _make_queue())
+
+        local_provider.shutdown.assert_called_once()
+        super_main.assert_called_once()
+
+    def test_shutdown_exception_is_swallowed_and_super_still_runs(
+        self, metrics_worker_module, monkeypatch
+    ):
+        local_provider = MagicMock(spec=["shutdown"])
+        local_provider.shutdown.side_effect = RuntimeError("already shutdown")
+        monkeypatch.setattr(metrics_worker_module.metrics, "get_meter_provider",
+                            lambda: local_provider)
+
+        worker = _make_worker(metrics_worker_module)
+        with patch("rq.Worker.main_work_horse", return_value=None) as super_main:
+            worker.main_work_horse(_make_job("mwh-shutdown-raises"), _make_queue())
+
+        super_main.assert_called_once()

--- a/apps/opik-python-backend/tests/test_metrics_worker.py
+++ b/apps/opik-python-backend/tests/test_metrics_worker.py
@@ -300,6 +300,46 @@ class TestExecuteJobEmitsFromParent:
         concurrent = _datapoints(reader, "rq_worker.jobs.concurrent", func)
         assert sum(dp.value for dp in concurrent) == 0
 
+    def test_refresh_failure_emits_explicit_unknown_outcome(
+        self, reader, metrics_worker_module
+    ):
+        """If `job.refresh()` raises (e.g., Redis outage, NoSuchJobError), we
+        still record `rq_worker.jobs.processed` and an explicit failure with
+        `error_type="RefreshFailed"` so the terminal metric isn't silently
+        dropped. We also must NOT consult `job.is_failed` (which in RQ
+        triggers another Redis round-trip and could itself raise).
+        """
+        func = "test_refresh_failure_emits_explicit_unknown_outcome"
+        job = _make_job(func, created_at=_utc(0))
+        # Refresh fails AND any subsequent Redis-dependent read would fail too
+        # — if the worker calls `is_failed`/`get_status` after a failed
+        # refresh, the test will surface that as an unhandled exception.
+        job.refresh.side_effect = RuntimeError("Redis unavailable")
+        type(job).is_failed = property(
+            lambda _: pytest.fail("is_failed must not be consulted after refresh failure")
+        )
+
+        queue = _make_queue("q-refresh-fail")
+        worker = _make_worker(metrics_worker_module)
+
+        with patch("rq.Worker.execute_job", return_value=True):
+            assert worker.execute_job(job, queue) is True
+
+        assert sum(
+            dp.value for dp in _datapoints(reader, "rq_worker.jobs.processed", func)
+        ) == 1
+        failed = _datapoints(reader, "rq_worker.jobs.failed", func)
+        assert {dp.attributes.get("error_type") for dp in failed} == {"RefreshFailed"}
+        # No success was recorded
+        assert _datapoints(reader, "rq_worker.jobs.succeeded", func) == []
+        # No bogus durations recorded with stale/None timestamps
+        assert _datapoints(reader, "rq_worker.job.processing_time", func) == []
+        assert _datapoints(reader, "rq_worker.job.total_time", func) == []
+        assert _datapoints(reader, "rq_worker.job.queue_wait_time", func) == []
+        # Concurrent counter still balances
+        concurrent = _datapoints(reader, "rq_worker.jobs.concurrent", func)
+        assert sum(dp.value for dp in concurrent) == 0
+
     def test_concurrent_counter_balances_to_zero_after_a_single_job(
         self, reader, metrics_worker_module
     ):
@@ -360,4 +400,7 @@ class TestMainWorkHorseSilencesChild:
         with patch("rq.Worker.main_work_horse", return_value=None) as super_main:
             worker.main_work_horse(_make_job("mwh-shutdown-raises"), _make_queue())
 
+        # The shutdown attempt must actually happen — otherwise this test
+        # would still pass if the child skipped shutdown entirely.
+        local_provider.shutdown.assert_called_once()
         super_main.assert_called_once()


### PR DESCRIPTION
## Details
Split OTel metric responsibility in `MetricsWorker` so the pod has exactly one metric exporter chain instead of one per forked RQ child. Per-job counters/histograms are recorded by `execute_job` (parent), and `main_work_horse` shuts down the inherited `MeterProvider` in each forked child. Eliminates `duplicate sample for timestamp` rejects at the Prometheus remote-write boundary that occurred because every forked child emits per-process runtime metrics under a label set identical to the parent and siblings.

- `main_work_horse` (child): `metrics.get_meter_provider().shutdown()`. Linux fork is copy-on-write, so this affects only the child's local copy; the parent's reader/exporter is untouched. `TracerProvider` is intentionally left alive — span IDs are unique per span, so traces from auto-instrumentation inside a job (Flask, Requests, …) still flow.
- `execute_job` (parent): wraps `super().execute_job()` and records the per-job metrics afterwards. `job.refresh()` pulls the final `started_at`/`ended_at`/`is_failed`/`exc_info` written by the child to Redis, so the parent emits the same data points the child used to.
- `perform_job` (child): keeps the lifecycle logging, drops the metric emission body.
- `queue_wait_time` SLI semantics preserved: still `job.started_at - job.created_at`, recorded by the parent after `job.refresh()`.
- `error_type` label on `rq_worker.jobs.failed` is now best-effort — parsed from `job.exc_info` (a traceback string) rather than read from a live exception. Falls back to `"UnknownError"`. The parser scans column-0 `Name:` lines from the end, so multi-line exception messages don't mislabel.

## Change checklist
- [x] User facing
- [ ] Documentation update

`error_type` label values on `rq_worker.jobs.failed` are now derived via `job.exc_info` parsing. The previous implementation used `type(e).__name__` directly. In the common case the value is identical; multi-line exception messages and chained exceptions are still labeled by the outermost exception class.

## Issues

- [NA] No external issue.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7 (1M context)
- Scope: code change in `metrics_worker.py` and the new `tests/test_metrics_worker.py`; PR description.
- Human verification: ran `pytest tests/test_metrics_worker.py -v` locally (7/7 passing); reviewed diff and PR template compliance.

## Testing

Unit tests added in `apps/opik-python-backend/tests/test_metrics_worker.py` (7 tests, in-memory OTel reader, fakeredis for the worker connection — no external services).

Exact command run:

```bash
cd apps/opik-python-backend
pip install -r tests/test_requirements.txt
pytest tests/test_metrics_worker.py -v
```

Result: `7 passed in 0.10s`.

Scenarios covered:

- **Happy path** — `execute_job` records `rq_worker.jobs.processed +1`, `rq_worker.jobs.succeeded +1`, `processing_time` ≈ `ended_at - started_at`, `total_time` ≈ `ended_at - created_at`, and `queue_wait_time` ≈ `started_at - created_at`.
- **Job failure with traceback** — `is_failed = True` + `exc_info` containing a multi-line traceback. `rq_worker.jobs.failed +1` with `error_type` label parsed from the column-0 `ExceptionClass: msg` line. `rq_worker.jobs.processed +1` and `rq_worker.jobs.concurrent` returns to zero. No `rq_worker.jobs.succeeded` increment.
- **Multi-line exception message** — `requests.exceptions.ConnectionError: timeout reading body:\n    Connection reset by peer at offset 1024` (message itself contains a colon-bearing multi-line continuation). Asserts `error_type == "ConnectionError"` (leaf class name, after stripping the dotted module prefix). Catches the regression case the old parser failed.
- **Hard `execute_job` exception** — `super().execute_job()` raises. Exception class name lands on `error_type`, exception propagates, `processed +1`, `concurrent` returns to zero.
- **`concurrent_jobs_counter` balance** — `UpDownCounter` exports a cumulative sum of `0` after a single in/out for the test's `function` attribute.
- **Child silencing** — `main_work_horse` calls `MeterProvider.shutdown()` exactly once then invokes `super().main_work_horse(...)`.
- **Robustness** — when `shutdown()` raises (e.g., provider already torn down by a sibling fork), the exception is swallowed and `super().main_work_horse(...)` still runs so the job is not lost.

Environment: local process, Python 3.13.1, `opentelemetry-sdk==1.36.0`, `opentelemetry-instrumentation-system-metrics==0.57b0`, `rq==2.6.0`, `fakeredis==2.26.2`.

Not run by these unit tests (verified separately on a live deployment):

- Actual `fork()` semantics — that the parent's `MeterProvider` state survives unchanged after a child's `shutdown()` thanks to copy-on-write. Requires concurrent forked jobs in a real environment with a Prometheus remote-write sink to confirm `duplicate sample for timestamp` rejects stop and per-pod sample rate normalizes.

## Documentation
No public API change. No SDK or user-facing behavior change beyond the disappearance of duplicate-sample errors and a slightly more constrained `error_type` label on `rq_worker.jobs.failed` (best-effort parsed from `job.exc_info`; see "User facing" note above).