### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -8941,6 +8941,13 @@ components:
           type: object
           additionalProperties:
             type: string
+        group_index:
+          type: integer
+          description: "Groups configs within a trigger: same group_index means AND\
+            \ between configs, different group_index means OR between groups. Null\
+            \ means a legacy/singleton group of one config. Always null for scope:project\
+            \ configs."
+          format: int32
         created_at:
           type: string
           format: date-time
@@ -9010,6 +9017,13 @@ components:
           type: object
           additionalProperties:
             type: string
+        group_index:
+          type: integer
+          description: "Groups configs within a trigger: same group_index means AND\
+            \ between configs, different group_index means OR between groups. Null\
+            \ means a legacy/singleton group of one config. Always null for scope:project\
+            \ configs."
+          format: int32
     AlertTrigger_Write:
       required:
       - event_type
@@ -9151,6 +9165,13 @@ components:
           type: object
           additionalProperties:
             type: string
+        group_index:
+          type: integer
+          description: "Groups configs within a trigger: same group_index means AND\
+            \ between configs, different group_index means OR between groups. Null\
+            \ means a legacy/singleton group of one config. Always null for scope:project\
+            \ configs."
+          format: int32
         created_at:
           type: string
           format: date-time

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -8941,6 +8941,13 @@ components:
           type: object
           additionalProperties:
             type: string
+        group_index:
+          type: integer
+          description: "Groups configs within a trigger: same group_index means AND\
+            \ between configs, different group_index means OR between groups. Null\
+            \ means a legacy/singleton group of one config. Always null for scope:project\
+            \ configs."
+          format: int32
         created_at:
           type: string
           format: date-time
@@ -9010,6 +9017,13 @@ components:
           type: object
           additionalProperties:
             type: string
+        group_index:
+          type: integer
+          description: "Groups configs within a trigger: same group_index means AND\
+            \ between configs, different group_index means OR between groups. Null\
+            \ means a legacy/singleton group of one config. Always null for scope:project\
+            \ configs."
+          format: int32
     AlertTrigger_Write:
       required:
       - event_type
@@ -9151,6 +9165,13 @@ components:
           type: object
           additionalProperties:
             type: string
+        group_index:
+          type: integer
+          description: "Groups configs within a trigger: same group_index means AND\
+            \ between configs, different group_index means OR between groups. Null\
+            \ means a legacy/singleton group of one config. Always null for scope:project\
+            \ configs."
+          format: int32
         created_at:
           type: string
           format: date-time

--- a/sdks/python/src/opik/rest_api/types/alert_trigger_config.py
+++ b/sdks/python/src/opik/rest_api/types/alert_trigger_config.py
@@ -13,6 +13,11 @@ class AlertTriggerConfig(UniversalBaseModel):
     alert_trigger_id: typing.Optional[str] = None
     type: AlertTriggerConfigType
     config_value: typing.Optional[typing.Dict[str, str]] = None
+    group_index: typing.Optional[int] = pydantic.Field(default=None)
+    """
+    Groups configs within a trigger: same group_index means AND between configs, different group_index means OR between groups. Null means a legacy/singleton group of one config. Always null for scope:project configs.
+    """
+
     created_at: typing.Optional[dt.datetime] = None
     created_by: typing.Optional[str] = None
     last_updated_at: typing.Optional[dt.datetime] = None

--- a/sdks/python/src/opik/rest_api/types/alert_trigger_config_public.py
+++ b/sdks/python/src/opik/rest_api/types/alert_trigger_config_public.py
@@ -13,6 +13,11 @@ class AlertTriggerConfigPublic(UniversalBaseModel):
     alert_trigger_id: typing.Optional[str] = None
     type: AlertTriggerConfigPublicType
     config_value: typing.Optional[typing.Dict[str, str]] = None
+    group_index: typing.Optional[int] = pydantic.Field(default=None)
+    """
+    Groups configs within a trigger: same group_index means AND between configs, different group_index means OR between groups. Null means a legacy/singleton group of one config. Always null for scope:project configs.
+    """
+
     created_at: typing.Optional[dt.datetime] = None
     created_by: typing.Optional[str] = None
     last_updated_at: typing.Optional[dt.datetime] = None

--- a/sdks/python/src/opik/rest_api/types/alert_trigger_config_write.py
+++ b/sdks/python/src/opik/rest_api/types/alert_trigger_config_write.py
@@ -11,6 +11,10 @@ class AlertTriggerConfigWrite(UniversalBaseModel):
     id: typing.Optional[str] = None
     type: AlertTriggerConfigWriteType
     config_value: typing.Optional[typing.Dict[str, str]] = None
+    group_index: typing.Optional[int] = pydantic.Field(default=None)
+    """
+    Groups configs within a trigger: same group_index means AND between configs, different group_index means OR between groups. Null means a legacy/singleton group of one config. Always null for scope:project configs.
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/typescript/src/opik/rest_api/api/types/AlertTriggerConfig.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/AlertTriggerConfig.ts
@@ -7,6 +7,8 @@ export interface AlertTriggerConfig {
     alertTriggerId?: string;
     type: OpikApi.AlertTriggerConfigType;
     configValue?: Record<string, string>;
+    /** Groups configs within a trigger: same group_index means AND between configs, different group_index means OR between groups. Null means a legacy/singleton group of one config. Always null for scope:project configs. */
+    groupIndex?: number;
     createdAt?: Date;
     createdBy?: string;
     lastUpdatedAt?: Date;

--- a/sdks/typescript/src/opik/rest_api/api/types/AlertTriggerConfigPublic.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/AlertTriggerConfigPublic.ts
@@ -7,6 +7,8 @@ export interface AlertTriggerConfigPublic {
     alertTriggerId?: string;
     type: OpikApi.AlertTriggerConfigPublicType;
     configValue?: Record<string, string>;
+    /** Groups configs within a trigger: same group_index means AND between configs, different group_index means OR between groups. Null means a legacy/singleton group of one config. Always null for scope:project configs. */
+    groupIndex?: number;
     createdAt?: Date;
     createdBy?: string;
     lastUpdatedAt?: Date;

--- a/sdks/typescript/src/opik/rest_api/api/types/AlertTriggerConfigWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/AlertTriggerConfigWrite.ts
@@ -6,4 +6,6 @@ export interface AlertTriggerConfigWrite {
     id?: string;
     type: OpikApi.AlertTriggerConfigWriteType;
     configValue?: Record<string, string>;
+    /** Groups configs within a trigger: same group_index means AND between configs, different group_index means OR between groups. Null means a legacy/singleton group of one config. Always null for scope:project configs. */
+    groupIndex?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/AlertTriggerConfig.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/AlertTriggerConfig.ts
@@ -16,6 +16,7 @@ export const AlertTriggerConfig: core.serialization.ObjectSchema<
         "config_value",
         core.serialization.record(core.serialization.string(), core.serialization.string()).optional(),
     ),
+    groupIndex: core.serialization.property("group_index", core.serialization.number().optional()),
     createdAt: core.serialization.property("created_at", core.serialization.date().optional()),
     createdBy: core.serialization.property("created_by", core.serialization.string().optional()),
     lastUpdatedAt: core.serialization.property("last_updated_at", core.serialization.date().optional()),
@@ -28,6 +29,7 @@ export declare namespace AlertTriggerConfig {
         alert_trigger_id?: string | null;
         type: AlertTriggerConfigType.Raw;
         config_value?: Record<string, string> | null;
+        group_index?: number | null;
         created_at?: string | null;
         created_by?: string | null;
         last_updated_at?: string | null;

--- a/sdks/typescript/src/opik/rest_api/serialization/types/AlertTriggerConfigPublic.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/AlertTriggerConfigPublic.ts
@@ -16,6 +16,7 @@ export const AlertTriggerConfigPublic: core.serialization.ObjectSchema<
         "config_value",
         core.serialization.record(core.serialization.string(), core.serialization.string()).optional(),
     ),
+    groupIndex: core.serialization.property("group_index", core.serialization.number().optional()),
     createdAt: core.serialization.property("created_at", core.serialization.date().optional()),
     createdBy: core.serialization.property("created_by", core.serialization.string().optional()),
     lastUpdatedAt: core.serialization.property("last_updated_at", core.serialization.date().optional()),
@@ -28,6 +29,7 @@ export declare namespace AlertTriggerConfigPublic {
         alert_trigger_id?: string | null;
         type: AlertTriggerConfigPublicType.Raw;
         config_value?: Record<string, string> | null;
+        group_index?: number | null;
         created_at?: string | null;
         created_by?: string | null;
         last_updated_at?: string | null;

--- a/sdks/typescript/src/opik/rest_api/serialization/types/AlertTriggerConfigWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/AlertTriggerConfigWrite.ts
@@ -15,6 +15,7 @@ export const AlertTriggerConfigWrite: core.serialization.ObjectSchema<
         "config_value",
         core.serialization.record(core.serialization.string(), core.serialization.string()).optional(),
     ),
+    groupIndex: core.serialization.property("group_index", core.serialization.number().optional()),
 });
 
 export declare namespace AlertTriggerConfigWrite {
@@ -22,5 +23,6 @@ export declare namespace AlertTriggerConfigWrite {
         id?: string | null;
         type: AlertTriggerConfigWriteType.Raw;
         config_value?: Record<string, string> | null;
+        group_index?: number | null;
     }
 }


### PR DESCRIPTION
## Details
Automated update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

**Triggered by BE merge:** https://github.com/comet-ml/opik/pull/6804

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate