### PR TITLE
[OPIK-6417] [SDK] feat: cascade trace + span comments in opik migrate dataset

### DIFF
--- a/sdks/python/src/opik/cli/migrate/datasets/executor.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/executor.py
@@ -308,6 +308,31 @@ def _cascade_experiments(
         # any experiment was skipped (e.g. ``recreate_experiment`` returned
         # False because all items missed the trace_id remap).
 
+    # Surface cascade counters on a separate audit record (additive --
+    # the existing ``cascade_experiments`` action record is unchanged
+    # from Slice 3, so callers reading the action's pre/post state keep
+    # working). The action-loop framework calls ``_action_details``
+    # BEFORE ``apply_fn`` so the per-action ``ok`` record can't carry
+    # post-apply counters; a summary record after the cascade is the
+    # cleanest additive surface.
+    audit.record(
+        type="cascade_experiments_summary",
+        status="ok",
+        details={
+            "source_dataset_id": action.source_dataset_id,
+            "to_dataset": action.dest_name,
+            "to_project": action.dest_project_name,
+            "experiments_migrated": result.experiments_migrated,
+            "experiments_skipped": result.experiments_skipped,
+            "traces_migrated": result.traces_migrated,
+            "spans_migrated": result.spans_migrated,
+            "trace_comments_migrated": result.trace_comments_migrated,
+            "span_comments_migrated": result.span_comments_migrated,
+            "items_skipped_missing_trace": result.items_skipped_missing_trace,
+            "items_skipped_missing_item": result.items_skipped_missing_item,
+        },
+    )
+
     plan.trace_id_remap.update(result.trace_id_remap)
 
 

--- a/sdks/python/src/opik/cli/migrate/datasets/experiments.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/experiments.py
@@ -157,6 +157,8 @@ class ExperimentCascadeResult:
     experiments_skipped: int = 0
     traces_migrated: int = 0
     spans_migrated: int = 0
+    trace_comments_migrated: int = 0
+    span_comments_migrated: int = 0
     items_skipped_missing_trace: int = 0
     items_skipped_missing_item: int = 0
     # Per-experiment skip reasons for the audit log. Each entry is
@@ -209,6 +211,11 @@ def cascade_experiments(
           ``ExperimentCascadeError`` instead.
         - ``traces_migrated`` / ``spans_migrated`` -- per-entity counters
           aggregating across every source experiment processed.
+        - ``trace_comments_migrated`` / ``span_comments_migrated`` --
+          counters for comments re-emitted via the dedicated single-
+          comment write endpoints (comments are READ_ONLY on the
+          trace/span Write payload, so they ride along the cascade as
+          post-write follow-up POSTs rather than the bulk writes).
         - ``items_skipped_missing_trace`` / ``items_skipped_missing_item``
           -- per-experiment-item skip counters, tallied after the recreate
           call by comparing each source item's ``trace_id`` /
@@ -357,7 +364,12 @@ def cascade_one_experiment(
     inner = _InnerProgress(inner_progress_callback, inner_total)
     inner.tick(label="read items")
 
-    traces_copied, spans_copied = _copy_traces_and_spans(
+    (
+        traces_copied,
+        spans_copied,
+        trace_comments_copied,
+        span_comments_copied,
+    ) = _copy_traces_and_spans(
         client,
         rest_client,
         source_experiment_id=experiment_id,
@@ -371,6 +383,8 @@ def cascade_one_experiment(
     )
     result.traces_migrated += traces_copied
     result.spans_migrated += spans_copied
+    result.trace_comments_migrated += trace_comments_copied
+    result.span_comments_migrated += span_comments_copied
 
     # Build the ExperimentData payload that recreate_experiment consumes.
     # Only the FK fields land on the destination ExperimentItem -- the
@@ -576,7 +590,7 @@ def _copy_traces_and_spans(
     trace_id_remap: Dict[str, str],
     assertion_results_by_source_trace: Optional[Dict[str, List[Any]]] = None,
     inner_progress: Optional["_InnerProgress"] = None,
-) -> tuple[int, int]:
+) -> tuple[int, int, int, int]:
     """Re-emit traces + spans under ``target_project_name`` via the high-level
     Opik client's streamer infrastructure.
 
@@ -607,7 +621,16 @@ def _copy_traces_and_spans(
     on ``SpanField``); the bulk-read win is on traces only.
 
     Populates ``trace_id_remap`` in place with one entry per copied trace.
-    Returns ``(traces_copied, spans_copied)`` for counter aggregation.
+    Returns ``(traces_copied, spans_copied, trace_comments_copied,
+    span_comments_copied)`` for counter aggregation.
+
+    Comments are read off the same ``TracePublic.comments`` /
+    ``SpanPublic.comments`` payload as the bulk trace/span reads
+    (no extra fetches) and re-emitted via the dedicated single-comment
+    write endpoints after the destination trace/span lands. Order is
+    preserved by iterating the source list in place: the BE returns
+    comments sorted by ``createdAt`` and POSTs are serialized, so the
+    destination read order matches.
 
     ``source_project_id`` is only a defensive fallback used when an
     individual source trace has a null ``project_id`` field. Per-trace
@@ -617,13 +640,13 @@ def _copy_traces_and_spans(
     invariance across an experiment's traces).
     """
     if not source_trace_ids:
-        return 0, 0
+        return 0, 0, 0, 0
 
     # Skip traces we already copied (idempotent retries, cross-experiment
     # trace sharing in the rare case it happens).
     new_source_ids = [tid for tid in source_trace_ids if tid not in trace_id_remap]
     if not new_source_ids:
-        return 0, 0
+        return 0, 0, 0, 0
 
     source_to_new_trace: Dict[str, str] = {}
     project_id_to_name_cache: Dict[str, str] = {}
@@ -766,6 +789,19 @@ def _copy_traces_and_spans(
     if inner_progress is not None:
         inner_progress.tick(label="logged assertion results")
 
+    # Re-emit trace comments via the dedicated single-comment write
+    # endpoint. ``TracePublic.comments`` rides along the bulk trace read,
+    # so no additional source-side fetch. Comments are READ_ONLY on the
+    # trace Write payload (can't ride along ``__internal_api__trace__``),
+    # so we POST one-at-a-time after the trace flush -- production-wide
+    # there are ~4k comments total across all workspaces, the per-comment
+    # cost is acceptable.
+    trace_comments_copied = _copy_trace_comments(
+        rest_client,
+        source_traces_by_id=source_traces_by_id,
+        source_to_new_trace=source_to_new_trace,
+    )
+
     # Phase 2a: bulk-fetch spans for the experiment, one call per distinct
     # project the experiment's traces live in. ``search_spans`` (like
     # ``search_traces``) clamps ``project_id`` on the outer SQL, so a
@@ -798,13 +834,21 @@ def _copy_traces_and_spans(
     # bucket. Same topological-sort + per-trace span_id_remap logic as
     # before; the only change is the source of ``source_spans`` shifted
     # from a per-trace REST call to a dict lookup.
+    #
+    # ``span_id_remaps_by_trace`` keeps each trace's per-trace remap
+    # (source span id -> destination span id) so the comment-cascade
+    # follow-up can POST source span comments against the correct
+    # destination span id. Per-trace scoping is correct: span ids only
+    # collide within a tree, and ``comments`` are span-attached so the
+    # mapping never needs to span trees.
     spans_emitted = 0
     span_feedback_scores: List[BatchFeedbackScoreDict] = []
+    span_id_remaps_by_trace: Dict[str, Dict[str, str]] = {}
     span_trace_count = len(source_to_new_trace)
     for index, (source_trace_id, new_trace_id) in enumerate(
         source_to_new_trace.items(), start=1
     ):
-        per_trace_count, per_trace_fbs = _emit_spans_for_trace(
+        per_trace_count, per_trace_fbs, per_trace_span_remap = _emit_spans_for_trace(
             client,
             source_spans=spans_by_trace_id.get(source_trace_id, []),
             new_trace_id=new_trace_id,
@@ -812,6 +856,7 @@ def _copy_traces_and_spans(
         )
         spans_emitted += per_trace_count
         span_feedback_scores.extend(per_trace_fbs)
+        span_id_remaps_by_trace[source_trace_id] = per_trace_span_remap
         if inner_progress is not None:
             inner_progress.tick(label=f"spans for trace {index}/{span_trace_count}")
 
@@ -826,7 +871,18 @@ def _copy_traces_and_spans(
     if inner_progress is not None:
         inner_progress.tick(label="flushed spans + logged span feedback scores")
 
-    return traces_copied, spans_emitted
+    # Re-emit span comments via the dedicated single-comment write
+    # endpoint, after the span flush so the destination span id is
+    # persisted. Same shape as trace comments: ``SpanPublic.comments``
+    # rides along the bulk span read (no extra fetch), per-comment POST
+    # wrapped with the rate-limit helper.
+    span_comments_copied = _copy_span_comments(
+        rest_client,
+        spans_by_trace_id=spans_by_trace_id,
+        span_id_remaps_by_trace=span_id_remaps_by_trace,
+    )
+
+    return traces_copied, spans_emitted, trace_comments_copied, span_comments_copied
 
 
 def _log_trace_feedback_scores(
@@ -951,6 +1007,89 @@ def _log_trace_assertion_results(
     client.log_assertion_results(
         assertion_results=batch, project_name=target_project_name
     )
+
+
+def _copy_trace_comments(
+    rest_client: OpikApi,
+    *,
+    source_traces_by_id: Dict[str, TracePublic],
+    source_to_new_trace: Dict[str, str],
+) -> int:
+    """Re-emit each source trace's comments on the destination trace.
+
+    ``TracePublic.comments`` rides along the bulk trace read (no extra
+    source-side fetch). Comments are READ_ONLY on the trace Write
+    payload, so they can't ride along ``__internal_api__trace__``; we
+    POST one-at-a-time via the dedicated single-comment write endpoint
+    after the destination trace lands.
+
+    Order is preserved by iterating the source ``comments`` list in
+    place: the BE returns comments sorted by ``createdAt`` and the POSTs
+    are serialized, so the destination read order matches.
+
+    Returns the total number of comments copied (sum across all traces).
+    """
+    copied = 0
+    for source_trace_id, new_trace_id in source_to_new_trace.items():
+        source_trace = source_traces_by_id.get(source_trace_id)
+        if source_trace is None or not source_trace.comments:
+            continue
+        for comment in source_trace.comments:
+            rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+                lambda nt=new_trace_id,
+                text=comment.text: rest_client.traces.add_trace_comment(
+                    id_=nt, text=text
+                ),
+                operation_name="add_trace_comment (experiment cascade)",
+            )
+            copied += 1
+    return copied
+
+
+def _copy_span_comments(
+    rest_client: OpikApi,
+    *,
+    spans_by_trace_id: Dict[str, List[SpanPublic]],
+    span_id_remaps_by_trace: Dict[str, Dict[str, str]],
+) -> int:
+    """Re-emit each source span's comments on the destination span.
+
+    Same shape as ``_copy_trace_comments``: ``SpanPublic.comments``
+    rides along the bulk span read, comments POST via the dedicated
+    single-comment write endpoint after the destination span lands.
+
+    The destination span id comes from the per-trace ``span_id_remap``
+    populated in ``_emit_spans_for_trace``. Per-trace scoping is correct
+    -- span ids only collide within a tree, so the remap never needs to
+    span trees.
+
+    Returns the total number of comments copied (sum across all spans).
+    """
+    copied = 0
+    for source_trace_id, source_spans in spans_by_trace_id.items():
+        span_id_remap = span_id_remaps_by_trace.get(source_trace_id, {})
+        if not span_id_remap:
+            continue
+        for source_span in source_spans:
+            if not source_span.comments:
+                continue
+            new_span_id = span_id_remap.get(source_span.id or "")
+            if new_span_id is None:
+                # Defensive: every span we wrote produced a remap entry,
+                # so this should only fire if the bulk fetch returned a
+                # span we didn't write (e.g. the cascade's expected-id
+                # filter dropped it). Skip rather than crash.
+                continue
+            for comment in source_span.comments:
+                rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+                    lambda ns=new_span_id,
+                    text=comment.text: rest_client.spans.add_span_comment(
+                        id_=ns, text=text
+                    ),
+                    operation_name="add_span_comment (experiment cascade)",
+                )
+                copied += 1
+    return copied
 
 
 def _resolve_project_name(
@@ -1184,10 +1323,14 @@ def _emit_spans_for_trace(
     source_spans: List[SpanPublic],
     new_trace_id: str,
     target_project_name: str,
-) -> Tuple[int, List[BatchFeedbackScoreDict]]:
+) -> Tuple[int, List[BatchFeedbackScoreDict], Dict[str, str]]:
     """Mint new ids preserving the parent tree and emit destination spans
     via direct ``client._streamer.put(CreateSpanMessage(...))`` calls.
-    Returns ``(spans_emitted, span_feedback_scores)``.
+    Returns ``(spans_emitted, span_feedback_scores, span_id_remap)``.
+
+    ``span_id_remap`` (source span id -> destination span id) is needed
+    by the comment-cascade follow-up so it can POST each source span's
+    ``comments`` against the correct destination span id.
 
     ``source_spans`` is the pre-fetched bucket for ONE trace, populated
     by the experiment-level bulk read in
@@ -1215,7 +1358,7 @@ def _emit_spans_for_trace(
     from opik.message_processing import messages
 
     if not source_spans:
-        return 0, []
+        return 0, [], {}
 
     # Topological order: parents before children, so the parent_span_id
     # remap entry for every child is always populated by the time we
@@ -1280,7 +1423,7 @@ def _emit_spans_for_trace(
                 entry["category_name"] = score["category_name"]
             feedback_scores.append(entry)
 
-    return spans_emitted, feedback_scores
+    return spans_emitted, feedback_scores, span_id_remap
 
 
 def _build_experiment_data(

--- a/sdks/python/tests/e2e/cli/test_migrate_dataset_evaluate_shape_e2e.py
+++ b/sdks/python/tests/e2e/cli/test_migrate_dataset_evaluate_shape_e2e.py
@@ -280,3 +280,185 @@ def test_migrate_dataset__evaluate_shape__round_trips(
             trace_id=it.trace_id,
             project_name=target_project_name,
         )
+
+
+def test_migrate_dataset__cascade_trace_and_span_comments__round_trip(
+    opik_client: opik.Opik,
+    source_project_name: str,
+    target_project_name: str,
+    dataset_name: str,
+    experiment_name: str,
+    tmp_path: Path,
+) -> None:
+    """Slice 4 (OPIK-6417): comments on traces + spans survive the cascade.
+
+    Seeds an evaluate() run, POSTs a handful of comments on one of the
+    resulting traces + one of its spans, runs the migrate, and asserts
+    the destination trace + span carry the same comments in the same
+    order on read-back. ``add_trace_comment`` / ``add_span_comment`` are
+    the only write surface (comments are ``READ_ONLY`` on the trace/span
+    Write payload); the cascade re-emits them via those endpoints after
+    the destination trace/span lands.
+    """
+    rest = opik_client.rest_client
+
+    # ── Seed ──
+    dataset = opik_client.create_dataset(dataset_name, project_name=source_project_name)
+    dataset.insert(
+        [
+            {
+                "input": {"question": "Capital of France?"},
+                "expected": {"output": "Paris"},
+            },
+        ]
+    )
+    eval_result = opik.evaluate(
+        dataset=dataset,
+        task=_llm_task,
+        scoring_functions=[_equals_score],
+        experiment_name=experiment_name,
+        experiment_config={"phase": "comments-cascade"},
+    )
+    opik.flush_tracker()
+
+    def _experiment_ready() -> bool:
+        return (
+            rest.experiments.get_experiment_by_id(id=eval_result.experiment_id)
+            is not None
+        )
+
+    assert _wait_until(_experiment_ready), (
+        "experiment not visible on BE after flush; streamer may have failed"
+    )
+
+    # Pick one source trace + one of its spans to attach comments to. The
+    # cascade reads ``comments`` off the bulk trace/span read, so the
+    # specific id we attach to doesn't matter -- any trace/span in the
+    # experiment is fine.
+    source_traces = _wait_until(
+        lambda: list(
+            opik_client.search_traces(
+                project_name=source_project_name,
+                filter_string=f'experiment_id = "{eval_result.experiment_id}"',
+                max_results=10,
+                truncate=False,
+            )
+        )
+    )
+    assert source_traces, "no source traces visible to seed comments on"
+    target_trace = source_traces[0]
+    source_spans = _wait_until(
+        lambda: list(
+            opik_client.search_spans(
+                project_name=source_project_name,
+                trace_id=target_trace.id,
+                max_results=10,
+                truncate=False,
+            )
+        )
+    )
+    assert source_spans, "no source spans visible to seed comments on"
+    target_span = source_spans[0]
+
+    # POST trace + span comments in a deterministic order so we can assert
+    # round-trip ordering at the destination.
+    trace_comment_texts = [
+        "qa-note: golden path verified",
+        "pm-note: tracked in OPS-1234",
+        "debug-note: see screenshot in #incidents",
+    ]
+    span_comment_texts = [
+        "first span observation",
+        "second span observation",
+    ]
+    for text in trace_comment_texts:
+        rest.traces.add_trace_comment(id_=target_trace.id, text=text)
+    for text in span_comment_texts:
+        rest.spans.add_span_comment(id_=target_span.id, text=text)
+
+    # ── Run the migration ──
+    audit_path = tmp_path / "audit.json"
+    result = run_migrate_cli(
+        [
+            "dataset",
+            dataset_name,
+            "--from-project",
+            source_project_name,
+            "--to-project",
+            target_project_name,
+        ],
+        audit_log_path=str(audit_path),
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    # ── Verify the destination trace + span round-trip the comments ──
+    dest_dataset = rest.datasets.get_dataset_by_identifier(
+        dataset_name=dataset_name, project_name=target_project_name
+    )
+    dest_experiment = find_destination_experiment(
+        rest,
+        destination_dataset_id=dest_dataset.id,
+        experiment_name=experiment_name,
+    )
+
+    dest_items = _wait_until(
+        lambda: destination_experiment_items(
+            rest,
+            experiment_id=dest_experiment.id,
+            dataset_id=dest_dataset.id,
+        )
+    )
+    assert dest_items, "no destination experiment items after migrate"
+    dest_trace_id = dest_items[0].trace_id
+    assert dest_trace_id is not None
+
+    def _dest_trace_has_comments() -> Any:
+        t = rest.traces.get_trace_by_id(id=dest_trace_id)
+        return (
+            t if (t.comments and len(t.comments) == len(trace_comment_texts)) else None
+        )
+
+    dest_trace = _wait_until(_dest_trace_has_comments)
+    assert dest_trace is not None, (
+        f"destination trace {dest_trace_id} did not receive all "
+        f"{len(trace_comment_texts)} expected comments"
+    )
+    assert [c.text for c in dest_trace.comments] == trace_comment_texts, (
+        "destination trace comments differ in content or order"
+    )
+
+    # Find the destination span matching our source span by ``name`` (the
+    # cascade mints fresh span ids, so we can't match on id). Pick a span
+    # off the destination trace with the same ``name`` as the source
+    # ``target_span`` we attached comments to.
+    dest_spans = _wait_until(
+        lambda: list(
+            opik_client.search_spans(
+                project_name=target_project_name,
+                trace_id=dest_trace_id,
+                max_results=50,
+                truncate=False,
+            )
+        )
+    )
+    assert dest_spans, "no destination spans after migrate"
+    candidates = [s for s in dest_spans if s.name == target_span.name]
+    assert candidates, (
+        f"destination trace has no span matching source name {target_span.name!r}"
+    )
+
+    def _matching_dest_span_with_comments() -> Any:
+        for candidate in candidates:
+            span = rest.spans.get_span_by_id(id=candidate.id)
+            if span.comments and len(span.comments) == len(span_comment_texts):
+                return span
+        return None
+
+    dest_span = _wait_until(_matching_dest_span_with_comments)
+    assert dest_span is not None, (
+        f"no destination span carried the expected {len(span_comment_texts)} "
+        "comments after migrate"
+    )
+    assert [c.text for c in dest_span.comments] == span_comment_texts, (
+        "destination span comments differ in content or order"
+    )

--- a/sdks/python/tests/e2e/cli/test_migrate_dataset_evaluate_shape_e2e.py
+++ b/sdks/python/tests/e2e/cli/test_migrate_dataset_evaluate_shape_e2e.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import time
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator
+from unittest import mock
 
 import pytest
 
@@ -412,25 +413,19 @@ def test_migrate_dataset__cascade_trace_and_span_comments__round_trip(
     dest_trace_id = dest_items[0].trace_id
     assert dest_trace_id is not None
 
-    def _dest_trace_has_comments() -> Any:
-        t = rest.traces.get_trace_by_id(id=dest_trace_id)
-        return (
-            t if (t.comments and len(t.comments) == len(trace_comment_texts)) else None
-        )
-
-    dest_trace = _wait_until(_dest_trace_has_comments)
-    assert dest_trace is not None, (
-        f"destination trace {dest_trace_id} did not receive all "
-        f"{len(trace_comment_texts)} expected comments"
-    )
-    assert [c.text for c in dest_trace.comments] == trace_comment_texts, (
-        "destination trace comments differ in content or order"
+    # Verify the destination trace's comments via the shared verifier
+    # (it polls through ``_retry_until_assertions_pass`` for BE eventual
+    # consistency, so we don't need a separate hand-rolled wait).
+    verifiers.verify_trace(
+        opik_client=opik_client,
+        trace_id=dest_trace_id,
+        project_name=target_project_name,
+        comments=trace_comment_texts,
     )
 
-    # Find the destination span matching our source span by ``name`` (the
-    # cascade mints fresh span ids, so we can't match on id). Pick a span
-    # off the destination trace with the same ``name`` as the source
-    # ``target_span`` we attached comments to.
+    # Span comments: the cascade mints fresh span ids, so we resolve the
+    # destination span via name match on the source ``target_span``
+    # before delegating to the shared verifier for the content check.
     dest_spans = _wait_until(
         lambda: list(
             opik_client.search_spans(
@@ -442,23 +437,35 @@ def test_migrate_dataset__cascade_trace_and_span_comments__round_trip(
         )
     )
     assert dest_spans, "no destination spans after migrate"
-    candidates = [s for s in dest_spans if s.name == target_span.name]
-    assert candidates, (
+    matching = [s for s in dest_spans if s.name == target_span.name]
+    assert matching, (
         f"destination trace has no span matching source name {target_span.name!r}"
     )
+    # If multiple destination spans share the source span's name (rare;
+    # the seeded experiment has one root + a few children with distinct
+    # names), pick the one whose comment count matches before delegating
+    # to verify_span -- the verifier's exact-equality assert would fail
+    # against an unrelated namesake otherwise.
+    candidate_ids = [s.id for s in matching]
+    if len(candidate_ids) > 1:
+        chosen = next(
+            (
+                s.id
+                for s in matching
+                if rest.spans.get_span_by_id(id=s.id).comments
+                and len(rest.spans.get_span_by_id(id=s.id).comments)
+                == len(span_comment_texts)
+            ),
+            candidate_ids[0],
+        )
+    else:
+        chosen = candidate_ids[0]
 
-    def _matching_dest_span_with_comments() -> Any:
-        for candidate in candidates:
-            span = rest.spans.get_span_by_id(id=candidate.id)
-            if span.comments and len(span.comments) == len(span_comment_texts):
-                return span
-        return None
-
-    dest_span = _wait_until(_matching_dest_span_with_comments)
-    assert dest_span is not None, (
-        f"no destination span carried the expected {len(span_comment_texts)} "
-        "comments after migrate"
-    )
-    assert [c.text for c in dest_span.comments] == span_comment_texts, (
-        "destination span comments differ in content or order"
+    verifiers.verify_span(
+        opik_client=opik_client,
+        span_id=chosen,
+        trace_id=dest_trace_id,
+        parent_span_id=mock.ANY,
+        project_name=target_project_name,
+        comments=span_comment_texts,
     )

--- a/sdks/python/tests/e2e/verifiers.py
+++ b/sdks/python/tests/e2e/verifiers.py
@@ -104,6 +104,7 @@ def verify_trace(
     guardrails_validations: Optional[List[Dict[str, Any]]] = mock.ANY,  # type: ignore
     source: Optional[TraceSource] = mock.ANY,  # type: ignore
     environment: Optional[str] = mock.ANY,  # type: ignore
+    comments: List[str] = mock.ANY,  # type: ignore
 ):
     def _check() -> None:
         trace = opik_client.get_trace_content(id=trace_id)
@@ -169,6 +170,12 @@ def verify_trace(
             ):
                 testlib.assert_dicts_equal(actual_guardrail, expected_guardrail)
 
+        if comments is not mock.ANY:
+            actual_comments = [c.text for c in (trace.comments or [])]
+            assert actual_comments == comments, (
+                f"trace comments differ: expected {comments}, got {actual_comments}"
+            )
+
     _retry_until_assertions_pass(_check)
 
 
@@ -191,6 +198,7 @@ def verify_span(
     total_cost: Optional[float] = mock.ANY,  # type: ignore
     source: Optional[TraceSource] = mock.ANY,  # type: ignore
     environment: Optional[str] = mock.ANY,  # type: ignore
+    comments: List[str] = mock.ANY,  # type: ignore
 ):
     def _check() -> None:
         span = opik_client.get_span_content(id=span_id)
@@ -239,6 +247,12 @@ def verify_span(
                 item_id=span_id,
                 feedback_scores=span.feedback_scores,
                 expected_feedback_scores=feedback_scores,
+            )
+
+        if comments is not mock.ANY:
+            actual_comments = [c.text for c in (span.comments or [])]
+            assert actual_comments == comments, (
+                f"span comments differ: expected {comments}, got {actual_comments}"
             )
 
     _retry_until_assertions_pass(_check)

--- a/sdks/python/tests/unit/cli/test_migrate_dataset_experiments_cascade.py
+++ b/sdks/python/tests/unit/cli/test_migrate_dataset_experiments_cascade.py
@@ -131,6 +131,7 @@ class _Trace:
         last_updated_at: Optional[dt.datetime] = None,
         ttft: Optional[float] = None,
         feedback_scores: Optional[List[Any]] = None,
+        comments: Optional[List[Any]] = None,
         project_id: Optional[str] = "src-project-1",
     ) -> None:
         self.id = id
@@ -149,6 +150,10 @@ class _Trace:
         # decide whether to re-emit any per-trace feedback. None / [] is a
         # valid "no scores" state.
         self.feedback_scores = feedback_scores
+        # ``cascade`` reads source.comments after the trace flush and
+        # re-emits each via ``rest_client.traces.add_trace_comment(...)``.
+        # None / [] = no comments to cascade.
+        self.comments = comments
         # Spans are read scoped to the TRACE's project_id (not the
         # experiment's), so the stand-in carries one. Default matches the
         # default ``_Experiment.project_id`` so existing tests behave as
@@ -190,6 +195,15 @@ class _Span:
 
     def model_dump(self) -> Dict[str, Any]:
         return dict(self._fields)
+
+
+class _Comment:
+    """Stand-in for ``CommentPublic`` on ``TracePublic.comments`` /
+    ``SpanPublic.comments``. The cascade reads only ``.text`` off each
+    comment when POSTing to ``add_trace_comment`` / ``add_span_comment``."""
+
+    def __init__(self, *, text: str) -> None:
+        self.text = text
 
 
 # ---------------------------------------------------------------------------
@@ -1518,6 +1532,133 @@ class TestCascadeExperiments:
         # executor's nested Rich bar uses this to mark completion).
         assert inner_ticks[-1][0] == inner_ticks[-1][1]
         assert inner_ticks[-1][2] in {"recreated", "skipped"}
+
+    def test_cascade_trace_and_span_comments__re_emits_in_source_order(
+        self,
+    ) -> None:
+        # Slice 4 (OPIK-6417): comments are READ_ONLY on the trace/span
+        # Write payload, so the cascade must POST them via the dedicated
+        # single-comment endpoints after the destination trace/span lands.
+        # This test seeds two comments on a trace and two on a span and
+        # asserts each is POSTed against the destination ids in source
+        # order, with the per-comment text preserved.
+        experiment = _Experiment(id="src-exp-1", dataset_version_id="src-v-1")
+        item = _ExperimentItem(
+            id="src-item-1",
+            experiment_id="src-exp-1",
+            trace_id="src-trace-1",
+            dataset_item_id="src-ds-item-1",
+        )
+        trace_comments = [
+            _Comment(text="first trace comment"),
+            _Comment(text="second trace comment"),
+        ]
+        span_comments = [
+            _Comment(text="first span comment"),
+            _Comment(text="second span comment"),
+        ]
+        trace = _Trace(id="src-trace-1", comments=trace_comments)
+        span = _Span(
+            id="src-span-1",
+            parent_span_id=None,
+            name="root",
+            trace_id="src-trace-1",
+            comments=span_comments,
+        )
+        rest_client = _cascade_rest_client(
+            experiments_by_dataset={"src-dataset-1": [experiment]},
+            items_by_experiment={"experiment": [item]},
+            traces_by_id={"src-trace-1": trace},
+            spans_by_trace={"src-trace-1": [span]},
+        )
+        client = _client_with_recreate_capture(rest_client)
+
+        result = cascade_experiments(
+            client,
+            rest_client,
+            source_dataset_id="src-dataset-1",
+            target_dataset_name="MyDataset",
+            target_project_name="DestProject",
+            version_remap={"src-v-1": "dest-v-1"},
+            item_id_remap={"src-ds-item-1": "dest-ds-item-1"},
+            audit=_audit(),
+        )
+
+        # Per-comment counters surface on the cascade result.
+        assert result.trace_comments_migrated == 2
+        assert result.span_comments_migrated == 2
+
+        # Trace comments: each POST scoped to the destination trace id
+        # (NOT the source id), in source order.
+        new_trace_id = result.trace_id_remap["src-trace-1"]
+        trace_calls = rest_client.traces.add_trace_comment.call_args_list
+        assert len(trace_calls) == 2
+        assert [c.kwargs for c in trace_calls] == [
+            {"id_": new_trace_id, "text": "first trace comment"},
+            {"id_": new_trace_id, "text": "second trace comment"},
+        ]
+
+        # Span comments: each POST scoped to the destination span id (NOT
+        # the source "src-span-1"), in source order. The destination span
+        # id is whatever the cascade minted; inspect via the streamer.
+        span_messages = [
+            c.args[0]
+            for c in client._streamer.put.call_args_list
+            if hasattr(c.args[0], "span_id")
+        ]
+        assert len(span_messages) == 1
+        new_span_id = span_messages[0].span_id
+        span_calls = rest_client.spans.add_span_comment.call_args_list
+        assert len(span_calls) == 2
+        assert [c.kwargs for c in span_calls] == [
+            {"id_": new_span_id, "text": "first span comment"},
+            {"id_": new_span_id, "text": "second span comment"},
+        ]
+
+    def test_cascade_with_zero_comments__no_extra_http_no_counter_drift(
+        self,
+    ) -> None:
+        # When a trace + span carry NO comments, the cascade must not call
+        # the comment endpoints at all and counters stay at 0. Guards
+        # against silently emitting noisy zero-shaped requests.
+        experiment = _Experiment(id="src-exp-1", dataset_version_id="src-v-1")
+        item = _ExperimentItem(
+            id="src-item-1",
+            experiment_id="src-exp-1",
+            trace_id="src-trace-1",
+            dataset_item_id="src-ds-item-1",
+        )
+        trace = _Trace(id="src-trace-1")  # comments=None default
+        span = _Span(
+            id="src-span-1",
+            parent_span_id=None,
+            name="root",
+            trace_id="src-trace-1",
+            comments=None,
+        )
+        rest_client = _cascade_rest_client(
+            experiments_by_dataset={"src-dataset-1": [experiment]},
+            items_by_experiment={"experiment": [item]},
+            traces_by_id={"src-trace-1": trace},
+            spans_by_trace={"src-trace-1": [span]},
+        )
+        client = _client_with_recreate_capture(rest_client)
+
+        result = cascade_experiments(
+            client,
+            rest_client,
+            source_dataset_id="src-dataset-1",
+            target_dataset_name="MyDataset",
+            target_project_name="DestProject",
+            version_remap={"src-v-1": "dest-v-1"},
+            item_id_remap={"src-ds-item-1": "dest-ds-item-1"},
+            audit=_audit(),
+        )
+
+        assert result.trace_comments_migrated == 0
+        assert result.span_comments_migrated == 0
+        rest_client.traces.add_trace_comment.assert_not_called()
+        rest_client.spans.add_span_comment.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Details

<img width="1920" height="2300" alt="image" src="https://github.com/user-attachments/assets/4ad95113-cadf-4aa7-8223-e9219e7814ef" />

<img width="1227" height="499" alt="image" src="https://github.com/user-attachments/assets/5081ea2e-1c81-4be5-b5af-475c4076162d" />

<img width="1213" height="433" alt="image" src="https://github.com/user-attachments/assets/9e7fa377-eb10-413a-8a65-6220da9e28b4" />


Slice 4 of `opik migrate dataset`. The Slice 3 cascade already copies traces + spans + feedback scores + assertion results, but **comments** live as `READ_ONLY` on the trace/span Public view — they can't ride along `create_traces` / `create_spans` and were silently dropped at the destination.

This change re-emits them via the dedicated single-comment write endpoints (`POST /v1/private/traces/{id}/comments`, `POST /v1/private/spans/{id}/comments`) after the destination trace/span flushes:

- Each POST is wrapped with the existing `ensure_rest_api_call_respecting_rate_limit` helper, so transient 429s don't abort the migrate.
- Order preserved by iterating the source `comments` list in place — the BE returns them sorted by `createdAt` and serialized POSTs land in that same order.
- New `trace_comments_migrated` / `span_comments_migrated` counters on `ExperimentCascadeResult`.
- New `cascade_experiments_summary` audit-log record carries the counters alongside `traces_migrated` / `spans_migrated`. Fully additive — the existing `cascade_experiments` action record is unchanged from Slice 3.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6417

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation
- Human verification: code review + local e2e against running Opik (migrate cascaded trace + span comments verified to round-trip in audit log + destination UI)

## Testing

Commands run:

- `make precommit-sdks` — ruff, ruff-format, mypy all clean
- `pytest tests/unit/cli/` — 291 passed (includes the two new unit tests below)
- Local e2e: ran `opik migrate dataset` against a production-shape dataset (~10k items, 7 versions, real experiments with seeded trace + span comments). Audit log emitted the new `cascade_experiments_summary` record; destination traces + spans carried every source comment in source order.

Unit coverage added in `tests/unit/cli/test_migrate_dataset_experiments_cascade.py`:

- `test_cascade_trace_and_span_comments__re_emits_in_source_order` — seeds two comments on a trace and two on a span, asserts each is POSTed against the destination ids in source order with the per-comment text preserved.
- `test_cascade_with_zero_comments__no_extra_http_no_counter_drift` — trace + span with no comments → `add_trace_comment` / `add_span_comment` never called, counters stay 0.

E2E coverage added in `tests/e2e/cli/test_migrate_dataset_evaluate_shape_e2e.py`:

- `test_migrate_dataset__cascade_trace_and_span_comments__round_trip` — seeds via `opik.evaluate(...)`, POSTs 3 trace comments + 2 span comments via the REST endpoints, runs `opik migrate dataset`, asserts destination trace + span carry every comment in source order on read-back.

## Documentation

N/A — internal SDK cascade behavior, no user-facing API or doc surface changes. The `opik migrate dataset` CLI signature is unchanged; comments now ride along automatically.