### PR TITLE
[NA] [BE] feat(otel): emit base2 exponential histograms for HTTP server metrics

### DIFF
--- a/apps/opik-backend/opik-otel-views.yaml
+++ b/apps/opik-backend/opik-otel-views.yaml
@@ -1,7 +1,14 @@
+# HTTP server semconv histograms are emitted with explicit-bucket advice
+# baked into the OTel Java instrumentation (boundaries cap at 10s). The
+# OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION env var does
+# not override that advice, so we set the aggregation explicitly here.
+# `base2_exponential_bucket_histogram` removes the 10s ceiling and keeps
+# quantile accuracy across the full latency range.
 - selector:
     instrument_name: http.server.request.duration
     instrument_type: HISTOGRAM
   view:
+    aggregation: base2_exponential_bucket_histogram
     attribute_keys:
       - http.request.method
       - url.scheme
@@ -18,6 +25,7 @@
     instrument_name: http.server.request.body.size
     instrument_type: HISTOGRAM
   view:
+    aggregation: base2_exponential_bucket_histogram
     attribute_keys:
       - http.request.method
       - url.scheme
@@ -34,6 +42,7 @@
     instrument_name: http.server.response.body.size
     instrument_type: HISTOGRAM
   view:
+    aggregation: base2_exponential_bucket_histogram
     attribute_keys:
       - http.request.method
       - url.scheme


### PR DESCRIPTION
## Details
Add an `aggregation: base2_exponential_bucket_histogram` override on the three HTTP server semconv histogram views in `apps/opik-backend/opik-otel-views.yaml` so they reach Prometheus as native histograms.

The OTel Java instrumentation bakes explicit-bucket advice into the stable HTTP semconv histograms (`http.server.request.duration`, `http.server.request.body.size`, `http.server.response.body.size`). That advice — boundaries capping at **10 seconds** — acts as an inline aggregation hint that takes precedence over the SDK's `OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION` env-var default. So even though the env var is now set to `base2_exponential_bucket_histogram` in dev/staging/prod (via comet-helm), these three histograms stay classic and `histogram_quantile(0.99, ...)` is clipped at 10s.

A view-level override in the existing `opik-otel-views.yaml` (loaded by the agent at startup via `-Dotel.experimental.metrics.view-config=/opt/opik/opik-otel-views.yaml`) takes precedence over the advice. The file already declares the three views to control attribute cardinality; this PR adds `aggregation: base2_exponential_bucket_histogram` on each.

The existing `attribute_keys` lists are unchanged.

## Change checklist
- [x] User facing
- [ ] Documentation update

`http_server_request_duration_seconds*`, `http_server_request_body_size_bytes*`, and `http_server_response_body_size_bytes*` change form in Prometheus: `_bucket` / `_count` / `_sum` companion series stop receiving new samples (and age out per retention), and the bare metric becomes a native histogram. Anything querying by the old companion-series names needs to migrate to the native-histogram functions (`histogram_quantile`, `histogram_count`, `histogram_sum` on the bare metric).

## Issues

- [NA] No external issue.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7 (1M context)
- Scope: edit to `apps/opik-backend/opik-otel-views.yaml`; PR description.
- Human verification: read entrypoint + Dockerfile to confirm the file is baked into the image (`COPY --chown=1001:1001 ... opik-otel-views.yaml ./` at `/opt/opik`) and that the agent loads it via `-Dotel.experimental.metrics.view-config=...`. Verified PromQL behavior on prod: today's classic queries return data; native queries return empty. After this lands, those will swap.

## Testing

Local: `python3 -c "import yaml; yaml.safe_load(open('apps/opik-backend/opik-otel-views.yaml'))"` → `YAML parses cleanly`. No functional unit tests apply (the file is loaded by the OTel Java agent at JVM start; it would refuse to load on a bad schema and emit a startup log line — that's the smoke signal at deploy time).

Manual:
- [ ] Build a new opik-backend image off this branch.
- [ ] Deploy to staging (cometml-staging on the dev cluster).
- [ ] Check pod startup log: agent should print something like `View config loaded from /opt/opik/opik-otel-views.yaml`. No `view-config error` lines.
- [ ] Prometheus on cometml-staging:
  - `count(http_server_request_duration_seconds_bucket{service_name="opik-backend", k8s_namespace_name="cometml-staging"})` → should drop to 0 (after retention/aging).
  - `histogram_count(rate(http_server_request_duration_seconds{service_name="opik-backend", k8s_namespace_name="cometml-staging"}[5m]))` → should return data.
  - `histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds{service_name="opik-backend", k8s_namespace_name="cometml-staging"}[5m])))` → can now exceed 10s for slow requests.
- [ ] Confirm `OTEL_JAVA_METRICS_CARDINALITY_LIMIT=4000` (prod-only, not in staging) is still enough headroom. Base2 exponential histograms can produce up to ~160 buckets per series; if cardinality matters, tune `aggregation_args` later.

## Documentation
No public docs change. Operators who deploy opik against a Prometheus that is **not** on 3.8+ (i.e., a Prometheus that still requires the `--enable-feature=native-histograms` flag for ingestion) will need to enable that flag or roll back this PR's view to `explicit_bucket_histogram`. The default Opik helm chart deploys against Prometheus 3.x.