### PR TITLE
[NA] [SDK] ci(load): quiet httpx INFO stream + grant checks:write so the run goes green

### DIFF
--- a/.github/workflows/load_tests.yml
+++ b/.github/workflows/load_tests.yml
@@ -18,14 +18,6 @@ env:
   OPIK_SENTRY_ENABLE: False
   OPIK_URL_OVERRIDE: http://localhost:8080
   OPIK_CONSOLE_LOGGING_LEVEL: WARNING
-  # Slow the SDK's connection-monitor daemon from its 10s default to 60s.
-  # The monitor pings via httpx, which emits an INFO log per request; under
-  # a 60-min CI run with -n 2 xdist workers this previously produced ~70k
-  # log lines that pytest's stream handler tried to write to (sometimes
-  # closed) captured stdout. ``log_cli_level = WARNING`` in ``pytest.ini``
-  # already filters those out at the handler level, so this is belt-and-
-  # suspenders: keeps liveness probing alive but at 1/6 the volume.
-  OPIK_CONNECTION_MONITOR_PING_INTERVAL: 60
 
 jobs:
   run-load-tests:

--- a/.github/workflows/load_tests.yml
+++ b/.github/workflows/load_tests.yml
@@ -18,6 +18,14 @@ env:
   OPIK_SENTRY_ENABLE: False
   OPIK_URL_OVERRIDE: http://localhost:8080
   OPIK_CONSOLE_LOGGING_LEVEL: WARNING
+  # Slow the SDK's connection-monitor daemon from its 10s default to 60s.
+  # The monitor pings via httpx, which emits an INFO log per request; under
+  # a 60-min CI run with -n 2 xdist workers this previously produced ~70k
+  # log lines that pytest's stream handler tried to write to (sometimes
+  # closed) captured stdout. ``log_cli_level = WARNING`` in ``pytest.ini``
+  # already filters those out at the handler level, so this is belt-and-
+  # suspenders: keeps liveness probing alive but at 1/6 the volume.
+  OPIK_CONNECTION_MONITOR_PING_INTERVAL: 60
 
 jobs:
   run-load-tests:

--- a/.github/workflows/load_tests.yml
+++ b/.github/workflows/load_tests.yml
@@ -3,6 +3,10 @@ run-name: "Load Tests ${{ github.ref_name }} by @${{ github.actor }}"
 
 permissions:
   contents: read
+  # checks: write so EnricoMi/publish-unit-test-result-action can post the
+  # "Load Test Results" check; without it the step gets 403 Forbidden and
+  # fails the whole workflow even when all scenarios passed.
+  checks: write
 
 on:
   schedule:

--- a/tests_load/pytest.ini
+++ b/tests_load/pytest.ini
@@ -2,7 +2,14 @@
 testpaths = suite
 addopts = -vv --durations=0 -p no:cacheprovider
 log_cli = true
-log_cli_level = INFO
+# WARNING (not INFO) so we don't stream every httpx ``INFO HTTP Request: ...``
+# line for the ~250k+ requests these scenarios make — under -n 2 + the
+# SDK's connection-monitor daemon, that previously dumped ~70k traceback
+# lines per CI run. Per-test metrics are written to
+# ``tests_load/.last_run/<test_name>.json`` regardless of log level, and
+# the workflow summary step renders them on the run page, so we don't
+# need INFO lines on stdout. SDK errors / warnings still surface.
+log_cli_level = WARNING
 python_files = test_*.py
 # Global hang-guard: any individual scenario that runs longer than this
 # is killed and reported as a failure, so a deadlock (e.g. SDK lock


### PR DESCRIPTION
## Details

Two related CI cleanups for the Load Tests workflow, both visible in the most recent green-suite run ([26418912221](https://github.com/comet-ml/opik/actions/runs/26418912221)) which still got marked as a workflow failure:

1. **Quiet the per-request httpx INFO stream.** `pytest.ini` had `log_cli_level = INFO`, which streamed every httpx `INFO HTTP Request: ...` line for the ~250k+ HTTP requests these scenarios make. Combined with the SDK's connection-monitor daemon tripping on closed stdout at session teardown (each tick dumps a ~30-line traceback), that previously produced ~70k log lines per CI run. Per-test metrics are still written to `tests_load/.last_run/<test_name>.json` and rendered on the run page by the summary step, so we don't need INFO lines on stdout. SDK errors / warnings still surface.

2. **Grant `checks: write`.** The workflow's `permissions:` block was `contents: read`, which means `EnricoMi/publish-unit-test-result-action` gets `403 Forbidden` when posting the "Load Test Results" check and fails the workflow even when every scenario passed — which is exactly what happened in the run linked above (green 10/10 suite, red workflow).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: 2 lines in `pytest.ini` + 4 lines in `.github/workflows/load_tests.yml`. No test or SDK change.
- Human verification: diagnosed by walking the 26418912221 run — visual summary shows all 10 tests delivered their expected counts, the workflow-level failure is from the Publish Test Report 403 and the noisy `--- Logging error ---` cascade.

## Testing

Local `pytest suite/python_sdk --load-scale 0.01 -n 2 --dist=worksteal` with `log_cli_level=WARNING`: no INFO chatter, just the per-test metrics teardown line. Clean.

## Documentation

n/a — the inline comments in both files explain the rationale at the point of change.