### PR TITLE
[OPIK-6582] [INFRA] [CI] fix: quote SC2086 vars across 6 high-density workflow files

### DIFF
--- a/.github/workflows/build_and_push_docker.yaml
+++ b/.github/workflows/build_and_push_docker.yaml
@@ -68,13 +68,13 @@ jobs:
             BUILD_MATRIX=$(echo "$BUILD_MATRIX" | jq '.exclude += [{"platform":"arm64"}]')
           fi
           
-          echo "build_matrix<<EOF" >> $GITHUB_OUTPUT
-          echo "$BUILD_MATRIX" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "build_matrix<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$BUILD_MATRIX" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
           
-          echo "merge_matrix<<EOF" >> $GITHUB_OUTPUT
-          echo "$MERGE_MATRIX" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "merge_matrix<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$MERGE_MATRIX" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
   build:
     needs: generate-matrix
@@ -100,7 +100,7 @@ jobs:
           else
             IMAGE_NAME="${{ inputs.image }}"
           fi
-          echo "image_name=$IMAGE_NAME" >> $GITHUB_OUTPUT
+          echo "image_name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@v6
@@ -116,8 +116,8 @@ jobs:
           else
             TAG="${{inputs.version}}"
           fi
-          docker pull ${{env.DOCKER_REGISTRY}}/opik-sandbox-executor-python:$TAG
-          docker save ${{env.DOCKER_REGISTRY}}/opik-sandbox-executor-python:$TAG | gzip > apps/opik-python-backend/opik-sandbox-executor-python.tar.gz
+          docker pull "${{env.DOCKER_REGISTRY}}/opik-sandbox-executor-python:$TAG"
+          docker save "${{env.DOCKER_REGISTRY}}/opik-sandbox-executor-python:$TAG" | gzip > apps/opik-python-backend/opik-sandbox-executor-python.tar.gz
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -192,7 +192,7 @@ jobs:
           else
             IMAGE_NAME="${{ inputs.image }}"
           fi
-          echo "image_name=$IMAGE_NAME" >> $GITHUB_OUTPUT
+          echo "image_name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -258,18 +258,24 @@ jobs:
             exit 1
           fi
           
+          # $TAG_ARGS and $DIGESTS are intentionally unquoted: each holds a
+          # space-separated argument list (`-t tag1 -t tag2 ...` and a list of
+          # digest refs) that must word-split into individual argv entries.
+          # Quoting would collapse each into a single argument and break the
+          # docker invocation.
+          # shellcheck disable=SC2086
           docker buildx imagetools create $TAG_ARGS $DIGESTS
 
       - name: Write Build Summary
         run: |
-          echo "### Docker images pushed: ${{ steps.set_vars.outputs.image_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo "### Docker images pushed: ${{ steps.set_vars.outputs.image_name }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.meta.outputs.tags }}" >> "$GITHUB_STEP_SUMMARY"
           if [[ "${{ inputs.image }}" == "opik-guardrails-backend" ]]; then
-            echo "Built for platforms: linux/amd64" >> $GITHUB_STEP_SUMMARY
+            echo "Built for platforms: linux/amd64" >> "$GITHUB_STEP_SUMMARY"
           elif [[ "${{ inputs.is_release }}" == "true" ]]; then
-            echo "Built for platforms: linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
+            echo "Built for platforms: linux/amd64, linux/arm64" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "Built for platforms: linux/amd64" >> $GITHUB_STEP_SUMMARY
+            echo "Built for platforms: linux/amd64" >> "$GITHUB_STEP_SUMMARY"
           fi
-          echo "- [View on GitHub Container Registry](https://github.com/${{ github.repository }}/pkgs/container/opik%2F${{ steps.set_vars.outputs.image_name }})" >> $GITHUB_STEP_SUMMARY
+          echo "- [View on GitHub Container Registry](https://github.com/${{ github.repository }}/pkgs/container/opik%2F${{ steps.set_vars.outputs.image_name }})" >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/opik_wizard_publish.yml
+++ b/.github/workflows/opik_wizard_publish.yml
@@ -129,16 +129,16 @@ jobs:
       - name: Workflow summary
         if: always()
         run: |
