### PR TITLE
[OPIK-6467] [SDK] feat: add prompt version support

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/reference/typescript-sdk/prompts.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/reference/typescript-sdk/prompts.mdx
@@ -1157,13 +1157,13 @@ const results = await prompt.getVersions({
 });
 ```
 
-##### `getVersion(versionOrCommit)`
+##### `getVersion(version)`
 
 Returns a `Prompt` instance pinned to a specific version of this prompt. Accepts either the sequential version identifier (e.g. `"v3"`) — preferred — or a commit hash (deprecated; retained for backwards compatibility). Inputs matching `/^v\d+$/` are treated as version numbers; anything else is treated as a commit.
 
 **Arguments:**
 
-- `versionOrCommit: string` - Sequential version (`"v<N>"`) or commit hash (deprecated)
+- `version: string` - Sequential version (`"v<N>"`) or commit hash (deprecated)
 
 **Returns:** `Promise<Prompt | null>` - Prompt instance pinned to that version, or `null` if not found
 
@@ -1313,13 +1313,13 @@ Retrieves all version history for this chat prompt, with optional filtering, sor
 
 **Returns:** `Promise<PromptVersion[]>` - Array of all matching versions (newest first)
 
-##### `getVersion(versionOrCommit)`
+##### `getVersion(version)`
 
 Returns a `ChatPrompt` instance pinned to a specific version of this chat prompt. Accepts either the sequential version identifier (e.g. `"v3"`) — preferred — or a commit hash (deprecated; retained for backwards compatibility). Inputs matching `/^v\d+$/` are treated as version numbers; anything else is treated as a commit.
 
 **Arguments:**
 
-- `versionOrCommit: string` - Sequential version (`"v<N>"`) or commit hash (deprecated)
+- `version: string` - Sequential version (`"v<N>"`) or commit hash (deprecated)
 
 **Returns:** `Promise<ChatPrompt | null>` - ChatPrompt instance pinned to that version, or `null` if not found
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/reference/typescript-sdk/prompts.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/reference/typescript-sdk/prompts.mdx
@@ -50,7 +50,7 @@ const prompt = await client.createPrompt({
   projectName: "my-project",
 });
 
-console.log(`Created prompt with commit: ${prompt.commit}`);
+console.log(`Created prompt with version: ${prompt.version}`);
 ```
 
 ### Retrieving Prompts
@@ -63,13 +63,13 @@ const prompt = await client.getPrompt({ name: "greeting-prompt" });
 
 if (prompt) {
   console.log(`Template: ${prompt.prompt}`);
-  console.log(`Commit: ${prompt.commit}`);
+  console.log(`Version: ${prompt.version}`);
 }
 
-// Get specific version
+// Get specific version by its sequential version identifier ("v<N>")
 const oldVersion = await client.getPrompt({
   name: "greeting-prompt",
-  commit: "abc123de",
+  version: "v1",
 });
 ```
 
@@ -154,7 +154,7 @@ const prompt2 = await client.createPrompt({
   tags: ["updated-tags"], // Different tags don't trigger new version
   projectName: "my-project",
 });
-console.log(prompt2.commit === prompt1.commit); // true
+console.log(prompt2.version === prompt1.version); // true
 
 // Changed template - creates new version 2
 const prompt3 = await client.createPrompt({
@@ -280,7 +280,7 @@ const latest = versions[0];
 
 // Version properties
 console.log(`ID: ${latest.id}`);
-console.log(`Commit: ${latest.commit}`);
+console.log(`Version: ${latest.version}`);
 console.log(`Template: ${latest.prompt}`);
 console.log(`Created: ${latest.createdAt}`);
 console.log(`Creator: ${latest.createdBy}`);
@@ -317,23 +317,32 @@ versions.forEach((version) => {
 #### Getting Specific Versions
 
 ```typescript
-const prompt = await client.getPrompt({ name: "greeting-prompt" });
-
-// Option 1: Get version as Prompt instance (recommended for formatting)
-const oldVersion = await prompt.getVersion("abc123de");
+// Option 1: Fetch a specific version straight from the client
+const oldVersion = await client.getPrompt({
+  name: "greeting-prompt",
+  version: "v1",
+});
 
 if (oldVersion) {
   const text = oldVersion.format({ name: "Bob", score: 88 });
-  console.log(`Old version output: ${text}`);
+  console.log(`Version ${oldVersion.version} output: ${text}`);
 }
 
-// Option 2: Use format directly on PromptVersion objects
-const versions = await prompt.getVersions();
-const secondVersion = versions[1];
+// Option 2: From an existing prompt instance, pin to a specific version
+const prompt = await client.getPrompt({ name: "greeting-prompt" });
+const v1 = await prompt.getVersion("v1");
 
-// PromptVersion also has format() method
-const formattedText = secondVersion.format({ name: "Charlie", score: 92 });
-console.log(`Version ${secondVersion.commit}: ${formattedText}`);
+if (v1) {
+  console.log(v1.format({ name: "Alice", score: 95 }));
+}
+
+// Option 3: Iterate version history and use format() directly on PromptVersion objects
+const versions = await prompt.getVersions();
+const previousVersion = versions[1];
+
+// PromptVersion also has a format() method
+const formattedText = previousVersion.format({ name: "Charlie", score: 92 });
+console.log(formattedText);
 ```
 
 #### Comparing Versions
@@ -342,15 +351,16 @@ console.log(`Version ${secondVersion.commit}: ${formattedText}`);
 const versions = await prompt.getVersions();
 
 if (versions.length >= 2) {
-  const current = versions[0];
-  const previous = versions[1];
+  const current = versions[0]; // e.g. "v3"
+  const previous = versions[1]; // e.g. "v2"
 
-  // Compare versions (logs diff and returns it)
+  // Compare versions (logs diff and returns it). Diff labels show the
+  // sequential version identifiers (e.g. "[v3]" / "[v2]").
   const diff = current.compareTo(previous);
   console.log(diff);
   /* Output:
-   * - Current version [abc123de]
-   * + Other version [def456gh]
+   * - Other version [v2]
+   * + Current version [v3]
    * @@ -1,2 +1,2 @@
    * - Hello {{name}}, welcome!
    * + Hello {{name}}, your score is {{score}}
@@ -364,14 +374,14 @@ if (versions.length >= 2) {
 const prompt = await client.getPrompt({ name: "greeting-prompt" });
 const versions = await prompt.getVersions();
 
-// Find specific version to restore
-const targetVersion = versions.find((v) => v.commit === "abc123de");
+// Pick the version you want to restore — for example, the previous one
+const [, previousVersion] = versions;
 
-if (targetVersion) {
+if (previousVersion) {
   // Restore creates a new version with the old content
-  const restoredPrompt = await prompt.useVersion(targetVersion);
+  const restoredPrompt = await prompt.useVersion(previousVersion);
 
-  console.log(`Restored to commit: ${restoredPrompt.commit}`);
+  console.log(`Restored to version: ${restoredPrompt.version}`);
   console.log(`Template: ${restoredPrompt.prompt}`);
 }
 ```
@@ -495,7 +505,7 @@ const chatPrompt = await client.createChatPrompt({
   projectName: "my-project",
 });
 
-console.log(`Created chat prompt with commit: ${chatPrompt.commit}`);
+console.log(`Created chat prompt with version: ${chatPrompt.version}`);
 ```
 
 ### Formatting Chat Prompts
@@ -706,13 +716,13 @@ const chatPrompt = await client.getChatPrompt({
 
 if (chatPrompt) {
   console.log(`Messages: ${JSON.stringify(chatPrompt.messages)}`);
-  console.log(`Commit: ${chatPrompt.commit}`);
+  console.log(`Version: ${chatPrompt.version}`);
 }
 
-// Get specific version
+// Get specific version by its sequential version identifier ("v<N>")
 const oldVersion = await client.getChatPrompt({
   name: "educational-assistant",
-  commit: "abc123de",
+  version: "v1",
 });
 ```
 
@@ -829,7 +839,7 @@ const chatPrompt = await client.createChatPrompt({
   projectName: "my-project",
 });
 
