### PR TITLE
[OPIK-6690] [SDK] fix: attach experiment prompts to each generated trace

### DIFF
--- a/sdks/python/src/opik/api_objects/experiment/experiment.py
+++ b/sdks/python/src/opik/api_objects/experiment/experiment.py
@@ -65,6 +65,10 @@ class Experiment:
     def tags(self) -> Optional[List[str]]:
         return self._tags
 
+    @property
+    def prompts(self) -> Optional[List[base_prompt.BasePrompt]]:
+        return self._prompts
+
     @functools.cached_property
     def dataset_id(self) -> str:
         return self._rest_client.datasets.get_dataset_by_identifier(

--- a/sdks/python/src/opik/evaluation/engine/engine.py
+++ b/sdks/python/src/opik/evaluation/engine/engine.py
@@ -10,7 +10,6 @@ from opik.api_objects import opik_client, trace, local_recording
 from opik.api_objects.dataset import dataset_item
 from opik.api_objects.experiment import experiment
 from opik.api_objects.dataset import execution_policy as dataset_execution_policy
-from opik.api_objects.prompt import base_prompt
 from opik.evaluation import rest_operations, test_case, test_result
 from opik.evaluation.types import LLMTask, ScoringKeyMappingType
 from opik.message_processing.emulation import models
@@ -75,14 +74,12 @@ class EvaluationEngine:
         workers: int,
         verbose: int,
         source: TraceSource,
-        prompts: Optional[List[base_prompt.BasePrompt]] = None,
     ) -> None:
         self._client = client
         self._project_name = project_name
         self._workers = workers
         self._verbose = verbose
         self._source = source
-        self._prompts = prompts
 
     # --- Private: metrics & scoring ---
 
@@ -192,8 +189,8 @@ class EvaluationEngine:
             client=self._client,
             execution_policy=execution_policy_dict or None,
         ):
-            if self._prompts:
-                for prompt_obj in self._prompts:
+            if experiment_ is not None and experiment_.prompts:
+                for prompt_obj in experiment_.prompts:
                     opik_context.attach_prompt_to_current_trace(prompt_obj)
 
             LOGGER.debug("[engine] Task started for item %s", item.id)

--- a/sdks/python/src/opik/evaluation/engine/engine.py
+++ b/sdks/python/src/opik/evaluation/engine/engine.py
@@ -10,6 +10,7 @@ from opik.api_objects import opik_client, trace, local_recording
 from opik.api_objects.dataset import dataset_item
 from opik.api_objects.experiment import experiment
 from opik.api_objects.dataset import execution_policy as dataset_execution_policy
+from opik.api_objects.prompt import base_prompt
 from opik.evaluation import rest_operations, test_case, test_result
 from opik.evaluation.types import LLMTask, ScoringKeyMappingType
 from opik.message_processing.emulation import models
@@ -74,12 +75,14 @@ class EvaluationEngine:
         workers: int,
         verbose: int,
         source: TraceSource,
+        prompts: Optional[List[base_prompt.BasePrompt]] = None,
     ) -> None:
         self._client = client
         self._project_name = project_name
         self._workers = workers
         self._verbose = verbose
         self._source = source
+        self._prompts = prompts
 
     # --- Private: metrics & scoring ---
 
@@ -189,6 +192,10 @@ class EvaluationEngine:
             client=self._client,
             execution_policy=execution_policy_dict or None,
         ):
+            if self._prompts:
+                for prompt_obj in self._prompts:
+                    opik_context.attach_prompt_to_current_trace(prompt_obj)
+
             LOGGER.debug("[engine] Task started for item %s", item.id)
             task_start = time.perf_counter()
             try:

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -266,7 +266,6 @@ def evaluate(
         experiment_scoring_functions=experiment_scoring_functions,
         dataset_filter_string=dataset_filter_string,
         source="experiment",
-        prompts=checked_prompts,
     )
 
 
