### PR TITLE
[OPIK-6550] [BE] perf: skip row-numbering CTE in version-id lookups

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -786,10 +786,10 @@ class DatasetItemServiceImpl implements DatasetItemService {
                             log.info("Feature toggle ON, using latest version for streaming dataset '{}' items",
                                     dataset.id());
                             return Mono
-                                    .fromCallable(() -> versionService.getLatestVersion(dataset.id(), workspaceId))
-                                    .flatMapMany(latestVersionOpt -> {
-                                        if (latestVersionOpt.isPresent()) {
-                                            UUID versionId = latestVersionOpt.get().id();
+                                    .fromCallable(() -> versionService.getLatestVersionId(dataset.id(), workspaceId))
+                                    .flatMapMany(latestVersionIdOpt -> {
+                                        if (latestVersionIdOpt.isPresent()) {
+                                            UUID versionId = latestVersionIdOpt.get();
                                             log.info("Streaming from latest version '{}' for dataset '{}'", versionId,
                                                     dataset.id());
                                             return versionDao.getItems(dataset.id(), versionId, request.steamLimit(),

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
@@ -199,6 +199,17 @@ public interface DatasetVersionDAO {
             @Bind("workspace_id") String workspaceId);
 
     @SqlQuery("""
+            SELECT id
+            FROM dataset_versions
+            WHERE workspace_id = :workspace_id
+              AND dataset_id = :dataset_id
+              AND version_hash = :version_hash
+            """)
+    Optional<UUID> findVersionIdByHash(@Bind("dataset_id") UUID datasetId,
+            @Bind("version_hash") String versionHash,
+            @Bind("workspace_id") String workspaceId);
+
+    @SqlQuery("""
             WITH version_sequences AS (
                 SELECT
                     id,
@@ -304,6 +315,17 @@ public interface DatasetVersionDAO {
                 AND dv.workspace_id = :workspace_id
             """)
     Optional<DatasetVersion> findByTag(@Bind("dataset_id") UUID datasetId, @Bind("tag") String tag,
+            @Bind("workspace_id") String workspaceId);
+
+    @SqlQuery("""
+            SELECT version_id
+            FROM dataset_version_tags
+            WHERE workspace_id = :workspace_id
+              AND dataset_id = :dataset_id
+              AND tag = :tag
+            """)
+    Optional<UUID> findVersionIdByTag(@Bind("dataset_id") UUID datasetId,
+            @Bind("tag") String tag,
             @Bind("workspace_id") String workspaceId);
 
     @SqlQuery("""

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionService.java
@@ -130,6 +130,14 @@ public interface DatasetVersionService {
     Optional<DatasetVersion> getLatestVersion(UUID datasetId, String workspaceId);
 
     /**
+     * Returns only the UUID of the latest version. Uses a PK lookup on
+     * dataset_version_tags and avoids the row-numbering CTE in
+     * {@link #getLatestVersion}, so cost stays O(1) regardless of how many
+     * versions a dataset has accumulated.
+     */
+    Optional<UUID> getLatestVersionId(UUID datasetId, String workspaceId);
+
+    /**
      * Gets a specific version by its ID.
      *
      * @param workspaceId the workspace ID
@@ -273,6 +281,12 @@ class DatasetVersionServiceImpl implements DatasetVersionService {
     @Override
     public Optional<DatasetVersion> getLatestVersion(@NonNull UUID datasetId, @NonNull String workspaceId) {
         return getVersionByTag(workspaceId, datasetId, LATEST_TAG);
+    }
+
+    @Override
+    public Optional<UUID> getLatestVersionId(@NonNull UUID datasetId, @NonNull String workspaceId) {
+        return template.inTransaction(READ_ONLY, handle -> handle.attach(DatasetVersionDAO.class)
+                .findVersionIdByTag(datasetId, LATEST_TAG, workspaceId));
     }
 
     @Override
@@ -540,19 +554,10 @@ class DatasetVersionServiceImpl implements DatasetVersionService {
         return template.inTransaction(READ_ONLY, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
 
-            // Try to find by hash first
-            var versionByHash = dao.findByHash(datasetId, hashOrTag, workspaceId);
-            if (versionByHash.isPresent()) {
-                return versionByHash.get().id();
-            }
-
-            // Try to find by tag
-            var versionByTag = dao.findByTag(datasetId, hashOrTag, workspaceId);
-            if (versionByTag.isPresent()) {
-                return versionByTag.get().id();
-            }
-
-            throw new NotFoundException(ERROR_VERSION_NOT_FOUND.formatted(hashOrTag, datasetId));
+            return dao.findVersionIdByHash(datasetId, hashOrTag, workspaceId)
+                    .or(() -> dao.findVersionIdByTag(datasetId, hashOrTag, workspaceId))
+                    .orElseThrow(() -> new NotFoundException(
+                            ERROR_VERSION_NOT_FOUND.formatted(hashOrTag, datasetId)));
         });
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -44,6 +44,7 @@ import com.comet.opik.api.resources.utils.resources.SpanResourceClient;
 import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
 import com.comet.opik.api.sorting.Direction;
 import com.comet.opik.api.sorting.SortingField;
+import com.comet.opik.domain.DatasetVersionDAO;
 import com.comet.opik.domain.DatasetVersionService;
 import com.comet.opik.domain.SpanEnrichmentOptions;
 import com.comet.opik.domain.TraceEnrichmentOptions;
@@ -76,6 +77,7 @@ import uk.co.jemos.podam.api.PodamFactory;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -5057,6 +5059,116 @@ class DatasetVersionResourceTest {
                     datasetId, 1, 10, DatasetVersionService.LATEST_TAG, API_KEY, TEST_WORKSPACE).content();
             assertThat(latestItems).hasSize(1);
             assertThat(latestItems.getFirst().description()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Lightweight version-id lookups (DAO):")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class LightweightVersionIdLookups {
+
+        private Optional<UUID> findVersionIdByTag(UUID datasetId, String tag, String workspaceId) {
+            return mySqlTemplate.inTransaction(WRITE, handle -> handle.attach(DatasetVersionDAO.class)
+                    .findVersionIdByTag(datasetId, tag, workspaceId));
+        }
+
+        private Optional<UUID> findVersionIdByHash(UUID datasetId, String versionHash, String workspaceId) {
+            return mySqlTemplate.inTransaction(WRITE, handle -> handle.attach(DatasetVersionDAO.class)
+                    .findVersionIdByHash(datasetId, versionHash, workspaceId));
+        }
+
+        @Test
+        @DisplayName("findVersionIdByTag: returns latest version's id for the 'latest' tag")
+        void findVersionIdByTag__whenLatestTag__thenReturnsVersionId() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 1);
+            var expected = getLatestVersion(datasetId);
+
+            var actual = findVersionIdByTag(datasetId, DatasetVersionService.LATEST_TAG, WORKSPACE_ID);
+
+            assertThat(actual).contains(expected.id());
+        }
+
+        @Test
+        @DisplayName("findVersionIdByTag: tracks the latest version across multiple writes")
+        void findVersionIdByTag__whenNewVersionCreated__thenReturnsNewestId() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 1);
+            var v1 = getLatestVersion(datasetId);
+            createDatasetItems(datasetId, 1);
+            var v2 = getLatestVersion(datasetId);
+            assertThat(v1.id()).isNotEqualTo(v2.id());
+
+            var actual = findVersionIdByTag(datasetId, DatasetVersionService.LATEST_TAG, WORKSPACE_ID);
+
+            assertThat(actual).contains(v2.id());
+        }
+
+        @Test
+        @DisplayName("findVersionIdByTag: returns the version a custom tag points to")
+        void findVersionIdByTag__whenCustomTag__thenReturnsTaggedVersionId() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 1);
+            var v1 = getLatestVersion(datasetId);
+            datasetResourceClient.createVersionTag(datasetId, v1.versionHash(),
+                    DatasetVersionTag.builder().tag("stable").build(), API_KEY, TEST_WORKSPACE);
+            createDatasetItems(datasetId, 1);
+            var v2 = getLatestVersion(datasetId);
+
+            assertThat(findVersionIdByTag(datasetId, "stable", WORKSPACE_ID)).contains(v1.id());
+            assertThat(findVersionIdByTag(datasetId, DatasetVersionService.LATEST_TAG, WORKSPACE_ID))
+                    .contains(v2.id());
+        }
+
+        @Test
+        @DisplayName("findVersionIdByTag: returns empty for unknown tag")
+        void findVersionIdByTag__whenTagUnknown__thenEmpty() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 1);
+
+            assertThat(findVersionIdByTag(datasetId, "nonexistent", WORKSPACE_ID)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("findVersionIdByTag: returns empty for another workspace (workspace isolation)")
+        void findVersionIdByTag__whenDifferentWorkspace__thenEmpty() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 1);
+
+            assertThat(findVersionIdByTag(datasetId, DatasetVersionService.LATEST_TAG, UUID.randomUUID().toString()))
+                    .isEmpty();
+        }
+
+        @Test
+        @DisplayName("findVersionIdByHash: returns version id for an existing hash")
+        void findVersionIdByHash__whenHashExists__thenReturnsVersionId() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 1);
+            var expected = getLatestVersion(datasetId);
+
+            var actual = findVersionIdByHash(datasetId, expected.versionHash(), WORKSPACE_ID);
+
+            assertThat(actual).contains(expected.id());
+        }
+
+        @Test
+        @DisplayName("findVersionIdByHash: returns empty for unknown hash")
+        void findVersionIdByHash__whenHashUnknown__thenEmpty() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 1);
+
+            assertThat(findVersionIdByHash(datasetId, "deadbeef", WORKSPACE_ID)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("findVersionIdByHash: returns empty for another workspace (workspace isolation)")
+        void findVersionIdByHash__whenDifferentWorkspace__thenEmpty() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 1);
+            var version = getLatestVersion(datasetId);
+
+            assertThat(findVersionIdByHash(datasetId, version.versionHash(), UUID.randomUUID().toString()))
+                    .isEmpty();
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -87,6 +87,7 @@ import java.util.stream.Stream;
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
 import static com.comet.opik.api.resources.utils.WireMockUtils.WireMockRuntime;
 import static com.comet.opik.api.resources.v1.priv.DatasetsResourceTest.IGNORED_FIELDS_DATA_ITEM;
+import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -5068,12 +5069,12 @@ class DatasetVersionResourceTest {
     class LightweightVersionIdLookups {
 
         private Optional<UUID> findVersionIdByTag(UUID datasetId, String tag, String workspaceId) {
-            return mySqlTemplate.inTransaction(WRITE, handle -> handle.attach(DatasetVersionDAO.class)
+            return mySqlTemplate.inTransaction(READ_ONLY, handle -> handle.attach(DatasetVersionDAO.class)
                     .findVersionIdByTag(datasetId, tag, workspaceId));
         }
 
         private Optional<UUID> findVersionIdByHash(UUID datasetId, String versionHash, String workspaceId) {
-            return mySqlTemplate.inTransaction(WRITE, handle -> handle.attach(DatasetVersionDAO.class)
+            return mySqlTemplate.inTransaction(READ_ONLY, handle -> handle.attach(DatasetVersionDAO.class)
                     .findVersionIdByHash(datasetId, versionHash, workspaceId));
         }
 


### PR DESCRIPTION
## Details

`POST /v1/private/datasets/items/stream` and `DatasetVersionService.resolveVersionId` only need a version UUID, but `DatasetVersionDAO.findByTag` / `findByHash` compute a per-version `ROW_NUMBER()` over every version of the dataset to assemble a `v1/v2/...` display name that the stream path immediately discards. With high-throughput batch writers (one observed pipeline accumulated ~37k versions on a single dataset), this scan grows linearly with version count and saturated the MySQL reader at ~830 stream calls/hour.

- Add `DatasetVersionDAO.findVersionIdByTag` — PK lookup on `dataset_version_tags(workspace_id, dataset_id, tag)`.
- Add `DatasetVersionDAO.findVersionIdByHash` — unique-key lookup on `dataset_versions(workspace_id, dataset_id, version_hash)`.
- Add `DatasetVersionService.getLatestVersionId` and switch the streaming-latest branch in `DatasetItemService` to it.
- Refactor `DatasetVersionService.resolveVersionId` to use both lightweight lookups (hash first, tag second), which also covers the explicit-version streaming branch and `compareVersions` / `restoreVersion`.
- The existing `findByTag` / `findByHash` / `getLatestVersion` are unchanged so paths that actually use the display name (UI list views, etc.) are unaffected.

No schema changes; all queries hit existing primary / unique keys.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6550

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: full implementation — DAO methods, service refactor, call-site swap, DAO unit tests
- Human verification: ran `mvn test -Dtest=DatasetVersionResourceTest` locally (112/112 green); manually inspected diff and existing test coverage of the changed code paths.

## Testing

**Command:**
```
cd apps/opik-backend && mvn test -Dtest=DatasetVersionResourceTest
```
Result: `Tests run: 112, Failures: 0, Errors: 0, Skipped: 0` — BUILD SUCCESS. Maven 3.9.9 / Java 21 / Docker 28 on macOS (Testcontainers spins up MySQL, ClickHouse, Redis, ZooKeeper).

**Added — `LightweightVersionIdLookups` nested class (8 tests):**

DAO-level coverage for the two new methods.

- `findVersionIdByTag__whenLatestTag__thenReturnsVersionId` — happy path for the `'latest'` tag.
- `findVersionIdByTag__whenNewVersionCreated__thenReturnsNewestId` — confirms the lookup tracks the current `latest` after a second write (i.e. matches what the old `findByTag().id()` returned).
- `findVersionIdByTag__whenCustomTag__thenReturnsTaggedVersionId` — non-`'latest'` tag points to the right version even after newer versions exist.
- `findVersionIdByTag__whenTagUnknown__thenEmpty` — unknown tag returns `Optional.empty()`.
- `findVersionIdByTag__whenDifferentWorkspace__thenEmpty` — workspace isolation.
- `findVersionIdByHash__whenHashExists__thenReturnsVersionId` — happy path.
- `findVersionIdByHash__whenHashUnknown__thenEmpty` — unknown hash returns `Optional.empty()`.
- `findVersionIdByHash__whenDifferentWorkspace__thenEmpty` — workspace isolation.

**Existing tests that exercise the changed code paths (all green):**

- `StreamDatasetItemsWithVersioning.streamItems_whenVersioningEnabled_thenUsesLatestVersion` — covers the new `getLatestVersionId` call in `DatasetItemService` (creates two versions, streams without specifying a version, asserts items match the latest).
- `StreamDatasetItemsWithVersioning.streamItems_whenVersionSpecified_thenUsesSpecifiedVersion` — covers the refactored `resolveVersionId` via both the `"v1"` tag (custom tag branch) and the `"latest"` tag, asserting v1 returns 2 items and latest returns 3.
- `RestoreVersion.restoreVersion__whenByHash__thenSuccess` — covers `resolveVersionId`'s hash branch (`findVersionIdByHash`).
- `RestoreVersion.restoreVersion__whenLatest__thenNoOp` and `restoreVersion__whenNotLatest__thenCreateNewVersion` — cover `resolveVersionId`'s tag branch.
- `RestoreVersion.restoreVersion__whenVersionNotFound__then404` — covers the not-found path (`NotFoundException`).

No tests skipped. Frontend / SDKs unaffected.

## Documentation