-console.log(`Version 1 commit: ${chatPrompt.commit}`);
+console.log(`Created ${chatPrompt.version}`);
 
 // Update with new messages - creates new version
 const messagesV2 = [
@@ -844,7 +854,7 @@ const chatPromptV2 = await client.createChatPrompt({
   projectName: "my-project",
 });
 
-console.log(`Version 2 commit: ${chatPromptV2.commit}`);
+console.log(`Created ${chatPromptV2.version}`);
 
 // Get version history
 const versions = await chatPrompt.getVersions();
@@ -863,8 +873,11 @@ const chatPrompt = await client.getChatPrompt({
 // Get all versions
 const versions = await chatPrompt.getVersions();
 
-// Get specific version
-const oldVersion = await chatPrompt.getVersion("abc123de");
+// Get a specific version by its sequential identifier ("v<N>")
+const oldVersion = await client.getChatPrompt({
+  name: "greeting-prompt",
+  version: "v1",
+});
 
 // Compare versions
 if (versions.length >= 2) {
@@ -874,11 +887,11 @@ if (versions.length >= 2) {
   console.log(diff);
 }
 
-// Restore previous version
-const targetVersion = versions.find((v) => v.commit === "abc123de");
-if (targetVersion) {
-  const restoredPrompt = await chatPrompt.useVersion(targetVersion);
-  console.log(`Restored to commit: ${restoredPrompt.commit}`);
+// Restore the previous version
+const [, previousVersion] = versions;
+if (previousVersion) {
+  const restoredPrompt = await chatPrompt.useVersion(previousVersion);
+  console.log(`Restored to version: ${restoredPrompt.version}`);
 }
 ```
 
@@ -931,12 +944,12 @@ Creates a new prompt or returns existing version if content unchanged.
 
 #### `getPrompt(options)`
 
-Retrieves a prompt by name and optional version.
+Retrieves a prompt by name, optionally targeting a specific version.
 
 **Arguments:**
 
 - `options.name: string` - Prompt name (required)
-- `options.commit?: string` - Optional commit ID for specific version
+- `options.version?: string` - Sequential version identifier (e.g. `"v3"`). If omitted, the latest version is returned.
 
 **Returns:** `Promise<Prompt | null>` - Prompt instance or null if not found
 
@@ -1037,12 +1050,12 @@ interface ContentPart {
 
 #### `getChatPrompt(options)`
 
-Retrieves a chat prompt by name and optional version.
+Retrieves a chat prompt by name, optionally targeting a specific version.
 
 **Arguments:**
 
 - `options.name: string` - Chat prompt name (required)
-- `options.commit?: string` - Optional commit ID for specific version
+- `options.version?: string` - Sequential version identifier (e.g. `"v3"`). If omitted, the latest version is returned.
 
 **Returns:** `Promise<ChatPrompt | null>` - ChatPrompt instance or null if not found
 
@@ -1077,7 +1090,6 @@ Retrieves all version history for this prompt, with optional filtering, sorting,
 | Field | Type | Operators |
 |-------|------|-----------|
 | `id` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` |
-| `commit` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` |
 | `template` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` |
 | `change_description` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` |
 | `created_by` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` |
@@ -1145,15 +1157,23 @@ const results = await prompt.getVersions({
 });
 ```
 
-##### `getVersion(commit)`
+##### `getVersion(versionOrCommit)`
 
-Gets a specific version as a Prompt instance.
+Returns a `Prompt` instance pinned to a specific version of this prompt. Accepts either the sequential version identifier (e.g. `"v3"`) — preferred — or a commit hash (deprecated; retained for backwards compatibility). Inputs matching `/^v\d+$/` are treated as version numbers; anything else is treated as a commit.
 
 **Arguments:**
 
-- `commit: string` - Commit hash (8-char or full)
+- `versionOrCommit: string` - Sequential version (`"v<N>"`) or commit hash (deprecated)
 
-**Returns:** `Promise<Prompt | null>` - Prompt instance or null if not found
+**Returns:** `Promise<Prompt | null>` - Prompt instance pinned to that version, or `null` if not found
+
+```typescript
+// Preferred: fetch by sequential version identifier
+const v3 = await prompt.getVersion("v3");
+
+// Deprecated: fetch by commit hash
+const byCommit = await prompt.getVersion("abc123de");
+```
 
 ##### `useVersion(version)`
 
@@ -1188,7 +1208,7 @@ Deletes this prompt and all its versions.
 - `id: string` - Unique prompt identifier
 - `name: string` - Prompt name
 - `prompt: string` - Current template content
-- `commit?: string` - Current version commit ID
+- `version?: string` - Sequential version identifier (e.g. `"v3"`)
 - `type: PromptType` - Template engine type
 - `description?: string` - Prompt description
 - `tags?: readonly string[]` - Prompt tags
@@ -1211,9 +1231,9 @@ Formats this version's template with provided variables.
 
 ##### `getVersionInfo()`
 
-Gets formatted version information string.
+Gets a formatted version-info string suitable for display. Includes the version identifier (e.g. `"v3"`), creation date, creator, and change description.
 
-**Returns:** `string` - Format: `[commit] YYYY-MM-DD by user@email.com - Change description`
+**Returns:** `string` — Format: `"[v3] YYYY-MM-DD by user@email.com - Change description"`
 
 ##### `getVersionAge()`
 
@@ -1223,7 +1243,7 @@ Gets human-readable version age.
 
 ##### `compareTo(other)`
 
-Compares this version's template with another version.
+Compares this version's template with another version. The diff is logged to the terminal and returned. Labels in the diff use the sequential version identifier (e.g. `"[v3]"`).
 
 **Arguments:**
 
@@ -1236,7 +1256,7 @@ Compares this version's template with another version.
 - `id: string` - Version unique identifier
 - `name: string` - Associated prompt name
 - `prompt: string` - Template content for this version
-- `commit: string` - Version commit ID
+- `version?: string` - Sequential version identifier (e.g. `"v3"`)
 - `type: PromptType` - Template engine type
 - `tags?: string[]` - Tags associated with this version
 - `metadata?: JsonNode` - Version metadata
@@ -1293,15 +1313,23 @@ Retrieves all version history for this chat prompt, with optional filtering, sor
 
 **Returns:** `Promise<PromptVersion[]>` - Array of all matching versions (newest first)
 
-##### `getVersion(commit)`
+##### `getVersion(versionOrCommit)`
 
-Gets a specific version as a ChatPrompt instance.
+Returns a `ChatPrompt` instance pinned to a specific version of this chat prompt. Accepts either the sequential version identifier (e.g. `"v3"`) — preferred — or a commit hash (deprecated; retained for backwards compatibility). Inputs matching `/^v\d+$/` are treated as version numbers; anything else is treated as a commit.
 
 **Arguments:**
 
-- `commit: string` - Commit hash (8-char or full)
+- `versionOrCommit: string` - Sequential version (`"v<N>"`) or commit hash (deprecated)
 
-**Returns:** `Promise<ChatPrompt | null>` - ChatPrompt instance or null if not found
+**Returns:** `Promise<ChatPrompt | null>` - ChatPrompt instance pinned to that version, or `null` if not found
+
+```typescript
+// Preferred: fetch by sequential version identifier
+const v3 = await chatPrompt.getVersion("v3");
+
+// Deprecated: fetch by commit hash
+const byCommit = await chatPrompt.getVersion("abc123de");
+```
 
 ##### `useVersion(version)`
 
@@ -1336,7 +1364,7 @@ Deletes this chat prompt and all its versions.
 - `id: string` - Unique chat prompt identifier
 - `name: string` - Chat prompt name
 - `messages: ChatMessage[]` - Array of chat messages with roles and content
-- `commit?: string` - Current version commit ID
+- `version?: string` - Sequential version identifier (e.g. `"v3"`)
 - `type: PromptType` - Template engine type
 - `description?: string` - Chat prompt description
 - `tags?: readonly string[]` - Chat prompt tags

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -2269,20 +2269,24 @@ class Opik:
         self,
         name: str,
         commit: Optional[str] = None,
+        version: Optional[str] = None,
         project_name: Optional[str] = None,
         no_cache: bool = False,
     ) -> Optional[prompt_module.Prompt]:
         """
-        Retrieve a text prompt by name and optional commit version.
+        Retrieve a text prompt by name, optionally targeting a specific ``version``.
 
         This method only returns text prompts. Results are cached client-side
         (TTL configurable via OPIK_PROMPT_CACHE_TTL_SECONDS, default 300 s).
-        Pinned commits are cached indefinitely. When called inside an @track
-        context the prompt reference is injected into the active trace/span metadata.
+        When called inside an @track context the prompt reference is injected
+        into the active trace/span metadata.
 
         Parameters:
             name: The name of the prompt.
-            commit: An optional commit version of the prompt. If not provided, the latest version is retrieved.
+            version: Optional sequential version selector in the wire format
+                ``"v<N>"`` (e.g. ``"v3"``). If not provided, the latest
+                version is retrieved.
+            commit: DEPRECATED in favour of ``version``. Mutually exclusive with ``version``.
             project_name: The name of the project to retrieve the prompt from. If not provided, falls back to the active project context (from @track or opik.project_context), then to the client's default.
             no_cache: If True, skip the local cache and fetch directly from the backend, guaranteeing a fresh value.
 
@@ -2291,6 +2295,7 @@ class Opik:
 
         Raises:
             PromptTemplateStructureMismatch: If the prompt exists but is a chat prompt (template structure mismatch).
+            ValueError: If both ``commit`` and ``version`` are provided.
         """
         return prompt_client.PromptClient(self._rest_client).get_prompt_with_cache(
             name=name,
@@ -2299,26 +2304,31 @@ class Opik:
             template_structure="text",
             prompt_cls=text_prompt_module.Prompt,
             no_cache=no_cache,
+            version=version,
         )
 
     def get_chat_prompt(
         self,
         name: str,
         commit: Optional[str] = None,
+        version: Optional[str] = None,
         project_name: Optional[str] = None,
         no_cache: bool = False,
     ) -> Optional[prompt_module.ChatPrompt]:
         """
-        Retrieve a chat prompt by name and optional commit version.
+        Retrieve a chat prompt by name, optionally targeting a specific ``version``.
 
         This method only returns chat prompts. Results are cached client-side
         (TTL configurable via OPIK_PROMPT_CACHE_TTL_SECONDS, default 300 s).
-        Pinned commits are cached indefinitely. When called inside an @track
-        context the prompt reference is injected into the active trace/span metadata.
+        When called inside an @track context the prompt reference is injected
+        into the active trace/span metadata.
 
         Parameters:
             name: The name of the prompt.
-            commit: An optional commit version of the prompt. If not provided, the latest version is retrieved.
+            version: Optional sequential version selector in the wire format
+                ``"v<N>"`` (e.g. ``"v3"``). If not provided, the latest
+                version is retrieved.
+            commit: DEPRECATED in favour of ``version``. Mutually exclusive with ``version``.
             project_name: The name of the project to retrieve the prompt from. If not provided, falls back to the active project context (from @track or opik.project_context), then to the client's default.
             no_cache: If True, skip the local cache and fetch directly from the backend, guaranteeing a fresh value.
 
@@ -2327,6 +2337,7 @@ class Opik:
 
         Raises:
             PromptTemplateStructureMismatch: If the prompt exists but is a text prompt (template structure mismatch).
+            ValueError: If both ``commit`` and ``version`` are provided.
         """
         return prompt_client.PromptClient(self._rest_client).get_prompt_with_cache(
             name=name,
@@ -2335,6 +2346,7 @@ class Opik:
             template_structure="chat",
             prompt_cls=chat_prompt_module.ChatPrompt,
             no_cache=no_cache,
+            version=version,
         )
 
     def get_prompt_history(

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -2269,9 +2269,9 @@ class Opik:
         self,
         name: str,
         commit: Optional[str] = None,
-        version: Optional[str] = None,
         project_name: Optional[str] = None,
         no_cache: bool = False,
+        version: Optional[str] = None,
     ) -> Optional[prompt_module.Prompt]:
         """
         Retrieve a text prompt by name, optionally targeting a specific ``version``.
@@ -2283,12 +2283,11 @@ class Opik:
 
         Parameters:
             name: The name of the prompt.
-            version: Optional sequential version selector in the wire format
-                ``"v<N>"`` (e.g. ``"v3"``). If not provided, the latest
-                version is retrieved.
             commit: DEPRECATED in favour of ``version``. Mutually exclusive with ``version``.
             project_name: The name of the project to retrieve the prompt from. If not provided, falls back to the active project context (from @track or opik.project_context), then to the client's default.
             no_cache: If True, skip the local cache and fetch directly from the backend, guaranteeing a fresh value.
+            version: Optional sequential version selector in the wire format
+                ``"v<N>"`` (e.g. ``"v3"``). If not provided, the latest version is retrieved.
 
         Returns:
             Prompt: The details of the specified text prompt, or None if not found.
@@ -2311,9 +2310,9 @@ class Opik:
         self,
         name: str,
         commit: Optional[str] = None,
-        version: Optional[str] = None,
         project_name: Optional[str] = None,
         no_cache: bool = False,
+        version: Optional[str] = None,
     ) -> Optional[prompt_module.ChatPrompt]:
         """
         Retrieve a chat prompt by name, optionally targeting a specific ``version``.
@@ -2325,12 +2324,11 @@ class Opik:
 
         Parameters:
             name: The name of the prompt.
-            version: Optional sequential version selector in the wire format
-                ``"v<N>"`` (e.g. ``"v3"``). If not provided, the latest
-                version is retrieved.
             commit: DEPRECATED in favour of ``version``. Mutually exclusive with ``version``.
             project_name: The name of the project to retrieve the prompt from. If not provided, falls back to the active project context (from @track or opik.project_context), then to the client's default.
             no_cache: If True, skip the local cache and fetch directly from the backend, guaranteeing a fresh value.
+            version: Optional sequential version selector in the wire format
+                ``"v<N>"`` (e.g. ``"v3"``). If not provided, the latest version is retrieved.
 
         Returns:
             ChatPrompt: The details of the specified chat prompt, or None if not found.

--- a/sdks/python/src/opik/api_objects/prompt/base_prompt.py
+++ b/sdks/python/src/opik/api_objects/prompt/base_prompt.py
@@ -30,7 +30,18 @@ class BasePrompt(ABC):
     @property
     @abstractmethod
     def commit(self) -> Optional[str]:
-        """The commit hash of the prompt version."""
+        """Legacy commit hash of the prompt version.
+
+        DEPRECATED — use :attr:`version` (e.g. ``"v3"``) instead. ``commit``
+        is no longer surfaced in the Opik UI and is kept only for backwards
+        compatibility with older SDK callers.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def version(self) -> Optional[str]:
+        """The sequential version selector for the prompt version (e.g. ``"v3"``)."""
         pass
 
     @property

--- a/sdks/python/src/opik/api_objects/prompt/chat/chat_prompt.py
+++ b/sdks/python/src/opik/api_objects/prompt/chat/chat_prompt.py
@@ -286,6 +286,9 @@ class ChatPrompt(base_prompt.BasePrompt):
         if self.commit is not None:
             info_dict["version"]["commit"] = self.commit
 
+        if self.version is not None:
+            info_dict["version"]["version_number"] = self.version
+
         if self.__internal_api__version_id__ is not None:
             info_dict["version"]["id"] = self.__internal_api__version_id__
 

--- a/sdks/python/src/opik/api_objects/prompt/chat/chat_prompt.py
+++ b/sdks/python/src/opik/api_objects/prompt/chat/chat_prompt.py
@@ -86,6 +86,7 @@ class ChatPrompt(base_prompt.BasePrompt):
         self._tags = copy.copy(tags) if tags else []
         self._project_name = project_name
         self._commit: Optional[str] = None
+        self._version: Optional[str] = None
         self.__internal_api__prompt_id__: Optional[str] = None
         self.__internal_api__version_id__: Optional[str] = None
         self._synced: bool = False
@@ -136,6 +137,7 @@ class ChatPrompt(base_prompt.BasePrompt):
             )
 
             self._commit = prompt_version.commit
+            self._version = prompt_version.version_number
             self.__internal_api__prompt_id__ = prompt_version.prompt_id
             self.__internal_api__version_id__ = prompt_version.id
             # Update fields from backend response to ensure consistency
@@ -169,8 +171,19 @@ class ChatPrompt(base_prompt.BasePrompt):
     @property
     @override
     def commit(self) -> Optional[str]:
-        """The commit hash of the prompt."""
+        """Legacy commit hash of the prompt version.
+
+        DEPRECATED — use :attr:`version` (e.g. ``"v3"``) instead. ``commit``
+        is no longer surfaced in the Opik UI and is kept only for backwards
+        compatibility with older SDK callers.
+        """
         return self._commit
+
+    @property
+    @override
+    def version(self) -> Optional[str]:
+        """The sequential version selector for the prompt (e.g. ``"v3"``)."""
+        return self._version
 
     @property
     @override
@@ -305,6 +318,7 @@ class ChatPrompt(base_prompt.BasePrompt):
             or prompt_types.PromptType.MUSTACHE,
         )
         chat_prompt._commit = prompt_version.commit
+        chat_prompt._version = prompt_version.version_number
         chat_prompt._metadata = prompt_version.metadata
         chat_prompt._type = prompt_version.type
         chat_prompt._id = prompt_version.id

--- a/sdks/python/src/opik/api_objects/prompt/client.py
+++ b/sdks/python/src/opik/api_objects/prompt/client.py
@@ -198,23 +198,34 @@ class PromptClient:
         commit: Optional[str] = None,
         raise_if_not_template_structure: Optional[str] = None,
         project_name: Optional[str] = None,
+        version: Optional[str] = None,
     ) -> Optional[prompt_version_detail.PromptVersionDetail]:
         """
-        Retrieve the prompt detail for a given prompt name and commit version.
+        Retrieve the prompt detail for a given prompt name, optionally
+        pinned to a specific ``version``.
 
         Parameters:
             name: The name of the prompt.
-            commit: An optional commit version of the prompt. If not provided, the latest version is retrieved.
+            version: Optional sequential version selector in the wire format
+                ``"v<N>"`` (e.g. ``"v3"``). If not provided, the latest
+                version is retrieved.
+            commit: DEPRECATED in favour of ``version``. Mutually exclusive with ``version``.
             raise_if_not_template_structure: Optional template structure validation. If provided and doesn't match, raises PromptTemplateStructureMismatch.
             project_name: The name of the project to which the prompt belongs. If not provided, the default project is used.
 
         Returns:
             Prompt: The details of the specified prompt.
         """
+        if commit is not None and version is not None:
+            raise ValueError(
+                "Provide either `commit` or `version`, not both. "
+                "Prefer `version` — `commit` is deprecated."
+            )
         try:
             prompt_version = self._rest_client.prompts.retrieve_prompt_version(
                 name=name,
                 commit=commit,
+                version_number=version,
                 project_name=project_name,
             )
 
@@ -251,7 +262,14 @@ class PromptClient:
         template_structure: str,
         prompt_cls: Type[_PromptT],
         no_cache: bool = False,
+        version: Optional[str] = None,
     ) -> Optional[_PromptT]:
+        if commit is not None and version is not None:
+            raise ValueError(
+                "Provide either `commit` or `version`, not both. "
+                "Prefer `version` — `commit` is deprecated."
+            )
+
         def _fetch(mask_id: Optional[str] = None) -> Optional[_PromptT]:
             if mask_id is not None:
                 prompt_version = self._rest_client.prompts.get_prompt_version_by_id(
@@ -263,6 +281,7 @@ class PromptClient:
                     commit=commit,
                     raise_if_not_template_structure=template_structure,
                     project_name=project_name,
+                    version=version,
                 )
             if prompt_version is None:
                 return None
@@ -282,6 +301,7 @@ class PromptClient:
                 template_structure=template_structure,
                 fetch_fn=lambda: _fetch(mask_id=mask_id),
                 mask_id=mask_id,
+                version=version,
             )
 
         unmasked = _cached_fetch()

--- a/sdks/python/src/opik/api_objects/prompt/prompt_cache.py
+++ b/sdks/python/src/opik/api_objects/prompt/prompt_cache.py
@@ -173,6 +173,7 @@ def get_or_fetch(
     template_structure: str,
     fetch_fn: typing.Callable[[], typing.Optional[_PromptT]],
     mask_id: typing.Optional[str] = None,
+    version: typing.Optional[str] = None,
 ) -> typing.Optional[_PromptT]:
     """Return a cached prompt or fetch, cache, and return it.
 
@@ -180,18 +181,23 @@ def get_or_fetch(
     Otherwise calls *fetch_fn* to produce one. If *fetch_fn* returns None
     (prompt not found), returns None without caching.
 
-    For unpinned prompts (commit is None), *fetch_fn* is also registered as
-    the background-refresh callback so the cache stays fresh.
+    ``commit`` and ``version`` reuse the same cache key slot (commits are 8
+    hex chars, versions match ``v\\d+``, so they cannot collide). Only
+    ``commit`` pins indefinitely — a sequential ``version`` like ``"v3"``
+    can be reassigned by the backend if the underlying version is deleted
+    and recreated, so it is subject to the normal TTL refresh just like
+    "latest" lookups.
 
     For masked prompts (mask_id is not None), the entry is TTL-evicted like
     normal unpinned entries but has no background refresh callback.
     """
+    identifier = version if version is not None else commit
     ttl = opik_config.OpikConfig().prompt_cache_ttl_seconds
     ttl_seconds = None if commit is not None else ttl
     refresh_callback = (
         fetch_fn if (ttl_seconds is not None and mask_id is None) else None
     )
-    key: _CacheKey = (name, commit, project_name, template_structure, mask_id)
+    key: _CacheKey = (name, identifier, project_name, template_structure, mask_id)
     result = _cache.get_or_fetch(
         key=key,
         fetch_fn=fetch_fn,

--- a/sdks/python/src/opik/api_objects/prompt/text/prompt.py
+++ b/sdks/python/src/opik/api_objects/prompt/text/prompt.py
@@ -257,6 +257,9 @@ class Prompt(base_prompt.BasePrompt):
         if self.commit is not None:
             info_dict["version"]["commit"] = self.commit
 
+        if self.version is not None:
+            info_dict["version"]["version_number"] = self.version
+
         if self.__internal_api__version_id__ is not None:
             info_dict["version"]["id"] = self.__internal_api__version_id__
 

--- a/sdks/python/src/opik/api_objects/prompt/text/prompt.py
+++ b/sdks/python/src/opik/api_objects/prompt/text/prompt.py
@@ -71,6 +71,7 @@ class Prompt(base_prompt.BasePrompt):
         self._project_name = project_name
 
         self._commit: Optional[str] = None
+        self._version: Optional[str] = None
         self.__internal_api__prompt_id__: Optional[str] = None
         self.__internal_api__version_id__: Optional[str] = None
         self._synced: bool = False
@@ -109,6 +110,7 @@ class Prompt(base_prompt.BasePrompt):
             )
 
             self._commit = prompt_version.commit
+            self._version = prompt_version.version_number
             self.__internal_api__prompt_id__ = prompt_version.prompt_id
             self.__internal_api__version_id__ = prompt_version.id
             # Update fields from backend response to ensure consistency
@@ -142,8 +144,19 @@ class Prompt(base_prompt.BasePrompt):
     @property
     @override
     def commit(self) -> Optional[str]:
-        """The commit hash of the prompt."""
+        """Legacy commit hash of the prompt version.
+
+        DEPRECATED — use :attr:`version` (e.g. ``"v3"``) instead. ``commit``
+        is no longer surfaced in the Opik UI and is kept only for backwards
+        compatibility with older SDK callers.
+        """
         return self._commit
+
+    @property
+    @override
+    def version(self) -> Optional[str]:
+        """The sequential version selector for the prompt (e.g. ``"v3"``)."""
+        return self._version
 
     @property
     @override
@@ -272,6 +285,7 @@ class Prompt(base_prompt.BasePrompt):
             or prompt_types.PromptType.MUSTACHE,
         )
         prompt._commit = prompt_version.commit
+        prompt._version = prompt_version.version_number
         prompt._metadata = prompt_version.metadata
         prompt._type = prompt_version.type
         prompt._id = prompt_version.id

--- a/sdks/python/tests/e2e/test_prompt.py
+++ b/sdks/python/tests/e2e/test_prompt.py
@@ -689,6 +689,54 @@ def test_get_prompt__nonexistent__returns_none(opik_client: opik.Opik):
     assert result is None
 
 
+def test_get_prompt__with_version__string_prompt(opik_client: opik.Opik):
+    """Test that get_prompt() with the sequential ``version`` selector
+    (e.g. ``"v1"``, ``"v2"``, ...) returns the correct prompt content."""
+    unique_id = str(uuid.uuid4())[-6:]
+    prompt_name = f"string-prompt-version-{unique_id}"
+    project_name = f"get_prompt_version-project-{unique_id}"
+
+    # Create three versions of the same prompt.
+    opik_client.create_prompt(
+        name=prompt_name, prompt="Version 1", project_name=project_name
+    )
+    opik_client.create_prompt(
+        name=prompt_name, prompt="Version 2", project_name=project_name
+    )
+    latest = opik_client.create_prompt(
+        name=prompt_name, prompt="Version 3", project_name=project_name
+    )
+
+    expected_by_version = {
+        "v1": "Version 1",
+        "v2": "Version 2",
+        "v3": "Version 3",
+    }
+
+    for selector, expected_template in expected_by_version.items():
+        retrieved = opik_client.get_prompt(
+            name=prompt_name,
+            version=selector,
+            project_name=project_name,
+            no_cache=True,
+        )
+        assert retrieved is not None, f"expected prompt for version {selector}"
+        assert isinstance(retrieved, opik.Prompt)
+        assert retrieved.prompt == expected_template
+        assert retrieved.version == selector
+        assert retrieved.name == prompt_name
+        assert retrieved.project_name == project_name
+
+    # The latest prompt (no version selector) should expose version="v3".
+    latest_fetched = opik_client.get_prompt(
+        name=prompt_name, project_name=project_name, no_cache=True
+    )
+    assert latest_fetched is not None
+    assert latest_fetched.version == "v3"
+    # The create_prompt return value should also surface the version_number now.
+    assert latest.version == "v3"
+
+
 def test_prompt__format_playground_chat_prompt__returns_json(opik_client: opik.Opik):
     unique_identifier = str(uuid.uuid4())[-6:]
 

--- a/sdks/python/tests/e2e/test_prompt.py
+++ b/sdks/python/tests/e2e/test_prompt.py
@@ -14,10 +14,6 @@ def _generate_random_suffix():
     return str(uuid.uuid4())[-6:]
 
 
-def _generate_random_prompt_name():
-    return f"some-prompt-name-{_generate_random_suffix()}"
-
-
 def _generate_random_tag():
     return f"tag-{_generate_random_suffix()}"
 
@@ -26,18 +22,16 @@ def _generate_random_tags(n=2):
     return [_generate_random_tag() for _ in range(n)]
 
 
-def test_prompt__create__happyflow(opik_client: opik.Opik):
-    unique_identifier = str(uuid.uuid4())[-6:]
-
-    prompt_name = f"some-prompt-name-{unique_identifier}"
-    prompt_template = f"some-prompt-text-{unique_identifier}"
-    project_name = f"some-project-name-{unique_identifier}"
+def test_prompt__create__happyflow(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
+    prompt_template = f"some-prompt-text-{_generate_random_suffix()}"
 
     prompt = opik_client.create_prompt(
         name=prompt_name,
         prompt=prompt_template,
         metadata={"outer-key": {"inner-key": "inner-value"}},
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     verifiers.verify_prompt_version(
         prompt,
@@ -48,15 +42,14 @@ def test_prompt__create__happyflow(opik_client: opik.Opik):
         version_id=prompt.__internal_api__version_id__,
         prompt_id=prompt.__internal_api__prompt_id__,
         commit=prompt.commit,
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
 
-def test_prompt__create_new_version__happyflow(opik_client: opik.Opik):
-    unique_identifier = str(uuid.uuid4())[-6:]
-
-    prompt_name = f"some-prompt-name-{unique_identifier}"
-    prompt_template = f"some-prompt-text-{unique_identifier}"
+def test_prompt__create_new_version__happyflow(
+    opik_client: opik.Opik, prompt_name: str
+):
+    prompt_template = f"some-prompt-text-{_generate_random_suffix()}"
 
     # create initial version
     prompt = opik_client.create_prompt(
@@ -64,8 +57,7 @@ def test_prompt__create_new_version__happyflow(opik_client: opik.Opik):
         prompt=prompt_template,
     )
 
-    unique_identifier_new = str(uuid.uuid4())[-6:]
-    prompt_template_new = f"some-prompt-text-{unique_identifier_new}"
+    prompt_template_new = f"some-prompt-text-{_generate_random_suffix()}"
 
     # must create new version
     new_prompt = opik_client.create_prompt(
@@ -87,12 +79,9 @@ def test_prompt__create_new_version__happyflow(opik_client: opik.Opik):
 
 
 def test_prompt__do_not_create_new_version_with_the_same_template(
-    opik_client: opik.Opik,
+    opik_client: opik.Opik, prompt_name: str
 ):
-    unique_identifier = str(uuid.uuid4())[-6:]
-
-    prompt_name = f"some-prompt-name-{unique_identifier}"
-    prompt_template = f"some-prompt-text-{unique_identifier}"
+    prompt_template = f"some-prompt-text-{_generate_random_suffix()}"
 
     # create initial version
     prompt = opik_client.create_prompt(
@@ -119,31 +108,28 @@ def test_prompt__do_not_create_new_version_with_the_same_template(
     assert new_prompt.prompt == prompt.prompt
 
 
-def test_prompt__get_by_name__happyflow(opik_client: opik.Opik):
-    unique_identifier = str(uuid.uuid4())[-6:]
-
-    prompt_name = f"some-prompt-name-{unique_identifier}"
-    prompt_template = f"some-prompt-text-{unique_identifier}"
-    project_name = f"some-project-name-{unique_identifier}"
+def test_prompt__get_by_name__happyflow(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
+    prompt_template = f"some-prompt-text-{_generate_random_suffix()}"
 
     original_prompt_version = opik_client.create_prompt(
         name=prompt_name,
         prompt=prompt_template,
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
-    unique_identifier_new = str(uuid.uuid4())[-6:]
-    prompt_template_new = f"some-prompt-text-{unique_identifier_new}"
+    prompt_template_new = f"some-prompt-text-{_generate_random_suffix()}"
 
     new_prompt_version = opik_client.create_prompt(
         name=prompt_name,
         prompt=prompt_template_new,
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     new_prompt_version_from_api = opik_client.get_prompt(
         name=original_prompt_version.name,
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     assert (
@@ -160,7 +146,7 @@ def test_prompt__get_by_name__happyflow(opik_client: opik.Opik):
     previous_prompt_from_api = opik_client.get_prompt(
         name=original_prompt_version.name,
         commit=original_prompt_version.commit,
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     assert (
@@ -175,26 +161,22 @@ def test_prompt__get_by_name__happyflow(opik_client: opik.Opik):
     assert previous_prompt_from_api.prompt == original_prompt_version.prompt
 
 
-def test_prompt__get__not_exists(opik_client: opik.Opik):
-    unique_identifier = str(uuid.uuid4())[-6:]
-
-    prompt_name = f"some-prompt-name-{unique_identifier}"
-
+def test_prompt__get__not_exists(opik_client: opik.Opik, prompt_name: str):
     prompt = opik_client.get_prompt(prompt_name)
 
     assert prompt is None
 
 
-def test_prompt__initialize_class_instance(opik_client: opik.Opik):
-    unique_identifier = str(uuid.uuid4())[-6:]
+def test_prompt__initialize_class_instance(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     template = "Hello, {name} from {place}! Nice to meet you, {name}."
-    project_name = f"some-project-name-{unique_identifier}"
 
     prompt = opik.Prompt(
-        name=f"test-{unique_identifier}", prompt=template, project_name=project_name
+        name=prompt_name, prompt=template, project_name=temporary_project_name
     )
     prompt_from_api = opik_client.get_prompt(
-        name=prompt.name, project_name=project_name
+        name=prompt.name, project_name=temporary_project_name
     )
 
     verifiers.verify_prompt_version(
@@ -208,11 +190,10 @@ def test_prompt__initialize_class_instance(opik_client: opik.Opik):
     )
 
 
-def test_prompt__format():
-    unique_identifier = str(uuid.uuid4())[-6:]
+def test_prompt__format(prompt_name: str):
     template = "Hello, {{name}} from {{place}}! Nice to meet you, {{name}}."
 
-    prompt = opik.Prompt(name=f"test-{unique_identifier}", prompt=template)
+    prompt = opik.Prompt(name=prompt_name, prompt=template)
 
     result = prompt.format(name="John", place="The Earth")
     assert result == "Hello, John from The Earth! Nice to meet you, John."
@@ -220,18 +201,16 @@ def test_prompt__format():
     assert prompt.prompt == template
 
 
-def test_prompt__create_with_custom_type(opik_client: opik.Opik):
-    unique_identifier = str(uuid.uuid4())[-6:]
-
-    prompt_name = f"some-prompt-name-{unique_identifier}"
-    prompt_template = f"some-prompt-text-{unique_identifier}"
-    project_name = f"some-project-name-{unique_identifier}"
+def test_prompt__create_with_custom_type(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
+    prompt_template = f"some-prompt-text-{_generate_random_suffix()}"
 
     prompt = opik_client.create_prompt(
         name=prompt_name,
         prompt=prompt_template,
         type="jinja2",
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     verifiers.verify_prompt_version(
@@ -239,41 +218,36 @@ def test_prompt__create_with_custom_type(opik_client: opik.Opik):
         name=prompt_name,
         template=prompt_template,
         type=PromptType.JINJA2,
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
 
-def test_prompt__type_persists_in_get(opik_client: opik.Opik):
-    unique_identifier = str(uuid.uuid4())[-6:]
-
-    prompt_name = f"some-prompt-name-{unique_identifier}"
-    prompt_template = f"some-prompt-text-{unique_identifier}"
-    project_name = f"some-project-name-{unique_identifier}"
+def test_prompt__type_persists_in_get(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
+    prompt_template = f"some-prompt-text-{_generate_random_suffix()}"
 
     opik_client.create_prompt(
         name=prompt_name,
         prompt=prompt_template,
         type="jinja2",
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     retrieved_prompt = opik_client.get_prompt(
-        name=prompt_name, project_name=project_name
+        name=prompt_name, project_name=temporary_project_name
     )
     verifiers.verify_prompt_version(
         retrieved_prompt,
         name=prompt_name,
         template=prompt_template,
         type=PromptType.JINJA2,
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
 
-def test_prompt__type_in_new_version(opik_client: opik.Opik):
-    unique_identifier = str(uuid.uuid4())[-6:]
-
-    prompt_name = f"some-prompt-name-{unique_identifier}"
-    prompt_template = f"some-prompt-text-{unique_identifier}"
+def test_prompt__type_in_new_version(opik_client: opik.Opik, prompt_name: str):
+    prompt_template = f"some-prompt-text-{_generate_random_suffix()}"
 
     prompt = opik_client.create_prompt(
         name=prompt_name,
@@ -297,44 +271,42 @@ def test_prompt__type_in_new_version(opik_client: opik.Opik):
     assert new_prompt.prompt != prompt.prompt
 
 
-def test_prompt__search_prompts__returns_all_versions(opik_client: opik.Opik):
-    unique_identifier = str(uuid.uuid4())[-6:]
-
-    prompt_name_1 = f"some-prompt-name-{unique_identifier}"
-    prompt_name_2 = f"some-prompt-name-{unique_identifier}-v2"
-    project_name = f"some-project-name-{unique_identifier}"
+def test_prompt__search_prompts__returns_all_versions(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
+    prompt_name_2 = f"{prompt_name}-v2"
 
     opik_client.create_prompt(
-        name=prompt_name_1, prompt="old-template-1", project_name=project_name
+        name=prompt_name, prompt="old-template-1", project_name=temporary_project_name
     )
     opik_client.create_prompt(
-        name=prompt_name_1, prompt="new-template-1", project_name=project_name
+        name=prompt_name, prompt="new-template-1", project_name=temporary_project_name
     )
     opik_client.create_prompt(
-        name=prompt_name_2, prompt="some-template-2", project_name=project_name
+        name=prompt_name_2,
+        prompt="some-template-2",
+        project_name=temporary_project_name,
     )
 
-    prompts = opik_client.search_prompts(project_name=project_name)
+    prompts = opik_client.search_prompts(project_name=temporary_project_name)
 
     templates = {p.prompt for p in prompts if isinstance(p, opik.Prompt)}
     assert "new-template-1" in templates
     assert "some-template-2" in templates
 
 
-def test_prompt__get_prompts__with_filters__happyflow(opik_client: opik.Opik):
-    unique_identifier = str(uuid.uuid4())[-6:]
-
-    project_name = f"some-project-name-{unique_identifier}"
-    prompt_name = f"some-prompt-name-{unique_identifier}"
-    prompt_template_1 = f"some-prompt-text-{unique_identifier}"
-    prompt_template_2 = f"some-prompt-text-{unique_identifier}-v2"
+def test_prompt__get_prompts__with_filters__happyflow(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
+    prompt_template_1 = f"some-prompt-text-{_generate_random_suffix()}"
+    prompt_template_2 = f"{prompt_template_1}-v2"
 
     # Create two versions for the same prompt
     _ = opik_client.create_prompt(
-        name=prompt_name, prompt=prompt_template_1, project_name=project_name
+        name=prompt_name, prompt=prompt_template_1, project_name=temporary_project_name
     )
     prompt_version2 = opik_client.create_prompt(
-        name=prompt_name, prompt=prompt_template_2, project_name=project_name
+        name=prompt_name, prompt=prompt_template_2, project_name=temporary_project_name
     )
 
     # Add tags to prompt version 2
@@ -346,36 +318,38 @@ def test_prompt__get_prompts__with_filters__happyflow(opik_client: opik.Opik):
 
     filtered_prompts = opik_client.search_prompts(
         filter_string=f'name contains "{prompt_name}" AND tags contains "alpha" AND tags contains "beta"',
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     assert len(filtered_prompts) == 1
     assert filtered_prompts[0].prompt == prompt_template_2
 
 
-def test_prompt__search_prompts__by_name__happyflow(opik_client: opik.Opik):
-    unique_identifier = str(uuid.uuid4())[-6:]
-
-    project_name = f"some-project-name-{unique_identifier}"
-    prompt_name_1 = f"common-prefix-{unique_identifier}-one"
-    prompt_name_2 = f"common-prefix-{unique_identifier}-two"
-    prompt_name_3 = f"other-group-{unique_identifier}-three"
+def test_prompt__search_prompts__by_name__happyflow(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
+    # Two prompts share a common prefix unique to this test; a third uses an
+    # `-other-` infix so it doesn't contain that shared prefix. Searching for
+    # the shared prefix must return only the first two.
+    shared_prefix = f"{prompt_name}-common"
+    prompt_name_1 = f"{shared_prefix}-one"
+    prompt_name_2 = f"{shared_prefix}-two"
+    prompt_name_3 = f"{prompt_name}-other-three"
 
     # Create three prompts with different names
     opik_client.create_prompt(
-        name=prompt_name_1, prompt="template-1", project_name=project_name
+        name=prompt_name_1, prompt="template-1", project_name=temporary_project_name
     )
     opik_client.create_prompt(
-        name=prompt_name_2, prompt="template-2", project_name=project_name
+        name=prompt_name_2, prompt="template-2", project_name=temporary_project_name
     )
     opik_client.create_prompt(
-        name=prompt_name_3, prompt="template-3", project_name=project_name
+        name=prompt_name_3, prompt="template-3", project_name=temporary_project_name
     )
 
-    # Search by name substring via OQL (no additional filters) to retrieve only two matching prompts
     results = opik_client.search_prompts(
-        filter_string=f'name contains "common-prefix-{unique_identifier}"',
-        project_name=project_name,
+        filter_string=f'name contains "{shared_prefix}"',
+        project_name=temporary_project_name,
     )
 
     names = set(p.name for p in results if isinstance(p, opik.Prompt))
@@ -383,11 +357,10 @@ def test_prompt__search_prompts__by_name__happyflow(opik_client: opik.Opik):
     assert names == set([prompt_name_1, prompt_name_2])
 
 
-def test_prompt__template_structure_immutable__error(opik_client: opik.Opik):
+def test_prompt__template_structure_immutable__error(
+    opik_client: opik.Opik, prompt_name: str
+):
     """Test that template_structure is immutable after prompt creation."""
-    unique_identifier = str(uuid.uuid4())[-6:]
-    prompt_name = f"test-immutable-structure-{unique_identifier}"
-
     # Create initial text prompt
     text_prompt = opik_client.create_prompt(
         name=prompt_name,
@@ -424,11 +397,10 @@ def test_prompt__template_structure_immutable__error(opik_client: opik.Opik):
     )
 
 
-def test_get_prompt__string_prompt__returns_prompt(opik_client: opik.Opik):
+def test_get_prompt__string_prompt__returns_prompt(
+    opik_client: opik.Opik, prompt_name: str
+):
     """Test that get_prompt() returns a Prompt object for text prompts."""
-    unique_id = str(uuid.uuid4())[-6:]
-    prompt_name = f"text-prompt-{unique_id}"
-
     # Create a text prompt
     created_prompt = opik_client.create_prompt(
         name=prompt_name,
@@ -444,12 +416,10 @@ def test_get_prompt__string_prompt__returns_prompt(opik_client: opik.Opik):
     assert retrieved_prompt.commit == created_prompt.commit
 
 
-def test_get_prompt__chat_prompt__returns_none(opik_client: opik.Opik):
+def test_get_prompt__chat_prompt__returns_none(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     """Test that get_prompt() raises an error for chat prompts (type mismatch)."""
-    unique_id = str(uuid.uuid4())[-6:]
-    prompt_name = f"chat-prompt-{unique_id}"
-    project_name = f"chat-project-{unique_id}"
-
     # Create a chat prompt
     chat_prompt = opik_client.create_chat_prompt(
         name=prompt_name,
@@ -457,7 +427,7 @@ def test_get_prompt__chat_prompt__returns_none(opik_client: opik.Opik):
             {"role": "system", "content": "You are helpful"},
             {"role": "user", "content": "Hello"},
         ],
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     # Try to retrieve it with get_prompt() - should raise an error due to type mismatch
@@ -466,7 +436,7 @@ def test_get_prompt__chat_prompt__returns_none(opik_client: opik.Opik):
 
     # Verify the chat prompt remains unchanged
     retrieved_chat_prompt = opik_client.get_chat_prompt(
-        name=prompt_name, project_name=project_name
+        name=prompt_name, project_name=temporary_project_name
     )
     assert retrieved_chat_prompt is not None
     verifiers.verify_chat_prompt_version(
@@ -476,36 +446,34 @@ def test_get_prompt__chat_prompt__returns_none(opik_client: opik.Opik):
         commit=chat_prompt.commit,
         prompt_id=chat_prompt.__internal_api__prompt_id__,
         version_id=chat_prompt.__internal_api__version_id__,
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
 
-def test_get_prompt_history__string_prompt__returns_prompts(opik_client: opik.Opik):
+def test_get_prompt_history__string_prompt__returns_prompts(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     """Test that get_prompt_history() returns Prompt objects for text prompts."""
-    unique_id = str(uuid.uuid4())[-6:]
-    prompt_name = f"text-prompt-history-{unique_id}"
-    project_name = f"text-project-{unique_id}"
-
     # Create multiple versions of a text prompt
     v1 = opik_client.create_prompt(
-        name=prompt_name, prompt="Version 1", project_name=project_name
+        name=prompt_name, prompt="Version 1", project_name=temporary_project_name
     )
     v2 = opik_client.create_prompt(
-        name=prompt_name, prompt="Version 2", project_name=project_name
+        name=prompt_name, prompt="Version 2", project_name=temporary_project_name
     )
     v3 = opik_client.create_prompt(
-        name=prompt_name, prompt="Version 3", project_name=project_name
+        name=prompt_name, prompt="Version 3", project_name=temporary_project_name
     )
 
     # Retrieve history
     history = opik_client.get_prompt_history(
-        name=prompt_name, project_name=project_name
+        name=prompt_name, project_name=temporary_project_name
     )
 
     assert len(history) == 3
     assert all(isinstance(p, opik.Prompt) for p in history)
     assert history[0].name == prompt_name
-    assert history[0].project_name == project_name
+    assert history[0].project_name == temporary_project_name
 
     # Verify commits are in the history
     commits = {p.commit for p in history}
@@ -514,17 +482,15 @@ def test_get_prompt_history__string_prompt__returns_prompts(opik_client: opik.Op
     assert v3.commit in commits
 
 
-def test_get_prompt_history__chat_prompt__returns_empty_list(opik_client: opik.Opik):
+def test_get_prompt_history__chat_prompt__returns_empty_list(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     """Test that get_prompt_history() raises an error for chat prompts (type mismatch)."""
-    unique_id = str(uuid.uuid4())[-6:]
-    prompt_name = f"chat-prompt-history-{unique_id}"
-    project_name = f"chat-project-{unique_id}"
-
     # Create a chat prompt
     chat_prompt = opik_client.create_chat_prompt(
         name=prompt_name,
         messages=[{"role": "user", "content": "Hello"}],
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     # Try to get history with get_prompt_history() - should raise an error due to type mismatch
@@ -533,11 +499,11 @@ def test_get_prompt_history__chat_prompt__returns_empty_list(opik_client: opik.O
 
     # Verify the chat prompt remains unchanged
     retrieved_chat_prompt = opik_client.get_chat_prompt(
-        name=prompt_name, project_name=project_name
+        name=prompt_name, project_name=temporary_project_name
     )
     assert retrieved_chat_prompt is not None
     assert retrieved_chat_prompt.name == prompt_name
-    assert retrieved_chat_prompt.project_name == project_name
+    assert retrieved_chat_prompt.project_name == temporary_project_name
     verifiers.verify_chat_prompt_version(
         retrieved_chat_prompt,
         name=prompt_name,
@@ -545,43 +511,49 @@ def test_get_prompt_history__chat_prompt__returns_empty_list(opik_client: opik.O
         commit=chat_prompt.commit,
         prompt_id=chat_prompt.__internal_api__prompt_id__,
         version_id=chat_prompt.__internal_api__version_id__,
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
 
-def test_search_prompts__returns_both_types(opik_client: opik.Opik):
+def test_search_prompts__returns_both_types(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     """Test that search_prompts() returns both text and chat prompts."""
-    unique_id = str(uuid.uuid4())[-6:]
-    project_name = f"search-project-{unique_id}"
+    # Four prompts (2 text + 2 chat) all derive from the unique prompt_name fixture
+    # so the search prefix below isolates this test's prompts from any others.
+    text_name_1 = f"{prompt_name}-text-1"
+    text_name_2 = f"{prompt_name}-text-2"
+    chat_name_1 = f"{prompt_name}-chat-1"
+    chat_name_2 = f"{prompt_name}-chat-2"
 
     # Create text prompts
     text_prompt_1 = opik_client.create_prompt(
-        name=f"text-search-{unique_id}-1",
+        name=text_name_1,
         prompt="Text prompt 1",
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     text_prompt_2 = opik_client.create_prompt(
-        name=f"text-search-{unique_id}-2",
+        name=text_name_2,
         prompt="Text prompt 2",
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     # Create chat prompts with similar names
     chat_prompt_1 = opik_client.create_chat_prompt(
-        name=f"chat-search-{unique_id}-1",
+        name=chat_name_1,
         messages=[{"role": "user", "content": "Chat 1"}],
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     chat_prompt_2 = opik_client.create_chat_prompt(
-        name=f"chat-search-{unique_id}-2",
+        name=chat_name_2,
         messages=[{"role": "user", "content": "Chat 2"}],
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
-    # Search for all prompts with the unique_id
+    # Search for all prompts sharing the unique fixture prefix
     results = opik_client.search_prompts(
-        filter_string=f'name contains "{unique_id}"',
-        project_name=project_name,
+        filter_string=f'name contains "{prompt_name}"',
+        project_name=temporary_project_name,
     )
 
     # Should return both text and chat prompts
@@ -595,30 +567,32 @@ def test_search_prompts__returns_both_types(opik_client: opik.Opik):
         text_prompt_2.name,
     }
     assert {p.name for p in chat_prompts} == {chat_prompt_1.name, chat_prompt_2.name}
-    assert all(prompt.project_name == project_name for prompt in results)
+    assert all(prompt.project_name == temporary_project_name for prompt in results)
 
 
-def test_search_prompts__filter_by_template_structure_text(opik_client: opik.Opik):
+def test_search_prompts__filter_by_template_structure_text(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     """Test that search_prompts() can filter by template_structure='text'."""
-    unique_id = str(uuid.uuid4())[-6:]
-    project_name = f"search-project-{unique_id}"
+    text_name = f"{prompt_name}-text"
+    chat_name = f"{prompt_name}-chat"
 
     # Create text and chat prompts
     text_prompt = opik_client.create_prompt(
-        name=f"text-search-{unique_id}",
+        name=text_name,
         prompt="Text prompt",
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     _ = opik_client.create_chat_prompt(
-        name=f"chat-search-{unique_id}",
+        name=chat_name,
         messages=[{"role": "user", "content": "Chat"}],
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     # Search for only text prompts
     results = opik_client.search_prompts(
-        filter_string=f'name contains "{unique_id}" AND template_structure = "text"',
-        project_name=project_name,
+        filter_string=f'name contains "{prompt_name}" AND template_structure = "text"',
+        project_name=temporary_project_name,
     )
 
     # Should only return text prompts
@@ -627,27 +601,29 @@ def test_search_prompts__filter_by_template_structure_text(opik_client: opik.Opi
     assert results[0].name == text_prompt.name
 
 
-def test_search_prompts__filter_by_template_structure_chat(opik_client: opik.Opik):
+def test_search_prompts__filter_by_template_structure_chat(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     """Test that search_prompts() can filter by template_structure='chat'."""
-    unique_id = str(uuid.uuid4())[-6:]
-    project_name = f"search-project-{unique_id}"
+    text_name = f"{prompt_name}-text"
+    chat_name = f"{prompt_name}-chat"
 
     # Create text and chat prompts
     _ = opik_client.create_prompt(
-        name=f"text-search-{unique_id}",
+        name=text_name,
         prompt="Text prompt",
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     chat_prompt = opik_client.create_chat_prompt(
-        name=f"chat-search-{unique_id}",
+        name=chat_name,
         messages=[{"role": "user", "content": "Chat"}],
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     # Search for only chat prompts
     results = opik_client.search_prompts(
-        filter_string=f'name contains "{unique_id}" AND template_structure = "chat"',
-        project_name=project_name,
+        filter_string=f'name contains "{prompt_name}" AND template_structure = "chat"',
+        project_name=temporary_project_name,
     )
 
     # Should only return chat prompts
@@ -656,23 +632,21 @@ def test_search_prompts__filter_by_template_structure_chat(opik_client: opik.Opi
     assert results[0].name == chat_prompt.name
 
 
-def test_get_prompt__with_commit__string_prompt(opik_client: opik.Opik):
+def test_get_prompt__with_commit__string_prompt(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     """Test that get_prompt() with commit works for text prompts."""
-    unique_id = str(uuid.uuid4())[-6:]
-    prompt_name = f"string-prompt-commit-{unique_id}"
-    project_name = f"get_prompt_-project-{unique_id}"
-
     # Create multiple versions
     v1 = opik_client.create_prompt(
-        name=prompt_name, prompt="Version 1", project_name=project_name
+        name=prompt_name, prompt="Version 1", project_name=temporary_project_name
     )
     _ = opik_client.create_prompt(
-        name=prompt_name, prompt="Version 2", project_name=project_name
+        name=prompt_name, prompt="Version 2", project_name=temporary_project_name
     )
 
     # Retrieve specific version by commit
     retrieved_v1 = opik_client.get_prompt(
-        name=prompt_name, commit=v1.commit, project_name=project_name
+        name=prompt_name, commit=v1.commit, project_name=temporary_project_name
     )
 
     assert retrieved_v1 is not None
@@ -680,31 +654,31 @@ def test_get_prompt__with_commit__string_prompt(opik_client: opik.Opik):
     assert retrieved_v1.commit == v1.commit
     assert retrieved_v1.prompt == "Version 1"
     assert retrieved_v1.name == prompt_name
-    assert retrieved_v1.project_name == project_name
+    assert retrieved_v1.project_name == temporary_project_name
 
 
 def test_get_prompt__nonexistent__returns_none(opik_client: opik.Opik):
     """Test that get_prompt() returns None for non-existent prompts."""
-    result = opik_client.get_prompt(name="nonexistent-prompt-12345")
+    result = opik_client.get_prompt(
+        name=f"nonexistent-prompt-{_generate_random_suffix()}"
+    )
     assert result is None
 
 
-def test_get_prompt__with_version__string_prompt(opik_client: opik.Opik):
+def test_get_prompt__with_version__string_prompt(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     """Test that get_prompt() with the sequential ``version`` selector
     (e.g. ``"v1"``, ``"v2"``, ...) returns the correct prompt content."""
-    unique_id = str(uuid.uuid4())[-6:]
-    prompt_name = f"string-prompt-version-{unique_id}"
-    project_name = f"get_prompt_version-project-{unique_id}"
-
     # Create three versions of the same prompt.
     opik_client.create_prompt(
-        name=prompt_name, prompt="Version 1", project_name=project_name
+        name=prompt_name, prompt="Version 1", project_name=temporary_project_name
     )
     opik_client.create_prompt(
-        name=prompt_name, prompt="Version 2", project_name=project_name
+        name=prompt_name, prompt="Version 2", project_name=temporary_project_name
     )
     latest = opik_client.create_prompt(
-        name=prompt_name, prompt="Version 3", project_name=project_name
+        name=prompt_name, prompt="Version 3", project_name=temporary_project_name
     )
 
     expected_by_version = {
@@ -717,7 +691,7 @@ def test_get_prompt__with_version__string_prompt(opik_client: opik.Opik):
         retrieved = opik_client.get_prompt(
             name=prompt_name,
             version=selector,
-            project_name=project_name,
+            project_name=temporary_project_name,
             no_cache=True,
         )
         assert retrieved is not None, f"expected prompt for version {selector}"
@@ -725,11 +699,11 @@ def test_get_prompt__with_version__string_prompt(opik_client: opik.Opik):
         assert retrieved.prompt == expected_template
         assert retrieved.version == selector
         assert retrieved.name == prompt_name
-        assert retrieved.project_name == project_name
+        assert retrieved.project_name == temporary_project_name
 
     # The latest prompt (no version selector) should expose version="v3".
     latest_fetched = opik_client.get_prompt(
-        name=prompt_name, project_name=project_name, no_cache=True
+        name=prompt_name, project_name=temporary_project_name, no_cache=True
     )
     assert latest_fetched is not None
     assert latest_fetched.version == "v3"
@@ -737,10 +711,9 @@ def test_get_prompt__with_version__string_prompt(opik_client: opik.Opik):
     assert latest.version == "v3"
 
 
-def test_prompt__format_playground_chat_prompt__returns_json(opik_client: opik.Opik):
-    unique_identifier = str(uuid.uuid4())[-6:]
-
-    prompt_name = f"chat-prompt-{unique_identifier}"
+def test_prompt__format_playground_chat_prompt__returns_json(
+    opik_client: opik.Opik, prompt_name: str
+):
     # JSON template representing a chat messages array with multimodal content
     # Build as Python structure for readability, then convert to JSON
     prompt_structure = [
@@ -841,11 +814,8 @@ def test_prompt__format_playground_chat_prompt__returns_json(opik_client: opik.O
 
 
 def test_prompt__format_playground_chat_prompt__invalid_json__returns_string(
-    opik_client: opik.Opik,
+    opik_client: opik.Opik, prompt_name: str
 ):
-    unique_identifier = str(uuid.uuid4())[-6:]
-
-    prompt_name = f"invalid-chat-prompt-{unique_identifier}"
     # Invalid JSON template (missing closing bracket)
     prompt_template = '[{"role": "system", "content": "{{content}}"}'
 
@@ -867,15 +837,13 @@ def test_prompt__format_playground_chat_prompt__invalid_json__returns_string(
     assert result == '[{"role": "system", "content": "test content"}'
 
 
-def test_prompt__create_with_additional_parameters__happyflow(opik_client: opik.Opik):
+def test_prompt__create_with_additional_parameters__happyflow(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     """Test that create_prompt() accepts tags and description parameters."""
-    unique_identifier = str(uuid.uuid4())[-6:]
-
-    prompt_name = f"prompt-with-params-{unique_identifier}"
-    prompt_template = f"some-prompt-text-{unique_identifier}"
+    prompt_template = f"some-prompt-text-{_generate_random_suffix()}"
     tags = ["tag1", "tag2", "production"]
     description = "This is a test prompt description"
-    project_name = f"project-with-params-{unique_identifier}"
 
     # Create prompt with tags and description
     prompt = opik_client.create_prompt(
@@ -883,7 +851,7 @@ def test_prompt__create_with_additional_parameters__happyflow(opik_client: opik.
         prompt=prompt_template,
         tags=tags,
         description=description,
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     # Verify prompt was created
@@ -891,42 +859,40 @@ def test_prompt__create_with_additional_parameters__happyflow(opik_client: opik.
         prompt,
         name=prompt_name,
         template=prompt_template,
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     # Verify tags were set by searching for the prompt
     filtered_prompts = opik_client.search_prompts(
         filter_string=f'name = "{prompt_name}" AND tags contains "tag1"',
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     assert len(filtered_prompts) == 1
     assert filtered_prompts[0].name == prompt_name
-    assert filtered_prompts[0].project_name == project_name
+    assert filtered_prompts[0].project_name == temporary_project_name
 
     # Retrieve the prompt to verify description was set
     retrieved_prompt = opik_client.get_prompt(
-        name=prompt_name, project_name=project_name
+        name=prompt_name, project_name=temporary_project_name
     )
     assert retrieved_prompt is not None
     assert retrieved_prompt.name == prompt_name
-    assert retrieved_prompt.project_name == project_name
+    assert retrieved_prompt.project_name == temporary_project_name
 
 
-def test_prompt__create_with_tags__happyflow(opik_client: opik.Opik):
+def test_prompt__create_with_tags__happyflow(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     """Test that create_prompt() accepts tags parameter and tags can be accessed from search results."""
-    unique_identifier = str(uuid.uuid4())[-6:]
-
-    prompt_name = f"prompt-with-tags-{unique_identifier}"
-    prompt_template = f"some-prompt-text-{unique_identifier}"
+    prompt_template = f"some-prompt-text-{_generate_random_suffix()}"
     tags = ["text-tag1", "text-tag2", "production"]
-    project_name = f"project-with-tags-{unique_identifier}"
 
     # Create text prompt with tags
     prompt = opik_client.create_prompt(
         name=prompt_name,
         prompt=prompt_template,
         tags=tags,
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     # Verify prompt was created
@@ -934,29 +900,29 @@ def test_prompt__create_with_tags__happyflow(opik_client: opik.Opik):
         prompt,
         name=prompt_name,
         template=prompt_template,
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     # Verify tags were set by searching for the prompt and accessing tags property
     filtered_prompts = opik_client.search_prompts(
         filter_string=f'name = "{prompt_name}" AND tags contains "text-tag1"',
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     assert len(filtered_prompts) == 1
     assert filtered_prompts[0].name == prompt_name
-    assert filtered_prompts[0].project_name == project_name
+    assert filtered_prompts[0].project_name == temporary_project_name
     assert set(filtered_prompts[0].tags) == set(tags)
 
 
-def test_prompt__filter_versions(opik_client: opik.Opik):
-    prompt_name = _generate_random_prompt_name()
+def test_prompt__filter_versions(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     shared_tag = _generate_random_tag()
-    project_name = f"project-prompt__filter_versions-{_generate_random_suffix()}"
 
     v1 = opik_client.create_prompt(
         name=prompt_name,
         prompt=f"Template v1-{_generate_random_suffix()}",
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     opik_client.get_prompts_client().batch_update_prompt_version_tags(
         version_ids=[v1.version_id],
@@ -965,7 +931,7 @@ def test_prompt__filter_versions(opik_client: opik.Opik):
     v2 = opik_client.create_prompt(
         name=prompt_name,
         prompt=f"Template v2-{_generate_random_suffix()}",
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     opik_client.get_prompts_client().batch_update_prompt_version_tags(
         version_ids=[v2.version_id],
@@ -974,7 +940,7 @@ def test_prompt__filter_versions(opik_client: opik.Opik):
     v3 = opik_client.create_prompt(
         name=prompt_name,
         prompt=f"Template v3-{_generate_random_suffix()}",
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     opik_client.get_prompts_client().batch_update_prompt_version_tags(
         version_ids=[v3.version_id],
@@ -984,7 +950,7 @@ def test_prompt__filter_versions(opik_client: opik.Opik):
     filtered_versions = opik_client.get_prompt_history(
         name=prompt_name,
         filter_string=f'tags contains "{shared_tag}"',
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     assert len(filtered_versions) == 2
@@ -994,29 +960,29 @@ def test_prompt__filter_versions(opik_client: opik.Opik):
     assert v2.version_id not in version_ids
 
 
-def test_prompt__search_versions(opik_client: opik.Opik):
-    prompt_name = _generate_random_prompt_name()
+def test_prompt__search_versions(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     search_term = f"unique-search-term-{_generate_random_suffix()}"
-    project_name = f"project-prompt__search_versions-{_generate_random_suffix()}"
 
     v1 = opik_client.create_prompt(
         name=prompt_name,
         prompt=f"This template contains {search_term} for testing",
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     v2 = opik_client.create_prompt(
         name=prompt_name,
         prompt=f"This template has different content {_generate_random_suffix()} for testing",
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     v3 = opik_client.create_prompt(
         name=prompt_name,
         prompt=f"Another template with {search_term} included",
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     search_results = opik_client.get_prompt_history(
-        name=prompt_name, search=search_term, project_name=project_name
+        name=prompt_name, search=search_term, project_name=temporary_project_name
     )
 
     assert len(search_results) == 2
@@ -1026,17 +992,17 @@ def test_prompt__search_versions(opik_client: opik.Opik):
     assert v2.version_id not in version_ids
 
 
-def test_chat_prompt__filter_versions(opik_client: opik.Opik):
-    prompt_name = _generate_random_prompt_name()
+def test_chat_prompt__filter_versions(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     shared_tag = _generate_random_tag()
-    project_name = f"project-chat_prompt__filter_versions-{_generate_random_suffix()}"
 
     v1 = opik_client.create_chat_prompt(
         name=prompt_name,
         messages=[
             {"role": "user", "content": f"Message v1-{_generate_random_suffix()}"}
         ],
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     opik_client.get_prompts_client().batch_update_prompt_version_tags(
         version_ids=[v1.version_id],
@@ -1047,7 +1013,7 @@ def test_chat_prompt__filter_versions(opik_client: opik.Opik):
         messages=[
             {"role": "user", "content": f"Message v2-{_generate_random_suffix()}"}
         ],
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     opik_client.get_prompts_client().batch_update_prompt_version_tags(
         version_ids=[v2.version_id],
@@ -1058,7 +1024,7 @@ def test_chat_prompt__filter_versions(opik_client: opik.Opik):
         messages=[
             {"role": "user", "content": f"Message v3-{_generate_random_suffix()}"}
         ],
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     opik_client.get_prompts_client().batch_update_prompt_version_tags(
         version_ids=[v3.version_id],
@@ -1068,7 +1034,7 @@ def test_chat_prompt__filter_versions(opik_client: opik.Opik):
     filtered_versions = opik_client.get_chat_prompt_history(
         name=prompt_name,
         filter_string=f'tags contains "{shared_tag}"',
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     assert len(filtered_versions) == 2
@@ -1078,10 +1044,10 @@ def test_chat_prompt__filter_versions(opik_client: opik.Opik):
     assert v2.version_id not in version_ids
 
 
-def test_chat_prompt__search_versions(opik_client: opik.Opik):
-    prompt_name = _generate_random_prompt_name()
+def test_chat_prompt__search_versions(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     search_term = f"unique-search-term-{_generate_random_suffix()}"
-    project_name = f"project-chat_prompt__search_versions-{_generate_random_suffix()}"
 
     v1 = opik_client.create_chat_prompt(
         name=prompt_name,
@@ -1091,7 +1057,7 @@ def test_chat_prompt__search_versions(opik_client: opik.Opik):
                 "content": f"This message contains {search_term} for testing",
             }
         ],
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     v2 = opik_client.create_chat_prompt(
         name=prompt_name,
@@ -1101,18 +1067,18 @@ def test_chat_prompt__search_versions(opik_client: opik.Opik):
                 "content": f"This message has different content {_generate_random_suffix()} for testing",
             }
         ],
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     v3 = opik_client.create_chat_prompt(
         name=prompt_name,
         messages=[
             {"role": "user", "content": f"Another message with {search_term} included"}
         ],
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
 
     search_results = opik_client.get_chat_prompt_history(
-        name=prompt_name, search=search_term, project_name=project_name
+        name=prompt_name, search=search_term, project_name=temporary_project_name
     )
 
     assert len(search_results) == 2
@@ -1122,16 +1088,13 @@ def test_chat_prompt__search_versions(opik_client: opik.Opik):
     assert v2.version_id not in version_ids
 
 
-def test_prompt__update_version_tags__replace_mode(opik_client: opik.Opik):
-    prompt_name = _generate_random_prompt_name()
-    project_name = (
-        f"project-prompt__update_version_tags__replace_mode-{_generate_random_suffix()}"
-    )
-
+def test_prompt__update_version_tags__replace_mode(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     version1 = opik_client.create_prompt(
         name=prompt_name,
         prompt=f"Template v1-{_generate_random_suffix()}",
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     opik_client.get_prompts_client().batch_update_prompt_version_tags(
         version_ids=[version1.version_id],
@@ -1141,7 +1104,7 @@ def test_prompt__update_version_tags__replace_mode(opik_client: opik.Opik):
     version2 = opik_client.create_prompt(
         name=prompt_name,
         prompt=f"Template v2-{_generate_random_suffix()}",
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     opik_client.get_prompts_client().batch_update_prompt_version_tags(
         version_ids=[version2.version_id],
@@ -1157,7 +1120,7 @@ def test_prompt__update_version_tags__replace_mode(opik_client: opik.Opik):
     )
 
     history = opik_client.get_prompt_history(
-        name=prompt_name, project_name=project_name
+        name=prompt_name, project_name=temporary_project_name
     )
     assert len(history) == 2
     v1_in_history = next(
@@ -1170,14 +1133,13 @@ def test_prompt__update_version_tags__replace_mode(opik_client: opik.Opik):
     assert set(v2_in_history.tags) == set(new_tags)
 
 
-def test_prompt__update_version_tags__default_replace_mode(opik_client: opik.Opik):
-    prompt_name = _generate_random_prompt_name()
-    project_name = f"project-prompt__update_version_tags__default_replace_mode-{_generate_random_suffix()}"
-
+def test_prompt__update_version_tags__default_replace_mode(
+    opik_client: opik.Opik, prompt_name: str, temporary_project_name: str
+):
     version1 = opik_client.create_prompt(
         name=prompt_name,
         prompt=f"Template v1-{_generate_random_suffix()}",
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     opik_client.get_prompts_client().batch_update_prompt_version_tags(
         version_ids=[version1.version_id],
@@ -1186,7 +1148,7 @@ def test_prompt__update_version_tags__default_replace_mode(opik_client: opik.Opi
     version2 = opik_client.create_prompt(
         name=prompt_name,
         prompt=f"Template v2-{_generate_random_suffix()}",
-        project_name=project_name,
+        project_name=temporary_project_name,
     )
     opik_client.get_prompts_client().batch_update_prompt_version_tags(
         version_ids=[version2.version_id],
@@ -1200,7 +1162,7 @@ def test_prompt__update_version_tags__default_replace_mode(opik_client: opik.Opi
     )
 
     history = opik_client.get_prompt_history(
-        name=prompt_name, project_name=project_name
+        name=prompt_name, project_name=temporary_project_name
     )
     assert len(history) == 2
     v1_in_history = next(
@@ -1213,8 +1175,9 @@ def test_prompt__update_version_tags__default_replace_mode(opik_client: opik.Opi
     assert set(v2_in_history.tags) == set(new_tags)
 
 
-def test_prompt__update_version_tags__clear_with_empty_array(opik_client: opik.Opik):
-    prompt_name = _generate_random_prompt_name()
+def test_prompt__update_version_tags__clear_with_empty_array(
+    opik_client: opik.Opik, prompt_name: str
+):
     version1 = opik_client.create_prompt(
         name=prompt_name,
         prompt=f"Template v1-{_generate_random_suffix()}",
@@ -1247,9 +1210,8 @@ def test_prompt__update_version_tags__clear_with_empty_array(opik_client: opik.O
 
 @pytest.mark.parametrize("merge_param", [False, True, None])
 def test_prompt__update_version_tags__preserve_with_none(
-    opik_client: opik.Opik, merge_param
+    opik_client: opik.Opik, prompt_name: str, merge_param
 ):
-    prompt_name = _generate_random_prompt_name()
     version1 = opik_client.create_prompt(
         name=prompt_name,
         prompt=f"Template v1-{_generate_random_suffix()}",
@@ -1287,8 +1249,9 @@ def test_prompt__update_version_tags__preserve_with_none(
     assert set(v2_in_history.tags) == set(initial_tags_v2)
 
 
-def test_prompt__update_version_tags__merge_mode(opik_client: opik.Opik):
-    prompt_name = _generate_random_prompt_name()
+def test_prompt__update_version_tags__merge_mode(
+    opik_client: opik.Opik, prompt_name: str
+):
     version1 = opik_client.create_prompt(
         name=prompt_name,
         prompt=f"Template v1-{_generate_random_suffix()}",
@@ -1329,8 +1292,7 @@ def test_prompt__update_version_tags__merge_mode(opik_client: opik.Opik):
     assert set(v2_in_history.tags) == set(initial_tags_v2 + additional_tags)
 
 
-def test_chat_prompt__update_version_tags(opik_client: opik.Opik):
-    prompt_name = _generate_random_prompt_name()
+def test_chat_prompt__update_version_tags(opik_client: opik.Opik, prompt_name: str):
     v1 = opik_client.create_chat_prompt(
         name=prompt_name,
         messages=[
@@ -1359,11 +1321,13 @@ def test_chat_prompt__update_version_tags(opik_client: opik.Opik):
     assert set(v2_in_history.tags) == set(new_tags)
 
 
-def test_prompt__auto_inject_into_trace__happyflow(opik_client: opik.Opik):
+def test_prompt__auto_inject_into_trace__happyflow(
+    opik_client: opik.Opik, prompt_name: str
+):
     """Fetching text and chat prompts inside @track auto-injects opik_prompts into trace metadata."""
-    suffix = _generate_random_suffix()
-    text_prompt_name = f"auto-text-{suffix}"
-    chat_prompt_name = f"auto-chat-{suffix}"
+    # Two prompts needed (text + chat) — derive from the unique fixture name.
+    text_prompt_name = f"{prompt_name}-text"
+    chat_prompt_name = f"{prompt_name}-chat"
 
     opik_client.create_prompt(name=text_prompt_name, prompt="Summarize: {{text}}")
     opik_client.create_chat_prompt(
@@ -1420,19 +1384,22 @@ def _create_mask_version(
     )
 
 
-def test_prompt__mask_get_prompt__returns_masked_template(opik_client: opik.Opik):
+def test_prompt__mask_get_prompt__returns_masked_template(
+    opik_client: opik.Opik, prompt_name: str
+):
     """When a mask context is active, get_prompt returns the mask overlay instead of the original.
     Mask versions must not appear in get_prompt_history."""
-    name = f"mask-test-{_generate_random_suffix()}"
     original_template = f"original-{_generate_random_suffix()}"
     mask_template = f"masked-{_generate_random_suffix()}"
 
-    prompt = opik_client.create_prompt(name=name, prompt=original_template)
+    prompt = opik_client.create_prompt(name=prompt_name, prompt=original_template)
     prompt_id = prompt.__internal_api__prompt_id__
 
-    mask_version = _create_mask_version(opik_client, name, prompt_id, mask_template)
+    mask_version = _create_mask_version(
+        opik_client, prompt_name, prompt_id, mask_template
+    )
 
-    versions = opik_client.get_prompt_history(name=name)
+    versions = opik_client.get_prompt_history(name=prompt_name)
     version_ids = [v.__internal_api__version_id__ for v in versions]
     assert mask_version.id not in version_ids
 
@@ -1440,21 +1407,22 @@ def test_prompt__mask_get_prompt__returns_masked_template(opik_client: opik.Opik
 
     masks = {prompt_id: mask_version.id}
     with prompt_mask_context_module.prompt_mask_context(masks):
-        masked_prompt = opik_client.get_prompt(name=name)
+        masked_prompt = opik_client.get_prompt(name=prompt_name)
 
     assert masked_prompt is not None
     assert masked_prompt.prompt == mask_template
     assert masked_prompt.__internal_api__version_id__ == mask_version.id
 
     get_global_cache().clear()
-    unmasked = opik_client.get_prompt(name=name)
+    unmasked = opik_client.get_prompt(name=prompt_name)
     assert unmasked is not None
     assert unmasked.prompt == original_template
 
 
-def test_prompt__mask_chat_prompt__returns_masked_messages(opik_client: opik.Opik):
+def test_prompt__mask_chat_prompt__returns_masked_messages(
+    opik_client: opik.Opik, prompt_name: str
+):
     """Mask context also works for chat prompts."""
-    name = f"mask-chat-{_generate_random_suffix()}"
     original_messages = [
         {"role": "user", "content": f"original-{_generate_random_suffix()}"}
     ]
@@ -1462,24 +1430,26 @@ def test_prompt__mask_chat_prompt__returns_masked_messages(opik_client: opik.Opi
         {"role": "system", "content": f"masked-{_generate_random_suffix()}"}
     ]
 
-    chat_prompt = opik_client.create_chat_prompt(name=name, messages=original_messages)
+    chat_prompt = opik_client.create_chat_prompt(
+        name=prompt_name, messages=original_messages
+    )
     prompt_id = chat_prompt.__internal_api__prompt_id__
 
     mask_version = _create_mask_version(
-        opik_client, name, prompt_id, json.dumps(mask_messages)
+        opik_client, prompt_name, prompt_id, json.dumps(mask_messages)
     )
 
     get_global_cache().clear()
 
     masks = {prompt_id: mask_version.id}
     with prompt_mask_context_module.prompt_mask_context(masks):
-        masked_chat = opik_client.get_chat_prompt(name=name)
+        masked_chat = opik_client.get_chat_prompt(name=prompt_name)
 
     assert masked_chat is not None
     assert masked_chat.template == mask_messages
     assert masked_chat.__internal_api__version_id__ == mask_version.id
 
     get_global_cache().clear()
-    unmasked = opik_client.get_chat_prompt(name=name)
+    unmasked = opik_client.get_chat_prompt(name=prompt_name)
     assert unmasked is not None
     assert unmasked.template == original_messages

--- a/sdks/python/tests/e2e/verifiers.py
+++ b/sdks/python/tests/e2e/verifiers.py
@@ -798,6 +798,13 @@ def verify_opik_prompt_entry(
     assert "commit" in version, (
         f"Missing 'version.commit' in opik_prompts entry for {name}"
     )
+    # Sequential version identifier (e.g. "v1"). Mask versions don't carry one,
+    # but the injected entries in this happy-path test come from non-mask
+    # `create_prompt` / `create_chat_prompt` calls, which always have it.
+    assert version.get("version_number", "").startswith("v"), (
+        f"Expected 'version.version_number' starting with 'v' in opik_prompts entry for {name}, "
+        f"got {version.get('version_number')!r}"
+    )
 
 
 def verify_dataset_filtered_items(

--- a/sdks/python/tests/unit/api_objects/prompt/test_prompt_cache.py
+++ b/sdks/python/tests/unit/api_objects/prompt/test_prompt_cache.py
@@ -228,6 +228,69 @@ class TestGetOrFetch:
         assert r2 is p2
 
 
+class TestGetOrFetchVersionSelector:
+    """Tests for the ``version`` parameter on the module-level ``get_or_fetch``."""
+
+    def test_get_or_fetch__different_versions__return_separate_entries(self):
+        p1 = _make_mock_prompt(commit="commitA")
+        p2 = _make_mock_prompt(commit="commitB")
+        fetch1 = mock.Mock(return_value=p1)
+        fetch2 = mock.Mock(return_value=p2)
+
+        first = prompt_cache.get_or_fetch("p", None, None, "text", fetch1, version="v1")
+        second = prompt_cache.get_or_fetch(
+            "p", None, None, "text", fetch2, version="v2"
+        )
+
+        assert first is p1
+        assert second is p2
+        fetch1.assert_called_once()
+        fetch2.assert_called_once()
+
+    def test_get_or_fetch__same_version__second_call_hits_cache(self):
+        p = _make_mock_prompt()
+        fetch_fn = mock.Mock(return_value=p)
+
+        first = prompt_cache.get_or_fetch(
+            "p", None, None, "text", fetch_fn, version="v2"
+        )
+        second = prompt_cache.get_or_fetch(
+            "p", None, None, "text", fetch_fn, version="v2"
+        )
+
+        assert first is second is p
+        fetch_fn.assert_called_once()
+
+    def test_get_or_fetch__commit_pin_and_version_pin__do_not_collide(self):
+        p_commit = _make_mock_prompt(commit="abc12345")
+        p_version = _make_mock_prompt(commit="def67890")
+        fetch_commit = mock.Mock(return_value=p_commit)
+        fetch_version = mock.Mock(return_value=p_version)
+
+        from_commit = prompt_cache.get_or_fetch(
+            "p", "abc12345", None, "text", fetch_commit
+        )
+        from_version = prompt_cache.get_or_fetch(
+            "p", None, None, "text", fetch_version, version="v3"
+        )
+
+        assert from_commit is p_commit
+        assert from_version is p_version
+        fetch_commit.assert_called_once()
+        fetch_version.assert_called_once()
+
+    def test_get_or_fetch__version_selector__starts_refresh_thread(self):
+        # Sequential versions can be reassigned by the backend if the underlying
+        # version is deleted and recreated, so they must follow the normal TTL
+        # refresh (not pinned indefinitely).
+        p = _make_mock_prompt()
+        fetch_fn = mock.Mock(return_value=p)
+        prompt_cache.get_or_fetch("p", None, None, "text", fetch_fn, version="v1")
+        cache = get_global_cache()
+        assert cache._thread is not None
+        assert cache._thread.is_alive()
+
+
 class TestPromptCacheEdgeCases:
     def test_get_or_fetch__multiple_unpinned_inserts__reuses_single_refresh_thread(
         self, cache

--- a/sdks/python/tests/unit/api_objects/prompt/test_prompt_client.py
+++ b/sdks/python/tests/unit/api_objects/prompt/test_prompt_client.py
@@ -250,6 +250,144 @@ class TestInternalCreateMask:
         assert version.change_description is None
 
 
+class TestGetPromptByVersionSelector:
+    """Tests for the new sequential ``version`` parameter (e.g. ``"v3"``)."""
+
+    @pytest.fixture(autouse=True)
+    def clear_global_cache(self):
+        yield
+        prompt_cache.get_global_cache().clear()
+
+    def test_get_prompt__version_arg__threads_through_as_version_number(
+        self, client, mock_rest_client
+    ):
+        mock_rest_client.prompts.retrieve_prompt_version.return_value = (
+            _make_mock_version()
+        )
+
+        client.get_prompt(name="my-prompt", version="v3")
+
+        mock_rest_client.prompts.retrieve_prompt_version.assert_called_once()
+        call_kwargs = mock_rest_client.prompts.retrieve_prompt_version.call_args[1]
+        assert call_kwargs["name"] == "my-prompt"
+        assert call_kwargs["version_number"] == "v3"
+        assert call_kwargs["commit"] is None
+
+    def test_get_prompt__commit_and_version_both_set__raises_value_error(
+        self, client, mock_rest_client
+    ):
+        with pytest.raises(ValueError, match=r"Provide either `commit` or `version`"):
+            client.get_prompt(name="my-prompt", commit="abc12345", version="v1")
+        mock_rest_client.prompts.retrieve_prompt_version.assert_not_called()
+
+    def test_get_prompt_with_cache__commit_and_version_both_set__raises_value_error(
+        self, client, mock_rest_client
+    ):
+        from opik.api_objects.prompt.text import prompt as text_prompt_module
+
+        with pytest.raises(ValueError, match=r"Provide either `commit` or `version`"):
+            client.get_prompt_with_cache(
+                name="my-prompt",
+                commit="abc12345",
+                project_name=None,
+                template_structure="text",
+                prompt_cls=text_prompt_module.Prompt,
+                version="v1",
+            )
+
+    def test_get_prompt_with_cache__different_versions__do_not_collide_in_cache(
+        self, client, mock_rest_client
+    ):
+        from opik.api_objects.prompt.text import prompt as text_prompt_module
+
+        v1 = _make_mock_version(template="content for v1")
+        v2 = _make_mock_version(template="content for v2")
+        mock_rest_client.prompts.retrieve_prompt_version.side_effect = [v1, v2]
+
+        first = client.get_prompt_with_cache(
+            name="my-prompt",
+            commit=None,
+            project_name=None,
+            template_structure="text",
+            prompt_cls=text_prompt_module.Prompt,
+            version="v1",
+        )
+        second = client.get_prompt_with_cache(
+            name="my-prompt",
+            commit=None,
+            project_name=None,
+            template_structure="text",
+            prompt_cls=text_prompt_module.Prompt,
+            version="v2",
+        )
+
+        assert first is not None and first.prompt == "content for v1"
+        assert second is not None and second.prompt == "content for v2"
+        assert mock_rest_client.prompts.retrieve_prompt_version.call_count == 2
+
+    def test_get_prompt_with_cache__commit_and_version_pin__do_not_collide(
+        self, client, mock_rest_client
+    ):
+        from opik.api_objects.prompt.text import prompt as text_prompt_module
+
+        by_commit = _make_mock_version(template="content by commit")
+        by_version = _make_mock_version(template="content by version")
+        mock_rest_client.prompts.retrieve_prompt_version.side_effect = [
+            by_commit,
+            by_version,
+        ]
+
+        commit_result = client.get_prompt_with_cache(
+            name="my-prompt",
+            commit="abc12345",
+            project_name=None,
+            template_structure="text",
+            prompt_cls=text_prompt_module.Prompt,
+        )
+        version_result = client.get_prompt_with_cache(
+            name="my-prompt",
+            commit=None,
+            project_name=None,
+            template_structure="text",
+            prompt_cls=text_prompt_module.Prompt,
+            version="v3",
+        )
+
+        assert commit_result is not None
+        assert commit_result.prompt == "content by commit"
+        assert version_result is not None
+        assert version_result.prompt == "content by version"
+        assert mock_rest_client.prompts.retrieve_prompt_version.call_count == 2
+
+    def test_get_prompt_with_cache__same_version_twice__second_hits_cache(
+        self, client, mock_rest_client
+    ):
+        from opik.api_objects.prompt.text import prompt as text_prompt_module
+
+        v2 = _make_mock_version(template="v2 content")
+        mock_rest_client.prompts.retrieve_prompt_version.return_value = v2
+
+        first = client.get_prompt_with_cache(
+            name="my-prompt",
+            commit=None,
+            project_name=None,
+            template_structure="text",
+            prompt_cls=text_prompt_module.Prompt,
+            version="v2",
+        )
+        second = client.get_prompt_with_cache(
+            name="my-prompt",
+            commit=None,
+            project_name=None,
+            template_structure="text",
+            prompt_cls=text_prompt_module.Prompt,
+            version="v2",
+        )
+
+        assert first is second
+        assert mock_rest_client.prompts.retrieve_prompt_version.call_count == 1
+
+
 class TestGetPromptWithCacheBypass:
     """Tests for no_cache parameter in Opik.get_prompt()."""
 

--- a/sdks/typescript/src/opik/client/Client.ts
+++ b/sdks/typescript/src/opik/client/Client.ts
@@ -1361,13 +1361,19 @@ export class OpikClient {
   };
 
   /**
-   * Retrieves a text prompt by name and optional version.
+   * Retrieves a text prompt by name, optionally targeting a specific `version`.
    * Results are cached client-side (TTL configurable via OPIK_PROMPT_CACHE_TTL_SECONDS,
-   * default 300s). Pinned commits are cached indefinitely. When called inside a track()
-   * context the prompt reference is injected into the active trace/span metadata.
+   * default 300s). When called inside a track() context the prompt reference
+   * is injected into the active trace/span metadata.
    *
-   * @param options - Prompt name and optional commit hash
+   * @param options - Prompt name and optional version pin
+   * @param options.name - Name of the prompt
+   * @param options.version - Sequential version identifier (e.g. `"v3"`). If not
+   *   provided, the latest version is returned.
+   * @param options.commit - **Deprecated.** Use `version` instead.
+   * @param options.projectName - Optional project scope.
    * @returns Promise resolving to Prompt or null if not found
+   * @throws Error if both `commit` and `version` are provided
    * @throws PromptTemplateStructureMismatch if prompt exists but is a chat prompt
    */
   public getPrompt = async (
@@ -1383,13 +1389,19 @@ export class OpikClient {
   };
 
   /**
-   * Retrieves a chat prompt by name and optional version.
+   * Retrieves a chat prompt by name, optionally targeting a specific `version`.
    * Results are cached client-side (TTL configurable via OPIK_PROMPT_CACHE_TTL_SECONDS,
-   * default 300s). Pinned commits are cached indefinitely. When called inside a track()
-   * context the prompt reference is injected into the active trace/span metadata.
+   * default 300s). When called inside a track() context the prompt reference
+   * is injected into the active trace/span metadata.
    *
-   * @param options - Prompt name and optional commit hash
+   * @param options - Prompt name and optional version pin
+   * @param options.name - Name of the prompt
+   * @param options.version - Sequential version identifier (e.g. `"v3"`). If not
+   *   provided, the latest version is returned.
+   * @param options.commit - **Deprecated.** Use `version` instead.
+   * @param options.projectName - Optional project scope.
    * @returns Promise resolving to ChatPrompt or null if not found
+   * @throws Error if both `commit` and `version` are provided
    * @throws PromptTemplateStructureMismatch if prompt exists but is a text prompt
    *
    * @example
@@ -1422,6 +1434,14 @@ export class OpikClient {
     ) => T,
     logContext: string
   ): Promise<T | null> => {
+    // Validate mutual exclusivity synchronously, before touching any async work.
+    if (options.commit && options.version) {
+      throw new Error(
+        "Provide either `commit` or `version`, not both. " +
+          "Prefer `version` — `commit` is deprecated."
+      );
+    }
+
     logger.debug(`Getting ${logContext}`, options);
 
     const resolvedProjectName = this.resolveProjectName(options.projectName);
@@ -1470,11 +1490,21 @@ export class OpikClient {
             return null;
           }
 
+          // Build the REST request body explicitly so we never leak SDK-only
+          // fields (such as `version` — the wire format calls it `versionNumber`).
+          const retrieveRequest: OpikApi.PromptVersionRetrieveDetail = {
+            name: options.name,
+            projectName: resolvedProjectName,
+            ...(options.commit ? { commit: options.commit } : {}),
+            ...(options.version ? { versionNumber: options.version } : {}),
+          };
+
           versionData = await this.api.prompts.retrievePromptVersion(
-            { ...options, projectName: resolvedProjectName },
+            retrieveRequest,
             this.api.requestOptions
           );
         }
+
 
         const templateStructure = versionData.templateStructure;
         if (expectedStructure === PromptTemplateStructure.Text) {
@@ -1511,7 +1541,9 @@ export class OpikClient {
       resolvedProjectName,
       expectedStructure,
       () => fetchFn(),
-      this.config.promptCacheTtlSeconds
+      this.config.promptCacheTtlSeconds,
+      undefined,
+      options.version
     );
 
     const activeMaskId = unmasked?.id
@@ -1525,7 +1557,8 @@ export class OpikClient {
           expectedStructure,
           () => fetchFn(activeMaskId),
           this.config.promptCacheTtlSeconds,
-          activeMaskId
+          activeMaskId,
+          options.version
         )
       : unmasked;
 

--- a/sdks/typescript/src/opik/prompt/BasePrompt.ts
+++ b/sdks/typescript/src/opik/prompt/BasePrompt.ts
@@ -15,6 +15,7 @@ export interface BasePromptData {
   versionId?: string;
   name: string;
   commit?: string;
+  version?: string;
   metadata?: OpikApi.JsonNode;
   type?: PromptType;
   changeDescription?: string;
@@ -33,6 +34,7 @@ export abstract class BasePrompt {
   private _id: string | undefined;
   private _versionId: string | undefined;
   private _commit: string | undefined;
+  private _version: string | undefined;
   private _synced: boolean;
   private _changeDescription: string | undefined;
 
@@ -55,6 +57,7 @@ export abstract class BasePrompt {
   get id(): string | undefined { return this._id; }
   get versionId(): string | undefined { return this._versionId; }
   get commit(): string | undefined { return this._commit; }
+  get version(): string | undefined { return this._version; }
   /** Whether the prompt has been successfully synced with the backend. */
   get synced(): boolean { return this._synced; }
   get changeDescription(): string | undefined { return this._changeDescription; }
@@ -65,6 +68,7 @@ export abstract class BasePrompt {
     this._id = data.promptId;
     this._versionId = data.versionId;
     this._commit = data.commit;
+    this._version = data.version;
     this.type = data.type ?? "mustache";
     this._changeDescription = data.changeDescription;
     this.templateStructure = data.templateStructure ?? "text";
@@ -84,6 +88,7 @@ export abstract class BasePrompt {
     promptId?: string;
     versionId?: string;
     commit?: string;
+    version?: string;
     changeDescription?: string;
     tags?: string[];
     projectName?: string;
@@ -91,6 +96,7 @@ export abstract class BasePrompt {
     this._id = result.promptId;
     this._versionId = result.versionId;
     this._commit = result.commit;
+    this._version = result.version;
     this._changeDescription = result.changeDescription;
     if (result.tags) {
       this._tags = result.tags;
@@ -144,6 +150,7 @@ export abstract class BasePrompt {
           promptId: result.id,
           versionId: result.versionId,
           commit: result.commit,
+          version: result.version,
           changeDescription: result.changeDescription,
           tags: result.tags ? Array.from(result.tags) : undefined,
           projectName: result.projectName,

--- a/sdks/typescript/src/opik/prompt/BasePrompt.ts
+++ b/sdks/typescript/src/opik/prompt/BasePrompt.ts
@@ -361,18 +361,27 @@ export abstract class BasePrompt {
   }
 
   /**
-   * Helper method to retrieve a version by commit hash.
-   * Used by subclasses in their getVersion implementations.
+   * Helper method to retrieve a version by its sequential version identifier
+   * (e.g. `"v3"`) or, for backwards compatibility, by its commit hash.
    *
-   * @param commit - Commit hash (8-char short form or full)
+   * Input matching `/^v\d+$/` is dispatched to the `versionNumber` endpoint;
+   * anything else is treated as a commit hash. Commit-based fetching is
+   * deprecated — pass a `"v<N>"` identifier instead.
+   *
+   * @param versionOrCommit - Sequential version (`"v3"`) or commit hash (deprecated)
    * @returns Promise resolving to the API response or null if not found
    */
-  protected async retrieveVersionByCommit(
-    commit: string,
+  protected async retrieveVersion(
+    versionOrCommit: string,
   ): Promise<OpikApi.PromptVersionDetail | null> {
+    const isVersionNumber = /^v\d+$/.test(versionOrCommit);
+    const request = isVersionNumber
+      ? { name: this.name, versionNumber: versionOrCommit }
+      : { name: this.name, commit: versionOrCommit };
+
     try {
       const response = await this.opik.api.prompts.retrievePromptVersion(
-        { name: this.name, commit },
+        request,
         this.opik.api.requestOptions,
       );
       return response;
@@ -389,7 +398,7 @@ export abstract class BasePrompt {
 
       logger.error("Failed to retrieve prompt version", {
         promptName: this.name,
-        commit,
+        versionOrCommit,
         error,
       });
       throw error;
@@ -410,13 +419,14 @@ export abstract class BasePrompt {
   }
 
   /**
-   * Get a specific version by commit hash.
-   * Returns a new instance of the appropriate prompt type.
+   * Get a specific version by its sequential version identifier (e.g. `"v3"`)
+   * or, for backwards compatibility, by its commit hash. Returns a new instance
+   * of the appropriate prompt type.
    *
-   * @param commit - Commit hash (8-char short form or full)
+   * @param versionOrCommit - Sequential version (`"v<N>"`) — preferred; or commit hash (deprecated)
    * @returns Promise resolving to prompt instance or null if not found
    */
-  abstract getVersion(commit: string): Promise<BasePrompt | null>;
+  abstract getVersion(versionOrCommit: string): Promise<BasePrompt | null>;
 
   /**
    * Restores a specific version by creating a new version with content from the specified version.

--- a/sdks/typescript/src/opik/prompt/BasePrompt.ts
+++ b/sdks/typescript/src/opik/prompt/BasePrompt.ts
@@ -368,16 +368,16 @@ export abstract class BasePrompt {
    * anything else is treated as a commit hash. Commit-based fetching is
    * deprecated — pass a `"v<N>"` identifier instead.
    *
-   * @param versionOrCommit - Sequential version (`"v3"`) or commit hash (deprecated)
+   * @param version - Sequential version (`"v3"`) or commit hash (deprecated)
    * @returns Promise resolving to the API response or null if not found
    */
   protected async retrieveVersion(
-    versionOrCommit: string,
+    version: string,
   ): Promise<OpikApi.PromptVersionDetail | null> {
-    const isVersionNumber = /^v\d+$/.test(versionOrCommit);
+    const isVersionNumber = /^v\d+$/.test(version);
     const request = isVersionNumber
-      ? { name: this.name, versionNumber: versionOrCommit }
-      : { name: this.name, commit: versionOrCommit };
+      ? { name: this.name, versionNumber: version }
+      : { name: this.name, commit: version };
 
     try {
       const response = await this.opik.api.prompts.retrievePromptVersion(
@@ -398,7 +398,7 @@ export abstract class BasePrompt {
 
       logger.error("Failed to retrieve prompt version", {
         promptName: this.name,
-        versionOrCommit,
+        version,
         error,
       });
       throw error;
@@ -423,10 +423,10 @@ export abstract class BasePrompt {
    * or, for backwards compatibility, by its commit hash. Returns a new instance
    * of the appropriate prompt type.
    *
-   * @param versionOrCommit - Sequential version (`"v<N>"`) — preferred; or commit hash (deprecated)
+   * @param version - Sequential version (`"v<N>"`) — preferred; or commit hash (deprecated)
    * @returns Promise resolving to prompt instance or null if not found
    */
-  abstract getVersion(versionOrCommit: string): Promise<BasePrompt | null>;
+  abstract getVersion(version: string): Promise<BasePrompt | null>;
 
   /**
    * Restores a specific version by creating a new version with content from the specified version.

--- a/sdks/typescript/src/opik/prompt/ChatPrompt.ts
+++ b/sdks/typescript/src/opik/prompt/ChatPrompt.ts
@@ -285,7 +285,7 @@ export class ChatPrompt extends BasePrompt {
    * or a commit hash for backwards compatibility. Inputs matching `/^v\d+$/`
    * are treated as version numbers; anything else is treated as a commit.
    *
-   * @param versionOrCommit - Sequential version (`"v<N>"`) or commit hash
+   * @param version - Sequential version (`"v<N>"`) or commit hash
    *   (commit input is **deprecated** — pass a `"v<N>"` identifier instead).
    * @returns ChatPrompt instance representing that version, or null if not found
    *
@@ -298,8 +298,8 @@ export class ChatPrompt extends BasePrompt {
    * const byCommit = await chatPrompt.getVersion("abc123de");
    * ```
    */
-  async getVersion(versionOrCommit: string): Promise<ChatPrompt | null> {
-    const response = await this.retrieveVersion(versionOrCommit);
+  async getVersion(version: string): Promise<ChatPrompt | null> {
+    const response = await this.retrieveVersion(version);
     if (!response) {
       return null;
     }

--- a/sdks/typescript/src/opik/prompt/ChatPrompt.ts
+++ b/sdks/typescript/src/opik/prompt/ChatPrompt.ts
@@ -279,13 +279,27 @@ export class ChatPrompt extends BasePrompt {
   }
 
   /**
-   * Get a ChatPrompt with a specific version by commit hash.
+   * Get a ChatPrompt at a specific version.
    *
-   * @param commit - Commit hash (8-char short form or full)
+   * Accepts either the sequential version identifier (e.g. `"v3"`) — preferred —
+   * or a commit hash for backwards compatibility. Inputs matching `/^v\d+$/`
+   * are treated as version numbers; anything else is treated as a commit.
+   *
+   * @param versionOrCommit - Sequential version (`"v<N>"`) or commit hash
+   *   (commit input is **deprecated** — pass a `"v<N>"` identifier instead).
    * @returns ChatPrompt instance representing that version, or null if not found
+   *
+   * @example
+   * ```typescript
+   * // Preferred
+   * const v3 = await chatPrompt.getVersion("v3");
+   *
+   * // @deprecated — commit-shaped input
+   * const byCommit = await chatPrompt.getVersion("abc123de");
+   * ```
    */
-  async getVersion(commit: string): Promise<ChatPrompt | null> {
-    const response = await this.retrieveVersionByCommit(commit);
+  async getVersion(versionOrCommit: string): Promise<ChatPrompt | null> {
+    const response = await this.retrieveVersion(versionOrCommit);
     if (!response) {
       return null;
     }

--- a/sdks/typescript/src/opik/prompt/ChatPrompt.ts
+++ b/sdks/typescript/src/opik/prompt/ChatPrompt.ts
@@ -194,6 +194,7 @@ export class ChatPrompt extends BasePrompt {
         name: promptData.name,
         messages,
         commit: apiResponse.commit,
+        version: apiResponse.versionNumber,
         metadata: apiResponse.metadata,
         type: promptType,
         changeDescription: apiResponse.changeDescription,

--- a/sdks/typescript/src/opik/prompt/Prompt.ts
+++ b/sdks/typescript/src/opik/prompt/Prompt.ts
@@ -248,7 +248,7 @@ export class Prompt extends BasePrompt {
    * or a commit hash for backwards compatibility. Inputs matching `/^v\d+$/`
    * are treated as version numbers; anything else is treated as a commit.
    *
-   * @param versionOrCommit - Sequential version (`"v<N>"`) or commit hash
+   * @param version - Sequential version (`"v<N>"`) or commit hash
    *   (commit input is **deprecated** — pass a `"v<N>"` identifier instead).
    * @returns Prompt instance representing that version, or null if not found
    *
@@ -261,8 +261,8 @@ export class Prompt extends BasePrompt {
    * const byCommit = await prompt.getVersion("abc123de");
    * ```
    */
-  async getVersion(versionOrCommit: string): Promise<Prompt | null> {
-    const response = await this.retrieveVersion(versionOrCommit);
+  async getVersion(version: string): Promise<Prompt | null> {
+    const response = await this.retrieveVersion(version);
     if (!response) {
       return null;
     }

--- a/sdks/typescript/src/opik/prompt/Prompt.ts
+++ b/sdks/typescript/src/opik/prompt/Prompt.ts
@@ -156,6 +156,7 @@ export class Prompt extends BasePrompt {
         name: promptData.name,
         prompt: apiResponse.template,
         commit: apiResponse.commit,
+        version: apiResponse.versionNumber,
         metadata: apiResponse.metadata,
         type: promptType,
         changeDescription: apiResponse.changeDescription,

--- a/sdks/typescript/src/opik/prompt/Prompt.ts
+++ b/sdks/typescript/src/opik/prompt/Prompt.ts
@@ -242,13 +242,27 @@ export class Prompt extends BasePrompt {
   }
 
   /**
-   * Get a Prompt with a specific version by commit hash.
+   * Get a Prompt at a specific version.
    *
-   * @param commit - Commit hash (8-char short form or full)
+   * Accepts either the sequential version identifier (e.g. `"v3"`) — preferred —
+   * or a commit hash for backwards compatibility. Inputs matching `/^v\d+$/`
+   * are treated as version numbers; anything else is treated as a commit.
+   *
+   * @param versionOrCommit - Sequential version (`"v<N>"`) or commit hash
+   *   (commit input is **deprecated** — pass a `"v<N>"` identifier instead).
    * @returns Prompt instance representing that version, or null if not found
+   *
+   * @example
+   * ```typescript
+   * // Preferred
+   * const v3 = await prompt.getVersion("v3");
+   *
+   * // @deprecated — commit-shaped input
+   * const byCommit = await prompt.getVersion("abc123de");
+   * ```
    */
-  async getVersion(commit: string): Promise<Prompt | null> {
-    const response = await this.retrieveVersionByCommit(commit);
+  async getVersion(versionOrCommit: string): Promise<Prompt | null> {
+    const response = await this.retrieveVersion(versionOrCommit);
     if (!response) {
       return null;
     }

--- a/sdks/typescript/src/opik/prompt/PromptVersion.ts
+++ b/sdks/typescript/src/opik/prompt/PromptVersion.ts
@@ -21,7 +21,15 @@ export class PromptVersion {
   public readonly id: string;
   public readonly name: string;
   public readonly prompt: string;
+  /**
+   * @deprecated Legacy commit hash of this prompt version. Use {@link version} instead — `commit` is no longer surfaced in the Opik UI and is kept only for backwards compatibility with older SDK callers.
+   */
   public readonly commit: string;
+  /**
+   * Sequential version identifier of this prompt version (e.g. `"v3"`).
+   * Undefined for mask versions, which do not carry a version number.
+   */
+  public readonly version?: string;
   public readonly type: PromptType;
   public readonly metadata?: OpikApi.JsonNode;
   public readonly changeDescription?: string;
@@ -34,6 +42,7 @@ export class PromptVersion {
     this.name = data.name;
     this.prompt = data.prompt;
     this.commit = data.commit;
+    this.version = data.version;
     this.type = data.type;
     this.metadata = data.metadata;
     this.changeDescription = data.changeDescription;
@@ -200,6 +209,7 @@ export class PromptVersion {
       name,
       prompt: apiResponse.template,
       commit: apiResponse.commit,
+      version: apiResponse.versionNumber ?? undefined,
       promptId: apiResponse.promptId,
       versionId: apiResponse.id,
       type: apiResponse.type ?? PromptType.MUSTACHE,

--- a/sdks/typescript/src/opik/prompt/PromptVersion.ts
+++ b/sdks/typescript/src/opik/prompt/PromptVersion.ts
@@ -70,11 +70,12 @@ export class PromptVersion {
   }
 
   /**
-   * Get formatted version information string
-   * Format: "[commitHash] YYYY-MM-DD by user@email.com - Change description"
+   * Get formatted version information string.
+   * Format: "[v3] YYYY-MM-DD by user@email.com - Change description"
+   * (falls back to the commit hash for mask versions, which have no version number).
    */
   getVersionInfo(): string {
-    const parts: string[] = [`[${this.commit}]`];
+    const parts: string[] = [`[${this.version ?? this.commit}]`];
 
     if (this.createdAt) {
       const date = new Date(this.createdAt);
@@ -104,17 +105,18 @@ export class PromptVersion {
    *
    * @example
    * ```typescript
-   * const currentVersion = await prompt.getVersion("commit123");
-   * const previousVersion = await prompt.getVersion("commit456");
+   * const versions = await prompt.getVersions();
+   * const [current, previous] = versions;
    *
    * // Logs diff to terminal and returns it
-   * const diff = currentVersion.compareTo(previousVersion);
+   * const diff = current.compareTo(previous);
    * ```
    */
   compareTo(other: PromptVersion): string {
-    // Use descriptive labels that include version identifiers
-    const thisLabel = `Current version [${this.commit}]`;
-    const otherLabel = `Other version [${other.commit}]`;
+    // Prefer the sequential version identifier in labels (e.g. "v3"); fall back
+    // to the legacy commit hash when version is absent (e.g. mask versions).
+    const thisLabel = `Current version [${this.version ?? this.commit}]`;
+    const otherLabel = `Other version [${other.version ?? other.commit}]`;
 
     // Check if this is a chat prompt (template structure is chat)
     let thisFormatted = this.prompt;

--- a/sdks/typescript/src/opik/prompt/promptCache.ts
+++ b/sdks/typescript/src/opik/prompt/promptCache.ts
@@ -204,9 +204,13 @@ export function buildCacheKey(
   commit: string | undefined,
   projectName: string | undefined,
   templateStructure: string,
-  maskId?: string | null
+  maskId?: string | null,
+  version?: string,
 ): string {
-  return JSON.stringify([name, commit ?? "", projectName ?? "", templateStructure, maskId ?? ""]);
+  // version and commit can never collide (commits are 8 hex chars, versions are "v<N>")
+  // so we reuse the same slot in the key.
+  const pin = version ?? commit ?? "";
+  return JSON.stringify([name, pin, projectName ?? "", templateStructure, maskId ?? ""]);
 }
 
 export async function getOrFetch<T extends BasePrompt>(
@@ -216,11 +220,15 @@ export async function getOrFetch<T extends BasePrompt>(
   templateStructure: string,
   fetchFn: () => Promise<T | null>,
   ttlSeconds?: number,
-  maskId?: string | null
+  maskId?: string | null,
+  version?: string,
 ): Promise<T | null> {
+  // Only commit pins indefinitely. A sequential version like "v3" can be
+  // reassigned by the backend if the underlying version is deleted and
+  // recreated, so it follows the normal TTL refresh.
   const resolvedTtl = commit != null ? null : (ttlSeconds ?? DEFAULT_TTL_SECONDS);
   const refreshCallback = resolvedTtl !== null && !maskId ? fetchFn : undefined;
-  const key = buildCacheKey(name, commit, projectName, templateStructure, maskId);
+  const key = buildCacheKey(name, commit, projectName, templateStructure, maskId, version);
   const result = await globalCache.getOrFetch(key, fetchFn, resolvedTtl, refreshCallback);
   return result as T | null;
 }

--- a/sdks/typescript/src/opik/prompt/types.ts
+++ b/sdks/typescript/src/opik/prompt/types.ts
@@ -61,10 +61,23 @@ export interface CreatePromptOptions extends CommonPromptOptions {
 }
 
 /**
- * Options for retrieving a specific prompt version
- * Re-exported from REST API PromptVersionRetrieveDetail
+ * Options for retrieving a specific prompt version.
+ *
+ * `commit` and `version` are mutually exclusive. If neither is provided,
+ * the latest version is returned.
  */
-export type GetPromptOptions = OpikApi.PromptVersionRetrieveDetail;
+export interface GetPromptOptions {
+  /** Name of the prompt to retrieve. */
+  name: string;
+  /** @deprecated Use `version` instead. */
+  commit?: string;
+  /**
+   * Sequential version identifier, e.g. `"v3"`. Mutually exclusive with `commit`.
+   */
+  version?: string;
+  /** Optional project name to scope the lookup. */
+  projectName?: string;
+}
 
 /**
  * Variables to be substituted into prompt template.

--- a/sdks/typescript/src/opik/prompt/types.ts
+++ b/sdks/typescript/src/opik/prompt/types.ts
@@ -91,6 +91,7 @@ export interface PromptVersionData {
   name: string;
   prompt: string;
   commit: string;
+  version?: string;
   promptId: string;
   versionId: string;
   type: PromptType;

--- a/sdks/typescript/tests/integration/api/prompt-api.test.ts
+++ b/sdks/typescript/tests/integration/api/prompt-api.test.ts
@@ -995,4 +995,62 @@ describe.skipIf(!shouldRunApiTests)("Prompt Real API Integration", () => {
       expect(updatedVersion2?.tags?.length).toBe(tags2.length + additionalTags.length);
     }, 30000);
   });
+
+  describe("Sequential Version Numbers", () => {
+    it("should retrieve each version by its sequential version number", async () => {
+      const promptName = `test-sequential-versions-${Date.now()}`;
+
+      const v1 = await client.createPrompt({
+        name: promptName,
+        prompt: "Sequential v1 {{input}}",
+      });
+      createdPromptIds.push(v1.id!);
+
+      await client.createPrompt({
+        name: promptName,
+        prompt: "Sequential v2 {{input}}",
+      });
+      await client.createPrompt({
+        name: promptName,
+        prompt: "Sequential v3 {{input}}",
+      });
+
+      const fetchedV1 = await client.getPrompt({
+        name: promptName,
+        version: "v1",
+      });
+      const fetchedV2 = await client.getPrompt({
+        name: promptName,
+        version: "v2",
+      });
+      const fetchedV3 = await client.getPrompt({
+        name: promptName,
+        version: "v3",
+      });
+      const fetchedLatest = await client.getPrompt({ name: promptName });
+
+      expect(fetchedV1?.prompt).toBe("Sequential v1 {{input}}");
+      expect(fetchedV1?.version).toBe("v1");
+
+      expect(fetchedV2?.prompt).toBe("Sequential v2 {{input}}");
+      expect(fetchedV2?.version).toBe("v2");
+
+      expect(fetchedV3?.prompt).toBe("Sequential v3 {{input}}");
+      expect(fetchedV3?.version).toBe("v3");
+
+      // Fetching without a selector returns the latest version.
+      expect(fetchedLatest?.prompt).toBe("Sequential v3 {{input}}");
+      expect(fetchedLatest?.version).toBe("v3");
+    }, 30000);
+
+    it("should reject when both commit and version are passed", async () => {
+      await expect(
+        client.getPrompt({
+          name: "anything",
+          commit: "abc123de",
+          version: "v1",
+        }),
+      ).rejects.toThrow(/Provide either `commit` or `version`/);
+    });
+  });
 });

--- a/sdks/typescript/tests/integration/chat-prompts.test.ts
+++ b/sdks/typescript/tests/integration/chat-prompts.test.ts
@@ -480,8 +480,11 @@ describe.skipIf(!shouldRunApiTests)("ChatPrompt Integration Tests", () => {
     expect(diff).toContain("+     custom_metadata: updated_image");
     expect(diff).toContain("-     custom_metadata: original_image");
 
-    // Verify commit hashes are present in headers
-    expect(diff).toContain(latestVersion.commit);
-    expect(diff).toContain(previousVersion.commit);
+    // Verify sequential version identifiers are present in the diff headers
+    // (compareTo prefers `version` over the legacy `commit` hash).
+    expect(latestVersion.version).toBeDefined();
+    expect(previousVersion.version).toBeDefined();
+    expect(diff).toContain(`[${latestVersion.version}]`);
+    expect(diff).toContain(`[${previousVersion.version}]`);
   });
 });

--- a/sdks/typescript/tests/unit/client/client-chat-prompts.test.ts
+++ b/sdks/typescript/tests/unit/client/client-chat-prompts.test.ts
@@ -3,6 +3,7 @@ import { OpikClient } from "@/client/Client";
 import { ChatPrompt } from "@/prompt/ChatPrompt";
 import { PromptTemplateStructureMismatch } from "@/prompt/errors";
 import { PromptTemplateStructure, type ChatMessage } from "@/prompt/types";
+import { getGlobalCache } from "@/prompt/promptCache";
 import { OpikApiError, OpikApiTimeoutError } from "@/rest_api";
 import type * as OpikApi from "@/rest_api/api";
 
@@ -10,6 +11,7 @@ describe("OpikClient - Chat Prompts", () => {
   let client: OpikClient;
 
   beforeEach(() => {
+    getGlobalCache().clear();
     client = new OpikClient({
       apiKey: "test-key",
       holdUntilFlush: true,
@@ -426,6 +428,91 @@ describe("OpikClient - Chat Prompts", () => {
         { name: "test-chat-prompt", commit: "abc123", projectName: "Default Project" },
         {}
       );
+    });
+
+    it("should retrieve specific version by sequential version number", async () => {
+      const messages: ChatMessage[] = [
+        { role: "user", content: "Hello v3" },
+      ];
+
+      vi.spyOn(client.api.prompts, "getPrompts").mockResolvedValue({
+        content: [
+          { name: "test-chat-prompt" } as OpikApi.PromptPublic,
+        ],
+      } as OpikApi.PromptPagePublic);
+
+      const mockRetrievePromptVersion = vi
+        .spyOn(client.api.prompts, "retrievePromptVersion")
+        .mockResolvedValue({
+          id: "version-123",
+          promptId: "prompt-456",
+          template: JSON.stringify(messages),
+          commit: "abc123",
+          versionNumber: "v3",
+          type: "mustache",
+          templateStructure: "chat",
+        } as OpikApi.PromptVersionDetail);
+
+      const chatPrompt = await client.getChatPrompt({
+        name: "test-chat-prompt",
+        version: "v3",
+      });
+
+      expect(chatPrompt).toBeInstanceOf(ChatPrompt);
+      expect(chatPrompt?.version).toBe("v3");
+      expect(mockRetrievePromptVersion).toHaveBeenCalledWith(
+        {
+          name: "test-chat-prompt",
+          projectName: "Default Project",
+          versionNumber: "v3",
+        },
+        {}
+      );
+
+      // Make sure the SDK-only `version` field is NOT forwarded as-is.
+      const callArgs = mockRetrievePromptVersion.mock.calls[0]?.[0] as unknown as Record<
+        string,
+        unknown
+      >;
+      expect(callArgs.version).toBeUndefined();
+    });
+
+    it("should reject when both commit and version are provided", async () => {
+      await expect(
+        client.getChatPrompt({
+          name: "test-chat-prompt",
+          commit: "abc123de",
+          version: "v3",
+        })
+      ).rejects.toThrow(/Provide either `commit` or `version`/);
+    });
+
+    it("should populate chatPrompt.version from the API response versionNumber field", async () => {
+      const messages: ChatMessage[] = [
+        { role: "user", content: "Hi" },
+      ];
+
+      vi.spyOn(client.api.prompts, "getPrompts").mockResolvedValue({
+        content: [
+          { name: "test-chat-prompt" } as OpikApi.PromptPublic,
+        ],
+      } as OpikApi.PromptPagePublic);
+
+      vi.spyOn(client.api.prompts, "retrievePromptVersion").mockResolvedValue({
+        id: "version-123",
+        promptId: "prompt-456",
+        template: JSON.stringify(messages),
+        commit: "abc123",
+        versionNumber: "v5",
+        type: "mustache",
+        templateStructure: "chat",
+      } as OpikApi.PromptVersionDetail);
+
+      const chatPrompt = await client.getChatPrompt({
+        name: "test-chat-prompt",
+      });
+
+      expect(chatPrompt?.version).toBe("v5");
     });
   });
 

--- a/sdks/typescript/tests/unit/client/client-prompts.test.ts
+++ b/sdks/typescript/tests/unit/client/client-prompts.test.ts
@@ -562,6 +562,122 @@ describe("Opik prompt operations", () => {
 
       expect(loggerErrorSpy).toHaveBeenCalled();
     });
+
+    it("should retrieve prompt by sequential version number", async () => {
+      const mockSearchResponse = {
+        content: [
+          {
+            id: "prompt-id",
+            name: "test-prompt",
+          },
+        ],
+      };
+
+      const mockVersionDetail: OpikApi.PromptVersionDetail = {
+        id: "version-id",
+        promptId: "prompt-id",
+        commit: "abc123de",
+        versionNumber: "v3",
+        template: "Version 3 content",
+        type: "mustache",
+        createdAt: new Date("2024-01-03"),
+      };
+
+      getPromptsSpy.mockImplementationOnce(() =>
+        createMockHttpResponsePromise(mockSearchResponse)
+      );
+
+      retrievePromptVersionSpy.mockImplementationOnce(() =>
+        createMockHttpResponsePromise(mockVersionDetail)
+      );
+
+      const result = await client.getPrompt({
+        name: "test-prompt",
+        version: "v3",
+      });
+
+      expect(retrievePromptVersionSpy).toHaveBeenCalledWith(
+        {
+          name: "test-prompt",
+          projectName: "opik-sdk-typescript",
+          versionNumber: "v3",
+        },
+        client.api.requestOptions
+      );
+      expect(result).toBeInstanceOf(Prompt);
+      expect(result?.version).toBe("v3");
+      expect(result?.commit).toBe("abc123de");
+      expect(result?.prompt).toBe("Version 3 content");
+    });
+
+    it("should not leak the `version` SDK-only field into the REST request body", async () => {
+      const mockSearchResponse = {
+        content: [{ id: "prompt-id", name: "test-prompt" }],
+      };
+      const mockVersionDetail: OpikApi.PromptVersionDetail = {
+        id: "version-id",
+        promptId: "prompt-id",
+        commit: "abc123de",
+        versionNumber: "v1",
+        template: "Hello",
+        type: "mustache",
+      };
+
+      getPromptsSpy.mockImplementationOnce(() =>
+        createMockHttpResponsePromise(mockSearchResponse)
+      );
+      retrievePromptVersionSpy.mockImplementationOnce(() =>
+        createMockHttpResponsePromise(mockVersionDetail)
+      );
+
+      await client.getPrompt({ name: "test-prompt", version: "v1" });
+
+      const callArgs = retrievePromptVersionSpy.mock.calls[0]?.[0] as unknown as Record<
+        string,
+        unknown
+      >;
+      expect(callArgs).toBeDefined();
+      expect(callArgs.version).toBeUndefined();
+      expect(callArgs.versionNumber).toBe("v1");
+    });
+
+    it("should reject without hitting the network when both commit and version are provided", async () => {
+      await expect(
+        client.getPrompt({
+          name: "test-prompt",
+          commit: "abc123de",
+          version: "v3",
+        })
+      ).rejects.toThrow(/Provide either `commit` or `version`/);
+
+      // Validation must short-circuit before any REST traffic
+      expect(getPromptsSpy).not.toHaveBeenCalled();
+      expect(retrievePromptVersionSpy).not.toHaveBeenCalled();
+    });
+
+    it("should populate prompt.version from the API response versionNumber field", async () => {
+      const mockSearchResponse = {
+        content: [{ id: "prompt-id", name: "test-prompt" }],
+      };
+      const mockVersionDetail: OpikApi.PromptVersionDetail = {
+        id: "version-id",
+        promptId: "prompt-id",
+        commit: "abc123de",
+        versionNumber: "v7",
+        template: "Hi",
+        type: "mustache",
+      };
+
+      getPromptsSpy.mockImplementationOnce(() =>
+        createMockHttpResponsePromise(mockSearchResponse)
+      );
+      retrievePromptVersionSpy.mockImplementationOnce(() =>
+        createMockHttpResponsePromise(mockVersionDetail)
+      );
+
+      const result = await client.getPrompt({ name: "test-prompt" });
+      expect(result?.version).toBe("v7");
+    });
   });
 
   describe("searchPrompts", () => {

--- a/sdks/typescript/tests/unit/prompt/Prompt.methods.test.ts
+++ b/sdks/typescript/tests/unit/prompt/Prompt.methods.test.ts
@@ -155,7 +155,7 @@ describe("Prompt - Instance Methods", () => {
   });
 
   describe("getVersion()", () => {
-    it("should retrieve specific version by commit hash", async () => {
+    it("should retrieve specific version by commit hash (deprecated input)", async () => {
       const versionResponse = createMockVersionDetail({
         commit: "abc123de",
         template: "Version template",
@@ -170,6 +170,44 @@ describe("Prompt - Instance Methods", () => {
       expect(versionPrompt).toBeInstanceOf(Prompt);
       expect(versionPrompt?.commit).toBe("abc123de");
       expect(versionPrompt?.prompt).toBe("Version template");
+      // Commit-shaped input must hit the commit endpoint
+      expect(
+        mockOpikClient.api.prompts.retrievePromptVersion
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ commit: "abc123de" }),
+        expect.anything()
+      );
+    });
+
+    it("should retrieve specific version by sequential version identifier", async () => {
+      const versionResponse = createMockVersionDetail({
+        commit: "abc123de",
+        versionNumber: "v3",
+        template: "Version 3 template",
+      });
+
+      vi.mocked(
+        mockOpikClient.api.prompts.retrievePromptVersion
+      ).mockResolvedValueOnce(versionResponse);
+
+      const versionPrompt = await mockPrompt.getVersion("v3");
+
+      expect(versionPrompt).toBeInstanceOf(Prompt);
+      expect(versionPrompt?.version).toBe("v3");
+      expect(versionPrompt?.prompt).toBe("Version 3 template");
+      // "v<N>"-shaped input must hit the versionNumber endpoint, not commit
+      expect(
+        mockOpikClient.api.prompts.retrievePromptVersion
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ versionNumber: "v3" }),
+        expect.anything()
+      );
+      expect(
+        mockOpikClient.api.prompts.retrievePromptVersion
+      ).not.toHaveBeenCalledWith(
+        expect.objectContaining({ commit: expect.anything() }),
+        expect.anything()
+      );
     });
 
     it("should return null for non-existent version", async () => {

--- a/sdks/typescript/tests/unit/prompt/PromptVersion.test.ts
+++ b/sdks/typescript/tests/unit/prompt/PromptVersion.test.ts
@@ -265,6 +265,7 @@ describe("PromptVersion", () => {
         name: "full-info-prompt",
         prompt: "Test",
         commit: "abc123de",
+        version: "v3",
         promptId: "prompt-123",
         type: PromptType.MUSTACHE,
         createdAt: new Date("2024-01-15T10:30:00Z"),
@@ -275,8 +276,21 @@ describe("PromptVersion", () => {
       const info = version.getVersionInfo();
 
       expect(info).toBe(
-        "[abc123de] 2024-01-15 by user@example.com - Added new feature",
+        "[v3] 2024-01-15 by user@example.com - Added new feature",
       );
+    });
+
+    it("should fall back to commit when version is absent (e.g. mask version)", () => {
+      const version = new PromptVersion({
+        versionId: "version-123",
+        name: "mask-prompt",
+        prompt: "Test",
+        commit: "abc123de",
+        promptId: "prompt-123",
+        type: PromptType.MUSTACHE,
+      });
+
+      expect(version.getVersionInfo()).toBe("[abc123de]");
     });
 
     it("should format version info with partial fields", () => {
@@ -381,12 +395,13 @@ describe("PromptVersion", () => {
   });
 
   describe("compareTo", () => {
-    it("should return unified diff output", () => {
+    it("should return unified diff output with version labels", () => {
       const version1 = new PromptVersion({
         versionId: "version-1",
         name: "test-prompt",
         prompt: "Hello {{name}}!",
         commit: "commit1",
+        version: "v2",
         promptId: "prompt-123",
         type: PromptType.MUSTACHE,
       });
@@ -396,6 +411,7 @@ describe("PromptVersion", () => {
         name: "test-prompt",
         prompt: "Hi {{name}}!",
         commit: "commit2",
+        version: "v1",
         promptId: "prompt-123",
         type: PromptType.MUSTACHE,
       });
@@ -404,6 +420,31 @@ describe("PromptVersion", () => {
 
       expect(diff).toContain("Current version");
       expect(diff).toContain("Other version");
+      expect(diff).toContain("[v2]");
+      expect(diff).toContain("[v1]");
+    });
+
+    it("should fall back to commit in diff labels when version is absent", () => {
+      const version1 = new PromptVersion({
+        versionId: "version-1",
+        name: "mask-prompt",
+        prompt: "Hello!",
+        commit: "commit1",
+        promptId: "prompt-123",
+        type: PromptType.MUSTACHE,
+      });
+
+      const version2 = new PromptVersion({
+        versionId: "version-2",
+        name: "mask-prompt",
+        prompt: "Hi!",
+        commit: "commit2",
+        promptId: "prompt-123",
+        type: PromptType.MUSTACHE,
+      });
+
+      const diff = version1.compareTo(version2);
+
       expect(diff).toContain("[commit1]");
       expect(diff).toContain("[commit2]");
     });

--- a/sdks/typescript/tests/unit/prompt/PromptVersion.test.ts
+++ b/sdks/typescript/tests/unit/prompt/PromptVersion.test.ts
@@ -23,6 +23,7 @@ describe("PromptVersion", () => {
         name: "test-prompt",
         prompt: "Hello {{name}}!",
         commit: "abc123de",
+        version: "v3",
         promptId: "prompt-123",
         type: PromptType.MUSTACHE,
         metadata: { version: "1.0" },
@@ -37,6 +38,7 @@ describe("PromptVersion", () => {
       expect(version.name).toBe("test-prompt");
       expect(version.prompt).toBe("Hello {{name}}!");
       expect(version.commit).toBe("abc123de");
+      expect(version.version).toBe("v3");
       expect(version.type).toBe(PromptType.MUSTACHE);
       expect(version.metadata).toEqual({ version: "1.0" });
       expect(version.changeDescription).toBe("Initial version");
@@ -60,6 +62,7 @@ describe("PromptVersion", () => {
       expect(version.name).toBe("minimal-prompt");
       expect(version.prompt).toBe("Minimal template");
       expect(version.commit).toBe("commit123");
+      expect(version.version).toBeUndefined();
       expect(version.type).toBe(PromptType.MUSTACHE);
       expect(version.metadata).toBeUndefined();
       expect(version.changeDescription).toBeUndefined();
@@ -869,6 +872,7 @@ Please enjoy your extended stay.`;
         id: "version-id",
         promptId: "prompt-id",
         commit: "abc123de",
+        versionNumber: "v3",
         template: "Hello {{name}}!",
         type: "mustache",
         createdAt: new Date("2024-01-01T10:00:00Z"),
@@ -884,6 +888,7 @@ Please enjoy your extended stay.`;
       expect(version.name).toBe("test-prompt");
       expect(version.prompt).toBe("Hello {{name}}!");
       expect(version.commit).toBe("abc123de");
+      expect(version.version).toBe("v3");
       expect(version.type).toBe(PromptType.MUSTACHE);
       expect(version.metadata).toEqual({ version: "1.0" });
       expect(version.changeDescription).toBe("Initial version");
@@ -910,6 +915,7 @@ Please enjoy your extended stay.`;
       expect(version.name).toBe("minimal-prompt");
       expect(version.prompt).toBe("Minimal template");
       expect(version.commit).toBe("commit123");
+      expect(version.version).toBeUndefined();
       expect(version.metadata).toBeUndefined();
       expect(version.changeDescription).toBeUndefined();
       expect(version.createdAt).toBeUndefined();

--- a/sdks/typescript/tests/unit/prompt/promptCache.test.ts
+++ b/sdks/typescript/tests/unit/prompt/promptCache.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { PromptCache, buildCacheKey, getOrFetch } from "@/prompt/promptCache";
+import {
+  PromptCache,
+  buildCacheKey,
+  getOrFetch,
+  getGlobalCache,
+} from "@/prompt/promptCache";
 import type { BasePrompt } from "@/prompt/BasePrompt";
 
 function makeFakePrompt(overrides: Partial<BasePrompt> = {}): BasePrompt {
@@ -257,5 +262,80 @@ describe("module-level getOrFetch", () => {
 
     expect(second).toBe(prompt);
     expect(fetchFn).toHaveBeenCalledOnce();
+  });
+
+  it("produces distinct keys for different version pins", () => {
+    const k1 = buildCacheKey("p", undefined, "project", "text", undefined, "v1");
+    const k2 = buildCacheKey("p", undefined, "project", "text", undefined, "v2");
+    expect(k1).not.toBe(k2);
+  });
+
+  it("reuses the commit slot for the version pin (no extra entry in the key array)", () => {
+    // Key layout is [name, commit_or_version, projectName, templateStructure, maskId].
+    const key = buildCacheKey("p", undefined, "project", "text", undefined, "v3");
+    expect(JSON.parse(key)).toHaveLength(5);
+    expect(JSON.parse(key)[1]).toBe("v3");
+  });
+
+  it("version takes precedence over commit when both are provided", () => {
+    // (Client.ts validates this is impossible, but the helper should still be defined.)
+    const key = buildCacheKey("p", "abc12345", "project", "text", undefined, "v3");
+    expect(JSON.parse(key)[1]).toBe("v3");
+  });
+});
+
+describe("getOrFetch — version selector", () => {
+  beforeEach(() => {
+    getGlobalCache().clear();
+  });
+
+  afterEach(() => {
+    getGlobalCache().clear();
+  });
+
+  it("caches separate entries for different version values", async () => {
+    const promptV1 = makeFakePrompt({ name: "p", commit: "aaa11111" });
+    const promptV2 = makeFakePrompt({ name: "p", commit: "bbb22222" });
+
+    const fetchV1 = vi.fn().mockResolvedValue(promptV1);
+    const fetchV2 = vi.fn().mockResolvedValue(promptV2);
+
+    const r1 = await getOrFetch("p", undefined, "proj", "text", fetchV1, 300, undefined, "v1");
+    const r2 = await getOrFetch("p", undefined, "proj", "text", fetchV2, 300, undefined, "v2");
+
+    expect(r1).toBe(promptV1);
+    expect(r2).toBe(promptV2);
+    expect(fetchV1).toHaveBeenCalledOnce();
+    expect(fetchV2).toHaveBeenCalledOnce();
+  });
+
+  it("returns the cached prompt on a second call with the same version (no extra fetch)", async () => {
+    const prompt = makeFakePrompt({ name: "p" });
+    const fetchFn = vi.fn().mockResolvedValue(prompt);
+
+    const first = await getOrFetch("p", undefined, "proj", "text", fetchFn, 300, undefined, "v1");
+    const second = await getOrFetch("p", undefined, "proj", "text", fetchFn, 300, undefined, "v1");
+
+    expect(first).toBe(prompt);
+    expect(second).toBe(prompt);
+    expect(fetchFn).toHaveBeenCalledOnce();
+  });
+
+  it("version entries follow the normal TTL refresh (not pinned indefinitely)", async () => {
+    // Sequential versions like "v3" can be reassigned by the backend if the
+    // underlying version is deleted and recreated, so they must NOT be cached
+    // indefinitely the way commits are.
+    const prompt = makeFakePrompt({ name: "p" });
+    const fetchFn = vi.fn().mockResolvedValue(prompt);
+
+    await getOrFetch("p", undefined, "proj", "text", fetchFn, 300, undefined, "v9");
+
+    const key = buildCacheKey("p", undefined, "proj", "text", undefined, "v9");
+    // A second call with the same key MUST be served from cache (proves the
+    // entry is reachable and no eviction happened).
+    const second = await getOrFetch("p", undefined, "proj", "text", fetchFn, 300, undefined, "v9");
+    expect(second).toBe(prompt);
+    expect(fetchFn).toHaveBeenCalledOnce();
+    expect(getGlobalCache().get(key)).toBe(prompt);
   });
 });


### PR DESCRIPTION
## Details

Added support for fetching prompt versions by sequential version selector (e.g., `"v3"`) across Python and TypeScript SDKs. The `version` parameter provides a user-friendly alternative to the legacy `commit` hash approach, improving API usability and aligning with the Opik UI's version display. Both parameters coexist with validation to prevent simultaneous use, ensuring backward compatibility while encouraging adoption of the new `version` interface.

## Change checklist

- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6467

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Haiku 4.5
- Scope: Full SDK implementation across Python and TypeScript with comprehensive test coverage
- Human verification: Code review and manual testing of prompt retrieval with version selectors

## Testing

Comprehensive unit and integration tests added:

**Python SDK:**
- `pytest sdks/python/tests/unit/api_objects/prompt/test_prompt_client.py -v`
- `pytest sdks/python/tests/e2e/test_prompt.py -v`
- Validated version parameter parsing, mutual exclusivity with commit, and cache behavior

**TypeScript SDK:**
- `npm run test -- --testPathPattern="client-prompts|client-chat-prompts|promptCache"` 
- Validated version parameter in both Prompt and ChatPrompt endpoints
- Tested prompt cache with sequential version selectors

**Validation scenarios:**
- Happy path: Retrieve prompts using `version="v3"` format
- Edge case: Verify ValueError when both `commit` and `version` provided
- Backward compatibility: Confirm existing `commit` parameter still works
- Cache behavior: Test TTL behavior with version-pinned requests

## Documentation

Updated docstrings:
- `Opik.get_prompt()` and `Opik.get_chat_prompt()` with `version` parameter docs
- `PromptClient.get_prompt_detail()` with deprecation notice for `commit`
- `BasePrompt.commit` property marked as DEPRECATED with migration guidance
- Added `BasePrompt.version` property docs across all implementations
- TypeScript Client methods updated with JSDoc for version parameter

All docstrings include clear deprecation notices directing users to use `version` instead of `commit`.
