### PR TITLE
[NA] [SDK] test(crewai): tolerate v1 agent reasoning-loop spans in cy…

### DIFF
--- a/sdks/python/tests/library_integration/crewai/test_crewai.py
+++ b/sdks/python/tests/library_integration/crewai/test_crewai.py
@@ -7,10 +7,10 @@ from opik.integrations.crewai import opik_tracker, track_crewai
 from . import constants
 from ... import llm_constants
 from ...testlib import (
-    ANY,
     ANY_BUT_NONE,
-    ANY_STRING,
     ANY_DICT,
+    ANY_LIST,
+    ANY_STRING,
     SpanModel,
     TraceModel,
     assert_equal,
@@ -157,28 +157,15 @@ def test_crewai__sequential_agent__cyclic_reference_inside_one_of_the_tasks__dat
                                 project_name=constants.PROJECT_NAME,
                                 start_time=ANY_BUT_NONE,
                                 tags=["crewai"],
-                                spans=[
-                                    SpanModel(
-                                        end_time=ANY_BUT_NONE,
-                                        id=ANY_STRING,
-                                        input=ANY_DICT,
-                                        metadata=ANY_DICT,
-                                        model=ANY_STRING,
-                                        name=ANY_STRING,  # depends on the provider
-                                        output=ANY_DICT,
-                                        project_name=constants.PROJECT_NAME,
-                                        provider=opik_provider,
-                                        start_time=ANY_BUT_NONE,
-                                        tags=ANY_BUT_NONE,
-                                        type="llm",
-                                        usage=ANY_DICT.containing(
-                                            constants.EXPECTED_SHORT_OPENAI_USAGE_LOGGED_FORMAT
-                                        ),
-                                        total_cost=ANY,
-                                        spans=[],
-                                        source="sdk",
-                                    )
-                                ],
+                                # CrewAI v1 nests an LLM-dependent reasoning loop
+                                # (generate_plan / check_max_iterations /
+                                # call_llm_and_parse / route_by_answer_type / finalize
+                                # / continue_iteration, etc.) between the agent span
+                                # and the LLM call. The number of reasoning iterations
+                                # varies per model, so we match the agent's children
+                                # loosely here and verify the LLM-span shape via a
+                                # tree walk after assert_equal.
+                                spans=ANY_LIST,
                                 source="sdk",
                             )
                         ],
@@ -206,28 +193,9 @@ def test_crewai__sequential_agent__cyclic_reference_inside_one_of_the_tasks__dat
                                 project_name=constants.PROJECT_NAME,
                                 start_time=ANY_BUT_NONE,
                                 tags=["crewai"],
-                                spans=[
-                                    SpanModel(
-                                        end_time=ANY_BUT_NONE,
-                                        id=ANY_STRING,
-                                        input=ANY_DICT,
-                                        metadata=ANY_DICT,
-                                        model=ANY_STRING,
-                                        name=ANY_STRING,  # depends on the provider
-                                        output=ANY_DICT,
-                                        project_name=constants.PROJECT_NAME,
-                                        provider=opik_provider,
-                                        start_time=ANY_BUT_NONE,
-                                        tags=ANY_BUT_NONE,
-                                        type="llm",
-                                        usage=ANY_DICT.containing(
-                                            constants.EXPECTED_SHORT_OPENAI_USAGE_LOGGED_FORMAT
-                                        ),
-                                        total_cost=ANY,
-                                        spans=[],
-                                        source="sdk",
-                                    )
-                                ],
+                                # See note above: matched loosely; LLM-span shape
+                                # asserted via _find_llm_spans below.
+                                spans=ANY_LIST,
                                 source="sdk",
                             )
                         ],
@@ -244,3 +212,30 @@ def test_crewai__sequential_agent__cyclic_reference_inside_one_of_the_tasks__dat
     assert len(fake_backend.span_trees) == 1
 
     assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
+
+    # The reasoning-loop spans CrewAI v1 inserts under each agent span hide the
+    # LLM call several levels deeper than v0. Walk the tree to verify that each
+    # task still produces at least one LLM span and that the provider/usage are
+    # captured correctly — the assertions that used to live inline above.
+    llm_spans = _find_llm_spans(fake_backend.trace_trees[0])
+    assert len(llm_spans) >= 2, (
+        f"expected at least one LLM span per task; found {len(llm_spans)}"
+    )
+    for llm_span in llm_spans:
+        assert llm_span.provider == opik_provider
+        assert llm_span.model is not None
+        assert llm_span.usage is not None
+        assert (
+            llm_span.usage.items()
+            >= constants.EXPECTED_SHORT_OPENAI_USAGE_LOGGED_FORMAT.items()
+        )
+
+
+def _find_llm_spans(node):
+    """Recursively collect every span of type=='llm' under a trace or span node."""
+    result = []
+    if getattr(node, "type", None) == "llm":
+        result.append(node)
+    for child in getattr(node, "spans", []) or []:
+        result.extend(_find_llm_spans(child))
+    return result


### PR DESCRIPTION
## Details

CrewAI v1 inserts an agent reasoning loop (`generate_plan` → `check_todos_available` → `initialize_reasoning` → `check_max_iterations` → `call_llm_and_parse` → `route_by_answer_type` → `finalize` → `continue_iteration` …) between the agent span and the LLM call. Iteration count depends on the model's stop behaviour and varies per run, so the previous strict span tree (`agent` → `[<llm-call>]`) fails identically across all four providers (openai / gemini / bedrock / anthropic) with the extra reasoning spans `added to iterable`.

- At each agent span, replace `spans=[<single llm span>]` with `spans=ANY_LIST` (variable-length reasoning loop is opaque to this test).
- Recover the previously-inline LLM provider / model / usage assertions via a small `_find_llm_spans` tree walk after `assert_equal`: collects every `type=='llm'` span in the tree, asserts at least 2 are present (one per task), and validates each one's `provider == opik_provider`, `model is not None`, and `usage` matches `EXPECTED_SHORT_OPENAI_USAGE_LOGGED_FORMAT`.
- The test's stated subject — cyclic-reference serialization succeeding without an exception during `crew.kickoff()` — remains covered by the rest of the strict trace tree (kickoff trace, kickoff span, both task spans, both agent spans being constructible).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: `tests/library_integration/crewai/test_crewai.py` only — test-side assertion loosening + tree-walk helper.
- Human verification: reviewed iteratively; diff is 41 insertions / 46 deletions; verified by spotting the failure pattern in the existing PR #6829 CI logs across all 4 model providers.

## Testing

Cannot exercise the integration locally (requires the four LLM provider credentials wired into CI). Net change shape:
- 1 file changed, 41 insertions(+), 46 deletions(-).
- Test still calls `assert_equal(EXPECTED_TRACE_TREE, ...)` against the (now-looser) tree, so any kickoff-time crash from cyclic-ref serialization still surfaces as a failure.
- LLM provider / model / usage assertions move into the post-`assert_equal` block and run for every LLM span found in the tree, so coverage is preserved (and slightly broadened — previously we only checked one specific LLM span per task, now we check all of them).

This branch is a follow-up to a CI failure spotted on PR #6829 — failing for harbor and CrewAI v1 in the same way they fail on the most recently merged PR (#6822). Filed separately because the change is orthogonal to the load-test work.

## Documentation

No docs changes needed.