### PR TITLE
[OPIK-6580] [INFRA] [CI] fix: clear actionlint events and expression findings

### DIFF
--- a/.github/workflows/build_and_push_docker.yaml
+++ b/.github/workflows/build_and_push_docker.yaml
@@ -16,13 +16,11 @@ on:
       build_from:
         type: string
         required: true
-        description: Original version to build from 
-        default: ""
+        description: Original version to build from
       build_comet_image:
         type: boolean
         required: true
         description: If to build a Comet integration image
-        default: false
       comet_build_args:
         type: string
         required: false
@@ -32,7 +30,6 @@ on:
         type: boolean
         required: true
         description: If this is a release build (will build multi-arch and push latest tag)
-        default: false
       is_adhoc:
         type: boolean
         required: false

--- a/.github/workflows/build_apps.yml
+++ b/.github/workflows/build_apps.yml
@@ -32,12 +32,10 @@ on:
         type: string
         required: true
         description: Version
-        default: ""
       is_release:
         type: boolean
         required: true
         description: Is release build
-        default: false
       is_adhoc:
         type: boolean
         required: false

--- a/.github/workflows/opik_wizard_publish.yml
+++ b/.github/workflows/opik_wizard_publish.yml
@@ -23,7 +23,6 @@ on:
         type: string
         required: true
         description: Version
-        default: ""
       is_release:
         type: boolean
         required: false

--- a/.github/workflows/publish_helm_chart.yaml
+++ b/.github/workflows/publish_helm_chart.yaml
@@ -15,7 +15,6 @@ on:
         type: string
         required: true
         description: Version
-        default: ""
 
 
 jobs:

--- a/.github/workflows/quickstart_guide_snippets_test.yml
+++ b/.github/workflows/quickstart_guide_snippets_test.yml
@@ -10,7 +10,13 @@ on:
     schedule:
     - cron: '0 12 * * *' # runs every day at noon UTC
     workflow_dispatch:
-    
+        inputs:
+            ALLURE_JOB_RUN_ID:
+                type: string
+                required: false
+                description: Allure job run ID for grouping test reports
+                default: ''
+
 run-name: Quickstart Guide Snippets Tests
 
 jobs:

--- a/.github/workflows/release-wrapper-release-n-deploy.yml
+++ b/.github/workflows/release-wrapper-release-n-deploy.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Notify Release-n-Deploy-Agent
         if: ${{ inputs.resumeUrl != '' }}
         run: |
-          echo "url: ${{ inputs }}"
           echo "All inputs: ${{ toJSON(inputs) }}"
           echo "resumeUrl input: '${{ inputs.resumeUrl }}'"
           

--- a/.github/workflows/typescript_sdk_integration_publish.yml
+++ b/.github/workflows/typescript_sdk_integration_publish.yml
@@ -33,7 +33,6 @@ on:
         type: string
         required: true
         description: Version
-        default: ""
       is_release:
         type: boolean
         required: false

--- a/.github/workflows/typescript_sdk_publish.yml
+++ b/.github/workflows/typescript_sdk_publish.yml
@@ -35,7 +35,6 @@ on:
         type: string
         required: true
         description: Version
-        default: ""
       is_release:
         type: boolean
         required: false


### PR DESCRIPTION
## Details

<img width="1760" height="2016" alt="image" src="https://github.com/user-attachments/assets/d46afddb-3657-4ed3-851c-506c7b75bc96" />

Resolves 12 actionlint findings (10 `[events]` + 2 `[expression]`) across 8 workflow files. First of 5 subtasks splitting [OPIK-6323](https://comet-ml.atlassian.net/browse/OPIK-6323) — the cosmetic-only batch with no SC2086 quoting work.

**`[events]` dead-default findings (10, across 7 files):** removed `default:` from `workflow_call` inputs that are also marked `required: true`. The default is dead code per actionlint — a required input must always be provided by the caller.

- `build_and_push_docker.yaml`: `build_from`, `build_comet_image`, `is_release`
- `build_apps.yml`: `version`, `is_release`
- `opik_wizard_publish.yml`: `version`
- `publish_helm_chart.yaml`: `version`
- `typescript_sdk_integration_publish.yml`: `version`
- `typescript_sdk_publish.yml`: `version`

Only `workflow_call` defaults were touched. `workflow_dispatch` defaults are kept — even when the input is `required: true`, the GitHub UI presents the default to the user and lets them edit it, so it's not dead.

**`[expression]` findings (2):**

- `quickstart_guide_snippets_test.yml`: line 5 referenced `github.event.inputs.ALLURE_JOB_RUN_ID` but the `workflow_dispatch:` block had no `inputs:` declared. Fixed by adding the input declaration so the expression resolves.
- `release-wrapper-release-n-deploy.yml`: removed the debug `echo "url: ${{ inputs }}"` (whole-object eval, which actionlint flags). The next line already echoes `toJSON(inputs)` correctly for debugging.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6580 (parent: OPIK-6323)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: identified findings via `actionlint`, applied mechanical edits to remove dead `default:` lines and the two `[expression]` issues
- Human verification: re-ran `actionlint` to confirm the targeted categories report zero findings, reviewed the full diff (8 files, +8/-12 lines) before commit

## Testing

```
$ actionlint .github/workflows/*.yml .github/workflows/*.yaml 2>&1 | grep -E '\[events\]|\[expression\]' || echo OK
OK
```

- Confirmed 0 `[events]` and 0 `[expression]` findings remaining repo-wide.
- Verified no behavioral change: `workflow_call` callers of these workflows already always pass `required: true` inputs explicitly, so the removed defaults were never reached.
- Manual `workflow_dispatch` of `quickstart_guide_snippets_test.yml` now exposes `ALLURE_JOB_RUN_ID` as a UI input (optional, defaults to empty) — previously the env var was unreachable.

Remaining baseline findings (`SC2086`, `SC2129`, `SC2162`, `SC2035`, `SC2004`) are intentionally out of scope here and tracked in subtasks 2-5 ([OPIK-6581](https://comet-ml.atlassian.net/browse/OPIK-6581), [OPIK-6582](https://comet-ml.atlassian.net/browse/OPIK-6582), [OPIK-6583](https://comet-ml.atlassian.net/browse/OPIK-6583), [OPIK-6584](https://comet-ml.atlassian.net/browse/OPIK-6584)).

## Documentation

No documentation changes — internal CI hygiene only.

[OPIK-6323]: https://comet-ml.atlassian.net/browse/OPIK-6323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPIK-6581]: https://comet-ml.atlassian.net/browse/OPIK-6581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