### PR TITLE
[NA] [SDK] ci(load): richer job-summary table (volume, submit time, rate, total)

### DIFF
--- a/.github/workflows/load_tests.yml
+++ b/.github/workflows/load_tests.yml
@@ -90,31 +90,111 @@ jobs:
               print("## Load test metrics\n\n_No metrics produced (suite did not run)._")
               raise SystemExit
 
+
           def fmt_seconds(value):
-              return f"{value:.1f} s" if isinstance(value, (int, float)) else "—"
+              if not isinstance(value, (int, float)):
+                  return "—"
+              return f"{value / 60:.1f} m" if value >= 60 else f"{value:.1f} s"
+
 
           def fmt_count(value):
-              return f"{value:,}" if isinstance(value, int) else (value or "—")
+              return f"{value:,}" if isinstance(value, (int, float)) else "—"
+
+
+          def submit_seconds(metrics):
+              # The submit phase is timed as "logging" for trace-based tests and
+              # as "insert" for the dataset-versions test.
+              for key in ("logging_seconds", "insert_seconds"):
+                  if isinstance(metrics.get(key), (int, float)):
+                      return metrics[key]
+              return None
+
+
+          def submitted_volume(metrics):
+              # Returns (count, label). Picks the most representative unit per
+              # test type so the table shows what was actually submitted.
+              if "expected_total_items" in metrics:
+                  return metrics["expected_total_items"], (
+                      f"{metrics['expected_total_items']:,} items"
+                  )
+              if "total_traces" in metrics:
+                  return metrics["total_traces"], (
+                      f"{metrics['total_traces']:,} traces"
+                  )
+              trace_count = metrics.get("trace_count")
+              spans_per_trace = metrics.get("spans_per_trace")
+              if isinstance(trace_count, int) and isinstance(spans_per_trace, int):
+                  return trace_count, (
+                      f"{trace_count:,} traces × {spans_per_trace} spans"
+                  )
+              if isinstance(trace_count, int):
+                  return trace_count, f"{trace_count:,} traces"
+              return None, "—"
+
+
+          def submit_rate(count, seconds):
+              if count is None or not isinstance(seconds, (int, float)) or seconds <= 0:
+                  return "—"
+              return f"{count / seconds:,.0f}/s"
+
+
+          def total_seconds(metrics):
+              parts = [
+                  metrics.get(key)
+                  for key in (
+                      "logging_seconds",
+                      "insert_seconds",
+                      "flush_seconds",
+                      "verify_seconds",
+                  )
+              ]
+              parts = [p for p in parts if isinstance(p, (int, float))]
+              return sum(parts) if parts else None
+
+
+          def delivered_count(metrics):
+              for key in ("delivered_trace_count", "delivered_item_count"):
+                  if key in metrics:
+                      return metrics[key]
+              return None
+
 
           print("## Load test metrics\n")
-          print("| Test | Logged | Flush | Verify | Delivered |")
-          print("| --- | ---: | ---: | ---: | ---: |")
+          print(
+              "_Submit = time spent calling decorated functions / context managers."
+              " Submit rate = volume ÷ submit time."
+              " Total = submit + flush + verify._\n"
+          )
+          print(
+              "| Test | Volume | Submit | Submit rate"
+              " | Flush | Verify | Total | Delivered |"
+          )
+          print(
+              "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |"
+          )
           payloads = []
           for path in files:
-              m = json.loads(path.read_text())
-              payloads.append(m)
-              name = m.get("test_name", path.stem)
-              logged = fmt_seconds(m.get("logging_seconds"))
-              flush = fmt_seconds(m.get("flush_seconds"))
-              verify = fmt_seconds(m.get("verify_seconds"))
-              delivered = fmt_count(m.get("delivered_trace_count"))
-              print(f"| `{name}` | {logged} | {flush} | {verify} | {delivered} |")
+              metrics = json.loads(path.read_text())
+              payloads.append(metrics)
+              name = metrics.get("test_name", path.stem)
+              count, volume_label = submitted_volume(metrics)
+              submit_s = submit_seconds(metrics)
+              print(
+                  f"| `{name}`"
+                  f" | {volume_label}"
+                  f" | {fmt_seconds(submit_s)}"
+                  f" | {submit_rate(count, submit_s)}"
+                  f" | {fmt_seconds(metrics.get('flush_seconds'))}"
+                  f" | {fmt_seconds(metrics.get('verify_seconds'))}"
+                  f" | {fmt_seconds(total_seconds(metrics))}"
+                  f" | {fmt_count(delivered_count(metrics))} |"
+              )
 
           print("\n<details>\n<summary>Per-test metrics (raw JSON)</summary>\n")
-          for m in payloads:
-              print(f"\n**{m.get('test_name', '?')}**")
+          for metrics in payloads:
+              print(f"\n**{metrics.get('test_name', '?')}**")
               print("```json")
-              print(json.dumps(m, indent=2))
+              print(json.dumps(metrics, indent=2))
               print("```")
           print("\n</details>")
           PY


### PR DESCRIPTION
## Details

Adds four new columns to the Load Tests workflow Step Summary so the run page shows what was actually submitted, how spread out the submissions were over time, and where the wall-clock went.

Before — one phase column per timer, no volume context:

| Test | Logged | Flush | Verify | Delivered |
| --- | ---: | ---: | ---: | ---: |
| `test_burst_single_loop` | 78.3 s | 12.1 s | 45.2 s | 50,000 |

After — submission volume + rate make spread visible at a glance:

| Test | Volume | Submit | Submit rate | Flush | Verify | Total | Delivered |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `test_burst_single_loop` | 50,000 traces | 1.3 m | 639/s | 12.1 s | 45.2 s | 2.3 m | 50,000 |
| `test_spread_over_time` | 10,000 traces | 10.0 m | 17/s | 0.9 s | 33.1 s | 10.6 m | 10,000 |
| `test_many_spans_per_trace` | 5,000 traces × 50 spans | 2.4 m | 34/s | 1.2 s | 1.1 m | 3.5 m | 5,000 |
| `test_dataset_insert_many_versions` | 2,500 items | 12.3 s | 203/s | — | 1.5 s | 13.8 s | 2,500 |

Key additions:

- **Volume**: declared submission count, formatted per test type — `2,500 items` for the dataset test, `5,000 traces × 50 spans` for span-fanout, plain `N traces` otherwise.
- **Submit**: time spent calling decorated functions / context managers (renamed from "Logged"). Reads `logging_seconds` for trace tests, `insert_seconds` for the dataset-versions test.
- **Submit rate**: volume ÷ submit-time. Spread test reports ~17/s (matches its 10k-over-600s design rate); burst reports ~639/s. Makes "how spread out was this?" answerable from the summary alone.
- **Total**: submit + flush + verify wall-clock, so end-to-end runtime is visible without summing columns in your head.

Durations switch from `s` to `m` once they cross 60s. Missing fields render as `—` rather than crashing.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: 95 lines in `.github/workflows/load_tests.yml`. Workflow-only — no SDK or test-suite change.
- Human verification: extracted the inline Python snippet from the workflow and ran it locally against synthetic metrics covering every test variant (trace-only, span-fanout, dataset, concurrent, missing-fields). Output rendered correctly for all cases — see the "After" table above.

## Testing

Local extract-and-run of the renderer against fabricated JSONs covering each `tests_load/.last_run/<test>.json` shape:
- `test_burst_single_loop` (`logging_seconds` + `delivered_trace_count`) → traces row.
- `test_spread_over_time` → rate matches the design ~17/s, so the column genuinely reflects spread.
- `test_concurrent_writers_share_one_client` (`total_traces`) → volume from the right key.
- `test_many_spans_per_trace` (`spans_per_trace`) → composite volume label.
- `test_dataset_insert_many_versions` (`insert_seconds`, `delivered_item_count`) → flush column shows `—`, others populated.
- Empty-metrics dict → all cells `—`, no exceptions.

## Documentation

n/a — inline-rendering Python in the workflow file. Column header row plus a one-line caption above the table document the new metrics.