### PR TITLE
[OPIK-5333] [BE]: agentic tools online scoring threads;

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -254,7 +254,7 @@ public class OnlineScoringEngine {
     public record ThreadTraceSkeleton(
             @NonNull UUID id,
             String name,
-            Instant startTime,
+            @NonNull Instant startTime,
             Instant endTime,
             Double duration,
             int spanCount,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -233,13 +233,20 @@ public class OnlineScoringEngine {
     /**
      * Compact per-trace summary shipped to the model as part of the thread skeleton.
      * Field set is small on purpose — anything beyond this is a {@code read} away.
+     *
+     * <p>{@code @JsonNaming(SnakeCaseStrategy)} keeps the wire shape consistent with
+     * {@link Trace}'s serialization (also snake_case via the same strategy), so the
+     * model sees the same field names in the skeleton and in a follow-up
+     * {@code read(type=trace, id=X)} response. Camel-case here would surprise the
+     * model with two different schemas for the same entity.
      */
+    @com.fasterxml.jackson.databind.annotation.JsonNaming(com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy.class)
     public record ThreadTraceSkeleton(
             UUID id,
             String name,
             Instant startTime,
             Instant endTime,
-            Double durationMs,
+            Double duration,
             int spanCount,
             int llmSpanCount) {
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.common.base.Preconditions;
 import com.jayway.jsonpath.JsonPath;
@@ -249,7 +251,7 @@ public class OnlineScoringEngine {
      * {@code read(type=trace, id=X)} response. Camel-case here would surprise the
      * model with two different schemas for the same entity.
      */
-    @com.fasterxml.jackson.databind.annotation.JsonNaming(com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     @Builder(toBuilder = true)
     public record ThreadTraceSkeleton(
             @NonNull UUID id,
@@ -898,13 +900,14 @@ public class OnlineScoringEngine {
      */
     public static String summarizeRequest(@NonNull ChatRequest request, @NonNull String modelName,
             boolean useTools) {
+        // Intentionally NOT computing total chars: m.toString() on a multi-MB rendered prompt
+        // allocates the full string just to measure its length, which would add ~2x prompt-size
+        // heap churn per evaluation. Message count + tool count are enough to identify what's
+        // happening; an operator who needs byte-level detail can hit the rule's debug log.
         int messageCount = request.messages() == null ? 0 : request.messages().size();
-        int totalChars = request.messages() == null
-                ? 0
-                : request.messages().stream().mapToInt(m -> m.toString().length()).sum();
         int toolSpecCount = request.toolSpecifications() == null ? 0 : request.toolSpecifications().size();
-        return String.format("model='%s', messages=%d (~%d chars), tools=%d, toolsEnabled=%s",
-                modelName, messageCount, totalChars, toolSpecCount, useTools);
+        return String.format("model='%s', messages=%d, tools=%d, toolsEnabled=%s",
+                modelName, messageCount, toolSpecCount, useTools);
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -883,6 +883,24 @@ public class OnlineScoringEngine {
     }
 
     /**
+     * Build a sanitized one-line description of the outgoing LLM request for user-facing logs.
+     * The full {@link ChatRequest} contains the rendered prompt, the user message with the
+     * trace's input/output, request parameters, and tool specs — surfacing all of it in a
+     * stored log lands trace content (and any tokens or PII it carries) in clear text
+     * downstream of whatever sinks the log feeds. Shape-only summary instead.
+     */
+    public static String summarizeRequest(@NonNull ChatRequest request, @NonNull String modelName,
+            boolean useTools) {
+        int messageCount = request.messages() == null ? 0 : request.messages().size();
+        int totalChars = request.messages() == null
+                ? 0
+                : request.messages().stream().mapToInt(m -> m.toString().length()).sum();
+        int toolSpecCount = request.toolSpecifications() == null ? 0 : request.toolSpecifications().size();
+        return String.format("model='%s', messages=%d (~%d chars), tools=%d, toolsEnabled=%s",
+                modelName, messageCount, totalChars, toolSpecCount, useTools);
+    }
+
+    /**
      * Build a sanitized one-line description of the LLM response. The full {@link ChatResponse}
      * carries the assistant text and any tool-call arguments, both of which can echo trace
      * content the model is reasoning about — surfacing the raw response in a user-facing log

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -10,6 +10,7 @@ import com.comet.opik.api.evaluators.LlmAsJudgeMessage;
 import com.comet.opik.api.evaluators.LlmAsJudgeMessageContent;
 import com.comet.opik.api.evaluators.LlmAsJudgeOutputSchema;
 import com.comet.opik.api.resources.v1.events.tools.StringTruncator;
+import com.comet.opik.api.resources.v1.events.tools.ToolRegistry;
 import com.comet.opik.api.resources.v1.events.tools.TraceCompressor;
 import com.comet.opik.domain.evaluators.python.TraceThreadPythonEvaluatorRequest;
 import com.comet.opik.domain.llm.structuredoutput.StructuredOutputStrategy;
@@ -31,6 +32,8 @@ import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.data.message.VideoContent;
 import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -190,6 +193,12 @@ public class OnlineScoringEngine {
      * <p>The {@code context} variable is replaced with the skeleton + drill-down
      * guidance so user-supplied prompt templates referencing {@code {{context}}}
      * keep working without modification.
+     *
+     * <p><strong>Precondition:</strong> all {@code evaluatorCode.messages()} must declare
+     * string content. Multimodal templates aren't supported on this path —
+     * {@link #renderThreadMessagesWithReplacement} throws on the first non-string entry.
+     * Callers should detect multimodal templates upstream via
+     * {@link #hasMultimodalTemplate(List)} and fall back to the inline path.
      */
     public static ChatRequest prepareThreadLlmRequestWithTools(
             @NonNull TraceThreadLlmAsJudgeCode evaluatorCode, @NonNull List<Trace> traces,
@@ -241,8 +250,9 @@ public class OnlineScoringEngine {
      * model with two different schemas for the same entity.
      */
     @com.fasterxml.jackson.databind.annotation.JsonNaming(com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @Builder(toBuilder = true)
     public record ThreadTraceSkeleton(
-            UUID id,
+            @NonNull UUID id,
             String name,
             Instant startTime,
             Instant endTime,
@@ -876,10 +886,58 @@ public class OnlineScoringEngine {
      * even when the context exceeds the size threshold (which may overflow the model's
      * window — in that case the operator should pick a different model for those workloads).
      */
+    /**
+     * Whether any of the template messages declares non-string (multimodal) content. The
+     * agentic-tools render path on threads only substitutes the context variable into string
+     * content — multimodal templates (image / audio / video alongside text) are rejected.
+     * Callers detect this here and fall back to the inline path rather than throwing.
+     */
+    public static boolean hasMultimodalTemplate(@NonNull List<LlmAsJudgeMessage> templateMessages) {
+        return templateMessages.stream().anyMatch(m -> !m.isStringContent());
+    }
+
     public static boolean supportsToolCalling(@NonNull LlmProvider provider) {
         return switch (provider) {
             case OPEN_AI, ANTHROPIC, GEMINI, OPEN_ROUTER, VERTEX_AI, BEDROCK -> true;
             case OLLAMA, CUSTOM_LLM, OPIK_FREE -> false;
         };
+    }
+
+    /**
+     * Build a sanitized one-line description of the LLM response. The full {@link ChatResponse}
+     * carries the assistant text and any tool-call arguments, both of which can echo trace
+     * content the model is reasoning about — surfacing the raw response in a user-facing log
+     * lands trace content (and any tokens or PII it carries) downstream of whatever sinks the
+     * log feeds. Shape-only summary instead.
+     */
+    public static String summarizeResponse(@NonNull ChatResponse response) {
+        var ai = response.aiMessage();
+        int textLength = ai.text() == null ? 0 : ai.text().length();
+        int toolCallCount = ai.toolExecutionRequests() == null ? 0 : ai.toolExecutionRequests().size();
+        var finishReason = response.metadata() == null ? null : response.metadata().finishReason();
+        return String.format("textChars=%d, toolCalls=%d, finishReason=%s",
+                textLength, toolCallCount, finishReason);
+    }
+
+    /**
+     * Attach the tool specs from {@code toolRegistry} and the given {@code toolChoice} to
+     * {@code request}'s parameters. Tool specs live inside {@link ChatRequestParameters}, so
+     * we copy the existing parameters via {@code overrideWith} and layer tool specs on top —
+     * setting {@code toolSpecifications} directly on the {@link ChatRequest} builder would
+     * conflict with parameters. {@code toBuilder()} (rather than a fresh builder + .messages())
+     * preserves any other top-level fields on ChatRequest, present or future, guarding against
+     * a "silently dropped fields" regression between the initial scoring call and the
+     * structured re-issue in the tool-call wrap-up.
+     */
+    public static ChatRequest addToolSpecs(@NonNull ChatRequest request, @NonNull ToolChoice toolChoice,
+            @NonNull ToolRegistry toolRegistry) {
+        var parameters = ChatRequestParameters.builder()
+                .overrideWith(request.parameters())
+                .toolSpecifications(toolRegistry.specs())
+                .toolChoice(toolChoice)
+                .build();
+        return request.toBuilder()
+                .parameters(parameters)
+                .build();
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -43,6 +43,7 @@ import org.slf4j.Logger;
 
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -53,6 +54,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -175,6 +177,100 @@ public class OnlineScoringEngine {
         var renderedMessages = renderThreadMessages(evaluatorCode.messages(),
                 Map.of(TraceThreadLlmAsJudgeCode.CONTEXT_VARIABLE_NAME, ""), traces);
         return buildChatRequest(renderedMessages, evaluatorCode.schema(), structuredOutputStrategy);
+    }
+
+    /**
+     * Variant for the agentic-tools branch: renders only a compact per-trace
+     * <em>skeleton</em> for the thread (ids, names, durations, span counts) plus a
+     * drill-down hint pointing at {@code read(type=trace, id=X)}. The model fetches
+     * any specific trace's full content (and its spans) on demand via ReadTool —
+     * the same lazy mechanism the trace-level path uses. Keeps the inline prompt
+     * bounded even on threads with thousands of traces.
+     *
+     * <p>The {@code context} variable is replaced with the skeleton + drill-down
+     * guidance so user-supplied prompt templates referencing {@code {{context}}}
+     * keep working without modification.
+     */
+    public static ChatRequest prepareThreadLlmRequestWithTools(
+            @NonNull TraceThreadLlmAsJudgeCode evaluatorCode, @NonNull List<Trace> traces,
+            @NonNull StructuredOutputStrategy structuredOutputStrategy) {
+        String skeleton;
+        try {
+            skeleton = OBJECT_MAPPER.writeValueAsString(toThreadSkeleton(traces));
+        } catch (JsonProcessingException ex) {
+            throw new UncheckedIOException(ex);
+        }
+        String drillDownHint = "Call read(type=trace, id=<uuid>) on any trace id from the"
+                + " thread skeleton above to inspect its full input/output + spans, or"
+                + " jq(type=trace, id=<uuid>, expression='<path>') for path-targeted lookups.";
+        String contextValue = "Thread skeleton (compact per-trace summary; use tools to drill in):\n"
+                + skeleton + "\n\n" + drillDownHint;
+
+        var renderedMessages = renderThreadMessagesWithReplacement(evaluatorCode.messages(),
+                TraceThreadLlmAsJudgeCode.CONTEXT_VARIABLE_NAME, contextValue);
+        return buildChatRequest(renderedMessages, evaluatorCode.schema(), structuredOutputStrategy);
+    }
+
+    /**
+     * Compact per-trace summary the agentic-tools branch renders into the prompt
+     * instead of the full trace list. ~100 chars per trace — so a 10K-trace thread
+     * is ~1 MB, well under the model's window even without further compression. The
+     * model picks ids from this list and drills in via ReadTool.
+     */
+    static List<ThreadTraceSkeleton> toThreadSkeleton(List<Trace> traces) {
+        return traces.stream()
+                .map(trace -> new ThreadTraceSkeleton(
+                        trace.id(),
+                        trace.name(),
+                        trace.startTime(),
+                        trace.endTime(),
+                        trace.duration(),
+                        trace.spanCount(),
+                        trace.llmSpanCount()))
+                .toList();
+    }
+
+    /**
+     * Compact per-trace summary shipped to the model as part of the thread skeleton.
+     * Field set is small on purpose — anything beyond this is a {@code read} away.
+     */
+    public record ThreadTraceSkeleton(
+            UUID id,
+            String name,
+            Instant startTime,
+            Instant endTime,
+            Double durationMs,
+            int spanCount,
+            int llmSpanCount) {
+    }
+
+    /**
+     * Light-weight twin of {@link #renderThreadMessages} that substitutes the
+     * already-rendered {@code context} string directly, skipping the
+     * Jackson-serialize-the-traces step. Used by the tools path where the variable
+     * value (the skeleton + drill-down hint) is computed by the caller.
+     */
+    private static List<ChatMessage> renderThreadMessagesWithReplacement(
+            List<LlmAsJudgeMessage> templateMessages, String variableName, String contextValue) {
+        Map<String, String> replacements = Map.of(variableName, contextValue);
+        return templateMessages.stream()
+                .map(templateMessage -> {
+                    if (templateMessage.isStringContent()) {
+                        var renderedMessage = TemplateParseUtils.render(
+                                templateMessage.asString(), replacements, PromptType.MUSTACHE);
+                        return switch (templateMessage.role()) {
+                            case USER -> (ChatMessage) UserMessage.from(renderedMessage);
+                            case SYSTEM -> (ChatMessage) SystemMessage.from(renderedMessage);
+                            default -> {
+                                log.info("No mapping for message role type {}", templateMessage.role());
+                                yield (ChatMessage) UserMessage.from(renderedMessage);
+                            }
+                        };
+                    }
+                    throw new UnsupportedOperationException(
+                            "Multimodal thread message content is not supported on the agentic-tools path");
+                })
+                .toList();
     }
 
     static List<ChatMessage> renderThreadMessages(
@@ -692,6 +788,27 @@ public class OnlineScoringEngine {
     public static int estimateTokensFromJson(@NonNull JsonNode fullJson, int charsPerToken) {
         Preconditions.checkArgument(charsPerToken >= 1, "charsPerToken must be >= 1, got %s", charsPerToken);
         return fullJson.toString().length() / charsPerToken;
+    }
+
+    /**
+     * Rough character-based token estimate for the thread context as it would be
+     * rendered on the inline path (full trace-list JSON, no spans). Used by
+     * {@code OnlineScoringTraceThreadLlmAsJudgeScorer} to decide whether a thread is
+     * big enough to switch to the agentic-tools path (skeleton + drill-down via
+     * ReadTool). The estimate is on the trace bodies only — spans aren't part of
+     * the inline thread render today, so factoring them in would over-trigger the
+     * tools branch.
+     *
+     * <p>Same {@code charsPerToken} contract as {@link #estimateTraceContextTokens}:
+     * configurable via {@code onlineScoring.agenticToolsCharsPerToken}.
+     */
+    public static int estimateThreadContextTokens(@NonNull List<Trace> traces, int charsPerToken) {
+        Preconditions.checkArgument(charsPerToken >= 1, "charsPerToken must be >= 1, got %s", charsPerToken);
+        try {
+            return OBJECT_MAPPER.writeValueAsString(fromTraceToThread(traces)).length() / charsPerToken;
+        } catch (JsonProcessingException ex) {
+            throw new UncheckedIOException(ex);
+        }
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -794,9 +794,15 @@ public class OnlineScoringEngine {
      * log, and the rethrow-with-error-log fallback. Callers supply only what actually differs:
      * the entity label ({@code "traceId"} / {@code "spanId"}), the id, the rule name, and a
      * supplier that builds the rendered evaluator input.
+     *
+     * <p>Error-path logging is split: {@code userFacingLogger} gets a sanitized one-liner
+     * (no Throwable, so internal class names / paths from the stack trace don't leak into the
+     * user-facing log sink), and {@code internalLogger} (the scorer's slf4j logger) gets the
+     * full stack trace.
      */
     public static Map<String, Object> logAndPrepareEvaluatorInput(
             @NonNull Logger userFacingLogger,
+            @NonNull Logger internalLogger,
             @NonNull Map<String, String> mdc,
             @NonNull String entityLabel,
             @NonNull Object entityId,
@@ -812,8 +818,9 @@ public class OnlineScoringEngine {
                 }
                 return data;
             } catch (Exception exception) {
-                userFacingLogger.error("Error preparing Python request for {} '{}': \n\n{}",
-                        entityLabel, entityId, exception.getMessage());
+                userFacingLogger.error("Error preparing Python request for {} '{}'", entityLabel, entityId);
+                internalLogger.error("Error preparing Python request for {} '{}'",
+                        entityLabel, entityId, exception);
                 throw exception;
             }
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -309,51 +309,10 @@ public class OnlineScoringEngine {
                 })
                 .collect(
                         Collectors.toMap(MessageVariableMapping::variableName, MessageVariableMapping::valueToReplace));
-
-        // render the message templates from evaluator rule
-        return templateMessages.stream()
-                .map(templateMessage -> {
-                    // Check if content is string (text) or array (multimodal)
-                    if (templateMessage.isStringContent()) {
-                        // String format: plain text content
-                        var renderedMessage = TemplateParseUtils.render(
-                                templateMessage.asString(), replacements, PromptType.MUSTACHE);
-                        return switch (templateMessage.role()) {
-                            case USER -> UserMessage.from(renderedMessage);
-                            case SYSTEM -> SystemMessage.from(renderedMessage);
-                            default -> {
-                                log.info("No mapping for message role type {}", templateMessage.role());
-                                yield null;
-                            }
-                        };
-                    } else if (templateMessage.isStructuredContent()) {
-                        // Array format: structured content parts
-                        return switch (templateMessage.role()) {
-                            case USER -> buildUserMessageFromContentParts(
-                                    templateMessage.asContentList(), replacements);
-                            case SYSTEM -> {
-                                // For SYSTEM messages with array content, extract first text part
-                                var textContent = templateMessage.asContentList().stream()
-                                        .filter(part -> "text".equals(part.type()))
-                                        .map(LlmAsJudgeMessageContent::text)
-                                        .filter(Objects::nonNull)
-                                        .map(text -> TemplateParseUtils.render(text, replacements, PromptType.MUSTACHE))
-                                        .findFirst()
-                                        .orElse("");
-                                yield SystemMessage.from(textContent);
-                            }
-                            default -> {
-                                log.info("No mapping for message role type {}", templateMessage.role());
-                                yield null;
-                            }
-                        };
-                    } else {
-                        log.warn("Unknown content type for message role {}", templateMessage.role());
-                        return null;
-                    }
-                })
-                .filter(Objects::nonNull)
-                .toList();
+        // Rendering itself is identical to trace / span flows once replacements are built —
+        // delegate so role-fan-out, multimodal handling, and prompt-type defaults stay in
+        // one place. The thread-specific bit is just the replacements assembly above.
+        return renderMessagesWithReplacements(templateMessages, replacements);
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -268,28 +268,23 @@ public class OnlineScoringEngine {
      * already-rendered {@code context} string directly, skipping the
      * Jackson-serialize-the-traces step. Used by the tools path where the variable
      * value (the skeleton + drill-down hint) is computed by the caller.
+     *
+     * <p>The caller (the thread scorer's {@code shouldUseAgenticTools} gate) detects
+     * multimodal templates upstream via {@link #hasMultimodalTemplate(List)} and falls
+     * back to the inline path, so by the time we get here {@code templateMessages} is
+     * guaranteed string-only. The assertion below is a defensive net rather than the
+     * primary safety mechanism — actual rendering delegates to
+     * {@link #renderMessagesWithReplacements} so role-switch / template-engine logic
+     * stays in one place.
      */
     private static List<ChatMessage> renderThreadMessagesWithReplacement(
             List<LlmAsJudgeMessage> templateMessages, String variableName, String contextValue) {
+        if (hasMultimodalTemplate(templateMessages)) {
+            throw new UnsupportedOperationException(
+                    "Multimodal thread message content is not supported on the agentic-tools path");
+        }
         Map<String, String> replacements = Map.of(variableName, contextValue);
-        return templateMessages.stream()
-                .map(templateMessage -> {
-                    if (templateMessage.isStringContent()) {
-                        var renderedMessage = TemplateParseUtils.render(
-                                templateMessage.asString(), replacements, PromptType.MUSTACHE);
-                        return switch (templateMessage.role()) {
-                            case USER -> (ChatMessage) UserMessage.from(renderedMessage);
-                            case SYSTEM -> (ChatMessage) SystemMessage.from(renderedMessage);
-                            default -> {
-                                log.info("No mapping for message role type {}", templateMessage.role());
-                                yield (ChatMessage) UserMessage.from(renderedMessage);
-                            }
-                        };
-                    }
-                    throw new UnsupportedOperationException(
-                            "Multimodal thread message content is not supported on the agentic-tools path");
-                })
-                .toList();
+        return renderMessagesWithReplacements(templateMessages, replacements);
     }
 
     static List<ChatMessage> renderThreadMessages(

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -846,6 +846,26 @@ public class OnlineScoringEngine {
      * window — in that case the operator should pick a different model for those workloads).
      */
     /**
+     * Shared error-logging helper for the {@code prepareEvaluation} catch blocks on the trace
+     * and thread scorers. The two loggers are intentional:
+     * <ul>
+     *   <li>{@code userFacingLogger} carries a sanitized one-liner with the entity id only —
+     *       no Throwable, so the stack trace (with internal class names / paths) doesn't leak
+     *       into the user-facing log sink.</li>
+     *   <li>{@code internalLogger} (the scorer's slf4j logger) carries the full stack trace
+     *       so an operator can diagnose what actually broke.</li>
+     * </ul>
+     * <p>The {@code idLabel} parameter ({@code "traceId"} / {@code "threadId"}) and {@code id}
+     * are formatted with single-quoted placeholders per the backend logging convention.
+     */
+    public static void logPreparingLlmRequestError(@NonNull Logger userFacingLogger,
+            @NonNull Logger internalLogger, @NonNull String idLabel, @NonNull Object id,
+            @NonNull Exception exception) {
+        userFacingLogger.error("Error preparing LLM request for {} '{}'", idLabel, id);
+        internalLogger.error("Error preparing LLM request for {} '{}'", idLabel, id, exception);
+    }
+
+    /**
      * Whether any of the template messages declares non-string (multimodal) content. The
      * agentic-tools render path on threads only substitutes the context variable into string
      * content — multimodal templates (image / audio / video alongside text) are rejected.

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -310,14 +310,12 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                 scoreRequest = OnlineScoringEngine.addToolSpecs(scoreRequest, ToolChoice.REQUIRED, toolRegistry);
             }
 
-            // Guarded behind isInfoEnabled() because summarizeRequest streams over the message
-            // list to total up character counts; SLF4J's parameter substitution defers the
-            // {} placeholder, but the helper invocation itself is still evaluated eagerly.
-            if (userFacingLogger.isInfoEnabled()) {
-                userFacingLogger.info("Sending traceId '{}' to LLM: {}",
-                        trace.id(), OnlineScoringEngine.summarizeRequest(scoreRequest,
-                                message.llmAsJudgeCode().model().name(), useTools));
-            }
+            // summarizeRequest is cheap (no per-message toString streaming since the chars-count
+            // field was removed). At INFO so operators watching their rule's UI logs see a
+            // matching "Sending" line between "Evaluating" and "Received response".
+            userFacingLogger.info("Sending traceId '{}' to LLM: {}",
+                    trace.id(), OnlineScoringEngine.summarizeRequest(scoreRequest,
+                            message.llmAsJudgeCode().model().name(), useTools));
 
             // fullJson is only useful downstream on the agentic-tools path (handleToolCalls
             // pre-seeds it into the tool cache). On the inline path we discard it — we already

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -207,7 +207,7 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                         .doOnNext(withMdc(mdc, chatResponse -> {
                             if (userFacingLogger.isInfoEnabled()) {
                                 userFacingLogger.info("Received response for traceId '{}': {}",
-                                        trace.id(), summarizeResponse(chatResponse));
+                                        trace.id(), OnlineScoringEngine.summarizeResponse(chatResponse));
                             }
                         }))
                         .flatMap(initialResponse -> prepared.useTools()
@@ -294,8 +294,7 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                     structuredRequest = scoreRequest;
                 }
             } catch (Exception exception) {
-                userFacingLogger.error("Error preparing LLM request for traceId '{}': \n\n{}",
-                        trace.id(), exception.getMessage());
+                userFacingLogger.error("Error preparing LLM request for traceId '{}'", trace.id(), exception);
                 throw exception;
             }
 
@@ -308,7 +307,7 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                 // AUTO so the model can decide when it has enough info to stop investigating;
                 // a uniform REQUIRED would loop forever because the wrap-up turn would also
                 // be forced to call a tool.
-                scoreRequest = addToolSpecs(scoreRequest, ToolChoice.REQUIRED);
+                scoreRequest = OnlineScoringEngine.addToolSpecs(scoreRequest, ToolChoice.REQUIRED, toolRegistry);
             }
 
             // Guarded behind isInfoEnabled() because summarizeRequest streams over the message
@@ -338,25 +337,6 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
         return Mono.fromCallable(() -> aiProxyService.scoreTrace(
                 request, message.llmAsJudgeCode().model(), message.workspaceId()))
                 .subscribeOn(Schedulers.boundedElastic());
-    }
-
-    // Package-private for unit tests.
-    ChatRequest addToolSpecs(ChatRequest request, ToolChoice toolChoice) {
-        // Tool specs live inside ChatRequestParameters, so we copy the existing parameters via
-        // overrideWith and layer tool specs on top — setting toolSpecifications directly on
-        // ChatRequest's builder would conflict with parameters. Using toBuilder() (rather than
-        // a fresh builder + .messages()) preserves any other top-level fields on ChatRequest,
-        // present or future, guarding against the same "silently dropped fields" regression
-        // that previously gave the initial scoring call a different shape from the final
-        // structured re-issue in handleToolCalls.
-        var parameters = ChatRequestParameters.builder()
-                .overrideWith(request.parameters())
-                .toolSpecifications(toolRegistry.specs())
-                .toolChoice(toolChoice)
-                .build();
-        return request.toBuilder()
-                .parameters(parameters)
-                .build();
     }
 
     private static boolean shouldUseTools(TraceToScoreLlmAsJudge message) {
@@ -496,20 +476,6 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
         return String.format("model='%s', messages=%d (~%d chars), tools=%d, toolsEnabled=%s",
                 message.llmAsJudgeCode().model().name(),
                 messageCount, totalChars, toolSpecCount, useTools);
-    }
-
-    /**
-     * Build a sanitized one-line description of the LLM response. As with the request,
-     * the full {@code ChatResponse} contains the assistant text and any tool-call
-     * arguments, both of which can echo trace content the model is reasoning about.
-     */
-    private static String summarizeResponse(ChatResponse response) {
-        var ai = response.aiMessage();
-        int textLength = ai.text() == null ? 0 : ai.text().length();
-        int toolCallCount = ai.toolExecutionRequests() == null ? 0 : ai.toolExecutionRequests().size();
-        var finishReason = response.metadata() == null ? null : response.metadata().finishReason();
-        return String.format("textChars=%d, toolCalls=%d, finishReason=%s",
-                textLength, toolCallCount, finishReason);
     }
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -24,7 +24,6 @@ import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
@@ -35,7 +34,6 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RedissonReactiveClient;
 import org.slf4j.Logger;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
@@ -57,8 +55,6 @@ import static com.comet.opik.infrastructure.log.LogContextAware.wrapWithMdc;
 @EagerSingleton
 @Slf4j
 public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<TraceToScoreLlmAsJudge> {
-
-    private static final int MAX_TOOL_CALL_ROUNDS = 10;
 
     /**
      * Per-variable substitution cap for the test-suite-assertion (tool-enabled) path. ≈ 4 KB chars
@@ -413,24 +409,6 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
         return useTools;
     }
 
-    /**
-     * Cumulative cap on tool-result string length across the whole tool-call loop. Beyond
-     * this, further tool calls return a budget-exhausted sentinel so the judge has to compose
-     * its final answer from already-gathered data. Sized for ~2 chars/token (random/code
-     * worst case) so even adversarial inputs stay under a 128 K-token window after accounting
-     * for system prompt, tool specs, user prompt, and assistant turns:
-     *
-     * <p>{@code 150_000 chars / 2 chars/tok ≈ 75 K tok} of tool results, leaving ≈ 50 K tok
-     * of headroom for the rest of the conversation. Pairs with
-     * {@link com.comet.opik.api.resources.v1.events.tools.ReadTool#OUTPUT_SAFETY_CHARS}
-     * (per-call cap with auto-tier-downgrade): up to ~7 max-cap reads fit before this cap.
-     */
-    static final long CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS = 150_000L;
-
-    private static final String BUDGET_EXHAUSTED_MESSAGE = "{\"error\": \"Cumulative tool-output"
-            + " budget (%d chars) exhausted for this judgment; further tool calls return this"
-            + " error. Respond now with your best assessment from the data already gathered.\"}";
-
     // Package-private for unit tests.
     Mono<ChatResponse> handleToolCalls(ChatResponse chatResponse, ChatRequest toolRequest,
             ChatRequest structuredRequest, TraceToScoreLlmAsJudge message, List<Span> spans,
@@ -441,12 +419,9 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
             return Mono.just(chatResponse);
         }
 
-        // Defer everything below to subscription time. Without this, the TraceToolContext +
-        // cache pre-seed + ArrayList allocation would happen at method-invoke time — fine
-        // under the current single-subscriber call shape, but a future caller composing the
-        // returned Mono differently (or subscribing twice) would observe the side effects
-        // out of sync with the chain. The early Mono.just above stays outside the defer
-        // because it's cold and pure.
+        // Defer everything below to subscription time so context + cache pre-seed + message
+        // list allocation happen exactly once per subscription. The early Mono.just above is
+        // cold and pure, so it doesn't need to be inside the defer.
         return Mono.defer(() -> {
             var trace = message.trace();
             var ctx = new TraceToolContext(trace, spans, message.workspaceId(), message.userName());
@@ -468,13 +443,13 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                     .toolChoice(ToolChoice.AUTO)
                     .build();
 
-            // Shared mutable state. handleToolCalls runs once per evaluation; the recursive
-            // toolCallLoop chains rounds sequentially via flatMap and the inner tool dispatch
-            // uses concatMap, so concurrent mutation can't occur here.
             var messages = new ArrayList<ChatMessage>(toolRequest.messages());
-            var budget = new ToolOutputBudget();
+            var budget = new ToolCallLoop.Budget();
 
-            return toolCallLoop(0, chatResponse, toolRequest, followUpParameters, message, messages, ctx, budget, mdc)
+            return ToolCallLoop.run(
+                    chatResponse, toolRequest, followUpParameters, toolRegistry,
+                    request -> scoreTraceReactive(request, message),
+                    messages, ctx, budget, trace.id().toString(), mdc)
                     .flatMap(loopFinalResponse -> {
                         // Force closure of the tool-using phase. Without this, the model can return prose
                         // that continues the investigation ("Now let me check...") instead of the required
@@ -493,83 +468,6 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                         return scoreTraceReactive(finalRequest, message);
                     });
         });
-    }
-
-    private Mono<ChatResponse> toolCallLoop(int round, ChatResponse currentResponse, ChatRequest toolRequest,
-            ChatRequestParameters followUpParameters, TraceToScoreLlmAsJudge message,
-            ArrayList<ChatMessage> messages, TraceToolContext ctx, ToolOutputBudget budget,
-            Map<String, String> mdc) {
-        if (round >= MAX_TOOL_CALL_ROUNDS) {
-            return Mono.just(currentResponse);
-        }
-        if (!currentResponse.aiMessage().hasToolExecutionRequests()) {
-            return Mono.just(currentResponse);
-        }
-
-        var trace = message.trace();
-
-        // Defer all side effects (the messages.add below, the tool executions, the followUp
-        // scoreTrace) until subscription. The early returns above are pure (cold Mono.just),
-        // so they don't need to live inside the defer.
-        return Mono.defer(() -> {
-            messages.add(currentResponse.aiMessage());
-
-            // concatMap (not flatMap) so tool executions in this round preserve order — the
-            // ToolExecutionResultMessages must follow their parent AiMessage in the message
-            // list in the same order the model emitted them, matching what OpenAI expects.
-            Flux<ToolExecutionResultMessage> roundResults = Flux
-                    .fromIterable(currentResponse.aiMessage().toolExecutionRequests())
-                    .concatMap(toolExecRequest -> executeToolOrBudgetExhausted(round, toolExecRequest, trace.id(),
-                            ctx, budget, mdc));
-
-            return roundResults
-                    .doOnNext(messages::add)
-                    .then(Mono.defer(() -> {
-                        // Defensive copy: ChatRequestBuilder stores the list by reference, so a later
-                        // iteration mutating `messages` would retroactively change what an async chat
-                        // client sees in this round's request. Snapshot per round.
-                        var followUp = toolRequest.toBuilder()
-                                .messages(new ArrayList<>(messages))
-                                .parameters(followUpParameters)
-                                .build();
-                        return scoreTraceReactive(followUp, message);
-                    }))
-                    .flatMap(nextResponse -> toolCallLoop(round + 1, nextResponse, toolRequest, followUpParameters,
-                            message, messages, ctx, budget, mdc));
-        });
-    }
-
-    private Mono<ToolExecutionResultMessage> executeToolOrBudgetExhausted(int round,
-            dev.langchain4j.agent.tool.ToolExecutionRequest toolExecRequest, UUID traceId,
-            TraceToolContext ctx, ToolOutputBudget budget, Map<String, String> mdc) {
-        // Apply MDC so the slf4j tags (workspace_id, trace_id, rule_id) follow the tool-loop
-        // log lines — the reactive chain may have hopped threads since prepareEvaluation set
-        // MDC, so we re-apply per call.
-        try (var logContext = wrapWithMdc(mdc)) {
-            log.debug("Tool call round '{}' for traceId '{}': tool '{}'",
-                    round, traceId, toolExecRequest.name());
-            if (budget.cumulative >= CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS) {
-                if (!budget.exhaustedLogged) {
-                    log.warn("Tool-output budget '{}' chars exhausted for traceId '{}';"
-                            + " subsequent tool calls return budget-exhausted sentinel",
-                            CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS, traceId);
-                    budget.exhaustedLogged = true;
-                }
-                return Mono.just(ToolExecutionResultMessage.from(toolExecRequest,
-                        BUDGET_EXHAUSTED_MESSAGE.formatted(CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS)));
-            }
-        }
-        return toolRegistry.execute(toolExecRequest.name(), toolExecRequest.arguments(), ctx)
-                .map(result -> {
-                    budget.cumulative += result.length();
-                    return ToolExecutionResultMessage.from(toolExecRequest, result);
-                });
-    }
-
-    /** Shared per-evaluation tool-output budget state. Mutated sequentially via concatMap. */
-    private static final class ToolOutputBudget {
-        long cumulative = 0L;
-        boolean exhaustedLogged = false;
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -441,50 +441,58 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
             return Mono.just(chatResponse);
         }
 
-        var trace = message.trace();
-        var ctx = new TraceToolContext(trace, spans, message.workspaceId(), message.userName());
-        // Pre-seed the active trace into the cache using the JSON that prepareEvaluation
-        // already built for the size estimate — saves a redundant traceCompressor.buildFullJson
-        // call on big-trace evaluations. Fall back to rebuilding if the caller didn't supply
-        // one (e.g. unit tests that call handleToolCalls directly).
-        ctx.cache(new EntityRef(EntityType.TRACE, trace.id().toString()),
-                fullJson != null ? fullJson : traceCompressor.buildFullJson(trace, spans));
+        // Defer everything below to subscription time. Without this, the TraceToolContext +
+        // cache pre-seed + ArrayList allocation would happen at method-invoke time — fine
+        // under the current single-subscriber call shape, but a future caller composing the
+        // returned Mono differently (or subscribing twice) would observe the side effects
+        // out of sync with the chain. The early Mono.just above stays outside the defer
+        // because it's cold and pure.
+        return Mono.defer(() -> {
+            var trace = message.trace();
+            var ctx = new TraceToolContext(trace, spans, message.workspaceId(), message.userName());
+            // Pre-seed the active trace into the cache using the JSON that prepareEvaluation
+            // already built for the size estimate — saves a redundant traceCompressor.buildFullJson
+            // call on big-trace evaluations. Fall back to rebuilding if the caller didn't supply
+            // one (e.g. unit tests that call handleToolCalls directly).
+            ctx.cache(new EntityRef(EntityType.TRACE, trace.id().toString()),
+                    fullJson != null ? fullJson : traceCompressor.buildFullJson(trace, spans));
 
-        // Subsequent rounds use tool_choice=AUTO so the model can decide when it has enough
-        // information to stop investigating. The initial call uses REQUIRED to force ≥1 tool
-        // call (see prepareEvaluation() — overcomes OpenAI's bias against calling tools when it
-        // can satisfy the output schema from visible context). If we kept REQUIRED on follow-ups,
-        // the wrap-up turn would loop forever, since every round would be forced to invoke
-        // a tool even after the model is ready to emit the final JSON.
-        var followUpParameters = ChatRequestParameters.builder()
-                .overrideWith(toolRequest.parameters())
-                .toolChoice(ToolChoice.AUTO)
-                .build();
+            // Subsequent rounds use tool_choice=AUTO so the model can decide when it has enough
+            // information to stop investigating. The initial call uses REQUIRED to force ≥1 tool
+            // call (see prepareEvaluation() — overcomes OpenAI's bias against calling tools when it
+            // can satisfy the output schema from visible context). If we kept REQUIRED on follow-ups,
+            // the wrap-up turn would loop forever, since every round would be forced to invoke
+            // a tool even after the model is ready to emit the final JSON.
+            var followUpParameters = ChatRequestParameters.builder()
+                    .overrideWith(toolRequest.parameters())
+                    .toolChoice(ToolChoice.AUTO)
+                    .build();
 
-        // Shared mutable state. handleToolCalls runs once per evaluation; the recursive
-        // toolCallLoop chains rounds sequentially via flatMap and the inner tool dispatch
-        // uses concatMap, so concurrent mutation can't occur here.
-        var messages = new ArrayList<ChatMessage>(toolRequest.messages());
-        var budget = new ToolOutputBudget();
+            // Shared mutable state. handleToolCalls runs once per evaluation; the recursive
+            // toolCallLoop chains rounds sequentially via flatMap and the inner tool dispatch
+            // uses concatMap, so concurrent mutation can't occur here.
+            var messages = new ArrayList<ChatMessage>(toolRequest.messages());
+            var budget = new ToolOutputBudget();
 
-        return toolCallLoop(0, chatResponse, toolRequest, followUpParameters, message, messages, ctx, budget, mdc)
-                .flatMap(loopFinalResponse -> {
-                    // Force closure of the tool-using phase. Without this, the model can return prose
-                    // that continues the investigation ("Now let me check...") instead of the required
-                    // JSON, even when the request carries no tool specs. Combined with the provider-native
-                    // structured-output strategy on `structuredRequest`, this gives both a soft and a
-                    // hard signal: "stop calling tools, emit only JSON now".
-                    messages.add(UserMessage.from(
-                            "You have completed your investigation using the available tools."
-                                    + " Now respond with ONLY the JSON object specified in the original instructions."
-                                    + " Do not call any more tools. Do not include any prose, commentary, or markdown"
-                                    + " fences — emit only the raw JSON object."));
+            return toolCallLoop(0, chatResponse, toolRequest, followUpParameters, message, messages, ctx, budget, mdc)
+                    .flatMap(loopFinalResponse -> {
+                        // Force closure of the tool-using phase. Without this, the model can return prose
+                        // that continues the investigation ("Now let me check...") instead of the required
+                        // JSON, even when the request carries no tool specs. Combined with the provider-native
+                        // structured-output strategy on `structuredRequest`, this gives both a soft and a
+                        // hard signal: "stop calling tools, emit only JSON now".
+                        messages.add(UserMessage.from(
+                                "You have completed your investigation using the available tools."
+                                        + " Now respond with ONLY the JSON object specified in the original instructions."
+                                        + " Do not call any more tools. Do not include any prose, commentary, or markdown"
+                                        + " fences — emit only the raw JSON object."));
 
-                    var finalRequest = structuredRequest.toBuilder()
-                            .messages(new ArrayList<>(messages))
-                            .build();
-                    return scoreTraceReactive(finalRequest, message);
-                });
+                        var finalRequest = structuredRequest.toBuilder()
+                                .messages(new ArrayList<>(messages))
+                                .build();
+                        return scoreTraceReactive(finalRequest, message);
+                    });
+        });
     }
 
     private Mono<ChatResponse> toolCallLoop(int round, ChatResponse currentResponse, ChatRequest toolRequest,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -24,7 +24,6 @@ import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.ToolChoice;
@@ -316,7 +315,8 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
             // {} placeholder, but the helper invocation itself is still evaluated eagerly.
             if (userFacingLogger.isInfoEnabled()) {
                 userFacingLogger.info("Sending traceId '{}' to LLM: {}",
-                        trace.id(), summarizeRequest(scoreRequest, message, useTools));
+                        trace.id(), OnlineScoringEngine.summarizeRequest(scoreRequest,
+                                message.llmAsJudgeCode().model().name(), useTools));
             }
 
             // fullJson is only useful downstream on the agentic-tools path (handleToolCalls
@@ -427,27 +427,10 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
             var messages = new ArrayList<ChatMessage>(toolRequest.messages());
             var budget = new ToolCallLoop.Budget();
 
-            return ToolCallLoop.run(
-                    chatResponse, toolRequest, followUpParameters, toolRegistry,
+            return ToolCallLoop.runWithWrapUp(
+                    chatResponse, toolRequest, structuredRequest, followUpParameters, toolRegistry,
                     request -> scoreTraceReactive(request, message),
-                    messages, ctx, budget, trace.id().toString(), mdc)
-                    .flatMap(loopFinalResponse -> {
-                        // Force closure of the tool-using phase. Without this, the model can return prose
-                        // that continues the investigation ("Now let me check...") instead of the required
-                        // JSON, even when the request carries no tool specs. Combined with the provider-native
-                        // structured-output strategy on `structuredRequest`, this gives both a soft and a
-                        // hard signal: "stop calling tools, emit only JSON now".
-                        messages.add(UserMessage.from(
-                                "You have completed your investigation using the available tools."
-                                        + " Now respond with ONLY the JSON object specified in the original instructions."
-                                        + " Do not call any more tools. Do not include any prose, commentary, or markdown"
-                                        + " fences — emit only the raw JSON object."));
-
-                        var finalRequest = structuredRequest.toBuilder()
-                                .messages(new ArrayList<>(messages))
-                                .build();
-                        return scoreTraceReactive(finalRequest, message);
-                    });
+                    messages, ctx, budget, trace.id().toString(), mdc);
         });
     }
 
@@ -459,24 +442,6 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
      */
     private record PreparedEvaluation(ChatRequest scoreRequest, ChatRequest structuredRequest, boolean useTools,
             JsonNode fullJson) {
-    }
-
-    /**
-     * Build a sanitized one-line description of the outgoing request for the user-facing
-     * log. The full {@code ChatRequest} contains the rendered system prompt, the user
-     * message with the trace's input/output, and request parameters — surfacing all of it
-     * in a stored log lands trace content (and any tokens or PII it carries) in clear
-     * text downstream of whatever sinks the user-facing log feeds. We log shape only.
-     */
-    private static String summarizeRequest(ChatRequest request, TraceToScoreLlmAsJudge message, boolean useTools) {
-        int messageCount = request.messages() == null ? 0 : request.messages().size();
-        int totalChars = request.messages() == null
-                ? 0
-                : request.messages().stream().mapToInt(m -> m.toString().length()).sum();
-        int toolSpecCount = request.toolSpecifications() == null ? 0 : request.toolSpecifications().size();
-        return String.format("model='%s', messages=%d (~%d chars), tools=%d, toolsEnabled=%s",
-                message.llmAsJudgeCode().model().name(),
-                messageCount, totalChars, toolSpecCount, useTools);
     }
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -405,7 +405,7 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
         // cold and pure, so it doesn't need to be inside the defer.
         return Mono.defer(() -> {
             var trace = message.trace();
-            var ctx = new TraceToolContext(trace, spans, message.workspaceId(), message.userName());
+            var ctx = TraceToolContext.forActiveTrace(trace, spans, message.workspaceId(), message.userName());
             // Pre-seed the active trace into the cache using the JSON that prepareEvaluation
             // already built for the size estimate — saves a redundant traceCompressor.buildFullJson
             // call on big-trace evaluations. Fall back to rebuilding if the caller didn't supply

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -206,7 +206,7 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                 .flatMap(prepared -> scoreTraceReactive(prepared.scoreRequest(), message)
                         .doOnNext(withMdc(mdc, chatResponse -> {
                             if (userFacingLogger.isInfoEnabled()) {
-                                userFacingLogger.info("Received response for traceId '{}': {}",
+                                userFacingLogger.info("Received response for traceId '{}': '{}'",
                                         trace.id(), OnlineScoringEngine.summarizeResponse(chatResponse));
                             }
                         }))
@@ -294,7 +294,8 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                     structuredRequest = scoreRequest;
                 }
             } catch (Exception exception) {
-                userFacingLogger.error("Error preparing LLM request for traceId '{}'", trace.id(), exception);
+                OnlineScoringEngine.logPreparingLlmRequestError(userFacingLogger, log, "traceId",
+                        trace.id(), exception);
                 throw exception;
             }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorer.java
@@ -96,7 +96,7 @@ public class OnlineScoringSpanUserDefinedMetricPythonScorer
     private Map<String, Object> prepareData(SpanToScoreUserDefinedMetricPython message, Map<String, String> mdc) {
         var span = message.span();
         return OnlineScoringEngine.logAndPrepareEvaluatorInput(
-                userFacingLogger, mdc, "spanId", span.id(), message.ruleName(),
+                userFacingLogger, log, mdc, "spanId", span.id(), message.ruleName(),
                 () -> new LinkedHashMap<>(OnlineScoringEngine.toReplacements(message.code().arguments(), span)));
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -6,6 +6,8 @@ import com.comet.opik.api.Trace;
 import com.comet.opik.api.Visibility;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluator;
 import com.comet.opik.api.events.TraceThreadToScoreLlmAsJudge;
+import com.comet.opik.api.resources.v1.events.tools.ToolRegistry;
+import com.comet.opik.api.resources.v1.events.tools.TraceToolContext;
 import com.comet.opik.domain.FeedbackScoreService;
 import com.comet.opik.domain.ProjectService;
 import com.comet.opik.domain.TraceService;
@@ -15,9 +17,18 @@ import com.comet.opik.domain.llm.ChatCompletionService;
 import com.comet.opik.domain.llm.LlmProviderFactory;
 import com.comet.opik.domain.threads.TraceThreadService;
 import com.comet.opik.infrastructure.OnlineScoringConfig;
+import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ToolChoice;
+import dev.langchain4j.model.chat.response.ChatResponse;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 import lombok.NonNull;
@@ -31,6 +42,7 @@ import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
 import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -49,15 +61,32 @@ import static com.comet.opik.infrastructure.log.LogContextAware.wrapWithMdc;
 @Slf4j
 public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseScorer<TraceThreadToScoreLlmAsJudge> {
 
+    private static final int MAX_TOOL_CALL_ROUNDS = 10;
+
+    /**
+     * Cumulative cap on tool-result string length across the whole tool-call loop. Same
+     * shape and sizing as the trace-level scorer's cap — see that class for the budget
+     * math. Pairs with {@link com.comet.opik.api.resources.v1.events.tools.ReadTool#OUTPUT_SAFETY_CHARS}.
+     */
+    static final long CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS = 150_000L;
+
+    private static final String BUDGET_EXHAUSTED_MESSAGE = "{\"error\": \"Cumulative tool-output"
+            + " budget (%d chars) exhausted for this judgment; further tool calls return this"
+            + " error. Respond now with your best assessment from the data already gathered.\"}";
+
     private final ChatCompletionService aiProxyService;
     private final Logger userFacingLogger;
     private final LlmProviderFactory llmProviderFactory;
     private final TraceThreadService traceThreadService;
     private final ProjectService projectService;
     private final AutomationRuleEvaluatorService automationRuleEvaluatorService;
+    private final ToolRegistry toolRegistry;
+    private final OnlineScoringConfig onlineScoringConfig;
+    private final ServiceTogglesConfig serviceTogglesConfig;
 
     @Inject
     public OnlineScoringTraceThreadLlmAsJudgeScorer(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
+            @NonNull @Config("serviceToggles") ServiceTogglesConfig serviceTogglesConfig,
             @NonNull RedissonReactiveClient redisson,
             @NonNull FeedbackScoreService feedbackScoreService,
             @NonNull ChatCompletionService aiProxyService,
@@ -65,7 +94,8 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
             @NonNull TraceService traceService,
             @NonNull TraceThreadService traceThreadService,
             @NonNull ProjectService projectService,
-            @NonNull AutomationRuleEvaluatorService automationRuleEvaluatorService) {
+            @NonNull AutomationRuleEvaluatorService automationRuleEvaluatorService,
+            @NonNull ToolRegistry toolRegistry) {
         super(config, redisson, feedbackScoreService, traceService, TRACE_THREAD_LLM_AS_JUDGE,
                 Constants.TRACE_THREAD_LLM_AS_JUDGE);
         this.aiProxyService = aiProxyService;
@@ -73,6 +103,9 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         this.traceThreadService = traceThreadService;
         this.projectService = projectService;
         this.automationRuleEvaluatorService = automationRuleEvaluatorService;
+        this.toolRegistry = toolRegistry;
+        this.onlineScoringConfig = config;
+        this.serviceTogglesConfig = serviceTogglesConfig;
         this.userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringTraceThreadLlmAsJudgeScorer.class);
     }
 
@@ -184,7 +217,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
      */
     private Mono<Void> scoreThread(TraceThreadToScoreLlmAsJudge message, List<Trace> traces, UUID threadModelId,
             String threadId, AutomationRuleEvaluator<?, ?> rule, Map<String, String> mdc) {
-        return Mono.fromCallable(() -> evaluate(message, traces, threadModelId, threadId, rule, mdc))
+        return evaluate(message, traces, threadModelId, threadId, rule, mdc)
                 .flatMap(scores -> storeThreadScores(scores, threadId, message.userName(), message.workspaceId()))
                 .doOnNext(withMdc(mdc, loggedScores -> userFacingLogger
                         .info("Scores for threadId '{}' stored successfully:\n\n{}", threadId, loggedScores)))
@@ -197,45 +230,252 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
     }
 
     /**
-     * Calls the LLM provider for the given thread and returns the resulting feedback scores. Caller
-     * guarantees {@code traces} is non-empty.
+     * Builds and runs the LLM scoring chain for the thread. Routes through the agentic-tools
+     * branch (skeleton + ReadTool/JqTool/SearchTool drill-down) when the inline-rendered thread
+     * would exceed the configured size threshold AND the provider supports tool-calling AND the
+     * toggle is on. Otherwise the inline path runs unchanged — same shape as today.
      */
-    private List<FeedbackScoreBatchItemThread> evaluate(TraceThreadToScoreLlmAsJudge message, List<Trace> traces,
-            UUID threadModelId, String threadId, AutomationRuleEvaluator<?, ?> rule, Map<String, String> mdc) {
+    private Mono<List<FeedbackScoreBatchItemThread>> evaluate(TraceThreadToScoreLlmAsJudge message,
+            List<Trace> traces, UUID threadModelId, String threadId, AutomationRuleEvaluator<?, ?> rule,
+            Map<String, String> mdc) {
+        return Mono.fromCallable(() -> prepareEvaluation(message, traces, threadId, rule, mdc))
+                .subscribeOn(Schedulers.parallel())
+                .flatMap(prepared -> scoreTraceReactive(prepared.scoreRequest(), message)
+                        .doOnNext(withMdc(mdc, chatResponse -> userFacingLogger.info(
+                                "Received response for threadId '{}':\n\n{}", threadId, chatResponse)))
+                        .flatMap(initialResponse -> prepared.useTools()
+                                ? handleToolCalls(initialResponse, prepared.scoreRequest(),
+                                        prepared.structuredRequest(), message, mdc)
+                                : Mono.just(initialResponse)))
+                .map(chatResponse -> {
+                    try (var logContext = wrapWithMdc(mdc)) {
+                        Project project = projectService.get(message.projectId(), message.workspaceId());
+                        var parsed = OnlineScoringEngine.toFeedbackScores(chatResponse);
+                        OnlineScoringEngine.logSkippedNullScores(userFacingLogger, parsed, "threadId", threadId);
+                        return parsed.scores().stream()
+                                .map(item -> FeedbackScoresMapper.INSTANCE.map(
+                                        item.toBuilder()
+                                                .id(threadModelId)
+                                                .projectId(message.projectId())
+                                                .projectName(project.name())
+                                                .source(ScoreSource.ONLINE_SCORING)
+                                                .build(),
+                                        threadId))
+                                .toList();
+                    }
+                });
+    }
+
+    /**
+     * Sync preparation step — picks the path (inline vs agentic-tools) and builds the chat
+     * request(s). Wrapped in {@code Mono.fromCallable} on {@code Schedulers.parallel()} by the
+     * caller because the body is CPU-bound (JSON serialization for the size estimate + prompt
+     * rendering); no blocking I/O happens here.
+     */
+    private PreparedEvaluation prepareEvaluation(TraceThreadToScoreLlmAsJudge message, List<Trace> traces,
+            String threadId, AutomationRuleEvaluator<?, ?> rule, Map<String, String> mdc) {
         try (var logContext = wrapWithMdc(mdc)) {
             userFacingLogger.info("Evaluating threadId '{}' sampled by rule '{}'", threadId, rule.getName());
 
-            Project project = projectService.get(message.projectId(), message.workspaceId());
+            String modelName = message.code().model().name();
+            int estimatedContextTokens = OnlineScoringEngine.estimateThreadContextTokens(
+                    traces, onlineScoringConfig.getAgenticToolsCharsPerToken());
+            boolean useTools = shouldUseAgenticTools(estimatedContextTokens, modelName, threadId);
 
             ChatRequest scoreRequest;
+            ChatRequest structuredRequest;
             try {
-                String modelName = message.code().model().name();
                 var strategy = llmProviderFactory.getStructuredOutputStrategy(modelName);
-                scoreRequest = OnlineScoringEngine.prepareThreadLlmRequest(message.code(), traces, strategy);
+                if (useTools) {
+                    // Tools path: skeleton + drill-down hint instead of full trace dump. The agent
+                    // drills into specific traces via read(type=trace, id=X) — same lazy pattern
+                    // the trace-level path uses. Spans for any one trace are fetched reactively in
+                    // ReadTool.readTrace only when the model actually asks for that trace.
+                    scoreRequest = OnlineScoringEngine.prepareThreadLlmRequestWithTools(
+                            message.code(), traces, strategy);
+                    // The post-tool-loop wrap-up uses the same structured-output strategy — for
+                    // threads there is no separate InstructionStrategy variant, so the initial and
+                    // wrap-up requests share a shape (modulo tool specs).
+                    structuredRequest = scoreRequest;
+                } else {
+                    scoreRequest = OnlineScoringEngine.prepareThreadLlmRequest(message.code(), traces, strategy);
+                    structuredRequest = scoreRequest;
+                }
             } catch (Exception exception) {
                 userFacingLogger.error("Error preparing LLM request for threadId '{}': \n\n{}",
                         threadId, exception.getMessage());
                 throw exception;
             }
 
+            if (useTools) {
+                // REQUIRED on the first call only — same reasoning as the trace scorer: forces
+                // ≥1 tool call before the model can answer from skeleton alone. Follow-up rounds
+                // switch to AUTO so the wrap-up turn can emit JSON without invoking a tool.
+                scoreRequest = addToolSpecs(scoreRequest, ToolChoice.REQUIRED);
+            }
+
             userFacingLogger.info("Sending threadId '{}' to LLM using the following input:\n\n{}",
                     threadId, scoreRequest);
-
-            var chatResponse = aiProxyService.scoreTrace(scoreRequest, message.code().model(), message.workspaceId());
-            userFacingLogger.info("Received response for threadId '{}':\n\n{}", threadId, chatResponse);
-
-            var parsed = OnlineScoringEngine.toFeedbackScores(chatResponse);
-            OnlineScoringEngine.logSkippedNullScores(userFacingLogger, parsed, "threadId", threadId);
-            return parsed.scores().stream()
-                    .map(item -> FeedbackScoresMapper.INSTANCE.map(
-                            item.toBuilder()
-                                    .id(threadModelId)
-                                    .projectId(message.projectId())
-                                    .projectName(project.name())
-                                    .source(ScoreSource.ONLINE_SCORING)
-                                    .build(),
-                            threadId))
-                    .toList();
+            return new PreparedEvaluation(scoreRequest, structuredRequest, useTools);
         }
+    }
+
+    /**
+     * Routing decision for whether to attach tool specs + run the tool-call loop for a thread.
+     * Threads don't have the experimentId-driven branch (no test-suite-assertion equivalent),
+     * so the decision is purely size-based: toggle on + estimated thread context above threshold
+     * + provider supports tool-calling. Falls back to inline + a user-facing warn when toggle
+     * is on and size is over but the provider can't handle tools.
+     */
+    boolean shouldUseAgenticTools(int estimatedContextTokens, String modelName, String threadId) {
+        boolean overSizeThreshold = serviceTogglesConfig.isAgenticToolsEnabled()
+                && estimatedContextTokens >= onlineScoringConfig.getAgenticToolsThresholdTokens();
+        // Skip the provider lookup when the toggle is off — most evaluations are toggle-off and
+        // this saves both a service hit and an unnecessary NPE-risk when the model is unknown.
+        if (!overSizeThreshold) {
+            return false;
+        }
+        boolean providerSupportsTools = OnlineScoringEngine.supportsToolCalling(
+                llmProviderFactory.getLlmProvider(modelName));
+        if (!providerSupportsTools) {
+            userFacingLogger.warn(
+                    "Thread context exceeds '{}' tokens but provider for model '{}' does not support tool"
+                            + " calling; falling back to inline path — may overflow context window.",
+                    onlineScoringConfig.getAgenticToolsThresholdTokens(), modelName);
+            return false;
+        }
+        userFacingLogger.info(
+                "Thread context exceeds '{}' tokens; switching to agentic-tools mode for threadId '{}'",
+                onlineScoringConfig.getAgenticToolsThresholdTokens(), threadId);
+        return true;
+    }
+
+    // Package-private for unit tests.
+    ChatRequest addToolSpecs(ChatRequest request, ToolChoice toolChoice) {
+        var parameters = ChatRequestParameters.builder()
+                .overrideWith(request.parameters())
+                .toolSpecifications(toolRegistry.specs())
+                .toolChoice(toolChoice)
+                .build();
+        return request.toBuilder()
+                .parameters(parameters)
+                .build();
+    }
+
+    /**
+     * Wraps the synchronous {@code ChatLanguageModel.chat} call in a Mono and schedules it on
+     * {@link Schedulers#boundedElastic()} so the blocking Jersey-client I/O doesn't pin the
+     * per-stream worker scheduler thread (OPIK-6308). Mirrors the trace scorer.
+     */
+    private Mono<ChatResponse> scoreTraceReactive(ChatRequest request, TraceThreadToScoreLlmAsJudge message) {
+        return Mono.fromCallable(() -> aiProxyService.scoreTrace(
+                request, message.code().model(), message.workspaceId()))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    // Package-private for unit tests.
+    Mono<ChatResponse> handleToolCalls(ChatResponse chatResponse, ChatRequest toolRequest,
+            ChatRequest structuredRequest, TraceThreadToScoreLlmAsJudge message, Map<String, String> mdc) {
+
+        AiMessage aiMessage = chatResponse.aiMessage();
+        if (!aiMessage.hasToolExecutionRequests()) {
+            return Mono.just(chatResponse);
+        }
+
+        // Thread-scoped context: no single active trace. ReadTool fetches any trace from the
+        // thread on demand via the standard read(type=trace, id=X) path. GetTraceSpansTool
+        // returns a redirect error on this context (see GetTraceSpansTool#execute).
+        var ctx = TraceToolContext.forThread(message.workspaceId(), message.userName());
+
+        var followUpParameters = ChatRequestParameters.builder()
+                .overrideWith(toolRequest.parameters())
+                .toolChoice(ToolChoice.AUTO)
+                .build();
+
+        var messages = new ArrayList<ChatMessage>(toolRequest.messages());
+        var budget = new ToolOutputBudget();
+
+        return toolCallLoop(0, chatResponse, toolRequest, followUpParameters, message, messages, ctx, budget, mdc)
+                .flatMap(loopFinalResponse -> {
+                    messages.add(UserMessage.from(
+                            "You have completed your investigation using the available tools."
+                                    + " Now respond with ONLY the JSON object specified in the original instructions."
+                                    + " Do not call any more tools. Do not include any prose, commentary, or markdown"
+                                    + " fences — emit only the raw JSON object."));
+                    var finalRequest = structuredRequest.toBuilder()
+                            .messages(new ArrayList<>(messages))
+                            .build();
+                    return scoreTraceReactive(finalRequest, message);
+                });
+    }
+
+    private Mono<ChatResponse> toolCallLoop(int round, ChatResponse currentResponse, ChatRequest toolRequest,
+            ChatRequestParameters followUpParameters, TraceThreadToScoreLlmAsJudge message,
+            ArrayList<ChatMessage> messages, TraceToolContext ctx, ToolOutputBudget budget,
+            Map<String, String> mdc) {
+        if (round >= MAX_TOOL_CALL_ROUNDS) {
+            return Mono.just(currentResponse);
+        }
+        if (!currentResponse.aiMessage().hasToolExecutionRequests()) {
+            return Mono.just(currentResponse);
+        }
+
+        // Defer side effects (messages.add, tool executions, followUp scoreTrace) until
+        // subscription. Early returns above are pure cold Mono.just and don't need defer.
+        return Mono.defer(() -> {
+            messages.add(currentResponse.aiMessage());
+
+            // concatMap (not flatMap) so tool executions within a round preserve order — same
+            // contract as the trace-level scorer.
+            Flux<ToolExecutionResultMessage> roundResults = Flux
+                    .fromIterable(currentResponse.aiMessage().toolExecutionRequests())
+                    .concatMap(toolExecRequest -> executeToolOrBudgetExhausted(round, toolExecRequest, message,
+                            ctx, budget, mdc));
+
+            return roundResults
+                    .doOnNext(messages::add)
+                    .then(Mono.defer(() -> {
+                        var followUp = toolRequest.toBuilder()
+                                .messages(new ArrayList<>(messages))
+                                .parameters(followUpParameters)
+                                .build();
+                        return scoreTraceReactive(followUp, message);
+                    }))
+                    .flatMap(nextResponse -> toolCallLoop(round + 1, nextResponse, toolRequest, followUpParameters,
+                            message, messages, ctx, budget, mdc));
+        });
+    }
+
+    private Mono<ToolExecutionResultMessage> executeToolOrBudgetExhausted(int round,
+            ToolExecutionRequest toolExecRequest, TraceThreadToScoreLlmAsJudge message,
+            TraceToolContext ctx, ToolOutputBudget budget, Map<String, String> mdc) {
+        try (var logContext = wrapWithMdc(mdc)) {
+            log.debug("Tool call round '{}' for ruleId '{}': tool '{}'",
+                    round, message.ruleId(), toolExecRequest.name());
+            if (budget.cumulative >= CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS) {
+                if (!budget.exhaustedLogged) {
+                    log.warn("Tool-output budget '{}' chars exhausted for ruleId '{}';"
+                            + " subsequent tool calls return budget-exhausted sentinel",
+                            CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS, message.ruleId());
+                    budget.exhaustedLogged = true;
+                }
+                return Mono.just(ToolExecutionResultMessage.from(toolExecRequest,
+                        BUDGET_EXHAUSTED_MESSAGE.formatted(CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS)));
+            }
+        }
+        return toolRegistry.execute(toolExecRequest.name(), toolExecRequest.arguments(), ctx)
+                .map(result -> {
+                    budget.cumulative += result.length();
+                    return ToolExecutionResultMessage.from(toolExecRequest, result);
+                });
+    }
+
+    /** Shared per-evaluation tool-output budget state. Mutated sequentially via concatMap. */
+    private static final class ToolOutputBudget {
+        long cumulative = 0L;
+        boolean exhaustedLogged = false;
+    }
+
+    private record PreparedEvaluation(ChatRequest scoreRequest, ChatRequest structuredRequest, boolean useTools) {
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -309,10 +309,10 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                 scoreRequest = OnlineScoringEngine.addToolSpecs(scoreRequest, ToolChoice.REQUIRED, toolRegistry);
             }
 
-            if (userFacingLogger.isInfoEnabled()) {
-                userFacingLogger.info("Sending threadId '{}' to LLM: {}",
-                        threadId, OnlineScoringEngine.summarizeRequest(scoreRequest, modelName, useTools));
-            }
+            // summarizeRequest is cheap (no per-message toString streaming). At INFO to mirror
+            // the trace scorer's symmetric Evaluating / Sending / Received chain.
+            userFacingLogger.info("Sending threadId '{}' to LLM: {}",
+                    threadId, OnlineScoringEngine.summarizeRequest(scoreRequest, modelName, useTools));
             return new PreparedEvaluation(scoreRequest, structuredRequest, useTools);
         }
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -339,8 +339,9 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         if (!providerSupportsTools) {
             userFacingLogger.warn(
                     "Thread context exceeds '{}' tokens but provider for model '{}' does not support tool"
-                            + " calling; falling back to inline path — may overflow context window.",
-                    onlineScoringConfig.getAgenticToolsThresholdTokens(), modelName);
+                            + " calling; falling back to inline path for threadId '{}' — may overflow"
+                            + " context window.",
+                    onlineScoringConfig.getAgenticToolsThresholdTokens(), modelName, threadId);
             return false;
         }
         // The thread agentic-tools render path only substitutes string content; multimodal
@@ -349,8 +350,8 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         if (OnlineScoringEngine.hasMultimodalTemplate(templateMessages)) {
             userFacingLogger.warn(
                     "Thread context exceeds '{}' tokens but evaluator template has multimodal content;"
-                            + " falling back to inline path — may overflow context window.",
-                    onlineScoringConfig.getAgenticToolsThresholdTokens());
+                            + " falling back to inline path for threadId '{}' — may overflow context window.",
+                    onlineScoringConfig.getAgenticToolsThresholdTokens(), threadId);
             return false;
         }
         userFacingLogger.info(

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -229,7 +229,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                 .flatMap(prepared -> scoreTraceReactive(prepared.scoreRequest(), message)
                         .doOnNext(withMdc(mdc, chatResponse -> {
                             if (userFacingLogger.isInfoEnabled()) {
-                                userFacingLogger.info("Received response for threadId '{}': {}",
+                                userFacingLogger.info("Received response for threadId '{}': '{}'",
                                         threadId, OnlineScoringEngine.summarizeResponse(chatResponse));
                             }
                         }))
@@ -293,7 +293,8 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                     structuredRequest = scoreRequest;
                 }
             } catch (Exception exception) {
-                userFacingLogger.error("Error preparing LLM request for threadId '{}'", threadId, exception);
+                OnlineScoringEngine.logPreparingLlmRequestError(userFacingLogger, log, "threadId",
+                        threadId, exception);
                 throw exception;
             }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -226,8 +226,12 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         return Mono.fromCallable(() -> prepareEvaluation(message, traces, threadId, rule, mdc))
                 .subscribeOn(Schedulers.parallel())
                 .flatMap(prepared -> scoreTraceReactive(prepared.scoreRequest(), message)
-                        .doOnNext(withMdc(mdc, chatResponse -> userFacingLogger.info(
-                                "Received response for threadId '{}':\n\n{}", threadId, chatResponse)))
+                        .doOnNext(withMdc(mdc, chatResponse -> {
+                            if (userFacingLogger.isInfoEnabled()) {
+                                userFacingLogger.info("Received response for threadId '{}': {}",
+                                        threadId, OnlineScoringEngine.summarizeResponse(chatResponse));
+                            }
+                        }))
                         .flatMap(initialResponse -> prepared.useTools()
                                 ? handleToolCalls(initialResponse, prepared.scoreRequest(),
                                         prepared.structuredRequest(), message, mdc)
@@ -266,6 +270,19 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
             int estimatedContextTokens = OnlineScoringEngine.estimateThreadContextTokens(
                     traces, onlineScoringConfig.getAgenticToolsCharsPerToken());
             boolean useTools = shouldUseAgenticTools(estimatedContextTokens, modelName, threadId);
+            // Multimodal templates (image / audio / video alongside the context variable) aren't
+            // supported on the agentic-tools render path — it only knows how to substitute string
+            // content. Downgrade to inline instead of throwing so the evaluation still completes;
+            // the trade-off is the same "may overflow context window" that we already accept for
+            // the provider-doesn't-support-tools branch above.
+            if (useTools && OnlineScoringEngine.hasMultimodalTemplate(message.code().messages())) {
+                userFacingLogger.warn(
+                        "Thread evaluator '{}' has multimodal template content; falling back to inline path"
+                                + " (agentic-tools render path only supports string-content templates) — may"
+                                + " overflow context window.",
+                        rule.getName());
+                useTools = false;
+            }
 
             ChatRequest scoreRequest;
             ChatRequest structuredRequest;
@@ -287,8 +304,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                     structuredRequest = scoreRequest;
                 }
             } catch (Exception exception) {
-                userFacingLogger.error("Error preparing LLM request for threadId '{}': \n\n{}",
-                        threadId, exception.getMessage());
+                userFacingLogger.error("Error preparing LLM request for threadId '{}'", threadId, exception);
                 throw exception;
             }
 
@@ -296,7 +312,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                 // REQUIRED on the first call only — same reasoning as the trace scorer: forces
                 // ≥1 tool call before the model can answer from skeleton alone. Follow-up rounds
                 // switch to AUTO so the wrap-up turn can emit JSON without invoking a tool.
-                scoreRequest = addToolSpecs(scoreRequest, ToolChoice.REQUIRED);
+                scoreRequest = OnlineScoringEngine.addToolSpecs(scoreRequest, ToolChoice.REQUIRED, toolRegistry);
             }
 
             userFacingLogger.info("Sending threadId '{}' to LLM using the following input:\n\n{}",
@@ -333,18 +349,6 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                 "Thread context exceeds '{}' tokens; switching to agentic-tools mode for threadId '{}'",
                 onlineScoringConfig.getAgenticToolsThresholdTokens(), threadId);
         return true;
-    }
-
-    // Package-private for unit tests.
-    ChatRequest addToolSpecs(ChatRequest request, ToolChoice toolChoice) {
-        var parameters = ChatRequestParameters.builder()
-                .overrideWith(request.parameters())
-                .toolSpecifications(toolRegistry.specs())
-                .toolChoice(toolChoice)
-                .build();
-        return request.toBuilder()
-                .parameters(parameters)
-                .build();
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -23,7 +23,6 @@ import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.ToolChoice;
@@ -268,8 +267,13 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
             userFacingLogger.info("Evaluating threadId '{}' sampled by rule '{}'", threadId, rule.getName());
 
             String modelName = message.code().model().name();
-            int estimatedContextTokens = OnlineScoringEngine.estimateThreadContextTokens(
-                    traces, onlineScoringConfig.getAgenticToolsCharsPerToken());
+            // Skip the JSON serialization that drives the token estimate when the toggle is off —
+            // we'd just throw the number away. shouldUseAgenticTools re-checks the toggle, so the
+            // estimate is only consulted on the agentic-tools path.
+            int estimatedContextTokens = serviceTogglesConfig.isAgenticToolsEnabled()
+                    ? OnlineScoringEngine.estimateThreadContextTokens(traces,
+                            onlineScoringConfig.getAgenticToolsCharsPerToken())
+                    : 0;
             boolean useTools = shouldUseAgenticTools(estimatedContextTokens, modelName, threadId,
                     message.code().messages());
 
@@ -305,8 +309,10 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                 scoreRequest = OnlineScoringEngine.addToolSpecs(scoreRequest, ToolChoice.REQUIRED, toolRegistry);
             }
 
-            userFacingLogger.info("Sending threadId '{}' to LLM using the following input:\n\n{}",
-                    threadId, scoreRequest);
+            if (userFacingLogger.isInfoEnabled()) {
+                userFacingLogger.info("Sending threadId '{}' to LLM: {}",
+                        threadId, OnlineScoringEngine.summarizeRequest(scoreRequest, modelName, useTools));
+            }
             return new PreparedEvaluation(scoreRequest, structuredRequest, useTools);
         }
     }
@@ -389,21 +395,10 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
             var messages = new ArrayList<ChatMessage>(toolRequest.messages());
             var budget = new ToolCallLoop.Budget();
 
-            return ToolCallLoop.run(
-                    chatResponse, toolRequest, followUpParameters, toolRegistry,
+            return ToolCallLoop.runWithWrapUp(
+                    chatResponse, toolRequest, structuredRequest, followUpParameters, toolRegistry,
                     request -> scoreTraceReactive(request, message),
-                    messages, ctx, budget, "threadId/ruleId=" + message.ruleId(), mdc)
-                    .flatMap(loopFinalResponse -> {
-                        messages.add(UserMessage.from(
-                                "You have completed your investigation using the available tools."
-                                        + " Now respond with ONLY the JSON object specified in the original instructions."
-                                        + " Do not call any more tools. Do not include any prose, commentary, or markdown"
-                                        + " fences — emit only the raw JSON object."));
-                        var finalRequest = structuredRequest.toBuilder()
-                                .messages(new ArrayList<>(messages))
-                                .build();
-                        return scoreTraceReactive(finalRequest, message);
-                    });
+                    messages, ctx, budget, "threadId/ruleId=" + message.ruleId(), mdc);
         });
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -382,31 +382,37 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
             return Mono.just(chatResponse);
         }
 
-        // Thread-scoped context: no single active trace. ReadTool fetches any trace from the
-        // thread on demand via the standard read(type=trace, id=X) path. GetTraceSpansTool
-        // returns a redirect error on this context (see GetTraceSpansTool#execute).
-        var ctx = TraceToolContext.forThread(message.workspaceId(), message.userName());
+        // Defer everything below to subscription time. Same reasoning as the trace-side
+        // scorer: keeps ctx/messages/budget allocation aligned with chain subscription, so a
+        // future caller that composes the returned Mono differently doesn't trigger the
+        // setup work at the wrong moment.
+        return Mono.defer(() -> {
+            // Thread-scoped context: no single active trace. ReadTool fetches any trace from the
+            // thread on demand via the standard read(type=trace, id=X) path. GetTraceSpansTool
+            // returns a redirect error on this context (see GetTraceSpansTool#execute).
+            var ctx = TraceToolContext.forThread(message.workspaceId(), message.userName());
 
-        var followUpParameters = ChatRequestParameters.builder()
-                .overrideWith(toolRequest.parameters())
-                .toolChoice(ToolChoice.AUTO)
-                .build();
+            var followUpParameters = ChatRequestParameters.builder()
+                    .overrideWith(toolRequest.parameters())
+                    .toolChoice(ToolChoice.AUTO)
+                    .build();
 
-        var messages = new ArrayList<ChatMessage>(toolRequest.messages());
-        var budget = new ToolOutputBudget();
+            var messages = new ArrayList<ChatMessage>(toolRequest.messages());
+            var budget = new ToolOutputBudget();
 
-        return toolCallLoop(0, chatResponse, toolRequest, followUpParameters, message, messages, ctx, budget, mdc)
-                .flatMap(loopFinalResponse -> {
-                    messages.add(UserMessage.from(
-                            "You have completed your investigation using the available tools."
-                                    + " Now respond with ONLY the JSON object specified in the original instructions."
-                                    + " Do not call any more tools. Do not include any prose, commentary, or markdown"
-                                    + " fences — emit only the raw JSON object."));
-                    var finalRequest = structuredRequest.toBuilder()
-                            .messages(new ArrayList<>(messages))
-                            .build();
-                    return scoreTraceReactive(finalRequest, message);
-                });
+            return toolCallLoop(0, chatResponse, toolRequest, followUpParameters, message, messages, ctx, budget, mdc)
+                    .flatMap(loopFinalResponse -> {
+                        messages.add(UserMessage.from(
+                                "You have completed your investigation using the available tools."
+                                        + " Now respond with ONLY the JSON object specified in the original instructions."
+                                        + " Do not call any more tools. Do not include any prose, commentary, or markdown"
+                                        + " fences — emit only the raw JSON object."));
+                        var finalRequest = structuredRequest.toBuilder()
+                                .messages(new ArrayList<>(messages))
+                                .build();
+                        return scoreTraceReactive(finalRequest, message);
+                    });
+        });
     }
 
     private Mono<ChatResponse> toolCallLoop(int round, ChatResponse currentResponse, ChatRequest toolRequest,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -20,10 +20,8 @@ import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
@@ -60,19 +58,6 @@ import static com.comet.opik.infrastructure.log.LogContextAware.wrapWithMdc;
 @EagerSingleton
 @Slf4j
 public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseScorer<TraceThreadToScoreLlmAsJudge> {
-
-    private static final int MAX_TOOL_CALL_ROUNDS = 10;
-
-    /**
-     * Cumulative cap on tool-result string length across the whole tool-call loop. Same
-     * shape and sizing as the trace-level scorer's cap — see that class for the budget
-     * math. Pairs with {@link com.comet.opik.api.resources.v1.events.tools.ReadTool#OUTPUT_SAFETY_CHARS}.
-     */
-    static final long CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS = 150_000L;
-
-    private static final String BUDGET_EXHAUSTED_MESSAGE = "{\"error\": \"Cumulative tool-output"
-            + " budget (%d chars) exhausted for this judgment; further tool calls return this"
-            + " error. Respond now with your best assessment from the data already gathered.\"}";
 
     private final ChatCompletionService aiProxyService;
     private final Logger userFacingLogger;
@@ -382,10 +367,8 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
             return Mono.just(chatResponse);
         }
 
-        // Defer everything below to subscription time. Same reasoning as the trace-side
-        // scorer: keeps ctx/messages/budget allocation aligned with chain subscription, so a
-        // future caller that composes the returned Mono differently doesn't trigger the
-        // setup work at the wrong moment.
+        // Defer to subscription time so context + message list allocation happen exactly once
+        // per subscription. Early Mono.just above stays outside the defer because it's cold.
         return Mono.defer(() -> {
             // Thread-scoped context: no single active trace. ReadTool fetches any trace from the
             // thread on demand via the standard read(type=trace, id=X) path. GetTraceSpansTool
@@ -398,9 +381,12 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                     .build();
 
             var messages = new ArrayList<ChatMessage>(toolRequest.messages());
-            var budget = new ToolOutputBudget();
+            var budget = new ToolCallLoop.Budget();
 
-            return toolCallLoop(0, chatResponse, toolRequest, followUpParameters, message, messages, ctx, budget, mdc)
+            return ToolCallLoop.run(
+                    chatResponse, toolRequest, followUpParameters, toolRegistry,
+                    request -> scoreTraceReactive(request, message),
+                    messages, ctx, budget, "threadId/ruleId=" + message.ruleId(), mdc)
                     .flatMap(loopFinalResponse -> {
                         messages.add(UserMessage.from(
                                 "You have completed your investigation using the available tools."
@@ -413,73 +399,6 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                         return scoreTraceReactive(finalRequest, message);
                     });
         });
-    }
-
-    private Mono<ChatResponse> toolCallLoop(int round, ChatResponse currentResponse, ChatRequest toolRequest,
-            ChatRequestParameters followUpParameters, TraceThreadToScoreLlmAsJudge message,
-            ArrayList<ChatMessage> messages, TraceToolContext ctx, ToolOutputBudget budget,
-            Map<String, String> mdc) {
-        if (round >= MAX_TOOL_CALL_ROUNDS) {
-            return Mono.just(currentResponse);
-        }
-        if (!currentResponse.aiMessage().hasToolExecutionRequests()) {
-            return Mono.just(currentResponse);
-        }
-
-        // Defer side effects (messages.add, tool executions, followUp scoreTrace) until
-        // subscription. Early returns above are pure cold Mono.just and don't need defer.
-        return Mono.defer(() -> {
-            messages.add(currentResponse.aiMessage());
-
-            // concatMap (not flatMap) so tool executions within a round preserve order — same
-            // contract as the trace-level scorer.
-            Flux<ToolExecutionResultMessage> roundResults = Flux
-                    .fromIterable(currentResponse.aiMessage().toolExecutionRequests())
-                    .concatMap(toolExecRequest -> executeToolOrBudgetExhausted(round, toolExecRequest, message,
-                            ctx, budget, mdc));
-
-            return roundResults
-                    .doOnNext(messages::add)
-                    .then(Mono.defer(() -> {
-                        var followUp = toolRequest.toBuilder()
-                                .messages(new ArrayList<>(messages))
-                                .parameters(followUpParameters)
-                                .build();
-                        return scoreTraceReactive(followUp, message);
-                    }))
-                    .flatMap(nextResponse -> toolCallLoop(round + 1, nextResponse, toolRequest, followUpParameters,
-                            message, messages, ctx, budget, mdc));
-        });
-    }
-
-    private Mono<ToolExecutionResultMessage> executeToolOrBudgetExhausted(int round,
-            ToolExecutionRequest toolExecRequest, TraceThreadToScoreLlmAsJudge message,
-            TraceToolContext ctx, ToolOutputBudget budget, Map<String, String> mdc) {
-        try (var logContext = wrapWithMdc(mdc)) {
-            log.debug("Tool call round '{}' for ruleId '{}': tool '{}'",
-                    round, message.ruleId(), toolExecRequest.name());
-            if (budget.cumulative >= CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS) {
-                if (!budget.exhaustedLogged) {
-                    log.warn("Tool-output budget '{}' chars exhausted for ruleId '{}';"
-                            + " subsequent tool calls return budget-exhausted sentinel",
-                            CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS, message.ruleId());
-                    budget.exhaustedLogged = true;
-                }
-                return Mono.just(ToolExecutionResultMessage.from(toolExecRequest,
-                        BUDGET_EXHAUSTED_MESSAGE.formatted(CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS)));
-            }
-        }
-        return toolRegistry.execute(toolExecRequest.name(), toolExecRequest.arguments(), ctx)
-                .map(result -> {
-                    budget.cumulative += result.length();
-                    return ToolExecutionResultMessage.from(toolExecRequest, result);
-                });
-    }
-
-    /** Shared per-evaluation tool-output budget state. Mutated sequentially via concatMap. */
-    private static final class ToolOutputBudget {
-        long cumulative = 0L;
-        boolean exhaustedLogged = false;
     }
 
     private record PreparedEvaluation(ChatRequest scoreRequest, ChatRequest structuredRequest, boolean useTools) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -5,6 +5,7 @@ import com.comet.opik.api.ScoreSource;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.Visibility;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluator;
+import com.comet.opik.api.evaluators.LlmAsJudgeMessage;
 import com.comet.opik.api.events.TraceThreadToScoreLlmAsJudge;
 import com.comet.opik.api.resources.v1.events.tools.ToolRegistry;
 import com.comet.opik.api.resources.v1.events.tools.TraceToolContext;
@@ -269,20 +270,8 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
             String modelName = message.code().model().name();
             int estimatedContextTokens = OnlineScoringEngine.estimateThreadContextTokens(
                     traces, onlineScoringConfig.getAgenticToolsCharsPerToken());
-            boolean useTools = shouldUseAgenticTools(estimatedContextTokens, modelName, threadId);
-            // Multimodal templates (image / audio / video alongside the context variable) aren't
-            // supported on the agentic-tools render path — it only knows how to substitute string
-            // content. Downgrade to inline instead of throwing so the evaluation still completes;
-            // the trade-off is the same "may overflow context window" that we already accept for
-            // the provider-doesn't-support-tools branch above.
-            if (useTools && OnlineScoringEngine.hasMultimodalTemplate(message.code().messages())) {
-                userFacingLogger.warn(
-                        "Thread evaluator '{}' has multimodal template content; falling back to inline path"
-                                + " (agentic-tools render path only supports string-content templates) — may"
-                                + " overflow context window.",
-                        rule.getName());
-                useTools = false;
-            }
+            boolean useTools = shouldUseAgenticTools(estimatedContextTokens, modelName, threadId,
+                    message.code().messages());
 
             ChatRequest scoreRequest;
             ChatRequest structuredRequest;
@@ -324,11 +313,13 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
     /**
      * Routing decision for whether to attach tool specs + run the tool-call loop for a thread.
      * Threads don't have the experimentId-driven branch (no test-suite-assertion equivalent),
-     * so the decision is purely size-based: toggle on + estimated thread context above threshold
-     * + provider supports tool-calling. Falls back to inline + a user-facing warn when toggle
-     * is on and size is over but the provider can't handle tools.
+     * so the decision is size-driven: toggle on + estimated thread context above threshold +
+     * provider supports tool-calling + template is string-content only. Falls back to inline +
+     * a user-facing warn when toggle is on and size is over but either the provider can't
+     * handle tools or the template carries multimodal parts.
      */
-    boolean shouldUseAgenticTools(int estimatedContextTokens, String modelName, String threadId) {
+    boolean shouldUseAgenticTools(int estimatedContextTokens, String modelName, String threadId,
+            List<LlmAsJudgeMessage> templateMessages) {
         boolean overSizeThreshold = serviceTogglesConfig.isAgenticToolsEnabled()
                 && estimatedContextTokens >= onlineScoringConfig.getAgenticToolsThresholdTokens();
         // Skip the provider lookup when the toggle is off — most evaluations are toggle-off and
@@ -343,6 +334,16 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                     "Thread context exceeds '{}' tokens but provider for model '{}' does not support tool"
                             + " calling; falling back to inline path — may overflow context window.",
                     onlineScoringConfig.getAgenticToolsThresholdTokens(), modelName);
+            return false;
+        }
+        // The thread agentic-tools render path only substitutes string content; multimodal
+        // templates (image / audio / video parts alongside text) would otherwise hit the
+        // safety throw in renderThreadMessagesWithReplacement and fail the evaluation.
+        if (OnlineScoringEngine.hasMultimodalTemplate(templateMessages)) {
+            userFacingLogger.warn(
+                    "Thread context exceeds '{}' tokens but evaluator template has multimodal content;"
+                            + " falling back to inline path — may overflow context window.",
+                    onlineScoringConfig.getAgenticToolsThresholdTokens());
             return false;
         }
         userFacingLogger.info(

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorer.java
@@ -115,7 +115,7 @@ public class OnlineScoringUserDefinedMetricPythonScorer
             Map<String, String> mdc) {
         var trace = message.trace();
         return OnlineScoringEngine.logAndPrepareEvaluatorInput(
-                userFacingLogger, mdc, "traceId", trace.id(), message.ruleName(),
+                userFacingLogger, log, mdc, "traceId", trace.id(), message.ruleName(),
                 () -> {
                     if (message.code().arguments().containsKey(SPANS_ARGUMENT_KEY)) {
                         return OnlineScoringEngine.toReplacements(message.code().arguments(), trace, spans);

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ToolCallLoop.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ToolCallLoop.java
@@ -5,6 +5,7 @@ import com.comet.opik.api.resources.v1.events.tools.TraceToolContext;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.response.ChatResponse;
@@ -65,6 +66,18 @@ final class ToolCallLoop {
             + " budget (%d chars) exhausted for this judgment; further tool calls return this"
             + " error. Respond now with your best assessment from the data already gathered.\"}";
 
+    /**
+     * Force closure of the tool-using phase. Without this, the model can return prose that
+     * continues the investigation ("Now let me check...") instead of the required JSON, even
+     * when the request carries no tool specs. Combined with the provider-native structured-
+     * output strategy on {@code structuredRequest}, gives both a soft and a hard signal:
+     * "stop calling tools, emit only JSON now".
+     */
+    private static final String WRAP_UP_USER_MESSAGE = "You have completed your investigation"
+            + " using the available tools. Now respond with ONLY the JSON object specified in"
+            + " the original instructions. Do not call any more tools. Do not include any"
+            + " prose, commentary, or markdown fences — emit only the raw JSON object.";
+
     private ToolCallLoop() {
     }
 
@@ -113,6 +126,39 @@ final class ToolCallLoop {
             @NonNull Map<String, String> mdc) {
         return toolCallLoop(0, initialResponse, toolRequest, followUpParameters, toolRegistry,
                 scoreTrace, messages, ctx, budget, logIdValue, mdc);
+    }
+
+    /**
+     * Wraps {@link #run} with the post-loop closure that both scorers need: append a forcing
+     * user-message ({@link #WRAP_UP_USER_MESSAGE}), rebuild a request from
+     * {@code structuredRequest} (no tool specs) with the snapshotted message list, and re-issue
+     * via {@code scoreTrace} to get the final structured JSON.
+     *
+     * <p>{@code structuredRequest} is the no-tools shape from {@code prepareEvaluation} used
+     * for the final structured re-issue; {@code toolRequest} (carrying tool specs) is reused
+     * for the in-loop rounds.
+     */
+    static Mono<ChatResponse> runWithWrapUp(
+            @NonNull ChatResponse initialResponse,
+            @NonNull ChatRequest toolRequest,
+            @NonNull ChatRequest structuredRequest,
+            @NonNull ChatRequestParameters followUpParameters,
+            @NonNull ToolRegistry toolRegistry,
+            @NonNull Function<ChatRequest, Mono<ChatResponse>> scoreTrace,
+            @NonNull ArrayList<ChatMessage> messages,
+            @NonNull TraceToolContext ctx,
+            @NonNull Budget budget,
+            @NonNull String logIdValue,
+            @NonNull Map<String, String> mdc) {
+        return run(initialResponse, toolRequest, followUpParameters, toolRegistry, scoreTrace,
+                messages, ctx, budget, logIdValue, mdc)
+                .flatMap(loopFinalResponse -> {
+                    messages.add(UserMessage.from(WRAP_UP_USER_MESSAGE));
+                    var finalRequest = structuredRequest.toBuilder()
+                            .messages(new ArrayList<>(messages))
+                            .build();
+                    return scoreTrace.apply(finalRequest);
+                });
     }
 
     private static Mono<ChatResponse> toolCallLoop(int round, ChatResponse currentResponse,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ToolCallLoop.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ToolCallLoop.java
@@ -167,9 +167,18 @@ final class ToolCallLoop {
             ArrayList<ChatMessage> messages, TraceToolContext ctx, Budget budget,
             String logIdValue, Map<String, String> mdc) {
         if (round >= MAX_TOOL_CALL_ROUNDS) {
+            // Don't append: the cap-round response may carry unfulfilled tool_executions_requests
+            // (we're abandoning them by hitting the cap). An AiMessage with tool_calls but no
+            // matching ToolExecutionResultMessage produces a malformed sequence that OpenAI /
+            // Anthropic reject. runWithWrapUp will bridge via the forcing user message.
             return Mono.just(currentResponse);
         }
         if (!currentResponse.aiMessage().hasToolExecutionRequests()) {
+            // Model stopped on its own — append its terminal AiMessage so the downstream wrap-up
+            // (runWithWrapUp) re-issues the structured request with the assistant's last turn in
+            // the conversation history. Without this, the wrap-up "emit only JSON" user message
+            // is appended in a vacuum where the model's final reasoning is missing.
+            messages.add(currentResponse.aiMessage());
             return Mono.just(currentResponse);
         }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ToolCallLoop.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ToolCallLoop.java
@@ -218,7 +218,10 @@ final class ToolCallLoop {
             Budget budget, String logIdValue, Map<String, String> mdc) {
         // Re-apply MDC so the slf4j tags (workspace_id, trace/thread id, rule_id) follow the
         // tool-loop log lines — the reactive chain may have hopped threads since the scorer's
-        // sync prep step set MDC.
+        // sync prep step set MDC. The toolRegistry.execute() call lives INSIDE this scope so
+        // its synchronous logs (e.g. ToolRegistry's "Unknown tool requested by judge" warn)
+        // carry the same tags. Async logs emitted from inside the tool's subscribed Mono still
+        // won't have MDC — that needs reactor-context propagation (a larger fix).
         try (var logContext = wrapWithMdc(mdc)) {
             log.debug("Tool call round '{}' for '{}': tool '{}'",
                     round, logIdValue, toolExecRequest.name());
@@ -232,11 +235,11 @@ final class ToolCallLoop {
                 return Mono.just(ToolExecutionResultMessage.from(toolExecRequest,
                         BUDGET_EXHAUSTED_MESSAGE.formatted(CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS)));
             }
+            return toolRegistry.execute(toolExecRequest.name(), toolExecRequest.arguments(), ctx)
+                    .map(result -> {
+                        budget.cumulative += result.length();
+                        return ToolExecutionResultMessage.from(toolExecRequest, result);
+                    });
         }
-        return toolRegistry.execute(toolExecRequest.name(), toolExecRequest.arguments(), ctx)
-                .map(result -> {
-                    budget.cumulative += result.length();
-                    return ToolExecutionResultMessage.from(toolExecRequest, result);
-                });
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ToolCallLoop.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ToolCallLoop.java
@@ -1,0 +1,187 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.resources.v1.events.tools.ToolRegistry;
+import com.comet.opik.api.resources.v1.events.tools.TraceToolContext;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.function.Function;
+
+import static com.comet.opik.infrastructure.log.LogContextAware.wrapWithMdc;
+
+/**
+ * Reactive tool-call loop shared by the trace- and thread-level LLM-as-judge scorers.
+ *
+ * <p>Both scorers' {@code handleToolCalls} need the same per-round shape:
+ * <ol>
+ *   <li>Append the current AI message to the running message list.</li>
+ *   <li>Execute each tool the model invoked in order (concatMap, not flatMap, so the
+ *       {@code ToolExecutionResultMessage}s follow their parent AI message in the same
+ *       order the model emitted them — OpenAI requires this).</li>
+ *   <li>Snapshot the message list, build the follow-up request, score it via the
+ *       caller-supplied scorer function.</li>
+ *   <li>Recurse on the response.</li>
+ * </ol>
+ *
+ * <p>What differs between the two scorers is just the message type
+ * ({@code TraceToScoreLlmAsJudge} vs {@code TraceThreadToScoreLlmAsJudge}) — the loop
+ * never inspects that. The caller passes the {@code scoreTrace} lambda which closes
+ * over its own message and threads it through to {@code ChatCompletionService}.
+ *
+ * <p>Stateful inputs ({@code messages}, {@code budget}) are caller-allocated so they
+ * outlive the loop and can be inspected after it ends (the trace scorer appends the
+ * forcing user-message and re-scores; the thread scorer does the same).
+ */
+@Slf4j
+final class ToolCallLoop {
+
+    static final int MAX_TOOL_CALL_ROUNDS = 10;
+
+    /**
+     * Cumulative cap on tool-result string length across the whole tool-call loop. Beyond
+     * this, further tool calls return a budget-exhausted sentinel so the judge has to compose
+     * its final answer from already-gathered data. Sized for ~2 chars/token (random/code
+     * worst case) so even adversarial inputs stay under a 128 K-token window after accounting
+     * for system prompt, tool specs, user prompt, and assistant turns:
+     *
+     * <p>{@code 150_000 chars / 2 chars/tok ≈ 75 K tok} of tool results, leaving ≈ 50 K tok
+     * of headroom for the rest of the conversation. Pairs with
+     * {@link com.comet.opik.api.resources.v1.events.tools.ReadTool#OUTPUT_SAFETY_CHARS}
+     * (per-call cap with auto-tier-downgrade): up to ~7 max-cap reads fit before this cap.
+     */
+    static final long CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS = 150_000L;
+
+    private static final String BUDGET_EXHAUSTED_MESSAGE = "{\"error\": \"Cumulative tool-output"
+            + " budget (%d chars) exhausted for this judgment; further tool calls return this"
+            + " error. Respond now with your best assessment from the data already gathered.\"}";
+
+    private ToolCallLoop() {
+    }
+
+    /**
+     * Per-evaluation tool-output budget state. Mutated sequentially via concatMap, so a plain
+     * non-volatile {@code long} + {@code boolean} is safe — no concurrent access.
+     */
+    static final class Budget {
+        long cumulative = 0L;
+        boolean exhaustedLogged = false;
+    }
+
+    /**
+     * Run the tool-call loop. Returns the LAST {@link ChatResponse} the loop produced —
+     * either the first response with no tool calls (model decided to stop) or the response
+     * after {@link #MAX_TOOL_CALL_ROUNDS}. Caller is responsible for the post-loop wrap-up
+     * (force-closing the tool-using phase + final structured re-issue).
+     *
+     * @param initialResponse    response from the initial scoreTrace call that may carry tool calls
+     * @param toolRequest        the request shape to reuse for follow-up rounds (carries the
+     *                           tool specs)
+     * @param followUpParameters parameters to attach to follow-up rounds — typically
+     *                           {@code tool_choice=AUTO} so the model can stop when ready
+     * @param toolRegistry       dispatcher for tool execution
+     * @param scoreTrace         function that calls the LLM. Typically
+     *                           {@code Mono.fromCallable(...).subscribeOn(boundedElastic())}
+     *                           so the blocking sync chat call doesn't pin the workers pool.
+     * @param messages           in-flight message list. The loop appends AI messages + tool
+     *                           result messages to it; caller can inspect it after the loop.
+     * @param ctx                tool execution context (trace-scoped or thread-scoped)
+     * @param budget             cumulative tool-output budget; survives across rounds
+     * @param logIdValue         entity identifier embedded in log lines so operators can grep
+     *                           by trace/thread id when chasing a specific run
+     * @param mdc                MDC tags applied to the internal log statements
+     */
+    static Mono<ChatResponse> run(
+            @NonNull ChatResponse initialResponse,
+            @NonNull ChatRequest toolRequest,
+            @NonNull ChatRequestParameters followUpParameters,
+            @NonNull ToolRegistry toolRegistry,
+            @NonNull Function<ChatRequest, Mono<ChatResponse>> scoreTrace,
+            @NonNull ArrayList<ChatMessage> messages,
+            @NonNull TraceToolContext ctx,
+            @NonNull Budget budget,
+            @NonNull String logIdValue,
+            @NonNull Map<String, String> mdc) {
+        return toolCallLoop(0, initialResponse, toolRequest, followUpParameters, toolRegistry,
+                scoreTrace, messages, ctx, budget, logIdValue, mdc);
+    }
+
+    private static Mono<ChatResponse> toolCallLoop(int round, ChatResponse currentResponse,
+            ChatRequest toolRequest, ChatRequestParameters followUpParameters,
+            ToolRegistry toolRegistry, Function<ChatRequest, Mono<ChatResponse>> scoreTrace,
+            ArrayList<ChatMessage> messages, TraceToolContext ctx, Budget budget,
+            String logIdValue, Map<String, String> mdc) {
+        if (round >= MAX_TOOL_CALL_ROUNDS) {
+            return Mono.just(currentResponse);
+        }
+        if (!currentResponse.aiMessage().hasToolExecutionRequests()) {
+            return Mono.just(currentResponse);
+        }
+
+        // Defer all side effects (messages.add, tool executions, follow-up scoreTrace) until
+        // subscription. The early returns above are pure Mono.just and stay outside the defer.
+        return Mono.defer(() -> {
+            messages.add(currentResponse.aiMessage());
+
+            // concatMap (not flatMap) so tool executions in this round preserve order — the
+            // ToolExecutionResultMessages must follow their parent AiMessage in the same
+            // order the model emitted them. OpenAI rejects out-of-order tool results.
+            Flux<ToolExecutionResultMessage> roundResults = Flux
+                    .fromIterable(currentResponse.aiMessage().toolExecutionRequests())
+                    .concatMap(toolExecRequest -> executeToolOrBudgetExhausted(round, toolExecRequest,
+                            toolRegistry, ctx, budget, logIdValue, mdc));
+
+            return roundResults
+                    .doOnNext(messages::add)
+                    .then(Mono.defer(() -> {
+                        // Defensive copy: ChatRequestBuilder stores the list by reference, so a later
+                        // iteration mutating `messages` would retroactively change what an async chat
+                        // client sees in this round's request. Snapshot per round.
+                        var followUp = toolRequest.toBuilder()
+                                .messages(new ArrayList<>(messages))
+                                .parameters(followUpParameters)
+                                .build();
+                        return scoreTrace.apply(followUp);
+                    }))
+                    .flatMap(nextResponse -> toolCallLoop(round + 1, nextResponse, toolRequest,
+                            followUpParameters, toolRegistry, scoreTrace, messages, ctx, budget,
+                            logIdValue, mdc));
+        });
+    }
+
+    private static Mono<ToolExecutionResultMessage> executeToolOrBudgetExhausted(int round,
+            ToolExecutionRequest toolExecRequest, ToolRegistry toolRegistry, TraceToolContext ctx,
+            Budget budget, String logIdValue, Map<String, String> mdc) {
+        // Re-apply MDC so the slf4j tags (workspace_id, trace/thread id, rule_id) follow the
+        // tool-loop log lines — the reactive chain may have hopped threads since the scorer's
+        // sync prep step set MDC.
+        try (var logContext = wrapWithMdc(mdc)) {
+            log.debug("Tool call round '{}' for '{}': tool '{}'",
+                    round, logIdValue, toolExecRequest.name());
+            if (budget.cumulative >= CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS) {
+                if (!budget.exhaustedLogged) {
+                    log.warn("Tool-output budget '{}' chars exhausted for '{}';"
+                            + " subsequent tool calls return budget-exhausted sentinel",
+                            CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS, logIdValue);
+                    budget.exhaustedLogged = true;
+                }
+                return Mono.just(ToolExecutionResultMessage.from(toolExecRequest,
+                        BUDGET_EXHAUSTED_MESSAGE.formatted(CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS)));
+            }
+        }
+        return toolRegistry.execute(toolExecRequest.name(), toolExecRequest.arguments(), ctx)
+                .map(result -> {
+                    budget.cumulative += result.length();
+                    return ToolExecutionResultMessage.from(toolExecRequest, result);
+                });
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/tools/GetTraceSpansTool.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/tools/GetTraceSpansTool.java
@@ -37,6 +37,15 @@ public class GetTraceSpansTool implements ToolExecutor {
         // fromCallable so any throw from SpanTreeSerializer is captured as a Mono error
         // and reported via ToolRegistry's onErrorResume — matches the legacy throw path.
         return Mono.fromCallable(() -> {
+            if (!ctx.hasActiveTrace()) {
+                // Thread-scoped evaluations have no single active trace. Redirect the model
+                // to the per-trace ReadTool path rather than NPEing on ctx.getTrace().
+                log.debug("get_trace_spans called with no active trace (thread-scoped evaluation)");
+                return ToolArgs.errorJson("get_trace_spans is only available for single-trace"
+                        + " evaluations. This is a thread-scoped evaluation — pick a trace from the"
+                        + " thread skeleton and call read(type=trace, id=<uuid>) to inspect its"
+                        + " spans instead.");
+            }
             log.debug("get_trace_spans tool call with arguments: '{}' for trace={}", arguments,
                     ctx.getTrace().id());
             String result = SpanTreeSerializer.serializeOverview(ctx.getSpans());

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/tools/TraceToolContext.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/tools/TraceToolContext.java
@@ -19,11 +19,15 @@ import java.util.Set;
  * judge invocation. One instance per {@code handleToolCalls} loop; the loop
  * runs sequentially on a single thread, so a plain {@link HashMap} is safe.
  *
- * <p>The active {@link Trace} and its spans are accessors; once {@code ReadTool}
- * lands (phase 2), they will also be pre-seeded into {@link #fetched} so
- * subsequent {@code jq} / {@code search} calls can target them without an
- * explicit {@code read}. Phase 1 only exposes them as plain accessors —
- * {@link #fetched} stays empty until later phases populate it.
+ * <p>Trace-scoped evaluations (LLM-as-judge on a single trace) carry the active
+ * {@link Trace} + its spans, which are also pre-seeded into {@link #fetched} so
+ * {@code jq} / {@code search} can target them without an explicit {@code read}.
+ *
+ * <p>Thread-scoped evaluations don't have a single active trace — the model
+ * drills into individual traces via {@code read(type=trace, id=X)} on
+ * thread-skeleton ids. Build those contexts with {@link #forThread} and check
+ * {@link #hasActiveTrace()} from any tool that requires the per-trace shortcut
+ * (only {@code GetTraceSpansTool} does today).
  */
 @Getter
 public final class TraceToolContext {
@@ -51,6 +55,33 @@ public final class TraceToolContext {
         this.spans = List.copyOf(spans);
         this.workspaceId = workspaceId;
         this.userName = userName;
+    }
+
+    private TraceToolContext(@NonNull String workspaceId, @NonNull String userName) {
+        this.trace = null;
+        this.spans = null;
+        this.workspaceId = workspaceId;
+        this.userName = userName;
+    }
+
+    /**
+     * Build a context for a thread-scoped evaluation — no single "active" trace,
+     * just workspace/user. The model accesses individual traces via
+     * {@code read(type=trace, id=X)} on the thread skeleton's trace ids; those
+     * reads land in {@link #fetched} on demand.
+     */
+    public static TraceToolContext forThread(@NonNull String workspaceId, @NonNull String userName) {
+        return new TraceToolContext(workspaceId, userName);
+    }
+
+    /**
+     * True for trace-scoped evaluations (built via the public constructor), false
+     * for thread-scoped ones (built via {@link #forThread}). Tools that need the
+     * active trace ({@link GetTraceSpansTool}) should branch on this rather than
+     * NPEing on {@link #getTrace()}.
+     */
+    public boolean hasActiveTrace() {
+        return trace != null;
     }
 
     public Optional<JsonNode> getCached(@NonNull EntityRef ref) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/tools/TraceToolContext.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/tools/TraceToolContext.java
@@ -47,21 +47,29 @@ public final class TraceToolContext {
      */
     private final Set<EntityRef> truncated = new HashSet<>();
 
-    public TraceToolContext(@NonNull Trace trace,
-            @NonNull List<Span> spans,
-            @NonNull String workspaceId,
-            @NonNull String userName) {
+    /**
+     * Single constructor with nullable {@code trace} / {@code spans} (final fields,
+     * so they're assigned exactly once here regardless of branch). Callers go through
+     * {@link #forActiveTrace} or {@link #forThread} rather than constructing directly;
+     * the explicit nulls live at the {@code forThread} call site where the absence of
+     * an active trace is the point.
+     */
+    private TraceToolContext(Trace trace, List<Span> spans,
+            @NonNull String workspaceId, @NonNull String userName) {
         this.trace = trace;
-        this.spans = List.copyOf(spans);
+        this.spans = spans != null ? List.copyOf(spans) : null;
         this.workspaceId = workspaceId;
         this.userName = userName;
     }
 
-    private TraceToolContext(@NonNull String workspaceId, @NonNull String userName) {
-        this.trace = null;
-        this.spans = null;
-        this.workspaceId = workspaceId;
-        this.userName = userName;
+    /**
+     * Build a context for a trace-scoped evaluation — the model has a single active
+     * trace whose spans are already in memory. {@link GetTraceSpansTool} hits this
+     * shortcut; other tools fall through to {@code read(type=trace, id=X)} as usual.
+     */
+    public static TraceToolContext forActiveTrace(@NonNull Trace trace, @NonNull List<Span> spans,
+            @NonNull String workspaceId, @NonNull String userName) {
+        return new TraceToolContext(trace, spans, workspaceId, userName);
     }
 
     /**
@@ -71,7 +79,7 @@ public final class TraceToolContext {
      * reads land in {@link #fetched} on demand.
      */
     public static TraceToolContext forThread(@NonNull String workspaceId, @NonNull String userName) {
-        return new TraceToolContext(workspaceId, userName);
+        return new TraceToolContext(null, null, workspaceId, userName);
     }
 
     /**

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
@@ -205,7 +205,10 @@ class OnlineScoringLlmAsJudgeScorerTest {
                 .parameters(params)
                 .build();
 
-        ChatRequest withTools = scorer.addToolSpecs(original, ToolChoice.REQUIRED);
+        ChatRequest withTools = OnlineScoringEngine.addToolSpecs(original, ToolChoice.REQUIRED,
+                new ToolRegistry(Set.of(
+                        stubTool(GetTraceSpansTool.NAME, "{}"),
+                        stubTool(ReadTool.NAME, "{}"))));
 
         // Tool specs come from the registry (sorted alphabetically by ToolRegistry).
         assertThat(withTools.toolSpecifications())

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
@@ -311,12 +311,16 @@ class OnlineScoringLlmAsJudgeScorerTest {
         // Final re-issue: uses structuredRequest's shape (no tool specs) and includes the
         // forcing UserMessage as the last accumulated message — soft signal "stop calling
         // tools, emit only JSON now" that complements the provider-native structured output.
-        // 4 elements: round-1's three + the forcing UserMessage appended after the loop.
+        // 5 elements: round-1's three + the terminal AiMessage from round-1's response (the
+        // loop's no-tool-calls early return now appends it so the wrap-up keeps the assistant's
+        // last turn in the conversation history) + the forcing UserMessage appended after.
         ChatRequest finalSent = sent.get(1);
         assertThat(finalSent.toolSpecifications()).isNullOrEmpty();
-        assertThat(finalSent.messages()).hasSize(4);
-        assertThat(finalSent.messages().get(3)).isInstanceOf(UserMessage.class);
-        assertThat(((UserMessage) finalSent.messages().get(3)).singleText())
+        assertThat(finalSent.messages()).hasSize(5);
+        assertThat(finalSent.messages().get(3)).isInstanceOf(AiMessage.class);
+        assertThat(((AiMessage) finalSent.messages().get(3)).text()).isEqualTo("ok");
+        assertThat(finalSent.messages().get(4)).isInstanceOf(UserMessage.class);
+        assertThat(((UserMessage) finalSent.messages().get(4)).singleText())
                 .contains("Now respond with ONLY the JSON object");
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -336,14 +336,19 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
             org.assertj.core.api.Assertions.assertThat(sent.get(0).toolSpecifications())
                     .extracting(dev.langchain4j.agent.tool.ToolSpecification::name)
                     .containsExactly("read");
-            // Final: no tool specs + the forcing UserMessage at the end.
+            // Final: no tool specs + the round-1 terminal AiMessage (appended by ToolCallLoop's
+            // no-tool-calls early return) + the forcing UserMessage at the end.
+            // 5 messages: UserMessage + AiMessage(tool calls) + ToolResult + AiMessage(terminal)
+            // + UserMessage(forcing).
             var finalSent = sent.get(1);
             org.assertj.core.api.Assertions.assertThat(finalSent.toolSpecifications()).isNullOrEmpty();
-            org.assertj.core.api.Assertions.assertThat(finalSent.messages()).hasSize(4);
+            org.assertj.core.api.Assertions.assertThat(finalSent.messages()).hasSize(5);
             org.assertj.core.api.Assertions.assertThat(finalSent.messages().get(3))
+                    .isInstanceOf(dev.langchain4j.data.message.AiMessage.class);
+            org.assertj.core.api.Assertions.assertThat(finalSent.messages().get(4))
                     .isInstanceOf(dev.langchain4j.data.message.UserMessage.class);
             org.assertj.core.api.Assertions.assertThat(
-                    ((dev.langchain4j.data.message.UserMessage) finalSent.messages().get(3)).singleText())
+                    ((dev.langchain4j.data.message.UserMessage) finalSent.messages().get(4)).singleText())
                     .contains("Now respond with ONLY the JSON object");
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -70,6 +70,8 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
     @Mock
     private OnlineScoringConfig onlineScoringConfig;
     @Mock
+    private com.comet.opik.infrastructure.ServiceTogglesConfig serviceTogglesConfig;
+    @Mock
     private RedissonReactiveClient redissonClient;
     @Mock
     private FeedbackScoreService feedbackScoreService;
@@ -85,6 +87,8 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
     private ProjectService projectService;
     @Mock
     private AutomationRuleEvaluatorService automationRuleEvaluatorService;
+    @Mock
+    private com.comet.opik.api.resources.v1.events.tools.ToolRegistry toolRegistry;
 
     private OnlineScoringTraceThreadLlmAsJudgeScorer scorer;
     private MockedStatic<UserFacingLoggingFactory> mockedFactory;
@@ -119,9 +123,15 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
 
         when(onlineScoringConfig.getStreams()).thenReturn(List.of(streamConfig));
         when(onlineScoringConfig.getConsumerGroupName()).thenReturn("online_scoring");
+        // Defaults for the size-based agentic-tools branch — under the threshold so the
+        // existing ScoringTests stay on the inline path. Routing-gate-specific tests
+        // override these per-case.
+        org.mockito.Mockito.lenient().when(onlineScoringConfig.getAgenticToolsCharsPerToken()).thenReturn(4);
+        org.mockito.Mockito.lenient().when(onlineScoringConfig.getAgenticToolsThresholdTokens()).thenReturn(50_000);
 
         scorer = new OnlineScoringTraceThreadLlmAsJudgeScorer(
                 onlineScoringConfig,
+                serviceTogglesConfig,
                 redissonClient,
                 feedbackScoreService,
                 aiProxyService,
@@ -129,7 +139,8 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
                 traceService,
                 traceThreadService,
                 projectService,
-                automationRuleEvaluatorService);
+                automationRuleEvaluatorService,
+                toolRegistry);
 
         projectId = UUID.randomUUID();
         ruleId = UUID.randomUUID();
@@ -144,6 +155,66 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
     void tearDown() {
         if (mockedFactory != null) {
             mockedFactory.close();
+        }
+    }
+
+    @Nested
+    class RoutingGateTests {
+
+        // Threads don't have an experimentId-driven branch (no test-suite-assertion equivalent),
+        // so the truth table is just toggle × tokens-vs-threshold × provider-supports-tools.
+        // Rows mirror the trace-side gate's design for symmetry.
+        @org.junit.jupiter.params.ParameterizedTest(name = "toggle={0}, tokens={1}, threshold={2}, provider={3} → expected useTools={4}")
+        @org.junit.jupiter.params.provider.CsvSource({
+                // size-based path — all three preconditions must hold
+                "true,  60000, 50000, OPEN_AI, true",
+                "true,  50000, 50000, OPEN_AI, true",
+                // below threshold → inline
+                "true,  49999, 50000, OPEN_AI, false",
+                // toggle off → inline even on huge contexts
+                "false, 60000, 50000, OPEN_AI, false",
+                // provider doesn't support tool calling → inline + warn
+                "true,  60000, 50000, OLLAMA,  false",
+                // no preconditions met
+                "false, 0,     50000, OPEN_AI, false",
+        })
+        void gateMatchesTruthTable(
+                boolean toggleEnabled, int estimatedTokens, int thresholdTokens,
+                com.comet.opik.api.LlmProvider provider, boolean expectedUseTools) {
+            String modelName = "gpt-test";
+            org.mockito.Mockito.when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(toggleEnabled);
+            org.mockito.Mockito.lenient().when(onlineScoringConfig.getAgenticToolsThresholdTokens())
+                    .thenReturn(thresholdTokens);
+            org.mockito.Mockito.lenient().when(llmProviderFactory.getLlmProvider(modelName)).thenReturn(provider);
+
+            boolean useTools = scorer.shouldUseAgenticTools(estimatedTokens, modelName, "thread-x");
+
+            org.assertj.core.api.Assertions.assertThat(useTools).isEqualTo(expectedUseTools);
+        }
+    }
+
+    @Nested
+    class ToolLoopTests {
+
+        @org.junit.jupiter.api.Test
+        void handleToolCallsReturnsImmediatelyWhenNoToolRequests() {
+            var plainResponse = dev.langchain4j.model.chat.response.ChatResponse.builder()
+                    .aiMessage(dev.langchain4j.data.message.AiMessage.from("done"))
+                    .build();
+            var toolRequest = dev.langchain4j.model.chat.request.ChatRequest.builder()
+                    .messages(dev.langchain4j.data.message.UserMessage.from("score"))
+                    .build();
+            var structuredRequest = dev.langchain4j.model.chat.request.ChatRequest.builder()
+                    .messages(dev.langchain4j.data.message.UserMessage.from("score"))
+                    .build();
+            var message = org.mockito.Mockito.mock(com.comet.opik.api.events.TraceThreadToScoreLlmAsJudge.class);
+
+            var result = scorer.handleToolCalls(
+                    plainResponse, toolRequest, structuredRequest, message, java.util.Map.of()).block();
+
+            org.assertj.core.api.Assertions.assertThat(result).isSameAs(plainResponse);
+            org.mockito.Mockito.verifyNoInteractions(aiProxyService);
+            org.mockito.Mockito.verifyNoInteractions(toolRegistry);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -196,6 +196,30 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
     @Nested
     class ToolLoopTests {
 
+        // Real evaluator code so the message mock can return a model that scoreTrace
+        // calls accept. We mirror the trace-side ToolLoopTests pattern.
+        private com.comet.opik.api.events.TraceThreadToScoreLlmAsJudge newMessage() {
+            var msg = org.mockito.Mockito.mock(com.comet.opik.api.events.TraceThreadToScoreLlmAsJudge.class);
+            var code = org.mockito.Mockito.mock(
+                    com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadLlmAsJudge.TraceThreadLlmAsJudgeCode.class);
+            var modelParams = org.mockito.Mockito.mock(
+                    com.comet.opik.api.evaluators.LlmAsJudgeModelParameters.class);
+            org.mockito.Mockito.lenient().when(code.model()).thenReturn(modelParams);
+            org.mockito.Mockito.lenient().when(modelParams.name()).thenReturn("gpt-test");
+            org.mockito.Mockito.lenient().when(msg.code()).thenReturn(code);
+            org.mockito.Mockito.lenient().when(msg.workspaceId()).thenReturn("ws-1");
+            org.mockito.Mockito.lenient().when(msg.userName()).thenReturn("user-1");
+            org.mockito.Mockito.lenient().when(msg.ruleId()).thenReturn(UUID.randomUUID());
+            return msg;
+        }
+
+        private static dev.langchain4j.agent.tool.ToolSpecification stubSpec(String name) {
+            return dev.langchain4j.agent.tool.ToolSpecification.builder()
+                    .name(name)
+                    .parameters(dev.langchain4j.model.chat.request.json.JsonObjectSchema.builder().build())
+                    .build();
+        }
+
         @org.junit.jupiter.api.Test
         void handleToolCallsReturnsImmediatelyWhenNoToolRequests() {
             var plainResponse = dev.langchain4j.model.chat.response.ChatResponse.builder()
@@ -215,6 +239,187 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
             org.assertj.core.api.Assertions.assertThat(result).isSameAs(plainResponse);
             org.mockito.Mockito.verifyNoInteractions(aiProxyService);
             org.mockito.Mockito.verifyNoInteractions(toolRegistry);
+        }
+
+        @org.junit.jupiter.api.Test
+        void handleToolCallsAccumulatesResultsAndFinalizesWithStructuredRequestShape() {
+            var message = newMessage();
+            var toolReq = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+                    .id("call-1")
+                    .name("read")
+                    .arguments("{}")
+                    .build();
+            var initialResponse = dev.langchain4j.model.chat.response.ChatResponse.builder()
+                    .aiMessage(dev.langchain4j.data.message.AiMessage.from(java.util.List.of(toolReq)))
+                    .build();
+            // Round-1 follow-up returns no more tool calls — loop exits.
+            var roundOneResponse = dev.langchain4j.model.chat.response.ChatResponse.builder()
+                    .aiMessage(dev.langchain4j.data.message.AiMessage.from("ok"))
+                    .build();
+            // Final structured wrap-up — handleToolCalls re-scores with the forcing user message.
+            var finalResponse = dev.langchain4j.model.chat.response.ChatResponse.builder()
+                    .aiMessage(dev.langchain4j.data.message.AiMessage.from("{\"thread_coherence\":4}"))
+                    .build();
+
+            org.mockito.Mockito.when(aiProxyService.scoreTrace(
+                    org.mockito.ArgumentMatchers.any(dev.langchain4j.model.chat.request.ChatRequest.class),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any()))
+                    .thenReturn(roundOneResponse, finalResponse);
+            // Tool execution returns a small JSON blob — exercises the messages.add(result) path.
+            org.mockito.Mockito.when(toolRegistry.execute(
+                    org.mockito.ArgumentMatchers.eq("read"),
+                    org.mockito.ArgumentMatchers.anyString(),
+                    org.mockito.ArgumentMatchers.any()))
+                    .thenReturn(reactor.core.publisher.Mono.just("{\"trace\":\"...\"}"));
+
+            var toolRequest = dev.langchain4j.model.chat.request.ChatRequest.builder()
+                    .messages(dev.langchain4j.data.message.UserMessage.from("score the thread"))
+                    .toolSpecifications(stubSpec("read"))
+                    .build();
+            var structuredRequest = dev.langchain4j.model.chat.request.ChatRequest.builder()
+                    .messages(dev.langchain4j.data.message.UserMessage.from("score the thread"))
+                    .build();
+
+            var result = scorer.handleToolCalls(
+                    initialResponse, toolRequest, structuredRequest, message, java.util.Map.of()).block();
+
+            org.assertj.core.api.Assertions.assertThat(result).isSameAs(finalResponse);
+
+            // 2 scoreTrace calls: round-1 follow-up (with tool specs) + final structured re-issue.
+            var requests = org.mockito.ArgumentCaptor.forClass(dev.langchain4j.model.chat.request.ChatRequest.class);
+            org.mockito.Mockito.verify(aiProxyService, org.mockito.Mockito.times(2)).scoreTrace(
+                    requests.capture(),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any());
+
+            var sent = requests.getAllValues();
+            // Round 1: 3 messages — UserMessage + AiMessage(tool calls) + ToolExecutionResultMessage.
+            org.assertj.core.api.Assertions.assertThat(sent.get(0).messages()).hasSize(3);
+            org.assertj.core.api.Assertions.assertThat(sent.get(0).toolSpecifications())
+                    .extracting(dev.langchain4j.agent.tool.ToolSpecification::name)
+                    .containsExactly("read");
+            // Final: no tool specs + the forcing UserMessage at the end.
+            var finalSent = sent.get(1);
+            org.assertj.core.api.Assertions.assertThat(finalSent.toolSpecifications()).isNullOrEmpty();
+            org.assertj.core.api.Assertions.assertThat(finalSent.messages()).hasSize(4);
+            org.assertj.core.api.Assertions.assertThat(finalSent.messages().get(3))
+                    .isInstanceOf(dev.langchain4j.data.message.UserMessage.class);
+            org.assertj.core.api.Assertions.assertThat(
+                    ((dev.langchain4j.data.message.UserMessage) finalSent.messages().get(3)).singleText())
+                    .contains("Now respond with ONLY the JSON object");
+        }
+
+        @org.junit.jupiter.api.Test
+        void handleToolCallsPropagatesScoreTraceFailureMidLoop() {
+            var message = newMessage();
+            var toolReq = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+                    .id("call-1")
+                    .name("read")
+                    .arguments("{}")
+                    .build();
+            var initialResponse = dev.langchain4j.model.chat.response.ChatResponse.builder()
+                    .aiMessage(dev.langchain4j.data.message.AiMessage.from(java.util.List.of(toolReq)))
+                    .build();
+
+            // Follow-up scoreTrace blows up (transient provider 503 after the per-LLM retry
+            // policy is exhausted). The contract: failure escapes handleToolCalls, the message
+            // returns un-ACKed, Redis Streams redelivers — same as the trace scorer's contract.
+            var providerFailure = new RuntimeException("provider 503");
+            org.mockito.Mockito.when(aiProxyService.scoreTrace(
+                    org.mockito.ArgumentMatchers.any(dev.langchain4j.model.chat.request.ChatRequest.class),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any()))
+                    .thenThrow(providerFailure);
+            org.mockito.Mockito.when(toolRegistry.execute(
+                    org.mockito.ArgumentMatchers.eq("read"),
+                    org.mockito.ArgumentMatchers.anyString(),
+                    org.mockito.ArgumentMatchers.any()))
+                    .thenReturn(reactor.core.publisher.Mono.just("{}"));
+
+            var toolRequest = dev.langchain4j.model.chat.request.ChatRequest.builder()
+                    .messages(dev.langchain4j.data.message.UserMessage.from("score"))
+                    .toolSpecifications(stubSpec("read"))
+                    .build();
+            var structuredRequest = dev.langchain4j.model.chat.request.ChatRequest.builder()
+                    .messages(dev.langchain4j.data.message.UserMessage.from("score"))
+                    .build();
+
+            org.assertj.core.api.Assertions
+                    .assertThatThrownBy(() -> scorer.handleToolCalls(
+                            initialResponse, toolRequest, structuredRequest, message, java.util.Map.of()).block())
+                    .isSameAs(providerFailure);
+
+            // Exactly one provider call attempted — the loop didn't swallow + continue.
+            org.mockito.Mockito.verify(aiProxyService, org.mockito.Mockito.times(1)).scoreTrace(
+                    org.mockito.ArgumentMatchers.any(dev.langchain4j.model.chat.request.ChatRequest.class),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any());
+        }
+
+        @org.junit.jupiter.api.Test
+        void handleToolCallsCapsAtMaxRoundsAndStillFiresWrapUpStructuredCall() {
+            var message = newMessage();
+            var toolReq = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+                    .id("call")
+                    .name("read")
+                    .arguments("{}")
+                    .build();
+            // Every response keeps emitting tool calls — the loop runs MAX_TOOL_CALL_ROUNDS=10
+            // times before bailing. After the cap, handleToolCalls still fires the wrap-up
+            // structured call. Total: 10 in-loop + 1 wrap-up = 11 scoreTrace calls.
+            var toolCallingResponse = dev.langchain4j.model.chat.response.ChatResponse.builder()
+                    .aiMessage(dev.langchain4j.data.message.AiMessage.from(java.util.List.of(toolReq)))
+                    .build();
+            var finalResponse = dev.langchain4j.model.chat.response.ChatResponse.builder()
+                    .aiMessage(dev.langchain4j.data.message.AiMessage.from("{\"thread_coherence\":3}"))
+                    .build();
+
+            org.mockito.Mockito.when(aiProxyService.scoreTrace(
+                    org.mockito.ArgumentMatchers.any(dev.langchain4j.model.chat.request.ChatRequest.class),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any()))
+                    // 10 in-loop returns (rounds 1..10), then the wrap-up structured call.
+                    .thenReturn(toolCallingResponse,
+                            toolCallingResponse, toolCallingResponse, toolCallingResponse, toolCallingResponse,
+                            toolCallingResponse, toolCallingResponse, toolCallingResponse, toolCallingResponse,
+                            toolCallingResponse, finalResponse);
+            org.mockito.Mockito.when(toolRegistry.execute(
+                    org.mockito.ArgumentMatchers.eq("read"),
+                    org.mockito.ArgumentMatchers.anyString(),
+                    org.mockito.ArgumentMatchers.any()))
+                    .thenReturn(reactor.core.publisher.Mono.just("{}"));
+
+            var toolRequest = dev.langchain4j.model.chat.request.ChatRequest.builder()
+                    .messages(dev.langchain4j.data.message.UserMessage.from("score"))
+                    .toolSpecifications(stubSpec("read"))
+                    .build();
+            var structuredRequest = dev.langchain4j.model.chat.request.ChatRequest.builder()
+                    .messages(dev.langchain4j.data.message.UserMessage.from("score"))
+                    .build();
+
+            var result = scorer.handleToolCalls(
+                    toolCallingResponse, toolRequest, structuredRequest, message, java.util.Map.of()).block();
+
+            org.assertj.core.api.Assertions.assertThat(result).isSameAs(finalResponse);
+
+            // 11 total scoreTrace calls: 10 in-loop + 1 wrap-up structured. The wrap-up still
+            // fires when the cap is hit — that's the safety net that prevents the model from
+            // continuing prose ("Now let me check…") past the loop boundary.
+            var requests = org.mockito.ArgumentCaptor.forClass(dev.langchain4j.model.chat.request.ChatRequest.class);
+            org.mockito.Mockito.verify(aiProxyService, org.mockito.Mockito.times(11)).scoreTrace(
+                    requests.capture(),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any());
+
+            var finalSent = requests.getAllValues().get(10);
+            org.assertj.core.api.Assertions.assertThat(finalSent.toolSpecifications()).isNullOrEmpty();
+            var lastMessage = finalSent.messages().get(finalSent.messages().size() - 1);
+            org.assertj.core.api.Assertions.assertThat(lastMessage)
+                    .isInstanceOf(dev.langchain4j.data.message.UserMessage.class);
+            org.assertj.core.api.Assertions.assertThat(
+                    ((dev.langchain4j.data.message.UserMessage) lastMessage).singleText())
+                    .contains("Now respond with ONLY the JSON object");
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -187,9 +187,46 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
                     .thenReturn(thresholdTokens);
             org.mockito.Mockito.lenient().when(llmProviderFactory.getLlmProvider(modelName)).thenReturn(provider);
 
-            boolean useTools = scorer.shouldUseAgenticTools(estimatedTokens, modelName, "thread-x");
+            boolean useTools = scorer.shouldUseAgenticTools(estimatedTokens, modelName, "thread-x",
+                    java.util.List.of(stringContentMessage()));
 
             org.assertj.core.api.Assertions.assertThat(useTools).isEqualTo(expectedUseTools);
+        }
+
+        @org.junit.jupiter.api.Test
+        void multimodalTemplateForcesInlineFallbackEvenWhenAllOtherPreconditionsHold() {
+            // Every other gate is satisfied (toggle on, over threshold, provider supports tools)
+            // but the template carries a non-string-content message. The agentic-tools render
+            // path can't substitute into multimodal templates, so we must downgrade to inline
+            // rather than letting renderThreadMessagesWithReplacement throw downstream.
+            String modelName = "gpt-test";
+            org.mockito.Mockito.when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
+            org.mockito.Mockito.lenient().when(onlineScoringConfig.getAgenticToolsThresholdTokens())
+                    .thenReturn(50_000);
+            org.mockito.Mockito.lenient().when(llmProviderFactory.getLlmProvider(modelName))
+                    .thenReturn(com.comet.opik.api.LlmProvider.OPEN_AI);
+
+            boolean useTools = scorer.shouldUseAgenticTools(60_000, modelName, "thread-x",
+                    java.util.List.of(multimodalContentMessage()));
+
+            org.assertj.core.api.Assertions.assertThat(useTools).isFalse();
+        }
+
+        private com.comet.opik.api.evaluators.LlmAsJudgeMessage stringContentMessage() {
+            return com.comet.opik.api.evaluators.LlmAsJudgeMessage.builder()
+                    .role(dev.langchain4j.data.message.ChatMessageType.USER)
+                    .content("evaluate {{context}}")
+                    .build();
+        }
+
+        private com.comet.opik.api.evaluators.LlmAsJudgeMessage multimodalContentMessage() {
+            // Non-null contentArray => isStringContent() == false (the multimodal branch
+            // hasMultimodalTemplate looks for). An empty list is enough for the predicate;
+            // we don't exercise the renderer in this test.
+            return com.comet.opik.api.evaluators.LlmAsJudgeMessage.builder()
+                    .role(dev.langchain4j.data.message.ChatMessageType.USER)
+                    .contentArray(java.util.List.of())
+                    .build();
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/ToolCallLoopTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/ToolCallLoopTest.java
@@ -37,8 +37,10 @@ class ToolCallLoopTest {
     @Test
     void earlyReturnWhenInitialResponseHasNoToolCalls() {
         // No tool execution requests on the initial response -> the loop must return it as-is
-        // without invoking scoreTrace or mutating the message list. Used by both scorers: if the
-        // model emits the final JSON immediately (no tool calls), we skip the loop entirely.
+        // without invoking scoreTrace. Used by both scorers: if the model emits the final JSON
+        // immediately (no tool calls), we skip the loop. The terminal AiMessage IS appended to
+        // `messages` so the downstream wrap-up can reuse the assistant's final turn in its
+        // re-issue conversation history.
         ChatResponse initial = ChatResponse.builder()
                 .aiMessage(AiMessage.from("final-answer"))
                 .build();
@@ -57,7 +59,10 @@ class ToolCallLoopTest {
 
         assertThat(result).isSameAs(initial);
         assertThat(scoreInvocations.get()).isZero();
-        assertThat(messages).hasSize(1);
+        // UserMessage("score") + the terminal AiMessage = 2 entries.
+        assertThat(messages).hasSize(2);
+        assertThat(messages.get(1)).isInstanceOf(AiMessage.class);
+        assertThat(((AiMessage) messages.get(1)).text()).isEqualTo("final-answer");
         assertThat(budget.cumulative).isZero();
     }
 
@@ -179,8 +184,9 @@ class ToolCallLoopTest {
 
         // Two follow-up calls fired: one after round 0's tools, one after round 1's.
         assertThat(capturedRequests).hasSize(2);
-        // Final loop state: original UserMessage + 2 rounds × (AiMessage + ToolResult) = 5.
-        assertThat(messages).hasSize(5);
+        // Final loop state: original UserMessage + 2 rounds × (AiMessage + ToolResult) +
+        // the terminal "done" AiMessage appended in the no-tool-calls early return = 6.
+        assertThat(messages).hasSize(6);
 
         // Each captured request must hold a distinct list instance — not an alias of the
         // caller-side `messages` and not an alias of any earlier captured request.

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/ToolCallLoopTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/ToolCallLoopTest.java
@@ -48,7 +48,7 @@ class ToolCallLoopTest {
         var budget = new ToolCallLoop.Budget();
 
         ChatResponse result = ToolCallLoop.run(
-                initial, baseRequest(), followUpParams(), registry(stubTool("ok")),
+                initial, baseRequest(), followUpParams(), registry(stubTool(TOOL_NAME, "ok")),
                 req -> {
                     scoreInvocations.incrementAndGet();
                     return Mono.just(initial);
@@ -76,7 +76,7 @@ class ToolCallLoopTest {
         var budget = new ToolCallLoop.Budget();
 
         ChatResponse result = ToolCallLoop.run(
-                toolCallingResponse, baseRequest(), followUpParams(), registry(stubTool("ok")),
+                toolCallingResponse, baseRequest(), followUpParams(), registry(stubTool(TOOL_NAME, "ok")),
                 req -> {
                     scoreInvocations.incrementAndGet();
                     return Mono.just(toolCallingResponse);
@@ -174,7 +174,7 @@ class ToolCallLoopTest {
             return Mono.just(responses.removeFirst());
         };
 
-        ToolCallLoop.run(round0, baseRequest(), followUpParams(), registry(stubTool("res")),
+        ToolCallLoop.run(round0, baseRequest(), followUpParams(), registry(stubTool(TOOL_NAME, "res")),
                 scoreTrace, messages, ctx(), budget, "trace-id", Map.of()).block();
 
         // Two follow-up calls fired: one after round 0's tools, one after round 1's.
@@ -190,7 +190,7 @@ class ToolCallLoopTest {
                 .isNotSameAs(capturedRequests.get(1).messages());
 
         // The first captured request was sent after round 0 only, so its snapshot must be
-        // strictly smaller than the second one's snapshot. (3 vs 5 in the current shape.)
+        // strictly smaller than the second one's snapshot.
         assertThat(capturedRequests.get(0).messages())
                 .hasSizeLessThan(capturedRequests.get(1).messages().size());
 
@@ -219,7 +219,8 @@ class ToolCallLoopTest {
         ChatResponse done = ChatResponse.builder()
                 .aiMessage(AiMessage.from("ok")).build();
 
-        Set<ToolExecutor> tools = Set.of(stubToolNamed("a"), stubToolNamed("b"), stubToolNamed("c"));
+        Set<ToolExecutor> tools = Set.of(stubTool("a", "result-a"), stubTool("b", "result-b"),
+                stubTool("c", "result-c"));
         var messages = new ArrayList<ChatMessage>(List.of(UserMessage.from("score")));
         var budget = new ToolCallLoop.Budget();
 
@@ -270,26 +271,7 @@ class ToolCallLoopTest {
                 .build();
     }
 
-    private static ToolExecutor stubTool(String result) {
-        return new ToolExecutor() {
-            @Override
-            public String name() {
-                return TOOL_NAME;
-            }
-
-            @Override
-            public ToolSpecification spec() {
-                return stubSpec(TOOL_NAME);
-            }
-
-            @Override
-            public Mono<String> execute(String arguments, TraceToolContext c) {
-                return Mono.just(result);
-            }
-        };
-    }
-
-    private static ToolExecutor stubToolNamed(String toolName) {
+    private static ToolExecutor stubTool(String toolName, String result) {
         return new ToolExecutor() {
             @Override
             public String name() {
@@ -303,7 +285,7 @@ class ToolCallLoopTest {
 
             @Override
             public Mono<String> execute(String arguments, TraceToolContext c) {
-                return Mono.just("result-" + toolName);
+                return Mono.just(result);
             }
         };
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/ToolCallLoopTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/ToolCallLoopTest.java
@@ -1,0 +1,310 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.Span;
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.resources.v1.events.tools.ToolExecutor;
+import com.comet.opik.api.resources.v1.events.tools.ToolRegistry;
+import com.comet.opik.api.resources.v1.events.tools.TraceToolContext;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
+import dev.langchain4j.model.chat.request.ToolChoice;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ToolCallLoopTest {
+
+    private static final String TOOL_NAME = "noop";
+
+    @Test
+    void earlyReturnWhenInitialResponseHasNoToolCalls() {
+        // No tool execution requests on the initial response -> the loop must return it as-is
+        // without invoking scoreTrace or mutating the message list. Used by both scorers: if the
+        // model emits the final JSON immediately (no tool calls), we skip the loop entirely.
+        ChatResponse initial = ChatResponse.builder()
+                .aiMessage(AiMessage.from("final-answer"))
+                .build();
+
+        AtomicInteger scoreInvocations = new AtomicInteger();
+        var messages = new ArrayList<ChatMessage>(List.of(UserMessage.from("score")));
+        var budget = new ToolCallLoop.Budget();
+
+        ChatResponse result = ToolCallLoop.run(
+                initial, baseRequest(), followUpParams(), registry(stubTool("ok")),
+                req -> {
+                    scoreInvocations.incrementAndGet();
+                    return Mono.just(initial);
+                },
+                messages, ctx(), budget, "trace-id", Map.of()).block();
+
+        assertThat(result).isSameAs(initial);
+        assertThat(scoreInvocations.get()).isZero();
+        assertThat(messages).hasSize(1);
+        assertThat(budget.cumulative).isZero();
+    }
+
+    @Test
+    void capsAtMaxToolCallRoundsWhenModelKeepsRequestingTools() {
+        // Model keeps emitting tool calls every round. The loop must terminate at
+        // MAX_TOOL_CALL_ROUNDS (10) — scoreTrace is invoked once per round (10 in-loop
+        // follow-up calls), and the cap-round response is returned without trying an 11th.
+        ToolExecutionRequest toolReq = ToolExecutionRequest.builder()
+                .id("t").name(TOOL_NAME).arguments("{}").build();
+        ChatResponse toolCallingResponse = ChatResponse.builder()
+                .aiMessage(AiMessage.from(List.of(toolReq))).build();
+
+        AtomicInteger scoreInvocations = new AtomicInteger();
+        var messages = new ArrayList<ChatMessage>(List.of(UserMessage.from("score")));
+        var budget = new ToolCallLoop.Budget();
+
+        ChatResponse result = ToolCallLoop.run(
+                toolCallingResponse, baseRequest(), followUpParams(), registry(stubTool("ok")),
+                req -> {
+                    scoreInvocations.incrementAndGet();
+                    return Mono.just(toolCallingResponse);
+                },
+                messages, ctx(), budget, "trace-id", Map.of()).block();
+
+        assertThat(result).isSameAs(toolCallingResponse);
+        // 10 in-loop follow-up scoreTrace calls — one per round before the cap kicks in.
+        assertThat(scoreInvocations.get()).isEqualTo(ToolCallLoop.MAX_TOOL_CALL_ROUNDS);
+    }
+
+    @Test
+    void budgetExhaustionReturnsSentinelWithoutDispatchingThroughRegistry() {
+        // First tool call returns a payload just under the cap; the second round's tool
+        // dispatch must see cumulative >= cap and skip the registry, returning the
+        // budget-exhausted sentinel as the tool result. The registry counter proves we
+        // never invoke the executor a second time.
+        AtomicInteger registryDispatches = new AtomicInteger();
+        long longResultLen = ToolCallLoop.CUMULATIVE_TOOL_OUTPUT_BUDGET_CHARS;
+        String longResult = "x".repeat((int) longResultLen);
+
+        ToolExecutor counting = new ToolExecutor() {
+            @Override
+            public String name() {
+                return TOOL_NAME;
+            }
+
+            @Override
+            public ToolSpecification spec() {
+                return stubSpec(TOOL_NAME);
+            }
+
+            @Override
+            public Mono<String> execute(String arguments, TraceToolContext c) {
+                registryDispatches.incrementAndGet();
+                return Mono.just(longResult);
+            }
+        };
+
+        ToolExecutionRequest toolReq = ToolExecutionRequest.builder()
+                .id("t").name(TOOL_NAME).arguments("{}").build();
+        ChatResponse toolCallingResponse = ChatResponse.builder()
+                .aiMessage(AiMessage.from(List.of(toolReq))).build();
+        ChatResponse finalResponse = ChatResponse.builder()
+                .aiMessage(AiMessage.from("done")).build();
+
+        // Round 0 -> tool dispatched (registry counter = 1, budget filled).
+        // Follow-up scoreTrace returns another tool-calling response, driving round 1.
+        // Round 1 -> budget is already at cap, dispatch is skipped (counter still 1),
+        // sentinel is returned. Follow-up scoreTrace then returns finalResponse — no
+        // tool calls — and the loop exits.
+        var responses = new ArrayList<>(List.of(toolCallingResponse, finalResponse));
+        var messages = new ArrayList<ChatMessage>(List.of(UserMessage.from("score")));
+        var budget = new ToolCallLoop.Budget();
+
+        ChatResponse result = ToolCallLoop.run(
+                toolCallingResponse, baseRequest(), followUpParams(), registry(counting),
+                req -> Mono.just(responses.removeFirst()),
+                messages, ctx(), budget, "trace-id", Map.of()).block();
+
+        assertThat(result).isSameAs(finalResponse);
+        assertThat(registryDispatches.get()).isEqualTo(1);
+        // Round 1's tool result is the sentinel — find it in the message list and confirm.
+        var sentinelHits = messages.stream()
+                .filter(m -> m instanceof ToolExecutionResultMessage trm
+                        && trm.text().contains("budget")
+                        && trm.text().contains("exhausted"))
+                .count();
+        assertThat(sentinelHits).isEqualTo(1L);
+        assertThat(budget.exhaustedLogged).isTrue();
+    }
+
+    @Test
+    void followUpRequestsCarryDefensiveMessageCopies() {
+        // Per-round follow-up requests must snapshot the message list, NOT share a reference
+        // to the in-flight one. Otherwise a later .add into `messages` (either by the loop
+        // itself in a subsequent round, or by the caller after the loop ends) would
+        // retroactively mutate what an async chat client sees for an earlier round's request.
+        ToolExecutionRequest toolReq = ToolExecutionRequest.builder()
+                .id("t").name(TOOL_NAME).arguments("{}").build();
+        ChatResponse round0 = ChatResponse.builder()
+                .aiMessage(AiMessage.from(List.of(toolReq))).build();
+        ChatResponse round1 = ChatResponse.builder()
+                .aiMessage(AiMessage.from(List.of(toolReq))).build();
+        ChatResponse done = ChatResponse.builder()
+                .aiMessage(AiMessage.from("ok")).build();
+
+        var capturedRequests = new ArrayList<ChatRequest>();
+        var responses = new ArrayList<>(List.of(round1, done));
+        var messages = new ArrayList<ChatMessage>(List.of(UserMessage.from("score")));
+        var budget = new ToolCallLoop.Budget();
+
+        Function<ChatRequest, Mono<ChatResponse>> scoreTrace = req -> {
+            capturedRequests.add(req);
+            return Mono.just(responses.removeFirst());
+        };
+
+        ToolCallLoop.run(round0, baseRequest(), followUpParams(), registry(stubTool("res")),
+                scoreTrace, messages, ctx(), budget, "trace-id", Map.of()).block();
+
+        // Two follow-up calls fired: one after round 0's tools, one after round 1's.
+        assertThat(capturedRequests).hasSize(2);
+        // Final loop state: original UserMessage + 2 rounds × (AiMessage + ToolResult) = 5.
+        assertThat(messages).hasSize(5);
+
+        // Each captured request must hold a distinct list instance — not an alias of the
+        // caller-side `messages` and not an alias of any earlier captured request.
+        assertThat(capturedRequests.get(0).messages()).isNotSameAs(messages);
+        assertThat(capturedRequests.get(1).messages()).isNotSameAs(messages);
+        assertThat(capturedRequests.get(0).messages())
+                .isNotSameAs(capturedRequests.get(1).messages());
+
+        // The first captured request was sent after round 0 only, so its snapshot must be
+        // strictly smaller than the second one's snapshot. (3 vs 5 in the current shape.)
+        assertThat(capturedRequests.get(0).messages())
+                .hasSizeLessThan(capturedRequests.get(1).messages().size());
+
+        // Snapshot the sizes, then mutate `messages` after the loop completes. The captured
+        // requests' message lists must remain stable — that's the real defensive-copy contract.
+        int size0 = capturedRequests.get(0).messages().size();
+        int size1 = capturedRequests.get(1).messages().size();
+        messages.add(UserMessage.from("post-loop mutation"));
+        assertThat(capturedRequests.get(0).messages()).hasSize(size0);
+        assertThat(capturedRequests.get(1).messages()).hasSize(size1);
+    }
+
+    @Test
+    void multipleToolCallsInOneRoundExecuteInOrder() {
+        // OpenAI requires tool-result messages to follow their parent AiMessage in the same
+        // order the model emitted them. concatMap (used internally) preserves that ordering;
+        // verify by emitting three tool calls in a single round and asserting the result
+        // messages land in the messages list in that exact order.
+        var orderedNames = List.of("a", "b", "c");
+        var toolReqs = orderedNames.stream()
+                .map(n -> ToolExecutionRequest.builder().id(n).name(n).arguments("{}").build())
+                .toList();
+
+        ChatResponse round0 = ChatResponse.builder()
+                .aiMessage(AiMessage.from(toolReqs)).build();
+        ChatResponse done = ChatResponse.builder()
+                .aiMessage(AiMessage.from("ok")).build();
+
+        Set<ToolExecutor> tools = Set.of(stubToolNamed("a"), stubToolNamed("b"), stubToolNamed("c"));
+        var messages = new ArrayList<ChatMessage>(List.of(UserMessage.from("score")));
+        var budget = new ToolCallLoop.Budget();
+
+        ToolCallLoop.run(round0, baseRequest(), followUpParams(), new ToolRegistry(tools),
+                req -> Mono.just(done), messages, ctx(), budget, "trace-id", Map.of()).block();
+
+        // Expected messages in order: original UserMessage, AiMessage(3 tool calls),
+        // ToolResult(a), ToolResult(b), ToolResult(c). Pull the names off the tool results
+        // in order to verify concatMap kept the model's order.
+        var resultNames = messages.stream()
+                .filter(m -> m instanceof ToolExecutionResultMessage)
+                .map(m -> ((ToolExecutionResultMessage) m).toolName())
+                .toList();
+        assertThat(resultNames).containsExactly("a", "b", "c");
+    }
+
+    // --- helpers ---
+
+    private static ChatRequest baseRequest() {
+        return ChatRequest.builder()
+                .messages(UserMessage.from("score"))
+                .toolSpecifications(stubSpec(TOOL_NAME))
+                .build();
+    }
+
+    private static ChatRequestParameters followUpParams() {
+        return ChatRequestParameters.builder().toolChoice(ToolChoice.AUTO).build();
+    }
+
+    private static ToolRegistry registry(ToolExecutor tool) {
+        return new ToolRegistry(Set.of(tool));
+    }
+
+    private static TraceToolContext ctx() {
+        Trace trace = Trace.builder()
+                .id(UUID.randomUUID())
+                .projectName("p")
+                .name("trace")
+                .startTime(Instant.now())
+                .build();
+        return new TraceToolContext(trace, List.<Span>of(), "ws", "user");
+    }
+
+    private static ToolSpecification stubSpec(String name) {
+        return ToolSpecification.builder()
+                .name(name)
+                .parameters(JsonObjectSchema.builder().build())
+                .build();
+    }
+
+    private static ToolExecutor stubTool(String result) {
+        return new ToolExecutor() {
+            @Override
+            public String name() {
+                return TOOL_NAME;
+            }
+
+            @Override
+            public ToolSpecification spec() {
+                return stubSpec(TOOL_NAME);
+            }
+
+            @Override
+            public Mono<String> execute(String arguments, TraceToolContext c) {
+                return Mono.just(result);
+            }
+        };
+    }
+
+    private static ToolExecutor stubToolNamed(String toolName) {
+        return new ToolExecutor() {
+            @Override
+            public String name() {
+                return toolName;
+            }
+
+            @Override
+            public ToolSpecification spec() {
+                return stubSpec(toolName);
+            }
+
+            @Override
+            public Mono<String> execute(String arguments, TraceToolContext c) {
+                return Mono.just("result-" + toolName);
+            }
+        };
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/ToolCallLoopTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/ToolCallLoopTest.java
@@ -1,6 +1,5 @@
 package com.comet.opik.api.resources.v1.events;
 
-import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.resources.v1.events.tools.ToolExecutor;
 import com.comet.opik.api.resources.v1.events.tools.ToolRegistry;
@@ -267,7 +266,7 @@ class ToolCallLoopTest {
                 .name("trace")
                 .startTime(Instant.now())
                 .build();
-        return new TraceToolContext(trace, List.<Span>of(), "ws", "user");
+        return TraceToolContext.forActiveTrace(trace, List.of(), "ws", "user");
     }
 
     private static ToolSpecification stubSpec(String name) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/tools/JqToolTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/tools/JqToolTest.java
@@ -177,7 +177,7 @@ class JqToolTest {
                 .name("active")
                 .startTime(Instant.now())
                 .build();
-        return new TraceToolContext(trace, List.of(), "ws", "user");
+        return TraceToolContext.forActiveTrace(trace, List.of(), "ws", "user");
     }
 
     private static TraceToolContext newCtxWithCachedSpan(UUID spanId, String spanBodyJson) {
@@ -194,6 +194,6 @@ class JqToolTest {
                 .name("active")
                 .startTime(Instant.now())
                 .build();
-        return new TraceToolContext(trace, List.of(), "ws", "user");
+        return TraceToolContext.forActiveTrace(trace, List.of(), "ws", "user");
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/tools/ReadToolTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/tools/ReadToolTest.java
@@ -305,7 +305,7 @@ class ReadToolTest {
                 .name("active")
                 .startTime(Instant.now())
                 .build();
-        var ctx = new TraceToolContext(trace, List.of(), "ws", "user");
+        var ctx = TraceToolContext.forActiveTrace(trace, List.of(), "ws", "user");
 
         var spanId = UUID.randomUUID();
         var ref = new EntityRef(EntityType.SPAN, spanId.toString());
@@ -392,7 +392,7 @@ class ReadToolTest {
                 .name("active")
                 .startTime(Instant.now())
                 .build();
-        var ctx = new TraceToolContext(trace, List.of(), "ws", "user");
+        var ctx = TraceToolContext.forActiveTrace(trace, List.of(), "ws", "user");
         // Mirror the production seed: cache the {trace, spans} composite under EntityRef(TRACE, id).
         JsonNode composite = new TraceCompressor().buildFullJson(trace, List.of());
         ctx.cache(new EntityRef(EntityType.TRACE, trace.id().toString()), composite);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/tools/SearchToolTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/tools/SearchToolTest.java
@@ -269,7 +269,7 @@ class SearchToolTest {
                 .name("active")
                 .startTime(Instant.now())
                 .build();
-        return new TraceToolContext(trace, List.of(), "ws", "user");
+        return TraceToolContext.forActiveTrace(trace, List.of(), "ws", "user");
     }
 
     private static TraceToolContext newCtxWithCachedSpan(UUID spanId, String spanBodyJson) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/tools/ToolRegistryTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/tools/ToolRegistryTest.java
@@ -210,7 +210,7 @@ class ToolRegistryTest {
                 .name("trace")
                 .startTime(Instant.now())
                 .build();
-        return new TraceToolContext(trace, List.of(), "ws", "user");
+        return TraceToolContext.forActiveTrace(trace, List.of(), "ws", "user");
     }
 
     private record RecordingTool(String name, AtomicReference<String> captured) implements ToolExecutor {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResourceTest.java
@@ -1678,7 +1678,7 @@ class AutomationRuleEvaluatorsResourceTest {
         // format, so both are accepted here.
         assertThat(logPage.content())
                 .anyMatch(log -> log.message().matches(
-                        "Received response for traceId '.*': textChars=\\d+, toolCalls=\\d+, finishReason=.*")
+                        "Received response for traceId '.*': 'textChars=\\d+, toolCalls=\\d+, finishReason=.*'")
                         || log.message().matches("(?s)Received response for traceId '.*':\\n\\n.*"));
         assertThat(logPage.content())
                 .anyMatch(log -> log.message().matches(

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResourceTest.java
@@ -1682,7 +1682,7 @@ class AutomationRuleEvaluatorsResourceTest {
                         || log.message().matches("(?s)Received response for traceId '.*':\\n\\n.*"));
         assertThat(logPage.content())
                 .anyMatch(log -> log.message().matches(
-                        "Sending traceId '.*' to LLM: model='.*', messages=\\d+ \\(~\\d+ chars\\), tools=\\d+, toolsEnabled=.*")
+                        "Sending traceId '.*' to LLM: model='.*', messages=\\d+, tools=\\d+, toolsEnabled=.*")
                         || log.message().matches(
                                 "Sending traceId '.*' to Python evaluator: 'arguments=\\[.*\\]'"));
         assertThat(logPage.content())


### PR DESCRIPTION
## Details

Extends the agentic-tools online-scoring path (merged via #6649 for traces) to **thread-level LLM-as-judge scoring**. When a thread's estimated context exceeds the configured size threshold, the scorer switches from inline (full trace-list dump) to an agentic loop: the model gets a compact per-trace **skeleton** in the prompt and pulls any specific trace's full content (and its spans) on demand via `read(type=trace, id=X)`. Same lazy fetch pattern as the trace-level path — keeps the inline prompt bounded on threads with hundreds or thousands of traces.

### What's in the diff

- **`OnlineScoringTraceThreadLlmAsJudgeScorer`** — gate (`shouldUseAgenticTools`) checks toggle + size + provider-supports-tools + string-only template, with user-facing warns identifying the threadId on every fallback branch. Multimodal templates (image/audio/video) fall back to inline rather than throw in the renderer.
- **`OnlineScoringEngine.prepareThreadLlmRequestWithTools`** + **`ThreadTraceSkeleton` record** (`{id, name, startTime, endTime, duration, spanCount, llmSpanCount}` with `@NonNull` on the always-present fields) — compact per-trace summary serialized as the thread context variable. Rendered via the shared `renderMessagesWithReplacements` so multimodal/role handling stays in one place.
- **New `ToolCallLoop` utility** (extracted, shared between trace + thread scorers) — owns the reactive tool-call loop: round cap, cumulative output budget, `concatMap` ordering for tool-result-after-AiMessage, `Mono.defer` for subscription-time side effects, and the post-loop wrap-up (force-closure user message + structured re-issue). Each scorer passes its own `scoreTrace` lambda; the loop never inspects the message type.
- **Shared helpers in `OnlineScoringEngine`** used by both scorers: `summarizeRequest`/`summarizeResponse` (shape-only, redacted user-facing log summaries), `addToolSpecs`, `logPreparingLlmRequestError` and `logAndPrepareEvaluatorInput` (both split user-facing one-liner from internal slf4j stack trace so internal class names don't leak into the user-facing log sink), `hasMultimodalTemplate` (multimodal-template detector).

### Behavioural notes

- No new env vars / migrations. Existing `TOGGLE_AGENTIC_TOOLS_ENABLED` and `ONLINE_SCORING_AGENTIC_TOOLS_THRESHOLD_TOKENS` cover both trace and thread paths.
- Token-estimation `OBJECT_MAPPER.writeValueAsString(...)` is short-circuited when the toggle is off, avoiding an MB-scale serialization on the inline path.
- When the model stops on its own mid-loop (no tool calls in the response), the terminal AiMessage is appended to the conversation history before the wrap-up re-issue so the model's final reasoning isn't lost. Cap-reached early returns deliberately don't append, since that response may carry unfulfilled tool_calls — appending would produce a malformed sequence providers reject. Asymmetry is documented inline.


## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-5651

## AI-WATERMARK

AI-WATERMARK: yes
- If yes:
  - Tools: Claude Code
  - Model(s): Opus 4.7
  - Scope: Development + Testing
  - Human verification: Yes

## Testing
- [x] `OnlineScoringTraceThreadLlmAsJudgeScorerTest` — routing-gate truth table (7 rows incl. multimodal fallback), scoring on both paths, full tool-loop integration through the shared `ToolCallLoop`.
- [x] `ToolCallLoopTest` — direct coverage of the extracted utility (early return, round cap, budget exhaustion, defensive message copies, tool-call ordering).
- [x] `OnlineScoringEngineTest` — `estimateThreadContextTokens`, `prepareThreadLlmRequestWithTools`, `hasMultimodalTemplate`, `ThreadTraceSkeleton` serialization, shared helpers.
- [x] `AutomationRuleEvaluatorsResourceTest$GetLogs` — log-shape integration test (asserts the redacted user-facing summaries match expected regex).
- [x] End-to-end sandbox: 10/10 thread scenarios scored, including 2 that previously overflowed the model's context window on the inline path.
- [x] Compile + spotless clean; ~170 unit tests green locally across the touched packages.

## Documentation
NA