### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -18669,6 +18669,7 @@ components:
       - geminiProviderEnabled
       - guardrailsEnabled
       - ollamaProviderEnabled
+      - ollieEnabled
       - openaiProviderEnabled
       - openrouterProviderEnabled
       - opikAIEnabled
@@ -18724,6 +18725,8 @@ components:
         customllmProviderEnabled:
           type: boolean
         ollamaProviderEnabled:
+          type: boolean
+        ollieEnabled:
           type: boolean
         v2WorkspaceAllowlistIds:
           uniqueItems: true

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -18669,6 +18669,7 @@ components:
       - geminiProviderEnabled
       - guardrailsEnabled
       - ollamaProviderEnabled
+      - ollieEnabled
       - openaiProviderEnabled
       - openrouterProviderEnabled
       - opikAIEnabled
@@ -18724,6 +18725,8 @@ components:
         customllmProviderEnabled:
           type: boolean
         ollamaProviderEnabled:
+          type: boolean
+        ollieEnabled:
           type: boolean
         v2WorkspaceAllowlistIds:
           uniqueItems: true

--- a/sdks/python/src/opik/rest_api/types/service_toggles_config.py
+++ b/sdks/python/src/opik/rest_api/types/service_toggles_config.py
@@ -34,6 +34,7 @@ class ServiceTogglesConfig(UniversalBaseModel):
     bedrock_provider_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="bedrockProviderEnabled")]
     customllm_provider_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="customllmProviderEnabled")]
     ollama_provider_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="ollamaProviderEnabled")]
+    ollie_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="ollieEnabled")]
     v2workspace_allowlist_ids: typing_extensions.Annotated[
         typing.List[str], FieldMetadata(alias="v2WorkspaceAllowlistIds")
     ]

--- a/sdks/typescript/src/opik/rest_api/api/types/ServiceTogglesConfig.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/ServiceTogglesConfig.ts
@@ -22,6 +22,7 @@ export interface ServiceTogglesConfig {
     bedrockProviderEnabled: boolean;
     customllmProviderEnabled: boolean;
     ollamaProviderEnabled: boolean;
+    ollieEnabled: boolean;
     v2WorkspaceAllowlistIds: string[];
     v1WorkspaceAllowlistIds: string[];
     forceWorkspaceVersion: string;

--- a/sdks/typescript/src/opik/rest_api/serialization/types/ServiceTogglesConfig.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/ServiceTogglesConfig.ts
@@ -29,6 +29,7 @@ export const ServiceTogglesConfig: core.serialization.ObjectSchema<
     bedrockProviderEnabled: core.serialization.boolean(),
     customllmProviderEnabled: core.serialization.boolean(),
     ollamaProviderEnabled: core.serialization.boolean(),
+    ollieEnabled: core.serialization.boolean(),
     v2WorkspaceAllowlistIds: core.serialization.list(core.serialization.string()),
     v1WorkspaceAllowlistIds: core.serialization.list(core.serialization.string()),
     forceWorkspaceVersion: core.serialization.string(),
@@ -60,6 +61,7 @@ export declare namespace ServiceTogglesConfig {
         bedrockProviderEnabled: boolean;
         customllmProviderEnabled: boolean;
         ollamaProviderEnabled: boolean;
+        ollieEnabled: boolean;
         v2WorkspaceAllowlistIds: string[];
         v1WorkspaceAllowlistIds: string[];
         forceWorkspaceVersion: string;


### PR DESCRIPTION
## Details
Automated update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

**Triggered by commit:** https://github.com/comet-ml/opik/commit/48df92a8a519b04f5b9acc24b6ff23b9a6886595

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate