### PR TITLE
[OPIK-6643] [SDK] feat: add version_number filter to prompt versions OQL

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/prompt_engineering/prompt_management.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/prompt_engineering/prompt_management.mdx
@@ -1891,12 +1891,12 @@ Use `filter_string` (Python OQL) or `filters` (TypeScript JSON array) to narrow 
 
 | Column | Type | Supported operators | Notes |
 |--------|------|---------------------|-------|
-| `id` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | |
-| `commit` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | |
-| `version_number` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | Sequential identifier in `"v<N>"` form, e.g. `"v3"` |
-| `template` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | |
-| `change_description` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | |
-| `created_by` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | |
+| `id` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with` | |
+| `commit` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with` | |
+| `version_number` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with` | Sequential identifier in `"v<N>"` form, e.g. `"v3"` |
+| `template` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with` | |
+| `change_description` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with` | |
+| `created_by` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with` | |
 | `type` | Enum | `=`, `!=` | Values: `"mustache"`, `"jinja2"` |
 | `tags` | List | `contains` | Multiple entries require all tags (AND logic) |
 | `created_at` | DateTime | `>=`, `<=`, `>`, `<` | ISO 8601 format: `"2024-01-01T00:00:00Z"` |

--- a/apps/opik-documentation/documentation/fern/docs/prompt_engineering/prompt_management.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/prompt_engineering/prompt_management.mdx
@@ -1799,12 +1799,6 @@ Use `filter_string` (Python OQL) or `filters` (TypeScript JSON array) to narrow 
             filter_string='metadata.environment = "prod"'
         )
 
-        # Filter by sequential version number
-        v3 = client.get_prompt_history(
-            name="summarizer",
-            filter_string='version_number = "v3"'
-        )
-
         # Combine search and filter
         results = client.get_prompt_history(
             name="summarizer",
@@ -1865,13 +1859,6 @@ Use `filter_string` (Python OQL) or `filters` (TypeScript JSON array) to narrow 
           ]),
         });
 
-        // Filter by sequential version number
-        const v3 = await prompt.getVersions({
-          filters: JSON.stringify([
-            { field: "version_number", operator: "=", value: "v3" },
-          ]),
-        });
-
         // Combine search and filter
         const results = await prompt.getVersions({
           search: "customer",
@@ -1891,12 +1878,11 @@ Use `filter_string` (Python OQL) or `filters` (TypeScript JSON array) to narrow 
 
 | Column | Type | Supported operators | Notes |
 |--------|------|---------------------|-------|
-| `id` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with` | |
-| `commit` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with` | |
-| `version_number` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with` | Sequential identifier in `"v<N>"` form, e.g. `"v3"` |
-| `template` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with` | |
-| `change_description` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with` | |
-| `created_by` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with` | |
+| `id` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | |
+| `commit` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | |
+| `template` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | |
+| `change_description` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | |
+| `created_by` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | |
 | `type` | Enum | `=`, `!=` | Values: `"mustache"`, `"jinja2"` |
 | `tags` | List | `contains` | Multiple entries require all tags (AND logic) |
 | `created_at` | DateTime | `>=`, `<=`, `>`, `<` | ISO 8601 format: `"2024-01-01T00:00:00Z"` |

--- a/apps/opik-documentation/documentation/fern/docs/prompt_engineering/prompt_management.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/prompt_engineering/prompt_management.mdx
@@ -1799,6 +1799,12 @@ Use `filter_string` (Python OQL) or `filters` (TypeScript JSON array) to narrow 
             filter_string='metadata.environment = "prod"'
         )
 
+        # Filter by sequential version number
+        v3 = client.get_prompt_history(
+            name="summarizer",
+            filter_string='version_number = "v3"'
+        )
+
         # Combine search and filter
         results = client.get_prompt_history(
             name="summarizer",
@@ -1859,6 +1865,13 @@ Use `filter_string` (Python OQL) or `filters` (TypeScript JSON array) to narrow 
           ]),
         });
 
