### PR TITLE
[OPIK-6656] [HELM] feat: run helm-docs locally via .hooks/pre-commit

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -78,6 +78,20 @@ run_precommit_scope "Python SDK" '^sdks/python/' 'sdks/python/.pre-commit-config
 run_precommit_scope "Optimizer SDK" '^sdks/opik_optimizer/' 'sdks/opik_optimizer/.pre-commit-config.yaml'
 run_precommit_scope "Guardrails backend" '^apps/opik-guardrails-backend/' 'apps/opik-guardrails-backend/.pre-commit-config.yaml'
 
+# Helm chart docs: regenerate chart README when chart files change.
+staged_helm=$(staged_files | grep -E '^deployment/helm_chart/.+/(values\.yaml|Chart\.yaml|README\.md\.gotmpl)$' || true)
+
+if [ -z "$staged_helm" ]; then
+  echo "No Helm chart files changed. Skipping helm-docs."
+elif ! command -v pre-commit >/dev/null 2>&1; then
+  echo "Helm chart files changed but pre-commit is not installed. Skipping local helm-docs."
+  echo "Install: pip install pre-commit  (or see https://pre-commit.com/#install)"
+else
+  echo "Helm chart files have been changed. Running helm-docs..."
+  pre-commit run helm-docs --files $staged_helm || true
+  git -C "$REPO_ROOT" add -u deployment/helm_chart/
+fi
+
 # Workflows / composite actions: validate with actionlint when available.
 # Composite actions (`.github/actions/*/action.yml`) cannot be linted directly —
 # they're validated transitively when a workflow that uses them is linted. For


### PR DESCRIPTION
## Details

<img width="694" height="905" alt="image" src="https://github.com/user-attachments/assets/6d07aedd-43a7-4bb5-8a6e-98cc0b79d794" />

Wires the existing root-level `helm-docs` hook (already pinned in [.pre-commit-config.yaml](.pre-commit-config.yaml)) into the local pre-commit script ([.hooks/pre-commit](.hooks/pre-commit)) so that staging chart `values.yaml` / `Chart.yaml` / `README.md.gotmpl` regenerates and auto-stages `deployment/helm_chart/opik/README.md` into the same commit. CI's `update-readme` job remains the safety net; this just closes the local gap that was surfacing as red CI on chart-touching PRs.

- Mirrors the existing scoped `actionlint` pattern in the same hook: detect → check tool availability → run → auto-stage
- Uses `pre-commit run helm-docs --files <staged>` so the docker image/version stay sourced from `.pre-commit-config.yaml` (no local/CI drift)
- `|| true` swallows pre-commit's "files were modified by this hook" exit code (same Spotless pattern in this file), so successful regeneration does not block the commit
- Graceful when `pre-commit` is not installed: warns with install hint and skips — does not block the commit
- Graceful when `docker` is not running or helm-docs errors: pre-commit exits non-zero, the `|| true` swallows it, and CI catches any actual drift on PR

## Change checklist

- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6656
- Surfaced by OPIK-6652 / PR #6830

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: assisted — ticket description authored the exact ~15-line patch; agent applied it, executed live test, and prepared this PR
- Human verification: live end-to-end test (described under Testing), self-review of resulting diff, manual diff inspection before commit

## Testing

Live end-to-end test against the real helm-docs hook, not just type/lint checks:

1. Added a test marker comment to a doc-annotated field in `deployment/helm_chart/opik/values.yaml` (`caCerts.additionalCACerts` description)
2. `git add deployment/helm_chart/opik/values.yaml`
3. `./.hooks/pre-commit` (ran the hook directly without committing)
4. Verified: hook matched the staged file via the regex, invoked `pre-commit run helm-docs --files …` which pulled `jnorwood/helm-docs:v1.14.2` and regenerated `deployment/helm_chart/opik/README.md`
5. Verified: `git status` showed `M  deployment/helm_chart/opik/README.md` (auto-staged into the index by the `git -C "$REPO_ROOT" add -u deployment/helm_chart/` line)
6. Verified: `git diff --cached -- deployment/helm_chart/opik/README.md` reflected the test marker text
7. Verified: script exited 0 and did not block the commit despite pre-commit's "files were modified by this hook" non-zero exit
8. Reverted values.yaml + README.md to origin/main state, committed only the hook change, and observed the hook run on its own commit — emitted "No Helm chart files changed. Skipping helm-docs." → gating works in both directions

Negative paths exercised by code review (not live, since both tools were present locally):
- `pre-commit` missing: `elif ! command -v pre-commit` branch warns + skips, no block
- No chart files staged: `if [ -z "$staged_helm" ]` branch logs skip, no block

## Documentation

N/A — the hook itself prints user-facing messages explaining what it is doing and what to install if `pre-commit` is not present. No external docs reference `.hooks/pre-commit` internals to update.