### PR TITLE
[OPIK-6621] [FE] feat: add AND/OR grouping to alert conditions

### DIFF
--- a/apps/opik-frontend/src/types/alerts.ts
+++ b/apps/opik-frontend/src/types/alerts.ts
@@ -30,6 +30,7 @@ export interface AlertTriggerConfig {
   alert_trigger_id?: string;
   type: ALERT_TRIGGER_CONFIG_TYPE;
   config_value: Record<string, string>;
+  group_index?: number | null;
   created_at?: string;
   created_by?: string;
   last_updated_at?: string;

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/EventTriggers.tsx
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/EventTriggers.tsx
@@ -19,34 +19,21 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
 import { Separator } from "@/ui/separator";
 import { Input } from "@/ui/input";
 import SelectBox from "@/shared/SelectBox/SelectBox";
-import { DropdownOption } from "@/types/shared";
 import { AlertFormType } from "./schema";
 import { TRIGGER_CONFIG } from "./helpers";
+import { WINDOW_OPTIONS } from "./constants";
 import { ALERT_EVENT_TYPE } from "@/types/alerts";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
 import { cn } from "@/lib/utils";
 import FeedbackScoreConditions, {
-  DEFAULT_FEEDBACK_SCORE_CONDITION,
+  DEFAULT_FEEDBACK_SCORE_CONDITION_GROUP,
 } from "./FeedbackScoreConditions";
 
 type EventTriggersProps = {
   form: UseFormReturn<AlertFormType>;
   projectId: string;
 };
-
-const WINDOW_OPTIONS: DropdownOption<string>[] = [
-  { label: "5 minutes", value: "300" },
-  { label: "15 minutes", value: "900" },
-  { label: "30 minutes", value: "1800" },
-  { label: "1 hour", value: "3600" },
-  { label: "6 hours", value: "21600" },
-  { label: "12 hours", value: "43200" },
-  { label: "24 hours", value: "86400" },
-  { label: "7 days", value: "604800" },
-  { label: "15 days", value: "1296000" },
-  { label: "30 days", value: "2592000" },
-];
 
 function getThresholdLabel(eventType: ALERT_EVENT_TYPE): string {
   switch (eventType) {
@@ -104,7 +91,7 @@ const EventTriggers: React.FunctionComponent<EventTriggersProps> = ({
         eventType,
         ...(isFeedbackScoreTrigger
           ? {
-              conditions: [DEFAULT_FEEDBACK_SCORE_CONDITION],
+              groups: [DEFAULT_FEEDBACK_SCORE_CONDITION_GROUP],
             }
           : {}),
       });
@@ -341,7 +328,7 @@ const EventTriggers: React.FunctionComponent<EventTriggersProps> = ({
                             field.eventType,
                           )}
                       </div>
-                      <div className="flex items-center">
+                      <div className="flex items-start pt-0.5">
                         <Button
                           type="button"
                           variant="minimal"

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/FeedbackScoreConditions.tsx
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/FeedbackScoreConditions.tsx
@@ -7,12 +7,7 @@ import { FormControl, FormField } from "@/ui/form";
 import { Input } from "@/ui/input";
 import { Button } from "@/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@/ui/toggle-group";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipPortal,
-  TooltipTrigger,
-} from "@/ui/tooltip";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import SelectBox from "@/shared/SelectBox/SelectBox";
 import FeedbackDefinitionsAndScoresSelectBox, {
   ScoreSource,
@@ -52,26 +47,20 @@ export const DEFAULT_FEEDBACK_SCORE_CONDITION_GROUP: FeedbackScoreConditionGroup
 const CONDITION_FIELDS = ["name", "operator", "threshold", "window"] as const;
 type ConditionField = (typeof CONDITION_FIELDS)[number];
 
-// A tooltip wrapper for disabled controls — Radix tooltips don't fire on
-// elements with pointer-events: none, so we wrap the disabled child in a
-// span that intercepts hover/focus.
+// Radix tooltips don't fire on elements with pointer-events: none (which
+// disabled buttons get from the Button variants), so when `disabled` is true
+// we wrap the child in a span that intercepts hover/focus for the tooltip.
 const DisabledTooltip: React.FC<{
   message: string;
   disabled: boolean;
   children: React.ReactNode;
-}> = ({ message, disabled, children }) => {
-  if (!disabled) return <>{children}</>;
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className="inline-flex cursor-not-allowed">{children}</span>
-      </TooltipTrigger>
-      <TooltipPortal>
-        <TooltipContent side="top">{message}</TooltipContent>
-      </TooltipPortal>
-    </Tooltip>
-  );
-};
+}> = ({ message, disabled, children }) => (
+  <TooltipWrapper content={disabled ? message : null}>
+    <span className={cn("inline-flex", disabled && "cursor-not-allowed")}>
+      {children}
+    </span>
+  </TooltipWrapper>
+);
 
 const SeparatorBadge: React.FC<{ kind: "AND" | "OR" }> = ({ kind }) => (
   <div className="py-0.5">

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/FeedbackScoreConditions.tsx
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/FeedbackScoreConditions.tsx
@@ -3,7 +3,7 @@ import { Path, useFieldArray, UseFormReturn } from "react-hook-form";
 import { LayoutGrid, Plus, Trash } from "lucide-react";
 import get from "lodash/get";
 
-import { FormControl, FormField } from "@/ui/form";
+import { FormControl, FormField, FormItem } from "@/ui/form";
 import { Input } from "@/ui/input";
 import { Button } from "@/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@/ui/toggle-group";
@@ -277,18 +277,20 @@ const ConditionRow: React.FC<ConditionRowProps> = ({
             control={form.control}
             name={fieldPath(triggerIndex, groupIndex, conditionIndex, "name")}
             render={({ field }) => (
-              <FormControl>
-                <FeedbackDefinitionsAndScoresSelectBox
-                  value={field.value as string}
-                  onChange={field.onChange}
-                  scoreSource={scoreSource}
-                  entityIds={[projectId]}
-                  multiselect={false}
-                  className={cn("h-8 min-w-[160px] flex-1", {
-                    "border-destructive": Boolean(errors.name),
-                  })}
-                />
-              </FormControl>
+              <FormItem className="flex min-w-[160px] flex-1">
+                <FormControl>
+                  <FeedbackDefinitionsAndScoresSelectBox
+                    value={field.value as string}
+                    onChange={field.onChange}
+                    scoreSource={scoreSource}
+                    entityIds={[projectId]}
+                    multiselect={false}
+                    className={cn("h-8 w-full", {
+                      "border-destructive": Boolean(errors.name),
+                    })}
+                  />
+                </FormControl>
+              </FormItem>
             )}
           />
           <FormField
@@ -300,28 +302,30 @@ const ConditionRow: React.FC<ConditionRowProps> = ({
               "operator",
             )}
             render={({ field }) => (
-              <FormControl>
-                <ToggleGroup
-                  type="single"
-                  variant="secondary"
-                  value={field.value as string}
-                  onValueChange={(v) => v && field.onChange(v)}
-                  className={cn("h-8 shrink-0", {
-                    "border-destructive": Boolean(errors.operator),
-                  })}
-                >
-                  {OPERATOR_VALUES.map((op) => (
-                    <ToggleGroupItem
-                      key={op}
-                      value={op}
-                      size="sm"
-                      aria-label={op === ">" ? "greater than" : "less than"}
-                    >
-                      {op}
-                    </ToggleGroupItem>
-                  ))}
-                </ToggleGroup>
-              </FormControl>
+              <FormItem className="shrink-0">
+                <FormControl>
+                  <ToggleGroup
+                    type="single"
+                    variant="secondary"
+                    value={field.value as string}
+                    onValueChange={(v) => v && field.onChange(v)}
+                    className={cn("h-8", {
+                      "border-destructive": Boolean(errors.operator),
+                    })}
+                  >
+                    {OPERATOR_VALUES.map((op) => (
+                      <ToggleGroupItem
+                        key={op}
+                        value={op}
+                        size="sm"
+                        aria-label={op === ">" ? "greater than" : "less than"}
+                      >
+                        {op}
+                      </ToggleGroupItem>
+                    ))}
+                  </ToggleGroup>
+                </FormControl>
+              </FormItem>
             )}
           />
           <FormField
@@ -333,47 +337,51 @@ const ConditionRow: React.FC<ConditionRowProps> = ({
               "threshold",
             )}
             render={({ field }) => (
-              <FormControl>
-                <Input
-                  className={cn("h-8 w-[87px] shrink-0 text-right", {
-                    "border-destructive": Boolean(errors.threshold),
-                  })}
-                  type="number"
-                  step="0.01"
-                  placeholder="0.7"
-                  value={field.value as string}
-                  onChange={field.onChange}
-                  onBlur={field.onBlur}
-                  name={field.name}
-                />
-              </FormControl>
+              <FormItem className="w-[87px] shrink-0">
+                <FormControl>
+                  <Input
+                    className={cn("h-8 text-right", {
+                      "border-destructive": Boolean(errors.threshold),
+                    })}
+                    type="number"
+                    step="0.01"
+                    placeholder="0.7"
+                    value={field.value as string}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                    name={field.name}
+                  />
+                </FormControl>
+              </FormItem>
             )}
           />
           <FormField
             control={form.control}
             name={fieldPath(triggerIndex, groupIndex, conditionIndex, "window")}
             render={({ field }) => (
-              <FormControl>
-                <SelectBox
-                  value={field.value as string}
-                  onChange={field.onChange}
-                  options={WINDOW_OPTIONS}
-                  className={cn("h-8 min-w-[160px] flex-1 text-left", {
-                    "border-destructive": Boolean(errors.window),
-                  })}
-                  placeholder="Select time window"
-                  renderTrigger={(value) => {
-                    const label = WINDOW_LABEL_BY_VALUE[value];
-                    if (!label) return null;
-                    return (
-                      <span className="truncate">
-                        <span className="text-muted-slate">In the last</span>{" "}
-                        {label}
-                      </span>
-                    );
-                  }}
-                />
-              </FormControl>
+              <FormItem className="flex min-w-[160px] flex-1">
+                <FormControl>
+                  <SelectBox
+                    value={field.value as string}
+                    onChange={field.onChange}
+                    options={WINDOW_OPTIONS}
+                    className={cn("h-8 w-full text-left", {
+                      "border-destructive": Boolean(errors.window),
+                    })}
+                    placeholder="Select time window"
+                    renderTrigger={(value) => {
+                      const label = WINDOW_LABEL_BY_VALUE[value];
+                      if (!label) return null;
+                      return (
+                        <span className="truncate">
+                          <span className="text-muted-slate">In the last</span>{" "}
+                          {label}
+                        </span>
+                      );
+                    }}
+                  />
+                </FormControl>
+              </FormItem>
             )}
           />
         </div>

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/FeedbackScoreConditions.tsx
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/FeedbackScoreConditions.tsx
@@ -158,8 +158,19 @@ const ConditionGroup: React.FC<ConditionGroupProps> = ({
   const addCondition = () =>
     conditionsFieldArray.append({ ...DEFAULT_FEEDBACK_SCORE_CONDITION });
 
-  const removeCondition = (conditionIndex: number) =>
-    conditionsFieldArray.remove(conditionIndex);
+  // Deleting the only condition in a group removes the whole group (so the
+  // user doesn't end up with an empty group), unless this is the last group
+  // — then the delete is disabled to keep at least one group around.
+  const handleDeleteCondition = (conditionIndex: number) => {
+    if (conditionsFieldArray.fields.length === 1) {
+      onRemove();
+    } else {
+      conditionsFieldArray.remove(conditionIndex);
+    }
+  };
+
+  const canDeleteCondition =
+    conditionsFieldArray.fields.length > 1 || canRemove;
 
   return (
     <div className="overflow-hidden rounded-md border border-border bg-soft-background">
@@ -174,7 +185,7 @@ const ConditionGroup: React.FC<ConditionGroupProps> = ({
         </div>
         <DisabledTooltip
           disabled={!canRemove}
-          message="Can't remove the last group — every alert needs at least one."
+          message="Can't remove — every alert needs at least one group with at least one condition."
         >
           <Button
             type="button"
@@ -200,8 +211,8 @@ const ConditionGroup: React.FC<ConditionGroupProps> = ({
               conditionIndex={conditionIndex}
               scoreSource={scoreSource}
               projectId={projectId}
-              onDelete={() => removeCondition(conditionIndex)}
-              canDelete={conditionsFieldArray.fields.length > 1}
+              onDelete={() => handleDeleteCondition(conditionIndex)}
+              canDelete={canDeleteCondition}
             />
           </React.Fragment>
         ))}
@@ -285,7 +296,7 @@ const ConditionRow: React.FC<ConditionRowProps> = ({
                     scoreSource={scoreSource}
                     entityIds={[projectId]}
                     multiselect={false}
-                    className={cn("h-8 w-full", {
+                    className={cn("h-8 w-full font-normal", {
                       "border-destructive": Boolean(errors.name),
                     })}
                   />
@@ -365,7 +376,7 @@ const ConditionRow: React.FC<ConditionRowProps> = ({
                     value={field.value as string}
                     onChange={field.onChange}
                     options={WINDOW_OPTIONS}
-                    className={cn("h-8 w-full text-left", {
+                    className={cn("h-8 w-full text-left font-normal", {
                       "border-destructive": Boolean(errors.window),
                     })}
                     placeholder="Select time window"
@@ -387,7 +398,7 @@ const ConditionRow: React.FC<ConditionRowProps> = ({
         </div>
         <DisabledTooltip
           disabled={!canDelete}
-          message="Can't remove the last condition — every group needs at least one."
+          message="Can't remove — every alert needs at least one group with at least one condition."
         >
           <Button
             type="button"

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/FeedbackScoreConditions.tsx
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/FeedbackScoreConditions.tsx
@@ -1,20 +1,34 @@
 import React from "react";
 import { Path, useFieldArray, UseFormReturn } from "react-hook-form";
-import { Plus, X } from "lucide-react";
+import { LayoutGrid, Plus, Trash } from "lucide-react";
 import get from "lodash/get";
 
-import { Label } from "@/ui/label";
-import { FormControl, FormField, FormItem } from "@/ui/form";
-import { Button } from "@/ui/button";
+import { FormControl, FormField } from "@/ui/form";
 import { Input } from "@/ui/input";
+import { Button } from "@/ui/button";
+import { ToggleGroup, ToggleGroupItem } from "@/ui/toggle-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipPortal,
+  TooltipTrigger,
+} from "@/ui/tooltip";
 import SelectBox from "@/shared/SelectBox/SelectBox";
 import FeedbackDefinitionsAndScoresSelectBox, {
   ScoreSource,
 } from "@/v2/pages-shared/experiments/FeedbackDefinitionsAndScoresSelectBox/FeedbackDefinitionsAndScoresSelectBox";
-import { DropdownOption } from "@/types/shared";
-import { AlertFormType, FeedbackScoreConditionType } from "./schema";
+import {
+  AlertFormType,
+  FeedbackScoreConditionGroupType,
+  FeedbackScoreConditionType,
+} from "./schema";
 import { ALERT_EVENT_TYPE } from "@/types/alerts";
 import { cn } from "@/lib/utils";
+import {
+  OPERATOR_VALUES,
+  WINDOW_LABEL_BY_VALUE,
+  WINDOW_OPTIONS,
+} from "./constants";
 
 type FeedbackScoreConditionsProps = {
   form: UseFormReturn<AlertFormType>;
@@ -25,28 +39,47 @@ type FeedbackScoreConditionsProps = {
 
 export const DEFAULT_FEEDBACK_SCORE_CONDITION: FeedbackScoreConditionType = {
   threshold: "",
-  window: "1800",
+  window: "86400",
   name: "",
   operator: ">",
 };
 
-const WINDOW_OPTIONS: DropdownOption<string>[] = [
-  { label: "5 minutes", value: "300" },
-  { label: "15 minutes", value: "900" },
-  { label: "30 minutes", value: "1800" },
-  { label: "1 hour", value: "3600" },
-  { label: "6 hours", value: "21600" },
-  { label: "12 hours", value: "43200" },
-  { label: "24 hours", value: "86400" },
-  { label: "7 days", value: "604800" },
-  { label: "15 days", value: "1296000" },
-  { label: "30 days", value: "2592000" },
-];
+export const DEFAULT_FEEDBACK_SCORE_CONDITION_GROUP: FeedbackScoreConditionGroupType =
+  {
+    conditions: [DEFAULT_FEEDBACK_SCORE_CONDITION],
+  };
 
-const OPERATOR_OPTIONS: DropdownOption<string>[] = [
-  { label: ">", value: ">" },
-  { label: "<", value: "<" },
-];
+const CONDITION_FIELDS = ["name", "operator", "threshold", "window"] as const;
+type ConditionField = (typeof CONDITION_FIELDS)[number];
+
+// A tooltip wrapper for disabled controls — Radix tooltips don't fire on
+// elements with pointer-events: none, so we wrap the disabled child in a
+// span that intercepts hover/focus.
+const DisabledTooltip: React.FC<{
+  message: string;
+  disabled: boolean;
+  children: React.ReactNode;
+}> = ({ message, disabled, children }) => {
+  if (!disabled) return <>{children}</>;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex cursor-not-allowed">{children}</span>
+      </TooltipTrigger>
+      <TooltipPortal>
+        <TooltipContent side="top">{message}</TooltipContent>
+      </TooltipPortal>
+    </Tooltip>
+  );
+};
+
+const SeparatorBadge: React.FC<{ kind: "AND" | "OR" }> = ({ kind }) => (
+  <div className="py-0.5">
+    <span className="text-xs font-medium leading-4 text-violet-600">
+      {kind}
+    </span>
+  </div>
+);
 
 const FeedbackScoreConditions: React.FC<FeedbackScoreConditionsProps> = ({
   form,
@@ -54,264 +87,331 @@ const FeedbackScoreConditions: React.FC<FeedbackScoreConditionsProps> = ({
   eventType,
   projectId,
 }) => {
-  const conditionsFieldArray = useFieldArray({
+  const groupsFieldArray = useFieldArray({
     control: form.control,
-    name: `triggers.${triggerIndex}.conditions` as "triggers.0.conditions",
+    name: `triggers.${triggerIndex}.groups` as "triggers.0.groups",
   });
 
   const scoreSource =
-    eventType === ALERT_EVENT_TYPE.trace_feedback_score
-      ? ScoreSource.TRACES
-      : eventType === ALERT_EVENT_TYPE.trace_thread_feedback_score
-        ? ScoreSource.THREADS
-        : ScoreSource.TRACES;
+    eventType === ALERT_EVENT_TYPE.trace_thread_feedback_score
+      ? ScoreSource.THREADS
+      : ScoreSource.TRACES;
 
-  const addCondition = () => {
-    conditionsFieldArray.append(DEFAULT_FEEDBACK_SCORE_CONDITION);
-  };
+  const addGroup = () =>
+    groupsFieldArray.append({
+      conditions: [{ ...DEFAULT_FEEDBACK_SCORE_CONDITION }],
+    });
 
-  const removeCondition = (conditionIndex: number) => {
-    conditionsFieldArray.remove(conditionIndex);
-  };
+  const removeGroup = (groupIndex: number) =>
+    groupsFieldArray.remove(groupIndex);
 
-  // Helper to get validation errors for a specific field in a condition
-  const getConditionFieldErrors = (
-    conditionIndex: number,
-    fieldName: "name" | "operator" | "threshold" | "window",
-  ) => {
-    return get(form.formState.errors, [
-      "triggers",
-      triggerIndex,
-      "conditions",
-      conditionIndex,
-      fieldName,
-    ]);
-  };
+  const canDeleteGroup = groupsFieldArray.fields.length > 1;
 
   return (
     <div className="flex flex-col gap-2">
-      {conditionsFieldArray.fields.map((condition, conditionIndex) => {
-        const isFirstCondition = conditionIndex === 0;
-        const canDelete = conditionsFieldArray.fields.length > 1;
-
-        const nameErrors = getConditionFieldErrors(conditionIndex, "name");
-        const operatorErrors = getConditionFieldErrors(
-          conditionIndex,
-          "operator",
-        );
-        const thresholdErrors = getConditionFieldErrors(
-          conditionIndex,
-          "threshold",
-        );
-        const windowErrors = getConditionFieldErrors(conditionIndex, "window");
-
-        const hasErrors =
-          nameErrors?.message ||
-          operatorErrors?.message ||
-          thresholdErrors?.message ||
-          windowErrors?.message;
-
-        return (
-          <div key={condition.id} className="flex flex-col gap-1">
-            <div className="flex items-end gap-2.5">
-              {/* Grouped inputs: feedback score name, operator, threshold */}
-              <div className="flex flex-1 items-end">
-                <FormField
-                  control={form.control}
-                  name={
-                    `triggers.${triggerIndex}.conditions.${conditionIndex}.name` as Path<AlertFormType>
-                  }
-                  render={({ field }) => {
-                    const validationErrors = getConditionFieldErrors(
-                      conditionIndex,
-                      "name",
-                    );
-                    return (
-                      <FormItem className="min-w-[150px] flex-1">
-                        {isFirstCondition && (
-                          <Label className="comet-body-s-accented">
-                            When average
-                          </Label>
-                        )}
-                        {!isFirstCondition && (
-                          <Label className="comet-body-s-accented">
-                            Or when average
-                          </Label>
-                        )}
-                        <FormControl>
-                          <FeedbackDefinitionsAndScoresSelectBox
-                            value={field.value as string}
-                            onChange={field.onChange}
-                            scoreSource={scoreSource}
-                            entityIds={[projectId]}
-                            multiselect={false}
-                            className={cn("h-8 rounded-r-none", {
-                              "border-destructive": Boolean(
-                                validationErrors?.message,
-                              ),
-                            })}
-                          />
-                        </FormControl>
-                      </FormItem>
-                    );
-                  }}
-                />
-                <FormField
-                  control={form.control}
-                  name={
-                    `triggers.${triggerIndex}.conditions.${conditionIndex}.operator` as Path<AlertFormType>
-                  }
-                  render={({ field }) => {
-                    const validationErrors = getConditionFieldErrors(
-                      conditionIndex,
-                      "operator",
-                    );
-                    return (
-                      <FormItem className="-ml-px w-16">
-                        <FormControl>
-                          <SelectBox
-                            value={field.value as string}
-                            onChange={field.onChange}
-                            options={OPERATOR_OPTIONS}
-                            className={cn("h-8 rounded-none text-left", {
-                              "border-destructive": Boolean(
-                                validationErrors?.message,
-                              ),
-                            })}
-                            placeholder=">"
-                          />
-                        </FormControl>
-                      </FormItem>
-                    );
-                  }}
-                />
-                <FormField
-                  control={form.control}
-                  name={
-                    `triggers.${triggerIndex}.conditions.${conditionIndex}.threshold` as Path<AlertFormType>
-                  }
-                  render={({ field }) => {
-                    const validationErrors = getConditionFieldErrors(
-                      conditionIndex,
-                      "threshold",
-                    );
-                    return (
-                      <FormItem className="-ml-px w-24">
-                        <FormControl>
-                          <Input
-                            className={cn("h-8 rounded-l-none", {
-                              "border-destructive": Boolean(
-                                validationErrors?.message,
-                              ),
-                            })}
-                            type="number"
-                            step="0.01"
-                            placeholder="0.7"
-                            value={field.value as string}
-                            onChange={field.onChange}
-                            onBlur={field.onBlur}
-                            name={field.name}
-                          />
-                        </FormControl>
-                      </FormItem>
-                    );
-                  }}
-                />
-              </div>
-              <FormField
-                control={form.control}
-                name={
-                  `triggers.${triggerIndex}.conditions.${conditionIndex}.window` as Path<AlertFormType>
-                }
-                render={({ field }) => {
-                  const validationErrors = getConditionFieldErrors(
-                    conditionIndex,
-                    "window",
-                  );
-                  return (
-                    <FormItem className="min-w-[120px] flex-1">
-                      <Label className="comet-body-s-accented">
-                        In the last
-                      </Label>
-                      <FormControl>
-                        <SelectBox
-                          value={field.value as string}
-                          onChange={field.onChange}
-                          options={WINDOW_OPTIONS}
-                          className={cn("h-8 text-left", {
-                            "border-destructive": Boolean(
-                              validationErrors?.message,
-                            ),
-                          })}
-                          placeholder="Select time window"
-                        />
-                      </FormControl>
-                    </FormItem>
-                  );
-                }}
-              />
-              {canDelete && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  className="mb-0.5"
-                  onClick={() => removeCondition(conditionIndex)}
-                >
-                  <X className="size-4" />
-                </Button>
-              )}
-            </div>
-            {/* Error messages row - displayed below the inputs */}
-            {hasErrors && (
-              <div className="flex gap-2.5">
-                <div className="flex flex-1 gap-0">
-                  <div className="min-w-[150px] flex-1">
-                    {nameErrors?.message && (
-                      <p className="text-[0.8rem] font-medium text-destructive">
-                        {String(nameErrors.message)}
-                      </p>
-                    )}
-                  </div>
-                  <div className="-ml-px w-16">
-                    {operatorErrors?.message && (
-                      <p className="text-[0.8rem] font-medium text-destructive">
-                        {String(operatorErrors.message)}
-                      </p>
-                    )}
-                  </div>
-                  <div className="-ml-px w-24">
-                    {thresholdErrors?.message && (
-                      <p className="text-[0.8rem] font-medium text-destructive">
-                        {String(thresholdErrors.message)}
-                      </p>
-                    )}
-                  </div>
-                </div>
-                <div className="min-w-[120px] flex-1">
-                  {windowErrors?.message && (
-                    <p className="text-[0.8rem] font-medium text-destructive">
-                      {String(windowErrors.message)}
-                    </p>
-                  )}
-                </div>
-                {canDelete && <div className="w-8" />}
-              </div>
-            )}
-          </div>
-        );
-      })}
-      <div className="flex pt-1">
+      {groupsFieldArray.fields.map((group, groupIndex) => (
+        <React.Fragment key={group.id}>
+          {groupIndex > 0 && <SeparatorBadge kind="OR" />}
+          <ConditionGroup
+            form={form}
+            triggerIndex={triggerIndex}
+            groupIndex={groupIndex}
+            scoreSource={scoreSource}
+            projectId={projectId}
+            label={`Group ${groupIndex + 1}`}
+            onRemove={() => removeGroup(groupIndex)}
+            canRemove={canDeleteGroup}
+          />
+        </React.Fragment>
+      ))}
+      <div className="flex h-8 items-center justify-center rounded-md border border-dashed border-border bg-soft-background">
         <Button
           type="button"
-          variant="outline"
-          size="sm"
-          onClick={addCondition}
+          variant="ghost"
+          size="xs"
+          className="text-foreground hover:text-primary-hover"
+          onClick={addGroup}
         >
-          <Plus className="mr-1 size-3" />
-          Add condition
+          <Plus className="mr-0.5 size-3" />
+          Add OR group
         </Button>
       </div>
+    </div>
+  );
+};
+
+type ConditionGroupProps = {
+  form: UseFormReturn<AlertFormType>;
+  triggerIndex: number;
+  groupIndex: number;
+  scoreSource: ScoreSource;
+  projectId: string;
+  label: string;
+  onRemove: () => void;
+  canRemove: boolean;
+};
+
+const ConditionGroup: React.FC<ConditionGroupProps> = ({
+  form,
+  triggerIndex,
+  groupIndex,
+  scoreSource,
+  projectId,
+  label,
+  onRemove,
+  canRemove,
+}) => {
+  const conditionsFieldArray = useFieldArray({
+    control: form.control,
+    name: `triggers.${triggerIndex}.groups.${groupIndex}.conditions` as "triggers.0.groups.0.conditions",
+  });
+
+  const addCondition = () =>
+    conditionsFieldArray.append({ ...DEFAULT_FEEDBACK_SCORE_CONDITION });
+
+  const removeCondition = (conditionIndex: number) =>
+    conditionsFieldArray.remove(conditionIndex);
+
+  return (
+    <div className="overflow-hidden rounded-md border border-border bg-soft-background">
+      <div className="flex h-8 items-center justify-between pl-2 pr-3">
+        <div className="flex items-center gap-1.5">
+          <span className="flex size-4 items-center justify-center rounded bg-violet-600 text-white">
+            <LayoutGrid className="size-2.5" />
+          </span>
+          <span className="text-xs font-medium leading-4 text-muted-slate">
+            {label}
+          </span>
+        </div>
+        <DisabledTooltip
+          disabled={!canRemove}
+          message="Can't remove the last group — every alert needs at least one."
+        >
+          <Button
+            type="button"
+            variant="minimal"
+            size="icon-3xs"
+            className="size-3 [&>svg]:size-3"
+            onClick={onRemove}
+            disabled={!canRemove}
+            aria-label="Remove group"
+          >
+            <Trash />
+          </Button>
+        </DisabledTooltip>
+      </div>
+      <div className="flex flex-col gap-1.5 px-1.5 pb-1.5">
+        {conditionsFieldArray.fields.map((condition, conditionIndex) => (
+          <React.Fragment key={condition.id}>
+            {conditionIndex > 0 && <SeparatorBadge kind="AND" />}
+            <ConditionRow
+              form={form}
+              triggerIndex={triggerIndex}
+              groupIndex={groupIndex}
+              conditionIndex={conditionIndex}
+              scoreSource={scoreSource}
+              projectId={projectId}
+              onDelete={() => removeCondition(conditionIndex)}
+              canDelete={conditionsFieldArray.fields.length > 1}
+            />
+          </React.Fragment>
+        ))}
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          className="self-start pl-1 text-foreground hover:text-primary-hover"
+          onClick={addCondition}
+        >
+          <Plus className="mr-0.5 size-3" />
+          Add AND condition
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+type ConditionRowProps = {
+  form: UseFormReturn<AlertFormType>;
+  triggerIndex: number;
+  groupIndex: number;
+  conditionIndex: number;
+  scoreSource: ScoreSource;
+  projectId: string;
+  onDelete: () => void;
+  canDelete: boolean;
+};
+
+const fieldPath = (
+  triggerIndex: number,
+  groupIndex: number,
+  conditionIndex: number,
+  field: ConditionField,
+) =>
+  `triggers.${triggerIndex}.groups.${groupIndex}.conditions.${conditionIndex}.${field}` as Path<AlertFormType>;
+
+const ConditionRow: React.FC<ConditionRowProps> = ({
+  form,
+  triggerIndex,
+  groupIndex,
+  conditionIndex,
+  scoreSource,
+  projectId,
+  onDelete,
+  canDelete,
+}) => {
+  const errorBase = [
+    "triggers",
+    triggerIndex,
+    "groups",
+    groupIndex,
+    "conditions",
+    conditionIndex,
+  ] as const;
+  const errors = Object.fromEntries(
+    CONDITION_FIELDS.map((f) => [
+      f,
+      (
+        get(form.formState.errors, [...errorBase, f]) as
+          | { message?: string }
+          | undefined
+      )?.message,
+    ]),
+  ) as Record<ConditionField, string | undefined>;
+  const hasErrors = CONDITION_FIELDS.some((f) => errors[f]);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex min-h-11 items-stretch overflow-hidden rounded-md border border-border bg-background">
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2 px-2 py-1.5">
+          <FormField
+            control={form.control}
+            name={fieldPath(triggerIndex, groupIndex, conditionIndex, "name")}
+            render={({ field }) => (
+              <FormControl>
+                <FeedbackDefinitionsAndScoresSelectBox
+                  value={field.value as string}
+                  onChange={field.onChange}
+                  scoreSource={scoreSource}
+                  entityIds={[projectId]}
+                  multiselect={false}
+                  className={cn("h-8 min-w-[160px] flex-1", {
+                    "border-destructive": Boolean(errors.name),
+                  })}
+                />
+              </FormControl>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name={fieldPath(
+              triggerIndex,
+              groupIndex,
+              conditionIndex,
+              "operator",
+            )}
+            render={({ field }) => (
+              <FormControl>
+                <ToggleGroup
+                  type="single"
+                  variant="secondary"
+                  value={field.value as string}
+                  onValueChange={(v) => v && field.onChange(v)}
+                  className={cn("h-8 shrink-0", {
+                    "border-destructive": Boolean(errors.operator),
+                  })}
+                >
+                  {OPERATOR_VALUES.map((op) => (
+                    <ToggleGroupItem
+                      key={op}
+                      value={op}
+                      size="sm"
+                      aria-label={op === ">" ? "greater than" : "less than"}
+                    >
+                      {op}
+                    </ToggleGroupItem>
+                  ))}
+                </ToggleGroup>
+              </FormControl>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name={fieldPath(
+              triggerIndex,
+              groupIndex,
+              conditionIndex,
+              "threshold",
+            )}
+            render={({ field }) => (
+              <FormControl>
+                <Input
+                  className={cn("h-8 w-[87px] shrink-0 text-right", {
+                    "border-destructive": Boolean(errors.threshold),
+                  })}
+                  type="number"
+                  step="0.01"
+                  placeholder="0.7"
+                  value={field.value as string}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                  name={field.name}
+                />
+              </FormControl>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name={fieldPath(triggerIndex, groupIndex, conditionIndex, "window")}
+            render={({ field }) => (
+              <FormControl>
+                <SelectBox
+                  value={field.value as string}
+                  onChange={field.onChange}
+                  options={WINDOW_OPTIONS}
+                  className={cn("h-8 min-w-[160px] flex-1 text-left", {
+                    "border-destructive": Boolean(errors.window),
+                  })}
+                  placeholder="Select time window"
+                  renderTrigger={(value) => {
+                    const label = WINDOW_LABEL_BY_VALUE[value];
+                    if (!label) return null;
+                    return (
+                      <span className="truncate">
+                        <span className="text-muted-slate">In the last</span>{" "}
+                        {label}
+                      </span>
+                    );
+                  }}
+                />
+              </FormControl>
+            )}
+          />
+        </div>
+        <DisabledTooltip
+          disabled={!canDelete}
+          message="Can't remove the last condition — every group needs at least one."
+        >
+          <Button
+            type="button"
+            variant="minimal"
+            size="icon-2xs"
+            className="h-auto w-6 rounded-none border-l border-border opacity-50 hover:opacity-100"
+            onClick={onDelete}
+            disabled={!canDelete}
+            aria-label="Remove condition"
+          >
+            <Trash />
+          </Button>
+        </DisabledTooltip>
+      </div>
+      {hasErrors && (
+        <div className="flex flex-wrap gap-x-2 px-2 text-[0.8rem] font-medium text-destructive">
+          {CONDITION_FIELDS.map(
+            (f) => errors[f] && <span key={f}>{errors[f]}</span>,
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/constants.ts
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/constants.ts
@@ -1,0 +1,21 @@
+import { DropdownOption } from "@/types/shared";
+
+export const WINDOW_OPTIONS: DropdownOption<string>[] = [
+  { label: "5 mins", value: "300" },
+  { label: "15 mins", value: "900" },
+  { label: "30 mins", value: "1800" },
+  { label: "1 hour", value: "3600" },
+  { label: "6 hours", value: "21600" },
+  { label: "12 hours", value: "43200" },
+  { label: "24 hours", value: "86400" },
+  { label: "7 days", value: "604800" },
+  { label: "15 days", value: "1296000" },
+  { label: "30 days", value: "2592000" },
+];
+
+export const WINDOW_LABEL_BY_VALUE: Record<string, string> = Object.fromEntries(
+  WINDOW_OPTIONS.map((o) => [o.value, o.label]),
+);
+
+export const OPERATOR_VALUES = [">", "<"] as const;
+export type OperatorValue = (typeof OPERATOR_VALUES)[number];

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/helpers.test.ts
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/helpers.test.ts
@@ -1,0 +1,239 @@
+import {
+  alertTriggersToFormTriggers,
+  formTriggersToAlertTriggers,
+} from "./helpers";
+import {
+  ALERT_EVENT_TYPE,
+  ALERT_TRIGGER_CONFIG_TYPE,
+  AlertTriggerConfig,
+} from "@/types/alerts";
+
+const fbScore = (
+  configValue: Record<string, string>,
+  groupIndex?: number | null,
+): AlertTriggerConfig => ({
+  type: ALERT_TRIGGER_CONFIG_TYPE["threshold:feedback_score"],
+  config_value: configValue,
+  ...(groupIndex === undefined ? {} : { group_index: groupIndex }),
+});
+
+describe("alertTriggersToFormTriggers", () => {
+  it("buckets configs with the same group_index into one AND group", () => {
+    const [trigger] = alertTriggersToFormTriggers([
+      {
+        event_type: ALERT_EVENT_TYPE.trace_feedback_score,
+        trigger_configs: [
+          fbScore(
+            {
+              name: "hallucination",
+              operator: ">",
+              threshold: "0.7",
+              window: "3600",
+            },
+            0,
+          ),
+          fbScore(
+            {
+              name: "answer_relevance",
+              operator: "<",
+              threshold: "0.5",
+              window: "3600",
+            },
+            0,
+          ),
+        ],
+      },
+    ]);
+
+    expect(trigger.groups).toHaveLength(1);
+    expect(trigger.groups?.[0].conditions).toHaveLength(2);
+  });
+
+  it("splits configs with different group_index into separate OR groups", () => {
+    const [trigger] = alertTriggersToFormTriggers([
+      {
+        event_type: ALERT_EVENT_TYPE.trace_feedback_score,
+        trigger_configs: [
+          fbScore(
+            { name: "a", operator: ">", threshold: "0.7", window: "3600" },
+            0,
+          ),
+          fbScore(
+            { name: "b", operator: ">", threshold: "0.8", window: "3600" },
+            1,
+          ),
+        ],
+      },
+    ]);
+
+    expect(trigger.groups).toHaveLength(2);
+    expect(trigger.groups?.[0].conditions[0].name).toBe("a");
+    expect(trigger.groups?.[1].conditions[0].name).toBe("b");
+  });
+
+  it("treats legacy configs without group_index as separate OR groups (own group of one)", () => {
+    const [trigger] = alertTriggersToFormTriggers([
+      {
+        event_type: ALERT_EVENT_TYPE.trace_feedback_score,
+        trigger_configs: [
+          fbScore({
+            name: "a",
+            operator: ">",
+            threshold: "0.7",
+            window: "3600",
+          }),
+          fbScore({
+            name: "b",
+            operator: ">",
+            threshold: "0.8",
+            window: "3600",
+          }),
+        ],
+      },
+    ]);
+
+    expect(trigger.groups).toHaveLength(2);
+    expect(trigger.groups?.[0].conditions).toHaveLength(1);
+    expect(trigger.groups?.[1].conditions).toHaveLength(1);
+  });
+
+  it("loads partial configs without dropping them so users can edit incomplete alerts", () => {
+    const [trigger] = alertTriggersToFormTriggers([
+      {
+        event_type: ALERT_EVENT_TYPE.trace_feedback_score,
+        trigger_configs: [
+          // missing 'name' — must still load (no filter), so the editor shows the empty field
+          fbScore({ operator: ">", threshold: "0.7", window: "3600" }, 0),
+        ],
+      },
+    ]);
+
+    expect(trigger.groups).toHaveLength(1);
+    expect(trigger.groups?.[0].conditions[0].name).toBe("");
+    expect(trigger.groups?.[0].conditions[0].threshold).toBe("0.7");
+  });
+
+  it("normalizes unknown operator strings to '>'", () => {
+    const [trigger] = alertTriggersToFormTriggers([
+      {
+        event_type: ALERT_EVENT_TYPE.trace_feedback_score,
+        trigger_configs: [
+          fbScore(
+            {
+              name: "a",
+              operator: "garbage",
+              threshold: "0.7",
+              window: "3600",
+            },
+            0,
+          ),
+        ],
+      },
+    ]);
+
+    expect(trigger.groups?.[0].conditions[0].operator).toBe(">");
+  });
+});
+
+describe("formTriggersToAlertTriggers", () => {
+  it("flattens groups and stamps group_index per group", () => {
+    const [trigger] = formTriggersToAlertTriggers([
+      {
+        eventType: ALERT_EVENT_TYPE.trace_feedback_score,
+        groups: [
+          {
+            conditions: [
+              { name: "a", operator: ">", threshold: "0.7", window: "3600" },
+              { name: "b", operator: "<", threshold: "0.5", window: "3600" },
+            ],
+          },
+          {
+            conditions: [
+              { name: "c", operator: ">", threshold: "0.8", window: "3600" },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    expect(trigger.trigger_configs).toHaveLength(3);
+    expect(trigger.trigger_configs?.[0].group_index).toBe(0);
+    expect(trigger.trigger_configs?.[1].group_index).toBe(0);
+    expect(trigger.trigger_configs?.[2].group_index).toBe(1);
+  });
+
+  it("drops conditions that are missing threshold or window (can't persist a partial threshold config)", () => {
+    const [trigger] = formTriggersToAlertTriggers([
+      {
+        eventType: ALERT_EVENT_TYPE.trace_feedback_score,
+        groups: [
+          {
+            conditions: [
+              { name: "a", operator: ">", threshold: "0.7", window: "3600" },
+              { name: "b", operator: ">", threshold: "", window: "3600" }, // dropped
+            ],
+          },
+        ],
+      },
+    ]);
+
+    expect(trigger.trigger_configs).toHaveLength(1);
+    expect(trigger.trigger_configs?.[0].config_value.name).toBe("a");
+  });
+
+  it("round-trips grouped configs back to the same shape", () => {
+    const incoming: AlertTriggerConfig[] = [
+      fbScore(
+        { name: "a", operator: ">", threshold: "0.7", window: "3600" },
+        0,
+      ),
+      fbScore(
+        { name: "b", operator: "<", threshold: "0.5", window: "3600" },
+        0,
+      ),
+      fbScore(
+        { name: "c", operator: ">", threshold: "0.8", window: "3600" },
+        1,
+      ),
+    ];
+    const form = alertTriggersToFormTriggers([
+      {
+        event_type: ALERT_EVENT_TYPE.trace_feedback_score,
+        trigger_configs: incoming,
+      },
+    ]);
+    const back = formTriggersToAlertTriggers(form);
+
+    expect(back[0].trigger_configs).toHaveLength(3);
+    expect(back[0].trigger_configs?.map((c) => c.group_index)).toEqual([
+      0, 0, 1,
+    ]);
+    expect(back[0].trigger_configs?.map((c) => c.config_value.name)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("compresses non-contiguous incoming group_index to a contiguous 0,1,... on save", () => {
+    const incoming: AlertTriggerConfig[] = [
+      fbScore(
+        { name: "a", operator: ">", threshold: "0.7", window: "3600" },
+        5,
+      ),
+      fbScore(
+        { name: "b", operator: ">", threshold: "0.8", window: "3600" },
+        9,
+      ),
+    ];
+    const form = alertTriggersToFormTriggers([
+      {
+        event_type: ALERT_EVENT_TYPE.trace_feedback_score,
+        trigger_configs: incoming,
+      },
+    ]);
+    const back = formTriggersToAlertTriggers(form);
+
+    expect(back[0].trigger_configs?.map((c) => c.group_index)).toEqual([0, 1]);
+  });
+});

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/helpers.ts
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/helpers.ts
@@ -152,18 +152,18 @@ const getAllThresholdConditionGroupsFromTriggerConfigs = (
   const groupBuckets = new Map<string, FeedbackScoreConditionType[]>();
   let fallbackKey = 0;
 
+  // Load every matching config (don't filter out partial ones) so existing
+  // alerts open in the editor — schema validation will flag any missing
+  // fields and the user can complete them.
   matching.forEach((config) => {
-    const rawOperator = config.config_value?.operator;
+    if (!config.config_value) return;
+    const rawOperator = config.config_value.operator;
     const condition: FeedbackScoreConditionType = {
-      threshold: config.config_value?.threshold || "",
-      window: config.config_value?.window || "",
-      name: config.config_value?.name || "",
+      threshold: config.config_value.threshold || "",
+      window: config.config_value.window || "",
+      name: config.config_value.name || "",
       operator: rawOperator === "<" ? "<" : ">",
     };
-
-    if (!condition.threshold || !condition.window || !condition.name) {
-      return;
-    }
 
     const key =
       config.group_index === null || config.group_index === undefined

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/helpers.ts
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/helpers.ts
@@ -14,7 +14,11 @@ import {
   AlertTriggerConfig,
   Alert,
 } from "@/types/alerts";
-import { TriggerFormType, FeedbackScoreConditionType } from "./schema";
+import {
+  TriggerFormType,
+  FeedbackScoreConditionType,
+  FeedbackScoreConditionGroupType,
+} from "./schema";
 import SlackIcon from "@/icons/slack.svg?react";
 import PagerDutyIcon from "@/icons/pagerduty.svg?react";
 
@@ -98,6 +102,16 @@ export const TRIGGER_CONFIG: Record<ALERT_EVENT_TYPE, TriggerConfig> = {
   },
 };
 
+const SIMPLE_THRESHOLD_CONFIG_TYPE: Partial<
+  Record<ALERT_EVENT_TYPE, ALERT_TRIGGER_CONFIG_TYPE>
+> = {
+  [ALERT_EVENT_TYPE.trace_cost]: ALERT_TRIGGER_CONFIG_TYPE["threshold:cost"],
+  [ALERT_EVENT_TYPE.trace_latency]:
+    ALERT_TRIGGER_CONFIG_TYPE["threshold:latency"],
+  [ALERT_EVENT_TYPE.trace_errors]:
+    ALERT_TRIGGER_CONFIG_TYPE["threshold:errors"],
+};
+
 const getThresholdFromTriggerConfigs = (
   configType: ALERT_TRIGGER_CONFIG_TYPE,
   triggerConfigs?: AlertTriggerConfig[],
@@ -123,55 +137,76 @@ const getThresholdFromTriggerConfigs = (
   return {};
 };
 
-const getAllThresholdConditionsFromTriggerConfigs = (
+const getAllThresholdConditionGroupsFromTriggerConfigs = (
   configType: ALERT_TRIGGER_CONFIG_TYPE,
   triggerConfigs?: AlertTriggerConfig[],
-): FeedbackScoreConditionType[] => {
+): FeedbackScoreConditionGroupType[] => {
   if (!triggerConfigs) return [];
 
-  const conditions = triggerConfigs
-    .filter((config) => config.type === configType)
-    .map((config) => ({
+  const matching = triggerConfigs.filter(
+    (config) => config.type === configType,
+  );
+
+  // Bucket by group_index. Configs without a group_index land in their own
+  // group (preserves the pre-grouping "implicit OR" semantics).
+  const groupBuckets = new Map<string, FeedbackScoreConditionType[]>();
+  let fallbackKey = 0;
+
+  matching.forEach((config) => {
+    const rawOperator = config.config_value?.operator;
+    const condition: FeedbackScoreConditionType = {
       threshold: config.config_value?.threshold || "",
       window: config.config_value?.window || "",
       name: config.config_value?.name || "",
-      operator: config.config_value?.operator || ">",
-    }))
-    .filter(
-      (condition) => condition.threshold && condition.window && condition.name,
-    );
+      operator: rawOperator === "<" ? "<" : ">",
+    };
 
-  return conditions;
+    if (!condition.threshold || !condition.window || !condition.name) {
+      return;
+    }
+
+    const key =
+      config.group_index === null || config.group_index === undefined
+        ? `__ungrouped_${fallbackKey++}`
+        : `g_${config.group_index}`;
+
+    const bucket = groupBuckets.get(key) ?? [];
+    bucket.push(condition);
+    groupBuckets.set(key, bucket);
+  });
+
+  return Array.from(groupBuckets.values()).map((conditions) => ({
+    conditions,
+  }));
 };
 
-const createThresholdTriggerConfig = (
-  configType: ALERT_TRIGGER_CONFIG_TYPE,
-  threshold?: string,
-  window?: string,
-  name?: string,
-  operator?: string,
-): AlertTriggerConfig[] => {
+type ThresholdConfigInput = {
+  configType: ALERT_TRIGGER_CONFIG_TYPE;
+  threshold?: string;
+  window?: string;
+  name?: string;
+  operator?: string;
+  groupIndex?: number;
+};
+
+const createThresholdTriggerConfig = ({
+  configType,
+  threshold,
+  window,
+  name,
+  operator,
+  groupIndex,
+}: ThresholdConfigInput): AlertTriggerConfig[] => {
   if (!threshold || !window) return [];
 
-  const config_value: Record<string, string> = {
-    threshold,
-    window,
-  };
+  const config_value: Record<string, string> = { threshold, window };
+  if (name) config_value.name = name;
+  if (operator) config_value.operator = operator;
 
-  // Add name and operator for feedback score triggers
-  if (name) {
-    config_value.name = name;
-  }
-  if (operator) {
-    config_value.operator = operator;
-  }
+  const config: AlertTriggerConfig = { type: configType, config_value };
+  if (groupIndex !== undefined) config.group_index = groupIndex;
 
-  return [
-    {
-      type: configType,
-      config_value,
-    },
-  ];
+  return [config];
 };
 
 export const alertTriggersToFormTriggers = (
@@ -180,41 +215,28 @@ export const alertTriggersToFormTriggers = (
   if (!triggers || triggers.length === 0) return [];
 
   return triggers.map((trigger) => {
-    // Extract threshold and window for cost/latency/errors triggers
-    let thresholdData = {};
-    if (trigger.event_type === ALERT_EVENT_TYPE.trace_cost) {
-      thresholdData = getThresholdFromTriggerConfigs(
-        ALERT_TRIGGER_CONFIG_TYPE["threshold:cost"],
-        trigger.trigger_configs,
-      );
-    } else if (trigger.event_type === ALERT_EVENT_TYPE.trace_latency) {
-      thresholdData = getThresholdFromTriggerConfigs(
-        ALERT_TRIGGER_CONFIG_TYPE["threshold:latency"],
-        trigger.trigger_configs,
-      );
-    } else if (trigger.event_type === ALERT_EVENT_TYPE.trace_errors) {
-      thresholdData = getThresholdFromTriggerConfigs(
-        ALERT_TRIGGER_CONFIG_TYPE["threshold:errors"],
-        trigger.trigger_configs,
-      );
-    }
+    const simpleThresholdType =
+      SIMPLE_THRESHOLD_CONFIG_TYPE[trigger.event_type];
+    const thresholdData = simpleThresholdType
+      ? getThresholdFromTriggerConfigs(
+          simpleThresholdType,
+          trigger.trigger_configs,
+        )
+      : {};
 
-    // Extract multiple conditions for feedback score triggers
-    let conditions: FeedbackScoreConditionType[] = [];
-    if (
+    const groups: FeedbackScoreConditionGroupType[] =
       trigger.event_type === ALERT_EVENT_TYPE.trace_feedback_score ||
       trigger.event_type === ALERT_EVENT_TYPE.trace_thread_feedback_score
-    ) {
-      conditions = getAllThresholdConditionsFromTriggerConfigs(
-        ALERT_TRIGGER_CONFIG_TYPE["threshold:feedback_score"],
-        trigger.trigger_configs,
-      );
-    }
+        ? getAllThresholdConditionGroupsFromTriggerConfigs(
+            ALERT_TRIGGER_CONFIG_TYPE["threshold:feedback_score"],
+            trigger.trigger_configs,
+          )
+        : [];
 
     return {
       eventType: trigger.event_type,
       ...thresholdData,
-      ...(conditions.length > 0 ? { conditions } : {}),
+      ...(groups.length > 0 ? { groups } : {}),
     };
   });
 };
@@ -225,49 +247,35 @@ export const formTriggersToAlertTriggers = (
   return triggers.map((trigger) => {
     const configs: AlertTriggerConfig[] = [];
 
-    // Add threshold config for cost/latency/errors triggers
-    if (trigger.eventType === ALERT_EVENT_TYPE.trace_cost) {
+    const simpleThresholdType = SIMPLE_THRESHOLD_CONFIG_TYPE[trigger.eventType];
+    if (simpleThresholdType) {
       configs.push(
-        ...createThresholdTriggerConfig(
-          ALERT_TRIGGER_CONFIG_TYPE["threshold:cost"],
-          trigger.threshold,
-          trigger.window,
-        ),
-      );
-    } else if (trigger.eventType === ALERT_EVENT_TYPE.trace_latency) {
-      configs.push(
-        ...createThresholdTriggerConfig(
-          ALERT_TRIGGER_CONFIG_TYPE["threshold:latency"],
-          trigger.threshold,
-          trigger.window,
-        ),
-      );
-    } else if (trigger.eventType === ALERT_EVENT_TYPE.trace_errors) {
-      configs.push(
-        ...createThresholdTriggerConfig(
-          ALERT_TRIGGER_CONFIG_TYPE["threshold:errors"],
-          trigger.threshold,
-          trigger.window,
-        ),
+        ...createThresholdTriggerConfig({
+          configType: simpleThresholdType,
+          threshold: trigger.threshold,
+          window: trigger.window,
+        }),
       );
     } else if (
       trigger.eventType === ALERT_EVENT_TYPE.trace_feedback_score ||
       trigger.eventType === ALERT_EVENT_TYPE.trace_thread_feedback_score
     ) {
-      // Add multiple threshold configs for feedback scores (one per condition)
-      if (trigger.conditions && trigger.conditions.length > 0) {
-        trigger.conditions.forEach((condition) => {
+      // Flatten groups into threshold configs with group_index.
+      // Same group_index = AND; different = OR.
+      trigger.groups?.forEach((group, groupIndex) => {
+        group.conditions.forEach((condition) => {
           configs.push(
-            ...createThresholdTriggerConfig(
-              ALERT_TRIGGER_CONFIG_TYPE["threshold:feedback_score"],
-              condition.threshold,
-              condition.window,
-              condition.name,
-              condition.operator,
-            ),
+            ...createThresholdTriggerConfig({
+              configType: ALERT_TRIGGER_CONFIG_TYPE["threshold:feedback_score"],
+              threshold: condition.threshold,
+              window: condition.window,
+              name: condition.name,
+              operator: condition.operator,
+              groupIndex,
+            }),
           );
         });
-      }
+      });
     }
 
     return {

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/schema.ts
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z, RefinementCtx } from "zod";
 import { ALERT_EVENT_TYPE, ALERT_TYPE } from "@/types/alerts";
 
 export const HeaderSchema = z.object({
@@ -9,110 +9,115 @@ export const HeaderSchema = z.object({
 export const FeedbackScoreConditionSchema = z.object({
   threshold: z.string(),
   window: z.string(),
-  name: z.string(), // Feedback score name
-  operator: z.string(), // Operator for comparison (>, <)
+  name: z.string(),
+  operator: z.enum([">", "<"]),
 });
+
+export const FeedbackScoreConditionGroupSchema = z.object({
+  conditions: z.array(FeedbackScoreConditionSchema),
+});
+
+const FEEDBACK_SCORE_TRIGGERS = new Set<ALERT_EVENT_TYPE>([
+  ALERT_EVENT_TYPE.trace_feedback_score,
+  ALERT_EVENT_TYPE.trace_thread_feedback_score,
+]);
+const SIMPLE_THRESHOLD_TRIGGERS = new Set<ALERT_EVENT_TYPE>([
+  ALERT_EVENT_TYPE.trace_cost,
+  ALERT_EVENT_TYPE.trace_latency,
+  ALERT_EVENT_TYPE.trace_errors,
+]);
+
+const CONDITION_REQUIRED_FIELDS = [
+  ["threshold", "Threshold is required"],
+  ["window", "Window is required"],
+  ["name", "Feedback score name is required"],
+  ["operator", "Operator is required"],
+] as const;
+
+const addRequired = (
+  ctx: RefinementCtx,
+  value: string | undefined,
+  path: (string | number)[],
+  message: string,
+) => {
+  if (!value || value.trim() === "") {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message, path });
+    return false;
+  }
+  return true;
+};
+
+const validateNumeric = (
+  ctx: RefinementCtx,
+  value: string,
+  path: (string | number)[],
+) => {
+  if (isNaN(parseFloat(value))) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Threshold must be a valid number",
+      path,
+    });
+  }
+};
 
 export const TriggerSchema = z
   .object({
     eventType: z.nativeEnum(ALERT_EVENT_TYPE),
     threshold: z.string().optional(),
     window: z.string().optional(),
-    name: z.string().optional(), // Feedback score name (deprecated, use conditions)
-    operator: z.string().optional(), // Operator for comparison (deprecated, use conditions)
-    conditions: z.array(FeedbackScoreConditionSchema).optional(), // Multiple conditions for feedback scores
+    name: z.string().optional(), // Feedback score name (deprecated, use groups)
+    operator: z.string().optional(), // Operator for comparison (deprecated, use groups)
+    groups: z.array(FeedbackScoreConditionGroupSchema).optional(), // AND within a group, OR between groups
   })
   .superRefine((data, ctx) => {
-    const isFeedbackScoreTrigger =
-      data.eventType === ALERT_EVENT_TYPE.trace_feedback_score ||
-      data.eventType === ALERT_EVENT_TYPE.trace_thread_feedback_score;
-
-    // Validate feedback score triggers (use conditions array)
-    if (isFeedbackScoreTrigger) {
-      if (!data.conditions || data.conditions.length === 0) {
+    if (FEEDBACK_SCORE_TRIGGERS.has(data.eventType)) {
+      if (!data.groups?.length) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: "At least one condition is required",
-          path: ["conditions"],
+          path: ["groups"],
         });
-      } else {
-        // Validate each condition
-        data.conditions.forEach((condition, index) => {
-          if (!condition.threshold || condition.threshold.trim() === "") {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: "Threshold is required",
-              path: ["conditions", index, "threshold"],
-            });
-          } else {
-            const thresholdNum = parseFloat(condition.threshold);
-            if (isNaN(thresholdNum)) {
-              ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: "Threshold must be a valid number",
-                path: ["conditions", index, "threshold"],
-              });
-            }
-          }
-
-          if (!condition.window || condition.window.trim() === "") {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: "Window is required",
-              path: ["conditions", index, "window"],
-            });
-          }
-
-          if (!condition.name || condition.name.trim() === "") {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: "Feedback score name is required",
-              path: ["conditions", index, "name"],
-            });
-          }
-
-          if (!condition.operator || condition.operator.trim() === "") {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: "Operator is required",
-              path: ["conditions", index, "operator"],
-            });
-          }
-        });
+        return;
       }
-    }
-
-    // Validate threshold for cost, latency, and errors triggers (not feedback scores)
-    const isSimpleThresholdTrigger =
-      data.eventType === ALERT_EVENT_TYPE.trace_cost ||
-      data.eventType === ALERT_EVENT_TYPE.trace_latency ||
-      data.eventType === ALERT_EVENT_TYPE.trace_errors;
-
-    if (isSimpleThresholdTrigger) {
-      if (!data.threshold || data.threshold.trim() === "") {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "Threshold is required",
-          path: ["threshold"],
-        });
-      } else {
-        const thresholdNum = parseFloat(data.threshold);
-        if (isNaN(thresholdNum)) {
+      data.groups.forEach((group, gi) => {
+        if (!group.conditions?.length) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            message: "Threshold must be a valid number",
-            path: ["threshold"],
+            message: "At least one condition is required",
+            path: ["groups", gi, "conditions"],
           });
+          return;
         }
-      }
-
-      if (!data.window || data.window.trim() === "") {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "Window is required",
-          path: ["window"],
+        group.conditions.forEach((condition, ci) => {
+          const base = ["groups", gi, "conditions", ci] as const;
+          for (const [field, message] of CONDITION_REQUIRED_FIELDS) {
+            const present = addRequired(
+              ctx,
+              condition[field],
+              [...base, field],
+              message,
+            );
+            if (field === "threshold" && present) {
+              validateNumeric(ctx, condition.threshold, [...base, "threshold"]);
+            }
+          }
         });
+      });
+      return;
+    }
+
+    if (SIMPLE_THRESHOLD_TRIGGERS.has(data.eventType)) {
+      const thresholdPresent = addRequired(
+        ctx,
+        data.threshold,
+        ["threshold"],
+        "Threshold is required",
+      );
+      if (thresholdPresent) {
+        validateNumeric(ctx, data.threshold!, ["threshold"]);
       }
+      addRequired(ctx, data.window, ["window"], "Window is required");
     }
   });
 
@@ -159,4 +164,7 @@ export type AlertFormType = z.infer<typeof AlertFormSchema>;
 export type TriggerFormType = z.infer<typeof TriggerSchema>;
 export type FeedbackScoreConditionType = z.infer<
   typeof FeedbackScoreConditionSchema
+>;
+export type FeedbackScoreConditionGroupType = z.infer<
+  typeof FeedbackScoreConditionGroupSchema
 >;


### PR DESCRIPTION
## Details

Add AND/OR grouping for multi-condition feedback-score alert triggers. Multiple conditions inside one group are combined with **AND**; different groups are combined with **OR**. Existing single-OR alerts continue to render — each legacy condition reads back as its own group, preserving today's semantics.

- Restructures the form from a flat `conditions[]` list to a nested `groups[].conditions[]` shape
- Serializes/deserializes a new `group_index` field on each `threshold:feedback_score` trigger config (BE contract documented on OPIK-6620)
- Pixel-perfect UI per the final Figma design (node `6157:9524`): group cards with the violet type icon, inline `AND`/`OR` separators, segmented `>`/`<` operator (`ToggleGroup` `secondary`), dashed "Add OR group" placeholder, and consistently-aligned trash icons (12px header / 24×44 row, both centered at 18px from the card's right edge)
- Score and window selects are `flex-1` so they fill the row; row wraps to a second line on narrow viewports
- The last group of an alert and the last condition of a group can't be deleted — the disabled trash icon shows an explanatory tooltip via the shared `TooltipWrapper` (wrapped in an `inline-flex cursor-not-allowed` span so Radix tooltips fire on pointer-events:none buttons, matching the precedent in `ExportAnnotatedDataButton.tsx`)
- Shared constants (`WINDOW_OPTIONS`, `WINDOW_LABEL_BY_VALUE`, `OPERATOR_VALUES`) extracted to `./constants.ts` and reused by `EventTriggers.tsx`
- Hex colors replaced with project tokens / Tailwind defaults: `bg-primary-100`, `text-primary`, `text-violet-600`; SVGs use `currentColor` so the wrapper's text utility drives the whole glyph

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6621

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: full implementation
- Human verification: code review + manual browser verification against Figma frame `6157:9524`

## Testing

Local verification on \`http://localhost:5174/default/projects/.../alerts/new\`:

- \`npm run lint\` — clean (project config, max-warnings=0)
- \`npm run typecheck\` — clean
- Manual flows: add a "Trace feedback score threshold" trigger → default state shows one Group with one condition (window defaults to 24 hours per designer note); \`+ Add AND condition\` adds a row with the violet \`AND\` separator; \`+ Add OR group\` adds a second group with the violet \`OR\` separator
- Verified disabled-state behavior: hovering the trash icon on the last group / last condition shows the explanatory tooltip
- Row layout: confirmed score and window selects grow to fill the row, and the row wraps to a second line when the panel is narrowed
- Confirmed group renumbering: after deleting middle groups, remaining groups relabel correctly (uses array index, not persistent ID)
- Round-trip with BE is blocked until OPIK-6620 lands; the form sends the JSON contract documented on that ticket

Tests not run: no unit tests added — the conditions UI is a small, visually-driven form with no logic beyond serialization helpers; reviewers should rely on Figma diff + manual flows.

## Documentation

N/A — internal alert configuration UI.