### PR TITLE
[OPIK-6455] [BE] feat: add environment ownership to prompt versions

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersion.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersion.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import org.jdbi.v3.json.Json;
 
@@ -42,6 +44,8 @@ public record PromptVersion(
                 PromptVersion.View.Detail.class}) PromptType type,
         @JsonView({PromptVersion.View.Public.class, Prompt.View.Detail.class,
                 PromptVersion.View.Detail.class}) @Schema(description = "version type discriminator; defaults to prompt_version") PromptVersionType versionType,
+        @JsonView({PromptVersion.View.Public.class, Prompt.View.Detail.class,
+                PromptVersion.View.Detail.class}) @Nullable @Pattern(regexp = Environment.NAME_PATTERN, message = Environment.NAME_PATTERN_MESSAGE) @Size(max = 150, message = "cannot exceed 150 characters") String environment,
         @JsonView({PromptVersion.View.Public.class, Prompt.View.Detail.class,
                 PromptVersion.View.Detail.class}) String changeDescription,
         @JsonView({PromptVersion.View.Public.class, Prompt.View.Detail.class,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersion.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersion.java
@@ -5,10 +5,12 @@ import com.comet.opik.utils.ValidationUtils;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -94,5 +96,11 @@ public record PromptVersion(
     @Override
     public PromptVersionType versionType() {
         return versionType == null ? PROMPT_VERSION : versionType;
+    }
+
+    @JsonIgnore
+    @AssertTrue(message = "environment cannot be set on a mask version")
+    public boolean isEnvironmentCompatibleWithVersionType() {
+        return environment == null || versionType() != PromptVersionType.MASK;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersion.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersion.java
@@ -2,10 +2,10 @@ package com.comet.opik.api;
 
 import com.comet.opik.api.validation.CommitValidation;
 import com.comet.opik.utils.ValidationUtils;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -99,8 +99,7 @@ public record PromptVersion(
     }
 
     @JsonIgnore
-    @AssertTrue(message = "environment cannot be set on a mask version")
-    public boolean isEnvironmentCompatibleWithVersionType() {
+    @AssertTrue(message = "environment cannot be set on a mask version") public boolean isEnvironmentCompatibleWithVersionType() {
         return environment == null || versionType() != PromptVersionType.MASK;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersionEnvironmentUpdate.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersionEnvironmentUpdate.java
@@ -16,7 +16,7 @@ import lombok.Builder;
         Set or clear the environment owned by a prompt version.
         - non-null name: maps the environment to this version; if another version of the same prompt currently owns the environment, ownership is moved atomically.
         - null: clears the environment from this version.
-        Auto-creates the environment in the workspace registry when set.
+        The environment must already exist in the workspace registry; unknown names return 404.
         """)
 public record PromptVersionEnvironmentUpdate(
         @Nullable @Pattern(regexp = Environment.NAME_PATTERN, message = Environment.NAME_PATTERN_MESSAGE) @Size(max = 150, message = "cannot exceed 150 characters") String environment) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersionEnvironmentUpdate.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersionEnvironmentUpdate.java
@@ -1,0 +1,23 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Schema(description = """
+        Set or clear the environment owned by a prompt version.
+        - non-null name: maps the environment to this version; if another version of the same prompt currently owns the environment, ownership is moved atomically.
+        - null: clears the environment from this version.
+        Auto-creates the environment in the workspace registry when set.
+        """)
+public record PromptVersionEnvironmentUpdate(
+        @Nullable @Pattern(regexp = Environment.NAME_PATTERN, message = Environment.NAME_PATTERN_MESSAGE) @Size(max = 150, message = "cannot exceed 150 characters") String environment) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersionRetrieve.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersionRetrieve.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 import static com.comet.opik.utils.ValidationUtils.NULL_OR_NOT_BLANK;
@@ -16,5 +17,6 @@ import static com.comet.opik.utils.ValidationUtils.NULL_OR_NOT_BLANK;
 public record PromptVersionRetrieve(
         @NotBlank String name,
         String commit,
+        @Pattern(regexp = Environment.NAME_PATTERN, message = Environment.NAME_PATTERN_MESSAGE) @Size(max = 150, message = "cannot exceed 150 characters") @Schema(description = "If provided, resolves to the version mapped to this environment for the prompt; mutually exclusive with commit") String environment,
         @Pattern(regexp = NULL_OR_NOT_BLANK, message = "must not be blank") @Schema(description = "If provided, scopes the search to the specified project") String projectName) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
@@ -384,7 +384,7 @@ public class PromptResource {
     }
 
     @PATCH
-    @Path("/versions/{versionId}")
+    @Path("/versions/{versionId}/environments")
     @Operation(operationId = "setPromptVersionEnvironment", summary = "Set prompt version environment", description = """
             Set or clear the environment owned by a prompt version.
             Setting a non-null environment moves ownership atomically: any previous owner of that

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
@@ -9,6 +9,7 @@ import com.comet.opik.api.PromptVersion;
 import com.comet.opik.api.PromptVersion.PromptVersionPage;
 import com.comet.opik.api.PromptVersionBatchUpdate;
 import com.comet.opik.api.PromptVersionCommitsRequest;
+import com.comet.opik.api.PromptVersionEnvironmentUpdate;
 import com.comet.opik.api.PromptVersionIdsRequest;
 import com.comet.opik.api.PromptVersionLink;
 import com.comet.opik.api.PromptVersionRetrieve;
@@ -134,21 +135,25 @@ public class PromptResource {
 
     @GET
     @Path("{id}")
-    @Operation(operationId = "getPromptById", summary = "Get prompt by id", description = "Get prompt by id; when mask_id is provided, requestedVersion is populated with that mask overlay", responses = {
+    @Operation(operationId = "getPromptById", summary = "Get prompt by id", description = "Get prompt by id; when mask_id or environment is provided, requestedVersion is populated with the resolved version. mask_id and environment are mutually exclusive.", responses = {
             @ApiResponse(responseCode = "200", description = "Prompt resource", content = @Content(schema = @Schema(implementation = Prompt.class))),
+            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = io.dropwizard.jersey.errors.ErrorMessage.class))),
             @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = io.dropwizard.jersey.errors.ErrorMessage.class))),
     })
     @JsonView({Prompt.View.Detail.class})
     public Response getPromptById(@PathParam("id") UUID id,
-            @Parameter(description = "Optional mask version id; when set, requestedVersion is the mask row for that id") @QueryParam("mask_id") UUID maskId) {
+            @Parameter(description = "Optional mask version id; when set, requestedVersion is the mask row for that id") @QueryParam("mask_id") UUID maskId,
+            @Parameter(description = "Optional environment name; when set, requestedVersion is the version mapped to that environment for the prompt") @QueryParam("environment") String environment) {
 
         String workspaceId = requestContext.get().getWorkspaceId();
 
-        log.info("Getting prompt by id '{}', mask_id '{}' on workspace_id '{}'", id, maskId, workspaceId);
+        log.info("Getting prompt by id '{}', mask_id '{}', environment '{}' on workspace_id '{}'", id, maskId,
+                environment, workspaceId);
 
-        Prompt prompt = promptService.getById(id, maskId);
+        Prompt prompt = promptService.getById(id, maskId, environment);
 
-        log.info("Got prompt by id '{}', mask_id '{}' on workspace_id '{}'", id, maskId, workspaceId);
+        log.info("Got prompt by id '{}', mask_id '{}', environment '{}' on workspace_id '{}'", id, maskId,
+                environment, workspaceId);
 
         return Response.ok(prompt).build();
     }
@@ -376,6 +381,31 @@ public class PromptResource {
         return Response.noContent().build();
     }
 
+    @PATCH
+    @Path("/versions/{versionId}")
+    @Operation(operationId = "setPromptVersionEnvironment", summary = "Set prompt version environment", description = """
+            Set or clear the environment owned by a prompt version.
+            Setting a non-null environment moves ownership atomically: any previous owner of that
+            environment for the same prompt has its environment cleared in the same transaction.
+            Setting null clears the environment from the version.
+            The environment is auto-created in the workspace registry when set.
+            """, responses = {
+            @ApiResponse(responseCode = "204", description = "No Content"),
+            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = io.dropwizard.jersey.errors.ErrorMessage.class))),
+            @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = io.dropwizard.jersey.errors.ErrorMessage.class)))
+    })
+    @RateLimited
+    public Response setPromptVersionEnvironment(@PathParam("versionId") UUID versionId,
+            @RequestBody(content = @Content(schema = @Schema(implementation = PromptVersionEnvironmentUpdate.class))) @Valid @NotNull PromptVersionEnvironmentUpdate request) {
+        String workspaceId = requestContext.get().getWorkspaceId();
+        log.info("Setting environment '{}' on prompt version '{}' on workspace_id '{}'",
+                request.environment(), versionId, workspaceId);
+        promptService.setVersionEnvironment(versionId, request.environment());
+        log.info("Successfully set environment '{}' on prompt version '{}' on workspace_id '{}'",
+                request.environment(), versionId, workspaceId);
+        return Response.noContent().build();
+    }
+
     @POST
     @Path("/versions/retrieve")
     @Operation(operationId = "retrievePromptVersion", summary = "Retrieve prompt version", description = "Retrieve prompt version", responses = {
@@ -390,14 +420,14 @@ public class PromptResource {
 
         String workspaceId = requestContext.get().getWorkspaceId();
 
-        log.info("Retrieving prompt name '{}'  with commit '{}' on workspace_id '{}'",
-                request.name(), request.commit(), workspaceId);
+        log.info("Retrieving prompt name '{}' with commit '{}', environment '{}' on workspace_id '{}'",
+                request.name(), request.commit(), request.environment(), workspaceId);
 
         PromptVersion promptVersion = promptService.retrievePromptVersion(
-                request.name(), request.commit(), request.projectName());
+                request.name(), request.commit(), request.environment(), request.projectName());
 
-        log.info("Retrieved prompt name '{}'  with commit '{}' on workspace_id '{}'", request.name(),
-                request.commit(), workspaceId);
+        log.info("Retrieved prompt name '{}' with commit '{}', environment '{}' on workspace_id '{}'", request.name(),
+                request.commit(), request.environment(), workspaceId);
 
         var responseBuilder = Response.ok(promptVersion);
         String fallbackMessage = requestContext.get().getWorkspaceFallbackMessage();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
@@ -3,6 +3,7 @@ package com.comet.opik.api.resources.v1.priv;
 import com.codahale.metrics.annotation.Timed;
 import com.comet.opik.api.BatchDelete;
 import com.comet.opik.api.CreatePromptVersion;
+import com.comet.opik.api.Environment;
 import com.comet.opik.api.Prompt;
 import com.comet.opik.api.Prompt.PromptPage;
 import com.comet.opik.api.PromptVersion;
@@ -42,6 +43,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
@@ -143,7 +145,7 @@ public class PromptResource {
     @JsonView({Prompt.View.Detail.class})
     public Response getPromptById(@PathParam("id") UUID id,
             @Parameter(description = "Optional mask version id; when set, requestedVersion is the mask row for that id") @QueryParam("mask_id") UUID maskId,
-            @Parameter(description = "Optional environment name; when set, requestedVersion is the version mapped to that environment for the prompt") @QueryParam("environment") String environment) {
+            @Parameter(description = "Optional environment name; when set, requestedVersion is the version mapped to that environment for the prompt") @QueryParam("environment") @Pattern(regexp = Environment.NAME_PATTERN, message = Environment.NAME_PATTERN_MESSAGE) @Size(max = 150, message = "cannot exceed 150 characters") String environment) {
 
         String workspaceId = requestContext.get().getWorkspaceId();
 
@@ -388,7 +390,7 @@ public class PromptResource {
             Setting a non-null environment moves ownership atomically: any previous owner of that
             environment for the same prompt has its environment cleared in the same transaction.
             Setting null clears the environment from the version.
-            The environment is auto-created in the workspace registry when set.
+            The environment must already exist in the workspace registry; unknown names return 404.
             """, responses = {
             @ApiResponse(responseCode = "204", description = "No Content"),
             @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = io.dropwizard.jersey.errors.ErrorMessage.class))),

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
@@ -58,7 +58,7 @@ interface EnvironmentDAO {
     @SqlQuery("SELECT name FROM environments WHERE workspace_id = :workspaceId")
     List<String> findAllNames(@Bind("workspaceId") String workspaceId);
 
-    @SqlQuery("SELECT COUNT(*) FROM environments WHERE workspace_id = :workspaceId AND LOWER(name) = LOWER(:name)")
+    @SqlQuery("SELECT COUNT(*) FROM environments WHERE workspace_id = :workspaceId AND name = :name")
     long countByName(@Bind("workspaceId") String workspaceId, @Bind("name") String name);
 
     @SqlQuery("SELECT COUNT(*) FROM environments WHERE workspace_id = :workspaceId")

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
@@ -58,6 +58,9 @@ interface EnvironmentDAO {
     @SqlQuery("SELECT name FROM environments WHERE workspace_id = :workspaceId")
     List<String> findAllNames(@Bind("workspaceId") String workspaceId);
 
+    @SqlQuery("SELECT COUNT(*) FROM environments WHERE workspace_id = :workspaceId AND LOWER(name) = LOWER(:name)")
+    long countByName(@Bind("workspaceId") String workspaceId, @Bind("name") String name);
+
     @SqlQuery("SELECT COUNT(*) FROM environments WHERE workspace_id = :workspaceId")
     long countByWorkspace(@Bind("workspaceId") String workspaceId);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
@@ -55,6 +55,8 @@ public interface EnvironmentService {
 
     void bulkCreate(Set<String> names, String workspaceId, String userName);
 
+    boolean existsByName(String name, String workspaceId);
+
     Environment update(UUID id, EnvironmentUpdate environmentUpdate);
 
     Environment get(UUID id);
@@ -187,6 +189,14 @@ class EnvironmentServiceImpl implements EnvironmentService {
 
         Instant now = Instant.now();
         created.forEach(env -> trackEnvironmentCreatedEvent(env, workspaceId, userName, SOURCE_INGESTION, now));
+    }
+
+    @Override
+    public boolean existsByName(@NonNull String name, @NonNull String workspaceId) {
+        return template.inTransaction(READ_ONLY, handle -> {
+            var repository = handle.attach(EnvironmentDAO.class);
+            return repository.countByName(workspaceId, name) > 0;
+        });
     }
 
     private void trackEnvironmentCreatedEvent(Environment environment, String workspaceId, String userName,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptDAO.java
@@ -74,6 +74,7 @@ public interface PromptDAO {
                         'change_description', pv.change_description,
                         'type', pv.type,
                         'version_type', pv.version_type,
+                        'environment', pv.environment,
                         'tags', pv.tags,
                         'created_at', pv.created_at,
                         'created_by', pv.created_by,
@@ -87,7 +88,7 @@ public interface PromptDAO {
                     ORDER BY pv.id DESC
                     LIMIT 1
                 ) AS latest_version
-                <if(mask_id)>
+                <if(mask_id || environment)>
                 ,
                 (
                     SELECT JSON_OBJECT(
@@ -99,6 +100,7 @@ public interface PromptDAO {
                         'change_description', pv.change_description,
                         'type', pv.type,
                         'version_type', pv.version_type,
+                        'environment', pv.environment,
                         'tags', pv.tags,
                         'created_at', pv.created_at,
                         'created_by', pv.created_by,
@@ -108,8 +110,8 @@ public interface PromptDAO {
                     FROM prompt_versions pv
                     WHERE pv.prompt_id = p.id
                     AND pv.workspace_id = p.workspace_id
-                    AND pv.id = :mask_id
-                    AND pv.version_type = 'mask'
+                    <if(mask_id)> AND pv.id = :mask_id AND pv.version_type = 'mask' <endif>
+                    <if(environment)> AND pv.environment = :environment AND pv.version_type = 'prompt_version' <endif>
                 ) AS requested_version
                 <endif>
             FROM prompts p
@@ -119,10 +121,15 @@ public interface PromptDAO {
     @UseStringTemplateEngine
     @AllowUnusedBindings
     Prompt findById(@Bind("id") UUID id, @Bind("workspace_id") String workspaceId,
-            @Define("mask_id") @Bind("mask_id") UUID maskId);
+            @Define("mask_id") @Bind("mask_id") UUID maskId,
+            @Define("environment") @Bind("environment") String environment);
 
     default Prompt findById(UUID id, String workspaceId) {
-        return findById(id, workspaceId, null);
+        return findById(id, workspaceId, null, null);
+    }
+
+    default Prompt findById(UUID id, String workspaceId, UUID maskId) {
+        return findById(id, workspaceId, maskId, null);
     }
 
     @SqlQuery("""
@@ -181,6 +188,7 @@ public interface PromptDAO {
                 'change_description', change_description,
                 'type', type,
                 'version_type', version_type,
+                'environment', environment,
                 'tags', tags,
                 'created_at', created_at,
                 'created_by', created_by,
@@ -283,6 +291,7 @@ public interface PromptDAO {
                     'change_description', pv.change_description,
                     'type', pv.type,
                     'version_type', pv.version_type,
+                    'environment', pv.environment,
                     'tags', pv.tags,
                     'created_at', pv.created_at,
                     'created_by', pv.created_by,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -20,6 +20,7 @@ import com.comet.opik.domain.filter.FilterQueryBuilder;
 import com.comet.opik.domain.filter.FilterStrategy;
 import com.comet.opik.domain.sorting.SortingQueryBuilder;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.lock.LockService;
 import com.comet.opik.utils.TemplateParseUtils;
 import com.google.common.eventbus.EventBus;
 import com.google.inject.ImplementedBy;
@@ -27,6 +28,7 @@ import io.dropwizard.jersey.errors.ErrorMessage;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -72,6 +74,10 @@ public interface PromptService {
 
     Prompt getById(UUID id, UUID maskId);
 
+    Prompt getById(UUID id, UUID maskId, String environment);
+
+    void setVersionEnvironment(UUID versionId, String environment);
+
     List<Prompt> getByIds(Set<UUID> ids);
 
     List<PromptVersion> retrieveVersionsByIds(List<UUID> ids);
@@ -90,9 +96,7 @@ public interface PromptService {
 
     Mono<Map<UUID, PromptVersion>> findVersionByIds(Set<UUID> ids);
 
-    PromptVersion retrievePromptVersion(String name, String commit, String projectName);
-
-    PromptVersion retrievePromptVersion(String name, String commit, UUID projectId);
+    PromptVersion retrievePromptVersion(String name, String commit, String environment, String projectName);
 
     PromptVersion restorePromptVersion(UUID promptId, UUID versionId);
 
@@ -112,6 +116,9 @@ class PromptServiceImpl implements PromptService {
     private static final String VERSION_ALREADY_EXISTS = "Prompt version already exists";
     private static final String PROMPT_NOT_FOUND = "Prompt not found";
     private static final String PROMPT_VERSION_NOT_FOUND = "Prompt version not found";
+    private static final String PROMPT_ENV_PROMOTE_LOCK = "prompt_env_promote";
+    private static final String MASK_ENV_NOT_ALLOWED = "environment cannot be set on a mask version";
+    private static final String ENV_MASK_MUTUALLY_EXCLUSIVE = "environment and mask_id are mutually exclusive";
 
     private final @NonNull Provider<RequestContext> requestContext;
     private final @NonNull IdGenerator idGenerator;
@@ -122,6 +129,8 @@ class PromptServiceImpl implements PromptService {
     private final @NonNull SortingFactoryPromptVersions sortingFactoryPromptVersions;
     private final @NonNull EventBus eventBus;
     private final @NonNull ProjectService projectService;
+    private final @NonNull EnvironmentService environmentService;
+    private final @NonNull LockService lockService;
 
     @Override
     public Prompt create(@NonNull Prompt promptRequest) {
@@ -333,6 +342,17 @@ class PromptServiceImpl implements PromptService {
         Prompt prompt = getOrCreatePrompt(workspaceId, createPromptVersion.name(), userName, templateStructure,
                 projectId);
 
+        String environment = StringUtils.trimToNull(createPromptVersion.version().environment());
+
+        if (environment != null) {
+            if (createPromptVersion.version().versionType() == PromptVersionType.MASK) {
+                throw new BadRequestException(MASK_ENV_NOT_ALLOWED);
+            }
+            environmentService.bulkCreate(Set.of(environment), workspaceId, userName);
+            return createVersionWithEnvironment(workspaceId, workspaceName, userName, projectId, prompt,
+                    createPromptVersion, id, commit, environment);
+        }
+
         EntityConstraintHandler<PromptVersion> handler = EntityConstraintHandler.handle(() -> {
             PromptVersion promptVersion = createPromptVersion.version().toBuilder()
                     .promptId(prompt.id())
@@ -358,6 +378,35 @@ class PromptServiceImpl implements PromptService {
                 return savedPromptVersion;
             });
         }
+    }
+
+    private PromptVersion createVersionWithEnvironment(String workspaceId, String workspaceName, String userName,
+            UUID projectId, Prompt prompt, CreatePromptVersion createPromptVersion, UUID id, String commit,
+            String environment) {
+        return lockService.executeWithLock(
+                new LockService.Lock(prompt.id(), PROMPT_ENV_PROMOTE_LOCK),
+                Mono.fromCallable(() -> {
+                    PromptVersion existing = transactionTemplate.inTransaction(READ_ONLY, handle -> {
+                        PromptVersionDAO dao = handle.attach(PromptVersionDAO.class);
+                        return dao.findByEnvironment(prompt.id(), environment, workspaceId);
+                    });
+                    if (existing != null) {
+                        throw new EntityAlreadyExistsException(new ErrorMessage(409,
+                                "Environment '%s' is already mapped to version '%s'"
+                                        .formatted(environment, existing.commit())));
+                    }
+
+                    PromptVersion promptVersion = createPromptVersion.version().toBuilder()
+                            .promptId(prompt.id())
+                            .createdBy(userName)
+                            .id(id)
+                            .commit(commit)
+                            .build();
+
+                    var saved = savePromptVersion(workspaceId, promptVersion);
+                    postPromptCommittedEvent(saved, workspaceId, workspaceName, userName, projectId);
+                    return saved;
+                }).subscribeOn(Schedulers.boundedElastic())).block();
     }
 
     @Override
@@ -494,23 +543,34 @@ class PromptServiceImpl implements PromptService {
 
     @Override
     public Prompt getById(@NonNull UUID id) {
-        return getById(id, null);
+        return getById(id, null, null);
     }
 
     @Override
     public Prompt getById(@NonNull UUID id, UUID maskId) {
+        return getById(id, maskId, null);
+    }
+
+    @Override
+    public Prompt getById(@NonNull UUID id, UUID maskId, String environment) {
+        String env = StringUtils.trimToNull(environment);
+
+        if (maskId != null && env != null) {
+            throw new BadRequestException(ENV_MASK_MUTUALLY_EXCLUSIVE);
+        }
+
         String workspaceId = requestContext.get().getWorkspaceId();
 
         return transactionTemplate.inTransaction(READ_ONLY, handle -> {
             PromptDAO promptDAO = handle.attach(PromptDAO.class);
 
-            Prompt prompt = promptDAO.findById(id, workspaceId, maskId);
+            Prompt prompt = promptDAO.findById(id, workspaceId, maskId, env);
 
             if (prompt == null) {
                 throw new NotFoundException(PROMPT_NOT_FOUND);
             }
 
-            if (maskId != null && prompt.requestedVersion() == null) {
+            if ((maskId != null || env != null) && prompt.requestedVersion() == null) {
                 throw new NotFoundException(PROMPT_VERSION_NOT_FOUND);
             }
 
@@ -674,17 +734,59 @@ class PromptServiceImpl implements PromptService {
     }
 
     @Override
-    public PromptVersion retrievePromptVersion(@NonNull String name, String commit, String projectName) {
+    public void setVersionEnvironment(@NonNull UUID versionId, String environment) {
+        String workspaceId = requestContext.get().getWorkspaceId();
+        String userName = requestContext.get().getUserName();
+        String env = StringUtils.trimToNull(environment);
+
+        PromptVersion version = getVersionById(versionId);
+
+        if (version.versionType() == PromptVersionType.MASK) {
+            throw new BadRequestException(MASK_ENV_NOT_ALLOWED);
+        }
+
+        UUID promptId = version.promptId();
+
+        if (env != null) {
+            environmentService.bulkCreate(Set.of(env), workspaceId, userName);
+        }
+
+        lockService.executeWithLock(
+                new LockService.Lock(promptId, PROMPT_ENV_PROMOTE_LOCK),
+                Mono.fromCallable(() -> transactionTemplate.inTransaction(WRITE, handle -> {
+                    PromptVersionDAO dao = handle.attach(PromptVersionDAO.class);
+                    if (env != null) {
+                        dao.clearEnvironment(promptId, workspaceId, env);
+                    }
+                    int updated = dao.updateEnvironment(versionId, workspaceId, env);
+                    if (updated == 0) {
+                        throw new NotFoundException(PROMPT_VERSION_NOT_FOUND);
+                    }
+                    return updated;
+                })).subscribeOn(Schedulers.boundedElastic())).block();
+
+        log.info("Set environment '{}' on prompt version '{}'", env, versionId);
+    }
+
+    @Override
+    public PromptVersion retrievePromptVersion(@NonNull String name, String commit, String environment,
+            String projectName) {
         String workspaceId = requestContext.get().getWorkspaceId();
         UUID projectId = null;
         if (StringUtils.isNotBlank(projectName)) {
             projectId = projectService.findProjectIdByName(workspaceId, projectName).orElse(null);
         }
-        return retrievePromptVersion(name, commit, projectId);
+        return retrievePromptVersion(name, commit, environment, projectId);
     }
 
-    @Override
-    public PromptVersion retrievePromptVersion(@NonNull String name, String commit, UUID projectId) {
+    private PromptVersion retrievePromptVersion(@NonNull String name, String commit, String environment,
+            UUID projectId) {
+        String env = StringUtils.trimToNull(environment);
+
+        if (env != null && StringUtils.isNotBlank(commit)) {
+            throw new BadRequestException("environment and commit are mutually exclusive");
+        }
+
         String workspaceId = requestContext.get().getWorkspaceId();
 
         Prompt prompt = findByName(workspaceId, name, projectId);
@@ -697,7 +799,12 @@ class PromptServiceImpl implements PromptService {
             }
 
             PromptVersion promptVersion;
-            if (commit == null) {
+            if (env != null) {
+                promptVersion = promptVersionDAO.findByEnvironment(prompt.id(), env, workspaceId);
+                if (promptVersion == null) {
+                    throw new NotFoundException(PROMPT_VERSION_NOT_FOUND);
+                }
+            } else if (commit == null) {
                 // Fetch latest version directly from prompt_versions table
                 List<PromptVersion> versions = promptVersionDAO.find(workspaceId, prompt.id(), 0, 1);
                 if (versions.isEmpty()) {
@@ -747,6 +854,7 @@ class PromptServiceImpl implements PromptService {
                 .createdBy(userName)
                 .changeDescription("Restored from version " + versionToRestore.commit())
                 .tags(null) // Don't propagate tags to restored version
+                .environment(null) // Don't propagate environment ownership to restored version
                 .build();
 
         PromptVersion restoredVersion = EntityConstraintHandler

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -736,7 +736,6 @@ class PromptServiceImpl implements PromptService {
     @Override
     public void setVersionEnvironment(@NonNull UUID versionId, String environment) {
         String workspaceId = requestContext.get().getWorkspaceId();
-        String userName = requestContext.get().getUserName();
         String env = StringUtils.trimToNull(environment);
 
         PromptVersion version = getVersionById(versionId);
@@ -747,8 +746,9 @@ class PromptServiceImpl implements PromptService {
 
         UUID promptId = version.promptId();
 
-        if (env != null) {
-            environmentService.bulkCreate(Set.of(env), workspaceId, userName);
+        if (env != null && !environmentService.existsByName(env, workspaceId)) {
+            throw new NotFoundException(
+                    "Environment '%s' does not exist in the workspace".formatted(env));
         }
 
         lockService.executeWithLock(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.function.Function;
 
 import static com.comet.opik.api.AlertEventType.PROMPT_COMMITTED;
@@ -345,9 +346,6 @@ class PromptServiceImpl implements PromptService {
         String environment = StringUtils.trimToNull(createPromptVersion.version().environment());
 
         if (environment != null) {
-            if (createPromptVersion.version().versionType() == PromptVersionType.MASK) {
-                throw new BadRequestException(MASK_ENV_NOT_ALLOWED);
-            }
             environmentService.bulkCreate(Set.of(environment), workspaceId, userName);
             return createVersionWithEnvironment(workspaceId, workspaceName, userName, projectId, prompt,
                     createPromptVersion, id, commit, environment);
@@ -383,30 +381,35 @@ class PromptServiceImpl implements PromptService {
     private PromptVersion createVersionWithEnvironment(String workspaceId, String workspaceName, String userName,
             UUID projectId, Prompt prompt, CreatePromptVersion createPromptVersion, UUID id, String commit,
             String environment) {
+        return withEnvironmentPromotionLock(prompt.id(), () -> {
+            PromptVersion existing = transactionTemplate.inTransaction(READ_ONLY, handle -> {
+                PromptVersionDAO dao = handle.attach(PromptVersionDAO.class);
+                return dao.findByEnvironment(prompt.id(), environment, workspaceId);
+            });
+            if (existing != null) {
+                throw new EntityAlreadyExistsException(new ErrorMessage(409,
+                        "Environment '%s' is already mapped to version '%s'"
+                                .formatted(environment, existing.commit())));
+            }
+
+            PromptVersion promptVersion = createPromptVersion.version().toBuilder()
+                    .promptId(prompt.id())
+                    .createdBy(userName)
+                    .id(id)
+                    .commit(commit)
+                    .build();
+
+            var saved = savePromptVersion(workspaceId, promptVersion);
+            postPromptCommittedEvent(saved, workspaceId, workspaceName, userName, projectId);
+            return saved;
+        });
+    }
+
+    private <T> T withEnvironmentPromotionLock(UUID promptId, Callable<T> action) {
         return lockService.executeWithLock(
-                new LockService.Lock(prompt.id(), PROMPT_ENV_PROMOTE_LOCK),
-                Mono.fromCallable(() -> {
-                    PromptVersion existing = transactionTemplate.inTransaction(READ_ONLY, handle -> {
-                        PromptVersionDAO dao = handle.attach(PromptVersionDAO.class);
-                        return dao.findByEnvironment(prompt.id(), environment, workspaceId);
-                    });
-                    if (existing != null) {
-                        throw new EntityAlreadyExistsException(new ErrorMessage(409,
-                                "Environment '%s' is already mapped to version '%s'"
-                                        .formatted(environment, existing.commit())));
-                    }
-
-                    PromptVersion promptVersion = createPromptVersion.version().toBuilder()
-                            .promptId(prompt.id())
-                            .createdBy(userName)
-                            .id(id)
-                            .commit(commit)
-                            .build();
-
-                    var saved = savePromptVersion(workspaceId, promptVersion);
-                    postPromptCommittedEvent(saved, workspaceId, workspaceName, userName, projectId);
-                    return saved;
-                }).subscribeOn(Schedulers.boundedElastic())).block();
+                new LockService.Lock(promptId, PROMPT_ENV_PROMOTE_LOCK),
+                Mono.fromCallable(action).subscribeOn(Schedulers.boundedElastic()))
+                .block();
     }
 
     @Override
@@ -751,19 +754,17 @@ class PromptServiceImpl implements PromptService {
                     "Environment '%s' does not exist in the workspace".formatted(env));
         }
 
-        lockService.executeWithLock(
-                new LockService.Lock(promptId, PROMPT_ENV_PROMOTE_LOCK),
-                Mono.fromCallable(() -> transactionTemplate.inTransaction(WRITE, handle -> {
-                    PromptVersionDAO dao = handle.attach(PromptVersionDAO.class);
-                    if (env != null) {
-                        dao.clearEnvironment(promptId, workspaceId, env);
-                    }
-                    int updated = dao.updateEnvironment(versionId, workspaceId, env);
-                    if (updated == 0) {
-                        throw new NotFoundException(PROMPT_VERSION_NOT_FOUND);
-                    }
-                    return updated;
-                })).subscribeOn(Schedulers.boundedElastic())).block();
+        withEnvironmentPromotionLock(promptId, () -> transactionTemplate.inTransaction(WRITE, handle -> {
+            PromptVersionDAO dao = handle.attach(PromptVersionDAO.class);
+            if (env != null) {
+                dao.clearEnvironment(promptId, workspaceId, env);
+            }
+            int updated = dao.updateEnvironment(versionId, workspaceId, env);
+            if (updated == 0) {
+                throw new NotFoundException(PROMPT_VERSION_NOT_FOUND);
+            }
+            return updated;
+        }));
 
         log.info("Set environment '{}' on prompt version '{}'", env, versionId);
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptVersionDAO.java
@@ -40,6 +40,7 @@ interface PromptVersionDAO {
                 change_description,
                 type,
                 version_type,
+                environment,
                 tags,
                 created_by,
                 workspace_id
@@ -53,6 +54,7 @@ interface PromptVersionDAO {
                 :bean.changeDescription,
                 :bean.type,
                 :bean.versionType,
+                :bean.environment,
                 :bean.tags,
                 :bean.createdBy,
                 :workspace_id
@@ -196,6 +198,32 @@ interface PromptVersionDAO {
 
     @SqlUpdate("DELETE FROM prompt_versions WHERE prompt_id = :prompt_id AND workspace_id = :workspace_id")
     int deleteByPromptId(@Bind("prompt_id") UUID promptId, @Bind("workspace_id") String workspaceId);
+
+    @SqlUpdate("""
+            UPDATE prompt_versions
+            SET environment = :environment
+            WHERE id = :id AND workspace_id = :workspace_id AND version_type = 'prompt_version'
+            """)
+    int updateEnvironment(@Bind("id") UUID id, @Bind("workspace_id") String workspaceId,
+            @Bind("environment") String environment);
+
+    @SqlUpdate("""
+            UPDATE prompt_versions
+            SET environment = NULL
+            WHERE prompt_id = :prompt_id AND workspace_id = :workspace_id AND environment = :environment
+            """)
+    int clearEnvironment(@Bind("prompt_id") UUID promptId, @Bind("workspace_id") String workspaceId,
+            @Bind("environment") String environment);
+
+    @SqlQuery("""
+            SELECT pv.*, p.template_structure
+            FROM prompt_versions pv
+            INNER JOIN prompts p ON pv.prompt_id = p.id
+            WHERE pv.prompt_id = :prompt_id AND pv.environment = :environment AND pv.workspace_id = :workspace_id
+            AND pv.version_type = 'prompt_version'
+            """)
+    PromptVersion findByEnvironment(@Bind("prompt_id") UUID promptId, @Bind("environment") String environment,
+            @Bind("workspace_id") String workspaceId);
 
     @SqlQuery("""
             SELECT pv.id, pv.commit, p.name AS prompt_name

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/PromptVersionColumnMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/PromptVersionColumnMapper.java
@@ -37,6 +37,10 @@ public class PromptVersionColumnMapper implements ColumnMapper<PromptVersion> {
                 .map(JsonNode::asText)
                 .map(PromptVersionType::fromString)
                 .orElse(PromptVersionType.PROMPT_VERSION);
+        String environment = Optional.ofNullable(jsonNode.get("environment"))
+                .filter(node -> !node.isNull())
+                .map(JsonNode::asText)
+                .orElse(null);
 
         return PromptVersion.builder()
                 .id(UUID.fromString(jsonNode.get("id").asText()))
@@ -47,6 +51,7 @@ public class PromptVersionColumnMapper implements ColumnMapper<PromptVersion> {
                 .changeDescription(jsonNode.get("change_description").asText())
                 .type(type)
                 .versionType(versionType)
+                .environment(environment)
                 .variables(TemplateParseUtils.extractVariables(template, type))
                 .tags(jsonNode.has("tags") && jsonNode.get("tags") != null && !jsonNode.get("tags").isNull()
                         ? JsonUtils.readValue(jsonNode.get("tags").asText(), SetFlatArgumentFactory.TYPE_REFERENCE)

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000072_add_environment_to_prompt_versions.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000072_add_environment_to_prompt_versions.sql
@@ -1,0 +1,10 @@
+--liquibase formatted sql
+--changeset borystkachenko:000072_add_environment_to_prompt_versions
+--comment: Add environment to prompt_versions and enforce single-owner invariant per (workspace, prompt, environment)
+
+ALTER TABLE prompt_versions ADD COLUMN environment VARCHAR(150) NULL;
+CREATE UNIQUE INDEX idx_prompt_versions_workspace_prompt_environment
+    ON prompt_versions (workspace_id, prompt_id, environment);
+
+--rollback DROP INDEX idx_prompt_versions_workspace_prompt_environment ON prompt_versions;
+--rollback ALTER TABLE prompt_versions DROP COLUMN environment;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000072_add_environment_to_prompt_versions.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000072_add_environment_to_prompt_versions.sql
@@ -3,8 +3,11 @@
 --comment: Add environment to prompt_versions and enforce single-owner invariant per (workspace, prompt, environment)
 
 ALTER TABLE prompt_versions ADD COLUMN environment VARCHAR(150) NULL;
+
+-- Enforce single-owner-per-environment per prompt; supports env-mapped version lookup on GET /prompts/{id}?environment=... and PATCH /versions/{id}.
 CREATE UNIQUE INDEX idx_prompt_versions_workspace_prompt_environment
     ON prompt_versions (workspace_id, prompt_id, environment);
 
 --rollback DROP INDEX idx_prompt_versions_workspace_prompt_environment ON prompt_versions;
 --rollback ALTER TABLE prompt_versions DROP COLUMN environment;
+

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/PromptResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/PromptResourceClient.java
@@ -5,6 +5,7 @@ import com.comet.opik.api.CreatePromptVersion;
 import com.comet.opik.api.Prompt;
 import com.comet.opik.api.PromptVersion;
 import com.comet.opik.api.PromptVersionCommitsRequest;
+import com.comet.opik.api.PromptVersionEnvironmentUpdate;
 import com.comet.opik.api.PromptVersionIdsRequest;
 import com.comet.opik.api.PromptVersionLink;
 import com.comet.opik.api.PromptVersionRetrieve;
@@ -129,9 +130,16 @@ public class PromptResourceClient {
     }
 
     public Response callGetPrompt(UUID id, UUID maskId, String apiKey, String workspaceName) {
+        return callGetPrompt(id, maskId, null, apiKey, workspaceName);
+    }
+
+    public Response callGetPrompt(UUID id, UUID maskId, String environment, String apiKey, String workspaceName) {
         WebTarget target = client.target(PROMPT_PATH.formatted(baseURI)).path(id.toString());
         if (maskId != null) {
             target = target.queryParam("mask_id", maskId);
+        }
+        if (environment != null) {
+            target = target.queryParam("environment", environment);
         }
         return target
                 .request()
@@ -231,15 +239,52 @@ public class PromptResourceClient {
                 .version(podamFactory.manufacturePojo(PromptVersion.class))
                 .build();
 
-        try (var response = client.target(PROMPT_PATH.formatted(baseURI) + "/versions")
-                .request()
-                .header(HttpHeaders.AUTHORIZATION, apiKey)
-                .header(RequestContext.WORKSPACE_HEADER, workspaceName)
-                .post(Entity.json(request))) {
+        try (var response = callCreatePromptVersion(request, apiKey, workspaceName)) {
 
             assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
 
             return response.readEntity(PromptVersion.class);
         }
+    }
+
+    public Response callCreatePromptVersion(CreatePromptVersion request, String apiKey, String workspaceName) {
+        return client.target(PROMPT_PATH.formatted(baseURI) + "/versions")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(RequestContext.WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(request));
+    }
+
+    public Response callGetPromptVersion(UUID versionId, String apiKey, String workspaceName) {
+        return client.target(PROMPT_PATH.formatted(baseURI) + "/versions/" + versionId)
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(RequestContext.WORKSPACE_HEADER, workspaceName)
+                .get();
+    }
+
+    public PromptVersion getPromptVersion(UUID versionId, String apiKey, String workspaceName) {
+        try (var response = callGetPromptVersion(versionId, apiKey, workspaceName)) {
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+            return response.readEntity(PromptVersion.class);
+        }
+    }
+
+    public Response callSetPromptVersionEnvironment(UUID versionId, PromptVersionEnvironmentUpdate update,
+            String apiKey, String workspaceName) {
+        return client.target(PROMPT_PATH.formatted(baseURI) + "/versions/" + versionId)
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(RequestContext.WORKSPACE_HEADER, workspaceName)
+                .method("PATCH", Entity.json(update));
+    }
+
+    public Response callRestorePromptVersion(UUID promptId, UUID versionId, String apiKey, String workspaceName) {
+        return client.target(PROMPT_PATH.formatted(baseURI)
+                + "/%s/versions/%s/restore".formatted(promptId, versionId))
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(RequestContext.WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(""));
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/PromptResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/PromptResourceClient.java
@@ -272,7 +272,7 @@ public class PromptResourceClient {
 
     public Response callSetPromptVersionEnvironment(UUID versionId, PromptVersionEnvironmentUpdate update,
             String apiKey, String workspaceName) {
-        return client.target(PROMPT_PATH.formatted(baseURI) + "/versions/" + versionId)
+        return client.target(PROMPT_PATH.formatted(baseURI) + "/versions/" + versionId + "/environments")
                 .request()
                 .header(HttpHeaders.AUTHORIZATION, apiKey)
                 .header(RequestContext.WORKSPACE_HEADER, workspaceName)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -2,11 +2,13 @@ package com.comet.opik.api.resources.v1.priv;
 
 import com.comet.opik.api.BatchDelete;
 import com.comet.opik.api.CreatePromptVersion;
+import com.comet.opik.api.Environment;
 import com.comet.opik.api.Prompt;
 import com.comet.opik.api.PromptType;
 import com.comet.opik.api.PromptVersion;
 import com.comet.opik.api.PromptVersionBatchUpdate;
 import com.comet.opik.api.PromptVersionCommitsRequest;
+import com.comet.opik.api.PromptVersionEnvironmentUpdate;
 import com.comet.opik.api.PromptVersionIdsRequest;
 import com.comet.opik.api.PromptVersionRetrieve;
 import com.comet.opik.api.PromptVersionType;
@@ -28,6 +30,7 @@ import com.comet.opik.api.resources.utils.RedisContainerUtils;
 import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
 import com.comet.opik.api.resources.utils.TestUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.EnvironmentsResourceClient;
 import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
 import com.comet.opik.api.resources.utils.resources.PromptResourceClient;
 import com.comet.opik.api.resources.utils.resources.PromptVersionResourceClient;
@@ -168,6 +171,7 @@ class PromptResourceTest {
     private PromptResourceClient promptResourceClient;
     private PromptVersionResourceClient promptVersionResourceClient;
     private ProjectResourceClient projectResourceClient;
+    private EnvironmentsResourceClient environmentsResourceClient;
 
     @BeforeAll
     void setUpAll(ClientSupport client) {
@@ -177,6 +181,7 @@ class PromptResourceTest {
         this.promptResourceClient = new PromptResourceClient(client, baseURI, factory);
         this.promptVersionResourceClient = new PromptVersionResourceClient(client, baseURI);
         this.projectResourceClient = new ProjectResourceClient(client, baseURI, factory);
+        this.environmentsResourceClient = new EnvironmentsResourceClient(client, baseURI);
 
         ClientSupportUtils.config(client);
 
@@ -4716,6 +4721,7 @@ class PromptResourceTest {
             var maskVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
                     .createdBy(USER)
                     .versionType(PromptVersionType.MASK)
+                    .environment(null)
                     .build();
 
             PromptVersion created = createPromptVersion(
@@ -4739,7 +4745,7 @@ class PromptResourceTest {
                     API_KEY, TEST_WORKSPACE);
 
             var maskVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
             createPromptVersion(
                     createPromptVersionRequest(prompt.name(), maskVersion, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -4764,7 +4770,7 @@ class PromptResourceTest {
                     API_KEY, TEST_WORKSPACE);
 
             var maskVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
             createPromptVersion(
                     createPromptVersionRequest(prompt.name(), maskVersion, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -4785,7 +4791,7 @@ class PromptResourceTest {
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             var maskVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
             var savedMask = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), maskVersion, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -4803,7 +4809,7 @@ class PromptResourceTest {
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             var maskVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
             var savedMask = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), maskVersion, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -4830,7 +4836,7 @@ class PromptResourceTest {
                     API_KEY, TEST_WORKSPACE);
 
             var maskVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
             var savedMask = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), maskVersion, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -4870,7 +4876,7 @@ class PromptResourceTest {
             var promptB = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
             createPrompt(promptB, API_KEY, TEST_WORKSPACE);
             var maskVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
             var maskOfB = createPromptVersion(
                     createPromptVersionRequest(promptB.name(), maskVersion, promptB.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -4909,13 +4915,13 @@ class PromptResourceTest {
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             var maskA = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
             var savedA = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), maskA, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
             var maskB = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
             var savedB = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), maskB, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -4958,13 +4964,400 @@ class PromptResourceTest {
             Thread.sleep(10);
 
             var maskVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
             createPromptVersion(
                     createPromptVersionRequest(prompt.name(), maskVersion, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
             Instant afterMask = getPrompt(promptId, API_KEY, TEST_WORKSPACE).lastUpdatedAt();
             assertThat(afterMask).isEqualTo(initial);
+        }
+    }
+
+    @Nested
+    @DisplayName("Prompt Environments")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class PromptEnvironments {
+
+        @BeforeEach
+        void clearWorkspaceEnvironments() {
+            // The env-per-workspace cap is small in tests; wipe between tests so auto-create has slots.
+            try (var listResponse = environmentsResourceClient.callFind(API_KEY, TEST_WORKSPACE)) {
+                var page = listResponse.readEntity(Environment.EnvironmentPage.class);
+                Set<UUID> ids = page.content().stream().map(Environment::id).collect(Collectors.toSet());
+                if (!ids.isEmpty()) {
+                    try (var deleteResponse = environmentsResourceClient.callBatchDelete(ids, API_KEY,
+                            TEST_WORKSPACE)) {
+                        assertThat(deleteResponse.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+                    }
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("Create version with environment: env is set on the version and auto-created in the workspace registry")
+        void shouldCreateVersionWithEnvironmentAndAutoCreateInRegistry() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            String env = uniqueEnvName("prod");
+            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+
+            var saved = createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            assertThat(saved.environment()).isEqualTo(env);
+            assertWorkspaceContainsEnvironment(env);
+        }
+
+        @Test
+        @DisplayName("Creating two versions with same env on same prompt: second returns 409 Conflict")
+        void duplicateEnvironmentOnSamePromptReturnsConflict() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            String env = uniqueEnvName("dup");
+            var first = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+            createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), first, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            var second = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+            try (var response = postVersionRaw(prompt.name(), second, prompt.templateStructure())) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
+            }
+        }
+
+        @Test
+        @DisplayName("Same env name is allowed on versions of different prompts")
+        void sameEnvironmentOnDifferentPromptsBothSucceed() {
+            var promptA = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(promptA, API_KEY, TEST_WORKSPACE);
+            var promptB = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(promptB, API_KEY, TEST_WORKSPACE);
+
+            String env = uniqueEnvName("shared");
+            var vA = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+            var savedA = createPromptVersion(
+                    createPromptVersionRequest(promptA.name(), vA, promptA.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            var vB = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+            var savedB = createPromptVersion(
+                    createPromptVersionRequest(promptB.name(), vB, promptB.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            assertThat(savedA.environment()).isEqualTo(env);
+            assertThat(savedB.environment()).isEqualTo(env);
+        }
+
+        @Test
+        @DisplayName("Creating a mask version with environment returns 400 Bad Request")
+        void creatingMaskWithEnvironmentReturnsBadRequest() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            var mask = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(uniqueEnvName("mask")).build();
+            try (var response = postVersionRaw(prompt.name(), mask, prompt.templateStructure())) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+            }
+        }
+
+        @Test
+        @DisplayName("GET /prompts/{id}?environment populates requestedVersion with the env-mapped version")
+        void getPromptByIdResolvesByEnvironment() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            UUID promptId = createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            // v1: no env
+            var v1 = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(null).build();
+            createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), v1, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            // v2: env=prod
+            String env = uniqueEnvName("resolve");
+            var v2 = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+            var savedV2 = createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), v2, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            // v3: no env (latest)
+            var v3 = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(null).build();
+            var savedV3 = createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), v3, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/" + promptId)
+                    .queryParam("environment", env)
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
+                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
+                    .get()) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+                Prompt fetched = response.readEntity(Prompt.class);
+                assertThat(fetched.requestedVersion()).isNotNull();
+                assertThat(fetched.requestedVersion().id()).isEqualTo(savedV2.id());
+                assertThat(fetched.requestedVersion().environment()).isEqualTo(env);
+                assertThat(fetched.latestVersion()).isNotNull();
+                assertThat(fetched.latestVersion().id()).isEqualTo(savedV3.id());
+            }
+        }
+
+        @Test
+        @DisplayName("GET /prompts/{id}?environment=unknown returns 404 Not Found")
+        void getPromptByIdWithUnknownEnvironmentReturnsNotFound() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            UUID promptId = createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/" + promptId)
+                    .queryParam("environment", uniqueEnvName("missing"))
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
+                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
+                    .get()) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+            }
+        }
+
+        @Test
+        @DisplayName("GET /prompts/{id} with both mask_id and environment returns 400 Bad Request")
+        void getPromptByIdWithBothEnvAndMaskReturnsBadRequest() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            UUID promptId = createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/" + promptId)
+                    .queryParam("mask_id", UUID.randomUUID())
+                    .queryParam("environment", uniqueEnvName("conflict"))
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
+                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
+                    .get()) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+            }
+        }
+
+        @Test
+        @DisplayName("PATCH /versions/{id} sets the environment on a version and auto-creates it in registry")
+        void patchSetsEnvironmentOnVersion() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(null).build();
+            var saved = createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            String env = uniqueEnvName("patch");
+            patchVersionEnvironment(saved.id(), env, HttpStatus.SC_NO_CONTENT);
+
+            assertThat(getVersionById(saved.id()).environment()).isEqualTo(env);
+            assertWorkspaceContainsEnvironment(env);
+        }
+
+        @Test
+        @DisplayName("PATCH /versions/{id} with null environment clears the env on the version")
+        void patchClearsEnvironmentOnVersion() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            String env = uniqueEnvName("clear");
+            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+            var saved = createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            patchVersionEnvironment(saved.id(), null, HttpStatus.SC_NO_CONTENT);
+
+            assertThat(getVersionById(saved.id()).environment()).isNull();
+        }
+
+        @Test
+        @DisplayName("PATCH /versions/{id} moves environment ownership: prev owner is cleared atomically")
+        void patchMovesEnvironmentBetweenVersionsOfSamePrompt() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            String env = uniqueEnvName("move");
+            var owner = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+            var savedOwner = createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), owner, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            var next = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(null).build();
+            var savedNext = createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), next, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            patchVersionEnvironment(savedNext.id(), env, HttpStatus.SC_NO_CONTENT);
+
+            assertThat(getVersionById(savedOwner.id()).environment()).isNull();
+            assertThat(getVersionById(savedNext.id()).environment()).isEqualTo(env);
+        }
+
+        @Test
+        @DisplayName("PATCH /versions/{id} on an unknown version returns 404 Not Found")
+        void patchOnUnknownVersionReturnsNotFound() {
+            patchVersionEnvironment(UUID.randomUUID(), uniqueEnvName("ghost"), HttpStatus.SC_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("PATCH /versions/{id} on a mask version returns 400 Bad Request")
+        void patchOnMaskVersionReturnsBadRequest() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            var mask = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
+            var savedMask = createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), mask, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            patchVersionEnvironment(savedMask.id(), uniqueEnvName("masked"), HttpStatus.SC_BAD_REQUEST);
+        }
+
+        @Test
+        @DisplayName("POST /versions/retrieve resolves by environment when provided")
+        void retrieveVersionByEnvironment() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            String env = uniqueEnvName("ret");
+            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+            var saved = createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            var request = PromptVersionRetrieve.builder()
+                    .name(prompt.name())
+                    .environment(env)
+                    .build();
+
+            try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/versions/retrieve")
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
+                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
+                    .post(Entity.json(request))) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+                PromptVersion retrieved = response.readEntity(PromptVersion.class);
+                assertThat(retrieved.id()).isEqualTo(saved.id());
+                assertThat(retrieved.environment()).isEqualTo(env);
+            }
+        }
+
+        @Test
+        @DisplayName("POST /versions/retrieve with both environment and commit returns 400 Bad Request")
+        void retrieveVersionWithBothEnvAndCommitReturnsBadRequest() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            var request = PromptVersionRetrieve.builder()
+                    .name(prompt.name())
+                    .environment(uniqueEnvName("both"))
+                    .commit("abcd1234")
+                    .build();
+
+            try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/versions/retrieve")
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
+                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
+                    .post(Entity.json(request))) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+            }
+        }
+
+        @Test
+        @DisplayName("Restored version is created without the source version's environment")
+        void restoredVersionDoesNotCarryEnvironment() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            UUID promptId = createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            String env = uniqueEnvName("restore");
+            var original = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+            var savedOriginal = createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), original, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            // Create a successor without env so restore creates a new latest version
+            var successor = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(null).build();
+            createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), successor, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            try (var response = client.target(RESOURCE_PATH.formatted(baseURI)
+                    + "/%s/versions/%s/restore".formatted(promptId, savedOriginal.id()))
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
+                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
+                    .post(Entity.json(""))) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+                PromptVersion restored = response.readEntity(PromptVersion.class);
+                assertThat(restored.id()).isNotEqualTo(savedOriginal.id());
+                assertThat(restored.environment()).isNull();
+            }
+
+            // original version still owns the env
+            assertThat(getVersionById(savedOriginal.id()).environment()).isEqualTo(env);
+        }
+
+        private String uniqueEnvName(String prefix) {
+            return prefix + "_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        }
+
+        private void patchVersionEnvironment(UUID versionId, String environment, int expectedStatus) {
+            var update = PromptVersionEnvironmentUpdate.builder().environment(environment).build();
+            try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/versions/" + versionId)
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
+                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
+                    .method("PATCH", Entity.json(update))) {
+                assertThat(response.getStatus()).isEqualTo(expectedStatus);
+            }
+        }
+
+        private Response postVersionRaw(String name, PromptVersion version, TemplateStructure templateStructure) {
+            var request = createPromptVersionRequest(name, version, templateStructure);
+            return client.target(RESOURCE_PATH.formatted(baseURI) + "/versions")
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
+                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
+                    .post(Entity.json(request));
+        }
+
+        private PromptVersion getVersionById(UUID versionId) {
+            try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/versions/" + versionId)
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
+                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
+                    .get()) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+                return response.readEntity(PromptVersion.class);
+            }
+        }
+
+        private void assertWorkspaceContainsEnvironment(String env) {
+            try (var response = environmentsResourceClient.callFind(API_KEY, TEST_WORKSPACE)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+                Environment.EnvironmentPage page = response.readEntity(Environment.EnvironmentPage.class);
+                assertThat(page.content()).extracting(Environment::name).contains(env);
+            }
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -5058,15 +5058,15 @@ class PromptResourceTest {
         }
 
         @Test
-        @DisplayName("Creating a mask version with environment returns 400 Bad Request")
-        void creatingMaskWithEnvironmentReturnsBadRequest() {
+        @DisplayName("Creating a mask version with environment returns 422 Unprocessable Content")
+        void creatingMaskWithEnvironmentReturnsUnprocessable() {
             var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             var mask = factory.manufacturePojo(PromptVersion.class).toBuilder()
                     .createdBy(USER).versionType(PromptVersionType.MASK).environment(uniqueEnvName("mask")).build();
             try (var response = postVersionRaw(prompt.name(), mask, prompt.templateStructure())) {
-                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_UNPROCESSABLE_ENTITY);
             }
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -5148,7 +5148,7 @@ class PromptResourceTest {
         }
 
         @Test
-        @DisplayName("PATCH /versions/{id} sets the environment on a version and auto-creates it in registry")
+        @DisplayName("PATCH /versions/{id} sets the environment on a version when the env exists in the workspace")
         void patchSetsEnvironmentOnVersion() {
             var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
@@ -5160,10 +5160,27 @@ class PromptResourceTest {
                     API_KEY, TEST_WORKSPACE);
 
             String env = uniqueEnvName("patch");
+            environmentsResourceClient.createEnvironment(
+                    Environment.builder().name(env).build(), API_KEY, TEST_WORKSPACE);
+
             patchVersionEnvironment(saved.id(), env, HttpStatus.SC_NO_CONTENT);
 
             assertThat(getVersionById(saved.id()).environment()).isEqualTo(env);
-            assertWorkspaceContainsEnvironment(env);
+        }
+
+        @Test
+        @DisplayName("PATCH /versions/{id} with an unknown environment returns 404 Not Found")
+        void patchOnUnknownEnvironmentReturnsNotFound() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(null).build();
+            var saved = createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            patchVersionEnvironment(saved.id(), uniqueEnvName("ghost"), HttpStatus.SC_NOT_FOUND);
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -5098,12 +5098,7 @@ class PromptResourceTest {
                     createPromptVersionRequest(prompt.name(), v3, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
-            try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/" + promptId)
-                    .queryParam("environment", env)
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .get()) {
+            try (var response = promptResourceClient.callGetPrompt(promptId, null, env, API_KEY, TEST_WORKSPACE)) {
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
                 Prompt fetched = response.readEntity(Prompt.class);
                 assertThat(fetched.requestedVersion()).isNotNull();
@@ -5120,12 +5115,8 @@ class PromptResourceTest {
             var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
             UUID promptId = createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
-            try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/" + promptId)
-                    .queryParam("environment", uniqueEnvName("missing"))
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .get()) {
+            try (var response = promptResourceClient.callGetPrompt(promptId, null, uniqueEnvName("missing"),
+                    API_KEY, TEST_WORKSPACE)) {
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
             }
         }
@@ -5136,13 +5127,8 @@ class PromptResourceTest {
             var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
             UUID promptId = createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
-            try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/" + promptId)
-                    .queryParam("mask_id", UUID.randomUUID())
-                    .queryParam("environment", uniqueEnvName("conflict"))
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .get()) {
+            try (var response = promptResourceClient.callGetPrompt(promptId, UUID.randomUUID(),
+                    uniqueEnvName("conflict"), API_KEY, TEST_WORKSPACE)) {
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
             }
         }
@@ -5165,7 +5151,8 @@ class PromptResourceTest {
 
             patchVersionEnvironment(saved.id(), env, HttpStatus.SC_NO_CONTENT);
 
-            assertThat(getVersionById(saved.id()).environment()).isEqualTo(env);
+            assertThat(promptResourceClient.getPromptVersion(saved.id(), API_KEY, TEST_WORKSPACE).environment())
+                    .isEqualTo(env);
         }
 
         @Test
@@ -5198,7 +5185,8 @@ class PromptResourceTest {
 
             patchVersionEnvironment(saved.id(), null, HttpStatus.SC_NO_CONTENT);
 
-            assertThat(getVersionById(saved.id()).environment()).isNull();
+            assertThat(promptResourceClient.getPromptVersion(saved.id(), API_KEY, TEST_WORKSPACE).environment())
+                    .isNull();
         }
 
         @Test
@@ -5222,8 +5210,10 @@ class PromptResourceTest {
 
             patchVersionEnvironment(savedNext.id(), env, HttpStatus.SC_NO_CONTENT);
 
-            assertThat(getVersionById(savedOwner.id()).environment()).isNull();
-            assertThat(getVersionById(savedNext.id()).environment()).isEqualTo(env);
+            assertThat(promptResourceClient.getPromptVersion(savedOwner.id(), API_KEY, TEST_WORKSPACE).environment())
+                    .isNull();
+            assertThat(promptResourceClient.getPromptVersion(savedNext.id(), API_KEY, TEST_WORKSPACE).environment())
+                    .isEqualTo(env);
         }
 
         @Test
@@ -5265,11 +5255,7 @@ class PromptResourceTest {
                     .environment(env)
                     .build();
 
-            try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/versions/retrieve")
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .post(Entity.json(request))) {
+            try (var response = promptResourceClient.callRetrievePromptVersion(request, API_KEY, TEST_WORKSPACE)) {
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
                 PromptVersion retrieved = response.readEntity(PromptVersion.class);
                 assertThat(retrieved.id()).isEqualTo(saved.id());
@@ -5289,11 +5275,7 @@ class PromptResourceTest {
                     .commit("abcd1234")
                     .build();
 
-            try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/versions/retrieve")
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .post(Entity.json(request))) {
+            try (var response = promptResourceClient.callRetrievePromptVersion(request, API_KEY, TEST_WORKSPACE)) {
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
             }
         }
@@ -5318,12 +5300,8 @@ class PromptResourceTest {
                     createPromptVersionRequest(prompt.name(), successor, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
-            try (var response = client.target(RESOURCE_PATH.formatted(baseURI)
-                    + "/%s/versions/%s/restore".formatted(promptId, savedOriginal.id()))
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .post(Entity.json(""))) {
+            try (var response = promptResourceClient.callRestorePromptVersion(promptId, savedOriginal.id(),
+                    API_KEY, TEST_WORKSPACE)) {
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
                 PromptVersion restored = response.readEntity(PromptVersion.class);
                 assertThat(restored.id()).isNotEqualTo(savedOriginal.id());
@@ -5331,7 +5309,8 @@ class PromptResourceTest {
             }
 
             // original version still owns the env
-            assertThat(getVersionById(savedOriginal.id()).environment()).isEqualTo(env);
+            assertThat(promptResourceClient.getPromptVersion(savedOriginal.id(), API_KEY, TEST_WORKSPACE).environment())
+                    .isEqualTo(env);
         }
 
         private String uniqueEnvName(String prefix) {
@@ -5340,33 +5319,15 @@ class PromptResourceTest {
 
         private void patchVersionEnvironment(UUID versionId, String environment, int expectedStatus) {
             var update = PromptVersionEnvironmentUpdate.builder().environment(environment).build();
-            try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/versions/" + versionId)
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .method("PATCH", Entity.json(update))) {
+            try (var response = promptResourceClient.callSetPromptVersionEnvironment(versionId, update, API_KEY,
+                    TEST_WORKSPACE)) {
                 assertThat(response.getStatus()).isEqualTo(expectedStatus);
             }
         }
 
         private Response postVersionRaw(String name, PromptVersion version, TemplateStructure templateStructure) {
-            var request = createPromptVersionRequest(name, version, templateStructure);
-            return client.target(RESOURCE_PATH.formatted(baseURI) + "/versions")
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .post(Entity.json(request));
-        }
-
-        private PromptVersion getVersionById(UUID versionId) {
-            try (var response = client.target(RESOURCE_PATH.formatted(baseURI) + "/versions/" + versionId)
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, API_KEY)
-                    .header(WORKSPACE_HEADER, TEST_WORKSPACE)
-                    .get()) {
-                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
-                return response.readEntity(PromptVersion.class);
-            }
+            return promptResourceClient.callCreatePromptVersion(
+                    createPromptVersionRequest(name, version, templateStructure), API_KEY, TEST_WORKSPACE);
         }
 
         private void assertWorkspaceContainsEnvironment(String env) {

--- a/sdks/typescript/src/opik/client/Client.ts
+++ b/sdks/typescript/src/opik/client/Client.ts
@@ -1212,6 +1212,7 @@ export class OpikClient {
 
       const promptData = await this.api.prompts.getPromptById(
         versionResponse.promptId,
+        {},
         this.api.requestOptions
       );
 


### PR DESCRIPTION
## Details
Adds first-class environment ownership for prompt versions, replacing the previous tag-based scheme and unifying naming with trace environments.

- **Schema**: new `environment VARCHAR(150) NULL` column on `prompt_versions` with a unique index on `(workspace_id, prompt_id, environment)` to enforce single-owner-per-prompt-per-env at the DB level (Liquibase migration `000072`).
- **Model**: `PromptVersion.environment` validated against `Environment.NAME_PATTERN` and capped at 150 chars; serialized in all `PromptVersion` JSON views.
- **New endpoint** `PATCH /v1/private/prompts/versions/{versionId}` (`PromptVersionEnvironmentUpdate`):
  - non-null value sets the environment on the version and atomically clears it from any previous owner of the same env on the same prompt;
  - null clears the env from the version;
  - auto-creates the environment in the workspace registry when set;
  - executes under a per-prompt distributed lock (`prompt_env_promote`) to make ownership transfer race-free.
- **`POST /v1/private/prompts/versions`** now accepts `environment` on the created version (atomic create+map; 409 if the env is already owned on that prompt, 400 on `mask` versions).
- **`GET /v1/private/prompts/{id}`** gains `?environment=`; populates `requestedVersion` with the env-mapped version. Mutually exclusive with `mask_id` (400 otherwise; 404 if env doesn't resolve).
- **`POST /v1/private/prompts/versions/retrieve`** gains `environment` (mutually exclusive with `commit`).
- **Mask versions** cannot own an environment (validated on create and on PATCH; 400).
- **Restore** does not propagate the source version's environment to the restored copy.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves #
- OPIK-6455

## Testing
New `@Nested("Prompt Environments")` block in `PromptResourceTest` covers:
- create version with env: sets env on the version and auto-registers it in the workspace registry;
- duplicate env on same prompt → 409;
- same env name allowed on versions of different prompts;
- creating a mask version with env → 400;
- `GET /prompts/{id}?environment` populates `requestedVersion`; unknown env → 404; combined with `mask_id` → 400;
- `PATCH /versions/{id}` sets, clears, and atomically moves env ownership; unknown version → 404; mask version → 400;
- `POST /versions/retrieve` resolves by env; env+commit → 400;
- restored version does not inherit env from source.

Run: `(cd apps/opik-backend && mvn -pl . test -Dtest=PromptResourceTest)`

## Documentation
OpenAPI schemas/descriptions updated on the new and changed endpoints (`PromptResource`, `PromptVersionEnvironmentUpdate`, `PromptVersionRetrieve`, `PromptVersion`). No standalone docs in this PR.
