### PR TITLE
[OPIK-6624] [CI] fix(release): skip on 403 "cannot publish over" instead of failing

### DIFF
--- a/.github/actions/typescript-sdk-build-and-publish/action.yml
+++ b/.github/actions/typescript-sdk-build-and-publish/action.yml
@@ -139,21 +139,34 @@ runs:
           PUBLISH_CMD="npm publish --access ${{ inputs.npm_access }}"
         fi
 
+        ALREADY_PUBLISHED=false
+        PUBLISH_LOG=$(mktemp)
+        trap 'rm -f "$PUBLISH_LOG"' EXIT
+
         while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
           echo "Publish attempt $ATTEMPT of $MAX_ATTEMPTS (timeout: ${TIMEOUT_SECONDS}s)..."
-          
-          # Use timeout command to prevent hanging indefinitely
-          if timeout $TIMEOUT_SECONDS $PUBLISH_CMD; then
+
+          # Use timeout to prevent hanging; tee to stream live AND capture for inspection.
+          if timeout $TIMEOUT_SECONDS $PUBLISH_CMD 2>&1 | tee "$PUBLISH_LOG"; then
             SUCCESS=true
             break
           else
-            EXIT_CODE=$?
-            if [ $EXIT_CODE -eq 124 ]; then
+            # PIPESTATUS[0] is the timeout/npm exit code; tee always succeeds.
+            EXIT_CODE=${PIPESTATUS[0]}
+            if [ "$EXIT_CODE" -eq 124 ]; then
               echo "Attempt $ATTEMPT timed out after ${TIMEOUT_SECONDS}s"
             else
               echo "Attempt $ATTEMPT failed with exit code $EXIT_CODE"
             fi
-            
+
+            # Non-retryable: version already published. The desired end state is achieved;
+            # treat as a skip-with-warning so concurrent / replay dispatches don't fail CI.
+            if grep -q "E403" "$PUBLISH_LOG" && grep -qi "cannot publish over" "$PUBLISH_LOG"; then
+              ALREADY_PUBLISHED=true
+              echo "::warning title=NPM publish skipped::${PACKAGE_NAME}@${NEW_VERSION} is already published; treating as success."
+              break
+            fi
+
             if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
               echo "Retrying in 10 seconds..."
               sleep 10
@@ -162,7 +175,7 @@ runs:
           fi
         done
 
-        if [ "$SUCCESS" = false ]; then
+        if [ "$SUCCESS" = false ] && [ "$ALREADY_PUBLISHED" = false ]; then
           echo "Failed to publish after $MAX_ATTEMPTS attempts"
           exit 1
         fi

--- a/.github/actions/typescript-sdk-build-and-publish/action.yml
+++ b/.github/actions/typescript-sdk-build-and-publish/action.yml
@@ -146,33 +146,37 @@ runs:
         while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
           echo "Publish attempt $ATTEMPT of $MAX_ATTEMPTS (timeout: ${TIMEOUT_SECONDS}s)..."
 
-          # Use timeout to prevent hanging; tee to stream live AND capture for inspection.
-          if timeout $TIMEOUT_SECONDS $PUBLISH_CMD 2>&1 | tee "$PUBLISH_LOG"; then
+          # Run the publish, streaming output live AND capturing it for inspection.
+          # Capture timeout/npm's exit code via PIPESTATUS[0] directly — don't rely on
+          # the pipeline's overall exit status, since `tee` masks failures when pipefail
+          # is off, and we don't want to depend on the shell's default flags.
+          timeout $TIMEOUT_SECONDS $PUBLISH_CMD 2>&1 | tee "$PUBLISH_LOG"
+          EXIT_CODE=${PIPESTATUS[0]}
+
+          if [ "$EXIT_CODE" -eq 0 ]; then
             SUCCESS=true
             break
-          else
-            # PIPESTATUS[0] is the timeout/npm exit code; tee always succeeds.
-            EXIT_CODE=${PIPESTATUS[0]}
-            if [ "$EXIT_CODE" -eq 124 ]; then
-              echo "Attempt $ATTEMPT timed out after ${TIMEOUT_SECONDS}s"
-            else
-              echo "Attempt $ATTEMPT failed with exit code $EXIT_CODE"
-            fi
-
-            # Non-retryable: version already published. The desired end state is achieved;
-            # treat as a skip-with-warning so concurrent / replay dispatches don't fail CI.
-            if grep -q "E403" "$PUBLISH_LOG" && grep -qi "cannot publish over" "$PUBLISH_LOG"; then
-              ALREADY_PUBLISHED=true
-              echo "::warning title=NPM publish skipped::${PACKAGE_NAME}@${NEW_VERSION} is already published; treating as success."
-              break
-            fi
-
-            if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
-              echo "Retrying in 10 seconds..."
-              sleep 10
-            fi
-            ATTEMPT=$((ATTEMPT + 1))
           fi
