### PR TITLE
[OPIK-6167] [FE] fix: avoid double right border in grouped rows

### DIFF
--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -832,14 +832,21 @@
 
   td:last-child,
   th:last-child,
-  // Pinned/grouped cells use box-shadow for their border (see getCommonPinningStyles)
-  .comet-pinned-cell,
-  .comet-grouped-cell ~ td {
+  // Pinned cells use box-shadow for their border (see getCommonPinningStyles)
+  .comet-pinned-cell {
     border-right: none;
   }
 
   .comet-pinned-last-left {
     box-shadow: inset -1px 0px 0px 0px hsl(var(--border));
+  }
+
+  // In group rows the grouped cell paints its right border via inline
+  // box-shadow; the immediately-adjacent aggregated cell is only a thin
+  // (~1px) phantom slot whose own border-right would render as a second
+  // line right next to it. Suppress only that one neighbour's border-right.
+  .comet-grouped-cell + td {
+    border-right: none;
   }
 }
 


### PR DESCRIPTION
## Details

BEFORE
<img width="894" height="439" alt="image" src="https://github.com/user-attachments/assets/395a3a8f-a27b-4284-b691-2f333f7b13f5" />
AFTER
<img width="1555" height="458" alt="image" src="https://github.com/user-attachments/assets/a7c94898-6400-4e02-a51d-832e8b148915" />


In group rows, the synthetic grouping column emitted by `generateGroupedRowCellDef` is always `size: 1, minSize: 1`. After `cells.sort` in `renderRow`, the grouped `<td>` moves to DOM position 0, so the immediately-adjacent `<td>` is rendered with `<col>[1]`'s width (1px). That phantom cell's own `border-right` was painting a second 1px line right next to the grouped cell's inline `box-shadow`, producing a visible double border.

The previous fix used the general sibling combinator (`.comet-grouped-cell ~ td`) which over-corrected: it stripped the right border off every cell after the grouped cell, leaving group rows without normal column separators. Switching to the adjacent sibling combinator (`+`) targets only the 1px phantom slot, killing the double border without affecting the other cells in the row.

- One-line semantic change in `apps/opik-frontend/src/main.scss`: `~` → `+`, plus an explanatory comment.
- No JS/TS changes. No changes to `DataTable.tsx`, `utils.tsx`, or shared cell components.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6167

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: CSS-only fix to `apps/opik-frontend/src/main.scss`
- Human verification: stylelint passes; manual UI verification pending

## Testing

- `npx stylelint src/main.scss` — clean

Manual checks to perform after merge / preview:
- Experiments page → group by "Item source" → grouped row shows a single right border at the end of the grouped cell, normal column separators (`pass_rate`, `duration`, etc.) restored on the same row
- Toggle grouping off and back on → non-group rows retain all expected borders
- Prompt detail → Experiments tab → same verification

## Documentation