-          echo "## Workflow Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version**: ${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Is Release**: ${{ env.IS_RELEASE }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Branch**: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Triggered by**: @${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Workflow Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Version**: ${{ env.VERSION }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Is Release**: ${{ env.IS_RELEASE }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Branch**: ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Triggered by**: @${{ github.actor }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ env.IS_RELEASE }}" == "true" ]; then
-            echo "✅ Package published to NPM: [opik-configure@${{ env.VERSION }}](https://www.npmjs.com/package/opik-configure/v/${{ env.VERSION }})" >> $GITHUB_STEP_SUMMARY
-            echo "✅ Git tag created: configure-v${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
+            echo "✅ Package published to NPM: [opik-configure@${{ env.VERSION }}](https://www.npmjs.com/package/opik-configure/v/${{ env.VERSION }})" >> "$GITHUB_STEP_SUMMARY"
+            echo "✅ Git tag created: configure-v${{ env.VERSION }}" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "ℹ️ Dry run completed - no changes published" >> $GITHUB_STEP_SUMMARY
+            echo "ℹ️ Dry run completed - no changes published" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
+++ b/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
@@ -30,7 +30,7 @@ jobs:
           if [ -z "$AUTHOR" ]; then
             AUTHOR="${{ github.actor }}"
           fi
-          echo "author=$AUTHOR" >> $GITHUB_OUTPUT
+          echo "author=$AUTHOR" >> "$GITHUB_OUTPUT"
 
       - name: Find originating PR
         id: find-pr
@@ -38,7 +38,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_URL=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0].html_url' 2>/dev/null || echo "")
-          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
 
   update-open-api-spec-and-fern-code:
     needs: resolve-trigger-context
@@ -80,7 +80,7 @@ jobs:
 
       - name: Set branch name
         run: |
-          echo "BRANCH_NAME=github-actions/NA-automatically-update-openapi-spec-and-fern-code-$(date +%Y-%m-%d-%H-%M-%S)" >> $GITHUB_ENV
+          echo "BRANCH_NAME=github-actions/NA-automatically-update-openapi-spec-and-fern-code-$(date +%Y-%m-%d-%H-%M-%S)" >> "$GITHUB_ENV"
 
       - name: Run Generate OpenAPI spec and Fern code
         env:
@@ -102,21 +102,21 @@ jobs:
           if [ "${{ github.event_name }}" == "push" ]; then
             ORIGINATING_PR="${{ needs.resolve-trigger-context.outputs.originating_pr_url }}"
             if [ -n "$ORIGINATING_PR" ]; then
-              echo "trigger_info=**Triggered by BE merge:** $ORIGINATING_PR" >> $GITHUB_OUTPUT
+              echo "trigger_info=**Triggered by BE merge:** $ORIGINATING_PR" >> "$GITHUB_OUTPUT"
             else
-              echo "trigger_info=**Triggered by commit:** https://github.com/${{ github.repository }}/commit/${{ github.sha }}" >> $GITHUB_OUTPUT
+              echo "trigger_info=**Triggered by commit:** https://github.com/${{ github.repository }}/commit/${{ github.sha }}" >> "$GITHUB_OUTPUT"
             fi
           else
-            echo "trigger_info=" >> $GITHUB_OUTPUT
+            echo "trigger_info=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check for changes
         id: check_changes
         run: |
           if git diff --quiet; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Commit files
@@ -190,8 +190,8 @@ jobs:
               AUTHOR_MENTION="<@$AUTHOR_SLACK_ID>"
             fi
           fi
-          echo "mention=$AUTHOR_MENTION" >> $GITHUB_OUTPUT
-          echo "author_display=$AUTHOR" >> $GITHUB_OUTPUT
+          echo "mention=$AUTHOR_MENTION" >> "$GITHUB_OUTPUT"
+          echo "author_display=$AUTHOR" >> "$GITHUB_OUTPUT"
 
       - name: Send Slack notification
         env:

--- a/.github/workflows/sync_provider_models.yml
+++ b/.github/workflows/sync_provider_models.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Set branch name
         run: |
-          echo "BRANCH_NAME=github-actions/NA-sync-provider-models-$(date +%Y-%m-%d-%H-%M-%S)" >> $GITHUB_ENV
+          echo "BRANCH_NAME=github-actions/NA-sync-provider-models-$(date +%Y-%m-%d-%H-%M-%S)" >> "$GITHUB_ENV"
 
       - name: Run sync script
         id: sync
