### PR TITLE
docs(changelog): weekly changelog for 2026-05-19

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-19.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-19.mdx
@@ -26,14 +26,6 @@ The `opik connect` and `opik endpoint` CLI commands have been reorganized with a
 - **Auto-configure on first run** — if no `~/.opik.config` file exists, `opik connect` now offers to run `opik configure` automatically (skipped in non-interactive / headless environments)
 - **Instant disconnect** — stopping a local runner session now notifies the backend immediately, so the connection status in the UI updates right away instead of waiting for a timeout
 
-## 🌍 Environments: Color Assignments & Bug Fixes
-
-Several improvements to how environments work in the UI and SDK:
-
-- **Auto-created environments get distinct colors** — environments created automatically from trace ingestion now receive a color from the palette (assigned deterministically by name hash), so they no longer all appear identical
-- **Inline validation errors** — when creating or editing an environment, backend errors (duplicate name, invalid value) now appear inline below the field instead of silently failing; the dialog stays open so you don't lose your input
-- **SDK: environment preserved on update** — calling `span.end()`, `span.update()`, `trace.end()`, or `trace.update()` no longer clears the `environment` field set at creation time
-
 ## 🎮 Playground: Gemma 4 Reasoning & Updated Default Models
 
 - **Gemma 4 no longer leaks reasoning traces** — the internal thinking output from Gemma 4 models was appearing at the top of Playground responses. It is now suppressed so you see only the final model response
@@ -43,8 +35,11 @@ Several improvements to how environments work in the UI and SDK:
 
 Fixed a bug in the `OpikADKOtelTracer` integration where the tracer would kill all active OpenTelemetry spans and re-patch the ADK exporter on every request via `__setstate__`. The patcher is now idempotent and delegates span creation to the original ADK tracer, so user-configured OTel pipelines are preserved.
 
-## 🔧 Bug Fixes
+## 🔧 Bug Fixes & Improvements
 
+- **Environments: auto-created environments get distinct colors** — environments created automatically from trace ingestion now receive a color from the palette (assigned deterministically by name hash), so they no longer all appear identical
+- **Environments: inline validation errors** — when creating or editing an environment, backend errors (duplicate name, invalid value) now appear inline below the field; the dialog stays open so you don't lose your input
+- **Environments: SDK preserves environment on update** — calling `span.end()`, `span.update()`, `trace.end()`, or `trace.update()` no longer clears the `environment` field set at creation time
 - **Experiments: "Item source" column** — the column previously labeled "Test suite" in the Experiments table is now called "Item source" and shows a dynamic icon reflecting the actual source (dataset, trace, manual, etc.)
 - **Dataset version copy no longer drops items** — when a dataset version was copied and the stored item count had drifted from the actual ClickHouse row count, some items could be silently lost. The copy now uses a live count, eliminating the discrepancy
 - **Self-hosted onboarding skip no longer loops** — clicking "Skip" during onboarding on deployments without demo data (self-hosted Docker Compose, self-hosted EKS) previously started a 5-minute polling loop. It now routes directly to the home page

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-19.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-19.mdx
@@ -26,28 +26,22 @@ The `opik connect` and `opik endpoint` CLI commands have been reorganized with a
 - **Auto-configure on first run** — if no `~/.opik.config` file exists, `opik connect` now offers to run `opik configure` automatically (skipped in non-interactive / headless environments)
 - **Instant disconnect** — stopping a local runner session now notifies the backend immediately, so the connection status in the UI updates right away instead of waiting for a timeout
 
-## 🎮 Playground: Gemma 4 Reasoning & Updated Default Models
-
-- **Gemma 4 no longer leaks reasoning traces** — the internal thinking output from Gemma 4 models was appearing at the top of Playground responses. It is now suppressed so you see only the final model response
-- **Updated default models for Gemini and Vertex AI** — the provider dropdown previously defaulted to deprecated model aliases that weren't selectable in the picker. Both providers now default to their current recommended models (`gemini-3.1-pro` for Gemini, `gemini-3.1-pro` for Vertex AI)
-
-## 🤖 Google ADK Integration: Re-patching Fix
-
-Fixed a bug in the `OpikADKOtelTracer` integration where the tracer would kill all active OpenTelemetry spans and re-patch the ADK exporter on every request via `__setstate__`. The patcher is now idempotent and delegates span creation to the original ADK tracer, so user-configured OTel pipelines are preserved.
-
 ## 🔧 Bug Fixes & Improvements
 
+- **Playground: Gemma 4 no longer leaks reasoning traces** — the internal thinking output from Gemma 4 models was appearing at the top of Playground responses; it is now suppressed so you see only the final model response
+- **Playground: updated default models for Gemini and Vertex AI** — the provider dropdown previously defaulted to deprecated model aliases that weren't selectable in the picker; both providers now default to their current recommended models
+- **Google ADK integration: re-patching fixed** — `OpikADKOtelTracer` was killing all active OpenTelemetry spans and re-patching the ADK exporter on every request; the patcher is now idempotent and preserves user-configured OTel pipelines
 - **Environments: auto-created environments get distinct colors** — environments created automatically from trace ingestion now receive a color from the palette (assigned deterministically by name hash), so they no longer all appear identical
 - **Environments: inline validation errors** — when creating or editing an environment, backend errors (duplicate name, invalid value) now appear inline below the field; the dialog stays open so you don't lose your input
 - **Environments: SDK preserves environment on update** — calling `span.end()`, `span.update()`, `trace.end()`, or `trace.update()` no longer clears the `environment` field set at creation time
 - **Experiments: "Item source" column** — the column previously labeled "Test suite" in the Experiments table is now called "Item source" and shows a dynamic icon reflecting the actual source (dataset, trace, manual, etc.)
-- **Dataset version copy no longer drops items** — when a dataset version was copied and the stored item count had drifted from the actual ClickHouse row count, some items could be silently lost. The copy now uses a live count, eliminating the discrepancy
-- **Self-hosted onboarding skip no longer loops** — clicking "Skip" during onboarding on deployments without demo data (self-hosted Docker Compose, self-hosted EKS) previously started a 5-minute polling loop. It now routes directly to the home page
-- **CSV dataset upload always available** — the CSV upload button in the dataset UI is now always shown. It was previously hidden on self-hosted Docker Compose and some staging environments even though the feature was fully functional
+- **Dataset version copy no longer drops items** — when a dataset version was copied and the stored item count had drifted from the actual ClickHouse row count, some items could be silently lost; the copy now uses a live count, eliminating the discrepancy
+- **Self-hosted onboarding skip no longer loops** — clicking "Skip" during onboarding on deployments without demo data (self-hosted Docker Compose, self-hosted EKS) previously started a 5-minute polling loop; it now routes directly to the home page
+- **CSV dataset upload always available** — the CSV upload button in the dataset UI is now always shown; it was previously hidden on self-hosted Docker Compose and some staging environments even though the feature was fully functional
 
 ## ⚡ Performance Improvements
 
