### PR TITLE
[OPIK-6583] [INFRA] [CI] fix: resolve remaining shellcheck findings in workflows

### DIFF
--- a/.github/workflows/build_and_publish_sdk.yaml
+++ b/.github/workflows/build_and_publish_sdk.yaml
@@ -39,9 +39,9 @@ jobs:
           id: setup
           run: |
             if [[ "${{inputs.version}}" == ""  ]]; then
-              echo "build_from=${{github.ref_name}}" | tee -a $GITHUB_OUTPUT
+              echo "build_from=${{github.ref_name}}" | tee -a "$GITHUB_OUTPUT"
             else
-              echo "build_from=${{inputs.version}}" | tee -a $GITHUB_OUTPUT
+              echo "build_from=${{inputs.version}}" | tee -a "$GITHUB_OUTPUT"
             fi
         - name: Checkout
           uses: actions/checkout@v6

--- a/.github/workflows/build_and_push_docker.yaml
+++ b/.github/workflows/build_and_push_docker.yaml
@@ -68,13 +68,15 @@ jobs:
             BUILD_MATRIX=$(echo "$BUILD_MATRIX" | jq '.exclude += [{"platform":"arm64"}]')
           fi
           
-          echo "build_matrix<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$BUILD_MATRIX" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-          
-          echo "merge_matrix<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$MERGE_MATRIX" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          {
+            echo "build_matrix<<EOF"
+            echo "$BUILD_MATRIX"
+            echo "EOF"
+
+            echo "merge_matrix<<EOF"
+            echo "$MERGE_MATRIX"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
   build:
     needs: generate-matrix

--- a/.github/workflows/build_apps.yml
+++ b/.github/workflows/build_apps.yml
@@ -97,15 +97,15 @@ jobs:
                 VERSION="${BASE_VERSION}-${fixedBranchName}-${{ github.run_number }}"
               fi
             fi
-            echo "version=${VERSION}" | tee -a $GITHUB_OUTPUT
-            echo "Version is ${VERSION}" >> $GITHUB_STEP_SUMMARY
+            echo "version=${VERSION}" | tee -a "$GITHUB_OUTPUT"
+            echo "Version is ${VERSION}" >> "$GITHUB_STEP_SUMMARY"
 
             if [ "${{inputs.ref}}" != "" ]; then
-              echo "build_from=${{inputs.ref}}" | tee -a $GITHUB_OUTPUT
+              echo "build_from=${{inputs.ref}}" | tee -a "$GITHUB_OUTPUT"
             elif [[ "${{inputs.version}}" == "" ]]; then
-              echo "build_from=${{github.ref_name}}" | tee -a $GITHUB_OUTPUT
+              echo "build_from=${{github.ref_name}}" | tee -a "$GITHUB_OUTPUT"
             else
-              echo "build_from=${{inputs.version}}" | tee -a $GITHUB_OUTPUT
+              echo "build_from=${{inputs.version}}" | tee -a "$GITHUB_OUTPUT"
             fi
             
   build-backend:

--- a/.github/workflows/clickhouse_migration_cluster_check.yml
+++ b/.github/workflows/clickhouse_migration_cluster_check.yml
@@ -54,21 +54,23 @@ jobs:
           
           if [ -n "$CHANGED_FILES" ]; then
             echo "📄 Found ClickHouse migration files to validate:"
+            # shellcheck disable=SC2086 # intentional word-split on newlines in CHANGED_FILES
             printf '%s\n' $CHANGED_FILES | while read -r file; do
               [ -n "$file" ] && echo "   - $file"
             done
-            
+
             # Save the files to environment variable for next step
-            echo "MIGRATION_FILES<<EOF" >> $GITHUB_ENV
+            echo "MIGRATION_FILES<<EOF" >> "$GITHUB_ENV"
+            # shellcheck disable=SC2086 # intentional word-split on newlines in CHANGED_FILES
             printf '%s\n' $CHANGED_FILES | while read -r file; do
-              [ -n "$file" ] && echo "$file" >> $GITHUB_ENV
+              [ -n "$file" ] && echo "$file" >> "$GITHUB_ENV"
             done
-            echo "EOF" >> $GITHUB_ENV
-            echo "HAS_MIGRATION_FILES=true" >> $GITHUB_ENV
+            echo "EOF" >> "$GITHUB_ENV"
+            echo "HAS_MIGRATION_FILES=true" >> "$GITHUB_ENV"
           else
             echo "📋 No ClickHouse migration files were added or modified."
             echo "✅ No validation needed."
-            echo "HAS_MIGRATION_FILES=false" >> $GITHUB_ENV
+            echo "HAS_MIGRATION_FILES=false" >> "$GITHUB_ENV"
           fi
 
       - name: Validate ClickHouse migrations have ON CLUSTER clause

--- a/.github/workflows/docker-vulnerability-scan.yaml
+++ b/.github/workflows/docker-vulnerability-scan.yaml
@@ -40,8 +40,8 @@ jobs:
           docker pull ${IMAGE_URL}
           BASENAME=$(basename ${IMAGE_URL} | cut -d: -f1)
           REPORT_NAME="trivy_${BASENAME}.txt"
-          echo "image-url=${IMAGE_URL}" >> $GITHUB_OUTPUT
-          echo "report-name=${REPORT_NAME}" >> $GITHUB_OUTPUT
+          echo "image-url=${IMAGE_URL}" >> "$GITHUB_OUTPUT"
+          echo "report-name=${REPORT_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@v0.35.0
@@ -62,7 +62,7 @@ jobs:
         id: set-outputs
         run: |
           REPORT_NAME="${{ steps.pull.outputs.report-name }}"
-          echo "report-file=${REPORT_NAME}" >> $GITHUB_OUTPUT
+          echo "report-file=${REPORT_NAME}" >> "$GITHUB_OUTPUT"
           if [ -f "${REPORT_NAME}" ]; then
             echo "Report generated: ${REPORT_NAME}"
             ls -lh "${REPORT_NAME}"
@@ -82,7 +82,7 @@ jobs:
             echo '```'
             echo ""
             echo "</details>"
-          } >> $GITHUB_STEP_SUMMARY
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload scan results as artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -31,7 +31,7 @@ jobs:
                   echo "$OUTPUT"
                   URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
                   echo "Preview URL: $URL"
