### PR TITLE
[NA] [FE] feat: show dataset version inline with item source in experiments

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/experiments/ItemSourceCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/ItemSourceCell.tsx
@@ -1,19 +1,26 @@
 import React from "react";
 import { CellContext } from "@tanstack/react-table";
-import { ChevronDown, ChevronUp, Database, ListChecks } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronUp,
+  Database,
+  GitCommitVertical,
+  ListChecks,
+} from "lucide-react";
 import get from "lodash/get";
 import isFunction from "lodash/isFunction";
 import isNumber from "lodash/isNumber";
 
 import { Button } from "@/ui/button";
 import { Checkbox } from "@/ui/checkbox";
+import { Tag } from "@/ui/tag";
 import CellWrapper from "@/shared/DataTableCells/CellWrapper";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
 import ResourceLink, {
   RESOURCE_TYPE,
 } from "@/shared/ResourceLink/ResourceLink";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import { CELL_TEXT_CLASS_MAP } from "@/constants/shared";
+import { CELL_TEXT_CLASS_MAP, getCellTagSize, TAG_SIZE_MAP } from "@/constants/shared";
 import { Explainer, ROW_HEIGHT } from "@/types/shared";
 import { DATASET_TYPE, EVALUATION_METHOD } from "@/types/datasets";
 import { cn } from "@/lib/utils";
