### PR TITLE
[OPIK-6638] [DOCS] docs(v2): add Python opik-mcp setup + usage page

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/mcp_server.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/mcp_server.mdx
@@ -1,0 +1,224 @@
+---
+headline: Opik's MCP server | Opik Documentation
+og:description: Configure Opik's Python MCP server with Claude Code, Cursor, and VS Code Copilot to read traces, log scores, and manage prompts from your AI host.
+og:site_name: Opik Documentation
+og:title: Integrate with Opik's MCP server
+title: Opik's MCP server
+---
+
+Opik's [MCP server](https://github.com/comet-ml/opik-mcp) is a Python 3.13+ package
+that connects your AI host (Claude Code, Cursor, VS Code Copilot, MCP Inspector)
+directly to your Opik workspace — read traces, log scores, save prompt versions,
+and ask Ollie investigative questions, all from the chat.
+
+> `opik-mcp` has been rewritten in Python. If you previously installed the
+> npx-based JavaScript server, replace `npx -y opik-mcp` with `uvx opik-mcp` in
+> the snippets below.
+
+## Before you start
+
+You will need:
+
+- **`OPIK_API_KEY`** — generate one at [`comet.com/api/my/settings`](https://www.comet.com/api/my/settings/).
+- **`COMET_WORKSPACE`** — the lowercase workspace name from your Comet URL. For example, `https://www.comet.com/acme-ai/...` → `COMET_WORKSPACE=acme-ai`.
+- **[`uv`](https://docs.astral.sh/uv/)** installed locally. The fastest way is `brew install uv` (macOS) or `curl -LsSf https://astral.sh/uv/install.sh | sh`. `uvx` (bundled with `uv`) fetches and runs the latest published `opik-mcp` on demand — no global install required.
+
+<Tip>
+**Pre-release note:** `opik-mcp` is not yet published to PyPI. Until the first
+PyPI release lands, replace `uvx opik-mcp` in any snippet on this page with
+`uvx --from git+https://github.com/comet-ml/opik-mcp.git opik-mcp`.
+</Tip>
+
+## Setting up the MCP server
+
+<Tabs>
+    <Tab title="Claude Code">
+
+    Add the server with one command:
+
+    ```bash
+    claude mcp add --transport stdio opik-mcp \
+      --env OPIK_API_KEY=<your-key> \
+      --env COMET_WORKSPACE=<your-workspace> \
+      -- uvx opik-mcp
+    ```
+
+    Or edit `~/.claude.json` directly:
+
+    ```json
+    {
+      "mcpServers": {
+        "opik-mcp": {
+          "type": "stdio",
+          "command": "uvx",
+          "args": ["opik-mcp"],
+          "env": {
+            "OPIK_API_KEY": "<your-key>",
+            "COMET_WORKSPACE": "<your-workspace>"
+          }
+        }
+      }
+    }
+    ```
+
+    Restart Claude Code, verify with `/mcp` (`opik-mcp` should appear as
+    connected), and then ask in the chat: **"list my Opik projects"**.
+
+    </Tab>
+    <Tab title="Cursor">
+
+    Edit `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project), or open
+    **Cmd+Shift+J → Features → Model Context Protocol**:
+
+    ```json
+    {
+      "mcpServers": {
+        "opik-mcp": {
+          "type": "stdio",
+          "command": "uvx",
+          "args": ["opik-mcp"],
+          "env": {
+            "OPIK_API_KEY": "<your-key>",
+            "COMET_WORKSPACE": "<your-workspace>"
+          }
+        }
+      }
+    }
+    ```
+
+    Reload Cursor; the green dot next to `opik-mcp` in the MCP panel confirms
+    the connection. Ask in chat: **"list my Opik projects"**.
+
+    <Tip>
+    **Cursor 60s timeout.** Cursor enforces a hard tool-call timeout that does
+    not reset on progress notifications. Long `ask_ollie` turns will fail on
+    Cursor — see [Known host limits](#known-host-limits).
+    </Tip>
+
+    </Tab>
+    <Tab title="VS Code Copilot">
+
+    Create or open `.vscode/mcp.json` in your workspace (or run the
+    **MCP: Open User Configuration** command to add it globally):
+
+    ```json
+    {
+      "servers": {
+        "opik-mcp": {
+          "type": "stdio",
+          "command": "uvx",
+          "args": ["opik-mcp"],
+          "env": {
+            "OPIK_API_KEY": "<your-key>",
+            "COMET_WORKSPACE": "<your-workspace>"
+          }
+        }
+      }
+    }
+    ```
+
+    Reload the window. The Copilot Chat **MCP** indicator shows `opik-mcp` once
+    the server is reachable. Ask in chat: **"list my Opik projects"**.
+
+    </Tab>
+    <Tab title="MCP Inspector">
+
+    For manual testing or debugging, run the inspector against `opik-mcp`:
+
+    ```bash
+    OPIK_API_KEY=<your-key> COMET_WORKSPACE=<your-workspace> \
+      npx @modelcontextprotocol/inspector uvx opik-mcp
+    ```
+
+    The inspector opens in your browser and lets you call each tool directly.
+
+    </Tab>
+</Tabs>
+
+<Tip>
+**Self-hosted Opik.** Add `COMET_URL_OVERRIDE` to the `env` block (and `OPIK_URL`
+if Opik lives at a non-default path). `ask_ollie` and `run_experiment` are
+available on Comet Cloud only — on self-hosted those calls fail at dispatch;
+use `read` / `list` / `write` directly.
+</Tip>
+
+## Using the MCP server
+
+### The tools at a glance
+
+| Tool | Purpose |
+|---|---|
+| `read` | Universal read by id / name / `opik://` URI. |
+| `list` | Universal list with optional name filter and pagination. |
+| `ask_ollie` | Investigate or synthesize via the Opik in-product assistant. |
+| `write` | Universal write — log traces/spans, score, comment, save prompts, manage test suites and experiments. |
+| `schema` | Introspect write-operation schemas (used by the LLM to construct valid payloads). |
+| `run_experiment` | Run an evaluation experiment end-to-end via Ollie. |
+
+### Browsing your workspace
+
+> list my Opik projects
+
+> what was the most recent trace logged to the "demo" project?
+
+> show me trace `<trace-id>`
+
+### Scoring, commenting, saving prompts
+
+> score trace `<trace-id>` 0.9 on helpfulness with reason "great recovery"
+
+> comment "retry with temperature=0" on span `<span-id>`
+
+> save the following text as a new version of the "rerank-system" prompt: ...
+
+For the full set of write operations and their payload shapes, ask the host
+**"show me the schema for trace.create"** (calls the `schema` tool) or see the
+[README](https://github.com/comet-ml/opik-mcp#tools).
+
+### Asking Ollie
+
+For investigative or cross-entity questions:
+
+> why are spans in the "demo" project slower this week than last?
+
+> compare experiments "rerank-v2" and "rerank-v3" on factuality
+
+`ask_ollie` returns a `thread_id` you can pass back on follow-ups to preserve
+context. For more about Ollie itself, see [Ollie](https://www.comet.com/docs/opik/ollie).
+See **Ollie & auto-approve** below before running write-style prompts in shared
+workspaces.
+
+## Ollie & auto-approve
+
+By default, writes that Ollie performs mid-stream (scores, comments, prompt
+versions, test-suite items) execute without a per-action confirmation step.
+Each auto-approved write is logged as a JSON audit row on the `opik_mcp.audit`
+Python logger.
+
+To require manual confirmation instead, set `OPIK_MCP_AUTO_APPROVE=disabled` in
+the server's `env` block. Ollie's confirmation requests then surface as typed
+errors that you can re-issue manually.
+
+`ask_ollie` and `run_experiment` are available on Comet Cloud only — on
+self-hosted those calls fail at dispatch; use `read` / `list` / `write`
+directly.
+
+## Known host limits
+
+- **Cursor enforces a 60-second hard tool-call timeout** that does not reset on
+  progress notifications. Long `ask_ollie` turns will fail on Cursor. For
+  long-running investigations, use Claude Code or VS Code Copilot.
+
+## Example conversation
+
+A typical investigative loop using Claude Code:
+
+> **You:** Why did the experiment "gpt-4o-rerank-v3" regress on factuality?
+>
+> **Claude:** *(calls `ask_ollie`)* Three traces failed because the reranker
+> dropped the system message. The remaining 12 traces scored above 0.8…
+>
+> **You:** Score the bottom 3 traces 0.2 with reason "dropped system message".
+>
+> **Claude:** *(calls `write` with `score.create` ×3)* Done — three scores
+> recorded on traces `<id-1>`, `<id-2>`, `<id-3>`.

--- a/apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/mcp_server.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/mcp_server.mdx
@@ -184,7 +184,7 @@ For investigative or cross-entity questions:
 > compare experiments "rerank-v2" and "rerank-v3" on factuality
 
 `ask_ollie` returns a `thread_id` you can pass back on follow-ups to preserve
-context. For more about Ollie itself, see [Ollie](https://www.comet.com/docs/opik/ollie).
+context. For more about Ollie itself, see [Ollie](/ollie).
 See **Ollie & auto-approve** below before running write-style prompts in shared
 workspaces.
 

--- a/apps/opik-documentation/documentation/fern/docs/prompt_engineering/mcp_server.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/prompt_engineering/mcp_server.mdx
@@ -8,7 +8,7 @@ title: Opik's MCP server
 ---
 
 <Note>
-  **opik-mcp has been rewritten in Python.** The instructions on this page describe the legacy npx-based JavaScript server. For the new Python server, see the v2 docs: [Opik's MCP server](https://www.comet.com/docs/opik/development/agent-configuration/mcp-server).
+  **opik-mcp has been rewritten in Python.** The instructions on this page describe the legacy npx-based JavaScript server. For the new Python server, see the v2 docs: [Opik's MCP server](/development/agent-configuration/mcp-server).
 </Note>
 
 Opik's [MCP server](https://github.com/comet-ml/opik-mcp) allows you to integrate

--- a/apps/opik-documentation/documentation/fern/docs/prompt_engineering/mcp_server.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/prompt_engineering/mcp_server.mdx
@@ -7,6 +7,10 @@ og:title: Integrate with Opik's MCP server for prompt engineering
 title: Opik's MCP server
 ---
 
+<Note>
+  **opik-mcp has been rewritten in Python.** The instructions on this page describe the legacy npx-based JavaScript server. For the new Python server, see the v2 docs: [Opik's MCP server](https://www.comet.com/docs/opik/development/agent-configuration/mcp-server).
+</Note>
+
 Opik's [MCP server](https://github.com/comet-ml/opik-mcp) allows you to integrate
 your IDE with Opik not just for prompt management, but also to access and
 analyze traces.

--- a/apps/opik-documentation/documentation/fern/versions/latest.yml
+++ b/apps/opik-documentation/documentation/fern/versions/latest.yml
@@ -123,6 +123,9 @@ navigation:
               - page: Getting started
                 path: ../docs-v2/prompt_engineering/getting-started.mdx
                 slug: getting-started
+              - page: MCP server
+                path: ../docs-v2/prompt_engineering/mcp_server.mdx
+                slug: mcp-server
               - page: Concepts
                 path: ../docs-v2/prompt_engineering/concepts.mdx
                 slug: concepts


### PR DESCRIPTION
## Details

New v2 docs page at `/development/agent-configuration/mcp-server` for the rewritten Python `opik-mcp` server, plus a deprecation banner on the v1 page pointing readers to the new v2 page.

- Created `apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/mcp_server.mdx` — install instructions (Claude Code / Cursor / VS Code Copilot / MCP Inspector tabs), tools table, usage patterns, Ollie integration, known host limits, example conversation
- Wired into `apps/opik-documentation/documentation/fern/versions/latest.yml` under Development → Agent configuration (slug `mcp-server`), between "Getting started" and "Concepts"
- Added a `<Note>` deprecation banner to the v1 `docs/prompt_engineering/mcp_server.mdx` linking to the new v2 URL

Spec: `comet-ml/opik-mcp` → `docs/superpowers/specs/2026-05-21-opik-mcp-v2-docs-design.md`

## Change checklist

- [x] User facing
- [x] Documentation update

## Issues

- [OPIK-6638](https://comet-ml.atlassian.net/browse/OPIK-6638)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: brainstorming → spec → implementation plan → per-task implementer + spec-compliance reviewer subagents → final cross-cutting reviewer subagent
- Human verification: local `fern docs dev` rendered + visually inspected; every example prompt on the new page was run end-to-end against a real Opik workspace (see vetted list below)

## Testing

- Local `fern docs dev` renders the new page without errors (`http://localhost:3000/docs/opik/development/agent-configuration/mcp-server` → HTTP 200, all sections + tabs + key strings present, no MDX errors in dev-server log)
- Nav entry "MCP server" appears between "Getting started" and "Concepts" under Development → Agent configuration (visually verified)
- All four install tabs render and switch cleanly (visually verified)
- v1 page shows the deprecation banner; rest of v1 content unchanged (visually verified)

### Vetted example prompts

Each blockquote prompt on the new page was run end-to-end on Claude Code against a real Opik workspace before merge:

- [x] list my Opik projects
- [x] what was the most recent trace logged to the "demo" project?
- [x] show me trace `<trace-id>`
- [x] score trace `<trace-id>` 0.9 on helpfulness with reason "great recovery"
- [x] comment "retry with temperature=0" on span `<span-id>`
- [x] save the following text as a new version of the "rerank-system" prompt: ...
- [x] why are spans in the "demo" project slower this week than last?
- [x] compare experiments "<exp-a>" and "<exp-b>" on factuality

## Documentation

This PR is itself a docs change.

[OPIK-6638]: https://comet-ml.atlassian.net/browse/OPIK-6638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