### PR TITLE
[OPIK-6493] [BE] fix: assign palette color to auto-created environments

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
@@ -27,7 +27,7 @@ interface EnvironmentDAO {
 
     @SqlBatch("INSERT IGNORE INTO environments (id, workspace_id, name, color, position, created_by, last_updated_by) "
             +
-            "VALUES (:bean.id, :workspaceId, :bean.name, 'default', 0, :userName, :userName)")
+            "VALUES (:bean.id, :workspaceId, :bean.name, COALESCE(:bean.color, 'default'), 0, :userName, :userName)")
     void saveBatch(@Bind("workspaceId") String workspaceId, @Bind("userName") String userName,
             @BindMethods("bean") List<Environment> environments);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
@@ -43,6 +43,14 @@ import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
 @ImplementedBy(EnvironmentServiceImpl.class)
 public interface EnvironmentService {
 
+    List<String> AUTO_COLORS = List.of(
+            "#64748b", "#8b5cf6", "#bf399e", "#f43f5e", "#ef4444",
+            "#f97316", "#eab308", "#10b981", "#06b6d4", "#3b82f6");
+
+    static String pickAutoColor(String name) {
+        return AUTO_COLORS.get(Math.floorMod(name.hashCode(), AUTO_COLORS.size()));
+    }
+
     Environment create(Environment environment);
 
     void bulkCreate(Set<String> names, String workspaceId, String userName);
@@ -84,8 +92,13 @@ class EnvironmentServiceImpl implements EnvironmentService {
         String userName = requestContext.get().getUserName();
         String workspaceId = requestContext.get().getWorkspaceId();
 
+        String color = StringUtils.isBlank(environment.color())
+                ? EnvironmentService.pickAutoColor(environment.name())
+                : environment.color();
+
         var newEnvironment = environment.toBuilder()
                 .id(id)
+                .color(color)
                 .createdBy(userName)
                 .lastUpdatedBy(userName)
                 .build();
@@ -153,6 +166,7 @@ class EnvironmentServiceImpl implements EnvironmentService {
                             .map(name -> Environment.builder()
                                     .id(idGenerator.generateId())
                                     .name(name)
+                                    .color(EnvironmentService.pickAutoColor(name))
                                     .build())
                             .toList();
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/EnvironmentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/EnvironmentsResourceTest.java
@@ -12,6 +12,7 @@ import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
 import com.comet.opik.api.resources.utils.TestUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
 import com.comet.opik.api.resources.utils.resources.EnvironmentsResourceClient;
+import com.comet.opik.domain.EnvironmentService;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.fasterxml.uuid.Generators;
@@ -174,16 +175,20 @@ class EnvironmentsResourceTest {
         }
 
         @Test
-        @DisplayName("create with only name uses defaults: color='default', position=0, description=null")
+        @DisplayName("create with only name picks a palette color, position=0, description=null")
         void createWithDefaults() {
             var input = Environment.builder().name(randomEnvName()).build();
-            var expected = input.toBuilder().color("default").position(0).build();
+            var expected = input.toBuilder()
+                    .color(EnvironmentService.pickAutoColor(input.name()))
+                    .position(0)
+                    .build();
 
             UUID id = environmentsClient.createEnvironment(input, API_KEY, WORKSPACE_NAME);
 
             try (var response = environmentsClient.callGet(id, API_KEY, WORKSPACE_NAME)) {
                 var fetched = response.readEntity(Environment.class);
                 assertCreatedMatches(fetched, expected);
+                assertThat(fetched.color()).isIn(EnvironmentService.AUTO_COLORS);
             }
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -62,6 +62,7 @@ import com.comet.opik.api.resources.utils.traces.TraceDBUtils;
 import com.comet.opik.api.sorting.Direction;
 import com.comet.opik.api.sorting.SortableFields;
 import com.comet.opik.api.sorting.SortingField;
+import com.comet.opik.domain.EnvironmentService;
 import com.comet.opik.domain.FeedbackScoreMapper;
 import com.comet.opik.domain.SpanType;
 import com.comet.opik.domain.cost.CostService;
@@ -2494,7 +2495,7 @@ class TracesResourceTest {
         private static final int ENVIRONMENT_CAP = 5;
 
         @Test
-        @DisplayName("when trace is created with a new environment, then it is auto-created")
+        @DisplayName("when trace is created with a new environment, then it is auto-created with a palette color")
         void create__whenTraceWithNewEnvironment__thenEnvironmentAutoCreated() {
             String apiKey = UUID.randomUUID().toString();
             String workspaceName = UUID.randomUUID().toString();
@@ -2517,8 +2518,13 @@ class TracesResourceTest {
                     .untilAsserted(() -> {
                         try (var response = environmentsResourceClient.callFind(apiKey, workspaceName)) {
                             var page = response.readEntity(Environment.EnvironmentPage.class);
-                            assertThat(page.content().stream().map(Environment::name))
-                                    .contains(envName);
+                            Environment autoCreated = page.content().stream()
+                                    .filter(env -> envName.equals(env.name()))
+                                    .findFirst()
+                                    .orElse(null);
+                            assertThat(autoCreated).isNotNull();
+                            assertThat(autoCreated.color())
+                                    .isEqualTo(EnvironmentService.pickAutoColor(envName));
                         }
                     });
         }


### PR DESCRIPTION
## Details

Environments auto-created from trace ingestion (and manual environment creates without an explicit color) all received `color='default'`, so the UI rendered every environment with the same color.

- Added `AUTO_COLORS` palette and `pickAutoColor(name)` helper on the `EnvironmentService` interface, matching the FE palette: `#64748b, #8b5cf6, #bf399e, #f43f5e, #ef4444, #f97316, #eab308, #10b981, #06b6d4, #3b82f6`
- `EnvironmentService.create()` now assigns a palette color when `environment.color()` is null/blank
- `EnvironmentService.bulkCreate()` (the trace-driven auto-create path) now assigns a palette color when building the new environment
- `EnvironmentDAO.saveBatch()` no longer hardcodes `'default'`; it now uses the service-supplied color, with `COALESCE(:bean.color, 'default')` as a safety fallback
- Color selection is deterministic by `name.hashCode()`, so the same environment name always maps to the same color across recreations

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6493

## Testing

- Updated `EnvironmentsResourceTest.createWithDefaults` to assert that a create without a color returns one of `AUTO_COLORS` and matches `pickAutoColor(name)`
- Updated `TracesResourceTest` "Environment auto-create on trace ingestion" test to assert the auto-created environment receives the expected palette color
- Manually verified via the reproduction script in the ticket: each of 10 random environments now renders with distinct palette colors in the UI

## Documentation

N/A
