### PR TITLE
[OPIK-6602] [SDK] feat: serialize migrate streamer + add concurrency diagnostics

### DIFF
--- a/sdks/python/src/opik/cli/migrate/_debug_http.py
+++ b/sdks/python/src/opik/cli/migrate/_debug_http.py
@@ -1,0 +1,119 @@
+"""DEBUG-gated httpx interception for ``opik migrate``.
+
+Exists for one purpose: surface OPIK-6602's "single-process migrate
+manufactures concurrent writes" claim as concrete log lines an operator
+can grep.
+
+A hook installed on the migrate-time ``opik.Opik`` client tags every
+outbound request with a start timestamp + thread id, then matches them
+to the response with elapsed time. The module also keeps a per-host
+in-flight counter so overlapping requests against the same host print
+``in_flight=N`` -- ``N > 1`` is the bug behavior.
+
+Pure DEBUG: when the ``opik`` logger isn't at DEBUG the hook is never
+installed and the counter is never touched, so production callers pay
+zero overhead.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import defaultdict
+from typing import Dict
+
+import httpx
+
+from ... import hooks as opik_hooks
+
+LOGGER = logging.getLogger("opik.cli.migrate._debug_http")
+
+_REQUEST_START_EXT_KEY = "opik_migrate_debug_start"
+_REQUEST_TID_EXT_KEY = "opik_migrate_debug_tid"
+
+# Per-host counters; one process worth of state, guarded by a single lock.
+# A migrate process talks to one host, so the dict has size 1 in practice.
+_in_flight_by_host: Dict[str, int] = defaultdict(int)
+_in_flight_lock = threading.Lock()
+
+
+def _on_request(request: httpx.Request) -> None:
+    tid = threading.get_ident()
+    now = time.monotonic()
+    request.extensions[_REQUEST_START_EXT_KEY] = now
+    request.extensions[_REQUEST_TID_EXT_KEY] = tid
+
+    host = request.url.host or "?"
+    with _in_flight_lock:
+        _in_flight_by_host[host] += 1
+        in_flight = _in_flight_by_host[host]
+
+    LOGGER.debug(
+        "migrate.http >>>   tid=%d host=%s in_flight=%d %s %s",
+        tid,
+        host,
+        in_flight,
+        request.method,
+        request.url.path,
+    )
+
+
+def _on_response(response: httpx.Response) -> None:
+    request = response.request
+    started = request.extensions.get(_REQUEST_START_EXT_KEY)
+    tid = request.extensions.get(_REQUEST_TID_EXT_KEY, threading.get_ident())
+    elapsed_ms = (time.monotonic() - started) * 1000.0 if started else float("nan")
+
+    host = request.url.host or "?"
+    with _in_flight_lock:
+        # response_hook fires once per response; redirected / retried
+        # requests in httpx run through the chain again and each gets
+        # its own request_hook fire, so the bookkeeping stays balanced.
+        _in_flight_by_host[host] = max(0, _in_flight_by_host[host] - 1)
+        in_flight = _in_flight_by_host[host]
+
+    LOGGER.debug(
+        "migrate.http <<<   tid=%d host=%s in_flight=%d %s %s -> %d (%.0fms)",
+        tid,
+        host,
+        in_flight,
+        request.method,
+        request.url.path,
+        response.status_code,
+        elapsed_ms,
+    )
+
+
+def install_if_debug() -> None:
+    """Register the migrate http hook iff the ``opik`` logger is at DEBUG.
+
+    Idempotent: calling more than once installs the same hook list each
+    time but the hooks themselves de-dupe by identity, and ``add_httpx_client_hook``
+    just appends to a list -- the second registration would only fire
+    the same logging callbacks twice, doubling log lines. The migrate
+    CLI calls this exactly once at startup, so the simple check below
+    is enough to guard ``opik migrate`` invocation while keeping other
+    test paths (which import the module) safe.
+    """
+    if not LOGGER.isEnabledFor(logging.DEBUG):
+        return
+
+    def _modifier(client: httpx.Client) -> None:
+        # Append rather than overwrite so any pre-existing hooks
+        # (e.g. set by integrations) keep firing.
+        existing = client.event_hooks
+        existing.setdefault("request", []).append(_on_request)
+        existing.setdefault("response", []).append(_on_response)
+        client.event_hooks = existing
+
+    opik_hooks.add_httpx_client_hook(
+        opik_hooks.HttpxClientHook(
+            client_modifier=_modifier,
+            client_init_arguments=None,
+        )
+    )
+    LOGGER.debug(
+        "migrate.http hook installed (DEBUG logging detected); future "
+        "opik.Opik() httpx clients will trace requests"
+    )

--- a/sdks/python/src/opik/cli/migrate/_debug_http.py
+++ b/sdks/python/src/opik/cli/migrate/_debug_http.py
@@ -37,6 +37,15 @@ _REQUEST_TID_EXT_KEY = "opik_migrate_debug_tid"
 _in_flight_by_host: Dict[str, int] = defaultdict(int)
 _in_flight_lock = threading.Lock()
 
+# Idempotency guard for ``install_if_debug``: once the migrate-time httpx
+# hook is registered on the SDK's global hook list, a second call must
+# not register it again -- the SDK's ``add_httpx_client_hook`` only
+# appends and ``apply_httpx_client_hooks`` invokes every entry, so a
+# double registration would fire ``_on_request`` / ``_on_response``
+# twice per request and double-count ``in_flight``.
+_install_lock = threading.Lock()
+_installed = False
+
 
 def _on_request(request: httpx.Request) -> None:
     tid = threading.get_ident()
@@ -88,32 +97,42 @@ def _on_response(response: httpx.Response) -> None:
 def install_if_debug() -> None:
     """Register the migrate http hook iff the ``opik`` logger is at DEBUG.
 
