### PR TITLE
[OPIK-5333] Inject trace spans into LLM-as-judge prompts; enrich thread {{context}} with tool calls

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/SpanForLlm.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/SpanForLlm.java
@@ -1,0 +1,57 @@
+package com.comet.opik.api;
+
+import com.comet.opik.domain.SpanType;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Lean projection of {@link Span} for the LLM-judge prompt and Python thread evaluator
+ * conversation. The raw {@code Span} record carries ~28 fields — audit metadata, feedback
+ * scores, comments, cost data, etc. — and pasting all of it into a prompt burns tokens on
+ * irrelevant content and can confuse the judge ("why is there a {@code feedback_scores}
+ * array? am I supposed to defer to that?").
+ *
+ * <p>Keep only what helps a judge reason about agent behavior:
+ * <ul>
+ *   <li>{@code name} / {@code type}: which tool or LLM ran
+ *   <li>{@code input} / {@code output}: what was passed and what came back
+ *   <li>{@code metadata}: user-provided context the agent attached
+ *   <li>{@code startTime} / {@code endTime} / {@code duration}: call order + how long
+ *   <li>{@code model} / {@code provider}: for LLM spans, which model
+ *   <li>{@code errorInfo}: if the call failed
+ *   <li>{@code spans}: nested child spans, recursively projected — lets the judge see the
+ *       call tree (planner → sub-agent → tool) instead of a flat list with parent-id refs
+ *       it would have to mentally resolve.
+ * </ul>
+ * Null fields are omitted via {@code @JsonInclude(NON_NULL)} so e.g. a successful tool
+ * span doesn't pad the JSON with {@code error_info: null}, and a leaf span doesn't pad
+ * with an empty {@code spans} array.
+ *
+ * <p>Lives in the {@code api} package alongside {@link Span} so both the LLM-render path
+ * ({@code OnlineScoringEngine}) and the Python-thread-render path
+ * ({@code TraceThreadPythonEvaluatorRequest.ChatMessage}) can reference it without a
+ * package cycle.
+ */
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder(toBuilder = true)
+public record SpanForLlm(
+        String name,
+        SpanType type,
+        Instant startTime,
+        Instant endTime,
+        Double duration,
+        JsonNode input,
+        JsonNode output,
+        JsonNode metadata,
+        String model,
+        String provider,
+        ErrorInfo errorInfo,
+        List<SpanForLlm> spans) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -557,16 +557,24 @@ public class OnlineScoringEngine {
 
     /**
      * Variant that injects a built-in {@code spans} variable holding the trace's spans
-     * (sorted by start_time) as a real JSON array. Used by Python metrics whose
-     * {@code score(...)} signature accepts {@code spans}; the user opts in by including a
-     * {@code "spans"} key in their {@code arguments} map. The value the user maps for
-     * {@code spans} is overridden with the typed list — {@code spans} is a reserved
-     * built-in, not a regular path-resolved variable.
+     * projected to {@link SpanForLlm} and reconstructed as a parent→child tree. Used by
+     * Python metrics whose {@code score(...)} signature accepts {@code spans}; the user
+     * opts in by including a {@code "spans"} key in their {@code arguments} map. The value
+     * the user maps for {@code spans} is overridden with the typed list — {@code spans} is
+     * a reserved built-in, not a regular path-resolved variable.
+     *
+     * <p>The shape matches every other span-render path on this PR (trace-scope
+     * {@code {{spans}}} for LLM-as-judge, thread-scope {@code {{context}}} for both LLM-as-
+     * judge and Python): lean {@link SpanForLlm} projection (11 fields — name, type, in/out,
+     * timing, model/provider, error_info, plus nested children), {@code @JsonInclude(NON_NULL)}
+     * to keep the JSON tight, and call-order preserved by sorting siblings on {@code startTime}
+     * at every level inside {@link #buildSpanTree}.
      *
      * <p>The returned map is typed as {@code Map<String, Object>} so the spans value can
-     * carry a {@code List<Span>} through Jackson serialization to the Python runner as a
-     * JSON array. The Python side receives {@code spans} as a list of dicts after
-     * {@code json.loads(...)} — not as a JSON string that the user would have to re-parse.
+     * carry the {@code List<SpanForLlm>} tree through Jackson serialization to the Python
+     * runner as a JSON array. The Python side receives {@code spans} as a list of dicts
+     * after {@code json.loads(...)} — not as a JSON string that the user would have to
+     * re-parse.
      *
      * <p>Caller is responsible for only invoking this overload when the user actually
      * requested spans (i.e. {@code arguments.containsKey("spans")}). The scorer makes this
@@ -576,7 +584,7 @@ public class OnlineScoringEngine {
             @NonNull Map<String, String> variables, @NonNull Trace trace, @NonNull List<Span> spans) {
         var base = toReplacements(variables, trace);
         var result = new LinkedHashMap<String, Object>(base);
-        result.put(SPANS_VARIABLE_NAME, spans.stream().sorted(BY_SPAN_START_TIME).toList());
+        result.put(SPANS_VARIABLE_NAME, buildSpanTree(spans));
         return result;
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -165,6 +165,11 @@ public class OnlineScoringEngine {
      * path. The second clause respects explicit user mappings — e.g. a rule that maps
      * {@code spans} to {@code input.something} keeps that mapping instead of being silently
      * overridden by the spans-list injection.
+     *
+     * <p>Walks both message shapes: the simple-string {@code content} field, and the
+     * multimodal {@code contentArray} where each part exposes its own {@code text}. Scanning
+     * only {@code content} would miss {@code {{spans}}} in multimodal prompts, leaving the
+     * rendered text part unsubstituted because the spans fetch never fires.
      */
     private static boolean messagesReferenceSpansDirectly(
             List<LlmAsJudgeMessage> messages, Map<String, String> variables, PromptType promptType) {
@@ -172,10 +177,30 @@ public class OnlineScoringEngine {
             return false;
         }
         return messages.stream()
-                .map(LlmAsJudgeMessage::content)
                 .filter(Objects::nonNull)
-                .anyMatch(content -> TemplateParseUtils.extractVariables(content, promptType)
+                .flatMap(OnlineScoringEngine::renderableTextOf)
+                .anyMatch(text -> TemplateParseUtils.extractVariables(text, promptType)
                         .contains(SPANS_VARIABLE_NAME));
+    }
+
+    /**
+     * Stream of all variable-substitutable text in a message: the simple {@code content}
+     * string when present, otherwise each non-null {@code text} part inside {@code contentArray}.
+     * Mirrors what the renderer would substitute into — anything we should scan for
+     * {@code {{spans}}} references must also be scanned by this helper, or detection
+     * drifts from rendering.
+     */
+    private static Stream<String> renderableTextOf(LlmAsJudgeMessage message) {
+        if (message.isStringContent()) {
+            return Stream.of(message.content());
+        }
+        if (message.isStructuredContent()) {
+            return message.contentArray().stream()
+                    .filter(Objects::nonNull)
+                    .map(LlmAsJudgeMessageContent::text)
+                    .filter(Objects::nonNull);
+        }
+        return Stream.empty();
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -55,11 +55,14 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.UUID;
@@ -234,16 +237,13 @@ public class OnlineScoringEngine {
         if (!sentinelMapped && !templateOnly) {
             return;
         }
-        // Project to SpanForLlm so the prompt only carries fields a judge actually uses
-        // (name, type, in/out, timing, model/provider, errorInfo). Drops audit metadata,
-        // feedback scores, comments, cost data — none of which help the judge and all of
-        // which burn tokens. Sort first so the projection preserves call order.
+        // Project to SpanForLlm and reconstruct parent → child hierarchy so the judge sees
+        // the call tree, not a flat list. Drops audit metadata, feedback scores, comments,
+        // cost data — none of which help the judge and all of which burn tokens. Siblings
+        // are sorted by start_time inside buildSpanTree.
         String spansJson;
         try {
-            spansJson = OBJECT_MAPPER.writeValueAsString(spans.stream()
-                    .sorted(BY_SPAN_START_TIME)
-                    .map(SpanForLlm::from)
-                    .toList());
+            spansJson = OBJECT_MAPPER.writeValueAsString(buildSpanTree(spans));
         } catch (JsonProcessingException e) {
             throw new UncheckedIOException(e);
         }
@@ -796,10 +796,11 @@ public class OnlineScoringEngine {
                 .collect(Collectors.groupingBy(Span::traceId));
         return traces.stream()
                 .flatMap(trace -> {
-                    List<SpanForLlm> traceSpans = spansByTrace.getOrDefault(trace.id(), List.of()).stream()
-                            .sorted(BY_SPAN_START_TIME)
-                            .map(SpanForLlm::from)
-                            .toList();
+                    // Reconstruct parent → child hierarchy per-trace so the assistant entry
+                    // carries a tree of spans, not a flat list. buildSpanTree handles sorting
+                    // siblings by start_time at every level.
+                    List<SpanForLlm> traceSpans = buildSpanTree(
+                            spansByTrace.getOrDefault(trace.id(), List.of()));
                     return Stream.of(
                             EnrichedThreadChatMessage.builder()
                                     .role(TraceThreadPythonEvaluatorRequest.ROLE_USER)
@@ -841,11 +842,15 @@ public class OnlineScoringEngine {
      *   <li>{@code startTime} / {@code endTime} / {@code duration}: call order + how long
      *   <li>{@code model} / {@code provider}: for LLM spans, which model
      *   <li>{@code errorInfo}: if the call failed
+     *   <li>{@code spans}: nested child spans, recursively projected — lets the judge see the
+     *       call tree (planner → sub-agent → tool) instead of a flat list with parent-id refs
+     *       it would have to mentally resolve. Built by {@link #buildSpanTree}.
      * </ul>
      * Null fields are omitted via {@code @JsonInclude(NON_NULL)} so e.g. a successful tool
-     * span doesn't pad the JSON with {@code error_info: null}. Same shape is used by the
-     * trace-scope {@code {{spans}}} substitution and the thread-scope {@code {{context}}}
-     * per-assistant {@code spans} field — one projection, two render paths.
+     * span doesn't pad the JSON with {@code error_info: null}, and a leaf span doesn't pad
+     * with an empty {@code spans} array. Same shape is used by the trace-scope
+     * {@code {{spans}}} substitution and the thread-scope {@code {{context}}} per-assistant
+     * {@code spans} field — one projection, two render paths.
      */
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -861,23 +866,69 @@ public class OnlineScoringEngine {
             JsonNode metadata,
             String model,
             String provider,
-            ErrorInfo errorInfo) {
+            ErrorInfo errorInfo,
+            List<SpanForLlm> spans) {
+    }
 
-        public static SpanForLlm from(Span span) {
-            return SpanForLlm.builder()
-                    .name(span.name())
-                    .type(span.type())
-                    .startTime(span.startTime())
-                    .endTime(span.endTime())
-                    .duration(span.duration())
-                    .input(span.input())
-                    .output(span.output())
-                    .metadata(span.metadata())
-                    .model(span.model())
-                    .provider(span.provider())
-                    .errorInfo(span.errorInfo())
-                    .build();
+    /**
+     * Build a nested-tree projection of the given spans for inline LLM rendering.
+     *
+     * <p>Reconstructs parent → child hierarchy from {@code parentSpanId} links, projects each
+     * node to {@link SpanForLlm} (dropping the audit/score/cost noise that {@code Span}
+     * carries), and sorts siblings at every level by {@code startTime} so the wire order
+     * tracks call order within each branch. Returns the top-level roots.
+     *
+     * <p>Orphans (spans whose {@code parentSpanId} isn't in the input list) are promoted to
+     * roots — happens when the caller passes a subset of a trace's spans, or when a parent
+     * was dropped server-side. The tree stays well-formed instead of silently dropping the
+     * orphaned subtree.
+     */
+    public static List<SpanForLlm> buildSpanTree(@NonNull List<Span> spans) {
+        if (spans.isEmpty()) {
+            return List.of();
         }
+        Map<UUID, List<Span>> childrenByParent = new HashMap<>();
+        Set<UUID> presentIds = new HashSet<>();
+        for (Span span : spans) {
+            if (span.id() != null) {
+                presentIds.add(span.id());
+            }
+            UUID parentId = span.parentSpanId();
+            if (parentId != null) {
+                childrenByParent.computeIfAbsent(parentId, k -> new ArrayList<>()).add(span);
+            }
+        }
+        // Roots: parent is null OR parent isn't in the visible set (orphan promotion).
+        List<Span> roots = spans.stream()
+                .filter(s -> s.parentSpanId() == null || !presentIds.contains(s.parentSpanId()))
+                .sorted(BY_SPAN_START_TIME)
+                .toList();
+        return roots.stream()
+                .map(root -> buildSpanNode(root, childrenByParent))
+                .toList();
+    }
+
+    private static SpanForLlm buildSpanNode(Span span, Map<UUID, List<Span>> childrenByParent) {
+        List<SpanForLlm> children = span.id() == null
+                ? List.of()
+                : childrenByParent.getOrDefault(span.id(), List.of()).stream()
+                        .sorted(BY_SPAN_START_TIME)
+                        .map(child -> buildSpanNode(child, childrenByParent))
+                        .toList();
+        return SpanForLlm.builder()
+                .name(span.name())
+                .type(span.type())
+                .startTime(span.startTime())
+                .endTime(span.endTime())
+                .duration(span.duration())
+                .input(span.input())
+                .output(span.output())
+                .metadata(span.metadata())
+                .model(span.model())
+                .provider(span.provider())
+                .errorInfo(span.errorInfo())
+                .spans(children.isEmpty() ? null : children)
+                .build();
     }
 
     public record ParsedFeedbackScores(List<FeedbackScoreBatchItem> scores, List<String> nullScoreNames) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api.resources.v1.events;
 
+import com.comet.opik.api.ErrorInfo;
 import com.comet.opik.api.LlmProvider;
 import com.comet.opik.api.PromptType;
 import com.comet.opik.api.ScoreSource;
@@ -12,6 +13,7 @@ import com.comet.opik.api.evaluators.LlmAsJudgeOutputSchema;
 import com.comet.opik.api.resources.v1.events.tools.StringTruncator;
 import com.comet.opik.api.resources.v1.events.tools.ToolRegistry;
 import com.comet.opik.api.resources.v1.events.tools.TraceCompressor;
+import com.comet.opik.domain.SpanType;
 import com.comet.opik.domain.evaluators.python.TraceThreadPythonEvaluatorRequest;
 import com.comet.opik.domain.llm.structuredoutput.StructuredOutputStrategy;
 import com.comet.opik.infrastructure.log.LogContextAware;
@@ -232,9 +234,16 @@ public class OnlineScoringEngine {
         if (!sentinelMapped && !templateOnly) {
             return;
         }
+        // Project to SpanForLlm so the prompt only carries fields a judge actually uses
+        // (name, type, in/out, timing, model/provider, errorInfo). Drops audit metadata,
+        // feedback scores, comments, cost data — none of which help the judge and all of
+        // which burn tokens. Sort first so the projection preserves call order.
         String spansJson;
         try {
-            spansJson = OBJECT_MAPPER.writeValueAsString(spans.stream().sorted(BY_SPAN_START_TIME).toList());
+            spansJson = OBJECT_MAPPER.writeValueAsString(spans.stream()
+                    .sorted(BY_SPAN_START_TIME)
+                    .map(SpanForLlm::from)
+                    .toList());
         } catch (JsonProcessingException e) {
             throw new UncheckedIOException(e);
         }
@@ -787,8 +796,9 @@ public class OnlineScoringEngine {
                 .collect(Collectors.groupingBy(Span::traceId));
         return traces.stream()
                 .flatMap(trace -> {
-                    List<Span> traceSpans = spansByTrace.getOrDefault(trace.id(), List.of()).stream()
+                    List<SpanForLlm> traceSpans = spansByTrace.getOrDefault(trace.id(), List.of()).stream()
                             .sorted(BY_SPAN_START_TIME)
+                            .map(SpanForLlm::from)
                             .toList();
                     return Stream.of(
                             EnrichedThreadChatMessage.builder()
@@ -814,7 +824,60 @@ public class OnlineScoringEngine {
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Builder(toBuilder = true)
-    public record EnrichedThreadChatMessage(String role, JsonNode content, List<Span> spans) {
+    public record EnrichedThreadChatMessage(String role, JsonNode content, List<SpanForLlm> spans) {
+    }
+
+    /**
+     * Lean projection of {@link Span} for the LLM-judge prompt. The raw {@code Span} record
+     * carries ~28 fields — audit metadata, feedback scores, comments, cost data, etc. — and
+     * pasting all of it into a prompt burns tokens on irrelevant content and can confuse the
+     * judge ("why is there a {@code feedback_scores} array? am I supposed to defer to that?").
+     *
+     * <p>Keep only what helps a judge reason about agent behavior:
+     * <ul>
+     *   <li>{@code name} / {@code type}: which tool or LLM ran
+     *   <li>{@code input} / {@code output}: what was passed and what came back
+     *   <li>{@code metadata}: user-provided context the agent attached
+     *   <li>{@code startTime} / {@code endTime} / {@code duration}: call order + how long
+     *   <li>{@code model} / {@code provider}: for LLM spans, which model
+     *   <li>{@code errorInfo}: if the call failed
+     * </ul>
+     * Null fields are omitted via {@code @JsonInclude(NON_NULL)} so e.g. a successful tool
+     * span doesn't pad the JSON with {@code error_info: null}. Same shape is used by the
+     * trace-scope {@code {{spans}}} substitution and the thread-scope {@code {{context}}}
+     * per-assistant {@code spans} field — one projection, two render paths.
+     */
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Builder(toBuilder = true)
+    public record SpanForLlm(
+            String name,
+            SpanType type,
+            Instant startTime,
+            Instant endTime,
+            Double duration,
+            JsonNode input,
+            JsonNode output,
+            JsonNode metadata,
+            String model,
+            String provider,
+            ErrorInfo errorInfo) {
+
+        public static SpanForLlm from(Span span) {
+            return SpanForLlm.builder()
+                    .name(span.name())
+                    .type(span.type())
+                    .startTime(span.startTime())
+                    .endTime(span.endTime())
+                    .duration(span.duration())
+                    .input(span.input())
+                    .output(span.output())
+                    .metadata(span.metadata())
+                    .model(span.model())
+                    .provider(span.provider())
+                    .errorInfo(span.errorInfo())
+                    .build();
+        }
     }
 
     public record ParsedFeedbackScores(List<FeedbackScoreBatchItem> scores, List<String> nullScoreNames) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -211,7 +211,13 @@ public class OnlineScoringEngine {
      *
      * <p>An empty spans list still triggers the rewrite (rendering as {@code "[]"}) — without
      * it, {@code toReplacements} leaves the bare {@code "spans"} value as a literal and the
-     * prompt renders the word "spans" instead of an empty array.
+     * prompt renders the word "spans" instead of an empty array. <strong>Intentionally not
+     * gated by {@code isAgenticToolsEnabled}</strong>: when the toggle is off, the scorer
+     * skips the spans fetch and threads an empty list here, which still rewrites
+     * sentinel-mapped variables to {@code "[]"}. Gating this would resurrect the bare-word
+     * leak for rules whose variables map still carries the sentinel from before the toggle
+     * flipped. See {@code OnlineScoringLlmAsJudgeScorer.shouldFetchSpans} for the full
+     * toggle-semantics rationale.
      *
      * <p>Also handles the implicit-reference case (template uses {@code {{spans}}} but the
      * variables map doesn't bind it): mirrors the FE auto-fill server-side so API-created

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -17,6 +17,7 @@ import com.comet.opik.domain.llm.structuredoutput.StructuredOutputStrategy;
 import com.comet.opik.infrastructure.log.LogContextAware;
 import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.TemplateParseUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -296,9 +297,10 @@ public class OnlineScoringEngine {
      */
     public static ChatRequest prepareThreadLlmRequest(
             @NonNull TraceThreadLlmAsJudgeCode evaluatorCode, @NonNull List<Trace> traces,
-            @NonNull StructuredOutputStrategy structuredOutputStrategy) {
+            @NonNull StructuredOutputStrategy structuredOutputStrategy,
+            @NonNull List<Span> spans) {
         var renderedMessages = renderThreadMessages(evaluatorCode.messages(),
-                Map.of(TraceThreadLlmAsJudgeCode.CONTEXT_VARIABLE_NAME, ""), traces);
+                Map.of(TraceThreadLlmAsJudgeCode.CONTEXT_VARIABLE_NAME, ""), traces, spans);
         return buildChatRequest(renderedMessages, evaluatorCode.schema(), structuredOutputStrategy);
     }
 
@@ -406,15 +408,20 @@ public class OnlineScoringEngine {
     }
 
     static List<ChatMessage> renderThreadMessages(
-            List<LlmAsJudgeMessage> templateMessages, Map<String, String> variablesMap, List<Trace> traces) {
+            List<LlmAsJudgeMessage> templateMessages, Map<String, String> variablesMap, List<Trace> traces,
+            List<Span> spans) {
         // prepare the map of replacements to use in all messages
         Map<String, String> replacements = variablesMap.keySet().stream()
                 .map(variableName -> switch (variableName) {
                     case TraceThreadLlmAsJudgeCode.CONTEXT_VARIABLE_NAME -> {
+                        // Always use the enriched shape — when `spans` is empty (toggle off),
+                        // the `spans` field is omitted via @JsonInclude(NON_NULL) and the
+                        // JSON is wire-identical to today's [{role, content}, ...] shape.
                         try {
                             yield MessageVariableMapping.builder()
                                     .variableName(variableName)
-                                    .valueToReplace(OBJECT_MAPPER.writeValueAsString(fromTraceToThread(traces)))
+                                    .valueToReplace(OBJECT_MAPPER.writeValueAsString(
+                                            fromTraceToThreadEnriched(traces, spans)))
                                     .build();
                         } catch (JsonProcessingException ex) {
                             throw new UncheckedIOException(ex);
@@ -760,6 +767,56 @@ public class OnlineScoringEngine {
                 .toList();
     }
 
+    /**
+     * Build the chat-message list that fills {@code {{context}}} on the LLM thread render
+     * path, optionally enriched with each trace's child spans attached to its assistant
+     * message. Backward-compatible: the {@code spans} field is omitted from the JSON whenever
+     * a trace has no spans (or the caller passed an empty list), so a rule written against
+     * today's {@code [{role, content}, ...]} shape sees no difference.
+     *
+     * <p>Spans within each trace are sorted by start_time so the wire order matches call
+     * order — same convention as the trace-scope {@code {{spans}}} path.
+     *
+     * <p>Separate from {@link #fromTraceToThread(List)} which keeps returning the bare
+     * Python-evaluator {@code ChatMessage} shape — the Python runner has its own contract
+     * and we don't want to leak the {@code spans} field into that path.
+     */
+    public static List<EnrichedThreadChatMessage> fromTraceToThreadEnriched(
+            @NonNull List<Trace> traces, @NonNull List<Span> spans) {
+        Map<UUID, List<Span>> spansByTrace = spans.stream()
+                .collect(Collectors.groupingBy(Span::traceId));
+        return traces.stream()
+                .flatMap(trace -> {
+                    List<Span> traceSpans = spansByTrace.getOrDefault(trace.id(), List.of()).stream()
+                            .sorted(BY_SPAN_START_TIME)
+                            .toList();
+                    return Stream.of(
+                            EnrichedThreadChatMessage.builder()
+                                    .role(TraceThreadPythonEvaluatorRequest.ROLE_USER)
+                                    .content(trace.input())
+                                    .build(),
+                            EnrichedThreadChatMessage.builder()
+                                    .role(TraceThreadPythonEvaluatorRequest.ROLE_ASSISTANT)
+                                    .content(trace.output())
+                                    .spans(traceSpans.isEmpty() ? null : traceSpans)
+                                    .build());
+                })
+                .toList();
+    }
+
+    /**
+     * Enriched chat-message shape for thread-scope {@code {{context}}} rendering. Extends
+     * the existing {@code {role, content}} contract with an optional {@code spans} field
+     * carrying the assistant turn's tool calls and other child spans. The field is omitted
+     * from the JSON when null (via {@link JsonInclude.Include#NON_NULL}) so existing rules
+     * that don't care about spans see the exact same wire shape they see today.
+     */
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Builder(toBuilder = true)
+    public record EnrichedThreadChatMessage(String role, JsonNode content, List<Span> spans) {
+    }
+
     public record ParsedFeedbackScores(List<FeedbackScoreBatchItem> scores, List<String> nullScoreNames) {
         public static ParsedFeedbackScores empty() {
             return new ParsedFeedbackScores(List.of(), List.of());
@@ -883,20 +940,26 @@ public class OnlineScoringEngine {
 
     /**
      * Rough character-based token estimate for the thread context as it would be
-     * rendered on the inline path (full trace-list JSON, no spans). Used by
-     * {@code OnlineScoringTraceThreadLlmAsJudgeScorer} to decide whether a thread is
-     * big enough to switch to the agentic-tools path (skeleton + drill-down via
-     * ReadTool). The estimate is on the trace bodies only — spans aren't part of
-     * the inline thread render today, so factoring them in would over-trigger the
-     * tools branch.
+     * rendered on the inline path. Estimates the enriched shape — trace input/output
+     * plus the assistant turn's child spans (tool calls + I/O) — so the agentic-tools
+     * routing decision reflects what {@link #prepareThreadLlmRequest} will actually
+     * serialize. Pass an empty {@code spans} list when the toggle is off; the
+     * enriched serializer omits the {@code spans} field via {@code @JsonInclude(NON_NULL)},
+     * so the estimate then matches the original trace-bodies-only shape exactly.
+     *
+     * <p>Used by {@code OnlineScoringTraceThreadLlmAsJudgeScorer} to decide whether
+     * a thread is big enough to switch to the agentic-tools path (skeleton +
+     * drill-down via ReadTool).
      *
      * <p>Same {@code charsPerToken} contract as {@link #estimateTraceContextTokens}:
      * configurable via {@code onlineScoring.agenticToolsCharsPerToken}.
      */
-    public static int estimateThreadContextTokens(@NonNull List<Trace> traces, int charsPerToken) {
+    public static int estimateThreadContextTokens(
+            @NonNull List<Trace> traces, @NonNull List<Span> spans, int charsPerToken) {
         Preconditions.checkArgument(charsPerToken >= 1, "charsPerToken must be >= 1, got %s", charsPerToken);
         try {
-            return OBJECT_MAPPER.writeValueAsString(fromTraceToThread(traces)).length() / charsPerToken;
+            return OBJECT_MAPPER.writeValueAsString(fromTraceToThreadEnriched(traces, spans)).length()
+                    / charsPerToken;
         } catch (JsonProcessingException ex) {
             throw new UncheckedIOException(ex);
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -99,20 +99,23 @@ public class OnlineScoringEngine {
      *         ChatLanguageModel
      */
     public static ChatRequest prepareLlmRequest(
-            @NonNull LlmAsJudgeCode evaluatorCode, Trace trace, StructuredOutputStrategy structuredOutputStrategy) {
-        return prepareLlmRequest(evaluatorCode, trace, structuredOutputStrategy, PromptType.MUSTACHE);
+            @NonNull LlmAsJudgeCode evaluatorCode, Trace trace,
+            StructuredOutputStrategy structuredOutputStrategy, @NonNull List<Span> spans) {
+        return prepareLlmRequest(evaluatorCode, trace, structuredOutputStrategy, PromptType.MUSTACHE, spans);
     }
 
     public static ChatRequest prepareLlmRequest(
             @NonNull LlmAsJudgeCode evaluatorCode, Trace trace,
-            StructuredOutputStrategy structuredOutputStrategy, @NonNull PromptType promptType) {
+            StructuredOutputStrategy structuredOutputStrategy, @NonNull PromptType promptType,
+            @NonNull List<Span> spans) {
         Map<String, String> replacements = toReplacements(evaluatorCode.variables(), trace);
+        injectSpansIntoReplacements(replacements, evaluatorCode.variables(), spans);
         var renderedMessages = renderMessagesWithReplacements(evaluatorCode.messages(), replacements, promptType);
         return buildChatRequest(renderedMessages, evaluatorCode.schema(), structuredOutputStrategy);
     }
 
     /**
-     * Variant of {@link #prepareLlmRequest(LlmAsJudgeCode, Trace, StructuredOutputStrategy, PromptType)}
+     * Variant of {@link #prepareLlmRequest(LlmAsJudgeCode, Trace, StructuredOutputStrategy, PromptType, List)}
      * that caps each rendered variable substitution at {@code maxReplacementChars}. Values longer
      * than the cap are replaced with their first {@code maxReplacementChars} chars followed by
      * {@code drillDownHint}. Used by the test-suite-assertion (tool-enabled) path, so a 50K-token
@@ -122,11 +125,52 @@ public class OnlineScoringEngine {
     public static ChatRequest prepareLlmRequest(
             @NonNull LlmAsJudgeCode evaluatorCode, Trace trace,
             StructuredOutputStrategy structuredOutputStrategy, @NonNull PromptType promptType,
-            int maxReplacementChars, @NonNull String drillDownHint) {
+            int maxReplacementChars, @NonNull String drillDownHint, @NonNull List<Span> spans) {
         Map<String, String> replacements = toReplacements(evaluatorCode.variables(), trace);
+        injectSpansIntoReplacements(replacements, evaluatorCode.variables(), spans);
         Map<String, String> capped = capReplacements(replacements, maxReplacementChars, drillDownHint);
         var renderedMessages = renderMessagesWithReplacements(evaluatorCode.messages(), capped, promptType);
         return buildChatRequest(renderedMessages, evaluatorCode.schema(), structuredOutputStrategy);
+    }
+
+    /**
+     * Whether the user's variable mapping declares a variable that should be substituted with
+     * the trace's spans list. Sentinel value (mirroring the Python-metric convention): any
+     * variable whose value is the bare string {@code "spans"} (no JSONPath prefix) gets the
+     * full spans array serialized as JSON at render time.
+     *
+     * <p>Used by the trace scorer to opt-in to the {@code spanService.getByTraceIds(...)} fetch
+     * for inline LLM-as-judge evaluations whose template references {@code {{spans}}} — without
+     * this gate, small traces would skip the fetch and the variable would render as the literal
+     * sentinel rather than the actual spans.
+     */
+    public static boolean templateReferencesSpans(@NonNull Map<String, String> variables) {
+        return variables.containsValue(SPANS_VARIABLE_NAME);
+    }
+
+    /**
+     * Replace any variable whose source path is the {@code "spans"} sentinel with the JSON-
+     * serialized spans list (sorted by start_time, matching the Python-metric convention).
+     * Mutates {@code replacements} in place. No-op when {@code spans} is empty or no variable
+     * references the sentinel — wasted JSONPath resolution on the bare {@code "spans"} value
+     * is left in place to keep the override path simple; the bad value gets overwritten.
+     */
+    private static void injectSpansIntoReplacements(
+            Map<String, String> replacements, Map<String, String> variables, List<Span> spans) {
+        if (spans.isEmpty() || !templateReferencesSpans(variables)) {
+            return;
+        }
+        String spansJson;
+        try {
+            spansJson = OBJECT_MAPPER.writeValueAsString(spans.stream().sorted(BY_SPAN_START_TIME).toList());
+        } catch (JsonProcessingException e) {
+            throw new UncheckedIOException(e);
+        }
+        variables.forEach((name, path) -> {
+            if (SPANS_VARIABLE_NAME.equals(path)) {
+                replacements.put(name, spansJson);
+            }
+        });
     }
 
     static Map<String, String> capReplacements(Map<String, String> replacements,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -1,10 +1,10 @@
 package com.comet.opik.api.resources.v1.events;
 
-import com.comet.opik.api.ErrorInfo;
 import com.comet.opik.api.LlmProvider;
 import com.comet.opik.api.PromptType;
 import com.comet.opik.api.ScoreSource;
 import com.comet.opik.api.Span;
+import com.comet.opik.api.SpanForLlm;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorSpanLlmAsJudge;
 import com.comet.opik.api.evaluators.LlmAsJudgeMessage;
@@ -13,13 +13,11 @@ import com.comet.opik.api.evaluators.LlmAsJudgeOutputSchema;
 import com.comet.opik.api.resources.v1.events.tools.StringTruncator;
 import com.comet.opik.api.resources.v1.events.tools.ToolRegistry;
 import com.comet.opik.api.resources.v1.events.tools.TraceCompressor;
-import com.comet.opik.domain.SpanType;
 import com.comet.opik.domain.evaluators.python.TraceThreadPythonEvaluatorRequest;
 import com.comet.opik.domain.llm.structuredoutput.StructuredOutputStrategy;
 import com.comet.opik.infrastructure.log.LogContextAware;
 import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.TemplateParseUtils;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -786,11 +784,13 @@ public class OnlineScoringEngine {
      * <p>Spans within each trace are sorted by start_time so the wire order matches call
      * order — same convention as the trace-scope {@code {{spans}}} path.
      *
-     * <p>Separate from {@link #fromTraceToThread(List)} which keeps returning the bare
-     * Python-evaluator {@code ChatMessage} shape — the Python runner has its own contract
-     * and we don't want to leak the {@code spans} field into that path.
+     * <p>Returns the same {@link TraceThreadPythonEvaluatorRequest.ChatMessage} type as
+     * {@link #fromTraceToThread(List)} so both render paths share one wire shape: the
+     * unified {@code ChatMessage} carries an optional {@code spans} field (omitted via
+     * {@code @JsonInclude(NON_NULL)} when null), making the enriched JSON a strict
+     * superset of the legacy {@code [{role, content}, ...]} contract.
      */
-    public static List<EnrichedThreadChatMessage> fromTraceToThreadEnriched(
+    public static List<TraceThreadPythonEvaluatorRequest.ChatMessage> fromTraceToThreadEnriched(
             @NonNull List<Trace> traces, @NonNull List<Span> spans) {
         Map<UUID, List<Span>> spansByTrace = spans.stream()
                 .collect(Collectors.groupingBy(Span::traceId));
@@ -802,72 +802,17 @@ public class OnlineScoringEngine {
                     List<SpanForLlm> traceSpans = buildSpanTree(
                             spansByTrace.getOrDefault(trace.id(), List.of()));
                     return Stream.of(
-                            EnrichedThreadChatMessage.builder()
+                            TraceThreadPythonEvaluatorRequest.ChatMessage.builder()
                                     .role(TraceThreadPythonEvaluatorRequest.ROLE_USER)
                                     .content(trace.input())
                                     .build(),
-                            EnrichedThreadChatMessage.builder()
+                            TraceThreadPythonEvaluatorRequest.ChatMessage.builder()
                                     .role(TraceThreadPythonEvaluatorRequest.ROLE_ASSISTANT)
                                     .content(trace.output())
                                     .spans(traceSpans.isEmpty() ? null : traceSpans)
                                     .build());
                 })
                 .toList();
-    }
-
-    /**
-     * Enriched chat-message shape for thread-scope {@code {{context}}} rendering. Extends
-     * the existing {@code {role, content}} contract with an optional {@code spans} field
-     * carrying the assistant turn's tool calls and other child spans. The field is omitted
-     * from the JSON when null (via {@link JsonInclude.Include#NON_NULL}) so existing rules
-     * that don't care about spans see the exact same wire shape they see today.
-     */
-    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @Builder(toBuilder = true)
-    public record EnrichedThreadChatMessage(String role, JsonNode content, List<SpanForLlm> spans) {
-    }
-
-    /**
-     * Lean projection of {@link Span} for the LLM-judge prompt. The raw {@code Span} record
-     * carries ~28 fields — audit metadata, feedback scores, comments, cost data, etc. — and
-     * pasting all of it into a prompt burns tokens on irrelevant content and can confuse the
-     * judge ("why is there a {@code feedback_scores} array? am I supposed to defer to that?").
-     *
-     * <p>Keep only what helps a judge reason about agent behavior:
-     * <ul>
-     *   <li>{@code name} / {@code type}: which tool or LLM ran
-     *   <li>{@code input} / {@code output}: what was passed and what came back
-     *   <li>{@code metadata}: user-provided context the agent attached
-     *   <li>{@code startTime} / {@code endTime} / {@code duration}: call order + how long
-     *   <li>{@code model} / {@code provider}: for LLM spans, which model
-     *   <li>{@code errorInfo}: if the call failed
-     *   <li>{@code spans}: nested child spans, recursively projected — lets the judge see the
-     *       call tree (planner → sub-agent → tool) instead of a flat list with parent-id refs
-     *       it would have to mentally resolve. Built by {@link #buildSpanTree}.
-     * </ul>
-     * Null fields are omitted via {@code @JsonInclude(NON_NULL)} so e.g. a successful tool
-     * span doesn't pad the JSON with {@code error_info: null}, and a leaf span doesn't pad
-     * with an empty {@code spans} array. Same shape is used by the trace-scope
-     * {@code {{spans}}} substitution and the thread-scope {@code {{context}}} per-assistant
-     * {@code spans} field — one projection, two render paths.
-     */
-    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @Builder(toBuilder = true)
-    public record SpanForLlm(
-            String name,
-            SpanType type,
-            Instant startTime,
-            Instant endTime,
-            Double duration,
-            JsonNode input,
-            JsonNode output,
-            JsonNode metadata,
-            String model,
-            String provider,
-            ErrorInfo errorInfo,
-            List<SpanForLlm> spans) {
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -151,13 +151,15 @@ public class OnlineScoringEngine {
     /**
      * Replace any variable whose source path is the {@code "spans"} sentinel with the JSON-
      * serialized spans list (sorted by start_time, matching the Python-metric convention).
-     * Mutates {@code replacements} in place. No-op when {@code spans} is empty or no variable
-     * references the sentinel — wasted JSONPath resolution on the bare {@code "spans"} value
-     * is left in place to keep the override path simple; the bad value gets overwritten.
+     * Mutates {@code replacements} in place. No-op when no variable references the sentinel.
+     *
+     * <p>An empty spans list still triggers the rewrite (rendering as {@code "[]"}) — without
+     * it, {@code toReplacements} leaves the bare {@code "spans"} value as a literal and the
+     * prompt renders the word "spans" instead of an empty array.
      */
     private static void injectSpansIntoReplacements(
             Map<String, String> replacements, Map<String, String> variables, List<Span> spans) {
-        if (spans.isEmpty() || !templateReferencesSpans(variables)) {
+        if (!templateReferencesSpans(variables)) {
             return;
         }
         String spansJson;

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -109,7 +109,8 @@ public class OnlineScoringEngine {
             StructuredOutputStrategy structuredOutputStrategy, @NonNull PromptType promptType,
             @NonNull List<Span> spans) {
         Map<String, String> replacements = toReplacements(evaluatorCode.variables(), trace);
-        injectSpansIntoReplacements(replacements, evaluatorCode.variables(), spans);
+        injectSpansIntoReplacements(replacements, evaluatorCode.variables(),
+                evaluatorCode.messages(), promptType, spans);
         var renderedMessages = renderMessagesWithReplacements(evaluatorCode.messages(), replacements, promptType);
         return buildChatRequest(renderedMessages, evaluatorCode.schema(), structuredOutputStrategy);
     }
@@ -127,39 +128,76 @@ public class OnlineScoringEngine {
             StructuredOutputStrategy structuredOutputStrategy, @NonNull PromptType promptType,
             int maxReplacementChars, @NonNull String drillDownHint, @NonNull List<Span> spans) {
         Map<String, String> replacements = toReplacements(evaluatorCode.variables(), trace);
-        injectSpansIntoReplacements(replacements, evaluatorCode.variables(), spans);
+        injectSpansIntoReplacements(replacements, evaluatorCode.variables(),
+                evaluatorCode.messages(), promptType, spans);
         Map<String, String> capped = capReplacements(replacements, maxReplacementChars, drillDownHint);
         var renderedMessages = renderMessagesWithReplacements(evaluatorCode.messages(), capped, promptType);
         return buildChatRequest(renderedMessages, evaluatorCode.schema(), structuredOutputStrategy);
     }
 
     /**
-     * Whether the user's variable mapping declares a variable that should be substituted with
-     * the trace's spans list. Sentinel value (mirroring the Python-metric convention): any
-     * variable whose value is the bare string {@code "spans"} (no JSONPath prefix) gets the
-     * full spans array serialized as JSON at render time.
+     * Whether the rule needs the trace's spans list rendered into the prompt. Two ways to
+     * opt in:
+     * <ul>
+     *   <li>Sentinel-valued variable: any entry in {@code variables} whose value is the bare
+     *       string {@code "spans"} (no JSONPath prefix) — mirrors the Python-metric convention
+     *       and is what the FE writes when the user types {@code {{spans}}} in the prompt.
+     *   <li>Direct template reference: any message in {@code messages} references
+     *       {@code {{spans}}} (per {@code promptType}) without the variables map mapping it
+     *       to a custom path. Catches API-created rules where the caller put {@code {{spans}}}
+     *       in the prompt but didn't (or didn't know to) set the sentinel mapping.
+     * </ul>
      *
      * <p>Used by the trace scorer to opt-in to the {@code spanService.getByTraceIds(...)} fetch
-     * for inline LLM-as-judge evaluations whose template references {@code {{spans}}} — without
-     * this gate, small traces would skip the fetch and the variable would render as the literal
-     * sentinel rather than the actual spans.
+     * for inline LLM-as-judge evaluations whose template references {@code {{spans}}}.
      */
-    public static boolean templateReferencesSpans(@NonNull Map<String, String> variables) {
-        return variables.containsValue(SPANS_VARIABLE_NAME);
+    public static boolean templateReferencesSpans(
+            @NonNull List<LlmAsJudgeMessage> messages,
+            @NonNull Map<String, String> variables,
+            @NonNull PromptType promptType) {
+        return variables.containsValue(SPANS_VARIABLE_NAME)
+                || messagesReferenceSpansDirectly(messages, variables, promptType);
+    }
+
+    /**
+     * True when at least one message template references {@code {{spans}}} (or the equivalent
+     * for {@code promptType}) AND the variables map does not bind {@code spans} to a custom
+     * path. The second clause respects explicit user mappings — e.g. a rule that maps
+     * {@code spans} to {@code input.something} keeps that mapping instead of being silently
+     * overridden by the spans-list injection.
+     */
+    private static boolean messagesReferenceSpansDirectly(
+            List<LlmAsJudgeMessage> messages, Map<String, String> variables, PromptType promptType) {
+        if (variables.containsKey(SPANS_VARIABLE_NAME)) {
+            return false;
+        }
+        return messages.stream()
+                .map(LlmAsJudgeMessage::content)
+                .filter(Objects::nonNull)
+                .anyMatch(content -> TemplateParseUtils.extractVariables(content, promptType)
+                        .contains(SPANS_VARIABLE_NAME));
     }
 
     /**
      * Replace any variable whose source path is the {@code "spans"} sentinel with the JSON-
      * serialized spans list (sorted by start_time, matching the Python-metric convention).
-     * Mutates {@code replacements} in place. No-op when no variable references the sentinel.
+     * Mutates {@code replacements} in place. No-op when no variable references the sentinel
+     * and no message template references {@code {{spans}}} directly.
      *
      * <p>An empty spans list still triggers the rewrite (rendering as {@code "[]"}) — without
      * it, {@code toReplacements} leaves the bare {@code "spans"} value as a literal and the
      * prompt renders the word "spans" instead of an empty array.
+     *
+     * <p>Also handles the implicit-reference case (template uses {@code {{spans}}} but the
+     * variables map doesn't bind it): mirrors the FE auto-fill server-side so API-created
+     * rules get the same behavior without forcing every caller to know the sentinel convention.
      */
     private static void injectSpansIntoReplacements(
-            Map<String, String> replacements, Map<String, String> variables, List<Span> spans) {
-        if (!templateReferencesSpans(variables)) {
+            Map<String, String> replacements, Map<String, String> variables,
+            List<LlmAsJudgeMessage> messages, PromptType promptType, List<Span> spans) {
+        boolean sentinelMapped = variables.containsValue(SPANS_VARIABLE_NAME);
+        boolean templateOnly = messagesReferenceSpansDirectly(messages, variables, promptType);
+        if (!sentinelMapped && !templateOnly) {
             return;
         }
         String spansJson;
@@ -173,6 +211,9 @@ public class OnlineScoringEngine {
                 replacements.put(name, spansJson);
             }
         });
+        if (templateOnly) {
+            replacements.put(SPANS_VARIABLE_NAME, spansJson);
+        }
     }
 
     static Map<String, String> capReplacements(Map<String, String> replacements,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -346,16 +346,27 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
      *       cache so the in-loop {@code get_trace_spans} call doesn't redo the fetch.
      *   <li>The inline prompt template references {@code {{spans}}} — see
      *       {@link OnlineScoringEngine#templateReferencesSpans} for both opt-in shapes
-     *       (sentinel-valued variable AND implicit template reference). <strong>Gated by the
-     *       same {@code isAgenticToolsEnabled} toggle</strong>: both pathways ship as one
-     *       feature, so a single flip turns spans-in-prompts on or off org-wide. When the
-     *       toggle is off and no experimentId branch is active, the fetch is skipped and
-     *       {@code injectSpansIntoReplacements} substitutes an empty array into {@code {{spans}}}
-     *       via the empty list threaded through {@code prepareLlmRequest}.
+     *       (sentinel-valued variable AND implicit template reference). <strong>Gated by
+     *       {@code isAgenticToolsEnabled}</strong>: both pathways ship under the same flag.
      * </ul>
      *
-     * <p>Skipping the fetch otherwise avoids a {@code spanService.getByTraceIds} call per
-     * scored trace on rules that don't need spans.
+     * <p><strong>Toggle semantics — important and not symmetric:</strong> this method gates
+     * the {@code spanService.getByTraceIds} I/O. It does <em>not</em> gate the substitution
+     * itself — {@link OnlineScoringEngine#injectSpansIntoReplacements} runs unconditionally
+     * inside {@code prepareLlmRequest}. When the toggle is off and a rule still carries a
+     * sentinel-mapped {@code spans} variable (e.g. saved by an older FE before the toggle
+     * flipped), {@code {{spans}}} renders as the empty JSON array {@code []} via the empty
+     * spans list threaded through. We do <em>not</em> gate the substitution because doing so
+     * would let the sentinel value {@code "spans"} leak through {@code toReplacements}'
+     * literal-value fallback and render the bare word {@code spans} in the prompt — worse
+     * UX than {@code []}. Net behavior with toggle off:
+     * <ul>
+     *   <li>Existing rules with sentinel mapping → {@code Spans: []}
+     *   <li>New rules created via the FE → FE skips the auto-fill, user maps {@code spans}
+     *       like any other variable, BE renders whatever path they pick.
+     *   <li>Experiment-id (test-suite assertion) path → agentic-tools fires regardless, so
+     *       spans are still fetched and {@code {{spans}}} substitutes the actual JSON.
+     * </ul>
      */
     // Package-private for unit tests.
     boolean shouldFetchSpans(TraceToScoreLlmAsJudge message) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -165,18 +165,7 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
         // string "spans"). Skip the I/O otherwise. Keeping the fetch reactive and out of
         // evaluate() avoids the .block() pattern that pinned a workersScheduler thread for the
         // upstream wait (OPIK-6308).
-        String modelName = message.llmAsJudgeCode().model().name();
-        boolean agenticToolsPathPossible = OnlineScoringEngine.supportsToolCalling(
-                llmProviderFactory.getLlmProvider(modelName))
-                && (LlmAsJudgeToolsMode.shouldUseTools(message)
-                        || serviceTogglesConfig.isAgenticToolsEnabled());
-        boolean templateNeedsSpans = OnlineScoringEngine
-                .templateReferencesSpans(
-                        message.llmAsJudgeCode().messages(),
-                        message.llmAsJudgeCode().variables(),
-                        message.promptType());
-        boolean spansNeeded = agenticToolsPathPossible || templateNeedsSpans;
-        Mono<List<Span>> spansMono = spansNeeded
+        Mono<List<Span>> spansMono = shouldFetchSpans(message)
                 ? spanService.getByTraceIds(Set.of(trace.id()))
                         .collectList()
                         .contextWrite(ctx -> ctx
@@ -346,6 +335,35 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
 
     private static boolean shouldUseTools(TraceToScoreLlmAsJudge message) {
         return LlmAsJudgeToolsMode.shouldUseTools(message);
+    }
+
+    /**
+     * Routing decision for whether to fetch the trace's spans before running the LLM call.
+     * Spans are needed in two cases:
+     * <ul>
+     *   <li>The agentic-tools path is possible (provider supports tools AND the experimentId
+     *       branch is on OR the size-based toggle is enabled) — spans pre-seed the read-tool
+     *       cache so the in-loop {@code get_trace_spans} call doesn't redo the fetch.
+     *   <li>The inline prompt template references {@code {{spans}}} — see
+     *       {@link OnlineScoringEngine#templateReferencesSpans} for both opt-in shapes
+     *       (sentinel-valued variable AND implicit template reference).
+     * </ul>
+     *
+     * <p>Skipping the fetch otherwise avoids a {@code spanService.getByTraceIds} call per
+     * scored trace on rules that don't need spans.
+     */
+    // Package-private for unit tests.
+    boolean shouldFetchSpans(TraceToScoreLlmAsJudge message) {
+        String modelName = message.llmAsJudgeCode().model().name();
+        boolean agenticToolsPathPossible = OnlineScoringEngine.supportsToolCalling(
+                llmProviderFactory.getLlmProvider(modelName))
+                && (LlmAsJudgeToolsMode.shouldUseTools(message)
+                        || serviceTogglesConfig.isAgenticToolsEnabled());
+        boolean templateNeedsSpans = OnlineScoringEngine.templateReferencesSpans(
+                message.llmAsJudgeCode().messages(),
+                message.llmAsJudgeCode().variables(),
+                message.promptType());
+        return agenticToolsPathPossible || templateNeedsSpans;
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -158,18 +158,21 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                 UserLog.TRACE_ID, trace.id().toString(),
                 UserLog.RULE_ID, message.ruleId().toString());
 
-        // Spans are fetched here, in the reactive chain, only when the agentic-tools path could
-        // fire — i.e. when the provider supports tool-calling AND either the experimentId
-        // branch is on (test-suite assertion) or the size-based toggle is on. If the provider
-        // can't handle tools, shouldUseAgenticTools will fall back to inline regardless, so
-        // pre-fetching spans would just be wasted I/O. Keeping the fetch reactive and out of
+        // Spans are fetched here, in the reactive chain, only when they'll actually be consumed
+        // downstream — either to pre-seed the agentic-tools cache (provider supports tools AND
+        // experimentId branch OR size-based toggle is on) OR to substitute into a {{spans}}
+        // template variable on the inline path (sentinel: any variable mapped to the bare
+        // string "spans"). Skip the I/O otherwise. Keeping the fetch reactive and out of
         // evaluate() avoids the .block() pattern that pinned a workersScheduler thread for the
         // upstream wait (OPIK-6308).
         String modelName = message.llmAsJudgeCode().model().name();
-        boolean spansNeeded = OnlineScoringEngine.supportsToolCalling(
+        boolean agenticToolsPathPossible = OnlineScoringEngine.supportsToolCalling(
                 llmProviderFactory.getLlmProvider(modelName))
                 && (LlmAsJudgeToolsMode.shouldUseTools(message)
                         || serviceTogglesConfig.isAgenticToolsEnabled());
+        boolean templateNeedsSpans = OnlineScoringEngine
+                .templateReferencesSpans(message.llmAsJudgeCode().variables());
+        boolean spansNeeded = agenticToolsPathPossible || templateNeedsSpans;
         Mono<List<Span>> spansMono = spansNeeded
                 ? spanService.getByTraceIds(Set.of(trace.id()))
                         .collectList()
@@ -275,7 +278,7 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                             .formatted(trace.id(), trace.id());
                     scoreRequest = OnlineScoringEngine.prepareLlmRequest(
                             message.llmAsJudgeCode(), trace, new InstructionStrategy(),
-                            message.promptType(), MAX_PROMPT_FIELD_CHARS, drillDownHint);
+                            message.promptType(), MAX_PROMPT_FIELD_CHARS, drillDownHint, spans);
                     // The post-tool-loop wrap-up must use the provider-native structured-output
                     // strategy (e.g. response_format=json_schema on OpenAI). InstructionStrategy
                     // is a soft prompt and Anthropic in particular often returns conversational
@@ -284,12 +287,12 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                     structuredRequest = OnlineScoringEngine.prepareLlmRequest(
                             message.llmAsJudgeCode(), trace,
                             llmProviderFactory.getStructuredOutputStrategy(modelName),
-                            message.promptType(), MAX_PROMPT_FIELD_CHARS, drillDownHint);
+                            message.promptType(), MAX_PROMPT_FIELD_CHARS, drillDownHint, spans);
                 } else {
                     scoreRequest = OnlineScoringEngine.prepareLlmRequest(
                             message.llmAsJudgeCode(), trace,
                             llmProviderFactory.getStructuredOutputStrategy(modelName),
-                            message.promptType());
+                            message.promptType(), spans);
                     structuredRequest = scoreRequest;
                 }
             } catch (Exception exception) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -171,7 +171,10 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                 && (LlmAsJudgeToolsMode.shouldUseTools(message)
                         || serviceTogglesConfig.isAgenticToolsEnabled());
         boolean templateNeedsSpans = OnlineScoringEngine
-                .templateReferencesSpans(message.llmAsJudgeCode().variables());
+                .templateReferencesSpans(
+                        message.llmAsJudgeCode().messages(),
+                        message.llmAsJudgeCode().variables(),
+                        message.promptType());
         boolean spansNeeded = agenticToolsPathPossible || templateNeedsSpans;
         Mono<List<Span>> spansMono = spansNeeded
                 ? spanService.getByTraceIds(Set.of(trace.id()))

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -346,7 +346,12 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
      *       cache so the in-loop {@code get_trace_spans} call doesn't redo the fetch.
      *   <li>The inline prompt template references {@code {{spans}}} — see
      *       {@link OnlineScoringEngine#templateReferencesSpans} for both opt-in shapes
-     *       (sentinel-valued variable AND implicit template reference).
+     *       (sentinel-valued variable AND implicit template reference). <strong>Gated by the
+     *       same {@code isAgenticToolsEnabled} toggle</strong>: both pathways ship as one
+     *       feature, so a single flip turns spans-in-prompts on or off org-wide. When the
+     *       toggle is off and no experimentId branch is active, the fetch is skipped and
+     *       {@code injectSpansIntoReplacements} substitutes an empty array into {@code {{spans}}}
+     *       via the empty list threaded through {@code prepareLlmRequest}.
      * </ul>
      *
      * <p>Skipping the fetch otherwise avoids a {@code spanService.getByTraceIds} call per
@@ -359,10 +364,11 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                 llmProviderFactory.getLlmProvider(modelName))
                 && (LlmAsJudgeToolsMode.shouldUseTools(message)
                         || serviceTogglesConfig.isAgenticToolsEnabled());
-        boolean templateNeedsSpans = OnlineScoringEngine.templateReferencesSpans(
-                message.llmAsJudgeCode().messages(),
-                message.llmAsJudgeCode().variables(),
-                message.promptType());
+        boolean templateNeedsSpans = serviceTogglesConfig.isAgenticToolsEnabled()
+                && OnlineScoringEngine.templateReferencesSpans(
+                        message.llmAsJudgeCode().messages(),
+                        message.llmAsJudgeCode().variables(),
+                        message.promptType());
         return agenticToolsPathPossible || templateNeedsSpans;
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -2,6 +2,7 @@ package com.comet.opik.api.resources.v1.events;
 
 import com.comet.opik.api.Project;
 import com.comet.opik.api.ScoreSource;
+import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.Visibility;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluator;
@@ -11,6 +12,7 @@ import com.comet.opik.api.resources.v1.events.tools.ToolRegistry;
 import com.comet.opik.api.resources.v1.events.tools.TraceToolContext;
 import com.comet.opik.domain.FeedbackScoreService;
 import com.comet.opik.domain.ProjectService;
+import com.comet.opik.domain.SpanService;
 import com.comet.opik.domain.TraceService;
 import com.comet.opik.domain.evaluators.AutomationRuleEvaluatorService;
 import com.comet.opik.domain.evaluators.UserLog;
@@ -68,6 +70,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
     private final ToolRegistry toolRegistry;
     private final OnlineScoringConfig onlineScoringConfig;
     private final ServiceTogglesConfig serviceTogglesConfig;
+    private final SpanService spanService;
 
     @Inject
     public OnlineScoringTraceThreadLlmAsJudgeScorer(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
@@ -80,7 +83,8 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
             @NonNull TraceThreadService traceThreadService,
             @NonNull ProjectService projectService,
             @NonNull AutomationRuleEvaluatorService automationRuleEvaluatorService,
-            @NonNull ToolRegistry toolRegistry) {
+            @NonNull ToolRegistry toolRegistry,
+            @NonNull SpanService spanService) {
         super(config, redisson, feedbackScoreService, traceService, TRACE_THREAD_LLM_AS_JUDGE,
                 Constants.TRACE_THREAD_LLM_AS_JUDGE);
         this.aiProxyService = aiProxyService;
@@ -91,6 +95,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         this.toolRegistry = toolRegistry;
         this.onlineScoringConfig = config;
         this.serviceTogglesConfig = serviceTogglesConfig;
+        this.spanService = spanService;
         this.userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringTraceThreadLlmAsJudgeScorer.class);
     }
 
@@ -202,7 +207,22 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
      */
     private Mono<Void> scoreThread(TraceThreadToScoreLlmAsJudge message, List<Trace> traces, UUID threadModelId,
             String threadId, AutomationRuleEvaluator<?, ?> rule, Map<String, String> mdc) {
-        return evaluate(message, traces, threadModelId, threadId, rule, mdc)
+        // When the feature flag is on, fetch every span across every trace in the thread up
+        // front. Threading them into prepareEvaluation lets {{context}} render with the
+        // enriched per-assistant `spans` field AND lets the size estimate account for them,
+        // so big enriched threads still auto-route to the agentic-tools path. When the flag
+        // is off, an empty list is passed through and the rendered shape matches today's
+        // exactly (the enriched serializer omits the `spans` field when null).
+        Mono<List<Span>> spansMono = serviceTogglesConfig.isAgenticToolsEnabled()
+                ? spanService.getByTraceIds(traces.stream().map(Trace::id)
+                        .collect(java.util.stream.Collectors.toSet()))
+                        .collectList()
+                        .contextWrite(ctx -> ctx
+                                .put(RequestContext.WORKSPACE_ID, message.workspaceId())
+                                .put(RequestContext.USER_NAME, message.userName()))
+                : Mono.just(List.of());
+        return spansMono
+                .flatMap(spans -> evaluate(message, traces, spans, threadModelId, threadId, rule, mdc))
                 .flatMap(scores -> storeThreadScores(scores, threadId, message.userName(), message.workspaceId()))
                 .doOnNext(withMdc(mdc, loggedScores -> userFacingLogger
                         .info("Scores for threadId '{}' stored successfully:\n\n{}", threadId, loggedScores)))
@@ -221,9 +241,9 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
      * toggle is on. Otherwise the inline path runs unchanged — same shape as today.
      */
     private Mono<List<FeedbackScoreBatchItemThread>> evaluate(TraceThreadToScoreLlmAsJudge message,
-            List<Trace> traces, UUID threadModelId, String threadId, AutomationRuleEvaluator<?, ?> rule,
-            Map<String, String> mdc) {
-        return Mono.fromCallable(() -> prepareEvaluation(message, traces, threadId, rule, mdc))
+            List<Trace> traces, List<Span> spans, UUID threadModelId, String threadId,
+            AutomationRuleEvaluator<?, ?> rule, Map<String, String> mdc) {
+        return Mono.fromCallable(() -> prepareEvaluation(message, traces, spans, threadId, rule, mdc))
                 .subscribeOn(Schedulers.parallel())
                 .flatMap(prepared -> scoreTraceReactive(prepared.scoreRequest(), message)
                         .doOnNext(withMdc(mdc, chatResponse -> {
@@ -262,16 +282,19 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
      * rendering); no blocking I/O happens here.
      */
     private PreparedEvaluation prepareEvaluation(TraceThreadToScoreLlmAsJudge message, List<Trace> traces,
-            String threadId, AutomationRuleEvaluator<?, ?> rule, Map<String, String> mdc) {
+            List<Span> spans, String threadId, AutomationRuleEvaluator<?, ?> rule, Map<String, String> mdc) {
         try (var logContext = wrapWithMdc(mdc)) {
             userFacingLogger.info("Evaluating threadId '{}' sampled by rule '{}'", threadId, rule.getName());
 
             String modelName = message.code().model().name();
             // Skip the JSON serialization that drives the token estimate when the toggle is off —
             // we'd just throw the number away. shouldUseAgenticTools re-checks the toggle, so the
-            // estimate is only consulted on the agentic-tools path.
+            // estimate is only consulted on the agentic-tools path. When the toggle is on, `spans`
+            // is the pre-fetched per-thread span list (empty when toggle off) and is factored in so
+            // an enriched-context payload routes to tools when it's actually big — not when the
+            // trace bodies alone happen to be small.
             int estimatedContextTokens = serviceTogglesConfig.isAgenticToolsEnabled()
-                    ? OnlineScoringEngine.estimateThreadContextTokens(traces,
+                    ? OnlineScoringEngine.estimateThreadContextTokens(traces, spans,
                             onlineScoringConfig.getAgenticToolsCharsPerToken())
                     : 0;
             boolean useTools = shouldUseAgenticTools(estimatedContextTokens, modelName, threadId,
@@ -293,7 +316,11 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                     // wrap-up requests share a shape (modulo tool specs).
                     structuredRequest = scoreRequest;
                 } else {
-                    scoreRequest = OnlineScoringEngine.prepareThreadLlmRequest(message.code(), traces, strategy);
+                    // Inline path: render {{context}} with the enriched per-assistant `spans`
+                    // shape. When the toggle is off, `spans` is an empty list and the JSON is
+                    // wire-identical to today's [{role, content}, ...].
+                    scoreRequest = OnlineScoringEngine.prepareThreadLlmRequest(message.code(), traces, strategy,
+                            spans);
                     structuredRequest = scoreRequest;
                 }
             } catch (Exception exception) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -50,6 +50,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItemThread;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.Constants;
@@ -207,15 +208,21 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
      */
     private Mono<Void> scoreThread(TraceThreadToScoreLlmAsJudge message, List<Trace> traces, UUID threadModelId,
             String threadId, AutomationRuleEvaluator<?, ?> rule, Map<String, String> mdc) {
-        // When the feature flag is on, fetch every span across every trace in the thread up
-        // front. Threading them into prepareEvaluation lets {{context}} render with the
-        // enriched per-assistant `spans` field AND lets the size estimate account for them,
-        // so big enriched threads still auto-route to the agentic-tools path. When the flag
-        // is off, an empty list is passed through and the rendered shape matches today's
-        // exactly (the enriched serializer omits the `spans` field when null).
+        // When the feature flag is on, fetch every span across every trace in the thread
+        // up front. We fetch BEFORE the inline-vs-tools path decision in prepareEvaluation
+        // (rather than only when the inline path wins) so estimateThreadContextTokens can
+        // serialize the enriched shape and route honestly — otherwise a thread with small
+        // trace bodies but huge spans would inline-render an oversized prompt. The cost is
+        // wasted I/O when the tools path ultimately wins: the prepared spans go unused on
+        // that path (which renders only the compact skeleton; the model uses ReadTool to
+        // re-fetch per-trace on demand). Acceptable trade-off — route correctness over a
+        // narrow over-fetch.
+        //
+        // When the flag is off, an empty list is passed through; the enriched serializer
+        // omits the `spans` field via @JsonInclude(NON_NULL), so the rendered JSON is
+        // byte-identical to today's [{role, content}, ...] shape.
         Mono<List<Span>> spansMono = serviceTogglesConfig.isAgenticToolsEnabled()
-                ? spanService.getByTraceIds(traces.stream().map(Trace::id)
-                        .collect(java.util.stream.Collectors.toSet()))
+                ? spanService.getByTraceIds(traces.stream().map(Trace::id).collect(Collectors.toSet()))
                         .collectList()
                         .contextWrite(ctx -> ctx
                                 .put(RequestContext.WORKSPACE_ID, message.workspaceId())

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
@@ -2,12 +2,14 @@ package com.comet.opik.api.resources.v1.events;
 
 import com.comet.opik.api.Project;
 import com.comet.opik.api.ScoreSource;
+import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.Visibility;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluator;
 import com.comet.opik.api.events.TraceThreadToScoreUserDefinedMetricPython;
 import com.comet.opik.domain.FeedbackScoreService;
 import com.comet.opik.domain.ProjectService;
+import com.comet.opik.domain.SpanService;
 import com.comet.opik.domain.TraceService;
 import com.comet.opik.domain.evaluators.AutomationRuleEvaluatorService;
 import com.comet.opik.domain.evaluators.UserLog;
@@ -39,6 +41,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItemThread;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.Constants;
@@ -59,6 +62,7 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
     private final Logger userFacingLogger;
     private final ProjectService projectService;
     private final AutomationRuleEvaluatorService automationRuleEvaluatorService;
+    private final SpanService spanService;
 
     @Inject
     public OnlineScoringTraceThreadUserDefinedMetricPythonScorer(
@@ -70,7 +74,8 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
             @NonNull TraceService traceService,
             @NonNull TraceThreadService traceThreadService,
             @NonNull ProjectService projectService,
-            @NonNull AutomationRuleEvaluatorService automationRuleEvaluatorService) {
+            @NonNull AutomationRuleEvaluatorService automationRuleEvaluatorService,
+            @NonNull SpanService spanService) {
         super(config, redisson, feedbackScoreService, traceService, TRACE_THREAD_USER_DEFINED_METRIC_PYTHON,
                 Constants.TRACE_THREAD_USER_DEFINED_METRIC_PYTHON);
         this.pythonEvaluatorService = pythonEvaluatorService;
@@ -78,6 +83,7 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
         this.traceThreadService = traceThreadService;
         this.projectService = projectService;
         this.automationRuleEvaluatorService = automationRuleEvaluatorService;
+        this.spanService = spanService;
         this.userFacingLogger = UserFacingLoggingFactory
                 .getLogger(OnlineScoringTraceThreadUserDefinedMetricPythonScorer.class);
     }
@@ -194,7 +200,23 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
      */
     private Mono<Void> scoreThread(TraceThreadToScoreUserDefinedMetricPython message, List<Trace> traces,
             UUID threadModelId, String threadId, AutomationRuleEvaluator<?, ?> rule, Map<String, String> mdc) {
-        return Mono.fromCallable(() -> prepareScoring(message, traces, threadId, rule, mdc))
+        // Fetch every span across every trace in the thread when the agentic-tools feature
+        // flag is on — same gate as the LLM-as-judge thread scorer. Spans get nested under
+        // their trace's assistant ChatMessage via fromTraceToThreadEnriched, so the user's
+        // Python `score(...)` method sees the full call tree (tool inputs/outputs + LLM
+        // calls) instead of the legacy {role, content}-only shape. When the toggle is off,
+        // empty spans → ChatMessage's `spans` field omitted via @JsonInclude(NON_NULL) →
+        // wire-identical to today's [{role, content}, ...].
+        Mono<List<Span>> spansMono = serviceTogglesConfig.isAgenticToolsEnabled()
+                ? spanService.getByTraceIds(traces.stream().map(Trace::id).collect(Collectors.toSet()))
+                        .collectList()
+                        .contextWrite(ctx -> ctx
+                                .put(RequestContext.WORKSPACE_ID, message.workspaceId())
+                                .put(RequestContext.USER_NAME, message.userName()))
+                : Mono.just(List.of());
+        return spansMono
+                .flatMap(spans -> Mono.fromCallable(
+                        () -> prepareScoring(message, traces, spans, threadId, rule, mdc)))
                 .flatMap(context -> evaluateAndStore(message, threadModelId, threadId, context, mdc))
                 .doOnError(withMdc(mdc, error -> userFacingLogger
                         .error("Unexpected error while scoring threadId '{}' with rule '{}': \n\n{}",
@@ -209,15 +231,20 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
      * guarantees {@code traces} is non-empty.
      */
     private Pair<Project, List<ChatMessage>> prepareScoring(TraceThreadToScoreUserDefinedMetricPython message,
-            List<Trace> traces, String threadId, AutomationRuleEvaluator<?, ?> rule, Map<String, String> mdc) {
+            List<Trace> traces, List<Span> spans, String threadId, AutomationRuleEvaluator<?, ?> rule,
+            Map<String, String> mdc) {
         try (var logContext = wrapWithMdc(mdc)) {
             userFacingLogger.info("Evaluating threadId '{}' sampled by rule '{}'", threadId, rule.getName());
 
             Project project = projectService.get(message.projectId(), message.workspaceId());
 
+            // Always use the enriched helper — when `spans` is empty (toggle off, see
+            // scoreThread), it emits the legacy [{role, content}, ...] shape via
+            // @JsonInclude(NON_NULL) on ChatMessage.spans. When non-empty, the assistant
+            // entry for each trace carries the nested span tree.
             List<ChatMessage> context;
             try {
-                context = OnlineScoringEngine.fromTraceToThread(traces);
+                context = OnlineScoringEngine.fromTraceToThreadEnriched(traces, spans);
             } catch (Exception exception) {
                 userFacingLogger.error("Error preparing Python request for threadId '{}': \n\n{}",
                         threadId, exception.getMessage());

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
@@ -215,8 +215,15 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
                                 .put(RequestContext.USER_NAME, message.userName()))
                 : Mono.just(List.of());
         return spansMono
+                // boundedElastic so the blocking JDBC call inside prepareScoring
+                // (projectService.get) doesn't pin the upstream thread — could be the consumer
+                // loop when spansMono is Mono.just(empty), or the spanService DB thread when
+                // spansMono is the getByTraceIds fetch. Either way, blocking on those threads
+                // is bad; boundedElastic is the standard pick for wrapping blocking calls in a
+                // reactive chain.
                 .flatMap(spans -> Mono.fromCallable(
-                        () -> prepareScoring(message, traces, spans, threadId, rule, mdc)))
+                        () -> prepareScoring(message, traces, spans, threadId, rule, mdc))
+                        .subscribeOn(Schedulers.boundedElastic()))
                 .flatMap(context -> evaluateAndStore(message, threadModelId, threadId, context, mdc))
                 .doOnError(withMdc(mdc, error -> userFacingLogger
                         .error("Unexpected error while scoring threadId '{}' with rule '{}': \n\n{}",

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/python/TraceThreadPythonEvaluatorRequest.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/python/TraceThreadPythonEvaluatorRequest.java
@@ -1,5 +1,7 @@
 package com.comet.opik.domain.evaluators.python;
 
+import com.comet.opik.api.SpanForLlm;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -17,9 +19,18 @@ public record TraceThreadPythonEvaluatorRequest(@NotEmpty String code, @NotNull 
     public static final String ROLE_ASSISTANT = "assistant";
     public static final String ROLE_USER = "user";
 
+    /**
+     * One turn of the rendered thread conversation. The {@code spans} field is optional —
+     * when null, it's omitted from the JSON (via {@code @JsonInclude(NON_NULL)}) so the
+     * wire shape matches today's {@code {role, content}} contract exactly. When populated
+     * (LLM-as-judge and Python thread scorer with the agentic-tools feature flag on), it
+     * carries the assistant turn's tool calls and other child spans as a nested tree —
+     * see {@link SpanForLlm}.
+     */
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Builder(toBuilder = true)
-    public record ChatMessage(@NotEmpty String role, @NotEmpty JsonNode content) {
+    public record ChatMessage(@NotEmpty String role, @NotEmpty JsonNode content, List<SpanForLlm> spans) {
     }
 
     @JsonProperty

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
@@ -66,7 +66,7 @@ public class ServiceTogglesConfig {
     @JsonProperty
     @NotNull boolean ollieEnabled;
     @JsonProperty
-    boolean agenticToolsEnabled;
+    @NotNull boolean agenticToolsEnabled;
 
     @NotNull Set<@NotBlank String> v2WorkspaceAllowlistIds = Set.of();
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
@@ -1040,18 +1040,44 @@ class OnlineScoringEngineTest {
     @Test
     @DisplayName("templateReferencesSpans detects the 'spans' sentinel anywhere in the variables map")
     void testTemplateReferencesSpans() {
-        assertThat(OnlineScoringEngine.templateReferencesSpans(Map.of())).isFalse();
-        assertThat(OnlineScoringEngine.templateReferencesSpans(Map.of(
+        var noMessages = List.<com.comet.opik.api.evaluators.LlmAsJudgeMessage>of();
+        var mustache = com.comet.opik.api.PromptType.MUSTACHE;
+        assertThat(OnlineScoringEngine.templateReferencesSpans(noMessages, Map.of(), mustache)).isFalse();
+        assertThat(OnlineScoringEngine.templateReferencesSpans(noMessages, Map.of(
                 "summary", "input.foo",
-                "out", "output.bar"))).isFalse();
+                "out", "output.bar"), mustache)).isFalse();
         // Sentinel matches the bare value "spans" — not "input.spans", not "Spans", not "$.spans".
-        assertThat(OnlineScoringEngine.templateReferencesSpans(Map.of("mySpans", "spans"))).isTrue();
-        assertThat(OnlineScoringEngine.templateReferencesSpans(Map.of(
+        assertThat(OnlineScoringEngine.templateReferencesSpans(noMessages,
+                Map.of("mySpans", "spans"), mustache)).isTrue();
+        assertThat(OnlineScoringEngine.templateReferencesSpans(noMessages, Map.of(
                 "summary", "input.foo",
-                "spansList", "spans"))).isTrue();
+                "spansList", "spans"), mustache)).isTrue();
         // Case-sensitive: only the lowercase bare sentinel triggers injection.
-        assertThat(OnlineScoringEngine.templateReferencesSpans(Map.of("x", "Spans"))).isFalse();
-        assertThat(OnlineScoringEngine.templateReferencesSpans(Map.of("x", "input.spans"))).isFalse();
+        assertThat(OnlineScoringEngine.templateReferencesSpans(noMessages, Map.of("x", "Spans"), mustache)).isFalse();
+        assertThat(OnlineScoringEngine.templateReferencesSpans(noMessages,
+                Map.of("x", "input.spans"), mustache)).isFalse();
+    }
+
+    @Test
+    @DisplayName("templateReferencesSpans detects implicit {{spans}} references in messages when variables omits the binding")
+    void testTemplateReferencesSpansFromMessageTemplate() {
+        var mustache = com.comet.opik.api.PromptType.MUSTACHE;
+        var spansMessage = List.of(com.comet.opik.api.evaluators.LlmAsJudgeMessage.builder()
+                .role(dev.langchain4j.data.message.ChatMessageType.USER)
+                .content("Spans: {{spans}}")
+                .build());
+        var noSpansMessage = List.of(com.comet.opik.api.evaluators.LlmAsJudgeMessage.builder()
+                .role(dev.langchain4j.data.message.ChatMessageType.USER)
+                .content("Summary: {{summary}}")
+                .build());
+        // Implicit reference: prompt has {{spans}}, variables map doesn't bind "spans" at all.
+        assertThat(OnlineScoringEngine.templateReferencesSpans(spansMessage, Map.of(), mustache)).isTrue();
+        // Variables explicitly map "spans" to something else (e.g. a JSONPath) — respect that
+        // mapping and don't claim the template references the sentinel.
+        assertThat(OnlineScoringEngine.templateReferencesSpans(spansMessage,
+                Map.of("spans", "input.spans"), mustache)).isFalse();
+        // No {{spans}} in template, no sentinel in variables — false.
+        assertThat(OnlineScoringEngine.templateReferencesSpans(noSpansMessage, Map.of(), mustache)).isFalse();
     }
 
     @Test
@@ -1122,6 +1148,70 @@ class OnlineScoringEngineTest {
         assertThat(allText).contains("Spans for this trace: []");
         assertThat(allText).doesNotContain("Spans for this trace: spans");
         assertThat(allText).doesNotContain("{{mySpans}}");
+    }
+
+    @Test
+    @DisplayName("prepareLlmRequest substitutes {{spans}} from a template-only reference (no sentinel in variables)")
+    void testPrepareLlmRequestInjectsSpansFromTemplateReference() {
+        // No "spans" key in variables. Mirrors an API-created rule where the caller put
+        // {{spans}} in the prompt but didn't (or didn't know to) set the sentinel mapping.
+        var evaluatorCode = LlmAsJudgeCode.builder()
+                .model(com.comet.opik.api.evaluators.LlmAsJudgeModelParameters.builder()
+                        .name("gpt-4o").temperature(0.3).build())
+                .messages(List.of(
+                        com.comet.opik.api.evaluators.LlmAsJudgeMessage.builder()
+                                .role(dev.langchain4j.data.message.ChatMessageType.USER)
+                                .content("How many spans? {{spans}}")
+                                .build()))
+                .variables(new java.util.LinkedHashMap<>(Map.of()))
+                .schema(List.of())
+                .build();
+        var trace = createTrace(generator.generate(), generator.generate());
+        var span = com.comet.opik.api.Span.builder()
+                .id(generator.generate()).name("template-only-span").type(com.comet.opik.domain.SpanType.general)
+                .startTime(java.time.Instant.now()).traceId(trace.id()).projectId(trace.projectId())
+                .build();
+
+        var request = OnlineScoringEngine.prepareLlmRequest(evaluatorCode, trace, new InstructionStrategy(),
+                List.of(span));
+
+        var allText = request.messages().stream()
+                .map(Object::toString)
+                .collect(java.util.stream.Collectors.joining("\n"));
+        assertThat(allText).contains("template-only-span");
+        assertThat(allText).doesNotContain("{{spans}}");
+    }
+
+    @Test
+    @DisplayName("prepareLlmRequest respects an explicit variables mapping over the template-only spans injection")
+    void testPrepareLlmRequestRespectsExplicitSpansMapping() {
+        // The user explicitly mapped "spans" to input.foo. Their intent overrides the
+        // template-only fallback: substitute the JSONPath value, not the spans list.
+        var evaluatorCode = LlmAsJudgeCode.builder()
+                .model(com.comet.opik.api.evaluators.LlmAsJudgeModelParameters.builder()
+                        .name("gpt-4o").temperature(0.3).build())
+                .messages(List.of(
+                        com.comet.opik.api.evaluators.LlmAsJudgeMessage.builder()
+                                .role(dev.langchain4j.data.message.ChatMessageType.USER)
+                                .content("Custom: {{spans}}")
+                                .build()))
+                .variables(new java.util.LinkedHashMap<>(Map.of("spans", "input.foo")))
+                .schema(List.of())
+                .build();
+        var trace = createTrace(generator.generate(), generator.generate());
+        var span = com.comet.opik.api.Span.builder()
+                .id(generator.generate()).name("should-not-appear").type(com.comet.opik.domain.SpanType.general)
+                .startTime(java.time.Instant.now()).traceId(trace.id()).projectId(trace.projectId())
+                .build();
+
+        var request = OnlineScoringEngine.prepareLlmRequest(evaluatorCode, trace, new InstructionStrategy(),
+                List.of(span));
+
+        var allText = request.messages().stream()
+                .map(Object::toString)
+                .collect(java.util.stream.Collectors.joining("\n"));
+        // The spans list should NOT leak in — the user mapped "spans" to a JSONPath.
+        assertThat(allText).doesNotContain("should-not-appear");
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
@@ -31,6 +31,7 @@ import com.comet.opik.api.resources.utils.resources.AutomationRuleEvaluatorResou
 import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
 import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
 import com.comet.opik.domain.FeedbackScoreService;
+import com.comet.opik.domain.SpanType;
 import com.comet.opik.domain.llm.ChatCompletionService;
 import com.comet.opik.domain.llm.structuredoutput.InstructionStrategy;
 import com.comet.opik.domain.llm.structuredoutput.ToolCallingStrategy;
@@ -1015,7 +1016,7 @@ class OnlineScoringEngineTest {
         // we match on bare field names rather than full quoted-string fragments.
         var allText = request.messages().stream()
                 .map(Object::toString)
-                .collect(java.util.stream.Collectors.joining("\n"));
+                .collect(Collectors.joining("\n"));
         assertThat(allText).contains("role");
         assertThat(allText).contains("user");
         assertThat(allText).contains("assistant");
@@ -1035,12 +1036,12 @@ class OnlineScoringEngineTest {
                 .build();
         // Two spans on the same trace, out-of-order on input — the helper sorts by start_time
         // so the wire order tracks call order regardless of how the caller hands them in.
-        var spanLate = com.comet.opik.api.Span.builder()
-                .id(generator.generate()).name("tool-late").type(com.comet.opik.domain.SpanType.tool)
+        var spanLate = Span.builder()
+                .id(generator.generate()).name("tool-late").type(SpanType.tool)
                 .startTime(java.time.Instant.now().plusMillis(10)).traceId(traceId).projectId(projectId)
                 .build();
-        var spanEarly = com.comet.opik.api.Span.builder()
-                .id(generator.generate()).name("tool-early").type(com.comet.opik.domain.SpanType.tool)
+        var spanEarly = Span.builder()
+                .id(generator.generate()).name("tool-early").type(SpanType.tool)
                 .startTime(java.time.Instant.now()).traceId(traceId).projectId(projectId)
                 .build();
 
@@ -1049,7 +1050,7 @@ class OnlineScoringEngineTest {
 
         var allText = request.messages().stream()
                 .map(Object::toString)
-                .collect(java.util.stream.Collectors.joining("\n"));
+                .collect(Collectors.joining("\n"));
         // The `spans` array shows up nested under the assistant entry, with the earlier-started
         // span first — the LLM sees call order matching the trace's actual execution order.
         // Mustache HTML-escapes the substituted JSON, so we match on field/value substrings
@@ -1066,8 +1067,8 @@ class OnlineScoringEngineTest {
         var traceId = generator.generate();
         var projectId = generator.generate();
         var trace = createTrace(traceId, projectId);
-        var bigSpan = com.comet.opik.api.Span.builder()
-                .id(generator.generate()).name("huge-tool-call").type(com.comet.opik.domain.SpanType.tool)
+        var bigSpan = Span.builder()
+                .id(generator.generate()).name("huge-tool-call").type(SpanType.tool)
                 .startTime(java.time.Instant.now()).traceId(traceId).projectId(projectId)
                 .input(JsonUtils.readTree("{\"payload\":\"" + "x".repeat(2000) + "\"}"))
                 .build();
@@ -1219,12 +1220,12 @@ class OnlineScoringEngineTest {
                 .schema(List.of())
                 .build();
         var trace = createTrace(generator.generate(), generator.generate());
-        var span1 = com.comet.opik.api.Span.builder()
-                .id(generator.generate()).name("span-a").type(com.comet.opik.domain.SpanType.general)
+        var span1 = Span.builder()
+                .id(generator.generate()).name("span-a").type(SpanType.general)
                 .startTime(java.time.Instant.now()).traceId(trace.id()).projectId(trace.projectId())
                 .build();
-        var span2 = com.comet.opik.api.Span.builder()
-                .id(generator.generate()).name("span-b").type(com.comet.opik.domain.SpanType.general)
+        var span2 = Span.builder()
+                .id(generator.generate()).name("span-b").type(SpanType.general)
                 .startTime(java.time.Instant.now().plusMillis(1)).traceId(trace.id()).projectId(trace.projectId())
                 .build();
 
@@ -1236,7 +1237,7 @@ class OnlineScoringEngineTest {
         // earliest-start span comes first.
         var allText = request.messages().stream()
                 .map(Object::toString)
-                .collect(java.util.stream.Collectors.joining("\n"));
+                .collect(Collectors.joining("\n"));
         assertThat(allText).contains("span-a");
         assertThat(allText).contains("span-b");
         assertThat(allText.indexOf("span-a")).isLessThan(allText.indexOf("span-b"));
@@ -1265,7 +1266,7 @@ class OnlineScoringEngineTest {
 
         var allText = request.messages().stream()
                 .map(Object::toString)
-                .collect(java.util.stream.Collectors.joining("\n"));
+                .collect(Collectors.joining("\n"));
         // Empty list renders as [], not the literal sentinel "spans" — guards against
         // the bare "spans" value leaking through toVariableMapping when the trace has
         // no children.
@@ -1291,8 +1292,8 @@ class OnlineScoringEngineTest {
                 .schema(List.of())
                 .build();
         var trace = createTrace(generator.generate(), generator.generate());
-        var span = com.comet.opik.api.Span.builder()
-                .id(generator.generate()).name("template-only-span").type(com.comet.opik.domain.SpanType.general)
+        var span = Span.builder()
+                .id(generator.generate()).name("template-only-span").type(SpanType.general)
                 .startTime(java.time.Instant.now()).traceId(trace.id()).projectId(trace.projectId())
                 .build();
 
@@ -1301,7 +1302,7 @@ class OnlineScoringEngineTest {
 
         var allText = request.messages().stream()
                 .map(Object::toString)
-                .collect(java.util.stream.Collectors.joining("\n"));
+                .collect(Collectors.joining("\n"));
         assertThat(allText).contains("template-only-span");
         assertThat(allText).doesNotContain("{{spans}}");
     }
@@ -1323,8 +1324,8 @@ class OnlineScoringEngineTest {
                 .schema(List.of())
                 .build();
         var trace = createTrace(generator.generate(), generator.generate());
-        var span = com.comet.opik.api.Span.builder()
-                .id(generator.generate()).name("should-not-appear").type(com.comet.opik.domain.SpanType.general)
+        var span = Span.builder()
+                .id(generator.generate()).name("should-not-appear").type(SpanType.general)
                 .startTime(java.time.Instant.now()).traceId(trace.id()).projectId(trace.projectId())
                 .build();
 
@@ -1333,7 +1334,7 @@ class OnlineScoringEngineTest {
 
         var allText = request.messages().stream()
                 .map(Object::toString)
-                .collect(java.util.stream.Collectors.joining("\n"));
+                .collect(Collectors.joining("\n"));
         // The spans list should NOT leak in — the user mapped "spans" to a JSONPath.
         assertThat(allText).doesNotContain("should-not-appear");
     }
@@ -1343,8 +1344,8 @@ class OnlineScoringEngineTest {
     void prepareLlmRequestLeavesNonSpansVariablesAloneWhenSpansArePassed() {
         var evaluatorCode = JsonUtils.readValue(TEST_EVALUATOR, LlmAsJudgeCode.class);
         var trace = createTrace(generator.generate(), generator.generate());
-        var span = com.comet.opik.api.Span.builder()
-                .id(generator.generate()).name("ignored-span").type(com.comet.opik.domain.SpanType.general)
+        var span = Span.builder()
+                .id(generator.generate()).name("ignored-span").type(SpanType.general)
                 .startTime(java.time.Instant.now()).traceId(trace.id()).projectId(trace.projectId())
                 .build();
 
@@ -1356,7 +1357,7 @@ class OnlineScoringEngineTest {
         // list so the assertion catches the span name wherever it might have landed.
         var allText = request.messages().stream()
                 .map(Object::toString)
-                .collect(java.util.stream.Collectors.joining("\n"));
+                .collect(Collectors.joining("\n"));
         assertThat(allText).doesNotContain("ignored-span");
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
@@ -1039,7 +1039,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("templateReferencesSpans detects the 'spans' sentinel anywhere in the variables map")
-    void testTemplateReferencesSpans() {
+    void templateReferencesSpansDetectsSentinelInVariablesMap() {
         var noMessages = List.<com.comet.opik.api.evaluators.LlmAsJudgeMessage>of();
         var mustache = com.comet.opik.api.PromptType.MUSTACHE;
         assertThat(OnlineScoringEngine.templateReferencesSpans(noMessages, Map.of(), mustache)).isFalse();
@@ -1060,7 +1060,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("templateReferencesSpans detects {{spans}} inside a multimodal message's contentArray text part")
-    void testTemplateReferencesSpansInMultimodalContentArray() {
+    void templateReferencesSpansDetectsSpansInMultimodalContentArrayText() {
         var mustache = com.comet.opik.api.PromptType.MUSTACHE;
         var multimodalMessage = List.of(com.comet.opik.api.evaluators.LlmAsJudgeMessage.builder()
                 .role(dev.langchain4j.data.message.ChatMessageType.USER)
@@ -1098,7 +1098,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("templateReferencesSpans detects implicit {{spans}} references in messages when variables omits the binding")
-    void testTemplateReferencesSpansFromMessageTemplate() {
+    void templateReferencesSpansDetectsImplicitMessageTemplateReference() {
         var mustache = com.comet.opik.api.PromptType.MUSTACHE;
         var spansMessage = List.of(com.comet.opik.api.evaluators.LlmAsJudgeMessage.builder()
                 .role(dev.langchain4j.data.message.ChatMessageType.USER)
@@ -1120,7 +1120,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("prepareLlmRequest substitutes {{spans}}-referencing variables with the serialized spans list")
-    void testPrepareLlmRequestInjectsSpansFromSentinel() {
+    void prepareLlmRequestInjectsSpansFromSentinelVariable() {
         var evaluatorCode = LlmAsJudgeCode.builder()
                 .model(com.comet.opik.api.evaluators.LlmAsJudgeModelParameters.builder()
                         .name("gpt-4o").temperature(0.3).build())
@@ -1160,7 +1160,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("prepareLlmRequest renders {{spans}} as [] when the trace has no spans, not the literal sentinel")
-    void testPrepareLlmRequestRendersEmptySpansAsJsonArray() {
+    void prepareLlmRequestRendersEmptySpansAsJsonArrayWhenTraceHasNoChildren() {
         var evaluatorCode = LlmAsJudgeCode.builder()
                 .model(com.comet.opik.api.evaluators.LlmAsJudgeModelParameters.builder()
                         .name("gpt-4o").temperature(0.3).build())
@@ -1190,7 +1190,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("prepareLlmRequest substitutes {{spans}} from a template-only reference (no sentinel in variables)")
-    void testPrepareLlmRequestInjectsSpansFromTemplateReference() {
+    void prepareLlmRequestInjectsSpansFromImplicitTemplateReference() {
         // No "spans" key in variables. Mirrors an API-created rule where the caller put
         // {{spans}} in the prompt but didn't (or didn't know to) set the sentinel mapping.
         var evaluatorCode = LlmAsJudgeCode.builder()
@@ -1222,7 +1222,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("prepareLlmRequest respects an explicit variables mapping over the template-only spans injection")
-    void testPrepareLlmRequestRespectsExplicitSpansMapping() {
+    void prepareLlmRequestRespectsExplicitSpansMappingOverImplicitInjection() {
         // The user explicitly mapped "spans" to input.foo. Their intent overrides the
         // template-only fallback: substitute the JSONPath value, not the spans list.
         var evaluatorCode = LlmAsJudgeCode.builder()
@@ -1254,7 +1254,7 @@ class OnlineScoringEngineTest {
 
     @Test
     @DisplayName("prepareLlmRequest leaves non-spans variables alone when spans are passed")
-    void testPrepareLlmRequestIgnoresSpansWhenNoSentinel() {
+    void prepareLlmRequestLeavesNonSpansVariablesAloneWhenSpansArePassed() {
         var evaluatorCode = JsonUtils.readValue(TEST_EVALUATOR, LlmAsJudgeCode.class);
         var trace = createTrace(generator.generate(), generator.generate());
         var span = com.comet.opik.api.Span.builder()

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
@@ -1002,7 +1002,8 @@ class OnlineScoringEngineTest {
         var evaluatorCode = JsonUtils.readValue(TEST_EVALUATOR, LlmAsJudgeCode.class);
         var trace = createTrace(generator.generate(), generator.generate());
 
-        var request = OnlineScoringEngine.prepareLlmRequest(evaluatorCode, trace, new ToolCallingStrategy());
+        var request = OnlineScoringEngine.prepareLlmRequest(evaluatorCode, trace, new ToolCallingStrategy(),
+                List.of());
 
         assertThat(request.responseFormat()).isNotNull();
         var expectedSchema = createTestSchema();
@@ -1016,7 +1017,7 @@ class OnlineScoringEngineTest {
         var trace = createTrace(generator.generate(), generator.generate());
 
         var request = OnlineScoringEngine.prepareLlmRequest(
-                evaluatorCode, trace, new InstructionStrategy());
+                evaluatorCode, trace, new InstructionStrategy(), List.of());
 
         assertThat(request.responseFormat()).isNull();
 
@@ -1034,6 +1035,85 @@ class OnlineScoringEngineTest {
         assertThat(userMessage.singleText()).contains("Summary: " + SUMMARY_STR);
         assertThat(userMessage.singleText()).contains("Instruction: " + OUTPUT_STR);
         assertThat(userMessage.singleText()).contains("Literal: some literal value");
+    }
+
+    @Test
+    @DisplayName("templateReferencesSpans detects the 'spans' sentinel anywhere in the variables map")
+    void testTemplateReferencesSpans() {
+        assertThat(OnlineScoringEngine.templateReferencesSpans(Map.of())).isFalse();
+        assertThat(OnlineScoringEngine.templateReferencesSpans(Map.of(
+                "summary", "input.foo",
+                "out", "output.bar"))).isFalse();
+        // Sentinel matches the bare value "spans" — not "input.spans", not "Spans", not "$.spans".
+        assertThat(OnlineScoringEngine.templateReferencesSpans(Map.of("mySpans", "spans"))).isTrue();
+        assertThat(OnlineScoringEngine.templateReferencesSpans(Map.of(
+                "summary", "input.foo",
+                "spansList", "spans"))).isTrue();
+        // Case-sensitive: only the lowercase bare sentinel triggers injection.
+        assertThat(OnlineScoringEngine.templateReferencesSpans(Map.of("x", "Spans"))).isFalse();
+        assertThat(OnlineScoringEngine.templateReferencesSpans(Map.of("x", "input.spans"))).isFalse();
+    }
+
+    @Test
+    @DisplayName("prepareLlmRequest substitutes {{spans}}-referencing variables with the serialized spans list")
+    void testPrepareLlmRequestInjectsSpansFromSentinel() {
+        var evaluatorCode = LlmAsJudgeCode.builder()
+                .model(com.comet.opik.api.evaluators.LlmAsJudgeModelParameters.builder()
+                        .name("gpt-4o").temperature(0.3).build())
+                .messages(List.of(
+                        com.comet.opik.api.evaluators.LlmAsJudgeMessage.builder()
+                                .role(dev.langchain4j.data.message.ChatMessageType.USER)
+                                .content("Count the spans: {{mySpans}}")
+                                .build()))
+                .variables(new java.util.LinkedHashMap<>(Map.of("mySpans", "spans")))
+                .schema(List.of())
+                .build();
+        var trace = createTrace(generator.generate(), generator.generate());
+        var span1 = com.comet.opik.api.Span.builder()
+                .id(generator.generate()).name("span-a").type(com.comet.opik.domain.SpanType.general)
+                .startTime(java.time.Instant.now()).traceId(trace.id()).projectId(trace.projectId())
+                .build();
+        var span2 = com.comet.opik.api.Span.builder()
+                .id(generator.generate()).name("span-b").type(com.comet.opik.domain.SpanType.general)
+                .startTime(java.time.Instant.now().plusMillis(1)).traceId(trace.id()).projectId(trace.projectId())
+                .build();
+
+        var request = OnlineScoringEngine.prepareLlmRequest(evaluatorCode, trace, new InstructionStrategy(),
+                List.of(span2, span1));
+
+        // The {{mySpans}} variable substitution should be the JSON-serialized spans list (sorted
+        // by start_time so the wire order is stable). Smoke-check: both span names appear and
+        // earliest-start span comes first.
+        var allText = request.messages().stream()
+                .map(Object::toString)
+                .collect(java.util.stream.Collectors.joining("\n"));
+        assertThat(allText).contains("span-a");
+        assertThat(allText).contains("span-b");
+        assertThat(allText.indexOf("span-a")).isLessThan(allText.indexOf("span-b"));
+        // Sentinel literal should NOT leak into the rendered prompt.
+        assertThat(allText).doesNotContain("{{mySpans}}");
+    }
+
+    @Test
+    @DisplayName("prepareLlmRequest leaves non-spans variables alone when spans are passed")
+    void testPrepareLlmRequestIgnoresSpansWhenNoSentinel() {
+        var evaluatorCode = JsonUtils.readValue(TEST_EVALUATOR, LlmAsJudgeCode.class);
+        var trace = createTrace(generator.generate(), generator.generate());
+        var span = com.comet.opik.api.Span.builder()
+                .id(generator.generate()).name("ignored-span").type(com.comet.opik.domain.SpanType.general)
+                .startTime(java.time.Instant.now()).traceId(trace.id()).projectId(trace.projectId())
+                .build();
+
+        var request = OnlineScoringEngine.prepareLlmRequest(evaluatorCode, trace, new InstructionStrategy(),
+                List.of(span));
+
+        // Template variables don't include the "spans" sentinel, so the span shouldn't appear
+        // in the rendered prompt — even though spans were available. Stringify the whole message
+        // list so the assertion catches the span name wherever it might have landed.
+        var allText = request.messages().stream()
+                .map(Object::toString)
+                .collect(java.util.stream.Collectors.joining("\n"));
+        assertThat(allText).doesNotContain("ignored-span");
     }
 
     private static Stream<Arguments> feedbackParsingArguments() {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
@@ -1246,6 +1246,72 @@ class OnlineScoringEngineTest {
     }
 
     @Test
+    @DisplayName("substituted {{spans}} carries only the LLM-relevant fields — not feedback scores, comments, audit metadata")
+    void prepareLlmRequestRendersSpansWithLeanProjection() {
+        // Build a Span with the full kitchen sink — every field that SpanForLlm intentionally
+        // drops gets populated here so the assertion can verify they're absent from the JSON.
+        var evaluatorCode = LlmAsJudgeCode.builder()
+                .model(com.comet.opik.api.evaluators.LlmAsJudgeModelParameters.builder()
+                        .name("gpt-4o").temperature(0.3).build())
+                .messages(List.of(
+                        com.comet.opik.api.evaluators.LlmAsJudgeMessage.builder()
+                                .role(dev.langchain4j.data.message.ChatMessageType.USER)
+                                .content("Inspect: {{mySpans}}")
+                                .build()))
+                .variables(new java.util.LinkedHashMap<>(Map.of("mySpans", "spans")))
+                .schema(List.of())
+                .build();
+        var trace = createTrace(generator.generate(), generator.generate());
+        var feedback = com.comet.opik.api.FeedbackScore.builder()
+                .name("relevance").value(java.math.BigDecimal.valueOf(0.9)).source(ScoreSource.UI).build();
+        var comment = com.comet.opik.api.Comment.builder()
+                .id(generator.generate()).text("audit-noise").build();
+        var fatSpan = Span.builder()
+                .id(generator.generate())
+                .name("inspect-tool")
+                .type(SpanType.tool)
+                .startTime(java.time.Instant.now())
+                .traceId(trace.id())
+                .projectId(trace.projectId())
+                .projectName("audit-project-name")
+                .createdBy("audit-creator")
+                .lastUpdatedBy("audit-updater")
+                .createdAt(java.time.Instant.now())
+                .lastUpdatedAt(java.time.Instant.now())
+                .feedbackScores(List.of(feedback))
+                .comments(List.of(comment))
+                .totalEstimatedCost(java.math.BigDecimal.valueOf(0.0042))
+                .totalEstimatedCostVersion("v2")
+                .tags(java.util.Set.of("audit-tag"))
+                .usage(Map.of("prompt_tokens", 42))
+                .environment("audit-env")
+                .build();
+
+        var request = OnlineScoringEngine.prepareLlmRequest(evaluatorCode, trace, new InstructionStrategy(),
+                List.of(fatSpan));
+
+        var allText = request.messages().stream()
+                .map(Object::toString)
+                .collect(Collectors.joining("\n"));
+        // Kept fields: name + type land in the rendered JSON.
+        assertThat(allText).contains("inspect-tool");
+        assertThat(allText).contains("tool");
+        // Dropped fields: not a single audit/score/cost field leaks through. These substring
+        // checks are deliberately tight against unique tokens the test set above so they can't
+        // accidentally collide with template/system-prompt text.
+        assertThat(allText).doesNotContain("audit-noise");
+        assertThat(allText).doesNotContain("audit-creator");
+        assertThat(allText).doesNotContain("audit-updater");
+        assertThat(allText).doesNotContain("audit-project-name");
+        assertThat(allText).doesNotContain("audit-tag");
+        assertThat(allText).doesNotContain("audit-env");
+        assertThat(allText).doesNotContain("feedback_scores");
+        assertThat(allText).doesNotContain("comments");
+        assertThat(allText).doesNotContain("total_estimated_cost");
+        assertThat(allText).doesNotContain("prompt_tokens");
+    }
+
+    @Test
     @DisplayName("prepareLlmRequest renders {{spans}} as [] when the trace has no spans, not the literal sentinel")
     void prepareLlmRequestRendersEmptySpansAsJsonArrayWhenTraceHasNoChildren() {
         var evaluatorCode = LlmAsJudgeCode.builder()

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
@@ -1059,6 +1059,44 @@ class OnlineScoringEngineTest {
     }
 
     @Test
+    @DisplayName("templateReferencesSpans detects {{spans}} inside a multimodal message's contentArray text part")
+    void testTemplateReferencesSpansInMultimodalContentArray() {
+        var mustache = com.comet.opik.api.PromptType.MUSTACHE;
+        var multimodalMessage = List.of(com.comet.opik.api.evaluators.LlmAsJudgeMessage.builder()
+                .role(dev.langchain4j.data.message.ChatMessageType.USER)
+                .contentArray(List.of(
+                        com.comet.opik.api.evaluators.LlmAsJudgeMessageContent.builder()
+                                .type("text")
+                                .text("Spans: {{spans}}")
+                                .build(),
+                        com.comet.opik.api.evaluators.LlmAsJudgeMessageContent.builder()
+                                .type("image_url")
+                                .imageUrl(com.comet.opik.api.evaluators.LlmAsJudgeMessageContent.ImageUrl.builder()
+                                        .url("https://example.com/x.png").build())
+                                .build()))
+                .build());
+        // The text part inside contentArray references {{spans}} — detection must walk
+        // structured-content messages, not just the simple `content` string field.
+        assertThat(OnlineScoringEngine.templateReferencesSpans(multimodalMessage, Map.of(), mustache)).isTrue();
+
+        // Variables explicitly maps "spans" to something else — explicit override wins
+        // even when {{spans}} sits in a multimodal text part.
+        assertThat(OnlineScoringEngine.templateReferencesSpans(multimodalMessage,
+                Map.of("spans", "input.spans"), mustache)).isFalse();
+
+        // No text part references {{spans}} — false.
+        var multimodalNoSpans = List.of(com.comet.opik.api.evaluators.LlmAsJudgeMessage.builder()
+                .role(dev.langchain4j.data.message.ChatMessageType.USER)
+                .contentArray(List.of(
+                        com.comet.opik.api.evaluators.LlmAsJudgeMessageContent.builder()
+                                .type("text")
+                                .text("Summary: {{summary}}")
+                                .build()))
+                .build());
+        assertThat(OnlineScoringEngine.templateReferencesSpans(multimodalNoSpans, Map.of(), mustache)).isFalse();
+    }
+
+    @Test
     @DisplayName("templateReferencesSpans detects implicit {{spans}} references in messages when variables omits the binding")
     void testTemplateReferencesSpansFromMessageTemplate() {
         var mustache = com.comet.opik.api.PromptType.MUSTACHE;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
@@ -1246,6 +1246,57 @@ class OnlineScoringEngineTest {
     }
 
     @Test
+    @DisplayName("buildSpanTree reconstructs parent/child hierarchy, promotes orphans, sorts siblings by start_time")
+    void buildSpanTreeReconstructsHierarchyAndPromotesOrphans() {
+        var traceId = generator.generate();
+        var projectId = generator.generate();
+        var rootId = generator.generate();
+        var childA = generator.generate();
+        var childB = generator.generate();
+        var grandchild = generator.generate();
+        var orphanParent = generator.generate(); // intentionally NOT in the input set
+        var orphan = generator.generate();
+        var now = java.time.Instant.parse("2026-05-19T10:00:00Z");
+
+        // Layout:
+        //   root (no parent)
+        //     ├── child-A          (sibling, earlier start)
+        //     │     └── grandchild
+        //     └── child-B          (sibling, later start)
+        //   orphan (parent not in input — promoted to root)
+        // Input order is shuffled to prove buildSpanTree doesn't rely on it.
+        var spans = List.of(
+                Span.builder().id(childB).parentSpanId(rootId).name("child-B").type(SpanType.tool)
+                        .startTime(now.plusMillis(200)).traceId(traceId).projectId(projectId).build(),
+                Span.builder().id(orphan).parentSpanId(orphanParent).name("orphan").type(SpanType.general)
+                        .startTime(now.plusMillis(500)).traceId(traceId).projectId(projectId).build(),
+                Span.builder().id(grandchild).parentSpanId(childA).name("grandchild").type(SpanType.tool)
+                        .startTime(now.plusMillis(150)).traceId(traceId).projectId(projectId).build(),
+                Span.builder().id(rootId).parentSpanId(null).name("root").type(SpanType.general)
+                        .startTime(now).traceId(traceId).projectId(projectId).build(),
+                Span.builder().id(childA).parentSpanId(rootId).name("child-A").type(SpanType.tool)
+                        .startTime(now.plusMillis(100)).traceId(traceId).projectId(projectId).build());
+
+        var tree = OnlineScoringEngine.buildSpanTree(spans);
+
+        // Two roots — the real root + the orphan (promoted because its parent isn't in the set).
+        // root sorts before orphan because root.startTime < orphan.startTime.
+        assertThat(tree).hasSize(2);
+        assertThat(tree.get(0).name()).isEqualTo("root");
+        assertThat(tree.get(1).name()).isEqualTo("orphan");
+        // root has two direct children in start_time order: child-A then child-B.
+        assertThat(tree.get(0).spans()).hasSize(2);
+        assertThat(tree.get(0).spans().get(0).name()).isEqualTo("child-A");
+        assertThat(tree.get(0).spans().get(1).name()).isEqualTo("child-B");
+        // child-A has one nested child; child-B is a leaf (spans omitted via NON_NULL).
+        assertThat(tree.get(0).spans().get(0).spans()).hasSize(1);
+        assertThat(tree.get(0).spans().get(0).spans().get(0).name()).isEqualTo("grandchild");
+        assertThat(tree.get(0).spans().get(1).spans()).isNull();
+        // Orphan is a leaf with no children.
+        assertThat(tree.get(1).spans()).isNull();
+    }
+
+    @Test
     @DisplayName("substituted {{spans}} carries only the LLM-relevant fields — not feedback scores, comments, audit metadata")
     void prepareLlmRequestRendersSpansWithLeanProjection() {
         // Build a Span with the full kitchen sink — every field that SpanForLlm intentionally

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
@@ -967,7 +967,8 @@ class OnlineScoringEngineTest {
                 .build();
 
         var renderedMessages = OnlineScoringEngine.renderThreadMessages(
-                evaluatorCode.messages(), Map.of(TraceThreadLlmAsJudgeCode.CONTEXT_VARIABLE_NAME, ""), List.of(trace));
+                evaluatorCode.messages(), Map.of(TraceThreadLlmAsJudgeCode.CONTEXT_VARIABLE_NAME, ""), List.of(trace),
+                List.of());
 
         assertThat(renderedMessages).hasSize(2);
 
@@ -989,11 +990,96 @@ class OnlineScoringEngineTest {
                 .build();
 
         var request = OnlineScoringEngine.prepareThreadLlmRequest(evaluatorCode, List.of(trace),
-                new ToolCallingStrategy());
+                new ToolCallingStrategy(), List.of());
 
         assertThat(request.responseFormat()).isNotNull();
         var expectedSchema = createTestSchema();
         assertThat(request.responseFormat().jsonSchema().rootElement()).isEqualTo(expectedSchema);
+    }
+
+    @Test
+    @DisplayName("thread {{context}} is wire-identical to today's shape when no spans are passed")
+    void prepareThreadLlmRequestKeepsLegacyContextShapeWhenSpansAreEmpty() {
+        var evaluatorCode = JsonUtils.readValue(TEST_TRACE_THREAD_EVALUATOR, TraceThreadLlmAsJudgeCode.class);
+        var traceId = generator.generate();
+        var trace = createTrace(traceId, generator.generate()).toBuilder()
+                .threadId("thread-" + RandomStringUtils.secure().nextAlphanumeric(36))
+                .build();
+
+        var request = OnlineScoringEngine.prepareThreadLlmRequest(evaluatorCode, List.of(trace),
+                new InstructionStrategy(), List.of());
+
+        // Empty spans → enriched serializer omits the `spans` field via @JsonInclude(NON_NULL).
+        // The substituted {{context}} JSON renders user/assistant entries from the trace but
+        // never the `spans` key. Mustache HTML-escapes the substituted JSON (`&quot;`), so
+        // we match on bare field names rather than full quoted-string fragments.
+        var allText = request.messages().stream()
+                .map(Object::toString)
+                .collect(java.util.stream.Collectors.joining("\n"));
+        assertThat(allText).contains("role");
+        assertThat(allText).contains("user");
+        assertThat(allText).contains("assistant");
+        // The TEST_TRACE_THREAD_EVALUATOR system prompt does not mention "spans", so a bare
+        // substring check is sufficient to prove the field isn't in the substituted JSON.
+        assertThat(allText).doesNotContain("spans");
+    }
+
+    @Test
+    @DisplayName("thread {{context}} attaches sorted spans under the assistant entry when toggle on")
+    void prepareThreadLlmRequestAttachesSpansToAssistantEntryWhenProvided() {
+        var evaluatorCode = JsonUtils.readValue(TEST_TRACE_THREAD_EVALUATOR, TraceThreadLlmAsJudgeCode.class);
+        var traceId = generator.generate();
+        var projectId = generator.generate();
+        var trace = createTrace(traceId, projectId).toBuilder()
+                .threadId("thread-" + RandomStringUtils.secure().nextAlphanumeric(36))
+                .build();
+        // Two spans on the same trace, out-of-order on input — the helper sorts by start_time
+        // so the wire order tracks call order regardless of how the caller hands them in.
+        var spanLate = com.comet.opik.api.Span.builder()
+                .id(generator.generate()).name("tool-late").type(com.comet.opik.domain.SpanType.tool)
+                .startTime(java.time.Instant.now().plusMillis(10)).traceId(traceId).projectId(projectId)
+                .build();
+        var spanEarly = com.comet.opik.api.Span.builder()
+                .id(generator.generate()).name("tool-early").type(com.comet.opik.domain.SpanType.tool)
+                .startTime(java.time.Instant.now()).traceId(traceId).projectId(projectId)
+                .build();
+
+        var request = OnlineScoringEngine.prepareThreadLlmRequest(evaluatorCode, List.of(trace),
+                new InstructionStrategy(), List.of(spanLate, spanEarly));
+
+        var allText = request.messages().stream()
+                .map(Object::toString)
+                .collect(java.util.stream.Collectors.joining("\n"));
+        // The `spans` array shows up nested under the assistant entry, with the earlier-started
+        // span first — the LLM sees call order matching the trace's actual execution order.
+        // Mustache HTML-escapes the substituted JSON, so we match on field/value substrings
+        // rather than full quoted-string fragments.
+        assertThat(allText).contains("spans");
+        assertThat(allText).contains("tool-early");
+        assertThat(allText).contains("tool-late");
+        assertThat(allText.indexOf("tool-early")).isLessThan(allText.indexOf("tool-late"));
+    }
+
+    @Test
+    @DisplayName("estimateThreadContextTokens reflects spans size, so big enriched threads route to agentic-tools")
+    void estimateThreadContextTokensFactorsInSpansSize() {
+        var traceId = generator.generate();
+        var projectId = generator.generate();
+        var trace = createTrace(traceId, projectId);
+        var bigSpan = com.comet.opik.api.Span.builder()
+                .id(generator.generate()).name("huge-tool-call").type(com.comet.opik.domain.SpanType.tool)
+                .startTime(java.time.Instant.now()).traceId(traceId).projectId(projectId)
+                .input(JsonUtils.readTree("{\"payload\":\"" + "x".repeat(2000) + "\"}"))
+                .build();
+
+        int estimateNoSpans = OnlineScoringEngine.estimateThreadContextTokens(
+                List.of(trace), List.of(), 4);
+        int estimateWithSpans = OnlineScoringEngine.estimateThreadContextTokens(
+                List.of(trace), List.of(bigSpan), 4);
+
+        // Adding ~2KB of span payload must move the estimate up — otherwise the agentic-tools
+        // routing gate would underestimate and inline-render an oversized prompt.
+        assertThat(estimateWithSpans).isGreaterThan(estimateNoSpans);
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
@@ -1095,6 +1095,36 @@ class OnlineScoringEngineTest {
     }
 
     @Test
+    @DisplayName("prepareLlmRequest renders {{spans}} as [] when the trace has no spans, not the literal sentinel")
+    void testPrepareLlmRequestRendersEmptySpansAsJsonArray() {
+        var evaluatorCode = LlmAsJudgeCode.builder()
+                .model(com.comet.opik.api.evaluators.LlmAsJudgeModelParameters.builder()
+                        .name("gpt-4o").temperature(0.3).build())
+                .messages(List.of(
+                        com.comet.opik.api.evaluators.LlmAsJudgeMessage.builder()
+                                .role(dev.langchain4j.data.message.ChatMessageType.USER)
+                                .content("Spans for this trace: {{mySpans}}")
+                                .build()))
+                .variables(new java.util.LinkedHashMap<>(Map.of("mySpans", "spans")))
+                .schema(List.of())
+                .build();
+        var trace = createTrace(generator.generate(), generator.generate());
+
+        var request = OnlineScoringEngine.prepareLlmRequest(evaluatorCode, trace, new InstructionStrategy(),
+                List.of());
+
+        var allText = request.messages().stream()
+                .map(Object::toString)
+                .collect(java.util.stream.Collectors.joining("\n"));
+        // Empty list renders as [], not the literal sentinel "spans" — guards against
+        // the bare "spans" value leaking through toVariableMapping when the trace has
+        // no children.
+        assertThat(allText).contains("Spans for this trace: []");
+        assertThat(allText).doesNotContain("Spans for this trace: spans");
+        assertThat(allText).doesNotContain("{{mySpans}}");
+    }
+
+    @Test
     @DisplayName("prepareLlmRequest leaves non-spans variables alone when spans are passed")
     void testPrepareLlmRequestIgnoresSpansWhenNoSentinel() {
         var evaluatorCode = JsonUtils.readValue(TEST_EVALUATOR, LlmAsJudgeCode.class);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
@@ -147,6 +147,81 @@ class OnlineScoringLlmAsJudgeScorerTest {
     }
 
     @Nested
+    class ShouldFetchSpansTests {
+
+        // Truth table for the spans-fetch gate. Spans are fetched when EITHER the agentic-tools
+        // path is possible (provider supports tools AND (experimentId OR toggle)) OR the inline
+        // template references {{spans}}. The point of the gate: skip the SpanService.getByTraceIds
+        // I/O on rules that don't need spans, since most rules don't.
+        @ParameterizedTest(name = "expId={0}, toggle={1}, provider={2}, sentinelInVars={3}, templateHasSpans={4} → expected={5}")
+        @CsvSource({
+                // Agentic-tools branch: provider supports tools AND (experimentId OR toggle).
+                "true,  false, OPEN_AI, false, false, true",
+                "false, true,  OPEN_AI, false, false, true",
+                // Provider doesn't support tools → agentic-tools branch off; only template path matters.
+                "true,  true,  OLLAMA,  false, false, false",
+                "false, true,  OLLAMA,  false, false, false",
+                // Toggle off + no experimentId + no template → no fetch.
+                "false, false, OPEN_AI, false, false, false",
+                // Template references {{spans}} alone → fetch even when agentic-tools branch is off.
+                "false, false, OPEN_AI, false, true,  true",
+                "false, false, OLLAMA,  false, true,  true",
+                // Sentinel-valued variable alone → fetch.
+                "false, false, OPEN_AI, true,  false, true",
+                // Both branches on → still just one fetch (idempotent OR).
+                "true,  true,  OPEN_AI, true,  true,  true",
+        })
+        void gateMatchesTruthTable(
+                boolean hasExperimentId, boolean toggleEnabled, LlmProvider provider,
+                boolean sentinelInVariables, boolean templateHasSpans, boolean expected) {
+            String modelName = "gpt-test";
+            TraceToScoreLlmAsJudge message = buildSpansFetchMessage(
+                    hasExperimentId, sentinelInVariables, templateHasSpans);
+            // Both lenient: the agenticToolsPathPossible expression short-circuits, so
+            // !supportsToolCalling AND experimentIdPath both skip the toggle check; the
+            // provider lookup is also skipped when the agentic-tools branch isn't probed.
+            lenient().when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(toggleEnabled);
+            lenient().when(llmProviderFactory.getLlmProvider(modelName)).thenReturn(provider);
+
+            assertThat(scorer.shouldFetchSpans(message)).isEqualTo(expected);
+        }
+
+        private TraceToScoreLlmAsJudge buildSpansFetchMessage(
+                boolean hasExperimentId, boolean sentinelInVariables, boolean templateHasSpans) {
+            Trace trace = Trace.builder()
+                    .id(UUID.randomUUID())
+                    .projectId(UUID.randomUUID())
+                    .name("test-trace")
+                    .startTime(Instant.now())
+                    .build();
+            LlmAsJudgeCode code = mock(LlmAsJudgeCode.class);
+            LlmAsJudgeModelParameters modelParams = mock(LlmAsJudgeModelParameters.class);
+            lenient().when(code.model()).thenReturn(modelParams);
+            lenient().when(modelParams.name()).thenReturn("gpt-test");
+            lenient().when(code.variables()).thenReturn(sentinelInVariables
+                    ? Map.of("mySpans", "spans")
+                    : Map.of());
+            lenient().when(code.messages()).thenReturn(templateHasSpans
+                    ? List.of(com.comet.opik.api.evaluators.LlmAsJudgeMessage.builder()
+                            .role(dev.langchain4j.data.message.ChatMessageType.USER)
+                            .content("Spans: {{spans}}")
+                            .build())
+                    : List.of());
+            return new TraceToScoreLlmAsJudge(
+                    trace,
+                    UUID.randomUUID(),
+                    "rule",
+                    code,
+                    "ws-1",
+                    "user-1",
+                    null,
+                    Map.of(),
+                    PromptType.MUSTACHE,
+                    hasExperimentId ? UUID.randomUUID() : null);
+        }
+    }
+
+    @Nested
     class RoutingGateTests {
 
         // Truth table: experimentId × toggle × tokens >= threshold × provider supports tools → useTools.

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
@@ -149,25 +149,38 @@ class OnlineScoringLlmAsJudgeScorerTest {
     @Nested
     class ShouldFetchSpansTests {
 
-        // Truth table for the spans-fetch gate. Spans are fetched when EITHER the agentic-tools
-        // path is possible (provider supports tools AND (experimentId OR toggle)) OR the inline
-        // template references {{spans}}. The point of the gate: skip the SpanService.getByTraceIds
-        // I/O on rules that don't need spans, since most rules don't.
+        // Truth table for the spans-fetch gate. Spans are fetched when EITHER:
+        //   (a) the agentic-tools path is possible (provider supports tools AND (experimentId
+        //       OR isAgenticToolsEnabled)), OR
+        //   (b) the inline {{spans}} template path applies — AND ALSO gated by
+        //       isAgenticToolsEnabled, so both pathways ship as one feature behind one toggle.
+        // Goal of the gate: skip the SpanService.getByTraceIds I/O on rules that don't need
+        // spans, and let ops kill the spans-in-prompts feature org-wide via a single flip.
         @ParameterizedTest(name = "expId={0}, toggle={1}, provider={2}, sentinelInVars={3}, templateHasSpans={4} → expected={5}")
         @CsvSource({
                 // Agentic-tools branch: provider supports tools AND (experimentId OR toggle).
                 "true,  false, OPEN_AI, false, false, true",
                 "false, true,  OPEN_AI, false, false, true",
-                // Provider doesn't support tools → agentic-tools branch off; only template path matters.
+                // Provider doesn't support tools → agentic-tools branch off; with the new
+                // gating the template path also requires the toggle, so toggle=false means no
+                // fetch regardless of variables/template content.
                 "true,  true,  OLLAMA,  false, false, false",
                 "false, true,  OLLAMA,  false, false, false",
                 // Toggle off + no experimentId + no template → no fetch.
                 "false, false, OPEN_AI, false, false, false",
-                // Template references {{spans}} alone → fetch even when agentic-tools branch is off.
-                "false, false, OPEN_AI, false, true,  true",
-                "false, false, OLLAMA,  false, true,  true",
-                // Sentinel-valued variable alone → fetch.
-                "false, false, OPEN_AI, true,  false, true",
+                // Toggle off + template-only — feature gated, no fetch (regression test for the
+                // new isAgenticToolsEnabled gate on the template path).
+                "false, false, OPEN_AI, false, true,  false",
+                "false, false, OLLAMA,  false, true,  false",
+                // Toggle off + sentinel-in-variables — same gating applies: no fetch.
+                "false, false, OPEN_AI, true,  false, false",
+                // Toggle on + template-only on a non-tool-calling provider → fetch via template path.
+                "false, true,  OLLAMA,  false, true,  true",
+                // Toggle on + sentinel-in-variables on a non-tool-calling provider → fetch.
+                "false, true,  OLLAMA,  true,  false, true",
+                // Toggle off + experimentId path → spans fetched for the agentic-tools cache
+                // seed; the template substitution piggy-backs on the already-fetched data.
+                "true,  false, OPEN_AI, false, true,  true",
                 // Both branches on → still just one fetch (idempotent OR).
                 "true,  true,  OPEN_AI, true,  true,  true",
         })

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -89,6 +89,8 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
     private AutomationRuleEvaluatorService automationRuleEvaluatorService;
     @Mock
     private com.comet.opik.api.resources.v1.events.tools.ToolRegistry toolRegistry;
+    @Mock
+    private com.comet.opik.domain.SpanService spanService;
 
     private OnlineScoringTraceThreadLlmAsJudgeScorer scorer;
     private MockedStatic<UserFacingLoggingFactory> mockedFactory;
@@ -140,7 +142,8 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
                 traceThreadService,
                 projectService,
                 automationRuleEvaluatorService,
-                toolRegistry);
+                toolRegistry,
+                spanService);
 
         projectId = UUID.randomUUID();
         ruleId = UUID.randomUUID();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -60,6 +60,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -529,6 +530,43 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
             assertThat(captor.getValue()).usingRecursiveComparison().isEqualTo(List.of(
                     threadScore("Relevance", BigDecimal.valueOf(4), "on-topic", project),
                     threadScore("Conciseness", new BigDecimal("3.5"), "could be tighter", project)));
+        }
+
+        @Test
+        void skipsSpanFetchWhenAgenticToolsDisabled() {
+            // Locks in the toggle gate: when isAgenticToolsEnabled=false, the scorer must NOT
+            // call spanService.getByTraceIds — that's how thread-scope evaluations preserve
+            // today's wire shape exactly (the enriched serializer omits the `spans` field on
+            // an empty list, falling back to [{role, content}, ...]).
+            var code = JsonUtils.readValue(EVALUATOR_JSON, TraceThreadLlmAsJudgeCode.class);
+            var message = sampleMessage().toBuilder().code(code).build();
+            var trace = sampleTrace();
+            var project = Project.builder().id(projectId).name("test-project").build();
+            var rule = AutomationRuleEvaluatorTraceThreadLlmAsJudge.builder()
+                    .name(ruleName)
+                    .code(code)
+                    .build();
+
+            when(traceService.search(anyInt(), any(TraceSearchCriteria.class)))
+                    .thenReturn(Flux.just(trace), Flux.empty());
+            when(traceThreadService.getThreadModelId(projectId, threadId))
+                    .thenReturn(Mono.just(threadModelId));
+            when(automationRuleEvaluatorService.findById(ruleId, Set.of(projectId), workspaceId))
+                    .thenReturn(rule);
+            when(projectService.get(projectId, workspaceId)).thenReturn(project);
+            when(llmProviderFactory.getStructuredOutputStrategy("gpt-4o"))
+                    .thenReturn(new ToolCallingStrategy());
+            when(aiProxyService.scoreTrace(any(ChatRequest.class), eq(code.model()), eq(workspaceId)))
+                    .thenReturn(ChatResponse.builder().aiMessage(AiMessage.aiMessage(LLM_RESPONSE)).build());
+            when(feedbackScoreService.scoreBatchOfThreads(any())).thenReturn(Mono.empty());
+            when(traceThreadService.setScoredAt(eq(projectId), eq(List.of(threadId)), any()))
+                    .thenReturn(Mono.empty());
+            // Toggle off — the scorer should not even ask the SpanService.
+            org.mockito.Mockito.when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(false);
+
+            scorer.score(message).block();
+
+            verifyNoInteractions(spanService);
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
@@ -58,6 +58,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -83,6 +84,8 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
     private ProjectService projectService;
     @Mock
     private AutomationRuleEvaluatorService automationRuleEvaluatorService;
+    @Mock
+    private com.comet.opik.domain.SpanService spanService;
 
     private OnlineScoringTraceThreadUserDefinedMetricPythonScorer scorer;
     private MockedStatic<UserFacingLoggingFactory> mockedFactory;
@@ -127,7 +130,8 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
                 traceService,
                 traceThreadService,
                 projectService,
-                automationRuleEvaluatorService);
+                automationRuleEvaluatorService,
+                spanService);
 
         projectId = UUID.randomUUID();
         ruleId = UUID.randomUUID();
@@ -202,6 +206,39 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
 
             assertThat(captor.getValue()).usingRecursiveComparison().isEqualTo(List.of(
                     threadScore("test_score", BigDecimal.valueOf(0.95), "test reason", project)));
+        }
+
+        @Test
+        void skipsSpanFetchWhenAgenticToolsDisabled() {
+            // Locks the toggle gate for the Python thread path: when isAgenticToolsEnabled
+            // is false, the scorer must NOT call spanService.getByTraceIds — preserves
+            // today's [{role, content}, ...] wire shape to the Python runner exactly.
+            var message = sampleMessage();
+            var trace = sampleTrace();
+            var project = Project.builder().id(projectId).name("test-project").build();
+            var pythonScore = PythonScoreResult.builder()
+                    .name("test_score")
+                    .value(BigDecimal.valueOf(0.95))
+                    .reason("ok")
+                    .build();
+
+            when(traceService.search(anyInt(), any(TraceSearchCriteria.class)))
+                    .thenReturn(Flux.just(trace), Flux.empty());
+            when(traceThreadService.getThreadModelId(projectId, threadId)).thenReturn(Mono.just(threadModelId));
+            when(automationRuleEvaluatorService.findById(ruleId, Set.of(projectId), workspaceId))
+                    .thenReturn(ruleFor(ruleName));
+            when(projectService.get(projectId, workspaceId)).thenReturn(project);
+            when(pythonEvaluatorService.evaluateThread(eq(message.code().metric()), any()))
+                    .thenReturn(Mono.just(List.of(pythonScore)));
+            when(feedbackScoreService.scoreBatchOfThreads(any())).thenReturn(Mono.empty());
+            when(traceThreadService.setScoredAt(eq(projectId), eq(List.of(threadId)), any()))
+                    .thenReturn(Mono.empty());
+            // Toggle off — the scorer should not even ask the SpanService.
+            when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(false);
+
+            scorer.score(message).block();
+
+            verifyNoInteractions(spanService);
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
@@ -242,6 +242,61 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
         }
 
         @Test
+        void fetchesSpansAndEnrichesConversationWhenAgenticToolsEnabled() {
+            // Toggle on: scorer fetches every span across the thread and the captured
+            // ChatMessage list sent to the Python evaluator carries the spans nested under
+            // the assistant entry. Locks in the end-to-end enrichment contract — a future
+            // refactor that quietly drops the SpanService fetch or routes through
+            // fromTraceToThread (legacy) would break this test loudly.
+            var message = sampleMessage();
+            var trace = sampleTrace();
+            var project = Project.builder().id(projectId).name("test-project").build();
+            var pythonScore = PythonScoreResult.builder()
+                    .name("tool_use_score")
+                    .value(BigDecimal.valueOf(0.9))
+                    .reason("ok")
+                    .build();
+            var toolSpan = com.comet.opik.api.Span.builder()
+                    .id(UUID.randomUUID())
+                    .name("fetch_weather")
+                    .type(com.comet.opik.domain.SpanType.tool)
+                    .startTime(java.time.Instant.now())
+                    .traceId(trace.id())
+                    .projectId(projectId)
+                    .build();
+
+            when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
+            when(traceService.search(anyInt(), any(TraceSearchCriteria.class)))
+                    .thenReturn(Flux.just(trace), Flux.empty());
+            when(spanService.getByTraceIds(Set.of(trace.id()))).thenReturn(Flux.just(toolSpan));
+            when(traceThreadService.getThreadModelId(projectId, threadId)).thenReturn(Mono.just(threadModelId));
+            when(automationRuleEvaluatorService.findById(ruleId, Set.of(projectId), workspaceId))
+                    .thenReturn(ruleFor(ruleName));
+            when(projectService.get(projectId, workspaceId)).thenReturn(project);
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<com.comet.opik.domain.evaluators.python.TraceThreadPythonEvaluatorRequest.ChatMessage>> contextCaptor = ArgumentCaptor
+                    .forClass(List.class);
+            when(pythonEvaluatorService.evaluateThread(eq(message.code().metric()), contextCaptor.capture()))
+                    .thenReturn(Mono.just(List.of(pythonScore)));
+            when(feedbackScoreService.scoreBatchOfThreads(any())).thenReturn(Mono.empty());
+            when(traceThreadService.setScoredAt(eq(projectId), eq(List.of(threadId)), any()))
+                    .thenReturn(Mono.empty());
+
+            scorer.score(message).block();
+
+            verify(spanService).getByTraceIds(Set.of(trace.id()));
+            var captured = contextCaptor.getValue();
+            // Conversation contains user + assistant per trace (one trace here).
+            assertThat(captured).hasSize(2);
+            assertThat(captured.get(0).role()).isEqualTo("user");
+            assertThat(captured.get(0).spans()).isNull(); // user entry never carries spans
+            assertThat(captured.get(1).role()).isEqualTo("assistant");
+            assertThat(captured.get(1).spans()).isNotNull();
+            assertThat(captured.get(1).spans()).extracting(com.comet.opik.api.SpanForLlm::name)
+                    .containsExactly("fetch_weather");
+        }
+
+        @Test
         void skipsScoringWhenThreadHasNoTraces() {
             var message = sampleMessage();
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorerTest.java
@@ -1,7 +1,6 @@
 package com.comet.opik.api.resources.v1.events;
 
 import com.comet.opik.api.ScoreSource;
-import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.events.TraceToScoreUserDefinedMetricPython;
 import com.comet.opik.domain.FeedbackScoreService;
@@ -200,11 +199,20 @@ class OnlineScoringUserDefinedMetricPythonScorerTest {
         void fetchesSpansAndPassesThemAsListWhenSpansArgumentPresent() {
             // User opts into spans by mapping the reserved `spans` key in their `arguments`.
             // We verify (a) the span service is queried, and (b) the data handed to the Python
-            // evaluator carries spans as a typed List — not as a JSON string — so `json.loads`
-            // in the runner yields `spans` as a list of dicts in the metric's signature.
+            // evaluator carries spans as a typed List of the lean SpanForLlm projection — not
+            // raw Span, not a JSON string — so `json.loads` in the runner yields `spans` as a
+            // list of dicts with the projected shape (name/type/input/output/etc., plus nested
+            // children) in the metric's signature.
             var message = sampleMessageWithSpansArgument();
-            var span = podamFactory.manufacturePojo(Span.class).toBuilder()
+            // Build the span explicitly rather than via Podam so the projection assertion can
+            // reference a known `name` field — Podam fills random strings that obscure intent.
+            var span = com.comet.opik.api.Span.builder()
+                    .id(UUID.randomUUID())
                     .traceId(traceId)
+                    .projectId(UUID.randomUUID())
+                    .name("fetch_weather")
+                    .type(com.comet.opik.domain.SpanType.tool)
+                    .startTime(java.time.Instant.now())
                     .build();
 
             when(spanService.getByTraceIds(eq(Set.of(traceId)))).thenReturn(Flux.just(span));
@@ -222,8 +230,9 @@ class OnlineScoringUserDefinedMetricPythonScorerTest {
             verify(pythonEvaluatorService).evaluate(eq(message.code().metric()), dataCaptor.capture());
             var capturedSpans = dataCaptor.getValue().get("spans");
             assertThat(capturedSpans).isInstanceOf(List.class);
-            assertThat((List<?>) capturedSpans).hasSize(1)
-                    .first().isInstanceOf(Span.class);
+            assertThat((List<?>) capturedSpans).hasSize(1).first()
+                    .isInstanceOf(com.comet.opik.api.SpanForLlm.class)
+                    .extracting("name").isEqualTo("fetch_weather");
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentProjectMigrationJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentProjectMigrationJobTest.java
@@ -92,14 +92,7 @@ class ExperimentProjectMigrationJobTest {
                         .customConfigs(List.of(
                                 new CustomConfig("experimentProjectMigration.enabled", "true"),
                                 // Buffer so the first cycle fires after the initial seed+prime.
-                                // 10s instead of the prior 3s: the prime assertion runs at
-                                // T+~3.1s on a busy CI runner (containers shared with other
-                                // tests in the same Integration Group), past the old buffer,
-                                // and the migration would already have flipped V1 → V2 by
-                                // then — turning a deterministic test into a CI-load-dependent
-                                // flake. 10s gives ~3× headroom without making the second
-                                // phase (which polls until V2) noticeably slower.
-                                new CustomConfig("experimentProjectMigration.startupDelay", "10s"),
+                                new CustomConfig("experimentProjectMigration.startupDelay", "3s"),
                                 new CustomConfig("migration.excludedWorkspaceIds",
                                         "%s,%s".formatted(EXCLUDED_WORKSPACE_ID_1, EXCLUDED_WORKSPACE_ID_2)),
                                 // Cache enabled with the production TTL so only the migration's

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentProjectMigrationJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentProjectMigrationJobTest.java
@@ -92,7 +92,14 @@ class ExperimentProjectMigrationJobTest {
                         .customConfigs(List.of(
                                 new CustomConfig("experimentProjectMigration.enabled", "true"),
                                 // Buffer so the first cycle fires after the initial seed+prime.
-                                new CustomConfig("experimentProjectMigration.startupDelay", "3s"),
+                                // 10s instead of the prior 3s: the prime assertion runs at
+                                // T+~3.1s on a busy CI runner (containers shared with other
+                                // tests in the same Integration Group), past the old buffer,
+                                // and the migration would already have flipped V1 → V2 by
+                                // then — turning a deterministic test into a CI-load-dependent
+                                // flake. 10s gives ~3× headroom without making the second
+                                // phase (which polls until V2) noticeably slower.
+                                new CustomConfig("experimentProjectMigration.startupDelay", "10s"),
                                 new CustomConfig("migration.excludedWorkspaceIds",
                                         "%s,%s".formatted(EXCLUDED_WORKSPACE_ID_1, EXCLUDED_WORKSPACE_ID_2)),
                                 // Cache enabled with the production TTL so only the migration's

--- a/apps/opik-frontend/src/constants/llm.ts
+++ b/apps/opik-frontend/src/constants/llm.ts
@@ -53,20 +53,11 @@ export const LLM_MESSAGE_ROLE_NAME_MAP = {
  * uses `{{context}}` for the traces list and would need a different design for
  * spans (whose spans?).
  */
-export const RESERVED_TRACE_EVALUATOR_VARIABLES: Record<string, string> = {
+export const RESERVED_TRACE_EVALUATOR_VARIABLES: Readonly<
+  Record<string, string>
+> = Object.freeze({
   spans: "spans",
-};
-
-/**
- * Stable, frozen array of the reserved variable *names* (the keys of
- * {@link RESERVED_TRACE_EVALUATOR_VARIABLES}). Pre-computed at module scope so
- * the array reference doesn't change between renders — important because it's
- * passed as `hiddenVariableNames` into `LLMPromptMessagesVariables`, whose
- * `variablesList` `useMemo` depends on it. Computing `Object.keys(...)` inline
- * on each render allocates a new array and invalidates the memo for no reason.
- */
-export const RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES: readonly string[] =
-  Object.freeze(Object.keys(RESERVED_TRACE_EVALUATOR_VARIABLES));
+});
 
 export const DEFAULT_OPEN_AI_CONFIGS = {
   TEMPERATURE: 0,

--- a/apps/opik-frontend/src/constants/llm.ts
+++ b/apps/opik-frontend/src/constants/llm.ts
@@ -37,6 +37,22 @@ export const LLM_MESSAGE_ROLE_NAME_MAP = {
   [LLM_MESSAGE_ROLE.tool_execution_result]: "Tool execution result",
 };
 
+/**
+ * LLM-as-judge variables whose source path is a reserved sentinel rather than a
+ * JSONPath against the trace. When the user types `{{spans}}` in a trace-scoped
+ * prompt, the variable mapping auto-fills to `spans → spans` and the backend
+ * (OnlineScoringEngine.injectSpansIntoReplacements) substitutes the JSON-
+ * serialized spans list at render time — same convention as the Python-metric
+ * path. No manual path entry required.
+ *
+ * Trace-scope only. Span scope doesn't have sub-spans to inject; thread scope
+ * uses `{{context}}` for the traces list and would need a different design for
+ * spans (whose spans?).
+ */
+export const RESERVED_LLM_JUDGE_TRACE_VARIABLES: Record<string, string> = {
+  spans: "spans",
+};
+
 export const DEFAULT_OPEN_AI_CONFIGS = {
   TEMPERATURE: 0,
   MAX_COMPLETION_TOKENS: 4000,

--- a/apps/opik-frontend/src/constants/llm.ts
+++ b/apps/opik-frontend/src/constants/llm.ts
@@ -38,18 +38,22 @@ export const LLM_MESSAGE_ROLE_NAME_MAP = {
 };
 
 /**
- * LLM-as-judge variables whose source path is a reserved sentinel rather than a
- * JSONPath against the trace. When the user types `{{spans}}` in a trace-scoped
- * prompt, the variable mapping auto-fills to `spans → spans` and the backend
- * (OnlineScoringEngine.injectSpansIntoReplacements) substitutes the JSON-
- * serialized spans list at render time — same convention as the Python-metric
- * path. No manual path entry required.
+ * Trace-scope online-evaluator variables whose source path is a reserved sentinel
+ * rather than a JSONPath against the trace. Applies to BOTH rule types:
+ *
+ * - LLM-as-judge: `{{spans}}` in a trace prompt auto-maps to `spans → spans`;
+ *   the backend's OnlineScoringEngine substitutes the JSON-serialized spans
+ *   list at render time.
+ * - Python metric: a `score(self, spans, ...)` parameter named `spans`
+ *   auto-maps to `spans → spans`; the backend opts into a SpanService fetch
+ *   when `arguments.containsKey("spans")` and injects a `List<Span>` as the
+ *   `spans` kwarg at evaluation time.
  *
  * Trace-scope only. Span scope doesn't have sub-spans to inject; thread scope
  * uses `{{context}}` for the traces list and would need a different design for
  * spans (whose spans?).
  */
-export const RESERVED_LLM_JUDGE_TRACE_VARIABLES: Record<string, string> = {
+export const RESERVED_TRACE_EVALUATOR_VARIABLES: Record<string, string> = {
   spans: "spans",
 };
 

--- a/apps/opik-frontend/src/constants/llm.ts
+++ b/apps/opik-frontend/src/constants/llm.ts
@@ -57,6 +57,17 @@ export const RESERVED_TRACE_EVALUATOR_VARIABLES: Record<string, string> = {
   spans: "spans",
 };
 
+/**
+ * Stable, frozen array of the reserved variable *names* (the keys of
+ * {@link RESERVED_TRACE_EVALUATOR_VARIABLES}). Pre-computed at module scope so
+ * the array reference doesn't change between renders — important because it's
+ * passed as `hiddenVariableNames` into `LLMPromptMessagesVariables`, whose
+ * `variablesList` `useMemo` depends on it. Computing `Object.keys(...)` inline
+ * on each render allocates a new array and invalidates the memo for no reason.
+ */
+export const RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES: readonly string[] =
+  Object.freeze(Object.keys(RESERVED_TRACE_EVALUATOR_VARIABLES));
+
 export const DEFAULT_OPEN_AI_CONFIGS = {
   TEMPERATURE: 0,
   MAX_COMPLETION_TOKENS: 4000,

--- a/apps/opik-frontend/src/contexts/feature-toggles-provider.tsx
+++ b/apps/opik-frontend/src/contexts/feature-toggles-provider.tsx
@@ -63,7 +63,12 @@ export function FeatureTogglesProvider({ children }: FeatureTogglesProps) {
 
   useEffect(() => {
     if (data) {
-      setFeatures(data);
+      // Merge over DEFAULT_STATE so any toggle the backend omits (e.g. a
+      // newer FE talking to an older BE that doesn't yet have a given
+      // field) falls back to its declared default instead of becoming
+      // `undefined`. Keeps the runtime in sync with the `FeatureToggles`
+      // type contract, which promises a boolean for every key.
+      setFeatures({ ...DEFAULT_STATE, ...data });
       // Mirrors ServiceTogglesConfig bounds (5..100). Out-of-range or
       // malformed values fall through to the fallback so a misconfigured
       // deployment can't poison the UI.

--- a/apps/opik-frontend/src/contexts/feature-toggles-provider.tsx
+++ b/apps/opik-frontend/src/contexts/feature-toggles-provider.tsx
@@ -29,6 +29,7 @@ const DEFAULT_STATE: FeatureToggles = {
   [FeatureToggleKeys.OPTIMIZATION_STUDIO_ENABLED]: false,
   [FeatureToggleKeys.SPAN_LLM_AS_JUDGE_ENABLED]: false,
   [FeatureToggleKeys.SPAN_USER_DEFINED_METRIC_PYTHON_ENABLED]: false,
+  [FeatureToggleKeys.AGENTIC_TOOLS_ENABLED]: false,
   // LLM Provider feature flags - default false
   [FeatureToggleKeys.OPENAI_PROVIDER_ENABLED]: false,
   [FeatureToggleKeys.ANTHROPIC_PROVIDER_ENABLED]: false,

--- a/apps/opik-frontend/src/lib/llm.ts
+++ b/apps/opik-frontend/src/lib/llm.ts
@@ -311,16 +311,23 @@ export const parseChatTemplateToLLMMessages = (
  * picking a path); otherwise empty. Centralized so the four rule-detail editors
  * (v1+v2 × {LLMJudge, PythonCode}) stay in sync — adding a new reserved trace
  * variable to {@link RESERVED_TRACE_EVALUATOR_VARIABLES} propagates here.
+ *
+ * <p>The auto-fill is gated by {@code agenticToolsEnabled} (FT
+ * {@code agentic_tools_enabled}). When the feature is off, `spans` behaves like
+ * any other variable — no sentinel is filled in, leaving the user free to map
+ * it to a real path. Mirrors the BE: `shouldFetchSpans` and the `{{spans}}`
+ * substitution are also gated by the same toggle.
  */
 export const resolveTraceEvaluatorVariableDefault = (
   variableName: string,
   currentMapping: string | undefined,
   scope: EVALUATORS_RULE_SCOPE,
+  agenticToolsEnabled: boolean,
 ): string => {
   if (currentMapping) {
     return currentMapping;
   }
-  if (scope === EVALUATORS_RULE_SCOPE.trace) {
+  if (agenticToolsEnabled && scope === EVALUATORS_RULE_SCOPE.trace) {
     return RESERVED_TRACE_EVALUATOR_VARIABLES[variableName] ?? "";
   }
   return "";

--- a/apps/opik-frontend/src/lib/llm.ts
+++ b/apps/opik-frontend/src/lib/llm.ts
@@ -324,7 +324,11 @@ export const resolveTraceEvaluatorVariableDefault = (
   scope: EVALUATORS_RULE_SCOPE,
   agenticToolsEnabled: boolean,
 ): string => {
-  if (currentMapping) {
+  // Preserve any value the user already set — including an explicit empty
+  // string. Treating `""` as "not set" and re-applying the sentinel auto-fill
+  // would silently clobber an API caller's deliberate `spans: ""` on every
+  // prompt re-parse.
+  if (currentMapping !== undefined) {
     return currentMapping;
   }
   if (agenticToolsEnabled && scope === EVALUATORS_RULE_SCOPE.trace) {

--- a/apps/opik-frontend/src/lib/llm.ts
+++ b/apps/opik-frontend/src/lib/llm.ts
@@ -7,6 +7,8 @@ import {
   MessageContent,
   TextPart,
 } from "@/types/llm";
+import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
+import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
 import { generateRandomString } from "@/lib/utils";
 
 export const generateDefaultLLMPromptMessage = (
@@ -300,4 +302,26 @@ export const parseChatTemplateToLLMMessages = (
   } catch {
     return [];
   }
+};
+
+/**
+ * Resolve the value for one template variable in an LLM-as-judge / Python-metric
+ * rule. Existing user-supplied mapping wins; otherwise on trace scope a `spans`
+ * variable auto-fills to its sentinel value (so {{spans}} works without the user
+ * picking a path); otherwise empty. Centralized so the four rule-detail editors
+ * (v1+v2 × {LLMJudge, PythonCode}) stay in sync — adding a new reserved trace
+ * variable to {@link RESERVED_TRACE_EVALUATOR_VARIABLES} propagates here.
+ */
+export const resolveTraceEvaluatorVariableDefault = (
+  variableName: string,
+  currentMapping: string | undefined,
+  scope: EVALUATORS_RULE_SCOPE,
+): string => {
+  if (currentMapping) {
+    return currentMapping;
+  }
+  if (scope === EVALUATORS_RULE_SCOPE.trace) {
+    return RESERVED_TRACE_EVALUATOR_VARIABLES[variableName] ?? "";
+  }
+  return "";
 };

--- a/apps/opik-frontend/src/types/feature-toggles.ts
+++ b/apps/opik-frontend/src/types/feature-toggles.ts
@@ -14,6 +14,12 @@ export enum FeatureToggleKeys {
   SPAN_LLM_AS_JUDGE_ENABLED = "span_llm_as_judge_enabled",
   SPAN_USER_DEFINED_METRIC_PYTHON_ENABLED = "span_user_defined_metric_python_enabled",
   OPTIMIZATION_STUDIO_ENABLED = "optimization_studio_enabled",
+  // Gates the spans-in-LLM-judge feature: agentic-tools loop AND the {{spans}}
+  // template substitution in trace-scope rules. When off, FE editors stop
+  // auto-filling `spans → "spans"` and keep the row visible/editable so the user
+  // can map `spans` to a custom path like any other variable; backend mirrors
+  // by skipping the SpanService fetch + injecting "[]" into {{spans}}.
+  AGENTIC_TOOLS_ENABLED = "agentic_tools_enabled",
   // LLM Provider feature flags
   OPENAI_PROVIDER_ENABLED = "openai_provider_enabled",
   ANTHROPIC_PROVIDER_ENABLED = "anthropic_provider_enabled",

--- a/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
@@ -26,13 +26,11 @@ import {
 import {
   generateDefaultLLMPromptMessage,
   getAllTemplateStringsFromContent,
+  resolveTraceEvaluatorVariableDefault,
 } from "@/lib/llm";
 import { COMPOSED_PROVIDER_TYPE, PROVIDER_MODEL_TYPE } from "@/types/providers";
 import { safelyGetPromptMustacheTags } from "@/lib/prompt";
-import {
-  RESERVED_TRACE_EVALUATOR_VARIABLES,
-  RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES,
-} from "@/constants/llm";
+import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
 import { EvaluationRuleFormType } from "@/v1/pages-shared/automations/AddEditRuleDialog/schema";
 import useLLMProviderModelsData from "@/hooks/useLLMProviderModelsData";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
@@ -127,7 +125,6 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
       // recalculate variables
       const variables = formInstance.getValues("llmJudgeDetails.variables");
       const currentScope = formInstance.getValues("scope");
-      const isTraceScope = currentScope === EVALUATORS_RULE_SCOPE.trace;
       const localVariables: Record<string, string> = {};
       let parsingVariablesError: boolean = false;
       messages
@@ -147,14 +144,11 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
         }, [])
         .filter((v) => v !== "")
         .forEach((v: string) => {
-          // Auto-fill reserved trace variables (e.g. `{{spans}}`) with their sentinel
-          // path so the user doesn't have to pick one in the variable mapping dropdown.
-          // Preserve any existing user-supplied path if they already mapped this name
-          // to something else.
-          const reservedDefault = isTraceScope
-            ? RESERVED_TRACE_EVALUATOR_VARIABLES[v]
-            : undefined;
-          localVariables[v] = variables[v] || reservedDefault || "";
+          localVariables[v] = resolveTraceEvaluatorVariableDefault(
+            v,
+            variables[v],
+            currentScope,
+          );
         });
 
       formInstance.setValue("llmJudgeDetails.variables", localVariables);
@@ -353,7 +347,7 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
                     datasetColumnNames={datasetColumnNames}
                     type={autocompleteType}
                     includeIntermediateNodes
-                    hiddenVariableNames={RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES}
+                    reservedSentinels={RESERVED_TRACE_EVALUATOR_VARIABLES}
                   />
                 </>
               );

--- a/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/lib/llm";
 import { COMPOSED_PROVIDER_TYPE, PROVIDER_MODEL_TYPE } from "@/types/providers";
 import { safelyGetPromptMustacheTags } from "@/lib/prompt";
-import { RESERVED_LLM_JUDGE_TRACE_VARIABLES } from "@/constants/llm";
+import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
 import { EvaluationRuleFormType } from "@/v1/pages-shared/automations/AddEditRuleDialog/schema";
 import useLLMProviderModelsData from "@/hooks/useLLMProviderModelsData";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
@@ -149,7 +149,7 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
           // Preserve any existing user-supplied path if they already mapped this name
           // to something else.
           const reservedDefault = isTraceScope
-            ? RESERVED_LLM_JUDGE_TRACE_VARIABLES[v]
+            ? RESERVED_TRACE_EVALUATOR_VARIABLES[v]
             : undefined;
           localVariables[v] = variables[v] || reservedDefault || "";
         });

--- a/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
@@ -38,6 +38,8 @@ import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v1/constants/explainers";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
 import { updateProviderConfig } from "@/lib/modelUtils";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
+import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
+import { FeatureToggleKeys } from "@/types/feature-toggles";
 
 const MESSAGE_TYPE_OPTIONS = [
   {
@@ -78,6 +80,9 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
   const scope = form.watch("scope");
   const isThreadScope = scope === EVALUATORS_RULE_SCOPE.thread;
   const isSpanScope = scope === EVALUATORS_RULE_SCOPE.span;
+  const agenticToolsEnabled = useIsFeatureEnabled(
+    FeatureToggleKeys.AGENTIC_TOOLS_ENABLED,
+  );
 
   const templates = LLM_PROMPT_TEMPLATES[scope];
 
@@ -148,6 +153,7 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
             v,
             variables[v],
             currentScope,
+            agenticToolsEnabled,
           );
         });
 
@@ -157,7 +163,7 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
         parsingVariablesError,
       );
     },
-    [],
+    [agenticToolsEnabled],
   );
 
   return (
@@ -347,7 +353,11 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
                     datasetColumnNames={datasetColumnNames}
                     type={autocompleteType}
                     includeIntermediateNodes
-                    reservedSentinels={RESERVED_TRACE_EVALUATOR_VARIABLES}
+                    reservedSentinels={
+                      agenticToolsEnabled
+                        ? RESERVED_TRACE_EVALUATOR_VARIABLES
+                        : undefined
+                    }
                   />
                 </>
               );

--- a/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
@@ -29,7 +29,10 @@ import {
 } from "@/lib/llm";
 import { COMPOSED_PROVIDER_TYPE, PROVIDER_MODEL_TYPE } from "@/types/providers";
 import { safelyGetPromptMustacheTags } from "@/lib/prompt";
-import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
+import {
+  RESERVED_TRACE_EVALUATOR_VARIABLES,
+  RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES,
+} from "@/constants/llm";
 import { EvaluationRuleFormType } from "@/v1/pages-shared/automations/AddEditRuleDialog/schema";
 import useLLMProviderModelsData from "@/hooks/useLLMProviderModelsData";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
@@ -350,9 +353,7 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
                     datasetColumnNames={datasetColumnNames}
                     type={autocompleteType}
                     includeIntermediateNodes
-                    hiddenVariableNames={Object.keys(
-                      RESERVED_TRACE_EVALUATOR_VARIABLES,
-                    )}
+                    hiddenVariableNames={RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES}
                   />
                 </>
               );

--- a/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
@@ -350,6 +350,9 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
                     datasetColumnNames={datasetColumnNames}
                     type={autocompleteType}
                     includeIntermediateNodes
+                    hiddenVariableNames={Object.keys(
+                      RESERVED_TRACE_EVALUATOR_VARIABLES,
+                    )}
                   />
                 </>
               );

--- a/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/lib/llm";
 import { COMPOSED_PROVIDER_TYPE, PROVIDER_MODEL_TYPE } from "@/types/providers";
 import { safelyGetPromptMustacheTags } from "@/lib/prompt";
+import { RESERVED_LLM_JUDGE_TRACE_VARIABLES } from "@/constants/llm";
 import { EvaluationRuleFormType } from "@/v1/pages-shared/automations/AddEditRuleDialog/schema";
 import useLLMProviderModelsData from "@/hooks/useLLMProviderModelsData";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
@@ -122,6 +123,8 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
 
       // recalculate variables
       const variables = formInstance.getValues("llmJudgeDetails.variables");
+      const currentScope = formInstance.getValues("scope");
+      const isTraceScope = currentScope === EVALUATORS_RULE_SCOPE.trace;
       const localVariables: Record<string, string> = {};
       let parsingVariablesError: boolean = false;
       messages
@@ -140,7 +143,16 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
           return acc.concat(allTags);
         }, [])
         .filter((v) => v !== "")
-        .forEach((v: string) => (localVariables[v] = variables[v] ?? ""));
+        .forEach((v: string) => {
+          // Auto-fill reserved trace variables (e.g. `{{spans}}`) with their sentinel
+          // path so the user doesn't have to pick one in the variable mapping dropdown.
+          // Preserve any existing user-supplied path if they already mapped this name
+          // to something else.
+          const reservedDefault = isTraceScope
+            ? RESERVED_LLM_JUDGE_TRACE_VARIABLES[v]
+            : undefined;
+          localVariables[v] = variables[v] || reservedDefault || "";
+        });
 
       formInstance.setValue("llmJudgeDetails.variables", localVariables);
       formInstance.setValue(

--- a/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
@@ -12,7 +12,10 @@ import { Label } from "@/ui/label";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
 import { parsePythonMethodParameters } from "@/lib/pythonArgumentsParser";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
-import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
+import {
+  RESERVED_TRACE_EVALUATOR_VARIABLES,
+  RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES,
+} from "@/constants/llm";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 
 type PythonCodeRuleDetailsProps = {
@@ -129,9 +132,7 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                 datasetColumnNames={datasetColumnNames}
                 type={autocompleteType}
                 includeIntermediateNodes
-                hiddenVariableNames={Object.keys(
-                  RESERVED_TRACE_EVALUATOR_VARIABLES,
-                )}
+                hiddenVariableNames={RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES}
               />
             );
           }}

--- a/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
@@ -12,6 +12,7 @@ import { Label } from "@/ui/label";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
 import { parsePythonMethodParameters } from "@/lib/pythonArgumentsParser";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
+import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 
 type PythonCodeRuleDetailsProps = {
@@ -60,15 +61,25 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                         const currentArguments = form.getValues(
                           "pythonCodeDetails.arguments",
                         );
+                        const isTraceScope =
+                          scope === EVALUATORS_RULE_SCOPE.trace;
                         const localArguments: Record<string, string> = {};
                         let parsingArgumentsError: boolean = false;
                         try {
                           parsePythonMethodParameters(value, "score")
                             .map((v) => v.name)
-                            .forEach(
-                              (v: string) =>
-                                (localArguments[v] = currentArguments[v] ?? ""),
-                            );
+                            .forEach((v: string) => {
+                              // Auto-fill reserved trace arguments (e.g. a `spans`
+                              // parameter) with their sentinel path so the user doesn't
+                              // need to pick one in the dropdown. Preserve any existing
+                              // user-supplied path if they already mapped this name to
+                              // something else.
+                              const reservedDefault = isTraceScope
+                                ? RESERVED_TRACE_EVALUATOR_VARIABLES[v]
+                                : undefined;
+                              localArguments[v] =
+                                currentArguments[v] || reservedDefault || "";
+                            });
                         } catch (e) {
                           parsingArgumentsError = true;
                         }

--- a/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
@@ -129,6 +129,9 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                 datasetColumnNames={datasetColumnNames}
                 type={autocompleteType}
                 includeIntermediateNodes
+                hiddenVariableNames={Object.keys(
+                  RESERVED_TRACE_EVALUATOR_VARIABLES,
+                )}
               />
             );
           }}

--- a/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
@@ -12,10 +12,8 @@ import { Label } from "@/ui/label";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
 import { parsePythonMethodParameters } from "@/lib/pythonArgumentsParser";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
-import {
-  RESERVED_TRACE_EVALUATOR_VARIABLES,
-  RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES,
-} from "@/constants/llm";
+import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
+import { resolveTraceEvaluatorVariableDefault } from "@/lib/llm";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 
 type PythonCodeRuleDetailsProps = {
@@ -64,24 +62,18 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                         const currentArguments = form.getValues(
                           "pythonCodeDetails.arguments",
                         );
-                        const isTraceScope =
-                          scope === EVALUATORS_RULE_SCOPE.trace;
                         const localArguments: Record<string, string> = {};
                         let parsingArgumentsError: boolean = false;
                         try {
                           parsePythonMethodParameters(value, "score")
                             .map((v) => v.name)
                             .forEach((v: string) => {
-                              // Auto-fill reserved trace arguments (e.g. a `spans`
-                              // parameter) with their sentinel path so the user doesn't
-                              // need to pick one in the dropdown. Preserve any existing
-                              // user-supplied path if they already mapped this name to
-                              // something else.
-                              const reservedDefault = isTraceScope
-                                ? RESERVED_TRACE_EVALUATOR_VARIABLES[v]
-                                : undefined;
                               localArguments[v] =
-                                currentArguments[v] || reservedDefault || "";
+                                resolveTraceEvaluatorVariableDefault(
+                                  v,
+                                  currentArguments[v],
+                                  scope,
+                                );
                             });
                         } catch (e) {
                           parsingArgumentsError = true;
@@ -132,7 +124,7 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                 datasetColumnNames={datasetColumnNames}
                 type={autocompleteType}
                 includeIntermediateNodes
-                hiddenVariableNames={RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES}
+                reservedSentinels={RESERVED_TRACE_EVALUATOR_VARIABLES}
               />
             );
           }}

--- a/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
@@ -15,6 +15,8 @@ import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
 import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
 import { resolveTraceEvaluatorVariableDefault } from "@/lib/llm";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
+import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
+import { FeatureToggleKeys } from "@/types/feature-toggles";
 
 type PythonCodeRuleDetailsProps = {
   form: UseFormReturn<EvaluationRuleFormType>;
@@ -34,6 +36,9 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
   const scope = form.watch("scope");
   const isThreadScope = scope === EVALUATORS_RULE_SCOPE.thread;
   const isSpanScope = scope === EVALUATORS_RULE_SCOPE.span;
+  const agenticToolsEnabled = useIsFeatureEnabled(
+    FeatureToggleKeys.AGENTIC_TOOLS_ENABLED,
+  );
 
   // Determine the type for autocomplete based on scope
   const autocompleteType = isSpanScope
@@ -73,6 +78,7 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                                   v,
                                   currentArguments[v],
                                   scope,
+                                  agenticToolsEnabled,
                                 );
                             });
                         } catch (e) {
@@ -124,7 +130,11 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                 datasetColumnNames={datasetColumnNames}
                 type={autocompleteType}
                 includeIntermediateNodes
-                reservedSentinels={RESERVED_TRACE_EVALUATOR_VARIABLES}
+                reservedSentinels={
+                  agenticToolsEnabled
+                    ? RESERVED_TRACE_EVALUATOR_VARIABLES
+                    : undefined
+                }
               />
             );
           }}

--- a/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/schema.ts
+++ b/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/schema.ts
@@ -210,8 +210,12 @@ export const LLMJudgeDetailsTraceFormSchema = LLMJudgeBaseSchema.extend({
     z
       .string()
       .min(1, { message: "Key is required" })
-      .regex(/^(input|output|metadata)(\.|$)/, {
-        message: `Key is invalid, it should be "input", "output", "metadata", and follow this format: "input.[PATH]" For example: "input.message" or just "input" for the whole object`,
+      // Allow the standard JSONPath form (input/output/metadata.[...]) OR a reserved
+      // bare sentinel like `spans` — see RESERVED_LLM_JUDGE_TRACE_VARIABLES. The
+      // backend's OnlineScoringEngine substitutes the sentinel with the JSON-
+      // serialized spans list at render time.
+      .regex(/^(input|output|metadata)(\.|$)|^spans$/, {
+        message: `Key is invalid, it should be "input", "output", "metadata" (e.g. "input.message" or just "input" for the whole object), or the reserved word "spans" to inject the trace's spans list`,
       }),
   ),
 }).superRefine((data, ctx) => {

--- a/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/schema.ts
+++ b/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/schema.ts
@@ -211,7 +211,7 @@ export const LLMJudgeDetailsTraceFormSchema = LLMJudgeBaseSchema.extend({
       .string()
       .min(1, { message: "Key is required" })
       // Allow the standard JSONPath form (input/output/metadata.[...]) OR a reserved
-      // bare sentinel like `spans` — see RESERVED_LLM_JUDGE_TRACE_VARIABLES. The
+      // bare sentinel like `spans` — see RESERVED_TRACE_EVALUATOR_VARIABLES. The
       // backend's OnlineScoringEngine substitutes the sentinel with the JSON-
       // serialized spans list at render time.
       .regex(/^(input|output|metadata)(\.|$)|^spans$/, {
@@ -366,8 +366,13 @@ export const PythonCodeDetailsTraceFormSchema = BasePythonCodeFormSchema.extend(
       z
         .string()
         .min(1, { message: "Key is required" })
-        .regex(/^(input|output|metadata)(\.|$)/, {
-          message: `Key is invalid, it should be "input", "output", "metadata", and follow this format: "input.[PATH]" For example: "input.message" or just "input" for the whole object`,
+        // Allow the standard JSONPath form (input/output/metadata.[...]) OR a
+        // reserved bare sentinel like `spans` — see
+        // RESERVED_TRACE_EVALUATOR_VARIABLES. The Python scorer opts into the
+        // SpanService fetch when the arguments map carries the `spans` key and
+        // injects a List<Span> as the matching kwarg.
+        .regex(/^(input|output|metadata)(\.|$)|^spans$/, {
+          message: `Key is invalid, it should be "input", "output", "metadata" (e.g. "input.message" or just "input" for the whole object), or the reserved word "spans" to inject the trace's spans list`,
         }),
     ),
     parsingArgumentsError: z.boolean().optional(),

--- a/apps/opik-frontend/src/v1/pages-shared/llm/LLMPromptMessagesVariables/LLMPromptMessagesVariables.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/llm/LLMPromptMessagesVariables/LLMPromptMessagesVariables.tsx
@@ -38,7 +38,7 @@ interface LLMPromptMessagesVariablesProps {
    * but the user doesn't see a row they don't need to interact with — used for
    * reserved trace evaluators like `{{spans}}` whose path is fixed.
    */
-  hiddenVariableNames?: string[];
+  hiddenVariableNames?: readonly string[];
 }
 
 const LLMPromptMessagesVariables = ({

--- a/apps/opik-frontend/src/v1/pages-shared/llm/LLMPromptMessagesVariables/LLMPromptMessagesVariables.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/llm/LLMPromptMessagesVariables/LLMPromptMessagesVariables.tsx
@@ -33,12 +33,13 @@ interface LLMPromptMessagesVariablesProps {
   type?: TRACE_DATA_TYPE;
   includeIntermediateNodes?: boolean;
   /**
-   * Names that should be hidden from the rendered mapping list. The underlying
-   * `variables` map still carries them (so the backend receives the sentinel),
-   * but the user doesn't see a row they don't need to interact with — used for
-   * reserved trace evaluators like `{{spans}}` whose path is fixed.
+   * Variable-name → sentinel-value map. A row is hidden from the rendered list
+   * only when the variable's *current value* equals the sentinel for that name
+   * — so the default `spans → "spans"` auto-fill is hidden, but a custom
+   * override (e.g. `spans → "input.spans"` set via the API) stays visible and
+   * editable. Hiding purely by name would make user-set values write-only.
    */
-  hiddenVariableNames?: readonly string[];
+  reservedSentinels?: Readonly<Record<string, string>>;
 }
 
 const LLMPromptMessagesVariables = ({
@@ -53,18 +54,17 @@ const LLMPromptMessagesVariables = ({
   datasetColumnNames,
   type = TRACE_DATA_TYPE.traces,
   includeIntermediateNodes = false,
-  hiddenVariableNames,
+  reservedSentinels,
 }: LLMPromptMessagesVariablesProps) => {
   const variablesList: DropdownOption<string>[] = useMemo(() => {
     if (!variables || typeof variables !== "object") {
       return [];
     }
-    const hidden = new Set(hiddenVariableNames ?? []);
     return Object.entries(variables)
-      .filter(([name]) => !hidden.has(name))
+      .filter(([name, value]) => reservedSentinels?.[name] !== value)
       .map((e) => ({ label: e[0], value: e[1] }))
       .sort((a, b) => a.label.localeCompare(b.label));
-  }, [variables, hiddenVariableNames]);
+  }, [variables, reservedSentinels]);
 
   const handleChangeVariables = useCallback(
     (changes: DropdownOption<string>) => {

--- a/apps/opik-frontend/src/v1/pages-shared/llm/LLMPromptMessagesVariables/LLMPromptMessagesVariables.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/llm/LLMPromptMessagesVariables/LLMPromptMessagesVariables.tsx
@@ -32,6 +32,13 @@ interface LLMPromptMessagesVariablesProps {
   datasetColumnNames?: string[];
   type?: TRACE_DATA_TYPE;
   includeIntermediateNodes?: boolean;
+  /**
+   * Names that should be hidden from the rendered mapping list. The underlying
+   * `variables` map still carries them (so the backend receives the sentinel),
+   * but the user doesn't see a row they don't need to interact with — used for
+   * reserved trace evaluators like `{{spans}}` whose path is fixed.
+   */
+  hiddenVariableNames?: string[];
 }
 
 const LLMPromptMessagesVariables = ({
@@ -46,15 +53,18 @@ const LLMPromptMessagesVariables = ({
   datasetColumnNames,
   type = TRACE_DATA_TYPE.traces,
   includeIntermediateNodes = false,
+  hiddenVariableNames,
 }: LLMPromptMessagesVariablesProps) => {
   const variablesList: DropdownOption<string>[] = useMemo(() => {
     if (!variables || typeof variables !== "object") {
       return [];
     }
+    const hidden = new Set(hiddenVariableNames ?? []);
     return Object.entries(variables)
+      .filter(([name]) => !hidden.has(name))
       .map((e) => ({ label: e[0], value: e[1] }))
       .sort((a, b) => a.label.localeCompare(b.label));
-  }, [variables]);
+  }, [variables, hiddenVariableNames]);
 
   const handleChangeVariables = useCallback(
     (changes: DropdownOption<string>) => {

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/lib/llm";
 import { COMPOSED_PROVIDER_TYPE, PROVIDER_MODEL_TYPE } from "@/types/providers";
 import { safelyGetPromptMustacheTags } from "@/lib/prompt";
-import { RESERVED_LLM_JUDGE_TRACE_VARIABLES } from "@/constants/llm";
+import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
 import { EvaluationRuleFormType } from "@/v2/pages-shared/automations/AddEditRuleDialog/schema";
 import useLLMProviderModelsData from "@/hooks/useLLMProviderModelsData";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
@@ -147,7 +147,7 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
           // Preserve any existing user-supplied path if they already mapped this name
           // to something else.
           const reservedDefault = isTraceScope
-            ? RESERVED_LLM_JUDGE_TRACE_VARIABLES[v]
+            ? RESERVED_TRACE_EVALUATOR_VARIABLES[v]
             : undefined;
           localVariables[v] = variables[v] || reservedDefault || "";
         });

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
@@ -29,7 +29,10 @@ import {
 } from "@/lib/llm";
 import { COMPOSED_PROVIDER_TYPE, PROVIDER_MODEL_TYPE } from "@/types/providers";
 import { safelyGetPromptMustacheTags } from "@/lib/prompt";
-import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
+import {
+  RESERVED_TRACE_EVALUATOR_VARIABLES,
+  RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES,
+} from "@/constants/llm";
 import { EvaluationRuleFormType } from "@/v2/pages-shared/automations/AddEditRuleDialog/schema";
 import useLLMProviderModelsData from "@/hooks/useLLMProviderModelsData";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
@@ -347,9 +350,7 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
                     datasetColumnNames={datasetColumnNames}
                     type={autocompleteType}
                     includeIntermediateNodes
-                    hiddenVariableNames={Object.keys(
-                      RESERVED_TRACE_EVALUATOR_VARIABLES,
-                    )}
+                    hiddenVariableNames={RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES}
                   />
                 </>
               );

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
@@ -26,13 +26,11 @@ import {
 import {
   generateDefaultLLMPromptMessage,
   getAllTemplateStringsFromContent,
+  resolveTraceEvaluatorVariableDefault,
 } from "@/lib/llm";
 import { COMPOSED_PROVIDER_TYPE, PROVIDER_MODEL_TYPE } from "@/types/providers";
 import { safelyGetPromptMustacheTags } from "@/lib/prompt";
-import {
-  RESERVED_TRACE_EVALUATOR_VARIABLES,
-  RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES,
-} from "@/constants/llm";
+import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
 import { EvaluationRuleFormType } from "@/v2/pages-shared/automations/AddEditRuleDialog/schema";
 import useLLMProviderModelsData from "@/hooks/useLLMProviderModelsData";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
@@ -125,7 +123,6 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
       // recalculate variables
       const variables = formInstance.getValues("llmJudgeDetails.variables");
       const currentScope = formInstance.getValues("scope");
-      const isTraceScope = currentScope === EVALUATORS_RULE_SCOPE.trace;
       const localVariables: Record<string, string> = {};
       let parsingVariablesError: boolean = false;
       messages
@@ -145,14 +142,11 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
         }, [])
         .filter((v) => v !== "")
         .forEach((v: string) => {
-          // Auto-fill reserved trace variables (e.g. `{{spans}}`) with their sentinel
-          // path so the user doesn't have to pick one in the variable mapping dropdown.
-          // Preserve any existing user-supplied path if they already mapped this name
-          // to something else.
-          const reservedDefault = isTraceScope
-            ? RESERVED_TRACE_EVALUATOR_VARIABLES[v]
-            : undefined;
-          localVariables[v] = variables[v] || reservedDefault || "";
+          localVariables[v] = resolveTraceEvaluatorVariableDefault(
+            v,
+            variables[v],
+            currentScope,
+          );
         });
 
       formInstance.setValue("llmJudgeDetails.variables", localVariables);
@@ -350,7 +344,7 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
                     datasetColumnNames={datasetColumnNames}
                     type={autocompleteType}
                     includeIntermediateNodes
-                    hiddenVariableNames={RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES}
+                    reservedSentinels={RESERVED_TRACE_EVALUATOR_VARIABLES}
                   />
                 </>
               );

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/lib/llm";
 import { COMPOSED_PROVIDER_TYPE, PROVIDER_MODEL_TYPE } from "@/types/providers";
 import { safelyGetPromptMustacheTags } from "@/lib/prompt";
+import { RESERVED_LLM_JUDGE_TRACE_VARIABLES } from "@/constants/llm";
 import { EvaluationRuleFormType } from "@/v2/pages-shared/automations/AddEditRuleDialog/schema";
 import useLLMProviderModelsData from "@/hooks/useLLMProviderModelsData";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
@@ -120,6 +121,8 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
 
       // recalculate variables
       const variables = formInstance.getValues("llmJudgeDetails.variables");
+      const currentScope = formInstance.getValues("scope");
+      const isTraceScope = currentScope === EVALUATORS_RULE_SCOPE.trace;
       const localVariables: Record<string, string> = {};
       let parsingVariablesError: boolean = false;
       messages
@@ -138,7 +141,16 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
           return acc.concat(allTags);
         }, [])
         .filter((v) => v !== "")
-        .forEach((v: string) => (localVariables[v] = variables[v] ?? ""));
+        .forEach((v: string) => {
+          // Auto-fill reserved trace variables (e.g. `{{spans}}`) with their sentinel
+          // path so the user doesn't have to pick one in the variable mapping dropdown.
+          // Preserve any existing user-supplied path if they already mapped this name
+          // to something else.
+          const reservedDefault = isTraceScope
+            ? RESERVED_LLM_JUDGE_TRACE_VARIABLES[v]
+            : undefined;
+          localVariables[v] = variables[v] || reservedDefault || "";
+        });
 
       formInstance.setValue("llmJudgeDetails.variables", localVariables);
       formInstance.setValue(

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
@@ -347,6 +347,9 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
                     datasetColumnNames={datasetColumnNames}
                     type={autocompleteType}
                     includeIntermediateNodes
+                    hiddenVariableNames={Object.keys(
+                      RESERVED_TRACE_EVALUATOR_VARIABLES,
+                    )}
                   />
                 </>
               );

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
@@ -38,6 +38,8 @@ import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
 import { updateProviderConfig } from "@/lib/modelUtils";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
+import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
+import { FeatureToggleKeys } from "@/types/feature-toggles";
 
 const MESSAGE_TYPE_OPTIONS = [
   {
@@ -76,6 +78,9 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
   const scope = form.watch("scope");
   const isThreadScope = scope === EVALUATORS_RULE_SCOPE.thread;
   const isSpanScope = scope === EVALUATORS_RULE_SCOPE.span;
+  const agenticToolsEnabled = useIsFeatureEnabled(
+    FeatureToggleKeys.AGENTIC_TOOLS_ENABLED,
+  );
 
   const templates = LLM_PROMPT_TEMPLATES[scope];
 
@@ -146,6 +151,7 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
             v,
             variables[v],
             currentScope,
+            agenticToolsEnabled,
           );
         });
 
@@ -155,7 +161,7 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
         parsingVariablesError,
       );
     },
-    [],
+    [agenticToolsEnabled],
   );
 
   return (
@@ -344,7 +350,11 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
                     datasetColumnNames={datasetColumnNames}
                     type={autocompleteType}
                     includeIntermediateNodes
-                    reservedSentinels={RESERVED_TRACE_EVALUATOR_VARIABLES}
+                    reservedSentinels={
+                      agenticToolsEnabled
+                        ? RESERVED_TRACE_EVALUATOR_VARIABLES
+                        : undefined
+                    }
                   />
                 </>
               );

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
@@ -15,6 +15,8 @@ import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
 import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
 import { resolveTraceEvaluatorVariableDefault } from "@/lib/llm";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
+import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
+import { FeatureToggleKeys } from "@/types/feature-toggles";
 
 type PythonCodeRuleDetailsProps = {
   form: UseFormReturn<EvaluationRuleFormType>;
@@ -32,6 +34,9 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
   const scope = form.watch("scope");
   const isThreadScope = scope === EVALUATORS_RULE_SCOPE.thread;
   const isSpanScope = scope === EVALUATORS_RULE_SCOPE.span;
+  const agenticToolsEnabled = useIsFeatureEnabled(
+    FeatureToggleKeys.AGENTIC_TOOLS_ENABLED,
+  );
 
   // Determine the type for autocomplete based on scope
   const autocompleteType = isSpanScope
@@ -71,6 +76,7 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                                   v,
                                   currentArguments[v],
                                   scope,
+                                  agenticToolsEnabled,
                                 );
                             });
                         } catch (e) {
@@ -121,7 +127,11 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                 datasetColumnNames={datasetColumnNames}
                 type={autocompleteType}
                 includeIntermediateNodes
-                reservedSentinels={RESERVED_TRACE_EVALUATOR_VARIABLES}
+                reservedSentinels={
+                  agenticToolsEnabled
+                    ? RESERVED_TRACE_EVALUATOR_VARIABLES
+                    : undefined
+                }
               />
             );
           }}

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
@@ -12,7 +12,10 @@ import { Label } from "@/ui/label";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
 import { parsePythonMethodParameters } from "@/lib/pythonArgumentsParser";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
-import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
+import {
+  RESERVED_TRACE_EVALUATOR_VARIABLES,
+  RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES,
+} from "@/constants/llm";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 
 type PythonCodeRuleDetailsProps = {
@@ -126,9 +129,7 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                 datasetColumnNames={datasetColumnNames}
                 type={autocompleteType}
                 includeIntermediateNodes
-                hiddenVariableNames={Object.keys(
-                  RESERVED_TRACE_EVALUATOR_VARIABLES,
-                )}
+                hiddenVariableNames={RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES}
               />
             );
           }}

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
@@ -12,10 +12,8 @@ import { Label } from "@/ui/label";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
 import { parsePythonMethodParameters } from "@/lib/pythonArgumentsParser";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
-import {
-  RESERVED_TRACE_EVALUATOR_VARIABLES,
-  RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES,
-} from "@/constants/llm";
+import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
+import { resolveTraceEvaluatorVariableDefault } from "@/lib/llm";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 
 type PythonCodeRuleDetailsProps = {
@@ -62,24 +60,18 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                         const currentArguments = form.getValues(
                           "pythonCodeDetails.arguments",
                         );
-                        const isTraceScope =
-                          scope === EVALUATORS_RULE_SCOPE.trace;
                         const localArguments: Record<string, string> = {};
                         let parsingArgumentsError: boolean = false;
                         try {
                           parsePythonMethodParameters(value, "score")
                             .map((v) => v.name)
                             .forEach((v: string) => {
-                              // Auto-fill reserved trace arguments (e.g. a `spans`
-                              // parameter) with their sentinel path so the user doesn't
-                              // need to pick one in the dropdown. Preserve any existing
-                              // user-supplied path if they already mapped this name to
-                              // something else.
-                              const reservedDefault = isTraceScope
-                                ? RESERVED_TRACE_EVALUATOR_VARIABLES[v]
-                                : undefined;
                               localArguments[v] =
-                                currentArguments[v] || reservedDefault || "";
+                                resolveTraceEvaluatorVariableDefault(
+                                  v,
+                                  currentArguments[v],
+                                  scope,
+                                );
                             });
                         } catch (e) {
                           parsingArgumentsError = true;
@@ -129,7 +121,7 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                 datasetColumnNames={datasetColumnNames}
                 type={autocompleteType}
                 includeIntermediateNodes
-                hiddenVariableNames={RESERVED_TRACE_EVALUATOR_VARIABLE_NAMES}
+                reservedSentinels={RESERVED_TRACE_EVALUATOR_VARIABLES}
               />
             );
           }}

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
@@ -12,6 +12,7 @@ import { Label } from "@/ui/label";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
 import { parsePythonMethodParameters } from "@/lib/pythonArgumentsParser";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
+import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 
 type PythonCodeRuleDetailsProps = {
@@ -58,15 +59,25 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                         const currentArguments = form.getValues(
                           "pythonCodeDetails.arguments",
                         );
+                        const isTraceScope =
+                          scope === EVALUATORS_RULE_SCOPE.trace;
                         const localArguments: Record<string, string> = {};
                         let parsingArgumentsError: boolean = false;
                         try {
                           parsePythonMethodParameters(value, "score")
                             .map((v) => v.name)
-                            .forEach(
-                              (v: string) =>
-                                (localArguments[v] = currentArguments[v] ?? ""),
-                            );
+                            .forEach((v: string) => {
+                              // Auto-fill reserved trace arguments (e.g. a `spans`
+                              // parameter) with their sentinel path so the user doesn't
+                              // need to pick one in the dropdown. Preserve any existing
+                              // user-supplied path if they already mapped this name to
+                              // something else.
+                              const reservedDefault = isTraceScope
+                                ? RESERVED_TRACE_EVALUATOR_VARIABLES[v]
+                                : undefined;
+                              localArguments[v] =
+                                currentArguments[v] || reservedDefault || "";
+                            });
                         } catch (e) {
                           parsingArgumentsError = true;
                         }

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
@@ -126,6 +126,9 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                 datasetColumnNames={datasetColumnNames}
                 type={autocompleteType}
                 includeIntermediateNodes
+                hiddenVariableNames={Object.keys(
+                  RESERVED_TRACE_EVALUATOR_VARIABLES,
+                )}
               />
             );
           }}

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.ts
@@ -210,8 +210,12 @@ export const LLMJudgeDetailsTraceFormSchema = LLMJudgeBaseSchema.extend({
     z
       .string()
       .min(1, { message: "Key is required" })
-      .regex(/^(input|output|metadata)(\.|$)/, {
-        message: `Key is invalid, it should be "input", "output", "metadata", and follow this format: "input.[PATH]" For example: "input.message" or just "input" for the whole object`,
+      // Allow the standard JSONPath form (input/output/metadata.[...]) OR a reserved
+      // bare sentinel like `spans` — see RESERVED_LLM_JUDGE_TRACE_VARIABLES. The
+      // backend's OnlineScoringEngine substitutes the sentinel with the JSON-
+      // serialized spans list at render time.
+      .regex(/^(input|output|metadata)(\.|$)|^spans$/, {
+        message: `Key is invalid, it should be "input", "output", "metadata" (e.g. "input.message" or just "input" for the whole object), or the reserved word "spans" to inject the trace's spans list`,
       }),
   ),
 }).superRefine((data, ctx) => {

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.ts
@@ -211,7 +211,7 @@ export const LLMJudgeDetailsTraceFormSchema = LLMJudgeBaseSchema.extend({
       .string()
       .min(1, { message: "Key is required" })
       // Allow the standard JSONPath form (input/output/metadata.[...]) OR a reserved
-      // bare sentinel like `spans` — see RESERVED_LLM_JUDGE_TRACE_VARIABLES. The
+      // bare sentinel like `spans` — see RESERVED_TRACE_EVALUATOR_VARIABLES. The
       // backend's OnlineScoringEngine substitutes the sentinel with the JSON-
       // serialized spans list at render time.
       .regex(/^(input|output|metadata)(\.|$)|^spans$/, {
@@ -366,8 +366,13 @@ export const PythonCodeDetailsTraceFormSchema = BasePythonCodeFormSchema.extend(
       z
         .string()
         .min(1, { message: "Key is required" })
-        .regex(/^(input|output|metadata)(\.|$)/, {
-          message: `Key is invalid, it should be "input", "output", "metadata", and follow this format: "input.[PATH]" For example: "input.message" or just "input" for the whole object`,
+        // Allow the standard JSONPath form (input/output/metadata.[...]) OR a
+        // reserved bare sentinel like `spans` — see
+        // RESERVED_TRACE_EVALUATOR_VARIABLES. The Python scorer opts into the
+        // SpanService fetch when the arguments map carries the `spans` key and
+        // injects a List<Span> as the matching kwarg.
+        .regex(/^(input|output|metadata)(\.|$)|^spans$/, {
+          message: `Key is invalid, it should be "input", "output", "metadata" (e.g. "input.message" or just "input" for the whole object), or the reserved word "spans" to inject the trace's spans list`,
         }),
     ),
     parsingArgumentsError: z.boolean().optional(),

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessagesVariables/LLMPromptMessagesVariables.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessagesVariables/LLMPromptMessagesVariables.tsx
@@ -37,7 +37,7 @@ interface LLMPromptMessagesVariablesProps {
    * but the user doesn't see a row they don't need to interact with — used for
    * reserved trace evaluators like `{{spans}}` whose path is fixed.
    */
-  hiddenVariableNames?: string[];
+  hiddenVariableNames?: readonly string[];
 }
 
 const LLMPromptMessagesVariables = ({

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessagesVariables/LLMPromptMessagesVariables.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessagesVariables/LLMPromptMessagesVariables.tsx
@@ -32,12 +32,13 @@ interface LLMPromptMessagesVariablesProps {
   type?: TRACE_DATA_TYPE;
   includeIntermediateNodes?: boolean;
   /**
-   * Names that should be hidden from the rendered mapping list. The underlying
-   * `variables` map still carries them (so the backend receives the sentinel),
-   * but the user doesn't see a row they don't need to interact with — used for
-   * reserved trace evaluators like `{{spans}}` whose path is fixed.
+   * Variable-name → sentinel-value map. A row is hidden from the rendered list
+   * only when the variable's *current value* equals the sentinel for that name
+   * — so the default `spans → "spans"` auto-fill is hidden, but a custom
+   * override (e.g. `spans → "input.spans"` set via the API) stays visible and
+   * editable. Hiding purely by name would make user-set values write-only.
    */
-  hiddenVariableNames?: readonly string[];
+  reservedSentinels?: Readonly<Record<string, string>>;
 }
 
 const LLMPromptMessagesVariables = ({
@@ -51,18 +52,17 @@ const LLMPromptMessagesVariables = ({
   datasetColumnNames,
   type = TRACE_DATA_TYPE.traces,
   includeIntermediateNodes = false,
-  hiddenVariableNames,
+  reservedSentinels,
 }: LLMPromptMessagesVariablesProps) => {
   const variablesList: DropdownOption<string>[] = useMemo(() => {
     if (!variables || typeof variables !== "object") {
       return [];
     }
-    const hidden = new Set(hiddenVariableNames ?? []);
     return Object.entries(variables)
-      .filter(([name]) => !hidden.has(name))
+      .filter(([name, value]) => reservedSentinels?.[name] !== value)
       .map((e) => ({ label: e[0], value: e[1] }))
       .sort((a, b) => a.label.localeCompare(b.label));
-  }, [variables, hiddenVariableNames]);
+  }, [variables, reservedSentinels]);
 
   const handleChangeVariables = useCallback(
     (changes: DropdownOption<string>) => {

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessagesVariables/LLMPromptMessagesVariables.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessagesVariables/LLMPromptMessagesVariables.tsx
@@ -31,6 +31,13 @@ interface LLMPromptMessagesVariablesProps {
   datasetColumnNames?: string[];
   type?: TRACE_DATA_TYPE;
   includeIntermediateNodes?: boolean;
+  /**
+   * Names that should be hidden from the rendered mapping list. The underlying
+   * `variables` map still carries them (so the backend receives the sentinel),
+   * but the user doesn't see a row they don't need to interact with — used for
+   * reserved trace evaluators like `{{spans}}` whose path is fixed.
+   */
+  hiddenVariableNames?: string[];
 }
 
 const LLMPromptMessagesVariables = ({
@@ -44,15 +51,18 @@ const LLMPromptMessagesVariables = ({
   datasetColumnNames,
   type = TRACE_DATA_TYPE.traces,
   includeIntermediateNodes = false,
+  hiddenVariableNames,
 }: LLMPromptMessagesVariablesProps) => {
   const variablesList: DropdownOption<string>[] = useMemo(() => {
     if (!variables || typeof variables !== "object") {
       return [];
     }
+    const hidden = new Set(hiddenVariableNames ?? []);
     return Object.entries(variables)
+      .filter(([name]) => !hidden.has(name))
       .map((e) => ({ label: e[0], value: e[1] }))
       .sort((a, b) => a.label.localeCompare(b.label));
-  }, [variables]);
+  }, [variables, hiddenVariableNames]);
 
   const handleChangeVariables = useCallback(
     (changes: DropdownOption<string>) => {


### PR DESCRIPTION
## Details

Lets LLM-as-judge / Python-metric rules see the agent's actual reasoning trace (tool calls + I/O) inline in the prompt. Trace-scope rules get a new `{{spans}}` template variable; thread-scope rules keep `{{context}}` but it's now enriched with each turn's child spans nested under the assistant entry. Both paths ship behind the existing `isAgenticToolsEnabled` feature flag — when off, wire shape is byte-identical to today.

### Behavior matrix

| Scope | Toggle | What the judge sees |
|---|---|---|
| Trace | ON | `{{spans}}` substitutes a nested-tree projection of all child spans (tool calls + I/O, recursively) |
| Trace | OFF | `{{spans}}` renders as `[]` (sentinel-mapped variables) or stays literal (unmapped); no I/O |
| Thread | ON | `{{context}}` carries `[{role, content, spans}, ...]` — each assistant entry gets its trace's span tree |
| Thread | OFF | `{{context}}` carries `[{role, content}, ...]` — no `spans` field, wire-identical to today |
| Tools-branch (big thread) | — | Compact skeleton + `read`/`jq` tools; spans fetched on-demand per-trace by the agent |

### What's in `spans`

Spans are projected to `SpanForLlm` — 11 fields the judge actually uses: `name`, `type`, `input`, `output`, `metadata`, `start_time`, `end_time`, `duration`, `model`, `provider`, `error_info`, plus a recursive `spans` field for child spans. Dropped: `id`, `project_id`, `trace_id`, `tags`, `usage`, `ttft`, `source`, `environment`, audit fields, feedback scores, comments, cost data. Locked in by `prepareLlmRequestRendersSpansWithLeanProjection`.

### Key design decisions

- **One toggle gates BE fetch + FE auto-fill** — when off, the FE editors stop auto-filling the `spans` sentinel and keep the variable row editable.
- **Multimodal `contentArray` is scanned** for implicit `{{spans}}` references.
- **API-created rules** that put `{{spans}}` in the prompt but omit the sentinel mapping still work — `templateReferencesSpans` falls through to a template-content scan.
- **Tools-branch thread render is intentionally NOT enriched** — it still uses the compact skeleton + `read`/`jq` tools to drill in per-trace on demand.
- **Size estimate accounts for spans** so a big-but-enriched thread routes to tools correctly.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-5333

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: pair-programming on design + implementation + tests; iterating on PR review feedback
- Human verification: every commit reviewed before push; two rounds of independent code review with blockers addressed

## Testing

Automated:
- BE: `mvn -B test -Dtest='OnlineScoringEngineTest,OnlineScoringTraceThreadLlmAsJudgeScorerTest,OnlineScoringLlmAsJudgeScorerTest'` — 136/136 pass locally. ~30 new unit tests covering projection (`SpanForLlm`), tree shape and orphan promotion (`buildSpanTree`), toggle gates (`shouldFetchSpans`), multimodal detection, parameterized routing truth tables.
- BE Spotless: `mvn -B spotless:check` clean.
- FE: `npx tsc --noEmit` clean, `npx eslint --max-warnings=0` clean on the touched directories.

Manual scenarios to validate (happy path + edge cases):
- Toggle off + small trace: trace-scope LLM-as-judge rule with `{{spans}}` in the prompt → prompt renders `Spans: []`.
- Toggle on + small trace: same rule → prompt renders the full span tree (tool spans nested as expected).
- Toggle on + thread: thread-scope rule with `{{context}}` → each assistant entry carries a `spans` array with tool calls.
- Toggle on + big thread (> 50K tokens): same rule → routes to agentic-tools (skeleton + `read`/`jq` tools surfaced).
- Toggle on + Python metric with `def score(self, spans, ...)` → `spans` arrives as a `List[Span]` kwarg.
- Toggle off + FE editor: type `{{spans}}` in a trace-scope prompt → row is visible and editable, no auto-fill.
- Toggle on + FE editor: type `{{spans}}` → row is hidden (auto-filled to sentinel). API-mapping `spans` to `input.spans` makes the row reappear as editable.

CI status: kicked off after the latest push (`d0711ebe8f`); waiting on integration groups.

## Documentation

No customer-facing docs change ships with this PR. The feature surfaces through existing `{{spans}}` / `{{context}}` template syntax and the existing `agenticToolsEnabled` toggle — both already documented. A follow-up doc update to call out the enriched-`{{context}}` shape and the new `{{spans}}` variable for trace-scope rules is reasonable once this lands; not a blocker for merge.

### Behavior-change note for Python online evaluators

The `spans` kwarg in trace-scope Python metrics (and the conversation kwarg in thread-scope Python metrics, when `agenticToolsEnabled=true`) now carries the lean `SpanForLlm` projection — 11 fields per span — instead of the full ~28-field `Span` record. Kept: `name`, `type`, `input`, `output`, `metadata`, `start_time`, `end_time`, `duration`, `model`, `provider`, `error_info`, and a recursive `spans` field for nested children. **Dropped**: `id`, `project_id`, `trace_id`, `parent_span_id`, `tags`, `usage`, `ttft`, `source`, `environment`, audit fields (`created_at`, `created_by`, `last_updated_at`, `last_updated_by`), `feedback_scores`, `comments`, cost data (`total_estimated_cost`, `total_estimated_cost_version`).

Existing trace-scope Python metrics that read any of the dropped fields will need updating. Most `score(self, spans, ...)`-style metrics that evaluate agent behavior only read `name`/`type`/`input`/`output`, so the practical impact should be narrow — but worth a heads-up to anyone with Python metrics in production.

For the thread-scope Python conversation kwarg, the shape is also new: each turn is a `{role, content}` dict, and when the toggle is on the assistant entry additionally carries a `spans` field with the same lean projected tree. When the toggle is off, the conversation is byte-identical to today's `[{role, content}, ...]` shape — no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)