### PR TITLE
[OPIK-6650] [SDK] fix: filter conflicting keys from dataset item data before unpacking

### DIFF
--- a/sdks/python/src/opik/api_objects/dataset/rest_operations.py
+++ b/sdks/python/src/opik/api_objects/dataset/rest_operations.py
@@ -125,7 +125,9 @@ def stream_dataset_items(
             # Strip DatasetItem field names from user data before unpacking to avoid
             # "multiple values for keyword argument" errors. This happens when user data
             # contains a key that matches a DatasetItem field (e.g. 'id' in HotpotQA).
-            conflicting = item.data.keys() & dataset_item.DatasetItem.model_fields.keys()
+            conflicting = (
+                item.data.keys() & dataset_item.DatasetItem.model_fields.keys()
+            )
             if conflicting and not _conflicting_keys_warned:
                 _conflicting_keys_warned = True
                 LOGGER.warning(
@@ -133,7 +135,11 @@ def stream_dataset_items(
                     "Rename these keys in your dataset to preserve them.",
                     sorted(conflicting),
                 )
-            extra_data = {k: v for k, v in item.data.items() if k not in dataset_item.DatasetItem.model_fields}
+            extra_data = {
+                k: v
+                for k, v in item.data.items()
+                if k not in dataset_item.DatasetItem.model_fields
+            }
 
             reconstructed_item = dataset_item.DatasetItem(
                 id=item.id,

--- a/sdks/python/src/opik/api_objects/dataset/rest_operations.py
+++ b/sdks/python/src/opik/api_objects/dataset/rest_operations.py
@@ -121,6 +121,18 @@ def stream_dataset_items(
                     pass_threshold=item.execution_policy.pass_threshold,
                 )
 
+            # Strip DatasetItem field names from user data before unpacking to avoid
+            # "multiple values for keyword argument" errors. This happens when user data
+            # contains a key that matches a DatasetItem field (e.g. 'id' in HotpotQA).
+            conflicting = item.data.keys() & dataset_item.DatasetItem.model_fields.keys()
+            if conflicting:
+                LOGGER.warning(
+                    "Dataset item data contains keys that shadow DatasetItem fields and will be ignored: %s. "
+                    "Rename these keys in your dataset to preserve them.",
+                    sorted(conflicting),
+                )
+            extra_data = {k: v for k, v in item.data.items() if k not in dataset_item.DatasetItem.model_fields}
+
             reconstructed_item = dataset_item.DatasetItem(
                 id=item.id,
                 trace_id=item.trace_id,
@@ -129,7 +141,7 @@ def stream_dataset_items(
                 description=item.description,
                 evaluators=evaluators,
                 execution_policy=execution_policy,
-                **item.data,
+                **extra_data,
             )
 
             yield reconstructed_item

--- a/sdks/python/src/opik/api_objects/dataset/rest_operations.py
+++ b/sdks/python/src/opik/api_objects/dataset/rest_operations.py
@@ -60,6 +60,7 @@ def stream_dataset_items(
     dataset_items_ids_left: Optional[Set[str]] = (
         set(dataset_item_ids) if dataset_item_ids else None
     )
+    _conflicting_keys_warned = False
 
     filters: Optional[str] = None
     if filter_string:
@@ -125,7 +126,8 @@ def stream_dataset_items(
             # "multiple values for keyword argument" errors. This happens when user data
             # contains a key that matches a DatasetItem field (e.g. 'id' in HotpotQA).
             conflicting = item.data.keys() & dataset_item.DatasetItem.model_fields.keys()
-            if conflicting:
+            if conflicting and not _conflicting_keys_warned:
+                _conflicting_keys_warned = True
                 LOGGER.warning(
                     "Dataset item data contains keys that shadow DatasetItem fields and will be ignored: %s. "
                     "Rename these keys in your dataset to preserve them.",

--- a/sdks/python/tests/unit/api_objects/dataset/test_stream_dataset_items.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_stream_dataset_items.py
@@ -1,9 +1,12 @@
 """Unit tests for stream_dataset_items() in rest_operations."""
 
+import logging
 from unittest.mock import Mock, patch
 
 from opik.api_objects.dataset import rest_operations
 from opik.rest_api.types import dataset_item as rest_dataset_item
+
+_LOGGER_NAME = "opik.api_objects.dataset.rest_operations"
 
 
 def _make_rest_item(item_id: str, data: dict) -> rest_dataset_item.DatasetItem:
@@ -20,6 +23,7 @@ def test_stream_dataset_items__colliding_id_key__uses_real_id_and_warns(caplog):
 
     mock_rest_client = Mock()
 
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
     with patch(
         "opik.api_objects.dataset.rest_operations.rest_stream_parser.read_and_parse_stream",
         side_effect=[[rest_item], []],
@@ -52,6 +56,7 @@ def test_stream_dataset_items__colliding_id_key__warning_emitted_only_once(caplo
 
     mock_rest_client = Mock()
 
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
     with patch(
         "opik.api_objects.dataset.rest_operations.rest_stream_parser.read_and_parse_stream",
         side_effect=[items_data, []],

--- a/sdks/python/tests/unit/api_objects/dataset/test_stream_dataset_items.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_stream_dataset_items.py
@@ -36,7 +36,9 @@ def test_stream_dataset_items__colliding_id_key__uses_real_id_and_warns(caplog):
     assert items[0].id == real_id
     assert "COLLISION" not in vars(items[0]).get("id", "")
 
-    warning_records = [r for r in caplog.records if r.levelname == "WARNING" and "shadow" in r.message]
+    warning_records = [
+        r for r in caplog.records if r.levelname == "WARNING" and "shadow" in r.message
+    ]
     assert len(warning_records) == 1
     assert "['id']" in warning_records[0].message
 
@@ -63,5 +65,7 @@ def test_stream_dataset_items__colliding_id_key__warning_emitted_only_once(caplo
         )
 
     assert len(result) == 3
-    warning_records = [r for r in caplog.records if r.levelname == "WARNING" and "shadow" in r.message]
+    warning_records = [
+        r for r in caplog.records if r.levelname == "WARNING" and "shadow" in r.message
+    ]
     assert len(warning_records) == 1

--- a/sdks/python/tests/unit/api_objects/dataset/test_stream_dataset_items.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_stream_dataset_items.py
@@ -1,0 +1,67 @@
+"""Unit tests for stream_dataset_items() in rest_operations."""
+
+from unittest.mock import Mock, patch
+
+from opik.api_objects.dataset import rest_operations
+from opik.rest_api.types import dataset_item as rest_dataset_item
+
+
+def _make_rest_item(item_id: str, data: dict) -> rest_dataset_item.DatasetItem:
+    return rest_dataset_item.DatasetItem(
+        id=item_id,
+        source="sdk",
+        data=data,
+    )
+
+
+def test_stream_dataset_items__colliding_id_key__uses_real_id_and_warns(caplog):
+    real_id = "real-uuid-1234"
+    rest_item = _make_rest_item(real_id, {"id": "COLLISION", "question": "What?"})
+
+    mock_rest_client = Mock()
+
+    with patch(
+        "opik.api_objects.dataset.rest_operations.rest_stream_parser.read_and_parse_stream",
+        side_effect=[[rest_item], []],
+    ):
+        items = list(
+            rest_operations.stream_dataset_items(
+                rest_client=mock_rest_client,
+                dataset_name="test-dataset",
+                project_name=None,
+            )
+        )
+
+    assert len(items) == 1
+    assert items[0].id == real_id
+    assert "COLLISION" not in vars(items[0]).get("id", "")
+
+    warning_records = [r for r in caplog.records if r.levelname == "WARNING" and "shadow" in r.message]
+    assert len(warning_records) == 1
+    assert "['id']" in warning_records[0].message
+
+
+def test_stream_dataset_items__colliding_id_key__warning_emitted_only_once(caplog):
+    """Warning is logged once per stream even when multiple items have the collision."""
+    items_data = [
+        _make_rest_item(f"uuid-{i}", {"id": f"hotpot-{i}", "question": "Q?"})
+        for i in range(3)
+    ]
+
+    mock_rest_client = Mock()
+
+    with patch(
+        "opik.api_objects.dataset.rest_operations.rest_stream_parser.read_and_parse_stream",
+        side_effect=[items_data, []],
+    ):
+        result = list(
+            rest_operations.stream_dataset_items(
+                rest_client=mock_rest_client,
+                dataset_name="test-dataset",
+                project_name=None,
+            )
+        )
+
+    assert len(result) == 3
+    warning_records = [r for r in caplog.records if r.levelname == "WARNING" and "shadow" in r.message]
+    assert len(warning_records) == 1

--- a/sdks/python/tests/unit/api_objects/dataset/test_stream_dataset_items.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_stream_dataset_items.py
@@ -1,12 +1,14 @@
 """Unit tests for stream_dataset_items() in rest_operations."""
 
-import logging
 from unittest.mock import Mock, patch
 
 from opik.api_objects.dataset import rest_operations
 from opik.rest_api.types import dataset_item as rest_dataset_item
 
-_LOGGER_NAME = "opik.api_objects.dataset.rest_operations"
+_SHADOW_WARNING = (
+    "Dataset item data contains keys that shadow DatasetItem fields and will be ignored: %s. "
+    "Rename these keys in your dataset to preserve them."
+)
 
 
 def _make_rest_item(item_id: str, data: dict) -> rest_dataset_item.DatasetItem:
@@ -17,17 +19,16 @@ def _make_rest_item(item_id: str, data: dict) -> rest_dataset_item.DatasetItem:
     )
 
 
-def test_stream_dataset_items__colliding_id_key__uses_real_id_and_warns(caplog):
+def test_stream_dataset_items__colliding_id_key__uses_real_id_and_warns():
     real_id = "real-uuid-1234"
     rest_item = _make_rest_item(real_id, {"id": "COLLISION", "question": "What?"})
 
     mock_rest_client = Mock()
 
-    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
     with patch(
         "opik.api_objects.dataset.rest_operations.rest_stream_parser.read_and_parse_stream",
         side_effect=[[rest_item], []],
-    ):
+    ), patch.object(rest_operations.LOGGER, "warning") as mock_warn:
         items = list(
             rest_operations.stream_dataset_items(
                 rest_client=mock_rest_client,
@@ -38,16 +39,11 @@ def test_stream_dataset_items__colliding_id_key__uses_real_id_and_warns(caplog):
 
     assert len(items) == 1
     assert items[0].id == real_id
-    assert "COLLISION" not in vars(items[0]).get("id", "")
 
-    warning_records = [
-        r for r in caplog.records if r.levelname == "WARNING" and "shadow" in r.message
-    ]
-    assert len(warning_records) == 1
-    assert "['id']" in warning_records[0].message
+    mock_warn.assert_called_once_with(_SHADOW_WARNING, ["id"])
 
 
-def test_stream_dataset_items__colliding_id_key__warning_emitted_only_once(caplog):
+def test_stream_dataset_items__colliding_id_key__warning_emitted_only_once():
     """Warning is logged once per stream even when multiple items have the collision."""
     items_data = [
         _make_rest_item(f"uuid-{i}", {"id": f"hotpot-{i}", "question": "Q?"})
@@ -56,11 +52,10 @@ def test_stream_dataset_items__colliding_id_key__warning_emitted_only_once(caplo
 
     mock_rest_client = Mock()
 
-    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
     with patch(
         "opik.api_objects.dataset.rest_operations.rest_stream_parser.read_and_parse_stream",
         side_effect=[items_data, []],
-    ):
+    ), patch.object(rest_operations.LOGGER, "warning") as mock_warn:
         result = list(
             rest_operations.stream_dataset_items(
                 rest_client=mock_rest_client,
@@ -70,7 +65,4 @@ def test_stream_dataset_items__colliding_id_key__warning_emitted_only_once(caplo
         )
 
     assert len(result) == 3
-    warning_records = [
-        r for r in caplog.records if r.levelname == "WARNING" and "shadow" in r.message
-    ]
-    assert len(warning_records) == 1
+    mock_warn.assert_called_once_with(_SHADOW_WARNING, ["id"])


### PR DESCRIPTION
## Details

When streaming dataset items from the backend, the SDK reconstructs `DatasetItem` objects by calling `DatasetItem(id=item.id, ..., **item.data)`. If `item.data` contains a key that matches a declared field on `DatasetItem` (e.g. `id` in HotPotQA datasets), Python raises `TypeError: got multiple values for keyword argument 'id'`, causing Optimization Studio runs to fail immediately with zero trials.

Fix: filter `item.data` keys against `DatasetItem.model_fields` before unpacking and emit a warning (once per stream) so dataset owners know which keys were dropped.

Verified via the S3 optimization log for the failing production run `019e4f45-e6c8-7379-bd9c-a439e9c50c3e` (dataset "HotPot30 - Comparison").

## Change checklist

- [x] Strip conflicting field names from `item.data` before `**` unpacking
- [x] Warning logged at most once per stream when keys are dropped
- [x] Unit tests covering single-collision and multi-item log-once behaviour

## Issues

OPIK-6650

## AI-WATERMARK

1

## Testing

- Unit tests in `sdks/python/tests/unit/api_objects/dataset/test_stream_dataset_items.py`
- Manually confirmed via S3 log that the crash was `TypeError: got multiple values for keyword argument 'id'`

## Documentation

No docs change needed.