-    Idempotent: calling more than once installs the same hook list each
-    time but the hooks themselves de-dupe by identity, and ``add_httpx_client_hook``
-    just appends to a list -- the second registration would only fire
-    the same logging callbacks twice, doubling log lines. The migrate
-    CLI calls this exactly once at startup, so the simple check below
-    is enough to guard ``opik migrate`` invocation while keeping other
-    test paths (which import the module) safe.
+    Idempotent across repeat calls: the first call (when DEBUG is on)
+    appends a single ``HttpxClientHook`` to the SDK's global list and
+    flips ``_installed`` to True; subsequent calls short-circuit. The
+    guard is essential because ``add_httpx_client_hook`` only appends
+    and ``apply_httpx_client_hooks`` fans every registered entry over
+    each new ``httpx.Client``, so a second registration would fire
+    ``_on_request`` / ``_on_response`` twice per request and corrupt
+    the ``in_flight`` counter.
+
+    Re-entrancy and threading: the lock makes two concurrent callers
+    (e.g. tests importing the module from multiple threads) safe.
     """
     if not LOGGER.isEnabledFor(logging.DEBUG):
         return
 
-    def _modifier(client: httpx.Client) -> None:
-        # Append rather than overwrite so any pre-existing hooks
-        # (e.g. set by integrations) keep firing.
-        existing = client.event_hooks
-        existing.setdefault("request", []).append(_on_request)
-        existing.setdefault("response", []).append(_on_response)
-        client.event_hooks = existing
+    global _installed
+    with _install_lock:
+        if _installed:
+            return
 
-    opik_hooks.add_httpx_client_hook(
-        opik_hooks.HttpxClientHook(
-            client_modifier=_modifier,
-            client_init_arguments=None,
+        def _modifier(client: httpx.Client) -> None:
+            # Append rather than overwrite so any pre-existing hooks
+            # (e.g. set by integrations) keep firing.
+            existing = client.event_hooks
+            existing.setdefault("request", []).append(_on_request)
+            existing.setdefault("response", []).append(_on_response)
+            client.event_hooks = existing
+
+        opik_hooks.add_httpx_client_hook(
+            opik_hooks.HttpxClientHook(
+                client_modifier=_modifier,
+                client_init_arguments=None,
+            )
         )
-    )
-    LOGGER.debug(
-        "migrate.http hook installed (DEBUG logging detected); future "
-        "opik.Opik() httpx clients will trace requests"
-    )
+        _installed = True
+        LOGGER.debug(
+            "migrate.http hook installed (DEBUG logging detected); future "
+            "opik.Opik() httpx clients will trace requests"
+        )

--- a/sdks/python/src/opik/cli/migrate/datasets/experiments.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/experiments.py
@@ -368,6 +368,19 @@ def cascade_one_experiment(
                 item.assertion_results
             )
 
+    # OPIK-6602 diagnostic: per-experiment counts before the cascade runs.
+    # Pairs with the post-cascade summary line below so a failing run can
+    # be grepped for the experiment id and the source-vs-target deltas.
+    LOGGER.debug(
+        "migrate.cascade experiment=%r (id=%s) source_items=%d distinct_trace_ids=%d "
+        "assertion_results_traces=%d",
+        experiment_name,
+        experiment_id,
+        len(items),
+        len(source_trace_ids),
+        len(assertion_results_by_source_trace),
+    )
+
     # Inner progress total = 1 (read items, just completed)
     # + 1 (bulk-read traces via search_traces(filter=experiment_id))
     # + N (per-trace emit ticks; the writes are streamer-batched so each
@@ -437,6 +450,24 @@ def cascade_one_experiment(
     # bit hot or cold (e.g. fewer ticks fired because idempotent-skip
     # removed traces from this experiment).
     inner.finish(label="recreated" if recreated else "skipped")
+
+    # OPIK-6602 diagnostic: post-cascade summary. ``recreate_experiment``
+    # returns True iff the experiment item batch was issued; the counts
+    # below are what we ATTEMPTED to send -- the target counts in the
+    # BE are what the test/E2E asserts on, but matching these against
+    # source on a failing run pinpoints whether we lost data on the
+    # READ path (source counts low), the WRITE path (target counts low
+    # despite source healthy), or the cascade scheduling.
+    LOGGER.debug(
+        "migrate.cascade experiment=%r recreated=%s traces_attempted=%d "
+        "spans_attempted=%d trace_comments=%d span_comments=%d",
+        experiment_name,
+        recreated,
+        traces_copied,
+        spans_copied,
+        trace_comments_copied,
+        span_comments_copied,
+    )
 
     if recreated:
         result.experiments_migrated += 1

--- a/sdks/python/src/opik/cli/migrate/datasets/version_replay.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/version_replay.py
@@ -191,6 +191,22 @@ def replay_all_versions(
             version_hash=source_version.version_hash,
         )
 
+        # OPIK-6602 diagnostic: per-version source-side counts. When a
+        # post-write fetch later shows fewer items on the target than the
+        # source had, the source-side debug line lets the operator confirm
+        # the bug is on the WRITE path, not a phantom-read on the source.
+        LOGGER.debug(
+            "migrate.replay v%d/%d source: dataset=%r version=%s (id=%s) "
+            "items_streamed=%d items_total=%s",
+            index + 1,
+            total,
+            source_name_after_rename,
+            source_version.version_name,
+            source_version.id,
+            len(curr_items_by_id),
+            getattr(source_version, "items_total", None),
+        )
+
         if index == 0:
             new_version_id, new_item_ids, delta = _replay_first_version(
                 rest_client,
@@ -243,6 +259,37 @@ def replay_all_versions(
             if queue:
                 result.item_id_remap[added.id] = queue.pop(0)
 
+        # OPIK-6602 diagnostic: re-fetch the target version we just wrote
+        # and compare against the source counts. Surfaces three failure
+        # shapes the QA stress run hit:
+        #
+        #   (a) target items_total < source items_total — BE silently
+        #       truncated during the carry-over copy (OPIK-6601 window),
+        #       confirmed when the post-apply read returns a number lower
+        #       than what we sent + the source streamed.
+        #   (b) target streamed-count != target items_total — BE metadata
+        #       and storage disagree (BE has cached aggregate, items table
+        #       is the truth or vice-versa).
+        #   (c) target streamed-count != source streamed-count — same as
+        #       (a) but observed through the stream rather than metadata.
+        #
+        # All three reads run AFTER the apply returns; if any of them
+        # disagree with the source we mark the line a warning so it stands
+        # out in mixed output. Debug-level by default so production users
+        # see nothing without OPIK_CONSOLE_LOGGING_LEVEL=DEBUG.
+        _log_post_apply_verification(
+            rest_client,
+            dest_dataset_id=dest_dataset_id,
+            dest_name=dest_name,
+            dest_project_name=dest_project_name,
+            source_version=source_version,
+            source_items_streamed=len(curr_items_by_id),
+            delta=delta,
+            new_version_id=new_version_id,
+            index=index,
+            total=total,
+        )
+
         result.versions_replayed += 1
 
         audit.record(
@@ -264,6 +311,122 @@ def replay_all_versions(
         base_version_id = new_version_id
 
     return result
+
+
+def _log_post_apply_verification(
+    rest_client: OpikApi,
+    *,
+    dest_dataset_id: str,
+    dest_name: str,
+    dest_project_name: str,
+    source_version: dataset_version_public.DatasetVersionPublic,
+    source_items_streamed: int,
+    delta: "VersionDelta",
+    new_version_id: str,
+    index: int,
+    total: int,
+) -> None:
+    """Re-fetch the destination version just written and compare counts.
+
+    OPIK-6602 / OPIK-6601 diagnostic. Short-circuits when the ``opik``
+    logger isn't at DEBUG so production callers pay zero extra HTTP cost.
+
+    Three sources of truth are compared:
+
+      * source streamed count (passed in, ``source_items_streamed``)
+      * target version's ``items_total`` (BE metadata) — fetched via
+        ``list_dataset_versions`` filtered to ``new_version_id``
+      * target streamed count — paginated ``stream_dataset_items`` at
+        the just-written version_hash
+
+    A mismatch between any pair is logged at WARNING so it surfaces in
+    mixed logs; matching counts go out at DEBUG.
+
+    All reads are wrapped with the SDK's rate-limit-aware retry helper
+    so a transient 429 mid-verification doesn't blow up the migrate
+    itself.
+    """
+    if not LOGGER.isEnabledFor(logging.DEBUG):
+        return
+
+    try:
+        # Find the just-written version row by id. ``list_dataset_versions``
+        # is paginated newest-first; the one we want is the latest, so a
+        # size=1 fetch is usually enough -- but we defensively page a few
+        # if we don't see our id at the top (some other writer raced us in,
+        # which is exactly the scenario this diagnostic exists to detect).
+        target_version: Optional[dataset_version_public.DatasetVersionPublic] = None
+        for page_idx in (1, 2, 3):
+            page = rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+                lambda p=page_idx: rest_client.datasets.list_dataset_versions(
+                    id=dest_dataset_id, page=p, size=_VERSIONS_PAGE_SIZE
+                )
+            )
+            for v in page.content or []:
+                if v.id == new_version_id:
+                    target_version = v
+                    break
+            if target_version is not None or not page.content:
+                break
+
+        if target_version is None:
+            LOGGER.warning(
+                "migrate.replay v%d/%d POST-APPLY: dataset=%r target version "
+                "id=%s NOT FOUND on the destination after apply returned -- "
+                "BE write/read inconsistency (OPIK-6601 visibility window?)",
+                index + 1,
+                total,
+                dest_name,
+                new_version_id,
+            )
+            return
+
+        target_items_total = target_version.items_total
+        target_stream = _stream_version_items_raw(
+            rest_client,
+            dataset_name=dest_name,
+            project_name=dest_project_name,
+            version_hash=target_version.version_hash,
+        )
+        target_streamed = sum(1 for _ in target_stream)
+
+        adds = len(delta.adds)
+        mods = len(delta.modifications)
+        dels = len(delta.deletions)
+
+        mismatched = (
+            target_items_total != source_items_streamed
+            or target_streamed != source_items_streamed
+            or target_streamed != target_items_total
+        )
+        level = logging.WARNING if mismatched else logging.DEBUG
+
+        LOGGER.log(
+            level,
+            "migrate.replay v%d/%d POST-APPLY: dataset=%r src_ver=%s -> "
+            "tgt_ver=%s | source_streamed=%d | target_items_total=%s | "
+            "target_streamed=%d | delta(+%d ~%d -%d)%s",
+            index + 1,
+            total,
+            dest_name,
+            source_version.version_name,
+            target_version.version_name,
+            source_items_streamed,
+            target_items_total,
+            target_streamed,
+            adds,
+            mods,
+            dels,
+            " <<< COUNT MISMATCH" if mismatched else "",
+        )
+    except Exception as exc:
+        # Diagnostic must never break the migrate. Log at debug + move on.
+        LOGGER.debug(
+            "migrate.replay v%d/%d POST-APPLY verification failed: %s",
+            index + 1,
+            total,
+            exc,
+        )
 
 
 def _replay_first_version(

--- a/sdks/python/src/opik/cli/migrate/main.py
+++ b/sdks/python/src/opik/cli/migrate/main.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 import sys
 import time
 from pathlib import Path
@@ -21,6 +22,7 @@ from rich.table import Table
 
 import opik
 
+from . import _debug_http
 from .audit import AuditLog, default_audit_path
 from .datasets.executor import execute_plan, record_planned
 from .datasets.planner import (
@@ -130,7 +132,31 @@ def _build_client(ctx: click.Context) -> opik.Opik:
 
     ``workspace=None`` means defer to the SDK's resolution chain
     (OPIK_WORKSPACE env -> ~/.opik.config -> 'default').
+
+    OPIK-6602: forces the streamer to a single consumer thread for the
+    duration of the migrate process so it never has multiple in-flight
+    HTTP writes against the same workspace. Migrate's dataset writes are
+    already serialized on the main thread (raw Fern client) -- this
+    change collapses the trace/span/feedback streamer to one consumer
+    too, removing manufactured workspace-level concurrency on the
+    experiment cascade phase. Tradeoff: the cascade gives up ~3x
+    parallelism on trace/span POSTs, so very large cascades migrate
+    slower. For a one-shot tool that's acceptable; the property the
+    ticket wants is "no concurrent same-workspace writes", and this is
+    the smallest change that delivers it.
+
+    ``setdefault`` rather than overwrite so an operator who needs to
+    benchmark / pre-empt the default can still set
+    ``OPIK_BACKGROUND_WORKERS`` on the shell before invoking migrate.
+
+    Installs the OPIK-6602 httpx-trace hook before constructing the
+    client so the new ``opik.Opik()``'s internal httpx client picks it
+    up via ``hooks.apply_httpx_client_hooks``. No-op unless the ``opik``
+    logger is at DEBUG.
     """