-                  echo "URL=$URL" >> $GITHUB_OUTPUT
+                  echo "URL=$URL" >> "$GITHUB_OUTPUT"
                   echo "🌿 Preview your docs: $URL" > preview_url.txt
 
             - name: Check for broken links
@@ -61,18 +61,22 @@ jobs:
                 ' linkinator_results.json)
                 
                 if [ -n "$BROKEN_LINKS" ]; then
-                  echo "**The following broken links were found:**" >> preview_url.txt
-                  echo "" >> preview_url.txt
-                  echo "$BROKEN_LINKS" >> preview_url.txt
+                  {
+                    echo "**The following broken links were found:**"
+                    echo ""
+                    echo "$BROKEN_LINKS"
+                  } >> preview_url.txt
                 else
                   echo "No broken links found" >> preview_url.txt
                 fi
-                
+
                 rm -f linkinator_results.json
 
-                echo "" >> preview_url.txt
-                echo "---" >> preview_url.txt
-                echo "📌 Results for commit ${{ github.sha }}" >> preview_url.txt
+                {
+                  echo ""
+                  echo "---"
+                  echo "📌 Results for commit ${{ github.sha }}"
+                } >> preview_url.txt
 
             - name: Comment URL in PR
               uses: thollander/actions-comment-pull-request@v3

--- a/.github/workflows/e2e_tests_post_merge.yml
+++ b/.github/workflows/e2e_tests_post_merge.yml
@@ -240,11 +240,13 @@ jobs:
             FLAKY="0"
           fi
           
-          echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
-          echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
-          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
-          echo "skipped=$SKIPPED" >> "$GITHUB_OUTPUT"
-          echo "flaky=$FLAKY" >> "$GITHUB_OUTPUT"
+          {
+            echo "total=$TOTAL"
+            echo "passed=$PASSED"
+            echo "failed=$FAILED"
+            echo "skipped=$SKIPPED"
+            echo "flaky=$FLAKY"
+          } >> "$GITHUB_OUTPUT"
           
           echo "::endgroup::"
 
