### PR TITLE
[OPIK-6544] [FE] feat: add edit option to dataset item row menu

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemRowActionsCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemRowActionsCell.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback, useState } from "react";
 import { CellContext } from "@tanstack/react-table";
-import { MoreHorizontal, Trash } from "lucide-react";
+import { MoreHorizontal, Pencil, Trash } from "lucide-react";
 
 import { Button } from "@/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu";
 import CellWrapper from "@/shared/DataTableCells/CellWrapper";
@@ -15,6 +16,10 @@ import { useDeleteItem } from "@/store/TestSuiteDraftStore";
 import RemoveDatasetItemsDialog from "./RemoveDatasetItemsDialog";
 import { useDatasetItemDeletePreference } from "./hooks/useDatasetItemDeletePreference";
 
+type CustomMeta = {
+  setActiveRowId?: (id: string) => void;
+};
+
 export const DatasetItemRowActionsCell: React.FC<
   CellContext<DatasetItem, unknown>
 > = (context) => {
@@ -22,6 +27,9 @@ export const DatasetItemRowActionsCell: React.FC<
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [dontAskAgain] = useDatasetItemDeletePreference();
   const deleteItem = useDeleteItem();
+
+  const { custom } = context.column.columnDef.meta ?? {};
+  const { setActiveRowId } = (custom ?? {}) as CustomMeta;
 
   const performDelete = useCallback(() => {
     deleteItem(datasetItem.id);
@@ -34,6 +42,10 @@ export const DatasetItemRowActionsCell: React.FC<
       setConfirmOpen(true);
     }
   }, [dontAskAgain, performDelete]);
+
+  const handleEditClick = useCallback(() => {
+    setActiveRowId?.(datasetItem.id);
+  }, [datasetItem.id, setActiveRowId]);
 
   return (
     <CellWrapper
@@ -55,6 +67,13 @@ export const DatasetItemRowActionsCell: React.FC<
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-52">
+          {setActiveRowId && (
+            <DropdownMenuItem onClick={handleEditClick}>
+              <Pencil className="mr-2 size-4" />
+              Edit
+            </DropdownMenuItem>
+          )}
+          {setActiveRowId && <DropdownMenuSeparator />}
           <DropdownMenuItem onClick={handleDeleteClick} variant="destructive">
             <Trash className="mr-2 size-4" />
             Delete

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
@@ -475,6 +475,7 @@ function DatasetItemsTab({
         ? [
             generateActionsColumDef({
               cell: DatasetItemRowActionsCell,
+              customMeta: { setActiveRowId },
             }),
           ]
         : []),
@@ -486,6 +487,7 @@ function DatasetItemsTab({
     canEditDatasets,
     getDraftStatusBorderClass,
     handleRowClick,
+    setActiveRowId,
   ]);
 
   const columnsToExport = useMemo(


### PR DESCRIPTION
## Details

<img width="852" height="858" alt="image" src="https://github.com/user-attachments/assets/2f3bb0a1-29fa-4608-bdc0-854f60e14b7e" />

https://github.com/user-attachments/assets/0f24b94c-e650-4247-b468-7b45780a44ce

Adds an `Edit` option to the `…` row action menu on dataset items, sitting above `Delete` with a separator between them. Until now the only way to open the edit panel from the row was clicking the dataset item ID; the action menu only exposed `Delete`. This brings the menu in line with what users expect (and with [OPIK-6544](https://comet-ml.atlassian.net/browse/OPIK-6544)).

- `DatasetItemRowActionsCell` now reads `setActiveRowId` from the column's `customMeta` and renders an `Edit` item that opens the side panel for the row (`Pencil` icon, mirrors the existing pattern in `VersionRowActionsCell`).
- `DatasetItemsTab` passes `setActiveRowId` through `generateActionsColumDef({ customMeta })`, so the cell stays decoupled from the page state.
- Single change covers **both** regular dataset items and test suite items — they share `DatasetItemsTab` and the same row-actions cell; only the side panel differs, and both panels are driven by `activeRowId`.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6544

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation
- Human verification: code review + manual smoke test in testing environment

## Testing

- `npm run typecheck` — pass
- `npm run lint` (via pre-commit hook on changed files) — pass
- `depcruise` (via pre-commit hook) — pass, no new violations
- Manual smoke test in the testing environment: open the `…` menu on a dataset item row and a test suite item row, click `Edit`, confirm the right-side edit panel opens with that row's content. Then click `Delete` to confirm the destructive item still works and the separator renders between the two.

## Documentation

N/A — purely additive UI change to an existing row action menu; no API or user-facing docs surface affected.


[OPIK-6544]: https://comet-ml.atlassian.net/browse/OPIK-6544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