### PR TITLE
[NA] [CI] fix(workflow): gate pr-auto-assign success echo behind successful gh pr edit

### DIFF
--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -59,7 +59,11 @@ jobs:
 
           echo "Attempting to assign PR #$PR_NUMBER to $ASSIGN_USER_LOGIN"
           # Note: If the user is already assigned, this command will succeed without error.
-          gh pr edit "$PR_NUMBER" --add-assignee "$ASSIGN_USER_LOGIN" --repo "${{ github.repository }}" || {
+          # External-collaborator PRs may fail (token lacks write on that user) — we log and
+          # continue rather than failing the workflow, so the success echo is gated to the
+          # success branch only.
+          if gh pr edit "$PR_NUMBER" --add-assignee "$ASSIGN_USER_LOGIN" --repo "${{ github.repository }}"; then
+            echo "Successfully assigned PR #$PR_NUMBER to $ASSIGN_USER_LOGIN"
+          else
             echo "❌ Failed to assign PR #$PR_NUMBER to $ASSIGN_USER_LOGIN, likely an external collaborator"
-          }
-          echo "Successfully assigned PR #$PR_NUMBER to $ASSIGN_USER_LOGIN"
+          fi

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -58,12 +58,20 @@ jobs:
           ASSIGN_USER_LOGIN="${{ steps.get_assignee_user.outputs.assigned_user }}"
 
           echo "Attempting to assign PR #$PR_NUMBER to $ASSIGN_USER_LOGIN"
-          # Note: If the user is already assigned, this command will succeed without error.
-          # External-collaborator PRs may fail (token lacks write on that user) — we log and
-          # continue rather than failing the workflow, so the success echo is gated to the
-          # success branch only.
+          # Notes:
+          # - If the user is already assigned, `gh pr edit` succeeds without error.
+          # - External-collaborator PRs may fail outright (token lacks write on that user) — we
+          #   log and continue rather than failing the workflow.
+          # - GitHub can also silently ignore assignees without push access while still exiting 0,
+          #   so we re-read the PR's assignees after the edit and confirm the user actually landed
+          #   before logging success.
           if gh pr edit "$PR_NUMBER" --add-assignee "$ASSIGN_USER_LOGIN" --repo "${{ github.repository }}"; then
-            echo "Successfully assigned PR #$PR_NUMBER to $ASSIGN_USER_LOGIN"
+            CURRENT_ASSIGNEES="$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json assignees --jq '.assignees[].login' 2>/dev/null || true)"
+            if grep -Fxq "$ASSIGN_USER_LOGIN" <<<"$CURRENT_ASSIGNEES"; then
+              echo "Successfully assigned PR #$PR_NUMBER to $ASSIGN_USER_LOGIN"
+            else
+              echo "⚠ gh pr edit returned success but $ASSIGN_USER_LOGIN is not in the assignees list (likely silently ignored by GitHub — no push access)"
+            fi
           else
             echo "❌ Failed to assign PR #$PR_NUMBER to $ASSIGN_USER_LOGIN, likely an external collaborator"
           fi


### PR DESCRIPTION
## Details

<img width="1920" height="2352" alt="image" src="https://github.com/user-attachments/assets/012ecb1b-8697-4000-af24-0fe799ac5459" />

The previous \`pr-auto-assign.yml\` always logged \`Successfully assigned PR #N to USER\` even when the preceding \`gh pr edit --add-assignee\` failed (the \`|| { ... }\` block only echoed an error and fell through). The misleading log made real failures invisible to anyone reviewing workflow runs.

This PR moves the success echo into the true branch of an \`if/then/else\`, so:
- The success message only fires on actual success.
- The failure branch keeps its existing \`❌ Failed...\` log without \`exit 1\` — preserving the tolerant behavior we rely on for external-collaborator PRs (where the token lacks write on that user, and we don't want to fail the workflow run).

No behavior change for the assignment itself; this is a logging fix that makes workflow logs honest.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

NA — mirrors the same fix applied in [comet-ml/ollie-assist#283](https://github.com/comet-ml/ollie-assist/pull/283) after a [baz-reviewer[bot] code-review flag](https://github.com/comet-ml/ollie-assist/pull/283#discussion_r3271395949). Keeping the two repos' \`pr-auto-assign.yml\` in sync.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation (1-file edit + commit/PR)
- Human verification: code review by author; identical edit already merged-pending on a sibling repo PR

## Testing

- No tests run — this is a workflow YAML change with no test infrastructure attached.
- Logical equivalence verified by inspection: the \`if gh pr edit ...; then ECHO_OK; else ECHO_ERR; fi\` form replaces \`gh pr edit ... || { ECHO_ERR; }; ECHO_OK\`, gating the success echo on the command's exit code without changing the failure-tolerance contract.
- Will be exercised on this PR itself once merged — opening, syncing, and re-pushing this branch's PR will run the workflow.

## Documentation

N/A — workflow-only change, no user-facing docs affected.