@@ -47,19 +47,25 @@ jobs:
           FORCE_REGEN_FLAG: ${{ inputs.force_regen == true && '--force-regen' || '' }}
         run: |
           set +e -o pipefail
+          # $FORCE_REGEN_FLAG is intentionally unquoted: it holds either
+          # `--force-regen` (a single flag) or the empty string. Quoting it
+          # would pass a literal empty argument to python, which is harmless
+          # here but conceptually wrong — the variable is acting as an
+          # optional argv slot, not a single value.
+          # shellcheck disable=SC2086
           python scripts/sync_provider_models.py $FORCE_REGEN_FLAG 2>sync_stderr.txt | tee sync_summary.txt
           EXIT_CODE=${PIPESTATUS[0]}
           set -e
-          echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
 
           # Capture summary for PR body (multiline output)
           {
             echo "summary<<EOF"
             cat sync_summary.txt
             echo "EOF"
-          } >> $GITHUB_OUTPUT
+          } >> "$GITHUB_OUTPUT"
 
-          if [ $EXIT_CODE -eq 1 ]; then
+          if [ "$EXIT_CODE" -eq 1 ]; then
             echo "No new models found, skipping PR creation."
           fi
 
@@ -68,19 +74,19 @@ jobs:
       - name: Print summary
         if: always() && steps.sync.outputs.summary != ''
         run: |
-          echo "## Sync Summary" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.sync.outputs.summary }}" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "## Sync Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.sync.outputs.summary }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Check for changes
         if: steps.sync.outputs.exit_code == '0'
         id: check_changes
         run: |
           if git diff --quiet; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Commit files

