### PR TITLE
[NA] [SDK] test(load): add think-time to test_burst_single_loop

### DIFF
--- a/tests_load/suite/python_sdk/test_bursts.py
+++ b/tests_load/suite/python_sdk/test_bursts.py
@@ -12,12 +12,14 @@ from ._helpers import Metrics
 
 
 def test_burst_single_loop(metrics: Metrics, load_scale: float) -> None:
-    """Worst-case burst: tight loop, zero think-time, single thread.
+    """Fast-paced burst from a single thread.
 
-    Calls a ``@opik.track``-decorated handler 50k times back-to-back
-    with no sleep between submits. This is the deliberate worst case —
-    it puts maximum pressure on the SDK's in-process queue and batch
-    flusher before any HTTP work catches up.
+    Calls a ``@opik.track``-decorated handler 50k times in a tight loop
+    with only the minimal randomised think-time (0.5–2 ms) shared by the
+    rest of the suite — enough to keep the runner's docker-compose Opik
+    stack from being DoS-ed when multiple heavy scenarios run in
+    parallel under xdist, but still tight enough that the SDK's
+    in-process queue and batch flusher are kept busy throughout.
 
     Volume: 50k traces, ~200 B input each.
 
@@ -41,6 +43,7 @@ def test_burst_single_loop(metrics: Metrics, load_scale: float) -> None:
     with metrics.timer("logging"):
         for _ in range(trace_count):
             handle_request(prompt=_helpers.random_text(trace_input_bytes))
+            _helpers.think_time()
 
     with metrics.timer("flush"):
         opik.flush_tracker()


### PR DESCRIPTION
## Details

At scale 1.0 with no pacing, `test_burst_single_loop` was taking ~17 min of wall-clock under the load_tests workflow's `xdist -n auto` (50 traces/sec — pure backend-contention bill, vs the SDK doing thousands/sec on its own) and kept the shared docker-compose Opik stack saturated while three other heavy scenarios ran in parallel. That backend saturation is what was OOM-killing the ingestion-rate workers downstream (`test_many_traces_one_span_each`, `test_many_spans_per_trace`).

Add `_helpers.think_time()` (0.5–2 ms randomised, the same pacing the rest of the suite already uses) inside the inner loop. The SDK's in-process queue and batcher are still kept busy throughout — at ~1.25 ms per trace, 50k traces still complete in ~60 s of submission — but the runner's backend isn't being DoS-ed any more. The scenario is no longer the "worst-case zero-pacing" burst; docstring updated to match.

The dataset-items scenario intentionally still has no think_time between `Dataset.insert()` calls — those are synchronous REST round-trips that already serialise on their own latency.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: a single test in `tests_load/suite/python_sdk/test_bursts.py` — drop "no think-time" from the design and use the suite-wide `_helpers.think_time()` to match the rest of the scenarios. Docstring updated.
- Human verification: identified by diagnosing the first weekly Load Tests workflow run on main (`test_many_traces_one_span_each` + `test_many_spans_per_trace` workers crashed; `test_burst_single_loop` took 17 min) — the burst test's zero-pacing was the structural cause. Local sanity-check on the new pacing: `--load-scale 0.05` passes in ~7 s, still proves the verify path.

## Testing

`pytest suite/python_sdk/test_bursts.py::test_burst_single_loop --load-scale 0.05` against local Opik: passed in 7.04 s with 2500/2500 traces delivered.

## Documentation

`test_burst_single_loop` docstring updated to reflect the new pacing — no longer described as "worst-case zero-pacing".