### PR TITLE
[OPIK-6646] [BE] fix: normalize project names to handle trailing whitespace

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
@@ -430,7 +430,7 @@ public class SpanService {
     private List<Span> bindSpanToProjectAndId(List<Span> spans, List<Project> projects) {
         Map<String, Project> projectPerName = projects.stream()
                 .collect(Collectors.toMap(
-                        Project::name,
+                        p -> p.name().strip(),
                         Function.identity(),
                         BinaryOperatorUtils.last(),
                         () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
@@ -430,7 +430,7 @@ public class SpanService {
     private List<Span> bindSpanToProjectAndId(List<Span> spans, List<Project> projects) {
         Map<String, Project> projectPerName = projects.stream()
                 .collect(Collectors.toMap(
-                        p -> p.name().strip(),
+                        WorkspaceUtils::stripProjectName,
                         Function.identity(),
                         BinaryOperatorUtils.last(),
                         () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -229,7 +229,7 @@ class TraceServiceImpl implements TraceService {
     private List<Trace> bindTraceToProjectAndId(List<Trace> traces, List<Project> projects) {
         Map<String, Project> projectPerName = projects.stream()
                 .collect(Collectors.toMap(
-                        Project::name,
+                        p -> p.name().strip(),
                         Function.identity(),
                         BinaryOperatorUtils.last(),
                         () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -229,7 +229,7 @@ class TraceServiceImpl implements TraceService {
     private List<Trace> bindTraceToProjectAndId(List<Trace> traces, List<Project> projects) {
         Map<String, Project> projectPerName = projects.stream()
                 .collect(Collectors.toMap(
-                        p -> p.name().strip(),
+                        WorkspaceUtils::stripProjectName,
                         Function.identity(),
                         BinaryOperatorUtils.last(),
                         () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/WorkspaceUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/WorkspaceUtils.java
@@ -1,7 +1,6 @@
 package com.comet.opik.utils;
 
 import com.comet.opik.api.Project;
-import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.StringUtils;
 
@@ -19,8 +18,8 @@ public class WorkspaceUtils {
         return StringUtils.isBlank(projectName) ? DEFAULT_PROJECT : projectName.strip();
     }
 
-    public static String stripProjectName(@NonNull Project project) {
-        return project.name().strip();
+    public static String stripProjectName(Project project) {
+        return project == null ? null : project.name().strip();
     }
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/WorkspaceUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/WorkspaceUtils.java
@@ -1,5 +1,6 @@
 package com.comet.opik.utils;
 
+import com.comet.opik.api.Project;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.StringUtils;
 
@@ -15,6 +16,10 @@ public class WorkspaceUtils {
 
     public static String getProjectName(String projectName) {
         return StringUtils.isBlank(projectName) ? DEFAULT_PROJECT : projectName.strip();
+    }
+
+    public static String stripProjectName(Project project) {
+        return project.name().strip();
     }
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/WorkspaceUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/WorkspaceUtils.java
@@ -14,7 +14,7 @@ public class WorkspaceUtils {
     }
 
     public static String getProjectName(String projectName) {
-        return StringUtils.isEmpty(projectName) ? DEFAULT_PROJECT : projectName;
+        return StringUtils.isBlank(projectName) ? DEFAULT_PROJECT : projectName.strip();
     }
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/WorkspaceUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/WorkspaceUtils.java
@@ -1,6 +1,7 @@
 package com.comet.opik.utils;
 
 import com.comet.opik.api.Project;
+import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.StringUtils;
 
@@ -18,7 +19,7 @@ public class WorkspaceUtils {
         return StringUtils.isBlank(projectName) ? DEFAULT_PROJECT : projectName.strip();
     }
 
-    public static String stripProjectName(Project project) {
+    public static String stripProjectName(@NonNull Project project) {
         return project.name().strip();
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/utils/WorkspaceUtilsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/utils/WorkspaceUtilsTest.java
@@ -10,7 +10,7 @@ import java.util.stream.Stream;
 
 import static com.comet.opik.domain.ProjectService.DEFAULT_PROJECT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class WorkspaceUtilsTest {
 
@@ -49,8 +49,8 @@ class WorkspaceUtilsTest {
     }
 
     @Test
-    void stripProjectName__whenProjectIsNull__throwsNpe() {
-        assertThrows(NullPointerException.class, () -> WorkspaceUtils.stripProjectName(null));
+    void stripProjectName__whenProjectIsNull__returnsNull() {
+        assertNull(WorkspaceUtils.stripProjectName(null));
     }
 
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/utils/WorkspaceUtilsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/utils/WorkspaceUtilsTest.java
@@ -1,7 +1,6 @@
 package com.comet.opik.utils;
 
 import com.comet.opik.api.Project;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -10,7 +9,6 @@ import java.util.stream.Stream;
 
 import static com.comet.opik.domain.ProjectService.DEFAULT_PROJECT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 class WorkspaceUtilsTest {
 
@@ -34,23 +32,18 @@ class WorkspaceUtilsTest {
 
     public static Stream<Arguments> stripProjectName() {
         return Stream.of(
-                Arguments.of("My Project", "My Project"),
-                Arguments.of("My Project ", "My Project"),
-                Arguments.of("  My Project", "My Project"),
-                Arguments.of("  My Project  ", "My Project"),
-                Arguments.of("\tMy Project\n", "My Project"));
+                Arguments.of(null, null),
+                Arguments.of(Project.builder().name("My Project").build(), "My Project"),
+                Arguments.of(Project.builder().name("My Project ").build(), "My Project"),
+                Arguments.of(Project.builder().name("  My Project").build(), "My Project"),
+                Arguments.of(Project.builder().name("  My Project  ").build(), "My Project"),
+                Arguments.of(Project.builder().name("\tMy Project\n").build(), "My Project"));
     }
 
     @ParameterizedTest
     @MethodSource
-    void stripProjectName(String storedName, String expected) {
-        Project project = Project.builder().name(storedName).build();
+    void stripProjectName(Project project, String expected) {
         assertEquals(expected, WorkspaceUtils.stripProjectName(project));
-    }
-
-    @Test
-    void stripProjectName__whenProjectIsNull__returnsNull() {
-        assertNull(WorkspaceUtils.stripProjectName(null));
     }
 
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/utils/WorkspaceUtilsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/utils/WorkspaceUtilsTest.java
@@ -1,5 +1,6 @@
 package com.comet.opik.utils;
 
+import com.comet.opik.api.Project;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -27,6 +28,22 @@ class WorkspaceUtilsTest {
     @MethodSource
     void getProjectName(String input, String expected) {
         assertEquals(expected, WorkspaceUtils.getProjectName(input));
+    }
+
+    public static Stream<Arguments> stripProjectName() {
+        return Stream.of(
+                Arguments.of("My Project", "My Project"),
+                Arguments.of("My Project ", "My Project"),
+                Arguments.of("  My Project", "My Project"),
+                Arguments.of("  My Project  ", "My Project"),
+                Arguments.of("\tMy Project\n", "My Project"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void stripProjectName(String storedName, String expected) {
+        Project project = Project.builder().name(storedName).build();
+        assertEquals(expected, WorkspaceUtils.stripProjectName(project));
     }
 
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/utils/WorkspaceUtilsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/utils/WorkspaceUtilsTest.java
@@ -1,0 +1,32 @@
+package com.comet.opik.utils;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static com.comet.opik.domain.ProjectService.DEFAULT_PROJECT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WorkspaceUtilsTest {
+
+    public static Stream<Arguments> getProjectName() {
+        return Stream.of(
+                Arguments.of(null, DEFAULT_PROJECT),
+                Arguments.of("", DEFAULT_PROJECT),
+                Arguments.of("   ", DEFAULT_PROJECT),
+                Arguments.of("\t\n", DEFAULT_PROJECT),
+                Arguments.of("My Project", "My Project"),
+                Arguments.of("My Project ", "My Project"),
+                Arguments.of("  My Project", "My Project"),
+                Arguments.of("  My Project  ", "My Project"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void getProjectName(String input, String expected) {
+        assertEquals(expected, WorkspaceUtils.getProjectName(input));
+    }
+
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/utils/WorkspaceUtilsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/utils/WorkspaceUtilsTest.java
@@ -1,6 +1,7 @@
 package com.comet.opik.utils;
 
 import com.comet.opik.api.Project;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -9,6 +10,7 @@ import java.util.stream.Stream;
 
 import static com.comet.opik.domain.ProjectService.DEFAULT_PROJECT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class WorkspaceUtilsTest {
 
@@ -44,6 +46,11 @@ class WorkspaceUtilsTest {
     void stripProjectName(String storedName, String expected) {
         Project project = Project.builder().name(storedName).build();
         assertEquals(expected, WorkspaceUtils.stripProjectName(project));
+    }
+
+    @Test
+    void stripProjectName__whenProjectIsNull__throwsNpe() {
+        assertThrows(NullPointerException.class, () -> WorkspaceUtils.stripProjectName(null));
     }
 
 }


### PR DESCRIPTION
## Details

<img width="728" height="831" alt="image" src="https://github.com/user-attachments/assets/8c98b8b5-7526-4afa-8c5d-155752cc68ea" />

Fixes a 500 error on span/trace batch endpoints when a project's stored name has trailing whitespace. MySQL's `utf8mb4_general_ci` collation is PAD SPACE and treats `"X"` and `"X "` as equal in `WHERE name IN (...)`, so `getOrCreate("X")` returns a `Project` row whose `name = "X "`. The downstream `TreeMap<String, Project>` built with `Project::name` and `String.CASE_INSENSITIVE_ORDER` does not pad — the lookup for `"X"` misses and `IllegalStateException: Project not found` is thrown. Fix is pure internal normalization: `WorkspaceUtils.getProjectName` now strips and treats blank as default, and a new `WorkspaceUtils.stripProjectName(Project)` helper is used as the TreeMap key extractor in `bindSpanToProjectAndId` / `bindTraceToProjectAndId`. Pre-existing rows with whitespace continue to display as-is — no DB migration, no API surface change.

`stripProjectName` returns `null` on a `null` `Project` rather than throwing — keeping the helper neutral about what the caller does next, per review. A broader idea raised in review — global whitespace stripping on Jackson deserialization — was scoped out and tracked as [OPIK-6672](https://comet-ml.atlassian.net/browse/OPIK-6672): blast radius spans the whole REST API and several fields legitimately preserve whitespace (`Trace.input`/`output`, `Span.error_info.message`, `FeedbackScore.reason`, `Comment.text`, `Prompt.template`).

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6646
- Follow-up filed: OPIK-6672

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: full implementation
- Human verification: code review + targeted unit tests + end-to-end verification on adhoc test envs

## Testing

### Unit tests
- `WorkspaceUtilsTest` — 14 cases:
  - 8 parameterized cases for `getProjectName` (null / empty / whitespace-only / leading / trailing / clean).
  - 5 parameterized cases for the new `stripProjectName` helper.
  - 1 single-case test asserting null input returns null: `stripProjectName(null)` → `null`.
- `mvn test -Dtest=WorkspaceUtilsTest` → 14 passed, 0 failures.
- `mvn spotless:check` → clean. Pre-commit hook passed.

### End-to-end verification against real MySQL

Side-by-side repro on two adhoc test environments: pr-6847 (FE-only PR, effectively `main` backend) vs pr-6845 (this fix). Same workspace, identical request payloads, **same DB rows** re-used across runs.

| Step | pr-6847 (no fix) | pr-6845 (this fix) |
|---|---|---|
| `POST /v1/private/projects` with `"Repro Trailing "` (15 chars, trailing space) | **201** (or 409 on re-run) | **201** (or 409 on re-run) |
| Read project back — stored name | `'Repro Trailing '`, len=15 ✓ | `'Repro Trailing '`, len=15 ✓ |
| `POST /v1/private/traces/batch` with `project_name="Repro Trailing"` (clean) | **500** ❌ | **204** ✓ |
| `POST /v1/private/spans/batch` with `project_name="Repro Trailing"` (clean) | **500** ❌ | **204** ✓ |
| `GET /v1/private/traces/{id}` | **404** — trace never landed | **200**, bound to the polluted project's id |
| Polluted project's `last_updated_trace_at` advanced after the batch | no (write failed) | **yes** ✓ |

Re-verified on the deployed pr-6845 env after the review round that added review-only changes around the new helper (build `2.0.48-6845-merge-2159`): same table, same outcome — the bind path is unaffected by the helper's null-handling shape (callers never pass a null `Project` today; this is purely a contract decision on the public utility).

Conclusions:
- Confirms the customer-reported 500 reproduces on unfixed code with the documented repro pattern.
- Confirms the fix resolves it: trace+span land in the **existing** polluted project (no orphan, no duplicate).
- DB row keeps its whitespace as-is — no data migration, no API surface change, no FE display change.

### Not run locally
Full backend integration test suite (requires Docker/MySQL/ClickHouse) — covered by CI, all green on the branch.

## Documentation

No `.md` doc change required — this is purely internal lookup normalization with no API or user-facing behavior change. Documentation artifacts for this PR live in:

- The architecture/flow diagram embedded in **Details** above.
- Verification tables on the Jira ticket (OPIK-6646) and follow-up scope on OPIK-6672.


[OPIK-6672]: https://comet-ml.atlassian.net/browse/OPIK-6672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