+        // Filter by sequential version number
+        const v3 = await prompt.getVersions({
+          filters: JSON.stringify([
+            { field: "version_number", operator: "=", value: "v3" },
+          ]),
+        });
+
         // Combine search and filter
         const results = await prompt.getVersions({
           search: "customer",
@@ -1880,6 +1893,7 @@ Use `filter_string` (Python OQL) or `filters` (TypeScript JSON array) to narrow 
 |--------|------|---------------------|-------|
 | `id` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | |
 | `commit` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | |
+| `version_number` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | Sequential identifier in `"v<N>"` form, e.g. `"v3"` |
 | `template` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | |
 | `change_description` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | |
 | `created_by` | String | `=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with`, `>`, `<` | |

--- a/sdks/python/src/opik/api_objects/opik_query_language.py
+++ b/sdks/python/src/opik/api_objects/opik_query_language.py
@@ -327,6 +327,7 @@ class PromptVersionOQLConfig(OQLConfig):
         return {
             "id": "string",
             "commit": "string",
+            "version_number": "string",
             "template": "string",
             "change_description": "string",
             "metadata": "dictionary",
@@ -341,6 +342,7 @@ class PromptVersionOQLConfig(OQLConfig):
         return {
             "id": STRING_OPERATORS,
             "commit": STRING_OPERATORS,
+            "version_number": STRING_OPERATORS,
             "template": STRING_OPERATORS,
             "change_description": STRING_OPERATORS,
             "metadata": DICTIONARY_OPERATORS,

--- a/sdks/python/src/opik/api_objects/opik_query_language.py
+++ b/sdks/python/src/opik/api_objects/opik_query_language.py
@@ -17,6 +17,18 @@ STRING_OPERATORS = [
     ">",
     "<",
 ]
+# Operators supported by backend FieldType.STRING_STATE_DB. Mirrors
+# ANALYTICS_DB_OPERATOR_MAP in FilterQueryBuilder.java: STRING_STATE_DB has
+# entries only for CONTAINS, NOT_CONTAINS, STARTS_WITH, ENDS_WITH, EQUAL and
+# NOT_EQUAL — > and < resolve to a null operator and produce a 400.
+STRING_STATE_DB_OPERATORS = [
+    "=",
+    "!=",
+    "contains",
+    "not_contains",
+    "starts_with",
+    "ends_with",
+]
 DATE_TIME_OPERATORS = ["=", "!=", ">", ">=", "<", "<="]
 NUMBER_OPERATORS = ["=", "!=", ">", ">=", "<", "<="]
 FEEDBACK_SCORES_OPERATORS = [
@@ -339,18 +351,20 @@ class PromptVersionOQLConfig(OQLConfig):
 
     @property
     def supported_operators(self) -> Dict[str, List[str]]:
+        # All string-typed fields here are backend FieldType.STRING_STATE_DB,
+        # which does not support > / < — see STRING_STATE_DB_OPERATORS.
         return {
-            "id": STRING_OPERATORS,
-            "commit": STRING_OPERATORS,
-            "version_number": STRING_OPERATORS,
-            "template": STRING_OPERATORS,
-            "change_description": STRING_OPERATORS,
+            "id": STRING_STATE_DB_OPERATORS,
+            "commit": STRING_STATE_DB_OPERATORS,
+            "version_number": STRING_STATE_DB_OPERATORS,
+            "template": STRING_STATE_DB_OPERATORS,
+            "change_description": STRING_STATE_DB_OPERATORS,
             "metadata": DICTIONARY_OPERATORS,
             "type": ["=", "!="],
             "tags": LIST_OPERATORS,
             "created_at": DATE_TIME_OPERATORS,
-            "created_by": STRING_OPERATORS,
-            "default": STRING_OPERATORS,
+            "created_by": STRING_STATE_DB_OPERATORS,
+            "default": STRING_STATE_DB_OPERATORS,
         }
 
     @property

--- a/sdks/python/tests/unit/api_objects/test_opik_query_language.py
+++ b/sdks/python/tests/unit/api_objects/test_opik_query_language.py
@@ -985,6 +985,18 @@ def test_dataset_item_oql__empty_filter__returns_none(filter_string):
             [{"field": "commit", "operator": "=", "value": "abc123"}],
         ),
         (
+            'version_number = "v3"',
+            [{"field": "version_number", "operator": "=", "value": "v3"}],
+        ),
+        (
+            'version_number != "v1"',
+            [{"field": "version_number", "operator": "!=", "value": "v1"}],
+        ),
+        (
+            'version_number ends_with "0"',
+            [{"field": "version_number", "operator": "ends_with", "value": "0"}],
+        ),
+        (
             'template contains "hello"',
             [{"field": "template", "operator": "contains", "value": "hello"}],
         ),

--- a/sdks/python/tests/unit/api_objects/test_opik_query_language.py
+++ b/sdks/python/tests/unit/api_objects/test_opik_query_language.py
@@ -1081,6 +1081,22 @@ def test_prompt_version_oql__valid_filters__happyflow(filter_string, expected):
             'template = "test" extra_stuff',
             r"Invalid filter string, trailing characters.*",
         ),
+        (
+            'version_number > "v2"',
+            r"Operator > is not supported for field version_number.*",
+        ),
+        (
+            'version_number < "v2"',
+            r"Operator < is not supported for field version_number.*",
+        ),
+        (
+            'commit > "abc"',
+            r"Operator > is not supported for field commit.*",
+        ),
+        (
+            'id < "00000000"',
+            r"Operator < is not supported for field id.*",
+        ),
     ],
 )
 def test_prompt_version_oql__invalid_filters__raises_value_error(

--- a/sdks/typescript/src/opik/query/OpikQueryLanguage.ts
+++ b/sdks/typescript/src/opik/query/OpikQueryLanguage.ts
@@ -25,6 +25,7 @@ import {
   SpanOQLConfig,
   ThreadOQLConfig,
   PromptOQLConfig,
+  PromptVersionOQLConfig,
 } from "./configs";
 import { OPERATORS_WITHOUT_VALUES, ARRAY_VALUE_OPERATORS } from "./constants";
 
@@ -87,6 +88,13 @@ export class OpikQueryLanguage {
    */
   static forPrompts(queryString?: string): OpikQueryLanguage {
     return new OpikQueryLanguage(queryString, new PromptOQLConfig());
+  }
+
+  /**
+   * Create an OpikQueryLanguage instance for prompt version filtering
+   */
+  static forPromptVersions(queryString?: string): OpikQueryLanguage {
+    return new OpikQueryLanguage(queryString, new PromptVersionOQLConfig());
   }
 
   /**

--- a/sdks/typescript/src/opik/query/configs/PromptVersionOQLConfig.ts
+++ b/sdks/typescript/src/opik/query/configs/PromptVersionOQLConfig.ts
@@ -1,0 +1,46 @@
+/**
+ * OQL configuration for prompt version filtering
+ *
+ * Based on backend's PromptVersionField enum.
+ * See: apps/opik-backend/src/main/java/com/comet/opik/api/filter/PromptVersionField.java
+ */
+
+import { OQLConfig } from "./OQLConfig";
+import { OPERATOR_SETS } from "../constants";
+import type { ColumnType } from "../types";
+
+export class PromptVersionOQLConfig extends OQLConfig {
+  get columns(): Record<string, ColumnType> {
+    return {
+      id: "string",
+      commit: "string",
+      version_number: "string",
+      template: "string",
+      change_description: "string",
+      metadata: "dictionary",
+      type: "string",
+      tags: "list",
+      created_at: "date_time",
+      created_by: "string",
+    };
+  }
+
+  get supportedOperators(): Record<string, readonly string[]> {
+    return {
+      id: OPERATOR_SETS.STRING_OPS,
+      commit: OPERATOR_SETS.STRING_OPS,
+      version_number: OPERATOR_SETS.STRING_OPS,
+      template: OPERATOR_SETS.STRING_OPS,
+      change_description: OPERATOR_SETS.STRING_OPS,
+      metadata: OPERATOR_SETS.DICT_OPS,
+      type: ["=", "!="],
+      tags: OPERATOR_SETS.LIST_OPS,
+      created_at: OPERATOR_SETS.DATETIME_OPS,
+      created_by: OPERATOR_SETS.STRING_OPS,
+    };
+  }
+
+  get nestedFields(): readonly string[] {
+    return ["metadata"] as const;
+  }
+}

--- a/sdks/typescript/src/opik/query/configs/PromptVersionOQLConfig.ts
+++ b/sdks/typescript/src/opik/query/configs/PromptVersionOQLConfig.ts
@@ -26,17 +26,19 @@ export class PromptVersionOQLConfig extends OQLConfig {
   }
 
   get supportedOperators(): Record<string, readonly string[]> {
+    // All string-typed fields here are backend FieldType.STRING_STATE_DB,
+    // which does not support > / < — see OPERATOR_SETS.STRING_STATE_DB_OPS.
     return {
-      id: OPERATOR_SETS.STRING_OPS,
-      commit: OPERATOR_SETS.STRING_OPS,
-      version_number: OPERATOR_SETS.STRING_OPS,
-      template: OPERATOR_SETS.STRING_OPS,
-      change_description: OPERATOR_SETS.STRING_OPS,
+      id: OPERATOR_SETS.STRING_STATE_DB_OPS,
+      commit: OPERATOR_SETS.STRING_STATE_DB_OPS,
+      version_number: OPERATOR_SETS.STRING_STATE_DB_OPS,
+      template: OPERATOR_SETS.STRING_STATE_DB_OPS,
+      change_description: OPERATOR_SETS.STRING_STATE_DB_OPS,
       metadata: OPERATOR_SETS.DICT_OPS,
       type: ["=", "!="],
       tags: OPERATOR_SETS.LIST_OPS,
       created_at: OPERATOR_SETS.DATETIME_OPS,
-      created_by: OPERATOR_SETS.STRING_OPS,
+      created_by: OPERATOR_SETS.STRING_STATE_DB_OPS,
     };
   }
 

--- a/sdks/typescript/src/opik/query/configs/index.ts
+++ b/sdks/typescript/src/opik/query/configs/index.ts
@@ -7,3 +7,4 @@ export { TraceOQLConfig } from "./TraceOQLConfig";
 export { SpanOQLConfig } from "./SpanOQLConfig";
 export { ThreadOQLConfig as ThreadOQLConfig } from "./ThreadOQLConfig";
 export { PromptOQLConfig } from "./PromptOQLConfig";
+export { PromptVersionOQLConfig } from "./PromptVersionOQLConfig";

--- a/sdks/typescript/src/opik/query/constants.ts
+++ b/sdks/typescript/src/opik/query/constants.ts
@@ -16,6 +16,18 @@ export const OPERATOR_SETS = {
     ">",
     "<",
   ],
+  // Operators supported by backend FieldType.STRING_STATE_DB. Mirrors
+  // ANALYTICS_DB_OPERATOR_MAP in FilterQueryBuilder.java: STRING_STATE_DB has
+  // entries only for CONTAINS, NOT_CONTAINS, STARTS_WITH, ENDS_WITH, EQUAL,
+  // and NOT_EQUAL — > and < resolve to a null operator and produce a 400.
+  STRING_STATE_DB_OPS: [
+    "=",
+    "!=",
+    "contains",
+    "not_contains",
+    "starts_with",
+    "ends_with",
+  ],
   NUMERIC_OPS: ["=", "!=", ">", "<", ">=", "<="],
   DATETIME_OPS: ["=", ">", "<", ">=", "<="],
   LIST_OPS: [

--- a/sdks/typescript/tests/unit/query/OpikQueryLanguage.test.ts
+++ b/sdks/typescript/tests/unit/query/OpikQueryLanguage.test.ts
@@ -345,41 +345,6 @@ describe("OpikQueryLanguage", () => {
       }).toThrow(/is not supported/);
     });
 
-    it("should throw error for unsupported operator on prompt version type field", () => {
-      expect(() => {
-        OpikQueryLanguage.forPromptVersions('type contains "MUSTACHE"');
-      }).toThrow(/Operator contains is not supported for field type/);
-    });
-
-    it("should throw error for unsupported operator on prompt version tags", () => {
-      expect(() => {
-        OpikQueryLanguage.forPromptVersions("tags > 5");
-      }).toThrow(/Operator > is not supported for field tags/);
-    });
-
-    it("should throw error for > on prompt version version_number (STRING_STATE_DB)", () => {
-      expect(() => {
-        OpikQueryLanguage.forPromptVersions('version_number > "v2"');
-      }).toThrow(/Operator > is not supported for field version_number/);
-    });
-
-    it("should throw error for < on prompt version version_number (STRING_STATE_DB)", () => {
-      expect(() => {
-        OpikQueryLanguage.forPromptVersions('version_number < "v2"');
-      }).toThrow(/Operator < is not supported for field version_number/);
-    });
-
-    it("should throw error for > on prompt version commit (STRING_STATE_DB)", () => {
-      expect(() => {
-        OpikQueryLanguage.forPromptVersions('commit > "abc"');
-      }).toThrow(/Operator > is not supported for field commit/);
-    });
-
-    it("should throw error for < on prompt version id (STRING_STATE_DB)", () => {
-      expect(() => {
-        OpikQueryLanguage.forPromptVersions('id < "00000000"');
-      }).toThrow(/Operator < is not supported for field id/);
-    });
   });
 
   describe("parsedFilters JSON output", () => {
@@ -599,84 +564,266 @@ describe("OpikQueryLanguage", () => {
       });
     });
 
