### PR TITLE
[OPIK-6578] [DOCS] feat: restructure jira-ticket commands to WHY/WHAT body + HOW comment

### DIFF
--- a/.agents/commands/comet/create-jira-ticket.md
+++ b/.agents/commands/comet/create-jira-ticket.md
@@ -4,7 +4,7 @@ Create a new Jira ticket in the OPIK project following the standard template str
 
 ## Instructions
 
-When the user wants to create a Jira ticket, gather the following information through conversation and then use the `mcp_Jira_home_jira_create_issue` tool to create the ticket.
+When the user wants to create a Jira ticket, gather the following information through conversation and then use the `mcp__Jira__home___jira_create_issue` tool to create the ticket.
 
 ## Required Information to Gather
 
@@ -13,7 +13,7 @@ When the user wants to create a Jira ticket, gather the following information th
 3. **Priority**: Low, Medium, High, or Highest
 4. **Labels**: Relevant labels (e.g., frontend, backend, sdk, playground, traces, ux-improvement)
 5. **Story Points**: Fibonacci scale (1, 2, 3, 5, 8, 13). If the user doesn't provide one, guesstimate based on the ticket's scope and complexity, and present your estimate for confirmation. **If the estimate is 21 or higher, do NOT create the ticket.** Instead, suggest splitting the work into 2+ smaller tickets so that each one is ≤ 13 story points. Help plan the split before proceeding.
-6. **Sprint**: Ask whether to add to the **active sprint** or **next sprint**. Use sprints with the "Opik Sprint" prefix. To find available sprints, use `mcp_Jira_home_jira_get_sprints_from_board` with board ID `524`.
+6. **Sprint**: Ask whether to add to the **active sprint** or **next sprint**. Use sprints with the "Opik Sprint" prefix. To find available sprints, use `mcp__Jira__home___jira_get_sprints_from_board` with board ID `524`.
 7. **Due Date**: Ask whether to set a due date: today, tomorrow, a week from today, or leave unset. Format as `YYYY-MM-DD`.
 8. **Assignee**: (Optional) Who should work on this
 
@@ -24,7 +24,7 @@ Every Task or Story **must** have a parent epic. Follow this logic:
 1. **If the user explicitly specifies an epic** in the prompt (e.g., "under OPIK-1234"), use that.
 2. **If the ticket is clearly tech debt** (refactoring, cleanup, paying down debt, removing workarounds, etc.), automatically use **OPIK-670** (Tech debt). No need to ask.
 3. **Otherwise**, you must help the user pick an epic:
-   - Use `mcp_Jira_home_jira_search` to find open epics in the OPIK project (JQL: `project = OPIK AND issuetype = Epic AND status != Done ORDER BY updated DESC`).
+   - Use `mcp__Jira__home___jira_search` to find open epics in the OPIK project (JQL: `project = OPIK AND issuetype = Epic AND status != Done ORDER BY updated DESC`).
    - Present the results as a table with columns: **#** (number for selection), **Key**, **Summary**, **Status**.
    - Based on the ticket's description, suggest which epic seems like the best fit.
    - Include a final option: **"Skip for now"** — if the user picks this, create the ticket without a parent.
