### PR TITLE
[OPIK-6515] [FE][BE] fix: gate onboarding demo-loading flow on demoDataEnabled toggle

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1011,6 +1011,9 @@ serviceToggles:
   # Default: true
   # Description: Whether or not dataset export to CSV feature is enabled
   datasetExportEnabled: ${DATASET_EXPORT_ENABLED:-"false"}
+  # Default: true
+  # Description: Whether the deployment is expected to produce demo project data on signup. When false, the FE skips the onboarding demo-loading screen and lets the user proceed to the empty workspace immediately.
+  demoDataEnabled: ${TOGGLE_DEMO_DATA_ENABLED:-"true"}
   # Default: false
   # Description: Whether or not Optimization Studio feature is enabled
   optimizationStudioEnabled: ${TOGGLE_OPTIMIZATION_STUDIO_ENABLED:-"false"}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
@@ -46,6 +46,8 @@ public class ServiceTogglesConfig {
     @NotNull boolean datasetVersioningEnabled;
     @JsonProperty
     @NotNull boolean datasetExportEnabled;
+    @JsonProperty
+    @NotNull boolean demoDataEnabled;
     // LLM Provider feature flags
     @JsonProperty
     @NotNull boolean openaiProviderEnabled;

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -582,6 +582,9 @@ serviceToggles:
   # Default: true
   # Description: Whether or not dataset export to CSV feature is enabled
   datasetExportEnabled: "true"
+  # Default: true
+  # Description: Whether the deployment is expected to produce demo project data on signup
+  demoDataEnabled: "true"
   # Default: false
   # Description: Whether or not Optimization Studio feature is enabled
   optimizationStudioEnabled: "false"

--- a/apps/opik-frontend/src/contexts/feature-toggles-provider.tsx
+++ b/apps/opik-frontend/src/contexts/feature-toggles-provider.tsx
@@ -25,6 +25,7 @@ const DEFAULT_STATE: FeatureToggles = {
   [FeatureToggleKeys.CSV_UPLOAD_ENABLED]: false,
   [FeatureToggleKeys.EXPORT_ENABLED]: true,
   [FeatureToggleKeys.DATASET_EXPORT_ENABLED]: true,
+  [FeatureToggleKeys.DEMO_DATA_ENABLED]: true,
   [FeatureToggleKeys.OPTIMIZATION_STUDIO_ENABLED]: false,
   [FeatureToggleKeys.SPAN_LLM_AS_JUDGE_ENABLED]: false,
   [FeatureToggleKeys.SPAN_USER_DEFINED_METRIC_PYTHON_ENABLED]: false,

--- a/apps/opik-frontend/src/types/feature-toggles.ts
+++ b/apps/opik-frontend/src/types/feature-toggles.ts
@@ -10,6 +10,7 @@ export enum FeatureToggleKeys {
   CSV_UPLOAD_ENABLED = "csv_upload_enabled",
   EXPORT_ENABLED = "export_enabled",
   DATASET_EXPORT_ENABLED = "dataset_export_enabled",
+  DEMO_DATA_ENABLED = "demo_data_enabled",
   SPAN_LLM_AS_JUDGE_ENABLED = "span_llm_as_judge_enabled",
   SPAN_USER_DEFINED_METRIC_PYTHON_ENABLED = "span_user_defined_metric_python_enabled",
   OPTIMIZATION_STUDIO_ENABLED = "optimization_studio_enabled",

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ConnectAgentStep.tsx
@@ -3,6 +3,8 @@ import useLocalStorageState from "use-local-storage-state";
 import { ArrowRight, MonitorPlay, Undo2 } from "lucide-react";
 import { useFeatureFlagVariantKey } from "posthog-js/react";
 import { Button } from "@/ui/button";
+import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
+import { FeatureToggleKeys } from "@/types/feature-toggles";
 import { Separator } from "@/ui/separator";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/ui/tabs";
 import Slack from "@/icons/slack.svg?react";
@@ -40,6 +42,9 @@ const ConnectAgentStep: React.FC = () => {
   const { goToStep, agentName } = useAgentOnboarding();
   const InviteDevButton = usePluginsStore((state) => state.InviteDevButton);
   const apiKey = useUserApiKey();
+  const demoDataEnabled = useIsFeatureEnabled(
+    FeatureToggleKeys.DEMO_DATA_ENABLED,
+  );
 
   // Variants: "control" = AI-assisted tab shows "Install with AI" (Opik skills prompt); "connect-to-ollie" = AI-assisted tab shows "Connect to Ollie"; "manual" = bypasses this modal entirely and renders the full integrations page (handled in NewQuickstart). Undefined falls back to "connect-to-ollie".
   const variant =
@@ -248,7 +253,7 @@ const ConnectAgentStep: React.FC = () => {
       }
       showFooterSeparator
       footer={
-        primaryReady ? (
+        primaryReady || !demoDataEnabled ? (
           <Button
             onClick={handleViewTraces}
             id="onboarding-step2-view-traces"

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/SelectIntentStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/SelectIntentStep.tsx
@@ -9,6 +9,8 @@ import {
   useAgentOnboarding,
   AGENT_ONBOARDING_STEPS,
 } from "./AgentOnboardingContext";
+import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
+import { FeatureToggleKeys } from "@/types/feature-toggles";
 import onboardingImageLightUrl from "/images/onboarding_image_light.svg";
 import onboardingImageDarkUrl from "/images/onboarding_image_dark.svg";
 
@@ -17,16 +19,26 @@ const SelectIntentStep: React.FC = () => {
   const { themeMode } = useTheme();
   const workspaceName = useActiveWorkspaceName();
   const navigate = useNavigate();
+  const demoDataEnabled = useIsFeatureEnabled(
+    FeatureToggleKeys.DEMO_DATA_ENABLED,
+  );
 
-  const { data: demoProject } = useDemoProject({ workspaceName, poll: false });
+  const { data: demoProject } = useDemoProject(
+    { workspaceName, poll: false },
+    { enabled: demoDataEnabled },
+  );
 
   const illustrationUrl =
     themeMode === THEME_MODE.DARK
       ? onboardingImageDarkUrl
       : onboardingImageLightUrl;
 
-  const handlePickDemo = () => {
+  const handleNoAgent = () => {
     trackEvent(OpikEvent.ONBOARDING_INTENT_SELECTED, { intent: "no-app" });
+    if (!demoDataEnabled) {
+      goToStep(AGENT_ONBOARDING_STEPS.DONE, { agentName: "" });
+      return;
+    }
     goToStep(AGENT_ONBOARDING_STEPS.DEMO_LOADING, { agentName: "" });
     if (demoProject) {
       void navigate({
@@ -65,7 +77,7 @@ const SelectIntentStep: React.FC = () => {
           </button>
 
           <button
-            onClick={handlePickDemo}
+            onClick={handleNoAgent}
             className="rounded-lg border border-border bg-background p-4 text-left transition-colors hover:border-primary hover:bg-muted"
           >
             <p className="comet-body-s font-medium">

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/NewQuickstart.test.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/NewQuickstart.test.tsx
@@ -13,6 +13,7 @@ let mockPollExpired = false;
 let mockFirstTraceProjectId: string | null = null;
 let mockProjectData: { id?: string } | undefined = undefined;
 let mockProjectIsPending = false;
+let mockDemoDataEnabled = true;
 // ──────────────────────────────────────────────────────────────────────────
 
 vi.mock("posthog-js/react", () => ({
@@ -145,6 +146,14 @@ vi.mock("@/contexts/PermissionsContext", () => ({
   })),
 }));
 
+vi.mock("@/contexts/feature-toggles-provider", () => ({
+  useIsFeatureEnabled: vi.fn(() => mockDemoDataEnabled),
+}));
+
+vi.mock("@/types/feature-toggles", () => ({
+  FeatureToggleKeys: { DEMO_DATA_ENABLED: "demo_data_enabled" },
+}));
+
 vi.mock("./AgentOnboarding/AgentOnboardingContext", () => ({
   AGENT_ONBOARDING_KEY: "agent-onboarding",
   MANUAL_ONBOARDING_KEY: "manual-onboarding",
@@ -187,6 +196,7 @@ describe("NewQuickstart — manual variant", () => {
     mockHasTraces = false;
     mockPollExpired = false;
     mockFirstTraceProjectId = null;
+    mockDemoDataEnabled = true;
   });
 
   it("redirects to home when onboarding was already done at mount", () => {
@@ -208,6 +218,23 @@ describe("NewQuickstart — manual variant", () => {
     fireEvent.click(screen.getByTestId("skip-btn"));
 
     expect(screen.getByTestId("demo-loading-content")).toBeInTheDocument();
+  });
+
+  it("marks onboarding done and navigates home when skip is pressed and demo data is disabled", () => {
+    mockDemoDataEnabled = false;
+    setManualDone(false);
+    render(<NewQuickstart />);
+
+    fireEvent.click(screen.getByTestId("skip-btn"));
+
+    expect(localStorageSetters[MANUAL_KEY]).toHaveBeenCalledWith(true);
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/$workspaceName/home",
+      params: { workspaceName: "test-ws" },
+    });
+    expect(
+      screen.queryByTestId("demo-loading-content"),
+    ).not.toBeInTheDocument();
   });
 
   it("returns to integrations page when DemoLoadingContent onRetry is called", () => {

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/NewQuickstart.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/NewQuickstart.tsx
@@ -18,6 +18,8 @@ import { usePermissions } from "@/contexts/PermissionsContext";
 import DemoLoadingContent from "./AgentOnboarding/DemoLoadingContent";
 import LoggedDataStatus from "@/v2/pages-shared/onboarding/IntegrationExplorer/components/LoggedDataStatus";
 import useFirstTraceReceived from "@/api/projects/useFirstTraceReceived";
+import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
+import { FeatureToggleKeys } from "@/types/feature-toggles";
 
 const AgentOnboardingQuickstart: React.FC = () => {
   const workspaceName = useActiveWorkspaceName();
@@ -67,6 +69,9 @@ const NewQuickstart: React.FC = () => {
   const [showDemoLoading, setShowDemoLoading] = useState(false);
   const workspaceName = useActiveWorkspaceName();
   const navigate = useNavigate();
+  const demoDataEnabled = useIsFeatureEnabled(
+    FeatureToggleKeys.DEMO_DATA_ENABLED,
+  );
 
   const [manualOnboardingDone, setManualOnboardingDone] =
     useLocalStorageState<boolean>(`${MANUAL_ONBOARDING_KEY}-${workspaceName}`, {
@@ -103,6 +108,18 @@ const NewQuickstart: React.FC = () => {
     });
   }, [navigate, workspaceName, firstTraceProjectId, setManualOnboardingDone]);
 
+  const handleSkip = useCallback(() => {
+    if (demoDataEnabled) {
+      setShowDemoLoading(true);
+      return;
+    }
+    setManualOnboardingDone(true);
+    void navigate({
+      to: "/$workspaceName/home",
+      params: { workspaceName },
+    });
+  }, [demoDataEnabled, navigate, workspaceName, setManualOnboardingDone]);
+
   if (variant === "manual") {
     if (wasDoneOnMount.current) {
       return <Navigate to="/$workspaceName/home" params={{ workspaceName }} />;
@@ -128,7 +145,7 @@ const NewQuickstart: React.FC = () => {
             />
           ) : undefined
         }
-        onSkip={() => setShowDemoLoading(true)}
+        onSkip={handleSkip}
       />
     );
   }


### PR DESCRIPTION
## Details

Onboarding's Skip path polled for a demo project that's never created on deployments without demo-data creation (self-hosted-eks, STSaaS), trapping users in a 5-minute loop where "Back to setup" looped back to the same Skip. Introduces a `demoDataEnabled` service toggle (default `true`, so OSS/Comet prod behavior is unchanged) and consumes it on the FE to either keep the existing demo redirect or hand users a direct escape to `/home`.

- BE: new `demoDataEnabled` field on `ServiceTogglesConfig` bound to `TOGGLE_DEMO_DATA_ENABLED` (default `true`).
- FE manual variant: when toggle is `false`, Skip marks onboarding done and routes to `/home`.
- FE agent variant: `SelectIntentStep`'s "I don't have an AI agent yet" card transitions to `DONE` (→ `/home`) instead of the demo loader; `ConnectAgentStep` reuses the existing "Explore Opik" button as the early-exit when the user has no trace yet.
- `useDemoProject` calls are gated on the toggle so disabled deployments skip the HTTP probe entirely.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6515

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.7
  - Scope: full implementation
  - Human verification: code review + manual testing across all three onboarding variants (manual / control / connect-to-ollie) with the toggle on and off; regression check that prod behavior is unchanged when toggle is `true`

## Testing

Commands run locally:
- `cd apps/opik-frontend && npm run lint && npx tsc --noEmit && npx vitest run src/v2/pages/GetStartedPage/NewQuickstart.test.tsx`
- `cd apps/opik-backend && mvn -q compile -DskipTests && mvn -q spotless:check`

Manual scenarios validated (all clear `agent-onboarding-<ws>` + `manual-onboarding-<ws>` between runs):

Toggle off (self-hosted-eks behavior):
- Manual variant + Skip → lands on `/$workspaceName/home`, no DemoLoadingContent, no `POST /v1/private/projects/retrieve`.
- Control variant + SelectIntentStep → both cards visible; "I don't have an AI agent yet" exits to `/home` via `DONE`.
- Control variant + ConnectAgentStep → "Explore Opik" button visible immediately, no "Generating demo data…" indicator, no demo polling.

Toggle on (regression — prod path preserved):
- Manual variant + Skip → DemoLoadingContent renders and polls (unchanged).
- Control variant + ConnectAgentStep → "Generating demo data…" indicator visible (unchanged).

Vitest: 14/14 in `NewQuickstart.test.tsx` (added a case covering the toggle-off Skip path).

## Documentation

N/A