@@ -365,7 +364,6 @@ def __internal_api__run_test_suite__(
         dataset_item_ids=dataset_item_ids,
         dataset_filter_string=dataset_filter_string,
         source=source,  # type: ignore[arg-type]
-        prompts=prompts,
     )
 
     suite_result = suite_result_constructor.build_suite_result(
@@ -494,7 +492,6 @@ def _evaluate_task(
     experiment_scoring_functions: List[ExperimentScoreFunction],
     dataset_filter_string: Optional[str],
     source: TraceSource,
-    prompts: Optional[List[base_prompt.BasePrompt]] = None,
 ) -> evaluation_result.EvaluationResult:
     start_time = time.time()
 
@@ -517,7 +514,6 @@ def _evaluate_task(
             workers=task_threads,
             verbose=verbose,
             source=source,
-            prompts=prompts,
         )
         test_results = evaluation_engine.run_and_score(
             dataset_items=items_iter,
@@ -591,7 +587,6 @@ def _evaluate_test_suite_task(
     evaluator_model: Optional[str],
     dataset_item_ids: Optional[List[str]] = None,
     dataset_filter_string: Optional[str] = None,
-    prompts: Optional[List[base_prompt.BasePrompt]] = None,
 ) -> Tuple[evaluation_result.EvaluationResult, float]:
     start_time = time.time()
 
@@ -612,7 +607,6 @@ def _evaluate_test_suite_task(
             workers=task_threads,
             verbose=verbose,
             source=source,
-            prompts=prompts,
         )
         test_results = evaluation_engine.run_and_score(
             dataset_items=items_iter,
@@ -1031,7 +1025,6 @@ def evaluate_prompt(
             workers=task_threads,
             verbose=verbose,
             source="experiment",
-            prompts=prompts,
         )
         test_results = evaluation_engine.run_and_score(
             dataset_items=items_iter,
@@ -1267,7 +1260,6 @@ def evaluate_optimization_trial(
         experiment_scoring_functions=experiment_scoring_functions,
         dataset_filter_string=dataset_filter_string,
         source="optimization",
-        prompts=checked_prompts,
     )
 
 

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -266,6 +266,7 @@ def evaluate(
         experiment_scoring_functions=experiment_scoring_functions,
         dataset_filter_string=dataset_filter_string,
         source="experiment",
+        prompts=checked_prompts,
     )
 
 
@@ -364,6 +365,7 @@ def __internal_api__run_test_suite__(
         dataset_item_ids=dataset_item_ids,
         dataset_filter_string=dataset_filter_string,
         source=source,  # type: ignore[arg-type]
+        prompts=prompts,
     )
 
     suite_result = suite_result_constructor.build_suite_result(
@@ -492,6 +494,7 @@ def _evaluate_task(
     experiment_scoring_functions: List[ExperimentScoreFunction],
     dataset_filter_string: Optional[str],
     source: TraceSource,
+    prompts: Optional[List[base_prompt.BasePrompt]] = None,
 ) -> evaluation_result.EvaluationResult:
     start_time = time.time()
 
@@ -514,6 +517,7 @@ def _evaluate_task(
             workers=task_threads,
             verbose=verbose,
             source=source,
+            prompts=prompts,
         )
         test_results = evaluation_engine.run_and_score(
             dataset_items=items_iter,
@@ -587,6 +591,7 @@ def _evaluate_test_suite_task(
     evaluator_model: Optional[str],
     dataset_item_ids: Optional[List[str]] = None,
     dataset_filter_string: Optional[str] = None,
+    prompts: Optional[List[base_prompt.BasePrompt]] = None,
 ) -> Tuple[evaluation_result.EvaluationResult, float]:
     start_time = time.time()
 
@@ -607,6 +612,7 @@ def _evaluate_test_suite_task(
             workers=task_threads,
             verbose=verbose,
             source=source,
+            prompts=prompts,
         )
         test_results = evaluation_engine.run_and_score(
             dataset_items=items_iter,
@@ -1025,6 +1031,7 @@ def evaluate_prompt(
             workers=task_threads,
             verbose=verbose,
             source="experiment",
+            prompts=prompts,
         )
         test_results = evaluation_engine.run_and_score(
             dataset_items=items_iter,
@@ -1260,6 +1267,7 @@ def evaluate_optimization_trial(
         experiment_scoring_functions=experiment_scoring_functions,
         dataset_filter_string=dataset_filter_string,
         source="optimization",
+        prompts=checked_prompts,
     )
 
 

--- a/sdks/python/tests/e2e/evaluation/test_experiment_evaluate.py
+++ b/sdks/python/tests/e2e/evaluation/test_experiment_evaluate.py
@@ -383,6 +383,12 @@ def test_experiment_creation_via_evaluate_function__multiple_prompts_arg_used__h
         sorted(experiment_items_contents, key=lambda item: str(item.dataset_item_data)),
     )
 
+    verifiers.verify_experiment_traces_have_opik_prompts(
+        opik_client=opik_client,
+        trace_ids=[item.trace_id for item in experiment_items_contents],
+        prompts=[prompt1, prompt2],
+    )
+
 
 def test_experiment_creation__name_can_be_omitted(
     opik_client: opik.Opik, dataset_name: str, experiment_name: str

--- a/sdks/python/tests/e2e/verifiers.py
+++ b/sdks/python/tests/e2e/verifiers.py
@@ -514,6 +514,44 @@ def _verify_experiment_metadata(
     assert experiment_metadata == metadata, f"{experiment_metadata} != {metadata}"
 
 
+def verify_experiment_traces_have_opik_prompts(
+    opik_client: opik.Opik,
+    trace_ids: List[str],
+    prompts: List[Prompt],
+) -> None:
+    """Verify each trace produced by an experiment carries `opik_prompts`
+    in its metadata. Backend needs this for trace-level prompt linkage."""
+    assert trace_ids, "Expected at least one trace_id to verify prompt injection"
+
+    expected_prompt_keys = sorted(
+        (p.__internal_api__prompt_id__, p.commit) for p in prompts
+    )
+
+    for trace_id in trace_ids:
+        assert synchronization.until(
+            lambda: opik_client.get_trace_content(id=trace_id) is not None,
+            allow_errors=True,
+        ), f"Failed to get trace {trace_id}"
+
+        trace_content = opik_client.get_trace_content(id=trace_id)
+        assert trace_content.metadata is not None, (
+            f"Trace {trace_id} has no metadata; expected opik_prompts"
+        )
+        actual_prompts = trace_content.metadata.get("opik_prompts")
+        assert actual_prompts, (
+            f"Trace {trace_id} metadata is missing 'opik_prompts': "
+            f"{trace_content.metadata}"
+        )
+        actual_keys = sorted(
+            (p.get("id"), (p.get("version") or {}).get("commit"))
+            for p in actual_prompts
+        )
+        assert actual_keys == expected_prompt_keys, (
+            f"Trace {trace_id} opik_prompts mismatch: "
+            f"actual={actual_keys}, expected={expected_prompt_keys}"
+        )
+
+
 def _verify_experiment_prompts(
     experiment_content: ExperimentPublic,
     prompts: Optional[List[Prompt]],

--- a/sdks/python/tests/unit/evaluation/test_evaluate.py
+++ b/sdks/python/tests/unit/evaluation/test_evaluate.py
@@ -57,6 +57,7 @@ def create_mock_experiment() -> tuple[mock.Mock, mock.Mock, mock.Mock]:
         Tuple of (mock_experiment, mock_create_experiment, mock_get_experiment_url_by_id)
     """
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -164,6 +165,7 @@ def test_evaluate__happyflow(
         raise Exception
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -421,6 +423,9 @@ def test_evaluate__prompts_are_attached_to_each_trace(fake_backend):
         mock_create_experiment,
         mock_get_experiment_url_by_id,
     ) = create_mock_experiment()
+    # The engine reads prompts off the experiment object it receives, so the
+    # mocked experiment must expose them (create_experiment is mocked here).
+    mock_experiment.prompts = prompts
 
     with patch_evaluation_dependencies(
         mock_create_experiment, mock_get_experiment_url_by_id
@@ -481,6 +486,9 @@ def test_evaluate_prompt__prompt_attached_to_each_trace(fake_backend):
         mock_create_experiment,
         mock_get_experiment_url_by_id,
     ) = create_mock_experiment()
+    # The engine reads prompts off the experiment object it receives, so the
+    # mocked experiment must expose them (create_experiment is mocked here).
+    mock_experiment.prompts = [prompt_obj]
     mock_models_factory_get, _ = create_mock_model(model_name=MODEL_NAME)
 
     with patch_evaluation_dependencies(
@@ -552,6 +560,7 @@ def test_evaluate_with_scoring_key_mapping(
         raise Exception
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -811,6 +820,7 @@ def test_evaluate___output_key_is_missing_in_task_output_dict__equals_metric_mis
         raise Exception
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -871,6 +881,7 @@ def test_evaluate__exception_raised_from_the_task__error_info_added_to_the_trace
         raise Exception("some-error-message")
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -1021,6 +1032,7 @@ def test_evaluate__with_random_sampler__happy_flow(
         raise Exception
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -1131,6 +1143,7 @@ def test_evaluate__with_random_sampler__total_items_reflects_sampled_count(
         return {"output": "hello"}
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -1223,6 +1236,7 @@ def test_evaluate__with_task_span_metrics__total_items_reflects_actual_count(
         return {"output": "hello"}
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -1320,6 +1334,7 @@ def test_evaluate__with_sampler_and_nb_samples__total_items_reflects_final_count
         return {"output": "hello"}
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -1446,6 +1461,7 @@ def test_evaluate_prompt_happyflow(
     )
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -1680,6 +1696,7 @@ def test_evaluate__aggregated_metric__happy_flow(
         raise Exception
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -2046,6 +2063,7 @@ def test_evaluate_prompt__with_random_sampling__happy_flow(
     )
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -2180,6 +2198,7 @@ def test_evaluate__2_trials_lead_to_2_experiment_items_per_dataset_item(
         raise Exception
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -2335,6 +2354,7 @@ def test_evaluate_prompt__2_trials_lead_to_2_experiment_items_per_dataset_item(
     )
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -2610,6 +2630,7 @@ def test_evaluate__with_experiment_scores_empty_results(fake_backend):
         return {"output": "hello"}
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_experiment.id = "experiment-id"
     mock_experiment.name = "test-experiment"
     mock_create_experiment = mock.Mock()
@@ -2948,6 +2969,7 @@ def test_evaluate__uses_streaming_by_default(fake_backend):
         return {"output": "hello"}
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -3013,6 +3035,7 @@ def test_evaluate__uses_streaming_with_dataset_item_ids(fake_backend):
         return {"output": "hello"}
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -3084,6 +3107,7 @@ def test_evaluate__falls_back_to_non_streaming_with_dataset_sampler(fake_backend
         return {"output": "hello"}
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 
@@ -3161,6 +3185,7 @@ def test_evaluate__streaming_with_nb_samples(fake_backend):
         return {"output": "hello"}
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_create_experiment = mock.Mock()
     mock_create_experiment.return_value = mock_experiment
 

--- a/sdks/python/tests/unit/evaluation/test_evaluate.py
+++ b/sdks/python/tests/unit/evaluation/test_evaluate.py
@@ -5,8 +5,8 @@ from unittest import mock
 import pytest
 
 import opik
-from opik import evaluation, exceptions, url_helpers
-from opik.api_objects import opik_client
+from opik import evaluation, exceptions, rest_api, url_helpers, PromptType
+from opik.api_objects import opik_client, prompt
 from opik.api_objects.dataset import dataset_item
 from opik.api_objects.experiment import experiment
 from opik.evaluation import (
@@ -369,6 +369,139 @@ def test_evaluate__happyflow(
         EXPECTED_TRACE_TREES, fake_backend.trace_trees
     ):
         assert_equal(expected_trace, actual_trace)
+
+
+def test_evaluate__prompts_are_attached_to_each_trace(fake_backend):
+    """When prompts are passed to `evaluate`, every trace produced by the
+    evaluation run must carry them in `metadata["opik_prompts"]` so the
+    backend can show prompt linkage on each trace (not only on the
+    experiment row)."""
+    mock_dataset = create_mock_dataset(
+        items=[
+            dataset_item.DatasetItem(
+                id="dataset-item-id-1",
+                input={"message": "say hello"},
+                reference="hello",
+            ),
+            dataset_item.DatasetItem(
+                id="dataset-item-id-2",
+                input={"message": "say bye"},
+                reference="bye",
+            ),
+        ]
+    )
+
+    prompts = [
+        prompt.Prompt.from_fern_prompt_version(
+            name="system_prompt",
+            prompt_version=rest_api.PromptVersionDetail(
+                template="You are a helpful assistant.",
+                commit="abc123",
+                type=PromptType.MUSTACHE,
+            ),
+        ),
+        prompt.Prompt.from_fern_prompt_version(
+            name="user_prompt",
+            prompt_version=rest_api.PromptVersionDetail(
+                template="Say what the user asks.",
+                commit="def456",
+                type=PromptType.MUSTACHE,
+            ),
+        ),
+    ]
+    expected_prompts_metadata = [p.__internal_api__to_info_dict__() for p in prompts]
+
+    def say_task(item: Dict[str, Any]):
+        if item["input"]["message"] == "say hello":
+            return {"output": "hello"}
+        return {"output": "bye"}
+
+    (
+        mock_experiment,
+        mock_create_experiment,
+        mock_get_experiment_url_by_id,
+    ) = create_mock_experiment()
+
+    with patch_evaluation_dependencies(
+        mock_create_experiment, mock_get_experiment_url_by_id
+    ):
+        evaluation.evaluate(
+            dataset=mock_dataset,
+            task=say_task,
+            experiment_name="experiment-with-prompts",
+            scoring_metrics=[metrics.Equals()],
+            prompts=prompts,
+            task_threads=1,
+        )
+
+    mock_create_experiment.assert_called_once_with(
+        dataset_name="the-dataset-name",
+        name="experiment-with-prompts",
+        experiment_config=None,
+        prompts=prompts,
+        tags=None,
+        dataset_version_id=None,
+        project_name=None,
+    )
+
+    assert len(fake_backend.trace_trees) == 2
+    for actual_trace in fake_backend.trace_trees:
+        assert actual_trace.metadata is not None, (
+            "Trace metadata must not be None when prompts are passed to evaluate"
+        )
+        assert actual_trace.metadata.get("opik_prompts") == expected_prompts_metadata
+
+
+def test_evaluate_prompt__prompt_attached_to_each_trace(fake_backend):
+    """`evaluate_prompt` should also attach the prompt to each generated trace."""
+    MODEL_NAME = "gpt-3.5-turbo"
+
+    mock_dataset = create_mock_dataset(
+        items=[
+            dataset_item.DatasetItem(
+                id="dataset-item-id-1",
+                question="Hello, world!",
+                reference="Hello, world!",
+            ),
+        ]
+    )
+
+    prompt_obj = prompt.Prompt.from_fern_prompt_version(
+        name="single_prompt",
+        prompt_version=rest_api.PromptVersionDetail(
+            template="LLM response: {{question}}",
+            commit="cafe01",
+            type=PromptType.MUSTACHE,
+        ),
+    )
+    expected_prompt_metadata = [prompt_obj.__internal_api__to_info_dict__()]
+
+    (
+        mock_experiment,
+        mock_create_experiment,
+        mock_get_experiment_url_by_id,
+    ) = create_mock_experiment()
+    mock_models_factory_get, _ = create_mock_model(model_name=MODEL_NAME)
+
+    with patch_evaluation_dependencies(
+        mock_create_experiment,
+        mock_get_experiment_url_by_id,
+        mock_models_factory_get=mock_models_factory_get,
+    ):
+        evaluation.evaluate_prompt(
+            dataset=mock_dataset,
+            messages=[{"role": "user", "content": "LLM response: {{question}}"}],
+            experiment_name="prompt-experiment",
+            model=MODEL_NAME,
+            prompt=prompt_obj,
+            scoring_metrics=[metrics.Equals()],
+            task_threads=1,
+        )
+
+    assert len(fake_backend.trace_trees) == 1
+    actual_trace = fake_backend.trace_trees[0]
+    assert actual_trace.metadata is not None
+    assert actual_trace.metadata.get("opik_prompts") == expected_prompt_metadata
 
 
 def test_evaluate_with_scoring_key_mapping(

--- a/sdks/python/tests/unit/evaluation/test_evaluate_experiment_name.py
+++ b/sdks/python/tests/unit/evaluation/test_evaluate_experiment_name.py
@@ -56,7 +56,7 @@ def test_evaluate__with_experiment_name_prefix__generates_name_with_prefix(
         return {"output": "hello"}
 
     mock_create_experiment = mock.Mock()
-    mock_create_experiment.return_value = mock.Mock()
+    mock_create_experiment.return_value = mock.Mock(prompts=None)
 
     mock_get_experiment_url_by_id = mock.Mock()
     mock_get_experiment_url_by_id.return_value = "any_url"
@@ -125,7 +125,7 @@ def test_evaluate__with_experiment_name_prefix_and_experiment_name__experiment_n
         return {"output": "hello"}
 
     mock_create_experiment = mock.Mock()
-    mock_create_experiment.return_value = mock.Mock()
+    mock_create_experiment.return_value = mock.Mock(prompts=None)
 
     mock_get_experiment_url_by_id = mock.Mock()
     mock_get_experiment_url_by_id.return_value = "any_url"
@@ -187,7 +187,7 @@ def test_evaluate__with_experiment_name_prefix_only__generates_unique_name(
         return {"output": "hello"}
 
     mock_create_experiment = mock.Mock()
-    mock_create_experiment.return_value = mock.Mock()
+    mock_create_experiment.return_value = mock.Mock(prompts=None)
 
     mock_get_experiment_url_by_id = mock.Mock()
     mock_get_experiment_url_by_id.return_value = "any_url"
@@ -257,6 +257,7 @@ def test_evaluate__without_experiment_name_prefix_or_name__generates_default_nam
         return {"output": "hello"}
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_experiment.id = "experiment-id"
     mock_experiment.name = None
     mock_create_experiment = mock.Mock()
@@ -315,9 +316,9 @@ def test_evaluate__with_experiment_name_prefix__multiple_calls_generate_unique_n
     def say_task(dataset_item: Dict[str, Any]):
         return {"output": "hello"}
 
-    mock_experiment1 = mock.Mock()
+    mock_experiment1 = mock.Mock(prompts=None)
     mock_experiment1.id = "experiment-id-1"
-    mock_experiment2 = mock.Mock()
+    mock_experiment2 = mock.Mock(prompts=None)
     mock_experiment2.id = "experiment-id-2"
 
     mock_create_experiment = mock.Mock()
@@ -417,7 +418,7 @@ def test_evaluate_prompt__with_experiment_name_prefix__generates_name_with_prefi
     )
 
     mock_create_experiment = mock.Mock()
-    mock_create_experiment.return_value = mock.Mock()
+    mock_create_experiment.return_value = mock.Mock(prompts=None)
 
     mock_get_experiment_url_by_id = mock.Mock()
     mock_get_experiment_url_by_id.return_value = "any_url"
@@ -493,7 +494,7 @@ def test_evaluate_prompt__with_experiment_name_prefix_and_experiment_name__exper
     )
 
     mock_create_experiment = mock.Mock()
-    mock_create_experiment.return_value = mock.Mock()
+    mock_create_experiment.return_value = mock.Mock(prompts=None)
 
     mock_get_experiment_url_by_id = mock.Mock()
     mock_get_experiment_url_by_id.return_value = "any_url"
@@ -565,7 +566,7 @@ def test_evaluate_prompt__with_experiment_name_prefix_only__generates_unique_nam
     )
 
     mock_create_experiment = mock.Mock()
-    mock_create_experiment.return_value = mock.Mock()
+    mock_create_experiment.return_value = mock.Mock(prompts=None)
 
     mock_get_experiment_url_by_id = mock.Mock()
     mock_get_experiment_url_by_id.return_value = "any_url"
@@ -644,7 +645,7 @@ def test_evaluate_prompt__without_experiment_name_prefix_or_name__generates_defa
     )
 
     mock_create_experiment = mock.Mock()
-    mock_create_experiment.return_value = mock.Mock()
+    mock_create_experiment.return_value = mock.Mock(prompts=None)
 
     mock_get_experiment_url_by_id = mock.Mock()
     mock_get_experiment_url_by_id.return_value = "any_url"
@@ -750,7 +751,7 @@ def test_evaluate_prompt__with_experiment_name_prefix__multiple_calls_generate_u
                     )
 
                     # First call
-                    mock_create_experiment.return_value = mock.Mock()
+                    mock_create_experiment.return_value = mock.Mock(prompts=None)
                     evaluation.evaluate_prompt(
                         dataset=mock_dataset,
                         messages=[
@@ -762,7 +763,7 @@ def test_evaluate_prompt__with_experiment_name_prefix__multiple_calls_generate_u
                     )
 
                     # Second call
-                    mock_create_experiment.return_value = mock.Mock()
+                    mock_create_experiment.return_value = mock.Mock(prompts=None)
                     evaluation.evaluate_prompt(
                         dataset=mock_dataset,
                         messages=[

--- a/sdks/python/tests/unit/evaluation/test_evaluate_test_suite.py
+++ b/sdks/python/tests/unit/evaluation/test_evaluate_test_suite.py
@@ -43,6 +43,7 @@ def _create_suite(mock_dataset, client=None):
 def test_run_tests__creates_experiment_with_evaluation_method_test_suite():
     mock_dataset = _create_mock_dataset()
     mock_experiment = mock.MagicMock()
+    mock_experiment.prompts = None
     mock_experiment.id = "exp-123"
     mock_experiment.name = "test-experiment"
 
@@ -73,6 +74,7 @@ def test_run_tests__passes_evaluation_method_not_dataset():
     """Verify it's specifically 'evaluation_suite', not 'dataset'."""
     mock_dataset = _create_mock_dataset()
     mock_experiment = mock.MagicMock()
+    mock_experiment.prompts = None
     mock_experiment.id = "exp-456"
     mock_experiment.name = "test-experiment-2"
 
@@ -104,6 +106,7 @@ def _call_run_tests(items, client=None):
     mock_dataset = _create_mock_dataset(items=items)
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_experiment.id = "exp-789"
     mock_experiment.name = "source-test-experiment"
 
@@ -188,6 +191,7 @@ def test_internal_run__with_optimization_id__trace_source_optimization(
     mock_dataset = _create_mock_dataset(items=items)
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_experiment.id = "exp-789"
     mock_experiment.name = "source-test-experiment"
 
@@ -254,6 +258,7 @@ def test_run_tests__explicit_client__used_for_experiment_creation():
     """When a suite has an explicit client, run_tests uses it."""
     mock_dataset = _create_mock_dataset()
     mock_experiment = mock.MagicMock()
+    mock_experiment.prompts = None
     mock_experiment.id = "exp-explicit"
     mock_experiment.name = "explicit-experiment"
 
@@ -292,6 +297,7 @@ def test_run_tests__explicit_client__propagated_to_worker_threads(
     mock_dataset = _create_mock_dataset(items=items)
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_experiment.id = "exp-thread"
     mock_experiment.name = "thread-test-experiment"
 
@@ -352,6 +358,7 @@ def test_run_tests__runs_per_item__task_called_n_times():
         return {"input": item, "output": "ok"}
 
     mock_experiment = mock.Mock(id="exp", name="exp")
+    mock_experiment.prompts = None
     with (
         mock.patch.object(
             opik_client.Opik, "create_experiment", return_value=mock_experiment
@@ -396,6 +403,7 @@ def test_run_tests__item_level_policy_overrides_suite_policy():
         return {"input": item, "output": "ok"}
 
     mock_experiment = mock.Mock(id="exp", name="exp")
+    mock_experiment.prompts = None
     with (
         mock.patch.object(
             opik_client.Opik, "create_experiment", return_value=mock_experiment
@@ -434,6 +442,7 @@ def test_run_tests__no_assertions__items_pass_with_single_run(fake_backend):
         return {"input": item, "output": "ok"}
 
     mock_experiment = mock.Mock(id="exp", name="exp")
+    mock_experiment.prompts = None
     with (
         mock.patch.object(
             opik_client.Opik, "create_experiment", return_value=mock_experiment
@@ -478,6 +487,7 @@ def test_run_tests__worker_threads_1__task_runs_in_caller_thread():
         return {"input": item, "output": "ok"}
 
     mock_experiment = mock.Mock(id="exp", name="exp")
+    mock_experiment.prompts = None
     with (
         mock.patch.object(
             opik_client.Opik, "create_experiment", return_value=mock_experiment
@@ -513,6 +523,7 @@ def test_run_tests__worker_threads_1__no_thread_pool_executor_created():
         return {"input": item, "output": "ok"}
 
     mock_experiment = mock.Mock(id="exp", name="exp")
+    mock_experiment.prompts = None
     with (
         mock.patch.object(
             opik_client.Opik, "create_experiment", return_value=mock_experiment
@@ -558,6 +569,7 @@ def test_run_tests__worker_threads_2__task_runs_in_worker_threads():
         return {"input": item, "output": "ok"}
 
     mock_experiment = mock.Mock(id="exp", name="exp")
+    mock_experiment.prompts = None
     with (
         mock.patch.object(
             opik_client.Opik, "create_experiment", return_value=mock_experiment
@@ -589,6 +601,7 @@ def test_run_tests__worker_threads_1__caller_context_client_restored():
     pre_existing_client = mock.MagicMock(spec=opik_client.Opik)
     suite_client = mock.MagicMock(spec=opik_client.Opik)
     mock_experiment = mock.Mock(id="exp", name="exp")
+    mock_experiment.prompts = None
     suite_client.create_experiment.return_value = mock_experiment
 
     suite = _create_suite(mock_dataset, client=suite_client)
@@ -626,6 +639,7 @@ def test_run_tests__worker_threads_1__task_exception_propagates():
         raise BoomError("synchronous failure")
 
     mock_experiment = mock.Mock(id="exp", name="exp")
+    mock_experiment.prompts = None
     with (
         mock.patch.object(
             opik_client.Opik, "create_experiment", return_value=mock_experiment

--- a/sdks/python/tests/unit/evaluation/test_experiment_item_project_name.py
+++ b/sdks/python/tests/unit/evaluation/test_experiment_item_project_name.py
@@ -25,6 +25,7 @@ def test_evaluate_llm_task_context__experiment_item_includes_trace_project_name(
 
     # Create mock experiment
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_experiment.insert = mock.Mock()
 
     # Create mock client
@@ -70,6 +71,7 @@ def test_evaluate_llm_task_context__experiment_item_includes_none_project_name()
 
     # Create mock experiment
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_experiment.insert = mock.Mock()
 
     # Create mock client
@@ -162,6 +164,7 @@ def test_evaluate_llm_task_context__experiment_item_includes_execution_policy():
     )
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_experiment.insert = mock.Mock()
     mock_client = mock.Mock(spec=opik.Opik)
 
@@ -195,6 +198,7 @@ def test_evaluate_llm_task_context__experiment_item_execution_policy_none_by_def
     )
 
     mock_experiment = mock.Mock()
+    mock_experiment.prompts = None
     mock_experiment.insert = mock.Mock()
     mock_client = mock.Mock(spec=opik.Opik)
 


### PR DESCRIPTION
## Details

When prompts are passed to `evaluate(prompts=...)` / `evaluate_prompt(prompt=...)` / `run_tests(prompts=...)`, they were linked to the experiment row (via `prompt_versions`) but never written to the per-item traces' metadata. As a result the trace UI's "Prompt" tab was empty for traces generated by experiments with prompts — same root cause as the Agent Playground case described in the ticket.

- The `EvaluationEngine` now reads the prompts off the `Experiment` object it already receives (new `Experiment.prompts` property), rather than threading the list through `_evaluate_task` / `_evaluate_test_suite_task` / `evaluate_prompt` / the engine constructor. The prompts already live on the experiment, so no extra parameter plumbing is needed and the behavior is uniform across `evaluate`, `evaluate_prompt`, `run_tests`, and optimization paths.
- Inside `_compute_test_result_for_llm_task`, each prompt is attached to the active trace via `opik_context.attach_prompt_to_current_trace`, which dedups by `(id, commit)` and writes them into `metadata.opik_prompts` — the same mechanism the decorator already uses for `update_current_trace(prompts=...)`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6690

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation (engine reads prompts from Experiment + unit + e2e test plumbing)
- Human verification: code review + local unit test run

## Testing

- Ran the new and existing Python SDK evaluation unit tests:
  - `python -m pytest sdks/python/tests/unit/evaluation/test_evaluate.py::test_evaluate__prompts_are_attached_to_each_trace sdks/python/tests/unit/evaluation/test_evaluate.py::test_evaluate_prompt__prompt_attached_to_each_trace` — 2 passed.
  - `python -m pytest sdks/python/tests/unit/evaluation/` — 495 passed (no regressions in the suite).
  - `python -m pytest sdks/python/tests/unit/decorator/test_tracker_outputs.py` — 38 passed (no prompt-attach regression).
- Ran ruff, ruff format, and mypy on the changed files — all pass (also enforced by pre-commit hooks on the commit).
- E2E test changes (`test_experiment_creation_via_evaluate_function__multiple_prompts_arg_used__happyflow` + new `verifiers.verify_experiment_traces_have_opik_prompts`) are wired in but require a live backend; not executed locally — collection-only check confirmed all e2e tests in `test_experiment_evaluate.py` collect cleanly.

Scenarios covered by the new unit tests:
- `evaluate(prompts=[p1, p2])` → each generated trace's `metadata.opik_prompts` equals `[p.__internal_api__to_info_dict__() for p in prompts]`.
- `evaluate_prompt(prompt=p)` → single-trace assertion of the same metadata key.

Note: because the engine reads prompts from the `Experiment` object, unit tests that mock `create_experiment` must set `mock_experiment.prompts` accordingly. Existing tests using bare `mock.Mock()` experiments were updated to set `prompts = None` so injection is correctly skipped.

## Documentation

N/A — internal SDK fix; no user-facing API change.