### PR TITLE
[OPIK-6482] [BE] fix: add (workspace_id, scope, id) index on dashboards to avoid filesort OOM

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000069_add_dashboards_workspace_scope_index.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000069_add_dashboards_workspace_scope_index.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--changeset thiagohora:000069_add_dashboards_workspace_scope_index
+--comment: Add covering index to satisfy dashboards list ORDER BY id DESC from index order and avoid filesort on SELECT * with JSON config (OPIK-6482)
+
+CREATE INDEX dashboards_workspace_scope_id_idx ON dashboards (workspace_id, scope, id);
+
+--rollback DROP INDEX dashboards_workspace_scope_id_idx ON dashboards;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000070_add_dashboards_workspace_scope_index.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000070_add_dashboards_workspace_scope_index.sql
@@ -1,7 +1,8 @@
 --liquibase formatted sql
---changeset thiagohora:000069_add_dashboards_workspace_scope_index
+--changeset thiagohora:000070_add_dashboards_workspace_scope_index
 --comment: Add covering index to satisfy dashboards list ORDER BY id DESC from index order and avoid filesort on SELECT * with JSON config (OPIK-6482)
 
 CREATE INDEX dashboards_workspace_scope_id_idx ON dashboards (workspace_id, scope, id);
 
 --rollback DROP INDEX dashboards_workspace_scope_id_idx ON dashboards;
+


### PR DESCRIPTION
## Details

Adds Liquibase migration `000069_add_dashboards_workspace_scope_index.sql` creating a composite index `dashboards_workspace_scope_id_idx (workspace_id, scope, id)` on the `dashboards` table so the list-dashboards query can satisfy its `ORDER BY id DESC` from index order and skip filesort.

- The DAO query in `DashboardDAO.find` (`SELECT * FROM dashboards WHERE workspace_id = ? [AND scope = ?] ORDER BY id DESC LIMIT ? OFFSET ?`) cannot reuse `PK(id)`, `UNIQUE(workspace_id, slug)` or `KEY(workspace_id, project_id)` for both filter and ordering — the optimizer falls back to filesort.
- With `SELECT *` including the JSON `config` column, the filesort copies the row into the sort buffer; on Aurora MySQL 8.0 this can raise `ER_OUT_OF_SORTMEMORY` (errno 1038) even at small LIMITs.
- The new composite index lets MySQL satisfy the equality filter and `ORDER BY id DESC` via a backward index scan, so the JSON column is never copied into a sort buffer.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6482

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: Diagnosis, drafting the migration file, and drafting this PR description. Index definition and reasoning reviewed by the author.
- Human verification: Author reviewed the EXPLAIN-based reasoning and the migration SQL before opening the PR.

## Testing

- [ ] Boot a fresh `opik-backend` against the dev `db-app-state` schema and confirm Liquibase applies `000069_add_dashboards_workspace_scope_index` (no changelog edit needed — picked up by the existing `<includeAll>` in `changelog.xml`).
- [ ] After migration, on a non-prod env run:
  ```sql
  EXPLAIN FORMAT=JSON SELECT * FROM dashboards
    WHERE workspace_id = '<id>' AND scope = 'workspace'
    ORDER BY id DESC LIMIT 50 OFFSET 0;
  ```
  Expect `key = dashboards_workspace_scope_id_idx`, no `using_filesort`, and a backward index scan.
- [ ] Verify `(workspace_id, slug)` lookups still use `dashboards_workspace_slug_uk` (`DashboardDAO.findByName`, slug uniqueness checks) — no regression on the slug path.
- [ ] No new write to the existing JDBI tests is required; if a DAO-level test for `find()` exists, run it.

## Documentation