### PR TITLE
[OPIK-6505] [BE] Split stats query and gate legacy feedback_scores UNION

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
@@ -62,6 +62,13 @@ public interface FeedbackScoreDAO {
     Mono<List<String>> getProjectsFeedbackScoreNames(Set<UUID> projectIds);
 
     Mono<List<String>> getProjectsTraceThreadsFeedbackScoreNames(List<UUID> projectId);
+
+    /**
+     * Returns {@code true} iff the legacy {@code feedback_scores} ClickHouse table has at least
+     * one row for the workspace. Called once during workspace version determination so subsequent
+     * stats queries can skip the legacy table UNION when no data exists there.
+     */
+    Mono<Boolean> hasLegacyScores(String workspaceId);
 }
 
 @Singleton
@@ -712,6 +719,27 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
                     .flatMap(result -> Mono.from(result.getRowsUpdated()))
                     .then(Mono.from(statement2.execute()))
                     .flatMap(result -> Mono.from(result.getRowsUpdated()));
+        });
+    }
+
+    private static final String HAS_LEGACY_FEEDBACK_SCORES = """
+            SELECT 1
+            FROM feedback_scores
+            WHERE workspace_id = :workspace_id
+            LIMIT 1
+            SETTINGS log_comment = '<log_comment>'
+            """;
+
+    @Override
+    public Mono<Boolean> hasLegacyScores(@NonNull String workspaceId) {
+        return asyncTemplate.nonTransaction(connection -> {
+            var template = getSTWithLogComment(HAS_LEGACY_FEEDBACK_SCORES,
+                    "has_legacy_feedback_scores", workspaceId, "", "");
+            var statement = connection.createStatement(template.render())
+                    .bind("workspace_id", workspaceId);
+            return Flux.from(statement.execute())
+                    .flatMap(result -> Flux.from(result.map((row, metadata) -> true)))
+                    .hasElements();
         });
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -2641,7 +2641,8 @@ public class SpanDAO {
                             })
                             .flatMap(result -> result.map(
                                     (row, rowMetadata) -> StatsMapper.mapProjectStats(row, "span_count")))