@@ -98,7 +98,7 @@ The intent of this split:
 Once all information is gathered, use the Jira MCP tool:
 
 ```
-mcp_Jira_home_jira_create_issue(
+mcp__Jira__home___jira_create_issue(
   project_key="OPIK",
   summary="[PREFIX] Title of the ticket",
   issue_type="Story|Task|Bug|Epic",
@@ -116,16 +116,16 @@ mcp_Jira_home_jira_create_issue(
 
 ### Field Reference
 - **Story Points**: use `customfield_10028` directly (the `story_points` alias does NOT work at creation time)
-- **Sprint**: use `customfield_10020` with the sprint ID (a plain number). Look up sprints via `mcp_Jira_home_jira_get_sprints_from_board` (board ID `524`), filter by "Opik Sprint" prefix, and pick the active or next future sprint based on user choice.
+- **Sprint**: use `customfield_10020` with the sprint ID (a plain number). Look up sprints via `mcp__Jira__home___jira_get_sprints_from_board` (board ID `524`), filter by "Opik Sprint" prefix, and pick the active or next future sprint based on user choice.
 - **Due Date**: use `duedate` with format `YYYY-MM-DD`. Calculate relative to today's date.
 - **Parent**: use `"parent": "OPIK-XXX"` (plain string, not an object) when creating under an epic.
 
 ## Post-Creation: Status Transition
 
 After creating the ticket:
-1. Wait briefly, then use `mcp_Jira_home_jira_get_issue` to check the ticket's status. A Jira automation will move it to **BACKLOG** status automatically.
+1. Wait briefly, then use `mcp__Jira__home___jira_get_issue` to check the ticket's status. A Jira automation will move it to **BACKLOG** status automatically.
 2. Once the status is confirmed as **BACKLOG**, **you MUST use the `AskUserQuestion` tool** (not inline text) to prompt: "The ticket is now in Backlog. Would you like me to move it to **TO DO**?"
-3. If the user confirms, use `mcp_Jira_home_jira_transition_issue` to move it to "TO DO".
+3. If the user confirms, use `mcp__Jira__home___jira_transition_issue` to move it to "TO DO".
 
 ## Post-Creation: HOW Comment (optional)
 

--- a/.agents/commands/comet/create-jira-ticket.md
+++ b/.agents/commands/comet/create-jira-ticket.md
@@ -65,6 +65,19 @@ The intent of this split:
 
 [High-level description of what needs to be implemented. Phrased so QA can derive test cases. Must describe the same thing the ticket title promises — title and WHAT are two views of the same scope. Avoid implementation specifics here — those belong in the HOW comment.]
 
+### Functional Requirements (optional)
+
+[Include when the WHAT has more than a couple of distinct behaviors worth enumerating, or when the acceptance criteria alone won't carry the full picture for a reader. Skip for simple tickets where the WHAT prose already says everything.]
+
+- [What the system should DO]
+- [Another behavior]
+
+### Non-Functional Requirements (optional)
+
+[Include when the ticket has performance, security, scalability, accessibility, or compatibility constraints that don't naturally fit in acceptance criteria. Skip when there are none worth calling out.]
+
+- [Performance / security / scalability / accessibility / compatibility constraint]
+
 ### Acceptance Criteria
 
 - [ ] [Criterion 1 — observable behavior or outcome]

--- a/.agents/commands/comet/create-jira-ticket.md
+++ b/.agents/commands/comet/create-jira-ticket.md
@@ -8,7 +8,7 @@ When the user wants to create a Jira ticket, gather the following information th
 
 ## Required Information to Gather
 
-1. **Summary/Title**: A concise title for the ticket (e.g., "[FE] Add feature X" or "[BE] Implement Y endpoint")
+1. **Summary/Title**: A concise title that communicates the **WHAT** on its own. Someone opening the ticket should understand what it does from the title alone, without needing to read the description. The title is a one-line version of the WHAT section in the description — the two must agree on scope. Use the area prefix (e.g., "[FE] Add feature X" or "[BE] Implement Y endpoint").
 2. **Issue Type**: Story, Task, Bug, or Epic
 3. **Priority**: Low, Medium, High, or Highest
 4. **Labels**: Relevant labels (e.g., frontend, backend, sdk, playground, traces, ux-improvement)
@@ -42,78 +42,56 @@ After an assignee is chosen, also add that assignee's `pod-<name>` label alongsi
 - If no assignee is set, skip this step — do not add a pod label.
 - Never add more than one `pod-*` label.
 
-## Template Sections to Fill
+## Description Structure: WHY and WHAT
 
-Ask the user to provide details for each section, then format the description using the template below.
+The ticket description contains exactly two sections: **WHY** and **WHAT**. Implementation details ("HOW") do NOT go in the description — they go in a separate Jira comment after the ticket is created (see "Post-Creation: HOW Comment" below).
+
+The intent of this split:
+
+- **WHY** answers: why does this ticket need to exist? After reading WHY, a reader understands the motivation.
+- **WHAT** answers: what needs to be done, at a level QA can derive test cases from. Acceptance criteria live here.
+- **HOW** (separate comment) answers: low-level implementation pointers. Optional, may go stale, intentionally not authoritative.
+
+**The WHAT and the title must agree.** The ticket summary is a one-line version of the WHAT. After drafting the description, re-read the title and the first sentence of the WHAT side by side — if they describe different things, fix one of them. The WHAT shouldn't introduce scope the title doesn't promise, and the title shouldn't promise scope the WHAT doesn't cover.
 
 ### Description Template
 
 ```
-## Description
+## WHY
 