--- a/.github/workflows/typescript_sdk_integration_publish.yml
+++ b/.github/workflows/typescript_sdk_integration_publish.yml
@@ -100,20 +100,20 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## ${{ env.INTEGRATION }} Build" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** ${{ steps.build_publish.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Event:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Is Release:** ${{ env.IS_RELEASE }}" >> $GITHUB_STEP_SUMMARY
+          echo "## ${{ env.INTEGRATION }} Build" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version:** ${{ steps.build_publish.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Event:** ${{ github.event_name }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Is Release:** ${{ env.IS_RELEASE }}" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ env.IS_RELEASE }}" = "true" ]; then
-            echo "**Published:** ✅ Published to NPM" >> $GITHUB_STEP_SUMMARY
-            echo "**Package:** 📦 ${{ steps.build_publish.outputs.package_name }}@${{ steps.build_publish.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-            echo "**NPM:** 🔗 https://www.npmjs.com/package/${{ steps.build_publish.outputs.package_name }}/v/${{ steps.build_publish.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Install with:**" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-            echo "npm install ${{ steps.build_publish.outputs.package_name }}@${{ steps.build_publish.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "**Published:** ✅ Published to NPM" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Package:** 📦 ${{ steps.build_publish.outputs.package_name }}@${{ steps.build_publish.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "**NPM:** 🔗 https://www.npmjs.com/package/${{ steps.build_publish.outputs.package_name }}/v/${{ steps.build_publish.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Install with:**" >> "$GITHUB_STEP_SUMMARY"
+            echo "\`\`\`bash" >> "$GITHUB_STEP_SUMMARY"
+            echo "npm install ${{ steps.build_publish.outputs.package_name }}@${{ steps.build_publish.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "**Status:** ⏭️ Build and tests only" >> $GITHUB_STEP_SUMMARY
+            echo "**Status:** ⏭️ Build and tests only" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/typescript_sdk_publish.yml
+++ b/.github/workflows/typescript_sdk_publish.yml
@@ -80,13 +80,13 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## TypeScript SDK Build" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** ${{ steps.build_publish.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Event:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Is Release:** ${{ env.IS_RELEASE }}" >> $GITHUB_STEP_SUMMARY
+          echo "## TypeScript SDK Build" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version:** ${{ steps.build_publish.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Event:** ${{ github.event_name }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Is Release:** ${{ env.IS_RELEASE }}" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ env.IS_RELEASE }}" = "true" ]; then
-            echo "**Published:** ✅ Published to NPM" >> $GITHUB_STEP_SUMMARY
+            echo "**Published:** ✅ Published to NPM" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo " ⏭️ Build only " >> $GITHUB_STEP_SUMMARY
+            echo " ⏭️ Build only " >> "$GITHUB_STEP_SUMMARY"
           fi


### PR DESCRIPTION
## Details

<img width="1920" height="2148" alt="image" src="https://github.com/user-attachments/assets/24f4bb0b-f378-489d-b33d-232222156e27" />

Resolves 68 SC2086 findings across 6 publish/build workflows. Third of 5 subtasks splitting [OPIK-6323](https://comet-ml.atlassian.net/browse/OPIK-6323). Each file is its own commit so the diff is browsable.

| File | SC2086 hits | Strategy |
|---|---|---|
| `build_and_push_docker.yaml` | 16 | quote 14 runner-managed redirects + `:$TAG`; **2 disabled** (intentional arg-list on `docker buildx imagetools create`) |
| `typescript_sdk_integration_publish.yml` | 14 | quote all (Summary `>> $GITHUB_STEP_SUMMARY`) |
| `sync_provider_models.yml` | 11 | quote 9 + `[ $EXIT_CODE -eq 1 ]` int compare; **1 disabled** (`python ... $FORCE_REGEN_FLAG`, optional argv slot) |
| `sdks_generate_openapi_spec_and_fern_code.yml` | 10 | quote all (`$GITHUB_OUTPUT` / `$GITHUB_ENV`) |
| `opik_wizard_publish.yml` | 10 | quote all (Workflow summary `>> $GITHUB_STEP_SUMMARY`) |
| `typescript_sdk_publish.yml` | 7 | quote all (Summary `>> $GITHUB_STEP_SUMMARY`) |

### Where `# shellcheck disable=SC2086` was used

Three intentional unquoted occurrences across two files — each carries a rationale comment in the YAML explaining why quoting would break behavior:

1. **`build_and_push_docker.yaml` line 264**: `docker buildx imagetools create $TAG_ARGS $DIGESTS` — both variables hold *space-separated argument lists* (`-t tag1 -t tag2 ...` and a list of digest refs) that must word-split into individual argv entries. Quoting collapses each into a single argument and breaks the docker invocation.
2. **`sync_provider_models.yml` line 50**: `python scripts/sync_provider_models.py $FORCE_REGEN_FLAG` — the variable holds either `--force-regen` or empty string, acting as an optional argv slot. Quoting would pass a literal empty argument to python.

Both are real arg-list cases — disable + rationale is the correct fix, not blanket quoting.

### Where simple quoting was sufficient

The other 65 occurrences are runner-managed env vars (`$GITHUB_OUTPUT`, `$GITHUB_STEP_SUMMARY`, `$GITHUB_ENV`), single-value variables (`$TAG`, `$EXIT_CODE`, `$IMAGE_NAME`), or `:$TAG` interpolations in image references. Quoting is purely defensive in all cases — no runtime behavior change.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6582 (parent: OPIK-6323)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: identified 68 SC2086 occurrences via `actionlint`, applied per-file fixes — bulk find-and-replace for runner-managed redirects, manual review of each `$VAR` use to identify the 3 arg-list cases requiring `disable=SC2086` instead of quoting
- Human verification: re-ran `actionlint` per file to confirm 0 SC2086 findings remain; manually verified each `disable=SC2086` site to confirm the rationale matches actual shell semantics

## Testing

```
$ for f in build_and_push_docker.yaml typescript_sdk_integration_publish.yml sync_provider_models.yml sdks_generate_openapi_spec_and_fern_code.yml opik_wizard_publish.yml typescript_sdk_publish.yml; do
    actionlint .github/workflows/$f 2>&1 | grep -c SC2086
  done
0
0
0
0
0
0
```

- 0 SC2086 findings remaining across all 6 target files.
- Scope discipline: 6 files changed, +79/−67 lines. One commit per file for review clarity (per the parent ticket's recommendation).
- The two workflows with `disable=SC2086` annotations (`build_and_push_docker.yaml`, `sync_provider_models.yml`) are dispatched by the release pipeline and the daily scheduler respectively — the actual `docker buildx imagetools create` and `python sync_provider_models.py --force-regen` invocations are exercised in production. The other 4 are pure quote-additions and unchanged at runtime.

## Documentation

No documentation changes — internal CI hygiene only.

[OPIK-6323]: https://comet-ml.atlassian.net/browse/OPIK-6323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