### PR TITLE
[DND-998] Build multi-arch docker images on every trigger

### DIFF
--- a/.github/workflows/build_and_push_docker.yaml
+++ b/.github/workflows/build_and_push_docker.yaml
@@ -35,6 +35,11 @@ on:
         required: false
         description: If this is an adhoc build (will skip comet variant)
         default: false
+      build_arm64:
+        type: boolean
+        required: false
+        description: Build multiarch images
+        default: true
     secrets:
       OPIK_FE_SENTRY_DSN:
         required: false
@@ -63,8 +68,9 @@ jobs:
             MERGE_MATRIX=$(echo "$MERGE_MATRIX" | jq '.exclude += [{"image_type":"comet"}]')
           fi
           
-          # Exclude arm64 if not a release build or if guardrails backend
-          if [[ "${{ inputs.is_release }}" != "true" ]] || [[ "${{ inputs.image }}" == "opik-guardrails-backend" ]]; then
+          # Exclude arm64 when the caller opts out, or for guardrails backend
+          # (no arm64 image available for it).
+          if [[ "${{ inputs.build_arm64 }}" != "true" ]] || [[ "${{ inputs.image }}" == "opik-guardrails-backend" ]]; then
             BUILD_MATRIX=$(echo "$BUILD_MATRIX" | jq '.exclude += [{"platform":"arm64"}]')
           fi
           
@@ -272,12 +278,10 @@ jobs:
         run: |
           echo "### Docker images pushed: ${{ steps.set_vars.outputs.image_name }}" >> "$GITHUB_STEP_SUMMARY"
           echo "${{ steps.meta.outputs.tags }}" >> "$GITHUB_STEP_SUMMARY"
-          if [[ "${{ inputs.image }}" == "opik-guardrails-backend" ]]; then
+          if [[ "${{ inputs.image }}" == "opik-guardrails-backend" ]] || [[ "${{ inputs.build_arm64 }}" != "true" ]]; then
             echo "Built for platforms: linux/amd64" >> "$GITHUB_STEP_SUMMARY"
-          elif [[ "${{ inputs.is_release }}" == "true" ]]; then
-            echo "Built for platforms: linux/amd64, linux/arm64" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "Built for platforms: linux/amd64" >> "$GITHUB_STEP_SUMMARY"
+            echo "Built for platforms: linux/amd64, linux/arm64" >> "$GITHUB_STEP_SUMMARY"
           fi
           echo "- [View on GitHub Container Registry](https://github.com/${{ github.repository }}/pkgs/container/opik%2F${{ steps.set_vars.outputs.image_name }})" >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/build_and_push_docker.yaml
+++ b/.github/workflows/build_and_push_docker.yaml
@@ -69,7 +69,6 @@ jobs:
           fi
           
           # Exclude arm64 when the caller opts out, or for guardrails backend
-          # (no arm64 image available for it).
           if [[ "${{ inputs.build_arm64 }}" != "true" ]] || [[ "${{ inputs.image }}" == "opik-guardrails-backend" ]]; then
             BUILD_MATRIX=$(echo "$BUILD_MATRIX" | jq '.exclude += [{"platform":"arm64"}]')
           fi

--- a/.github/workflows/build_apps.yml
+++ b/.github/workflows/build_apps.yml
@@ -26,6 +26,11 @@ on:
         required: true
         description: Build guardrails backend
         default: true
+      build_arm64:
+        type: boolean
+        required: false
+        description: Build multiarch images
+        default: true
   workflow_call:
     inputs:
       version:
@@ -51,7 +56,12 @@ on:
         required: false
         description: Build guardrails backend
         default: true
-        
+      build_arm64:
+        type: boolean
+        required: false
+        description: Build multiarch images
+        default: true
+
     outputs:
       version:
         description: "The version that was built"
@@ -121,6 +131,8 @@ jobs:
       comet_build_args: ""
       is_release: ${{ inputs.is_release || false }}
       is_adhoc: ${{ inputs.is_adhoc || false }}
+      # default to multi-arch (true) when caller/trigger omits the input (push events have no inputs context); only an explicit `false` opts out
+      build_arm64: ${{ inputs.build_arm64 != false }}
 
   build-sandbox-executor-python:
     if: ${{ !inputs.is_adhoc }}
@@ -136,6 +148,7 @@ jobs:
       comet_build_args: ""
       is_release: ${{ inputs.is_release || false }}
       is_adhoc: ${{ inputs.is_adhoc || false }}
+      build_arm64: ${{ inputs.build_arm64 != false }}
 
   build-python-backend:
     if: always() && needs.set-version.result == 'success'
@@ -152,6 +165,7 @@ jobs:
       comet_build_args: ""
       is_release: ${{ inputs.is_release || false }}
       is_adhoc: ${{ inputs.is_adhoc || false }}
