### PR TITLE
[NA] [BE] fix(migration): isolate experiment-project-migration on a dedicated scheduler

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1383,6 +1383,14 @@ experimentProjectMigration:
   lockWaitTime: ${EXPERIMENT_PROJECT_MIGRATION_LOCK_WAIT_TIME:-100ms}
   # Per-cycle timeout — safety net for stuck cycles, not normal completion
   jobTimeout: ${EXPERIMENT_PROJECT_MIGRATION_JOB_TIMEOUT:-1h}
+  # Dedicated reactor scheduler isolating this job from the shared boundedElastic.
+  # Max threads in the pool — the job runs sequentially per replica; a small cap suffices.
+  schedulerThreadCap: ${EXPERIMENT_PROJECT_MIGRATION_SCHEDULER_THREAD_CAP:-4}
+  # Max tasks queued when all threads are busy — backpressure buffer for the sequential flow.
+  schedulerQueuedTaskCap: ${EXPERIMENT_PROJECT_MIGRATION_SCHEDULER_QUEUED_TASK_CAP:-100}
+  # Idle-thread TTL — should typically exceed `interval` so threads survive the between-cycle
+  # idle window and don't churn on every tick.
+  schedulerThreadTtl: ${EXPERIMENT_PROJECT_MIGRATION_SCHEDULER_THREAD_TTL:-60s}
 
 # Shared configuration for V1 → V2 entity project migration jobs
 # Centralised so all migration jobs (experiments, datasets, etc.) share the same exclusion list

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMigrationService.java
@@ -8,6 +8,7 @@ import com.comet.opik.infrastructure.ExperimentDenormalizationConfig;
 import com.comet.opik.infrastructure.ExperimentProjectMigrationConfig;
 import com.comet.opik.infrastructure.MigrationConfig;
 import com.google.common.collect.Lists;
+import io.dropwizard.lifecycle.Managed;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -21,9 +22,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -36,7 +39,7 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 @Slf4j
 @Singleton
