### PR TITLE
[NA] [FE] replace Get Help with View Docs link on get started page

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationExplorer/IntegrationGetHelp.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationExplorer/IntegrationGetHelp.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Button } from "@/ui/button";
-import { HelpCircle } from "lucide-react";
+import { BookOpen } from "lucide-react";
 import HelpGuideDialog from "@/v2/pages-shared/onboarding/IntegrationExplorer/components/HelpGuideDialog";
 import { useIntegrationExplorer } from "@/v2/pages-shared/onboarding/IntegrationExplorer/IntegrationExplorerContext";
+import { buildDocsUrl } from "@/v2/lib/utils";
 
 type IntegrationGetHelpProps = {
   className?: string;
@@ -11,7 +12,7 @@ type IntegrationGetHelpProps = {
 
 const IntegrationGetHelp: React.FunctionComponent<IntegrationGetHelpProps> = ({
   className,
-  label = "Get help",
+  label = "View docs",
 }) => {
   const { helpGuideDialogOpen, setHelpGuideDialogOpen } =
     useIntegrationExplorer();
@@ -25,13 +26,15 @@ const IntegrationGetHelp: React.FunctionComponent<IntegrationGetHelpProps> = ({
       <Button
         variant="outline"
         size="sm"
-        onClick={() => handleOpenChange(true)}
         className={className}
         id="integration-get-help-button"
         data-fs-element="IntegrationGetHelpButton"
+        asChild
       >
-        <HelpCircle className="mr-1.5 size-3.5" />
-        {label}
+        <a href={buildDocsUrl()} target="_blank" rel="noopener noreferrer">
+          <BookOpen className="mr-1.5 size-3.5" />
+          {label}
+        </a>
       </Button>
 
       <HelpGuideDialog


### PR DESCRIPTION
## Details

Replaces the "Get Help" button (which opened a modal) on the get started / onboarding page with a "View docs" link that goes directly to the Opik documentation (`https://www.comet.com/docs/opik?from=llm`). The icon is updated from `HelpCircle` to `BookOpen`. The help guide dialog code is retained in the component for potential future use.

## Change checklist

- [x] I have added tests for the changes (N/A — UI copy/link change)
- [x] I have updated the documentation if needed (N/A)

## Issues

N/A

## AI-WATERMARK

This PR was generated with the assistance of Claude Code.

## Testing

Verified visually on the get started page (`/get-started`). Button renders as "View docs" with a book icon and opens the docs URL in a new tab.

## Documentation

N/A