### PR TITLE
[NA] [CI] [GHA] security: use npm ci instead of npm install in Docker and lint workflows

### DIFF
--- a/.github/workflows/frontend_linter.yml
+++ b/.github/workflows/frontend_linter.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: "20"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: ESLint
         run: npm run lint

--- a/.github/workflows/publish_cursor_extension.yml
+++ b/.github/workflows/publish_cursor_extension.yml
@@ -23,7 +23,7 @@ jobs:
         node-version: '22'
 
     - name: Install dependencies
-      run: npm install
+      run: npm ci
 
     - name: Package Extension
       run: npm run build

--- a/.github/workflows/typescript_sdk_linter.yml
+++ b/.github/workflows/typescript_sdk_linter.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: "20"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: ESLint
         run: npm run lint

--- a/apps/opik-frontend/Dockerfile
+++ b/apps/opik-frontend/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /opt/frontend
 
 COPY package*.json ./
 COPY patches ./patches
-RUN npm install
+RUN npm ci
 # Copy and build the application
 COPY . .
 


### PR DESCRIPTION
## Details

<img width="832" height="843" alt="image" src="https://github.com/user-attachments/assets/8b046044-f025-40ad-a5bc-500555d693a6" />

After the [TanStack supply-chain compromise on 2026-05-11](https://github.com/TanStack/router/security/advisories/GHSA-g7cv-rxg3-hmpx) (Mini Shai-Hulud), an internal audit confirmed Opik was not affected — `@tanstack/react-router` is locked to `1.36.3` while the malicious versions were `1.169.5`/`1.169.8`. However, the audit surfaced long-standing hygiene gaps in build paths that used `npm install` instead of `npm ci`, leaving them exposed to *future* supply-chain attacks because they don't strictly respect the lockfile.

This PR switches `npm install` → `npm ci` in:

- `apps/opik-frontend/Dockerfile` (production image build)
- `.github/workflows/frontend_linter.yml` (working dir `apps/opik-frontend`)
- `.github/workflows/typescript_sdk_linter.yml` (working dir `sdks/typescript`)
- `.github/workflows/publish_cursor_extension.yml` (working dir `extensions/cursor` — ships a `.vsix` to Open VSX)

`npm ci`:
- Fails if `package-lock.json` is out of sync with `package.json` (no silent lockfile drift)
- Installs **exactly** the versions in the lockfile (no chance of resolving a malicious newly-published version even if the caret range matches)
- Is faster and more deterministic than `npm install` for CI/Docker builds

This is the same fix recommended in the post-mortem of the previous Axios incident (AI-177).

## Change checklist

- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-

(No Opik ticket — tracked internally under AI-177 in Jira's AI project, which is outside the linter's allowlist.)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: Audited remaining `npm install` usages in repo, added the two `[CI]` workflow swaps in commit `860a04875` on top of the human-authored Dockerfile + frontend_linter changes. Drafted this PR description from the original Summary/Test-plan content to match the repo template.
- Human verification: All 3 lockfile sync checks (`apps/opik-frontend`, `sdks/typescript`, `extensions/cursor`) verified locally via `npm ci --dry-run` before push.

## Testing

- `npm ci --dry-run` passes locally in all 3 directories (`apps/opik-frontend`, `sdks/typescript`, `extensions/cursor`) — confirms each `package-lock.json` is in sync with its `package.json`, so `npm ci` will succeed in CI.
- The frontend linter, TS SDK linter, and Docker build workflows on this PR exercise the changed code paths; passing CI = real-world validation that the swap works.
- The `publish_cursor_extension.yml` workflow is `workflow_dispatch`-only and won't run automatically on this PR; will be exercised on the next manual release of the Cursor extension. If preferred, it can be tested with a manual dispatch on this branch before merging.
- No unit or e2e tests apply to a build-tooling change of this kind.

## Documentation

No documentation changes required. This is an internal build-system hygiene change with no user-facing behavior, no API surface change, and no developer-workflow change (contributors already run `npm install` locally and that is not affected).

## Related

- Internal investigation: [Notion page](https://www.notion.so/3647124010a381a0ba9ac65c5bf975b7)
- Previous incident, same recommendation: [AI-177 Axios](https://comet-ml.atlassian.net/browse/AI-177)
- Architecture diagram: `diagrams/opik-npm-ci-migration-diagram.html` in the repo
