### PR TITLE
[NA] [SDK] revert(load): remove test_concurrent_writers_race_stress

### DIFF
--- a/tests_load/README.md
+++ b/tests_load/README.md
@@ -38,7 +38,6 @@ down for local smoke runs.
 | `test_bursts.py::test_burst_single_loop` | 50k traces, tight loop, no think-time |
 | `test_bursts.py::test_spread_over_time` | 10k traces evenly spread over 10 minutes |
 | `test_bursts.py::test_concurrent_writers_share_one_client` | 30 threads × 1k traces = 30k traces sharing one client |
-| `test_bursts.py::test_concurrent_writers_race_stress` | 100 threads × 500 traces, no think-time, batcher flush interval monkey-patched 2 s → 5 ms — tuned specifically to surface missing-lock regressions in `BatchManager.flush_ready` (OPIK-6444 shape) |
 | `test_dataset_items.py::test_dataset_insert_many_versions` | 50 sequential `Dataset.insert()` calls × 50 items × ~4 KB payload = 2.5k items across 50 versions. Verifies `dataset.get_items()` round-trips the full count — catches the multi-replica ClickHouse `COPY_VERSION_ITEMS` short-read truncation that drops items on prod (won't reproduce against single-replica localhost) |
 
 Every test:

--- a/tests_load/suite/python_sdk/test_bursts.py
+++ b/tests_load/suite/python_sdk/test_bursts.py
@@ -1,15 +1,11 @@
 """Burst, spread, and concurrent scenarios."""
 
-import contextlib
 import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import Iterator, List, Set
+from typing import List, Set
 
 import opik
-import pytest
-from opik.api_objects import opik_client
-from opik.message_processing.batching import batch_manager_constuctors
 
 from . import _helpers
 from ._helpers import Metrics
@@ -177,122 +173,3 @@ def test_concurrent_writers_share_one_client(
         )
 
     metrics["delivered_trace_count"] = len(delivered_trace_ids)
-
-
-_RACE_FLUSH_INTERVAL_SECONDS: float = 0.005
-
-
-@contextlib.contextmanager
-def _race_stress_flush_interval() -> Iterator[None]:
-    """Monkey-patches the batch flush interval down for the duration of one test.
-
-    The production default is 2.0 s, so a typical submission window only
-    contains ~1 flush cycle — far too few for a missing-lock regression in
-    ``BatchManager.flush_ready`` (OPIK-6444) to surface reliably. Lowering
-    the interval to 5 ms matches the unit-test setup and gives ~hundreds of
-    flush cycles per submission window, turning a flaky catch into a
-    near-deterministic one.
-
-    Also drops any existing global Opik client so the next ``@opik.track``
-    constructs a fresh client that picks up the patched intervals.
-    """
-    saved_trace = batch_manager_constuctors.CREATE_TRACES_MESSAGE_BATCHER_FLUSH_INTERVAL_SECONDS
-    saved_span = batch_manager_constuctors.CREATE_SPANS_MESSAGE_BATCHER_FLUSH_INTERVAL_SECONDS
-
-    batch_manager_constuctors.CREATE_TRACES_MESSAGE_BATCHER_FLUSH_INTERVAL_SECONDS = _RACE_FLUSH_INTERVAL_SECONDS
-    batch_manager_constuctors.CREATE_SPANS_MESSAGE_BATCHER_FLUSH_INTERVAL_SECONDS = _RACE_FLUSH_INTERVAL_SECONDS
-    opik_client.reset_global_client(end_client=True)
-    try:
-        yield
-    finally:
-        batch_manager_constuctors.CREATE_TRACES_MESSAGE_BATCHER_FLUSH_INTERVAL_SECONDS = saved_trace
-        batch_manager_constuctors.CREATE_SPANS_MESSAGE_BATCHER_FLUSH_INTERVAL_SECONDS = saved_span
-        opik_client.reset_global_client(end_client=True)
-
-
-# 300 s hang-guard: with the lock in place this scenario finishes in ~5 s at
-# scale 0.05 and ~2 min at scale 1.0. If a regression in batch_manager makes
-# flush deadlock against a concurrent add (the OPIK-6444 family of bugs),
-# observed behaviour is a hard hang on opik.flush_tracker() or
-# verify_exact_trace_ids — without this marker the worker would silently
-# burn the entire workflow timeout. With it, the hang surfaces as a fast
-# `Failed: Timeout >300.0s` failure in the report.
-@pytest.mark.timeout(300)
-def test_concurrent_writers_race_stress(
-    metrics: Metrics, load_scale: float
-) -> None:
-    """High-pressure race-condition stress test for the SDK batch manager.
-
-    Tuned specifically to maximize the number of flush cycles that fire
-    while messages are being added concurrently, so a missing lock around
-    ``BatchManager.flush_ready`` (the OPIK-6444 regression shape) surfaces
-    reliably rather than only on lucky runs:
-
-    - 100 threads (vs 30 in the realistic concurrent test) maximize
-      contention on the shared batcher's accumulator.
-    - **Zero think-time** keeps the submission window tight so multiple
-      flush cycles must overlap with adds.
-    - The batcher's per-type flush interval is monkey-patched from the
-      production default (2.0 s) down to 5 ms via
-      ``_race_stress_flush_interval``, so ~hundreds of flush cycles fire
-      during submission instead of ~1.
-
-    Volume: 100 threads × 500 traces = 50k traces (100k messages).
-
-    Verifies every submitted trace id lands with required fields set.
-    Any dropped CREATE message fails via ``verify_exact_trace_ids``; any
-    dropped UPDATE message fails via the ``end_time``/``name`` field
-    check in ``verify_traces``.
-    """
-    thread_workers: int = 100
-    traces_per_worker: int = int(500 * load_scale)
-    total_traces: int = thread_workers * traces_per_worker
-    trace_input_bytes: int = 100
-    project_name: str = _helpers.unique_project_name("concurrent-race")
-
-    metrics["project_name"] = project_name
-    metrics["thread_workers"] = thread_workers
-    metrics["traces_per_worker"] = traces_per_worker
-    metrics["total_traces"] = total_traces
-    metrics["trace_input_bytes"] = trace_input_bytes
-    metrics["flush_interval_seconds"] = _RACE_FLUSH_INTERVAL_SECONDS
-
-    submitted_trace_ids: List[str] = []
-    submitted_lock: threading.Lock = threading.Lock()
-
-    with _race_stress_flush_interval():
-        @opik.track(project_name=project_name)
-        def handle_request(worker_id: int, prompt: str) -> str:
-            trace_id: str = opik.opik_context.get_current_trace_data().id
-            with submitted_lock:
-                submitted_trace_ids.append(trace_id)
-            return f"worker-{worker_id}: {prompt}"
-
-        def worker(worker_id: int) -> None:
-            for _ in range(traces_per_worker):
-                handle_request(
-                    worker_id=worker_id,
-                    prompt=_helpers.random_text(trace_input_bytes),
-                )
-
-        with metrics.timer("logging"):
-            with ThreadPoolExecutor(max_workers=thread_workers) as pool:
-                futures: List[Future[None]] = [
-                    pool.submit(worker, w) for w in range(thread_workers)
-                ]
-                for future in futures:
-                    future.result()
-
-        with metrics.timer("flush"):
-            opik.flush_tracker()
-
-        client = _helpers.opik_client()
-        with metrics.timer("verify"):
-            delivered_trace_ids: Set[str] = _helpers.verify_exact_trace_ids(
-                client,
-                project_name=project_name,
-                expected_ids=set(submitted_trace_ids),
-                timeout_seconds=1200,
-            )
-
-        metrics["delivered_trace_count"] = len(delivered_trace_ids)


### PR DESCRIPTION
## Details

The race-stress scenario added in OPIK-6576 / PR #6829 ran reliably locally but proved too fragile under xdist's 4-worker concurrent load on the GitHub Actions runner: the worker process was killed by the OS (at ~225 s, well under the explicit `@pytest.mark.timeout(300)`) while three other heavy scenarios — `heavy_payload`, `attachments`, `many_traces_one_span_each` — ran simultaneously against the same docker-compose Opik stack on the same 7 GB runner. Reducing thread count, lowering volume and adding think-time each shifted the failure mode without resolving it.

Remove the scenario for now so the suite stays green in CI. The underlying intent — catching missing-lock regressions in `BatchManager.flush_ready` (OPIK-6444 shape) — is still served by:

- the OPIK-6444 unit regression test in `tests/unit/message_processing/batching/test_flushing_thread.py`, which uses a 5 ms flush interval + aggressive probe to catch the bug deterministically;
- the existing `test_concurrent_writers_share_one_client` scenario, which runs at the production flush interval but with realistic think-time and 30 threads.

The supporting machinery (`_race_stress_flush_interval` context manager, `_RACE_FLUSH_INTERVAL_SECONDS` constant, unused imports) is also removed. `pytest-timeout` and the 1200 s global `pytest.ini` timeout stay — they're useful hang-guards for any future scenario regardless of this revert. README scenario table loses its race-stress row; the other 10 scenarios are unaffected.

A more isolated race-detection approach (separate workflow step running the race-stress scenario serially without xdist) can be revisited in a focused follow-up if we decide it's worth the maintenance cost.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: delete one scenario from `tests_load/suite/python_sdk/test_bursts.py`, drop the one row in `tests_load/README.md` that referenced it. No other test affected.
- Human verification: ran `pytest suite/python_sdk --collect-only` after removal — **10 tests collected** (was 11). All remaining scenarios unaffected.

## Testing

`pytest suite/python_sdk --collect-only` post-removal: 10 tests collected, no errors.

## Documentation

`tests_load/README.md` scenario table updated — the race-stress row removed.