### PR TITLE
[OPIK-6595] [QA] feat: Dataset CRUD smoke (SDK-create + UI-create variants)

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPageHeader.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPageHeader.tsx
@@ -81,11 +81,21 @@ const DatasetItemsPageHeader: React.FunctionComponent<
         <div className="flex items-center gap-2">
           {hasDraft && (
             <>
-              <Button variant="outline" size="sm" onClick={onDiscardClick}>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onDiscardClick}
+                data-testid="dataset-items-discard-button"
+              >
                 <X className="mr-1 size-4" />
                 Discard changes
               </Button>
-              <Button variant="default" size="sm" onClick={onSaveClick}>
+              <Button
+                variant="default"
+                size="sm"
+                onClick={onSaveClick}
+                data-testid="dataset-items-commit-button"
+              >
                 <Check className="mr-1 size-4" />
                 Save changes
               </Button>

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
@@ -622,6 +622,7 @@ function DatasetItemsTab({
                 variant="default"
                 size={isCompactToolbar ? "icon-sm" : "sm"}
                 onClick={handleNewDatasetItemClick}
+                data-testid="dataset-items-add-button"
               >
                 {isCompactToolbar ? <Plus /> : "Add item"}
               </Button>

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/AddVersionDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/AddVersionDialog.tsx
@@ -41,7 +41,10 @@ const AddVersionDialog: React.FC<AddVersionDialogProps> = ({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent
+        className="max-w-lg"
+        data-testid="dataset-version-commit-dialog"
+      >
         <DialogHeader>
           <DialogTitle>Save changes</DialogTitle>
         </DialogHeader>

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -8,6 +8,17 @@ export interface ProjectRef {
   name: string;
 }
 
+export interface DatasetRef {
+  id: string;
+  name: string;
+  description: string | null;
+}
+
+export interface DatasetItemRef {
+  id: string;
+  data: Record<string, unknown>;
+}
+
 export function makeBackendClient(apiKey: string | null = null) {
   const env = loadEnvConfig();
   const opik = new Opik({
@@ -39,6 +50,53 @@ export function makeBackendClient(apiKey: string | null = null) {
       return content
         .filter((p) => typeof p.name === 'string' && p.name.startsWith(prefix))
         .map((p) => ({ id: String(p.id), name: p.name as string }));
+    },
+
+    async listDatasetsWithPrefix(prefix: string): Promise<DatasetRef[]> {
+      const page = await opik.api.datasets.findDatasets({ name: prefix, size: 500 });
+      const content = page.content ?? [];
+      return content
+        .filter((d) => typeof d.name === 'string' && d.name.startsWith(prefix))
+        .map((d) => ({
+          id: String(d.id),
+          name: d.name as string,
+          description: d.description ?? null,
+        }));
+    },
+
+    async findDatasetByName(name: string, projectName?: string): Promise<DatasetRef | null> {
+      try {
+        const dataset = await opik.api.datasets.getDatasetByIdentifier({
+          datasetName: name,
+          ...(projectName ? { projectName } : {}),
+        });
+        return {
+          id: String(dataset.id),
+          name: dataset.name,
+          description: dataset.description ?? null,
+        };
+      } catch (err) {
+        if (isNotFoundError(err)) return null;
+        throw err;
+      }
+    },
+
+    async deleteDataset(id: string): Promise<void> {
+      try {
+        await opik.api.datasets.deleteDataset(id);
+      } catch (err) {
+        if (isNotFoundError(err)) return;
+        throw err;
+      }
+    },
+
+    async getDatasetItems(datasetId: string): Promise<DatasetItemRef[]> {
+      const page = await opik.api.datasets.getDatasetItems(datasetId);
+      const content = page.content ?? [];
+      return content.map((item) => ({
+        id: String(item.id),
+        data: (item.data ?? {}) as Record<string, unknown>,
+      }));
     },
   };
 }

--- a/tests_end_to_end/e2e/core/backend/index.ts
+++ b/tests_end_to_end/e2e/core/backend/index.ts
@@ -1,1 +1,7 @@
-export { makeBackendClient, type BackendClient, type ProjectRef } from './client';
+export {
+  makeBackendClient,
+  type BackendClient,
+  type ProjectRef,
+  type DatasetRef as BackendDatasetRef,
+  type DatasetItemRef,
+} from './client';

--- a/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
+++ b/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
@@ -7,6 +7,13 @@ export interface PythonSdkClient {
     output: string;
     workspace?: string;
   }): Promise<{ id: string; name: string; project_id: string }>;
+  createDataset(args: {
+    name: string;
+    project_name: string;
+    description?: string;
+    items?: Array<Record<string, unknown>>;
+    workspace?: string;
+  }): Promise<{ id: string; name: string }>;
 }
 
 export class PythonSdkBridgeError extends Error {
@@ -81,6 +88,9 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
     },
     async createTrace(args) {
       return request<{ id: string; name: string; project_id: string }>('POST', '/traces', args);
+    },
+    async createDataset(args) {
+      return request<{ id: string; name: string }>('POST', '/datasets', args);
     },
   };
 }

--- a/tests_end_to_end/e2e/fixtures/dataset.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/dataset.fixture.ts
@@ -1,0 +1,64 @@
+import { test as baseTest } from './trace.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+
+export interface DatasetItemSeed {
+  input: string;
+  expected_output: string;
+}
+
+export interface DatasetRef {
+  id: string;
+  name: string;
+  projectId: string;
+  projectName: string;
+  description: string | null;
+  items: DatasetItemSeed[];
+}
+
+export interface DatasetFixtures {
+  dataset: DatasetRef;
+}
+
+const SEED_ITEMS: DatasetItemSeed[] = [
+  { input: 'seed input 1', expected_output: 'seed output 1' },
+  { input: 'seed input 2', expected_output: 'seed output 2' },
+  { input: 'seed input 3', expected_output: 'seed output 3' },
+];
+
+export const test = baseTest.extend<DatasetFixtures>({
+  dataset: async ({ sdkClient, backendClient, project, testNamespace }, use, testInfo) => {
+    const name = `${testNamespace}-ds`;
+    const description = `seeded by ${testInfo.title}`;
+    const created = await sdkClient.python.createDataset({
+      project_name: project.name,
+      name,
+      description,
+      items: SEED_ITEMS as unknown as Array<Record<string, unknown>>,
+    });
+    const ref: DatasetRef = {
+      id: created.id,
+      name: created.name,
+      projectId: project.id,
+      projectName: project.name,
+      description,
+      items: SEED_ITEMS,
+    };
+    await testInfo.attach('opik.dataset', {
+      body: JSON.stringify(ref, null, 2),
+      contentType: 'application/json',
+    });
+    await use(ref);
+    // Datasets do NOT cascade with project deletion — they outlive their
+    // parent project (the project_id becomes a dangling reference). Delete
+    // explicitly before the project fixture tears down.
+    if (!shouldLeaveArtifacts(testInfo)) {
+      try {
+        await backendClient.deleteDataset(created.id);
+      } catch (err) {
+        console.warn(`[dataset fixture] delete warning for ${name}:`, err);
+      }
+    }
+  },
+});
+
+export { expect } from './trace.fixture';

--- a/tests_end_to_end/e2e/fixtures/dataset.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/dataset.fixture.ts
@@ -48,9 +48,7 @@ export const test = baseTest.extend<DatasetFixtures>({
       contentType: 'application/json',
     });
     await use(ref);
-    // Datasets do NOT cascade with project deletion — they outlive their
-    // parent project (the project_id becomes a dangling reference). Delete
-    // explicitly before the project fixture tears down.
+    /** Datasets don't cascade with project deletion — explicit delete required. */
     if (!shouldLeaveArtifacts(testInfo)) {
       try {
         await backendClient.deleteDataset(created.id);

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-export { test, expect } from './trace.fixture';
+export { test, expect } from './dataset.fixture';
 export type { ProjectFixtures } from './project.fixture';
 export type { ScratchDir, ScratchDirFixtures } from './scratch-dir.fixture';
 export type {
@@ -8,4 +8,5 @@ export type {
   FailureArtifactsFixtures,
 } from './failure-artifacts.fixture';
 export type { TraceRef, TraceFixtures } from './trace.fixture';
+export type { DatasetRef, DatasetFixtures, DatasetItemSeed } from './dataset.fixture';
 export type { ProjectRef } from '../core/backend';

--- a/tests_end_to_end/e2e/global-setup.ts
+++ b/tests_end_to_end/e2e/global-setup.ts
@@ -28,8 +28,7 @@ async function sweepOrphans(apiKey: string | null): Promise<void> {
   const backend = makeBackendClient(apiKey);
   const cutoff = Date.now() - ORPHAN_MAX_AGE_MS;
 
-  // Sweep datasets first so they don't outlive the project they reference
-  // (dataset rows do not cascade-delete with their parent project).
+  /** Sweep datasets before projects — datasets don't cascade-delete with their parent project. */
   try {
     const staleDatasets = await backend.listDatasetsWithPrefix('cuj-');
     let sweptCount = 0;

--- a/tests_end_to_end/e2e/global-setup.ts
+++ b/tests_end_to_end/e2e/global-setup.ts
@@ -27,6 +27,31 @@ function parseRunIdTimestamp(name: string): number | null {
 async function sweepOrphans(apiKey: string | null): Promise<void> {
   const backend = makeBackendClient(apiKey);
   const cutoff = Date.now() - ORPHAN_MAX_AGE_MS;
+
+  // Sweep datasets first so they don't outlive the project they reference
+  // (dataset rows do not cascade-delete with their parent project).
+  try {
+    const staleDatasets = await backend.listDatasetsWithPrefix('cuj-');
+    let sweptCount = 0;
+    for (const d of staleDatasets) {
+      const ts = parseRunIdTimestamp(d.name);
+      if (ts === null) continue;
+      if (ts < cutoff) {
+        try {
+          await backend.deleteDataset(d.id);
+          sweptCount++;
+        } catch {
+          // Best-effort; another runner may have just deleted it.
+        }
+      }
+    }
+    if (sweptCount > 0) {
+      console.log(`[global-setup] Swept ${sweptCount} orphaned datasets (>6h old)`);
+    }
+  } catch (e) {
+    console.warn('[global-setup] dataset orphan sweep warning (continuing):', e);
+  }
+
   try {
     const stale = await backend.listProjectsWithPrefix('cuj-');
     let sweptCount = 0;

--- a/tests_end_to_end/e2e/global-teardown.ts
+++ b/tests_end_to_end/e2e/global-teardown.ts
@@ -22,6 +22,26 @@ async function globalTeardown() {
   console.log(`[global-teardown] Sweeping entities with prefix ${prefix}`);
 
   try {
+    // Sweep datasets BEFORE projects so dangling-project-reference datasets
+    // don't survive the project deletion (datasets do not cascade with the
+    // project they were created under).
+    const datasets = await backend.listDatasetsWithPrefix(prefix);
+    if (datasets.length === 0) {
+      console.log('  no datasets to sweep');
+    }
+    for (const d of datasets) {
+      try {
+        await backend.deleteDataset(d.id);
+        console.log(`  deleted dataset ${d.name}`);
+      } catch (e) {
+        console.warn(`  dataset ${d.name} delete warning:`, e);
+      }
+    }
+  } catch (e) {
+    console.warn('[global-teardown] dataset sweep warning:', e);
+  }
+
+  try {
     const projects = await backend.listProjectsWithPrefix(prefix);
     if (projects.length === 0) {
       console.log('  no projects to sweep');

--- a/tests_end_to_end/e2e/global-teardown.ts
+++ b/tests_end_to_end/e2e/global-teardown.ts
@@ -21,10 +21,8 @@ async function globalTeardown() {
 
   console.log(`[global-teardown] Sweeping entities with prefix ${prefix}`);
 
+  /** Sweep datasets before projects — datasets don't cascade-delete with their parent project. */
   try {
-    // Sweep datasets BEFORE projects so dangling-project-reference datasets
-    // don't survive the project deletion (datasets do not cascade with the
-    // project they were created under).
     const datasets = await backend.listDatasetsWithPrefix(prefix);
     if (datasets.length === 0) {
       console.log('  no datasets to sweep');

--- a/tests_end_to_end/e2e/pom/dataset-items.page.ts
+++ b/tests_end_to_end/e2e/pom/dataset-items.page.ts
@@ -18,8 +18,6 @@ export class DatasetItemsPage {
   async waitForReady(): Promise<void> {
     await this.page.getByRole('tab', { name: 'Items', selected: true }).waitFor({ state: 'visible' });
     const realRow = this.itemsTableBody.locator('tr[data-row-id]').first();
-    // Empty-state copy is "No <entityName> items yet" — for datasets that's
-    // "No dataset items yet".
     const emptyState = this.page.getByText('No dataset items yet');
     await Promise.race([
       realRow.waitFor({ state: 'visible' }),
@@ -27,62 +25,34 @@ export class DatasetItemsPage {
     ]);
   }
 
-  /**
-   * Count of item rows currently rendered in the items table body. While the
-   * page is in Draft mode, the "Showing X-Y of Z" text reflects the
-   * pre-draft committed count and is stale; the rendered row count is the
-   * source of truth for assertions during a test.
-   */
+  /** Rendered row count — the "Showing X of Y" text is stale during drafts. */
   async countItems(): Promise<number> {
     return this.itemsTableBody.locator('tr[data-row-id]').count();
   }
 
-  /** True iff the page header shows the "Draft" badge. */
   draftBadge(): Locator {
     return this.page.getByText('Draft', { exact: true });
   }
 
-  /** Locator matching the page header version label (`v1`, `v2`, ...). */
   versionLabel(version: number): Locator {
     return this.page.getByText(`v${version}`, { exact: true });
   }
 
-  /** Item row by zero-based index in the visible table body. */
   itemRow(index: number): Locator {
     return this.itemsTableBody.locator('tr[data-row-id]').nth(index);
   }
 
-  /** Item row by its dataset_item id. */
   itemRowById(id: string): Locator {
     return this.itemsTableBody.locator(`tr[data-row-id="${id}"]`);
   }
 
-  /**
-   * Open the "Add item" side-panel. Waits for the panel to be on-screen.
-   *
-   * Prefers the dataset-items-add-button testid (added in this PR). Falls
-   * back to role+name "Add item" so the test passes against deployments
-   * that don't yet carry the new FE testid.
-   */
   async clickAddItem(): Promise<void> {
-    const byTestid = this.page.getByTestId('dataset-items-add-button');
-    const byRole = this.page.getByRole('button', { name: 'Add item' });
-    const button = (await byTestid.count()) > 0 ? byTestid : byRole;
+    const button = await this.preferTestid('dataset-items-add-button', { role: 'button', name: 'Add item' });
     await button.click();
     await this.addItemPanel.waitFor({ state: 'visible' });
-    // The panel root is always mounted in the DOM; "open" is signaled by
-    // transform: translateX(0px) rather than by display/visibility.
-    await this.page.waitForFunction(() => {
-      const el = document.querySelector('[data-testid="dataset-item-panel"]') as HTMLElement | null;
-      const t = el?.style.transform ?? '';
-      return t.includes('translateX(0');
-    });
+    await this.waitForPanelTransform('translateX(0');
   }
 
-  /**
-   * Fill the open Add-item panel's column textareas. Pass one entry per
-   * dataset column; the FE auto-detects the schema from existing items.
-   */
   async fillAddItemPanel(fields: Record<string, string>): Promise<void> {
     for (const [column, value] of Object.entries(fields)) {
       await this.addItemPanel
@@ -92,32 +62,14 @@ export class DatasetItemsPage {
     }
   }
 
-  /**
-   * Click the panel-level "Save changes" — stages the new item as a draft and
-   * adds it to the rendered table. The change is NOT yet committed to the
-   * backend; commitDraft() must be called to persist.
-   */
+  /** Stages the new item as a draft; commitDraft() persists it. */
   async submitAddItemPanel(): Promise<void> {
     await this.addItemPanel.getByRole('button', { name: 'Save changes' }).click();
-    // The panel stays mounted in the DOM after close; "closed" is signaled
-    // by transform: translateX(100%) (slides off-screen) rather than
-    // display/visibility, so waitFor({state: 'hidden'}) never fires.
-    await this.page.waitForFunction(() => {
-      const el = document.querySelector('[data-testid="dataset-item-panel"]') as HTMLElement | null;
-      const t = el?.style.transform ?? '';
-      return t.includes('translateX(100%)');
-    });
+    await this.waitForPanelTransform('translateX(100%)');
     await this.draftBadge().waitFor({ state: 'visible' });
   }
 
-  /**
-   * Commit all staged draft changes as a new dataset version. Opens the
-   * version-commit modal, optionally fills a version note, submits, and
-   * waits for the Draft badge to clear.
-   *
-   * Prefers the testids added in this PR; falls back to role+name for
-   * deployments without the new attributes.
-   */
+  /** Commits all staged drafts as a new dataset version via the confirmation modal. */
   async commitDraft(opts: { versionNote?: string } = {}): Promise<void> {
     await this.pageLevelCommitButton().click();
     const modal = await this.versionCommitModal();
@@ -130,39 +82,13 @@ export class DatasetItemsPage {
     await this.draftBadge().waitFor({ state: 'hidden' });
   }
 
-  /**
-   * Discard all staged draft changes without committing.
-   */
   async discardDraft(): Promise<void> {
-    const byTestid = this.page.getByTestId('dataset-items-discard-button');
-    const byRole = this.page.getByRole('button', { name: 'Discard changes' });
-    const button = (await byTestid.count()) > 0 ? byTestid : byRole;
+    const button = await this.preferTestid('dataset-items-discard-button', { role: 'button', name: 'Discard changes' });
     await button.click();
     await this.draftBadge().waitFor({ state: 'hidden' });
   }
 
-  private pageLevelCommitButton(): Locator {
-    // The page header's "Save changes" button shares its accessible name
-    // with the modal-level Save button (the panel-level button is hidden by
-    // the time commitDraft() runs). Prefer the testid added in this PR;
-    // fall back to "first visible 'Save changes' button" — the page-level
-    // button is mounted first in the DOM, so .first() picks it.
-    const byTestid = this.page.getByTestId('dataset-items-commit-button');
-    return byTestid.or(this.page.getByRole('button', { name: 'Save changes' })).first();
-  }
-
-  private async versionCommitModal(): Promise<Locator> {
-    const byTestid = this.page.getByTestId('dataset-version-commit-dialog');
-    if ((await byTestid.count()) > 0) return byTestid;
-    return this.page.getByRole('dialog', { name: 'Save changes' });
-  }
-
-  /**
-   * Open the row's Actions menu at the given index, click Delete, and confirm
-   * the "Remove suite items" dialog (shared component with Test Suites — the
-   * title says "suite" even on the Datasets page). Stages a deletion as a
-   * draft; commitDraft() must be called to persist.
-   */
+  /** Confirmation dialog title reads "Remove suite items" — component is shared with Test Suites. */
   async deleteItemByIndex(index: number): Promise<void> {
     const row = this.itemRow(index);
     await row.getByRole('button', { name: 'Actions menu' }).click();
@@ -175,13 +101,8 @@ export class DatasetItemsPage {
   }
 
   /**
-   * Empty-state Add: when the dataset has zero items, the FE opens a modal
-   * dialog "Add dataset item" with a JSON-editor textbox instead of the
-   * sliding side-panel. The smoke test exercises this path when adding the
-   * first item to a UI-created empty dataset.
-   *
-   * Submits the JSON immediately (no draft staging — the modal commits as
-   * v2 directly). Resolves when the row appears in the items table.
+   * Empty-state Add takes a different FE path: opens a JSON-editor modal that
+   * commits directly (no draft staging) instead of the sliding side-panel.
    */
   async addItemViaEmptyStateModal(fields: Record<string, unknown>): Promise<void> {
     const triggers = this.page
@@ -191,8 +112,6 @@ export class DatasetItemsPage {
     await triggers.first().click();
     const modal = this.page.getByRole('dialog', { name: 'Add dataset item' });
     await modal.waitFor({ state: 'visible' });
-    // The textbox is a CodeMirror-style code editor with prefilled template.
-    // Select-all + type replaces the content.
     const editor = modal.getByRole('textbox');
     await editor.click();
     await this.page.keyboard.press('ControlOrMeta+A');
@@ -200,17 +119,39 @@ export class DatasetItemsPage {
     await this.page.keyboard.type(JSON.stringify(fields));
     await modal.getByRole('button', { name: 'Add dataset item' }).click();
     await modal.waitFor({ state: 'hidden' });
-    // The modal commits directly (no draft); wait for the new row to render.
     await this.itemsTableBody.locator('tr[data-row-id]').first().waitFor({ state: 'visible' });
   }
 
-  /** Add-item side-panel root. */
   get addItemPanel(): Locator {
     return this.page.getByTestId('dataset-item-panel');
   }
 
-  /** Items table tbody — scopes row queries to the data rowgroup. */
   private get itemsTableBody(): Locator {
     return this.page.getByRole('tabpanel', { name: 'Items' }).locator('tbody');
+  }
+
+  /** Panel stays mounted; open/closed is animated via CSS transform, not display/visibility. */
+  private async waitForPanelTransform(value: string): Promise<void> {
+    await this.page.waitForFunction((expected) => {
+      const el = document.querySelector('[data-testid="dataset-item-panel"]') as HTMLElement | null;
+      return (el?.style.transform ?? '').includes(expected);
+    }, value);
+  }
+
+  private pageLevelCommitButton(): Locator {
+    const byTestid = this.page.getByTestId('dataset-items-commit-button');
+    return byTestid.or(this.page.getByRole('button', { name: 'Save changes' })).first();
+  }
+
+  private async versionCommitModal(): Promise<Locator> {
+    const byTestid = this.page.getByTestId('dataset-version-commit-dialog');
+    if ((await byTestid.count()) > 0) return byTestid;
+    return this.page.getByRole('dialog', { name: 'Save changes' });
+  }
+
+  private async preferTestid(testid: string, role: { role: 'button'; name: string }): Promise<Locator> {
+    const byTestid = this.page.getByTestId(testid);
+    if ((await byTestid.count()) > 0) return byTestid;
+    return this.page.getByRole(role.role, { name: role.name });
   }
 }

--- a/tests_end_to_end/e2e/pom/dataset-items.page.ts
+++ b/tests_end_to_end/e2e/pom/dataset-items.page.ts
@@ -25,7 +25,7 @@ export class DatasetItemsPage {
     ]);
   }
 
-  /** Rendered row count — the "Showing X of Y" text is stale during drafts. */
+  /** Rendered row count on the current page. Table is paginated (default 10/page); the "Showing X of Y" text is stale during drafts. */
   async countItems(): Promise<number> {
     return this.itemsTableBody.locator('tr[data-row-id]').count();
   }

--- a/tests_end_to_end/e2e/pom/dataset-items.page.ts
+++ b/tests_end_to_end/e2e/pom/dataset-items.page.ts
@@ -1,0 +1,216 @@
+import type { Page, Locator } from '@playwright/test';
+import { loadEnvConfig } from '../config/env.config';
+
+export class DatasetItemsPage {
+  constructor(
+    private readonly page: Page,
+    private readonly projectId: string,
+    private readonly datasetId: string,
+  ) {}
+
+  async goto(): Promise<void> {
+    const env = loadEnvConfig();
+    await this.page.goto(
+      `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/datasets/${this.datasetId}/items`,
+    );
+  }
+
+  async waitForReady(): Promise<void> {
+    await this.page.getByRole('tab', { name: 'Items', selected: true }).waitFor({ state: 'visible' });
+    const realRow = this.itemsTableBody.locator('tr[data-row-id]').first();
+    // Empty-state copy is "No <entityName> items yet" — for datasets that's
+    // "No dataset items yet".
+    const emptyState = this.page.getByText('No dataset items yet');
+    await Promise.race([
+      realRow.waitFor({ state: 'visible' }),
+      emptyState.waitFor({ state: 'visible' }),
+    ]);
+  }
+
+  /**
+   * Count of item rows currently rendered in the items table body. While the
+   * page is in Draft mode, the "Showing X-Y of Z" text reflects the
+   * pre-draft committed count and is stale; the rendered row count is the
+   * source of truth for assertions during a test.
+   */
+  async countItems(): Promise<number> {
+    return this.itemsTableBody.locator('tr[data-row-id]').count();
+  }
+
+  /** True iff the page header shows the "Draft" badge. */
+  draftBadge(): Locator {
+    return this.page.getByText('Draft', { exact: true });
+  }
+
+  /** Locator matching the page header version label (`v1`, `v2`, ...). */
+  versionLabel(version: number): Locator {
+    return this.page.getByText(`v${version}`, { exact: true });
+  }
+
+  /** Item row by zero-based index in the visible table body. */
+  itemRow(index: number): Locator {
+    return this.itemsTableBody.locator('tr[data-row-id]').nth(index);
+  }
+
+  /** Item row by its dataset_item id. */
+  itemRowById(id: string): Locator {
+    return this.itemsTableBody.locator(`tr[data-row-id="${id}"]`);
+  }
+
+  /**
+   * Open the "Add item" side-panel. Waits for the panel to be on-screen.
+   *
+   * Prefers the dataset-items-add-button testid (added in this PR). Falls
+   * back to role+name "Add item" so the test passes against deployments
+   * that don't yet carry the new FE testid.
+   */
+  async clickAddItem(): Promise<void> {
+    const byTestid = this.page.getByTestId('dataset-items-add-button');
+    const byRole = this.page.getByRole('button', { name: 'Add item' });
+    const button = (await byTestid.count()) > 0 ? byTestid : byRole;
+    await button.click();
+    await this.addItemPanel.waitFor({ state: 'visible' });
+    // The panel root is always mounted in the DOM; "open" is signaled by
+    // transform: translateX(0px) rather than by display/visibility.
+    await this.page.waitForFunction(() => {
+      const el = document.querySelector('[data-testid="dataset-item-panel"]') as HTMLElement | null;
+      const t = el?.style.transform ?? '';
+      return t.includes('translateX(0');
+    });
+  }
+
+  /**
+   * Fill the open Add-item panel's column textareas. Pass one entry per
+   * dataset column; the FE auto-detects the schema from existing items.
+   */
+  async fillAddItemPanel(fields: Record<string, string>): Promise<void> {
+    for (const [column, value] of Object.entries(fields)) {
+      await this.addItemPanel
+        .getByRole('region', { name: column })
+        .getByPlaceholder('Enter text for this field…')
+        .fill(value);
+    }
+  }
+
+  /**
+   * Click the panel-level "Save changes" — stages the new item as a draft and
+   * adds it to the rendered table. The change is NOT yet committed to the
+   * backend; commitDraft() must be called to persist.
+   */
+  async submitAddItemPanel(): Promise<void> {
+    await this.addItemPanel.getByRole('button', { name: 'Save changes' }).click();
+    // The panel stays mounted in the DOM after close; "closed" is signaled
+    // by transform: translateX(100%) (slides off-screen) rather than
+    // display/visibility, so waitFor({state: 'hidden'}) never fires.
+    await this.page.waitForFunction(() => {
+      const el = document.querySelector('[data-testid="dataset-item-panel"]') as HTMLElement | null;
+      const t = el?.style.transform ?? '';
+      return t.includes('translateX(100%)');
+    });
+    await this.draftBadge().waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Commit all staged draft changes as a new dataset version. Opens the
+   * version-commit modal, optionally fills a version note, submits, and
+   * waits for the Draft badge to clear.
+   *
+   * Prefers the testids added in this PR; falls back to role+name for
+   * deployments without the new attributes.
+   */
+  async commitDraft(opts: { versionNote?: string } = {}): Promise<void> {
+    await this.pageLevelCommitButton().click();
+    const modal = await this.versionCommitModal();
+    await modal.waitFor({ state: 'visible' });
+    if (opts.versionNote !== undefined) {
+      await modal.getByRole('textbox', { name: 'Version note (optional)' }).fill(opts.versionNote);
+    }
+    await modal.getByRole('button', { name: 'Save changes' }).click();
+    await modal.waitFor({ state: 'hidden' });
+    await this.draftBadge().waitFor({ state: 'hidden' });
+  }
+
+  /**
+   * Discard all staged draft changes without committing.
+   */
+  async discardDraft(): Promise<void> {
+    const byTestid = this.page.getByTestId('dataset-items-discard-button');
+    const byRole = this.page.getByRole('button', { name: 'Discard changes' });
+    const button = (await byTestid.count()) > 0 ? byTestid : byRole;
+    await button.click();
+    await this.draftBadge().waitFor({ state: 'hidden' });
+  }
+
+  private pageLevelCommitButton(): Locator {
+    // The page header's "Save changes" button shares its accessible name
+    // with the modal-level Save button (the panel-level button is hidden by
+    // the time commitDraft() runs). Prefer the testid added in this PR;
+    // fall back to "first visible 'Save changes' button" — the page-level
+    // button is mounted first in the DOM, so .first() picks it.
+    const byTestid = this.page.getByTestId('dataset-items-commit-button');
+    return byTestid.or(this.page.getByRole('button', { name: 'Save changes' })).first();
+  }
+
+  private async versionCommitModal(): Promise<Locator> {
+    const byTestid = this.page.getByTestId('dataset-version-commit-dialog');
+    if ((await byTestid.count()) > 0) return byTestid;
+    return this.page.getByRole('dialog', { name: 'Save changes' });
+  }
+
+  /**
+   * Open the row's Actions menu at the given index, click Delete, and confirm
+   * the "Remove suite items" dialog (shared component with Test Suites — the
+   * title says "suite" even on the Datasets page). Stages a deletion as a
+   * draft; commitDraft() must be called to persist.
+   */
+  async deleteItemByIndex(index: number): Promise<void> {
+    const row = this.itemRow(index);
+    await row.getByRole('button', { name: 'Actions menu' }).click();
+    await this.page.getByRole('menuitem', { name: 'Delete' }).click();
+    const dialog = this.page.getByRole('dialog', { name: 'Remove suite items' });
+    await dialog.waitFor({ state: 'visible' });
+    await dialog.getByRole('button', { name: 'Remove suite items' }).click();
+    await dialog.waitFor({ state: 'hidden' });
+    await this.draftBadge().waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Empty-state Add: when the dataset has zero items, the FE opens a modal
+   * dialog "Add dataset item" with a JSON-editor textbox instead of the
+   * sliding side-panel. The smoke test exercises this path when adding the
+   * first item to a UI-created empty dataset.
+   *
+   * Submits the JSON immediately (no draft staging — the modal commits as
+   * v2 directly). Resolves when the row appears in the items table.
+   */
+  async addItemViaEmptyStateModal(fields: Record<string, unknown>): Promise<void> {
+    const triggers = this.page
+      .getByRole('button', { name: 'Add new item' })
+      .or(this.page.getByTestId('dataset-items-add-button'))
+      .or(this.page.getByRole('button', { name: 'Add item' }));
+    await triggers.first().click();
+    const modal = this.page.getByRole('dialog', { name: 'Add dataset item' });
+    await modal.waitFor({ state: 'visible' });
+    // The textbox is a CodeMirror-style code editor with prefilled template.
+    // Select-all + type replaces the content.
+    const editor = modal.getByRole('textbox');
+    await editor.click();
+    await this.page.keyboard.press('ControlOrMeta+A');
+    await this.page.keyboard.press('Delete');
+    await this.page.keyboard.type(JSON.stringify(fields));
+    await modal.getByRole('button', { name: 'Add dataset item' }).click();
+    await modal.waitFor({ state: 'hidden' });
+    // The modal commits directly (no draft); wait for the new row to render.
+    await this.itemsTableBody.locator('tr[data-row-id]').first().waitFor({ state: 'visible' });
+  }
+
+  /** Add-item side-panel root. */
+  get addItemPanel(): Locator {
+    return this.page.getByTestId('dataset-item-panel');
+  }
+
+  /** Items table tbody — scopes row queries to the data rowgroup. */
+  private get itemsTableBody(): Locator {
+    return this.page.getByRole('tabpanel', { name: 'Items' }).locator('tbody');
+  }
+}

--- a/tests_end_to_end/e2e/pom/datasets.page.ts
+++ b/tests_end_to_end/e2e/pom/datasets.page.ts
@@ -22,17 +22,12 @@ export class DatasetsPage {
     ]);
   }
 
-  /** Locator for the dataset row by exact name, scoped to the data rowgroup. */
   datasetRow(name: string): Locator {
     return this.page
       .locator('tbody tr[data-row-id]')
       .filter({ has: this.page.getByRole('cell', { name, exact: true }) });
   }
 
-  /**
-   * Click the name cell of the row matching the given dataset name. Resolves
-   * to a DatasetItemsPage after the URL transitions to /datasets/<id>/items.
-   */
   async openDatasetByName(name: string): Promise<DatasetItemsPage> {
     if (!this.projectId) {
       throw new Error('DatasetsPage.openDatasetByName: call goto(projectId) first');
@@ -43,8 +38,6 @@ export class DatasetsPage {
     if (!datasetId) {
       throw new Error(`DatasetsPage.openDatasetByName: row for "${name}" has no data-row-id`);
     }
-    // Click the name cell (second td, after the select checkbox) — avoids the
-    // row-action menu at the far right.
     await row.getByRole('cell', { name, exact: true }).click();
     await this.page.waitForURL((url) =>
       url.pathname.includes(`/datasets/${datasetId}/items`),
@@ -52,20 +45,12 @@ export class DatasetsPage {
     return new DatasetItemsPage(this.page, this.projectId, datasetId);
   }
 
-  /** Open the side-panel "Create dataset" dialog. */
   async clickCreateDataset(): Promise<void> {
     await this.page.getByRole('button', { name: 'Create dataset' }).click();
     await this.createDialog.waitFor({ state: 'visible' });
-    // The panel root is always mounted; "open" is signaled by transform
-    // translateX(0px) rather than display/visibility.
-    await this.page.waitForFunction(() => {
-      const el = document.querySelector('[data-testid="create-dataset-sidebar"]') as HTMLElement | null;
-      const t = el?.style.transform ?? '';
-      return t.includes('translateX(0');
-    });
+    await this.waitForCreateDialogTransform('translateX(0');
   }
 
-  /** Fill the Step-1 fields of the create dialog. Does NOT submit. */
   async fillCreateDialog(args: { name: string; description?: string }): Promise<void> {
     await this.createDialog.getByRole('textbox', { name: 'Name' }).fill(args.name);
     if (args.description !== undefined) {
@@ -73,16 +58,7 @@ export class DatasetsPage {
     }
   }
 
-  /**
-   * Submit the create dialog: Next on Step 1 → Create on Step 2 (which is the
-   * CSV-or-SDK chooser; we create an empty dataset shell with no data) → Close
-   * the success step. Resolves when the dialog closes and the new row appears
-   * in the list.
-   *
-   * The dialog is three-step: name/description → add data → success. The
-   * success step does NOT auto-close — we click the Close (X) button to
-   * dismiss it.
-   */
+  /** Three-step dialog: name+description → CSV/SDK chooser → success. Success step doesn't auto-close. */
   async submitCreateDialog(): Promise<void> {
     await this.createDialog.getByRole('button', { name: 'Next' }).click();
     await this.createDialog
@@ -93,16 +69,18 @@ export class DatasetsPage {
       .getByRole('heading', { name: 'Dataset created!', level: 3 })
       .waitFor({ state: 'visible' });
     await this.createDialog.getByRole('button', { name: 'Close' }).click();
-    // Panel stays mounted; "closed" = transform translateX(100%).
-    await this.page.waitForFunction(() => {
-      const el = document.querySelector('[data-testid="create-dataset-sidebar"]') as HTMLElement | null;
-      const t = el?.style.transform ?? '';
-      return t.includes('translateX(100%)');
-    });
+    await this.waitForCreateDialogTransform('translateX(100%)');
   }
 
-  /** Side-panel root — used to scope selectors inside the create dialog. */
   get createDialog(): Locator {
     return this.page.getByTestId('create-dataset-sidebar');
+  }
+
+  /** Panel stays mounted; open/closed state is animated via CSS transform, not display/visibility. */
+  private async waitForCreateDialogTransform(value: string): Promise<void> {
+    await this.page.waitForFunction((expected) => {
+      const el = document.querySelector('[data-testid="create-dataset-sidebar"]') as HTMLElement | null;
+      return (el?.style.transform ?? '').includes(expected);
+    }, value);
   }
 }

--- a/tests_end_to_end/e2e/pom/datasets.page.ts
+++ b/tests_end_to_end/e2e/pom/datasets.page.ts
@@ -1,0 +1,108 @@
+import type { Page, Locator } from '@playwright/test';
+import { loadEnvConfig } from '../config/env.config';
+import { DatasetItemsPage } from './dataset-items.page';
+
+export class DatasetsPage {
+  private projectId: string | null = null;
+
+  constructor(private readonly page: Page) {}
+
+  async goto(projectId: string): Promise<void> {
+    this.projectId = projectId;
+    const env = loadEnvConfig();
+    await this.page.goto(`${env.baseUrl}/${env.workspace}/projects/${projectId}/datasets/`);
+  }
+
+  async waitForReady(): Promise<void> {
+    const realRow = this.page.locator('tbody tr[data-row-id]').first();
+    const emptyState = this.page.getByText('No datasets yet');
+    await Promise.race([
+      realRow.waitFor({ state: 'visible' }),
+      emptyState.waitFor({ state: 'visible' }),
+    ]);
+  }
+
+  /** Locator for the dataset row by exact name, scoped to the data rowgroup. */
+  datasetRow(name: string): Locator {
+    return this.page
+      .locator('tbody tr[data-row-id]')
+      .filter({ has: this.page.getByRole('cell', { name, exact: true }) });
+  }
+
+  /**
+   * Click the name cell of the row matching the given dataset name. Resolves
+   * to a DatasetItemsPage after the URL transitions to /datasets/<id>/items.
+   */
+  async openDatasetByName(name: string): Promise<DatasetItemsPage> {
+    if (!this.projectId) {
+      throw new Error('DatasetsPage.openDatasetByName: call goto(projectId) first');
+    }
+    const row = this.datasetRow(name);
+    await row.waitFor({ state: 'visible' });
+    const datasetId = await row.getAttribute('data-row-id');
+    if (!datasetId) {
+      throw new Error(`DatasetsPage.openDatasetByName: row for "${name}" has no data-row-id`);
+    }
+    // Click the name cell (second td, after the select checkbox) — avoids the
+    // row-action menu at the far right.
+    await row.getByRole('cell', { name, exact: true }).click();
+    await this.page.waitForURL((url) =>
+      url.pathname.includes(`/datasets/${datasetId}/items`),
+    );
+    return new DatasetItemsPage(this.page, this.projectId, datasetId);
+  }
+
+  /** Open the side-panel "Create dataset" dialog. */
+  async clickCreateDataset(): Promise<void> {
+    await this.page.getByRole('button', { name: 'Create dataset' }).click();
+    await this.createDialog.waitFor({ state: 'visible' });
+    // The panel root is always mounted; "open" is signaled by transform
+    // translateX(0px) rather than display/visibility.
+    await this.page.waitForFunction(() => {
+      const el = document.querySelector('[data-testid="create-dataset-sidebar"]') as HTMLElement | null;
+      const t = el?.style.transform ?? '';
+      return t.includes('translateX(0');
+    });
+  }
+
+  /** Fill the Step-1 fields of the create dialog. Does NOT submit. */
+  async fillCreateDialog(args: { name: string; description?: string }): Promise<void> {
+    await this.createDialog.getByRole('textbox', { name: 'Name' }).fill(args.name);
+    if (args.description !== undefined) {
+      await this.createDialog.getByRole('textbox', { name: 'Description' }).fill(args.description);
+    }
+  }
+
+  /**
+   * Submit the create dialog: Next on Step 1 → Create on Step 2 (which is the
+   * CSV-or-SDK chooser; we create an empty dataset shell with no data) → Close
+   * the success step. Resolves when the dialog closes and the new row appears
+   * in the list.
+   *
+   * The dialog is three-step: name/description → add data → success. The
+   * success step does NOT auto-close — we click the Close (X) button to
+   * dismiss it.
+   */
+  async submitCreateDialog(): Promise<void> {
+    await this.createDialog.getByRole('button', { name: 'Next' }).click();
+    await this.createDialog
+      .getByRole('heading', { name: 'Add data', level: 3 })
+      .waitFor({ state: 'visible' });
+    await this.createDialog.getByRole('button', { name: 'Create' }).click();
+    await this.createDialog
+      .getByRole('heading', { name: 'Dataset created!', level: 3 })
+      .waitFor({ state: 'visible' });
+    await this.createDialog.getByRole('button', { name: 'Close' }).click();
+    // Panel stays mounted; "closed" = transform translateX(100%).
+    await this.page.waitForFunction(() => {
+      const el = document.querySelector('[data-testid="create-dataset-sidebar"]') as HTMLElement | null;
+      const t = el?.style.transform ?? '';
+      return t.includes('translateX(100%)');
+    });
+  }
+
+  /** Side-panel root — used to scope selectors inside the create dialog. */
+  get createDialog(): Locator {
+    return this.page.getByTestId('create-dataset-sidebar');
+  }
+}

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/main.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from opik.rest_api.core.api_error import ApiError
 
-from .routes import health, projects, traces
+from .routes import datasets, health, projects, traces
 
 app = FastAPI(title="opik-sdk-driver", version="0.0.1")
 
@@ -18,3 +18,4 @@ async def _api_error_handler(_request: Request, exc: ApiError) -> JSONResponse:
 app.include_router(health.router)
 app.include_router(projects.router)
 app.include_router(traces.router)
+app.include_router(datasets.router)

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/datasets.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/datasets.py
@@ -1,0 +1,33 @@
+import atexit
+
+from fastapi import APIRouter, Header
+
+from ..opik_factory import make_opik_client
+from ..schemas import DatasetCreate, DatasetResponse
+
+router = APIRouter(prefix="/datasets", tags=["datasets"])
+
+
+@router.post("", response_model=DatasetResponse, status_code=201)
+def create_dataset(
+    body: DatasetCreate,
+    x_opik_api_key: str | None = Header(default=None),
+) -> DatasetResponse:
+    # Public create_dataset() returns a Dataset with .id directly, so no
+    # post-create lookup is needed (unlike traces, where @opik.track
+    # doesn't surface the ID). flush=True drains the streamer that
+    # dataset.insert(items) enqueues to before we return.
+    client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
+    try:
+        dataset = client.create_dataset(
+            name=body.name,
+            description=body.description,
+            project_name=body.project_name,
+        )
+        if body.items:
+            dataset.insert(body.items)
+    finally:
+        client.end(flush=True)
+        atexit.unregister(client.end)
+
+    return DatasetResponse(id=str(dataset.id), name=dataset.name)

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/datasets.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/datasets.py
@@ -13,10 +13,10 @@ def create_dataset(
     body: DatasetCreate,
     x_opik_api_key: str | None = Header(default=None),
 ) -> DatasetResponse:
-    # Public create_dataset() returns a Dataset with .id directly, so no
-    # post-create lookup is needed (unlike traces, where @opik.track
-    # doesn't surface the ID). flush=True drains the streamer that
-    # dataset.insert(items) enqueues to before we return.
+    """Wraps client.create_dataset(...) + optional dataset.insert(items).
+
+    flush=True on client.end() drains the streamer that insert() enqueues to.
+    """
     client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
     try:
         dataset = client.create_dataset(

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict
 
 
@@ -29,3 +31,18 @@ class TraceResponse(BaseModel):
     id: str
     name: str
     project_id: str
+
+
+class DatasetCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    project_name: str
+    description: str | None = None
+    items: list[dict[str, Any]] | None = None
+    workspace: str | None = None
+
+
+class DatasetResponse(BaseModel):
+    id: str
+    name: str

--- a/tests_end_to_end/e2e/tests/datasets/dataset-crud-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/datasets/dataset-crud-smoke.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from '@e2e/fixtures';
+import { DatasetsPage } from '@e2e/pom/datasets.page';
+
+test.describe('Dataset CRUD — smoke', { tag: ['@t1-smoke', '@datasets'] }, () => {
+  // The dataset items toolbar collapses to an icon-only "Add item" button
+  // (no accessible name) at < ~850px container width — i.e. anything narrower
+  // than ~1280px viewport with the sidebar expanded. Use a wider viewport so
+  // the labelled button shape is exercised, and so legacy environments without
+  // the dataset-items-add-button testid (deployed pre this PR) still pass.
+  test.use({ viewport: { width: 1600, height: 900 } });
+
+  test('SDK-seeded dataset renders in list and items page; UI add and delete commit as new versions', async ({
+    dataset,
+    project,
+    page,
+  }) => {
+    const datasets = new DatasetsPage(page);
+    await datasets.goto(project.id);
+    await datasets.waitForReady();
+
+    await expect(datasets.datasetRow(dataset.name)).toBeVisible();
+
+    const items = await datasets.openDatasetByName(dataset.name);
+    await items.waitForReady();
+    expect(await items.countItems()).toBe(3);
+
+    // Stage a new item via the side-panel.
+    await items.clickAddItem();
+    await items.fillAddItemPanel({
+      input: 'ui-added input',
+      expected_output: 'ui-added output',
+    });
+    await items.submitAddItemPanel();
+    expect(await items.countItems()).toBe(4);
+
+    // Commit the draft as a new version (v2).
+    await items.commitDraft();
+    await expect(items.versionLabel(2)).toBeVisible();
+    expect(await items.countItems()).toBe(4);
+
+    // Stage a delete of the row just added (most-recent-first ordering puts
+    // the UI-added row at index 0).
+    await items.deleteItemByIndex(0);
+    expect(await items.countItems()).toBe(3);
+
+    // Commit the deletion as v3.
+    await items.commitDraft();
+    await expect(items.versionLabel(3)).toBeVisible();
+    expect(await items.countItems()).toBe(3);
+  });
+
+  test('UI-created dataset and UI-added first item round-trip to the SDK', async ({
+    project,
+    backendClient,
+    testNamespace,
+    page,
+  }) => {
+    const name = `${testNamespace}-ui-ds`;
+    const description = 'created via UI dialog';
+
+    const datasets = new DatasetsPage(page);
+    await datasets.goto(project.id);
+    await datasets.waitForReady();
+
+    await datasets.clickCreateDataset();
+    await datasets.fillCreateDialog({ name, description });
+    await datasets.submitCreateDialog();
+    await expect(datasets.datasetRow(name)).toBeVisible();
+
+    // "I created a dataset via the UI yesterday — now I look it up via the
+    // SDK". Round-trip the metadata.
+    const found = await backendClient.findDatasetByName(name);
+    expect(found).not.toBeNull();
+    expect(found?.name).toBe(name);
+    expect(found?.description).toBe(description);
+
+    // Drill into the items page and add the first item via the empty-state
+    // JSON-editor modal (the populated-table sliding panel is a different
+    // code path, exercised by Test A).
+    const items = await datasets.openDatasetByName(name);
+    await items.waitForReady();
+    const newItem = { input: 'ui input', expected_output: 'ui output' };
+    await items.addItemViaEmptyStateModal(newItem);
+
+    // SDK-verify the new item round-trips.
+    const fetchedItems = await backendClient.getDatasetItems(found!.id);
+    expect(fetchedItems).toHaveLength(1);
+    expect(fetchedItems[0].data).toMatchObject(newItem);
+
+    // Test B owns dataset teardown (no dataset fixture used). global-teardown's
+    // cuj-* sweep is the safety net; this inline delete keeps the worker's
+    // workspace clean between consecutive cases.
+    await backendClient.deleteDataset(found!.id);
+  });
+});

--- a/tests_end_to_end/e2e/tests/datasets/dataset-crud-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/datasets/dataset-crud-smoke.spec.ts
@@ -2,11 +2,7 @@ import { test, expect } from '@e2e/fixtures';
 import { DatasetsPage } from '@e2e/pom/datasets.page';
 
 test.describe('Dataset CRUD — smoke', { tag: ['@t1-smoke', '@datasets'] }, () => {
-  // The dataset items toolbar collapses to an icon-only "Add item" button
-  // (no accessible name) at < ~850px container width — i.e. anything narrower
-  // than ~1280px viewport with the sidebar expanded. Use a wider viewport so
-  // the labelled button shape is exercised, and so legacy environments without
-  // the dataset-items-add-button testid (deployed pre this PR) still pass.
+  /** Items toolbar collapses to icon-only (no accessible name) below ~850px container width. */
   test.use({ viewport: { width: 1600, height: 900 } });
 
   test('SDK-seeded dataset renders in list and items page; UI add and delete commit as new versions', async ({
@@ -24,7 +20,6 @@ test.describe('Dataset CRUD — smoke', { tag: ['@t1-smoke', '@datasets'] }, () 
     await items.waitForReady();
     expect(await items.countItems()).toBe(3);
 
-    // Stage a new item via the side-panel.
     await items.clickAddItem();
     await items.fillAddItemPanel({
       input: 'ui-added input',
@@ -33,17 +28,13 @@ test.describe('Dataset CRUD — smoke', { tag: ['@t1-smoke', '@datasets'] }, () 
     await items.submitAddItemPanel();
     expect(await items.countItems()).toBe(4);
 
-    // Commit the draft as a new version (v2).
     await items.commitDraft();
     await expect(items.versionLabel(2)).toBeVisible();
     expect(await items.countItems()).toBe(4);
 
-    // Stage a delete of the row just added (most-recent-first ordering puts
-    // the UI-added row at index 0).
     await items.deleteItemByIndex(0);
     expect(await items.countItems()).toBe(3);
 
-    // Commit the deletion as v3.
     await items.commitDraft();
     await expect(items.versionLabel(3)).toBeVisible();
     expect(await items.countItems()).toBe(3);
@@ -67,29 +58,21 @@ test.describe('Dataset CRUD — smoke', { tag: ['@t1-smoke', '@datasets'] }, () 
     await datasets.submitCreateDialog();
     await expect(datasets.datasetRow(name)).toBeVisible();
 
-    // "I created a dataset via the UI yesterday — now I look it up via the
-    // SDK". Round-trip the metadata.
     const found = await backendClient.findDatasetByName(name);
     expect(found).not.toBeNull();
     expect(found?.name).toBe(name);
     expect(found?.description).toBe(description);
 
-    // Drill into the items page and add the first item via the empty-state
-    // JSON-editor modal (the populated-table sliding panel is a different
-    // code path, exercised by Test A).
+    /** Empty datasets use a different Add Item path than the sliding panel — see POM. */
     const items = await datasets.openDatasetByName(name);
     await items.waitForReady();
     const newItem = { input: 'ui input', expected_output: 'ui output' };
     await items.addItemViaEmptyStateModal(newItem);
 
-    // SDK-verify the new item round-trips.
     const fetchedItems = await backendClient.getDatasetItems(found!.id);
     expect(fetchedItems).toHaveLength(1);
     expect(fetchedItems[0].data).toMatchObject(newItem);
 
-    // Test B owns dataset teardown (no dataset fixture used). global-teardown's
-    // cuj-* sweep is the safety net; this inline delete keeps the worker's
-    // workspace clean between consecutive cases.
     await backendClient.deleteDataset(found!.id);
   });
 });


### PR DESCRIPTION
## Details

Second CUJ smoke test in the Opik 2.0 E2E suite — slot 2 of 6 in the data-plane test sequence. Seeds datasets via the Python SDK code path (`opik.Opik().create_dataset(...).insert(...)` → bridge route) and verifies they round-trip end-to-end through the Datasets list + dataset items pages, plus exercises both write-direction paths (SDK-create → UI-verify and UI-create → SDK-verify) in two paired test cases. Sets the SDK-create + UI-create pair-in-one-PR pattern the next two CUJ tickets (OPIK-6137 Test Suites, OPIK-6598 Annotation Queue) will copy.

Cross-package: ships four FE `data-testid` additions on the Datasets UI to disambiguate the three near-identical "Save changes" buttons that co-exist during draft mode (panel stage, page commit, modal confirm) plus the items toolbar Add button that collapses to icon-only at narrow viewports. Also extends the test-infra orphan sweep (`global-setup.ts` + `global-teardown.ts`) to cover datasets — datasets do NOT cascade-delete with their parent project, so the per-run `cuj-{runId}-` sweep needs to handle them explicitly. Without this, every run would leave a dangling dataset behind.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6595

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: full implementation across bridge route, SDK client method, fixture, backend-client inspection methods, two POMs, two test cases, four FE testids, and dataset orphan sweep additions to global setup/teardown
- Human verification: code review + manual staging runs (cloud) at each phase gate + final 7-test gate run with prefix-sweep verification

## Testing


### What each test verifies (UI-first, REST used only by fixtures + backend-client inspection)

| Test | Assertions |
|---|---|
| `SDK-seeded dataset renders in list and items page; UI add and delete commit as new versions` | Seeds a 3-item dataset via the bridge. Asserts the row appears in the list view, drills into the items page, exercises the side-panel Add Item flow + page-level commit (asserts v2 + Draft cleared), then Actions-menu Delete + commit (asserts v3 + Draft cleared). Two full Draft→commit cycles. |
| `UI-created dataset and UI-added first item round-trip to the SDK` | Drives the Create-dataset dialog end-to-end (name + description → Next → Create → success → Close), verifies via `backendClient.findDatasetByName` that name + description round-trip. Then drills into the empty items page, exercises the empty-state JSON-editor modal (different code path from the populated-table side-panel — handled by a separate `addItemViaEmptyStateModal` POM method), and verifies the item content via `backendClient.getDatasetItems`. |

REST is used only by the fixtures (project + dataset create via bridge), by `backendClient` for inspection in Test B's UI-create-verify path, and by `global-setup`/`global-teardown` orphan sweeps. Tests and POMs never call REST.


## Documentation
