### PR TITLE
[OPIK-6551] [BE] feat: add ollieEnabled service toggle from TOGGLE_OLLIE_ENABLED

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1038,6 +1038,9 @@ serviceToggles:
   # Default: true
   # Description: Whether or not Ollama provider is enabled
   ollamaProviderEnabled: ${TOGGLE_OLLAMA_PROVIDER_ENABLED:-"true"}
+  # Default: false
+  # Description: Whether or not the Ollie AI assistant integration is enabled.
+  ollieEnabled: ${TOGGLE_OLLIE_ENABLED:-"false"}
   # Default: "" (empty, no allowlisted workspaces)
   # Description: Comma-separated list of workspace IDs that should always receive V2 navigation.
   # Valid values: comma-separated workspace IDs (e.g. "ws-id-1,ws-id-2"), or "" (empty, disabled).

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
@@ -63,6 +63,8 @@ public class ServiceTogglesConfig {
     @NotNull boolean customllmProviderEnabled;
     @JsonProperty
     @NotNull boolean ollamaProviderEnabled;
+    @JsonProperty
+    @NotNull boolean ollieEnabled;
 
     @NotNull Set<@NotBlank String> v2WorkspaceAllowlistIds = Set.of();
 

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -609,6 +609,9 @@ serviceToggles:
   # Default: true
   # Description: Whether or not Ollama provider is enabled
   ollamaProviderEnabled: "true"
+  # Default: false
+  # Description: Whether or not the Ollie AI assistant integration is enabled.
+  ollieEnabled: "false"
   # Default: "" (empty, no allowlisted workspaces)
   # Description: Comma-separated list of workspace IDs that should always receive V2 navigation.
   # Valid values: comma-separated workspace IDs (e.g. "ws-id-1,ws-id-2"), or "" (empty, disabled).


### PR DESCRIPTION
## Details

Adds an `ollieEnabled` field to `ServiceTogglesConfig`, sourced from the `TOGGLE_OLLIE_ENABLED` env var (default `false`). It's auto-exposed to the FE via the existing `GET /v1/private/toggles/` endpoint so the FE can hide Ollie-only UI (Assistant sidebar — OPIK-6511, Opik Connect tab — OPIK-6517) when the deployment hasn't opted into Ollie.

The companion change in [comet-ml-helm-chart#447](https://github.com/comet-ml/comet-ml-helm-chart/pull/447) renders `TOGGLE_OLLIE_ENABLED` into the Opik backend ConfigMap, gated by the same Helm-level guard (`comet.opik.ollie.enabled && comet.pythonPanels.enabled`) that comet-backend already uses for its own `OLLIE_ENABLED`. Both env vars derive from the same chart inputs but each service follows its own naming convention (`TOGGLE_*` for Opik toggles). OSS Opik deployments leave the env var unset → default `false` → Ollie UI stays hidden.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6551
- Unblocks OPIK-6511, OPIK-6517

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: backend config field + env-var wiring + test config; no behavioral logic
- Human verification: diff reviewed before push; spotless ran clean locally

## Testing

- `mvn -pl apps/opik-backend spotless:apply` ran via the repo's pre-commit hook on push — clean.
- No new unit tests: this is a passthrough `@JsonProperty boolean` on an existing `@Data` config class consumed by the existing `ServiceTogglesResource`. The field defaults to `false` in `config-test.yml`, so the toggles endpoint integration tests continue to assert the full response shape.
- Manual verification plan once merged into a deployable env:
  - Hit `GET /v1/private/toggles/` with `TOGGLE_OLLIE_ENABLED=true` → expect `"ollieEnabled": true`.
  - Hit the same endpoint unset → expect `"ollieEnabled": false`.
- FE wiring (hiding the sidebar/tab) is intentionally out of scope; OPIK-6511 and OPIK-6517 will consume this flag.

## Documentation

No user-facing doc changes — this is an internal feature toggle. The `config.yml` entry follows the existing `Default:` / `Description:` comment convention so the env var is self-documenting alongside the other toggles.