+      build_arm64: ${{ inputs.build_arm64 != false }}
 
   # build-guardrails-backend:
   #   if: inputs.build_guardrails != false 
@@ -180,6 +194,7 @@ jobs:
       comet_build_args: ${{ !inputs.is_adhoc && 'BUILD_MODE=comet' || '' }}
       is_release: ${{ inputs.is_release || false }}
       is_adhoc: ${{ inputs.is_adhoc || false }}
+      build_arm64: ${{ inputs.build_arm64 != false }}
 
   create-git-tag:
     if: |

--- a/.github/workflows/build_apps.yml
+++ b/.github/workflows/build_apps.yml
@@ -131,8 +131,8 @@ jobs:
       comet_build_args: ""
       is_release: ${{ inputs.is_release || false }}
       is_adhoc: ${{ inputs.is_adhoc || false }}
-      # default to multi-arch (true) when caller/trigger omits the input (push events have no inputs context); only an explicit `false` opts out
-      build_arm64: ${{ inputs.build_arm64 != false }}
+      # push events have no `inputs` context, so force multi-arch there; otherwise honor the input (workflow_dispatch / workflow_call use the declared default: true)
+      build_arm64: ${{ github.event_name == 'push' || inputs.build_arm64 }}
 
   build-sandbox-executor-python:
     if: ${{ !inputs.is_adhoc }}
@@ -148,7 +148,7 @@ jobs:
       comet_build_args: ""
       is_release: ${{ inputs.is_release || false }}
       is_adhoc: ${{ inputs.is_adhoc || false }}
-      build_arm64: ${{ inputs.build_arm64 != false }}
+      build_arm64: ${{ github.event_name == 'push' || inputs.build_arm64 }}
 
   build-python-backend:
     if: always() && needs.set-version.result == 'success'
@@ -165,7 +165,7 @@ jobs:
       comet_build_args: ""
       is_release: ${{ inputs.is_release || false }}
       is_adhoc: ${{ inputs.is_adhoc || false }}
-      build_arm64: ${{ inputs.build_arm64 != false }}
+      build_arm64: ${{ github.event_name == 'push' || inputs.build_arm64 }}
 
   # build-guardrails-backend:
   #   if: inputs.build_guardrails != false 
@@ -194,7 +194,7 @@ jobs:
       comet_build_args: ${{ !inputs.is_adhoc && 'BUILD_MODE=comet' || '' }}
       is_release: ${{ inputs.is_release || false }}
       is_adhoc: ${{ inputs.is_adhoc || false }}
-      build_arm64: ${{ inputs.build_arm64 != false }}
+      build_arm64: ${{ github.event_name == 'push' || inputs.build_arm64 }}
 
   create-git-tag:
     if: |


### PR DESCRIPTION
## Summary
Until now Opik docker images were only built multi-arch on release; main, branch, and adhoc builds were `linux/amd64`-only (the arm64 platform was excluded from the matrix unless `is_release=true`).

This PR flips that:
- Removes the `is_release` gate from the arm64 matrix exclusion in `build_and_push_docker.yaml`.
- Adds a new `build_arm64: boolean` input (default `true`) on both `build_and_push_docker.yaml` and `build_apps.yml` so callers / `workflow_dispatch` can opt back to amd64-only.
- `opik-guardrails-backend` stays amd64-only regardless (no arm64 image available).

Pure GitHub-Actions edits — no reuse of comet-ml/gha-tools (since opik is public).

## Notes
The passthrough is `build_arm64: ${{ github.event_name == 'push' || inputs.build_arm64 }}` rather than the project's usual `|| false` style. Two reasons:
- For a default-**true** param, `inputs.X || true` would override an explicit `false`, and `inputs.X || false` defaults to false on omit. Neither default-style works.
- On `push` events the `inputs` context isn't populated, and GHA's expression engine coerces `null` and `false` both to `0`, so `inputs.build_arm64 != false` is `0 != 0` → `false` (silently disabling arm64 on every main-branch push). Branching on `github.event_name == 'push'` sidesteps the coercion.

`workflow_dispatch` and `workflow_call` apply the declared `default: true` when omitted, so they fall through the second operand correctly.

## Test plan
- [ ] On a branch push, both backend and frontend produce `linux/amd64` + `linux/arm64` manifests (verify with `docker buildx imagetools inspect ghcr.io/comet-ml/opik/opik-backend:<version>`).
- [ ] `opik-guardrails-backend` (when re-enabled) still builds only amd64.
- [ ] `workflow_dispatch` with `build_arm64: false` produces amd64-only.
- [ ] Adhoc PR test env build is still functional (slower now, but multi-arch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)