### PR TITLE
[NA] [QA] fix: wait for traces table to fully render before scanning Moderation header

### DIFF
--- a/tests_end_to_end/typescript-tests/tests/online-scoring/online-scoring.spec.ts
+++ b/tests_end_to_end/typescript-tests/tests/online-scoring/online-scoring.spec.ts
@@ -7,8 +7,9 @@ import { modelConfigLoader } from '../../helpers/model-config-loader';
 
 // Timeout constants
 const RULE_ACTIVATION_TIMEOUT = 10000; // 10 seconds for rule to fully activate in backend
-const PAGE_REFRESH_TIMEOUT = 3000; // 3 seconds wait after page refresh
+const TABLE_READY_TIMEOUT = 4000; // 4 seconds per attempt for table to render rows / Moderation header after reload
 const POST_RELOAD_TIMEOUT = 1000; // 1 second wait after page reload
+const EXPECTED_ROW_COUNT = 10;
 
 const enabledModels = modelConfigLoader.getEnabledModelsForOnlineScoring();
 
@@ -107,16 +108,39 @@ test.describe('Online Scoring Tests', () => {
 
         // Retry loop: wait for Moderation column header in the table, then check score value.
         // Scoring is async and Anthropic models can take longer, so we allow generous retries.
+        // Critical: each iteration must wait for the table to FULLY render (rows + dynamic
+        // feedback-score columns) before scanning the header — header cells are appended
+        // after a second API call resolves, so a fresh DOM snapshot right after reload
+        // contains only the static columns and the Moderation header will be missing.
         const maxAttempts = 25;
+        const tableRows = page.locator('table tbody tr');
+        const headerCells = page.locator('table thead th, table thead td');
         let moderationColumnIndex = -1;
         let moderationValue = '';
 
         for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-          // Find Moderation column in thead
-          const headerCells = page.locator('table thead th, table thead td');
+          try {
+            await expect(tableRows).toHaveCount(EXPECTED_ROW_COUNT, { timeout: TABLE_READY_TIMEOUT });
+          } catch {
+            console.log(`Traces table not yet showing ${EXPECTED_ROW_COUNT} rows (attempt ${attempt}/${maxAttempts}), refreshing...`);
+            await page.reload();
+            await page.waitForTimeout(POST_RELOAD_TIMEOUT);
+            continue;
+          }
+
+          try {
+            await expect(headerCells.filter({ hasText: 'Moderation' }).first()).toBeVisible({
+              timeout: TABLE_READY_TIMEOUT,
+            });
+          } catch {
+            console.log(`Moderation column header not found yet (attempt ${attempt}/${maxAttempts}), refreshing...`);
+            await page.reload();
+            await page.waitForTimeout(POST_RELOAD_TIMEOUT);
+            continue;
+          }
+
           const headerCount = await headerCells.count();
           moderationColumnIndex = -1;
-
           for (let i = 0; i < headerCount; i++) {
             const cellText = await headerCells.nth(i).textContent();
             if (cellText?.includes('Moderation')) {
@@ -126,16 +150,15 @@ test.describe('Online Scoring Tests', () => {
           }
 
           if (moderationColumnIndex === -1) {
-            console.log(`Moderation column header not found yet (attempt ${attempt}/${maxAttempts}), refreshing...`);
+            console.log(`Moderation column header disappeared between visibility check and index scan (attempt ${attempt}/${maxAttempts}), refreshing...`);
             await page.reload();
-            await page.waitForTimeout(PAGE_REFRESH_TIMEOUT);
+            await page.waitForTimeout(POST_RELOAD_TIMEOUT);
             continue;
           }
 
           console.log(`Found Moderation column at index ${moderationColumnIndex} (attempt ${attempt})`);
 
-          // Check if there's a score value (not "-")
-          const firstRow = page.locator('table tbody tr').first();
+          const firstRow = tableRows.first();
           const moderationCell = firstRow.locator('td').nth(moderationColumnIndex);
           moderationValue = (await moderationCell.textContent())?.trim() || '';
           console.log(`Moderation value: ${moderationValue}`);
@@ -147,7 +170,7 @@ test.describe('Online Scoring Tests', () => {
           if (attempt < maxAttempts) {
             console.log(`Score not populated yet (attempt ${attempt}/${maxAttempts}), refreshing...`);
             await page.reload();
-            await page.waitForTimeout(PAGE_REFRESH_TIMEOUT);
+            await page.waitForTimeout(POST_RELOAD_TIMEOUT);
           }
         }
 
@@ -155,10 +178,9 @@ test.describe('Online Scoring Tests', () => {
           throw new Error(`Moderation column did not appear after ${maxAttempts} attempts`);
         }
 
-        const tableRows = page.locator('table tbody tr');
         const rowCount = await tableRows.count();
         console.log(`Found ${rowCount} rows in traces table`);
-        expect(rowCount).toBeGreaterThanOrEqual(10);
+        expect(rowCount).toBeGreaterThanOrEqual(EXPECTED_ROW_COUNT);
 
         // The value should be "0" (safe content)
         expect(moderationValue).toBe('0');


### PR DESCRIPTION
## Details

The online-scoring moderation flow test polled `table thead th` with a fixed 3s wait per reload. On production the traces table renders static columns first and appends dynamic feedback-score columns after a second API call, so the scan ran before the Moderation header was mounted and every retry re-raced the same too-short timer.

- All six provider/model variants were failing identically only on the prod sanity launches while local, staging, self-hosted, and post-merge stayed green — root cause was a DOM render race in the test, not a backend regression.
- Each retry now uses Playwright auto-retrying assertions (`toHaveCount` on `tbody tr`, then `toBeVisible` on the Moderation header) before reading the column index, so the loop early-returns the moment the table is actually ready instead of always burning a fixed 3s.
- Per-attempt budget is bounded so the 25-attempt loop still fits in the 120s test timeout in the happy path.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: investigation + full implementation
- Human verification: confirmed the failure mode by inspecting the Playwright trace artefact (table still showing the loading spinner when the locator scan ran); manually verified scoring rows render correctly on production; ran the updated test against production via CI and observed it now passes.

## Testing

How tested:
- `npx tsc --noEmit` from `tests_end_to_end/typescript-tests/` — no new TypeScript errors in `online-scoring.spec.ts` (pre-existing errors in unrelated `prompts/prompt-tags.spec.ts` left untouched).
- Re-ran the Prod Happy Paths sanity launch on this branch via CI — the previously-failing `Online scoring full moderation flow` tests across all six provider/model variants (Anthropic Claude Haiku 4.5 / Sonnet 4.6 / Opus 4.6 and OpenAI GPT 5.4 / 5.4 Mini / 5.4 Nano) now pass.
- Scenarios validated: happy path where the moderation feedback score is already present when the traces page first renders; retry path where dynamic feedback-score columns are appended after the initial header paint.
- Environment: production target (`https://www.comet.com/opik`), GitHub-hosted runner, chromium project.

## Documentation

N/A — test-only change, no user-facing or product documentation affected.