### PR TITLE
[OPIK-6613] fix(deps): bump docker base + urllib3 to clear CRITICAL+HIGH CVEs in opik-python-backend

### DIFF
--- a/apps/opik-python-backend/Dockerfile
+++ b/apps/opik-python-backend/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build to reduce final image size
-FROM docker:29.2.1 AS builder
+FROM docker:29.5.1 AS builder
 
 # Build dependencies (only needed during pip install)
 RUN apk add --no-cache tini python3 py3-pip build-base python3-dev musl-dev gcc libffi-dev && \
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 ##############################################################
 # Runtime stage - minimal packages only
-FROM docker:29.2.1
+FROM docker:29.5.1
 
 # First upgrading to latest available versions to mitigate CVEs
 RUN apk add --no-cache --upgrade libexpat

--- a/apps/opik-python-backend/requirements.txt
+++ b/apps/opik-python-backend/requirements.txt
@@ -14,7 +14,7 @@ MarkupSafe==3.0.3
 packaging==26.0
 pydantic-settings>=2.0.0,<3.0.0,!=2.9.0
 requests==2.33.1
-urllib3==2.6.3
+urllib3==2.7.0
 Werkzeug==3.1.3
 opentelemetry-api==1.36.0
 opentelemetry-sdk==1.36.0


### PR DESCRIPTION
## Details

Single PR that closes **all CRITICAL + HIGH CVE findings** on `opik-python-backend:2.0.39` from the trivy scan of self-hosted **v4.17.1**.

Two changes — one Dockerfile, one requirements.txt:

1. **`apps/opik-python-backend/Dockerfile`** — bump `FROM docker:29.2.1` → `FROM docker:29.5.1` (both builder + runtime stages).
2. **`apps/opik-python-backend/requirements.txt`** — bump `urllib3` `2.6.3` → `2.7.0`.

## CVEs cleared

### CRITICAL (3 unique / 17 raw — tracked in [OPIK-6613](https://comet-ml.atlassian.net/browse/OPIK-6613))

Closed by the docker base bump (live in the bundled docker/containerd/runc/dockerd binaries):

| CVE | Component | Old → New |
|---|---|---|
| [CVE-2026-33186](https://avd.aquasec.com/nvd/cve-2026-33186) | gRPC-Go authz bypass | v1.76.0/v1.78.0 → 1.79.3 |
| [CVE-2026-31789](https://avd.aquasec.com/nvd/cve-2026-31789) | OpenSSL 32-bit heap overflow | 3.5.5-r0 → 3.5.6-r0 |
| [CVE-2025-68121](https://avd.aquasec.com/nvd/cve-2025-68121) | Go stdlib crypto/tls | v1.25.6 → 1.25.7+ |

### HIGH (29 unique / 127 raw — tracked in [OPIK-6619](https://comet-ml.atlassian.net/browse/OPIK-6619))

- **125 of 127 raw HIGH** closed by the docker base bump — Go-binary CVEs across docker/containerd/runc/ctr/dockerd/docker-proxy/buildx/compose + Alpine OS CVEs (zlib, nghttp2-libs, openssl, musl-utils) since `docker:29.5.1` ships Alpine 3.23.4.
- **Remaining 2 HIGH** closed by `urllib3` 2.6.3 → 2.7.0:

| CVE | Package | Old → New |
|---|---|---|
| [CVE-2026-44431](https://avd.aquasec.com/nvd/cve-2026-44431) | `urllib3` | 2.6.3 → 2.7.0 |
| [CVE-2026-44432](https://avd.aquasec.com/nvd/cve-2026-44432) | `urllib3` | 2.6.3 → 2.7.0 |

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6613
- OPIK-6619

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (CLI)
- Model(s): Claude Opus 4.7 (1M context)
- Scope: Identified CVEs via trivy scan output, picked `docker:29.5.1` (latest stable on Docker Hub at time of PR), bumped `urllib3` to the trivy-listed fix version. Verified that the docker base bump clears all gobinary + alpine OS HIGH findings, leaving only urllib3 to fix in requirements. PR description and commit messages authored with AI assistance.
- Human verification: I (Nimrod) reviewed the CVE list against the trivy JSON output, confirmed `docker:29.5.1` exists on Docker Hub, and verified both diffs before pushing.

## Testing

- [ ] CI passes (existing opik-python-backend tests)
- [ ] Smoke build of `opik-python-backend` image
- [ ] Verify Docker-in-Docker code execution sandbox still functions (`PYTHON_CODE_EXECUTOR_STRATEGY="docker"` path — this is the main reason the image is built `FROM docker:*`)
- [ ] Re-scan with trivy on the rebuilt image and confirm CRITICAL + HIGH CVEs no longer appear

No new test scenarios — base image bump + targeted Python dep bump, no application logic change.

## Documentation

No documentation changes needed — internal base image + dep upgrade, not user-facing.

[OPIK-6613]: https://comet-ml.atlassian.net/browse/OPIK-6613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPIK-6619]: https://comet-ml.atlassian.net/browse/OPIK-6619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