@@ -40,6 +47,11 @@ const ItemSourceCell = <TData,>(context: CellContext<TData, unknown>) => {
   const evaluationMethod = get(cellData, "evaluation_method", undefined) as
     | EVALUATION_METHOD
     | undefined;
+  const versionName = get(
+    cellData,
+    "dataset_version_summary.version_name",
+    undefined,
+  ) as string | undefined;
   const isDeleted = isFunction(getIsDeleted)
     ? getIsDeleted(cellData)
     : undefined;
@@ -50,6 +62,8 @@ const ItemSourceCell = <TData,>(context: CellContext<TData, unknown>) => {
     ? RESOURCE_TYPE.testSuite
     : RESOURCE_TYPE.dataset;
 
+  const tagSize = getCellTagSize(context, TAG_SIZE_MAP);
+
   return (
     <CellWrapper
       metadata={context.column.columnDef.meta}
@@ -57,11 +71,11 @@ const ItemSourceCell = <TData,>(context: CellContext<TData, unknown>) => {
       className="items-center py-1.5"
     >
       <TooltipWrapper content={name}>
-        <div className="flex min-w-0 flex-1 items-center gap-2">
+        <div className="flex min-w-0 flex-1 items-center gap-1">
           <span className="flex size-5 shrink-0 items-center justify-center rounded bg-muted text-muted-slate">
             <Icon className="size-3" />
           </span>
-          <div className="min-w-0 flex-1">
+          <div className="min-w-0 shrink overflow-hidden">
             {id ? (
               <ResourceLink
                 id={id}
@@ -73,6 +87,16 @@ const ItemSourceCell = <TData,>(context: CellContext<TData, unknown>) => {
               "-"
             )}
           </div>
+          {versionName && (
+            <Tag
+              size={tagSize}
+              variant="transparent"
+              className="flex shrink-0 items-center gap-0 border-0 p-0 text-muted-slate"
+            >
+              <GitCommitVertical className="size-[10px] text-muted-slate" />
+              {versionName}
+            </Tag>
+          )}
         </div>
       </TooltipWrapper>
     </CellWrapper>

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/ItemSourceCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/ItemSourceCell.tsx
@@ -20,7 +20,11 @@ import ResourceLink, {
   RESOURCE_TYPE,
 } from "@/shared/ResourceLink/ResourceLink";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import { CELL_TEXT_CLASS_MAP, getCellTagSize, TAG_SIZE_MAP } from "@/constants/shared";
+import {
+  CELL_TEXT_CLASS_MAP,
+  getCellTagSize,
+  TAG_SIZE_MAP,
+} from "@/constants/shared";
 import { Explainer, ROW_HEIGHT } from "@/types/shared";
 import { DATASET_TYPE, EVALUATION_METHOD } from "@/types/datasets";
 import { cn } from "@/lib/utils";

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/ItemSourceCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/ItemSourceCell.tsx
@@ -97,7 +97,7 @@ const ItemSourceCell = <TData,>(context: CellContext<TData, unknown>) => {
               variant="transparent"
               className="flex shrink-0 items-center gap-0 border-0 p-0 text-muted-slate"
             >
-              <GitCommitVertical className="size-[10px] text-muted-slate" />
+              <GitCommitVertical className="size-[10px]" />
               {versionName}
             </Tag>
           )}

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo } from "react";
 import sortBy from "lodash/sortBy";
 import isNumber from "lodash/isNumber";
-import { CircleCheck, Database } from "lucide-react";
+import { CircleCheck, Database, GitCommitVertical } from "lucide-react";
 
 import useBreadcrumbsStore from "@/store/BreadcrumbsStore";
 import { Experiment } from "@/types/datasets";
@@ -107,19 +107,36 @@ const CompareExperimentsDetails: React.FunctionComponent<
           />
         )}
         {experiment?.dataset_id && (
-          <Tag
-            size="md"
-            variant="transparent"
-            className="flex shrink-0 items-center gap-1"
+          <TooltipWrapper
+            content={[
+              isTestSuiteExperiment(experiment) ? "Test suite" : "Dataset",
+              ": ",
+              experiment.dataset_name || "Deleted",
+              experiment.dataset_version_summary?.version_name
+                ? ` ${experiment.dataset_version_summary.version_name}`
+                : "",
+            ].join("")}
           >
-            <Database
-              className="size-3 shrink-0"
-              style={{ color: "var(--color-yellow)" }}
-            />
-            <span className="comet-body-s-accented truncate text-muted-slate">
-              {experiment.dataset_name || "Deleted test suite"}
-            </span>
-          </Tag>
+            <Tag
+              size="md"
+              variant="transparent"
+              className="flex shrink-0 items-center gap-1"
+            >
+              <Database
+                className="size-3 shrink-0"
+                style={{ color: "var(--color-yellow)" }}
+              />
+              <span className="comet-body-s-accented truncate text-muted-slate">
+                {experiment.dataset_name || "Deleted test suite"}
+              </span>
+              {experiment.dataset_version_summary?.version_name && (
+                <span className="flex items-center gap-0 pt-px text-muted-slate" style={{ fontSize: "12px" }}>
+                  <GitCommitVertical className="size-[10px]" />
+                  {experiment.dataset_version_summary.version_name}
+                </span>
+              )}
+            </Tag>
+          </TooltipWrapper>
         )}
         {experiment?.prompt_versions &&
           experiment.prompt_versions.length > 0 && (

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
@@ -130,7 +130,7 @@ const CompareExperimentsDetails: React.FunctionComponent<
                 {experiment.dataset_name || "Deleted test suite"}
               </span>
               {experiment.dataset_version_summary?.version_name && (
-                <span className="flex items-center gap-0 pt-px text-muted-slate text-xs">
+                <span className="flex items-center gap-0 pt-px text-xs text-muted-slate">
                   <GitCommitVertical className="size-[10px]" />
                   {experiment.dataset_version_summary.version_name}
                 </span>

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
@@ -130,7 +130,10 @@ const CompareExperimentsDetails: React.FunctionComponent<
                 {experiment.dataset_name || "Deleted test suite"}
               </span>
               {experiment.dataset_version_summary?.version_name && (
-                <span className="flex items-center gap-0 pt-px text-muted-slate" style={{ fontSize: "12px" }}>
+                <span
+                  className="flex items-center gap-0 pt-px text-muted-slate"
+                  style={{ fontSize: "12px" }}
+                >
                   <GitCommitVertical className="size-[10px]" />
                   {experiment.dataset_version_summary.version_name}
                 </span>

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
@@ -130,10 +130,7 @@ const CompareExperimentsDetails: React.FunctionComponent<
                 {experiment.dataset_name || "Deleted test suite"}
               </span>
               {experiment.dataset_version_summary?.version_name && (
-                <span
-                  className="flex items-center gap-0 pt-px text-muted-slate"
-                  style={{ fontSize: "12px" }}
-                >
+                <span className="flex items-center gap-0 pt-px text-muted-slate text-xs">
                   <GitCommitVertical className="size-[10px]" />
                   {experiment.dataset_version_summary.version_name}
                 </span>

--- a/apps/opik-frontend/src/v2/pages/ExperimentsPage/GeneralDatasetsTab/GeneralDatasetsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/ExperimentsPage/GeneralDatasetsTab/GeneralDatasetsTab.tsx
@@ -81,7 +81,6 @@ import DataTableVirtualBody from "@/shared/DataTable/DataTableVirtualBody";
 import { ChartData } from "@/v2/pages-shared/experiments/FeedbackScoresChartsWrapper/FeedbackScoresChartContent";
 import GroupsButton from "@/shared/GroupsButton/GroupsButton";
 import TextCell from "@/shared/DataTableCells/TextCell";
-import DatasetVersionCell from "@/shared/DataTableCells/DatasetVersionCell";
 import ItemSourceCell, {
   ITEM_SOURCE_LABEL,
 } from "@/v2/pages-shared/experiments/ItemSourceCell";
@@ -128,7 +127,6 @@ const DEFAULT_COLUMNS_ORDER: string[] = [
   COLUMN_ID_ID,
   COLUMN_NAME_ID,
   COLUMN_DATASET_ID,
-  "dataset_version",
   "pass_rate",
   "trace_count",
   "duration.p50",
@@ -213,15 +211,6 @@ const GeneralDatasetsTab: React.FC<GeneralDatasetsTabProps> = ({
           nameKey: "dataset_name",
           idKey: "dataset_id",
         },
-      },
-      {
-        id: "dataset_version",
-        label: "Test suite version",
-        type: COLUMN_TYPE.string,
-        iconType: "version" as const,
-        accessorFn: (row: GroupedExperiment) =>
-          row.dataset_version_summary?.version_name || "",
-        cell: DatasetVersionCell as never,
       },
       {
         id: "created_at",

--- a/apps/opik-frontend/src/v2/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
@@ -31,7 +31,6 @@ import CommentsCell from "@/shared/DataTableCells/CommentsCell";
 import FeedbackScoreListCell from "@/shared/DataTableCells/FeedbackScoreListCell";
 import PassRateCell from "@/shared/DataTableCells/PassRateCell";
 import TextCell from "@/shared/DataTableCells/TextCell";
-import DatasetVersionCell from "@/shared/DataTableCells/DatasetVersionCell";
 import ListCell from "@/shared/DataTableCells/ListCell";
 import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { transformExperimentScores } from "@/lib/feedback-scores";
@@ -93,7 +92,6 @@ const DEFAULT_COLUMNS_ORDER: string[] = [
   COLUMN_NAME_ID,
   "prompt",
   COLUMN_DATASET_ID,
-  "dataset_version",
   "pass_rate",
   "trace_count",
   "duration.p50",
@@ -208,15 +206,6 @@ const ExperimentsTab: React.FC<ExperimentsTabProps> = ({ promptId }) => {
           nameKey: "dataset_name",
           idKey: "dataset_id",
         },
-      },
-      {
-        id: "dataset_version",
-        label: "Test suite version",
-        type: COLUMN_TYPE.string,
-        iconType: "version" as const,
-        accessorFn: (row: GroupedExperiment) =>
-          row.dataset_version_summary?.version_name || "",
-        cell: DatasetVersionCell as never,
       },
       {
         id: "created_at",


### PR DESCRIPTION
## Details

Surfaces the dataset/test suite version used by an experiment inline — removing the dedicated standalone column and instead placing the version directly next to the item source name where the context is most relevant.

- **Experiments table** (`ItemSourceCell`): A compact version pill (commit icon + version name) now appears inline after the item source link. The link wrapper no longer expands to fill the full cell width, so the pill sits directly adjacent to the name while preserving truncation on narrow columns.
- **Experiment detail page** (`CompareExperimentsDetails`): The version is added inside the existing item source tag in the header, with a tooltip showing the pattern `<type>: <name> <version>` (e.g. "Test suite: my-suite v1.0").
- **Removed**: The standalone "Test suite version" column has been removed from both `GeneralDatasetsTab` and the `PromptPage` experiments tab, since the version is now surfaced inline.

Pill styling: muted-slate color, 10px icon, no border, no padding, no gap between icon and label.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: full implementation
- Human verification: code review + manual testing in local dev environment

## Testing

- `npm run lint && npm run typecheck` — passed
- Manually verified in local dev environment:
  - Version pill appears next to item source name in experiments table
  - Version pill appears in experiment detail page header
  - Tooltip on detail page shows correct `<type>: <name> <version>` format
  - No version pill rendered when `dataset_version_summary` is absent
  - Truncation preserved on narrow columns

## Documentation

N/A