### PR TITLE
fix(prompts): hide raw/pretty toggle in create & edit text prompts

### DIFF
--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/EditPromptSheet.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/EditPromptSheet.tsx
@@ -13,7 +13,6 @@ import { ChevronDown, Plus, Sparkles } from "lucide-react";
 import { Sheet, SheetContent, SheetTopBar } from "@/ui/sheet";
 import { Label } from "@/ui/label";
 import { Button } from "@/ui/button";
-import MarkdownPreview from "@/shared/MarkdownPreview/MarkdownPreview";
 import AutoResizeTextarea from "@/v2/pages-shared/agent-configuration/fields/AutoResizeTextarea";
 import { useActiveProjectId } from "@/store/AppStore";
 import useCreatePromptVersionMutation from "@/api/prompts/useCreatePromptVersionMutation";
@@ -54,8 +53,6 @@ const EditPromptSheet: React.FC<EditPromptSheetProps> = ({
 }) => {
   const activeProjectId = useActiveProjectId();
   const isChatPrompt = templateStructure === PROMPT_TEMPLATE_STRUCTURE.CHAT;
-
-  const [viewMode, setViewMode] = useState<"pretty" | "raw">("raw");
 
   const metadataString = promptMetadata
     ? JSON.stringify(promptMetadata, null, 2)
@@ -99,7 +96,6 @@ const EditPromptSheet: React.FC<EditPromptSheetProps> = ({
     setShowRawView(false);
     setRawJsonValue("");
     setIsRawJsonValid(true);
-    setViewMode("raw");
   }, [open]);
 
   const [showInvalidJSON, setShowInvalidJSON] = useBooleanTimeoutState({});
@@ -255,43 +251,13 @@ const EditPromptSheet: React.FC<EditPromptSheetProps> = ({
             <div className="space-y-1.5">
               <Label>Prompt</Label>
               <div className="rounded-md border bg-soft-background">
-                <div className="flex items-center justify-between border-b px-3 py-1.5">
-                  <Button
-                    variant="ghost"
-                    size="2xs"
-                    onClick={() =>
-                      setViewMode((m) => (m === "pretty" ? "raw" : "pretty"))
-                    }
-                  >
-                    {viewMode === "pretty" ? (
-                      <>
-                        Pretty <Sparkles className="ml-1 size-3" />
-                      </>
-                    ) : (
-                      <>Raw</>
-                    )}
-                    <ChevronDown className="ml-1 size-3" />
-                  </Button>
-                </div>
                 <div className="min-h-[120px] p-3">
-                  {viewMode === "pretty" ? (
-                    localText ? (
-                      <MarkdownPreview className="prose-sm">
-                        {localText}
-                      </MarkdownPreview>
-                    ) : (
-                      <span className="comet-body-s text-light-slate">
-                        Type your prompt...
-                      </span>
-                    )
-                  ) : (
-                    <AutoResizeTextarea
-                      value={localText}
-                      onChange={handleContentChange}
-                      placeholder="Type your prompt..."
-                      className="comet-body-s"
-                    />
-                  )}
+                  <AutoResizeTextarea
+                    value={localText}
+                    onChange={handleContentChange}
+                    placeholder="Type your prompt..."
+                    className="comet-body-s"
+                  />
                 </div>
               </div>
               <p className="comet-body-xs text-light-slate">

--- a/apps/opik-frontend/src/v2/pages/PromptsPage/CreatePromptSheet.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptsPage/CreatePromptSheet.tsx
@@ -16,7 +16,6 @@ import { LLMMessage } from "@/types/llm";
 import LLMPromptMessages from "@/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessages";
 import ChatPromptRawView from "@/v2/pages-shared/llm/ChatPromptRawView/ChatPromptRawView";
 import { generateDefaultLLMPromptMessage, getNextMessageType } from "@/lib/llm";
-import MarkdownPreview from "@/shared/MarkdownPreview/MarkdownPreview";
 import AutoResizeTextarea from "@/v2/pages-shared/agent-configuration/fields/AutoResizeTextarea";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import usePromptCreateMutation from "@/api/prompts/usePromptCreateMutation";
@@ -30,8 +29,6 @@ type CreatePromptSheetProps = {
   setOpen: (open: boolean) => void;
   templateStructure: PROMPT_TEMPLATE_STRUCTURE;
 };
-
-type PromptView = "raw" | "pretty";
 
 const CreatePromptSheet: React.FC<CreatePromptSheetProps> = ({
   open,
@@ -51,7 +48,6 @@ const CreatePromptSheet: React.FC<CreatePromptSheetProps> = ({
   const [template, setTemplate] = useState("");
   const [metadata, setMetadata] = useState("");
   const [description, setDescription] = useState("");
-  const [promptView, setPromptView] = useState<PromptView>("raw");
   const [messages, setMessages] = useState<LLMMessage[]>([
     generateDefaultLLMPromptMessage(),
   ]);
@@ -170,23 +166,7 @@ const CreatePromptSheet: React.FC<CreatePromptSheetProps> = ({
             <div className="space-y-1.5">
               <Label>Prompt</Label>
               <div className="rounded-md border bg-soft-background">
-                <div className="flex items-center justify-between border-b px-3 py-1.5">
-                  <Button
-                    variant="ghost"
-                    size="2xs"
-                    onClick={() =>
-                      setPromptView((v) => (v === "pretty" ? "raw" : "pretty"))
-                    }
-                  >
-                    {promptView === "pretty" ? (
-                      <>
-                        Pretty <Sparkles className="ml-1 size-3" />
-                      </>
-                    ) : (
-                      <>Raw</>
-                    )}
-                    <ChevronDown className="ml-1 size-3" />
-                  </Button>
+                <div className="flex items-center justify-end border-b px-3 py-1.5">
                   <TooltipWrapper content="Copy prompt">
                     <Button
                       variant="minimal"
@@ -198,24 +178,12 @@ const CreatePromptSheet: React.FC<CreatePromptSheetProps> = ({
                   </TooltipWrapper>
                 </div>
                 <div className="min-h-[120px] p-3">
-                  {promptView === "pretty" ? (
-                    template ? (
-                      <MarkdownPreview className="prose-sm">
-                        {template}
-                      </MarkdownPreview>
-                    ) : (
-                      <span className="comet-body-s text-light-slate">
-                        Type your prompt...
-                      </span>
-                    )
-                  ) : (
-                    <AutoResizeTextarea
-                      value={template}
-                      onChange={setTemplate}
-                      placeholder="Type your prompt..."
-                      className="comet-body-s"
-                    />
-                  )}
+                  <AutoResizeTextarea
+                    value={template}
+                    onChange={setTemplate}
+                    placeholder="Type your prompt..."
+                    className="comet-body-s"
+                  />
                 </div>
               </div>
               <p className="comet-body-xs text-light-slate">


### PR DESCRIPTION
## Summary
- Removed the Raw/Pretty toggle from the prompt-library **Create prompt** sheet (text prompt path); the textarea is now the only editor.
- Removed the matching Raw/Pretty toggle from the **Edit prompt** sheet (text prompt path).
- Chat-prompt screens are unchanged.
<img width="720" height="870" alt="image" src="https://github.com/user-attachments/assets/763cfe37-2616-499e-9c27-55491a71aba7" />

## Test plan
- [ ] Open the prompt library and click "Create prompt" → text prompt: only the raw textarea is visible, no Raw/Pretty button, copy button still works.
- [ ] Open an existing text prompt and click "Edit" → only the raw textarea is visible, no Raw/Pretty button.
- [ ] Chat-prompt create/edit flows still show their JSON/Pretty toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)