### PR TITLE
[OPIK-6547] [INFRA] ci: add Scout issue triage workflow

### DIFF
--- a/.github/workflows/scout.yml
+++ b/.github/workflows/scout.yml
@@ -35,4 +35,4 @@ jobs:
           SCOUT_GITHUB_REPO_NAME: ${{ vars.SCOUT_GITHUB_REPO_NAME }}
           OPIK_API_KEY: ${{ secrets.OPIK_API_KEY }}
           OPIK_WORKSPACE: ${{ vars.OPIK_WORKSPACE }}
-          ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.inputs.issue_number }}

--- a/.github/workflows/scout.yml
+++ b/.github/workflows/scout.yml
@@ -1,0 +1,38 @@
+name: Scout Issue Triage
+
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to triage
+        required: true
+        type: number
+
+# One Scout run per issue at a time
+concurrency:
+  group: scout-issue-${{ github.event.issue.number || github.event.inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - name: Run Scout
+        uses: comet-ml/scout-repo-agent@main
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ github.token }}
+        env:
+          SCOUT_ESCALATION_TAG: ${{ vars.SCOUT_ESCALATION_TAG }}
+          SCOUT_GITHUB_REPO_OWNER: ${{ vars.SCOUT_GITHUB_REPO_OWNER }}
+          SCOUT_GITHUB_REPO_NAME: ${{ vars.SCOUT_GITHUB_REPO_NAME }}
+          OPIK_API_KEY: ${{ secrets.OPIK_API_KEY }}
+          OPIK_WORKSPACE: ${{ vars.OPIK_WORKSPACE }}
+          ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}

--- a/.github/workflows/scout.yml
+++ b/.github/workflows/scout.yml
@@ -27,12 +27,12 @@ jobs:
       - name: Run Scout
         uses: comet-ml/scout-repo-agent@main
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.SCOUT_ANTHROPIC_API_KEY }}
           github_token: ${{ github.token }}
         env:
           SCOUT_ESCALATION_TAG: ${{ vars.SCOUT_ESCALATION_TAG }}
           SCOUT_GITHUB_REPO_OWNER: ${{ vars.SCOUT_GITHUB_REPO_OWNER }}
           SCOUT_GITHUB_REPO_NAME: ${{ vars.SCOUT_GITHUB_REPO_NAME }}
-          OPIK_API_KEY: ${{ secrets.OPIK_API_KEY }}
-          OPIK_WORKSPACE: ${{ vars.OPIK_WORKSPACE }}
+          OPIK_API_KEY: ${{ secrets.SCOUT_OPIK_API_KEY }}
+          OPIK_WORKSPACE: ${{ vars.SCOUT_OPIK_WORKSPACE }}
           ISSUE_NUMBER: ${{ github.event.issue.number || github.event.inputs.issue_number }}


### PR DESCRIPTION
## Details
Add `.github/workflows/scout.yml` that runs [comet-ml/scout-repo-agent](https://github.com/comet-ml/scout-repo-agent) on newly opened issues. Scout posts a structured triage comment (similar issues, relevant source files, suggested fix) and applies an escalation label for complex design issues. A `workflow_dispatch` trigger is included for ad-hoc reruns against a specific issue number.

- Uses `comet-ml/scout-repo-agent@main`.
- Uses the built-in `${{ github.token }}` — no PAT or GitHub App required; comments appear as `github-actions[bot]`.
- Activity is traced to Opik for observability.

Before this workflow can run, the following must be configured in `Settings → Secrets and variables → Actions`:
- Secrets: `SCOUT_ANTHROPIC_API_KEY`, `SCOUT_OPIK_API_KEY`
- Variables: `SCOUT_GITHUB_REPO_OWNER`, `SCOUT_GITHUB_REPO_NAME`, `SCOUT_ESCALATION_TAG`, `SCOUT_OPIK_WORKSPACE`

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-6547

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: Authored the workflow YAML and PR copy
- Human verification: Workflow inputs/env values cross-checked against the scout-repo-agent README example

## Testing
- The change is a single new YAML workflow; no existing tests are affected and no local commands were run.
- Pre-merge plan once repo secrets/variables are configured:
  - Trigger `Scout Issue Triage` via `workflow_dispatch` against an existing test issue and verify a triage comment is posted by `github-actions[bot]`.
  - Open a fresh test issue and confirm the `issues: opened` trigger fires Scout end-to-end.
  - Verify the run is traced to Opik under the configured workspace.

## Documentation
N/A in this repo — Scout's user-facing documentation lives in `comet-ml/scout-repo-agent` README.