+
+          if [ "$EXIT_CODE" -eq 124 ]; then
+            echo "Attempt $ATTEMPT timed out after ${TIMEOUT_SECONDS}s"
+          else
+            echo "Attempt $ATTEMPT failed with exit code $EXIT_CODE"
+          fi
+
+          # Non-retryable: version already published. The desired end state is achieved;
+          # treat as a skip-with-warning so concurrent / replay dispatches don't fail CI.
+          if grep -q "E403" "$PUBLISH_LOG" && grep -qi "cannot publish over" "$PUBLISH_LOG"; then
+            ALREADY_PUBLISHED=true
+            echo "::warning title=NPM publish skipped::${PACKAGE_NAME}@${NEW_VERSION} is already published; treating as success."
+            break
+          fi
+
+          if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+            echo "Retrying in 10 seconds..."
+            sleep 10
+          fi
+          ATTEMPT=$((ATTEMPT + 1))
         done
 
         if [ "$SUCCESS" = false ] && [ "$ALREADY_PUBLISHED" = false ]; then


### PR DESCRIPTION
## Details

<img width="2080" height="3030" alt="image" src="https://github.com/user-attachments/assets/963f06e4-53df-4cf4-94ff-609721dc79cd" />

When `npm publish` returns `403 Forbidden — You cannot publish over the previously published versions: X.Y.Z`, the version is already in the registry and retrying produces the same error. The retry loop in `.github/actions/typescript-sdk-build-and-publish/action.yml` currently hammers the same 403 three times and then fails CI — even though the desired end state (version published) has been achieved.

This PR detects that exact signature and short-circuits the loop with a `::warning::` and a successful exit. Other errors (network blips, transient registry 5xx, real auth failures) still retry as before.

Triggered by the [2026-05-20 re-dispatch of `opik@2.0.42`](https://github.com/comet-ml/opik/actions/runs/26149349373/job/76957298405): after `NPM_TOKEN` was rotated to recover from the morning's auth failure (the parent issue, OPIK-6617), the workflow was redispatched. `2.0.42` had already been successfully published at 12:22:13 UTC by another run, so the retry hit:

```
npm error code E403
npm error 403 403 Forbidden - PUT https://registry.npmjs.org/opik - You cannot publish over the previously published versions: 2.0.42.
Attempt 3 failed with exit code 1
Failed to publish after 3 attempts
```

### Mechanics

- Capture `npm publish` output via `tee` to a tmpfile — streams live to the log AND lets us inspect after failure.
- After a failed attempt, grep the captured log for `E403` AND `cannot publish over` (case-insensitive).
- If matched: emit `::warning title=NPM publish skipped::<pkg>@<version> is already published; treating as success.`, break the retry loop with `ALREADY_PUBLISHED=true`, exit 0.
- If not matched: keep current retry behavior — transient errors still retry up to 3 times.
- The trailing `PACKAGE_NAME` / `PUBLISHED_VERSION` env exports run unconditionally, so the downstream Summary step still has the values it expects.

### Race-safety

Catching the 403 *after* the publish attempt is strictly better than a naive pre-publish "does it exist?" check. The pre-check pattern has a TOCTOU race: run A checks (not present) → run B publishes → run A publishes → run A fails. The post-attempt catch is race-free by construction — we only see this error after a winning concurrent run has finished, which is exactly the safe condition under which to no-op.

`opik_wizard_publish.yml` has its own pre-publish existence check (lines 90–98); revisit only if that pattern shows a race in practice. Out of scope for this PR.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6624
- Related: OPIK-6617 (preflight that surfaces the upstream `NPM_TOKEN` issue cleanly).

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation (composite action edit, signature detection logic, ticket, PR)
- Human verification: code review, traced live evidence from the failed run #26149349373/job/76957298405, confirmed `opik@2.0.42` actually landed in the registry at 12:22:13 UTC via `npm view opik time`, `actionlint` + `shellcheck` clean on the modified composite (baseline-matched against `origin/main` — no new findings)

## Testing

Static checks:

- `actionlint .github/workflows/typescript_sdk_publish.yml .github/workflows/typescript_sdk_integration_publish.yml` — line-count identical to `origin/main` baseline (12/12); no new findings introduced. Pre-existing `SC2129` / `SC2086` style warnings are on lines I didn't touch.
- `shellcheck` on the extracted publish step's `run:` block — only false positives remain (`SC2296` on `${{ inputs.* }}` GHA syntax that shellcheck can't parse; `SC2086` on `$PUBLISH_CMD` which is *intentionally* word-split to expand into multiple argv tokens — same pattern as before this change).
- Manually traced the 2026-05-20 12:14 UTC failed run to confirm the exact error signature: `npm error code E403` + `You cannot publish over the previously published versions: 2.0.42`. The grep predicate matches this verbatim.

End-to-end validation plan:

Once this PR merges, redispatch `typescript_sdk_publish.yml` from `main` with `version=2.0.42, is_release=true`. Expected outcome:

```
::warning title=NPM publish skipped::opik@2.0.42 is already published; treating as success.
```

Job exits 0. Compare to the current behavior on [run #26149349373/job/76957298405](https://github.com/comet-ml/opik/actions/runs/26149349373/job/76957298405) where the same conditions produce a hard failure after three retries.

Negative test: dispatch with `version=2.0.43` (or any unpublished version) while `NPM_TOKEN` is misconfigured — expected: preflight catches it (parent PR #6790) before we get this far; if somehow we do reach the publish step with bad auth, the grep predicate does *not* match (the signature is `E403 cannot publish over`, not generic `E403`), so the retry behavior is preserved.

## Documentation

N/A — internal CI plumbing change; no user-facing or developer-facing documentation surface changed.