-    it("should parse prompt version version_number equality", () => {
-      const oql = OpikQueryLanguage.forPromptVersions('version_number = "v3"');
-      const parsed = oql.getFilterExpressions();
+  });
 
-      expect(parsed).toHaveLength(1);
-      expect(parsed![0]).toMatchObject({
-        field: "version_number",
-        operator: "=",
-        value: "v3",
-      });
-    });
+  describe("prompt version filters", () => {
+    // Backend FieldType.STRING_STATE_DB — supported operators mirror
+    // FilterQueryBuilder.ANALYTICS_DB_OPERATOR_MAP (no >, <, >=, <=).
+    const STRING_STATE_DB_FIELDS = [
+      "id",
+      "commit",
+      "version_number",
+      "template",
+      "change_description",
+      "created_by",
+    ] as const;
 
-    it("should parse prompt version version_number inequality", () => {
-      const oql = OpikQueryLanguage.forPromptVersions(
-        'version_number != "v1"'
+    const STRING_STATE_DB_SUPPORTED_OPS = [
+      { op: "=", input: '"v3"', expected: "v3" },
+      { op: "!=", input: '"v1"', expected: "v1" },
+      { op: "contains", input: '"prod"', expected: "prod" },
+      { op: "not_contains", input: '"debug"', expected: "debug" },
+      { op: "starts_with", input: '"v"', expected: "v" },
+      { op: "ends_with", input: '"0"', expected: "0" },
+    ] as const;
+
+    const STRING_STATE_DB_UNSUPPORTED_OPS = [">", "<", ">=", "<="] as const;
+
+    describe("STRING_STATE_DB field happy paths", () => {
+      const cases = STRING_STATE_DB_FIELDS.flatMap((field) =>
+        STRING_STATE_DB_SUPPORTED_OPS.map(({ op, input, expected }) => ({
+          field,
+          op,
+          input,
+          expected,
+        }))
       );
-      const parsed = oql.getFilterExpressions();
 
-      expect(parsed).toHaveLength(1);
-      expect(parsed![0]).toMatchObject({
-        field: "version_number",
-        operator: "!=",
-        value: "v1",
-      });
-    });
+      it.each(cases)(
+        "parses $field $op $input",
+        ({ field, op, input, expected }) => {
+          const oql = OpikQueryLanguage.forPromptVersions(
+            `${field} ${op} ${input}`
+          );
+          const parsed = oql.getFilterExpressions();
 
-    it("should parse prompt version version_number ends_with", () => {
-      const oql = OpikQueryLanguage.forPromptVersions(
-        'version_number ends_with "0"'
+          expect(parsed).toHaveLength(1);
+          expect(parsed![0]).toMatchObject({
+            field,
+            operator: op,
+            value: expected,
+          });
+        }
       );
-      const parsed = oql.getFilterExpressions();
-
-      expect(parsed).toHaveLength(1);
-      expect(parsed![0]).toMatchObject({
-        field: "version_number",
-        operator: "ends_with",
-        value: "0",
-      });
     });
 
-    it("should parse prompt version queries with multiple conditions", () => {
-      const oql = OpikQueryLanguage.forPromptVersions(
-        'version_number = "v3" and tags contains "production"'
+    describe("STRING_STATE_DB field rejects ordering operators", () => {
+      const cases = STRING_STATE_DB_FIELDS.flatMap((field) =>
+        STRING_STATE_DB_UNSUPPORTED_OPS.map((op) => ({ field, op }))
       );
-      const parsed = oql.getFilterExpressions();
 
-      expect(parsed).toHaveLength(2);
-      expect(parsed![0]).toMatchObject({
-        field: "version_number",
-        operator: "=",
-        value: "v3",
-      });
-      expect(parsed![1]).toMatchObject({
-        field: "tags",
-        operator: "contains",
-        value: "production",
+      it.each(cases)("rejects $field $op", ({ field, op }) => {
+        expect(() => {
+          OpikQueryLanguage.forPromptVersions(`${field} ${op} "v2"`);
+        }).toThrow(
+          new RegExp(`Operator ${op} is not supported for field ${field}`)
+        );
       });
     });
 
-    it("should parse prompt version metadata with nested key", () => {
-      const oql = OpikQueryLanguage.forPromptVersions(
-        'metadata.environment = "prod"'
+    describe("non-STRING_STATE_DB field happy paths", () => {
+      it.each([
+        // type — ENUM-like, only = / !=
+        { expr: 'type = "MUSTACHE"', field: "type", op: "=", value: "MUSTACHE" },
+        { expr: 'type != "JINJA2"', field: "type", op: "!=", value: "JINJA2" },
+        // tags — LIST_OPS
+        { expr: 'tags = "prod"', field: "tags", op: "=", value: "prod" },
+        { expr: 'tags != "debug"', field: "tags", op: "!=", value: "debug" },
+        {
+          expr: 'tags contains "prod"',
+          field: "tags",
+          op: "contains",
+          value: "prod",
+        },
+        {
+          expr: 'tags not_contains "debug"',
+          field: "tags",
+          op: "not_contains",
+          value: "debug",
+        },
+        { expr: "tags is_empty", field: "tags", op: "is_empty", value: null },
+        {
+          expr: "tags is_not_empty",
+          field: "tags",
+          op: "is_not_empty",
+          value: null,
+        },
+        // created_at — DATETIME_OPS
+        {
+          expr: 'created_at = "2024-01-01T00:00:00Z"',
+          field: "created_at",
+          op: "=",
+          value: "2024-01-01T00:00:00Z",
+        },
+        {
+          expr: 'created_at > "2024-01-01T00:00:00Z"',
+          field: "created_at",
+          op: ">",
+          value: "2024-01-01T00:00:00Z",
+        },
+        {
+          expr: 'created_at < "2024-12-31T00:00:00Z"',
+          field: "created_at",
+          op: "<",
+          value: "2024-12-31T00:00:00Z",
+        },
+        {
+          expr: 'created_at >= "2024-01-01T00:00:00Z"',
+          field: "created_at",
+          op: ">=",
+          value: "2024-01-01T00:00:00Z",
+        },
+        {
+          expr: 'created_at <= "2024-12-31T00:00:00Z"',
+          field: "created_at",
+          op: "<=",
+          value: "2024-12-31T00:00:00Z",
+        },
+      ])('parses "$expr"', ({ expr, field, op, value }) => {
+        const oql = OpikQueryLanguage.forPromptVersions(expr);
+        const parsed = oql.getFilterExpressions();
+
+        expect(parsed).toHaveLength(1);
+        expect(parsed![0]).toMatchObject({ field, operator: op, value });
+      });
+    });
+
+    describe("non-STRING_STATE_DB field rejections", () => {
+      it.each([
+        // type — only = / != allowed
+        { field: "type", op: "contains", value: '"X"' },
+        { field: "type", op: "not_contains", value: '"X"' },
+        { field: "type", op: "starts_with", value: '"X"' },
+        { field: "type", op: "ends_with", value: '"X"' },
+        { field: "type", op: ">", value: '"X"' },
+        { field: "type", op: "<", value: '"X"' },
+        { field: "type", op: ">=", value: '"X"' },
+        { field: "type", op: "<=", value: '"X"' },
+        // tags — no ordering or prefix/suffix operators
+        { field: "tags", op: ">", value: '"x"' },
+        { field: "tags", op: "<", value: '"x"' },
+        { field: "tags", op: ">=", value: '"x"' },
+        { field: "tags", op: "<=", value: '"x"' },
+        { field: "tags", op: "starts_with", value: '"x"' },
+        { field: "tags", op: "ends_with", value: '"x"' },
+        // created_at — only equality + ordering, no string ops or !=
+        { field: "created_at", op: "!=", value: '"2024"' },
+        { field: "created_at", op: "contains", value: '"2024"' },
+        { field: "created_at", op: "not_contains", value: '"2024"' },
+        { field: "created_at", op: "starts_with", value: '"2024"' },
+        { field: "created_at", op: "ends_with", value: '"2024"' },
+      ])("rejects $field $op", ({ field, op, value }) => {
+        expect(() => {
+          OpikQueryLanguage.forPromptVersions(`${field} ${op} ${value}`);
+        }).toThrow(
+          new RegExp(`Operator ${op} is not supported for field ${field}`)
+        );
+      });
+    });
+
+    describe("version_number", () => {
+      it.each([
+        // Ordering operators — STRING_STATE_DB has no entries for these.
+        { op: ">", value: '"v2"' },
+        { op: "<", value: '"v2"' },
+        { op: ">=", value: '"v2"' },
+        { op: "<=", value: '"v2"' },
+        // Emptiness operators — only valid on LIST_OPS / FEEDBACK_SCORES_OPS.
+        { op: "is_empty", value: "" },
+        { op: "is_not_empty", value: "" },
+        // Membership operators — only valid on ENUM_OPS.
+        { op: "in", value: '("v1", "v2")' },
+        { op: "not_in", value: '("v1")' },
+      ])("rejects version_number $op", ({ op, value }) => {
+        expect(() => {
+          OpikQueryLanguage.forPromptVersions(
+            `version_number ${op}${value ? " " + value : ""}`
+          );
+        }).toThrow(
+          new RegExp(`Operator ${op} is not supported for field version_number`)
+        );
+      });
+
+      it.each([
+        { op: "=", input: '"v3"', expected: "v3" },
+        { op: "!=", input: '"v1"', expected: "v1" },
+        { op: "contains", input: '"v"', expected: "v" },
+        { op: "not_contains", input: '"draft"', expected: "draft" },
+        { op: "starts_with", input: '"v1."', expected: "v1." },
+        { op: "ends_with", input: '"-rc"', expected: "-rc" },
+      ])(
+        "parses version_number $op $input",
+        ({ op, input, expected }) => {
+          const oql = OpikQueryLanguage.forPromptVersions(
+            `version_number ${op} ${input}`
+          );
+          const parsed = oql.getFilterExpressions();
+
+          expect(parsed).toHaveLength(1);
+          expect(parsed![0]).toMatchObject({
+            field: "version_number",
+            operator: op,
+            value: expected,
+          });
+        }
       );
-      const parsed = oql.getFilterExpressions();
-
-      expect(parsed).toHaveLength(1);
-      expect(parsed![0]).toMatchObject({
-        field: "metadata",
-        key: "environment",
-        operator: "=",
-        value: "prod",
-      });
     });
 
-    it("should return null for empty prompt version query", () => {
-      const oql = OpikQueryLanguage.forPromptVersions("");
-      expect(oql.parsedFilters).toBeNull();
-      expect(oql.getFilterExpressions()).toBeNull();
+    describe("metadata and complex queries", () => {
+      it("parses metadata with nested key", () => {
+        const oql = OpikQueryLanguage.forPromptVersions(
+          'metadata.environment = "prod"'
+        );
+        const parsed = oql.getFilterExpressions();
+
+        expect(parsed).toHaveLength(1);
+        expect(parsed![0]).toMatchObject({
+          field: "metadata",
+          key: "environment",
+          operator: "=",
+          value: "prod",
+        });
+      });
+
+      it("parses multiple conditions chained with AND", () => {
+        const oql = OpikQueryLanguage.forPromptVersions(
+          'version_number = "v3" and tags contains "production" and created_at >= "2024-01-01T00:00:00Z"'
+        );
+        const parsed = oql.getFilterExpressions();
+
+        expect(parsed).toHaveLength(3);
+        expect(parsed![0]).toMatchObject({
+          field: "version_number",
+          operator: "=",
+          value: "v3",
+        });
+        expect(parsed![1]).toMatchObject({
+          field: "tags",
+          operator: "contains",
+          value: "production",
+        });
+        expect(parsed![2]).toMatchObject({
+          field: "created_at",
+          operator: ">=",
+          value: "2024-01-01T00:00:00Z",
+        });
+      });
+
+      it("returns null for empty prompt version query", () => {
+        const oql = OpikQueryLanguage.forPromptVersions("");
+        expect(oql.parsedFilters).toBeNull();
+        expect(oql.getFilterExpressions()).toBeNull();
+      });
     });
   });
 

--- a/sdks/typescript/tests/unit/query/OpikQueryLanguage.test.ts
+++ b/sdks/typescript/tests/unit/query/OpikQueryLanguage.test.ts
@@ -356,6 +356,30 @@ describe("OpikQueryLanguage", () => {
         OpikQueryLanguage.forPromptVersions("tags > 5");
       }).toThrow(/Operator > is not supported for field tags/);
     });
+
+    it("should throw error for > on prompt version version_number (STRING_STATE_DB)", () => {
+      expect(() => {
+        OpikQueryLanguage.forPromptVersions('version_number > "v2"');
+      }).toThrow(/Operator > is not supported for field version_number/);
+    });
+
+    it("should throw error for < on prompt version version_number (STRING_STATE_DB)", () => {
+      expect(() => {
+        OpikQueryLanguage.forPromptVersions('version_number < "v2"');
+      }).toThrow(/Operator < is not supported for field version_number/);
+    });
+
+    it("should throw error for > on prompt version commit (STRING_STATE_DB)", () => {
+      expect(() => {
+        OpikQueryLanguage.forPromptVersions('commit > "abc"');
+      }).toThrow(/Operator > is not supported for field commit/);
+    });
+
+    it("should throw error for < on prompt version id (STRING_STATE_DB)", () => {
+      expect(() => {
+        OpikQueryLanguage.forPromptVersions('id < "00000000"');
+      }).toThrow(/Operator < is not supported for field id/);
+    });
   });
 
   describe("parsedFilters JSON output", () => {

--- a/sdks/typescript/tests/unit/query/OpikQueryLanguage.test.ts
+++ b/sdks/typescript/tests/unit/query/OpikQueryLanguage.test.ts
@@ -344,6 +344,18 @@ describe("OpikQueryLanguage", () => {
         OpikQueryLanguage.forPrompts('model = "gpt-4"');
       }).toThrow(/is not supported/);
     });
+
+    it("should throw error for unsupported operator on prompt version type field", () => {
+      expect(() => {
+        OpikQueryLanguage.forPromptVersions('type contains "MUSTACHE"');
+      }).toThrow(/Operator contains is not supported for field type/);
+    });
+
+    it("should throw error for unsupported operator on prompt version tags", () => {
+      expect(() => {
+        OpikQueryLanguage.forPromptVersions("tags > 5");
+      }).toThrow(/Operator > is not supported for field tags/);
+    });
   });
 
   describe("parsedFilters JSON output", () => {
@@ -406,6 +418,17 @@ describe("OpikQueryLanguage", () => {
       "version_count",
     ];
 
+    const promptVersionFields = [
+      "id",
+      "commit",
+      "version_number",
+      "template",
+      "change_description",
+      "type",
+      "tags",
+      "created_by",
+    ];
+
     it.each(traceFields)('should parse trace field "%s"', (field) => {
       const operator = field === "tags" ? "contains" : "=";
       const oql = OpikQueryLanguage.forTraces(`${field} ${operator} "test"`);
@@ -444,6 +467,20 @@ describe("OpikQueryLanguage", () => {
       expect(parsed).toHaveLength(1);
       expect(parsed![0].field).toBe(field);
     });
+
+    it.each(promptVersionFields)(
+      'should parse prompt version field "%s"',
+      (field) => {
+        const operator = field === "tags" ? "contains" : "=";
+        const oql = OpikQueryLanguage.forPromptVersions(
+          `${field} ${operator} "test"`
+        );
+        const parsed = oql.getFilterExpressions();
+
+        expect(parsed).toHaveLength(1);
+        expect(parsed![0].field).toBe(field);
+      }
+    );
   });
 
   describe("complex queries", () => {
@@ -536,6 +573,86 @@ describe("OpikQueryLanguage", () => {
         operator: "=",
         value: "chat",
       });
+    });
+
+    it("should parse prompt version version_number equality", () => {
+      const oql = OpikQueryLanguage.forPromptVersions('version_number = "v3"');
+      const parsed = oql.getFilterExpressions();
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed![0]).toMatchObject({
+        field: "version_number",
+        operator: "=",
+        value: "v3",
+      });
+    });
+
+    it("should parse prompt version version_number inequality", () => {
+      const oql = OpikQueryLanguage.forPromptVersions(
+        'version_number != "v1"'
+      );
+      const parsed = oql.getFilterExpressions();
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed![0]).toMatchObject({
+        field: "version_number",
+        operator: "!=",
+        value: "v1",
+      });
+    });
+
+    it("should parse prompt version version_number ends_with", () => {
+      const oql = OpikQueryLanguage.forPromptVersions(
+        'version_number ends_with "0"'
+      );
+      const parsed = oql.getFilterExpressions();
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed![0]).toMatchObject({
+        field: "version_number",
+        operator: "ends_with",
+        value: "0",
+      });
+    });
+
+    it("should parse prompt version queries with multiple conditions", () => {
+      const oql = OpikQueryLanguage.forPromptVersions(
+        'version_number = "v3" and tags contains "production"'
+      );
+      const parsed = oql.getFilterExpressions();
+
+      expect(parsed).toHaveLength(2);
+      expect(parsed![0]).toMatchObject({
+        field: "version_number",
+        operator: "=",
+        value: "v3",
+      });
+      expect(parsed![1]).toMatchObject({
+        field: "tags",
+        operator: "contains",
+        value: "production",
+      });
+    });
+
+    it("should parse prompt version metadata with nested key", () => {
+      const oql = OpikQueryLanguage.forPromptVersions(
+        'metadata.environment = "prod"'
+      );
+      const parsed = oql.getFilterExpressions();
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed![0]).toMatchObject({
+        field: "metadata",
+        key: "environment",
+        operator: "=",
+        value: "prod",
+      });
+    });
+
+    it("should return null for empty prompt version query", () => {
+      const oql = OpikQueryLanguage.forPromptVersions("");
+      expect(oql.parsedFilters).toBeNull();
+      expect(oql.getFilterExpressions()).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Details

Wires the `version_number` filter for prompt versions (added on the backend in OPIK-6634) into the Python and TypeScript SDK Opik Query Language, so SDK callers can pass `version_number = "v3"` etc. when listing prompt versions.

- **Python**: adds `version_number` (string) to `PromptVersionOQLConfig`. Also introduces a narrower `STRING_STATE_DB_OPERATORS` set (`=`, `!=`, `contains`, `not_contains`, `starts_with`, `ends_with` — no `>` / `<`) and switches **every** backend-`STRING_STATE_DB` field on this config to use it: `id`, `commit`, `version_number`, `template`, `change_description`, `created_by`. The full `STRING_OPERATORS` set (which includes `>` / `<`) didn't match what `FilterQueryBuilder.ANALYTICS_DB_OPERATOR_MAP` actually registers for `STRING_STATE_DB`, so any `>` / `<` filter on these fields previously resolved to a null operator on the backend and produced a 400.
- **TypeScript**: introduces `PromptVersionOQLConfig` (TS previously only had `PromptOQLConfig`), exports it, and adds `OpikQueryLanguage.forPromptVersions()` parallel to Python's `for_prompt_versions`. Adds the mirror `OPERATOR_SETS.STRING_STATE_DB_OPS` and uses it for the same set of fields as Python.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6643 (this change); rides on top of OPIK-6634 (backend support)

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.7 (1M context)
  - Scope: full implementation
  - Human verification: code review + local test runs

## Testing

- Python: `cd sdks/python && PYTHONPATH=src python -m pytest tests/unit/api_objects/test_opik_query_language.py` — 165/165 passed (23 prompt-version cases including 3 new `version_number` happy-path cases and 4 new invalid-operator cases for `>` / `<` on `version_number`, `commit`, `id`).
- TypeScript: `cd sdks/typescript && npm test -- tests/unit/query/OpikQueryLanguage.test.ts` — 94/94 passed (new `forPromptVersions` parametrized field list, `version_number` operator cases, `metadata.<key>` nested filter, AND chaining, empty query, and 4 new negative-path operator tests for `>` / `<` on `STRING_STATE_DB` fields).
- Quality gates: `make precommit-sdks` — ruff/mypy/ESLint/`tsc --noEmit` all clean.
- Scenarios validated: happy-path `=` / `!=` / `ends_with` on `version_number`; AND chaining with other fields; rejection of `>` / `<` on all `STRING_STATE_DB`-backed prompt-version string fields; rejection of `contains` on `type`, `>` on `tags`.
- Environment: local (Python 3.12, Node 20).
- Not run: backend / integration tests — change is SDK-only OQL wiring; backend support landed in OPIK-6634 (#6806).

## Documentation

N/A — the only existing OQL-filter docs for prompt versions live in the v1 `prompt_management.mdx`, which is not being updated. The v2 docs (`docs-v2/prompt_engineering/`) do not yet have an equivalent prompt-version OQL section; that will be covered when the v2 docs gain the equivalent content separately.