### PR TITLE
[OPIK-6511] [FE] fix: hide assistant sidebar wrapper when Ollie disabled

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/AssistantPrewarmer.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantPrewarmer.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import useAssistantBackend from "@/plugins/comet/useAssistantBackend";
+import { useAssistantCompute } from "@/plugins/comet/useAssistantBackend";
 import useAssistantPhaseStore from "@/store/AssistantPhaseStore";
 
 // Mounts at workspace level so PageLayout can read the resolved phase before
@@ -7,12 +7,13 @@ import useAssistantPhaseStore from "@/store/AssistantPhaseStore";
 // Ollie. Shares the `assistant-compute` query key with the sidebar, so this
 // also serves as the compute prewarm.
 const AssistantPrewarmer: React.FC = () => {
-  const { phase } = useAssistantBackend();
+  const { data: computeResult } = useAssistantCompute();
   const setPhase = useAssistantPhaseStore((s) => s.setPhase);
 
   useEffect(() => {
-    setPhase(phase);
-  }, [phase, setPhase]);
+    if (!computeResult) return;
+    setPhase(computeResult.enabled ? "idle" : "disabled");
+  }, [computeResult, setPhase]);
 
   return null;
 };

--- a/apps/opik-frontend/src/plugins/comet/AssistantPrewarmer.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantPrewarmer.tsx
@@ -11,7 +11,13 @@ const AssistantPrewarmer: React.FC = () => {
   const setPhase = useAssistantPhaseStore((s) => s.setPhase);
 
   useEffect(() => {
-    if (!computeResult) return;
+    // Reset to "idle" while data is undefined (initial fetch, workspace
+    // switch, refetch) so a previous workspace's "disabled" phase doesn't
+    // keep the wrapper hidden in a workspace where it should be shown.
+    if (!computeResult) {
+      setPhase("idle");
+      return;
+    }
     setPhase(computeResult.enabled ? "idle" : "disabled");
   }, [computeResult, setPhase]);
 

--- a/apps/opik-frontend/src/plugins/comet/AssistantPrewarmer.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantPrewarmer.tsx
@@ -1,8 +1,19 @@
-import React from "react";
-import { usePrewarmAssistantCompute } from "@/plugins/comet/useAssistantBackend";
+import React, { useEffect } from "react";
+import useAssistantBackend from "@/plugins/comet/useAssistantBackend";
+import useAssistantPhaseStore from "@/store/AssistantPhaseStore";
 
+// Mounts at workspace level so PageLayout can read the resolved phase before
+// the AssistantSidebar wrapper would otherwise reserve space for a disabled
+// Ollie. Shares the `assistant-compute` query key with the sidebar, so this
+// also serves as the compute prewarm.
 const AssistantPrewarmer: React.FC = () => {
-  usePrewarmAssistantCompute();
+  const { phase } = useAssistantBackend();
+  const setPhase = useAssistantPhaseStore((s) => s.setPhase);
+
+  useEffect(() => {
+    setPhase(phase);
+  }, [phase, setPhase]);
+
   return null;
 };
 

--- a/apps/opik-frontend/src/plugins/comet/useAssistantBackend.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAssistantBackend.ts
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import cometApi from "@/plugins/comet/api";
 import { useActiveWorkspaceName } from "@/store/AppStore";
 import { IS_ASSISTANT_DEV } from "@/plugins/comet/constants/assistant";
+import type { AssistantBackendPhase } from "@/types/assistant-sidebar";
 
 const HEALTH_POLL_INTERVAL_MS = 1000;
 const HEALTH_POLL_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
@@ -35,14 +36,6 @@ const fetchAssistantCompute = async (
   const baseUrl = data.computeURL.replace(/\/api\/get-python-panel-url$/, "");
   return { baseUrl, enabled: true };
 };
-
-export type AssistantBackendPhase =
-  | "idle"
-  | "compute"
-  | "health"
-  | "ready"
-  | "error"
-  | "disabled";
 
 interface UseAssistantBackendResult {
   backendUrl: string | null;
@@ -261,23 +254,4 @@ export default function useAssistantBackend(
     retry,
     retryCount,
   };
-}
-
-// Shares the `assistant-compute` queryKey so the sidebar's later subscription
-// reuses the prewarmed cache instead of re-issuing the request. Plugin-level
-// gating (OSS vs Comet) is handled by whether the AssistantPrewarmer plugin
-// component is registered in the store.
-export function usePrewarmAssistantCompute(): void {
-  const workspaceName = useActiveWorkspaceName();
-  const queryClient = useQueryClient();
-
-  useEffect(() => {
-    if (IS_ASSISTANT_DEV) return;
-    if (!workspaceName) return;
-    queryClient.prefetchQuery({
-      queryKey: getComputeQueryKey(workspaceName),
-      queryFn: ({ signal }) => fetchAssistantCompute(workspaceName, signal),
-      staleTime: Infinity,
-    });
-  }, [workspaceName, queryClient]);
 }

--- a/apps/opik-frontend/src/plugins/comet/useAssistantBackend.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAssistantBackend.ts
@@ -80,23 +80,29 @@ interface UseAssistantBackendOptions {
   enabled?: boolean;
 }
 
-export default function useAssistantBackend(
-  options?: UseAssistantBackendOptions,
-): UseAssistantBackendResult {
+// Compute-only slice of the assistant backend. Shared with `AssistantPrewarmer`
+// so it can detect Ollie-disabled without running a second copy of the
+// health-poll + pod-death recovery state machine that lives in the full hook.
+export function useAssistantCompute(options?: UseAssistantBackendOptions) {
   const configEnabled = options?.enabled ?? true;
   const workspaceName = useActiveWorkspaceName();
-
-  const {
-    data: computeResult,
-    isLoading: isComputeLoading,
-    error: computeError,
-  } = useQuery<ComputeResult>({
+  return useQuery<ComputeResult>({
     queryKey: getComputeQueryKey(workspaceName),
     queryFn: ({ signal }) => fetchAssistantCompute(workspaceName, signal),
     enabled: !IS_ASSISTANT_DEV && configEnabled && !!workspaceName,
     staleTime: Infinity,
     retry: 2,
   });
+}
+
+export default function useAssistantBackend(
+  options?: UseAssistantBackendOptions,
+): UseAssistantBackendResult {
+  const {
+    data: computeResult,
+    isLoading: isComputeLoading,
+    error: computeError,
+  } = useAssistantCompute(options);
 
   const baseUrl = computeResult?.baseUrl ?? null;
   const computeEnabled = computeResult?.enabled ?? false;

--- a/apps/opik-frontend/src/store/AssistantPhaseStore.ts
+++ b/apps/opik-frontend/src/store/AssistantPhaseStore.ts
@@ -7,9 +7,6 @@ interface AssistantPhaseStore {
   setPhase: (phase: AssistantBackendPhase) => void;
 }
 
-// Default "idle" keeps OSS behavior unchanged: when no plugin writes to this
-// store, the layout gate `phase !== "disabled"` stays true and falls through
-// to the existing `!!AssistantSidebar` check, which is null in OSS.
 const useAssistantPhaseStore = create<AssistantPhaseStore>((set) => ({
   phase: "idle",
   setPhase: (phase) => set({ phase }),

--- a/apps/opik-frontend/src/store/AssistantPhaseStore.ts
+++ b/apps/opik-frontend/src/store/AssistantPhaseStore.ts
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+
+import type { AssistantBackendPhase } from "@/types/assistant-sidebar";
+
+interface AssistantPhaseStore {
+  phase: AssistantBackendPhase;
+  setPhase: (phase: AssistantBackendPhase) => void;
+}
+
+// Default "idle" keeps OSS behavior unchanged: when no plugin writes to this
+// store, the layout gate `phase !== "disabled"` stays true and falls through
+// to the existing `!!AssistantSidebar` check, which is null in OSS.
+const useAssistantPhaseStore = create<AssistantPhaseStore>((set) => ({
+  phase: "idle",
+  setPhase: (phase) => set({ phase }),
+}));
+
+export default useAssistantPhaseStore;

--- a/apps/opik-frontend/src/types/assistant-sidebar.ts
+++ b/apps/opik-frontend/src/types/assistant-sidebar.ts
@@ -5,6 +5,14 @@ export type BridgeSurface = "sidebar" | "page";
 export type AssistantSurfaceVariant = "page" | "sidebar" | "collapsed";
 export type NotificationType = "success" | "error" | "info";
 
+export type AssistantBackendPhase =
+  | "idle"
+  | "compute"
+  | "health"
+  | "ready"
+  | "error"
+  | "disabled";
+
 export interface ProjectStats {
   traceCount: number;
   experimentCount: number;

--- a/apps/opik-frontend/src/v2/layout/PageLayout/PageLayout.tsx
+++ b/apps/opik-frontend/src/v2/layout/PageLayout/PageLayout.tsx
@@ -4,6 +4,7 @@ import SideBar from "@/v2/layout/SideBar/SideBar";
 import TopBar from "@/v2/layout/TopBar/TopBar";
 import useLocalStorageState from "use-local-storage-state";
 import usePluginsStore from "@/store/PluginsStore";
+import useAssistantPhaseStore from "@/store/AssistantPhaseStore";
 import WelcomeWizardDialog from "@/v2/pages-shared/WelcomeWizard/WelcomeWizardDialog";
 import useWelcomeWizardStatus from "@/api/welcome-wizard/useWelcomeWizardStatus";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
@@ -48,6 +49,7 @@ const PageLayout = () => {
 
   const RetentionBanner = usePluginsStore((state) => state.RetentionBanner);
   const AssistantSidebar = usePluginsStore((state) => state.AssistantSidebar);
+  const assistantPhase = useAssistantPhaseStore((s) => s.phase);
 
   const matchRoute = useMatchRoute();
   // TODO: OPIK-6260 - Remove /home match once home page redesign is restored
@@ -59,7 +61,12 @@ const PageLayout = () => {
       to: "/$workspaceName/projects/$projectId/home",
     });
 
-  const showAssistantSidebar = !!AssistantSidebar && !isOlliePage;
+  // `assistantPhase` defaults to "idle" and is only set to "disabled" by the
+  // AssistantPrewarmer plugin after `/opik/ollie/compute` returns
+  // `{enabled: false}`. In OSS no plugin writes to the store, so the gate
+  // falls through to `!!AssistantSidebar` (null in OSS).
+  const showAssistantSidebar =
+    !!AssistantSidebar && !isOlliePage && assistantPhase !== "disabled";
 
   const assistantWidth = showAssistantSidebar ? assistantSidebarWidth : 0;
   const { isPhone } = useIsPhone();


### PR DESCRIPTION
## Details

In Comet-built Opik FE builds (`--mode comet`), disabling Ollie via helm (`comet.opik.ollie.enabled=false`) left a ~400px blank white strip on the right of every non-Ollie page. The inner `AssistantSidebar` plugin correctly returned `null` for `phase: "disabled"`, but `PageLayout`'s outer wrapper still reserved the stored width (default 400px) and the `--assistant-sidebar-width` CSS var stayed non-zero, displacing main content.

Route the resolved backend phase through a new core `AssistantPhaseStore` so the layout gate can collapse the wrapper before space is reserved. The `AssistantPrewarmer` plugin (already mounted at workspace level) publishes the phase via a new compute-only `useAssistantCompute` hook so the pod-death recovery state machine isn't duplicated when the sidebar is also mounted.

- `AssistantBackendPhase` type moved to `types/assistant-sidebar.ts` so the core store can import it without reaching into `plugins/comet/` (preserves the plugin-isolation rule from `WorkspaceGuard.tsx`).
- `useAssistantCompute` is the compute-only slice of `useAssistantBackend`; the full hook now delegates to it.
- Orphaned `usePrewarmAssistantCompute` removed.

**Why this is not observed in OSS Opik:** OSS builds with `BUILD_MODE=production`, so `PluginsStore.setupPlugins` exits early for unknown plugin folders. `AssistantSidebar` is never registered, the existing `!!AssistantSidebar` gate is `false`, and the wrapper is never rendered. The bug only surfaces in `--mode comet` builds shipped via `comet-ml-helm-chart`.

**OSS safety of this fix:** In OSS no plugin writes to `AssistantPhaseStore`, so `phase` stays `"idle"`. The new `phase !== "disabled"` clause is always true in OSS and falls through to `!!AssistantSidebar` (null). Behavior unchanged.

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6511

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: Root-cause analysis, fix design, implementation, PR review pass, this description
- Human verification: Author reviewed all diffs; pre-commit ran ESLint, `tsc --noEmit`, and dep-cruiser locally (all green) on both commits

## Testing

Pre-commit on each commit:

- `npm run lint:fix` (ESLint + Stylelint) — passed
- `npm run typecheck` (`tsc --project tsconfig.json --noEmit`) — passed
- `npm run deps:validate` (dependency-cruiser) — passed, no new violations

Manual scenarios to validate before merge:

- **Ollie disabled (e.g. self-hosted-eks):** load any non-Ollie page; verify no blank strip on the right and main content uses full width.
- **Ollie enabled (dev/prod):** sidebar still mounts, loader renders during `compute`/`health` phases, iframe renders when `ready`.
- **OSS build (`BUILD_MODE=production`):** sidebar absent as before; no extra network calls for `/opik/ollie/compute`.
- **First-visit flash:** on first visit in a disabled-Ollie env, the wrapper may briefly render with the loader during `phase: "compute"` (~50–200ms) before collapsing. Acceptable trade-off (avoids a flash for the common Ollie-enabled case). Subsequent visits hit the cached `staleTime: Infinity` result and render correctly from the start.

## Documentation

No documentation changes required — this is an internal layout-gating fix; the helm option `comet.opik.ollie.enabled` and its behavior are unchanged.