+    os.environ.setdefault("OPIK_BACKGROUND_WORKERS", "1")
+    _debug_http.install_if_debug()
+
     workspace = ctx.obj.get("workspace")
     api_key = ctx.obj.get("api_key")
     kwargs = {}

--- a/sdks/python/tests/e2e/cli/test_migrate_dataset_stress_e2e.py
+++ b/sdks/python/tests/e2e/cli/test_migrate_dataset_stress_e2e.py
@@ -1,0 +1,391 @@
+"""Stress repro for OPIK-6602: single-process ``opik migrate`` should not
+manufacture concurrent writes against the same workspace.
+
+Manifests as silent data loss against the current ``main`` branch:
+
+* ``qa-v1-stress-traces-5k``: 100 dataset items + 5000 trace experiment
+  items -> 50/100 dataset items, 2500/5000 experiment items survived.
+* ``qa-v1-stress-mega``: 1468 dataset items across 27 versions ->
+  833/1468 dataset items, 19/27 versions diverged.
+
+Each parametrize shape mirrors one of those QA setups. Assertions are
+exact: target item count == source item count at every layer the QA
+failure surfaced -- per-version ``items_total``, per-version streamed
+item count, dataset-level ``dataset_items_count``, experiment item count.
+Anything less is the failure mode the ticket describes.
+
+Notes on shape selection:
+
+* The ``mega`` shape seeds 27 sequential versions on the same dataset to
+  exercise the carry-over copy path (``COPY_VERSION_ITEMS`` in
+  ``DatasetItemVersionDAO``). The OPIK-6601 visibility window fires
+  on this path; a single-version seed can't reach it.
+* The ``traces-5k`` shape stresses the experiment cascade (5k traces
+  streamed while migrate is mid-flight on the dataset rename / replay
+  / experiment-recreate sequence).
+
+Seeding chunks every bulk-write to stay under the BE's per-request caps
+(``DatasetItemBatch.@Size(max=1000)``, ``TraceBatch.@Size(max=1000)``,
+``SpanBatch.@Size(max=1000)``).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+from typing import Iterator, List, TypeVar
+
+import pytest
+
+import opik
+from opik import id_helpers
+from opik.rest_api import OpikApi
+from opik.rest_api.types.dataset_item_write import DatasetItemWrite
+from opik.rest_api.types.experiment_item import ExperimentItem
+from opik.rest_api.types.span_write import SpanWrite
+from opik.rest_api.types.trace_write import TraceWrite
+
+from ...conftest import random_chars
+from ...testlib import generate_project_name
+from .conftest import (
+    apply_changes,
+    chronological_versions,
+    create_dataset_shell,
+    destination_experiment_items,
+    find_destination_experiment,
+    run_migrate_cli,
+    stream_items_wire,
+)
+
+PROJECT_NAME = generate_project_name("e2e", __name__)
+
+# BE per-request caps (DatasetItemBatch / TraceBatch / SpanBatch / ExperimentItem
+# batch all share the same @Size(max=1000) constraint at the time of writing).
+_BULK_INSERT_CHUNK = 1000
+
+T = TypeVar("T")
+
+
+def _chunked(items: List[T], size: int) -> Iterator[List[T]]:
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+@pytest.fixture
+def dataset_name() -> Iterator[str]:
+    yield f"e2e-migrate-stress-{random_chars()}"
+
+
+# Parametrize shapes.
+#
+#   (num_versions, items_added_per_version, num_trace_experiment_items)
+#
+# ``smoke``       — small enough to run in roughly a minute on a local
+#                   backend, still multi-version + cascade.
+# ``mega``        — mirrors qa-v1-stress-mega: 27 versions, ~54 items each
+#                   (= 1458 total dataset items, close to 1468). Exercises
+#                   the OPIK-6601 carry-over visibility race.
+# ``traces-5k``   — mirrors qa-v1-stress-traces-5k: 100 items, 5000 trace
+#                   experiment items. Exercises the experiment cascade.
+_STRESS_SHAPES = [
+    pytest.param(3, 20, 100, id="smoke"),
+    pytest.param(27, 54, 0, marks=pytest.mark.slow, id="mega"),
+    pytest.param(1, 100, 5000, marks=pytest.mark.slow, id="traces-5k"),
+]
+
+
+def _seed_experiment_with_traces(
+    rest: OpikApi,
+    *,
+    experiment_name: str,
+    dataset_name: str,
+    dataset_id: str,
+    dataset_version_id: str,
+    project_name: str,
+    experiment_item_ids: List[str],
+) -> tuple[str, List[str]]:
+    """Create one trace + one root span per ``experiment_item_id``, then
+    attach them as ``experiment_items`` rows on a fresh experiment.
+
+    Returns ``(experiment_id, trace_ids)``. Every bulk write is chunked at
+    the BE @Size(max=1000) cap so this scales past the conftest helper's
+    one-shot calls.
+    """
+    if not experiment_item_ids:
+        # Caller wants an experiment-less stress shape.
+        return "", []
+
+    now = dt.datetime.now(dt.timezone.utc)
+
+    trace_writes: List[TraceWrite] = []
+    span_writes: List[SpanWrite] = []
+    trace_ids: List[str] = []
+
+    for index, item_id in enumerate(experiment_item_ids):
+        trace_id = id_helpers.generate_id()
+        trace_ids.append(trace_id)
+        trace_writes.append(
+            TraceWrite(
+                id=trace_id,
+                project_name=project_name,
+                name=f"task-{index}",
+                start_time=now,
+                end_time=now + dt.timedelta(milliseconds=10),
+                input={"item": item_id},
+                output={"answer": f"output-{index}"},
+                metadata={"item_id": item_id},
+                tags=["e2e-stress"],
+            )
+        )
+        span_writes.append(
+            SpanWrite(
+                id=id_helpers.generate_id(),
+                project_name=project_name,
+                trace_id=trace_id,
+                parent_span_id=None,
+                name=f"root-{index}",
+                type="general",
+                start_time=now,
+                end_time=now + dt.timedelta(milliseconds=10),
+                input={"item": item_id},
+                output={"answer": f"output-{index}"},
+            )
+        )
+
+    for chunk in _chunked(trace_writes, _BULK_INSERT_CHUNK):
+        rest.traces.create_traces(traces=chunk)
+    for chunk in _chunked(span_writes, _BULK_INSERT_CHUNK):
+        rest.spans.create_spans(spans=chunk)
+
+    new_experiment_id = id_helpers.generate_id()
+    rest.experiments.create_experiment(
+        id=new_experiment_id,
+        name=experiment_name,
+        dataset_name=dataset_name,
+        type="regular",
+        evaluation_method="dataset",
+        dataset_version_id=dataset_version_id,
+        project_name=project_name,
+    )
+
+    experiment_items = [
+        ExperimentItem(
+            id=id_helpers.generate_id(),
+            experiment_id=new_experiment_id,
+            dataset_item_id=item_id,
+            trace_id=trace_id,
+        )
+        for item_id, trace_id in zip(experiment_item_ids, trace_ids)
+    ]
+    for chunk in _chunked(experiment_items, _BULK_INSERT_CHUNK):
+        rest.experiments.create_experiment_items(experiment_items=chunk)
+
+    return new_experiment_id, trace_ids
+
+
+@pytest.mark.parametrize(
+    ("num_versions", "items_added_per_version", "num_trace_experiment_items"),
+    _STRESS_SHAPES,
+)
+def test_migrate_dataset__stress__no_silent_data_loss(
+    opik_client: opik.Opik,
+    source_project_name: str,
+    target_project_name: str,
+    dataset_name: str,
+    tmp_path: Path,
+    num_versions: int,
+    items_added_per_version: int,
+    num_trace_experiment_items: int,
+) -> None:
+    """Seed a multi-version source dataset (optionally with a large
+    experiment) and assert NO items are silently dropped on the destination.
+
+    The QA-failure dimensions verified at each layer:
+
+    * Dataset-level: ``dataset_items_count`` matches source.
+    * Version chain: target version count == source version count.
+    * Per-version: ``items_total`` matches at every version, AND the
+      streamed item count at each version matches what the source
+      streamed for that version.
+    * Experiment cascade: destination experiment items count == source
+      experiment items count (when the shape includes an experiment).
+    """
+    rest = opik_client.rest_client
+    total_source_items = num_versions * items_added_per_version
+
+    # ── Seed source dataset with N versions. ──
+    source_id = create_dataset_shell(rest, dataset_name, source_project_name)
+
+    # v1: single batch_group_id -> one BE version.
+    v1_payloads = [
+        DatasetItemWrite(
+            source="manual",
+            data={"q": f"v1-i{i}", "a": f"A1-{i}"},
+        )
+        for i in range(items_added_per_version)
+    ]
+    batch_group_id = id_helpers.generate_id()
+    for chunk in _chunked(v1_payloads, _BULK_INSERT_CHUNK):
+        rest.datasets.create_or_update_dataset_items(
+            dataset_id=source_id,
+            items=chunk,
+            batch_group_id=batch_group_id,
+        )
+    base_version_id = (
+        rest.datasets.list_dataset_versions(id=source_id, page=1, size=1).content[0].id
+    )
+
+    # v2..vN: each ``apply_dataset_item_changes`` with added_items drives
+    # the BE's carry-over copy path that OPIK-6601's visibility race fires
+    # on. We capture the new version id after each apply for the next call.
+    for v in range(2, num_versions + 1):
+        added_items = [
+            {"data": {"q": f"v{v}-i{i}", "a": f"A{v}-{i}"}, "source": "manual"}
+            for i in range(items_added_per_version)
+        ]
+        assert items_added_per_version <= _BULK_INSERT_CHUNK
+        base_version_id = apply_changes(
+            rest,
+            source_id,
+            base_version_id=base_version_id,
+            added_items=added_items,
+            change_description=f"v{v}",
+        )
+
+    # ── Pre-migration: verify the source itself is healthy. ──
+    # If the source seed itself diverged (BE race fired during seeding),
+    # the test would falsely blame the migration. Catch that up-front so
+    # a failing assertion further down is unambiguously about migrate.
+    src_dataset_row = rest.datasets.get_dataset_by_identifier(
+        dataset_name=dataset_name, project_name=source_project_name
+    )
+    src_versions = chronological_versions(rest, src_dataset_row.id)
+    assert len(src_versions) == num_versions, (
+        f"source has {len(src_versions)} versions, expected {num_versions} "
+        "— seeding itself diverged before we ran migrate"
+    )
+    assert src_dataset_row.dataset_items_count == total_source_items, (
+        f"source dataset_items_count={src_dataset_row.dataset_items_count}, "
+        f"expected {total_source_items} — seeding itself diverged "
+        "(possible OPIK-6600/6601 BE race during the seed)"
+    )
+    for idx, sv in enumerate(src_versions):
+        expected_total = (idx + 1) * items_added_per_version
+        assert sv.items_total == expected_total, (
+            f"source v{idx + 1} items_total={sv.items_total}, "
+            f"expected {expected_total} — seeding itself diverged"
+        )
+
+    # Latest-version streamed items: build the source-side ground truth
+    # for the per-version stream comparison below.
+    src_items_per_version = []
+    for sv in src_versions:
+        src_items = stream_items_wire(
+            rest,
+            dataset_name=dataset_name,
+            project_name=source_project_name,
+            version_hash=sv.version_hash,
+        )
+        src_items_per_version.append(len(src_items))
+
+    # ── Optional: seed an experiment with N traces. ──
+    item_ids_in_latest = [
+        it.id
+        for it in stream_items_wire(
+            rest,
+            dataset_name=dataset_name,
+            project_name=source_project_name,
+            version_hash=src_versions[-1].version_hash,
+        )
+        if it.id is not None
+    ]
+    experiment_name = f"e2e-stress-{random_chars()}"
+    source_experiment_id, trace_ids = "", []
+    if num_trace_experiment_items > 0:
+        assert item_ids_in_latest, "no dataset item ids to seed against"
+        # Rotate item ids if the experiment is larger than the dataset.
+        experiment_item_ids = [
+            item_ids_in_latest[i % len(item_ids_in_latest)]
+            for i in range(num_trace_experiment_items)
+        ]
+        source_experiment_id, trace_ids = _seed_experiment_with_traces(
+            rest,
+            experiment_name=experiment_name,
+            dataset_name=dataset_name,
+            dataset_id=source_id,
+            dataset_version_id=src_versions[-1].id,
+            project_name=source_project_name,
+            experiment_item_ids=experiment_item_ids,
+        )
+        assert len(trace_ids) == num_trace_experiment_items
+
+    # ── Run the migration. ──
+    audit_path = tmp_path / "audit.json"
+    result = run_migrate_cli(
+        [
+            "dataset",
+            dataset_name,
+            "--to-project",
+            target_project_name,
+        ],
+        audit_log_path=str(audit_path),
+    )
+    assert result.returncode == 0, (
+        f"opik migrate exited non-zero ({result.returncode}).\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+    # ── Verify destination: version count, dataset_items_count, per-version. ──
+    tgt_dataset_row = rest.datasets.get_dataset_by_identifier(
+        dataset_name=dataset_name, project_name=target_project_name
+    )
+    tgt_versions = chronological_versions(rest, tgt_dataset_row.id)
+    assert len(tgt_versions) == num_versions, (
+        f"target version count {len(tgt_versions)} != source {num_versions}"
+    )
+    assert tgt_dataset_row.dataset_items_count == total_source_items, (
+        f"target dataset_items_count={tgt_dataset_row.dataset_items_count}, "
+        f"expected {total_source_items}. "
+        f"Lost {total_source_items - tgt_dataset_row.dataset_items_count} items "
+        "— this is the OPIK-6602 self-concurrency failure mode."
+    )
+    for idx, (sv, tv) in enumerate(zip(src_versions, tgt_versions)):
+        expected_total = (idx + 1) * items_added_per_version
+        assert tv.items_total == expected_total, (
+            f"target v{idx + 1} items_total={tv.items_total}, "
+            f"expected {expected_total} (source v{idx + 1} had "
+            f"items_total={sv.items_total}). "
+            "OPIK-6601-style carry-over truncation on the destination."
+        )
+        tgt_v_items = stream_items_wire(
+            rest,
+            dataset_name=dataset_name,
+            project_name=target_project_name,
+            version_hash=tv.version_hash,
+        )
+        assert len(tgt_v_items) == src_items_per_version[idx], (
+            f"target v{idx + 1} streamed {len(tgt_v_items)} items, "
+            f"source streamed {src_items_per_version[idx]} — "
+            "items vanished between source and target at the per-version stream layer."
+        )
+
+    # ── Optional: verify destination experiment item count. ──
+    if num_trace_experiment_items > 0:
+        dest_exp = find_destination_experiment(
+            rest,
+            destination_dataset_id=tgt_dataset_row.id,
+            experiment_name=experiment_name,
+        )
+        dest_items = destination_experiment_items(
+            rest,
+            experiment_id=dest_exp.id,
+            dataset_id=tgt_dataset_row.id,
+        )
+        assert len(dest_items) == num_trace_experiment_items, (
+            f"target experiment items {len(dest_items)} != source "
+            f"{num_trace_experiment_items}. "
+            f"Lost {num_trace_experiment_items - len(dest_items)} experiment items — "
+            "OPIK-6602 self-concurrency failure mode."
+        )
+        # Sanity: destination experiment is a fresh entity (not the source).
+        assert dest_exp.id != source_experiment_id

--- a/sdks/python/tests/e2e/cli/test_migrate_dataset_stress_e2e.py
+++ b/sdks/python/tests/e2e/cli/test_migrate_dataset_stress_e2e.py
@@ -39,6 +39,7 @@ import pytest
 
 import opik
 from opik import id_helpers
+from opik.api_objects import rest_helpers
 from opik.rest_api import OpikApi
 from opik.rest_api.types.dataset_item_write import DatasetItemWrite
 from opik.rest_api.types.experiment_item import ExperimentItem
@@ -152,20 +153,32 @@ def _seed_experiment_with_traces(
             )
         )
 
+    # Wrap bulk writes with the SDK's 429-aware retry helper so this test
+    # is runnable on rate-limited environments (staging enforces per-user
+    # general_events limits that local Docker does not).
     for chunk in _chunked(trace_writes, _BULK_INSERT_CHUNK):
-        rest.traces.create_traces(traces=chunk)
+        rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+            lambda c=chunk: rest.traces.create_traces(traces=c),
+            operation_name="stress E2E seed: create_traces",
+        )
     for chunk in _chunked(span_writes, _BULK_INSERT_CHUNK):
-        rest.spans.create_spans(spans=chunk)
+        rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+            lambda c=chunk: rest.spans.create_spans(spans=c),
+            operation_name="stress E2E seed: create_spans",
+        )
 
     new_experiment_id = id_helpers.generate_id()
-    rest.experiments.create_experiment(
-        id=new_experiment_id,
-        name=experiment_name,
-        dataset_name=dataset_name,
-        type="regular",
-        evaluation_method="dataset",
-        dataset_version_id=dataset_version_id,
-        project_name=project_name,
+    rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+        lambda: rest.experiments.create_experiment(
+            id=new_experiment_id,
+            name=experiment_name,
+            dataset_name=dataset_name,
+            type="regular",
+            evaluation_method="dataset",
+            dataset_version_id=dataset_version_id,
+            project_name=project_name,
+        ),
+        operation_name="stress E2E seed: create_experiment",
     )
 
     experiment_items = [
@@ -178,7 +191,12 @@ def _seed_experiment_with_traces(
         for item_id, trace_id in zip(experiment_item_ids, trace_ids)
     ]
     for chunk in _chunked(experiment_items, _BULK_INSERT_CHUNK):
-        rest.experiments.create_experiment_items(experiment_items=chunk)
+        rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+            lambda c=chunk: rest.experiments.create_experiment_items(
+                experiment_items=c
+            ),
+            operation_name="stress E2E seed: create_experiment_items",
+        )
 
     return new_experiment_id, trace_ids
 
@@ -226,10 +244,13 @@ def test_migrate_dataset__stress__no_silent_data_loss(
     ]
     batch_group_id = id_helpers.generate_id()
     for chunk in _chunked(v1_payloads, _BULK_INSERT_CHUNK):
-        rest.datasets.create_or_update_dataset_items(
-            dataset_id=source_id,
-            items=chunk,
-            batch_group_id=batch_group_id,
+        rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+            lambda c=chunk: rest.datasets.create_or_update_dataset_items(
+                dataset_id=source_id,
+                items=c,
+                batch_group_id=batch_group_id,
+            ),
+            operation_name="stress E2E seed: create_or_update_dataset_items",
         )
     base_version_id = (
         rest.datasets.list_dataset_versions(id=source_id, page=1, size=1).content[0].id
@@ -244,12 +265,15 @@ def test_migrate_dataset__stress__no_silent_data_loss(
             for i in range(items_added_per_version)
         ]
         assert items_added_per_version <= _BULK_INSERT_CHUNK
-        base_version_id = apply_changes(
-            rest,
-            source_id,
-            base_version_id=base_version_id,
-            added_items=added_items,
-            change_description=f"v{v}",
+        base_version_id = rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+            lambda: apply_changes(
+                rest,
+                source_id,
+                base_version_id=base_version_id,
+                added_items=added_items,
+                change_description=f"v{v}",
+            ),
+            operation_name="stress E2E seed: apply_changes (v2..vN)",
         )
 
     # ── Pre-migration: verify the source itself is healthy. ──


### PR DESCRIPTION
## Details

<img width="1760" height="2962" alt="image" src="https://github.com/user-attachments/assets/8b58ec0e-e122-4bcd-8eef-d3f47a4cccac" />

`opik migrate` now forces `OPIK_BACKGROUND_WORKERS=1` for the migrate-time `opik.Opik()` client. This reduces workspace-level in-flight HTTP writes during the experiment cascade from up to **5 → 2** (4 streamer consumers + main thread → 1 streamer consumer + main thread). Migrate's dataset writes were already serialized on the main thread (raw Fern client); this collapses the trace/span/feedback streamer to a single consumer alongside it.

Also adds DEBUG-gated diagnostics so a future failing run is grep-able:

- per-version source counts + post-apply re-fetch of destination (`items_total`, streamed count) with WARNING on mismatch in `version_replay.py`
- per-experiment cascade summary in `experiments.py` (source items, trace ids, span/comment counts attempted)
- migrate-scoped httpx event hook (`_debug_http.py`) tagging every outbound request with thread id, start/end timestamps, elapsed ms, and a per-host `in_flight` counter; installed only when the `opik` logger is at DEBUG so production callers pay zero overhead. Idempotent across repeat calls (review fix at `6932701f1`).

Adds a stress E2E (`tests/e2e/cli/test_migrate_dataset_stress_e2e.py`) mirroring the QA repro shapes (`qa-v1-stress-traces-5k`: 100 items + 5000 cascade; `qa-v1-stress-mega`: 1458 items × 27 versions). The test asserts exact counts at every layer (`dataset_items_count`, per-version `items_total`, per-version stream, experiment items) so a future regression that silently drops items fails loudly. Slow shapes marked with `pytest.mark.slow`. Seed bulk-writes wrap with `ensure_rest_api_call_respecting_rate_limit` (commit `2006b472b`) so the test is runnable on rate-limited environments.

**Honest scope.** The user-visible data loss QA reported requires concurrent writers on the same `dataset_version` chain (OPIK-6600) or a multi-replica ClickHouse visibility window (OPIK-6601). Migrate by itself does NOT manufacture dataset-endpoint concurrency — verified via the new httpx interceptor showing 63 dataset writes all at `in_flight ≤ 1` across a mega-shape run. Staging A/B (below) further confirms Option A doesn't change pass/fail status on the multi-replica BE topology QA used. **This PR is defensive hardening + diagnostics + a regression net**; the user-visible data loss must still be addressed BE-side under OPIK-6600 / OPIK-6601.

## Change checklist

- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6602

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (claude-opus-4-7, 1M context)
- Model(s): Claude Opus 4.7
- Scope: full implementation (code + tests + diagnostics + commit message)
- Human verification: code review by author, manual run of migrate CLI with DEBUG, full stress E2E suite passes (3/3) locally + against staging both with and without the fix

## Testing

Tested on two BE topologies:

**Local Opik backend** (`http://localhost:5174/api`, single-replica ClickHouse, default `opik.sh --backend` setup):
- Stress E2E: `pytest tests/e2e/cli/test_migrate_dataset_stress_e2e.py -v` → 3/3 PASS in 57.7s
- DEBUG run: confirmed `migrate.http hook installed` line fires; per-version POST-APPLY counts agree at every version; 39 of 40 dataset HTTP windows at `in_flight=1`, one `in_flight=2` (background `is-alive/ping`)

**Staging** (`https://staging.dev.comet.com/opik/api`, multi-replica — the BE topology QA was on): ran the full stress matrix WITH and WITHOUT Option A to A/B the effect:

| Shape | Run 1 (with fix, `background_workers=1`) | Run 2 (without fix, `background_workers=4`) |
|---|---|---|
| `smoke` | ✅ PASS | ✅ PASS |
| `mega` (1458 × 27) | ✅ PASS | ✅ PASS |
| `traces-5k` (5000 cascade) | ✅ PASS (6m30s) | ✅ PASS (7m16s) |

Both configurations pass at QA-equivalent scale on staging. Option A's `5 → 2` reduction doesn't change pass/fail on the topologies tested.

**Negative test:** ran a separate same-dataset concurrent script (5 threads × 10 rounds × 5 items on ONE shared dataset) — reproduces OPIK-6600's symptoms reliably (76-80% data loss, 3/3 runs). Confirms our diagnostics + test infrastructure can catch the BE bug when same-dataset concurrency is present; confirms migrate alone doesn't produce that concurrency.

**Pre-commit:** ruff, ruff format, mypy → all pass.

## Documentation

N/A — debug-only diagnostics, no new user-facing behavior. The single user-observable change (slightly slower experiment cascade for very large datasets due to single streamer consumer; staging traces-5k went from 7m16s to 6m30s — actually faster because of less BE contention, but local Docker doesn't reproduce that) is documented in the in-code comment at `cli/migrate/main.py:_build_client`.