### PR TITLE
[NA] [SDK] ci(load): drop xdist concurrency from -n auto to -n 2

### DIFF
--- a/.github/workflows/load_tests.yml
+++ b/.github/workflows/load_tests.yml
@@ -57,14 +57,20 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run Python SDK load tests
-        # -n auto + --dist=worksteal runs each scenario in its own worker
-        # process (9 tests, ubuntu-latest has 4 vCPUs). Each test uses a
-        # unique project so isolation holds. Worksteal balances the very
-        # uneven per-test durations (spread is window-locked at 600 s,
+        # -n 2 + --dist=worksteal runs two scenarios in parallel at a time.
+        # `-n auto` (= 4 workers on ubuntu-latest) was the previous setting
+        # but reliably OOM-killed the heaviest scenarios
+        # (test_many_traces_one_span_each, test_many_spans_per_trace) when
+        # they ended up co-scheduled with other heavy tests against the
+        # same docker-compose Opik stack on the runner's 7 GB RAM. -n 2
+        # halves concurrent backend pressure and per-runner memory, at the
+        # cost of ~1.5x wall-clock (~32 min -> ~50 min). Each test still
+        # uses a unique project so isolation holds. Worksteal balances the
+        # very uneven per-test durations (spread is window-locked at 600 s,
         # others run in 1-6 min).
         run: |
           cd ${{ github.workspace }}/tests_load
-          pytest suite/python_sdk -n auto --dist=worksteal --junitxml=${{ github.workspace }}/load_test_results.xml
+          pytest suite/python_sdk -n 2 --dist=worksteal --junitxml=${{ github.workspace }}/load_test_results.xml
 
       - name: Render metrics into job summary
         if: always()

--- a/tests_load/README.md
+++ b/tests_load/README.md
@@ -76,7 +76,11 @@ pytest suite/python_sdk                                 # serial
 pytest suite/python_sdk -n auto --dist=worksteal        # parallel via pytest-xdist
 ```
 
-The scheduled workflow runs with `-n auto --dist=worksteal`. Each
+The scheduled workflow runs with `-n 2 --dist=worksteal` — `-n auto`
+(4 workers on ubuntu-latest) was reliably OOM-killing the highest-
+volume ingestion-rate scenarios when they coincided with other heavy
+tests against the same docker-compose Opik stack on the 7 GB runner.
+Each
 scenario uses a unique project name so worker isolation holds; the
 shared backend will see meaningful concurrent load, which is itself
 useful coverage.


### PR DESCRIPTION
## Details

Every Load Tests workflow run so far has failed in the same shape: the two highest-volume scenarios (`test_many_traces_one_span_each` and `test_many_spans_per_trace`) get OS-killed mid-run with no Python traceback — xdist reports them as `worker 'gw0' crashed` / `worker 'gw3' crashed`, which is what the OOM-killer hitting the worker process looks like from xdist's side.

Root cause is the runner topology, not any single test: 4 xdist workers + a full docker-compose Opik stack (ClickHouse + MySQL + MinIO + backend + nginx) on the same 7 GB ubuntu-latest runner can't hold all four high-volume scenarios in memory at once. Per-test fixes only shifted which scenario got killed — adding think-time to `test_burst_single_loop` (PR #6856) brought burst wall-clock down but the freed-up backend headroom just went to the next test in line, which then ran longer and met the OOM-killer instead.

Halve concurrency: `-n auto` → `-n 2`. Two scenarios run in parallel at a time, the other two wait. Trade-offs:

- expected wall-clock goes from ~32 min to ~50 min (still well under the 60 min job timeout);
- per-runner memory and concurrent backend pressure both drop ~2×;
- `--dist=worksteal` keeps balancing the very uneven per-test durations (spread is window-locked at 600 s, others run 1–6 min).

If we ever want to bring concurrency back up, the proper fix is a larger runner (e.g. `ubuntu-latest-4-cores-16gb`) or splitting the suite into two workflow jobs that don't share a backend. Both are follow-ups out of scope for this CI hotfix.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: one-line workflow change (`-n auto` → `-n 2`) plus matching README note explaining why.
- Human verification: diagnosed by walking the failing Load Tests runs (e.g. https://github.com/comet-ml/opik/actions/runs/26416963910) — same two workers crash regardless of which other test we paced down.

## Testing

`pytest suite/python_sdk -n 2 --dist=worksteal` locally smoke-tested at `--load-scale 0.01` — passes in roughly the same wall-clock as `-n auto` for low volumes. The structural difference shows up at scale 1.0 in CI, which is the next scheduled run.

## Documentation

`tests_load/README.md` updated: scheduled workflow now described as `-n 2 --dist=worksteal`, with a one-paragraph note on why `-n auto` was reduced.