@@ -273,75 +275,78 @@ jobs:
         run: |
           SUITE="${{ github.event.inputs.suite || 'happypaths' }}"
           TESTOPS_URL="${{ steps.set-outputs.outputs.testops_url }}"
-          
+
           TOTAL="${{ steps.parse-results.outputs.total }}"
           PASSED="${{ steps.parse-results.outputs.passed }}"
           FAILED="${{ steps.parse-results.outputs.failed }}"
           SKIPPED="${{ steps.parse-results.outputs.skipped }}"
-          
+
+          # Redirect stdout to the summary file for the remainder of this step
+          exec >> "$GITHUB_STEP_SUMMARY"
+
           # Header
-          echo "# 🧪 E2E Test Results" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          
+          echo "# 🧪 E2E Test Results"
+          echo ""
+
           # Status banner
           if [ "${{ steps.run-tests.outcome }}" == "success" ]; then
-            echo "> ✅ **All tests passed!**" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ✅ **All tests passed!**"
           elif [ "${{ steps.run-tests.outcome }}" == "failure" ]; then
-            echo "> ❌ **$FAILED test(s) failed** - Please review the results below" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ❌ **$FAILED test(s) failed** - Please review the results below"
           else
-            echo "> ⚠️ **Test run status: ${{ steps.run-tests.outcome }}**" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ⚠️ **Test run status: ${{ steps.run-tests.outcome }}**"
           fi
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          
+          echo ""
+
           # Configuration table
-          echo "## 📝 Configuration" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Property | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| **Suite** | \`$SUITE\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| **Branch** | \`${{ github.ref_name }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| **Commit** | [\`${GITHUB_SHA:0:7}\`](https://github.com/${{ github.repository }}/commit/${{ github.sha }}) |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| **Trigger** | ${{ github.event_name == 'push' && 'Post-merge (push to main)' || 'Manual dispatch' }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| **Author** | @${{ steps.get-pr-info.outputs.author }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          
+          echo "## 📝 Configuration"
+          echo ""
+          echo "| Property | Value |"
+          echo "|----------|-------|"
+          echo "| **Suite** | \`$SUITE\` |"
+          echo "| **Branch** | \`${{ github.ref_name }}\` |"
+          echo "| **Commit** | [\`${GITHUB_SHA:0:7}\`](https://github.com/${{ github.repository }}/commit/${{ github.sha }}) |"
+          echo "| **Trigger** | ${{ github.event_name == 'push' && 'Post-merge (push to main)' || 'Manual dispatch' }} |"
+          echo "| **Author** | @${{ steps.get-pr-info.outputs.author }} |"
+          echo ""
+
           # Results table
-          echo "## 📊 Results" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Status | Count |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|--------|------:|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| ✅ Passed | $PASSED |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| ❌ Failed | $FAILED |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| ⏭️ Skipped | $SKIPPED |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| **Total** | **$TOTAL** |" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          
+          echo "## 📊 Results"
+          echo ""
+          echo "| Status | Count |"
+          echo "|--------|------:|"
+          echo "| ✅ Passed | $PASSED |"
+          echo "| ❌ Failed | $FAILED |"
+          echo "| ⏭️ Skipped | $SKIPPED |"
+          echo "| **Total** | **$TOTAL** |"
+          echo ""
+
           # Links section
-          echo "## 🔗 Quick Links" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Resource | Link |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|----------|------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| 📊 **TestOps Dashboard** | [View detailed results, traces & history]($TESTOPS_URL) |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| 📄 **Playwright Report** | [Download from Artifacts below](#artifacts) |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| 📚 **E2E Test Guide** | [Quickstart documentation](https://github.com/${{ github.repository }}/blob/main/tests_end_to_end/QUICKSTART.md) |" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          
+          echo "## 🔗 Quick Links"
+          echo ""
+          echo "| Resource | Link |"
+          echo "|----------|------|"
+          echo "| 📊 **TestOps Dashboard** | [View detailed results, traces & history]($TESTOPS_URL) |"
+          echo "| 📄 **Playwright Report** | [Download from Artifacts below](#artifacts) |"
+          echo "| 📚 **E2E Test Guide** | [Quickstart documentation](https://github.com/${{ github.repository }}/blob/main/tests_end_to_end/QUICKSTART.md) |"
+          echo ""
+
           # Debugging section (only on failure)
           if [ "${{ steps.run-tests.outcome }}" == "failure" ]; then
-            echo "## 🔧 Debugging Guide" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "### Quick steps to investigate failures:" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "1. **Open TestOps** → Click the link above to see detailed failure traces, screenshots, and video recordings" >> "$GITHUB_STEP_SUMMARY"
-            echo "2. **Download Playwright Report** → The HTML report includes step-by-step traces for each test" >> "$GITHUB_STEP_SUMMARY"
-            echo "3. **Check test logs** → Expand the 'Run E2E test suite' step above for console output" >> "$GITHUB_STEP_SUMMARY"
-            echo "4. **Run locally** → See the [Quickstart Guide](https://github.com/${{ github.repository }}/blob/main/tests_end_to_end/QUICKSTART.md) for local debugging" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "### Common failure causes:" >> "$GITHUB_STEP_SUMMARY"
-            echo "- UI element selectors changed" >> "$GITHUB_STEP_SUMMARY"
-            echo "- API response format changed" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Timing/race conditions" >> "$GITHUB_STEP_SUMMARY"
-            echo "- New feature requiring test updates" >> "$GITHUB_STEP_SUMMARY"
+            echo "## 🔧 Debugging Guide"
+            echo ""
+            echo "### Quick steps to investigate failures:"
+            echo ""
+            echo "1. **Open TestOps** → Click the link above to see detailed failure traces, screenshots, and video recordings"
+            echo "2. **Download Playwright Report** → The HTML report includes step-by-step traces for each test"
+            echo "3. **Check test logs** → Expand the 'Run E2E test suite' step above for console output"
+            echo "4. **Run locally** → See the [Quickstart Guide](https://github.com/${{ github.repository }}/blob/main/tests_end_to_end/QUICKSTART.md) for local debugging"
+            echo ""
+            echo "### Common failure causes:"
+            echo "- UI element selectors changed"
+            echo "- API response format changed"
+            echo "- Timing/race conditions"
+            echo "- New feature requiring test updates"
           fi
 
       # ========================================

--- a/.github/workflows/lib-guardrails-tests.yml
+++ b/.github/workflows/lib-guardrails-tests.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install checks from guardrails hub
         run: |
-          guardrails configure --token $GUARDRAILS_API_KEY --disable-metrics --enable-remote-inferencing;
+          guardrails configure --token "$GUARDRAILS_API_KEY" --disable-metrics --enable-remote-inferencing;
           guardrails hub install hub://guardrails/politeness_check
 
       - name: Run tests

--- a/.github/workflows/lib-integration-tests-runner.yml
+++ b/.github/workflows/lib-integration-tests-runner.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Print has secrets into output
         id: init
         run: |
-          echo "has_secrets=${{ secrets.OPENAI_API_KEY != '' }}" >> $GITHUB_OUTPUT
+          echo "has_secrets=${{ secrets.OPENAI_API_KEY != '' }}" >> "$GITHUB_OUTPUT"
 
   missed_api_key_warning:
     name: Missed OpenAI API Key Warning
@@ -95,7 +95,7 @@ jobs:
       - name: Make LIBS variable global (workaround for cron)
         id: init
         run: |
-          echo "LIBS=${{ env.LIBS }}" >> $GITHUB_OUTPUT
+          echo "LIBS=${{ env.LIBS }}" >> "$GITHUB_OUTPUT"
 
   openai_tests:
     needs: [init_environment]
@@ -255,7 +255,7 @@ jobs:
           else
             TYPE="Manual Dispatch"
           fi
-          echo "type=$TYPE" >> $GITHUB_OUTPUT
+          echo "type=$TYPE" >> "$GITHUB_OUTPUT"
 
       - name: Send Slack notification
         env:

--- a/.github/workflows/opik_wizard_publish.yml
+++ b/.github/workflows/opik_wizard_publish.yml
@@ -129,16 +129,17 @@ jobs:
       - name: Workflow summary
         if: always()
         run: |
-          echo "## Workflow Summary" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Version**: ${{ env.VERSION }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Is Release**: ${{ env.IS_RELEASE }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Branch**: ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Triggered by**: @${{ github.actor }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
+          exec >> "$GITHUB_STEP_SUMMARY"
+          echo "## Workflow Summary"
+          echo ""
+          echo "- **Version**: ${{ env.VERSION }}"
+          echo "- **Is Release**: ${{ env.IS_RELEASE }}"
+          echo "- **Branch**: ${{ github.ref_name }}"
+          echo "- **Triggered by**: @${{ github.actor }}"
+          echo ""
           if [ "${{ env.IS_RELEASE }}" == "true" ]; then
-            echo "✅ Package published to NPM: [opik-configure@${{ env.VERSION }}](https://www.npmjs.com/package/opik-configure/v/${{ env.VERSION }})" >> "$GITHUB_STEP_SUMMARY"
-            echo "✅ Git tag created: configure-v${{ env.VERSION }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "✅ Package published to NPM: [opik-configure@${{ env.VERSION }}](https://www.npmjs.com/package/opik-configure/v/${{ env.VERSION }})"
+            echo "✅ Git tag created: configure-v${{ env.VERSION }}"
           else
-            echo "ℹ️ Dry run completed - no changes published" >> "$GITHUB_STEP_SUMMARY"
+            echo "ℹ️ Dry run completed - no changes published"
           fi

--- a/.github/workflows/publish_cursor_extension.yml
+++ b/.github/workflows/publish_cursor_extension.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Get Extension Filename
       id: get_filename
-      run: echo "filename=$(ls *.vsix)" >> $GITHUB_OUTPUT
+      run: echo "filename=$(ls ./*.vsix)" >> "$GITHUB_OUTPUT"
 
     - name: Publish Extension to Open VSX
       env:

--- a/.github/workflows/publish_helm_chart.yaml
+++ b/.github/workflows/publish_helm_chart.yaml
@@ -104,7 +104,7 @@ jobs:
             
             # 2. Restore timestamps for existing files from gh-pages git history
             echo "Restoring file timestamps from git history..."
-            git ls-files -z | while read -d $'\0' file; do
+            git ls-files -z | while read -r -d $'\0' file; do
               if [ -f "$file" ]; then
                 TIME=$(git log -1 --format="%cI" -- "$file")
                 if [ -n "$TIME" ]; then
@@ -148,6 +148,6 @@ jobs:
 
         - name: Summary
           run: |
-            echo "Helm chart is published, version is : $VERSION" >> $GITHUB_STEP_SUMMARY
+            echo "Helm chart is published, version is : $VERSION" >> "$GITHUB_STEP_SUMMARY"
 
 

--- a/.github/workflows/python_sdk_unit_tests.yml
+++ b/.github/workflows/python_sdk_unit_tests.yml
@@ -45,7 +45,7 @@ jobs:
         run: env
 
       - name: Print event object
-        run: cat $GITHUB_EVENT_PATH
+        run: cat "$GITHUB_EVENT_PATH"
 
       - name: Print the PR title
         env:

--- a/.github/workflows/release-wrapper-release-n-deploy.yml
+++ b/.github/workflows/release-wrapper-release-n-deploy.yml
@@ -27,11 +27,11 @@ jobs:
         id: status
         run: |
           if [ "${{ needs.trigger-release.result }}" == "success" ]; then
-            echo "status=completed" >> $GITHUB_OUTPUT
-            echo "conclusion=success" >> $GITHUB_OUTPUT
+            echo "status=completed" >> "$GITHUB_OUTPUT"
+            echo "conclusion=success" >> "$GITHUB_OUTPUT"
           else
-            echo "status=completed" >> $GITHUB_OUTPUT
-            echo "conclusion=failure" >> $GITHUB_OUTPUT
+            echo "status=completed" >> "$GITHUB_OUTPUT"
+            echo "conclusion=failure" >> "$GITHUB_OUTPUT"
           fi
           
       - name: Notify Release-n-Deploy-Agent

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set version
         id: version
         run: |
-          echo "version=$(cat version.txt)" | tee -a $GITHUB_OUTPUT
+          echo "version=$(cat version.txt)" | tee -a "$GITHUB_OUTPUT"
 
   create-git-tag:
     needs:
@@ -176,7 +176,7 @@ jobs:
           IFS='.' read -r -a version_parts <<< "$BASE_VERSION"
           # Ensure all version parts are set
           for i in {0..2}; do
-            version_parts[$i]=${version_parts[$i]:-0}
+            version_parts[i]=${version_parts[i]:-0}
           done
           # Convert to decimal before incrementing to avoid octal interpretation issues
           version_parts[2]=$((10#${version_parts[2]} + 1))
@@ -184,7 +184,7 @@ jobs:
 
           # Update version file with the new version
           echo "$new_version" > version.txt
-          echo "new_version=${new_version}" >> $GITHUB_OUTPUT
+          echo "new_version=${new_version}" >> "$GITHUB_OUTPUT"
 
       - name: Commit all version changes
         run: |
@@ -205,4 +205,4 @@ jobs:
             git push origin main
           fi
           
-          echo "Version updated to ${{ steps.update_version.outputs.new_version }} on main" >> $GITHUB_STEP_SUMMARY
+          echo "Version updated to ${{ steps.update_version.outputs.new_version }} on main" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sdk-e2e-library-tests.yaml
+++ b/.github/workflows/sdk-e2e-library-tests.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Print has secrets into output
         id: init
         run: |
-          echo "has_secrets=${{ secrets.OPENAI_API_KEY != '' }}" >> $GITHUB_OUTPUT
+          echo "has_secrets=${{ secrets.OPENAI_API_KEY != '' }}" >> "$GITHUB_OUTPUT"
 
   missed_api_key_warning:
     name: Missed OpenAI API Key Warning
@@ -84,7 +84,7 @@ jobs:
       - name: Make LIBS variable global (workaround for cron)
         id: init
         run: |
-          echo "LIBS=${{ env.LIBS }}" >> $GITHUB_OUTPUT
+          echo "LIBS=${{ env.LIBS }}" >> "$GITHUB_OUTPUT"
 
       - name: Run latest Opik server
         env:

--- a/.github/workflows/span_cost_upload_daily.yml
+++ b/.github/workflows/span_cost_upload_daily.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Set branch name and update the file
         run: |
-          echo "BRANCH_NAME=github-actions/NA-automatically-update-model-prices-file-$(date +%Y-%m-%d-%H-%M-%S)" >> $GITHUB_ENV
+          echo "BRANCH_NAME=github-actions/NA-automatically-update-model-prices-file-$(date +%Y-%m-%d-%H-%M-%S)" >> "$GITHUB_ENV"
           curl -o apps/opik-backend/src/main/resources/model_prices_and_context_window.json https://raw.githubusercontent.com/BerriAI/litellm/refs/heads/main/model_prices_and_context_window.json
           cp apps/opik-backend/src/main/resources/model_prices_and_context_window.json apps/opik-frontend/src/data/model_prices_and_context_window.json
 
@@ -26,9 +26,9 @@ jobs:
         id: check_changes
         run: |
           if git diff --quiet; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Commit files

--- a/.github/workflows/sync_provider_models.yml
+++ b/.github/workflows/sync_provider_models.yml
@@ -74,10 +74,12 @@ jobs:
       - name: Print summary
         if: always() && steps.sync.outputs.summary != ''
         run: |
-          echo "## Sync Summary" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          echo "${{ steps.sync.outputs.summary }}" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Sync Summary"
+            echo '```'
+            echo "${{ steps.sync.outputs.summary }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Check for changes
         if: steps.sync.outputs.exit_code == '0'

--- a/.github/workflows/trigger_test_env_on_label.yaml
+++ b/.github/workflows/trigger_test_env_on_label.yaml
@@ -48,7 +48,7 @@ jobs:
           echo "Merge base: $MERGE_BASE"
           
           # Get the tag at or before the merge-base
-          BASE_TAG=$(git describe --tags --abbrev=0 $MERGE_BASE 2>/dev/null || echo "")
+          BASE_TAG=$(git describe --tags --abbrev=0 "$MERGE_BASE" 2>/dev/null || echo "")
           
           if [ -z "$BASE_TAG" ]; then
             echo "❌ No tag found at merge-base"
@@ -56,8 +56,8 @@ jobs:
           fi
           
           echo "The tag at merge-base: $BASE_TAG"
-          echo "version=${BASE_TAG}" | tee -a $GITHUB_OUTPUT
-          echo "**Base Version**: \`${BASE_TAG}\`" >> $GITHUB_STEP_SUMMARY
+          echo "version=${BASE_TAG}" | tee -a "$GITHUB_OUTPUT"
+          echo "**Base Version**: \`${BASE_TAG}\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment on PR - Deployment Started
         uses: actions/github-script@v7

--- a/.github/workflows/typescript_sdk_integration_publish.yml
+++ b/.github/workflows/typescript_sdk_integration_publish.yml
@@ -100,20 +100,21 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## ${{ env.INTEGRATION }} Build" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Version:** ${{ steps.build_publish.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Event:** ${{ github.event_name }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Is Release:** ${{ env.IS_RELEASE }}" >> "$GITHUB_STEP_SUMMARY"
+          exec >> "$GITHUB_STEP_SUMMARY"
+          echo "## ${{ env.INTEGRATION }} Build"
+          echo ""
+          echo "**Version:** ${{ steps.build_publish.outputs.version }}"
+          echo "**Event:** ${{ github.event_name }}"
+          echo "**Is Release:** ${{ env.IS_RELEASE }}"
           if [ "${{ env.IS_RELEASE }}" = "true" ]; then
-            echo "**Published:** ✅ Published to NPM" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Package:** 📦 ${{ steps.build_publish.outputs.package_name }}@${{ steps.build_publish.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
-            echo "**NPM:** 🔗 https://www.npmjs.com/package/${{ steps.build_publish.outputs.package_name }}/v/${{ steps.build_publish.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Install with:**" >> "$GITHUB_STEP_SUMMARY"
-            echo "\`\`\`bash" >> "$GITHUB_STEP_SUMMARY"
-            echo "npm install ${{ steps.build_publish.outputs.package_name }}@${{ steps.build_publish.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
-            echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Published:** ✅ Published to NPM"
+            echo "**Package:** 📦 ${{ steps.build_publish.outputs.package_name }}@${{ steps.build_publish.outputs.version }}"
+            echo "**NPM:** 🔗 https://www.npmjs.com/package/${{ steps.build_publish.outputs.package_name }}/v/${{ steps.build_publish.outputs.version }}"
+            echo ""
+            echo "**Install with:**"
+            echo "\`\`\`bash"
+            echo "npm install ${{ steps.build_publish.outputs.package_name }}@${{ steps.build_publish.outputs.version }}"
+            echo "\`\`\`"
           else
-            echo "**Status:** ⏭️ Build and tests only" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Status:** ⏭️ Build and tests only"
           fi

--- a/.github/workflows/typescript_sdk_publish.yml
+++ b/.github/workflows/typescript_sdk_publish.yml
@@ -80,13 +80,14 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## TypeScript SDK Build" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Version:** ${{ steps.build_publish.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Event:** ${{ github.event_name }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Is Release:** ${{ env.IS_RELEASE }}" >> "$GITHUB_STEP_SUMMARY"
+          exec >> "$GITHUB_STEP_SUMMARY"
+          echo "## TypeScript SDK Build"
+          echo ""
+          echo "**Version:** ${{ steps.build_publish.outputs.version }}"
+          echo "**Event:** ${{ github.event_name }}"
+          echo "**Is Release:** ${{ env.IS_RELEASE }}"
           if [ "${{ env.IS_RELEASE }}" = "true" ]; then
-            echo "**Published:** ✅ Published to NPM" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Published:** ✅ Published to NPM"
           else
-            echo " ⏭️ Build only " >> "$GITHUB_STEP_SUMMARY"
+            echo " ⏭️ Build only "
           fi


### PR DESCRIPTION
## Details

<img width="1920" height="3510" alt="image" src="https://github.com/user-attachments/assets/be6ae961-b28e-4028-98da-0a24816c987e" />

Resolves the long-tail of actionlint/shellcheck findings — subtask 4 of 5 under [OPIK-6323](https://comet-ml.atlassian.net/browse/OPIK-6323) — so default-severity actionlint runs clean across the entire `.github/workflows/` tree. With this PR, the AC for the parent ticket ("actionlint runs cleanly … with default shellcheck severity (info)") can be enforced by tightening the actionlint workflow in subtask 5.

**What changed (21 files, +168/-150):**

- **41 SC2086** — quoted bare `$GITHUB_OUTPUT` / `$GITHUB_ENV` / `$GITHUB_STEP_SUMMARY` and similar vars across 15 workflows. 2 deliberate word-splits in `clickhouse_migration_cluster_check.yml` (iterating a newline-separated string with `printf '%s\n' $CHANGED_FILES | while read`) got `# shellcheck disable=SC2086` with an inline rationale.
- **11 SC2129** — collapsed repeated `>> "$FILE"` redirects into single `{ ...; } >> "$FILE"` blocks. For whole-step `$GITHUB_STEP_SUMMARY` writers (e.g. `e2e_tests_post_merge.yml` Phase 5 summary, `typescript_sdk_publish.yml`, `opik_wizard_publish.yml`), used `exec >> "$GITHUB_STEP_SUMMARY"` once at the top of the step instead of wrapping the whole script in a `{ ... }` block — same effect, cleaner diff.
- **1 SC2162** — added `-r` to `read` in `publish_helm_chart.yaml` so backslashes in filenames aren't mangled.
- **1 SC2035** — `ls *.vsix` → `ls ./*.vsix` in `publish_cursor_extension.yml` (so a filename starting with `-` can't be interpreted as a flag).
- **1 SC2004** — `version_parts[$i]` → `version_parts[i]` in `release.yaml` (bash array indices are evaluated as arithmetic; the `$` is redundant).

No changes outside `.github/workflows/`. The deliberate word-split sites are the only ones that received `# shellcheck disable=...` — every other finding was fixed by adjusting the code.

## Change checklist

- [x] All 41 remaining SC2086 findings resolved in the 14 SC2086 long-tail files (plus `e2e_tests_post_merge.yml` SC2129 carry-over).
- [x] SC2129, SC2162, SC2035, SC2004 findings resolved.
- [x] No changes outside the listed workflow files.
- [x] `actionlint -shellcheck=shellcheck .github/workflows/*.yml .github/workflows/*.yaml` exits 0 at default (info+) severity.

## Issues

- Jira: [OPIK-6583](https://comet-ml.atlassian.net/browse/OPIK-6583)
- Parent: [OPIK-6323](https://comet-ml.atlassian.net/browse/OPIK-6323)
- Sibling already merged: OPIK-6582 (#6753) — 6 high-density SC2086 files.

## Testing

- [x] `actionlint -shellcheck=shellcheck .github/workflows/*.yml .github/workflows/*.yaml` → exit 0 locally (actionlint 1.7.12, shellcheck via Homebrew).
- [x] `pre-commit run --files <changed files>` clean.
- [x] CI run on this branch.

Functional behavior of each workflow is unchanged — every fix is a quoting / redirect-block refactor that is semantically equivalent to the original. The two `exec >> "$GITHUB_STEP_SUMMARY"` sites in `e2e_tests_post_merge.yml`, `typescript_sdk_publish.yml`, `typescript_sdk_integration_publish.yml`, and `opik_wizard_publish.yml` are confined to the final summary step of each job, where stdout was unused.

## Documentation

No docs change needed — this is a CI hygiene cleanup with no user-facing behavior change.

[OPIK-6323]: https://comet-ml.atlassian.net/browse/OPIK-6323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPIK-6583]: https://comet-ml.atlassian.net/browse/OPIK-6583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