### PR TITLE
[OPIK-6552] disable demo project by default for self-hosted customers

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1018,7 +1018,7 @@ serviceToggles:
   # Default: true
   # Description: Whether or not dataset export to CSV feature is enabled
   datasetExportEnabled: ${DATASET_EXPORT_ENABLED:-"false"}
-  # Default: true
+  # Default: false
   # Description: Whether the deployment is expected to produce demo project data on signup. When false, the FE skips the onboarding demo-loading screen and lets the user proceed to the empty workspace immediately.
   demoDataEnabled: ${TOGGLE_DEMO_DATA_ENABLED:-"false"}
   # Default: false

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1020,7 +1020,7 @@ serviceToggles:
   datasetExportEnabled: ${DATASET_EXPORT_ENABLED:-"false"}
   # Default: true
   # Description: Whether the deployment is expected to produce demo project data on signup. When false, the FE skips the onboarding demo-loading screen and lets the user proceed to the empty workspace immediately.
-  demoDataEnabled: ${TOGGLE_DEMO_DATA_ENABLED:-"true"}
+  demoDataEnabled: ${TOGGLE_DEMO_DATA_ENABLED:-"false"}
   # Default: false
   # Description: Whether or not Optimization Studio feature is enabled
   optimizationStudioEnabled: ${TOGGLE_OPTIMIZATION_STUDIO_ENABLED:-"false"}


### PR DESCRIPTION
## Details
`TOGGLE_DEMO_DATA_ENABLED` should be disabled by default to follow existing configuration for self-hosted/STSaaS customers. None of those customers had the feature enabled previously. 
It was introduced in 2024 during Opik launch. The way it works when enabled (`OPIK_DEMO_PROJECT_CREATION=True` in `comet-backend`): during user signup platform BE sends a call to `OPIK_DEMO_PROJECT_CREATION_URL` (in cloud: http://opik-python-backend:8000/v1/private/post_user_signup) to trigger demo data generation.
The feature is only enabled in production cloud and our test envs.
**Additionally to changing the default in code**, production-cloud and Comet test envs should be explicitly configured to `TOGGLE_DEMO_DATA_ENABLED=True` to maintain current flow.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6552

## AI-WATERMARK

AI-WATERMARK: no

## Testing

## Documentation