-- **Dataset streaming uses less backend CPU** — resolved a query pattern that caused the MySQL reader to scan all dataset versions on every `/datasets/items/stream` call. Under high request volume this was pushing database CPU to 80–99%; it now uses a direct primary-key lookup instead
+- **Dataset streaming uses less backend CPU** — resolved a query pattern that caused the MySQL reader to scan all dataset versions on every `/datasets/items/stream` call; under high request volume this was pushing database CPU to 80–99%, it now uses a direct primary-key lookup instead
 - **Workspace selector loads faster** — the workspace dropdown now fetches a lighter summary endpoint, reducing the number of backend queries on each page load for users with many workspaces
 
 ---

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-19.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-19.mdx
@@ -1,0 +1,81 @@
+Here are the most relevant improvements we've made since the last release:
+
+## 🚀 Client-Side Prompt Caching (Python & TypeScript SDKs)
+
+`client.get_prompt()` and `client.get_chat_prompt()` now cache results in-process, so repeated calls inside a hot path skip the network round-trip entirely. Pinned commits are cached indefinitely; latest-version lookups use a 5-minute TTL that refreshes in the background so your code always gets a reasonably fresh value without blocking.
+
+**What's new:**
+
+- **Automatic caching** — results are cached on the first fetch; subsequent calls return instantly from memory
+- **Configurable TTL** — set `OPIK_PROMPT_CACHE_TTL_SECONDS` to adjust the freshness window (default: 300 s)
+- **Bypass when needed** — pass `no_cache=True` / `noCache: true` to force a live fetch from the backend
+- **Prompt metadata injected into traces** — when you fetch a prompt inside an `@track` context, the prompt ID and commit are automatically recorded in the trace metadata so you know which version was used at inference time
+- **TypeScript SDK** — the same caching and metadata injection are available in the TypeScript client
+
+```python
+# Cached after the first call — no extra latency on subsequent invocations
+prompt = client.get_prompt("my-system-prompt")
+
+# Force a fresh fetch, bypassing the cache
+prompt = client.get_prompt("my-system-prompt", no_cache=True)
+```
+
+## 📦 `opik migrate dataset` CLI Command
+
+A new `opik migrate dataset` command lets you move a dataset — including its full version history, all linked experiments, traces, and spans — from one project to another within the same workspace, in a single command.
+
+```bash
+# Migrate a dataset with a dry-run preview
+opik migrate dataset "MyDataset" --to-project=NewProject --dry-run
+
+# Execute the migration
+opik migrate dataset "MyDataset" --to-project=NewProject
+
+# Migrate from a specific source project
+opik migrate dataset "MyDataset" --from-project=OldProject --to-project=NewProject
+```
+
+Test suites linked to the dataset are migrated as well. An audit log is written so you can trace exactly what was copied.
+
+## 🔌 `opik connect` CLI Improvements
+
+The `opik connect` and `opik endpoint` CLI commands have been reorganized with a much better error experience:
+
+- **Formatted error output** — configuration problems now show a labelled card (Reason / Workspace / URL / Config / Fix / Docs) so you can see exactly what's wrong and how to fix it without reading a stack trace
+- **Auto-configure on first run** — if no `~/.opik.config` file exists, `opik connect` now offers to run `opik configure` automatically (skipped in non-interactive / headless environments)
+- **Instant disconnect** — stopping a local runner session now notifies the backend immediately, so the connection status in the UI updates right away instead of waiting for a timeout
+
+## 🌍 Environments: Color Assignments & Bug Fixes
+
+Several improvements to how environments work in the UI and SDK:
+
+- **Auto-created environments get distinct colors** — environments created automatically from trace ingestion now receive a color from the palette (assigned deterministically by name hash), so they no longer all appear identical
+- **Inline validation errors** — when creating or editing an environment, backend errors (duplicate name, invalid value) now appear inline below the field instead of silently failing; the dialog stays open so you don't lose your input
+- **SDK: environment preserved on update** — calling `span.end()`, `span.update()`, `trace.end()`, or `trace.update()` no longer clears the `environment` field set at creation time
+
+## 🎮 Playground: Gemma 4 Reasoning & Updated Default Models
+
+- **Gemma 4 no longer leaks reasoning traces** — the internal thinking output from Gemma 4 models was appearing at the top of Playground responses. It is now suppressed so you see only the final model response
+- **Updated default models for Gemini and Vertex AI** — the provider dropdown previously defaulted to deprecated model aliases that weren't selectable in the picker. Both providers now default to their current recommended models (`gemini-3.1-pro` for Gemini, `gemini-3.1-pro` for Vertex AI)
+
+## 🤖 Google ADK Integration: Re-patching Fix
+
+Fixed a bug in the `OpikADKOtelTracer` integration where the tracer would kill all active OpenTelemetry spans and re-patch the ADK exporter on every request via `__setstate__`. The patcher is now idempotent and delegates span creation to the original ADK tracer, so user-configured OTel pipelines are preserved.
+
+## 🔧 Bug Fixes
+
+- **Experiments: "Item source" column** — the column previously labeled "Test suite" in the Experiments table is now called "Item source" and shows a dynamic icon reflecting the actual source (dataset, trace, manual, etc.)
+- **Dataset version copy no longer drops items** — when a dataset version was copied and the stored item count had drifted from the actual ClickHouse row count, some items could be silently lost. The copy now uses a live count, eliminating the discrepancy
+- **Self-hosted onboarding skip no longer loops** — clicking "Skip" during onboarding on deployments without demo data (self-hosted Docker Compose, self-hosted EKS) previously started a 5-minute polling loop. It now routes directly to the home page
+- **CSV dataset upload always available** — the CSV upload button in the dataset UI is now always shown. It was previously hidden on self-hosted Docker Compose and some staging environments even though the feature was fully functional
+
+## ⚡ Performance Improvements
+
+- **Dataset streaming uses less backend CPU** — resolved a query pattern that caused the MySQL reader to scan all dataset versions on every `/datasets/items/stream` call. Under high request volume this was pushing database CPU to 80–99%; it now uses a direct primary-key lookup instead
+- **Workspace selector loads faster** — the workspace dropdown now fetches a lighter summary endpoint, reducing the number of backend queries on each page load for users with many workspaces
+
+---
+
+And much more! 👉 [See full commit log on GitHub](https://github.com/comet-ml/opik/compare/2.0.31...2.0.37)
+
+_Releases_: `2.0.32`, `2.0.33`, `2.0.34`, `2.0.35`, `2.0.36`, `2.0.37`

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-19.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-19.mdx
@@ -1,5 +1,3 @@
-Here are the most relevant improvements we've made since the last release:
-
 ## 🚀 Client-Side Prompt Caching (Python & TypeScript SDKs)
 
 `client.get_prompt()` and `client.get_chat_prompt()` now cache results in-process, so repeated calls inside a hot path skip the network round-trip entirely. Pinned commits are cached indefinitely; latest-version lookups use a 5-minute TTL that refreshes in the background so your code always gets a reasonably fresh value without blocking.

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-19.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-19.mdx
@@ -20,23 +20,6 @@ prompt = client.get_prompt("my-system-prompt")
 prompt = client.get_prompt("my-system-prompt", no_cache=True)
 ```
 
-## 📦 `opik migrate dataset` CLI Command
-
-A new `opik migrate dataset` command lets you move a dataset — including its full version history, all linked experiments, traces, and spans — from one project to another within the same workspace, in a single command.
-
-```bash
-# Migrate a dataset with a dry-run preview
-opik migrate dataset "MyDataset" --to-project=NewProject --dry-run
-
-# Execute the migration
-opik migrate dataset "MyDataset" --to-project=NewProject
-
-# Migrate from a specific source project
-opik migrate dataset "MyDataset" --from-project=OldProject --to-project=NewProject
-```
-
-Test suites linked to the dataset are migrated as well. An audit log is written so you can trace exactly what was copied.
-
 ## 🔌 `opik connect` CLI Improvements
 
 The `opik connect` and `opik endpoint` CLI commands have been reorganized with a much better error experience:


### PR DESCRIPTION
## Details

Adds the weekly changelog entry covering releases `2.0.32`–`2.0.37` (the week of May 12–18, 2026). Groups related changes by theme, verifies each against the codebase (not just commit messages), and excludes anything behind a feature toggle that defaults to off (agentic tools scoring, Ollie sidebar, Optimization Studio).

**Changes documented:**
- Python/TypeScript SDK client-side prompt caching with trace metadata injection
- `opik connect` CLI improvements: Rich-formatted errors, auto-configure on first run, instant disconnect
- Environments: auto-assigned palette colors, inline validation errors, environment field preserved on SDK update/end
- Playground: Gemma 4 reasoning trace suppression, updated Gemini/Vertex AI default models
- Google ADK integration idempotent re-patching fix
- Bug fixes: silent dataset item loss during version copy, self-hosted onboarding skip loop, CSV upload always visible
- Performance: dataset streaming query optimization, workspace selector lite endpoint

`opik migrate dataset` is excluded — will be documented separately when the full feature is ready.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (claude-sonnet-4-6)
- Model(s): claude-sonnet-4-6
- Scope: Full changelog entry — reviewed commits since 2026-05-12, verified API/config names against codebase, excluded feature-flagged items (TOGGLE_AGENTIC_TOOLS_ENABLED, TOGGLE_OLLIE_ENABLED, TOGGLE_OPTIMIZATION_STUDIO_ENABLED all default false), grouped and wrote user-facing copy
- Human verification: Commit messages, file diffs, and config.yml defaults checked for each item included

## Testing

Documentation-only change. Verified:
- New `.mdx` file added to `apps/opik-documentation/documentation/fern/docs/changelog/2026-05-19.mdx`
- The Fern `changelog:` directive in `versions/latest.yml` automatically picks up all files in the directory — no navigation config change needed
- All API names (`get_prompt`, `get_chat_prompt`, `no_cache`, `OPIK_PROMPT_CACHE_TTL_SECONDS`) and config keys verified against the codebase

## Documentation

This PR _is_ the documentation change.

https://claude.ai/code/session_01T9yZkbs2iJSNzHYEFGr4ms