### PR TITLE
[NA] [BE] fix: include workspace-level datasets in project dataset listings

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetDAO.java
@@ -98,7 +98,7 @@ public interface DatasetDAO {
             SELECT COUNT(id) FROM datasets
             WHERE workspace_id = :workspace_id
             <if(name)> AND name like concat('%', :name, '%') <endif>
-            <if(project_id)> AND project_id = :project_id <endif>
+            <if(project_id)> AND (project_id = :project_id OR project_id IS NULL) <endif>
             <if(filters)> AND <filters> <endif>
             <if(visibility)> AND visibility = :visibility <endif>
             <if(with_experiments_only)> AND last_created_experiment_at IS NOT NULL <endif>
@@ -188,7 +188,7 @@ public interface DatasetDAO {
             SELECT * FROM datasets
             WHERE workspace_id = :workspace_id
             <if(name)> AND name like concat('%', :name, '%') <endif>
-            <if(project_id)> AND project_id = :project_id <endif>
+            <if(project_id)> AND (project_id = :project_id OR project_id IS NULL) <endif>
             <if(filters)> AND <filters> <endif>
             <if(visibility)> AND visibility = :visibility <endif>
             <if(with_experiments_only)> AND last_created_experiment_at IS NOT NULL <endif>

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceFindProjectDatasetsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceFindProjectDatasetsTest.java
@@ -603,6 +603,46 @@ class DatasetsResourceFindProjectDatasetsTest {
     }
 
     @Test
+    @DisplayName("when workspace-level datasets exist, then include them alongside project-scoped datasets")
+    void getProjectDatasets__includesWorkspaceLevelDatasets() {
+        String workspaceName = UUID.randomUUID().toString();
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var projectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey, workspaceName);
+        var otherProjectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey, workspaceName);
+
+        List<UUID> projectDatasetIds = buildDatasets().stream()
+                .map(d -> d.toBuilder().projectId(projectId).build())
+                .map(dataset -> createAndAssert(dataset, apiKey, workspaceName))
+                .toList();
+
+        // workspace-level datasets (projectId=null) simulate V1 / pre-migration datasets
+        List<UUID> workspaceDatasetIds = buildDatasets().stream()
+                .map(dataset -> createAndAssert(dataset, apiKey, workspaceName))
+                .toList();
+
+        // datasets in another project — must not appear
+        buildDatasets().stream()
+                .map(d -> d.toBuilder().projectId(otherProjectId).build())
+                .forEach(dataset -> createAndAssert(dataset, apiKey, workspaceName));
+
+        int totalExpected = projectDatasetIds.size() + workspaceDatasetIds.size();
+        var actualPage = datasetResourceClient.getProjectDatasets(projectId, 1, totalExpected + 50, workspaceName,
+                apiKey);
+
+        var expectedIds = new HashSet<UUID>();
+        expectedIds.addAll(projectDatasetIds);
+        expectedIds.addAll(workspaceDatasetIds);
+
+        var actualIds = new HashSet<>(actualPage.content().stream().map(Dataset::id).toList());
+
+        assertThat(actualPage.total()).isEqualTo(totalExpected);
+        assertThat(actualIds).isEqualTo(expectedIds);
+    }
+
+    @Test
     @DisplayName("when searching by dataset name, then return matching datasets")
     void getProjectDatasets__whenSearchingByDatasetName__thenReturnMatchingDatasets() {
         UUID datasetSuffix = UUID.randomUUID();


### PR DESCRIPTION
## Details

`GET /v1/private/projects/{projectId}/datasets` (used by the Optimization Studio dataset selector) used a strict `project_id = :project_id` SQL filter in `DatasetDAO.find()` and `DatasetDAO.findCount()`. This made workspace-level datasets (`project_id IS NULL`) — i.e. V1/pre-migration datasets — invisible in the dropdown, so users could not start an optimization run against them.

Fix: change both queries to `(project_id = :project_id OR project_id IS NULL)`, matching the pattern already used by `getOrCreate` and `findByName` for single-dataset lookups.

## Change checklist

- [x] `DatasetDAO.find()`: added `OR project_id IS NULL` to the `<if(project_id)>` condition
- [x] `DatasetDAO.findCount()`: same change
- [x] New integration test `getProjectDatasets__includesWorkspaceLevelDatasets()` verifies workspace-level datasets appear in project listings and that other-project datasets are excluded

## Issues

Fixes Optimization Studio dataset selector not showing V1/workspace-level datasets.

## AI-WATERMARK

1

## Testing

New test in `DatasetsResourceFindProjectDatasetsTest` covers the scenario end-to-end via the HTTP endpoint.

## Documentation

No docs change needed.