### PR TITLE
[OPIK-6579] [BE] feat: extend experiment project migration to handle deleted-project and no-inference tail

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -1728,10 +1728,11 @@ public class ExperimentDAO {
             """;
 
     /**
-     * Returns workspaces with at least one eligible orphan experiment, ordered by smallest
-     * count first. An experiment is eligible when its latest row has {@code project_id = ''}
-     * (checked via {@code argMax} in HAVING — see {@link #HAS_VERSION1_EXPERIMENTS}) and all
-     * its linked traces resolve to a single non-empty project.
+     * Returns workspaces with at least one orphan experiment, ordered by smallest count first.
+     * An experiment is orphan when its latest row has {@code project_id = ''} — dedup against the
+     * {@code ReplacingMergeTree} versions via {@code GROUP BY id + argMax(project_id, last_updated_at)}.
+     * Demo names and the env-excluded workspaces are filtered out at the DB so the service only
+     * iterates workspaces it can actually migrate.
      */
     private static final String FIND_ELIGIBLE_EXPERIMENT_WORKSPACES = """
             SELECT
@@ -1742,18 +1743,12 @@ public class ExperimentDAO {
                     e.workspace_id AS workspace_id,
                     e.id AS id
                 FROM experiments e
-                INNER JOIN experiment_items ei
-                    ON e.workspace_id = ei.workspace_id AND e.id = ei.experiment_id
-                INNER JOIN traces t
-                    ON ei.workspace_id = t.workspace_id AND ei.trace_id = t.id
                 WHERE e.name NOT IN :demo_experiment_names
-                AND t.project_id != ''
                 <if(excluded_workspace_ids)>
                 AND e.workspace_id NOT IN :excluded_workspace_ids
                 <endif>
                 GROUP BY e.workspace_id, e.id
-                HAVING count(DISTINCT t.project_id) = 1
-                AND argMax(e.project_id, e.last_updated_at) = ''
+                HAVING argMax(e.project_id, e.last_updated_at) = ''
             )
             GROUP BY workspace_id
             ORDER BY experiments_count ASC
@@ -1762,24 +1757,35 @@ public class ExperimentDAO {
             """;
 
     /**
-     * For one workspace, returns each eligible experiment id and the (single) trace project_id
-     * to migrate it to. Same dedup pattern as {@link #FIND_ELIGIBLE_EXPERIMENT_WORKSPACES}.
+     * For each orphan experiment in a workspace, returns the trace-derived classification:
+     * {@code project_id} is any non-empty trace project_id (meaningful only when
+     * {@code project_count = 1}); {@code project_count} is the distinct count of non-empty trace
+     * project_ids — {@code 0} = no inference, {@code 1} = certain, {@code > 1} = ambiguous.
+     *
+     * <p>The {@code CAST(t.project_id AS String)} converts away from {@code FixedString(36)},
+     * whose LEFT JOIN no-match default (36 NUL bytes, not {@code ''}) would slip past the
+     * {@code != ''} guard and trip the downstream UUID parser.
      */
     private static final String COMPUTE_EXPERIMENT_PROJECT_MAPPING = """
             SELECT
                 e.id AS experiment_id,
-                any(t.project_id) AS project_id
+                anyIf(et.project_id, et.project_id != '') AS project_id,
+                countDistinctIf(et.project_id, et.project_id != '') AS project_count
             FROM experiments e
-            INNER JOIN experiment_items ei
-                ON e.workspace_id = ei.workspace_id AND e.id = ei.experiment_id
-            INNER JOIN traces t
-                ON ei.workspace_id = t.workspace_id AND ei.trace_id = t.id
+            LEFT JOIN (
+                SELECT
+                    ei.workspace_id,
+                    ei.experiment_id,
+                    CAST(t.project_id AS String) AS project_id
+                FROM experiment_items ei
+                INNER JOIN traces t
+                    ON ei.workspace_id = t.workspace_id AND ei.trace_id = t.id
+                WHERE ei.workspace_id = :workspace_id
+            ) et ON e.workspace_id = et.workspace_id AND e.id = et.experiment_id
             WHERE e.workspace_id = :workspace_id
             AND e.name NOT IN :demo_experiment_names
-            AND t.project_id != ''
             GROUP BY e.id
-            HAVING count(DISTINCT t.project_id) = 1
-            AND argMax(e.project_id, e.last_updated_at) = ''
+            HAVING argMax(e.project_id, e.last_updated_at) = ''
             SETTINGS log_comment = '<log_comment>'
             """;
 
@@ -2864,14 +2870,18 @@ public class ExperimentDAO {
     Flux<ExperimentProjectMapping> computeExperimentProjectMapping() {
         return asyncTemplate.stream(connection -> makeFluxContextAware((userName, workspaceId) -> {
             var template = getSTWithLogComment(COMPUTE_EXPERIMENT_PROJECT_MAPPING,
-                    "compute_certain_experiment_project_mapping", workspaceId, userName, "");
+                    "compute_experiment_project_mapping", workspaceId, userName, "");
             var statement = connection.createStatement(template.render())
                     .bind("demo_experiment_names", DemoData.EXPERIMENTS);
             return bindWorkspaceIdToFlux(statement).subscriberContext(userName, workspaceId);
         }))
                 .flatMap(result -> result.map((row, metadata) -> ExperimentProjectMapping.builder()
                         .experimentId(UUID.fromString(row.get("experiment_id", String.class)))
-                        .projectId(UUID.fromString(row.get("project_id", String.class)))
+                        .projectId(Optional.ofNullable(row.get("project_id", String.class))
+                                .filter(StringUtils::isNotBlank)
+                                .map(UUID::fromString)
+                                .orElse(null))
+                        .projectCount(row.get("project_count", Long.class))
                         .build()));
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMapping.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMapping.java
@@ -6,5 +6,5 @@ import lombok.NonNull;
 import java.util.UUID;
 
 @Builder(toBuilder = true)
-public record ExperimentProjectMapping(@NonNull UUID experimentId, @NonNull UUID projectId) {
+public record ExperimentProjectMapping(@NonNull UUID experimentId, UUID projectId, long projectCount) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMigrationService.java
@@ -44,15 +44,19 @@ public class ExperimentProjectMigrationService implements Managed {
     public static final String METRIC_NAMESPACE = "opik.migration.experiment_project";
 
     public static final AttributeKey<String> RESULT_KEY = stringKey("result");
+    public static final AttributeKey<String> REASON_KEY = stringKey("reason");
 
     public static final Attributes RESULT_ERROR = Attributes.of(RESULT_KEY, "error");
 
+    private static final String REASON_ALL_AMBIGUOUS = "all_ambiguous";
+
     private static final Attributes RESULT_MIGRATED = Attributes.of(RESULT_KEY, "migrated");
     private static final Attributes RESULT_NO_CERTAIN = Attributes.of(RESULT_KEY, "no_certain_experiments");
-    private static final Attributes RESULT_ALL_SKIPPED = Attributes.of(RESULT_KEY, "all_skipped_deleted_project");
-    private static final Attributes SKIP_REASON_DELETED_PROJECT = Attributes.of(stringKey("reason"), "deleted_project");
+    private static final Attributes RESULT_ALL_AMBIGUOUS = Attributes.of(RESULT_KEY, "all_ambiguous");
 
-    private static final String TRAPPED_REASON_DELETED_PROJECT = "deleted_project";
+    private static final Attributes REASON_NO_INFERENCE = Attributes.of(REASON_KEY, "no_inference");
+    private static final Attributes REASON_DELETED_PROJECT = Attributes.of(REASON_KEY, "deleted_project");
+    private static final Attributes REASON_AMBIGUOUS = Attributes.of(REASON_KEY, "ambiguous");
 
     private final @NonNull ExperimentDAO experimentDAO;
     private final @NonNull ExperimentItemService experimentItemService;
@@ -69,6 +73,7 @@ public class ExperimentProjectMigrationService implements Managed {
     private final LongGauge cycleEnvExcludedWorkspaces;
     private final LongHistogram workspaceDuration;
     private final LongCounter experimentsSkipped;
+    private final LongCounter experimentsAssignedToDefault;
     private final LongHistogram batchSize;
 
     /**
@@ -109,7 +114,7 @@ public class ExperimentProjectMigrationService implements Managed {
         this.cycleTrappedWorkspaces = meter
                 .gaugeBuilder("%s.cycle.trapped_workspaces".formatted(METRIC_NAMESPACE))
                 .setDescription(
-                        "Number of workspaces locally skipped because all their certain experiments point to deleted projects")
+                        "Number of workspaces locally skipped because all their remaining experiments are ambiguous")
                 .ofLongs()
                 .build();
         this.cycleEnvExcludedWorkspaces = meter
@@ -127,6 +132,10 @@ public class ExperimentProjectMigrationService implements Managed {
         this.experimentsSkipped = meter
                 .counterBuilder("%s.experiments.skipped".formatted(METRIC_NAMESPACE))
                 .setDescription("Total number of experiments skipped during migration, tagged by reason")
+                .build();
+        this.experimentsAssignedToDefault = meter
+                .counterBuilder("%s.experiments.assigned_to_default".formatted(METRIC_NAMESPACE))
+                .setDescription("Total number of experiments assigned to the Default Project")
                 .build();
         this.batchSize = meter
                 .histogramBuilder("%s.batch.size".formatted(METRIC_NAMESPACE))
@@ -234,7 +243,17 @@ public class ExperimentProjectMigrationService implements Managed {
 
     private Mono<Boolean> migrateValidatedMappings(
             String workspaceId, List<ExperimentProjectMapping> mappings, int batchSize, long workspaceStartMillis) {
-        var inferredProjectIds = mappings.stream()
+        var ambiguous = mappings.stream()
+                .filter(mapping -> mapping.projectCount() > 1)
+                .toList();
+        var noInference = mappings.stream()
+                .filter(mapping -> mapping.projectCount() == 0)
+                .toList();
+        var withInferred = mappings.stream()
+                .filter(mapping -> mapping.projectCount() == 1 && mapping.projectId() != null)
+                .toList();
+
+        var inferredProjectIds = withInferred.stream()
                 .map(ExperimentProjectMapping::projectId)
                 .collect(Collectors.toUnmodifiableSet());
         return Mono.fromCallable(() -> projectService.findByIds(workspaceId, inferredProjectIds))
@@ -243,26 +262,22 @@ public class ExperimentProjectMigrationService implements Managed {
                     var validProjectIds = existingProjects.stream()
                             .map(Project::id)
                             .collect(Collectors.toUnmodifiableSet());
-                    var validated = mappings.stream()
+                    var certain = withInferred.stream()
                             .filter(mapping -> validProjectIds.contains(mapping.projectId()))
                             .toList();
-                    var skippedDeleted = mappings.size() - validated.size();
-                    if (skippedDeleted > 0) {
-                        log.info("Skipping experiments with deleted project, workspaceId='{}', count='{}'",
-                                workspaceId, skippedDeleted);
-                        experimentsSkipped.add(skippedDeleted, SKIP_REASON_DELETED_PROJECT);
-                    }
+                    var certainDeleted = withInferred.stream()
+                            .filter(mapping -> !validProjectIds.contains(mapping.projectId()))
+                            .toList();
+
+                    logAndEmitMetrics(workspaceId, ambiguous, certainDeleted, noInference);
+
+                    var defaultAssigned = getDefaultAssigned(workspaceId, certainDeleted, noInference);
+                    var validated = Stream.concat(certain.stream(), defaultAssigned).toList();
                     if (CollectionUtils.isEmpty(validated)) {
                         log.info(
-                                "All certain experiments point to deleted projects, marking workspace as trapped, workspaceId='{}'",
+                                "All remaining experiments are ambiguous, marking workspace as trapped, workspaceId='{}'",
                                 workspaceId);
-                        return Mono
-                                .fromRunnable(() -> workspacesService.markMigrationSkipped(
-                                        workspaceId, TRAPPED_REASON_DELETED_PROJECT))
-                                .subscribeOn(migrationScheduler)
-                                .doFinally(signalType -> recordWorkspaceDuration(
-                                        RESULT_ALL_SKIPPED, workspaceStartMillis))
-                                .then(Mono.empty());
+                        return markMigrationSkipped(workspaceId, workspaceStartMillis, Mono.empty());
                     }
                     var byProject = validated.stream()
                             .collect(Collectors.groupingBy(ExperimentProjectMapping::projectId));
@@ -277,19 +292,76 @@ public class ExperimentProjectMigrationService implements Managed {
                                     workspaceId, byProject.size()))
                             .then(triggerReaggregation(workspaceId, validated))
                             .then(evictWorkspaceVersionCache(workspaceId))
-                            .doOnSuccess(__ -> {
+                            .then(Mono.defer(() -> {
+                                if (!ambiguous.isEmpty()) {
+                                    log.info(
+                                            "Migration completed with remaining ambiguous experiments, marking workspace as trapped, workspaceId='{}', migrated='{}', ambiguous='{}'",
+                                            workspaceId, validated.size(), ambiguous.size());
+                                    return markMigrationSkipped(workspaceId, workspaceStartMillis, Mono.just(false));
+                                }
                                 var duration = Duration
                                         .ofMillis(System.currentTimeMillis() - workspaceStartMillis);
                                 log.info(
-                                        "Workspace migration completed, workspaceId='{}', migrated='{}', skippedDeletedProject='{}', duration='{}'",
-                                        workspaceId, validated.size(), skippedDeleted, duration);
+                                        "Workspace migration completed, workspaceId='{}', migrated='{}', certainDeleted='{}', noInference='{}', duration='{}'",
+                                        workspaceId, validated.size(), certainDeleted.size(), noInference.size(),
+                                        duration);
                                 recordWorkspaceDuration(RESULT_MIGRATED, workspaceStartMillis);
-                            });
+                                return Mono.just(true);
+                            }));
                 });
     }
 
     private void recordWorkspaceDuration(Attributes resultAttributes, long startMillis) {
         workspaceDuration.record(System.currentTimeMillis() - startMillis, resultAttributes);
+    }
+
+    private void logAndEmitMetrics(
+            String workspaceId,
+            List<ExperimentProjectMapping> ambiguous,
+            List<ExperimentProjectMapping> certainDeleted,
+            List<ExperimentProjectMapping> noInference) {
+        if (!ambiguous.isEmpty()) {
+            log.info("Skipping ambiguous experiments, workspaceId='{}', count='{}'",
+                    workspaceId, ambiguous.size());
+            experimentsSkipped.add(ambiguous.size(), REASON_AMBIGUOUS);
+        }
+        if (!certainDeleted.isEmpty()) {
+            log.info("Assigning certain but deleted experiments to Default Project, workspaceId='{}', count='{}'",
+                    workspaceId, certainDeleted.size());
+            experimentsAssignedToDefault.add(certainDeleted.size(), REASON_DELETED_PROJECT);
+        }
+        if (!noInference.isEmpty()) {
+            log.info("Assigning no-inference experiments to Default Project, workspaceId='{}', count='{}'",
+                    workspaceId, noInference.size());
+            experimentsAssignedToDefault.add(noInference.size(), REASON_NO_INFERENCE);
+        }
+    }
+
+    /**
+     * Re-targets the certain-deleted and no-inference mappings to the workspace's Default
+     * Project. {@link ProjectService#getOrCreate} is the same path trace ingestion takes, so a
+     * missing Default Project is provisioned in-line rather than trapping the workspace. The
+     * lookup is skipped entirely when neither bucket has rows.
+     */
+    private Stream<ExperimentProjectMapping> getDefaultAssigned(
+            String workspaceId, List<ExperimentProjectMapping> certainDeleted,
+            List<ExperimentProjectMapping> noInference) {
+        var defaultProjectId = certainDeleted.size() + noInference.size() > 0
+                ? projectService.getOrCreate(workspaceId, ProjectService.DEFAULT_PROJECT, SYSTEM_USER).id()
+                : null;
+        return defaultProjectId == null
+                ? Stream.empty()
+                : Stream.concat(certainDeleted.stream(), noInference.stream())
+                        .map(mapping -> mapping.toBuilder()
+                                .projectId(defaultProjectId)
+                                .build());
+    }
+
+    private Mono<Boolean> markMigrationSkipped(String workspaceId, long workspaceStartMillis, Mono<Boolean> result) {
+        return Mono.fromRunnable(() -> workspacesService.markMigrationSkipped(workspaceId, REASON_ALL_AMBIGUOUS))
+                .subscribeOn(migrationScheduler)
+                .doFinally(signalType -> recordWorkspaceDuration(RESULT_ALL_AMBIGUOUS, workspaceStartMillis))
+                .then(result);
     }
 
     private Mono<Long> batchUpdateProjectId(

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentProjectMigrationJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentProjectMigrationJobTest.java
@@ -20,7 +20,6 @@ import com.comet.opik.api.resources.utils.resources.ExperimentResourceClient;
 import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
 import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
 import com.comet.opik.api.resources.utils.resources.WorkspaceResourceClient;
-import com.comet.opik.domain.workspaces.WorkspacesService;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.auth.RequestContext;
@@ -42,7 +41,6 @@ import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import uk.co.jemos.podam.api.PodamFactory;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -57,9 +55,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DropwizardAppExtensionProvider.class)
 class ExperimentProjectMigrationJobTest {
-
-    private static final String EXCLUDED_WORKSPACE_ID_1 = UUID.randomUUID().toString();
-    private static final String EXCLUDED_WORKSPACE_ID_2 = UUID.randomUUID().toString();
 
     private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
     private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
@@ -91,10 +86,6 @@ class ExperimentProjectMigrationJobTest {
                         .redisUrl(REDIS.getRedisURI())
                         .customConfigs(List.of(
                                 new CustomConfig("experimentProjectMigration.enabled", "true"),
-                                // Buffer so the first cycle fires after the initial seed+prime.
-                                new CustomConfig("experimentProjectMigration.startupDelay", "3s"),
-                                new CustomConfig("migration.excludedWorkspaceIds",
-                                        "%s,%s".formatted(EXCLUDED_WORKSPACE_ID_1, EXCLUDED_WORKSPACE_ID_2)),
                                 // Cache enabled with the production TTL so only the migration's
                                 // evictCache can flip a cached V1 to V2 within the test windows.
                                 new CustomConfig("cacheManager.enabled", "true"),
@@ -122,221 +113,27 @@ class ExperimentProjectMigrationJobTest {
     }
 
     @Test
-    void migrateEligibleExperimentsAcrossWorkspaces() {
-        // Workspace A: one eligible experiment (smallest first per FIND_ELIGIBLE ordering).
-        var apiKeyA = randomName("api-key");
-        var workspaceNameA = randomName("workspace");
-        var workspaceIdA = UUID.randomUUID().toString();
-        mockTargetWorkspace(wireMock.server(), apiKeyA, workspaceNameA, workspaceIdA, randomName("user"));
-        var projectNameA = randomName("project");
-        var seededA = seedCertainExperiment(apiKeyA, workspaceNameA, projectNameA);
-        var experimentIdA = seededA.getLeft();
-        var projectIdA = seededA.getRight();
-        var beforeA = experimentResourceClient.getExperiment(experimentIdA, apiKeyA, workspaceNameA);
+    void scheduledJobMigratesEligibleWorkspaceToV2() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
 
-        // Workspace B: two eligible experiments in the same project (multi-experiment per workspace).
-        var apiKeyB = randomName("api-key");
-        var workspaceNameB = randomName("workspace");
-        var workspaceIdB = UUID.randomUUID().toString();
-        mockTargetWorkspace(wireMock.server(), apiKeyB, workspaceNameB, workspaceIdB, randomName("user"));
-        var projectNameB = randomName("project");
-        var projectIdB = createProject(apiKeyB, workspaceNameB, projectNameB);
-        var datasetNameB = randomName("dataset");
-        createDatasetWithProject(apiKeyB, workspaceNameB, datasetNameB, projectIdB);
-        var experimentIdsB = new ArrayList<UUID>();
-        for (int i = 0; i < 2; i++) {
-            var traceId = createTrace(apiKeyB, workspaceNameB, projectNameB);
-            var experimentId = createOrphanExperiment(apiKeyB, workspaceNameB, datasetNameB);
-            linkExperimentToTraces(apiKeyB, workspaceNameB, experimentId, traceId);
-            experimentIdsB.add(experimentId);
-        }
-        var beforesB = new ArrayList<Experiment>();
-        for (var id : experimentIdsB) {
-            beforesB.add(experimentResourceClient.getExperiment(id, apiKeyB, workspaceNameB));
-        }
+        var projectName = randomName("project");
+        var seededA = seedCertainExperiment(apiKey, workspaceName, projectName);
+        var experimentId = seededA.getLeft();
+        var projectId = seededA.getRight();
+        var before = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
 
         // Prime the workspace_version cache to V1 before the first migration cycle fires.
         // This forces the post-migration V2 read to depend on evictWorkspaceVersionCache
         // actually clearing the cached V1, exercising the evictCache path end-to-end.
-        assertWorkspaceVersion(apiKeyA, workspaceNameA, OpikVersion.VERSION_1);
-        assertWorkspaceVersion(apiKeyB, workspaceNameB, OpikVersion.VERSION_1);
+        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_1);
 
-        // A single cycle picks up both workspaces (workspacesPerRun=20 default) and
-        // FIND_ELIGIBLE_EXPERIMENT_WORKSPACES orders smallest-first; both should reach V2.
-        assertWorkspaceVersion2(apiKeyA, workspaceNameA);
-        assertWorkspaceVersion2(apiKeyB, workspaceNameB);
-
-        assertExperimentMigrated(apiKeyA, workspaceNameA, experimentIdA, beforeA, projectIdA, projectNameA);
-        for (int i = 0; i < experimentIdsB.size(); i++) {
-            assertExperimentMigrated(apiKeyB, workspaceNameB, experimentIdsB.get(i),
-                    beforesB.get(i), projectIdB, projectNameB);
-        }
-    }
-
-    /**
-     * Single workspace covering all non-eligible filter points in one cycle:
-     * <ul>
-     *   <li>"ambiguous" experiment is filtered at {@code COMPUTE_MAPPING}
-     *       ({@code HAVING count(DISTINCT t.project_id) = 1}).</li>
-     *   <li>"deleted-project" experiment reaches {@code COMPUTE_MAPPING} but is filtered at
-     *       {@code projectService.findByIds} ({@code skippedDeleted > 0} branch in
-     *       {@code migrateValidatedMappings}).</li>
-     *   <li>"demo" experiment is eligible-shaped (one trace in a single live project) but
-     *       filtered by {@code WHERE e.name NOT IN :demo_experiment_names} in both
-     *       {@code FIND_ELIGIBLE} and {@code COMPUTE_MAPPING}. Demo data is invisible to the
-     *       workspace V1 entity check, so this gap can only be detected at the experiment level.</li>
-     * </ul>
-     * Workspace stays V1 because the ambiguous and deleted-project orphans keep it V1; the
-     * eligible one migrates to its inferred project; the demo experiment's empty project_id is
-     * preserved.
-     */
-    @Test
-    void mixedWorkspaceMigratesEligibleAndKeepsNonEligibleAsV1() {
-        var apiKey = randomName("api-key");
-        var workspaceName = randomName("workspace");
-        var workspaceId = UUID.randomUUID().toString();
-        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
-
-        // Eligible: one trace in a single alive project => migrates.
-        var eligibleProjectName = randomName("project");
-        var eligibleProjectId = createProject(apiKey, workspaceName, eligibleProjectName);
-        var datasetName = randomName("dataset");
-        createDatasetWithProject(apiKey, workspaceName, datasetName, eligibleProjectId);
-        var eligibleTraceId = createTrace(apiKey, workspaceName, eligibleProjectName);
-        var eligibleExperimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
-        linkExperimentToTraces(apiKey, workspaceName, eligibleExperimentId, eligibleTraceId);
-
-        // Ambiguous: two traces in two different projects => filtered at COMPUTE_MAPPING.
-        var ambiguousProjectName1 = randomName("project");
-        var ambiguousProjectName2 = randomName("project");
-        createProject(apiKey, workspaceName, ambiguousProjectName1);
-        createProject(apiKey, workspaceName, ambiguousProjectName2);
-        var ambiguousTrace1Id = createTrace(apiKey, workspaceName, ambiguousProjectName1);
-        var ambiguousTrace2Id = createTrace(apiKey, workspaceName, ambiguousProjectName2);
-        var ambiguousExperimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
-        linkExperimentToTraces(apiKey, workspaceName, ambiguousExperimentId,
-                ambiguousTrace1Id, ambiguousTrace2Id);
-
-        // Deleted-project: one trace in a single project that gets deleted in MySQL after seeding.
-        // Reaches COMPUTE_MAPPING (single project), gets filtered at projectService.findByIds.
-        var deletedProjectName = randomName("project");
-        var deletedProjectId = createProject(apiKey, workspaceName, deletedProjectName);
-        var deletedTraceId = createTrace(apiKey, workspaceName, deletedProjectName);
-        var deletedExperimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
-        linkExperimentToTraces(apiKey, workspaceName, deletedExperimentId, deletedTraceId);
-        projectResourceClient.deleteProject(deletedProjectId, apiKey, workspaceName);
-
-        // Demo: eligible-shaped (single trace in the live eligible project) but filtered by
-        // demo-name exclusion in both FIND_ELIGIBLE and COMPUTE_MAPPING.
-        var demoTraceId = createTrace(apiKey, workspaceName, eligibleProjectName);
-        var demoExperimentId = experimentResourceClient.create(
-                experimentResourceClient.createPartialExperiment()
-                        .id(null)
-                        .name(DemoData.EXPERIMENTS.getFirst())
-                        .datasetName(datasetName)
-                        .build(),
-                apiKey, workspaceName);
-        linkExperimentToTraces(apiKey, workspaceName, demoExperimentId, demoTraceId);
-
-        var eligibleBefore = experimentResourceClient.getExperiment(eligibleExperimentId, apiKey, workspaceName);
-        var ambiguousBefore = experimentResourceClient.getExperiment(ambiguousExperimentId, apiKey, workspaceName);
-        var deletedBefore = experimentResourceClient.getExperiment(deletedExperimentId, apiKey, workspaceName);
-        var demoBefore = experimentResourceClient.getExperiment(demoExperimentId, apiKey, workspaceName);
-
-        assertWorkspaceVersion1(apiKey, workspaceName);
-
-        assertExperimentMigrated(apiKey, workspaceName, eligibleExperimentId, eligibleBefore,
-                eligibleProjectId, eligibleProjectName);
-        assertExperimentUnchanged(apiKey, workspaceName, ambiguousExperimentId, ambiguousBefore);
-        assertExperimentUnchanged(apiKey, workspaceName, deletedExperimentId, deletedBefore);
-        assertExperimentUnchanged(apiKey, workspaceName, demoExperimentId, demoBefore);
-    }
-
-    @Test
-    void skipExperimentWhenInferredProjectWasDeleted(WorkspacesService workspacesService) {
-        var apiKey = randomName("api-key");
-        var workspaceName = randomName("workspace");
-        var workspaceId = UUID.randomUUID().toString();
-        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
-
-        var projectName = randomName("project");
-        var projectId = createProject(apiKey, workspaceName, projectName);
-        var datasetName = randomName("dataset");
-        createDatasetWithProject(apiKey, workspaceName, datasetName, projectId);
-        var traceId = createTrace(apiKey, workspaceName, projectName);
-        var experimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
-        linkExperimentToTraces(apiKey, workspaceName, experimentId, traceId);
-
-        projectResourceClient.deleteProject(projectId, apiKey, workspaceName);
-
-        var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
-
-        assertWorkspaceVersion1(apiKey, workspaceName);
-
-        assertExperimentUnchanged(apiKey, workspaceName, experimentId, beforeMigration);
-
-        // Trapped workspaces persist via the workspaces.migration_skipped_at column; the next
-        // cycle reads that list to assemble its exclusion set, so the workspace must appear here.
-        Awaitility.await().atMost(15, TimeUnit.SECONDS).untilAsserted(
-                () -> assertThat(workspacesService.findMigrationSkippedWorkspaceIds()).contains(workspaceId));
-    }
-
-    @Test
-    void skipExperimentWithNoTraceLinks() {
-        var apiKey = randomName("api-key");
-        var workspaceName = randomName("workspace");
-        var workspaceId = UUID.randomUUID().toString();
-        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
-
-        var projectName = randomName("project");
-        var projectId = createProject(apiKey, workspaceName, projectName);
-        var datasetName = randomName("dataset");
-        createDatasetWithProject(apiKey, workspaceName, datasetName, projectId);
-        var experimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
-
-        var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
-
-        assertWorkspaceVersion1(apiKey, workspaceName);
-
-        assertExperimentUnchanged(apiKey, workspaceName, experimentId, beforeMigration);
-    }
-
-    @Test
-    void skipPreMarkedTrappedWorkspaces(WorkspacesService workspacesService) {
-        // Pre-mark a workspace as skipped via the workspaces table BEFORE seeding any experiments.
-        // The cycle's exclusion set is the union of migration.excludedWorkspaceIds config and
-        // findMigrationSkippedWorkspaceIds(), so this workspace must be omitted — proven by the
-        // eligible experiment never getting migrated.
-        var apiKey = randomName("api-key");
-        var workspaceName = randomName("workspace");
-        var workspaceId = UUID.randomUUID().toString();
-        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
-
-        var seeded = seedCertainExperiment(apiKey, workspaceName, randomName("project"));
-        var experimentId = seeded.getLeft();
-        var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
-
-        workspacesService.markMigrationSkipped(workspaceId, "test-pre-marked-trap");
-
-        assertWorkspaceVersion1(apiKey, workspaceName);
-
-        assertExperimentUnchanged(apiKey, workspaceName, experimentId, beforeMigration);
-    }
-
-    @Test
-    void skipExcludedWorkspaces() {
-        var apiKey = randomName("api-key");
-        var workspaceName = randomName("workspace");
-        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, EXCLUDED_WORKSPACE_ID_1, randomName("user"));
-
-        var projectName = randomName("project");
-        var seeded = seedCertainExperiment(apiKey, workspaceName, projectName);
-        var experimentId = seeded.getLeft();
-        var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
-
-        assertWorkspaceVersion1(apiKey, workspaceName);
-
-        assertExperimentUnchanged(apiKey, workspaceName, experimentId, beforeMigration);
+        // The scheduler fires the job, the job invokes the cycle, the cycle promotes the
+        // workspace. We don't assert which bucket — just that the wiring eventually works.
+        assertWorkspaceVersion2(apiKey, workspaceName);
+        assertExperimentMigrated(apiKey, workspaceName, experimentId, before, projectId, projectName);
     }
 
     private Pair<UUID, UUID> seedCertainExperiment(String apiKey, String workspaceName, String projectName) {
@@ -413,14 +210,13 @@ class ExperimentProjectMigrationJobTest {
                         () -> assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_2));
     }
 
-    private void assertWorkspaceVersion1(String apiKey, String workspaceName) {
-        Awaitility.await().atMost(15, TimeUnit.SECONDS).during(12, TimeUnit.SECONDS).untilAsserted(
-                () -> assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_1));
-    }
-
     private void assertExperimentMigrated(
-            String apiKey, String workspaceName, UUID experimentId,
-            Experiment beforeMigration, UUID expectedProjectId, String expectedProjectName) {
+            String apiKey,
+            String workspaceName,
+            UUID experimentId,
+            Experiment beforeMigration,
+            UUID expectedProjectId,
+            String expectedProjectName) {
         var actual = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
         var expected = beforeMigration.toBuilder()
                 .projectId(expectedProjectId)
@@ -429,12 +225,5 @@ class ExperimentProjectMigrationJobTest {
                 .build();
         assertExperimentEqual(actual, expected);
         assertThat(actual.lastUpdatedAt()).isAfter(beforeMigration.lastUpdatedAt());
-    }
-
-    private void assertExperimentUnchanged(
-            String apiKey, String workspaceName, UUID experimentId, Experiment beforeMigration) {
-        var actual = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
-        assertExperimentEqual(actual, beforeMigration);
-        assertThat(actual.lastUpdatedAt()).isEqualTo(beforeMigration.lastUpdatedAt());
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentProjectMigrationServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentProjectMigrationServiceTest.java
@@ -1,0 +1,528 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.Dataset;
+import com.comet.opik.api.Experiment;
+import com.comet.opik.api.ExperimentItem;
+import com.comet.opik.api.OpikVersion;
+import com.comet.opik.api.Project;
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.DatasetResourceClient;
+import com.comet.opik.api.resources.utils.resources.ExperimentResourceClient;
+import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
+import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
+import com.comet.opik.api.resources.utils.resources.WorkspaceResourceClient;
+import com.comet.opik.domain.workspaces.WorkspacesService;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.redis.testcontainers.RedisContainer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.comet.opik.api.resources.utils.AuthTestUtils.mockTargetWorkspace;
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.api.resources.utils.resources.ExperimentTestAssertions.assertExperimentEqual;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class ExperimentProjectMigrationServiceTest {
+
+    private static final String EXCLUDED_WORKSPACE_ID_1 = UUID.randomUUID().toString();
+    private static final String EXCLUDED_WORKSPACE_ID_2 = UUID.randomUUID().toString();
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE_CONTAINER = ClickHouseContainerUtils
+            .newClickHouseContainer(ZOOKEEPER_CONTAINER);
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(REDIS, CLICKHOUSE_CONTAINER, MYSQL, ZOOKEEPER_CONTAINER).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils
+                .newDatabaseAnalyticsFactory(CLICKHOUSE_CONTAINER, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE_CONTAINER);
+
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .runtimeInfo(wireMock.runtimeInfo())
+                        .redisUrl(REDIS.getRedisURI())
+                        .customConfigs(List.of(
+                                new CustomConfig("migration.excludedWorkspaceIds",
+                                        "%s,%s".formatted(EXCLUDED_WORKSPACE_ID_1, EXCLUDED_WORKSPACE_ID_2)),
+                                // Cache enabled with the production TTL so only the migration's
+                                // evictCache can flip a cached V1 to V2 between assertions.
+                                new CustomConfig("cacheManager.enabled", "true"),
+                                new CustomConfig("cacheManager.caches.workspace_version", "PT5M")))
+                        .build());
+    }
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    private ProjectResourceClient projectResourceClient;
+    private DatasetResourceClient datasetResourceClient;
+    private ExperimentResourceClient experimentResourceClient;
+    private TraceResourceClient traceResourceClient;
+    private WorkspaceResourceClient workspaceResourceClient;
+    private ExperimentProjectMigrationService migrationService;
+
+    @BeforeAll
+    void setUpAll(ClientSupport clientSupport, ExperimentProjectMigrationService migrationService) {
+        var baseUrl = TestUtils.getBaseUrl(clientSupport);
+
+        projectResourceClient = new ProjectResourceClient(clientSupport, baseUrl, factory);
+        datasetResourceClient = new DatasetResourceClient(clientSupport, baseUrl);
+        experimentResourceClient = new ExperimentResourceClient(clientSupport, baseUrl, factory);
+        traceResourceClient = new TraceResourceClient(clientSupport, baseUrl);
+        workspaceResourceClient = new WorkspaceResourceClient(clientSupport, baseUrl, factory);
+        this.migrationService = migrationService;
+    }
+
+    @Test
+    void migrateEligibleExperimentsAcrossWorkspaces() {
+        // Workspace A: one eligible experiment (smallest first per FIND_ELIGIBLE ordering).
+        var apiKeyA = randomName("api-key");
+        var workspaceNameA = randomName("workspace");
+        var workspaceIdA = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKeyA, workspaceNameA, workspaceIdA, randomName("user"));
+        var projectNameA = randomName("project");
+        var seededA = seedCertainExperiment(apiKeyA, workspaceNameA, projectNameA);
+        var experimentIdA = seededA.getLeft();
+        var projectIdA = seededA.getRight();
+        var beforeA = experimentResourceClient.getExperiment(experimentIdA, apiKeyA, workspaceNameA);
+
+        // Workspace B: two eligible experiments in the same project (multi-experiment per workspace).
+        var apiKeyB = randomName("api-key");
+        var workspaceNameB = randomName("workspace");
+        var workspaceIdB = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKeyB, workspaceNameB, workspaceIdB, randomName("user"));
+        var projectNameB = randomName("project");
+        var projectIdB = createProject(apiKeyB, workspaceNameB, projectNameB);
+        var datasetNameB = randomName("dataset");
+        createDatasetWithProject(apiKeyB, workspaceNameB, datasetNameB, projectIdB);
+        var experimentIdsB = new ArrayList<UUID>();
+        for (int i = 0; i < 2; i++) {
+            var traceId = createTrace(apiKeyB, workspaceNameB, projectNameB);
+            var experimentId = createOrphanExperiment(apiKeyB, workspaceNameB, datasetNameB);
+            linkExperimentToTraces(apiKeyB, workspaceNameB, experimentId, traceId);
+            experimentIdsB.add(experimentId);
+        }
+        var beforesB = new ArrayList<Experiment>();
+        for (var id : experimentIdsB) {
+            beforesB.add(experimentResourceClient.getExperiment(id, apiKeyB, workspaceNameB));
+        }
+
+        // Prime the workspace_version cache to V1 before triggering the cycle. The post-cycle V2
+        // read must then depend on evictWorkspaceVersionCache actually clearing the cached V1,
+        // exercising the evictCache path end-to-end.
+        assertWorkspaceVersion(apiKeyA, workspaceNameA, OpikVersion.VERSION_1);
+        assertWorkspaceVersion(apiKeyB, workspaceNameB, OpikVersion.VERSION_1);
+
+        // A single cycle picks up both workspaces (workspacesPerRun=20 default) and
+        // FIND_ELIGIBLE_EXPERIMENT_WORKSPACES orders smallest-first; both should reach V2.
+        migrationService.runMigrationCycle().block();
+
+        assertWorkspaceVersion(apiKeyA, workspaceNameA, OpikVersion.VERSION_2);
+        assertWorkspaceVersion(apiKeyB, workspaceNameB, OpikVersion.VERSION_2);
+
+        assertExperimentMigrated(apiKeyA, workspaceNameA, experimentIdA, beforeA, projectIdA, projectNameA);
+        for (int i = 0; i < experimentIdsB.size(); i++) {
+            assertExperimentMigrated(apiKeyB, workspaceNameB, experimentIdsB.get(i),
+                    beforesB.get(i), projectIdB, projectNameB);
+        }
+    }
+
+    /**
+     * Idempotency on re-run: once a workspace is migrated, a second cycle must not touch its
+     * experiments again. The first cycle promotes the workspace to V2 and stamps the experiment
+     * with the system user; the second cycle's eligibility query (orphan check) finds no
+     * candidates, and even if {@code BATCH_SET_PROJECT_ID} were reached it has a
+     * {@code WHERE project_id = ''} guard that prevents double writes. Asserted via
+     * {@code lastUpdatedAt} stability between cycles.
+     */
+    @Test
+    void secondCycleIsNoopAfterSuccessfulMigration() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+        var projectName = randomName("project");
+        var seeded = seedCertainExperiment(apiKey, workspaceName, projectName);
+        var experimentId = seeded.getLeft();
+        var projectId = seeded.getRight();
+        var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_2);
+        assertExperimentMigrated(apiKey, workspaceName, experimentId, beforeMigration, projectId, projectName);
+        var afterFirstCycle = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+
+        // Second cycle: the workspace is no longer eligible (no orphans) and the experiment row
+        // must not be re-written.
+        migrationService.runMigrationCycle().block();
+
+        var afterSecondCycle = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+        assertThat(afterSecondCycle.lastUpdatedAt()).isEqualTo(afterFirstCycle.lastUpdatedAt());
+        assertExperimentEqual(afterSecondCycle, afterFirstCycle);
+        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_2);
+    }
+
+    /**
+     * Single workspace covering all four classifier buckets in one cycle:
+     * <ul>
+     *   <li><b>certain</b> — one trace in a single alive project => migrates to inferred project.</li>
+     *   <li><b>certain-deleted</b> — one trace in a project later deleted in MySQL => migrates to
+     *       Default Project.</li>
+     *   <li><b>no-inference</b> — orphan experiment with no experiment_items => migrates to Default
+     *       Project.</li>
+     *   <li><b>ambiguous</b> — two traces in two different projects => skipped.</li>
+     * </ul>
+     * Also covers the demo-name filter: an experiment named like a demo is eligible-shaped but
+     * filtered by {@code WHERE e.name NOT IN :demo_experiment_names} in {@code FIND_ELIGIBLE} and
+     * {@code COMPUTE_MAPPING}; demo data is invisible to the V1 entity check, so the gap can only
+     * be detected at the experiment level.
+     *
+     * <p>Outcome: workspace stays V1 because of the remaining ambiguous orphan, gets trapped with
+     * {@code all_ambiguous}, and the demo experiment's empty project_id is preserved.
+     */
+    @Test
+    void mixedWorkspaceMigratesAcrossBucketsAndTrapsOnAmbiguous(WorkspacesService workspacesService) {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        // Certain: one trace in a single alive project => migrates to inferred project.
+        var certainProjectName = randomName("project");
+        var certainProjectId = createProject(apiKey, workspaceName, certainProjectName);
+        var datasetName = randomName("dataset");
+        createDatasetWithProject(apiKey, workspaceName, datasetName, certainProjectId);
+        var certainTraceId = createTrace(apiKey, workspaceName, certainProjectName);
+        var certainExperimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+        linkExperimentToTraces(apiKey, workspaceName, certainExperimentId, certainTraceId);
+
+        // Ambiguous: two traces in two different projects => skipped.
+        var ambiguousProjectName1 = randomName("project");
+        var ambiguousProjectName2 = randomName("project");
+        createProject(apiKey, workspaceName, ambiguousProjectName1);
+        createProject(apiKey, workspaceName, ambiguousProjectName2);
+        var ambiguousTrace1Id = createTrace(apiKey, workspaceName, ambiguousProjectName1);
+        var ambiguousTrace2Id = createTrace(apiKey, workspaceName, ambiguousProjectName2);
+        var ambiguousExperimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+        linkExperimentToTraces(apiKey, workspaceName, ambiguousExperimentId,
+                ambiguousTrace1Id, ambiguousTrace2Id);
+
+        // Certain-deleted: one trace in a single project that is then deleted in MySQL.
+        // Was: skipped. Now: migrates to Default Project.
+        var deletedProjectName = randomName("project");
+        var deletedProjectId = createProject(apiKey, workspaceName, deletedProjectName);
+        var deletedTraceId = createTrace(apiKey, workspaceName, deletedProjectName);
+        var deletedExperimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+        linkExperimentToTraces(apiKey, workspaceName, deletedExperimentId, deletedTraceId);
+        projectResourceClient.deleteProject(deletedProjectId, apiKey, workspaceName);
+
+        // No-inference: orphan experiment with no traces => migrates to Default Project.
+        var noInferenceExperimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+
+        // Demo: eligible-shaped (single trace in the live certain project) but filtered by demo-name.
+        var demoTraceId = createTrace(apiKey, workspaceName, certainProjectName);
+        var demoExperimentId = experimentResourceClient.create(
+                experimentResourceClient.createPartialExperiment()
+                        .id(null)
+                        .name(DemoData.EXPERIMENTS.getFirst())
+                        .datasetName(datasetName)
+                        .build(),
+                apiKey, workspaceName);
+        linkExperimentToTraces(apiKey, workspaceName, demoExperimentId, demoTraceId);
+
+        var certainBefore = experimentResourceClient.getExperiment(certainExperimentId, apiKey, workspaceName);
+        var ambiguousBefore = experimentResourceClient.getExperiment(ambiguousExperimentId, apiKey, workspaceName);
+        var deletedBefore = experimentResourceClient.getExperiment(deletedExperimentId, apiKey, workspaceName);
+        var noInferenceBefore = experimentResourceClient.getExperiment(
+                noInferenceExperimentId, apiKey, workspaceName);
+        var demoBefore = experimentResourceClient.getExperiment(demoExperimentId, apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        // Ambiguous keeps the workspace pinned to V1; the cycle migrates the other three buckets
+        // and traps the workspace with all_ambiguous.
+        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_1);
+
+        assertExperimentMigrated(apiKey, workspaceName, certainExperimentId, certainBefore,
+                certainProjectId, certainProjectName);
+        assertExperimentMigratedToDefault(apiKey, workspaceName, deletedExperimentId, deletedBefore);
+        assertExperimentMigratedToDefault(apiKey, workspaceName, noInferenceExperimentId, noInferenceBefore);
+        assertExperimentUnchanged(apiKey, workspaceName, ambiguousExperimentId, ambiguousBefore);
+        assertExperimentUnchanged(apiKey, workspaceName, demoExperimentId, demoBefore);
+
+        assertWorkspaceTrapped(workspacesService, workspaceId, "all_ambiguous");
+    }
+
+    @Test
+    void migrateDeletedProjectExperimentToDefaultProject() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var projectName = randomName("project");
+        var projectId = createProject(apiKey, workspaceName, projectName);
+        var datasetName = randomName("dataset");
+        createDatasetWithProject(apiKey, workspaceName, datasetName, projectId);
+        var traceId = createTrace(apiKey, workspaceName, projectName);
+        var experimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+        linkExperimentToTraces(apiKey, workspaceName, experimentId, traceId);
+
+        projectResourceClient.deleteProject(projectId, apiKey, workspaceName);
+
+        var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_2);
+
+        assertExperimentMigratedToDefault(apiKey, workspaceName, experimentId, beforeMigration);
+    }
+
+    @Test
+    void migrateNoInferenceExperimentToDefaultProject() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var projectName = randomName("project");
+        var projectId = createProject(apiKey, workspaceName, projectName);
+        var datasetName = randomName("dataset");
+        createDatasetWithProject(apiKey, workspaceName, datasetName, projectId);
+        var experimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+
+        var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_2);
+
+        assertExperimentMigratedToDefault(apiKey, workspaceName, experimentId, beforeMigration);
+    }
+
+    /**
+     * Workspace whose only orphan is ambiguous: the early {@code validated.isEmpty()} short-circuit
+     * in {@code migrateValidatedMappings} traps the workspace before any writes happen. Distinct
+     * from the post-write trap covered by {@link #mixedWorkspaceMigratesAcrossBucketsAndTrapsOnAmbiguous},
+     * which goes through the full batch-update / reaggregation / cache-evict chain first.
+     */
+    @Test
+    void trapWorkspaceWithOnlyAmbiguousExperiments(WorkspacesService workspacesService) {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var projectName1 = randomName("project");
+        var projectName2 = randomName("project");
+        createProject(apiKey, workspaceName, projectName1);
+        createProject(apiKey, workspaceName, projectName2);
+        var datasetName = randomName("dataset");
+        createDatasetWithProject(apiKey, workspaceName, datasetName,
+                createProject(apiKey, workspaceName, randomName("project")));
+        var trace1Id = createTrace(apiKey, workspaceName, projectName1);
+        var trace2Id = createTrace(apiKey, workspaceName, projectName2);
+        var experimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+        linkExperimentToTraces(apiKey, workspaceName, experimentId, trace1Id, trace2Id);
+
+        var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_1);
+        assertExperimentUnchanged(apiKey, workspaceName, experimentId, beforeMigration);
+        assertWorkspaceTrapped(workspacesService, workspaceId, "all_ambiguous");
+    }
+
+    @Test
+    void skipPreMarkedTrappedWorkspaces(WorkspacesService workspacesService) {
+        // Explicitly tests the trap exclusion: pre-mark a workspace as skipped, seed an eligible
+        // experiment, run the cycle, and assert it was excluded (V1 + unchanged).
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        workspacesService.markMigrationSkipped(workspaceId, "test-pre-marked-trap");
+
+        var seeded = seedCertainExperiment(apiKey, workspaceName, randomName("project"));
+        var experimentId = seeded.getLeft();
+        var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_1);
+        assertExperimentUnchanged(apiKey, workspaceName, experimentId, beforeMigration);
+    }
+
+    @Test
+    void skipExcludedWorkspaces() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, EXCLUDED_WORKSPACE_ID_1, randomName("user"));
+
+        var projectName = randomName("project");
+        var seeded = seedCertainExperiment(apiKey, workspaceName, projectName);
+        var experimentId = seeded.getLeft();
+        var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_1);
+        assertExperimentUnchanged(apiKey, workspaceName, experimentId, beforeMigration);
+    }
+
+    private Pair<UUID, UUID> seedCertainExperiment(String apiKey, String workspaceName, String projectName) {
+        var projectId = createProject(apiKey, workspaceName, projectName);
+        var datasetName = randomName("dataset");
+        createDatasetWithProject(apiKey, workspaceName, datasetName, projectId);
+        var traceId = createTrace(apiKey, workspaceName, projectName);
+        var experimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+        linkExperimentToTraces(apiKey, workspaceName, experimentId, traceId);
+        return Pair.of(experimentId, projectId);
+    }
+
+    private String randomName(String prefix) {
+        return "%s-%s".formatted(prefix, RandomStringUtils.secure().nextAlphanumeric(32));
+    }
+
+    private UUID createProject(String apiKey, String workspaceName, String projectName) {
+        return projectResourceClient.createProject(
+                factory.manufacturePojo(Project.class).toBuilder().name(projectName).build(),
+                apiKey, workspaceName);
+    }
+
+    private void createDatasetWithProject(String apiKey, String workspaceName, String datasetName, UUID projectId) {
+        datasetResourceClient.createDataset(
+                factory.manufacturePojo(Dataset.class).toBuilder()
+                        .name(datasetName)
+                        .projectId(projectId)
+                        .projectName(null)
+                        .build(),
+                apiKey, workspaceName);
+    }
+
+    private UUID createTrace(String apiKey, String workspaceName, String projectName) {
+        return traceResourceClient.createTrace(
+                factory.manufacturePojo(Trace.class).toBuilder()
+                        .id(null)
+                        .projectName(projectName)
+                        .projectId(null)
+                        .startTime(Instant.now())
+                        .feedbackScores(null)
+                        .usage(null)
+                        .build(),
+                apiKey, workspaceName);
+    }
+
+    private UUID createOrphanExperiment(String apiKey, String workspaceName, String datasetName) {
+        return experimentResourceClient.create(
+                experimentResourceClient.createPartialExperiment()
+                        .id(null)
+                        .datasetName(datasetName)
+                        .build(),
+                apiKey, workspaceName);
+    }
+
+    private void linkExperimentToTraces(String apiKey, String workspaceName, UUID experimentId, UUID... traceIds) {
+        var items = Arrays.stream(traceIds)
+                .map(traceId -> factory.manufacturePojo(ExperimentItem.class).toBuilder()
+                        .experimentId(experimentId)
+                        .traceId(traceId)
+                        .feedbackScores(null)
+                        .build())
+                .collect(Collectors.toUnmodifiableSet());
+        experimentResourceClient.createExperimentItem(items, apiKey, workspaceName);
+    }
+
+    private void assertWorkspaceVersion(String apiKey, String workspaceName, OpikVersion expected) {
+        assertThat(workspaceResourceClient.getWorkspaceVersion(apiKey, workspaceName).opikVersion())
+                .isEqualTo(expected);
+    }
+
+    private void assertExperimentMigrated(
+            String apiKey, String workspaceName, UUID experimentId,
+            Experiment beforeMigration, UUID expectedProjectId, String expectedProjectName) {
+        var actual = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+        var expected = beforeMigration.toBuilder()
+                .projectId(expectedProjectId)
+                .projectName(expectedProjectName)
+                .lastUpdatedBy(RequestContext.SYSTEM_USER)
+                .build();
+        assertExperimentEqual(actual, expected);
+        assertThat(actual.lastUpdatedAt()).isAfter(beforeMigration.lastUpdatedAt());
+    }
+
+    private void assertExperimentMigratedToDefault(
+            String apiKey, String workspaceName, UUID experimentId, Experiment beforeMigration) {
+        var actual = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+        assertThat(actual.projectId()).isNotNull();
+        var expected = beforeMigration.toBuilder()
+                .projectId(actual.projectId())
+                .projectName(ProjectService.DEFAULT_PROJECT)
+                .lastUpdatedBy(RequestContext.SYSTEM_USER)
+                .build();
+        assertExperimentEqual(actual, expected);
+        assertThat(actual.lastUpdatedAt()).isAfter(beforeMigration.lastUpdatedAt());
+    }
+
+    private void assertExperimentUnchanged(
+            String apiKey, String workspaceName, UUID experimentId, Experiment beforeMigration) {
+        var actual = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+        assertExperimentEqual(actual, beforeMigration);
+        assertThat(actual.lastUpdatedAt()).isEqualTo(beforeMigration.lastUpdatedAt());
+    }
+
+    private void assertWorkspaceTrapped(WorkspacesService workspacesService, String workspaceId, String reason) {
+        assertThat(workspacesService.findMigrationSkippedWorkspaceIds()).contains(workspaceId);
+        assertThat(workspacesService.findById(workspaceId))
+                .hasValueSatisfying(w -> assertThat(w.migrationSkippedReason()).isEqualTo(reason));
+    }
+}

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -738,7 +738,7 @@ datasetVersioningMigration:
 # Assigns project_id to orphan experiments (V1 → V2 workspace migration).
 # Runs as a recurring job, processing workspaces in batches.
 experimentProjectMigration:
-  # Master switch — disabled in tests by default
+  # Master switch — disabled by default, enable for staged rollout
   enabled: false
   # Number of workspaces to process per job run (smallest first)
   workspacesPerRun: 20
@@ -747,11 +747,12 @@ experimentProjectMigration:
   # Interval between recurring job runs
   interval: 5s
   # Delay before first run after app startup
-  startupDelay: 0s
+  startupDelay: 5s
   # Distributed lock timeout — prevents overlap across replicas. Must stay < jobTimeout.
   # Short in tests so the lock releases between cycles and Awaitility windows can stay brief.
   lockTimeout: 5s
-  # Max time to wait for the distributed lock when another replica holds it
+  # Max time to wait for the distributed lock when another replica holds it. Kept brief so a held
+  # lock doesn't block this fire — the next scheduled tick will try again.
   lockWaitTime: 100ms
   # Per-cycle timeout — short for tests so hangs fail fast
   jobTimeout: 30s


### PR DESCRIPTION
## Details

Extend the experiment project migration job to cover the two tail buckets it previously left orphaned: experiments whose inferred project was deleted, and experiments with no usable traces (no items, or all traces with empty `project_id`). Both now migrate to the workspace's Default Project instead of keeping the workspace stuck at V1.

- `FIND_ELIGIBLE_EXPERIMENT_WORKSPACES` is broadened: no JOIN gate, so any workspace with a non-demo orphan surfaces. The service classifies per workspace.
- `COMPUTE_EXPERIMENT_PROJECT_MAPPING` returns `(experiment_id, project_id, project_count)`. The service buckets per orphan into certain / certain-deleted / no-inference / ambiguous.
- Certain → inferred project (existing behaviour). Certain-deleted and no-inference → Default Project via `ProjectService.getOrCreate` (same path trace ingestion uses; the Default Project is provisioned in-line if missing, so no `default_project_missing` trap is needed — strict improvement over the original ticket plan, which proposed a trap for that case). Ambiguous → skip; workspace is trapped with `all_ambiguous` once the cycle's other buckets are written.
- Trap reason `deleted_project` retired (the bucket migrates now). `all_ambiguous` added.
- Metrics: new `experiments.assigned_to_default{reason=deleted_project|no_inference}` counter; `experiments.skipped{reason=ambiguous}` exposed and `{reason=deleted_project}` retired; `workspace.duration{result=all_ambiguous}` added, `{all_skipped_deleted_project}` retired.

The SQL fix that took the longest to land: `traces.project_id` is `FixedString(36)`, whose LEFT JOIN no-match default is 36 NUL bytes — not `''` — and trips both the `!= ''` guard and the downstream UUID parser. The subquery casts to `String` so the no-match default normalises to a real empty string.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6579

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: assisted (design discussion, SQL debugging, test scaffolding); human review and final approval on every change
- Human verification: code review, repeated test runs across iterations, ticket/spec cross-check

## Testing

Backend integration tests via testcontainers (ClickHouse + MySQL + Redis + Zookeeper):

- `mvn test -Dtest=ExperimentProjectMigrationServiceTest` (9 tests):
  - `migrateEligibleExperimentsAcrossWorkspaces` — multi-workspace certain bucket; primes the workspace_version V1 cache and verifies the post-migration V2 read depends on `evictWorkspaceVersionCache`.
  - `secondCycleIsNoopAfterSuccessfulMigration` — idempotency; second cycle leaves the experiment's `lastUpdatedAt` unchanged.
  - `mixedWorkspaceMigratesAcrossBucketsAndTrapsOnAmbiguous` — all four buckets in one workspace + demo filter + POST-WRITE trap.
  - `migrateDeletedProjectExperimentToDefaultProject` — certain-deleted bucket end-to-end → Default (auto-created via `getOrCreate`).
  - `migrateNoInferenceExperimentToDefaultProject` — no-inference bucket end-to-end → Default (auto-created via `getOrCreate`).
  - `trapWorkspaceWithOnlyAmbiguousExperiments` — EARLY trap path before any writes.
  - `skipPreMarkedTrappedWorkspaces` — DB-trap exclusion.
  - `skipExcludedWorkspaces` — env-config exclusion.
- `mvn test -Dtest=ExperimentProjectMigrationJobTest` (1 smoke):
  - `scheduledJobMigratesEligibleWorkspaceToV2` — Quartz → job → service wiring smoke; Awaitility-paced.

All 10 tests pass.

Out-of-band before merge: safety verification of V2 UI / SDK behaviour when `experiment.project_id = DefaultProject.id` and `traces[].project_id = <deleted>`, per the ticket's "Safety verification needed before shipping" section.

## Documentation

N/A — no user-facing docs changes. Rollout SQL (`UPDATE workspaces SET migration_skipped_at = NULL, migration_skipped_reason = NULL WHERE migration_skipped_reason = 'deleted_project'`) is tracked separately in OPIK-6577.