### PR TITLE
[OPIK-6686] [BE] fix: scope prompt name uniqueness to project level

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000077_update_prompts_unique_constraint.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000077_update_prompts_unique_constraint.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+--changeset boryst:000077_update_prompts_unique_constraint
+
+ALTER TABLE prompts DROP INDEX `prompts_workspace_id_name_uk`;
+ALTER TABLE prompts ADD CONSTRAINT `prompts_workspace_id_project_id_name_uk` UNIQUE (workspace_id, project_id, name);
+
+--rollback ALTER TABLE prompts DROP INDEX `prompts_workspace_id_project_id_name_uk`;
+--rollback ALTER TABLE prompts ADD CONSTRAINT `prompts_workspace_id_name_uk` UNIQUE (workspace_id, name);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -1044,7 +1044,7 @@ class PromptResourceTest {
                     .projectId(null)
                     .build();
 
-            Prompt duplicatedPrompt = buildPrompt().build();
+            Prompt duplicatedPrompt = buildPrompt().projectName("conflict-test-project").build();
             createPrompt(duplicatedPrompt, API_KEY, TEST_WORKSPACE);
 
             return Stream.of(
@@ -1072,6 +1072,22 @@ class PromptResourceTest {
                     Arguments.of(buildPrompt().name("").build(),
                             HttpStatus.SC_UNPROCESSABLE_ENTITY,
                             new ErrorMessage(List.of("name must not be blank")), ErrorMessage.class));
+        }
+
+        @Test
+        @DisplayName("when creating prompts with the same name in different projects, then both succeed")
+        void when__creatingPromptsWithSameNameInDifferentProjects__thenBothSucceed() {
+            String sharedName = UUID.randomUUID().toString();
+
+            var prompt1 = buildPrompt().name(sharedName).projectName("project-alpha").build();
+            var prompt2 = buildPrompt().name(sharedName).projectName("project-beta").build();
+
+            var id1 = createPrompt(prompt1, API_KEY, TEST_WORKSPACE);
+            var id2 = createPrompt(prompt2, API_KEY, TEST_WORKSPACE);
+
+            assertThat(id1).isNotNull();
+            assertThat(id2).isNotNull();
+            assertThat(id1).isNotEqualTo(id2);
         }
     }
 
@@ -1133,11 +1149,13 @@ class PromptResourceTest {
             var prompt = buildPrompt()
                     .lastUpdatedBy(USER)
                     .createdBy(USER)
+                    .projectName("update-conflict-project")
                     .build();
 
             var prompt2 = buildPrompt()
                     .lastUpdatedBy(USER)
                     .createdBy(USER)
+                    .projectName("update-conflict-project")
                     .build();
 
             UUID promptId = createPrompt(prompt, API_KEY, TEST_WORKSPACE);


### PR DESCRIPTION
## Details

Prompt name uniqueness was enforced at workspace level (`workspace_id, name`), causing a conflict when the same prompt name was used in two different projects within the same workspace.

- Migration `000077`: drops the old `prompts_workspace_id_name_uk UNIQUE (workspace_id, name)` constraint and replaces it with `prompts_workspace_id_project_id_name_uk UNIQUE (workspace_id, project_id, name)`, scoping uniqueness to the project.
- Updated two existing conflict tests to use a `projectName` so that the DB constraint is exercised correctly (MySQL treats `NULL != NULL` in unique indexes, so workspace-scoped prompts with `project_id = NULL` would not have fired the old constraint shape).
- Added a new test verifying that the same prompt name can be created in two different projects without conflict.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-6686

## Testing

- `when__promptIsInvalid__thenReturnError` — existing conflict cases (duplicate ID and duplicate name) still return 409 when prompts share a project.
- `when__updatingPromptNameToAnExistingOne__thenReturnConflict` — updating a prompt's name to an existing name within the same project still returns 409.
- `when__creatingPromptsWithSameNameInDifferentProjects__thenBothSucceed` — new test: same name across two different projects succeeds.

## Documentation

No documentation changes required. The uniqueness scoping is an internal constraint change with no API surface change.