-public class ExperimentProjectMigrationService {
+public class ExperimentProjectMigrationService implements Managed {
 
     public static final String METRIC_NAMESPACE = "opik.migration.experiment_project";
 
@@ -67,6 +70,14 @@ public class ExperimentProjectMigrationService {
     private final LongHistogram workspaceDuration;
     private final LongCounter experimentsSkipped;
     private final LongHistogram batchSize;
+
+    /**
+     * Dedicated bounded-elastic scheduler isolating the migration's blocking JDBC work and
+     * its post-collect CPU-heavy lambdas from the shared {@link Schedulers#boundedElastic()}
+     * and from the reactive client (R2DBC/Redisson) event loops. Sized for the sequential
+     * concatMap flow; daemon threads so JVM shutdown is never blocked by the migration pool.
+     */
+    private volatile Scheduler migrationScheduler;
 
     @Inject
     public ExperimentProjectMigrationService(
@@ -124,6 +135,29 @@ public class ExperimentProjectMigrationService {
                 .build();
     }
 
+    @Override
+    public void start() {
+        if (migrationScheduler == null) {
+            migrationScheduler = Schedulers.newBoundedElastic(
+                    config.schedulerThreadCap(),
+                    config.schedulerQueuedTaskCap(),
+                    "experiment-project-migration-service",
+                    (int) config.schedulerThreadTtl().toJavaDuration().toSeconds(),
+                    true);
+            log.info(
+                    "Initialized experiment project migration scheduler, threadCap='{}', queuedTaskCap='{}', threadTtl='{}'",
+                    config.schedulerThreadCap(), config.schedulerQueuedTaskCap(), config.schedulerThreadTtl());
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (migrationScheduler != null && !migrationScheduler.isDisposed()) {
+            migrationScheduler.dispose();
+            log.info("Experiment project migration scheduler disposed");
+        }
+    }
+
     public Mono<Void> runMigrationCycle() {
         return Mono.fromCallable(() -> {
             var skippedWorkspaceIds = workspacesService.findMigrationSkippedWorkspaceIds();
@@ -139,11 +173,13 @@ public class ExperimentProjectMigrationService {
                     skippedWorkspaceIds.stream())
                     .collect(Collectors.toUnmodifiableSet());
         })
-                .subscribeOn(Schedulers.boundedElastic())
+                .subscribeOn(migrationScheduler)
                 .flatMapMany(excludedWorkspaceIds -> experimentDAO
                         .findEligibleExperimentWorkspaces(excludedWorkspaceIds, config.workspacesPerRun())
                         .contextWrite(ctx -> setRequestContext(ctx, SYSTEM_USER, ""))
                         .collectList()
+                        // Hop downstream off the ClickHouse R2DBC thread before the per-workspace iteration.
+                        .publishOn(migrationScheduler)
                         .flatMapMany(eligibleWorkspaces -> {
                             cycleEligibleWorkspaces.record(eligibleWorkspaces.size());
                             if (CollectionUtils.isEmpty(eligibleWorkspaces)) {
@@ -153,6 +189,10 @@ public class ExperimentProjectMigrationService {
                             log.info("Found workspaces with eligible experiments, count='{}'",
                                     eligibleWorkspaces.size());
                             return Flux.fromIterable(eligibleWorkspaces)
+                                    // Pin every per-workspace concatMap iteration to migrationScheduler —
+                                    // items 2 -> N would otherwise emit on whichever client thread completed
+                                    // the previous workspace's reactive tail.
+                                    .publishOn(migrationScheduler)
                                     .concatMap(workspace -> migrateWorkspace(
                                             workspace.workspaceId(),
                                             workspace.experimentsCount(),
@@ -168,17 +208,25 @@ public class ExperimentProjectMigrationService {
         return experimentDAO.computeExperimentProjectMapping()
                 .contextWrite(ctx -> setRequestContext(ctx, SYSTEM_USER, workspaceId))
                 .collectList()
+                // Hop downstream off the ClickHouse R2DBC thread before iterating/grouping the
+                // mappings; for a large workspace these CPU lists are non-trivial.
+                .publishOn(migrationScheduler)
                 .flatMap(mappings -> {
                     if (CollectionUtils.isEmpty(mappings)) {
                         log.info("No certain experiments to migrate, workspaceId='{}'", workspaceId);
                         recordWorkspaceDuration(RESULT_NO_CERTAIN, workspaceStartMillis);
                         return Mono.empty();
                     }
+                    var duration = Duration.ofMillis(System.currentTimeMillis() - workspaceStartMillis);
+                    log.info(
+                            "Computed certain experiment project mappings, workspaceId='{}', count='{}', duration='{}'",
+                            workspaceId, mappings.size(), duration);
                     return migrateValidatedMappings(workspaceId, mappings, batchSize, workspaceStartMillis);
                 })
                 .onErrorResume(throwable -> {
-                    log.error("Workspace migration failed, will retry next cycle, workspaceId='{}'",
-                            workspaceId, throwable);
+                    var duration = Duration.ofMillis(System.currentTimeMillis() - workspaceStartMillis);
+                    log.error("Workspace migration failed, will retry next cycle, workspaceId='{}', duration='{}'",
+                            workspaceId, duration, throwable);
                     recordWorkspaceDuration(RESULT_ERROR, workspaceStartMillis);
                     return Mono.empty();
                 });
@@ -190,7 +238,7 @@ public class ExperimentProjectMigrationService {
                 .map(ExperimentProjectMapping::projectId)
                 .collect(Collectors.toUnmodifiableSet());
         return Mono.fromCallable(() -> projectService.findByIds(workspaceId, inferredProjectIds))
-                .subscribeOn(Schedulers.boundedElastic())
+                .subscribeOn(migrationScheduler)
                 .flatMap(existingProjects -> {
                     var validProjectIds = existingProjects.stream()
                             .map(Project::id)
@@ -211,7 +259,7 @@ public class ExperimentProjectMigrationService {
                         return Mono
                                 .fromRunnable(() -> workspacesService.markMigrationSkipped(
                                         workspaceId, TRAPPED_REASON_DELETED_PROJECT))
-                                .subscribeOn(Schedulers.boundedElastic())
+                                .subscribeOn(migrationScheduler)
                                 .doFinally(signalType -> recordWorkspaceDuration(
                                         RESULT_ALL_SKIPPED, workspaceStartMillis))
                                 .then(Mono.empty());
@@ -219,14 +267,22 @@ public class ExperimentProjectMigrationService {
                     var byProject = validated.stream()
                             .collect(Collectors.groupingBy(ExperimentProjectMapping::projectId));
                     return Flux.fromIterable(byProject.entrySet())
+                            // Pin every per-project concatMap iteration to migrationScheduler — also
+                            // covers the CPU inside batchUpdateProjectId (Lists.partition).
+                            .publishOn(migrationScheduler)
                             .concatMap(entry -> batchUpdateProjectId(
                                     workspaceId, entry.getKey(), entry.getValue(), batchSize))
+                            .doOnComplete(() -> log.info(
+                                    "Batch project ID updates completed, workspaceId='{}', projectGroups='{}'",
+                                    workspaceId, byProject.size()))
                             .then(triggerReaggregation(workspaceId, validated))
                             .then(evictWorkspaceVersionCache(workspaceId))
                             .doOnSuccess(__ -> {
+                                var duration = Duration
+                                        .ofMillis(System.currentTimeMillis() - workspaceStartMillis);
                                 log.info(
-                                        "Workspace migration completed, workspaceId='{}', migrated='{}', skippedDeletedProject='{}'",
-                                        workspaceId, validated.size(), skippedDeleted);
+                                        "Workspace migration completed, workspaceId='{}', migrated='{}', skippedDeletedProject='{}', duration='{}'",
+                                        workspaceId, validated.size(), skippedDeleted, duration);
                                 recordWorkspaceDuration(RESULT_MIGRATED, workspaceStartMillis);
                             });
                 });
@@ -239,6 +295,10 @@ public class ExperimentProjectMigrationService {
     private Mono<Long> batchUpdateProjectId(
             String workspaceId, UUID projectId, List<ExperimentProjectMapping> experiments, int maxBatchSize) {
         return Flux.fromIterable(Lists.partition(experiments, maxBatchSize))
+                // Pin every per-batch concatMap iteration to migrationScheduler — the per-batch
+                // stream/collect for items 2 -> N would otherwise run on the R2DBC thread of the
+                // previous batchSetProjectId's completion, accumulating on large workspaces.
+                .publishOn(migrationScheduler)
                 .concatMap(batch -> {
                     var experimentIds = batch.stream()
                             .map(ExperimentProjectMapping::experimentId)
@@ -262,13 +322,18 @@ public class ExperimentProjectMigrationService {
                 .collect(Collectors.toUnmodifiableSet());
         return experimentItemService.filterExperimentIdsByStatus(experimentIds, FINISHED_STATUSES)
                 .collect(Collectors.toUnmodifiableSet())
+                // Hop downstream off the ClickHouse R2DBC thread before the publishing hop.
+                .publishOn(migrationScheduler)
                 .flatMap(finished -> {
                     if (finished.isEmpty()) {
                         log.info("No finished experiments to reaggregate, workspaceId='{}', candidateCount='{}'",
                                 workspaceId, experimentIds.size());
                         return Mono.empty();
                     }
-                    return experimentAggregationPublisher.publish(finished, workspaceId, SYSTEM_USER);
+                    return experimentAggregationPublisher.publish(finished, workspaceId, SYSTEM_USER)
+                            .doOnSuccess(unused -> log.info(
+                                    "Reaggregation triggered, workspaceId='{}', finishedCount='{}'",
+                                    workspaceId, finished.size()));
                 })
                 .contextWrite(ctx -> setRequestContext(ctx, SYSTEM_USER, workspaceId))
                 .onErrorResume(throwable -> {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ExperimentProjectMigrationConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ExperimentProjectMigrationConfig.java
@@ -21,7 +21,10 @@ public record ExperimentProjectMigrationConfig(
         @NotNull @MinDuration(value = 0, unit = TimeUnit.SECONDS) @MaxDuration(value = 10, unit = TimeUnit.MINUTES) Duration startupDelay,
         @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 30, unit = TimeUnit.MINUTES) Duration lockTimeout,
         @NotNull @MinDuration(value = 50, unit = TimeUnit.MILLISECONDS) @MaxDuration(value = 5, unit = TimeUnit.SECONDS) Duration lockWaitTime,
-        @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 1, unit = TimeUnit.HOURS) Duration jobTimeout) {
+        @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 1, unit = TimeUnit.HOURS) Duration jobTimeout,
+        @Min(2) @Max(8) int schedulerThreadCap,
+        @Min(10) @Max(1_000) int schedulerQueuedTaskCap,
+        @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 1, unit = TimeUnit.HOURS) Duration schedulerThreadTtl) {
 
     @JsonIgnore
     @AssertTrue(message = "lockTimeout must be shorter than jobTimeout") public boolean isLockTimeoutShorterThanJobTimeout() {

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -742,6 +742,14 @@ experimentProjectMigration:
   lockWaitTime: 100ms
   # Per-cycle timeout — short for tests so hangs fail fast
   jobTimeout: 30s
+  # Dedicated reactor scheduler isolating this job from the shared boundedElastic.
+  # Max threads in the pool — the job runs sequentially per replica; a small cap suffices.
+  schedulerThreadCap: 2
+  # Max tasks queued when all threads are busy — backpressure buffer for the sequential flow.
+  schedulerQueuedTaskCap: 50
+  # Idle-thread TTL — should typically exceed `interval` so threads survive the between-cycle
+  # idle window and don't churn on every tick.
+  schedulerThreadTtl: 10s
 
 # Shared configuration for V1 → V2 entity project migration jobs
 # Centralised so all migration jobs (experiments, datasets, etc.) share the same exclusion list


### PR DESCRIPTION
## Details

Isolates the experiment-project migration job from the shared `Schedulers.boundedElastic()` and from the reactive client (ClickHouse R2DBC / Redisson) event loops, so that cycles on heavy workspaces no longer cause service-wide slowness or health-check failures.

- New dedicated `Schedulers.newBoundedElastic("experiment-project-migration-service", ...)` with daemon threads, sized via three new config keys (`schedulerThreadCap`, `schedulerQueuedTaskCap`, `schedulerThreadTtl`) with validation bounds.
- All blocking JDBI calls (`findMigrationSkippedWorkspaceIds`, `projectService.findByIds`, `markMigrationSkipped`) moved off shared `boundedElastic` via `subscribeOn(migrationScheduler)`.
- Six `publishOn(migrationScheduler)` hops: three after `collectList()/collect()` on R2DBC Flux/Mono (so CPU-heavy stream/groupBy/Lists.partition lambdas don't pin ClickHouse Netty event-loop threads), and three before each `concatMap` so iterations 2..N don't emit on whichever client thread completed the previous inner's reactive tail.
- Scheduler lifecycle bound to Dropwizard via `Managed`: created in `start()`, disposed in `stop()`, field is `volatile` for safe publication between Jetty lifecycle thread and Quartz worker threads. Auto-registered through Guicey's `ManagedInstaller`. Mirrors the pattern already used by `BaseRedisSubscriber` and `OptimizationLogFlusherJob`.
- Phase-completion logs added (computed mappings, batch updates completed, reaggregation triggered, workspace completed/failed with duration) for operational visibility.

## Change checklist

- [ ] User facing
- [ ] Documentation update

## Issues

- NA — production-issue hotfix, no ticket.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: assisted — design, implementation, and iteration on scheduler isolation and Managed lifecycle wiring
- Human verification: code review across multiple iterations, local compile (`mvn compile`), existing integration test suite (`ExperimentProjectMigrationJobTest`, 6/6 green on previous run)

## Testing

- `mvn -DskipTests compile` — clean build on the final tree.
- `ExperimentProjectMigrationJobTest` exercises the full reactive chain end-to-end against real ClickHouse + MySQL + Redis containers, implicitly covering every new `subscribeOn`/`publishOn` placement and the `Managed.start()` initialization (any null scheduler would NPE on the first `subscribeOn`).
- Test config (`config-test.yml`) added with conservative values (threadCap=2, queueCap=50, ttl=10s) so tests run on a minimal dedicated pool.
- Load-style verification (large-workspace cycle does not degrade health checks) is operational, not unit-tested — relies on existing OTel histograms (`opik.migration.experiment_project.workspace.duration`, `cycle.duration`) plus thread-pool / connection-pool metrics for regression detection in staging and prod.

## Documentation

N/A — operational fix, no user-facing or developer-facing documentation changes. Config keys are documented inline in `apps/opik-backend/config.yml`.