### PR TITLE
[OPIK-6596] [QA] feat: Experiments smoke (SDK-create + UI-verify, deterministic evaluator)

### DIFF
--- a/tests_end_to_end/e2e/.gitignore
+++ b/tests_end_to_end/e2e/.gitignore
@@ -8,6 +8,10 @@ core/backend/generated/
 .runners/
 .e2e-run-id
 
+# Local credentials (templates checked in, real values gitignored)
+.env.local
+.env.cloud
+
 # Reports
 allure-results/
 playwright-report/

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -19,6 +19,12 @@ export interface DatasetItemRef {
   data: Record<string, unknown>;
 }
 
+export interface ExperimentRefDetail {
+  id: string;
+  name: string;
+  datasetId: string | null;
+}
+
 export function makeBackendClient(apiKey: string | null = null) {
   const env = loadEnvConfig();
   const opik = new Opik({
@@ -97,6 +103,39 @@ export function makeBackendClient(apiKey: string | null = null) {
         id: String(item.id),
         data: (item.data ?? {}) as Record<string, unknown>,
       }));
+    },
+
+    async findExperimentByName(name: string): Promise<ExperimentRefDetail | null> {
+      const page = await opik.api.experiments.findExperiments({ name, size: 50 });
+      const content = page.content ?? [];
+      const match = content.find((e) => e.name === name);
+      if (!match) return null;
+      return {
+        id: String(match.id),
+        name: match.name as string,
+        datasetId: match.datasetId ? String(match.datasetId) : null,
+      };
+    },
+
+    async listExperimentsWithPrefix(prefix: string): Promise<ExperimentRefDetail[]> {
+      const page = await opik.api.experiments.findExperiments({ name: prefix, size: 500 });
+      const content = page.content ?? [];
+      return content
+        .filter((e) => typeof e.name === 'string' && (e.name as string).startsWith(prefix))
+        .map((e) => ({
+          id: String(e.id),
+          name: e.name as string,
+          datasetId: e.datasetId ? String(e.datasetId) : null,
+        }));
+    },
+
+    async deleteExperiment(id: string): Promise<void> {
+      try {
+        await opik.api.experiments.deleteExperimentsById({ ids: [id] });
+      } catch (err) {
+        if (isNotFoundError(err)) return;
+        throw err;
+      }
     },
   };
 }

--- a/tests_end_to_end/e2e/core/backend/index.ts
+++ b/tests_end_to_end/e2e/core/backend/index.ts
@@ -4,4 +4,5 @@ export {
   type ProjectRef,
   type DatasetRef as BackendDatasetRef,
   type DatasetItemRef,
+  type ExperimentRefDetail,
 } from './client';

--- a/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
+++ b/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
@@ -14,6 +14,28 @@ export interface PythonSdkClient {
     items?: Array<Record<string, unknown>>;
     workspace?: string;
   }): Promise<{ id: string; name: string }>;
+  evaluateExperiment(args: {
+    project_name: string;
+    dataset_name: string;
+    experiment_name: string;
+    items: Array<Record<string, unknown>>;
+    dataset_description?: string;
+    workspace?: string;
+  }): Promise<{
+    experiment_id: string;
+    experiment_name: string;
+    dataset_id: string;
+    item_count: number;
+    scored_item_count: number;
+    scores: Array<{
+      dataset_item_id: string;
+      input: string;
+      expected_output: string;
+      task_output: string;
+      score_name: string;
+      score_value: number;
+    }>;
+  }>;
 }
 
 export class PythonSdkBridgeError extends Error {
@@ -91,6 +113,23 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
     },
     async createDataset(args) {
       return request<{ id: string; name: string }>('POST', '/datasets', args);
+    },
+    async evaluateExperiment(args) {
+      return request<{
+        experiment_id: string;
+        experiment_name: string;
+        dataset_id: string;
+        item_count: number;
+        scored_item_count: number;
+        scores: Array<{
+          dataset_item_id: string;
+          input: string;
+          expected_output: string;
+          task_output: string;
+          score_name: string;
+          score_value: number;
+        }>;
+      }>('POST', '/experiments/evaluate', args);
     },
   };
 }

