### PR TITLE
[OPIK-6191] [BE] feat: implement migration job to assign project_id to alerts and split multi-project alerts

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1483,6 +1483,30 @@ automationRuleProjectMigration:
   schedulerQueuedTaskCap: ${AUTOMATION_RULE_PROJECT_MIGRATION_SCHEDULER_QUEUED_TASK_CAP:-100}
   schedulerThreadTtl: ${AUTOMATION_RULE_PROJECT_MIGRATION_SCHEDULER_THREAD_TTL:-60s}
 
+# Assigns project_id to orphan alerts and splits multi-project alerts (V1 → V2 workspace migration).
+# Runs as a recurring job, processing workspaces in batches.
+alertProjectMigration:
+  # Master switch — disabled by default, enable for staged rollout
+  enabled: ${ALERT_PROJECT_MIGRATION_ENABLED:-false}
+  # Number of workspaces to process per job run (smallest first)
+  workspacesPerRun: ${ALERT_PROJECT_MIGRATION_WORKSPACES_PER_RUN:-100}
+  # Number of orphan alerts to process per workspace per cycle
+  alertBatchSize: ${ALERT_PROJECT_MIGRATION_ALERT_BATCH_SIZE:-100}
+  # Interval between recurring job runs
+  interval: ${ALERT_PROJECT_MIGRATION_INTERVAL:-30s}
+  # Delay before first run after app startup
+  startupDelay: ${ALERT_PROJECT_MIGRATION_STARTUP_DELAY:-30s}
+  # Distributed lock timeout — prevents overlap across replicas.
+  lockTimeout: ${ALERT_PROJECT_MIGRATION_LOCK_TIMEOUT:-5m}
+  # Max time to wait for the distributed lock when another replica holds it.
+  lockWaitTime: ${ALERT_PROJECT_MIGRATION_LOCK_WAIT_TIME:-100ms}
+  # Per-cycle timeout — safety net for stuck cycles, not normal completion
+  jobTimeout: ${ALERT_PROJECT_MIGRATION_JOB_TIMEOUT:-1h}
+  # Dedicated reactor scheduler isolating this job from the shared boundedElastic.
+  schedulerThreadCap: ${ALERT_PROJECT_MIGRATION_SCHEDULER_THREAD_CAP:-4}
+  schedulerQueuedTaskCap: ${ALERT_PROJECT_MIGRATION_SCHEDULER_QUEUED_TASK_CAP:-100}
+  schedulerThreadTtl: ${ALERT_PROJECT_MIGRATION_SCHEDULER_THREAD_TTL:-60s}
+
 # Shared configuration for V1 → V2 entity project migration jobs
 # Centralised so all migration jobs (experiments, datasets, etc.) share the same exclusion list
 migration:

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/AlertProjectMigrationJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/AlertProjectMigrationJob.java
@@ -1,0 +1,133 @@
+package com.comet.opik.api.resources.v1.jobs;
+
+import com.comet.opik.domain.AlertProjectMigrationService;
+import com.comet.opik.infrastructure.AlertProjectMigrationConfig;
+import com.comet.opik.infrastructure.lock.LockService;
+import io.dropwizard.jobs.Job;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongHistogram;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.InterruptableJob;
+import org.quartz.JobExecutionContext;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.comet.opik.domain.AlertProjectMigrationService.METRIC_NAMESPACE;
+import static com.comet.opik.domain.AlertProjectMigrationService.RESULT_ERROR;
+import static com.comet.opik.domain.AlertProjectMigrationService.RESULT_KEY;
+import static com.comet.opik.infrastructure.lock.LockService.Lock;
+
+@Singleton
+@Slf4j
+@DisallowConcurrentExecution
+public class AlertProjectMigrationJob extends Job implements InterruptableJob {
+
+    private static final Lock JOB_LOCK = new Lock("opik_job", AlertProjectMigrationJob.class.getSimpleName());
+
+    private static final Attributes RESULT_SUCCESS = Attributes.of(RESULT_KEY, "success");
+    private static final Attributes RESULT_LOCK_SKIPPED = Attributes.of(RESULT_KEY, "lock_skipped");
+
+    private final AlertProjectMigrationService migrationService;
+    private final AlertProjectMigrationConfig config;
+    private final LockService lockService;
+
+    private final AtomicBoolean interrupted = new AtomicBoolean(false);
+    private final AtomicReference<Disposable> currentExecution = new AtomicReference<>();
+
+    private final LongHistogram cycleDuration;
+
+    @Inject
+    public AlertProjectMigrationJob(
+            @NonNull AlertProjectMigrationService migrationService,
+            @NonNull @Config("alertProjectMigration") AlertProjectMigrationConfig config,
+            @NonNull LockService lockService) {
+        this.migrationService = migrationService;
+        this.config = config;
+        this.lockService = lockService;
+
+        var meter = GlobalOpenTelemetry.get().getMeter(METRIC_NAMESPACE);
+        this.cycleDuration = meter
+                .histogramBuilder("%s.cycle.duration".formatted(METRIC_NAMESPACE))
+                .setDescription("Duration of an alert project migration cycle, tagged by result")
+                .setUnit("ms")
+                .ofLongs()
+                .build();
+    }
+
+    @Override
+    public void doJob(JobExecutionContext context) {
+        if (!config.enabled()) {
+            log.info("Alert project migration job is disabled, skipping");
+            return;
+        }
+        if (interrupted.get()) {
+            log.info("Alert project migration job was interrupted before execution, skipping");
+            return;
+        }
+        log.info("Starting alert project migration job");
+        var startMillis = System.currentTimeMillis();
+        var subscription = lockService.bestEffortLock(
+                JOB_LOCK,
+                Mono.defer(() -> {
+                    if (interrupted.get()) {
+                        log.info("Alert project migration was interrupted before processing, skipping");
+                        return Mono.empty();
+                    }
+                    return migrationService.runMigrationCycle()
+                            .timeout(config.jobTimeout().toJavaDuration())
+                            .doOnSuccess(unused -> {
+                                long durationMillis = System.currentTimeMillis() - startMillis;
+                                var duration = Duration.ofMillis(durationMillis);
+                                cycleDuration.record(durationMillis, RESULT_SUCCESS);
+                                log.info("Alert project migration cycle finished, duration='{}'", duration);
+                            });
+                }),
+                Mono.defer(() -> {
+                    long durationMillis = System.currentTimeMillis() - startMillis;
+                    var duration = Duration.ofMillis(durationMillis);
+                    cycleDuration.record(durationMillis, RESULT_LOCK_SKIPPED);
+                    log.info("Could not acquire lock, another instance is already running, duration='{}'", duration);
+                    return Mono.empty();
+                }),
+                config.lockTimeout().toJavaDuration(),
+                config.lockWaitTime().toJavaDuration(),
+                false)
+                .onErrorResume(throwable -> {
+                    long durationMillis = System.currentTimeMillis() - startMillis;
+                    var duration = Duration.ofMillis(durationMillis);
+                    cycleDuration.record(durationMillis, RESULT_ERROR);
+                    if (interrupted.get()) {
+                        log.warn("Alert project migration was interrupted, duration='{}'", duration, throwable);
+                    } else {
+                        log.error("Alert project migration failed, duration='{}'", duration, throwable);
+                    }
+                    return Mono.empty();
+                })
+                .doFinally(signal -> currentExecution.set(null))
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe();
+        currentExecution.set(subscription);
+    }
+
+    @Override
+    public void interrupt() {
+        log.info("Interrupting alert project migration job");
+        interrupted.set(true);
+        var execution = currentExecution.get();
+        if (execution != null && !execution.isDisposed()) {
+            execution.dispose();
+            log.info("Alert project migration job interrupted successfully");
+        }
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertDAO.java
@@ -75,6 +75,7 @@ public interface AlertDAO {
                 WHERE a.workspace_id = :workspaceId
                     <if(id)> AND a.id = :id <endif>
                     <if(project_id)> AND a.project_id = :project_id <endif>
+                    <if(project_id_is_null)> AND a.project_id IS NULL <endif>
             ),
             trigger_ids AS (
                 SELECT id
@@ -316,7 +317,10 @@ public interface AlertDAO {
     @SqlQuery(FIND)
     @UseStringTemplateEngine
     @AllowUnusedBindings
-    List<Alert> findByWorkspaceId(@Bind("workspaceId") String workspaceId);
+    List<Alert> findByWorkspaceId(
+            @Bind("workspaceId") String workspaceId,
+            @Define("project_id_is_null") boolean projectIdIsNull,
+            @Define("limit") @Bind("limit") int limit);
 
     @SqlUpdate("UPDATE alerts SET project_id = :projectId WHERE id = :alertId AND workspace_id = :workspaceId")
     void updateAlertProjectId(@Bind("alertId") UUID alertId, @Bind("projectId") UUID projectId,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertDAO.java
@@ -18,6 +18,7 @@ import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.sqlobject.config.RegisterArgumentFactory;
 import org.jdbi.v3.sqlobject.config.RegisterColumnMapper;
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.AllowUnusedBindings;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -283,6 +284,56 @@ public interface AlertDAO {
                     WHERE  a.id IN (<ids>) AND a.workspace_id = :workspaceId;
             """)
     void delete(@BindList("ids") Set<UUID> ids, @Bind("workspaceId") String workspaceId);
+
+    record EligibleAlertWorkspace(String workspaceId, long alertCount) {
+    }
+
+    default List<EligibleAlertWorkspace> findEligibleAlertWorkspaces(Set<String> excludedWorkspaceIds, int limit) {
+        var excluded = new java.util.ArrayList<>(excludedWorkspaceIds);
+        var demoNames = DemoData.ALERTS;
+        return findEligibleAlertWorkspacesQuery(!excluded.isEmpty(), excluded, !demoNames.isEmpty(), demoNames, limit);
+    }
+
+    @SqlQuery("""
+            SELECT workspace_id, COUNT(*) AS alert_count
+            FROM alerts
+            WHERE project_id IS NULL
+            <if(hasExcluded)> AND workspace_id NOT IN (<excludedWorkspaceIds>) <endif>
+            <if(hasDemoNames)> AND name NOT IN (<demoNames>) <endif>
+            GROUP BY workspace_id
+            ORDER BY alert_count ASC
+            LIMIT :limit
+            """)
+    @UseStringTemplateEngine
+    @RegisterConstructorMapper(EligibleAlertWorkspace.class)
+    List<EligibleAlertWorkspace> findEligibleAlertWorkspacesQuery(
+            @Define("hasExcluded") boolean hasExcluded,
+            @BindList(onEmpty = BindList.EmptyHandling.NULL_VALUE) List<String> excludedWorkspaceIds,
+            @Define("hasDemoNames") boolean hasDemoNames,
+            @BindList(onEmpty = BindList.EmptyHandling.NULL_VALUE) List<String> demoNames,
+            @Bind("limit") int limit);
+
+    @SqlQuery(FIND)
+    @UseStringTemplateEngine
+    @AllowUnusedBindings
+    List<Alert> findByWorkspaceId(@Bind("workspaceId") String workspaceId);
+
+    @SqlUpdate("UPDATE alerts SET project_id = :projectId WHERE id = :alertId AND workspace_id = :workspaceId")
+    void updateAlertProjectId(@Bind("alertId") UUID alertId, @Bind("projectId") UUID projectId,
+            @Bind("workspaceId") String workspaceId);
+
+    @SqlUpdate("""
+            DELETE FROM alert_trigger_configs
+            WHERE alert_trigger_id IN (SELECT id FROM alert_triggers WHERE alert_id = :alertId)
+            AND config_type = 'scope:project'
+            """)
+    void deleteScopeProjectConfigs(@Bind("alertId") UUID alertId);
+
+    @SqlUpdate("DELETE FROM alert_trigger_configs WHERE alert_trigger_id IN (<triggerIds>)")
+    void deleteTriggerConfigsByIds(@BindList("triggerIds") Set<UUID> triggerIds);
+
+    @SqlUpdate("DELETE FROM alert_triggers WHERE id IN (<triggerIds>)")
+    void deleteTriggersByIds(@BindList("triggerIds") Set<UUID> triggerIds);
 
     @Slf4j
     class AlertWithWebhookRowMapper implements RowMapper<Alert> {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertDAO.java
@@ -286,12 +286,6 @@ public interface AlertDAO {
             """)
     void delete(@BindList("ids") Set<UUID> ids, @Bind("workspaceId") String workspaceId);
 
-    default List<EligibleAlertWorkspace> findEligibleAlertWorkspaces(Set<String> excludedWorkspaceIds, int limit) {
-        var excluded = new java.util.ArrayList<>(excludedWorkspaceIds);
-        var demoNames = DemoData.ALERTS;
-        return findEligibleAlertWorkspacesQuery(!excluded.isEmpty(), excluded, !demoNames.isEmpty(), demoNames, limit);
-    }
-
     @SqlQuery("""
             SELECT workspace_id, COUNT(*) AS alert_count
             FROM alerts
@@ -304,7 +298,7 @@ public interface AlertDAO {
             """)
     @UseStringTemplateEngine
     @RegisterConstructorMapper(EligibleAlertWorkspace.class)
-    List<EligibleAlertWorkspace> findEligibleAlertWorkspacesQuery(
+    List<EligibleAlertWorkspace> findEligibleAlertWorkspaces(
             @Define("hasExcluded") boolean hasExcluded,
             @BindList(onEmpty = BindList.EmptyHandling.NULL_VALUE) List<String> excludedWorkspaceIds,
             @Define("hasDemoNames") boolean hasDemoNames,
@@ -319,9 +313,9 @@ public interface AlertDAO {
             @Define("project_id_is_null") boolean projectIdIsNull,
             @Define("limit") @Bind("limit") int limit);
 
-    @SqlUpdate("UPDATE alerts SET project_id = :projectId WHERE id = :alertId AND workspace_id = :workspaceId")
+    @SqlUpdate("UPDATE alerts SET project_id = :projectId, last_updated_by = :userName WHERE id = :alertId AND workspace_id = :workspaceId")
     void updateAlertProjectId(@Bind("alertId") UUID alertId, @Bind("projectId") UUID projectId,
-            @Bind("workspaceId") String workspaceId);
+            @Bind("workspaceId") String workspaceId, @Bind("userName") String userName);
 
     @SqlUpdate("""
             DELETE FROM alert_trigger_configs

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertDAO.java
@@ -286,9 +286,6 @@ public interface AlertDAO {
             """)
     void delete(@BindList("ids") Set<UUID> ids, @Bind("workspaceId") String workspaceId);
 
-    record EligibleAlertWorkspace(String workspaceId, long alertCount) {
-    }
-
     default List<EligibleAlertWorkspace> findEligibleAlertWorkspaces(Set<String> excludedWorkspaceIds, int limit) {
         var excluded = new java.util.ArrayList<>(excludedWorkspaceIds);
         var demoNames = DemoData.ALERTS;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertProjectMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertProjectMigrationService.java
@@ -50,8 +50,6 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 @Singleton
 public class AlertProjectMigrationService implements Managed {
 
-    private static final int MAX_ORPHAN_ALERTS_PER_WORKSPACE = 100;
-
     public static final String METRIC_NAMESPACE = "opik.migration.alert_project";
     public static final AttributeKey<String> RESULT_KEY = stringKey("result");
     public static final AttributeKey<String> REASON_KEY = stringKey("reason");
@@ -184,9 +182,9 @@ public class AlertProjectMigrationService implements Managed {
     }
 
     private void doMigrateWorkspace(String workspaceId, long startMillis) {
-        var orphanAlerts = transactionTemplate.inTransaction(READ_ONLY,
+        List<Alert> orphanAlerts = transactionTemplate.inTransaction(READ_ONLY,
                 handle -> handle.attach(AlertDAO.class)
-                        .findByWorkspaceId(workspaceId, true, MAX_ORPHAN_ALERTS_PER_WORKSPACE));
+                        .findByWorkspaceId(workspaceId, true, config.alertBatchSize()));
 
         if (orphanAlerts.isEmpty()) {
             log.info("No orphan alerts found, workspaceId='{}'", workspaceId);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertProjectMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertProjectMigrationService.java
@@ -30,7 +30,7 @@ import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
 import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -218,11 +218,11 @@ public class AlertProjectMigrationService implements Managed {
     private void migrateAlert(String workspaceId, Alert alert, Supplier<UUID> defaultProjectIdSupplier) {
         var rawProjectIds = collectScopeProjectIds(alert);
 
-        var validProjectIds = rawProjectIds.isEmpty()
-                ? Set.<UUID>of()
+        List<UUID> validProjectIds = rawProjectIds.isEmpty()
+                ? List.of()
                 : projectService.findByIds(workspaceId, rawProjectIds).stream()
                         .map(Project::id)
-                        .collect(Collectors.toUnmodifiableSet());
+                        .collect(Collectors.toUnmodifiableList());
 
         if (!rawProjectIds.isEmpty() && validProjectIds.size() < rawProjectIds.size()) {
             log.info(
@@ -237,7 +237,7 @@ public class AlertProjectMigrationService implements Managed {
             String workspaceId,
             Alert alert,
             Set<UUID> rawProjectIds,
-            Set<UUID> validProjectIds,
+            List<UUID> validProjectIds,
             Supplier<UUID> defaultProjectIdSupplier,
             Handle handle) {
         var alertDAO = handle.attach(AlertDAO.class);
@@ -256,10 +256,8 @@ public class AlertProjectMigrationService implements Managed {
         } else {
             // One or more valid projects. Group triggers per project.
             // null key holds workspace-wide + all-deleted-project triggers → own Default Project alert.
-            List<UUID> sortedProjectIds = validProjectIds.stream()
-                    .sorted(Comparator.comparing(UUID::toString))
-                    .collect(Collectors.toList());
-            UUID firstProjectId = sortedProjectIds.get(0);
+            // validProjectIds is already ordered by id (ORDER BY id in findByIds query).
+            UUID firstProjectId = validProjectIds.get(0);
 
             Map<UUID, List<AlertTrigger>> triggersByProject = groupTriggersByProject(alert, validProjectIds);
             List<AlertTrigger> defaultTriggers = triggersByProject.getOrDefault(null, List.of());
@@ -294,17 +292,17 @@ public class AlertProjectMigrationService implements Managed {
             }
 
             // Remaining valid projects get new alerts with only their own triggers.
-            for (int i = 1; i < sortedProjectIds.size(); i++) {
-                UUID projectId = sortedProjectIds.get(i);
+            for (int i = 1; i < validProjectIds.size(); i++) {
+                UUID projectId = validProjectIds.get(i);
                 List<AlertTrigger> triggersForProject = triggersByProject.getOrDefault(projectId, List.of());
                 cloneAlertForProject(workspaceId, alert, projectId, triggersForProject, handle);
                 newAlertsCreated.add(1);
             }
 
-            if (sortedProjectIds.size() > 1) {
+            if (validProjectIds.size() > 1) {
                 alertsSplit.add(1);
                 log.info("Alert split, workspaceId='{}', alertId='{}', projectCount='{}'",
-                        workspaceId, alert.id(), sortedProjectIds.size());
+                        workspaceId, alert.id(), validProjectIds.size());
             } else {
                 alertsAssigned.add(1);
                 log.info("Alert assigned to single project, workspaceId='{}', alertId='{}', projectId='{}'",
@@ -333,7 +331,7 @@ public class AlertProjectMigrationService implements Managed {
             String workspaceId,
             Alert alert,
             Set<UUID> rawProjectIds,
-            Set<UUID> validProjectIds,
+            List<UUID> validProjectIds,
             Supplier<UUID> defaultProjectIdSupplier) {
         transactionTemplate.inTransaction(WRITE, handle -> {
             executeAlertMigration(workspaceId, alert, rawProjectIds, validProjectIds, defaultProjectIdSupplier,
@@ -383,7 +381,7 @@ public class AlertProjectMigrationService implements Managed {
         }
     }
 
-    private Map<UUID, List<AlertTrigger>> groupTriggersByProject(Alert alert, Set<UUID> validProjectIds) {
+    private Map<UUID, List<AlertTrigger>> groupTriggersByProject(Alert alert, Collection<UUID> validProjectIds) {
         Map<UUID, List<AlertTrigger>> groups = new HashMap<>();
         if (alert.triggers() == null) {
             return groups;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertProjectMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertProjectMigrationService.java
@@ -393,7 +393,13 @@ public class AlertProjectMigrationService implements Managed {
                     if (StringUtils.isBlank(projectIdsStr)) {
                         return Stream.empty();
                     }
-                    return JsonUtils.<Set<UUID>>readCollectionValue(projectIdsStr, Set.class, UUID.class).stream();
+                    try {
+                        return JsonUtils.<Set<UUID>>readCollectionValue(projectIdsStr, Set.class, UUID.class).stream();
+                    } catch (Exception e) {
+                        log.warn("Skipping malformed '{}' value for trigger '{}', treating as workspace-wide",
+                                AlertTriggerConfig.PROJECT_IDS_CONFIG_KEY, trigger.id(), e);
+                        return Stream.empty();
+                    }
                 })
                 .collect(Collectors.toUnmodifiableSet());
     }
@@ -427,18 +433,7 @@ public class AlertProjectMigrationService implements Managed {
             return Set.of();
         }
         return alert.triggers().stream()
-                .filter(t -> t.triggerConfigs() != null)
-                .flatMap(t -> t.triggerConfigs().stream())
-                .filter(c -> c.type() == AlertTriggerConfigType.SCOPE_PROJECT)
-                .flatMap(c -> {
-                    var projectIdsStr = c.configValue() != null
-                            ? c.configValue().get(AlertTriggerConfig.PROJECT_IDS_CONFIG_KEY)
-                            : null;
-                    if (StringUtils.isBlank(projectIdsStr)) {
-                        return Stream.empty();
-                    }
-                    return JsonUtils.<Set<UUID>>readCollectionValue(projectIdsStr, Set.class, UUID.class).stream();
-                })
+                .flatMap(t -> extractTriggerProjectIds(t).stream())
                 .collect(Collectors.toUnmodifiableSet());
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertProjectMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertProjectMigrationService.java
@@ -63,6 +63,7 @@ public class AlertProjectMigrationService implements Managed {
 
     private final TransactionTemplate transactionTemplate;
     private final ProjectService projectService;
+    private final IdGenerator idGenerator;
     private final AlertProjectMigrationConfig config;
     private final MigrationConfig migrationConfig;
 
@@ -80,10 +81,12 @@ public class AlertProjectMigrationService implements Managed {
     public AlertProjectMigrationService(
             @NonNull TransactionTemplate transactionTemplate,
             @NonNull ProjectService projectService,
+            @NonNull IdGenerator idGenerator,
             @NonNull @Config("alertProjectMigration") AlertProjectMigrationConfig config,
             @NonNull @Config("migration") MigrationConfig migrationConfig) {
         this.transactionTemplate = transactionTemplate;
         this.projectService = projectService;
+        this.idGenerator = idGenerator;
         this.config = config;
         this.migrationConfig = migrationConfig;
 
@@ -152,9 +155,7 @@ public class AlertProjectMigrationService implements Managed {
             log.info(
                     "Starting alert project migration cycle, workspacesPerRun='{}', envExcludedWorkspaces='{}'",
                     config.workspacesPerRun(), envExcluded.size());
-            var eligible = transactionTemplate.inTransaction(READ_ONLY,
-                    handle -> handle.attach(AlertDAO.class).findEligibleAlertWorkspaces(envExcluded,
-                            config.workspacesPerRun()));
+            var eligible = fetchEligibleWorkspaces(envExcluded);
             cycleEligibleWorkspaces.record(eligible.size());
             if (eligible.isEmpty()) {
                 log.info("No workspaces with orphan alerts found, consider disabling the job");
@@ -182,9 +183,7 @@ public class AlertProjectMigrationService implements Managed {
     }
 
     private void doMigrateWorkspace(String workspaceId, long startMillis) {
-        List<Alert> orphanAlerts = transactionTemplate.inTransaction(READ_ONLY,
-                handle -> handle.attach(AlertDAO.class)
-                        .findByWorkspaceId(workspaceId, true, config.alertBatchSize()));
+        List<Alert> orphanAlerts = fetchOrphanAlerts(workspaceId);
 
         if (orphanAlerts.isEmpty()) {
             log.info("No orphan alerts found, workspaceId='{}'", workspaceId);
@@ -231,11 +230,7 @@ public class AlertProjectMigrationService implements Managed {
                     workspaceId, alert.id(), rawProjectIds.size(), validProjectIds.size());
         }
 
-        transactionTemplate.inTransaction(WRITE, handle -> {
-            executeAlertMigration(workspaceId, alert, rawProjectIds, validProjectIds, defaultProjectIdSupplier,
-                    handle);
-            return null;
-        });
+        executeMigrationTransaction(workspaceId, alert, rawProjectIds, validProjectIds, defaultProjectIdSupplier);
     }
 
     private void executeAlertMigration(
@@ -250,7 +245,7 @@ public class AlertProjectMigrationService implements Managed {
 
         if (validProjectIds.isEmpty()) {
             var defaultProjectId = defaultProjectIdSupplier.get();
-            alertDAO.updateAlertProjectId(alert.id(), defaultProjectId, workspaceId);
+            alertDAO.updateAlertProjectId(alert.id(), defaultProjectId, workspaceId, SYSTEM_USER);
             if (!isWorkspaceWide) {
                 alertDAO.deleteScopeProjectConfigs(alert.id());
             }
@@ -284,7 +279,7 @@ public class AlertProjectMigrationService implements Managed {
                     alertDAO.deleteTriggersByIds(toDelete);
                 }
             }
-            alertDAO.updateAlertProjectId(alert.id(), firstProjectId, workspaceId);
+            alertDAO.updateAlertProjectId(alert.id(), firstProjectId, workspaceId, SYSTEM_USER);
             alertDAO.deleteScopeProjectConfigs(alert.id());
 
             // Workspace-wide + deleted-project triggers get their own new Default Project alert.
@@ -318,10 +313,39 @@ public class AlertProjectMigrationService implements Managed {
         }
     }
 
+    private List<EligibleAlertWorkspace> fetchEligibleWorkspaces(Set<String> excluded) {
+        var excludedList = new ArrayList<>(excluded);
+        var demoNames = DemoData.ALERTS;
+        return transactionTemplate.inTransaction(READ_ONLY,
+                handle -> handle.attach(AlertDAO.class).findEligibleAlertWorkspaces(
+                        !excludedList.isEmpty(), excludedList,
+                        !demoNames.isEmpty(), demoNames,
+                        config.workspacesPerRun()));
+    }
+
+    private List<Alert> fetchOrphanAlerts(String workspaceId) {
+        return transactionTemplate.inTransaction(READ_ONLY,
+                handle -> handle.attach(AlertDAO.class)
+                        .findByWorkspaceId(workspaceId, true, config.alertBatchSize()));
+    }
+
+    private void executeMigrationTransaction(
+            String workspaceId,
+            Alert alert,
+            Set<UUID> rawProjectIds,
+            Set<UUID> validProjectIds,
+            Supplier<UUID> defaultProjectIdSupplier) {
+        transactionTemplate.inTransaction(WRITE, handle -> {
+            executeAlertMigration(workspaceId, alert, rawProjectIds, validProjectIds, defaultProjectIdSupplier,
+                    handle);
+            return null;
+        });
+    }
+
     private void cloneAlertForProject(String workspaceId, Alert source, UUID targetProjectId,
             List<AlertTrigger> triggers, Handle handle) {
-        var newAlertId = UUID.randomUUID();
-        var newWebhookId = UUID.randomUUID();
+        var newAlertId = idGenerator.generateId();
+        var newWebhookId = idGenerator.generateId();
 
         var newWebhook = source.webhook().toBuilder()
                 .id(newWebhookId)
@@ -404,13 +428,13 @@ public class AlertProjectMigrationService implements Managed {
     }
 
     private AlertTrigger cloneTrigger(AlertTrigger source, UUID newAlertId) {
-        var newTriggerId = UUID.randomUUID();
+        var newTriggerId = idGenerator.generateId();
         List<AlertTriggerConfig> nonScopeConfigs = source.triggerConfigs() == null
                 ? null
                 : source.triggerConfigs().stream()
                         .filter(c -> c.type() != AlertTriggerConfigType.SCOPE_PROJECT)
                         .map(c -> c.toBuilder()
-                                .id(UUID.randomUUID())
+                                .id(idGenerator.generateId())
                                 .alertTriggerId(newTriggerId)
                                 .createdAt(null)
                                 .lastUpdatedAt(null)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertProjectMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertProjectMigrationService.java
@@ -1,0 +1,448 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.Alert;
+import com.comet.opik.api.AlertTrigger;
+import com.comet.opik.api.AlertTriggerConfig;
+import com.comet.opik.api.AlertTriggerConfigType;
+import com.comet.opik.api.Project;
+import com.comet.opik.infrastructure.AlertProjectMigrationConfig;
+import com.comet.opik.infrastructure.MigrationConfig;
+import com.comet.opik.utils.JsonUtils;
+import io.dropwizard.lifecycle.Managed;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongGauge;
+import io.opentelemetry.api.metrics.LongHistogram;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.jdbi.v3.core.Handle;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
+import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.comet.opik.infrastructure.auth.RequestContext.SYSTEM_USER;
+import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
+import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+@Slf4j
+@Singleton
+public class AlertProjectMigrationService implements Managed {
+
+    public static final String METRIC_NAMESPACE = "opik.migration.alert_project";
+    public static final AttributeKey<String> RESULT_KEY = stringKey("result");
+    public static final AttributeKey<String> REASON_KEY = stringKey("reason");
+    public static final Attributes RESULT_ERROR = Attributes.of(RESULT_KEY, "error");
+
+    private static final Attributes RESULT_MIGRATED = Attributes.of(RESULT_KEY, "migrated");
+    private static final Attributes RESULT_NO_ORPHAN_ALERTS = Attributes.of(RESULT_KEY, "no_orphan_alerts");
+
+    private static final Attributes REASON_WORKSPACE_WIDE = Attributes.of(REASON_KEY, "workspace_wide");
+    private static final Attributes REASON_ALL_PROJECTS_DELETED = Attributes.of(REASON_KEY, "all_projects_deleted");
+
+    private final TransactionTemplate transactionTemplate;
+    private final ProjectService projectService;
+    private final AlertProjectMigrationConfig config;
+    private final MigrationConfig migrationConfig;
+
+    private final LongHistogram cycleEligibleWorkspaces;
+    private final LongGauge cycleEnvExcludedWorkspaces;
+    private final LongHistogram workspaceDuration;
+    private final LongCounter alertsAssigned;
+    private final LongCounter alertsSplit;
+    private final LongCounter newAlertsCreated;
+    private final LongCounter alertsAssignedToDefault;
+
+    private volatile Scheduler migrationScheduler;
+
+    @Inject
+    public AlertProjectMigrationService(
+            @NonNull TransactionTemplate transactionTemplate,
+            @NonNull ProjectService projectService,
+            @NonNull @Config("alertProjectMigration") AlertProjectMigrationConfig config,
+            @NonNull @Config("migration") MigrationConfig migrationConfig) {
+        this.transactionTemplate = transactionTemplate;
+        this.projectService = projectService;
+        this.config = config;
+        this.migrationConfig = migrationConfig;
+
+        var meter = GlobalOpenTelemetry.get().getMeter(METRIC_NAMESPACE);
+        this.cycleEligibleWorkspaces = meter
+                .histogramBuilder("%s.cycle.eligible_workspaces".formatted(METRIC_NAMESPACE))
+                .setDescription("Number of workspaces with orphan alerts found per cycle")
+                .ofLongs()
+                .build();
+        this.cycleEnvExcludedWorkspaces = meter
+                .gaugeBuilder("%s.cycle.env_excluded_workspaces".formatted(METRIC_NAMESPACE))
+                .setDescription("Number of workspaces excluded via MIGRATION_EXCLUDED_WORKSPACE_IDS env var")
+                .ofLongs()
+                .build();
+        this.workspaceDuration = meter
+                .histogramBuilder("%s.workspace.duration".formatted(METRIC_NAMESPACE))
+                .setDescription("Duration of a single workspace alert migration, tagged by result")
+                .setUnit("ms")
+                .ofLongs()
+                .build();
+        this.alertsAssigned = meter
+                .counterBuilder("%s.alerts.assigned".formatted(METRIC_NAMESPACE))
+                .setDescription("Number of alerts directly assigned to a single valid project")
+                .build();
+        this.alertsSplit = meter
+                .counterBuilder("%s.alerts.split".formatted(METRIC_NAMESPACE))
+                .setDescription("Number of source alerts that were split into multiple project-scoped alerts")
+                .build();
+        this.newAlertsCreated = meter
+                .counterBuilder("%s.new_alerts.created".formatted(METRIC_NAMESPACE))
+                .setDescription("Number of new alert rows inserted as a result of splits")
+                .build();
+        this.alertsAssignedToDefault = meter
+                .counterBuilder("%s.alerts.assigned_to_default".formatted(METRIC_NAMESPACE))
+                .setDescription("Number of alerts assigned to the Default Project, tagged by reason")
+                .build();
+    }
+
+    @Override
+    public void start() {
+        if (migrationScheduler == null) {
+            migrationScheduler = Schedulers.newBoundedElastic(
+                    config.schedulerThreadCap(),
+                    config.schedulerQueuedTaskCap(),
+                    "alert-project-migration-service",
+                    (int) config.schedulerThreadTtl().toJavaDuration().toSeconds(),
+                    true);
+            log.info(
+                    "Initialized alert project migration scheduler, threadCap='{}', queuedTaskCap='{}', threadTtl='{}'",
+                    config.schedulerThreadCap(), config.schedulerQueuedTaskCap(), config.schedulerThreadTtl());
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (migrationScheduler != null && !migrationScheduler.isDisposed()) {
+            migrationScheduler.dispose();
+            log.info("Alert project migration scheduler disposed");
+        }
+    }
+
+    public Mono<Void> runMigrationCycle() {
+        return Mono.fromCallable(() -> {
+            var envExcluded = migrationConfig.getExcludedWorkspaceIds();
+            cycleEnvExcludedWorkspaces.set(envExcluded.size());
+            log.info(
+                    "Starting alert project migration cycle, workspacesPerRun='{}', envExcludedWorkspaces='{}'",
+                    config.workspacesPerRun(), envExcluded.size());
+            var eligible = transactionTemplate.inTransaction(READ_ONLY,
+                    handle -> handle.attach(AlertDAO.class).findEligibleAlertWorkspaces(envExcluded,
+                            config.workspacesPerRun()));
+            cycleEligibleWorkspaces.record(eligible.size());
+            if (eligible.isEmpty()) {
+                log.info("No workspaces with orphan alerts found, consider disabling the job");
+            } else {
+                log.info("Found workspaces with orphan alerts, count='{}'", eligible.size());
+            }
+            return eligible;
+        })
+                .subscribeOn(migrationScheduler)
+                .flatMapMany(Flux::fromIterable)
+                .publishOn(migrationScheduler)
+                .concatMap(workspace -> migrateWorkspace(workspace.workspaceId()))
+                .then();
+    }
+
+    private Mono<Void> migrateWorkspace(String workspaceId) {
+        var startMillis = System.currentTimeMillis();
+        return Mono.<Void>fromRunnable(() -> doMigrateWorkspace(workspaceId, startMillis))
+                .subscribeOn(migrationScheduler)
+                .onErrorResume(throwable -> {
+                    log.error("Workspace migration failed, workspaceId='{}'", workspaceId, throwable);
+                    recordWorkspaceDuration(RESULT_ERROR, startMillis);
+                    return Mono.empty();
+                });
+    }
+
+    private void doMigrateWorkspace(String workspaceId, long startMillis) {
+        var orphanAlerts = transactionTemplate.inTransaction(READ_ONLY,
+                handle -> handle.attach(AlertDAO.class).findByWorkspaceId(workspaceId))
+                .stream()
+                .filter(alert -> alert.projectId() == null)
+                .toList();
+
+        if (orphanAlerts.isEmpty()) {
+            log.info("No orphan alerts found, workspaceId='{}'", workspaceId);
+            recordWorkspaceDuration(RESULT_NO_ORPHAN_ALERTS, startMillis);
+            return;
+        }
+
+        log.info("Migrating workspace, workspaceId='{}', orphanAlertCount='{}'",
+                workspaceId, orphanAlerts.size());
+
+        // Default Project is resolved lazily and at most once per workspace cycle.
+        UUID[] defaultProjectIdHolder = {null};
+        Supplier<UUID> defaultProjectIdSupplier = () -> {
+            if (defaultProjectIdHolder[0] == null) {
+                defaultProjectIdHolder[0] = projectService
+                        .getOrCreate(workspaceId, ProjectService.DEFAULT_PROJECT, SYSTEM_USER).id();
+                log.info("Resolved Default Project, workspaceId='{}', projectId='{}'",
+                        workspaceId, defaultProjectIdHolder[0]);
+            }
+            return defaultProjectIdHolder[0];
+        };
+
+        for (var alert : orphanAlerts) {
+            migrateAlert(workspaceId, alert, defaultProjectIdSupplier);
+        }
+
+        recordWorkspaceDuration(RESULT_MIGRATED, startMillis);
+        log.info("Workspace migration completed, workspaceId='{}', alertCount='{}'",
+                workspaceId, orphanAlerts.size());
+    }
+
+    private void migrateAlert(String workspaceId, Alert alert, Supplier<UUID> defaultProjectIdSupplier) {
+        var rawProjectIds = collectScopeProjectIds(alert);
+
+        var validProjectIds = rawProjectIds.isEmpty()
+                ? Set.<UUID>of()
+                : projectService.findByIds(workspaceId, rawProjectIds).stream()
+                        .map(Project::id)
+                        .collect(Collectors.toUnmodifiableSet());
+
+        if (!rawProjectIds.isEmpty() && validProjectIds.size() < rawProjectIds.size()) {
+            log.info(
+                    "Some project IDs no longer exist, workspaceId='{}', alertId='{}', raw='{}', valid='{}'",
+                    workspaceId, alert.id(), rawProjectIds.size(), validProjectIds.size());
+        }
+
+        transactionTemplate.inTransaction(WRITE, handle -> {
+            executeAlertMigration(workspaceId, alert, rawProjectIds, validProjectIds, defaultProjectIdSupplier,
+                    handle);
+            return null;
+        });
+    }
+
+    private void executeAlertMigration(
+            String workspaceId,
+            Alert alert,
+            Set<UUID> rawProjectIds,
+            Set<UUID> validProjectIds,
+            Supplier<UUID> defaultProjectIdSupplier,
+            Handle handle) {
+        var alertDAO = handle.attach(AlertDAO.class);
+        boolean isWorkspaceWide = rawProjectIds.isEmpty();
+
+        if (validProjectIds.isEmpty()) {
+            var defaultProjectId = defaultProjectIdSupplier.get();
+            alertDAO.updateAlertProjectId(alert.id(), defaultProjectId, workspaceId);
+            if (!isWorkspaceWide) {
+                alertDAO.deleteScopeProjectConfigs(alert.id());
+            }
+            alertsAssignedToDefault.add(1, isWorkspaceWide ? REASON_WORKSPACE_WIDE : REASON_ALL_PROJECTS_DELETED);
+            log.info("Alert assigned to Default Project, workspaceId='{}', alertId='{}', reason='{}'",
+                    workspaceId, alert.id(), isWorkspaceWide ? "workspace_wide" : "all_projects_deleted");
+
+        } else {
+            // One or more valid projects. Group triggers per project.
+            // null key holds workspace-wide + all-deleted-project triggers → own Default Project alert.
+            List<UUID> sortedProjectIds = validProjectIds.stream()
+                    .sorted(Comparator.comparing(UUID::toString))
+                    .collect(Collectors.toList());
+            UUID firstProjectId = sortedProjectIds.get(0);
+
+            Map<UUID, List<AlertTrigger>> triggersByProject = groupTriggersByProject(alert, validProjectIds);
+            List<AlertTrigger> defaultTriggers = triggersByProject.getOrDefault(null, List.of());
+            List<AlertTrigger> firstProjectTriggers = triggersByProject.getOrDefault(firstProjectId, List.of());
+
+            // Original alert keeps only first-project triggers; everything else is removed.
+            Set<UUID> keepIds = firstProjectTriggers.stream()
+                    .map(AlertTrigger::id)
+                    .collect(Collectors.toUnmodifiableSet());
+            if (alert.triggers() != null) {
+                Set<UUID> toDelete = alert.triggers().stream()
+                        .map(AlertTrigger::id)
+                        .filter(id -> !keepIds.contains(id))
+                        .collect(Collectors.toUnmodifiableSet());
+                if (!toDelete.isEmpty()) {
+                    alertDAO.deleteTriggerConfigsByIds(toDelete);
+                    alertDAO.deleteTriggersByIds(toDelete);
+                }
+            }
+            alertDAO.updateAlertProjectId(alert.id(), firstProjectId, workspaceId);
+            alertDAO.deleteScopeProjectConfigs(alert.id());
+
+            // Workspace-wide + deleted-project triggers get their own new Default Project alert.
+            if (!defaultTriggers.isEmpty()) {
+                UUID defaultProjectId = defaultProjectIdSupplier.get();
+                cloneAlertForProject(workspaceId, alert, defaultProjectId, defaultTriggers, handle);
+                newAlertsCreated.add(1);
+                alertsAssignedToDefault.add(1, REASON_WORKSPACE_WIDE);
+                log.info(
+                        "Default Project alert created for workspace-wide/deleted triggers, workspaceId='{}', alertId='{}'",
+                        workspaceId, alert.id());
+            }
+
+            // Remaining valid projects get new alerts with only their own triggers.
+            for (int i = 1; i < sortedProjectIds.size(); i++) {
+                UUID projectId = sortedProjectIds.get(i);
+                List<AlertTrigger> triggersForProject = triggersByProject.getOrDefault(projectId, List.of());
+                cloneAlertForProject(workspaceId, alert, projectId, triggersForProject, handle);
+                newAlertsCreated.add(1);
+            }
+
+            if (sortedProjectIds.size() > 1) {
+                alertsSplit.add(1);
+                log.info("Alert split, workspaceId='{}', alertId='{}', projectCount='{}'",
+                        workspaceId, alert.id(), sortedProjectIds.size());
+            } else {
+                alertsAssigned.add(1);
+                log.info("Alert assigned to single project, workspaceId='{}', alertId='{}', projectId='{}'",
+                        workspaceId, alert.id(), firstProjectId);
+            }
+        }
+    }
+
+    private void cloneAlertForProject(String workspaceId, Alert source, UUID targetProjectId,
+            List<AlertTrigger> triggers, Handle handle) {
+        var newAlertId = UUID.randomUUID();
+        var newWebhookId = UUID.randomUUID();
+
+        var newWebhook = source.webhook().toBuilder()
+                .id(newWebhookId)
+                .name("Webhook for alert " + newAlertId)
+                .createdAt(null)
+                .lastUpdatedAt(null)
+                .createdBy(SYSTEM_USER)
+                .lastUpdatedBy(SYSTEM_USER)
+                .build();
+        handle.attach(WebhookDAO.class).save(workspaceId, newWebhook);
+
+        var newAlert = source.toBuilder()
+                .id(newAlertId)
+                .projectId(targetProjectId)
+                .createdAt(null)
+                .lastUpdatedAt(null)
+                .createdBy(SYSTEM_USER)
+                .lastUpdatedBy(SYSTEM_USER)
+                .build();
+        handle.attach(AlertDAO.class).save(workspaceId, newAlert, newWebhookId);
+
+        if (CollectionUtils.isNotEmpty(triggers)) {
+            var newTriggers = triggers.stream()
+                    .map(trigger -> cloneTrigger(trigger, newAlertId))
+                    .toList();
+            handle.attach(AlertTriggerDAO.class).saveBatch(newTriggers);
+
+            var newConfigs = newTriggers.stream()
+                    .filter(t -> CollectionUtils.isNotEmpty(t.triggerConfigs()))
+                    .flatMap(t -> t.triggerConfigs().stream())
+                    .toList();
+            if (!newConfigs.isEmpty()) {
+                handle.attach(AlertTriggerConfigDAO.class).saveBatch(newConfigs);
+            }
+        }
+    }
+
+    private Map<UUID, List<AlertTrigger>> groupTriggersByProject(Alert alert, Set<UUID> validProjectIds) {
+        Map<UUID, List<AlertTrigger>> groups = new HashMap<>();
+        if (alert.triggers() == null) {
+            return groups;
+        }
+        for (var trigger : alert.triggers()) {
+            var validForTrigger = extractTriggerProjectIds(trigger).stream()
+                    .filter(validProjectIds::contains)
+                    .collect(Collectors.toUnmodifiableSet());
+            if (validForTrigger.isEmpty()) {
+                groups.computeIfAbsent(null, k -> new ArrayList<>()).add(trigger);
+            } else {
+                for (var projectId : validForTrigger) {
+                    groups.computeIfAbsent(projectId, k -> new ArrayList<>()).add(trigger);
+                }
+            }
+        }
+        return groups;
+    }
+
+    private Set<UUID> extractTriggerProjectIds(AlertTrigger trigger) {
+        if (trigger.triggerConfigs() == null) {
+            return Set.of();
+        }
+        return trigger.triggerConfigs().stream()
+                .filter(c -> c.type() == AlertTriggerConfigType.SCOPE_PROJECT)
+                .flatMap(c -> {
+                    var projectIdsStr = c.configValue() != null
+                            ? c.configValue().get(AlertTriggerConfig.PROJECT_IDS_CONFIG_KEY)
+                            : null;
+                    if (StringUtils.isBlank(projectIdsStr)) {
+                        return Stream.empty();
+                    }
+                    return JsonUtils.<Set<UUID>>readCollectionValue(projectIdsStr, Set.class, UUID.class).stream();
+                })
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private AlertTrigger cloneTrigger(AlertTrigger source, UUID newAlertId) {
+        var newTriggerId = UUID.randomUUID();
+        List<AlertTriggerConfig> nonScopeConfigs = source.triggerConfigs() == null
+                ? null
+                : source.triggerConfigs().stream()
+                        .filter(c -> c.type() != AlertTriggerConfigType.SCOPE_PROJECT)
+                        .map(c -> c.toBuilder()
+                                .id(UUID.randomUUID())
+                                .alertTriggerId(newTriggerId)
+                                .createdAt(null)
+                                .lastUpdatedAt(null)
+                                .createdBy(SYSTEM_USER)
+                                .lastUpdatedBy(SYSTEM_USER)
+                                .build())
+                        .toList();
+        return source.toBuilder()
+                .id(newTriggerId)
+                .alertId(newAlertId)
+                .createdAt(null)
+                .createdBy(SYSTEM_USER)
+                .triggerConfigs(nonScopeConfigs)
+                .build();
+    }
+
+    private Set<UUID> collectScopeProjectIds(Alert alert) {
+        if (alert.triggers() == null) {
+            return Set.of();
+        }
+        return alert.triggers().stream()
+                .filter(t -> t.triggerConfigs() != null)
+                .flatMap(t -> t.triggerConfigs().stream())
+                .filter(c -> c.type() == AlertTriggerConfigType.SCOPE_PROJECT)
+                .flatMap(c -> {
+                    var projectIdsStr = c.configValue() != null
+                            ? c.configValue().get(AlertTriggerConfig.PROJECT_IDS_CONFIG_KEY)
+                            : null;
+                    if (StringUtils.isBlank(projectIdsStr)) {
+                        return Stream.empty();
+                    }
+                    return JsonUtils.<Set<UUID>>readCollectionValue(projectIdsStr, Set.class, UUID.class).stream();
+                })
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private void recordWorkspaceDuration(Attributes resultAttributes, long startMillis) {
+        workspaceDuration.record(System.currentTimeMillis() - startMillis, resultAttributes);
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertProjectMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertProjectMigrationService.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -48,6 +49,8 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 @Slf4j
 @Singleton
 public class AlertProjectMigrationService implements Managed {
+
+    private static final int MAX_ORPHAN_ALERTS_PER_WORKSPACE = 100;
 
     public static final String METRIC_NAMESPACE = "opik.migration.alert_project";
     public static final AttributeKey<String> RESULT_KEY = stringKey("result");
@@ -165,7 +168,7 @@ public class AlertProjectMigrationService implements Managed {
                 .subscribeOn(migrationScheduler)
                 .flatMapMany(Flux::fromIterable)
                 .publishOn(migrationScheduler)
-                .concatMap(workspace -> migrateWorkspace(workspace.workspaceId()))
+                .flatMap(workspace -> migrateWorkspace(workspace.workspaceId()), config.schedulerThreadCap())
                 .then();
     }
 
@@ -182,10 +185,8 @@ public class AlertProjectMigrationService implements Managed {
 
     private void doMigrateWorkspace(String workspaceId, long startMillis) {
         var orphanAlerts = transactionTemplate.inTransaction(READ_ONLY,
-                handle -> handle.attach(AlertDAO.class).findByWorkspaceId(workspaceId))
-                .stream()
-                .filter(alert -> alert.projectId() == null)
-                .toList();
+                handle -> handle.attach(AlertDAO.class)
+                        .findByWorkspaceId(workspaceId, true, MAX_ORPHAN_ALERTS_PER_WORKSPACE));
 
         if (orphanAlerts.isEmpty()) {
             log.info("No orphan alerts found, workspaceId='{}'", workspaceId);
@@ -197,15 +198,15 @@ public class AlertProjectMigrationService implements Managed {
                 workspaceId, orphanAlerts.size());
 
         // Default Project is resolved lazily and at most once per workspace cycle.
-        UUID[] defaultProjectIdHolder = {null};
+        AtomicReference<UUID> defaultProjectIdRef = new AtomicReference<>();
         Supplier<UUID> defaultProjectIdSupplier = () -> {
-            if (defaultProjectIdHolder[0] == null) {
-                defaultProjectIdHolder[0] = projectService
-                        .getOrCreate(workspaceId, ProjectService.DEFAULT_PROJECT, SYSTEM_USER).id();
-                log.info("Resolved Default Project, workspaceId='{}', projectId='{}'",
-                        workspaceId, defaultProjectIdHolder[0]);
+            UUID id = defaultProjectIdRef.get();
+            if (id == null) {
+                id = projectService.getOrCreate(workspaceId, ProjectService.DEFAULT_PROJECT, SYSTEM_USER).id();
+                defaultProjectIdRef.set(id);
+                log.info("Resolved Default Project, workspaceId='{}', projectId='{}'", workspaceId, id);
             }
-            return defaultProjectIdHolder[0];
+            return id;
         };
 
         for (var alert : orphanAlerts) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertTriggerConfigDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AlertTriggerConfigDAO.java
@@ -23,7 +23,7 @@ interface AlertTriggerConfigDAO {
 
     @SqlBatch("INSERT INTO alert_trigger_configs (id, alert_trigger_id, config_type, config_value, group_index, created_by, last_updated_by, created_at) "
             +
-            "VALUES (:bean.id, :alertTriggerId, :bean.type, :bean.configValue, :bean.groupIndex, :bean.createdBy, :bean.lastUpdatedBy, COALESCE(:bean.createdAt, CURRENT_TIMESTAMP(6)))")
+            "VALUES (:bean.id, :bean.alertTriggerId, :bean.type, :bean.configValue, :bean.groupIndex, :bean.createdBy, :bean.lastUpdatedBy, COALESCE(:bean.createdAt, CURRENT_TIMESTAMP(6)))")
     void saveBatch(@BindMethods("bean") List<AlertTriggerConfig> alertTriggerConfigs);
 
     class AlertTriggerConfigTypeArgumentFactory extends AbstractArgumentFactory<AlertTriggerConfigType> {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DemoData.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DemoData.java
@@ -57,4 +57,7 @@ public class DemoData {
 
     /** MySQL (utf8mb4_unicode_ci) — matching is case-insensitive, no need for case variants. */
     public static final List<String> AUTOMATION_RULES = List.of();
+
+    /** MySQL (utf8mb4_unicode_ci) — matching is case-insensitive, no need for case variants. */
+    public static final List<String> ALERTS = List.of();
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EligibleAlertWorkspace.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EligibleAlertWorkspace.java
@@ -1,0 +1,8 @@
+package com.comet.opik.domain;
+
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder(toBuilder = true)
+public record EligibleAlertWorkspace(@NonNull String workspaceId, long alertCount) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
@@ -52,7 +52,7 @@ interface ProjectDAO {
     @SqlQuery("SELECT * FROM projects WHERE id = :id AND workspace_id = :workspaceId")
     Project findById(@Bind("id") UUID id, @Bind("workspaceId") String workspaceId);
 
-    @SqlQuery("SELECT * FROM projects WHERE id IN (<ids>) AND workspace_id = :workspaceId")
+    @SqlQuery("SELECT * FROM projects WHERE id IN (<ids>) AND workspace_id = :workspaceId ORDER BY id")
     List<Project> findByIds(@BindList("ids") Set<UUID> ids, @Bind("workspaceId") String workspaceId);
 
     @SqlQuery("SELECT COUNT(*) FROM projects " +

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/AlertProjectMigrationConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/AlertProjectMigrationConfig.java
@@ -1,0 +1,32 @@
+package com.comet.opik.infrastructure;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.dropwizard.util.Duration;
+import io.dropwizard.validation.MaxDuration;
+import io.dropwizard.validation.MinDuration;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.util.concurrent.TimeUnit;
+
+@Builder(toBuilder = true)
+public record AlertProjectMigrationConfig(
+        boolean enabled,
+        @Min(1) @Max(200) int workspacesPerRun,
+        @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 1, unit = TimeUnit.HOURS) Duration interval,
+        @NotNull @MinDuration(value = 0, unit = TimeUnit.SECONDS) @MaxDuration(value = 10, unit = TimeUnit.MINUTES) Duration startupDelay,
+        @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 30, unit = TimeUnit.MINUTES) Duration lockTimeout,
+        @NotNull @MinDuration(value = 50, unit = TimeUnit.MILLISECONDS) @MaxDuration(value = 5, unit = TimeUnit.SECONDS) Duration lockWaitTime,
+        @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 1, unit = TimeUnit.HOURS) Duration jobTimeout,
+        @Min(2) @Max(8) int schedulerThreadCap,
+        @Min(10) @Max(1_000) int schedulerQueuedTaskCap,
+        @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 1, unit = TimeUnit.HOURS) Duration schedulerThreadTtl) {
+
+    @JsonIgnore
+    @AssertTrue(message = "lockTimeout must be shorter than jobTimeout") public boolean isLockTimeoutShorterThanJobTimeout() {
+        return lockTimeout.toJavaDuration().compareTo(jobTimeout.toJavaDuration()) < 0;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/AlertProjectMigrationConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/AlertProjectMigrationConfig.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 public record AlertProjectMigrationConfig(
         boolean enabled,
         @Min(1) @Max(200) int workspacesPerRun,
+        @Min(1) @Max(10_000) int alertBatchSize,
         @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 1, unit = TimeUnit.HOURS) Duration interval,
         @NotNull @MinDuration(value = 0, unit = TimeUnit.SECONDS) @MaxDuration(value = 10, unit = TimeUnit.MINUTES) Duration startupDelay,
         @NotNull @MinDuration(value = 5, unit = TimeUnit.SECONDS) @MaxDuration(value = 30, unit = TimeUnit.MINUTES) Duration lockTimeout,

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
@@ -144,6 +144,9 @@ public class OpikConfiguration extends JobConfiguration {
             .build();
 
     @Valid @NotNull @JsonProperty
+    private AlertProjectMigrationConfig alertProjectMigration = AlertProjectMigrationConfig.builder().build();
+
+    @Valid @NotNull @JsonProperty
     private LocalRunnerConfig localRunner = new LocalRunnerConfig();
 
     @Valid @NotNull @JsonProperty

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListener.java
@@ -1,5 +1,6 @@
 package com.comet.opik.infrastructure.bi;
 
+import com.comet.opik.api.resources.v1.jobs.AlertProjectMigrationJob;
 import com.comet.opik.api.resources.v1.jobs.AutomationRuleProjectMigrationJob;
 import com.comet.opik.api.resources.v1.jobs.DatasetProjectMigrationJob;
 import com.comet.opik.api.resources.v1.jobs.DatasetVersionItemsTotalMigrationJob;
@@ -65,6 +66,7 @@ public class OpikGuiceyLifecycleEventListener implements GuiceyLifecycleListener
                 scheduleDatasetProjectMigrationJobIfEnabled();
                 schedulePromptProjectMigrationJobIfEnabled();
                 scheduleAutomationRuleProjectMigrationJobIfEnabled();
+                scheduleAlertProjectMigrationJobIfEnabled();
             }
 
             case GuiceyLifecycle.ApplicationShutdown -> shutdownJobManagerScheduler();
@@ -351,6 +353,17 @@ public class OpikGuiceyLifecycleEventListener implements GuiceyLifecycleListener
             return;
         }
         scheduleRepeatingJob(AutomationRuleProjectMigrationJob.class,
+                config.interval().toJavaDuration(),
+                config.startupDelay().toJavaDuration());
+    }
+
+    private void scheduleAlertProjectMigrationJobIfEnabled() {
+        var config = injector.get().getInstance(OpikConfiguration.class).getAlertProjectMigration();
+        if (config == null || !config.enabled()) {
+            log.info("Alert project migration job is disabled");
+            return;
+        }
+        scheduleRepeatingJob(AlertProjectMigrationJob.class,
                 config.interval().toJavaDuration(),
                 config.startupDelay().toJavaDuration());
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/AlertProjectMigrationJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/AlertProjectMigrationJobTest.java
@@ -1,0 +1,159 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.Alert;
+import com.comet.opik.api.AlertEventType;
+import com.comet.opik.api.AlertTrigger;
+import com.comet.opik.api.AlertTriggerConfig;
+import com.comet.opik.api.AlertTriggerConfigType;
+import com.comet.opik.api.AlertType;
+import com.comet.opik.api.Project;
+import com.comet.opik.api.Webhook;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.AlertResourceClient;
+import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.comet.opik.utils.JsonUtils;
+import com.redis.testcontainers.RedisContainer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hc.core5.http.HttpStatus;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static com.comet.opik.api.AlertTriggerConfig.PROJECT_IDS_CONFIG_KEY;
+import static com.comet.opik.api.resources.utils.AuthTestUtils.mockTargetWorkspace;
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class AlertProjectMigrationJobTest {
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE_CONTAINER = ClickHouseContainerUtils
+            .newClickHouseContainer(ZOOKEEPER_CONTAINER);
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(REDIS, CLICKHOUSE_CONTAINER, MYSQL, ZOOKEEPER_CONTAINER).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils
+                .newDatabaseAnalyticsFactory(CLICKHOUSE_CONTAINER, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE_CONTAINER);
+
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .runtimeInfo(wireMock.runtimeInfo())
+                        .redisUrl(REDIS.getRedisURI())
+                        .customConfigs(List.of(
+                                new CustomConfig("alertProjectMigration.enabled", "true"),
+                                new CustomConfig("alertProjectMigration.startupDelay", "1s"),
+                                new CustomConfig("alertProjectMigration.interval", "5s")))
+                        .build());
+    }
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    private AlertResourceClient alertResourceClient;
+    private ProjectResourceClient projectResourceClient;
+
+    @BeforeAll
+    void setUpAll(ClientSupport clientSupport) {
+        var baseUrl = TestUtils.getBaseUrl(clientSupport);
+        alertResourceClient = new AlertResourceClient(clientSupport);
+        projectResourceClient = new ProjectResourceClient(clientSupport, baseUrl, factory);
+    }
+
+    @Test
+    void scheduledJobMigratesEligibleAlert() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var projectId = projectResourceClient.createProject(
+                factory.manufacturePojo(Project.class).toBuilder().name(randomName("project")).build(),
+                apiKey, workspaceName);
+
+        var alertId = createOrphanAlert(apiKey, workspaceName, projectId);
+
+        // Job fires after startupDelay=1s; Awaitility polls until project_id is assigned.
+        // We don't assert which bucket — just that the end-to-end wiring works.
+        Awaitility.await().atMost(30, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    var alert = alertResourceClient.getAlertById(alertId, apiKey, workspaceName, HttpStatus.SC_OK);
+                    assertThat(alert.projectId()).isEqualTo(projectId);
+                });
+    }
+
+    private UUID createOrphanAlert(String apiKey, String workspaceName, UUID targetProjectId) {
+        var scopeConfig = AlertTriggerConfig.builder()
+                .type(AlertTriggerConfigType.SCOPE_PROJECT)
+                .configValue(Map.of(PROJECT_IDS_CONFIG_KEY, JsonUtils.writeValueAsString(Set.of(targetProjectId))))
+                .build();
+
+        var trigger = AlertTrigger.builder()
+                .eventType(AlertEventType.PROMPT_CREATED)
+                .triggerConfigs(List.of(scopeConfig))
+                .build();
+
+        var webhook = factory.manufacturePojo(Webhook.class).toBuilder()
+                .createdBy(null)
+                .createdAt(null)
+                .secretToken(UUID.randomUUID().toString())
+                .build();
+
+        var alert = Alert.builder()
+                .name(randomName("alert"))
+                .alertType(AlertType.GENERAL)
+                .enabled(true)
+                .webhook(webhook)
+                .triggers(List.of(trigger))
+                .projectId(null)
+                .build();
+
+        return alertResourceClient.createAlert(alert, apiKey, workspaceName, HttpStatus.SC_CREATED);
+    }
+
+    private static String randomName(String prefix) {
+        return "%s-%s".formatted(prefix, RandomStringUtils.secure().nextAlphanumeric(32));
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/AlertProjectMigrationServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/AlertProjectMigrationServiceTest.java
@@ -1,0 +1,425 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.Alert;
+import com.comet.opik.api.AlertEventType;
+import com.comet.opik.api.AlertTrigger;
+import com.comet.opik.api.AlertTriggerConfig;
+import com.comet.opik.api.AlertTriggerConfigType;
+import com.comet.opik.api.AlertType;
+import com.comet.opik.api.Project;
+import com.comet.opik.api.Webhook;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.AlertResourceClient;
+import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.comet.opik.utils.JsonUtils;
+import com.redis.testcontainers.RedisContainer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hc.core5.http.HttpStatus;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.comet.opik.api.AlertTriggerConfig.PROJECT_IDS_CONFIG_KEY;
+import static com.comet.opik.api.resources.utils.AuthTestUtils.mockTargetWorkspace;
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class AlertProjectMigrationServiceTest {
+
+    private static final String EXCLUDED_WORKSPACE_ID_1 = UUID.randomUUID().toString();
+    private static final String EXCLUDED_WORKSPACE_ID_2 = UUID.randomUUID().toString();
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE_CONTAINER = ClickHouseContainerUtils
+            .newClickHouseContainer(ZOOKEEPER_CONTAINER);
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(REDIS, CLICKHOUSE_CONTAINER, MYSQL, ZOOKEEPER_CONTAINER).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils
+                .newDatabaseAnalyticsFactory(CLICKHOUSE_CONTAINER, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE_CONTAINER);
+
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .runtimeInfo(wireMock.runtimeInfo())
+                        .redisUrl(REDIS.getRedisURI())
+                        .customConfigs(List.of(
+                                new CustomConfig("migration.excludedWorkspaceIds",
+                                        "%s,%s".formatted(EXCLUDED_WORKSPACE_ID_1, EXCLUDED_WORKSPACE_ID_2))))
+                        .build());
+    }
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    private AlertResourceClient alertResourceClient;
+    private ProjectResourceClient projectResourceClient;
+    private AlertProjectMigrationService migrationService;
+
+    @BeforeAll
+    void setUpAll(ClientSupport clientSupport, AlertProjectMigrationService migrationService) {
+        var baseUrl = TestUtils.getBaseUrl(clientSupport);
+
+        alertResourceClient = new AlertResourceClient(clientSupport);
+        projectResourceClient = new ProjectResourceClient(clientSupport, baseUrl, factory);
+        this.migrationService = migrationService;
+    }
+
+    // --- Tests ---
+
+    @Test
+    void workspaceWideAlertAssignedToDefaultProject() {
+        var ws = newWorkspace();
+        var defaultProjectId = createProject(ws, ProjectService.DEFAULT_PROJECT);
+
+        var alertId = createOrphanAlert(ws, randomName("alert"), List.of(
+                workspaceWideTrigger(AlertEventType.PROMPT_CREATED),
+                workspaceWideTrigger(AlertEventType.PROMPT_COMMITTED)));
+
+        migrationService.runMigrationCycle().block();
+
+        var alert = getAlert(ws, alertId);
+        assertThat(alert.projectId()).isEqualTo(defaultProjectId);
+        assertThat(alert.triggers()).hasSize(2);
+        assertNoScopeProjectConfig(alert);
+    }
+
+    @Test
+    void singleProjectAlertMigratedInPlace() {
+        var ws = newWorkspace();
+        var p1 = createProject(ws, randomName("project"));
+
+        var alertId = createOrphanAlert(ws, randomName("alert"), List.of(
+                scopedTrigger(AlertEventType.PROMPT_CREATED, p1)));
+
+        migrationService.runMigrationCycle().block();
+
+        var alert = getAlert(ws, alertId);
+        assertThat(alert.projectId()).isEqualTo(p1);
+        assertThat(alert.triggers()).hasSize(1);
+        assertNoScopeProjectConfig(alert);
+    }
+
+    @Test
+    void singleProjectWithWorkspaceWideTriggerSplitsDefaultAlert() {
+        var ws = newWorkspace();
+        var p1 = createProject(ws, randomName("project"));
+        var defaultProjectId = createProject(ws, ProjectService.DEFAULT_PROJECT);
+
+        var alertId = createOrphanAlert(ws, randomName("alert"), List.of(
+                scopedTrigger(AlertEventType.PROMPT_CREATED, p1),
+                workspaceWideTrigger(AlertEventType.PROMPT_COMMITTED)));
+
+        migrationService.runMigrationCycle().block();
+
+        // Original alert should be scoped to p1 with only the scoped trigger
+        var originalAlert = getAlert(ws, alertId);
+        assertThat(originalAlert.projectId()).isEqualTo(p1);
+        assertThat(originalAlert.triggers()).hasSize(1);
+        assertThat(originalAlert.triggers().getFirst().eventType()).isEqualTo(AlertEventType.PROMPT_CREATED);
+        assertNoScopeProjectConfig(originalAlert);
+
+        // A new alert should have been created for the Default Project with the workspace-wide trigger
+        var defaultAlerts = getAlertsForProject(ws, defaultProjectId);
+        assertThat(defaultAlerts).hasSize(1);
+        var defaultAlert = defaultAlerts.getFirst();
+        assertThat(defaultAlert.projectId()).isEqualTo(defaultProjectId);
+        assertThat(defaultAlert.triggers()).hasSize(1);
+        assertThat(defaultAlert.triggers().getFirst().eventType()).isEqualTo(AlertEventType.PROMPT_COMMITTED);
+        assertNoScopeProjectConfig(defaultAlert);
+    }
+
+    @Test
+    void multiProjectAlertSplitByProject() {
+        var ws = newWorkspace();
+        var p1 = createProject(ws, randomName("project"));
+        var p2 = createProject(ws, randomName("project"));
+        var firstId = lexFirst(p1, p2);
+        var secondId = firstId.equals(p1) ? p2 : p1;
+
+        var alertId = createOrphanAlert(ws, randomName("alert"), List.of(
+                scopedTrigger(AlertEventType.PROMPT_CREATED, p1),
+                scopedTrigger(AlertEventType.PROMPT_COMMITTED, p2)));
+
+        migrationService.runMigrationCycle().block();
+
+        // Original alert keeps first (lex) project's trigger
+        var originalAlert = getAlert(ws, alertId);
+        assertThat(originalAlert.projectId()).isEqualTo(firstId);
+        assertThat(originalAlert.triggers()).hasSize(1);
+        assertNoScopeProjectConfig(originalAlert);
+
+        // A new alert was created for the second project
+        var secondAlerts = getAlertsForProject(ws, secondId);
+        assertThat(secondAlerts).hasSize(1);
+        var secondAlert = secondAlerts.getFirst();
+        assertThat(secondAlert.projectId()).isEqualTo(secondId);
+        assertThat(secondAlert.triggers()).hasSize(1);
+        assertNoScopeProjectConfig(secondAlert);
+    }
+
+    @Test
+    void multiProjectWithWorkspaceWideTriggerCreatesThreeAlerts() {
+        var ws = newWorkspace();
+        var p1 = createProject(ws, randomName("project"));
+        var p2 = createProject(ws, randomName("project"));
+        var defaultProjectId = createProject(ws, ProjectService.DEFAULT_PROJECT);
+        var firstId = lexFirst(p1, p2);
+        var secondId = firstId.equals(p1) ? p2 : p1;
+
+        var alertId = createOrphanAlert(ws, randomName("alert"), List.of(
+                scopedTrigger(AlertEventType.PROMPT_CREATED, p1),
+                scopedTrigger(AlertEventType.PROMPT_COMMITTED, p2),
+                workspaceWideTrigger(AlertEventType.PROMPT_DELETED)));
+
+        migrationService.runMigrationCycle().block();
+
+        // Original alert: assigned to lex-first project, 1 trigger, no scope
+        var originalAlert = getAlert(ws, alertId);
+        assertThat(originalAlert.projectId()).isEqualTo(firstId);
+        assertThat(originalAlert.triggers()).hasSize(1);
+        assertNoScopeProjectConfig(originalAlert);
+
+        // Second project: 1 trigger
+        var secondAlerts = getAlertsForProject(ws, secondId);
+        assertThat(secondAlerts).hasSize(1);
+        assertThat(secondAlerts.getFirst().triggers()).hasSize(1);
+        assertNoScopeProjectConfig(secondAlerts.getFirst());
+
+        // Default Project: 1 trigger (workspace-wide)
+        var defaultAlerts = getAlertsForProject(ws, defaultProjectId);
+        assertThat(defaultAlerts).hasSize(1);
+        assertThat(defaultAlerts.getFirst().projectId()).isEqualTo(defaultProjectId);
+        assertThat(defaultAlerts.getFirst().triggers()).hasSize(1);
+        assertThat(defaultAlerts.getFirst().triggers().getFirst().eventType())
+                .isEqualTo(AlertEventType.PROMPT_DELETED);
+        assertNoScopeProjectConfig(defaultAlerts.getFirst());
+    }
+
+    @Test
+    void allProjectsDeletedAlertAssignedToDefault() {
+        var ws = newWorkspace();
+        var defaultProjectId = createProject(ws, ProjectService.DEFAULT_PROJECT);
+        var nonExistentProjectId = UUID.randomUUID();
+
+        var alertId = createOrphanAlert(ws, randomName("alert"), List.of(
+                scopedTrigger(AlertEventType.PROMPT_CREATED, nonExistentProjectId)));
+
+        migrationService.runMigrationCycle().block();
+
+        var alert = getAlert(ws, alertId);
+        assertThat(alert.projectId()).isEqualTo(defaultProjectId);
+        assertNoScopeProjectConfig(alert);
+    }
+
+    @Test
+    void missingDefaultProjectIsAutoCreatedDuringMigration() {
+        var ws = newWorkspace();
+        // Default Project intentionally NOT pre-created — the migration must create it on demand.
+
+        var alertId = createOrphanAlert(ws, randomName("alert"), List.of(
+                workspaceWideTrigger(AlertEventType.PROMPT_CREATED)));
+
+        migrationService.runMigrationCycle().block();
+
+        var alert = getAlert(ws, alertId);
+        assertThat(alert.projectId()).isNotNull();
+
+        var defaultProject = projectResourceClient.getProject(alert.projectId(), ws.apiKey(), ws.workspaceName());
+        assertThat(defaultProject.name()).isEqualTo(ProjectService.DEFAULT_PROJECT);
+    }
+
+    @Test
+    void envExcludedWorkspacesAreNotMigrated() {
+        var ws = new WorkspaceCtx(randomName("api-key"), randomName("workspace"), EXCLUDED_WORKSPACE_ID_1);
+        mockTargetWorkspace(wireMock.server(), ws.apiKey(), ws.workspaceName(), ws.workspaceId(), randomName("user"));
+
+        var alertId = createOrphanAlert(ws, randomName("alert"), List.of(
+                workspaceWideTrigger(AlertEventType.PROMPT_CREATED)));
+
+        migrationService.runMigrationCycle().block();
+
+        var alert = getAlert(ws, alertId);
+        assertThat(alert.projectId()).isNull();
+    }
+
+    @Test
+    void secondCycleIsNoopAfterMigration() {
+        var ws = newWorkspace();
+        var p1 = createProject(ws, randomName("project"));
+
+        var alertId = createOrphanAlert(ws, randomName("alert"), List.of(
+                scopedTrigger(AlertEventType.PROMPT_CREATED, p1)));
+
+        migrationService.runMigrationCycle().block();
+
+        var afterFirstCycle = getAlert(ws, alertId);
+        assertThat(afterFirstCycle.projectId()).isEqualTo(p1);
+
+        migrationService.runMigrationCycle().block();
+
+        var afterSecondCycle = getAlert(ws, alertId);
+        assertThat(afterSecondCycle.lastUpdatedAt()).isEqualTo(afterFirstCycle.lastUpdatedAt());
+    }
+
+    @Test
+    void postMigrationAlertIsEditableViaApi() {
+        var ws = newWorkspace();
+        var p1 = createProject(ws, randomName("project"));
+
+        var alertId = createOrphanAlert(ws, randomName("alert"), List.of(
+                scopedTrigger(AlertEventType.PROMPT_CREATED, p1)));
+
+        migrationService.runMigrationCycle().block();
+
+        var migrated = getAlert(ws, alertId);
+        assertThat(migrated.projectId()).isEqualTo(p1);
+        assertNoScopeProjectConfig(migrated);
+
+        // Update the alert: set project_id explicitly (scope:project already gone after migration)
+        var updatedAlert = migrated.toBuilder()
+                .projectId(p1)
+                .triggers(migrated.triggers().stream()
+                        .map(t -> t.toBuilder()
+                                .createdBy(null)
+                                .createdAt(null)
+                                .build())
+                        .toList())
+                .build();
+
+        alertResourceClient.updateAlert(alertId, updatedAlert, ws.apiKey(), ws.workspaceName(),
+                HttpStatus.SC_NO_CONTENT);
+    }
+
+    // --- Helper types and methods ---
+
+    private record WorkspaceCtx(String apiKey, String workspaceName, String workspaceId) {
+    }
+
+    private WorkspaceCtx newWorkspace() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+        return new WorkspaceCtx(apiKey, workspaceName, workspaceId);
+    }
+
+    private UUID createProject(WorkspaceCtx ws, String name) {
+        return projectResourceClient.createProject(
+                factory.manufacturePojo(Project.class).toBuilder().name(name).build(),
+                ws.apiKey(), ws.workspaceName());
+    }
+
+    private UUID createOrphanAlert(WorkspaceCtx ws, String name, List<AlertTrigger> triggers) {
+        var webhook = factory.manufacturePojo(Webhook.class).toBuilder()
+                .createdBy(null)
+                .createdAt(null)
+                .secretToken(UUID.randomUUID().toString())
+                .build();
+
+        var alert = Alert.builder()
+                .name(name)
+                .alertType(AlertType.GENERAL)
+                .enabled(true)
+                .webhook(webhook)
+                .triggers(triggers)
+                .projectId(null)
+                .build();
+
+        return alertResourceClient.createAlert(alert, ws.apiKey(), ws.workspaceName(), HttpStatus.SC_CREATED);
+    }
+
+    private static AlertTrigger scopedTrigger(AlertEventType eventType, UUID... projectIds) {
+        var scopeConfig = AlertTriggerConfig.builder()
+                .type(AlertTriggerConfigType.SCOPE_PROJECT)
+                .configValue(Map.of(PROJECT_IDS_CONFIG_KEY,
+                        JsonUtils.writeValueAsString(Set.of(projectIds))))
+                .build();
+
+        return AlertTrigger.builder()
+                .eventType(eventType)
+                .triggerConfigs(List.of(scopeConfig))
+                .build();
+    }
+
+    private static AlertTrigger workspaceWideTrigger(AlertEventType eventType) {
+        return AlertTrigger.builder()
+                .eventType(eventType)
+                .triggerConfigs(List.of())
+                .build();
+    }
+
+    private Alert getAlert(WorkspaceCtx ws, UUID alertId) {
+        return alertResourceClient.getAlertById(alertId, ws.apiKey(), ws.workspaceName(), HttpStatus.SC_OK);
+    }
+
+    private List<Alert> getAlertsForProject(WorkspaceCtx ws, UUID projectId) {
+        return alertResourceClient
+                .findAlertsByProject(projectId, ws.apiKey(), ws.workspaceName(), 1, 100, HttpStatus.SC_OK)
+                .content();
+    }
+
+    private static void assertNoScopeProjectConfig(Alert alert) {
+        if (alert.triggers() == null) {
+            return;
+        }
+        for (var trigger : alert.triggers()) {
+            if (trigger.triggerConfigs() == null) {
+                continue;
+            }
+            assertThat(trigger.triggerConfigs())
+                    .noneMatch(c -> c.type() == AlertTriggerConfigType.SCOPE_PROJECT);
+        }
+    }
+
+    private static UUID lexFirst(UUID... ids) {
+        return Arrays.stream(ids)
+                .min(Comparator.comparing(UUID::toString))
+                .orElseThrow();
+    }
+
+    private static String randomName(String prefix) {
+        return "%s-%s".formatted(prefix, RandomStringUtils.secure().nextAlphanumeric(32));
+    }
+}

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -842,6 +842,21 @@ automationRuleProjectMigration:
   # idle window and don't churn on every tick.
   schedulerThreadTtl: 10s
 
+# Alert Project Migration configuration
+# Assigns project_id to orphan alerts and splits multi-project alerts (V1 → V2 workspace migration).
+alertProjectMigration:
+  enabled: false
+  workspacesPerRun: 20
+  alertBatchSize: 100
+  interval: 5s
+  startupDelay: 5s
+  lockTimeout: 5s
+  lockWaitTime: 100ms
+  jobTimeout: 30s
+  schedulerThreadCap: 2
+  schedulerQueuedTaskCap: 50
+  schedulerThreadTtl: 10s
+
 # Shared configuration for V1 → V2 entity project migration jobs
 # Centralised so all migration jobs (experiments, datasets, etc.) share the same exclusion list
 migration:


### PR DESCRIPTION
## Details

Implements the D7 migration job (V1 → V2 workspace migration) that assigns `project_id` to orphan alerts and splits alerts that span multiple projects into individual per-project alerts.

**Migration logic per alert:**
- **Workspace-wide** (no `scope:project` configs on any trigger): assigns the whole alert to Default Project; no trigger changes
- **Single or multiple valid projects**: original alert is updated to the lex-first valid project and keeps only that project's triggers; remaining valid projects each get a new cloned alert with their own triggers; workspace-wide / all-deleted-project triggers are grouped into a separate new Default Project alert
- **All projects deleted**: assigns to Default Project; deletes stale `scope:project` configs
- **Missing Default Project**: auto-created via `ProjectService.getOrCreate` — never traps the workspace

Trigger-level granularity distinguishes workspace-wide triggers (no `scope:project` config), project-specific triggers, and deleted-project triggers within the same alert. Each resulting alert receives only the triggers that belong to it.

After migration, all `scope:project` trigger configs are removed so alerts can be edited via the API without hitting `validateNoProjectScopeConflict`.

**Key implementation notes:**
- Quartz job mirroring `ExperimentProjectMigrationJob` — same lock, scheduler isolation, and feature-flag pattern
- No workspace skip/trap tracking (Option C): every situation resolves to a valid outcome, so the eligible workspaces query naturally empties out once done
- Per-alert operation runs in a single MySQL transaction
- Demo alert names excluded via `DemoData.ALERTS` placeholder; env-var workspace exclusion list honoured

**New files:**
- `AlertProjectMigrationConfig.java` — config record with `ALERT_PROJECT_MIGRATION_*` env-var overrides
- `AlertProjectMigrationService.java` — `Managed` service with full 6-bucket classification and trigger-level split logic
- `AlertProjectMigrationJob.java` — Quartz job wiring the service into the scheduler
- `AlertProjectMigrationServiceTest.java` — 10 integration tests covering all split/assignment buckets
- `AlertProjectMigrationJobTest.java` — end-to-end scheduler wiring test using Awaitility

**Modified files:**
- `AlertDAO.java` — adds eligibility query, `findByWorkspaceId`, `updateAlertProjectId`, `deleteScopeProjectConfigs`, `deleteTriggerConfigsByIds`, `deleteTriggersByIds`
- `DemoData.java` — adds empty `ALERTS` placeholder
- `OpikConfiguration.java` / `config.yml` / `config-test.yml` — adds `alertProjectMigration` config block

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-6191

## Testing

Integration tests in `AlertProjectMigrationServiceTest` cover:
- Workspace-wide alert → Default Project assigned, triggers unchanged
- Single-project alert → migrated in place, `scope:project` config deleted
- Single-project alert with workspace-wide triggers → original keeps project trigger, new Default Project alert created for workspace-wide trigger
- Multi-project alert → split into one alert per project (lex-first keeps original ID)
- Multi-project + workspace-wide triggers → three-way split (P1, P2, Default Project)
- All projects deleted → falls back to Default Project, stale configs deleted
- Missing Default Project → auto-created during migration
- Env-excluded workspaces → skipped, alert stays orphan
- Idempotency → second cycle is a no-op (`lastUpdatedAt` stable)
- Post-migration editability → API update returns 204 after `scope:project` cleanup

`AlertProjectMigrationJobTest` verifies the Quartz scheduler fires the job and migrates an eligible alert end-to-end (Awaitility, 30s budget).

## Documentation

No user-facing documentation changes. New env-vars introduced:

| Variable | Default | Description |
|---|---|---|
| `ALERT_PROJECT_MIGRATION_ENABLED` | `false` | Enable the migration job |
| `ALERT_PROJECT_MIGRATION_WORKSPACES_PER_RUN` | `20` | Workspaces processed per cycle |
| `ALERT_PROJECT_MIGRATION_INTERVAL` | `30s` | Cycle interval |
| `ALERT_PROJECT_MIGRATION_STARTUP_DELAY` | `30s` | Delay before first run |
| `ALERT_PROJECT_MIGRATION_LOCK_TIMEOUT` | `5m` | Distributed lock timeout |
| `ALERT_PROJECT_MIGRATION_JOB_TIMEOUT` | `1h` | Per-cycle safety timeout |
