### PR TITLE
[OPIK-6188] [BE] feat: implement prompt project migration job (D4)

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1431,6 +1431,36 @@ datasetProjectMigration:
   schedulerQueuedTaskCap: ${DATASET_PROJECT_MIGRATION_SCHEDULER_QUEUED_TASK_CAP:-100}
   schedulerThreadTtl: ${DATASET_PROJECT_MIGRATION_SCHEDULER_THREAD_TTL:-60s}
 
+# Prompt Project Migration configuration (D4)
+# Assigns project_id to orphan prompts (V1 → V2 workspace migration). Mirrors
+# experimentProjectMigration. Operational prerequisite (enforced via the rollout runbook, not in
+# code): D1 (OPIK-6184) and OPIK-6579 must be fully shipped to this environment first because the
+# only inference signal is experiment.project_id.
+promptProjectMigration:
+  # Master switch — disabled by default, enable for staged rollout
+  enabled: ${PROMPT_PROJECT_MIGRATION_ENABLED:-false}
+  # Number of workspaces to process per job run (smallest first)
+  workspacesPerRun: ${PROMPT_PROJECT_MIGRATION_WORKSPACES_PER_RUN:-20}
+  # Number of prompts to update per MySQL UPDATE batch
+  promptBatchSize: ${PROMPT_PROJECT_MIGRATION_BATCH_SIZE:-1000}
+  # Interval between recurring job runs
+  interval: ${PROMPT_PROJECT_MIGRATION_INTERVAL:-30s}
+  # Delay before first run after app startup
+  startupDelay: ${PROMPT_PROJECT_MIGRATION_STARTUP_DELAY:-30s}
+  # Distributed lock timeout — prevents overlap across replicas. Intentionally shorter than
+  # jobTimeout: the WHERE project_id IS NULL predicate makes the cycle idempotent so replica
+  # overlap after lock expiry is safe.
+  lockTimeout: ${PROMPT_PROJECT_MIGRATION_LOCK_TIMEOUT:-5m}
+  # Max time to wait for the distributed lock when another replica holds it
+  lockWaitTime: ${PROMPT_PROJECT_MIGRATION_LOCK_WAIT_TIME:-100ms}
+  # Per-cycle timeout — safety net for stuck cycles, not normal completion
+  jobTimeout: ${PROMPT_PROJECT_MIGRATION_JOB_TIMEOUT:-1h}
+  # Dedicated reactor scheduler isolating this job from the shared boundedElastic.
+  schedulerThreadCap: ${PROMPT_PROJECT_MIGRATION_SCHEDULER_THREAD_CAP:-4}
+  schedulerQueuedTaskCap: ${PROMPT_PROJECT_MIGRATION_SCHEDULER_QUEUED_TASK_CAP:-100}
+  # Idle-thread TTL — should typically exceed `interval` so threads survive the idle window.
+  schedulerThreadTtl: ${PROMPT_PROJECT_MIGRATION_SCHEDULER_THREAD_TTL:-60s}
+
 # Shared configuration for V1 → V2 entity project migration jobs
 # Centralised so all migration jobs (experiments, datasets, etc.) share the same exclusion list
 migration:

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/PromptProjectMigrationJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/PromptProjectMigrationJob.java
@@ -1,0 +1,135 @@
+package com.comet.opik.api.resources.v1.jobs;
+
+import com.comet.opik.domain.PromptProjectMigrationService;
+import com.comet.opik.infrastructure.PromptProjectMigrationConfig;
+import com.comet.opik.infrastructure.lock.LockService;
+import io.dropwizard.jobs.Job;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongHistogram;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.InterruptableJob;
+import org.quartz.JobExecutionContext;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.comet.opik.domain.PromptProjectMigrationService.METRIC_NAMESPACE;
+import static com.comet.opik.domain.PromptProjectMigrationService.RESULT_ERROR;
+import static com.comet.opik.domain.PromptProjectMigrationService.RESULT_KEY;
+import static com.comet.opik.infrastructure.lock.LockService.Lock;
+
+@Singleton
+@Slf4j
+@DisallowConcurrentExecution
+public class PromptProjectMigrationJob extends Job implements InterruptableJob {
+
+    private static final Lock JOB_LOCK = new Lock("opik_job", PromptProjectMigrationJob.class.getSimpleName());
+
+    private static final Attributes RESULT_SUCCESS = Attributes.of(RESULT_KEY, "success");
+    private static final Attributes RESULT_LOCK_SKIPPED = Attributes.of(RESULT_KEY, "lock_skipped");
+
+    private final PromptProjectMigrationService migrationService;
+    private final PromptProjectMigrationConfig config;
+    private final LockService lockService;
+
+    private final AtomicBoolean interrupted = new AtomicBoolean(false);
+    private final AtomicReference<Disposable> currentExecution = new AtomicReference<>();
+
+    private final LongHistogram cycleDuration;
+
+    @Inject
+    public PromptProjectMigrationJob(
+            @NonNull PromptProjectMigrationService migrationService,
+            @NonNull @Config("promptProjectMigration") PromptProjectMigrationConfig config,
+            @NonNull LockService lockService) {
+        this.migrationService = migrationService;
+        this.config = config;
+        this.lockService = lockService;
+
+        var meter = GlobalOpenTelemetry.get().getMeter(METRIC_NAMESPACE);
+        this.cycleDuration = meter
+                .histogramBuilder("%s.cycle.duration".formatted(METRIC_NAMESPACE))
+                .setDescription(
+                        "Duration of a prompt project migration cycle, tagged by result")
+                .setUnit("ms")
+                .ofLongs()
+                .build();
+    }
+
+    @Override
+    public void doJob(JobExecutionContext context) {
+        if (!config.enabled()) {
+            log.debug("Prompt project migration job is disabled, skipping");
+            return;
+        }
+        if (interrupted.get()) {
+            log.info("Prompt project migration job was interrupted before execution, skipping");
+            return;
+        }
+        log.info("Starting prompt project migration job");
+        var startMillis = System.currentTimeMillis();
+        var subscription = lockService.bestEffortLock(
+                JOB_LOCK,
+                Mono.defer(() -> {
+                    if (interrupted.get()) {
+                        log.info("Prompt project migration was interrupted before processing, skipping");
+                        return Mono.empty();
+                    }
+                    return migrationService.runMigrationCycle()
+                            .timeout(config.jobTimeout().toJavaDuration())
+                            .doOnSuccess(unused -> {
+                                long durationMillis = System.currentTimeMillis() - startMillis;
+                                var duration = Duration.ofMillis(durationMillis);
+                                cycleDuration.record(durationMillis, RESULT_SUCCESS);
+                                log.info("Prompt project migration cycle finished, duration='{}'", duration);
+                            });
+                }),
+                Mono.defer(() -> {
+                    long durationMillis = System.currentTimeMillis() - startMillis;
+                    var duration = Duration.ofMillis(durationMillis);
+                    cycleDuration.record(durationMillis, RESULT_LOCK_SKIPPED);
+                    log.info("Could not acquire lock, another instance is already running, duration='{}'", duration);
+                    return Mono.empty();
+                }),
+                config.lockTimeout().toJavaDuration(),
+                config.lockWaitTime().toJavaDuration(),
+                false)
+                // Resume on errors so the recurring job stays alive
+                .onErrorResume(throwable -> {
+                    long durationMillis = System.currentTimeMillis() - startMillis;
+                    var duration = Duration.ofMillis(durationMillis);
+                    cycleDuration.record(durationMillis, RESULT_ERROR);
+                    if (interrupted.get()) {
+                        log.warn("Prompt project migration was interrupted, duration='{}'", duration, throwable);
+                    } else {
+                        log.error("Prompt project migration failed, duration='{}'", duration, throwable);
+                    }
+                    return Mono.empty();
+                })
+                .doFinally(signal -> currentExecution.set(null))
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe();
+        currentExecution.set(subscription);
+    }
+
+    @Override
+    public void interrupt() {
+        log.info("Interrupting prompt project migration job");
+        interrupted.set(true);
+        var execution = currentExecution.get();
+        if (execution != null && !execution.isDisposed()) {
+            execution.dispose();
+            log.info("Prompt project migration job interrupted successfully");
+        }
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EligiblePromptWorkspace.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EligiblePromptWorkspace.java
@@ -1,0 +1,8 @@
+package com.comet.opik.domain;
+
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder(toBuilder = true)
+public record EligiblePromptWorkspace(@NonNull String workspaceId, long promptsCount) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -1858,6 +1858,41 @@ public class ExperimentDAO {
             SETTINGS log_comment = '<log_comment>'
             """;
 
+    /**
+     * For one workspace and a set of orphan prompt IDs, returns the trace-derived classification
+     * for each prompt that has at least one referencing experiment: {@code project_id} is any
+     * non-orphan {@code project_id} of a referencing experiment (meaningful only when
+     * {@code project_count = 1}); {@code project_count} is the distinct count of non-orphan
+     * project_ids — {@code 0} = no inference, {@code 1} = certain, {@code > 1} = ambiguous.
+     * Same shape as {@link #COMPUTE_EXPERIMENT_PROJECT_MAPPING} so the prompt and experiment
+     * cycles classify the same way.
+     *
+     * <p>{@code argMax(_, last_updated_at)} on the inner aggregate dedupes ReplacingMergeTree
+     * duplicates by picking the latest row per experiment id. Prompt references are immutable
+     * per the data contract but {@code project_id} can flip during the D1 migration, so the
+     * latest one is what the inference must observe. The outer {@code anyIf} / {@code countDistinctIf}
+     * then filter on {@code project_id != ''} so experiments still orphan post-D1 are correctly
+     * invisible to the inference.
+     */
+    private static final String COMPUTE_PROMPT_PROJECT_CLASSIFICATION = """
+            SELECT
+                prompt_id_ref AS prompt_id,
+                anyIf(latest_project_id, latest_project_id != '') AS project_id,
+                countDistinctIf(latest_project_id, latest_project_id != '') AS project_count
+            FROM (
+                SELECT
+                    argMax(project_id, last_updated_at) AS latest_project_id,
+                    argMax(arrayConcat([prompt_id], mapKeys(prompt_versions)), last_updated_at) AS prompt_id_refs
+                FROM experiments
+                WHERE workspace_id = :workspace_id
+                GROUP BY id
+            )
+            ARRAY JOIN prompt_id_refs AS prompt_id_ref
+            WHERE prompt_id_ref IN :prompt_ids
+            GROUP BY prompt_id_ref
+            SETTINGS log_comment = '<log_comment>'
+            """;
+
     private final @NonNull ConnectionFactory connectionFactory;
     private final @NonNull TransactionTemplateAsync asyncTemplate;
     private final @NonNull SortingQueryBuilder sortingQueryBuilder;
@@ -2963,5 +2998,34 @@ public class ExperimentDAO {
                                 .distinctProjectCount(row.get("distinct_project_count", Long.class))
                                 .build())))
                 .flatMap(Mono::justOrEmpty);
+    }
+
+    /**
+     * Bulk classification for the prompt project migration. For the workspace from the request
+     * context and a set of orphan prompt IDs, returns one {@link PromptProjectClassification}
+     * per prompt that has at least one referencing experiment. Prompts absent from the result
+     * have no referencing experiments at all and the caller treats them the same as
+     * {@code projectCount = 0} — i.e. no-inference → Default Project.
+     */
+    Flux<PromptProjectClassification> computePromptProjectClassification(Set<UUID> promptIds) {
+        if (CollectionUtils.isEmpty(promptIds)) {
+            return Flux.empty();
+        }
+        return asyncTemplate.stream(connection -> makeFluxContextAware((userName, workspaceId) -> {
+            var details = "promptCount=%d".formatted(promptIds.size());
+            var template = getSTWithLogComment(COMPUTE_PROMPT_PROJECT_CLASSIFICATION,
+                    "compute_prompt_project_classification", workspaceId, userName, details);
+            var statement = connection.createStatement(template.render())
+                    .bind("prompt_ids", promptIds);
+            return bindWorkspaceIdToFlux(statement).subscriberContext(userName, workspaceId);
+        }))
+                .flatMap(result -> result.map((row, metadata) -> PromptProjectClassification.builder()
+                        .promptId(UUID.fromString(row.get("prompt_id", String.class)))
+                        .projectId(Optional.ofNullable(row.get("project_id", String.class))
+                                .filter(StringUtils::isNotBlank)
+                                .map(UUID::fromString)
+                                .orElse(null))
+                        .projectCount(row.get("project_count", Long.class))
+                        .build()));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptDAO.java
@@ -328,4 +328,76 @@ public interface PromptDAO {
     List<PromptVersionLink> findPromptsByCommits(
             @Define("commits") @BindList("commits") Collection<String> commits,
             @Bind("workspace_id") String workspaceId);
+
+    /**
+     * Per-workspace orphan-prompt counts for the prompt project migration eligibility scan.
+     * Returns workspaces with at least one non-demo prompt whose {@code project_id IS NULL},
+     * smallest-first so a single cycle can drain low-volume workspaces. Demo prompts are
+     * excluded via {@link DemoData#PROMPTS} (utf8mb4_unicode_ci is case-insensitive so a single
+     * canonical entry covers all casings). The optional {@code excluded_workspace_ids} bind
+     * folds the migration's env-var exclusion list and the persisted trap list into one query.
+     */
+    @SqlQuery("""
+            SELECT
+                workspace_id,
+                COUNT(*) AS prompts_count
+            FROM prompts
+            WHERE project_id IS NULL
+                AND name NOT IN (<demo_prompt_names>)
+                <if(excluded_workspace_ids)> AND workspace_id NOT IN (<excluded_workspace_ids>) <endif>
+            GROUP BY workspace_id
+            ORDER BY prompts_count ASC
+            LIMIT :limit
+            """)
+    @UseStringTemplateEngine
+    @AllowUnusedBindings
+    @RegisterConstructorMapper(EligiblePromptWorkspace.class)
+    List<EligiblePromptWorkspace> findEligiblePromptWorkspaces(
+            @Bind("limit") int limit,
+            @Define("demo_prompt_names") @BindList("demo_prompt_names") List<String> demoPromptNames,
+            @Define("excluded_workspace_ids") @BindList(value = "excluded_workspace_ids", onEmpty = BindList.EmptyHandling.NULL_VALUE) Set<String> excludedWorkspaceIds);
+
+    /**
+     * Returns up to {@code :limit} orphan, non-demo prompt IDs for a single workspace. The cap
+     * bounds the per-workspace-per-cycle memory and the size of the ClickHouse {@code IN} list
+     * in the downstream classification query. Workspaces with more orphans than the cap are
+     * drained over subsequent cycles — the eligibility scan finds them again until none remain.
+     */
+    @SqlQuery("""
+            SELECT id
+            FROM prompts
+            WHERE workspace_id = :workspace_id
+                AND project_id IS NULL
+                AND name NOT IN (<demo_prompt_names>)
+            LIMIT :limit
+            """)
+    @UseStringTemplateEngine
+    @AllowUnusedBindings
+    List<UUID> findOrphanPromptIds(
+            @Bind("workspace_id") String workspaceId,
+            @Define("demo_prompt_names") @BindList("demo_prompt_names") List<String> demoPromptNames,
+            @Bind("limit") int limit);
+
+    /**
+     * Idempotent batch assignment. The {@code project_id IS NULL} predicate is the concurrency
+     * guard — a concurrent user write that has already set the column to a different value is
+     * preserved, and re-runs of the migration are no-ops on already-assigned rows. The schema's
+     * {@code ON UPDATE CURRENT_TIMESTAMP(6)} on {@code last_updated_at} stamps the row time.
+     */
+    @SqlUpdate("""
+            UPDATE prompts
+            SET project_id = :project_id,
+                last_updated_by = :user_name
+            WHERE workspace_id = :workspace_id
+                AND id IN (<prompt_ids>)
+                AND project_id IS NULL
+            """)
+    @UseStringTemplateEngine
+    @AllowUnusedBindings
+    int batchSetProjectId(
+            @Bind("workspace_id") String workspaceId,
+            @Define("prompt_ids") @BindList("prompt_ids") Set<UUID> promptIds,
+            @Bind("project_id") UUID projectId,
+            @Bind("user_name") String userName);
+
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptProjectClassification.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptProjectClassification.java
@@ -1,0 +1,17 @@
+package com.comet.opik.domain;
+
+import lombok.Builder;
+import lombok.NonNull;
+
+import java.util.UUID;
+
+/**
+ * Per-prompt classification result, sister to {@link ExperimentProjectMapping}. {@code projectId}
+ * is any non-orphan {@code project_id} of an experiment that references this prompt via either
+ * the legacy {@code prompt_id} column or the {@code prompt_versions} map; meaningful only when
+ * {@code projectCount = 1}. {@code projectCount} is the distinct count of such non-orphan
+ * project_ids — {@code 0} = no inference, {@code 1} = certain, {@code > 1} = ambiguous.
+ */
+@Builder(toBuilder = true)
+public record PromptProjectClassification(@NonNull UUID promptId, UUID projectId, long projectCount) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptProjectMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptProjectMigrationService.java
@@ -288,10 +288,24 @@ public class PromptProjectMigrationService implements Managed {
         var assignments = mergeAssignments(certainAssignments,
                 getDefaultAssignments(workspaceId, deletedPromptIds, noInference));
 
+        // findOrphanPromptIds caps at batchSize, so the current view is only "the whole workspace"
+        // when the result came back short — a full-page result means more orphans may still exist
+        // and the trap decisions below must defer to a later cycle instead of permanently excluding
+        // the workspace based on a partial sample.
+        boolean isTailBatch = orphanIds.size() < batchSize;
+
         if (assignments.isEmpty()) {
-            log.info("Only ambiguous prompts in workspace, trapping all_ambiguous, workspaceId='{}', count='{}'",
+            if (isTailBatch) {
+                log.info(
+                        "All remaining orphan prompts in workspace are ambiguous, trapping all_ambiguous, workspaceId='{}', count='{}'",
+                        workspaceId, ambiguous.size());
+                return markMigrationSkipped(workspaceId, workspaceStartMillis, Mono.empty());
+            }
+            log.info(
+                    "Current batch is fully ambiguous but workspace may have more orphans, deferring trap to next cycle, workspaceId='{}', batchAmbiguous='{}'",
                     workspaceId, ambiguous.size());
-            return markMigrationSkipped(workspaceId, workspaceStartMillis, Mono.empty());
+            recordWorkspaceDuration(RESULT_ALL_AMBIGUOUS, workspaceStartMillis);
+            return Mono.empty();
         }
 
         return Flux.fromIterable(assignments.entrySet())
@@ -300,15 +314,21 @@ public class PromptProjectMigrationService implements Managed {
                 .reduce(0L, Long::sum)
                 .flatMap(totalUpdated -> {
                     var duration = Duration.ofMillis(System.currentTimeMillis() - workspaceStartMillis);
-                    if (!ambiguous.isEmpty()) {
+                    if (!ambiguous.isEmpty() && isTailBatch) {
                         log.info(
                                 "Migration completed with remaining ambiguous prompts, marking workspace as trapped, workspaceId='{}', migrated='{}', ambiguous='{}', duration='{}'",
                                 workspaceId, totalUpdated, ambiguous.size(), duration);
                         return markMigrationSkipped(workspaceId, workspaceStartMillis, Mono.just(false));
                     }
-                    log.info(
-                            "Workspace prompt migration completed, workspaceId='{}', migrated='{}', deletedProject='{}', noInference='{}', duration='{}'",
-                            workspaceId, totalUpdated, deletedPromptIds.size(), noInference.size(), duration);
+                    if (!ambiguous.isEmpty()) {
+                        log.info(
+                                "Batch migration completed; workspace has remaining orphans for next cycle, workspaceId='{}', migrated='{}', batchAmbiguous='{}', duration='{}'",
+                                workspaceId, totalUpdated, ambiguous.size(), duration);
+                    } else {
+                        log.info(
+                                "Workspace prompt migration completed, workspaceId='{}', migrated='{}', deletedProject='{}', noInference='{}', duration='{}'",
+                                workspaceId, totalUpdated, deletedPromptIds.size(), noInference.size(), duration);
+                    }
                     recordWorkspaceDuration(RESULT_MIGRATED, workspaceStartMillis);
                     return Mono.just(true);
                 });

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptProjectMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptProjectMigrationService.java
@@ -1,0 +1,436 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.Project;
+import com.comet.opik.domain.workspaces.WorkspacesService;
+import com.comet.opik.infrastructure.MigrationConfig;
+import com.comet.opik.infrastructure.PromptProjectMigrationConfig;
+import com.google.common.collect.Lists;
+import io.dropwizard.lifecycle.Managed;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongGauge;
+import io.opentelemetry.api.metrics.LongHistogram;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
+import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.comet.opik.infrastructure.auth.RequestContext.SYSTEM_USER;
+import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
+import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
+import static com.comet.opik.utils.AsyncUtils.setRequestContext;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+/**
+ * D4 migration — assigns {@code project_id} to V1 (workspace-scoped) prompts. Sister to
+ * {@link ExperimentProjectMigrationService}: same Quartz / Managed / scheduler-isolation shape
+ * and the same four-bucket classification (certain / certain-deleted → Default Project /
+ * no-inference → Default Project / ambiguous → skip). Differs only in the SQL — eligibility is
+ * a pure MySQL scan of the {@code prompts} table, classification reads experiments in ClickHouse
+ * to map each orphan prompt to a project via either the legacy {@code prompt_id} column or the
+ * {@code prompt_versions} map.
+ */
+@Slf4j
+@Singleton
+public class PromptProjectMigrationService implements Managed {
+
+    public static final String METRIC_NAMESPACE = "opik.migration.prompt_project";
+
+    public static final AttributeKey<String> RESULT_KEY = stringKey("result");
+    public static final AttributeKey<String> REASON_KEY = stringKey("reason");
+
+    public static final Attributes RESULT_ERROR = Attributes.of(RESULT_KEY, "error");
+
+    private static final String REASON_ALL_AMBIGUOUS = "all_ambiguous";
+
+    private static final Attributes RESULT_MIGRATED = Attributes.of(RESULT_KEY, "migrated");
+    private static final Attributes RESULT_NO_ORPHAN_PROMPTS = Attributes.of(RESULT_KEY, "no_orphan_prompts");
+    private static final Attributes RESULT_ALL_AMBIGUOUS = Attributes.of(RESULT_KEY, "all_ambiguous");
+
+    private static final Attributes REASON_AMBIGUOUS = Attributes.of(REASON_KEY, "ambiguous");
+    private static final Attributes REASON_DELETED_PROJECT = Attributes.of(REASON_KEY, "deleted_project");
+    private static final Attributes REASON_NO_INFERENCE = Attributes.of(REASON_KEY, "no_inference");
+
+    /**
+     * Classifier output for a single orphan prompt. Maps directly to the {@code projectCount}
+     * column from the ClickHouse classification query — {@code 0} → no-inference (route to
+     * Default Project), {@code 1} → certain (assign inferred unless project deleted), anything
+     * higher → ambiguous (skip and trap on cycle exit).
+     */
+    private enum Bucket {
+        CERTAIN,
+        NO_INFERENCE,
+        AMBIGUOUS
+    }
+
+    private final @NonNull TransactionTemplate transactionTemplate;
+    private final @NonNull ExperimentDAO experimentDAO;
+    private final @NonNull ProjectService projectService;
+    private final @NonNull WorkspacesService workspacesService;
+    private final @NonNull PromptProjectMigrationConfig config;
+    private final @NonNull MigrationConfig migrationConfig;
+
+    private final LongHistogram cycleEligibleWorkspaces;
+    private final LongGauge cycleTrappedWorkspaces;
+    private final LongGauge cycleEnvExcludedWorkspaces;
+    private final LongHistogram workspaceDuration;
+    private final LongCounter promptsSkipped;
+    private final LongCounter promptsAssignedToDefault;
+    private final LongHistogram batchSize;
+
+    /**
+     * Dedicated bounded-elastic scheduler isolating this job's blocking JDBC work and CPU
+     * post-collect from {@link Schedulers#boundedElastic()} and the reactive client event loops.
+     */
+    private volatile Scheduler migrationScheduler;
+
+    @Inject
+    public PromptProjectMigrationService(
+            @NonNull TransactionTemplate transactionTemplate,
+            @NonNull ExperimentDAO experimentDAO,
+            @NonNull ProjectService projectService,
+            @NonNull WorkspacesService workspacesService,
+            @NonNull @Config("promptProjectMigration") PromptProjectMigrationConfig config,
+            @NonNull @Config("migration") MigrationConfig migrationConfig) {
+        this.transactionTemplate = transactionTemplate;
+        this.experimentDAO = experimentDAO;
+        this.projectService = projectService;
+        this.workspacesService = workspacesService;
+        this.config = config;
+        this.migrationConfig = migrationConfig;
+
+        var meter = GlobalOpenTelemetry.get().getMeter(METRIC_NAMESPACE);
+        this.cycleEligibleWorkspaces = meter
+                .histogramBuilder("%s.cycle.eligible_workspaces".formatted(METRIC_NAMESPACE))
+                .setDescription("Number of workspaces with orphan prompts found per cycle")
+                .ofLongs()
+                .build();
+        this.cycleTrappedWorkspaces = meter
+                .gaugeBuilder("%s.cycle.trapped_workspaces".formatted(METRIC_NAMESPACE))
+                .setDescription(
+                        "Number of workspaces locally skipped because all their remaining prompts are ambiguous")
+                .ofLongs()
+                .build();
+        this.cycleEnvExcludedWorkspaces = meter
+                .gaugeBuilder("%s.cycle.env_excluded_workspaces".formatted(METRIC_NAMESPACE))
+                .setDescription(
+                        "Number of workspaces excluded via MIGRATION_EXCLUDED_WORKSPACE_IDS")
+                .ofLongs()
+                .build();
+        this.workspaceDuration = meter
+                .histogramBuilder("%s.workspace.duration".formatted(METRIC_NAMESPACE))
+                .setDescription("Duration of a single workspace migration, tagged by result")
+                .setUnit("ms")
+                .ofLongs()
+                .build();
+        this.promptsSkipped = meter
+                .counterBuilder("%s.prompts.skipped".formatted(METRIC_NAMESPACE))
+                .setDescription("Prompts skipped during migration, tagged by reason")
+                .build();
+        this.promptsAssignedToDefault = meter
+                .counterBuilder("%s.prompts.assigned_to_default".formatted(METRIC_NAMESPACE))
+                .setDescription("Prompts re-routed to Default Project, tagged by reason")
+                .build();
+        this.batchSize = meter
+                .histogramBuilder("%s.batch.size".formatted(METRIC_NAMESPACE))
+                .setDescription("Size of each successful MySQL UPDATE batch")
+                .ofLongs()
+                .build();
+    }
+
+    @Override
+    public void start() {
+        if (migrationScheduler == null) {
+            migrationScheduler = Schedulers.newBoundedElastic(
+                    config.schedulerThreadCap(),
+                    config.schedulerQueuedTaskCap(),
+                    "prompt-project-migration-service",
+                    (int) config.schedulerThreadTtl().toJavaDuration().toSeconds(),
+                    true);
+            log.info(
+                    "Initialized prompt project migration scheduler, threadCap='{}', queuedTaskCap='{}', threadTtl='{}'",
+                    config.schedulerThreadCap(), config.schedulerQueuedTaskCap(), config.schedulerThreadTtl());
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (migrationScheduler != null && !migrationScheduler.isDisposed()) {
+            migrationScheduler.dispose();
+            log.info("Prompt project migration scheduler disposed");
+        }
+    }
+
+    public Mono<Void> runMigrationCycle() {
+        return Mono.fromCallable(() -> {
+            var skippedWorkspaceIds = workspacesService.findPromptProjectMigrationSkippedWorkspaceIds();
+            var envExcludedWorkspaceIds = migrationConfig.getExcludedWorkspaceIds();
+            cycleTrappedWorkspaces.set(skippedWorkspaceIds.size());
+            cycleEnvExcludedWorkspaces.set(envExcludedWorkspaceIds.size());
+            log.info(
+                    "Starting prompt project migration cycle, workspacesPerRun='{}', promptBatchSize='{}', trappedWorkspaces='{}', envExcludedWorkspaces='{}'",
+                    config.workspacesPerRun(), config.promptBatchSize(), skippedWorkspaceIds.size(),
+                    envExcludedWorkspaceIds.size());
+            return Stream.concat(
+                    envExcludedWorkspaceIds.stream(),
+                    skippedWorkspaceIds.stream())
+                    .collect(Collectors.toUnmodifiableSet());
+        })
+                .subscribeOn(migrationScheduler)
+                .flatMapMany(excludedWorkspaceIds -> Mono
+                        .fromCallable(() -> findEligibleWorkspaces(excludedWorkspaceIds))
+                        .subscribeOn(migrationScheduler)
+                        .flatMapMany(eligibleWorkspaces -> {
+                            cycleEligibleWorkspaces.record(eligibleWorkspaces.size());
+                            if (CollectionUtils.isEmpty(eligibleWorkspaces)) {
+                                log.info("No workspaces with orphan prompts found, consider disabling the job");
+                                return Flux.empty();
+                            }
+                            log.info("Found workspaces with orphan prompts, count='{}'", eligibleWorkspaces.size());
+                            return Flux.fromIterable(eligibleWorkspaces)
+                                    .publishOn(migrationScheduler)
+                                    .concatMap(workspace -> migrateWorkspace(
+                                            workspace.workspaceId(),
+                                            workspace.promptsCount(),
+                                            config.promptBatchSize()));
+                        }))
+                .then();
+    }
+
+    private Mono<Boolean> migrateWorkspace(String workspaceId, long promptsCount, int batchSize) {
+        log.info("Starting workspace migration, workspaceId='{}', promptsCount='{}'", workspaceId, promptsCount);
+        var workspaceStartMillis = System.currentTimeMillis();
+        return Mono
+                .fromCallable(() -> findOrphanIds(workspaceId, batchSize))
+                .subscribeOn(migrationScheduler)
+                .flatMap(orphanIds -> {
+                    if (CollectionUtils.isEmpty(orphanIds)) {
+                        log.info("No orphan prompts to migrate, workspaceId='{}'", workspaceId);
+                        recordWorkspaceDuration(RESULT_NO_ORPHAN_PROMPTS, workspaceStartMillis);
+                        return Mono.empty();
+                    }
+                    return classifyAndMigrate(workspaceId, Set.copyOf(orphanIds), batchSize, workspaceStartMillis);
+                })
+                .onErrorResume(throwable -> {
+                    var duration = Duration.ofMillis(System.currentTimeMillis() - workspaceStartMillis);
+                    log.error("Workspace migration failed, will retry next cycle, workspaceId='{}', duration='{}'",
+                            workspaceId, duration, throwable);
+                    recordWorkspaceDuration(RESULT_ERROR, workspaceStartMillis);
+                    return Mono.empty();
+                });
+    }
+
+    private Mono<Boolean> classifyAndMigrate(
+            String workspaceId,
+            Set<UUID> orphanIds,
+            int batchSize,
+            long workspaceStartMillis) {
+        return experimentDAO.computePromptProjectClassification(orphanIds)
+                .contextWrite(ctx -> setRequestContext(ctx, SYSTEM_USER, workspaceId))
+                .collectList()
+                .publishOn(migrationScheduler)
+                .flatMap(classifications -> applyClassifications(
+                        workspaceId, orphanIds, classifications, batchSize, workspaceStartMillis));
+    }
+
+    private Mono<Boolean> applyClassifications(
+            String workspaceId,
+            Set<UUID> orphanIds,
+            List<PromptProjectClassification> classifications,
+            int batchSize,
+            long workspaceStartMillis) {
+        var classified = classifications.stream()
+                .collect(Collectors.toUnmodifiableMap(PromptProjectClassification::promptId, c -> c));
+
+        var byBucket = orphanIds.stream()
+                .collect(Collectors.groupingBy(
+                        promptId -> bucketOf(classified.get(promptId)),
+                        Collectors.toUnmodifiableSet()));
+        var ambiguous = byBucket.getOrDefault(Bucket.AMBIGUOUS, Set.of());
+        var noInference = byBucket.getOrDefault(Bucket.NO_INFERENCE, Set.of());
+        var certainByProject = byBucket.getOrDefault(Bucket.CERTAIN, Set.of()).stream()
+                .collect(Collectors.groupingBy(
+                        promptId -> classified.get(promptId).projectId(),
+                        Collectors.toUnmodifiableSet()));
+
+        var existingProjectIds = certainByProject.isEmpty()
+                ? Set.<UUID>of()
+                : projectService.findByIds(workspaceId, certainByProject.keySet()).stream()
+                        .map(Project::id)
+                        .collect(Collectors.toUnmodifiableSet());
+        var certainAssignments = certainByProject.entrySet().stream()
+                .filter(entry -> existingProjectIds.contains(entry.getKey()))
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
+        var deletedPromptIds = certainByProject.entrySet().stream()
+                .filter(entry -> !existingProjectIds.contains(entry.getKey()))
+                .flatMap(entry -> entry.getValue().stream())
+                .collect(Collectors.toUnmodifiableSet());
+
+        logAndEmitMetrics(workspaceId, ambiguous, deletedPromptIds, noInference);
+
+        var assignments = mergeAssignments(certainAssignments,
+                getDefaultAssignments(workspaceId, deletedPromptIds, noInference));
+
+        if (assignments.isEmpty()) {
+            log.info("Only ambiguous prompts in workspace, trapping all_ambiguous, workspaceId='{}', count='{}'",
+                    workspaceId, ambiguous.size());
+            return markMigrationSkipped(workspaceId, workspaceStartMillis, Mono.empty());
+        }
+
+        return Flux.fromIterable(assignments.entrySet())
+                .publishOn(migrationScheduler)
+                .concatMap(entry -> batchUpdateProjectId(workspaceId, entry.getKey(), entry.getValue(), batchSize))
+                .reduce(0L, Long::sum)
+                .flatMap(totalUpdated -> {
+                    var duration = Duration.ofMillis(System.currentTimeMillis() - workspaceStartMillis);
+                    if (!ambiguous.isEmpty()) {
+                        log.info(
+                                "Migration completed with remaining ambiguous prompts, marking workspace as trapped, workspaceId='{}', migrated='{}', ambiguous='{}', duration='{}'",
+                                workspaceId, totalUpdated, ambiguous.size(), duration);
+                        return markMigrationSkipped(workspaceId, workspaceStartMillis, Mono.just(false));
+                    }
+                    log.info(
+                            "Workspace prompt migration completed, workspaceId='{}', migrated='{}', deletedProject='{}', noInference='{}', duration='{}'",
+                            workspaceId, totalUpdated, deletedPromptIds.size(), noInference.size(), duration);
+                    recordWorkspaceDuration(RESULT_MIGRATED, workspaceStartMillis);
+                    return Mono.just(true);
+                });
+    }
+
+    private Bucket bucketOf(PromptProjectClassification classification) {
+        if (classification == null || classification.projectCount() == 0) {
+            return Bucket.NO_INFERENCE;
+        }
+        if (classification.projectCount() == 1 && classification.projectId() != null) {
+            return Bucket.CERTAIN;
+        }
+        return Bucket.AMBIGUOUS;
+    }
+
+    private void logAndEmitMetrics(
+            String workspaceId,
+            Set<UUID> ambiguous,
+            Set<UUID> deletedPromptIds,
+            Set<UUID> noInference) {
+        if (!ambiguous.isEmpty()) {
+            log.info("Skipping ambiguous prompts, workspaceId='{}', count='{}'", workspaceId, ambiguous.size());
+            promptsSkipped.add(ambiguous.size(), REASON_AMBIGUOUS);
+        }
+        if (!deletedPromptIds.isEmpty()) {
+            log.info("Assigning deleted-project prompts to Default Project, workspaceId='{}', count='{}'",
+                    workspaceId, deletedPromptIds.size());
+            promptsAssignedToDefault.add(deletedPromptIds.size(), REASON_DELETED_PROJECT);
+        }
+        if (!noInference.isEmpty()) {
+            log.info("Assigning no-inference prompts to Default Project, workspaceId='{}', count='{}'",
+                    workspaceId, noInference.size());
+            promptsAssignedToDefault.add(noInference.size(), REASON_NO_INFERENCE);
+        }
+    }
+
+    /**
+     * Re-targets the certain-deleted and no-inference prompt sets to the workspace's Default
+     * Project. {@link ProjectService#getOrCreate} is the same path trace ingestion takes, so a
+     * missing Default Project is provisioned in-line rather than trapping the workspace. Returns
+     * an empty map when neither bucket has rows so the caller can skip the merge cheaply.
+     */
+    private Map<UUID, Set<UUID>> getDefaultAssignments(
+            String workspaceId,
+            Set<UUID> deletedPromptIds,
+            Set<UUID> noInference) {
+        if (deletedPromptIds.isEmpty() && noInference.isEmpty()) {
+            return Map.of();
+        }
+        var defaultProjectId = projectService
+                .getOrCreate(workspaceId, ProjectService.DEFAULT_PROJECT, SYSTEM_USER)
+                .id();
+        var combined = Stream.concat(deletedPromptIds.stream(), noInference.stream())
+                .collect(Collectors.toUnmodifiableSet());
+        return Map.of(defaultProjectId, combined);
+    }
+
+    /**
+     * Merges two project_id → prompt_id bucket maps. The Default Project key could coincide with
+     * a {@code certainAssignments} key (an experiment legitimately points to the Default
+     * Project), so the merge combines the two prompt sets rather than letting either side
+     * shadow the other.
+     */
+    private Map<UUID, Set<UUID>> mergeAssignments(
+            Map<UUID, Set<UUID>> certainAssignments,
+            Map<UUID, Set<UUID>> defaultAssignments) {
+        return Stream.concat(certainAssignments.entrySet().stream(), defaultAssignments.entrySet().stream())
+                .collect(Collectors.toUnmodifiableMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (certainPromptIds, defaultPromptIds) -> Stream
+                                .concat(certainPromptIds.stream(), defaultPromptIds.stream())
+                                .collect(Collectors.toUnmodifiableSet())));
+    }
+
+    private Mono<Boolean> markMigrationSkipped(
+            String workspaceId,
+            long workspaceStartMillis,
+            Mono<Boolean> result) {
+        return Mono.fromRunnable(() -> workspacesService.markPromptProjectMigrationSkipped(
+                workspaceId, REASON_ALL_AMBIGUOUS))
+                .subscribeOn(migrationScheduler)
+                .doFinally(signalType -> recordWorkspaceDuration(RESULT_ALL_AMBIGUOUS, workspaceStartMillis))
+                .then(result);
+    }
+
+    private Mono<Long> batchUpdateProjectId(
+            String workspaceId,
+            UUID projectId,
+            Set<UUID> promptIds,
+            int maxBatchSize) {
+        return Flux.fromIterable(Lists.partition(List.copyOf(promptIds), maxBatchSize))
+                .publishOn(migrationScheduler)
+                .concatMap(batch -> Mono.fromCallable(() -> {
+                    var batchSet = Set.copyOf(batch);
+                    var updated = batchSetProjectId(workspaceId, batchSet, projectId);
+                    batchSize.record(batch.size());
+                    log.debug("Updated prompt batch, workspaceId='{}', projectId='{}', requested='{}', updated='{}'",
+                            workspaceId, projectId, batch.size(), updated);
+                    return updated;
+                }).subscribeOn(migrationScheduler))
+                .reduce(0L, Long::sum);
+    }
+
+    private List<EligiblePromptWorkspace> findEligibleWorkspaces(Set<String> excludedWorkspaceIds) {
+        return transactionTemplate.inTransaction(READ_ONLY,
+                handle -> handle.attach(PromptDAO.class).findEligiblePromptWorkspaces(
+                        config.workspacesPerRun(), DemoData.PROMPTS, excludedWorkspaceIds));
+    }
+
+    private List<UUID> findOrphanIds(String workspaceId, int limit) {
+        return transactionTemplate.inTransaction(READ_ONLY,
+                handle -> handle.attach(PromptDAO.class).findOrphanPromptIds(workspaceId, DemoData.PROMPTS, limit));
+    }
+
+    private int batchSetProjectId(String workspaceId, Set<UUID> promptIds, UUID projectId) {
+        return transactionTemplate.inTransaction(WRITE,
+                handle -> handle.attach(PromptDAO.class).batchSetProjectId(workspaceId, promptIds, projectId,
+                        SYSTEM_USER));
+    }
+
+    private void recordWorkspaceDuration(Attributes resultAttributes, long startMillis) {
+        workspaceDuration.record(System.currentTimeMillis() - startMillis, resultAttributes);
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/Workspace.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/Workspace.java
@@ -24,6 +24,8 @@ public record Workspace(
         String experimentProjectMigrationSkipReason,
         Instant datasetProjectMigrationSkippedAt,
         String datasetProjectMigrationSkipReason,
+        Instant promptProjectMigrationSkippedAt,
+        String promptProjectMigrationSkipReason,
         boolean hasLegacyScores,
         Instant createdAt,
         String createdBy,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesDAO.java
@@ -90,8 +90,50 @@ public interface WorkspacesDAO {
     @SqlQuery("SELECT id FROM workspaces WHERE experiment_project_migration_skipped_at IS NOT NULL")
     List<String> findExperimentProjectMigrationSkippedWorkspaceIds();
 
-    @SqlQuery("SELECT COUNT(*) FROM workspaces WHERE experiment_project_migration_skipped_at IS NOT NULL")
-    long countExperimentProjectMigrationSkipped();
+    /**
+     * Atomic NULL → timestamp transition for the prompt-project-migration trap flag. Parallel to
+     * {@link #updateExperimentProjectMigrationSkippedIfNull} but scoped to the prompt cycle's own
+     * column so the two migrations record their traps independently.
+     */
+    @SqlUpdate("""
+            UPDATE workspaces
+            SET prompt_project_migration_skipped_at = :skippedAt,
+                prompt_project_migration_skip_reason = :reason,
+                last_updated_by = :userName
+            WHERE id = :id AND prompt_project_migration_skipped_at IS NULL
+            """)
+    int updatePromptProjectMigrationSkippedIfNull(@Bind("id") String id,
+            @Bind("skippedAt") Instant skippedAt,
+            @Bind("reason") String reason,
+            @Bind("userName") String userName);
+
+    /**
+     * Plain INSERT (no upsert). Paired with {@link #updatePromptProjectMigrationSkippedIfNull}
+     * for the missing-row case, mirroring {@link #insertExperimentProjectMigrationSkipped}.
+     */
+    @SqlUpdate("""
+            INSERT INTO workspaces (
+                id,
+                prompt_project_migration_skipped_at,
+                prompt_project_migration_skip_reason,
+                created_by,
+                last_updated_by
+            )
+            VALUES (
+                :id,
+                :skippedAt,
+                :reason,
+                :userName,
+                :userName
+            )
+            """)
+    void insertPromptProjectMigrationSkipped(@Bind("id") String id,
+            @Bind("skippedAt") Instant skippedAt,
+            @Bind("reason") String reason,
+            @Bind("userName") String userName);
+
+    @SqlQuery("SELECT id FROM workspaces WHERE prompt_project_migration_skipped_at IS NOT NULL")
+    List<String> findPromptProjectMigrationSkippedWorkspaceIds();
 
     /**
      * Atomic NULL → timestamp transition for the dataset-project-migration-skipped flag. Returns 1 only when

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesService.java
@@ -53,7 +53,14 @@ public interface WorkspacesService {
 
     List<String> findExperimentProjectMigrationSkippedWorkspaceIds();
 
-    long countExperimentProjectMigrationSkipped();
+    /**
+     * Prompt-cycle parallel of {@link #markExperimentProjectMigrationSkipped}, recording the trap
+     * in the dedicated {@code prompt_project_migration_skipped_at} column so the experiment trap
+     * state isn't disturbed.
+     */
+    boolean markPromptProjectMigrationSkipped(String workspaceId, String reason);
+
+    List<String> findPromptProjectMigrationSkippedWorkspaceIds();
 
     /**
      * Idempotent: subsequent calls do not overwrite the original timestamp/reason. Audit columns
@@ -176,9 +183,30 @@ class WorkspacesServiceImpl implements WorkspacesService {
     }
 
     @Override
-    public long countExperimentProjectMigrationSkipped() {
+    public boolean markPromptProjectMigrationSkipped(@NonNull String workspaceId, @NonNull String reason) {
+        return transactionTemplate.inTransaction(WRITE, handle -> {
+            var dao = handle.attach(WorkspacesDAO.class);
+            var now = Instant.now();
+            if (dao.updatePromptProjectMigrationSkippedIfNull(workspaceId, now, reason, SYSTEM_USER) > 0) {
+                return true;
+            }
+            try {
+                dao.insertPromptProjectMigrationSkipped(workspaceId, now, reason, SYSTEM_USER);
+                return true;
+            } catch (UnableToExecuteStatementException exception) {
+                if (exception.getCause() instanceof SQLException sql
+                        && SQL_STATE_INTEGRITY_CONSTRAINT_VIOLATION.equals(sql.getSQLState())) {
+                    return dao.updatePromptProjectMigrationSkippedIfNull(workspaceId, now, reason, SYSTEM_USER) > 0;
+                }
+                throw exception;
+            }
+        });
+    }
+
+    @Override
+    public List<String> findPromptProjectMigrationSkippedWorkspaceIds() {
         return transactionTemplate.inTransaction(READ_ONLY,
-                handle -> handle.attach(WorkspacesDAO.class).countExperimentProjectMigrationSkipped());
+                handle -> handle.attach(WorkspacesDAO.class).findPromptProjectMigrationSkippedWorkspaceIds());
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
@@ -135,6 +135,10 @@ public class OpikConfiguration extends JobConfiguration {
             .build();
 
     @Valid @NotNull @JsonProperty
+    private PromptProjectMigrationConfig promptProjectMigration = PromptProjectMigrationConfig.builder()
+            .build();
+
+    @Valid @NotNull @JsonProperty
     private LocalRunnerConfig localRunner = new LocalRunnerConfig();
 
     @Valid @NotNull @JsonProperty

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/PromptProjectMigrationConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/PromptProjectMigrationConfig.java
@@ -1,0 +1,41 @@
+package com.comet.opik.infrastructure;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.dropwizard.util.Duration;
+import io.dropwizard.validation.MaxDuration;
+import io.dropwizard.validation.MinDuration;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Config for the D4 prompt project migration. Field-for-field parallel of
+ * {@link ExperimentProjectMigrationConfig}; defaults survived D1 prod and the prompt volume is
+ * smaller. Operationally D4 requires D1 (experiments) and OPIK-6579 (the experiment-migration
+ * tail) to be fully shipped — without that, nearly every prompt falls through to the no-inference
+ * bucket and ends up in Default Project. That ordering is enforced via the rollout runbook, not
+ * in code.
+ */
+@Builder(toBuilder = true)
+public record PromptProjectMigrationConfig(
+        boolean enabled,
+        @Min(1) @Max(100) int workspacesPerRun,
+        @Min(100) @Max(1000) int promptBatchSize,
+        @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 1, unit = TimeUnit.HOURS) Duration interval,
+        @NotNull @MinDuration(value = 0, unit = TimeUnit.SECONDS) @MaxDuration(value = 10, unit = TimeUnit.MINUTES) Duration startupDelay,
+        @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 30, unit = TimeUnit.MINUTES) Duration lockTimeout,
+        @NotNull @MinDuration(value = 50, unit = TimeUnit.MILLISECONDS) @MaxDuration(value = 5, unit = TimeUnit.SECONDS) Duration lockWaitTime,
+        @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 1, unit = TimeUnit.HOURS) Duration jobTimeout,
+        @Min(2) @Max(8) int schedulerThreadCap,
+        @Min(10) @Max(1_000) int schedulerQueuedTaskCap,
+        @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 1, unit = TimeUnit.HOURS) Duration schedulerThreadTtl) {
+
+    @JsonIgnore
+    @AssertTrue(message = "lockTimeout must be shorter than jobTimeout") public boolean isLockTimeoutShorterThanJobTimeout() {
+        return lockTimeout.toJavaDuration().compareTo(jobTimeout.toJavaDuration()) < 0;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListener.java
@@ -6,6 +6,7 @@ import com.comet.opik.api.resources.v1.jobs.ExperimentDenormalizationJob;
 import com.comet.opik.api.resources.v1.jobs.ExperimentProjectMigrationJob;
 import com.comet.opik.api.resources.v1.jobs.LocalRunnerReaperJob;
 import com.comet.opik.api.resources.v1.jobs.MetricsAlertJob;
+import com.comet.opik.api.resources.v1.jobs.PromptProjectMigrationJob;
 import com.comet.opik.api.resources.v1.jobs.RetentionCatchUpJob;
 import com.comet.opik.api.resources.v1.jobs.RetentionEstimationJob;
 import com.comet.opik.api.resources.v1.jobs.RetentionSlidingWindowJob;
@@ -61,6 +62,7 @@ public class OpikGuiceyLifecycleEventListener implements GuiceyLifecycleListener
                 scheduleDatasetVersionItemsTotalMigrationJobIfEnabled();
                 scheduleExperimentProjectMigrationJobIfEnabled();
                 scheduleDatasetProjectMigrationJobIfEnabled();
+                schedulePromptProjectMigrationJobIfEnabled();
             }
 
             case GuiceyLifecycle.ApplicationShutdown -> shutdownJobManagerScheduler();
@@ -325,6 +327,17 @@ public class OpikGuiceyLifecycleEventListener implements GuiceyLifecycleListener
             return;
         }
         scheduleRepeatingJob(DatasetProjectMigrationJob.class,
+                config.interval().toJavaDuration(),
+                config.startupDelay().toJavaDuration());
+    }
+
+    private void schedulePromptProjectMigrationJobIfEnabled() {
+        var config = injector.get().getInstance(OpikConfiguration.class).getPromptProjectMigration();
+        if (config == null || !config.enabled()) {
+            log.info("Prompt project migration job is disabled");
+            return;
+        }
+        scheduleRepeatingJob(PromptProjectMigrationJob.class,
                 config.interval().toJavaDuration(),
                 config.startupDelay().toJavaDuration());
     }

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000076_add_prompt_project_migration_skipped_to_workspaces.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000076_add_prompt_project_migration_skipped_to_workspaces.sql
@@ -1,0 +1,10 @@
+--liquibase formatted sql
+--changeset andrescrz:000076_add_prompt_project_migration_skipped_to_workspaces
+--comment: Per-entity trap columns for the prompt project migration (D4). Mirrors the experiment (000074) and dataset (000075) trap pairs so the prompt cycle can record its own all_ambiguous trap without colliding with the others. Placed AFTER dataset_project_migration_skip_reason to keep the three trap groups visually adjacent.
+
+ALTER TABLE workspaces
+    ADD COLUMN prompt_project_migration_skipped_at TIMESTAMP(6) DEFAULT NULL AFTER dataset_project_migration_skip_reason,
+    ADD COLUMN prompt_project_migration_skip_reason VARCHAR(255) DEFAULT NULL AFTER prompt_project_migration_skipped_at,
+    ADD INDEX workspaces_prompt_proj_migration_skipped_idx (prompt_project_migration_skipped_at);
+
+--rollback ALTER TABLE workspaces DROP INDEX workspaces_prompt_proj_migration_skipped_idx, DROP COLUMN prompt_project_migration_skip_reason, DROP COLUMN prompt_project_migration_skipped_at;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/PromptTestAssertions.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/PromptTestAssertions.java
@@ -1,0 +1,50 @@
+package com.comet.opik.api.resources.utils.resources;
+
+import com.comet.opik.api.Prompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Shared prompt-row test assertions. Sister to {@link ExperimentTestAssertions}.
+ *
+ * <p>{@link #PROMPT_IGNORED_FIELDS} is the canonical recursive-comparison ignore list, kept as
+ * a single source of truth across the prompt tests so each one opts out of the same response-side
+ * absences (write-only fields, server-resolved {@code projectName}) and complex subobjects
+ * ({@code latestVersion}, {@code requestedVersion}). {@link #assertPromptEqual} then re-asserts
+ * every ignored field individually so the helper doesn't silently let drift slip through —
+ * scenario-specific timestamps ({@code lastUpdatedAt}) are still the caller's responsibility.
+ */
+public class PromptTestAssertions {
+
+    public static final String[] PROMPT_IGNORED_FIELDS = {
+            "latestVersion",
+            "requestedVersion",
+            "template",
+            "metadata",
+            "changeDescription",
+            "type",
+            "projectName"};
+
+    /**
+     * Asserts that {@code actual} matches {@code expected} via recursive comparison ignoring
+     * {@link #PROMPT_IGNORED_FIELDS}, plus per-field equality on every one of those ignored
+     * fields so coverage stays tight. {@code lastUpdatedAt} stays inside the recursive
+     * comparison: callers that need {@code isAfter} semantics (e.g. migration tests) should
+     * patch {@code expected.lastUpdatedAt} to {@code actual.lastUpdatedAt} before calling and
+     * assert the timestamp progression themselves on top of this baseline.
+     */
+    public static void assertPromptEqual(Prompt actual, Prompt expected) {
+        assertThat(actual)
+                .usingRecursiveComparison()
+                .ignoringFields(PROMPT_IGNORED_FIELDS)
+                .isEqualTo(expected);
+
+        assertThat(actual.latestVersion()).isEqualTo(expected.latestVersion());
+        assertThat(actual.requestedVersion()).isEqualTo(expected.requestedVersion());
+        assertThat(actual.template()).isEqualTo(expected.template());
+        assertThat(actual.metadata()).isEqualTo(expected.metadata());
+        assertThat(actual.changeDescription()).isEqualTo(expected.changeDescription());
+        assertThat(actual.type()).isEqualTo(expected.type());
+        assertThat(actual.projectName()).isEqualTo(expected.projectName());
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceFindProjectPromptsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceFindProjectPromptsTest.java
@@ -50,6 +50,7 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static com.comet.opik.api.resources.utils.resources.PromptTestAssertions.PROMPT_IGNORED_FIELDS;
 import static com.comet.opik.api.sorting.SortableFields.CREATED_AT;
 import static com.comet.opik.api.sorting.SortableFields.CREATED_BY;
 import static com.comet.opik.api.sorting.SortableFields.DESCRIPTION;
@@ -67,8 +68,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 class PromptResourceFindProjectPromptsTest {
 
     private static final String RESOURCE_PATH = "%s/v1/private/prompts";
-    public static final String[] PROMPT_IGNORED_FIELDS = {"latestVersion", "requestedVersion", "template", "metadata",
-            "changeDescription", "type", "projectName"};
 
     private static final String USER = UUID.randomUUID().toString();
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.comet.opik.api.resources.utils.TestUtils.toURLEncodedQueryParam;
+import static com.comet.opik.api.resources.utils.resources.PromptTestAssertions.PROMPT_IGNORED_FIELDS;
 import static com.comet.opik.api.sorting.SortableFields.CREATED_AT;
 import static com.comet.opik.api.sorting.SortableFields.CREATED_BY;
 import static com.comet.opik.api.sorting.SortableFields.DESCRIPTION;
@@ -52,8 +53,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PromptResourceProjectScopedPromptsTest {
 
     private static final String RESOURCE_PATH = "%s/v1/private/prompts";
-    public static final String[] PROMPT_IGNORED_FIELDS = {"latestVersion", "requestedVersion", "template", "metadata",
-            "changeDescription", "type", "projectName"};
 
     private static final String USER = UUID.randomUUID().toString();
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -104,6 +104,7 @@ import static com.comet.opik.api.resources.utils.TestHttpClientUtils.FAKE_API_KE
 import static com.comet.opik.api.resources.utils.TestHttpClientUtils.NO_API_KEY_RESPONSE;
 import static com.comet.opik.api.resources.utils.TestHttpClientUtils.UNAUTHORIZED_RESPONSE;
 import static com.comet.opik.api.resources.utils.TestUtils.toURLEncodedQueryParam;
+import static com.comet.opik.api.resources.utils.resources.PromptTestAssertions.PROMPT_IGNORED_FIELDS;
 import static com.comet.opik.api.sorting.SortableFields.CREATED_AT;
 import static com.comet.opik.api.sorting.SortableFields.CREATED_BY;
 import static com.comet.opik.api.sorting.SortableFields.DESCRIPTION;
@@ -130,8 +131,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 class PromptResourceTest {
 
     private static final String RESOURCE_PATH = "%s/v1/private/prompts";
-    public static final String[] PROMPT_IGNORED_FIELDS = {"latestVersion", "requestedVersion", "template", "metadata",
-            "changeDescription", "type", "projectName"};
 
     private static final String API_KEY = UUID.randomUUID().toString();
     private static final String USER = UUID.randomUUID().toString();

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/PromptProjectMigrationJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/PromptProjectMigrationJobTest.java
@@ -1,0 +1,158 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.Dataset;
+import com.comet.opik.api.Experiment.PromptVersionLink;
+import com.comet.opik.api.Project;
+import com.comet.opik.api.PromptVersion;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.DatasetResourceClient;
+import com.comet.opik.api.resources.utils.resources.ExperimentResourceClient;
+import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
+import com.comet.opik.api.resources.utils.resources.PromptResourceClient;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.redis.testcontainers.RedisContainer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static com.comet.opik.api.resources.utils.AuthTestUtils.mockTargetWorkspace;
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Wiring smoke test for the D4 Quartz job. The bucket logic, trap conditions, exclusion lists,
+ * and idempotency live in {@link PromptProjectMigrationServiceTest} — this class only verifies
+ * that the scheduler -> job -> service plumbing fires and a migration actually happens. Keep
+ * scenarios here minimal so the Awaitility windows can stay short.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class PromptProjectMigrationJobTest {
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE_CONTAINER = ClickHouseContainerUtils
+            .newClickHouseContainer(ZOOKEEPER_CONTAINER);
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(REDIS, CLICKHOUSE_CONTAINER, MYSQL, ZOOKEEPER_CONTAINER).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils
+                .newDatabaseAnalyticsFactory(CLICKHOUSE_CONTAINER, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE_CONTAINER);
+
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .runtimeInfo(wireMock.runtimeInfo())
+                        .redisUrl(REDIS.getRedisURI())
+                        .customConfigs(List.of(
+                                new CustomConfig("promptProjectMigration.enabled", "true")))
+                        .build());
+    }
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    private ProjectResourceClient projectResourceClient;
+    private DatasetResourceClient datasetResourceClient;
+    private ExperimentResourceClient experimentResourceClient;
+    private PromptResourceClient promptResourceClient;
+
+    @BeforeAll
+    void setUpAll(ClientSupport clientSupport) {
+        var baseUrl = TestUtils.getBaseUrl(clientSupport);
+
+        projectResourceClient = new ProjectResourceClient(clientSupport, baseUrl, factory);
+        datasetResourceClient = new DatasetResourceClient(clientSupport, baseUrl);
+        experimentResourceClient = new ExperimentResourceClient(clientSupport, baseUrl, factory);
+        promptResourceClient = new PromptResourceClient(clientSupport, baseUrl, factory);
+    }
+
+    @Test
+    void scheduledJobMigratesEligibleWorkspace() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var projectName = randomName("project");
+        var projectId = projectResourceClient.createProject(
+                factory.manufacturePojo(Project.class).toBuilder().name(projectName).build(),
+                apiKey, workspaceName);
+
+        var datasetName = randomName("dataset");
+        datasetResourceClient.createDataset(
+                factory.manufacturePojo(Dataset.class).toBuilder()
+                        .name(datasetName)
+                        .projectId(projectId)
+                        .projectName(null)
+                        .build(),
+                apiKey, workspaceName);
+
+        var prompt = PromptResourceClient.buildPrompt(factory);
+        var version = promptResourceClient.createPromptVersion(prompt, apiKey, workspaceName);
+        var versionLink = buildVersionLink(version, prompt.name());
+
+        var experiment = experimentResourceClient.createPartialExperiment()
+                .id(null)
+                .datasetName(datasetName)
+                .projectId(projectId)
+                .projectName(projectName)
+                .promptVersion(versionLink)
+                .build();
+        experimentResourceClient.create(experiment, apiKey, workspaceName);
+
+        // The scheduler fires the job, the job runs a cycle, the cycle migrates the prompt.
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).untilAsserted(
+                () -> assertThat(promptResourceClient.getPrompt(versionLink.promptId(), apiKey, workspaceName)
+                        .projectId()).isEqualTo(projectId));
+    }
+
+    private static PromptVersionLink buildVersionLink(PromptVersion promptVersion, String promptName) {
+        return PromptVersionLink.builder()
+                .id(promptVersion.id())
+                .commit(promptVersion.commit())
+                .promptId(promptVersion.promptId())
+                .promptName(promptName)
+                .build();
+    }
+
+    private String randomName(String prefix) {
+        return "%s-%s".formatted(prefix, RandomStringUtils.secure().nextAlphanumeric(32));
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/PromptProjectMigrationServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/PromptProjectMigrationServiceTest.java
@@ -1,0 +1,647 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.Dataset;
+import com.comet.opik.api.Experiment.PromptVersionLink;
+import com.comet.opik.api.Project;
+import com.comet.opik.api.Prompt;
+import com.comet.opik.api.PromptVersion;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.DatasetResourceClient;
+import com.comet.opik.api.resources.utils.resources.ExperimentResourceClient;
+import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
+import com.comet.opik.api.resources.utils.resources.PromptResourceClient;
+import com.comet.opik.api.resources.utils.resources.PromptTestAssertions;
+import com.comet.opik.domain.workspaces.WorkspacesService;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.redis.testcontainers.RedisContainer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static com.comet.opik.api.resources.utils.AuthTestUtils.mockTargetWorkspace;
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class PromptProjectMigrationServiceTest {
+
+    private static final String EXCLUDED_WORKSPACE_ID = UUID.randomUUID().toString();
+    /**
+     * Pinned to the {@code @Min(100)} floor so {@link #oversizedWorkspaceDrainsAcrossCycles}
+     * can trigger spillover with a tractable seed (BATCH_SIZE + 1 prompts) — well above any
+     * other test's prompt count so the rest of the class is unaffected.
+     */
+    private static final int BATCH_SIZE = 100;
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE_CONTAINER = ClickHouseContainerUtils
+            .newClickHouseContainer(ZOOKEEPER_CONTAINER);
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(REDIS, CLICKHOUSE_CONTAINER, MYSQL, ZOOKEEPER_CONTAINER).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils
+                .newDatabaseAnalyticsFactory(CLICKHOUSE_CONTAINER, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE_CONTAINER);
+
+        // Job stays disabled here on purpose. The service-level tests drive the cycle directly
+        // via PromptProjectMigrationService.runMigrationCycle().block() — deterministic and fast,
+        // no Quartz interleaving with the test's seed/assert phases.
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .runtimeInfo(wireMock.runtimeInfo())
+                        .redisUrl(REDIS.getRedisURI())
+                        .customConfigs(List.of(
+                                new CustomConfig("migration.excludedWorkspaceIds", EXCLUDED_WORKSPACE_ID),
+                                new CustomConfig("promptProjectMigration.promptBatchSize",
+                                        String.valueOf(BATCH_SIZE))))
+                        .build());
+    }
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    private ProjectResourceClient projectResourceClient;
+    private DatasetResourceClient datasetResourceClient;
+    private ExperimentResourceClient experimentResourceClient;
+    private PromptResourceClient promptResourceClient;
+    private PromptProjectMigrationService migrationService;
+
+    @BeforeAll
+    void setUpAll(ClientSupport clientSupport, PromptProjectMigrationService migrationService) {
+        var baseUrl = TestUtils.getBaseUrl(clientSupport);
+
+        projectResourceClient = new ProjectResourceClient(clientSupport, baseUrl, factory);
+        datasetResourceClient = new DatasetResourceClient(clientSupport, baseUrl);
+        experimentResourceClient = new ExperimentResourceClient(clientSupport, baseUrl, factory);
+        promptResourceClient = new PromptResourceClient(clientSupport, baseUrl, factory);
+        this.migrationService = migrationService;
+    }
+
+    @Test
+    void migrateCertainPromptViaLegacyAndModernPaths() {
+        // Three prompts: one referenced only via legacy prompt_id, one only via prompt_versions map,
+        // one via both. All resolve to the same project and migrate to it.
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var projectName = randomName("project");
+        var projectId = createProject(apiKey, workspaceName, projectName);
+        var datasetName = createDatasetWithProject(apiKey, workspaceName, projectId);
+
+        var legacyLink = createOrphanPromptVersion(apiKey, workspaceName);
+        var modernLink = createOrphanPromptVersion(apiKey, workspaceName);
+        var bothLink = createOrphanPromptVersion(apiKey, workspaceName);
+
+        // Experiment 1: legacy prompt_id only.
+        createExperimentInProject(apiKey, workspaceName, datasetName, projectId, projectName,
+                legacyLink, null);
+        // Experiment 2: prompt_versions map only.
+        createExperimentInProject(apiKey, workspaceName, datasetName, projectId, projectName,
+                null, List.of(modernLink));
+        // Experiment 3: both fields set, redundantly referencing the same prompt.
+        createExperimentInProject(apiKey, workspaceName, datasetName, projectId, projectName,
+                bothLink, List.of(bothLink));
+
+        var legacyBefore = promptResourceClient.getPrompt(legacyLink.promptId(), apiKey, workspaceName);
+        var modernBefore = promptResourceClient.getPrompt(modernLink.promptId(), apiKey, workspaceName);
+        var bothBefore = promptResourceClient.getPrompt(bothLink.promptId(), apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertPromptMigratedTo(apiKey, workspaceName, legacyLink.promptId(), legacyBefore, projectId);
+        assertPromptMigratedTo(apiKey, workspaceName, modernLink.promptId(), modernBefore, projectId);
+        assertPromptMigratedTo(apiKey, workspaceName, bothLink.promptId(), bothBefore, projectId);
+    }
+
+    /**
+     * Single workspace covering all four classifier buckets in one cycle:
+     * <ul>
+     *     <li><b>certain</b> — one referencing experiment in a single alive project => assigned.</li>
+     *     <li><b>certain-deleted</b> — one referencing experiment in a project later deleted in
+     *     MySQL => routed to Default Project.</li>
+     *     <li><b>no-inference</b> — orphan prompt with no referencing experiment => routed to
+     *     Default Project.</li>
+     *     <li><b>ambiguous</b> — referencing experiments in two distinct live projects => skipped.</li>
+     * </ul>
+     * Also covers the demo-name filter: a demo-named prompt is workspace-orphan but excluded from
+     * the eligibility query, so it's invisible to the cycle even when other prompts in the
+     * workspace migrate.
+     *
+     * <p>Outcome: workspace gets trapped with {@code all_ambiguous} because the ambiguous prompt
+     * is left behind; the other three buckets land on their assigned projects and the demo prompt
+     * stays orphan.
+     */
+    @Test
+    void mixedWorkspaceMigratesAcrossBucketsAndTrapsOnAmbiguous(WorkspacesService workspacesService) {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var aliveProjectName = randomName("project");
+        var aliveProjectId = createProject(apiKey, workspaceName, aliveProjectName);
+        var aliveDataset = createDatasetWithProject(apiKey, workspaceName, aliveProjectId);
+
+        var certainLink = createOrphanPromptVersion(apiKey, workspaceName);
+        createExperimentInProject(apiKey, workspaceName, aliveDataset, aliveProjectId, aliveProjectName,
+                certainLink, null);
+
+        var deletedProjectName = randomName("project");
+        var deletedProjectId = createProject(apiKey, workspaceName, deletedProjectName);
+        var deletedDataset = createDatasetWithProject(apiKey, workspaceName, deletedProjectId);
+        var deletedLink = createOrphanPromptVersion(apiKey, workspaceName);
+        createExperimentInProject(apiKey, workspaceName, deletedDataset, deletedProjectId, deletedProjectName,
+                deletedLink, null);
+        projectResourceClient.deleteProject(deletedProjectId, apiKey, workspaceName);
+
+        var noInferenceLink = createOrphanPromptVersion(apiKey, workspaceName);
+
+        var secondAliveProjectName = randomName("project");
+        var secondAliveProjectId = createProject(apiKey, workspaceName, secondAliveProjectName);
+        var secondAliveDataset = createDatasetWithProject(apiKey, workspaceName, secondAliveProjectId);
+        var ambiguousLink = createOrphanPromptVersion(apiKey, workspaceName);
+        createExperimentInProject(apiKey, workspaceName, aliveDataset, aliveProjectId, aliveProjectName,
+                ambiguousLink, null);
+        createExperimentInProject(apiKey, workspaceName, secondAliveDataset, secondAliveProjectId,
+                secondAliveProjectName, ambiguousLink, null);
+
+        // Demo: eligible-shaped but excluded by the demo-name filter on the eligibility query.
+        var demoName = DemoData.PROMPTS.getFirst();
+        var demoPrompt = Prompt.builder().name(demoName).projectId(null).projectName(null).build();
+        var demoVersion = promptResourceClient.createPromptVersion(demoPrompt, apiKey, workspaceName);
+        var demoLink = buildVersionLink(demoVersion, demoName);
+        createExperimentInProject(apiKey, workspaceName, aliveDataset, aliveProjectId, aliveProjectName,
+                demoLink, null);
+
+        var certainBefore = promptResourceClient.getPrompt(certainLink.promptId(), apiKey, workspaceName);
+        var deletedBefore = promptResourceClient.getPrompt(deletedLink.promptId(), apiKey, workspaceName);
+        var noInferenceBefore = promptResourceClient.getPrompt(noInferenceLink.promptId(), apiKey, workspaceName);
+        var ambiguousBefore = promptResourceClient.getPrompt(ambiguousLink.promptId(), apiKey, workspaceName);
+        var demoBefore = promptResourceClient.getPrompt(demoLink.promptId(), apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertPromptMigratedTo(apiKey, workspaceName, certainLink.promptId(), certainBefore, aliveProjectId);
+        assertPromptMigratedToDefault(apiKey, workspaceName, deletedLink.promptId(), deletedBefore);
+        assertPromptMigratedToDefault(apiKey, workspaceName, noInferenceLink.promptId(), noInferenceBefore);
+        assertPromptUnchanged(apiKey, workspaceName, ambiguousLink.promptId(), ambiguousBefore);
+        assertPromptUnchanged(apiKey, workspaceName, demoLink.promptId(), demoBefore);
+
+        assertWorkspaceTrapped(workspacesService, workspaceId, "all_ambiguous");
+    }
+
+    @Test
+    void migrateDeletedProjectPromptToDefaultProject() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var projectName = randomName("project");
+        var projectId = createProject(apiKey, workspaceName, projectName);
+        var datasetName = createDatasetWithProject(apiKey, workspaceName, projectId);
+        var promptLink = createOrphanPromptVersion(apiKey, workspaceName);
+        createExperimentInProject(apiKey, workspaceName, datasetName, projectId, projectName,
+                promptLink, null);
+
+        projectResourceClient.deleteProject(projectId, apiKey, workspaceName);
+
+        var before = promptResourceClient.getPrompt(promptLink.promptId(), apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertPromptMigratedToDefault(apiKey, workspaceName, promptLink.promptId(), before);
+    }
+
+    @Test
+    void migrateNoInferencePromptToDefaultProject() {
+        // Orphan prompt with zero referencing experiments => no-inference bucket => Default Project.
+        // Also verifies the cycle provisions Default Project in-line when it's missing
+        // (projectService.getOrCreate path).
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var promptLink = createOrphanPromptVersion(apiKey, workspaceName);
+        var before = promptResourceClient.getPrompt(promptLink.promptId(), apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertPromptMigratedToDefault(apiKey, workspaceName, promptLink.promptId(), before);
+    }
+
+    @Test
+    void migrateNoInferencePromptWhenAllReferencingExperimentsAreOrphan() {
+        // Prompt referenced only by experiments that are still orphan (project_id = ''). Those
+        // experiments are correctly invisible to the classification (anyIf / countDistinctIf on
+        // project_id != '') and the prompt falls into no-inference => Default Project.
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var datasetName = randomName("dataset");
+        datasetResourceClient.createDataset(
+                factory.manufacturePojo(Dataset.class).toBuilder()
+                        .name(datasetName)
+                        .projectId(null)
+                        .projectName(null)
+                        .build(),
+                apiKey, workspaceName);
+        var promptLink = createOrphanPromptVersion(apiKey, workspaceName);
+        var orphanExperiment = experimentResourceClient.createPartialExperiment()
+                .id(null)
+                .datasetName(datasetName)
+                .promptVersion(promptLink)
+                .promptVersions(List.of(promptLink))
+                .build();
+        experimentResourceClient.create(orphanExperiment, apiKey, workspaceName);
+
+        var before = promptResourceClient.getPrompt(promptLink.promptId(), apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertPromptMigratedToDefault(apiKey, workspaceName, promptLink.promptId(), before);
+    }
+
+    /**
+     * Workspace whose only orphan is ambiguous: the early {@code assignments.isEmpty()}
+     * short-circuit in {@code applyClassifications} traps the workspace before any writes happen.
+     * Distinct from the post-write trap exercised by
+     * {@link #mixedWorkspaceMigratesAcrossBucketsAndTrapsOnAmbiguous}, which goes through the
+     * full batch-update chain first.
+     */
+    @Test
+    void trapWorkspaceWithOnlyAmbiguousPrompts(WorkspacesService workspacesService) {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var projectName1 = randomName("project");
+        var projectId1 = createProject(apiKey, workspaceName, projectName1);
+        var dataset1 = createDatasetWithProject(apiKey, workspaceName, projectId1);
+        var projectName2 = randomName("project");
+        var projectId2 = createProject(apiKey, workspaceName, projectName2);
+        var dataset2 = createDatasetWithProject(apiKey, workspaceName, projectId2);
+
+        var promptLink = createOrphanPromptVersion(apiKey, workspaceName);
+        createExperimentInProject(apiKey, workspaceName, dataset1, projectId1, projectName1,
+                promptLink, null);
+        createExperimentInProject(apiKey, workspaceName, dataset2, projectId2, projectName2,
+                promptLink, null);
+
+        var before = promptResourceClient.getPrompt(promptLink.promptId(), apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertPromptUnchanged(apiKey, workspaceName, promptLink.promptId(), before);
+        assertWorkspaceTrapped(workspacesService, workspaceId, "all_ambiguous");
+    }
+
+    @Test
+    void skipPreMarkedTrappedWorkspaces(WorkspacesService workspacesService) {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        workspacesService.markPromptProjectMigrationSkipped(workspaceId, "test-pre-marked-trap");
+
+        var projectName = randomName("project");
+        var projectId = createProject(apiKey, workspaceName, projectName);
+        var datasetName = createDatasetWithProject(apiKey, workspaceName, projectId);
+        var promptLink = createOrphanPromptVersion(apiKey, workspaceName);
+        createExperimentInProject(apiKey, workspaceName, datasetName, projectId, projectName,
+                promptLink, null);
+
+        var before = promptResourceClient.getPrompt(promptLink.promptId(), apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertPromptUnchanged(apiKey, workspaceName, promptLink.promptId(), before);
+    }
+
+    @Test
+    void skipExcludedWorkspaces() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, EXCLUDED_WORKSPACE_ID, randomName("user"));
+
+        var projectName = randomName("project");
+        var projectId = createProject(apiKey, workspaceName, projectName);
+        var datasetName = createDatasetWithProject(apiKey, workspaceName, projectId);
+        var promptLink = createOrphanPromptVersion(apiKey, workspaceName);
+        createExperimentInProject(apiKey, workspaceName, datasetName, projectId, projectName,
+                promptLink, null);
+
+        var before = promptResourceClient.getPrompt(promptLink.promptId(), apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertPromptUnchanged(apiKey, workspaceName, promptLink.promptId(), before);
+    }
+
+    /**
+     * Multi-workspace cycle: one cycle picks up every eligible workspace in scope (up to
+     * {@code workspacesPerRun}), ordered smallest-first. Both workspaces should reach a migrated
+     * state in a single {@code runMigrationCycle().block()}. Mirrors D1's
+     * {@code migrateEligibleExperimentsAcrossWorkspaces}.
+     */
+    @Test
+    void migrateEligiblePromptsAcrossWorkspaces() {
+        // Workspace A: one orphan prompt (smaller — processed first by FIND_ELIGIBLE_PROMPT_WORKSPACES).
+        var apiKeyA = randomName("api-key");
+        var workspaceNameA = randomName("workspace");
+        var workspaceIdA = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKeyA, workspaceNameA, workspaceIdA, randomName("user"));
+        var projectNameA = randomName("project");
+        var projectIdA = createProject(apiKeyA, workspaceNameA, projectNameA);
+        var datasetNameA = createDatasetWithProject(apiKeyA, workspaceNameA, projectIdA);
+        var promptLinkA = createOrphanPromptVersion(apiKeyA, workspaceNameA);
+        createExperimentInProject(apiKeyA, workspaceNameA, datasetNameA, projectIdA, projectNameA,
+                promptLinkA, null);
+
+        // Workspace B: two orphan prompts in the same alive project.
+        var apiKeyB = randomName("api-key");
+        var workspaceNameB = randomName("workspace");
+        var workspaceIdB = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKeyB, workspaceNameB, workspaceIdB, randomName("user"));
+        var projectNameB = randomName("project");
+        var projectIdB = createProject(apiKeyB, workspaceNameB, projectNameB);
+        var datasetNameB = createDatasetWithProject(apiKeyB, workspaceNameB, projectIdB);
+        var promptLinkB1 = createOrphanPromptVersion(apiKeyB, workspaceNameB);
+        var promptLinkB2 = createOrphanPromptVersion(apiKeyB, workspaceNameB);
+        createExperimentInProject(apiKeyB, workspaceNameB, datasetNameB, projectIdB, projectNameB,
+                promptLinkB1, null);
+        createExperimentInProject(apiKeyB, workspaceNameB, datasetNameB, projectIdB, projectNameB,
+                promptLinkB2, null);
+
+        var beforeA = promptResourceClient.getPrompt(promptLinkA.promptId(), apiKeyA, workspaceNameA);
+        var beforeB1 = promptResourceClient.getPrompt(promptLinkB1.promptId(), apiKeyB, workspaceNameB);
+        var beforeB2 = promptResourceClient.getPrompt(promptLinkB2.promptId(), apiKeyB, workspaceNameB);
+
+        migrationService.runMigrationCycle().block();
+
+        assertPromptMigratedTo(apiKeyA, workspaceNameA, promptLinkA.promptId(), beforeA, projectIdA);
+        assertPromptMigratedTo(apiKeyB, workspaceNameB, promptLinkB1.promptId(), beforeB1, projectIdB);
+        assertPromptMigratedTo(apiKeyB, workspaceNameB, promptLinkB2.promptId(), beforeB2, projectIdB);
+    }
+
+    /**
+     * Pagination: a workspace with more orphans than {@code promptBatchSize} drains across
+     * successive cycles. Cycle 1 processes exactly {@code BATCH_SIZE} prompts (the
+     * {@code findOrphanPromptIds.LIMIT :limit} cap); cycle 2 picks up the remaining one. The
+     * eligibility scan keeps finding the workspace until it's empty.
+     */
+    @Test
+    void oversizedWorkspaceDrainsAcrossCycles() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        // No-inference path: BATCH_SIZE + 1 orphan prompts with zero referencing experiments.
+        // Cycle drives them all to Default Project, but only BATCH_SIZE per pass.
+        var promptIds = new ArrayList<UUID>();
+        for (int i = 0; i < BATCH_SIZE + 1; i++) {
+            promptIds.add(createOrphanPromptVersion(apiKey, workspaceName).promptId());
+        }
+
+        migrationService.runMigrationCycle().block();
+
+        var migratedAfterCycle1 = countMigrated(apiKey, workspaceName, promptIds);
+        assertThat(migratedAfterCycle1)
+                .as("cycle 1 should migrate exactly BATCH_SIZE prompts, leaving 1 orphan")
+                .isEqualTo(BATCH_SIZE);
+
+        migrationService.runMigrationCycle().block();
+
+        var migratedAfterCycle2 = countMigrated(apiKey, workspaceName, promptIds);
+        assertThat(migratedAfterCycle2)
+                .as("cycle 2 should drain the last orphan")
+                .isEqualTo(BATCH_SIZE + 1);
+    }
+
+    /**
+     * Edge case for {@code mergeAssignments}: when the workspace's Default Project happens to
+     * coincide with a {@code certainAssignments} key (an experiment legitimately references the
+     * Default Project), the merge function unions the two prompt sets rather than letting either
+     * side shadow the other. Both the certain and the no-inference prompt should land on the
+     * Default Project.
+     */
+    @Test
+    void defaultProjectKeyCollisionUnionsCertainAndNoInferencePromptSets() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        // Pre-create Default Project so the certain-experiment references it as its alive project.
+        var defaultProjectId = createProject(apiKey, workspaceName, ProjectService.DEFAULT_PROJECT);
+        var datasetName = createDatasetWithProject(apiKey, workspaceName, defaultProjectId);
+
+        // Certain: prompt referenced by an experiment pointing at Default Project → its key in
+        // certainAssignments collides with the Default Project key produced by getDefaultAssignments.
+        var certainLink = createOrphanPromptVersion(apiKey, workspaceName);
+        createExperimentInProject(apiKey, workspaceName, datasetName, defaultProjectId,
+                ProjectService.DEFAULT_PROJECT, certainLink, null);
+
+        // No-inference: prompt with no referencing experiment → routed to Default by
+        // getDefaultAssignments, hitting the same key.
+        var noInferenceLink = createOrphanPromptVersion(apiKey, workspaceName);
+
+        var certainBefore = promptResourceClient.getPrompt(certainLink.promptId(), apiKey, workspaceName);
+        var noInferenceBefore = promptResourceClient.getPrompt(noInferenceLink.promptId(), apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        // Both prompts must land on the Default Project — neither shadows the other.
+        assertPromptMigratedTo(apiKey, workspaceName, certainLink.promptId(), certainBefore, defaultProjectId);
+        assertPromptMigratedTo(apiKey, workspaceName, noInferenceLink.promptId(), noInferenceBefore,
+                defaultProjectId);
+    }
+
+    @Test
+    void secondCycleIsNoopAfterSuccessfulMigration() {
+        // Idempotency: after the first cycle assigns a prompt, a second cycle must not re-write
+        // it (eligibility excludes it, batch UPDATE's project_id IS NULL guard would prevent any
+        // double write even if it ran). Asserted via full-row equality between cycles.
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var projectName = randomName("project");
+        var projectId = createProject(apiKey, workspaceName, projectName);
+        var datasetName = createDatasetWithProject(apiKey, workspaceName, projectId);
+        var promptLink = createOrphanPromptVersion(apiKey, workspaceName);
+        createExperimentInProject(apiKey, workspaceName, datasetName, projectId, projectName,
+                promptLink, null);
+
+        var before = promptResourceClient.getPrompt(promptLink.promptId(), apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertPromptMigratedTo(apiKey, workspaceName, promptLink.promptId(), before, projectId);
+        var afterFirst = promptResourceClient.getPrompt(promptLink.promptId(), apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertPromptUnchanged(apiKey, workspaceName, promptLink.promptId(), afterFirst);
+    }
+
+    private UUID createProject(String apiKey, String workspaceName, String projectName) {
+        return projectResourceClient.createProject(
+                factory.manufacturePojo(Project.class).toBuilder().name(projectName).build(),
+                apiKey, workspaceName);
+    }
+
+    private String createDatasetWithProject(String apiKey, String workspaceName, UUID projectId) {
+        var datasetName = randomName("dataset");
+        datasetResourceClient.createDataset(
+                factory.manufacturePojo(Dataset.class).toBuilder()
+                        .name(datasetName)
+                        .projectId(projectId)
+                        .projectName(null)
+                        .build(),
+                apiKey, workspaceName);
+        return datasetName;
+    }
+
+    private PromptVersionLink createOrphanPromptVersion(String apiKey, String workspaceName) {
+        var prompt = PromptResourceClient.buildPrompt(factory);
+        var version = promptResourceClient.createPromptVersion(prompt, apiKey, workspaceName);
+        return buildVersionLink(version, prompt.name());
+    }
+
+    private static PromptVersionLink buildVersionLink(PromptVersion promptVersion, String promptName) {
+        return PromptVersionLink.builder()
+                .id(promptVersion.id())
+                .commit(promptVersion.commit())
+                .promptId(promptVersion.promptId())
+                .promptName(promptName)
+                .build();
+    }
+
+    private void createExperimentInProject(
+            String apiKey,
+            String workspaceName,
+            String datasetName,
+            UUID projectId,
+            String projectName,
+            PromptVersionLink promptVersion,
+            List<PromptVersionLink> promptVersions) {
+        var experiment = experimentResourceClient.createPartialExperiment()
+                .id(null)
+                .datasetName(datasetName)
+                .projectId(projectId)
+                .projectName(projectName)
+                .promptVersion(promptVersion)
+                .promptVersions(promptVersions)
+                .build();
+        experimentResourceClient.create(experiment, apiKey, workspaceName);
+    }
+
+    private void assertPromptMigratedToDefault(
+            String apiKey,
+            String workspaceName,
+            UUID promptId,
+            Prompt beforeMigration) {
+        var actual = promptResourceClient.getPrompt(promptId, apiKey, workspaceName);
+        assertThat(actual.projectId()).isNotNull();
+        var project = projectResourceClient.getProject(actual.projectId(), apiKey, workspaceName);
+        assertThat(project.name()).isEqualTo(ProjectService.DEFAULT_PROJECT);
+        assertPromptMigratedTo(apiKey, workspaceName, promptId, beforeMigration, actual.projectId());
+    }
+
+    /**
+     * Common post-cycle check for any prompt the migration successfully assigned: full equality
+     * against {@code beforeMigration} via {@link PromptTestAssertions#assertPromptEqual} (with
+     * the expected projectId / lastUpdatedBy patched onto the snapshot — {@code lastUpdatedAt}
+     * is also copied from the actual row since it's auto-updated by the schema), then the
+     * isAfter check pins the timestamp progression that's specific to the "row was written" case.
+     */
+    private void assertPromptMigratedTo(
+            String apiKey,
+            String workspaceName,
+            UUID promptId,
+            Prompt beforeMigration,
+            UUID expectedProjectId) {
+        var actual = promptResourceClient.getPrompt(promptId, apiKey, workspaceName);
+        var expected = beforeMigration.toBuilder()
+                .projectId(expectedProjectId)
+                .lastUpdatedBy(RequestContext.SYSTEM_USER)
+                .lastUpdatedAt(actual.lastUpdatedAt())
+                .build();
+        PromptTestAssertions.assertPromptEqual(actual, expected);
+        assertThat(actual.lastUpdatedAt()).isAfter(beforeMigration.lastUpdatedAt());
+    }
+
+    private void assertPromptUnchanged(
+            String apiKey,
+            String workspaceName,
+            UUID promptId,
+            Prompt beforeMigration) {
+        var actual = promptResourceClient.getPrompt(promptId, apiKey, workspaceName);
+        PromptTestAssertions.assertPromptEqual(actual, beforeMigration);
+    }
+
+    private void assertWorkspaceTrapped(WorkspacesService workspacesService, String workspaceId, String reason) {
+        assertThat(workspacesService.findPromptProjectMigrationSkippedWorkspaceIds()).contains(workspaceId);
+        assertThat(workspacesService.findById(workspaceId))
+                .hasValueSatisfying(w -> assertThat(w.promptProjectMigrationSkipReason()).isEqualTo(reason));
+    }
+
+    private long countMigrated(String apiKey, String workspaceName, List<UUID> promptIds) {
+        return promptIds.stream()
+                .map(id -> promptResourceClient.getPrompt(id, apiKey, workspaceName).projectId())
+                .filter(java.util.Objects::nonNull)
+                .count();
+    }
+
+    private String randomName(String prefix) {
+        return "%s-%s".formatted(prefix, RandomStringUtils.secure().nextAlphanumeric(32));
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/PromptProjectMigrationServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/PromptProjectMigrationServiceTest.java
@@ -465,6 +465,113 @@ class PromptProjectMigrationServiceTest {
     }
 
     /**
+     * Partial-batch all-ambiguous: a workspace with more orphans than {@code promptBatchSize}
+     * whose current batch happens to be entirely ambiguous must NOT be trapped on this cycle —
+     * the workspace may still have non-ambiguous orphans on the next page. Without the
+     * {@code isTailBatch} guard this is a silent data-loss path: workspace gets permanently
+     * excluded after cycle 1 and the remaining orphans are stranded.
+     *
+     * <p>Known residual: when every orphan in the workspace is genuinely ambiguous,
+     * {@code findOrphanPromptIds} keeps returning a full {@code BATCH_SIZE}-sized page each
+     * cycle so {@code isTailBatch} stays false forever and the workspace cycles indefinitely
+     * without trapping. The indefinite cycle is annoying (visible in metrics / logs) but is
+     * strictly better than the silent-data-loss alternative. Closing this cleanly requires
+     * {@code ORDER BY id ASC} + cursor-style spillover in {@code findOrphanPromptIds} and is
+     * a follow-up to this PR.
+     */
+    @Test
+    void partialBatchAllAmbiguousDoesNotTrap(WorkspacesService workspacesService) {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        // Two distinct alive projects shared across every ambiguous prompt so each prompt's
+        // classification has projectCount == 2 → AMBIGUOUS bucket.
+        var projectName1 = randomName("project");
+        var projectId1 = createProject(apiKey, workspaceName, projectName1);
+        var dataset1 = createDatasetWithProject(apiKey, workspaceName, projectId1);
+        var projectName2 = randomName("project");
+        var projectId2 = createProject(apiKey, workspaceName, projectName2);
+        var dataset2 = createDatasetWithProject(apiKey, workspaceName, projectId2);
+
+        // BATCH_SIZE + 2 ambiguous prompts: cycle 1 fetches BATCH_SIZE (non-tail, all-ambiguous),
+        // so the guard defers the trap. None get migrated either, so the workspace remains
+        // eligible — which is the correctness contract we're protecting.
+        var promptIds = new ArrayList<UUID>();
+        for (int i = 0; i < BATCH_SIZE + 2; i++) {
+            var link = createOrphanPromptVersion(apiKey, workspaceName);
+            createExperimentInProject(apiKey, workspaceName, dataset1, projectId1, projectName1, link, null);
+            createExperimentInProject(apiKey, workspaceName, dataset2, projectId2, projectName2, link, null);
+            promptIds.add(link.promptId());
+        }
+
+        migrationService.runMigrationCycle().block();
+
+        assertThat(countMigrated(apiKey, workspaceName, promptIds))
+                .as("cycle 1 must not migrate any ambiguous prompt")
+                .isZero();
+        assertWorkspaceNotTrapped(workspacesService, workspaceId);
+    }
+
+    /**
+     * Partial-batch mixed buckets: a workspace with more orphans than {@code promptBatchSize}
+     * whose current batch contains both certain and ambiguous prompts must migrate the certain
+     * prompts and NOT trap on the post-write decision — the workspace still has more orphans
+     * (including the ambiguous remainder) for the next cycle. Without the {@code isTailBatch}
+     * guard the post-write trap fires and strands the rest.
+     */
+    @Test
+    void partialBatchMixedAmbiguousAndCertainDoesNotTrap(WorkspacesService workspacesService) {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        // One alive project for the certain bucket, two alive projects for the ambiguous bucket.
+        var certainProjectName = randomName("project");
+        var certainProjectId = createProject(apiKey, workspaceName, certainProjectName);
+        var certainDataset = createDatasetWithProject(apiKey, workspaceName, certainProjectId);
+        var ambiguousProjectName1 = randomName("project");
+        var ambiguousProjectId1 = createProject(apiKey, workspaceName, ambiguousProjectName1);
+        var ambiguousDataset1 = createDatasetWithProject(apiKey, workspaceName, ambiguousProjectId1);
+        var ambiguousProjectName2 = randomName("project");
+        var ambiguousProjectId2 = createProject(apiKey, workspaceName, ambiguousProjectName2);
+        var ambiguousDataset2 = createDatasetWithProject(apiKey, workspaceName, ambiguousProjectId2);
+
+        // 51 certain + 51 ambiguous = BATCH_SIZE + 2 total. Pigeonhole: any 100-of-102 slice must
+        // include at least 49 of each bucket — cycle 1's batch is guaranteed to have both certain
+        // and ambiguous prompts regardless of MySQL fetch order.
+        int perBucket = (BATCH_SIZE + 2) / 2;
+        var certainPromptIds = new ArrayList<UUID>();
+        for (int i = 0; i < perBucket; i++) {
+            var link = createOrphanPromptVersion(apiKey, workspaceName);
+            createExperimentInProject(apiKey, workspaceName, certainDataset, certainProjectId, certainProjectName,
+                    link, null);
+            certainPromptIds.add(link.promptId());
+        }
+        var ambiguousPromptIds = new ArrayList<UUID>();
+        for (int i = 0; i < perBucket; i++) {
+            var link = createOrphanPromptVersion(apiKey, workspaceName);
+            createExperimentInProject(apiKey, workspaceName, ambiguousDataset1, ambiguousProjectId1,
+                    ambiguousProjectName1, link, null);
+            createExperimentInProject(apiKey, workspaceName, ambiguousDataset2, ambiguousProjectId2,
+                    ambiguousProjectName2, link, null);
+            ambiguousPromptIds.add(link.promptId());
+        }
+
+        migrationService.runMigrationCycle().block();
+
+        assertThat(countMigrated(apiKey, workspaceName, certainPromptIds))
+                .as("cycle 1 must migrate at least some certain prompts in the batch")
+                .isPositive();
+        assertThat(countMigrated(apiKey, workspaceName, ambiguousPromptIds))
+                .as("ambiguous prompts are never written by the cycle")
+                .isZero();
+        assertWorkspaceNotTrapped(workspacesService, workspaceId);
+    }
+
+    /**
      * Edge case for {@code mergeAssignments}: when the workspace's Default Project happens to
      * coincide with a {@code certainAssignments} key (an experiment legitimately references the
      * Default Project), the merge function unions the two prompt sets rather than letting either
@@ -632,6 +739,10 @@ class PromptProjectMigrationServiceTest {
         assertThat(workspacesService.findPromptProjectMigrationSkippedWorkspaceIds()).contains(workspaceId);
         assertThat(workspacesService.findById(workspaceId))
                 .hasValueSatisfying(w -> assertThat(w.promptProjectMigrationSkipReason()).isEqualTo(reason));
+    }
+
+    private void assertWorkspaceNotTrapped(WorkspacesService workspacesService, String workspaceId) {
+        assertThat(workspacesService.findPromptProjectMigrationSkippedWorkspaceIds()).doesNotContain(workspaceId);
     }
 
     private long countMigrated(String apiKey, String workspaceName, List<UUID> promptIds) {

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -796,6 +796,24 @@ datasetProjectMigration:
   # idle window and don't churn on every tick.
   schedulerThreadTtl: 10s
 
+# Prompt Project Migration configuration (D4)
+# Assigns project_id to orphan prompts (V1 → V2 workspace migration). Runs as a recurring job.
+promptProjectMigration:
+  # Master switch — disabled in tests by default; tests opt in via CustomConfig overrides.
+  enabled: false
+  workspacesPerRun: 20
+  promptBatchSize: 1000
+  interval: 5s
+  # Non-zero so the first scheduled fire lands after the JobTest's initial seed + prime.
+  # ServiceTest disables the job entirely and drives the cycle directly via runMigrationCycle().
+  startupDelay: 5s
+  lockTimeout: 5s
+  lockWaitTime: 100ms
+  jobTimeout: 30s
+  schedulerThreadCap: 2
+  schedulerQueuedTaskCap: 50
+  schedulerThreadTtl: 10s
+
 # Shared configuration for V1 → V2 entity project migration jobs
 # Centralised so all migration jobs (experiments, datasets, etc.) share the same exclusion list
 migration:


### PR DESCRIPTION
## Details

D4 of the V1 → V2 workspace migration plan: a recurring Quartz job that assigns `project_id` to V1 (workspace-scoped) orphan prompts.

The cycle mirrors D1 + OPIK-6579 structurally — same Managed + scheduler-isolation shape, same four-bucket classification (certain → assigned, certain-deleted → Default, no-inference → Default, ambiguous → skip), same `all_ambiguous` workspace trap. Differs only in the SQL: eligibility is a pure MySQL scan of the `prompts` table; classification reads experiments in ClickHouse and maps each orphan prompt to a project via either the legacy `prompt_id` column or the modern `prompt_versions` map.

**What ships**

- Liquibase 000076 — `prompt_project_migration_skipped_at` / `_skip_reason` columns + index on `workspaces`, placed adjacent to the existing experiment / dataset trap pairs.
- `WorkspacesService` / `WorkspacesDAO` gain the prompt mark / find methods.
- New `PromptProjectMigrationConfig`, `PromptProjectMigrationService` (Managed) and `PromptProjectMigrationJob` (Quartz, interruptible, distributed-lock-guarded). Wired into `OpikConfiguration`, `config.yml` (with `PROMPT_PROJECT_MIGRATION_*` env-var overrides), and `OpikGuiceyLifecycleEventListener`.
- `PromptDAO` gains eligibility / orphan-IDs / batch-UPDATE queries; `ExperimentDAO.computePromptProjectClassification` returns the `(projectId, projectCount)` shape per orphan prompt.
- `findOrphanPromptIds.LIMIT` bounds per-workspace per-cycle memory and the ClickHouse `IN` list — oversized workspaces drain across cycles.
- Metrics emitted under `opik.migration.prompt_project.*`.

**Design notes**

- **No `d1PrerequisiteComplete` startup gate**: ordering is enforced via the rollout runbook. D4 must only be enabled after D1 + OPIK-6579 are fully shipped — without that, almost every prompt falls through to the no-inference bucket.
- **No `default_project_missing` trap**: `projectService.getOrCreate` provisions the Default Project in-line (same path trace ingestion uses), matching the OPIK-6579 design.

**Pre-merge action item** (operational, not a code change)

- Run the demo-audit query from the ticket against prod and extend `DemoData.PROMPTS` if any obvious demo / sample / tutorial pattern appears in the top-50 orphan-prompt names.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-6188

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation (Java migration trio, SQL queries, schema migration, integration tests) with iterative code-review feedback
- Human verification: design review, local integration-test runs against MySQL + ClickHouse + Redis testcontainers, manual inspection of generated SQL and reactive flow

## Testing

- `mvn test -Dtest='PromptProjectMigrationServiceTest,PromptProjectMigrationJobTest'` — 13 tests (12 service + 1 Quartz wiring smoke), green locally
- Regression run against D1: `mvn test -Dtest='ExperimentProjectMigrationServiceTest,ExperimentProjectMigrationJobTest'` — 9 tests, green
- Regression run against the three pre-existing prompt resource tests that now reuse the centralised `PromptTestAssertions.PROMPT_IGNORED_FIELDS`: `PromptResourceTest*` (266), `PromptResourceFindProjectPromptsTest` (46), `PromptResourceProjectScopedPromptsTest` (5) — all green
- Scenarios validated by the new ServiceTest suite:
  - certain prompt via legacy `prompt_id`, modern `prompt_versions`, and both paths simultaneously
  - mixed workspace covering all four buckets in one cycle (certain / deleted-project / no-inference / ambiguous) with `all_ambiguous` post-write trap
  - no-inference when zero referencing experiments
  - no-inference when all referencing experiments are still orphan post-D1
  - all-ambiguous pre-write short-circuit trap
  - demo prompts excluded from migration
  - env-excluded and pre-trapped workspaces never touched
  - idempotency on re-run
  - multi-workspace cycle (smallest-first iteration)
  - oversized-workspace pagination spillover across cycles
  - `mergeAssignments` Default-Project / certain-project key collision union
- CI will run the full backend test suite + Spotless + lint on submission

## Documentation

N/A — internal migration job; operator-facing docs (runbook + Grafana dashboard) tracked as follow-up tickets per the parent epic OPIK-6182.