-[Brief overview of what needs to be done and why. Explain the context and motivation for this work.]
+[Why this ticket needs to exist. The motivation, the problem being solved, the context the implementer would otherwise miss. 2-6 sentences usually. Long enough to be clear, short enough that a reviewer doesn't skim past it.]
 
-## User Story
+## WHAT
 
-As a [type of user], I want to [action/goal] so that I can [benefit/outcome].
+[High-level description of what needs to be implemented. Phrased so QA can derive test cases. Must describe the same thing the ticket title promises — title and WHAT are two views of the same scope. Avoid implementation specifics here — those belong in the HOW comment.]
 
-## User Journey
+### Acceptance Criteria
 
-[Describe the step-by-step flow of how a user will interact with this feature:]
-1. User navigates to [location]
-2. User clicks/interacts with [element]
-3. System responds by [action]
-4. User sees [result]
-[Continue as needed...]
-
-## Requirements
-
-### Functional Requirements
-
-[List the functional requirements - what the system should DO]
-
-**1. [Requirement Category]**
-- [Specific requirement]
-- [Specific requirement]
-
-**2. [Requirement Category]**
-- [Specific requirement]
-- [Specific requirement]
-
-### Non-Functional Requirements
-
-[List non-functional requirements - performance, security, scalability, etc.]
-- [Requirement]
-- [Requirement]
-
-## Acceptance Criteria
-
-[Checklist of criteria that must be met for the ticket to be considered complete]
-- [ ] [Criterion 1]
+- [ ] [Criterion 1 — observable behavior or outcome]
 - [ ] [Criterion 2]
 - [ ] [Criterion 3]
 - [ ] No lint errors or TypeScript errors (if applicable)
 - [ ] Unit tests added (if applicable)
 - [ ] Documentation updated (if applicable)
+
+### Out of Scope (optional)
+
+- [Things the reader might assume are in scope but aren't]
 ```
 
 ## Example Conversation Flow
 
-1. Ask: "What feature or task would you like to create a ticket for?"
-2. Ask: "Can you describe the user story? (As a [user], I want to [goal] so that [benefit])"
-3. Ask: "What is the user journey? How will users interact with this feature step by step?"
-4. Ask: "What are the functional requirements? What should the system do?"
-5. Ask: "Are there any non-functional requirements? (performance, security, etc.)"
-6. Ask: "What are the acceptance criteria? How do we know when this is done?"
-7. Ask: "What issue type is this? (Story/Task/Bug/Epic)"
-8. Ask: "What priority? (Low/Medium/High/Highest)"
-9. Ask: "Any labels to add? (e.g., frontend, backend, sdk)"
-10. Present your **Story Points** guesstimate and ask for confirmation (or let user override)
-11. **Parent Epic**: If not already determined (tech debt or explicit), search for open epics, present a table, suggest the best fit, and let the user pick or skip.
-12. Ask: "Add to the **active sprint** or the **next sprint**?"
-13. Ask: "Set a due date? (today / tomorrow / a week from today / leave unset)"
-14. Ask: "Should this be assigned to anyone?"
-15. If an assignee is chosen, determine their pod and add the corresponding `pod-<name>` label. If uncertain, ask the user to pick from the known pods (see **Assignee Pod Label**).
+1. Ask: "What's this ticket about? (one or two sentences — what needs to happen and why)"
+2. From that, draft a **WHY** (motivation) and a **WHAT** (high-level description + acceptance criteria). Show your draft and ask for corrections before continuing.
+3. Ask: "What issue type is this? (Story/Task/Bug/Epic)"
+4. Ask: "What priority? (Low/Medium/High/Highest)"
+5. Ask: "Any labels to add? (e.g., frontend, backend, sdk)"
+6. Present your **Story Points** guesstimate and ask for confirmation (or let user override)
+7. **Parent Epic**: If not already determined (tech debt or explicit), search for open epics, present a table, suggest the best fit, and let the user pick or skip.
+8. Ask: "Add to the **active sprint** or the **next sprint**?"
+9. Ask: "Set a due date? (today / tomorrow / a week from today / leave unset)"
+10. Ask: "Should this be assigned to anyone?"
+11. If an assignee is chosen, determine their pod and add the corresponding `pod-<name>` label. If uncertain, ask the user to pick from the known pods (see **Assignee Pod Label**).
 
 ## Creating the Ticket
 
@@ -149,6 +127,64 @@ After creating the ticket:
 2. Once the status is confirmed as **BACKLOG**, **you MUST use the `AskUserQuestion` tool** (not inline text) to prompt: "The ticket is now in Backlog. Would you like me to move it to **TO DO**?"
 3. If the user confirms, use `mcp_Jira_home_jira_transition_issue` to move it to "TO DO".
 
+## Post-Creation: HOW Comment (optional)
+
+After the status transition, decide whether to post a HOW comment. The HOW lives in a Jira comment, not in the description.
+
+### When to post a HOW
+
+Post a HOW only when there is substance worth surfacing that the implementer wouldn't already get from the WHAT and from reading the code. If there isn't — skip it. A missing HOW comment is better than a filler one, and `/comet:work-on-jira-ticket` handles the no-HOW case gracefully.
+
+A HOW is worth posting when the creator has one or more of:
+
+- Stable landmarks the implementer might miss (architectural seams, long-lived service classes, the right package to land in)
+- An existing pattern in the codebase worth mirroring rather than reinventing
+- Reusable building blocks (shared records, existing DAOs, established events) the implementer should know about before designing from scratch
+- A constraint that isn't obvious from the surface area of the WHAT (e.g., "workspace scoping is enforced at the DAO layer")
+- Open questions the agent / creator wasn't sure about — framed as questions, not as decisions
+
+A HOW should NOT contain:
+
+- Step-by-step implementation checklists with code snippets
+- Regenerated acceptance criteria (those belong in the WHAT)
+- A specific design choice presented as *the* choice when alternatives are reasonable — surface the trade-off, don't pre-decide
+- Long bullet trees that repeat what the WHAT already said
+
+Length follows substance. Two sentences of real insight beats fifteen lines of generic scaffolding. Be specific *when you are confident*; be brief *when you aren't*.
+
+### How to post
+
+Use `mcp__Jira__home___jira_add_comment` with the ticket key and a body that starts with `# HOW` on the first line. Plain Markdown is fine — `#`, `##`, backticks for inline code, `-` for bullets. Jira renders these as real headers / inline code / bullets.
+
+Example shape (for a hypothetical `[BE] Add an endpoint to bulk-delete experiments` ticket):
+
+```
+# HOW
+
+Pieces likely still relevant:
+
+- Traces and spans already have batch-delete endpoints — mirror that shape.
+- Shared `BatchDelete` record in `com.comet.opik.api` is reused by other batch endpoints.
+- Workspace scoping is enforced at the DAO layer across this area — keep that invariant.
+- Cascading deletes touch `experiment_items`; existing DAO code already handles that relationship.
+
+Open questions for the implementer:
+
+- Feedback scores: traces null them out on delete; do experiments need the same treatment?
+- Partial-failure semantics: 404 if any id is missing, or best-effort delete of valid ones?
+```
+
+### Re-runs against an existing ticket
+
+If `/comet:create-jira-ticket` is run again against an existing ticket (e.g., to update the HOW), prefer editing the previous HOW comment over piling up new ones:
+
+1. Fetch the ticket's comments via `mcp__Jira__home___jira_get_issue` with `comment_limit` greater than zero.
+2. Find the most-recent comment whose body matches `^#\s*HOW\b` (case-insensitive) **and** whose `author.email` matches the authenticated user's email.
+3. If found: `mcp__Jira__home___jira_edit_comment` with the new HOW body.
+4. If not found (no prior HOW, or only HOWs posted by other users): `mcp__Jira__home___jira_add_comment` a new one.
+
+The author check matters: `jira_edit_comment` does not enforce ownership at the MCP layer (Jira permissions decide), so without it a user with "Edit All Comments" could clobber a teammate's HOW.
+
 ## Title Prefixes
 
 Use these prefixes in the summary based on the work area:
@@ -176,6 +212,7 @@ Never display the ticket key as plain text — always wrap it in a markdown link
 ## Notes
 
 - The project key is always `OPIK`
-- Description uses Markdown format (## for headers, - for bullets, **bold** for bold). The Jira MCP tool converts Markdown to Jira wiki markup automatically.
+- Description uses plain Markdown (`##` for headers, `-` for bullets, backticks for inline code). Jira renders Markdown as real headers / formatting.
 - Acceptance criteria should be checkboxes using `- [ ]` syntax
 - Always include standard acceptance criteria like "No lint errors" and "Tests added" where applicable
+- The description is for **WHY** and **WHAT** only. **HOW** goes in a separate comment after the ticket is created — see "Post-Creation: HOW Comment" above.

--- a/.agents/commands/comet/work-on-jira-ticket.md
+++ b/.agents/commands/comet/work-on-jira-ticket.md
@@ -56,9 +56,10 @@ This workflow will:
 ### 3. Build Jira Context
 
 - **Key, Title, Type, Status, Priority, Assignee, Labels**
-- **Description**: verbatim if short, otherwise concise summary + key quotes.
+- **Description**: verbatim if short, otherwise concise summary + key quotes. The description contains the **WHY** (motivation) and **WHAT** (high-level scope + acceptance criteria); implementation details ("HOW") live in a separate comment — see below.
 - **If no description**: Note this and suggest adding context for better implementation planning.
 - **Comments**: newest → oldest, `[author @ date] summary` with important snippets.
+- **HOW comment**: scan comments for the most recent one whose body matches `^#\s*HOW\b` (case-insensitive). If found, surface it as the **implementation suggestion** — clearly framed as a note from when the ticket was filed, not a plan of record. The current code state is authoritative; the HOW is one input. If no HOW comment exists, proceed without one — many tickets won't have one, and that's fine (older tickets predate the convention; some tickets have nothing worth adding beyond the WHAT).
 - **Epic/Story context**: Include parent issue information if available.
 
 ---
@@ -80,6 +81,7 @@ This workflow will:
 
 - **Bugfix**: repro steps, root cause hypothesis, affected files, fix approach, risks, tests, verification.
 - **Feature**: user story recap, acceptance criteria, implementation plan, tests, rollout notes.
+- **HOW comment, if one exists**: weave its suggestions into the plan **after** independently reading the current code state. If the HOW conflicts with what the code looks like today, trust the code and note the divergence in your plan. The HOW is a hint from when the ticket was filed, not a contract.
 - **Always reference shared + domain guidance in the right place**:
   - **Global policy**: `.agents/rules/*` (git workflow, security, code style, routing)
   - **Backend guidance**: `.agents/skills/opik-backend/*`


### PR DESCRIPTION
## Details

<img width="1920" height="3490" alt="image" src="https://github.com/user-attachments/assets/0e86b27c-9f24-4af9-9d3c-b74adf551400" />

Restructures the `/comet:create-jira-ticket` and `/comet:work-on-jira-ticket` slash commands so every ticket has three clearly-separated scopes — **WHY**, **WHAT**, and **HOW** — with the HOW moved out of the ticket description and into an optional Jira comment.

- Description template is now just `## WHY` and `## WHAT` (with acceptance criteria nested under WHAT). The old multi-section template (Description / User Story / User Journey / Functional & Non-Functional Requirements / Acceptance Criteria) is replaced.
- Title and WHAT must agree on scope — the title is a one-line version of the WHAT, so opening a ticket tells you what it does from the name alone.
- After ticket creation, `/comet:create-jira-ticket` decides whether to post a HOW comment with `# HOW` on the first line. The HOW is **optional** — a missing HOW beats a filler HOW.
- HOW content is framed as "puzzle pieces the implementer might miss" (landmarks, patterns to mirror, building blocks, open questions) — not step-by-step code or a regenerated AC list.
- `/comet:work-on-jira-ticket` scans comments for `^#\s*HOW\b` (case-insensitive), surfaces the most recent match as a possibly-stale suggestion, and falls back gracefully when none exists. Older tickets without a HOW comment keep working.
- On re-run against an existing ticket, the create-side prefers editing the prior HOW (matched by marker **and** author email) over piling up new comments. The author-email guard prevents users with "Edit All Comments" permission from clobbering teammates' suggestions.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6578

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation
- Human verification: interactive iteration on the design (3 scopes, optional HOW, edit-in-place with author guard) and on the HOW philosophy ("puzzle pieces, not assembly")

## Testing

N/A — documentation-only change to two slash-command markdown files. The new behavior will be exercised the next time `/comet:create-jira-ticket` or `/comet:work-on-jira-ticket` is invoked.

Manual verification done while authoring:
- Confirmed plain Markdown headers (`# HOW`, `## Subsection`) render as real Jira headers when sent via `mcp__Jira__home___jira_add_comment` (verified on OPIK-6578 comments 94986, 94987, 94989).
- Confirmed `jira_edit_comment` round-trips identically and supports edit-in-place re-runs.

## Documentation

The two slash-command files themselves are the documentation:
- [.agents/commands/comet/create-jira-ticket.md](.agents/commands/comet/create-jira-ticket.md)
- [.agents/commands/comet/work-on-jira-ticket.md](.agents/commands/comet/work-on-jira-ticket.md)

No other docs touched.