--- a/tests_end_to_end/e2e/fixtures/experiment.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/experiment.fixture.ts
@@ -1,0 +1,104 @@
+import { test as baseTest } from './dataset.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+
+export interface ExperimentItemSeed {
+  input: string;
+  expected_output: string;
+  task_output: string;
+}
+
+export interface ExperimentItemScore {
+  datasetItemId: string;
+  input: string;
+  expectedOutput: string;
+  taskOutput: string;
+  scoreName: string;
+  scoreValue: number;
+}
+
+export interface ExperimentRef {
+  experimentId: string;
+  experimentName: string;
+  datasetId: string;
+  datasetName: string;
+  projectName: string;
+  items: ExperimentItemSeed[];
+  evaluator: { name: string; type: 'Equals' };
+  expectedScores: number[];
+  scores: ExperimentItemScore[];
+}
+
+export interface ExperimentFixtures {
+  experiment: ExperimentRef;
+}
+
+/**
+ * 2-pass-1-fail seed: rows where task_output === expected_output score 1.0,
+ * the mismatched row scores 0.0. Exercises both pass and fail surfaces so a
+ * broken evaluator that silently scores everything 1.0 (or 0.0) is caught.
+ */
+const SEED_ITEMS: ExperimentItemSeed[] = [
+  { input: 'What is 2 + 2?', expected_output: '4', task_output: '4' },
+  { input: 'What is the capital of France?', expected_output: 'Paris', task_output: 'Paris' },
+  { input: 'What is 1 + 1?', expected_output: '2', task_output: 'NOT_TWO' },
+];
+
+const EXPECTED_SCORES = [1.0, 1.0, 0.0];
+
+export const test = baseTest.extend<ExperimentFixtures>({
+  experiment: async ({ sdkClient, backendClient, project, testNamespace }, use, testInfo) => {
+    const datasetName = `${testNamespace}-exp-ds`;
+    const experimentName = `${testNamespace}-exp`;
+
+    const created = await sdkClient.python.evaluateExperiment({
+      project_name: project.name,
+      dataset_name: datasetName,
+      experiment_name: experimentName,
+      items: SEED_ITEMS as unknown as Array<Record<string, unknown>>,
+    });
+
+    const scores: ExperimentItemScore[] = created.scores.map((s) => ({
+      datasetItemId: s.dataset_item_id,
+      input: s.input,
+      expectedOutput: s.expected_output,
+      taskOutput: s.task_output,
+      scoreName: s.score_name,
+      scoreValue: s.score_value,
+    }));
+
+    const ref: ExperimentRef = {
+      experimentId: created.experiment_id,
+      experimentName: created.experiment_name,
+      datasetId: created.dataset_id,
+      datasetName,
+      projectName: project.name,
+      items: SEED_ITEMS,
+      evaluator: { name: 'equals_metric', type: 'Equals' },
+      expectedScores: EXPECTED_SCORES,
+      scores,
+    };
+
+    await testInfo.attach('opik.experiment', {
+      body: JSON.stringify(ref, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use(ref);
+
+    /** Teardown order: experiment first (it references the dataset), then dataset (it references the project). Project fixture handles its own delete. */
+    if (!shouldLeaveArtifacts(testInfo)) {
+      try {
+        await backendClient.deleteExperiment(created.experiment_id);
+      } catch (err) {
+        console.warn(`[experiment fixture] delete experiment warning for ${experimentName}:`, err);
+      }
+      try {
+        await backendClient.deleteDataset(created.dataset_id);
+      } catch (err) {
+        console.warn(`[experiment fixture] delete dataset warning for ${datasetName}:`, err);
+      }
+    }
+  },
+});
+
+export { expect } from './dataset.fixture';

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-export { test, expect } from './dataset.fixture';
+export { test, expect } from './experiment.fixture';
 export type { ProjectFixtures } from './project.fixture';
 export type { ScratchDir, ScratchDirFixtures } from './scratch-dir.fixture';
 export type {
@@ -9,4 +9,10 @@ export type {
 } from './failure-artifacts.fixture';
 export type { TraceRef, TraceFixtures } from './trace.fixture';
 export type { DatasetRef, DatasetFixtures, DatasetItemSeed } from './dataset.fixture';
+export type {
+  ExperimentRef,
+  ExperimentFixtures,
+  ExperimentItemSeed,
+  ExperimentItemScore,
+} from './experiment.fixture';
 export type { ProjectRef } from '../core/backend';

--- a/tests_end_to_end/e2e/global-setup.ts
+++ b/tests_end_to_end/e2e/global-setup.ts
@@ -28,7 +28,29 @@ async function sweepOrphans(apiKey: string | null): Promise<void> {
   const backend = makeBackendClient(apiKey);
   const cutoff = Date.now() - ORPHAN_MAX_AGE_MS;
 
-  /** Sweep datasets before projects — datasets don't cascade-delete with their parent project. */
+  /** Sweep order: experiments → datasets → projects. Experiments reference datasets which reference projects. */
+  try {
+    const staleExperiments = await backend.listExperimentsWithPrefix('cuj-');
+    let sweptCount = 0;
+    for (const e of staleExperiments) {
+      const ts = parseRunIdTimestamp(e.name);
+      if (ts === null) continue;
+      if (ts < cutoff) {
+        try {
+          await backend.deleteExperiment(e.id);
+          sweptCount++;
+        } catch {
+          // Best-effort; another runner may have just deleted it.
+        }
+      }
+    }
+    if (sweptCount > 0) {
+      console.log(`[global-setup] Swept ${sweptCount} orphaned experiments (>6h old)`);
+    }
+  } catch (e) {
+    console.warn('[global-setup] experiment orphan sweep warning (continuing):', e);
+  }
+
   try {
     const staleDatasets = await backend.listDatasetsWithPrefix('cuj-');
     let sweptCount = 0;

--- a/tests_end_to_end/e2e/global-teardown.ts
+++ b/tests_end_to_end/e2e/global-teardown.ts
@@ -21,7 +21,24 @@ async function globalTeardown() {
 
   console.log(`[global-teardown] Sweeping entities with prefix ${prefix}`);
 
-  /** Sweep datasets before projects — datasets don't cascade-delete with their parent project. */
+  /** Sweep order: experiments → datasets → projects. Experiments reference datasets which reference projects. */
+  try {
+    const experiments = await backend.listExperimentsWithPrefix(prefix);
+    if (experiments.length === 0) {
+      console.log('  no experiments to sweep');
+    }
+    for (const e of experiments) {
+      try {
+        await backend.deleteExperiment(e.id);
+        console.log(`  deleted experiment ${e.name}`);
+      } catch (err) {
+        console.warn(`  experiment ${e.name} delete warning:`, err);
+      }
+    }
+  } catch (err) {
+    console.warn('[global-teardown] experiment sweep warning:', err);
+  }
+
   try {
     const datasets = await backend.listDatasetsWithPrefix(prefix);
     if (datasets.length === 0) {

--- a/tests_end_to_end/e2e/pom/experiment-detail.page.ts
+++ b/tests_end_to_end/e2e/pom/experiment-detail.page.ts
@@ -1,0 +1,55 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export class ExperimentDetailPage {
+  constructor(
+    private readonly page: Page,
+    private readonly experimentId: string,
+  ) {}
+
+  async waitForReady(): Promise<void> {
+    // The page renders the experiment name as the h1.
+    const h1 = this.page.getByRole('heading', { level: 1 });
+    await h1.waitFor({ state: 'visible' });
+    // Items table is inside the "Experiment items" tabpanel; wait for at least one row.
+    await this.itemRows.first().waitFor({ state: 'visible' });
+  }
+
+  async countItems(): Promise<number> {
+    return this.itemRows.count();
+  }
+
+  async readItemScore(datasetItemId: string, metricName: string): Promise<number> {
+    const cell = this.scoreCell(datasetItemId, metricName);
+    await expect(cell, `score cell for dataset item ${datasetItemId} / metric ${metricName}`)
+      .toBeVisible();
+    const text = ((await cell.textContent()) ?? '').trim();
+    const value = parseFloat(text);
+    if (Number.isNaN(value)) {
+      throw new Error(
+        `ExperimentDetailPage.readItemScore: could not parse "${text}" as a number for item ${datasetItemId} metric ${metricName}`,
+      );
+    }
+    return value;
+  }
+
+  async readAggregateScore(): Promise<number> {
+    const valueEl = this.page.getByTestId('feedback-score-tag-value').first();
+    await expect(valueEl, 'aggregate score chip value').toBeVisible();
+    const text = ((await valueEl.textContent()) ?? '').trim();
+    const value = parseFloat(text);
+    if (Number.isNaN(value)) {
+      throw new Error(`ExperimentDetailPage.readAggregateScore: could not parse "${text}" as a number`);
+    }
+    return value;
+  }
+
+  private scoreCell(datasetItemId: string, metricName: string): Locator {
+    return this.page.locator(
+      `td[data-cell-id="${datasetItemId}_feedback_scores_${metricName}"]`,
+    );
+  }
+
+  get itemRows(): Locator {
+    return this.page.locator('tbody tr[data-row-id]');
+  }
+}

--- a/tests_end_to_end/e2e/pom/experiments.page.ts
+++ b/tests_end_to_end/e2e/pom/experiments.page.ts
@@ -1,0 +1,62 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { loadEnvConfig } from '../config/env.config';
+import { ExperimentDetailPage } from './experiment-detail.page';
+
+export class ExperimentsPage {
+  private projectId: string | null = null;
+
+  constructor(private readonly page: Page) {}
+
+  async goto(projectId: string): Promise<void> {
+    this.projectId = projectId;
+    const env = loadEnvConfig();
+    await this.page.goto(`${env.baseUrl}/${env.workspace}/projects/${projectId}/experiments`);
+  }
+
+  async waitForReady(): Promise<void> {
+    const heading = this.page.getByRole('heading', { name: 'Experiments', level: 1 });
+    await heading.waitFor({ state: 'visible' });
+    const realRow = this.rows.first();
+    const emptyState = this.page.getByText('No experiments yet');
+    await Promise.race([
+      realRow.waitFor({ state: 'visible' }),
+      emptyState.waitFor({ state: 'visible' }),
+    ]);
+  }
+
+  async countExperiments(): Promise<number> {
+    return this.rows.count();
+  }
+
+  rowById(experimentId: string): Locator {
+    return this.page.locator(`tr[data-row-id="${experimentId}"]`);
+  }
+
+  async expectExperimentNameInList(experimentId: string, expectedName: string): Promise<void> {
+    const cell = this.page.locator(`td[data-cell-id="${experimentId}_name"]`);
+    await expect(cell, `experiment row ${experimentId} name cell`).toHaveText(expectedName);
+  }
+
+  async openExperimentById(experimentId: string): Promise<ExperimentDetailPage> {
+    if (!this.projectId) {
+      throw new Error('ExperimentsPage.openExperimentById: call goto(projectId) first');
+    }
+    const row = this.rowById(experimentId);
+    await row.waitFor({ state: 'visible' });
+    // The row is cursor-pointer but the dataset cell contains a link to the
+    // dataset page. Click the experiment-name cell to navigate to detail.
+    await this.page.locator(`td[data-cell-id="${experimentId}_name"]`).click();
+    await this.page.waitForURL((url) => {
+      return (
+        url.pathname.includes(`/experiments/`) &&
+        url.pathname.endsWith(`/compare`) &&
+        url.search.includes(encodeURIComponent(experimentId))
+      );
+    });
+    return new ExperimentDetailPage(this.page, experimentId);
+  }
+
+  get rows(): Locator {
+    return this.page.locator('tbody tr[data-row-id]');
+  }
+}

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/main.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from opik.rest_api.core.api_error import ApiError
 
-from .routes import datasets, health, projects, traces
+from .routes import datasets, experiments, health, projects, traces
 
 app = FastAPI(title="opik-sdk-driver", version="0.0.1")
 
@@ -19,3 +19,4 @@ app.include_router(health.router)
 app.include_router(projects.router)
 app.include_router(traces.router)
 app.include_router(datasets.router)
+app.include_router(experiments.router)

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/experiments.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/experiments.py
@@ -40,7 +40,7 @@ def evaluate_experiment(
             description=body.dataset_description,
             project_name=body.project_name,
         )
-        dataset.insert(body.items)
+        dataset.insert([item.model_dump() for item in body.items])
 
         def _task(item: dict) -> dict:
             return {"output": item["task_output"]}

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/experiments.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/experiments.py
@@ -1,0 +1,86 @@
+import atexit
+
+import opik
+from fastapi import APIRouter, Header
+from opik.evaluation import evaluate
+from opik.evaluation.metrics import Equals
+
+from ..opik_factory import make_opik_client
+from ..schemas import (
+    ExperimentEvaluateRequest,
+    ExperimentEvaluateResponse,
+    ExperimentItemScore,
+)
+
+router = APIRouter(prefix="/experiments", tags=["experiments"])
+
+
+_SCORE_METRIC_NAME = "equals_metric"
+
+
+@router.post("/evaluate", response_model=ExperimentEvaluateResponse, status_code=201)
+def evaluate_experiment(
+    body: ExperimentEvaluateRequest,
+    x_opik_api_key: str | None = Header(default=None),
+) -> ExperimentEvaluateResponse:
+    """Seed dataset + run deterministic-evaluator evaluate in one shot.
+
+    The task is a no-op echo that returns the item's `task_output` field,
+    so the seed shape controls each row's pass/fail outcome. Scoring uses
+    Equals(case_sensitive=False) keyed on output vs expected_output.
+    """
+    # evaluate() calls opik_client.get_global_client() internally and ignores
+    # any locally-constructed client. Bind the request-scoped client as the
+    # global so the auth/workspace context propagates into the evaluate path.
+    client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
+    opik.set_global_client(client, context_wise=True)
+    try:
+        dataset = client.create_dataset(
+            name=body.dataset_name,
+            description=body.dataset_description,
+            project_name=body.project_name,
+        )
+        dataset.insert(body.items)
+
+        def _task(item: dict) -> dict:
+            return {"output": item["task_output"]}
+
+        result = evaluate(
+            dataset=dataset,
+            task=_task,
+            scoring_metrics=[Equals(case_sensitive=False)],
+            experiment_name=body.experiment_name,
+            project_name=body.project_name,
+            task_threads=1,
+            verbose=0,
+            scoring_key_mapping={"reference": "expected_output"},
+        )
+    finally:
+        client.end(flush=True)
+        atexit.unregister(client.end)
+
+    scores: list[ExperimentItemScore] = []
+    for tr in result.test_results:
+        for sr in tr.score_results:
+            if sr.name != _SCORE_METRIC_NAME:
+                continue
+            item_content = tr.test_case.dataset_item_content or {}
+            scores.append(
+                ExperimentItemScore(
+                    dataset_item_id=str(tr.test_case.dataset_item_id),
+                    input=str(item_content.get("input", "")),
+                    expected_output=str(item_content.get("expected_output", "")),
+                    task_output=str(item_content.get("task_output", "")),
+                    score_name=sr.name,
+                    score_value=float(sr.value),
+                )
+            )
+
+    return ExperimentEvaluateResponse(
+        experiment_id=str(result.experiment_id),
+        experiment_name=result.experiment_name or body.experiment_name,
+        dataset_id=str(result.dataset_id),
+        item_count=len(body.items),
+        scored_item_count=len(result.test_results),
+        scores=scores,
+    )

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
@@ -46,3 +46,32 @@ class DatasetCreate(BaseModel):
 class DatasetResponse(BaseModel):
     id: str
     name: str
+
+
+class ExperimentEvaluateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    project_name: str
+    dataset_name: str
+    experiment_name: str
+    items: list[dict[str, Any]]
+    dataset_description: str | None = None
+    workspace: str | None = None
+
+
+class ExperimentItemScore(BaseModel):
+    dataset_item_id: str
+    input: str
+    expected_output: str
+    task_output: str
+    score_name: str
+    score_value: float
+
+
+class ExperimentEvaluateResponse(BaseModel):
+    experiment_id: str
+    experiment_name: str
+    dataset_id: str
+    item_count: int
+    scored_item_count: int
+    scores: list[ExperimentItemScore]

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
@@ -48,13 +48,21 @@ class DatasetResponse(BaseModel):
     name: str
 
 
+class ExperimentItemSeed(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    input: str
+    expected_output: str
+    task_output: str
+
+
 class ExperimentEvaluateRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     project_name: str
     dataset_name: str
     experiment_name: str
-    items: list[dict[str, Any]]
+    items: list[ExperimentItemSeed]
     dataset_description: str | None = None
     workspace: str | None = None
 

--- a/tests_end_to_end/e2e/tests/experiments/experiments-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/experiments/experiments-smoke.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@e2e/fixtures';
+import { ExperimentsPage } from '@e2e/pom/experiments.page';
+
+test.describe('Experiments — smoke', { tag: ['@t1-smoke', '@experiments'] }, () => {
+  test('SDK-seeded experiment renders in list and shows per-item deterministic scores', async ({
+    experiment,
+    project,
+    page,
+  }) => {
+    const experiments = new ExperimentsPage(page);
+
+    await test.step('Experiment row appears on the list page', async () => {
+      await experiments.goto(project.id);
+      await experiments.waitForReady();
+      expect(await experiments.countExperiments()).toBe(1);
+      await experiments.expectExperimentNameInList(experiment.experimentId, experiment.experimentName);
+    });
+
+    const detail = await test.step('Open the experiment detail page', async () => {
+      return experiments.openExperimentById(experiment.experimentId);
+    });
+
+    await test.step('Detail page renders all seeded items', async () => {
+      await detail.waitForReady();
+      expect(await detail.countItems()).toBe(experiment.items.length);
+    });
+
+    await test.step('Per-item scores match the bridge response (closed-loop on datasetItemId)', async () => {
+      for (const seedScore of experiment.scores) {
+        const uiScore = await detail.readItemScore(seedScore.datasetItemId, experiment.evaluator.name);
+        expect(uiScore, `score for item "${seedScore.input}" (id=${seedScore.datasetItemId})`)
+          .toBeCloseTo(seedScore.scoreValue, 5);
+      }
+    });
+
+    await test.step('Aggregate score chip reflects 2/3 pass rate', async () => {
+      const aggregate = await detail.readAggregateScore();
+      expect(aggregate, 'aggregate chip = mean of per-item scores').toBeCloseTo(2 / 3, 1);
+    });
+
+    await test.step('Seed shape is 2-pass-1-fail (sanity)', async () => {
+      expect(experiment.scores.filter((s) => s.scoreValue === 1.0), 'pass rows').toHaveLength(2);
+      expect(experiment.scores.filter((s) => s.scoreValue === 0.0), 'fail rows').toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Details

Fourth CUJ smoke test in the Opik 2.0 E2E suite — slot 4 of 6 in the data-plane test sequence. Seeds an experiment via the Python SDK code path (\`opik.evaluation.evaluate(...)\` with the \`Equals\` heuristic → bridge route) and verifies it round-trips end-to-end through the Experiments list and detail pages, including per-item metric values and the aggregate score chip.

Adds an experiments sweep to \`global-setup.ts\` and \`global-teardown.ts\` ordered **experiments → datasets → projects** (mirroring the dataset-before-project order added in OPIK-6595). Experiments reference datasets which reference projects, so the chain has to unwind from the top.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6596

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation across bridge route, SDK client method, fixture, backend-client inspection methods, two POMs, one test, sweep ordering changes, and the .gitignore defensive fix
- Human verification: code review + manual staging runs at each phase gate + final 8-test gate run with post-run prefix-sweep verification

## Testing

Verified end-to-end on staging with the bridge auto-spawning via Playwright's \`webServer\` config:
Result: \`8 passed (1.2m)\`.


### What the experiments test verifies

| Step | Surface | Assertion |
|---|---|---|
| Experiment row appears on the list page | List-view DOM (project-scoped \`/{workspace}/projects/{projectId}/experiments\`) | \`countExperiments() === 1\` + name cell text matches the seed |
| Open the experiment detail page | List → detail navigation | Clicks the experiment-name cell, waits for the compare URL |
| Detail page renders all seeded items | Detail-view items table | \`countItems() === 3\` |
| Per-item scores match the bridge response | Detail-view items table | For each \`{datasetItemId, scoreValue}\` returned by the bridge, the UI's score cell at \`td[data-cell-id=\"{datasetItemId}_feedback_scores_equals_metric\"]\` matches via \`toBeCloseTo(..., 5)\` |
| Aggregate score chip reflects 2/3 pass rate | \`feedback-score-tag-value\` testid | \`toBeCloseTo(2/3, 1)\` — robust against \`0.67\` vs \`0.6667\` rendering |
| Seed shape is 2-pass-1-fail | Fixture self-check | Catches accidental seed regressions in code review |

Each step is a \`test.step(...)\` boundary so the Playwright HTML report (and future Allure integration) shows where exactly any failure occurred without needing the trace viewer.

REST is used only by the fixtures (project + dataset + experiment create via the bridge), by \`backendClient\` for experiment-existence inspection in the fixture's teardown, and by \`global-setup\`/\`global-teardown\` orphan sweeps. The test body and POMs never call REST.

## Documentation
NA