### PR TITLE
[OPIK-5723] [SCRIPTS] feat: surface Gemma 4 + clean dead Gemma in Gemini sync

### DIFF
--- a/scripts/sync_provider_models.py
+++ b/scripts/sync_provider_models.py
@@ -94,8 +94,6 @@ GEMINI_EXCLUDE_PATTERNS = [
     r"-image-generation",
     r"-computer-use-",
     r"^learnlm",
-    r"^gemma",
-    r"^gemini-gemma",
     r"^gemini-robotics",
     r"^text-embedding",
     r"^aqa$",
@@ -153,6 +151,15 @@ GEMINI_DROPDOWN_EXCLUDE = [
     r"-latest$",
     r"^nano-banana",
     r"-image",
+    r"-tts",
+    # Google removed Gemma 2 and Gemma 3 from the AI Studio Gemini API in
+    # April 2026 (replaced by Gemma 4). The LiteLLM prices JSON still ships
+    # `gemini/gemma-3-*-it` and `gemini/gemini-gemma-2-*-it` entries, but
+    # generateContent on /v1beta no longer routes them. Hide from dropdown
+    # until Gemma 4 (`gemma-4-31b-it`, `gemma-4-26b-a4b-it`) lands in the
+    # sync sources.
+    r"^gemma-(2|3)-",
+    r"^gemini-gemma-",
 ]
 
 VERTEXAI_DROPDOWN_EXCLUDE = [
@@ -200,11 +207,28 @@ def _anthropic_sort_key(entry: ModelEntry) -> tuple:
 
 
 def _gemini_sort_key(entry: ModelEntry) -> tuple:
-    """Sort Gemini/VertexAI: by generation desc, then Pro → Flash → Flash-Lite."""
+    """Sort Gemini first by generation, then Gemma by generation/size.
+
+    Within Gemini: Pro → Flash → Flash-Lite.
+    Within Gemma: base `gemma-N-*b-it` (small → large) before `gemma-Nn-*` variants.
+    """
     value = entry.value.removeprefix("vertex_ai/")
+
+    # Gemma family (including legacy `gemini-gemma-*`) — sorts after Gemini.
+    gemma = re.match(r'^(?:gemini-)?gemma-(\d+)(n)?(?:-(e?\d+)b-)?', value)
+    if gemma:
+        major = int(gemma.group(1))
+        is_3n = gemma.group(2) == "n"
+        size_token = gemma.group(3) or ""
+        size_digits = re.search(r"\d+", size_token)
+        size = int(size_digits.group()) if size_digits else 99
+        sub = 0 if not is_3n else 1
+        return (1, -major, sub, size, value)
+
+    # Gemini family — existing behaviour.
     m = re.match(r'^gemini-(\d+)(?:\.(\d+))?', value)
     if not m:
-        return (99, 0, 0, value)
+        return (1, 99, 0, 99, value)
     major, minor = int(m.group(1)), int(m.group(2)) if m.group(2) else 0
     if '-pro' in value:
         tier = 0
@@ -214,7 +238,7 @@ def _gemini_sort_key(entry: ModelEntry) -> tuple:
         tier = 1
     else:
         tier = 3
-    return (-major, -minor, tier, value)
+    return (0, -major, -minor, tier, value)
 
 
 def _deduplicate_by_base(entries: list[ModelEntry]) -> list[ModelEntry]:
@@ -334,6 +358,10 @@ def generate_anthropic_label(model_str: str) -> str:
 
 def generate_gemini_label(model_str: str) -> str:
     s = model_str.removeprefix("vertex_ai/")
+    # Google dropped the "Gemini" prefix from Gemma branding; the prices JSON
+    # still carries the old `gemini-gemma-*` keys. Collapse to match current
+    # naming so the dropdown reads "Gemma 2 …" not "Gemini Gemma 2 …".
+    s = re.sub(r"^gemini-gemma-", "gemma-", s)
     parts = s.split("-")
     result = []
     for p in parts:


### PR DESCRIPTION
## Details

Updates `scripts/sync_provider_models.py` so the daily provider-sync workflow exposes Gemma chat models on the Gemini provider going forward.

**Generated artifacts (Java enum, TS types, dropdown YAML, `llm-models-default.yaml`) are intentionally NOT in this PR.** The daily cron will produce them on the next scheduled run and upload them to the CDN through the existing workflow path. This keeps the review scope to script logic only.

Script changes:

- Drop `^gemma` and `^gemini-gemma` from `GEMINI_EXCLUDE_PATTERNS` so Gemma models surfaced by `generativelanguage.googleapis.com/v1beta/models` are no longer filtered. Verified live against the API: it currently exposes `gemma-4-31b-it` and `gemma-4-26b-a4b-it` with `generateContent` support. Gemma 2 / Gemma 3 were retired by Google in April 2026.
- Add `-tts`, `^gemma-(2|3)-`, and `^gemini-gemma-` to `GEMINI_DROPDOWN_EXCLUDE`. Keeps `gemini-3.1-flash-tts-preview` out of the Playground picker, and hides the dead Gemma 2 / 3 IDs that still ship in the LiteLLM prices JSON. Models stay in the backend enum so older traces using them still resolve.
- Extend `_gemini_sort_key` with a family tier (Gemini=0, Gemma=1) so Gemma sorts after Gemini in the dropdown, ordered by generation desc and parameter size asc.
- Collapse the legacy `gemini-gemma-` label prefix to `gemma-` in `generate_gemini_label` so any future Gemma row reads "Gemma N …" not "Gemini Gemma N …".

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5723

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: script logic only (artifact generation delegated to existing CI workflow)
- Human verification: live API verification (`/v1beta/models` returns Gemma 4 with `generateContent`), end-to-end `generateContent` call against `gemma-4-31b-it`, local dry-run + force-regen, manual sort-key test

## Testing

- `python scripts/sync_provider_models.py --dry-run` with `GEMINI_API_KEY` set: Gemini section reports `+ gemma-4-26b-a4b-it` and `+ gemma-4-31b-it` under "Added".
- Direct API call: `POST /v1beta/models/gemma-4-31b-it:generateContent` returned a response with usage metadata (including `thoughtsTokenCount`, so reasoning-capable).
- Synthetic sort-key test confirmed ordering: `gemini-3.1-pro-preview` → … → `gemini-2.0-flash-lite` → `gemma-4-31b-it` etc., with Gemma after Gemini grouped by generation/size.
- Static inspection of backend tests referencing `GeminiModelName`: only `LlmProviderFactoryTest.testGetService` enumerates `values()` parametrically, no count/membership assertions; no test updates required when Gemma 4 lands.

Once merged, the daily `Sync Provider Models Daily` workflow on `main` will produce the artifact PR + S3 upload + CloudFront invalidation through its normal path.

## Documentation

N/A