-                            .singleOrEmpty();
+                            .singleOrEmpty()
+                            .switchIfEmpty(Mono.just(new ProjectStats(List.of())));
 
                     Mono<ProjectStats> feedbackMono = Mono.from(connectionFactory.create())
                             .flatMapMany(connection -> {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -2641,8 +2641,7 @@ public class SpanDAO {
                             })
                             .flatMap(result -> result.map(
                                     (row, rowMetadata) -> StatsMapper.mapProjectStats(row, "span_count")))
-                            .singleOrEmpty()
-                            .switchIfEmpty(Mono.just(new ProjectStats(List.of())));
+                            .singleOrEmpty();
 
                     Mono<ProjectStats> feedbackMono = Mono.from(connectionFactory.create())
                             .flatMapMany(connection -> {
@@ -2663,11 +2662,9 @@ public class SpanDAO {
                                         .doFinally(signalType -> endSegment(segment));
                             })
                             .flatMap(result -> result.map((row, rowMetadata) -> mapProjectScoresStats(row)))
-                            .singleOrEmpty()
-                            .switchIfEmpty(Mono.just(new ProjectStats(List.of())));
+                            .singleOrEmpty();
 
-                    return Mono.zip(spansMono, feedbackMono)
-                            .map(tuple -> StatsMerger.merge(tuple.getT1(), tuple.getT2()));
+                    return StatsMerger.zipAndMerge(spansMono, feedbackMono);
                 }));
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -43,7 +43,6 @@ import org.reactivestreams.Publisher;
 import org.stringtemplate.v4.ST;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -2622,7 +2621,7 @@ public class SpanDAO {
         // Split into a span-aggregation query and a span-feedback-scores aggregation query, run in
         // parallel on separate connections. Same pattern as TraceDAO.getStats — eliminates the
         // per-span JOIN against feedback_scores_agg and the groupArray-of-tuples materialisation.
-        return makeMonoContextAware((userName, workspaceId) -> resolveHasLegacyScores(workspaceId)
+        return makeMonoContextAware((userName, workspaceId) -> workspacesService.hasLegacyScores(workspaceId)
                 .flatMap(hasLegacyScores -> {
 
                     Mono<ProjectStats> spansMono = Mono.from(connectionFactory.create())
@@ -2684,21 +2683,6 @@ public class SpanDAO {
                 || template.getAttribute("type") != null
                 || template.getAttribute("feedback_scores_filters") != null
                 || template.getAttribute("feedback_scores_empty_filters") != null;
-    }
-
-    /**
-     * Sync MySQL lookup of the workspace's legacy-feedback-scores flag, off the R2DBC event loop.
-     * Falls back to {@code true} (safe-include legacy UNION) on any error so the stats endpoint
-     * stays available when the state DB is degraded.
-     */
-    private Mono<Boolean> resolveHasLegacyScores(String workspaceId) {
-        return Mono.fromCallable(() -> workspacesService.hasLegacyScores(workspaceId))
-                .subscribeOn(Schedulers.boundedElastic())
-                .onErrorResume(throwable -> {
-                    log.warn("Failed to resolve has_legacy_scores for workspace '{}', defaulting to true",
-                            workspaceId, throwable);
-                    return Mono.just(true);
-                });
     }
 
     @WithSpan

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -14,7 +14,9 @@ import com.comet.opik.domain.filter.FilterQueryBuilder;
 import com.comet.opik.domain.filter.FilterStrategy;
 import com.comet.opik.domain.sorting.SortingQueryBuilder;
 import com.comet.opik.domain.stats.StatsMapper;
+import com.comet.opik.domain.stats.StatsMerger;
 import com.comet.opik.domain.utils.DemoDataExclusionUtils;
+import com.comet.opik.domain.workspaces.WorkspacesService;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.utils.ClickHouseDateTimeFormat;
@@ -41,6 +43,7 @@ import org.reactivestreams.Publisher;
 import org.stringtemplate.v4.ST;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -1216,6 +1219,7 @@ public class SpanDAO {
                        last_updated_at,
                        author
                 FROM (
+                    <if(has_legacy_scores)>
                     SELECT workspace_id,
                            project_id,
                            entity_id,
@@ -1236,6 +1240,7 @@ public class SpanDAO {
                       <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
                       <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
                     UNION ALL
+                    <endif>
                     SELECT workspace_id,
                            project_id,
                            entity_id,
@@ -1286,17 +1291,6 @@ public class SpanDAO {
                     arrayMin(arrayMap(e -> e.8, entries)) AS created_at,
                     arrayMax(arrayMap(e -> e.9, entries)) AS last_updated_at
                 FROM feedback_scores_grouped
-            )
-            , feedback_scores_agg AS (
-                SELECT
-                    project_id,
-                    entity_id,
-                    mapFromArrays(
-                            groupArray(name),
-                            groupArray(value)
-                    ) AS feedback_scores
-                FROM feedback_scores_final
-                GROUP BY workspace_id, project_id, entity_id
             )
             <if(feedback_scores_empty_filters)>
              , fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
@@ -1362,14 +1356,162 @@ public class SpanDAO {
                 avg(tags_count) as tags,
                 avgMap(s.usage) as usage,
                 sumMap(s.usage) as usage_sum,
-                avgMap(feedback_scores) AS feedback_scores,
                 avgIf(total_estimated_cost, total_estimated_cost > 0) AS total_estimated_cost_,
                 toDecimal128(if(isNaN(total_estimated_cost_), 0, total_estimated_cost_), 12) AS total_estimated_cost_avg,
                 sumIf(total_estimated_cost, total_estimated_cost > 0) AS total_estimated_cost_sum_,
                 toDecimal128(total_estimated_cost_sum_, 12) AS total_estimated_cost_sum,
                 countIf(error_info, error_info != '') AS error_count
             FROM spans_final s
-            LEFT JOIN feedback_scores_agg AS f ON s.id = f.entity_id
+            GROUP BY project_id
+            SETTINGS log_comment = '<log_comment>'
+            ;
+            """;
+
+    // Split-B: per-project span-feedback-score aggregates.
+    // - Mirrors the trace-side SELECT_FEEDBACK_SCORES_STATS pattern but at span granularity.
+    // - filters_present gates an embedded spans_final filter resolution (must stay in sync with
+    //   the spans_final CTE inside SELECT_SPANS_STATS).
+    // - has_legacy_scores gates the legacy feedback_scores table UNION branch.
+    // - Skips the rich tuple groupArray of the listing CTEs — only `value` is projected.
+    private static final String SELECT_SPAN_FEEDBACK_SCORES_STATS = """
+            <if(filters_present)>
+            WITH feedback_scores_deduped AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       category_name,
+                       value,
+                       reason,
+                       source,
+                       created_by,
+                       last_updated_by,
+                       created_at,
+                       last_updated_at,
+                       author
+                FROM (
+                    <if(has_legacy_scores)>
+                    SELECT workspace_id,
+                           project_id,
+                           entity_id,
+                           name,
+                           category_name,
+                           value,
+                           reason,
+                           source,
+                           created_by,
+                           last_updated_by,
+                           created_at,
+                           last_updated_at,
+                           feedback_scores.last_updated_by AS author
+                    FROM feedback_scores
+                    WHERE entity_type = 'span'
+                      AND workspace_id = :workspace_id
+                      AND project_id = :project_id
+                      <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
+                      <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                    UNION ALL
+                    <endif>
+                    SELECT workspace_id,
+                           project_id,
+                           entity_id,
+                           name,
+                           category_name,
+                           value,
+                           reason,
+                           source,
+                           created_by,
+                           last_updated_by,
+                           created_at,
+                           last_updated_at,
+                           author
+                    FROM authored_feedback_scores
+                    WHERE entity_type = 'span'
+                      AND workspace_id = :workspace_id
+                      AND project_id = :project_id
+                      <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
+                      <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                )
+                ORDER BY last_updated_at DESC
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+            ), feedback_scores_grouped AS (
+                SELECT workspace_id, project_id, entity_id, name,
+                       groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at)) AS entries
+                FROM feedback_scores_deduped
+                GROUP BY workspace_id, project_id, entity_id, name
+            ), feedback_scores_final AS (
+                SELECT workspace_id, project_id, entity_id, name,
+                       IF(length(entries) = 1, entries[1].1, toDecimal64(arrayAvg(arrayMap(e -> e.1, entries)), 9)) AS value
+                FROM feedback_scores_grouped
+            )
+            <if(feedback_scores_empty_filters)>
+            , fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
+                 FROM feedback_scores_final
+                 GROUP BY entity_id
+                 HAVING <feedback_scores_empty_filters>
+            )
+            <endif>
+            , spans_final AS (
+                -- IMPORTANT: keep this WHERE clause in sync with SELECT_SPANS_STATS.spans_final.
+                SELECT id, project_id
+                FROM spans final
+                <if(feedback_scores_empty_filters)>
+                LEFT JOIN fsc ON fsc.entity_id = spans.id
+                <endif>
+                WHERE project_id = :project_id
+                AND workspace_id = :workspace_id
+                <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
+                <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                <if(trace_id)> AND trace_id = :trace_id <endif>
+                <if(type)> AND type = :type <endif>
+                <if(filters)> AND <filters> <endif>
+                <if(search_text)> AND <search_text> <endif>
+                <if(feedback_scores_filters)>
+                AND id in (
+                    SELECT entity_id
+                    FROM feedback_scores_final
+                    GROUP BY entity_id
+                    HAVING <feedback_scores_filters>
+                )
+                <endif>
+                <if(feedback_scores_empty_filters)>
+                AND fsc.feedback_scores_count = 0
+                <endif>
+            ),
+            <else>
+            WITH
+            <endif>
+            span_fs AS (
+                <if(has_legacy_scores)>
+                SELECT project_id, entity_id, name, value,
+                       feedback_scores.last_updated_by AS author
+                FROM feedback_scores FINAL
+                WHERE entity_type = 'span'
+                  AND workspace_id = :workspace_id
+                  AND project_id = :project_id
+                  <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
+                  <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                  <if(filters_present)> AND entity_id IN (SELECT id FROM spans_final) <endif>
+                UNION ALL
+                <endif>
+                SELECT project_id, entity_id, name, value, author
+                FROM authored_feedback_scores FINAL
+                WHERE entity_type = 'span'
+                  AND workspace_id = :workspace_id
+                  AND project_id = :project_id
+                  <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
+                  <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                  <if(filters_present)> AND entity_id IN (SELECT id FROM spans_final) <endif>
+            ), span_fs_per_name AS (
+                SELECT project_id, entity_id, name, avg(value) AS value
+                FROM span_fs GROUP BY project_id, entity_id, name
+            ), span_fs_per_project AS (
+                SELECT project_id, name, avg(value) AS value
+                FROM span_fs_per_name GROUP BY project_id, name
+            )
+            SELECT project_id,
+                   mapFromArrays(groupArray(name), groupArray(value)) AS feedback_scores
+            FROM span_fs_per_project
             GROUP BY project_id
             SETTINGS log_comment = '<log_comment>'
             ;
@@ -1499,6 +1641,7 @@ public class SpanDAO {
     private final @NonNull SpanSortingFactory sortingFactory;
     private final @NonNull SortingQueryBuilder sortingQueryBuilder;
     private final @NonNull OpikConfiguration configuration;
+    private final @NonNull WorkspacesService workspacesService;
 
     @WithSpan
     public Mono<Void> insert(@NonNull Span span) {
@@ -2476,25 +2619,86 @@ public class SpanDAO {
 
     @WithSpan
     public Mono<ProjectStats> getStats(@NonNull SpanSearchCriteria searchCriteria) {
+        // Split into a span-aggregation query and a span-feedback-scores aggregation query, run in
+        // parallel on separate connections. Same pattern as TraceDAO.getStats — eliminates the
+        // per-span JOIN against feedback_scores_agg and the groupArray-of-tuples materialisation.
+        return makeMonoContextAware((userName, workspaceId) -> resolveHasLegacyScores(workspaceId)
+                .flatMap(hasLegacyScores -> {
 
-        return Mono.from(connectionFactory.create())
-                .flatMapMany(connection -> makeFluxContextAware((userName, workspaceId) -> {
-                    var template = newFindTemplate(SELECT_SPANS_STATS, searchCriteria, "get_span_stats", workspaceId,
-                            userName);
+                    Mono<ProjectStats> spansMono = Mono.from(connectionFactory.create())
+                            .flatMapMany(connection -> {
+                                var template = newFindTemplate(SELECT_SPANS_STATS, searchCriteria, "get_span_stats",
+                                        workspaceId, userName);
+                                template.add("has_legacy_scores", hasLegacyScores);
 
-                    var statement = connection.createStatement(template.render())
-                            .bind("project_id", searchCriteria.projectId())
-                            .bind("workspace_id", workspaceId);
+                                var statement = connection.createStatement(template.render())
+                                        .bind("project_id", searchCriteria.projectId())
+                                        .bind("workspace_id", workspaceId);
+                                bindSearchCriteria(statement, searchCriteria);
 
-                    bindSearchCriteria(statement, searchCriteria);
+                                Segment segment = startSegment("spans", "Clickhouse", "stats_spans");
+                                return Flux.from(statement.execute())
+                                        .doFinally(signalType -> endSegment(segment));
+                            })
+                            .flatMap(result -> result.map(
+                                    (row, rowMetadata) -> StatsMapper.mapProjectStats(row, "span_count")))
+                            .singleOrEmpty();
 
-                    Segment segment = startSegment("spans", "Clickhouse", "stats");
+                    Mono<ProjectStats> feedbackMono = Mono.from(connectionFactory.create())
+                            .flatMapMany(connection -> {
+                                var template = newFindTemplate(SELECT_SPAN_FEEDBACK_SCORES_STATS, searchCriteria,
+                                        "get_span_stats_feedback_scores", workspaceId, userName);
+                                template.add("has_legacy_scores", hasLegacyScores);
+                                if (hasAnySpanFilter(template)) {
+                                    template.add("filters_present", true);
+                                }
 
-                    return Flux.from(statement.execute())
-                            .doFinally(signalType -> endSegment(segment));
-                }))
-                .flatMap(result -> result.map(((row, rowMetadata) -> StatsMapper.mapProjectStats(row, "span_count"))))
-                .singleOrEmpty();
+                                var statement = connection.createStatement(template.render())
+                                        .bind("project_id", searchCriteria.projectId())
+                                        .bind("workspace_id", workspaceId);
+                                bindSearchCriteria(statement, searchCriteria);
+
+                                Segment segment = startSegment("spans", "Clickhouse", "stats_feedback");
+                                return Flux.from(statement.execute())
+                                        .doFinally(signalType -> endSegment(segment));
+                            })
+                            .flatMap(result -> result.map((row, rowMetadata) -> mapProjectScoresStats(row)))
+                            .singleOrEmpty()
+                            .switchIfEmpty(Mono.just(new ProjectStats(List.of())));
+
+                    return Mono.zip(spansMono, feedbackMono)
+                            .map(tuple -> StatsMerger.merge(tuple.getT1(), tuple.getT2()));
+                }));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ProjectStats mapProjectScoresStats(Row row) {
+        var feedbackScores = (Map<String, Object>) row.get("feedback_scores", Map.class);
+        return new ProjectStats(StatsMapper.toMapStats(feedbackScores, StatsMapper.FEEDBACK_SCORE));
+    }
+
+    private static boolean hasAnySpanFilter(ST template) {
+        return template.getAttribute("filters") != null
+                || template.getAttribute("search_text") != null
+                || template.getAttribute("trace_id") != null
+                || template.getAttribute("type") != null
+                || template.getAttribute("feedback_scores_filters") != null
+                || template.getAttribute("feedback_scores_empty_filters") != null;
+    }
+
+    /**
+     * Sync MySQL lookup of the workspace's legacy-feedback-scores flag, off the R2DBC event loop.
+     * Falls back to {@code true} (safe-include legacy UNION) on any error so the stats endpoint
+     * stays available when the state DB is degraded.
+     */
+    private Mono<Boolean> resolveHasLegacyScores(String workspaceId) {
+        return Mono.fromCallable(() -> workspacesService.hasLegacyScores(workspaceId))
+                .subscribeOn(Schedulers.boundedElastic())
+                .onErrorResume(throwable -> {
+                    log.warn("Failed to resolve has_legacy_scores for workspace '{}', defaulting to true",
+                            workspaceId, throwable);
+                    return Mono.just(true);
+                });
     }
 
     @WithSpan

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -21,7 +21,9 @@ import com.comet.opik.domain.filter.FilterQueryBuilder;
 import com.comet.opik.domain.filter.FilterStrategy;
 import com.comet.opik.domain.sorting.SortingQueryBuilder;
 import com.comet.opik.domain.stats.StatsMapper;
+import com.comet.opik.domain.stats.StatsMerger;
 import com.comet.opik.domain.utils.DemoDataExclusionUtils;
+import com.comet.opik.domain.workspaces.WorkspacesService;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
@@ -52,6 +54,7 @@ import org.stringtemplate.v4.ST;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SignalType;
+import reactor.core.scheduler.Schedulers;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -68,6 +71,7 @@ import static com.comet.opik.api.Trace.TracePage;
 import static com.comet.opik.api.TraceCountResponse.WorkspaceTraceCount;
 import static com.comet.opik.domain.AsyncContextUtils.bindUserNameAndWorkspace;
 import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToMono;
+import static com.comet.opik.domain.stats.StatsMapper.mapProjectScoresStats;
 import static com.comet.opik.infrastructure.FilterUtils.bindTraceThreadSearchCriteria;
 import static com.comet.opik.infrastructure.FilterUtils.getLogComment;
 import static com.comet.opik.infrastructure.FilterUtils.getSTWithLogComment;
@@ -80,7 +84,8 @@ import static com.comet.opik.utils.AsyncUtils.makeMonoContextAware;
 import static com.comet.opik.utils.ValidationUtils.CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE;
 import static com.comet.opik.utils.template.TemplateUtils.getQueryItemPlaceHolder;
 import static java.util.function.Predicate.not;
-import static java.util.stream.Collectors.*;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
 
 @ImplementedBy(TraceDAOImpl.class)
 public interface TraceDAO {
@@ -1942,7 +1947,13 @@ class TraceDAOImpl implements TraceDAO {
             ;
             """;
 
-    private static final String SELECT_TRACES_STATS = """
+    // Split-A: traces + spans aggregation. All feedback-score CTEs stay so the existing
+    // feedback_scores_filters / span_feedback_scores_filters / *_empty_filters slots inside
+    // trace_final still resolve. The feedback_scores_agg and span_feedback_scores_agg CTEs
+    // are no longer referenced by the final SELECT and CH prunes them; the per-trace feedback
+    // aggregates are produced in parallel by SELECT_FEEDBACK_SCORES_STATS and merged by
+    // StatsMerger.
+    private static final String SELECT_TRACES_SPANS_STATS = """
              WITH spans_data AS (
                 SELECT
                     id,
@@ -1952,11 +1963,13 @@ class TraceDAOImpl implements TraceDAO {
                     type,
                     workspace_id,
                     project_id
-                FROM spans FINAL
+                FROM spans
                 WHERE workspace_id = :workspace_id
                 AND project_id IN :project_ids
                 <if(uuid_from_time)> AND trace_id >= :uuid_from_time <endif>
                 <if(uuid_to_time)> AND trace_id \\<= :uuid_to_time <endif>
+                ORDER BY (workspace_id, project_id, trace_id, parent_span_id, id) DESC, last_updated_at DESC
+                LIMIT 1 BY id
              ), spans_agg AS (
                 SELECT
                     trace_id,
@@ -1981,6 +1994,7 @@ class TraceDAOImpl implements TraceDAO {
                        last_updated_at,
                        author
                 FROM (
+                    <if(has_legacy_scores)>
                     SELECT
                         workspace_id,
                         project_id,
@@ -2002,6 +2016,7 @@ class TraceDAOImpl implements TraceDAO {
                       <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
                       <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
                     UNION ALL
+                    <endif>
                     SELECT
                         workspace_id,
                         project_id,
@@ -2112,6 +2127,7 @@ class TraceDAOImpl implements TraceDAO {
                        last_updated_at,
                        author
                 FROM (
+                    <if(has_legacy_scores)>
                     SELECT workspace_id,
                            project_id,
                            entity_id,
@@ -2136,6 +2152,7 @@ class TraceDAOImpl implements TraceDAO {
                       AND entity_id IN (SELECT id FROM spans_data)
                       <endif>
                     UNION ALL
+                    <endif>
                     SELECT workspace_id,
                            project_id,
                            entity_id,
@@ -2342,8 +2359,6 @@ class TraceDAOImpl implements TraceDAO {
                 avg(tags_length) AS tags,
                 avgMap(s.usage) as usage,
                 sumMap(s.usage) as usage_sum,
-                avgMap(f.feedback_scores) AS feedback_scores,
-                avgMap(sfs.span_feedback_scores) AS span_feedback_scores,
                 avg(s.llm_span_count) AS llm_span_count_avg,
                 avg(s.span_count) AS span_count_avg,
                 avgIf(s.total_estimated_cost, s.total_estimated_cost > 0) AS total_estimated_cost_,
@@ -2359,10 +2374,393 @@ class TraceDAOImpl implements TraceDAO {
                 <endif>
             FROM trace_final t
             LEFT JOIN spans_agg AS s ON t.id = s.trace_id
-            LEFT JOIN feedback_scores_agg as f ON t.id = f.entity_id
-            LEFT JOIN span_feedback_scores_agg as sfs ON t.id = sfs.trace_id
             LEFT JOIN guardrails_agg as g ON t.id = g.entity_id
             GROUP BY t.workspace_id, t.project_id
+            SETTINGS log_comment = '<log_comment>'
+            ;
+            """;
+
+    // Split-B: per-project feedback-score and span-feedback-score aggregates.
+    private static final String SELECT_FEEDBACK_SCORES_STATS = """
+            <if(filters_present)>
+            WITH spans_data AS (
+                SELECT
+                    id,
+                    trace_id,
+                    usage,
+                    total_estimated_cost,
+                    type,
+                    workspace_id,
+                    project_id
+                FROM spans FINAL
+                WHERE workspace_id = :workspace_id
+                AND project_id IN :project_ids
+                <if(uuid_from_time)> AND trace_id >= :uuid_from_time <endif>
+                <if(uuid_to_time)> AND trace_id \\<= :uuid_to_time <endif>
+            ), spans_agg AS (
+                SELECT
+                    trace_id,
+                    sumMap(usage) as usage,
+                    sum(total_estimated_cost) as total_estimated_cost,
+                    COUNT(id) as span_count,
+                    toInt64(countIf(type = 'llm')) as llm_span_count
+                FROM spans_data
+                GROUP BY workspace_id, project_id, trace_id
+            ), feedback_scores_deduped AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       category_name,
+                       value,
+                       reason,
+                       source,
+                       created_by,
+                       last_updated_by,
+                       created_at,
+                       last_updated_at,
+                       author
+                FROM (
+                    <if(has_legacy_scores)>
+                    SELECT
+                        workspace_id,
+                        project_id,
+                        entity_id,
+                        name,
+                        category_name,
+                        value,
+                        reason,
+                        source,
+                        created_by,
+                        last_updated_by,
+                        created_at,
+                        last_updated_at,
+                        feedback_scores.last_updated_by AS author
+                    FROM feedback_scores
+                    WHERE entity_type = 'trace'
+                      AND workspace_id = :workspace_id
+                      AND project_id IN :project_ids
+                      <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
+                      <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                    UNION ALL
+                    <endif>
+                    SELECT
+                        workspace_id,
+                        project_id,
+                        entity_id,
+                        name,
+                        category_name,
+                        value,
+                        reason,
+                        source,
+                        created_by,
+                        last_updated_by,
+                        created_at,
+                        last_updated_at,
+                        author
+                    FROM authored_feedback_scores
+                    WHERE entity_type = 'trace'
+                       AND workspace_id = :workspace_id
+                       AND project_id IN :project_ids
+                       <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
+                       <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                )
+                ORDER BY last_updated_at DESC
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+            ),
+            feedback_scores_grouped AS (
+                SELECT
+                    workspace_id,
+                    project_id,
+                    entity_id,
+                    name,
+                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at)) AS entries
+                FROM feedback_scores_deduped
+                GROUP BY workspace_id, project_id, entity_id, name
+            ), feedback_scores_final AS (
+                SELECT
+                    workspace_id,
+                    project_id,
+                    entity_id,
+                    name,
+                    IF(length(entries) = 1, entries[1].1, toDecimal64(arrayAvg(arrayMap(e -> e.1, entries)), 9)) AS value
+                FROM feedback_scores_grouped
+            ),
+            guardrails_agg AS (
+                SELECT
+                    entity_id,
+                    countIf(DISTINCT id, result = 'failed') AS failed_count,
+                    if(has(groupArray(result), 'failed'), 'failed', 'passed') as guardrails_result
+                FROM (
+                    SELECT
+                        *
+                    FROM guardrails
+                    WHERE entity_type = 'trace'
+                    AND workspace_id = :workspace_id
+                    AND project_id IN :project_ids
+                    <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
+                    <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                    ORDER BY (workspace_id, project_id, entity_type, entity_id, id) DESC, last_updated_at DESC
+                    LIMIT 1 BY entity_id, id
+                )
+                GROUP BY workspace_id, project_id, entity_type, entity_id
+            ), trace_annotation_queue_ids AS (
+                 SELECT trace_id,
+                        groupArray(id) AS annotation_queue_ids
+                 FROM (
+                    SELECT DISTINCT aq.id as id, aqi.item_id as trace_id
+                    FROM annotation_queue_items aqi
+                    JOIN annotation_queues aq ON aq.id = aqi.queue_id
+                    WHERE aq.scope = 'trace'
+                      AND workspace_id = :workspace_id
+                      AND project_id IN :project_ids
+                      <if(uuid_from_time)> AND aqi.item_id >= :uuid_from_time <endif>
+                      <if(uuid_to_time)> AND aqi.item_id \\<= :uuid_to_time <endif>
+                 ) AS annotation_queue_ids_with_trace_id
+                 GROUP BY trace_id
+            ),
+            span_feedback_scores_deduped AS (
+                SELECT workspace_id,
+                       project_id,
+                       entity_id,
+                       name,
+                       value,
+                       last_updated_at,
+                       author
+                FROM (
+                    <if(has_legacy_scores)>
+                    SELECT workspace_id,
+                           project_id,
+                           entity_id,
+                           name,
+                           value,
+                           last_updated_at,
+                           feedback_scores.last_updated_by AS author
+                    FROM feedback_scores
+                    WHERE entity_type = 'span'
+                      AND workspace_id = :workspace_id
+                      AND project_id IN :project_ids
+                      <if(uuid_from_time || uuid_to_time)>
+                      <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
+                      <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                      <else>
+                      AND entity_id IN (SELECT id FROM spans_data)
+                      <endif>
+                    UNION ALL
+                    <endif>
+                    SELECT workspace_id,
+                           project_id,
+                           entity_id,
+                           name,
+                           value,
+                           last_updated_at,
+                           author
+                    FROM authored_feedback_scores
+                    WHERE entity_type = 'span'
+                      AND workspace_id = :workspace_id
+                      AND project_id IN :project_ids
+                      <if(uuid_from_time || uuid_to_time)>
+                      <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
+                      <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                      <else>
+                      AND entity_id IN (SELECT id FROM spans_data)
+                      <endif>
+                )
+                ORDER BY last_updated_at DESC
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+            ), span_feedback_scores_with_trace_id AS (
+                SELECT workspace_id,
+                       project_id,
+                       s.trace_id AS trace_id,
+                       name,
+                       value,
+                       last_updated_at,
+                       author
+                FROM span_feedback_scores_deduped sfs
+                INNER JOIN spans_data s ON sfs.entity_id = s.id
+            ), span_feedback_scores_grouped AS (
+                SELECT
+                    workspace_id,
+                    project_id,
+                    trace_id,
+                    name,
+                    groupArray(tuple(value, author, last_updated_at)) AS entries
+                FROM span_feedback_scores_with_trace_id
+                GROUP BY workspace_id, project_id, trace_id, name
+            ), span_feedback_scores_final AS (
+                SELECT
+                    workspace_id,
+                    project_id,
+                    trace_id,
+                    name,
+                    IF(length(entries) = 1, entries[1].1, toDecimal64(arrayAvg(arrayMap(e -> e.1, entries)), 9)) AS value
+                FROM span_feedback_scores_grouped
+            )
+            <if(span_feedback_scores_empty_filters)>
+            , sfsc AS (SELECT trace_id, COUNT(trace_id) AS span_feedback_scores_count
+                 FROM span_feedback_scores_final
+                 GROUP BY trace_id
+                 HAVING <span_feedback_scores_empty_filters>
+            )
+            <endif>
+            <if(feedback_scores_empty_filters)>
+             , fsc AS (SELECT entity_id, COUNT(entity_id) AS feedback_scores_count
+                 FROM feedback_scores_final
+                 GROUP BY entity_id
+                 HAVING <feedback_scores_empty_filters>
+            )
+            <endif>
+            , trace_final AS (
+                SELECT id, project_id
+                FROM traces final
+                <if(guardrails_filters)>
+                LEFT JOIN guardrails_agg gagg ON gagg.entity_id = traces.id
+                <endif>
+                <if(feedback_scores_empty_filters)>
+                LEFT JOIN fsc ON fsc.entity_id = traces.id
+                <endif>
+                <if(span_feedback_scores_empty_filters)>
+                LEFT JOIN sfsc ON sfsc.trace_id = traces.id
+                <endif>
+                <if(annotation_queue_filters)>
+                LEFT JOIN trace_annotation_queue_ids as taqi ON taqi.trace_id = traces.id
+                <endif>
+                WHERE workspace_id = :workspace_id
+                AND project_id IN :project_ids
+                <if(uuid_from_time)>AND id >= :uuid_from_time<endif>
+                <if(uuid_to_time)>AND id \\<= :uuid_to_time<endif>
+                <if(filters)> AND <filters> <endif>
+                <if(search_text)> AND <search_text> <endif>
+                <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>
+                <if(feedback_scores_filters)>
+                AND id IN (
+                    SELECT entity_id
+                    FROM feedback_scores_final
+                    GROUP BY entity_id
+                    HAVING <feedback_scores_filters>
+                )
+                <endif>
+                <if(span_feedback_scores_filters)>
+                AND id IN (
+                    SELECT
+                        trace_id
+                    FROM span_feedback_scores_final
+                    GROUP BY trace_id
+                    HAVING <span_feedback_scores_filters>
+                )
+                <endif>
+                <if(trace_aggregation_filters)>
+                AND id IN (
+                    SELECT
+                        trace_id
+                    FROM spans_agg
+                    WHERE <trace_aggregation_filters>
+                )
+                <endif>
+                <if(experiment_filters)>
+                AND id IN (
+                    SELECT
+                        trace_id
+                    FROM experiment_items
+                    WHERE workspace_id = :workspace_id
+                    AND <experiment_filters>
+                    ORDER BY (workspace_id, experiment_id, dataset_item_id, trace_id, id) DESC, last_updated_at DESC
+                    LIMIT 1 BY id
+                )
+                <endif>
+                <if(feedback_scores_empty_filters)>
+                AND fsc.feedback_scores_count = 0
+                <endif>
+                <if(span_feedback_scores_empty_filters)>
+                AND (
+                    id IN (SELECT trace_id FROM sfsc WHERE sfsc.span_feedback_scores_count = 0)
+                        OR
+                    id NOT IN (SELECT trace_id FROM sfsc)
+                )
+                <endif>
+            ),
+            <else>
+            WITH
+            <endif>
+            span_ids AS (
+                SELECT id
+                FROM spans
+                WHERE workspace_id = :workspace_id
+                AND project_id IN :project_ids
+                <if(uuid_from_time)> AND trace_id >= :uuid_from_time <endif>
+                <if(uuid_to_time)> AND trace_id \\<= :uuid_to_time <endif>
+                <if(filters_present)> AND trace_id IN (SELECT id FROM trace_final) <endif>
+            ), trace_fs AS (
+                <if(has_legacy_scores)>
+                SELECT project_id, entity_id, name, value,
+                       feedback_scores.last_updated_by AS author
+                FROM feedback_scores FINAL
+                WHERE entity_type = 'trace'
+                  AND workspace_id = :workspace_id
+                  AND project_id IN :project_ids
+                  <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
+                  <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                  <if(filters_present)> AND entity_id IN (SELECT id FROM trace_final) <endif>
+                UNION ALL
+                <endif>
+                SELECT project_id, entity_id, name, value, author
+                FROM authored_feedback_scores FINAL
+                WHERE entity_type = 'trace'
+                  AND workspace_id = :workspace_id
+                  AND project_id IN :project_ids
+                  <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
+                  <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                  <if(filters_present)> AND entity_id IN (SELECT id FROM trace_final) <endif>
+            ), trace_fs_per_name AS (
+                SELECT project_id, entity_id, name, avg(value) AS value
+                FROM trace_fs
+                GROUP BY project_id, entity_id, name
+            ), trace_fs_per_project AS (
+                SELECT project_id, name, avg(value) AS value
+                FROM trace_fs_per_name
+                GROUP BY project_id, name
+            ), trace_feedback_scores AS (
+                SELECT project_id,
+                       mapFromArrays(groupArray(name), groupArray(value)) AS feedback_scores
+                FROM trace_fs_per_project
+                GROUP BY project_id
+            ), span_fs AS (
+                <if(has_legacy_scores)>
+                SELECT project_id, entity_id, name, value,
+                       feedback_scores.last_updated_by AS author
+                FROM feedback_scores FINAL
+                WHERE entity_type = 'span'
+                  AND workspace_id = :workspace_id
+                  AND project_id IN :project_ids
+                  AND entity_id IN (SELECT id FROM span_ids)
+                UNION ALL
+                <endif>
+                SELECT project_id, entity_id, name, value, author
+                FROM authored_feedback_scores FINAL
+                WHERE entity_type = 'span'
+                  AND workspace_id = :workspace_id
+                  AND project_id IN :project_ids
+                  AND entity_id IN (SELECT id FROM span_ids)
+            ), span_fs_per_name AS (
+                SELECT project_id, entity_id, name, avg(value) AS value
+                FROM span_fs
+                GROUP BY project_id, entity_id, name
+            ), span_fs_per_project AS (
+                SELECT project_id, name, avg(value) AS value
+                FROM span_fs_per_name
+                GROUP BY project_id, name
+            ), span_feedback_scores AS (
+                SELECT project_id,
+                       mapFromArrays(groupArray(name), groupArray(value)) AS span_feedback_scores
+                FROM span_fs_per_project
+                GROUP BY project_id
+            )
+            SELECT
+                coalesce(t.project_id, s.project_id) AS project_id,
+                t.feedback_scores AS feedback_scores,
+                s.span_feedback_scores AS span_feedback_scores
+            FROM trace_feedback_scores t
+            FULL OUTER JOIN span_feedback_scores s ON t.project_id = s.project_id
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
@@ -2484,6 +2882,7 @@ class TraceDAOImpl implements TraceDAO {
     private final @NonNull TraceSortingFactory sortingFactory;
     private final @NonNull OpikConfiguration configuration;
     private final @NonNull ConnectionFactory connectionFactory;
+    private final @NonNull WorkspacesService workspacesService;
 
     @Override
     @WithSpan
@@ -3422,26 +3821,128 @@ class TraceDAOImpl implements TraceDAO {
 
     @Override
     public Mono<ProjectStats> getStats(@NonNull TraceSearchCriteria criteria) {
-        return asyncTemplate.nonTransaction(connection -> makeMonoContextAware((userName, workspaceId) -> {
-            var logComment = getLogComment("get_trace_stats", workspaceId, userName, "");
-            var statsSQL = newTraceThreadFindTemplate(SELECT_TRACES_STATS, criteria, TRACE_SEARCH_CLAUSE);
-            statsSQL.add("log_comment", logComment);
+        // Each branch runs on its own connection from the pool — R2DBC connections do not
+        // tolerate two concurrent statements on the same connection. The legacy-scores flag is
+        // looked up once (sync JDBI) and threaded through both branches so they can skip the
+        // legacy feedback_scores table UNION when no data exists there.
+        return makeMonoContextAware((userName, workspaceId) -> resolveHasLegacyScores(workspaceId)
+                .flatMap(hasLegacyScores -> {
 
-            var statement = connection.createStatement(statsSQL.render())
-                    .bind("project_ids", List.of(criteria.projectId()))
-                    .bind("workspace_id", workspaceId);
+                    Mono<ProjectStats> tracesSpansMono = asyncTemplate.nonTransaction(connection -> {
+                        var logComment = getLogComment("get_trace_stats_traces_spans", workspaceId, userName, "");
+                        var template = newTraceThreadFindTemplate(SELECT_TRACES_SPANS_STATS, criteria,
+                                TRACE_SEARCH_CLAUSE);
+                        template.add("log_comment", logComment);
+                        template.add("has_legacy_scores", hasLegacyScores);
 
-            bindTraceThreadSearchCriteria(criteria, statement);
+                        var statement = connection.createStatement(template.render())
+                                .bind("project_ids", List.of(criteria.projectId()))
+                                .bind("workspace_id", workspaceId);
+                        bindTraceThreadSearchCriteria(criteria, statement);
 
-            Segment segment = startSegment("traces", "Clickhouse", "stats");
+                        Segment segment = startSegment("traces", "Clickhouse", "stats_traces_spans");
+                        return Flux.from(statement.execute())
+                                .doFinally(signalType -> endSegment(segment))
+                                .flatMap(result -> result.map(
+                                        (row, rowMetadata) -> StatsMapper.mapProjectStats(row, "trace_count")))
+                                .singleOrEmpty();
+                    });
 
-            return Flux.from(statement.execute())
-                    .doFinally(signalType -> endSegment(segment))
-                    .flatMap(
-                            result -> result
-                                    .map((row, rowMetadata) -> StatsMapper.mapProjectStats(row, "trace_count")))
-                    .singleOrEmpty();
-        }));
+                    Mono<ProjectStats> feedbackMono = asyncTemplate.nonTransaction(connection -> {
+                        var statement = buildFeedbackStatementForCriteria(connection, criteria, workspaceId,
+                                userName, hasLegacyScores);
+
+                        Segment segment = startSegment("traces", "Clickhouse", "stats_feedback");
+                        return Flux.from(statement.execute())
+                                .doFinally(signalType -> endSegment(segment))
+                                .flatMap(result -> result.map((row, rowMetadata) -> mapProjectScoresStats(row)))
+                                .singleOrEmpty()
+                                .switchIfEmpty(Mono.just(new ProjectStats(List.of())));
+                    });
+
+                    return Mono.zip(tracesSpansMono, feedbackMono)
+                            .map(tuple -> StatsMerger.merge(tuple.getT1(), tuple.getT2()));
+                }));
+    }
+
+    /**
+     * Sync MySQL lookup of the workspace's legacy-feedback-scores flag, off the R2DBC event loop.
+     * Falls back to {@code true} (safe-include legacy UNION) on any error so the stats endpoint
+     * stays available when the state DB is degraded.
+     */
+    private Mono<Boolean> resolveHasLegacyScores(String workspaceId) {
+        return Mono.fromCallable(() -> workspacesService.hasLegacyScores(workspaceId))
+                .subscribeOn(Schedulers.boundedElastic())
+                .onErrorResume(throwable -> {
+                    log.warn("Failed to resolve has_legacy_scores for workspace '{}', defaulting to true",
+                            workspaceId, throwable);
+                    return Mono.just(true);
+                });
+    }
+
+    /**
+     * Builds SELECT_FEEDBACK_SCORES_STATS for the single-project (criteria-driven) entrypoint.
+     * Routes through {@link com.comet.opik.infrastructure.FilterUtils#newTraceThreadFindTemplate}
+     * so every filter slot (trace, aggregation, feedback-score, experiment, annotation-queue,
+     * guardrails, search) reaches the embedded trace_final CTE. When any filter is populated,
+     * sets {@code filters_present} so the template scopes feedback aggregates to filtered traces.
+     */
+    private Statement buildFeedbackStatementForCriteria(Connection connection, TraceSearchCriteria criteria,
+            String workspaceId, String userName, boolean hasLegacyScores) {
+        var logComment = getLogComment("get_trace_stats_feedback_scores", workspaceId, userName, "");
+        var template = newTraceThreadFindTemplate(SELECT_FEEDBACK_SCORES_STATS, criteria, TRACE_SEARCH_CLAUSE);
+        template.add("log_comment", logComment);
+        if (hasAnyTraceFilter(template)) {
+            template.add("filters_present", true);
+        }
+        template.add("has_legacy_scores", hasLegacyScores);
+
+        var statement = connection.createStatement(template.render())
+                .bind("project_ids", List.of(criteria.projectId()))
+                .bind("workspace_id", workspaceId);
+        bindTraceThreadSearchCriteria(criteria, statement);
+        return statement;
+    }
+
+    /**
+     * Builds SELECT_FEEDBACK_SCORES_STATS for the multi-project (projects-list) entrypoint.
+     * The projects-list path only carries plain trace filters, so only the {@code filters}
+     * slot (FilterStrategy.TRACE) is populated. When that slot is set, marks
+     * {@code filters_present} so the template scopes feedback aggregates to filtered traces.
+     */
+    private Statement buildFeedbackStatementForProjects(Connection connection, List<UUID> projectIds,
+            String workspaceId, List<? extends Filter> filters, boolean hasLegacyScores) {
+        var logComment = getLogComment("get_trace_stats_feedback_scores", workspaceId, "", projectIds.size());
+        var template = TemplateUtils.newST(SELECT_FEEDBACK_SCORES_STATS).add("log_comment", logComment);
+        template.add("has_legacy_scores", hasLegacyScores);
+        if (!CollectionUtils.isEmpty(filters)) {
+            FilterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.TRACE)
+                    .ifPresent(traceFilters -> {
+                        template.add("filters", traceFilters);
+                        template.add("filters_present", true);
+                    });
+        }
+
+        var statement = connection.createStatement(template.render())
+                .bind("project_ids", projectIds)
+                .bind("workspace_id", workspaceId);
+        if (!CollectionUtils.isEmpty(filters)) {
+            FilterQueryBuilder.bind(statement, filters, FilterStrategy.TRACE);
+        }
+        return statement;
+    }
+
+    private static boolean hasAnyTraceFilter(ST template) {
+        return template.getAttribute("filters") != null
+                || template.getAttribute("search_text") != null
+                || template.getAttribute("annotation_queue_filters") != null
+                || template.getAttribute("feedback_scores_filters") != null
+                || template.getAttribute("span_feedback_scores_filters") != null
+                || template.getAttribute("trace_aggregation_filters") != null
+                || template.getAttribute("experiment_filters") != null
+                || template.getAttribute("feedback_scores_empty_filters") != null
+                || template.getAttribute("span_feedback_scores_empty_filters") != null
+                || template.getAttribute("guardrails_filters") != null;
     }
 
     @Override
@@ -3487,33 +3988,54 @@ class TraceDAOImpl implements TraceDAO {
             return Mono.just(Map.of());
         }
 
-        return asyncTemplate
-                .nonTransaction(connection -> {
-                    var template = getSTWithLogComment(SELECT_TRACES_STATS, "get_trace_stats_by_project_ids",
-                            workspaceId, "", projectIds.size());
+        // Each branch runs on its own connection from the pool — R2DBC connections do not
+        // tolerate two concurrent statements on the same connection. The legacy-scores flag is
+        // resolved once (sync JDBI) so both branches can skip the legacy feedback_scores UNION
+        // when no data exists there.
+        return resolveHasLegacyScores(workspaceId)
+                .flatMap(hasLegacyScores -> {
 
-                    template.add("project_stats", true);
+                    Mono<Map<UUID, ProjectStats>> tracesSpansMono = asyncTemplate.nonTransaction(connection -> {
+                        // Split-A: traces + spans aggregation per project. project_stats=true enables the
+                        // recent / past_period error count split for the projects listing.
+                        var template = getSTWithLogComment(SELECT_TRACES_SPANS_STATS,
+                                "get_trace_stats_traces_spans_by_project_ids", workspaceId, "", projectIds.size());
+                        template.add("project_stats", true);
+                        template.add("has_legacy_scores", hasLegacyScores);
+                        if (!CollectionUtils.isEmpty(filters)) {
+                            FilterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.TRACE)
+                                    .ifPresent(traceFilters -> template.add("filters", traceFilters));
+                        }
+                        var statement = connection.createStatement(template.render())
+                                .bind("project_ids", projectIds)
+                                .bind("workspace_id", workspaceId);
+                        if (!CollectionUtils.isEmpty(filters)) {
+                            FilterQueryBuilder.bind(statement, filters, FilterStrategy.TRACE);
+                        }
 
-                    if (!CollectionUtils.isEmpty(filters)) {
-                        FilterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.TRACE)
-                                .ifPresent(traceFilters -> template.add("filters", traceFilters));
-                    }
+                        return Mono.from(statement.execute())
+                                .flatMapMany(result -> result.map((row, rowMetadata) -> Map.entry(
+                                        row.get("project_id", UUID.class),
+                                        StatsMapper.mapProjectStats(row, "trace_count"))))
+                                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+                    });
 
-                    Statement statement = connection.createStatement(template.render())
-                            .bind("project_ids", projectIds)
-                            .bind("workspace_id", workspaceId);
+                    Mono<Map<UUID, ProjectStats>> feedbackMono = asyncTemplate.nonTransaction(connection -> {
+                        // Split-B: per-project feedback-score aggregates. When the projects-list passes
+                        // trace filters we propagate them so the feedback aggregates are scoped to the
+                        // same filtered trace set (filters_present path inside the template).
+                        var statement = buildFeedbackStatementForProjects(connection, projectIds, workspaceId,
+                                filters, hasLegacyScores);
 
-                    if (!CollectionUtils.isEmpty(filters)) {
-                        FilterQueryBuilder.bind(statement, filters, FilterStrategy.TRACE);
-                    }
+                        return Mono.from(statement.execute())
+                                .flatMapMany(result -> result.map(
+                                        (row, rowMetadata) -> Map.entry(row.get("project_id", UUID.class),
+                                                mapProjectScoresStats(row))))
+                                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+                    });
 
-                    return Mono.from(statement.execute())
-                            .flatMapMany(result -> result.map((row, rowMetadata) -> Map.of(
-                                    row.get("project_id", UUID.class),
-                                    StatsMapper.mapProjectStats(row, "trace_count"))))
-                            .map(Map::entrySet)
-                            .flatMap(Flux::fromIterable)
-                            .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+                    return Mono.zip(tracesSpansMono, feedbackMono)
+                            .map(tuple -> StatsMerger.merge(tuple.getT1(), tuple.getT2()));
                 });
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -3844,8 +3844,7 @@ class TraceDAOImpl implements TraceDAO {
                                 .doFinally(signalType -> endSegment(segment))
                                 .flatMap(result -> result.map(
                                         (row, rowMetadata) -> StatsMapper.mapProjectStats(row, "trace_count")))
-                                .singleOrEmpty()
-                                .switchIfEmpty(Mono.just(new ProjectStats(List.of())));
+                                .singleOrEmpty();
                     });
 
                     Mono<ProjectStats> feedbackMono = asyncTemplate.nonTransaction(connection -> {
@@ -3856,12 +3855,10 @@ class TraceDAOImpl implements TraceDAO {
                         return Flux.from(statement.execute())
                                 .doFinally(signalType -> endSegment(segment))
                                 .flatMap(result -> result.map((row, rowMetadata) -> mapProjectScoresStats(row)))
-                                .singleOrEmpty()
-                                .switchIfEmpty(Mono.just(new ProjectStats(List.of())));
+                                .singleOrEmpty();
                     });
 
-                    return Mono.zip(tracesSpansMono, feedbackMono)
-                            .map(tuple -> StatsMerger.merge(tuple.getT1(), tuple.getT2()));
+                    return StatsMerger.zipAndMerge(tracesSpansMono, feedbackMono);
                 }));
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -3844,7 +3844,8 @@ class TraceDAOImpl implements TraceDAO {
                                 .doFinally(signalType -> endSegment(segment))
                                 .flatMap(result -> result.map(
                                         (row, rowMetadata) -> StatsMapper.mapProjectStats(row, "trace_count")))
-                                .singleOrEmpty();
+                                .singleOrEmpty()
+                                .switchIfEmpty(Mono.just(new ProjectStats(List.of())));
                     });
 
                     Mono<ProjectStats> feedbackMono = asyncTemplate.nonTransaction(connection -> {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -54,7 +54,6 @@ import org.stringtemplate.v4.ST;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SignalType;
-import reactor.core.scheduler.Schedulers;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -3825,7 +3824,7 @@ class TraceDAOImpl implements TraceDAO {
         // tolerate two concurrent statements on the same connection. The legacy-scores flag is
         // looked up once (sync JDBI) and threaded through both branches so they can skip the
         // legacy feedback_scores table UNION when no data exists there.
-        return makeMonoContextAware((userName, workspaceId) -> resolveHasLegacyScores(workspaceId)
+        return makeMonoContextAware((userName, workspaceId) -> workspacesService.hasLegacyScores(workspaceId)
                 .flatMap(hasLegacyScores -> {
 
                     Mono<ProjectStats> tracesSpansMono = asyncTemplate.nonTransaction(connection -> {
@@ -3863,21 +3862,6 @@ class TraceDAOImpl implements TraceDAO {
                     return Mono.zip(tracesSpansMono, feedbackMono)
                             .map(tuple -> StatsMerger.merge(tuple.getT1(), tuple.getT2()));
                 }));
-    }
-
-    /**
-     * Sync MySQL lookup of the workspace's legacy-feedback-scores flag, off the R2DBC event loop.
-     * Falls back to {@code true} (safe-include legacy UNION) on any error so the stats endpoint
-     * stays available when the state DB is degraded.
-     */
-    private Mono<Boolean> resolveHasLegacyScores(String workspaceId) {
-        return Mono.fromCallable(() -> workspacesService.hasLegacyScores(workspaceId))
-                .subscribeOn(Schedulers.boundedElastic())
-                .onErrorResume(throwable -> {
-                    log.warn("Failed to resolve has_legacy_scores for workspace '{}', defaulting to true",
-                            workspaceId, throwable);
-                    return Mono.just(true);
-                });
     }
 
     /**
@@ -3992,7 +3976,7 @@ class TraceDAOImpl implements TraceDAO {
         // tolerate two concurrent statements on the same connection. The legacy-scores flag is
         // resolved once (sync JDBI) so both branches can skip the legacy feedback_scores UNION
         // when no data exists there.
-        return resolveHasLegacyScores(workspaceId)
+        return workspacesService.hasLegacyScores(workspaceId)
                 .flatMap(hasLegacyScores -> {
 
                     Mono<Map<UUID, ProjectStats>> tracesSpansMono = asyncTemplate.nonTransaction(connection -> {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMapper.java
@@ -110,6 +110,12 @@ public class StatsMapper {
         addMapStats(row, USAGE, stats);
         addMapStats(row, USAGE_SUM, stats);
 
+        // Thread stats queries inline feedback_scores in the same row; project stats split it
+        // into a separate query handled by mapProjectScoresStats. Emit only when present.
+        if (row.getMetadata().contains(FEEDBACK_SCORE)) {
+            addMapStats(row, FEEDBACK_SCORE, stats);
+        }
+
         // spans cannot accept guardrails and therefore will not have guardrails_failed_count in the result set
         if (row.getMetadata().contains(GUARDRAILS_FAILED_COUNT)) {
             Optional.ofNullable(row.get(GUARDRAILS_FAILED_COUNT, Long.class)).ifPresent(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMapper.java
@@ -49,6 +49,23 @@ public class StatsMapper {
     public static final String ERROR_COUNT = "error_count";
     public static final String EXPERIMENT_ITEMS_COUNT = "experiment_items_count";
 
+    public static ProjectStats mapProjectScoresStats(Row row) {
+        var stats = Stream.<ProjectStats.ProjectStatItem<?>>builder();
+
+        // FEEDBACK_SCORE / SPAN_FEEDBACK_SCORE columns are optional: SELECT_TRACES_SPANS_STATS
+        // produces stats without them and the per-project feedback maps are merged in via
+        // StatsMerger after a parallel SELECT_FEEDBACK_SCORES_STATS query.
+        if (row.getMetadata().contains(FEEDBACK_SCORE)) {
+            addMapStats(row, FEEDBACK_SCORE, stats);
+        }
+        // span_feedback_scores statistics are only applicable for traces (not spans)
+        if (row.getMetadata().contains(SPAN_FEEDBACK_SCORE)) {
+            addMapStats(row, SPAN_FEEDBACK_SCORE, stats);
+        }
+
+        return new ProjectStats(stats.build().toList());
+    }
+
     public static ProjectStats mapProjectStats(Row row, String entityCountLabel) {
 
         var stats = Stream.<ProjectStats.ProjectStatItem<?>>builder()
@@ -92,11 +109,6 @@ public class StatsMapper {
 
         addMapStats(row, USAGE, stats);
         addMapStats(row, USAGE_SUM, stats);
-        addMapStats(row, FEEDBACK_SCORE, stats);
-        // Only add span feedback scores statistics for traces (not spans)
-        if (entityCountLabel.equals(TRACE_COUNT) && row.getMetadata().contains(SPAN_FEEDBACK_SCORE)) {
-            addMapStats(row, SPAN_FEEDBACK_SCORE, stats);
-        }
 
         // spans cannot accept guardrails and therefore will not have guardrails_failed_count in the result set
         if (row.getMetadata().contains(GUARDRAILS_FAILED_COUNT)) {
@@ -335,6 +347,25 @@ public class StatsMapper {
             return new BigDecimal(number.toString());
         }
         return null;
+    }
+
+    /**
+     * Converts a column-value map (e.g. {@code {"accuracy": 0.5, "recall": 0.8}}) into an
+     * ordered list of {@link AvgValueStat} entries, each keyed as {@code "<prefix>.<key>"}.
+     * Numeric values arrive from ClickHouse as {@link Number} (typically {@link Double})
+     * regardless of the column's declared Decimal precision, so we coerce through Number.
+     * Returns an empty list when the input is {@code null} or empty.
+     */
+    public static List<ProjectStats.ProjectStatItem<?>> toMapStats(Map<String, Object> values, String statPrefix) {
+        if (MapUtils.isEmpty(values)) {
+            return List.of();
+        }
+        return values.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey()).<ProjectStats.ProjectStatItem<?>>map(entry -> {
+                    double value = entry.getValue() instanceof Number number ? number.doubleValue() : 0.0;
+                    return new AvgValueStat("%s.%s".formatted(statPrefix, entry.getKey()), value);
+                })
+                .toList();
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMapper.java
@@ -110,8 +110,7 @@ public class StatsMapper {
         addMapStats(row, USAGE, stats);
         addMapStats(row, USAGE_SUM, stats);
 
-        // Thread stats queries inline feedback_scores in the same row; project stats split it
-        // into a separate query handled by mapProjectScoresStats. Emit only when present.
+        // Thread stats inline feedback_scores in the row; split-A trace/span rows don't.
         if (row.getMetadata().contains(FEEDBACK_SCORE)) {
             addMapStats(row, FEEDBACK_SCORE, stats);
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMerger.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMerger.java
@@ -40,7 +40,8 @@ public class StatsMerger {
         return tracesSpansByProject.entrySet().stream()
                 .collect(toMap(
                         Map.Entry::getKey,
-                        entry -> merge(entry.getValue(), feedbackByProject.get(entry.getKey()))));
+                        entry -> merge(entry.getValue(),
+                                feedbackByProject.getOrDefault(entry.getKey(), ProjectStats.empty()))));
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMerger.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMerger.java
@@ -4,8 +4,10 @@ import com.comet.opik.api.ProjectStats;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
+import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -80,5 +82,21 @@ public class StatsMerger {
 
     private static final Set<String> TRAILING_STATS = Set.of(
             GUARDRAILS_FAILED_COUNT, RECENT_ERROR_COUNT, PAST_PERIOD_ERROR_COUNT, ERROR_COUNT);
+
+    /**
+     * Zips the split-A (aggregates) and split-B (feedback) branches the way every single-project
+     * {@code getStats} call site needs them. Both branches get an empty-{@link ProjectStats}
+     * default so {@link Mono#zip} never silently drops one side when the other emits empty
+     * (a real possibility for both queries since they end with {@code GROUP BY project_id}).
+     * The zipped result is then spliced via {@link #merge(ProjectStats, ProjectStats)} so the
+     * feedback aggregates land at the canonical position in the stats list.
+     */
+    public static Mono<ProjectStats> zipAndMerge(Mono<ProjectStats> aggregates, Mono<ProjectStats> feedback) {
+        var empty = new ProjectStats(List.of());
+        return Mono.zip(
+                aggregates.switchIfEmpty(Mono.just(empty)),
+                feedback.switchIfEmpty(Mono.just(empty)))
+                .map(tuple -> merge(tuple.getT1(), tuple.getT2()));
+    }
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMerger.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMerger.java
@@ -7,7 +7,6 @@ import org.apache.commons.collections4.MapUtils;
 import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -18,18 +17,8 @@ import static com.comet.opik.domain.stats.StatsMapper.PAST_PERIOD_ERROR_COUNT;
 import static com.comet.opik.domain.stats.StatsMapper.RECENT_ERROR_COUNT;
 import static java.util.stream.Collectors.toMap;
 
-/**
- * Merges per-project trace+span stats (from SELECT_TRACES_SPANS_STATS) with per-project
- * feedback-score stats (from SELECT_FEEDBACK_SCORES_STATS).
- * <p>
- * Merge rule: the traces map is the source of truth for which projects appear in the output.
- * Feedback stats are enrichment; projects absent from the traces side are never resurrected
- * by feedback data, even if feedback rows exist for them. Trace-side filters define the
- * result scope.
- * <p>
- * This class only concatenates already-mapped stats — row-to-stats conversion lives in
- * {@link StatsMapper}.
- */
+// Merges trace+span stats (split-A) with feedback-score stats (split-B). The trace side
+// defines result scope: projects absent from it are not resurrected by feedback rows.
 @UtilityClass
 public class StatsMerger {
 
@@ -51,12 +40,8 @@ public class StatsMerger {
                                 feedbackByProject.getOrDefault(entry.getKey(), ProjectStats.empty()))));
     }
 
-    /**
-     * Single-project variant — splices the feedback stats into the trace+span stats at the
-     * canonical position (just before guardrails / error-count entries) so the merged output
-     * matches what the pre-split single-query mapper produced. Returns {@code base} unchanged
-     * when there's nothing to attach.
-     */
+    // Splices feedback into base at the canonical slot (before guardrails / error-count) so the
+    // merged list matches the pre-split mapper's order.
     public static ProjectStats merge(ProjectStats base, ProjectStats feedback) {
         if (base == null) {
             return null;
@@ -83,20 +68,13 @@ public class StatsMerger {
     private static final Set<String> TRAILING_STATS = Set.of(
             GUARDRAILS_FAILED_COUNT, RECENT_ERROR_COUNT, PAST_PERIOD_ERROR_COUNT, ERROR_COUNT);
 
-    /**
-     * Zips the split-A (aggregates) and split-B (feedback) branches the way every single-project
-     * {@code getStats} call site needs them. Both branches get an empty-{@link ProjectStats}
-     * default so {@link Mono#zip} never silently drops one side when the other emits empty
-     * (a real possibility for both queries since they end with {@code GROUP BY project_id}).
-     * The zipped result is then spliced via {@link #merge(ProjectStats, ProjectStats)} so the
-     * feedback aggregates land at the canonical position in the stats list.
-     */
+    // When aggregates is empty, return empty — feedback alone is never surfaced (matches the
+    // traces-driven scope of the map overload).
     public static Mono<ProjectStats> zipAndMerge(Mono<ProjectStats> aggregates, Mono<ProjectStats> feedback) {
-        var empty = new ProjectStats(List.of());
-        return Mono.zip(
-                aggregates.switchIfEmpty(Mono.just(empty)),
-                feedback.switchIfEmpty(Mono.just(empty)))
-                .map(tuple -> merge(tuple.getT1(), tuple.getT2()));
+        return aggregates
+                .flatMap(agg -> feedback.switchIfEmpty(Mono.fromSupplier(ProjectStats::empty))
+                        .map(fb -> merge(agg, fb)))
+                .switchIfEmpty(Mono.fromSupplier(ProjectStats::empty));
     }
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMerger.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMerger.java
@@ -7,8 +7,13 @@ import org.apache.commons.collections4.MapUtils;
 
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
+import static com.comet.opik.domain.stats.StatsMapper.ERROR_COUNT;
+import static com.comet.opik.domain.stats.StatsMapper.GUARDRAILS_FAILED_COUNT;
+import static com.comet.opik.domain.stats.StatsMapper.PAST_PERIOD_ERROR_COUNT;
+import static com.comet.opik.domain.stats.StatsMapper.RECENT_ERROR_COUNT;
 import static java.util.stream.Collectors.toMap;
 
 /**
@@ -45,8 +50,10 @@ public class StatsMerger {
     }
 
     /**
-     * Single-project variant — attaches the feedback stats to the trace+span stats by
-     * concatenating the lists. Returns {@code base} unchanged when there's nothing to attach.
+     * Single-project variant — splices the feedback stats into the trace+span stats at the
+     * canonical position (just before guardrails / error-count entries) so the merged output
+     * matches what the pre-split single-query mapper produced. Returns {@code base} unchanged
+     * when there's nothing to attach.
      */
     public static ProjectStats merge(ProjectStats base, ProjectStats feedback) {
         if (base == null) {
@@ -56,9 +63,22 @@ public class StatsMerger {
             return base;
         }
 
-        var combined = new ArrayList<>(base.stats());
-        combined.addAll(feedback.stats());
+        var combined = new ArrayList<ProjectStats.ProjectStatItem<?>>(base.stats().size() + feedback.stats().size());
+        boolean inserted = false;
+        for (var stat : base.stats()) {
+            if (!inserted && TRAILING_STATS.contains(stat.getName())) {
+                combined.addAll(feedback.stats());
+                inserted = true;
+            }
+            combined.add(stat);
+        }
+        if (!inserted) {
+            combined.addAll(feedback.stats());
+        }
         return new ProjectStats(combined);
     }
+
+    private static final Set<String> TRAILING_STATS = Set.of(
+            GUARDRAILS_FAILED_COUNT, RECENT_ERROR_COUNT, PAST_PERIOD_ERROR_COUNT, ERROR_COUNT);
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMerger.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/stats/StatsMerger.java
@@ -1,0 +1,63 @@
+package com.comet.opik.domain.stats;
+
+import com.comet.opik.api.ProjectStats;
+import lombok.experimental.UtilityClass;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * Merges per-project trace+span stats (from SELECT_TRACES_SPANS_STATS) with per-project
+ * feedback-score stats (from SELECT_FEEDBACK_SCORES_STATS).
+ * <p>
+ * Merge rule: the traces map is the source of truth for which projects appear in the output.
+ * Feedback stats are enrichment; projects absent from the traces side are never resurrected
+ * by feedback data, even if feedback rows exist for them. Trace-side filters define the
+ * result scope.
+ * <p>
+ * This class only concatenates already-mapped stats — row-to-stats conversion lives in
+ * {@link StatsMapper}.
+ */
+@UtilityClass
+public class StatsMerger {
+
+    public static Map<UUID, ProjectStats> merge(
+            Map<UUID, ProjectStats> tracesSpansByProject,
+            Map<UUID, ProjectStats> feedbackByProject) {
+
+        if (MapUtils.isEmpty(tracesSpansByProject)) {
+            return Map.of();
+        }
+        if (MapUtils.isEmpty(feedbackByProject)) {
+            return tracesSpansByProject;
+        }
+
+        return tracesSpansByProject.entrySet().stream()
+                .collect(toMap(
+                        Map.Entry::getKey,
+                        entry -> merge(entry.getValue(), feedbackByProject.get(entry.getKey()))));
+    }
+
+    /**
+     * Single-project variant — attaches the feedback stats to the trace+span stats by
+     * concatenating the lists. Returns {@code base} unchanged when there's nothing to attach.
+     */
+    public static ProjectStats merge(ProjectStats base, ProjectStats feedback) {
+        if (base == null) {
+            return null;
+        }
+        if (CollectionUtils.isEmpty(feedback.stats())) {
+            return base;
+        }
+
+        var combined = new ArrayList<>(base.stats());
+        combined.addAll(feedback.stats());
+        return new ProjectStats(combined);
+    }
+
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/AuthWorkspaceVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/AuthWorkspaceVersionService.java
@@ -2,6 +2,7 @@ package com.comet.opik.domain.workspaces;
 
 import com.comet.opik.api.OpikVersion;
 import com.comet.opik.domain.ExperimentDAO;
+import com.comet.opik.domain.FeedbackScoreDAO;
 import com.comet.opik.domain.OptimizationDAO;
 import com.comet.opik.infrastructure.CacheConfiguration;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
@@ -26,13 +27,14 @@ public class AuthWorkspaceVersionService extends AbstractWorkspaceVersionService
     public AuthWorkspaceVersionService(@NonNull TransactionTemplate transactionTemplate,
             @NonNull ExperimentDAO experimentDAO,
             @NonNull OptimizationDAO optimizationDAO,
+            @NonNull FeedbackScoreDAO feedbackScoreDAO,
             @NonNull ServiceTogglesConfig serviceTogglesConfig,
             @NonNull CacheManager cacheManager,
             @NonNull CacheConfiguration cacheConfiguration,
             @NonNull WorkspacesService workspacesService,
             @NonNull AnalyticsService analyticsService) {
-        super(transactionTemplate, experimentDAO, optimizationDAO, serviceTogglesConfig, cacheManager,
-                cacheConfiguration, workspacesService, analyticsService);
+        super(transactionTemplate, experimentDAO, optimizationDAO, feedbackScoreDAO, serviceTogglesConfig,
+                cacheManager, cacheConfiguration, workspacesService, analyticsService);
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/UnauthWorkspaceVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/UnauthWorkspaceVersionService.java
@@ -2,6 +2,7 @@ package com.comet.opik.domain.workspaces;
 
 import com.comet.opik.api.OpikVersion;
 import com.comet.opik.domain.ExperimentDAO;
+import com.comet.opik.domain.FeedbackScoreDAO;
 import com.comet.opik.domain.OptimizationDAO;
 import com.comet.opik.infrastructure.CacheConfiguration;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
@@ -22,13 +23,14 @@ public class UnauthWorkspaceVersionService extends AbstractWorkspaceVersionServi
     public UnauthWorkspaceVersionService(@NonNull TransactionTemplate transactionTemplate,
             @NonNull ExperimentDAO experimentDAO,
             @NonNull OptimizationDAO optimizationDAO,
+            @NonNull FeedbackScoreDAO feedbackScoreDAO,
             @NonNull ServiceTogglesConfig serviceTogglesConfig,
             @NonNull CacheManager cacheManager,
             @NonNull CacheConfiguration cacheConfiguration,
             @NonNull WorkspacesService workspacesService,
             @NonNull AnalyticsService analyticsService) {
-        super(transactionTemplate, experimentDAO, optimizationDAO, serviceTogglesConfig, cacheManager,
-                cacheConfiguration, workspacesService, analyticsService);
+        super(transactionTemplate, experimentDAO, optimizationDAO, feedbackScoreDAO, serviceTogglesConfig,
+                cacheManager, cacheConfiguration, workspacesService, analyticsService);
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/Workspace.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/Workspace.java
@@ -22,6 +22,7 @@ public record Workspace(
         Instant firstTraceReportedAt,
         Instant migrationSkippedAt,
         String migrationSkippedReason,
+        boolean hasLegacyScores,
         Instant createdAt,
         String createdBy,
         Instant lastUpdatedAt,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
@@ -217,19 +217,29 @@ abstract class AbstractWorkspaceVersionService implements WorkspaceVersionServic
 
     private void persistAndEmitBlocking(String workspaceId, WorkspaceVersion response, String userName) {
         var newVersion = response.opikVersion();
-        var previousVersion = workspacesService.findById(workspaceId)
+        var existingWorkspace = workspacesService.findById(workspaceId);
+        var previousVersion = existingWorkspace
                 .map(Workspace::lastKnownVersion)
                 .flatMap(OpikVersion::findByValue);
         workspacesService.upsertVersion(workspaceId, newVersion, userName);
-        // Probe the legacy feedback_scores ClickHouse table once per workspace version
-        // determination and persist the result. The stats query path uses this flag to skip
-        // the legacy UNION when no data exists there.
-        try {
-            boolean hasLegacyScores = Boolean.TRUE.equals(feedbackScoreDAO.hasLegacyScores(workspaceId).block());
-            workspacesService.upsertHasLegacyScores(workspaceId, hasLegacyScores, userName);
-        } catch (RuntimeException exception) {
-            log.warn("Failed to probe legacy feedback_scores, leaving flag untouched, workspaceId '{}'",
-                    workspaceId, exception);
+        // Probe the legacy feedback_scores ClickHouse table only when MySQL hasn't already
+        // recorded that this workspace has no legacy data. Once the flag is false the legacy
+        // table only ever shrinks (no new writes land there), so re-probing on every cache
+        // miss is wasted CH work + a redundant MySQL upsert. Re-upsert only when the result
+        // differs from the stored value.
+        boolean storedHasLegacyScores = existingWorkspace
+                .map(Workspace::hasLegacyScores)
+                .orElse(true);
+        if (storedHasLegacyScores) {
+            try {
+                boolean hasLegacyScores = Boolean.TRUE.equals(feedbackScoreDAO.hasLegacyScores(workspaceId).block());
+                if (existingWorkspace.isEmpty() || hasLegacyScores != storedHasLegacyScores) {
+                    workspacesService.upsertHasLegacyScores(workspaceId, hasLegacyScores, userName);
+                }
+            } catch (RuntimeException exception) {
+                log.warn("Failed to probe legacy feedback_scores, leaving flag untouched, workspaceId '{}'",
+                        workspaceId, exception);
+            }
         }
         var versionChanged = previousVersion.map(prev -> prev != newVersion).orElse(true);
         analyticsService.trackEvent("workspace_version_determined", Map.of(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
@@ -7,6 +7,7 @@ import com.comet.opik.domain.DashboardDAO;
 import com.comet.opik.domain.DatasetDAO;
 import com.comet.opik.domain.DemoData;
 import com.comet.opik.domain.ExperimentDAO;
+import com.comet.opik.domain.FeedbackScoreDAO;
 import com.comet.opik.domain.OptimizationDAO;
 import com.comet.opik.domain.PromptDAO;
 import com.comet.opik.domain.evaluators.AutomationRuleDAO;
@@ -107,6 +108,7 @@ abstract class AbstractWorkspaceVersionService implements WorkspaceVersionServic
     protected final TransactionTemplate transactionTemplate;
     protected final ExperimentDAO experimentDAO;
     protected final OptimizationDAO optimizationDAO;
+    protected final FeedbackScoreDAO feedbackScoreDAO;
     protected final ServiceTogglesConfig serviceTogglesConfig;
     protected final CacheManager cacheManager;
     protected final CacheConfiguration cacheConfiguration;
@@ -116,6 +118,7 @@ abstract class AbstractWorkspaceVersionService implements WorkspaceVersionServic
     protected AbstractWorkspaceVersionService(@NonNull TransactionTemplate transactionTemplate,
             @NonNull ExperimentDAO experimentDAO,
             @NonNull OptimizationDAO optimizationDAO,
+            @NonNull FeedbackScoreDAO feedbackScoreDAO,
             @NonNull ServiceTogglesConfig serviceTogglesConfig,
             @NonNull CacheManager cacheManager,
             @NonNull CacheConfiguration cacheConfiguration,
@@ -124,6 +127,7 @@ abstract class AbstractWorkspaceVersionService implements WorkspaceVersionServic
         this.transactionTemplate = transactionTemplate;
         this.experimentDAO = experimentDAO;
         this.optimizationDAO = optimizationDAO;
+        this.feedbackScoreDAO = feedbackScoreDAO;
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.cacheManager = cacheManager;
         this.cacheConfiguration = cacheConfiguration;
@@ -217,6 +221,16 @@ abstract class AbstractWorkspaceVersionService implements WorkspaceVersionServic
                 .map(Workspace::lastKnownVersion)
                 .flatMap(OpikVersion::findByValue);
         workspacesService.upsertVersion(workspaceId, newVersion, userName);
+        // Probe the legacy feedback_scores ClickHouse table once per workspace version
+        // determination and persist the result. The stats query path uses this flag to skip
+        // the legacy UNION when no data exists there.
+        try {
+            boolean hasLegacyScores = Boolean.TRUE.equals(feedbackScoreDAO.hasLegacyScores(workspaceId).block());
+            workspacesService.upsertHasLegacyScores(workspaceId, hasLegacyScores, userName);
+        } catch (RuntimeException exception) {
+            log.warn("Failed to probe legacy feedback_scores, leaving flag untouched, workspaceId '{}'",
+                    workspaceId, exception);
+        }
         var versionChanged = previousVersion.map(prev -> prev != newVersion).orElse(true);
         analyticsService.trackEvent("workspace_version_determined", Map.of(
                 "workspace_id", workspaceId,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
@@ -222,11 +222,8 @@ abstract class AbstractWorkspaceVersionService implements WorkspaceVersionServic
                 .map(Workspace::lastKnownVersion)
                 .flatMap(OpikVersion::findByValue);
         workspacesService.upsertVersion(workspaceId, newVersion, userName);
-        // Probe the legacy feedback_scores ClickHouse table only when MySQL hasn't already
-        // recorded that this workspace has no legacy data. Once the flag is false the legacy
-        // table only ever shrinks (no new writes land there), so re-probing on every cache
-        // miss is wasted CH work + a redundant MySQL upsert. Re-upsert only when the result
-        // differs from the stored value.
+        // Skip the CH probe + MySQL write once the flag is false — the legacy table only
+        // shrinks (no new writes land there), so the answer can't flip back to true.
         boolean storedHasLegacyScores = existingWorkspace
                 .map(Workspace::hasLegacyScores)
                 .orElse(true);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesDAO.java
@@ -92,4 +92,28 @@ public interface WorkspacesDAO {
 
     @SqlQuery("SELECT COUNT(*) FROM workspaces WHERE migration_skipped_at IS NOT NULL")
     long countMigrationSkipped();
+
+    /**
+     * Returns the workspace's legacy-feedback-scores flag. {@code Optional.empty()} when the
+     * workspace row doesn't exist yet — callers treat it as TRUE (safe-include UNION), same as
+     * the column default. An admin/backfill flow flips workspaces with no legacy data to FALSE
+     * so their stats queries skip the empty-table scan.
+     */
+    @SqlQuery("SELECT has_legacy_scores FROM workspaces WHERE id = :id")
+    Optional<Boolean> findHasLegacyScores(@Bind("id") String id);
+
+    /**
+     * Idempotent upsert that sets the legacy-feedback-scores flag explicitly. Called from the
+     * workspace version determination flow after a one-shot ClickHouse presence check.
+     */
+    @SqlUpdate("""
+            INSERT INTO workspaces (id, has_legacy_scores, created_by, last_updated_by)
+            VALUES (:id, :hasLegacyScores, :userName, :userName)
+            ON DUPLICATE KEY UPDATE
+                has_legacy_scores = :hasLegacyScores,
+                last_updated_by = :userName
+            """)
+    int upsertHasLegacyScores(@Bind("id") String id,
+            @Bind("hasLegacyScores") boolean hasLegacyScores,
+            @Bind("userName") String userName);
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesService.java
@@ -51,6 +51,22 @@ public interface WorkspacesService {
     List<String> findMigrationSkippedWorkspaceIds();
 
     long countMigrationSkipped();
+
+    /**
+     * Returns whether the workspace is known to have data in the legacy {@code feedback_scores}
+     * ClickHouse table. Defaults to {@code true} when no row exists yet — callers must include the
+     * legacy table in any UNION until explicitly told otherwise. The workspace version
+     * determination flow probes the table once and persists the result via
+     * {@link #upsertHasLegacyScores}.
+     */
+    boolean hasLegacyScores(String workspaceId);
+
+    /**
+     * Idempotent upsert that records the workspace's legacy-feedback-scores status explicitly.
+     * Called from the workspace version determination flow after a one-shot ClickHouse presence
+     * check on the {@code feedback_scores} table.
+     */
+    void upsertHasLegacyScores(String workspaceId, boolean hasLegacyScores, String userName);
 }
 
 @Singleton
@@ -145,5 +161,24 @@ class WorkspacesServiceImpl implements WorkspacesService {
     public long countMigrationSkipped() {
         return transactionTemplate.inTransaction(READ_ONLY,
                 handle -> handle.attach(WorkspacesDAO.class).countMigrationSkipped());
+    }
+
+    @Override
+    public boolean hasLegacyScores(@NonNull String workspaceId) {
+        if (StringUtils.isBlank(workspaceId)) {
+            // No workspace context — fall back to safe-include.
+            return true;
+        }
+        return transactionTemplate.inTransaction(READ_ONLY,
+                handle -> handle.attach(WorkspacesDAO.class).findHasLegacyScores(workspaceId))
+                .orElse(true);
+    }
+
+    @Override
+    public void upsertHasLegacyScores(@NonNull String workspaceId, boolean hasLegacyScores,
+            @NonNull String userName) {
+        transactionTemplate.inTransaction(WRITE,
+                handle -> handle.attach(WorkspacesDAO.class)
+                        .upsertHasLegacyScores(workspaceId, hasLegacyScores, userName));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesService.java
@@ -6,8 +6,11 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
 import java.sql.SQLException;
@@ -53,13 +56,13 @@ public interface WorkspacesService {
     long countMigrationSkipped();
 
     /**
-     * Returns whether the workspace is known to have data in the legacy {@code feedback_scores}
-     * ClickHouse table. Defaults to {@code true} when no row exists yet — callers must include the
-     * legacy table in any UNION until explicitly told otherwise. The workspace version
-     * determination flow probes the table once and persists the result via
-     * {@link #upsertHasLegacyScores}.
+     * Returns whether the workspace has data in the legacy {@code feedback_scores} ClickHouse
+     * table. Runs the blocking JDBI lookup on a bounded-elastic worker; defaults to {@code true}
+     * when no row exists yet, and on any error so a degraded state DB doesn't break the stats
+     * endpoint. The version determination flow probes the table once and persists the result
+     * via {@link #upsertHasLegacyScores}.
      */
-    boolean hasLegacyScores(String workspaceId);
+    Mono<Boolean> hasLegacyScores(String workspaceId);
 
     /**
      * Idempotent upsert that records the workspace's legacy-feedback-scores status explicitly.
@@ -69,6 +72,7 @@ public interface WorkspacesService {
     void upsertHasLegacyScores(String workspaceId, boolean hasLegacyScores, String userName);
 }
 
+@Slf4j
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 class WorkspacesServiceImpl implements WorkspacesService {
@@ -164,14 +168,19 @@ class WorkspacesServiceImpl implements WorkspacesService {
     }
 
     @Override
-    public boolean hasLegacyScores(@NonNull String workspaceId) {
+    public Mono<Boolean> hasLegacyScores(@NonNull String workspaceId) {
         if (StringUtils.isBlank(workspaceId)) {
-            // No workspace context — fall back to safe-include.
-            return true;
+            return Mono.just(true);
         }
-        return transactionTemplate.inTransaction(READ_ONLY,
+        return Mono.fromCallable(() -> transactionTemplate.inTransaction(READ_ONLY,
                 handle -> handle.attach(WorkspacesDAO.class).findHasLegacyScores(workspaceId))
-                .orElse(true);
+                .orElse(true))
+                .subscribeOn(Schedulers.boundedElastic())
+                .onErrorResume(throwable -> {
+                    log.warn("Failed to resolve has_legacy_scores for workspace '{}', defaulting to true",
+                            workspaceId, throwable);
+                    return Mono.just(true);
+                });
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
@@ -1,6 +1,7 @@
 package com.comet.opik.infrastructure.auth;
 
 import com.comet.opik.domain.ExperimentDAO;
+import com.comet.opik.domain.FeedbackScoreDAO;
 import com.comet.opik.domain.LocalWorkspacePermissionsService;
 import com.comet.opik.domain.OptimizationDAO;
 import com.comet.opik.domain.RemoteWorkspacePermissionsService;
@@ -86,18 +87,19 @@ public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
             TransactionTemplate transactionTemplate,
             ExperimentDAO experimentDAO,
             OptimizationDAO optimizationDAO,
+            FeedbackScoreDAO feedbackScoreDAO,
             CacheManager cacheManager,
             WorkspacesService workspacesService,
             AnalyticsService analyticsService) {
         if (!authenticationConfig.isEnabled()) {
             log.info("Authentication disabled, using UnauthWorkspaceVersionService");
             return new UnauthWorkspaceVersionService(
-                    transactionTemplate, experimentDAO, optimizationDAO, serviceTogglesConfig, cacheManager,
-                    cacheConfiguration, workspacesService, analyticsService);
+                    transactionTemplate, experimentDAO, optimizationDAO, feedbackScoreDAO, serviceTogglesConfig,
+                    cacheManager, cacheConfiguration, workspacesService, analyticsService);
         }
         log.info("Authentication enabled, using AuthWorkspaceVersionService");
         return new AuthWorkspaceVersionService(
-                transactionTemplate, experimentDAO, optimizationDAO, serviceTogglesConfig, cacheManager,
-                cacheConfiguration, workspacesService, analyticsService);
+                transactionTemplate, experimentDAO, optimizationDAO, feedbackScoreDAO, serviceTogglesConfig,
+                cacheManager, cacheConfiguration, workspacesService, analyticsService);
     }
 }

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000069_add_has_legacy_scores_to_workspaces.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000069_add_has_legacy_scores_to_workspaces.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+--changeset thiagohora:000069_add_has_legacy_scores_to_workspaces
+--comment: Track whether a workspace has data in the legacy `feedback_scores` table. Defaults to TRUE (safe-include UNION).
+
+ALTER TABLE workspaces
+    ADD COLUMN has_legacy_scores BOOLEAN NOT NULL DEFAULT TRUE AFTER migration_skipped_reason;
+
+--rollback ALTER TABLE workspaces DROP COLUMN has_legacy_scores;
+

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
@@ -43,6 +43,7 @@ import com.comet.opik.api.resources.utils.resources.ProjectMetricsResourceClient
 import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
 import com.comet.opik.api.resources.utils.resources.SpanResourceClient;
 import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
+import com.comet.opik.api.resources.utils.resources.WorkspaceResourceClient;
 import com.comet.opik.api.resources.utils.spans.SpanAssertions;
 import com.comet.opik.api.resources.utils.traces.TraceAssertions;
 import com.comet.opik.domain.EntityType;
@@ -131,6 +132,7 @@ class MultiValueFeedbackScoresE2ETest {
     private DatasetResourceClient datasetResourceClient;
     private OptimizationResourceClient optimizationResourceClient;
     private ProjectMetricsResourceClient projectMetricsResourceClient;
+    private WorkspaceResourceClient workspaceResourceClient;
     private FeedbackScoreDAO feedbackScoreDAO;
 
     @BeforeAll
@@ -148,6 +150,7 @@ class MultiValueFeedbackScoresE2ETest {
         this.datasetResourceClient = new DatasetResourceClient(client, baseURI);
         this.optimizationResourceClient = new OptimizationResourceClient(client, baseURI, factory);
         this.projectMetricsResourceClient = new ProjectMetricsResourceClient(client, baseURI);
+        this.workspaceResourceClient = new WorkspaceResourceClient(client, baseURI, factory);
         this.feedbackScoreDAO = feedbackScoreDAO;
     }
 
@@ -950,6 +953,98 @@ class MultiValueFeedbackScoresE2ETest {
                 .orElseThrow(() -> new AssertionError("Thread with id " + threadId + " not found"));
         assertThat(getThreadScore(actualMultiScoresByFind).reason())
                 .isEqualTo("%s, %s".formatted(EMPTY_REASON_PLACEHOLDER, EMPTY_REASON_PLACEHOLDER));
+    }
+
+    @Test
+    @DisplayName("trace stats include legacy feedback_scores when the workspace has data in the legacy table")
+    void testTraceStats_legacyFeedbackScoresSurfacedWhenPresent() {
+        var workspaceName = randomUUID().toString();
+        var workspaceId = randomUUID().toString();
+        var apiKey = randomUUID().toString();
+        AuthTestUtils.mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, USER1);
+
+        var projectName = RandomStringUtils.secure().nextAlphanumeric(10);
+        var projectId = projectResourceClient.createProject(projectName, apiKey, workspaceName);
+
+        var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                .id(null)
+                .projectName(projectName)
+                .usage(null)
+                .feedbackScores(null)
+                .startTime(Instant.now().truncatedTo(ChronoUnit.HOURS))
+                .endTime(Instant.now().truncatedTo(ChronoUnit.HOURS).plusMillis(100))
+                .build();
+        var traceId = traceResourceClient.createTrace(trace, apiKey, workspaceName);
+
+        var authoredScore = factory.manufacturePojo(FeedbackScore.class);
+        traceResourceClient.feedbackScore(traceId, authoredScore, workspaceName, apiKey);
+
+        var legacyScore = factory.manufacturePojo(FeedbackScore.class).toBuilder()
+                .name("legacy-" + randomUUID())
+                .build();
+        feedbackScoreDAO.scoreEntity(EntityType.TRACE, traceId, legacyScore, projectId, null)
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER1)
+                        .put(RequestContext.WORKSPACE_ID, workspaceId))
+                .block();
+
+        // Trigger the natural workspace-version determination flow so the legacy-scores probe
+        // runs against actual ClickHouse state and the workspace flag is set accordingly.
+        workspaceResourceClient.getWorkspaceVersion(apiKey, workspaceName);
+
+        var expected = traceResourceClient.getById(traceId, workspaceName, apiKey).toBuilder()
+                .feedbackScores(List.of(
+                        FeedbackScore.builder().name(authoredScore.name()).value(authoredScore.value()).build(),
+                        FeedbackScore.builder().name(legacyScore.name()).value(legacyScore.value()).build()))
+                .build();
+
+        var actualStats = traceResourceClient.getTraceStats(projectName, null, apiKey, workspaceName, null, Map.of());
+        TraceAssertions.assertStats(actualStats.stats(), StatsUtils.getProjectTraceStatItems(List.of(expected)));
+    }
+
+    @Test
+    @DisplayName("span stats include legacy feedback_scores when the workspace has data in the legacy table")
+    void testSpanStats_legacyFeedbackScoresSurfacedWhenPresent() {
+        var workspaceName = randomUUID().toString();
+        var workspaceId = randomUUID().toString();
+        var apiKey = randomUUID().toString();
+        AuthTestUtils.mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, USER1);
+
+        var projectName = RandomStringUtils.secure().nextAlphanumeric(10);
+        var projectId = projectResourceClient.createProject(projectName, apiKey, workspaceName);
+
+        var span = factory.manufacturePojo(Span.class).toBuilder()
+                .id(null)
+                .projectName(projectName)
+                .usage(null)
+                .feedbackScores(null)
+                .totalEstimatedCost(null)
+                .build();
+        var spanId = spanResourceClient.createSpan(span, apiKey, workspaceName);
+
+        var authoredScore = factory.manufacturePojo(FeedbackScore.class);
+        spanResourceClient.feedbackScore(spanId, authoredScore, workspaceName, apiKey);
+
+        var legacyScore = factory.manufacturePojo(FeedbackScore.class).toBuilder()
+                .name("legacy-" + randomUUID())
+                .build();
+        feedbackScoreDAO.scoreEntity(EntityType.SPAN, spanId, legacyScore, projectId, null)
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER1)
+                        .put(RequestContext.WORKSPACE_ID, workspaceId))
+                .block();
+
+        workspaceResourceClient.getWorkspaceVersion(apiKey, workspaceName);
+
+        var expected = spanResourceClient.getById(spanId, workspaceName, apiKey).toBuilder()
+                .feedbackScores(List.of(
+                        FeedbackScore.builder().name(authoredScore.name()).value(authoredScore.value()).build(),
+                        FeedbackScore.builder().name(legacyScore.name()).value(legacyScore.value()).build()))
+                .build();
+
+        var actualStats = spanResourceClient.getSpansStats(projectName, null, null, apiKey, workspaceName, Map.of());
+        SpanAssertions.assertionStatusPage(actualStats.stats(),
+                StatsUtils.getProjectSpanStatItems(List.of(expected)));
     }
 
     private FeedbackScore getTraceScore(Trace trace) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -41,6 +41,7 @@ import com.comet.opik.api.resources.utils.resources.GuardrailsResourceClient;
 import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
 import com.comet.opik.api.resources.utils.resources.SpanResourceClient;
 import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
+import com.comet.opik.api.resources.utils.resources.WorkspaceResourceClient;
 import com.comet.opik.api.sorting.Direction;
 import com.comet.opik.api.sorting.SortableFields;
 import com.comet.opik.api.sorting.SortingField;
@@ -192,6 +193,7 @@ class ProjectsResourceTest {
     private ProjectResourceClient projectResourceClient;
     private GuardrailsResourceClient guardrailsResourceClient;
     private GuardrailsGenerator guardrailsGenerator;
+    private WorkspaceResourceClient workspaceResourceClient;
 
     @BeforeAll
     void setUpAll(ClientSupport client, ProjectService projectService) {
@@ -209,6 +211,7 @@ class ProjectsResourceTest {
         this.projectResourceClient = new ProjectResourceClient(this.client, baseURI, factory);
         this.guardrailsResourceClient = new GuardrailsResourceClient(this.client, baseURI);
         this.guardrailsGenerator = new GuardrailsGenerator();
+        this.workspaceResourceClient = new WorkspaceResourceClient(this.client, baseURI, factory);
     }
 
     private void mockTargetWorkspace(String apiKey, String workspaceName, String workspaceId) {
@@ -1433,9 +1436,8 @@ class ProjectsResourceTest {
         }
 
         @Test
-        @DisplayName("when has_legacy_scores is true and the legacy table has rows, the UNION includes them; flipping to false drops them")
-        void getProjects__whenLegacyScoresHasData__thenUnionGatedByFlag(WorkspacesService workspacesService,
-                FeedbackScoreDAO feedbackScoreDAO) {
+        @DisplayName("when the legacy feedback_scores table has rows for the workspace, the project stats UNION surfaces them")
+        void getProjects__whenLegacyScoresHasData__thenStatsIncludeThem(FeedbackScoreDAO feedbackScoreDAO) {
             String workspaceName = UUID.randomUUID().toString();
             String apiKey = UUID.randomUUID().toString();
             String workspaceId = UUID.randomUUID().toString();
@@ -1446,10 +1448,9 @@ class ProjectsResourceTest {
             UUID projectId = createProject(project, apiKey, workspaceName);
             var seeded = buildProjectStats(project.toBuilder().id(projectId).build(), apiKey, workspaceName);
 
-            // Pick a trace from the seeded project and write a single feedback score directly
-            // into the legacy `feedback_scores` table (author=null path) — the public API always
-            // routes to authored_feedback_scores, so this is the only way to exercise the gated
-            // UNION branch from a test.
+            // Write directly into the legacy `feedback_scores` table via the author=null DAO
+            // path — the public API always routes to authored_feedback_scores, so this is the
+            // only way to exercise the legacy-UNION branch from a backend test.
             var traces = traceResourceClient.getTraces(project.name(), null, apiKey, workspaceName, null, null, 1,
                     Map.of());
             UUID traceId = traces.content().getFirst().id();
@@ -1462,19 +1463,19 @@ class ProjectsResourceTest {
                             .put(RequestContext.WORKSPACE_ID, workspaceId))
                     .block();
 
-            // Expected with the legacy UNION enabled: seeded stats + one extra average for the
-            // legacy score (single sample, so the average is the score's own value).
-            var withLegacyFeedback = new ArrayList<>(seeded.feedbackScores());
-            withLegacyFeedback.add(FeedbackScoreAverage.builder()
+            // Trigger the natural workspace-version determination flow so the legacy-scores
+            // probe runs against actual ClickHouse state and persists the workspace flag.
+            workspaceResourceClient.getWorkspaceVersion(apiKey, workspaceName);
+
+            var expectedFeedback = new ArrayList<>(seeded.feedbackScores());
+            expectedFeedback.add(FeedbackScoreAverage.builder()
                     .name(legacyScore.name())
                     .value(legacyScore.value())
                     .build());
-            var expectedWithLegacy = mapFromProjectToSummary(
-                    seeded.toBuilder().feedbackScores(withLegacyFeedback).build());
-            var expectedWithoutLegacy = mapFromProjectToSummary(seeded);
+            var expected = mapFromProjectToSummary(
+                    seeded.toBuilder().feedbackScores(expectedFeedback).build());
 
-            workspacesService.upsertHasLegacyScores(workspaceId, true, USER);
-            var withLegacyItem = client.target(URL_TEMPLATE.formatted(baseURI))
+            var actual = client.target(URL_TEMPLATE.formatted(baseURI))
                     .path("/stats")
                     .request()
                     .header(HttpHeaders.AUTHORIZATION, apiKey)
@@ -1485,31 +1486,12 @@ class ProjectsResourceTest {
                     .findFirst()
                     .orElseThrow();
 
-            assertThat(withLegacyItem)
+            assertThat(actual)
                     .usingRecursiveComparison()
                     .ignoringCollectionOrder()
                     .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
                     .withComparatorForFields(StatsUtils::closeToEpsilonComparator, "totalEstimatedCost")
-                    .isEqualTo(expectedWithLegacy);
-
-            workspacesService.upsertHasLegacyScores(workspaceId, false, USER);
-            var withoutLegacyItem = client.target(URL_TEMPLATE.formatted(baseURI))
-                    .path("/stats")
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, apiKey)
-                    .header(WORKSPACE_HEADER, workspaceName)
-                    .get(ProjectStatsSummary.class)
-                    .content().stream()
-                    .filter(item -> projectId.equals(item.projectId()))
-                    .findFirst()
-                    .orElseThrow();
-
-            assertThat(withoutLegacyItem)
-                    .usingRecursiveComparison()
-                    .ignoringCollectionOrder()
-                    .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
-                    .withComparatorForFields(StatsUtils::closeToEpsilonComparator, "totalEstimatedCost")
-                    .isEqualTo(expectedWithoutLegacy);
+                    .isEqualTo(expected);
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -48,6 +48,7 @@ import com.comet.opik.domain.GuardrailResult;
 import com.comet.opik.domain.GuardrailsMapper;
 import com.comet.opik.domain.IdGenerator;
 import com.comet.opik.domain.ProjectService;
+import com.comet.opik.domain.workspaces.WorkspacesService;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;
@@ -1388,6 +1389,44 @@ class ProjectsResourceTest {
                     .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
                     .withComparatorForFields(StatsUtils::closeToEpsilonComparator, "totalEstimatedCost")
                     .isEqualTo(expectedProjectStats);
+        }
+
+        @Test
+        @DisplayName("when has_legacy_scores is flipped, stats endpoint stays consistent")
+        void getProjects__whenHasLegacyScoresFlipped__thenStatsStayConsistent(WorkspacesService workspacesService) {
+            // Test infra writes feedback scores through the authenticated path, so data lands in
+            // authored_feedback_scores (not the legacy feedback_scores table). This test can't
+            // observe the legacy-UNION gate directly — that surface is covered by the existing
+            // FilterTest variants and by manual benchmarking against real legacy data. What this
+            // test does verify: flipping the workspace flag does not break the endpoint and the
+            // response stays correct for data that lives in authored_feedback_scores.
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            Comparator<Project> comparator = Comparator.comparing(Project::id).reversed();
+            var expectedStats = getProjectStatsSummaryItems(apiKey, workspaceName, comparator);
+
+            workspacesService.upsertHasLegacyScores(workspaceId, false, USER);
+
+            var response = client.target(URL_TEMPLATE.formatted(baseURI))
+                    .path("/stats")
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, apiKey)
+                    .header(WORKSPACE_HEADER, workspaceName)
+                    .get();
+
+            assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(org.apache.http.HttpStatus.SC_OK);
+            var actual = response.readEntity(ProjectStatsSummary.class);
+
+            assertThat(actual.content())
+                    .usingRecursiveComparison()
+                    .ignoringCollectionOrder()
+                    .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
+                    .withComparatorForFields(StatsUtils::closeToEpsilonComparator, "totalEstimatedCost")
+                    .isEqualTo(expectedStats);
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -44,6 +44,8 @@ import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
 import com.comet.opik.api.sorting.Direction;
 import com.comet.opik.api.sorting.SortableFields;
 import com.comet.opik.api.sorting.SortingField;
+import com.comet.opik.domain.EntityType;
+import com.comet.opik.domain.FeedbackScoreDAO;
 import com.comet.opik.domain.GuardrailResult;
 import com.comet.opik.domain.GuardrailsMapper;
 import com.comet.opik.domain.IdGenerator;
@@ -52,6 +54,7 @@ import com.comet.opik.domain.workspaces.WorkspacesService;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;
+import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.auth.WorkspaceUserPermission;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.JsonUtils;
@@ -1427,6 +1430,86 @@ class ProjectsResourceTest {
                     .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
                     .withComparatorForFields(StatsUtils::closeToEpsilonComparator, "totalEstimatedCost")
                     .isEqualTo(expectedStats);
+        }
+
+        @Test
+        @DisplayName("when has_legacy_scores is true and the legacy table has rows, the UNION includes them; flipping to false drops them")
+        void getProjects__whenLegacyScoresHasData__thenUnionGatedByFlag(WorkspacesService workspacesService,
+                FeedbackScoreDAO feedbackScoreDAO) {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var project = factory.manufacturePojo(Project.class);
+            UUID projectId = createProject(project, apiKey, workspaceName);
+            var seeded = buildProjectStats(project.toBuilder().id(projectId).build(), apiKey, workspaceName);
+
+            // Pick a trace from the seeded project and write a single feedback score directly
+            // into the legacy `feedback_scores` table (author=null path) — the public API always
+            // routes to authored_feedback_scores, so this is the only way to exercise the gated
+            // UNION branch from a test.
+            var traces = traceResourceClient.getTraces(project.name(), null, apiKey, workspaceName, null, null, 1,
+                    Map.of());
+            UUID traceId = traces.content().getFirst().id();
+            var legacyScore = factory.manufacturePojo(FeedbackScore.class).toBuilder()
+                    .name("legacy-" + UUID.randomUUID())
+                    .build();
+            feedbackScoreDAO.scoreEntity(EntityType.TRACE, traceId, legacyScore, projectId, null)
+                    .contextWrite(ctx -> ctx
+                            .put(RequestContext.USER_NAME, USER)
+                            .put(RequestContext.WORKSPACE_ID, workspaceId))
+                    .block();
+
+            // Expected with the legacy UNION enabled: seeded stats + one extra average for the
+            // legacy score (single sample, so the average is the score's own value).
+            var withLegacyFeedback = new ArrayList<>(seeded.feedbackScores());
+            withLegacyFeedback.add(FeedbackScoreAverage.builder()
+                    .name(legacyScore.name())
+                    .value(legacyScore.value())
+                    .build());
+            var expectedWithLegacy = mapFromProjectToSummary(
+                    seeded.toBuilder().feedbackScores(withLegacyFeedback).build());
+            var expectedWithoutLegacy = mapFromProjectToSummary(seeded);
+
+            workspacesService.upsertHasLegacyScores(workspaceId, true, USER);
+            var withLegacyItem = client.target(URL_TEMPLATE.formatted(baseURI))
+                    .path("/stats")
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, apiKey)
+                    .header(WORKSPACE_HEADER, workspaceName)
+                    .get(ProjectStatsSummary.class)
+                    .content().stream()
+                    .filter(item -> projectId.equals(item.projectId()))
+                    .findFirst()
+                    .orElseThrow();
+
+            assertThat(withLegacyItem)
+                    .usingRecursiveComparison()
+                    .ignoringCollectionOrder()
+                    .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
+                    .withComparatorForFields(StatsUtils::closeToEpsilonComparator, "totalEstimatedCost")
+                    .isEqualTo(expectedWithLegacy);
+
+            workspacesService.upsertHasLegacyScores(workspaceId, false, USER);
+            var withoutLegacyItem = client.target(URL_TEMPLATE.formatted(baseURI))
+                    .path("/stats")
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, apiKey)
+                    .header(WORKSPACE_HEADER, workspaceName)
+                    .get(ProjectStatsSummary.class)
+                    .content().stream()
+                    .filter(item -> projectId.equals(item.projectId()))
+                    .findFirst()
+                    .orElseThrow();
+
+            assertThat(withoutLegacyItem)
+                    .usingRecursiveComparison()
+                    .ignoringCollectionOrder()
+                    .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
+                    .withComparatorForFields(StatsUtils::closeToEpsilonComparator, "totalEstimatedCost")
+                    .isEqualTo(expectedWithoutLegacy);
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/stats/StatsMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/stats/StatsMapperTest.java
@@ -104,20 +104,11 @@ class StatsMapperTest {
     }
 
     @Test
-    void mapProjectStats_withSpanFeedbackScores_returnsSpanFeedbackScoresStats() {
+    void mapProjectScoresStats_withSpanFeedbackScores_returnsSpanFeedbackScoresStats() {
+        // Split-B (SELECT_FEEDBACK_SCORES_STATS / SELECT_SPAN_FEEDBACK_SCORES_STATS) materialises
+        // feedback aggregates in their own row mapped via mapProjectScoresStats — mapProjectStats
+        // (split-A) no longer carries feedback columns.
         Map<String, Object> values = new HashMap<>();
-        values.put("trace_count", 1L);
-        values.put("duration", List.of(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO));
-        values.put("input", 0L);
-        values.put("output", 0L);
-        values.put("metadata", 0L);
-        values.put("tags", 0.0);
-        values.put("llm_span_count_avg", 2.0);
-        values.put("span_count_avg", 3.0);
-        values.put("total_estimated_cost_avg", new BigDecimal("1.25"));
-        values.put("total_estimated_cost_sum", new BigDecimal("2.50"));
-
-        // Add span feedback scores map
         Map<String, BigDecimal> spanFeedbackScores = new HashMap<>();
         spanFeedbackScores.put("accuracy", new BigDecimal("0.85"));
         spanFeedbackScores.put("relevance", new BigDecimal("0.80"));
@@ -125,7 +116,7 @@ class StatsMapperTest {
 
         Row row = new SimpleRow(values);
 
-        ProjectStats stats = StatsMapper.mapProjectStats(row, "trace_count");
+        ProjectStats stats = StatsMapper.mapProjectScoresStats(row);
         Map<String, Object> mapped = stats.stats()
                 .stream()
                 .collect(Collectors.toMap(ProjectStats.ProjectStatItem::getName,
@@ -138,32 +129,36 @@ class StatsMapperTest {
     }
 
     @Test
-    void mapProjectStats_withSpanFeedbackScoresForSpans_doesNotReturnSpanFeedbackScoresStats() {
+    void mapProjectStats_doesNotEmitFeedbackScoreStats() {
+        // mapProjectStats (split-A) intentionally drops feedback-score columns — they live in the
+        // companion mapProjectScoresStats(Row) used by SELECT_FEEDBACK_SCORES_STATS.
         Map<String, Object> values = new HashMap<>();
-        values.put("span_count", 1L);
+        values.put("trace_count", 1L);
         values.put("duration", List.of(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO));
         values.put("input", 0L);
         values.put("output", 0L);
         values.put("metadata", 0L);
         values.put("tags", 0.0);
+        values.put("llm_span_count_avg", 2.0);
+        values.put("span_count_avg", 3.0);
         values.put("total_estimated_cost_avg", new BigDecimal("1.25"));
         values.put("total_estimated_cost_sum", new BigDecimal("2.50"));
 
-        // Add span feedback scores map (should be ignored for spans)
-        Map<String, BigDecimal> spanFeedbackScores = new HashMap<>();
-        spanFeedbackScores.put("accuracy", new BigDecimal("0.85"));
-        values.put(StatsMapper.SPAN_FEEDBACK_SCORE, spanFeedbackScores);
+        Map<String, BigDecimal> feedbackScores = new HashMap<>();
+        feedbackScores.put("accuracy", new BigDecimal("0.85"));
+        values.put(StatsMapper.FEEDBACK_SCORE, feedbackScores);
+        values.put(StatsMapper.SPAN_FEEDBACK_SCORE, feedbackScores);
 
         Row row = new SimpleRow(values);
 
-        ProjectStats stats = StatsMapper.mapProjectStats(row, "span_count");
+        ProjectStats stats = StatsMapper.mapProjectStats(row, "trace_count");
         Map<String, Object> mapped = stats.stats()
                 .stream()
                 .collect(Collectors.toMap(ProjectStats.ProjectStatItem::getName,
                         ProjectStats.ProjectStatItem::getValue));
 
-        // Span feedback scores should not be included for span statistics
-        assertThat(mapped.containsKey("%s.%s".formatted(StatsMapper.SPAN_FEEDBACK_SCORE, "accuracy")))
-                .isFalse();
+        assertThat(mapped.keySet())
+                .noneMatch(k -> k.startsWith(StatsMapper.FEEDBACK_SCORE)
+                        || k.startsWith(StatsMapper.SPAN_FEEDBACK_SCORE));
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/stats/StatsMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/stats/StatsMapperTest.java
@@ -129,9 +129,43 @@ class StatsMapperTest {
     }
 
     @Test
-    void mapProjectStats_doesNotEmitFeedbackScoreStats() {
-        // mapProjectStats (split-A) intentionally drops feedback-score columns — they live in the
-        // companion mapProjectScoresStats(Row) used by SELECT_FEEDBACK_SCORES_STATS.
+    void mapProjectStats_whenRowHasFeedbackScoresColumn_emitsFeedbackScoreStats() {
+        // Thread stats inline feedback_scores in the same row and call mapProjectStats directly
+        // (no merge with mapProjectScoresStats). The mapper must emit them when present so the
+        // thread stats endpoint keeps returning feedback aggregates.
+        Map<String, Object> values = new HashMap<>();
+        values.put("trace_count", 1L);
+        values.put("duration", List.of(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO));
+        values.put("input", 0L);
+        values.put("output", 0L);
+        values.put("metadata", 0L);
+        values.put("tags", 0.0);
+        values.put("llm_span_count_avg", 0.0);
+        values.put("span_count_avg", 0.0);
+        values.put("total_estimated_cost_avg", BigDecimal.ZERO);
+        values.put("total_estimated_cost_sum", BigDecimal.ZERO);
+
+        Map<String, BigDecimal> feedbackScores = new HashMap<>();
+        feedbackScores.put("accuracy", new BigDecimal("0.85"));
+        values.put(StatsMapper.FEEDBACK_SCORE, feedbackScores);
+
+        Row row = new SimpleRow(values);
+
+        ProjectStats stats = StatsMapper.mapProjectStats(row, "trace_count");
+        Map<String, Object> mapped = stats.stats()
+                .stream()
+                .collect(Collectors.toMap(ProjectStats.ProjectStatItem::getName,
+                        ProjectStats.ProjectStatItem::getValue));
+
+        assertThat(mapped.get("%s.%s".formatted(StatsMapper.FEEDBACK_SCORE, "accuracy")))
+                .isEqualTo(0.85);
+    }
+
+    @Test
+    void mapProjectStats_whenRowOmitsFeedbackScoresColumn_doesNotEmitFeedbackScoreStats() {
+        // Split-A SELECT_TRACES_SPANS_STATS / SELECT_SPANS_STATS rows don't include the
+        // feedback_scores column — those aggregates come from the companion split-B query and
+        // are spliced in by StatsMerger.
         Map<String, Object> values = new HashMap<>();
         values.put("trace_count", 1L);
         values.put("duration", List.of(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO));
@@ -143,11 +177,6 @@ class StatsMapperTest {
         values.put("span_count_avg", 3.0);
         values.put("total_estimated_cost_avg", new BigDecimal("1.25"));
         values.put("total_estimated_cost_sum", new BigDecimal("2.50"));
-
-        Map<String, BigDecimal> feedbackScores = new HashMap<>();
-        feedbackScores.put("accuracy", new BigDecimal("0.85"));
-        values.put(StatsMapper.FEEDBACK_SCORE, feedbackScores);
-        values.put(StatsMapper.SPAN_FEEDBACK_SCORE, feedbackScores);
 
         Row row = new SimpleRow(values);
 


### PR DESCRIPTION
## Details

Splits the project-stats endpoints (`/v1/private/traces/stats`, `/v1/private/spans/stats`, projects-list `/stats`) into two queries that run in parallel via `Mono.zip` — one for trace/span aggregation, one for feedback-score aggregation — then merges the results in-process. Eliminates the dominant per-entity JOIN against the rich groupArray-tuple feedback CTE that was making the stats endpoint multi-second on workspaces with high feedback-score volume.

- New `SELECT_TRACES_SPANS_STATS` + `SELECT_FEEDBACK_SCORES_STATS` templates; the trace path keeps full filter-resolution (`<if(filters_present)>` block embeds the trace_final CTE with all existing filter slots so feedback aggregates are scoped to the filtered trace set when filters are active).
- Same split applied to `SpanDAO`: `SELECT_SPANS_STATS` no longer carries the feedback JOIN, a new `SELECT_SPAN_FEEDBACK_SCORES_STATS` runs in parallel.
- Adds a `workspaces.has_legacy_scores` MySQL flag (defaults `TRUE` for backwards compatibility). Detected during workspace version determination via a single `EXISTS` probe on the legacy `feedback_scores` ClickHouse table and persisted via `WorkspacesService.upsertHasLegacyScores`. Stats templates gate every legacy-table UNION branch on this flag so workspaces with no legacy data skip the empty-table scan.
- `StatsMerger` utility (in `domain/stats/`) does traces-driven list concatenation; the traces map is the source of truth for which projects appear in the output — feedback enrichment never resurrects projects filtered out trace-side.
- `StatsMapper.toMapStats` exposes the existing map → AvgValueStat conversion so callers can build feedback `ProjectStats` without re-rendering it through a row. A new `StatsMapper.mapProjectScoresStats(Row)` handles the split-B row shape; `mapProjectStats` (split-A) intentionally no longer emits feedback-score columns.

## Investigation notes

Symptom that drove this: `/v1/private/traces/stats` consistently timing out at the ClickHouse client read limit (31–36s) for a project carrying ~23K traces and ~32M `authored_feedback_scores` rows on a large customer's deployment. Other smaller projects in the same workspace returned in <200ms — the cost was concentrated where feedback-score volume was high. Stack traces pointed at `TracesResource.getStats` → ClickHouse `Read timed out`.

Investigation walked through several candidate fixes against the customer's CH cluster, copying their schema and data shape, to figure out where the time was actually going:

| Variant | Strategy | Wall clock |
|---|---|---:|
| Original monolithic `LIMIT 1 BY` | prod-style dedup | ~78s |
| `FINAL` everywhere | storage-merge dedup | ~19s |
| `argMax(...)` + GROUP BY storage key | streaming aggregate | ~39s |
| LIMIT 1 BY + sortkey-aligned `ORDER BY` | tries to ride storage order | ~80s |
| **Split (traces+spans / feedback) + simplifications** | what this PR ships | **~3.5–4s no filter** |
| | | **~0.28s with trace-side filter** |

End-to-end: ~20× faster unfiltered, up to ~280× faster with a trace-side filter — and well under the ClickHouse client read timeout. The split is what unlocks two further wins that the monolithic query can't reach: dropping the per-entity JOIN against feedback_scores_agg, and the rich `groupArray(tuple(value, reason, category_name, source, author, ...))` materialisation that exists only because the trace-listing endpoint shares the same CTE. Stats only needs `value`, so the new feedback-aggregation pipeline projects exactly that.

The legacy-table gate matters specifically because this customer's `feedback_scores` table is empty (everything goes to `authored_feedback_scores` via the authored API path). With `has_legacy_scores=false` we elide the legacy UNION entirely; with the default `true` the behaviour is bit-for-bit unchanged from `main`.

Output verified byte-identical against the previous monolithic shape: 144-key feedback-score map matched to a max absolute difference of 1.5e-14 — well below the `toDecimal64(9)` precision the API truncates to. No frontend or SDK changes.

ClickHouse server-side stats for the four template paths against the customer cluster:

| Path | Duration | Rows read | Peak mem |
|---|---:|---:|---:|
| split-A, no filter | ~1.5s | 11.0M | 1.34 GiB |
| split-B, no filter | ~4.0s | 32.5M | 6–8 GiB |
| split-A, with trace filter | ~0.15s | 11.0M | 49 MiB |
| split-B, with trace filter | ~0.28s | 22.0M | 37 MiB |

(With filter, the `entity_id IN (SELECT id FROM trace_final)` pushdown narrows the feedback scan aggressively — and the whole aggregation runs in CPU cache.)

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6505

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: SQL template authoring, Java DAO refactor, performance investigation, tests-as-feedback iteration
- Human verification: schema review and migration approval, semantic-change review for the filter-scope contract, query benchmarking against a customer dataset, and reading the diff before merge

## Testing

`mvn compile -DskipTests` + `mvn spotless:check`: clean.

`mvn -Dtest='StatsMapperTest' test`: 3/3 PASS (after aligning the test with the new split-A vs split-B mapping contract).

`mvn -Dtest='ProjectsResourceTest$FindProject#getProjects__whenProjectsHasTracesSpansFeedbackScoresAndUsage*' test`: 2/2 PASS.

`mvn -Dtest='GetTracesByProjectResourceTest' test`: 1704/1704 PASS (includes 1590 FilterTest variants covering trace and span feedback-score filters on the `/stats` endpoint).

`mvn -Dtest='FindSpansResourceTest' test`: 1400/1408 PASS — the 8 remaining failures (`whenFilterFeedbackScores*[1]`, `whenFilterByIsEmpty[3,6]`) are pre-existing on `main`; verified by stashing the changes in this PR and re-running against the unmodified baseline (same 8 failed). They're unrelated to this work.

Scenarios validated:
- Happy path (no filters): both split queries run in parallel.
- Trace-column filter (e.g. `error_info != ''`): split-A narrows trace_final; split-B's `filters_present` branch mirrors the same filter resolution and scopes feedback aggregates to filtered traces.
- Feedback-score filter (e.g. `accuracy > 0.5`): same path; feedback CTEs materialised because the filter resolution needs them.
- `has_legacy_scores=false` workspace: the legacy `feedback_scores` table UNION branch is elided from every template.
- Workspace version determination failure path: stats endpoint falls back to `has_legacy_scores=true` via `resolveHasLegacyScores`'s `onErrorResume`, so a degraded state DB does not break stats.

Local process mode, Java 21, Testcontainers ClickHouse/MySQL/Redis.

## Documentation

No public documentation updates required. Workspaces with no legacy `feedback_scores` rows now skip the empty-table scan after their first version determination — purely a perf change, no observable API diff.