### PR TITLE
[NA] [BE] fix: prevent semaphore permits from going negative in LockService

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedissonLockService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedissonLockService.java
@@ -89,7 +89,7 @@ class RedissonLockService implements LockService {
         long ttlInMillis = Math.max(duration.toMillis(), defaultLockTTL.toMillis());
 
         return semaphore
-                .setPermits(1)
+                .trySetPermits(1)
                 .then(Mono.defer(() -> semaphore.acquire(duration.toMillis(), TimeUnit.MILLISECONDS)))
                 .flatMap(locked -> expire(Duration.ofMillis(ttlInMillis), locked, semaphore));
     }
@@ -139,7 +139,7 @@ class RedissonLockService implements LockService {
         RPermitExpirableSemaphoreReactive semaphore = getSemaphore(lock);
         log.debug(TRYING_TO_LOCK_WITH, lock);
 
-        return Mono.defer(() -> semaphore.setPermits(1)
+        return Mono.defer(() -> semaphore.trySetPermits(1)
                 //Try to acquire the lock until the lockWaitTime expires if the lock is not available it will return Mono.empty()
                 // If the lock is acquired, it sets the expiration time using the actionTimeout
                 .then(Mono.defer(() -> semaphore.tryAcquire(lockWaitTime.toMillis(), actionTimeout.toMillis(),

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/RedissonLockServiceIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/RedissonLockServiceIntegrationTest.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
 import static com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
@@ -342,5 +343,49 @@ class RedissonLockServiceIntegrationTest {
         // Verify the fallback action was executed
         assertEquals(1, results.size());
         assertEquals("fallback-action", results.getFirst());
+    }
+
+    /**
+     * Regression guard for the production failure where bestEffortLock with
+     * holdUntilExpiry=false drove the underlying Redis counter to -1 across replicas,
+     * blocking subsequent job cycles until the semaphore key fully expired.
+     */
+    @Test
+    void testBestEffortLock_DoesNotDriveCounterNegative(LockService lockService, RedissonReactiveClient redisClient) {
+        var lock = new LockService.Lock(UUID.randomUUID(), "best-effort-lock-permit-underflow");
+        var semaphore = redisClient.getPermitExpirableSemaphore(lock.key());
+
+        var longLeaseSeconds = 30;
+        // Inject the divergent state: temporarily raise the limit to 2 and acquire both
+        // with a long lease so both permits remain valid for the rest of the test. This
+        // mirrors the production shape where the semaphore ends up holding more permits
+        // than the configured limit and the next bestEffortLock cycle observes that
+        // divergence.
+        assertThat(semaphore.trySetPermits(2).block()).isTrue();
+        var permit1 = semaphore.tryAcquire(0L, longLeaseSeconds, TimeUnit.SECONDS).block();
+        var permit2 = semaphore.tryAcquire(0L, longLeaseSeconds, TimeUnit.SECONDS).block();
+        assertThat(permit1).isNotNull();
+        assertThat(permit2).isNotNull();
+        assertEquals(0, semaphore.availablePermits().block());
+
+        // Run a best-effort acquire while the divergent state is in place. The fix
+        // (trySetPermits) leaves the counter at 0; the pre-fix (setPermits) drops it to -1.
+        StepVerifier.create(lockService.bestEffortLock(
+                lock,
+                Mono.fromCallable(() -> "no-op-action"),
+                Mono.empty(),
+                Duration.ofSeconds(1),
+                Duration.ofMillis(100)))
+                .verifyComplete();
+
+        // availablePermits() opportunistically cleans up expired permits; with the long
+        // lease above, both injected permits are still valid, so it returns the raw
+        // counter value.
+        assertThat(semaphore.availablePermits().block())
+                .as("counter must not underflow when bestEffortLock runs against a divergent state")
+                .isGreaterThanOrEqualTo(0);
+
+        semaphore.release(permit1).block();
+        semaphore.release(permit2).block();
     }
 }


### PR DESCRIPTION
## Details

Recurrent jobs using `bestEffortLock` with `holdUntilExpiry=false` were occasionally driving the underlying Redis permit counter below zero in multi-replica setups, blocking subsequent cycles across all replicas until the semaphore key fully expired.

The root cause was the use of Redisson's `setPermits(1)` on every acquire: when the semaphore's state ever diverged from the configured limit, that call could compute a negative delta and underflow the counter. The fix switches both `bestEffortLock` and `executeWithLock` to `trySetPermits(1)`, which only initialises the counter when missing and never modifies an existing value — preserving the intent (initialise once) while making the underflow path unreachable.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: assisted (root cause investigation, fix, regression test)
- Human verification: code review + integration test verifying the regression against both pre-fix and post-fix code

## Testing

- Added `RedissonLockServiceIntegrationTest#testBestEffortLock_DoesNotDriveCounterNegative` covering the regression. Verified it fails against the pre-fix `setPermits` code (counter observed at -1) and passes against the fix.
- Ran the full `RedissonLockServiceIntegrationTest` suite (10 tests) against the fix: all pass.
- Commands run locally:
  - `mvn test -Dtest=RedissonLockServiceIntegrationTest`
  - `mvn test-compile`

## Documentation

N/A — internal infrastructure change with no user-facing API or behaviour difference under normal operation.