### PR TITLE
[OPIK-6623] fix(security): bump Corretto + netty + jetty + httpclient5 to clear HIGH CVEs in opik-backend

### DIFF
--- a/apps/opik-backend/Dockerfile
+++ b/apps/opik-backend/Dockerfile
@@ -16,7 +16,7 @@ RUN mvn versions:set -DnewVersion=${OPIK_VERSION} && \
     mvn clean package -DskipTests
 
 ###############################
-FROM amazoncorretto:21.0.10-al2023
+FROM amazoncorretto:21.0.11-al2023
 
 # Add metadata labels
 LABEL org.opencontainers.image.title="Opik Backend"

--- a/apps/opik-backend/pom.xml
+++ b/apps/opik-backend/pom.xml
@@ -71,7 +71,21 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.2.6.Final</version>
+                <version>4.2.13.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>12.1.7</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.ee10</groupId>
+                <artifactId>jetty-ee10-bom</artifactId>
+                <version>12.1.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -269,7 +283,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.6</version>
+            <version>5.6.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## Details

Closes the HIGH-severity findings on `opik-backend:2.0.39` identified by the trivy scan of self-hosted **v4.17.1**. All bumps are patch-level within their existing major versions — no framework migration needed (opik-backend is already on Dropwizard 5 + Jetty 12).

Three targeted changes across two files:

1. **`apps/opik-backend/Dockerfile`** — `FROM amazoncorretto:21.0.10-al2023` → `21.0.11-al2023` (Corretto patch released 2026-05-09). Clears ~304 raw OS-package HIGH findings.
2. **`apps/opik-backend/pom.xml`** dependencyManagement:
   - `netty-bom` 4.2.6.Final → **4.2.13.Final** (closes 6 netty CVEs)
   - **+** `jetty-bom` **12.1.7** (new explicit import, closes CVE-2026-1605)
   - **+** `jetty-ee10-bom` **12.1.7** (new explicit import, closes CVE-2026-2332)
3. **`apps/opik-backend/pom.xml`** dependencies: `httpclient5` 5.6 → **5.6.1** (closes CVE-2026-40542)

The Jetty BOM imports override the transitive 12.1.1 brought in by Dropwizard 5.0.0's `dropwizard-dependencies` BOM.

## CVEs cleared

| CVE | Component | Old → New |
|---|---|---|
| [CVE-2026-33870](https://avd.aquasec.com/nvd/cve-2026-33870) | `io.netty:netty-codec-http` | 4.2.6.Final → 4.2.13.Final |
| [CVE-2026-33871](https://avd.aquasec.com/nvd/cve-2026-33871) | `io.netty:netty-codec-http2` | 4.2.6.Final → 4.2.13.Final |
| [CVE-2026-42579](https://avd.aquasec.com/nvd/cve-2026-42579) | `io.netty:netty-codec-dns` | 4.2.6.Final → 4.2.13.Final |
| [CVE-2026-42583](https://avd.aquasec.com/nvd/cve-2026-42583) | `io.netty:netty-codec-compression` | 4.2.6.Final → 4.2.13.Final |
| [CVE-2026-42584](https://avd.aquasec.com/nvd/cve-2026-42584) | `io.netty:netty-codec-http` | 4.2.6.Final → 4.2.13.Final |
| [CVE-2026-42587](https://avd.aquasec.com/nvd/cve-2026-42587) | `io.netty:netty-codec-http(2)` | 4.2.6.Final → 4.2.13.Final |
| [CVE-2026-1605](https://avd.aquasec.com/nvd/cve-2026-1605) | `org.eclipse.jetty:jetty-server` | 12.1.1 → 12.1.7 |
| [CVE-2026-2332](https://avd.aquasec.com/nvd/cve-2026-2332) | `org.eclipse.jetty:jetty-http` | 12.1.1 → 12.1.7 |
| [CVE-2026-40542](https://avd.aquasec.com/nvd/cve-2026-40542) | `org.apache.httpcomponents.client5:httpclient5` | 5.6 → 5.6.1 |

Plus ~304 raw OS-package HIGHs (glibc, openssl, etc.) cleared by the Corretto base bump.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6623

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (CLI)
- Model(s): Claude Opus 4.7 (1M context)
- Scope: Identified the 7 unique Java HIGH CVEs and 1 OS base bump via trivy scan output. Verified that opik-backend is already on Dropwizard 5 + Jetty 12 (no major migration needed, unlike comet-backend). Chose patch-level bumps within each major and added explicit Jetty BOMs to override Dropwizard's transitive Jetty 12.1.1. PR description and commit message authored with AI assistance.
- Human verification: I (Nimrod) reviewed the CVE list against the trivy JSON, confirmed each fix-target version on Maven Central, and inspected the pom.xml diff before pushing.

## Testing

- [ ] CI passes (existing opik-backend tests)
- [ ] Verify Maven build resolves all deps with the new BOM overrides (no version conflicts)
- [ ] Smoke build of `opik-backend` image
- [ ] Re-scan with trivy on the rebuilt image — expect HIGH count to drop to 0 (or only-no-fix-yet CVEs remain)

No new test scenarios — patch-level dep bumps + base image refresh, no application logic change.

## Documentation

No documentation changes needed — dep/base-image hardening, not user-facing.