### PR TITLE
[NA] [BE] refactor: use version number in restored prompt description

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -865,7 +865,7 @@ class PromptServiceImpl implements PromptService {
                 .id(newVersionId)
                 .commit(newCommit)
                 .createdBy(userName)
-                .changeDescription("Restored from version " + versionToRestore.commit())
+                .changeDescription("Restored from version " + versionToRestore.versionNumber())
                 .tags(null) // Don't propagate tags to restored version
                 .environment(null) // Don't propagate environment ownership to restored version
                 .build();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -861,11 +861,13 @@ class PromptServiceImpl implements PromptService {
         UUID newVersionId = idGenerator.generateId();
         String newCommit = CommitUtils.getCommit(newVersionId);
 
+        String versionRef = StringUtils.defaultIfBlank(versionToRestore.versionNumber(), versionToRestore.commit());
+
         PromptVersion newVersion = versionToRestore.toBuilder()
                 .id(newVersionId)
                 .commit(newCommit)
                 .createdBy(userName)
-                .changeDescription("Restored from version " + versionToRestore.versionNumber())
+                .changeDescription("Restored from version " + versionRef)
                 .tags(null) // Don't propagate tags to restored version
                 .environment(null) // Don't propagate environment ownership to restored version
                 .build();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -3012,7 +3012,7 @@ class PromptResourceTest {
 
                 // Additional checks specific to restore semantics
                 assertThat(restoredVersion.changeDescription())
-                        .isEqualTo("Restored from version " + createdV1.commit());
+                        .isEqualTo("Restored from version " + createdV1.versionNumber());
                 assertThat(restoredVersion.id()).isNotEqualTo(createdV1.id());
                 assertThat(restoredVersion.id()).isNotEqualTo(createdV2.id());
                 assertThat(restoredVersion.commit()).isNotEqualTo(createdV1.commit());


### PR DESCRIPTION
## Details

Updates `PromptService.restorePromptVersion` to set the restored version's `change_description` to `"Restored from version <versionNumber>"` (e.g. `Restored from version v1`) instead of the opaque commit hash. This is a small UX improvement so users see a human-friendly reference to the restored source version.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: full implementation (one-line change + test assertion update)
- Human verification: code review + targeted test run

## Testing

- `mvn test -Dtest='PromptResourceTest$RestorePromptVersionTests' -pl apps/opik-backend` — both tests pass (2/2)
- `mvn compile -DskipTests` — clean
- `mvn spotless:check` — clean
- Existing `shouldRestorePromptVersion` test asserts `change_description == "Restored from version " + createdV1.versionNumber()` and confirms via response body the new value is `Restored from version v1`.

## Documentation

N/A — internal user-visible string only; no API contract change.