### PR TITLE
[OPIK-6539] [BE][FE] fix: suppress Gemma reasoning, bump deprecated Gemini/Vertex default models

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiChatModelMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiChatModelMapper.java
@@ -15,11 +15,18 @@ interface GeminiChatModelMapper {
 
     GeminiChatModelMapper INSTANCE = Mappers.getMapper(GeminiChatModelMapper.class);
 
+    // Gemma 4 always returns `thought=true` Parts from the Google AI Studio API,
+    // regardless of `thinkingConfig.includeThoughts`. With `returnThinking=null`
+    // (LangChain4j's default), those parts get concatenated into the response
+    // text, surfacing the reasoning trace to end users. Forcing `false` drops
+    // them — matching how Gemini 2.5/3 already behaves (Gemini suppresses
+    // thought parts API-side unless the client explicitly opts in).
     @Mapping(expression = "java(request.model())", target = "modelName")
     @Mapping(expression = "java(request.maxCompletionTokens())", target = "maxOutputTokens")
     @Mapping(expression = "java(request.stop())", target = "stopSequences")
     @Mapping(expression = "java(request.temperature())", target = "temperature")
     @Mapping(expression = "java(request.topP())", target = "topP")
+    @Mapping(expression = "java(Boolean.FALSE)", target = "returnThinking")
     GoogleAiGeminiChatModel toGeminiChatModel(
             @NonNull String apiKey, @NonNull ChatCompletionRequest request, @NonNull Duration timeout, int maxRetries,
             boolean logRequests, boolean logResponses);
@@ -29,6 +36,7 @@ interface GeminiChatModelMapper {
     @Mapping(expression = "java(request.stop())", target = "stopSequences")
     @Mapping(expression = "java(request.temperature())", target = "temperature")
     @Mapping(expression = "java(request.topP())", target = "topP")
+    @Mapping(expression = "java(Boolean.FALSE)", target = "returnThinking")
     GoogleAiGeminiStreamingChatModel toGeminiStreamingChatModel(
             @NonNull String apiKey, @NonNull ChatCompletionRequest request, @NonNull Duration timeout, int maxRetries,
             boolean logRequests, boolean logResponses);

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiClientGenerator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiClientGenerator.java
@@ -54,7 +54,8 @@ public class GeminiClientGenerator implements LlmProviderClientGenerator<GoogleA
                 .modelName(modelParameters.name())
                 .apiKey(config.apiKey())
                 .logRequests(llmProviderClientConfig.getLogRequests())
-                .logResponses(llmProviderClientConfig.getLogResponses());
+                .logResponses(llmProviderClientConfig.getLogResponses())
+                .returnThinking(false);
 
         Optional.ofNullable(llmProviderClientConfig.getConnectTimeout())
                 .ifPresent(connectTimeout -> modelBuilder.timeout(connectTimeout.toJavaDuration()));

--- a/apps/opik-frontend/src/constants/providers.ts
+++ b/apps/opik-frontend/src/constants/providers.ts
@@ -70,14 +70,14 @@ export const PROVIDERS: PROVIDERS_TYPE = {
     icon: GeminiIcon,
     apiKeyName: "GEMINI_API_KEY",
     apiKeyURL: "https://aistudio.google.com/apikey",
-    defaultModel: PROVIDER_MODEL_TYPE.GEMINI_3_PRO,
+    defaultModel: PROVIDER_MODEL_TYPE.GEMINI_3_1_PRO,
   },
   [PROVIDER_TYPE.VERTEX_AI]: {
     label: "Vertex AI",
     value: PROVIDER_TYPE.VERTEX_AI,
     icon: VertexAIIcon,
     apiKeyName: "VERTEX_API_KEY",
-    defaultModel: PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_2_5_PRO_PREVIEW_04_17,
+    defaultModel: PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_1_PRO,
   },
   [PROVIDER_TYPE.BEDROCK]: {
     label: "Bedrock",


### PR DESCRIPTION
## Details

Two Gemini-provider hygiene fixes discovered while testing Gemma 4 support (OPIK-5723 / #6701).

**1. Suppress Gemma reasoning trace in Playground responses (OPIK-6539)**

Forces `returnThinking=false` on the LangChain4j Gemini chat / streaming clients so `thought=true` Parts from Gemma 4 are dropped before the response text is built. End users now see just the final answer for `gemma-4-31b-it` / `gemma-4-26b-a4b-it`, matching how Gemini 2.5 / 3 already behave.

- `GeminiChatModelMapper.java`: added `@Mapping(expression = "java(Boolean.FALSE)", target = "returnThinking")` to both `toGeminiChatModel` and `toGeminiStreamingChatModel`.
- `GeminiClientGenerator.java`: added `.returnThinking(false)` to the builder used by `generateChat` (LLM-as-a-judge flow).

Root cause: Gemma 4 always returns `thought=true` Parts from Google's AI Studio API, regardless of `thinkingConfig.includeThoughts` (and `thinkingBudget=0` is rejected as unsupported). LangChain4j's `PartsAndContentsMapper#fromGPartsToAiMessage` treats a `null` `returnThinking` (Opik's previous default) as "concatenate thoughts into response text". Forcing `FALSE` discards them. Gemini 2.5 / 3 weren't affected because Google's API suppresses thought parts on those models unless the client opts in via `thinkingConfig.includeThoughts=true`.

**2. Bump deprecated default Gemini / Vertex AI models in `providers.ts`**

The Gemini provider's hardcoded default `defaultModel` was `GEMINI_3_PRO` (`gemini-3-pro-preview`), which has a past `deprecation_date` in the LiteLLM prices JSON and is therefore excluded from the dropdown by the sync script's deprecated-model filter. Result: when a user added the Gemini provider with no other providers configured, the Playground defaulted to a model that wasn't selectable in the picker. Backend routing still worked (the Java enum keeps deprecated entries via add-only design) so completions succeeded while the UI looked broken. Vertex AI had the same shape of bug.

- `apps/opik-frontend/src/constants/providers.ts`:
  - Gemini default: `GEMINI_3_PRO` → `GEMINI_3_1_PRO`
  - Vertex AI default: `VERTEX_AI_GEMINI_2_5_PRO_PREVIEW_04_17` → `VERTEX_AI_GEMINI_3_1_PRO`

Both replacements match the top-of-dropdown entry, so when a user adds either provider with no other providers configured, the Playground starts on a model the picker can actually highlight.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6539
- Discovered while testing OPIK-5723 (#6701)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: full implementation (root cause analysis, fix, verification)
- Human verification: direct Gemini API verification (Gemma 4 returns 2 parts: thought + answer; Gemini 3.1 Pro returns 1 part), LangChain4j bytecode inspection of `PartsAndContentsMapper.fromGPartsToAiMessage`, `mvn compile -DskipTests` clean, generated `GeminiChatModelMapperImpl.java` confirmed to emit `returnThinking(Boolean.FALSE)`, manual review of `providerModels.ts` top-of-dropdown entries to pick non-deprecated replacements

## Testing

- `mvn compile -DskipTests` in `apps/opik-backend` succeeds.
- Generated `target/generated-sources/annotations/.../GeminiChatModelMapperImpl.java` contains `returnThinking(Boolean.FALSE)` for both chat (line 34) and streaming (line 56) variants.
- Pre-merge smoke tests (recommended):
  1. Run a prompt against `gemma-4-31b-it` in the Playground and confirm only the final answer is shown (no grey reasoning block at the top).
  2. Add the Gemini provider in a fresh workspace with no other providers configured; confirm the Playground default is now `gemini-3.1-pro-preview` (selectable from the dropdown) instead of the deprecated `gemini-3-pro-preview`.
  3. Same check for Vertex AI provider.
- Regression check: verify Gemini 3.1 Pro / 2.5 Pro still respond normally with the `returnThinking=false` builder option (no-op for them since the API already suppresses thought parts).

## Documentation

N/A