### PR TITLE
[NA] [BE] fix: stop BaseRedisSubscriberTest.shouldRemoveConsumerOnStop flaking

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
@@ -416,7 +416,11 @@ class BaseRedisSubscriberTest {
             subscriber.stop();
 
             // Verify this specific consumer was removed from the group
-            var consumersAfterStop = stream.listConsumers(config.getConsumerGroupName()).block();
+            // listConsumers returns an empty Mono (block() -> null) when the group has no
+            // consumers, which is the expected state right after removing the last one.
+            var consumersAfterStop = stream.listConsumers(config.getConsumerGroupName())
+                    .blockOptional()
+                    .orElse(List.of());
             assertThat(consumersAfterStop)
                     .noneMatch(consumer -> subscriber.getConsumerId().equals(consumer.getName()));
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TestStreamConfiguration.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TestStreamConfiguration.java
@@ -32,8 +32,13 @@ public class TestStreamConfiguration implements StreamConfiguration {
     @Builder.Default
     private Duration poolingInterval = Duration.milliseconds(100);
 
+    // BaseRedisSubscriber.stop() uses this as the .block() timeout when removing the consumer from
+    // the group. If it expires before Redis responds, stop() disposes the consumerScheduler and
+    // cancels the in-flight removeConsumer call, leaving the consumer behind. 100ms is tighter than
+    // Redis-container response under load and made shouldRemoveConsumerOnStop fail 8/8 locally; 2s
+    // is still well under any test wait and matches the headroom prod has at 5s.
     @Builder.Default
-    private Duration longPollingDuration = Duration.milliseconds(100);
+    private Duration longPollingDuration = Duration.seconds(2);
 
     @Builder.Default
     private int claimIntervalRatio = 10;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TestStreamConfiguration.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TestStreamConfiguration.java
@@ -32,13 +32,18 @@ public class TestStreamConfiguration implements StreamConfiguration {
     @Builder.Default
     private Duration poolingInterval = Duration.milliseconds(100);
 
-    // BaseRedisSubscriber.stop() uses this as the .block() timeout when removing the consumer from
-    // the group. If it expires before Redis responds, stop() disposes the consumerScheduler and
-    // cancels the in-flight removeConsumer call, leaving the consumer behind. 100ms is tighter than
-    // Redis-container response under load and made shouldRemoveConsumerOnStop fail 8/8 locally; 2s
-    // is still well under any test wait and matches the headroom prod has at 5s.
+    // Used both as the read-loop XREADGROUP BLOCK timeout and as BaseRedisSubscriber.stop()'s
+    // removeConsumer .block() timeout. Trade-off:
+    //   - Too short (100ms): Redis-container response under load can exceed it, the in-flight
+    //     removeConsumer call is then cancelled by consumerScheduler disposal in stop(),
+    //     and the consumer is left in the group (shouldRemoveConsumerOnStop fails 8/8 locally).
+    //   - Too long (>=1s): one read-loop cycle takes >=1s, so autoClaim (gated by
+    //     claimIntervalRatio polls) doesn't fire within the 2s test budget and the RetryTests fail.
+    // 500ms gives ~5× headroom for Redis response while keeping autoClaim firing inside 2s
+    // (chain ~= 100ms poolingInterval + 500ms block; with claimIntervalRatio=2 the retry tests
+    // override, autoClaim fires around t ~= 1.2s).
     @Builder.Default
-    private Duration longPollingDuration = Duration.seconds(2);
+    private Duration longPollingDuration = Duration.milliseconds(500);
 
     @Builder.Default
     private int claimIntervalRatio = 10;


### PR DESCRIPTION
## Details

`BaseRedisSubscriberTest$LifecycleTests.shouldRemoveConsumerOnStop` has been failing on `main` (Integration Group 6) and is reproducible locally **8/8** runs. Root cause is a timing race in test scaffolding, not in production code:

1. `BaseRedisSubscriber.stop()` calls `removeConsumer().block(longPollingDuration)` to wait for Redis to remove the consumer from the group.
2. Right after, `stop()` disposes `consumerScheduler`. If the `block()` timeout fires before Redis responds, the in-flight reactive `removeConsumer` chain (still pending on that scheduler) is cancelled by the disposal, and the consumer is left in the group.
3. The test then asserts the consumer is gone and fails.

`TestStreamConfiguration.longPollingDuration` was `100ms`, which is tighter than Redis-container response under load. Production default is `5s`.

### The trade-off

`longPollingDuration` is used in **two** places, with conflicting needs:

- **Read-loop `XREADGROUP` BLOCK timeout** — wants short so the poll cycle finishes inside the 2s test budget; `RetryTests` need `autoClaim` (gated by `claimIntervalRatio` polls) to fire within that window.
- **`stop()`'s `removeConsumer` block timeout** — wants long enough that Redis-container response always fits, so `consumerScheduler` disposal doesn't cancel an in-flight removal.

Picked **`500ms`** as the sweet spot:

- ~5× headroom over typical Redis container response → `shouldRemoveConsumerOnStop` reliable.
- Read-loop chain ≈ `100ms` poolingInterval + `500ms` block; with `claimIntervalRatio = 2` (the `RetryTests` override), `autoClaim` fires around `t ≈ 1.2s`, well inside the 2s test budget.

Also handle the now-reachable empty-group case: `stream.listConsumers(...)` returns an empty `Mono` (`block() → null`) when the group has no consumers, so wrap with `blockOptional().orElse(List.of())`.

Both changes are test-only; production behavior is unchanged.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Opus 4.7
- Scope: full investigation + fix, including the 2s overshoot and the 500ms retune
- Human verification: 8/8 baseline failures, 10/10 post-fix passes across both nested classes locally; targeted stress runs after each iteration

## Testing

Commands run (logs in `/tmp/opik-test-logs/baseredis-*.log`):
- Baseline (current `main`): `mvn test -Dtest='BaseRedisSubscriberTest$LifecycleTests'` × 8 → **0 / 8** (every run failed `shouldRemoveConsumerOnStop:421`).
- After first attempt (`longPollingDuration = 2s`): `LifecycleTests` → **10 / 10**, but CI surfaced `RetryTests.shouldAckAndRemoveAfterMaxRetries` and `RetryTests.shouldHandleMixedSuccessRetryableAndNonRetryableMessagesInSameBatch` failing because the longer block pushed `autoClaim` past the 2s `await`.
- Final (`longPollingDuration = 500ms`): `mvn test -Dtest='BaseRedisSubscriberTest$LifecycleTests,BaseRedisSubscriberTest$RetryTests'` × 10 → **10 / 10**, all 4 tests pass on every iteration.

| Setting | LifecycleTests | RetryTests |
|---|---|---|
| 100ms (baseline) | ✗ 8/8 fail | ✓ pass |
| 2s (first fix) | ✓ pass | ✗ fail (autoClaim past 2s) |
| **500ms (final)** | **✓ 10/10** | **✓ 10/10** |

## Documentation

N/A — test-scaffolding fix. Inline comments on `TestStreamConfiguration.longPollingDuration` and on the `listConsumers` block explain the invariants for future readers.