### PR TITLE
[OPIK-6532] [SDK] feat: cascade optimizations on opik migrate dataset (Slice 5)

### DIFF
--- a/sdks/python/src/opik/cli/imports/experiment.py
+++ b/sdks/python/src/opik/cli/imports/experiment.py
@@ -490,13 +490,15 @@ def recreate_experiment(
 
         # Create the experiment.
         # Migrate path forwards fidelity fields (evaluation_method, tags,
-        # dataset_version_id, project_name) verbatim; the import-from-disk
-        # path is unchanged to avoid silently altering historical import
-        # behavior. ``optimization_id`` is deliberately NOT forwarded on the
-        # migrate path: Slice 3 doesn't cascade the optimization entity, so
-        # the pointer would dangle. Same policy as ``prompt_versions`` above
-        # (strip rather than leave broken UI links). Slice 4 can repopulate
-        # via a remap when it ships the optimization cascade.
+        # dataset_version_id, project_name, optimization_id) verbatim;
+        # the import-from-disk path is unchanged to avoid silently
+        # altering historical import behavior. ``optimization_id`` was
+        # dropped on the migrate path through Slice 4 (no optimization
+        # cascade); Slice 5 (OPIK-6532) ships the cascade and the
+        # caller (``_build_experiment_data``) remaps the source id to
+        # the destination id before this function sees it, so by the
+        # time we get here ``experiment_info["optimization_id"]`` is
+        # already a destination-valid pointer.
         create_kwargs: Dict[str, Any] = {
             "dataset_name": destination_dataset_name,
             "name": experiment_name,
@@ -510,6 +512,9 @@ def recreate_experiment(
             create_kwargs["tags"] = experiment_info.get("tags")
             create_kwargs["dataset_version_id"] = target_dataset_version_id
             create_kwargs["project_name"] = target_project_name
+            optimization_id = experiment_info.get("optimization_id")
+            if optimization_id:
+                create_kwargs["optimization_id"] = optimization_id
 
         experiment = client.create_experiment(**create_kwargs)
 
@@ -653,8 +658,10 @@ def recreate_experiment(
                         debug,
                     )
                     rest_helpers.ensure_rest_api_call_respecting_rate_limit(
-                        lambda b=batch: client._rest_client.experiments.create_experiment_items(
-                            experiment_items=b
+                        lambda b=batch: (
+                            client._rest_client.experiments.create_experiment_items(
+                                experiment_items=b
+                            )
                         )
                     )
                 console.print(

--- a/sdks/python/src/opik/cli/migrate/datasets/_progress.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/_progress.py
@@ -1,0 +1,32 @@
+"""Shared progress-callback type aliases for the dataset migrate cascades.
+
+All three dataset-level cascade phases -- ``version_replay``,
+``optimizations``, ``experiments`` -- expose progress hooks with the
+same `` (completed: int, total: int, label: str) -> None`` shape so the
+executor can drive Rich progress bars without each cascade module
+needing to know about Rich. Centralizing the type alias here removes
+the previous drift surface (three separate definitions: two named, one
+inline) and gives a single source of truth.
+
+``label == "done"`` is the cross-cascade convention for the final
+tick; consumers use it to switch the bar to a 100% / "done" rendering
+and to drop the mid-loop ``(N/total)`` suffix.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+# Outer progress: ``(completed, total, label)`` -- fired once per work
+# item (version, optimization, experiment). ``completed`` is the count
+# done so far when the callback fires (so a mid-loop ``completed + 1``
+# matches "currently processing the next item"). ``label == "done"``
+# signals the final tick with ``completed == total``.
+ProgressCallback = Callable[[int, int, str], None]
+
+# Inner progress: same shape as ``ProgressCallback`` but ticks within a
+# single outer item (only used by the experiment cascade today, where
+# each experiment has multiple read/write phases). Aliased separately
+# so the per-call-site intent is documented at the type level even
+# though the underlying signature is identical.
+InnerProgressCallback = Callable[[int, int, str], None]

--- a/sdks/python/src/opik/cli/migrate/datasets/executor.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/executor.py
@@ -224,17 +224,25 @@ def _cascade_optimizations(
             # Drop the "(N/total)" suffix in that frame so the bar doesn't
             # render "(total+1/total)" from the +1 offset that helps mid-
             # loop ticks read as "currently processing the (Nth+1) item".
-            if label == "done":
+            is_done = label == "done"
+            if is_done:
                 description = f"→ {action.dest_project_name} · done"
             else:
                 description = (
                     f"→ {action.dest_project_name} · {label} ({completed + 1}/{total})"
                 )
+            # ``total`` might be 0 on a zero-optimization dataset; clamp to
+            # >= 1 so the Rich bar doesn't render as divide-by-zero NaN%.
+            # The same value is used for the bar's ``completed`` on the
+            # "done" tick so the zero-optimization path still renders as
+            # 100% (otherwise the bar would lazily add the task at total=1
+            # and never advance, leaving an already-finished migration
+            # stuck at 0%).
+            bar_total = max(total, 1)
             if task_id is None:
-                # Create the task lazily on the first callback. ``total``
-                # might be 0 on a zero-optimization dataset; clamp to >= 1
-                # so the Rich bar doesn't render as divide-by-zero NaN%.
-                task_id = progress.add_task(description, total=max(total, 1))
+                task_id = progress.add_task(description, total=bar_total)
+            if is_done:
+                progress.update(task_id, completed=bar_total, description=description)
             else:
                 progress.update(task_id, completed=completed, description=description)
 

--- a/sdks/python/src/opik/cli/migrate/datasets/executor.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/executor.py
@@ -201,19 +201,52 @@ def _cascade_optimizations(
     ``CascadeExperiments`` action can re-point each experiment's
     ``optimization_id`` FK at the new destination optimization id.
 
-    No Rich progress bar: production has tens to low-hundreds of
-    optimizations per dataset at most, so the audit's per-optimization
-    ``migrate_optimization`` records (emitted inside
-    ``cascade_optimizations``) give users enough granular feedback
-    without the executor needing to drive an extra nested bar.
+    Drives a Rich progress bar that ticks once per optimization. The
+    algorithmic core in ``cascade_optimizations`` stays console-agnostic
+    -- the bar is driven by the per-optimization callback. Production
+    datasets carry tens to low-hundreds of optimizations at most, so a
+    simple single-level bar is plenty (no nested per-optimization detail
+    bar like the experiment cascade has).
     """
-    result = cascade_optimizations(
-        rest_client,
-        source_dataset_id=action.source_dataset_id,
-        target_dataset_name=action.dest_name,
-        target_project_name=action.dest_project_name,
-        audit=audit,
-    )
+    with Progress(
+        TextColumn("[bold blue]Cascading optimizations"),
+        BarColumn(),
+        TaskProgressColumn(),
+        TextColumn("{task.description}"),
+        console=_console,
+        transient=False,
+    ) as progress:
+        task_id: Optional[int] = None
+
+        def _on_optimization_start(completed: int, total: int, label: str) -> None:
+            nonlocal task_id
+            # ``label == "done"`` signals the final tick (completed=total).
+            # Drop the "(N/total)" suffix in that frame so the bar doesn't
+            # render "(total+1/total)" from the +1 offset that helps mid-
+            # loop ticks read as "currently processing the (Nth+1) item".
+            if label == "done":
+                description = f"→ {action.dest_project_name} · done"
+            else:
+                description = (
+                    f"→ {action.dest_project_name} · {label} ({completed + 1}/{total})"
+                )
+            if task_id is None:
+                # Create the task lazily on the first callback. ``total``
+                # might be 0 on a zero-optimization dataset; clamp to >= 1
+                # so the Rich bar doesn't render as divide-by-zero NaN%.
+                task_id = progress.add_task(description, total=max(total, 1))
+            else:
+                progress.update(task_id, completed=completed, description=description)
+
+        result = cascade_optimizations(
+            rest_client,
+            source_dataset_id=action.source_dataset_id,
+            target_dataset_name=action.dest_name,
+            target_project_name=action.dest_project_name,
+            audit=audit,
+            progress_callback=_on_optimization_start,
+        )
+
     plan.optimization_id_remap.update(result.id_remap)
 
 

--- a/sdks/python/src/opik/cli/migrate/datasets/executor.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/executor.py
@@ -21,8 +21,10 @@ from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn
 from ..audit import AuditLog
 from .._base import execute_plan_loop, record_planned_loop
 from .experiments import cascade_experiments
+from .optimizations import cascade_optimizations
 from .planner import (
     CascadeExperiments,
+    CascadeOptimizations,
     CreateDestination,
     MigrationPlan,
     RenameSource,
@@ -107,6 +109,8 @@ def _apply_action(
         )
     elif isinstance(action, ReplayVersions):
         _replay_versions(client, rest_client, action, plan=plan, audit=audit)
+    elif isinstance(action, CascadeOptimizations):
+        _cascade_optimizations(rest_client, action, plan=plan, audit=audit)
     elif isinstance(action, CascadeExperiments):
         _cascade_experiments(client, rest_client, action, plan=plan, audit=audit)
     else:
@@ -183,6 +187,34 @@ def _replay_versions(
 
     plan.version_remap.update(result.version_remap)
     plan.item_id_remap.update(result.item_id_remap)
+
+
+def _cascade_optimizations(
+    rest_client: OpikApi,
+    action: CascadeOptimizations,
+    *,
+    plan: MigrationPlan,
+    audit: AuditLog,
+) -> None:
+    """Recreate every source-dataset optimization under the destination
+    project and populate ``plan.optimization_id_remap`` so the subsequent
+    ``CascadeExperiments`` action can re-point each experiment's
+    ``optimization_id`` FK at the new destination optimization id.
+
+    No Rich progress bar: production has tens to low-hundreds of
+    optimizations per dataset at most, so the audit's per-optimization
+    ``migrate_optimization`` records (emitted inside
+    ``cascade_optimizations``) give users enough granular feedback
+    without the executor needing to drive an extra nested bar.
+    """
+    result = cascade_optimizations(
+        rest_client,
+        source_dataset_id=action.source_dataset_id,
+        target_dataset_name=action.dest_name,
+        target_project_name=action.dest_project_name,
+        audit=audit,
+    )
+    plan.optimization_id_remap.update(result.id_remap)
 
 
 def _cascade_experiments(
@@ -297,6 +329,7 @@ def _cascade_experiments(
             target_project_name=action.dest_project_name,
             version_remap=plan.version_remap,
             item_id_remap=plan.item_id_remap,
+            optimization_id_remap=plan.optimization_id_remap,
             audit=audit,
             progress_callback=_on_experiment_start,
             inner_progress_callback=_on_inner_step,
@@ -361,6 +394,13 @@ def _action_details(action: object) -> Dict[str, Any]:
             "to_dataset": action.dest_name,
             "to_project": action.dest_project_name,
             "is_test_suite": action.is_test_suite,
+        }
+    if isinstance(action, CascadeOptimizations):
+        return {
+            "type": "cascade_optimizations",
+            "source_dataset_id": action.source_dataset_id,
+            "to_dataset": action.dest_name,
+            "to_project": action.dest_project_name,
         }
     if isinstance(action, CascadeExperiments):
         return {

--- a/sdks/python/src/opik/cli/migrate/datasets/experiments.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/experiments.py
@@ -50,7 +50,7 @@ import logging
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, cast
+from typing import Any, Dict, List, Literal, Optional, Set, Tuple, cast
 
 import opik
 import opik.id_helpers as id_helpers_module
@@ -74,21 +74,26 @@ from ..errors import ExperimentCascadeError
 
 LOGGER = logging.getLogger(__name__)
 
-# Outer progress: ``(completed, total, label)`` -- fired once before each
-# experiment with ``completed`` = experiments done so far. ``label="done"``
-# signals the final tick (executor uses it to strip the ``(N/total)``
-# suffix and avoid an off-by-one display at completion).
-ProgressCallback = Callable[[int, int, str], None]
+# Outer + inner progress callback shapes are shared across all dataset
+# cascade phases (version_replay, optimizations, experiments) -- see
+# ``datasets/_progress.py`` for the single source of truth. Re-exported
+# from this module so existing call sites that ``from .experiments
+# import ProgressCallback`` keep working.
+from ._progress import InnerProgressCallback, ProgressCallback  # noqa: E402, F401
 
-# Inner progress: ``(completed, total, label)`` -- ticks within a single
-# experiment so the outer experiment-level bar isn't a frozen one-step-
-# per-experiment readout. ``total`` is the number of inner steps for THIS
-# experiment (recomputed per experiment, since experiments can have wildly
-# different trace counts). ``label`` describes the step that just
-# completed (e.g. ``"trace 47/150"``, ``"spans for trace 47/150"``,
-# ``"flush"``, ``"recreate"``). Executor renders this on a nested Rich
-# bar; tests use it to assert the cascade ticks every read/write phase.
-InnerProgressCallback = Callable[[int, int, str], None]
+# Notes specific to the experiment cascade's usage of these callbacks:
+#
+# - The outer ``ProgressCallback`` fires once before each experiment;
+#   ``label="done"`` signals the final tick with ``completed == total``.
+#
+# - The inner ``InnerProgressCallback`` ticks within a single experiment so
+#   the outer experiment-level bar isn't a frozen one-step-per-experiment
+#   readout. ``total`` is the number of inner steps for THIS experiment
+#   (recomputed per experiment, since experiments can have wildly different
+#   trace counts). ``label`` describes the step that just completed (e.g.
+#   ``"trace 47/150"``, ``"spans for trace 47/150"``, ``"flush"``,
+#   ``"recreate"``). Executor renders this on a nested Rich bar; tests use
+#   it to assert the cascade ticks every read/write phase.
 
 
 class _InnerProgress:

--- a/sdks/python/src/opik/cli/migrate/datasets/experiments.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/experiments.py
@@ -22,17 +22,17 @@ source dataset was referenced by experiments in multiple projects. Slice 4
 
 FK remap during recreation:
 
-  source dataset_id         -> dest_dataset_id            (Slice 1)
-  source dataset_version_id -> plan.version_remap[old]    (Slice 2)
-  source dataset_item_id    -> plan.item_id_remap[old]    (Slice 2)
-  source trace_id           -> built here as traces copy  (this slice)
-  source project_id         -> target_project_name        (this slice)
+  source dataset_id         -> dest_dataset_id                  (Slice 1)
+  source dataset_version_id -> plan.version_remap[old]          (Slice 2)
+  source dataset_item_id    -> plan.item_id_remap[old]          (Slice 2)
+  source trace_id           -> built here as traces copy        (this slice)
+  source project_id         -> target_project_name              (this slice)
+  source optimization_id    -> plan.optimization_id_remap[old]  (Slice 5)
 
 Stripped on the destination experiment (matches Jacques's "strip the link"
 policy from the epic discussion; the pointers would otherwise dangle):
 
   prompt_versions  -- prompt entity isn't cascaded in v1 (epic open question)
-  optimization_id  -- optimization entity is cascaded in Slice 4 (OPIK-6417)
 
 Spans cascade with their parent trace; tree ordering is preserved via
 ``sort_spans_topologically`` from the import path so ``parent_span_id``
@@ -161,6 +161,12 @@ class ExperimentCascadeResult:
     span_comments_migrated: int = 0
     items_skipped_missing_trace: int = 0
     items_skipped_missing_item: int = 0
+    # Source experiments that carried an ``optimization_id`` but had no
+    # entry in ``optimization_id_remap`` -- defensive counter; should
+    # always be zero when ``CascadeOptimizations`` ran first as the
+    # planner guarantees. Non-zero values indicate a planning bug
+    # (e.g. action ordering broken) rather than a user-visible failure.
+    experiments_with_orphan_optimization_id: int = 0
     # Per-experiment skip reasons for the audit log. Each entry is
     # ``{"id": ..., "name": ..., "reason": ...}``; capped at the most
     # recent failures to keep the audit JSON bounded.
@@ -176,6 +182,7 @@ def cascade_experiments(
     target_project_name: str,
     version_remap: Dict[str, str],
     item_id_remap: Dict[str, str],
+    optimization_id_remap: Optional[Dict[str, str]] = None,
     audit: AuditLog,
     progress_callback: Optional[ProgressCallback] = None,
     inner_progress_callback: Optional[InnerProgressCallback] = None,
@@ -226,6 +233,13 @@ def cascade_experiments(
     result = ExperimentCascadeResult()
     del audit  # not currently used (umbrella action wraps via execute_plan_loop)
 
+    # Default to an empty remap so callers that haven't picked up the
+    # new kwarg (older tests, ad-hoc invocations) behave the same as
+    # before: any source ``optimization_id`` falls into the orphan path
+    # and the field is omitted from the destination payload.
+    if optimization_id_remap is None:
+        optimization_id_remap = {}
+
     source_experiments = list(_list_source_experiments(rest_client, source_dataset_id))
     total = len(source_experiments)
 
@@ -257,6 +271,7 @@ def cascade_experiments(
             target_project_name=target_project_name,
             version_remap=version_remap,
             item_id_remap=item_id_remap,
+            optimization_id_remap=optimization_id_remap,
             result=result,
             inner_progress_callback=inner_progress_callback,
         )
@@ -276,6 +291,7 @@ def cascade_one_experiment(
     target_project_name: str,
     version_remap: Dict[str, str],
     item_id_remap: Dict[str, str],
+    optimization_id_remap: Optional[Dict[str, str]] = None,
     result: ExperimentCascadeResult,
     inner_progress_callback: Optional[InnerProgressCallback] = None,
 ) -> None:
@@ -392,7 +408,12 @@ def cascade_one_experiment(
     # assertion_results/etc.) is READ-ONLY on the BE and reconstructs
     # from the underlying trace + span + assertion entities (which the
     # cascade copies in _copy_traces_and_spans).
-    experiment_data = _build_experiment_data(source_experiment, items)
+    experiment_data = _build_experiment_data(
+        source_experiment,
+        items,
+        optimization_id_remap=optimization_id_remap or {},
+        result=result,
+    )
 
     target_version_id = version_remap.get(source_experiment.dataset_version_id or "")
 
@@ -1427,7 +1448,11 @@ def _emit_spans_for_trace(
 
 
 def _build_experiment_data(
-    source: ExperimentPublic, items: List[experiment_item.ExperimentItemContent]
+    source: ExperimentPublic,
+    items: List[experiment_item.ExperimentItemContent],
+    *,
+    optimization_id_remap: Dict[str, str],
+    result: ExperimentCascadeResult,
 ) -> ExperimentData:
     """Adapt the REST ``ExperimentPublic`` + items into the
     ``ExperimentData`` dataclass that ``recreate_experiment`` consumes.
@@ -1436,6 +1461,14 @@ def _build_experiment_data(
     the BE schema field names; we mirror that here so ``recreate_experiment``
     can read fields like ``type`` / ``evaluation_method`` / ``optimization_id``
     / ``tags`` / ``metadata`` / ``dataset_name`` verbatim.
+
+    ``optimization_id`` is re-pointed at the destination optimization id
+    via ``optimization_id_remap`` (populated by the prior
+    ``CascadeOptimizations`` action). If the source experiment carries an
+    ``optimization_id`` but the remap doesn't have an entry, the field is
+    omitted to avoid a dangling-pointer write and
+    ``experiments_with_orphan_optimization_id`` is incremented for the
+    audit — this only happens if planner ordering was broken.
 
     Per-item payload carries only the FK fields. The BE's ``ExperimentItem``
     Write view accepts only ``id`` / ``experiment_id`` / ``dataset_item_id``
@@ -1450,12 +1483,6 @@ def _build_experiment_data(
     dedicated ``assertion_results.store_assertions_batch`` endpoint scoped
     to the new trace id); the BE surfaces the rest on read.
     """
-    # ``optimization_id`` is intentionally omitted from the payload: Slice 3
-    # doesn't cascade the optimization entity (Slice 4 owns it), so even if
-    # the source experiment carried one, forwarding it would produce a
-    # dangling pointer at the destination. ``recreate_experiment`` also
-    # drops it via the migrate-path guard; omitting it here keeps the
-    # intent visible at the call site too.
     experiment_dict: Dict[str, Any] = {
         "id": source.id,
         "name": source.name,
@@ -1469,6 +1496,25 @@ def _build_experiment_data(
             source.evaluation_method if source.evaluation_method else "dataset"
         ),
     }
+
+    source_optimization_id = source.optimization_id
+    if source_optimization_id:
+        destination_optimization_id = optimization_id_remap.get(source_optimization_id)
+        if destination_optimization_id:
+            experiment_dict["optimization_id"] = destination_optimization_id
+        else:
+            # Defensive: CascadeOptimizations runs before CascadeExperiments,
+            # so the remap should always contain this id. Log loudly and
+            # omit the field rather than write a dangling FK.
+            LOGGER.warning(
+                "Source experiment %s carries optimization_id %s with no "
+                "entry in optimization_id_remap; omitting from destination "
+                "payload. Planner ordering is likely broken.",
+                source.id,
+                source_optimization_id,
+            )
+            result.experiments_with_orphan_optimization_id += 1
+
     items_dicts = [
         {
             "id": item.id,

--- a/sdks/python/src/opik/cli/migrate/datasets/optimizations.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/optimizations.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 import opik.id_helpers as id_helpers_module
 from opik.api_objects import rest_helpers
@@ -53,6 +53,13 @@ LOGGER = logging.getLogger(__name__)
 # request flood (production has tens to low-hundreds of optimizations
 # per dataset at most).
 _OPTIMIZATION_PAGE_SIZE = 100
+
+# Progress callback: ``(completed, total, label)`` -- fired once before
+# each optimization with ``completed`` = optimizations done so far.
+# ``label="done"`` signals the final tick (executor uses it to mark the
+# bar at 100% cleanly). Mirrors the shape used by ``replay_all_versions``
+# and the Slice 3 experiment cascade.
+ProgressCallback = Callable[[int, int, str], None]
 
 
 @dataclass
@@ -79,9 +86,14 @@ def cascade_optimizations(
     target_dataset_name: str,
     target_project_name: str,
     audit: AuditLog,
+    progress_callback: Optional[ProgressCallback] = None,
 ) -> OptimizationCascadeResult:
     """Enumerate source optimizations referencing ``source_dataset_id``
     and recreate each one at the destination with a fresh id.
+
+    ``progress_callback(completed, total, label)`` fires once before each
+    optimization so callers can drive a progress bar; matches the shape
+    used by ``replay_all_versions`` and the experiment cascade.
 
     Returns
     -------
@@ -104,9 +116,19 @@ def cascade_optimizations(
             "No optimizations reference dataset %s; cascade is a no-op.",
             source_dataset_id,
         )
+        # Fire one terminal callback so callers can finalize a progress
+        # display (e.g. close a Rich Progress block) even when there's
+        # nothing to migrate.
+        if progress_callback is not None:
+            progress_callback(0, 0, "done")
         return result
 
-    for optimization in source_optimizations:
+    total = len(source_optimizations)
+    for index, optimization in enumerate(source_optimizations):
+        label = optimization.name or optimization.id or f"<optimization[{index}]>"
+        if progress_callback is not None:
+            progress_callback(index, total, label)
+
         source_id = optimization.id
         if not source_id:
             # Defensive: the BE should always return an id. Skip rather
@@ -167,6 +189,9 @@ def cascade_optimizations(
                 "optimization_status": optimization.status,
             },
         )
+
+    if progress_callback is not None:
+        progress_callback(total, total, "done")
 
     return result
 

--- a/sdks/python/src/opik/cli/migrate/datasets/optimizations.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/optimizations.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Optional
+from typing import Dict, List, Optional
 
 import opik.id_helpers as id_helpers_module
 from opik.api_objects import rest_helpers
@@ -44,6 +44,7 @@ from opik.rest_api.types.optimization_studio_config_write import (
 )
 
 from ..audit import AuditLog
+from ._progress import ProgressCallback
 
 LOGGER = logging.getLogger(__name__)
 
@@ -53,13 +54,6 @@ LOGGER = logging.getLogger(__name__)
 # request flood (production has tens to low-hundreds of optimizations
 # per dataset at most).
 _OPTIMIZATION_PAGE_SIZE = 100
-
-# Progress callback: ``(completed, total, label)`` -- fired once before
-# each optimization with ``completed`` = optimizations done so far.
-# ``label="done"`` signals the final tick (executor uses it to mark the
-# bar at 100% cleanly). Mirrors the shape used by ``replay_all_versions``
-# and the Slice 3 experiment cascade.
-ProgressCallback = Callable[[int, int, str], None]
 
 
 @dataclass

--- a/sdks/python/src/opik/cli/migrate/datasets/optimizations.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/optimizations.py
@@ -1,0 +1,215 @@
+"""Optimization cascade for ``opik migrate dataset`` (Slice 5).
+
+Recreates every optimization referencing the source dataset under the
+destination project so the destination's Optimization Studio shows the
+same rows + trial groupings as the source. Runs AFTER ``ReplayVersions``
+and BEFORE ``CascadeExperiments``: the experiment cascade reads the
+populated ``plan.optimization_id_remap`` to re-point each experiment's
+``optimization_id`` FK at the destination optimization id.
+
+Optimization is a real BE entity (its own UUID, own row in
+``OptimizationDAO``, own ``dataset_id`` / ``project_id`` FKs). The
+"group" view in the UI is computed by the BE at read time from
+``numTrials`` + per-experiment aggregates; the persisted shape is one
+Optimization row + N Experiment rows where
+``Experiment.optimization_id == Optimization.id``.
+
+Source-side enumeration uses ``find_optimizations(dataset_id=...)``
+which is project-agnostic, mirroring how ``find_experiments`` works in
+Slice 3 — cross-project optimizations are migrated transparently with
+no extra plumbing.
+
+Aggregated stats (``numTrials``, ``feedbackScores``, ``experimentScores``,
+``baseline*`` / ``best*``, ``totalOptimizationCost``) are READ-ONLY on
+the BE and recomputed from constituent experiments at read time. They're
+NOT forwarded to ``create_optimization`` — the BE silently drops them
+and the destination row would carry stale numbers if it didn't.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import opik.id_helpers as id_helpers_module
+from opik.api_objects import rest_helpers
+from opik.rest_api import OpikApi
+from opik.rest_api.types.optimization_public import OptimizationPublic
+from opik.rest_api.types.optimization_studio_config_public import (
+    OptimizationStudioConfigPublic,
+)
+from opik.rest_api.types.optimization_studio_config_write import (
+    OptimizationStudioConfigWrite,
+)
+
+from ..audit import AuditLog
+
+LOGGER = logging.getLogger(__name__)
+
+# ``find_optimizations`` is paginated; the cascade walks it to
+# exhaustion. 100 is the same page size used by the Slice 3 experiment
+# cascade, which keeps the per-call payload small without producing a
+# request flood (production has tens to low-hundreds of optimizations
+# per dataset at most).
+_OPTIMIZATION_PAGE_SIZE = 100
+
+
+@dataclass
+class OptimizationCascadeResult:
+    """Aggregated outcome of one ``CascadeOptimizations`` action.
+
+    Populated as the cascade walks source optimizations. ``id_remap`` is
+    copied onto ``plan.optimization_id_remap`` by the executor so the
+    subsequent ``CascadeExperiments`` action can read it when re-pointing
+    each experiment's ``optimization_id`` FK.
+    """
+
+    id_remap: Dict[str, str] = field(default_factory=dict)
+    optimizations_total: int = 0
+    optimizations_migrated: int = 0
+    optimizations_skipped: int = 0
+    skipped_optimizations: List[Dict[str, str]] = field(default_factory=list)
+
+
+def cascade_optimizations(
+    rest_client: OpikApi,
+    *,
+    source_dataset_id: str,
+    target_dataset_name: str,
+    target_project_name: str,
+    audit: AuditLog,
+) -> OptimizationCascadeResult:
+    """Enumerate source optimizations referencing ``source_dataset_id``
+    and recreate each one at the destination with a fresh id.
+
+    Returns
+    -------
+    OptimizationCascadeResult
+        Carries ``id_remap`` (source optimization id -> newly-minted
+        destination optimization id) and per-action counters. The
+        executor copies ``id_remap`` onto ``plan.optimization_id_remap``
+        so ``CascadeExperiments`` can read it when re-pointing
+        experiment FK references.
+    """
+    result = OptimizationCascadeResult()
+
+    source_optimizations = list(
+        _list_source_optimizations(rest_client, source_dataset_id)
+    )
+    result.optimizations_total = len(source_optimizations)
+
+    if not source_optimizations:
+        LOGGER.info(
+            "No optimizations reference dataset %s; cascade is a no-op.",
+            source_dataset_id,
+        )
+        return result
+
+    for optimization in source_optimizations:
+        source_id = optimization.id
+        if not source_id:
+            # Defensive: the BE should always return an id. Skip rather
+            # than fail — we can't build a remap entry without a source
+            # id, and other optimizations are still recoverable.
+            LOGGER.warning(
+                "Source optimization missing id; skipping. payload=%r",
+                optimization,
+            )
+            result.optimizations_skipped += 1
+            result.skipped_optimizations.append(
+                {
+                    "id": "",
+                    "name": optimization.name or "",
+                    "reason": "source optimization missing id",
+                }
+            )
+            continue
+
+        destination_id = id_helpers_module.generate_id()
+        studio_config_write = _studio_config_public_to_write(optimization.studio_config)
+
+        # Read-only aggregates (num_trials, feedback_scores, baseline_*,
+        # best_*, total_optimization_cost) are intentionally omitted —
+        # the BE recomputes them from constituent experiments at read
+        # time and silently drops them on write.
+        rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+            lambda src=optimization, new_id=destination_id, cfg=studio_config_write: (
+                rest_client.optimizations.create_optimization(
+                    id=new_id,
+                    name=src.name,
+                    dataset_name=target_dataset_name,
+                    project_name=target_project_name,
+                    objective_name=src.objective_name,
+                    status=src.status,
+                    metadata=src.metadata,
+                    studio_config=cfg,
+                    last_updated_at=src.last_updated_at,
+                )
+            )
+        )
+
+        result.id_remap[source_id] = destination_id
+        result.optimizations_migrated += 1
+
+        audit.record(
+            type="migrate_optimization",
+            status="ok",
+            details={
+                "type": "migrate_optimization",
+                "source_id": source_id,
+                "destination_id": destination_id,
+                "name": optimization.name,
+                "objective_name": optimization.objective_name,
+                # Use ``optimization_status`` rather than ``status`` so the
+                # entry.update(details) merge in AuditLog.record doesn't
+                # shadow the audit-level success/failure status.
+                "optimization_status": optimization.status,
+            },
+        )
+
+    return result
+
+
+def _studio_config_public_to_write(
+    public: Optional[OptimizationStudioConfigPublic],
+) -> Optional[OptimizationStudioConfigWrite]:
+    """Reconstruct the Read variant as the Write variant.
+
+    The two Fern-generated types are structurally identical (same
+    fields, same nesting); only the class identity differs. Pydantic's
+    ``model_validate`` over ``model_dump`` round-trips the fidelity
+    without us having to hand-map each field. ``extra="allow"`` on both
+    sides preserves any forward-compatible BE additions.
+    """
+    if public is None:
+        return None
+    return OptimizationStudioConfigWrite.model_validate(public.model_dump())
+
+
+def _list_source_optimizations(
+    rest_client: OpikApi, source_dataset_id: str
+) -> List[OptimizationPublic]:
+    """Page through ``find_optimizations(dataset_id=...)`` to exhaustion.
+
+    No filtering by project: optimizations are project-scoped at write
+    time but tied to the dataset, so a single ``find_optimizations`` call
+    returns every row regardless of which project it lives in (mirrors
+    how ``find_experiments`` works in Slice 3).
+    """
+    collected: List[OptimizationPublic] = []
+    page = 1
+    while True:
+        response = rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+            lambda: rest_client.optimizations.find_optimizations(
+                dataset_id=source_dataset_id,
+                page=page,
+                size=_OPTIMIZATION_PAGE_SIZE,
+            )
+        )
+        page_content = response.content or []
+        collected.extend(page_content)
+        if len(page_content) < _OPTIMIZATION_PAGE_SIZE:
+            break
+        page += 1
+    return collected

--- a/sdks/python/src/opik/cli/migrate/datasets/planner.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/planner.py
@@ -84,6 +84,31 @@ class ReplayVersions:
 
 
 @dataclass(frozen=True)
+class CascadeOptimizations:
+    """Cascade every optimization referencing the source dataset.
+
+    Umbrella action ordered AFTER ``ReplayVersions`` and BEFORE
+    ``CascadeExperiments`` so the destination optimization ids are known
+    by the time experiments are recreated and can FK to them via
+    ``plan.optimization_id_remap``.
+
+    Source-side reads use ``find_optimizations(dataset_id=...)`` which is
+    project-agnostic: a single query returns every optimization tied to
+    the source dataset regardless of which project it lives in (mirrors
+    ``find_experiments(dataset_id=...)`` in Slice 3). Destination-side
+    each optimization is recreated under ``dest_project_name`` with a
+    fresh client-side UUID.
+
+    Empty optimizations (zero constituent experiments) are migrated as
+    well — they're still user-visible rows in the Optimization Studio UI.
+    """
+
+    source_dataset_id: str
+    dest_name: str
+    dest_project_name: str
+
+
+@dataclass(frozen=True)
 class CascadeExperiments:
     """Cascade every experiment referencing the source dataset.
 
@@ -91,8 +116,10 @@ class CascadeExperiments:
     over every experiment that referenced it. Reuses ``ReplayVersions``'s
     ``version_remap`` and ``item_id_remap`` (already populated on the plan)
     to rewrite each experiment's ``dataset_version_id`` /
-    ``dataset_item_id`` FK fields, and builds its own ``trace_id`` remap as
-    traces ride along with the experiments.
+    ``dataset_item_id`` FK fields, reads ``CascadeOptimizations``'s
+    ``optimization_id_remap`` to re-point each experiment's
+    ``optimization_id``, and builds its own ``trace_id`` remap as traces
+    ride along with the experiments.
 
     Per-experiment failures stop the cascade (the audit log captures
     partial progress on the ``failed`` entry). Per-item missing-trace /
@@ -134,6 +161,7 @@ class MigrationPlan(BaseMigrationPlan):
     version_remap: Dict[str, str] = field(default_factory=dict)
     item_id_remap: Dict[str, str] = field(default_factory=dict)
     trace_id_remap: Dict[str, str] = field(default_factory=dict)
+    optimization_id_remap: Dict[str, str] = field(default_factory=dict)
 
 
 def build_dataset_plan(
@@ -155,9 +183,14 @@ def build_dataset_plan(
       3. ``ReplayVersions`` — replays every source dataset version onto
          the target, populating ``plan.version_remap`` and
          ``plan.item_id_remap``.
-      4. ``CascadeExperiments`` — recreates every experiment referencing
+      4. ``CascadeOptimizations`` — recreates every optimization
+         referencing the source dataset under the destination project,
+         populating ``plan.optimization_id_remap`` so the next action can
+         re-point experiment FK references.
+      5. ``CascadeExperiments`` — recreates every experiment referencing
          the source dataset under the destination project, with traces +
-         spans riding along.
+         spans riding along, and re-points each experiment's
+         ``optimization_id`` via ``plan.optimization_id_remap``.
     """
     # Fail fast if --to-project doesn't exist. Catches typos before any
     # rename/create/copy work, and prevents auto-creating a stray project.
@@ -229,9 +262,23 @@ def build_dataset_plan(
         )
     )
 
-    # Cascade experiments must run AFTER ReplayVersions so that
-    # plan.version_remap / plan.item_id_remap are populated when the
-    # cascade reads them.
+    # CascadeOptimizations runs AFTER ReplayVersions (the destination
+    # dataset exists by now) and BEFORE CascadeExperiments so the
+    # experiment-write phase can FK to the new destination optimization
+    # ids via plan.optimization_id_remap. Action is always emitted; it's
+    # a no-op when zero optimizations reference the source dataset.
+    plan.actions.append(
+        CascadeOptimizations(
+            source_dataset_id=source.id,
+            dest_name=source.name,
+            dest_project_name=to_project,
+        )
+    )
+
+    # Cascade experiments must run AFTER ReplayVersions and
+    # CascadeOptimizations so plan.version_remap / plan.item_id_remap /
+    # plan.optimization_id_remap are populated when the cascade reads
+    # them.
     plan.actions.append(
         CascadeExperiments(
             source_dataset_id=source.id,

--- a/sdks/python/src/opik/cli/migrate/datasets/version_replay.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/version_replay.py
@@ -42,7 +42,7 @@ import json
 import logging
 import sys
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 
 from opik.api_objects import rest_helpers, rest_stream_parser
 from opik.rest_api import OpikApi
@@ -55,6 +55,7 @@ from opik.rest_api.types import (
 
 from ..audit import AuditLog
 from ..errors import ReplayError
+from ._progress import ProgressCallback
 
 LOGGER = logging.getLogger(__name__)
 
@@ -139,7 +140,7 @@ def replay_all_versions(
     dest_name: str,
     dest_project_name: str,
     audit: AuditLog,
-    progress_callback: Optional[Callable[[int, int, str], None]] = None,
+    progress_callback: Optional[ProgressCallback] = None,
 ) -> ReplayResult:
     """Replay every source version onto the destination in chronological order.
 

--- a/sdks/python/src/opik/cli/migrate/main.py
+++ b/sdks/python/src/opik/cli/migrate/main.py
@@ -25,6 +25,7 @@ from .audit import AuditLog, default_audit_path
 from .datasets.executor import execute_plan, record_planned
 from .datasets.planner import (
     CascadeExperiments,
+    CascadeOptimizations,
     CreateDestination,
     MigrationPlan,
     RenameSource,
@@ -307,6 +308,12 @@ def _print_plan(plan: MigrationPlan) -> None:
                 str(idx),
                 "replay versions",
                 f"{action.source_name_after_rename} → {action.dest_name} (full history)",
+            )
+        elif isinstance(action, CascadeOptimizations):
+            table.add_row(
+                str(idx),
+                "cascade optimizations",
+                f"optimizations → project {action.dest_project_name}",
             )
         elif isinstance(action, CascadeExperiments):
             table.add_row(

--- a/sdks/python/tests/e2e/cli/conftest.py
+++ b/sdks/python/tests/e2e/cli/conftest.py
@@ -338,6 +338,7 @@ def seed_experiment_with_trace_tree(
     spans_per_trace: int = 2,
     feedback_scores_per_trace: Optional[List[Dict[str, Any]]] = None,
     per_item_extras: Optional[List[Dict[str, Any]]] = None,
+    optimization_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Create a source experiment + one trace per ``item_id`` + a small span
     tree per trace, then attach everything via ``create_experiment_items``.
@@ -463,17 +464,20 @@ def seed_experiment_with_trace_tree(
     import opik.id_helpers as _id_helpers
 
     new_experiment_id = _id_helpers.generate_id()
-    rest_client.experiments.create_experiment(
-        id=new_experiment_id,
-        name=experiment_name,
-        dataset_name=dataset_name,
-        type=experiment_type,
-        evaluation_method=evaluation_method,
-        tags=experiment_tags,
-        metadata=experiment_config,
-        dataset_version_id=dataset_version_id,
-        project_name=project_name,
-    )
+    create_experiment_kwargs: Dict[str, Any] = {
+        "id": new_experiment_id,
+        "name": experiment_name,
+        "dataset_name": dataset_name,
+        "type": experiment_type,
+        "evaluation_method": evaluation_method,
+        "tags": experiment_tags,
+        "metadata": experiment_config,
+        "dataset_version_id": dataset_version_id,
+        "project_name": project_name,
+    }
+    if optimization_id is not None:
+        create_experiment_kwargs["optimization_id"] = optimization_id
+    rest_client.experiments.create_experiment(**create_experiment_kwargs)
 
     extras_list = per_item_extras or [{} for _ in item_ids]
     if len(extras_list) != len(item_ids):

--- a/sdks/python/tests/e2e/cli/test_migrate_dataset_optimizations_e2e.py
+++ b/sdks/python/tests/e2e/cli/test_migrate_dataset_optimizations_e2e.py
@@ -1,0 +1,269 @@
+"""End-to-end test for ``opik migrate dataset`` Slice 5 — optimization cascade.
+
+Optimization is a real BE entity, not a logical group-by: it has its own
+UUID, its own row in ``OptimizationDAO``, and its own ``dataset_id`` /
+``project_id`` FKs. The Optimization Studio "group" view in the UI is
+computed by the BE at read time from each experiment's ``optimization_id``
+FK plus the optimization's aggregated stats (``numTrials``, etc.); the
+persisted shape is one Optimization row + N Experiment rows where
+``Experiment.optimization_id == Optimization.id``.
+
+Slice 5's contract: when ``opik migrate dataset`` runs, every optimization
+referencing the source dataset is recreated under the destination project
+with a fresh id, and every experiment carrying that ``optimization_id``
+is recreated at the destination with its FK re-pointed at the new
+destination optimization id. The destination's Optimization Studio shows
+the same rows + trial groupings as the source.
+
+Shape pinned by this test:
+
+  1. Source dataset in project A with 3 items
+  2. One Optimization (``opt``) on the source dataset
+  3. Two TRIAL experiments seeded as ``opt``'s trials (each has 1 item)
+  4. One CONTROL ``regular`` experiment with no optimization_id (1 item)
+  5. Run ``opik migrate dataset ... --to-project=<destination>``
+  6. Assert:
+     a. Destination has exactly one optimization tied to the
+        destination dataset, with a fresh id (NOT the source id).
+     b. Both trial experiments are recreated under the destination
+        project with their ``optimization_id`` pointing at the
+        destination optimization (NOT the source optimization id).
+     c. The control experiment has no ``optimization_id`` (untouched).
+     d. The destination optimization's fidelity fields
+        (``name`` / ``objective_name`` / ``status``) match the source.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+import opik
+import opik.id_helpers as id_helpers_module
+from opik.rest_api import OpikApi
+
+from ...conftest import random_chars
+from ...testlib import generate_project_name
+from .conftest import (
+    create_dataset_shell,
+    find_destination_experiment,
+    run_migrate_cli,
+    seed_experiment_with_trace_tree,
+    stream_items_wire,
+)
+
+PROJECT_NAME = generate_project_name("e2e", __name__)
+
+
+@pytest.fixture
+def dataset_name() -> Iterator[str]:
+    yield f"e2e-migrate-opt-{random_chars()}"
+
+
+def _create_source_optimization(
+    rest: OpikApi,
+    *,
+    dataset_name: str,
+    project_name: str,
+    optimization_name: str,
+) -> str:
+    """Create an Optimization tied to ``dataset_name`` in ``project_name``
+    and return its id. The cascade will discover this via
+    ``find_optimizations(dataset_id=...)``.
+    """
+    optimization_id = id_helpers_module.generate_id()
+    rest.optimizations.create_optimization(
+        id=optimization_id,
+        name=optimization_name,
+        dataset_name=dataset_name,
+        project_name=project_name,
+        objective_name="accuracy",
+        status="completed",
+    )
+    return optimization_id
+
+
+def test_migrate_dataset__optimization_cascade__trials_grouped_at_destination(
+    opik_client: opik.Opik,
+    source_project_name: str,
+    target_project_name: str,
+    dataset_name: str,
+    tmp_path: Path,
+) -> None:
+    rest = opik_client.rest_client
+
+    # ── Seed the source dataset with 3 items (2 for trials, 1 for control) ──
+    from opik import id_helpers
+    from opik.rest_api.types.dataset_item_write import DatasetItemWrite
+
+    source_dataset_id = create_dataset_shell(rest, dataset_name, source_project_name)
+    rest.datasets.create_or_update_dataset_items(
+        dataset_id=source_dataset_id,
+        items=[
+            DatasetItemWrite(source="manual", data={"q": "trial-a", "a": "A"}),
+            DatasetItemWrite(source="manual", data={"q": "trial-b", "a": "B"}),
+            DatasetItemWrite(source="manual", data={"q": "control", "a": "C"}),
+        ],
+        batch_group_id=id_helpers.generate_id(),
+    )
+    v1 = rest.datasets.list_dataset_versions(
+        id=source_dataset_id, page=1, size=1
+    ).content[0]
+
+    v1_items = stream_items_wire(
+        rest,
+        dataset_name=dataset_name,
+        project_name=source_project_name,
+        version_hash=v1.version_hash,
+    )
+    by_q = {(it.data or {}).get("q"): it.id for it in v1_items}
+    trial_a_item_id = by_q["trial-a"]
+    trial_b_item_id = by_q["trial-b"]
+    control_item_id = by_q["control"]
+    assert trial_a_item_id and trial_b_item_id and control_item_id
+
+    # ── Create the source optimization ──
+    optimization_name = f"e2e-opt-{random_chars()}"
+    source_optimization_id = _create_source_optimization(
+        rest,
+        dataset_name=dataset_name,
+        project_name=source_project_name,
+        optimization_name=optimization_name,
+    )
+
+    # ── Seed two trial experiments pointing at the optimization ──
+    # ``experiment_type="trial"`` is what the Optimization Studio UI
+    # filters on for the trial sub-list under an optimization row.
+    trial_a_name = f"trial-a-{random_chars()}"
+    trial_b_name = f"trial-b-{random_chars()}"
+    seed_experiment_with_trace_tree(
+        rest,
+        experiment_name=trial_a_name,
+        dataset_name=dataset_name,
+        dataset_id=source_dataset_id,
+        dataset_version_id=v1.id,
+        project_name=source_project_name,
+        item_ids=[trial_a_item_id],
+        experiment_type="trial",
+        optimization_id=source_optimization_id,
+    )
+    seed_experiment_with_trace_tree(
+        rest,
+        experiment_name=trial_b_name,
+        dataset_name=dataset_name,
+        dataset_id=source_dataset_id,
+        dataset_version_id=v1.id,
+        project_name=source_project_name,
+        item_ids=[trial_b_item_id],
+        experiment_type="trial",
+        optimization_id=source_optimization_id,
+    )
+
+    # ── Seed a control regular experiment with no optimization_id ──
+    # Pins that the cascade only touches experiments that actually had
+    # an optimization_id; the control experiment must round-trip with
+    # no optimization_id at the destination.
+    control_name = f"control-{random_chars()}"
+    seed_experiment_with_trace_tree(
+        rest,
+        experiment_name=control_name,
+        dataset_name=dataset_name,
+        dataset_id=source_dataset_id,
+        dataset_version_id=v1.id,
+        project_name=source_project_name,
+        item_ids=[control_item_id],
+        experiment_type="regular",
+        optimization_id=None,
+    )
+
+    # ── Run the migration ──
+    audit_path = tmp_path / "audit.json"
+    result = run_migrate_cli(
+        [
+            "dataset",
+            dataset_name,
+            "--from-project",
+            source_project_name,
+            "--to-project",
+            target_project_name,
+        ],
+        audit_log_path=str(audit_path),
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    # ── Verify destination optimization fidelity ──
+    dest_dataset = rest.datasets.get_dataset_by_identifier(
+        dataset_name=dataset_name, project_name=target_project_name
+    )
+    dest_optimizations_page = rest.optimizations.find_optimizations(
+        dataset_id=dest_dataset.id, page=1, size=10
+    )
+    dest_optimizations = list(dest_optimizations_page.content or [])
+    assert len(dest_optimizations) == 1, (
+        f"expected exactly one destination optimization tied to dataset "
+        f"{dest_dataset.id}, got {len(dest_optimizations)}"
+    )
+    dest_optimization = dest_optimizations[0]
+
+    # Fresh destination id -- migrate is copy-not-move; source id must
+    # not be reused.
+    assert dest_optimization.id != source_optimization_id, (
+        "destination optimization id must be fresh; source id reused"
+    )
+    # Fidelity fields round-trip verbatim.
+    assert dest_optimization.name == optimization_name
+    assert dest_optimization.objective_name == "accuracy"
+    assert dest_optimization.status == "completed"
+    assert dest_optimization.dataset_id == dest_dataset.id
+
+    # ── Verify trial experiments are re-pointed at the destination optimization ──
+    dest_trial_a = find_destination_experiment(
+        rest,
+        destination_dataset_id=dest_dataset.id,
+        experiment_name=trial_a_name,
+    )
+    dest_trial_b = find_destination_experiment(
+        rest,
+        destination_dataset_id=dest_dataset.id,
+        experiment_name=trial_b_name,
+    )
+    assert dest_trial_a.optimization_id == dest_optimization.id, (
+        f"trial a should FK to destination optimization {dest_optimization.id}, "
+        f"got {dest_trial_a.optimization_id}"
+    )
+    assert dest_trial_b.optimization_id == dest_optimization.id, (
+        f"trial b should FK to destination optimization {dest_optimization.id}, "
+        f"got {dest_trial_b.optimization_id}"
+    )
+    # Defence-in-depth: neither trial should still point at the source id.
+    for dest_trial, label in ((dest_trial_a, "a"), (dest_trial_b, "b")):
+        assert dest_trial.optimization_id != source_optimization_id, (
+            f"trial {label}'s destination optimization_id must NOT be the "
+            f"source id (cascade failed to remap)"
+        )
+
+    # ── Verify control experiment is untouched (no optimization_id) ──
+    dest_control = find_destination_experiment(
+        rest,
+        destination_dataset_id=dest_dataset.id,
+        experiment_name=control_name,
+    )
+    assert not dest_control.optimization_id, (
+        f"control experiment must not have an optimization_id at the "
+        f"destination, got {dest_control.optimization_id!r}"
+    )
+
+    # ── Audit log carries per-optimization records ──
+    import json
+
+    audit = json.loads(audit_path.read_text())
+    migrate_optimization_records = [
+        a for a in audit["actions"] if a["type"] == "migrate_optimization"
+    ]
+    assert len(migrate_optimization_records) == 1
+    record = migrate_optimization_records[0]
+    assert record["status"] == "ok"
+    assert record["source_id"] == source_optimization_id
+    assert record["destination_id"] == dest_optimization.id

--- a/sdks/python/tests/unit/cli/test_migrate_dataset_experiments_cascade.py
+++ b/sdks/python/tests/unit/cli/test_migrate_dataset_experiments_cascade.py
@@ -712,9 +712,14 @@ class TestCascadeExperiments:
         # Other metadata keys preserved.
         assert kwargs["experiment_config"].get("other") == "keep"
 
-    def test_optimization_id__stripped_on_destination(self) -> None:
-        # Slice 3 doesn't cascade the optimization entity, so any
-        # ``optimization_id`` pointer is dropped to avoid a dangling FK.
+    def test_optimization_id__remapped_to_destination_when_remap_has_entry(
+        self,
+    ) -> None:
+        # Slice 5 cascades the optimization entity. The experiment cascade
+        # consults ``optimization_id_remap`` (populated by the prior
+        # CascadeOptimizations action) and forwards the destination
+        # optimization id so the destination experiment binds to the
+        # destination optimization row.
         experiment = _Experiment(
             id="src-exp-1",
             optimization_id="src-opt-abc",
@@ -734,7 +739,7 @@ class TestCascadeExperiments:
         )
         client = _client_with_recreate_capture(rest_client)
 
-        cascade_experiments(
+        result = cascade_experiments(
             client,
             rest_client,
             source_dataset_id="src-dataset-1",
@@ -742,13 +747,100 @@ class TestCascadeExperiments:
             target_project_name="DestProject",
             version_remap={"src-v-1": "dest-v-1"},
             item_id_remap={"src-ds-item-1": "dest-ds-item-1"},
+            optimization_id_remap={"src-opt-abc": "dest-opt-xyz"},
             audit=_audit(),
         )
 
         kwargs = client.create_experiment.call_args.kwargs
-        assert "optimization_id" not in kwargs, (
-            "optimization_id should not be forwarded on the migrate path"
+        assert kwargs["optimization_id"] == "dest-opt-xyz"
+        # Orphan counter stays zero on the happy path.
+        assert result.experiments_with_orphan_optimization_id == 0
+
+    def test_optimization_id__missing_remap__omitted_with_orphan_counter(
+        self,
+    ) -> None:
+        # Defensive path: source experiment carries an ``optimization_id``
+        # but the remap doesn't have an entry. The field is omitted from
+        # the destination payload (no dangling FK) and the orphan
+        # counter increments so the audit log surfaces the planner
+        # ordering bug. Experiment is still created (degraded fidelity,
+        # not a hard failure).
+        experiment = _Experiment(
+            id="src-exp-1",
+            optimization_id="src-opt-abc",
+            dataset_version_id="src-v-1",
         )
+        item = _ExperimentItem(
+            id="src-item-1",
+            experiment_id="src-exp-1",
+            trace_id="src-trace-1",
+            dataset_item_id="src-ds-item-1",
+        )
+        rest_client = _cascade_rest_client(
+            experiments_by_dataset={"src-dataset-1": [experiment]},
+            items_by_experiment={"experiment": [item]},
+            traces_by_id={"src-trace-1": _Trace(id="src-trace-1")},
+            spans_by_trace={"src-trace-1": []},
+        )
+        client = _client_with_recreate_capture(rest_client)
+
+        result = cascade_experiments(
+            client,
+            rest_client,
+            source_dataset_id="src-dataset-1",
+            target_dataset_name="MyDataset",
+            target_project_name="DestProject",
+            version_remap={"src-v-1": "dest-v-1"},
+            item_id_remap={"src-ds-item-1": "dest-ds-item-1"},
+            optimization_id_remap={},  # empty -> orphan path
+            audit=_audit(),
+        )
+
+        kwargs = client.create_experiment.call_args.kwargs
+        assert "optimization_id" not in kwargs
+        assert result.experiments_with_orphan_optimization_id == 1
+        assert result.experiments_migrated == 1
+
+    def test_optimization_id__source_has_none__remap_not_consulted(
+        self,
+    ) -> None:
+        # Source experiment has no ``optimization_id`` at all -- field
+        # must not appear on the destination payload and the orphan
+        # counter must stay zero regardless of remap contents.
+        experiment = _Experiment(
+            id="src-exp-1",
+            optimization_id=None,
+            dataset_version_id="src-v-1",
+        )
+        item = _ExperimentItem(
+            id="src-item-1",
+            experiment_id="src-exp-1",
+            trace_id="src-trace-1",
+            dataset_item_id="src-ds-item-1",
+        )
+        rest_client = _cascade_rest_client(
+            experiments_by_dataset={"src-dataset-1": [experiment]},
+            items_by_experiment={"experiment": [item]},
+            traces_by_id={"src-trace-1": _Trace(id="src-trace-1")},
+            spans_by_trace={"src-trace-1": []},
+        )
+        client = _client_with_recreate_capture(rest_client)
+
+        result = cascade_experiments(
+            client,
+            rest_client,
+            source_dataset_id="src-dataset-1",
+            target_dataset_name="MyDataset",
+            target_project_name="DestProject",
+            version_remap={"src-v-1": "dest-v-1"},
+            item_id_remap={"src-ds-item-1": "dest-ds-item-1"},
+            optimization_id_remap={"unrelated": "noise"},
+            audit=_audit(),
+        )
+
+        kwargs = client.create_experiment.call_args.kwargs
+        assert "optimization_id" not in kwargs
+        assert result.experiments_with_orphan_optimization_id == 0
 
     def test_trace_id_remap__populated_and_project_rewritten_on_destination(
         self,

--- a/sdks/python/tests/unit/cli/test_migrate_dataset_optimizations_cascade.py
+++ b/sdks/python/tests/unit/cli/test_migrate_dataset_optimizations_cascade.py
@@ -1,0 +1,496 @@
+"""Tests for ``opik migrate dataset`` Slice 5 — optimization cascade.
+
+Slice 5 sits between Slice 2 (``ReplayVersions``) and Slice 3
+(``CascadeExperiments``). It recreates every optimization referencing
+the source dataset under the destination project and populates
+``plan.optimization_id_remap`` so the experiment cascade can re-point
+each experiment's ``optimization_id`` FK.
+
+Scope this module covers (ticket AC for OPIK-6532):
+
+* Optimization fidelity round-trip (name / objective_name / status /
+  metadata / studio_config carried verbatim)
+* READ-ONLY aggregates (num_trials / feedback_scores / baseline_* /
+  best_* / total_optimization_cost) not forwarded
+* Fresh client-side UUID minted per source optimization; ``id_remap``
+  populated with source -> destination
+* Empty optimization (zero trials) round-trips and produces a remap entry
+* Zero-optimization datasets are a no-op (returns empty result, no
+  REST call)
+* Per-optimization ``migrate_optimization`` audit record emitted
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from opik.cli.migrate.audit import AuditLog
+from opik.cli.migrate.datasets import optimizations as optimizations_module
+from opik.cli.migrate.datasets.optimizations import cascade_optimizations
+
+
+# ---------------------------------------------------------------------------
+# Stand-in wire shapes for the cascade's reads.
+#
+# The cascade reads ``OptimizationPublic`` from ``find_optimizations`` and
+# writes via ``create_optimization``. Constructing the real pydantic
+# models would impose ~20 fields per row; the cascade only inspects a
+# handful, so we use plain objects with the fields it actually reads.
+# ---------------------------------------------------------------------------
+
+
+class _Optimization:
+    def __init__(
+        self,
+        *,
+        id: str,
+        name: Optional[str] = "opt",
+        objective_name: str = "accuracy",
+        status: str = "completed",
+        dataset_name: str = "MyDataset",
+        dataset_id: Optional[str] = "src-dataset-1",
+        metadata: Optional[Any] = None,
+        studio_config: Optional[Any] = None,
+        last_updated_at: Optional[Any] = None,
+        # READ-ONLY aggregates -- attached so we can assert the cascade
+        # does NOT forward them on the create call.
+        num_trials: Optional[int] = None,
+        feedback_scores: Optional[List[Any]] = None,
+        experiment_scores: Optional[List[Any]] = None,
+        baseline_objective_score: Optional[float] = None,
+        best_objective_score: Optional[float] = None,
+        baseline_duration: Optional[float] = None,
+        best_duration: Optional[float] = None,
+        baseline_cost: Optional[float] = None,
+        best_cost: Optional[float] = None,
+        total_optimization_cost: Optional[float] = None,
+    ) -> None:
+        self.id = id
+        self.name = name
+        self.objective_name = objective_name
+        self.status = status
+        self.dataset_name = dataset_name
+        self.dataset_id = dataset_id
+        self.metadata = metadata
+        self.studio_config = studio_config
+        self.last_updated_at = last_updated_at
+        self.num_trials = num_trials
+        self.feedback_scores = feedback_scores
+        self.experiment_scores = experiment_scores
+        self.baseline_objective_score = baseline_objective_score
+        self.best_objective_score = best_objective_score
+        self.baseline_duration = baseline_duration
+        self.best_duration = best_duration
+        self.baseline_cost = baseline_cost
+        self.best_cost = best_cost
+        self.total_optimization_cost = total_optimization_cost
+
+
+class _Page:
+    def __init__(self, content: List[_Optimization]) -> None:
+        self.content = content
+
+
+def _audit() -> AuditLog:
+    """Real AuditLog so the cascade's per-optimization ``record`` calls
+    land in a list we can assert on. The audit log carries no side
+    effects until ``write`` is called, so using the real type in tests
+    is cheaper than building a coupled mock."""
+    return AuditLog(command="migrate dataset", args={})
+
+
+def _cascade_rest_client(
+    pages: List[_Page],
+    *,
+    create_side_effect: Optional[Any] = None,
+) -> MagicMock:
+    """Build a rest_client mock for the optimization cascade.
+
+    ``find_optimizations`` is called once per page until a short page
+    breaks the loop. ``create_optimization`` is captured so individual
+    tests can assert on its kwargs.
+    """
+    rest_client = MagicMock()
+    rest_client.optimizations.find_optimizations.side_effect = pages
+    if create_side_effect is not None:
+        rest_client.optimizations.create_optimization.side_effect = create_side_effect
+    else:
+        rest_client.optimizations.create_optimization.return_value = None
+    return rest_client
+
+
+# ---------------------------------------------------------------------------
+# Cascade tests
+# ---------------------------------------------------------------------------
+
+
+class TestCascadeOptimizations:
+    def test_no_source_optimizations__noop_no_remap_no_create_calls(self) -> None:
+        # Empty result page -> no create_optimization calls, empty
+        # remap, counters at zero. Slice 5 always emits the action; the
+        # cascade handles the zero case quietly.
+        rest_client = _cascade_rest_client([_Page([])])
+
+        result = cascade_optimizations(
+            rest_client,
+            source_dataset_id="src-dataset-1",
+            target_dataset_name="MyDataset",
+            target_project_name="DestProject",
+            audit=_audit(),
+        )
+
+        assert result.id_remap == {}
+        assert result.optimizations_total == 0
+        assert result.optimizations_migrated == 0
+        assert result.optimizations_skipped == 0
+        rest_client.optimizations.create_optimization.assert_not_called()
+
+    def test_one_optimization__fidelity_fields_forwarded_and_remap_populated(
+        self,
+    ) -> None:
+        # Full fidelity copy of the fields the BE round-trips:
+        # name, objective_name, status, metadata, studio_config,
+        # last_updated_at. Dest dataset_name + project_name are taken
+        # from the action, NOT from the source row (the source name was
+        # renamed to <name>_v1 by the time the cascade runs).
+        opt = _Optimization(
+            id="src-opt-1",
+            name="overnight-tune",
+            objective_name="f1",
+            status="completed",
+            metadata={"trial_count": 12, "user_note": "kept"},
+            studio_config=None,
+            num_trials=12,
+            baseline_objective_score=0.5,
+            best_objective_score=0.81,
+            total_optimization_cost=4.20,
+        )
+        rest_client = _cascade_rest_client([_Page([opt])])
+
+        result = cascade_optimizations(
+            rest_client,
+            source_dataset_id="src-dataset-1",
+            target_dataset_name="MyDataset",
+            target_project_name="DestProject",
+            audit=_audit(),
+        )
+
+        rest_client.optimizations.create_optimization.assert_called_once()
+        kwargs = rest_client.optimizations.create_optimization.call_args.kwargs
+        # Fresh destination id -- not the source id.
+        assert kwargs["id"] != "src-opt-1"
+        assert kwargs["id"] == result.id_remap["src-opt-1"]
+        # Fidelity fields forwarded verbatim.
+        assert kwargs["name"] == "overnight-tune"
+        assert kwargs["objective_name"] == "f1"
+        assert kwargs["status"] == "completed"
+        assert kwargs["metadata"] == {"trial_count": 12, "user_note": "kept"}
+        # Destination scoping comes from the action, not the source row.
+        assert kwargs["dataset_name"] == "MyDataset"
+        assert kwargs["project_name"] == "DestProject"
+
+    def test_readonly_aggregates__not_forwarded_on_create(self) -> None:
+        # ``num_trials`` / ``feedback_scores`` / ``baseline_*`` / ``best_*``
+        # / ``total_optimization_cost`` are recomputed by the BE at read
+        # time from constituent experiments. The cascade must NOT forward
+        # them -- if it did, they'd be silently dropped on write today
+        # but might persist (with stale numbers) under a future BE
+        # schema change.
+        opt = _Optimization(
+            id="src-opt-1",
+            num_trials=99,
+            feedback_scores=[MagicMock()],
+            experiment_scores=[MagicMock()],
+            baseline_objective_score=0.1,
+            best_objective_score=0.9,
+            baseline_duration=10.0,
+            best_duration=2.0,
+            baseline_cost=1.0,
+            best_cost=0.5,
+            total_optimization_cost=42.0,
+        )
+        rest_client = _cascade_rest_client([_Page([opt])])
+
+        cascade_optimizations(
+            rest_client,
+            source_dataset_id="src-dataset-1",
+            target_dataset_name="MyDataset",
+            target_project_name="DestProject",
+            audit=_audit(),
+        )
+
+        kwargs = rest_client.optimizations.create_optimization.call_args.kwargs
+        for forbidden in (
+            "num_trials",
+            "feedback_scores",
+            "experiment_scores",
+            "baseline_objective_score",
+            "best_objective_score",
+            "baseline_duration",
+            "best_duration",
+            "baseline_cost",
+            "best_cost",
+            "total_optimization_cost",
+        ):
+            assert forbidden not in kwargs, (
+                f"{forbidden} is BE-computed; cascade must not forward it"
+            )
+
+    def test_empty_optimization__zero_trials__still_migrated(self) -> None:
+        # Optimization with zero constituent experiments is still a
+        # user-visible row in the Optimization Studio UI; migrating it
+        # preserves the user's setup even if no trials ran yet.
+        opt = _Optimization(id="src-opt-1", num_trials=0, name="never-ran")
+        rest_client = _cascade_rest_client([_Page([opt])])
+
+        result = cascade_optimizations(
+            rest_client,
+            source_dataset_id="src-dataset-1",
+            target_dataset_name="MyDataset",
+            target_project_name="DestProject",
+            audit=_audit(),
+        )
+
+        assert result.optimizations_migrated == 1
+        assert "src-opt-1" in result.id_remap
+        rest_client.optimizations.create_optimization.assert_called_once()
+
+    def test_multiple_optimizations__each_gets_distinct_destination_id(
+        self,
+    ) -> None:
+        opt1 = _Optimization(id="src-opt-1", name="run-a")
+        opt2 = _Optimization(id="src-opt-2", name="run-b")
+        opt3 = _Optimization(id="src-opt-3", name="run-c")
+        rest_client = _cascade_rest_client([_Page([opt1, opt2, opt3])])
+
+        result = cascade_optimizations(
+            rest_client,
+            source_dataset_id="src-dataset-1",
+            target_dataset_name="MyDataset",
+            target_project_name="DestProject",
+            audit=_audit(),
+        )
+
+        assert result.optimizations_migrated == 3
+        assert set(result.id_remap.keys()) == {
+            "src-opt-1",
+            "src-opt-2",
+            "src-opt-3",
+        }
+        # Destination ids must be unique (fresh UUIDs).
+        assert len(set(result.id_remap.values())) == 3
+
+    def test_audit__per_optimization_record_emitted(self) -> None:
+        # Each successful migration emits a ``migrate_optimization`` audit
+        # record carrying source_id -> destination_id mapping plus
+        # name / objective_name / status so users can trace what moved.
+        opt = _Optimization(
+            id="src-opt-1",
+            name="overnight",
+            objective_name="accuracy",
+            status="completed",
+        )
+        rest_client = _cascade_rest_client([_Page([opt])])
+        audit = _audit()
+
+        cascade_optimizations(
+            rest_client,
+            source_dataset_id="src-dataset-1",
+            target_dataset_name="MyDataset",
+            target_project_name="DestProject",
+            audit=audit,
+        )
+
+        migrate_records = [
+            r for r in audit.actions if r["type"] == "migrate_optimization"
+        ]
+        assert len(migrate_records) == 1
+        record = migrate_records[0]
+        # Audit-level status conveys action success/failure -- must not
+        # be shadowed by the optimization's own status.
+        assert record["status"] == "ok"
+        assert record["source_id"] == "src-opt-1"
+        assert record["destination_id"] != "src-opt-1"
+        assert record["name"] == "overnight"
+        assert record["objective_name"] == "accuracy"
+        # Optimization's own status lives under a non-shadowing key.
+        assert record["optimization_status"] == "completed"
+
+    def test_pagination__exhausts_pages_until_short(self) -> None:
+        # find_optimizations is paginated; the cascade walks until a
+        # short page (< page_size). With page_size=100 in production,
+        # two pages of 100 and a final short page of 50 should fire
+        # three reads in order.
+        page_size = optimizations_module._OPTIMIZATION_PAGE_SIZE
+        page_a = _Page([_Optimization(id=f"src-{i}") for i in range(page_size)])
+        page_b = _Page(
+            [_Optimization(id=f"src-{page_size + i}") for i in range(page_size)]
+        )
+        page_c = _Page([_Optimization(id=f"src-{2 * page_size + i}") for i in range(3)])
+        rest_client = _cascade_rest_client([page_a, page_b, page_c])
+
+        result = cascade_optimizations(
+            rest_client,
+            source_dataset_id="src-dataset-1",
+            target_dataset_name="MyDataset",
+            target_project_name="DestProject",
+            audit=_audit(),
+        )
+
+        assert result.optimizations_total == 2 * page_size + 3
+        # 3 reads + N writes.
+        assert rest_client.optimizations.find_optimizations.call_count == 3
+
+    def test_create_optimization_raises__exception_propagates(self) -> None:
+        # The BE returns 409 on id conflict (we mint client-side UUIDs
+        # so within-run collisions are infinitesimal but possible across
+        # retries). Surface as a cascade error rather than silently
+        # continuing; the audit log's surrounding ``failed`` entry will
+        # capture partial progress via the umbrella action.
+        opt = _Optimization(id="src-opt-1")
+        rest_client = _cascade_rest_client(
+            [_Page([opt])],
+            create_side_effect=RuntimeError("409 conflict"),
+        )
+
+        with pytest.raises(RuntimeError, match="409 conflict"):
+            cascade_optimizations(
+                rest_client,
+                source_dataset_id="src-dataset-1",
+                target_dataset_name="MyDataset",
+                target_project_name="DestProject",
+                audit=_audit(),
+            )
+
+    def test_source_missing_id__skipped_not_remapped(self) -> None:
+        # Defensive path: BE returns an optimization without an id.
+        # Skip rather than fail -- other optimizations are still
+        # recoverable, and a non-zero ``optimizations_skipped`` counter
+        # in the audit surfaces the malformed row for investigation.
+        ok = _Optimization(id="src-opt-1")
+        bad = _Optimization(id="")
+        rest_client = _cascade_rest_client([_Page([ok, bad])])
+
+        result = cascade_optimizations(
+            rest_client,
+            source_dataset_id="src-dataset-1",
+            target_dataset_name="MyDataset",
+            target_project_name="DestProject",
+            audit=_audit(),
+        )
+
+        assert result.optimizations_migrated == 1
+        assert result.optimizations_skipped == 1
+        assert list(result.id_remap.keys()) == ["src-opt-1"]
+
+
+class TestCascadeOptimizationsWithExperiments:
+    """End-to-end planner-shape assertion: the optimization remap built
+    by Slice 5 is observable to Slice 3's experiment cascade via the
+    shared ``MigrationPlan``. The actual experiment-cascade FK forwarding
+    is asserted in ``test_migrate_dataset_experiments_cascade``; this
+    test only pins the wiring (action ordering + remap propagation).
+    """
+
+    def test_plan_remap__populated_by_cascade__readable_by_subsequent_actions(
+        self,
+    ) -> None:
+        from opik.cli.migrate.datasets.planner import MigrationPlan
+        from opik.cli.migrate.datasets.resolver import ResolvedDataset
+
+        opt = _Optimization(id="src-opt-1", name="trained")
+        rest_client = _cascade_rest_client([_Page([opt])])
+        plan = MigrationPlan(
+            source=ResolvedDataset(
+                id="src-1",
+                name="MyDataset",
+                project_name=None,
+                description=None,
+                visibility=None,
+                tags=None,
+                type="dataset",
+            ),
+            target_name="MyDataset",
+            to_project="DestProject",
+        )
+
+        result = cascade_optimizations(
+            rest_client,
+            source_dataset_id="src-1",
+            target_dataset_name="MyDataset",
+            target_project_name="DestProject",
+            audit=_audit(),
+        )
+        plan.optimization_id_remap.update(result.id_remap)
+
+        # Subsequent CascadeExperiments would read plan.optimization_id_remap;
+        # the wiring works as long as result.id_remap propagates here.
+        assert plan.optimization_id_remap == result.id_remap
+        assert "src-opt-1" in plan.optimization_id_remap
+
+
+# ---------------------------------------------------------------------------
+# Studio config Read -> Write reconstruction
+# ---------------------------------------------------------------------------
+
+
+class TestStudioConfigReconstruction:
+    """The Fern-generated Read and Write variants of
+    ``OptimizationStudioConfig`` are structurally identical but
+    nominally distinct; the cascade has to reconstruct the Write
+    variant from the Read variant so the typed ``create_optimization``
+    parameter is satisfied. Pin the round-trip so any future Fern
+    regeneration that changes the shape on one side gets caught.
+    """
+
+    def test_none_in_none_out(self) -> None:
+        from opik.cli.migrate.datasets.optimizations import (
+            _studio_config_public_to_write,
+        )
+
+        assert _studio_config_public_to_write(None) is None
+
+    def test_round_trip__fields_preserved(self) -> None:
+        from opik.cli.migrate.datasets.optimizations import (
+            _studio_config_public_to_write,
+        )
+        from opik.rest_api.types.optimization_studio_config_public import (
+            OptimizationStudioConfigPublic,
+        )
+        from opik.rest_api.types.studio_evaluation_public import (
+            StudioEvaluationPublic,
+        )
+        from opik.rest_api.types.studio_llm_model_public import (
+            StudioLlmModelPublic,
+        )
+        from opik.rest_api.types.studio_message_public import StudioMessagePublic
+        from opik.rest_api.types.studio_metric_public import StudioMetricPublic
+        from opik.rest_api.types.studio_optimizer_public import (
+            StudioOptimizerPublic,
+        )
+        from opik.rest_api.types.studio_prompt_public import StudioPromptPublic
+
+        public = OptimizationStudioConfigPublic(
+            dataset_name="MyDataset",
+            prompt=StudioPromptPublic(
+                messages=[StudioMessagePublic(role="system", content="you are helpful")]
+            ),
+            llm_model=StudioLlmModelPublic(
+                model="gpt-4o", parameters={"temperature": 0.2}
+            ),
+            evaluation=StudioEvaluationPublic(
+                metrics=[StudioMetricPublic(type="accuracy")]
+            ),
+            optimizer=StudioOptimizerPublic(type="grid", parameters={"steps": 5}),
+        )
+        write = _studio_config_public_to_write(public)
+        assert write is not None
+        # Round-trip via model_dump -- the typed Write variant accepts
+        # extra fields so this also covers any forward-compatible BE
+        # additions on the Public variant.
+        write_dump: Dict[str, Any] = write.model_dump()
+        public_dump: Dict[str, Any] = public.model_dump()
+        assert write_dump == public_dump

--- a/sdks/python/tests/unit/cli/test_migrate_dataset_planner.py
+++ b/sdks/python/tests/unit/cli/test_migrate_dataset_planner.py
@@ -90,13 +90,16 @@ class TestMigrateHelp:
 
 
 class TestPlanBuilding:
-    def test_build_dataset_plan__default_flow__orders_rename_create_replay_cascade(
+    def test_build_dataset_plan__default_flow__orders_rename_create_replay_optimizations_experiments(
         self,
     ) -> None:
         # The plan emits: rename source -> create destination -> replay
-        # versions -> cascade experiments. Each action depends on the
-        # previous one having completed (ReplayVersions populates the
-        # version_remap that CascadeExperiments reads).
+        # versions -> cascade optimizations -> cascade experiments. The
+        # order is load-bearing: CascadeOptimizations populates
+        # plan.optimization_id_remap which CascadeExperiments reads when
+        # re-pointing each experiment's optimization_id FK. Pin the
+        # sequence so a future reorder can't break that contract
+        # silently.
         rest_client = _planner_rest_client(
             [
                 _Page([_DatasetRow(id="src-1", name="MyDataset", description="d")]),
@@ -116,12 +119,15 @@ class TestPlanBuilding:
             "RenameSource",
             "CreateDestination",
             "ReplayVersions",
+            "CascadeOptimizations",
             "CascadeExperiments",
         ]
         rename = plan.actions[0]
         assert rename.from_name == "MyDataset"
         assert rename.to_name == "MyDataset_v1"
         assert plan.target_name == "MyDataset"
+        # New remap dict starts empty; _cascade_optimizations populates it.
+        assert plan.optimization_id_remap == {}
 
     def test_build_dataset_plan__test_suite__type_forwarded_to_destination(
         self,
@@ -151,6 +157,7 @@ class TestPlanBuilding:
             "RenameSource",
             "CreateDestination",
             "ReplayVersions",
+            "CascadeOptimizations",
             "CascadeExperiments",
         ]
         replay = plan.actions[2]


### PR DESCRIPTION
## Details

<img width="1920" height="3384" alt="image" src="https://github.com/user-attachments/assets/76863ba9-0ca3-447a-8f94-a0a64ec83550" />

Slice 5 of `opik migrate dataset`. Recreates every optimization referencing the source dataset under the destination project with a fresh UUID and re-points each experiment's `optimization_id` FK at the new destination id, so the destination's Optimization Studio shows the same rows and trial groupings as the source — instead of un-grouped experiments. Until now the cascade silently dropped `optimization_id` because no remap existed yet (see the old `_build_experiment_data` guard).

- New `CascadeOptimizations` planner action ordered between `ReplayVersions` and `CascadeExperiments`; `optimization_id_remap` added to `MigrationPlan`.
- New `cascade_optimizations` module: paginated `find_optimizations(dataset_id=...)` enumeration (project-agnostic), per-row recreate with fidelity fields (`name`, `objective_name`, `status`, `metadata`, `studio_config`, `last_updated_at`). Read-only aggregates (`num_trials`, `feedback_scores`, `baseline_*`, `best_*`, `total_optimization_cost`) deliberately omitted — the BE recomputes them at read time.
- Experiment cascade re-points `optimization_id` via the remap; orphan path (source has id but remap doesn't) increments `experiments_with_orphan_optimization_id` and omits the field rather than write a dangling FK.
- `recreate_experiment` (import path) forwards `optimization_id` on the migrate path; the prior "deliberately not forwarded" guard is gone.
- Per-optimization `migrate_optimization` audit records with `source_id` → `destination_id`. Uses `optimization_status` key so `entry.update(details)` in `AuditLog.record` doesn't shadow the audit-level success/failure status.
- Studio config `Read` → `Write` reconstruction via `model_validate(model_dump())` since the Fern-generated variants are nominally distinct but structurally identical.

## Change checklist

- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6532

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation (planner action, optimization cascade module, experiment-cascade remap wiring, import-path forwarding, unit tests, E2E test)
- Human verification: spec review against ticket AC, manual pre-commit + full unit-test sweep, code review by author

## Testing

Commands run from the worktree root:

- `cd sdks/python && python -m pytest tests/unit/cli/ -q` — **305 passed**.
- `pre-commit run --config sdks/python/.pre-commit-config.yaml --files <changed files>` — trim-whitespace, end-of-file, ruff, ruff-format, mypy all pass.
- `cd sdks/python && python -m pytest tests/e2e/cli/test_migrate_dataset_optimizations_e2e.py --collect-only` — collects cleanly. (Full E2E run requires a live backend and is intended for CI.)

Scenarios validated by the new tests:

- Optimization fidelity round-trip; read-only aggregates not forwarded.
- Empty optimization (zero trials) still migrated and remapped.
- Pagination exhausts pages until a short page.
- `create_optimization` exception (e.g. 409) propagates as a cascade error rather than silently continuing.
- Source row missing id is skipped, not failed.
- Experiment with `optimization_id` and a remap entry → destination FK re-pointed.
- Experiment with `optimization_id` but no remap entry → field omitted, orphan counter incremented, experiment still created (degraded fidelity, not hard failure).
- Experiment with no `optimization_id` → field stays absent regardless of remap contents.
- Planner emits the 5-action sequence: `RenameSource → CreateDestination → ReplayVersions → CascadeOptimizations → CascadeExperiments`.
- E2E: 1 optimization + 2 trial experiments + 1 control experiment → after migrate, destination has exactly 1 optimization (fresh id), both trials' `optimization_id` re-pointed at the destination row, control experiment's `optimization_id` stays null, audit log carries the per-optimization record.

## Documentation

N/A — no user-facing CLI flag changes; audit-log JSON additions are additive (new `migrate_optimization` records, new `cascade_optimizations` action type, new `experiments_with_orphan_optimization_id` counter). User-facing CLI docs + audit-log schema finalization are tracked in a separate ticket per the original scope.