### PR TITLE
[OPIK-6696] [BE] feat(datasets): copy_from coords on createOrUpdateDatasetItems + applyDatasetItemChanges

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItemBatch.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItemBatch.java
@@ -35,7 +35,9 @@ public record DatasetItemBatch(
         @JsonView({
                 DatasetItem.View.Write.class}) @Schema(description = "Optional batch group ID to group multiple batches into a single dataset version. If null, mutates the latest version instead of creating a new one.") UUID batchGroupId,
         @JsonView({
-                DatasetItem.View.Write.class}) @Schema(description = "If true, the new version's row set equals exactly the items in this batch. The server skips the INSERT FROM SELECT that copies unchanged rows from the previous version, avoiding multi-replica read-after-write inconsistency. Items absent from the payload are absent from the new version (deletions implicit). Ignored when batch_group_id is null.") Boolean snapshot)
+                DatasetItem.View.Write.class}) @Schema(description = "OPIK-6696. Optional. Dataset to read carry-forward rows from when materializing the new version. Required together with copy_from_version_id. When both are set, the INSERT FROM SELECT that copies unchanged rows reads from this (dataset, version) pair instead of the destination dataset's prior version, avoiding the multi-replica read-after-write window. When null, the existing behavior applies (reads from the destination's prior version).") UUID copyFromDatasetId,
+        @JsonView({
+                DatasetItem.View.Write.class}) @Schema(description = "OPIK-6696. Optional. Version within copy_from_dataset_id to read carry-forward rows from. Required together with copy_from_dataset_id.") UUID copyFromVersionId)
         implements
             RateEventContainer {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItemBatch.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItemBatch.java
@@ -34,10 +34,13 @@ public record DatasetItemBatch(
         @JsonView({DatasetItem.View.Write.class}) @NotNull @Size(min = 1, max = 1000) @Valid List<DatasetItem> items,
         @JsonView({
                 DatasetItem.View.Write.class}) @Schema(description = "Optional batch group ID to group multiple batches into a single dataset version. If null, mutates the latest version instead of creating a new one.") UUID batchGroupId,
+        // OPIK-6696: when both copy_from_* coordinates are set, the INSERT FROM SELECT that copies
+        // unchanged rows reads from this (dataset, version) pair instead of the destination dataset's
+        // prior version, avoiding the multi-replica read-after-write window.
         @JsonView({
-                DatasetItem.View.Write.class}) @Schema(description = "OPIK-6696. Optional. Dataset to read carry-forward rows from when materializing the new version. Required together with copy_from_version_id. When both are set, the INSERT FROM SELECT that copies unchanged rows reads from this (dataset, version) pair instead of the destination dataset's prior version, avoiding the multi-replica read-after-write window. When null, the existing behavior applies (reads from the destination's prior version).") UUID copyFromDatasetId,
+                DatasetItem.View.Write.class}) @Schema(description = "Optional. Dataset to read carry-forward rows from when materializing the new version. Required together with copy_from_version_id. When null, carry-forward rows are read from the destination dataset's prior version.") UUID copyFromDatasetId,
         @JsonView({
-                DatasetItem.View.Write.class}) @Schema(description = "OPIK-6696. Optional. Version within copy_from_dataset_id to read carry-forward rows from. Required together with copy_from_dataset_id.") UUID copyFromVersionId)
+                DatasetItem.View.Write.class}) @Schema(description = "Optional. Version within copy_from_dataset_id to read carry-forward rows from. Required together with copy_from_dataset_id.") UUID copyFromVersionId)
         implements
             RateEventContainer {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItemBatch.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItemBatch.java
@@ -33,7 +33,9 @@ public record DatasetItemBatch(
                 DatasetItem.View.Write.class}) @Schema(description = "Optional. Associates the batch with a project by ID. Takes precedence over project_name.") UUID projectId,
         @JsonView({DatasetItem.View.Write.class}) @NotNull @Size(min = 1, max = 1000) @Valid List<DatasetItem> items,
         @JsonView({
-                DatasetItem.View.Write.class}) @Schema(description = "Optional batch group ID to group multiple batches into a single dataset version. If null, mutates the latest version instead of creating a new one.") UUID batchGroupId)
+                DatasetItem.View.Write.class}) @Schema(description = "Optional batch group ID to group multiple batches into a single dataset version. If null, mutates the latest version instead of creating a new one.") UUID batchGroupId,
+        @JsonView({
+                DatasetItem.View.Write.class}) @Schema(description = "If true, the new version's row set equals exactly the items in this batch. The server skips the INSERT FROM SELECT that copies unchanged rows from the previous version, avoiding multi-replica read-after-write inconsistency. Items absent from the payload are absent from the new version (deletions implicit). Ignored when batch_group_id is null.") Boolean snapshot)
         implements
             RateEventContainer {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItemChanges.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItemChanges.java
@@ -44,9 +44,12 @@ public record DatasetItemChanges(
 
         @JsonView(DatasetItemChanges.View.Write.class) @Schema(description = "When true, clears the version-level execution policy (removes inherited policy from base version)") Boolean clearExecutionPolicy,
 
-        @JsonView(DatasetItemChanges.View.Write.class) @Schema(description = "OPIK-6696. Optional. Dataset to read carry-forward rows from when materializing the new version. Required together with copy_from_version_id. When both are set, the INSERT FROM SELECT that copies unchanged rows reads from this (dataset, version) pair instead of the destination dataset's prior version, avoiding the multi-replica read-after-write window. When null, the existing behavior applies (reads from the destination's prior version).") UUID copyFromDatasetId,
+        // OPIK-6696: when both copy_from_* coordinates are set, the INSERT FROM SELECT that copies
+        // unchanged rows reads from this (dataset, version) pair instead of the destination dataset's
+        // prior version, avoiding the multi-replica read-after-write window.
+        @JsonView(DatasetItemChanges.View.Write.class) @Schema(description = "Optional. Dataset to read carry-forward rows from when materializing the new version. Required together with copy_from_version_id. When null, carry-forward rows are read from the destination dataset's prior version.") UUID copyFromDatasetId,
 
-        @JsonView(DatasetItemChanges.View.Write.class) @Schema(description = "OPIK-6696. Optional. Version within copy_from_dataset_id to read carry-forward rows from. Required together with copy_from_dataset_id.") UUID copyFromVersionId) {
+        @JsonView(DatasetItemChanges.View.Write.class) @Schema(description = "Optional. Version within copy_from_dataset_id to read carry-forward rows from. Required together with copy_from_dataset_id.") UUID copyFromVersionId) {
 
     public static class View {
         public static class Write {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItemChanges.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItemChanges.java
@@ -42,7 +42,11 @@ public record DatasetItemChanges(
 
         @JsonView(DatasetItemChanges.View.Write.class) @Valid @Schema(description = "Optional default execution policy for items in this version") ExecutionPolicy executionPolicy,
 
-        @JsonView(DatasetItemChanges.View.Write.class) @Schema(description = "When true, clears the version-level execution policy (removes inherited policy from base version)") Boolean clearExecutionPolicy) {
+        @JsonView(DatasetItemChanges.View.Write.class) @Schema(description = "When true, clears the version-level execution policy (removes inherited policy from base version)") Boolean clearExecutionPolicy,
+
+        @JsonView(DatasetItemChanges.View.Write.class) @Schema(description = "OPIK-6696. Optional. Dataset to read carry-forward rows from when materializing the new version. Required together with copy_from_version_id. When both are set, the INSERT FROM SELECT that copies unchanged rows reads from this (dataset, version) pair instead of the destination dataset's prior version, avoiding the multi-replica read-after-write window. When null, the existing behavior applies (reads from the destination's prior version).") UUID copyFromDatasetId,
+
+        @JsonView(DatasetItemChanges.View.Write.class) @Schema(description = "OPIK-6696. Optional. Version within copy_from_dataset_id to read carry-forward rows from. Required together with copy_from_dataset_id.") UUID copyFromVersionId) {
 
     public static class View {
         public static class Write {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
@@ -488,9 +488,11 @@ public class DatasetsResource {
         }
     }
 
-    // OPIK-6696: the copy_from_* coordinates let callers pin the carry-forward read source to a
-    // specific (dataset, version) pair, avoiding the multi-replica read-after-write window when
-    // chaining version writes against a destination that may not have replicated yet.
+    /**
+     * OPIK-6696: the copy_from_* coordinates let callers pin the carry-forward read source to a
+     * specific (dataset, version) pair, avoiding the multi-replica read-after-write window when
+     * chaining version writes against a destination that may not have replicated yet.
+     */
     @PUT
     @Path("/items")
     @Operation(operationId = "createOrUpdateDatasetItems", summary = "Create/update dataset items", description = """
@@ -617,9 +619,11 @@ public class DatasetsResource {
         return Response.status(Response.Status.ACCEPTED).build();
     }
 
-    // OPIK-6696: the copy_from_* coordinates let callers pin the carry-forward (and edit-via-SELECT-INSERT)
-    // read source to a specific (dataset, version) pair, avoiding the multi-replica read-after-write window
-    // when chaining version writes against a destination that may not have replicated yet.
+    /**
+     * OPIK-6696: the copy_from_* coordinates let callers pin the carry-forward (and edit-via-SELECT-INSERT)
+     * read source to a specific (dataset, version) pair, avoiding the multi-replica read-after-write window
+     * when chaining version writes against a destination that may not have replicated yet.
+     */
     @POST
     @Path("/{id}/items/changes")
     @Operation(operationId = "applyDatasetItemChanges", summary = "Apply changes to dataset items", description = """

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
@@ -488,6 +488,9 @@ public class DatasetsResource {
         }
     }
 
+    // OPIK-6696: the copy_from_* coordinates let callers pin the carry-forward read source to a
+    // specific (dataset, version) pair, avoiding the multi-replica read-after-write window when
+    // chaining version writes against a destination that may not have replicated yet.
     @PUT
     @Path("/items")
     @Operation(operationId = "createOrUpdateDatasetItems", summary = "Create/update dataset items", description = """
@@ -495,11 +498,9 @@ public class DatasetsResource {
             Each item's 'id' field is the stable identifier and upsert key.
             Provide it to update an existing item, or omit it to create a new one.
 
-            OPIK-6696: set 'copy_from_dataset_id' and 'copy_from_version_id' together to read carry-forward
-            rows from the supplied (dataset, version) pair instead of the destination's prior version.
-            This avoids the multi-replica read-after-write window when chaining version writes against a
-            destination that may not have replicated yet. When the fields are null, the existing behavior
-            applies (carry-forward reads from the destination's prior version).""", responses = {
+            Set 'copy_from_dataset_id' and 'copy_from_version_id' together to read carry-forward rows
+            from the supplied (dataset, version) pair instead of the destination's prior version. When
+            the fields are null, carry-forward rows are read from the destination's prior version.""", responses = {
             @ApiResponse(responseCode = "204", description = "No content"),
     })
     @RateLimited
@@ -616,6 +617,9 @@ public class DatasetsResource {
         return Response.status(Response.Status.ACCEPTED).build();
     }
 
+    // OPIK-6696: the copy_from_* coordinates let callers pin the carry-forward (and edit-via-SELECT-INSERT)
+    // read source to a specific (dataset, version) pair, avoiding the multi-replica read-after-write window
+    // when chaining version writes against a destination that may not have replicated yet.
     @POST
     @Path("/{id}/items/changes")
     @Operation(operationId = "applyDatasetItemChanges", summary = "Apply changes to dataset items", description = """
@@ -628,11 +632,10 @@ public class DatasetsResource {
 
             Use `override=true` query parameter to force version creation even with stale baseVersion.
 
-            OPIK-6696: set 'copy_from_dataset_id' and 'copy_from_version_id' together on the request body
-            to read carry-forward rows (and the edit-via-SELECT-INSERT source rows) from the supplied
-            (dataset, version) pair instead of the destination's prior version. This avoids the
-            multi-replica read-after-write window when chaining version writes against a destination that
-            may not have replicated yet. When the fields are null, the existing behavior applies.
+            Set 'copy_from_dataset_id' and 'copy_from_version_id' together on the request body to read
+            carry-forward rows from the supplied (dataset, version) pair instead of the destination's
+            prior version. When the fields are null, carry-forward rows are read from the destination's
+            prior version.
             """, responses = {
             @ApiResponse(responseCode = "201", description = "Version created successfully", content = @Content(schema = @Schema(implementation = DatasetVersion.class))),
             @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
@@ -493,7 +493,11 @@ public class DatasetsResource {
     @Operation(operationId = "createOrUpdateDatasetItems", summary = "Create/update dataset items", description = """
             Create/update dataset items based on dataset item id.
             Each item's 'id' field is the stable identifier and upsert key.
-            Provide it to update an existing item, or omit it to create a new one.""", responses = {
+            Provide it to update an existing item, or omit it to create a new one.
+
+            Set 'snapshot' to true to make the new version's row set equal exactly the items in the
+            request payload. Items absent from the payload are absent from the new version (implicit
+            deletion). Requires 'batch_group_id' to be set.""", responses = {
             @ApiResponse(responseCode = "204", description = "No content"),
     })
     @RateLimited

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetsResource.java
@@ -495,9 +495,11 @@ public class DatasetsResource {
             Each item's 'id' field is the stable identifier and upsert key.
             Provide it to update an existing item, or omit it to create a new one.
 
-            Set 'snapshot' to true to make the new version's row set equal exactly the items in the
-            request payload. Items absent from the payload are absent from the new version (implicit
-            deletion). Requires 'batch_group_id' to be set.""", responses = {
+            OPIK-6696: set 'copy_from_dataset_id' and 'copy_from_version_id' together to read carry-forward
+            rows from the supplied (dataset, version) pair instead of the destination's prior version.
+            This avoids the multi-replica read-after-write window when chaining version writes against a
+            destination that may not have replicated yet. When the fields are null, the existing behavior
+            applies (carry-forward reads from the destination's prior version).""", responses = {
             @ApiResponse(responseCode = "204", description = "No content"),
     })
     @RateLimited
@@ -625,6 +627,12 @@ public class DatasetsResource {
             - Returns 409 Conflict if baseVersion is stale and override is not set
 
             Use `override=true` query parameter to force version creation even with stale baseVersion.
+
+            OPIK-6696: set 'copy_from_dataset_id' and 'copy_from_version_id' together on the request body
+            to read carry-forward rows (and the edit-via-SELECT-INSERT source rows) from the supplied
+            (dataset, version) pair instead of the destination's prior version. This avoids the
+            multi-replica read-after-write window when chaining version writes against a destination that
+            may not have replicated yet. When the fields are null, the existing behavior applies.
             """, responses = {
             @ApiResponse(responseCode = "201", description = "Version created successfully", content = @Content(schema = @Schema(implementation = DatasetVersion.class))),
             @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/DatasetItemBatchValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/DatasetItemBatchValidator.java
@@ -8,6 +8,21 @@ public class DatasetItemBatchValidator implements ConstraintValidator<DatasetIte
 
     @Override
     public boolean isValid(DatasetItemBatch datasetItemBatch, ConstraintValidatorContext context) {
-        return datasetItemBatch.datasetName() != null || datasetItemBatch.datasetId() != null;
+        if (datasetItemBatch.datasetName() == null && datasetItemBatch.datasetId() == null) {
+            return false;
+        }
+
+        // OPIK-6696: copy_from_dataset_id and copy_from_version_id must be set together (or both null).
+        boolean hasCopyFromDataset = datasetItemBatch.copyFromDatasetId() != null;
+        boolean hasCopyFromVersion = datasetItemBatch.copyFromVersionId() != null;
+        if (hasCopyFromDataset != hasCopyFromVersion) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(
+                    "copy_from_dataset_id and copy_from_version_id must be provided together")
+                    .addConstraintViolation();
+            return false;
+        }
+
+        return true;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/DatasetItemBatchValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/DatasetItemBatchValidator.java
@@ -4,7 +4,17 @@ import com.comet.opik.api.DatasetItemBatch;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
+import java.util.UUID;
+
 public class DatasetItemBatchValidator implements ConstraintValidator<DatasetItemBatchValidation, DatasetItemBatch> {
+
+    // OPIK-6696: shared by every endpoint accepting copy_from coordinates so the rule and its error
+    // text stay in sync. The DatasetItemChanges endpoint validates the same pair in the service layer.
+    public static final String COPY_FROM_PAIR_MESSAGE = "copy_from_dataset_id and copy_from_version_id must be provided together";
+
+    public static boolean isCopyFromPairConsistent(UUID copyFromDatasetId, UUID copyFromVersionId) {
+        return (copyFromDatasetId == null) == (copyFromVersionId == null);
+    }
 
     @Override
     public boolean isValid(DatasetItemBatch datasetItemBatch, ConstraintValidatorContext context) {
@@ -12,13 +22,9 @@ public class DatasetItemBatchValidator implements ConstraintValidator<DatasetIte
             return false;
         }
 
-        // OPIK-6696: copy_from_dataset_id and copy_from_version_id must be set together (or both null).
-        boolean hasCopyFromDataset = datasetItemBatch.copyFromDatasetId() != null;
-        boolean hasCopyFromVersion = datasetItemBatch.copyFromVersionId() != null;
-        if (hasCopyFromDataset != hasCopyFromVersion) {
+        if (!isCopyFromPairConsistent(datasetItemBatch.copyFromDatasetId(), datasetItemBatch.copyFromVersionId())) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(
-                    "copy_from_dataset_id and copy_from_version_id must be provided together")
+            context.buildConstraintViolationWithTemplate(COPY_FROM_PAIR_MESSAGE)
                     .addConstraintViolation();
             return false;
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1621,6 +1621,22 @@ class DatasetItemServiceImpl implements DatasetItemService {
             return validateSpans(workspaceId, normalizedItems)
                     .then(validateTraces(workspaceId, normalizedItems))
                     .then(Mono.defer(() -> {
+                        // OPIK-6696: snapshot mode skips the classification SELECT against the
+                        // destination version (subject to multi-replica read-after-write). All
+                        // payload rows are counted as "added"; callers in snapshot mode are
+                        // expected not to re-submit the same stable id within a batch group.
+                        if (Boolean.TRUE.equals(batch.snapshot())) {
+                            log.info("Inserting into version '{}' in snapshot mode: items='{}'",
+                                    versionId, normalizedItems.size());
+                            return versionDao
+                                    .insertItems(datasetId, versionId, normalizedItems, workspaceId, userName)
+                                    .then(Mono.fromCallable(() -> {
+                                        updateVersionCountsForInsert(versionId, workspaceId,
+                                                normalizedItems.size(), 0, userName);
+                                        return versionService.getVersionById(workspaceId, datasetId, versionId);
+                                    }).subscribeOn(Schedulers.boundedElastic()));
+                        }
+
                         // Get existing item IDs to determine which are new vs updates
                         return versionDao.getItemIdsAndHashes(datasetId, versionId)
                                 .collectList()
@@ -1760,8 +1776,16 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                     userName);
                         }
 
-                        // Versions exist - apply delta on top of the latest
                         UUID baseVersionId = latestVersion.get().id();
+
+                        // OPIK-6696: snapshot mode skips the INSERT FROM SELECT that copies unchanged
+                        // rows from baseVersionId. The new version's row set equals the payload exactly.
+                        if (Boolean.TRUE.equals(batch.snapshot())) {
+                            return createVersionAsSnapshot(datasetId, baseVersionId, validatedItems, batchGroupId,
+                                    workspaceId, userName);
+                        }
+
+                        // Versions exist - apply delta on top of the latest
                         return createVersionWithDelta(datasetId, baseVersionId, validatedItems, batchGroupId,
                                 workspaceId, userName);
                     }));
@@ -1898,6 +1922,59 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                         workspaceId,
                                         userName);
                             });
+                });
+    }
+
+    // OPIK-6696: snapshot mode. The new version's row set equals exactly the payload.
+    // Unlike createVersionWithDelta, this skips:
+    //   - the getItemIdsAndHashes SELECT against baseVersionId (classification)
+    //   - applyDelta's copyUnchangedItems step (the INSERT FROM SELECT that suffers from
+    //     multi-replica read-after-write inconsistency described in OPIK-6601)
+    // Items absent from the payload are absent from the new version (implicit deletion).
+    private Mono<DatasetVersion> createVersionAsSnapshot(UUID datasetId, UUID baseVersionId,
+            List<DatasetItem> items, UUID batchGroupId, String workspaceId, String userName) {
+        log.info("Creating snapshot-mode version for dataset '{}', baseVersion '{}', itemCount '{}'",
+                datasetId, baseVersionId, items.size());
+
+        UUID newVersionId = idGenerator.generateId();
+
+        List<DatasetItem> snapshotItems = items.stream()
+                .map(item -> {
+                    UUID stableId = item.datasetItemId() != null
+                            ? item.datasetItemId()
+                            : (item.id() != null ? item.id() : idGenerator.generateId());
+                    return item.toBuilder()
+                            .datasetItemId(stableId)
+                            .datasetId(datasetId)
+                            .build();
+                })
+                .toList();
+
+        List<UUID> rowIds = generateUuidPool(idGenerator, snapshotItems.size());
+        List<DatasetItem> itemsWithRowIds = withAssignedRowIds(snapshotItems, rowIds);
+
+        return versionDao.insertItems(datasetId, newVersionId, itemsWithRowIds, workspaceId, userName)
+                .flatMap(itemsTotal -> {
+                    log.info("Inserted '{}' snapshot items for dataset '{}', new version '{}'",
+                            itemsTotal, datasetId, newVersionId);
+
+                    String changeDescription = batchGroupId != null
+                            ? "Auto-created from SDK batch operation"
+                            : null;
+
+                    return createVersionFromDelta(
+                            datasetId,
+                            newVersionId,
+                            itemsTotal.intValue(),
+                            baseVersionId,
+                            null, // No tags
+                            changeDescription,
+                            null, // Inherit evaluators from base version
+                            null, // Inherit execution policy from base version
+                            false, // Don't clear execution policy
+                            batchGroupId,
+                            workspaceId,
+                            userName);
                 });
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -22,6 +22,7 @@ import com.comet.opik.api.error.IdentifierMismatchException;
 import com.comet.opik.api.filter.DatasetItemFilter;
 import com.comet.opik.api.filter.ExperimentsComparisonFilter;
 import com.comet.opik.api.sorting.SortingFactoryDatasets;
+import com.comet.opik.api.validation.DatasetItemBatchValidator;
 import com.comet.opik.infrastructure.FeatureFlags;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
@@ -1370,10 +1371,11 @@ class DatasetItemServiceImpl implements DatasetItemService {
             log.info("Applying delta changes for dataset '{}', baseVersion '{}', override '{}'",
                     datasetId, changes.baseVersion(), override);
 
-            // OPIK-6696: copy_from_dataset_id and copy_from_version_id must be set together.
-            if ((changes.copyFromDatasetId() == null) != (changes.copyFromVersionId() == null)) {
-                return Mono.error(new BadRequestException(
-                        "copy_from_dataset_id and copy_from_version_id must be provided together"));
+            // OPIK-6696: copy_from_dataset_id and copy_from_version_id must be set together. Shares the
+            // rule and error text with DatasetItemBatchValidator (the DatasetItemBatch endpoint).
+            if (!DatasetItemBatchValidator.isCopyFromPairConsistent(changes.copyFromDatasetId(),
+                    changes.copyFromVersionId())) {
+                return Mono.error(new BadRequestException(DatasetItemBatchValidator.COPY_FROM_PAIR_MESSAGE));
             }
 
             // Verify dataset exists (using explicit workspaceId since we're in reactive context)
@@ -1449,19 +1451,10 @@ class DatasetItemServiceImpl implements DatasetItemService {
             // caller supplied instead of the destination's just-minted prior version. For migrate
             // this is source v_i — stable and fully replicated, avoiding the multi-replica
             // read-after-write window.
-            UUID copyDatasetId = changes.copyFromDatasetId() != null ? changes.copyFromDatasetId() : datasetId;
-            UUID copyVersionId = changes.copyFromVersionId() != null ? changes.copyFromVersionId() : baseVersionId;
-
-            // Validate caller-supplied copy-from coords resolve to a real (workspace-scoped) version
-            // on the named dataset. Without this, a bogus or cross-workspace pair would silently
-            // produce a new version with zero carry-forwards instead of returning an error.
-            if (changes.copyFromDatasetId() != null) {
-                DatasetVersion sourceVersion = versionService.getVersionById(workspaceId, copyDatasetId, copyVersionId);
-                if (!sourceVersion.datasetId().equals(copyDatasetId)) {
-                    return Mono.error(new NotFoundException(
-                            "Version '%s' does not belong to dataset '%s'".formatted(copyVersionId, copyDatasetId)));
-                }
-            }
+            CopyFromCoordinates copyFrom = resolveAndValidateCopyFrom(workspaceId, changes.copyFromDatasetId(),
+                    changes.copyFromVersionId(), datasetId, baseVersionId);
+            UUID copyDatasetId = copyFrom.datasetId();
+            UUID copyVersionId = copyFrom.versionId();
 
             // OPIK-6390: size the unchanged-UUID pool from a live ClickHouse count instead of the
             // MySQL items_total, which can drift below the actual row count and silently truncate
@@ -1846,6 +1839,30 @@ class DatasetItemServiceImpl implements DatasetItemService {
                 });
     }
 
+    private record CopyFromCoordinates(UUID datasetId, UUID versionId) {
+    }
+
+    // OPIK-6696: resolves the source the carry-forward COPY (and supporting reads) runs against — the
+    // caller-supplied (dataset, version) pair when provided, otherwise the destination's prior version.
+    // When the caller supplies coordinates, validates they resolve to a real workspace-scoped version on
+    // the named dataset, throwing NotFound otherwise — without this a bogus or cross-workspace pair would
+    // silently produce a version with all incoming items classified as adds and zero carry-forwards.
+    private CopyFromCoordinates resolveAndValidateCopyFrom(String workspaceId, UUID copyFromDatasetId,
+            UUID copyFromVersionId, UUID fallbackDatasetId, UUID fallbackVersionId) {
+
+        if (copyFromDatasetId == null) {
+            return new CopyFromCoordinates(fallbackDatasetId, fallbackVersionId);
+        }
+
+        DatasetVersion sourceVersion = versionService.getVersionById(workspaceId, copyFromDatasetId,
+                copyFromVersionId);
+        if (!sourceVersion.datasetId().equals(copyFromDatasetId)) {
+            throw new NotFoundException(
+                    "Version '%s' does not belong to dataset '%s'".formatted(copyFromVersionId, copyFromDatasetId));
+        }
+        return new CopyFromCoordinates(copyFromDatasetId, copyFromVersionId);
+    }
+
     private Mono<DatasetVersion> createVersionWithDelta(UUID datasetId, UUID baseVersionId,
             List<DatasetItem> items, UUID batchGroupId, String workspaceId, String userName,
             UUID copyFromDatasetId, UUID copyFromVersionId) {
@@ -1854,20 +1871,10 @@ class DatasetItemServiceImpl implements DatasetItemService {
         // classification SELECT both read from that (dataset, version) pair instead of the
         // destination's just-minted prior version. For migrate this is source v_i — stable, fully
         // replicated, free of the multi-replica read-after-write window.
-        UUID copyDatasetId = copyFromDatasetId != null ? copyFromDatasetId : datasetId;
-        UUID copyVersionId = copyFromVersionId != null ? copyFromVersionId : baseVersionId;
-
-        // Validate caller-supplied copy-from coords resolve to a real (workspace-scoped) version
-        // on the named dataset. Without this, a bogus or cross-workspace pair would silently produce
-        // a new version with all incoming items classified as adds (the classification SELECT would
-        // return empty) and no carry-forwards (the COPY would also return empty).
-        if (copyFromDatasetId != null) {
-            DatasetVersion sourceVersion = versionService.getVersionById(workspaceId, copyDatasetId, copyVersionId);
-            if (!sourceVersion.datasetId().equals(copyDatasetId)) {
-                return Mono.error(new NotFoundException(
-                        "Version '%s' does not belong to dataset '%s'".formatted(copyVersionId, copyDatasetId)));
-            }
-        }
+        CopyFromCoordinates copyFrom = resolveAndValidateCopyFrom(workspaceId, copyFromDatasetId, copyFromVersionId,
+                datasetId, baseVersionId);
+        UUID copyDatasetId = copyFrom.datasetId();
+        UUID copyVersionId = copyFrom.versionId();
 
         log.info(
                 "Creating version with delta for dataset '{}', baseVersion '{}', itemCount '{}', copyFromDatasetId '{}', copyFromVersionId '{}'",

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -679,7 +679,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                                         // Copy unchanged items using copyVersionItems (exclude matching filters)
                                                         return versionDao
                                                                 .copyVersionItems(datasetId, baseVersionId,
-                                                                        newVersionId,
+                                                                        datasetId, newVersionId,
                                                                         batchUpdate.filters(), copyUuids)
                                                                 .flatMap(unchangedCount -> createVersionMetadata(
                                                                         datasetId, newVersionId, baseVersionId,
@@ -1039,7 +1039,8 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                     List<UUID> uuids = generateUuidPool(idGenerator, baseItemsCount);
 
                                     // Use efficient filter-based copy - copies items NOT matching the filters
-                                    copyMono = versionDao.copyVersionItems(datasetId, baseVersionId, newVersionId,
+                                    copyMono = versionDao.copyVersionItems(datasetId, baseVersionId,
+                                            datasetId, newVersionId,
                                             filters, uuids);
                                 }
 
@@ -1369,6 +1370,12 @@ class DatasetItemServiceImpl implements DatasetItemService {
             log.info("Applying delta changes for dataset '{}', baseVersion '{}', override '{}'",
                     datasetId, changes.baseVersion(), override);
 
+            // OPIK-6696: copy_from_dataset_id and copy_from_version_id must be set together.
+            if ((changes.copyFromDatasetId() == null) != (changes.copyFromVersionId() == null)) {
+                return Mono.error(new BadRequestException(
+                        "copy_from_dataset_id and copy_from_version_id must be provided together"));
+            }
+
             // Verify dataset exists (using explicit workspaceId since we're in reactive context)
             datasetService.findById(datasetId, workspaceId, null);
 
@@ -1437,13 +1444,21 @@ class DatasetItemServiceImpl implements DatasetItemService {
                     .filter(Objects::nonNull)
                     .collect(Collectors.toSet());
 
+            // OPIK-6696: when copy-from coordinates are supplied, the COPY (and supporting reads:
+            // pool sizing, edit-via-SELECT-INSERT) all run against the (dataset, version) pair the
+            // caller supplied instead of the destination's just-minted prior version. For migrate
+            // this is source v_i — stable and fully replicated, avoiding the multi-replica
+            // read-after-write window.
+            UUID copyDatasetId = changes.copyFromDatasetId() != null ? changes.copyFromDatasetId() : datasetId;
+            UUID copyVersionId = changes.copyFromVersionId() != null ? changes.copyFromVersionId() : baseVersionId;
+
             // OPIK-6390: size the unchanged-UUID pool from a live ClickHouse count instead of the
             // MySQL items_total, which can drift below the actual row count and silently truncate
             // the copy. Excludes the same ids the subsequent applyDelta excludes from the COPY.
             Set<UUID> excludedFromCopy = new HashSet<>(deletedIds);
             excludedFromCopy.addAll(editedDatasetItemIds);
 
-            return versionDao.countRowsInVersion(datasetId, baseVersionId, excludedFromCopy, null, workspaceId)
+            return versionDao.countRowsInVersion(copyDatasetId, copyVersionId, excludedFromCopy, null, workspaceId)
                     .flatMap(unchangedCount -> {
 
                         // Generate UUIDs for all items in the correct order for ClickHouse's ORDER BY id DESC
@@ -1474,16 +1489,19 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                                     .build());
                                 });
 
-                        // Edit items via INSERT...SELECT (merge happens in SQL, not Java)
+                        // Edit items via INSERT...SELECT (merge happens in SQL, not Java).
+                        // OPIK-6696: reads source rows from copy-from coords, inserts into datasetId.
                         Mono<Long> editedCountMono = versionDao.editItemsViaSelectInsert(
-                                datasetId, baseVersionId, newVersionId,
+                                copyDatasetId, copyVersionId,
+                                datasetId, newVersionId,
                                 editedItemEdits, editedUuids);
 
-                        // Apply delta for added items + copy unchanged (exclude edited + deleted)
+                        // Apply delta for added items + copy unchanged (exclude edited + deleted).
+                        // OPIK-6696: COPY reads from copy-from coords, writes into datasetId/newVersionId.
                         return editedCountMono
-                                .flatMap(editedCount -> versionDao.applyDelta(datasetId, baseVersionId, newVersionId,
+                                .flatMap(editedCount -> versionDao.applyDelta(datasetId, newVersionId,
                                         addedItemsWithIds, List.of(), deletedIds, unchangedUuids,
-                                        editedDatasetItemIds)
+                                        editedDatasetItemIds, copyDatasetId, copyVersionId)
                                         .map(otherCount -> editedCount + otherCount))
                                 .flatMap(itemsTotal -> {
                                     log.info("Applied delta to dataset '{}': itemsTotal '{}'", datasetId, itemsTotal);
@@ -1621,22 +1639,6 @@ class DatasetItemServiceImpl implements DatasetItemService {
             return validateSpans(workspaceId, normalizedItems)
                     .then(validateTraces(workspaceId, normalizedItems))
                     .then(Mono.defer(() -> {
-                        // OPIK-6696: snapshot mode skips the classification SELECT against the
-                        // destination version (subject to multi-replica read-after-write). All
-                        // payload rows are counted as "added"; callers in snapshot mode are
-                        // expected not to re-submit the same stable id within a batch group.
-                        if (Boolean.TRUE.equals(batch.snapshot())) {
-                            log.info("Inserting into version '{}' in snapshot mode: items='{}'",
-                                    versionId, normalizedItems.size());
-                            return versionDao
-                                    .insertItems(datasetId, versionId, normalizedItems, workspaceId, userName)
-                                    .then(Mono.fromCallable(() -> {
-                                        updateVersionCountsForInsert(versionId, workspaceId,
-                                                normalizedItems.size(), 0, userName);
-                                        return versionService.getVersionById(workspaceId, datasetId, versionId);
-                                    }).subscribeOn(Schedulers.boundedElastic()));
-                        }
-
                         // Get existing item IDs to determine which are new vs updates
                         return versionDao.getItemIdsAndHashes(datasetId, versionId)
                                 .collectList()
@@ -1776,18 +1778,12 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                     userName);
                         }
 
+                        // Versions exist - apply delta on top of the latest. OPIK-6696: if the caller
+                        // supplied copy-from coordinates, the COPY of unchanged rows will read from that
+                        // (dataset, version) pair instead of the destination's just-minted prior version.
                         UUID baseVersionId = latestVersion.get().id();
-
-                        // OPIK-6696: snapshot mode skips the INSERT FROM SELECT that copies unchanged
-                        // rows from baseVersionId. The new version's row set equals the payload exactly.
-                        if (Boolean.TRUE.equals(batch.snapshot())) {
-                            return createVersionAsSnapshot(datasetId, baseVersionId, validatedItems, batchGroupId,
-                                    workspaceId, userName);
-                        }
-
-                        // Versions exist - apply delta on top of the latest
                         return createVersionWithDelta(datasetId, baseVersionId, validatedItems, batchGroupId,
-                                workspaceId, userName);
+                                workspaceId, userName, batch.copyFromDatasetId(), batch.copyFromVersionId());
                     }));
         });
     }
@@ -1840,14 +1836,24 @@ class DatasetItemServiceImpl implements DatasetItemService {
     }
 
     private Mono<DatasetVersion> createVersionWithDelta(UUID datasetId, UUID baseVersionId,
-            List<DatasetItem> items, UUID batchGroupId, String workspaceId, String userName) {
-        log.info("Creating version with delta for dataset '{}', baseVersion '{}', itemCount '{}'",
-                datasetId, baseVersionId, items.size());
+            List<DatasetItem> items, UUID batchGroupId, String workspaceId, String userName,
+            UUID copyFromDatasetId, UUID copyFromVersionId) {
+
+        // OPIK-6696: when copy-from coordinates are supplied, the COPY of unchanged rows and the
+        // classification SELECT both read from that (dataset, version) pair instead of the
+        // destination's just-minted prior version. For migrate this is source v_i — stable, fully
+        // replicated, free of the multi-replica read-after-write window.
+        UUID copyDatasetId = copyFromDatasetId != null ? copyFromDatasetId : datasetId;
+        UUID copyVersionId = copyFromVersionId != null ? copyFromVersionId : baseVersionId;
+
+        log.info(
+                "Creating version with delta for dataset '{}', baseVersion '{}', itemCount '{}', copyFromDatasetId '{}', copyFromVersionId '{}'",
+                datasetId, baseVersionId, items.size(), copyDatasetId, copyVersionId);
 
         UUID newVersionId = idGenerator.generateId();
 
-        // Get existing item IDs from the base version to determine adds vs edits
-        return versionDao.getItemIdsAndHashes(datasetId, baseVersionId)
+        // Get existing item IDs from the copy-from version to determine adds vs edits
+        return versionDao.getItemIdsAndHashes(copyDatasetId, copyVersionId)
                 .collectList()
                 .flatMap(existingItems -> {
                     Set<UUID> existingItemIds = existingItems.stream()
@@ -1880,7 +1886,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                     log.info("Classified items: added='{}', edited='{}' for dataset '{}'",
                             addedItems.size(), editedItems.size(), datasetId);
 
-                    // Calculate unchanged items: items in base version that are NOT being edited
+                    // Calculate unchanged items: items in copy-from version that are NOT being edited
                     Set<UUID> editedItemIds = editedItems.stream()
                             .map(DatasetItem::datasetItemId)
                             .collect(Collectors.toSet());
@@ -1895,10 +1901,10 @@ class DatasetItemServiceImpl implements DatasetItemService {
                     // Assign row IDs to added items
                     List<DatasetItem> addedItemsWithIds = withAssignedRowIds(addedItems, addedUuids);
 
-                    // Apply delta changes - no deletions in PUT flow
-                    return versionDao.applyDelta(datasetId, baseVersionId, newVersionId,
+                    // Apply delta changes - no deletions in PUT flow. COPY reads from copy-from coords.
+                    return versionDao.applyDelta(datasetId, newVersionId,
                             addedItemsWithIds, editedItems, Set.of(), unchangedUuids,
-                            Set.of())
+                            Set.of(), copyDatasetId, copyVersionId)
                             .flatMap(itemsTotal -> {
                                 log.info("Applied delta to dataset '{}': itemsTotal '{}'", datasetId, itemsTotal);
 
@@ -1922,59 +1928,6 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                         workspaceId,
                                         userName);
                             });
-                });
-    }
-
-    // OPIK-6696: snapshot mode. The new version's row set equals exactly the payload.
-    // Unlike createVersionWithDelta, this skips:
-    //   - the getItemIdsAndHashes SELECT against baseVersionId (classification)
-    //   - applyDelta's copyUnchangedItems step (the INSERT FROM SELECT that suffers from
-    //     multi-replica read-after-write inconsistency described in OPIK-6601)
-    // Items absent from the payload are absent from the new version (implicit deletion).
-    private Mono<DatasetVersion> createVersionAsSnapshot(UUID datasetId, UUID baseVersionId,
-            List<DatasetItem> items, UUID batchGroupId, String workspaceId, String userName) {
-        log.info("Creating snapshot-mode version for dataset '{}', baseVersion '{}', itemCount '{}'",
-                datasetId, baseVersionId, items.size());
-
-        UUID newVersionId = idGenerator.generateId();
-
-        List<DatasetItem> snapshotItems = items.stream()
-                .map(item -> {
-                    UUID stableId = item.datasetItemId() != null
-                            ? item.datasetItemId()
-                            : (item.id() != null ? item.id() : idGenerator.generateId());
-                    return item.toBuilder()
-                            .datasetItemId(stableId)
-                            .datasetId(datasetId)
-                            .build();
-                })
-                .toList();
-
-        List<UUID> rowIds = generateUuidPool(idGenerator, snapshotItems.size());
-        List<DatasetItem> itemsWithRowIds = withAssignedRowIds(snapshotItems, rowIds);
-
-        return versionDao.insertItems(datasetId, newVersionId, itemsWithRowIds, workspaceId, userName)
-                .flatMap(itemsTotal -> {
-                    log.info("Inserted '{}' snapshot items for dataset '{}', new version '{}'",
-                            itemsTotal, datasetId, newVersionId);
-
-                    String changeDescription = batchGroupId != null
-                            ? "Auto-created from SDK batch operation"
-                            : null;
-
-                    return createVersionFromDelta(
-                            datasetId,
-                            newVersionId,
-                            itemsTotal.intValue(),
-                            baseVersionId,
-                            null, // No tags
-                            changeDescription,
-                            null, // Inherit evaluators from base version
-                            null, // Inherit execution policy from base version
-                            false, // Don't clear execution policy
-                            batchGroupId,
-                            workspaceId,
-                            userName);
                 });
     }
 
@@ -2074,12 +2027,14 @@ class DatasetItemServiceImpl implements DatasetItemService {
         return versionDao.countRowsInVersion(datasetId, baseVersionId, excludedFromCopy, null, workspaceId)
                 .flatMap(unchangedCount -> {
                     List<UUID> unchangedUuids = generateUnchangedUuidsReversed(unchangedCount.intValue());
-                    return versionDao.applyDelta(datasetId, baseVersionId, newVersionId,
+                    // Same-dataset copy (no copy-from override) — source = target = (datasetId, baseVersionId).
+                    return versionDao.applyDelta(datasetId, newVersionId,
                             List.of(), // no added items in this flow
                             editedItems,
                             deletedIds,
                             unchangedUuids,
-                            Set.of());
+                            Set.of(),
+                            datasetId, baseVersionId);
                 });
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1452,6 +1452,17 @@ class DatasetItemServiceImpl implements DatasetItemService {
             UUID copyDatasetId = changes.copyFromDatasetId() != null ? changes.copyFromDatasetId() : datasetId;
             UUID copyVersionId = changes.copyFromVersionId() != null ? changes.copyFromVersionId() : baseVersionId;
 
+            // Validate caller-supplied copy-from coords resolve to a real (workspace-scoped) version
+            // on the named dataset. Without this, a bogus or cross-workspace pair would silently
+            // produce a new version with zero carry-forwards instead of returning an error.
+            if (changes.copyFromDatasetId() != null) {
+                DatasetVersion sourceVersion = versionService.getVersionById(workspaceId, copyDatasetId, copyVersionId);
+                if (!sourceVersion.datasetId().equals(copyDatasetId)) {
+                    return Mono.error(new NotFoundException(
+                            "Version '%s' does not belong to dataset '%s'".formatted(copyVersionId, copyDatasetId)));
+                }
+            }
+
             // OPIK-6390: size the unchanged-UUID pool from a live ClickHouse count instead of the
             // MySQL items_total, which can drift below the actual row count and silently truncate
             // the copy. Excludes the same ids the subsequent applyDelta excludes from the COPY.
@@ -1845,6 +1856,18 @@ class DatasetItemServiceImpl implements DatasetItemService {
         // replicated, free of the multi-replica read-after-write window.
         UUID copyDatasetId = copyFromDatasetId != null ? copyFromDatasetId : datasetId;
         UUID copyVersionId = copyFromVersionId != null ? copyFromVersionId : baseVersionId;
+
+        // Validate caller-supplied copy-from coords resolve to a real (workspace-scoped) version
+        // on the named dataset. Without this, a bogus or cross-workspace pair would silently produce
+        // a new version with all incoming items classified as adds (the classification SELECT would
+        // return empty) and no carry-forwards (the COPY would also return empty).
+        if (copyFromDatasetId != null) {
+            DatasetVersion sourceVersion = versionService.getVersionById(workspaceId, copyDatasetId, copyVersionId);
+            if (!sourceVersion.datasetId().equals(copyDatasetId)) {
+                return Mono.error(new NotFoundException(
+                        "Version '%s' does not belong to dataset '%s'".formatted(copyVersionId, copyDatasetId)));
+            }
+        }
 
         log.info(
                 "Creating version with delta for dataset '{}', baseVersion '{}', itemCount '{}', copyFromDatasetId '{}', copyFromVersionId '{}'",

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -3039,7 +3039,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             @NonNull UUID targetDatasetId, @NonNull UUID targetVersionId,
             List<DatasetItemFilter> excludeFilters, @NonNull List<UUID> uuids) {
 
-        log.info(
+        log.debug(
                 "Copying items from (dataset '{}', version '{}') to (dataset '{}', version '{}'), excludeFilters='{}', uuidPoolSize='{}'",
                 sourceDatasetId, sourceVersionId, targetDatasetId, targetVersionId,
                 excludeFilters != null ? excludeFilters.size() : 0, uuids.size());
@@ -3084,7 +3084,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                 return Flux.from(statement.execute())
                         .flatMap(Result::getRowsUpdated)
                         .reduce(0L, Long::sum)
-                        .doOnSuccess(copiedCount -> log.info(
+                        .doOnSuccess(copiedCount -> log.debug(
                                 "Copied '{}' items from (dataset '{}', version '{}') to (dataset '{}', version '{}')",
                                 copiedCount, sourceDatasetId, sourceVersionId, targetDatasetId, targetVersionId))
                         .doFinally(signalType -> endSegment(segment));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -1822,6 +1822,9 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     SETTINGS short_circuit_function_evaluation = 'force_enable'
                     """;
 
+    // OPIK-6696: the inserted rows carry :targetDatasetId, not the source's dataset_id. This supports
+    // cross-dataset edit-via-SELECT-INSERT where the read source (:sourceDatasetId) differs from the
+    // destination dataset.
     private static final String EDIT_ITEM_VIA_SELECT_INSERT = """
             INSERT INTO dataset_item_versions (
                 id,
@@ -1850,7 +1853,6 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             SELECT
                 :newId as id,
                 src.dataset_item_id,
-                -- OPIK-6696: target dataset_id, not source's (cross-dataset edit-via-SELECT-INSERT)
                 :targetDatasetId as dataset_id,
                 :newVersionId as dataset_version_id,
                 <if(data)> mapFromArrays(:data_keys, :data_values) <else> src.data <endif> as data,
@@ -1903,6 +1905,12 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
     //     and items disappeared silently. The fallback UUIDv7 preserves insert atomicity at the
     //     cost of putting overflowing rows ahead of added/edited rows in id-desc order — a
     //     visible-but-non-destructive degradation only reached if the pool is undersized.
+    //
+    // OPIK-6696:
+    //   - the inserted rows carry :targetDatasetId, not the source's dataset_id. When
+    //     copy_from_dataset_id differs from the destination, the read source is a different dataset
+    //     (e.g. migrate replay reads from the source workspace's dataset and writes into the
+    //     destination workspace's dataset), so the inserted rows must carry the destination dataset_id.
     private static final String COPY_VERSION_ITEMS = """
             INSERT INTO dataset_item_versions (
                 id,
@@ -1933,10 +1941,6 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                    arrayElement(:uuids, src.rn),
                    toString(generateUUIDv7())) AS id,
                 src.dataset_item_id,
-                -- OPIK-6696: target dataset_id, not source's. When copy_from_dataset_id differs from
-                -- the destination, the read source is a different dataset (e.g. migrate replay reads
-                -- from the source workspace's dataset and writes into the destination workspace's
-                -- dataset). The inserted rows must carry the destination dataset_id.
                 :targetDatasetId as dataset_id,
                 :targetVersionId as dataset_version_id,
                 src.data,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -97,13 +97,18 @@ public interface DatasetItemVersionDAO {
      * If excludeFilters is null or empty, all items are copied.
      *
      * @param datasetId the dataset ID
+     * @param sourceDatasetId the source dataset to copy rows from (typically equals targetDatasetId;
+     *                        OPIK-6696 allows them to differ when the caller wants to read carry-forward
+     *                        rows from a stable upstream dataset to avoid multi-replica read-after-write)
      * @param sourceVersionId the source version to copy from
+     * @param targetDatasetId the destination dataset (inserted rows carry this dataset_id, not source's)
      * @param targetVersionId the new version ID to copy to
      * @param excludeFilters optional filters to exclude items (null or empty = copy all)
      * @param uuids pre-generated UUIDv7 pool for the new item IDs (should be at least 2x expected item count)
      * @return the number of items copied
      */
-    Mono<Long> copyVersionItems(UUID datasetId, UUID sourceVersionId, UUID targetVersionId,
+    Mono<Long> copyVersionItems(UUID sourceDatasetId, UUID sourceVersionId,
+            UUID targetDatasetId, UUID targetVersionId,
             List<DatasetItemFilter> excludeFilters, List<UUID> uuids);
 
     /**
@@ -112,19 +117,34 @@ public interface DatasetItemVersionDAO {
      * Unchanged items will be copied with UUIDs from unchangedUuids.
      *
      * @param datasetId         Dataset ID
-     * @param baseVersionId     Base version ID to copy unchanged items from
+     * @param datasetId         Dataset whose versions are being mutated (destination)
      * @param newVersionId      New version ID to create
      * @param addedItems        Items to add (with id already set)
      * @param editedItems       Items to edit (with id already set)
      * @param deletedIds        Stable dataset_item_ids to delete
      * @param unchangedUuids    UUIDs to assign to unchanged items (pre-generated in correct order)
+     * @param additionalExcludeIds  Extra stable IDs to exclude from the copy (callers that ran a separate
+     *                              edit/insert step pass those IDs here)
+     * @param copyFromDatasetId Dataset to read carry-forward rows from. OPIK-6696: when this differs
+     *                          from {@code datasetId}, the COPY reads from a (typically stable) source
+     *                          version instead of the destination's just-minted prior version,
+     *                          avoiding the multi-replica read-after-write window.
+     * @param copyFromVersionId Version within {@code copyFromDatasetId} to read carry-forward rows from
      * @return Number of items in the new version
      */
-    Mono<Long> applyDelta(UUID datasetId, UUID baseVersionId, UUID newVersionId,
+    Mono<Long> applyDelta(UUID datasetId, UUID newVersionId,
             List<DatasetItem> addedItems, List<DatasetItem> editedItems, Set<UUID> deletedIds,
-            List<UUID> unchangedUuids, Set<UUID> additionalExcludeIds);
+            List<UUID> unchangedUuids, Set<UUID> additionalExcludeIds,
+            UUID copyFromDatasetId, UUID copyFromVersionId);
 
-    Mono<Long> editItemsViaSelectInsert(UUID datasetId, UUID baseVersionId, UUID newVersionId,
+    /**
+     * Edit items via INSERT...SELECT. Reads each item's base row from
+     * {@code (sourceDatasetId, sourceVersionId)} and inserts the edited row into
+     * {@code (targetDatasetId, newVersionId)}. OPIK-6696: source coords may point at a stable
+     * upstream version to avoid the destination's read-after-write window.
+     */
+    Mono<Long> editItemsViaSelectInsert(UUID sourceDatasetId, UUID sourceVersionId,
+            UUID targetDatasetId, UUID newVersionId,
             List<DatasetItemEdit> editedItems, List<UUID> newRowIds);
 
     /**
@@ -1830,7 +1850,8 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             SELECT
                 :newId as id,
                 src.dataset_item_id,
-                src.dataset_id,
+                -- OPIK-6696: target dataset_id, not source's (cross-dataset edit-via-SELECT-INSERT)
+                :targetDatasetId as dataset_id,
                 :newVersionId as dataset_version_id,
                 <if(data)> mapFromArrays(:data_keys, :data_values) <else> src.data <endif> as data,
                 <if(description)> :description <else> src.description <endif> as description,
@@ -1854,8 +1875,8 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                 SELECT *
                 FROM dataset_item_versions
                 WHERE workspace_id = :workspace_id
-                AND dataset_id = :datasetId
-                AND dataset_version_id = :baseVersionId
+                AND dataset_id = :sourceDatasetId
+                AND dataset_version_id = :sourceVersionId
                 AND dataset_item_id = :datasetItemId
                 ORDER by (workspace_id, dataset_id, dataset_version_id, id) DESC, last_updated_at DESC
                 LIMIT 1
@@ -1912,7 +1933,11 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                    arrayElement(:uuids, src.rn),
                    toString(generateUUIDv7())) AS id,
                 src.dataset_item_id,
-                src.dataset_id,
+                -- OPIK-6696: target dataset_id, not source's. When copy_from_dataset_id differs from
+                -- the destination, the read source is a different dataset (e.g. migrate replay reads
+                -- from the source workspace's dataset and writes into the destination workspace's
+                -- dataset). The inserted rows must carry the destination dataset_id.
+                :targetDatasetId as dataset_id,
                 :targetVersionId as dataset_version_id,
                 src.data,
                 src.description,
@@ -3010,12 +3035,13 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
 
     @Override
     @WithSpan
-    public Mono<Long> copyVersionItems(@NonNull UUID datasetId, @NonNull UUID sourceVersionId,
-            @NonNull UUID targetVersionId, List<DatasetItemFilter> excludeFilters, @NonNull List<UUID> uuids) {
+    public Mono<Long> copyVersionItems(@NonNull UUID sourceDatasetId, @NonNull UUID sourceVersionId,
+            @NonNull UUID targetDatasetId, @NonNull UUID targetVersionId,
+            List<DatasetItemFilter> excludeFilters, @NonNull List<UUID> uuids) {
 
         log.info(
-                "Copying items from version '{}' to version '{}' for dataset '{}', excludeFilters='{}', uuidPoolSize='{}'",
-                sourceVersionId, targetVersionId, datasetId,
+                "Copying items from (dataset '{}', version '{}') to (dataset '{}', version '{}'), excludeFilters='{}', uuidPoolSize='{}'",
+                sourceDatasetId, sourceVersionId, targetDatasetId, targetVersionId,
                 excludeFilters != null ? excludeFilters.size() : 0, uuids.size());
 
         return Mono.deferContextual(ctx -> {
@@ -3040,8 +3066,9 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
 
             return asyncTemplate.nonTransaction(connection -> {
                 var statement = connection.createStatement(query)
-                        .bind("datasetId", datasetId.toString())
+                        .bind("datasetId", sourceDatasetId.toString())
                         .bind("sourceVersionId", sourceVersionId.toString())
+                        .bind("targetDatasetId", targetDatasetId.toString())
                         .bind("targetVersionId", targetVersionId.toString())
                         .bind("uuids", uuidStrings)
                         .bind("workspace_id", workspaceId)
@@ -3058,8 +3085,8 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                         .flatMap(Result::getRowsUpdated)
                         .reduce(0L, Long::sum)
                         .doOnSuccess(copiedCount -> log.info(
-                                "Copied '{}' items from version '{}' to version '{}' for dataset '{}'",
-                                copiedCount, sourceVersionId, targetVersionId, datasetId))
+                                "Copied '{}' items from (dataset '{}', version '{}') to (dataset '{}', version '{}')",
+                                copiedCount, sourceDatasetId, sourceVersionId, targetDatasetId, targetVersionId))
                         .doFinally(signalType -> endSegment(segment));
             });
         });
@@ -3067,15 +3094,17 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
 
     @Override
     @WithSpan
-    public Mono<Long> applyDelta(@NonNull UUID datasetId, @NonNull UUID baseVersionId,
-            @NonNull UUID newVersionId, @NonNull List<DatasetItem> addedItems,
-            @NonNull List<DatasetItem> editedItems, @NonNull Set<UUID> deletedIds,
-            @NonNull List<UUID> unchangedUuids, @NonNull Set<UUID> additionalExcludeIds) {
+    public Mono<Long> applyDelta(@NonNull UUID datasetId, @NonNull UUID newVersionId,
+            @NonNull List<DatasetItem> addedItems, @NonNull List<DatasetItem> editedItems,
+            @NonNull Set<UUID> deletedIds, @NonNull List<UUID> unchangedUuids,
+            @NonNull Set<UUID> additionalExcludeIds,
+            @NonNull UUID copyFromDatasetId, @NonNull UUID copyFromVersionId) {
 
-        log.info("Applying delta for dataset '{}': baseVersion='{}', newVersion='{}', " +
-                "added='{}', edited='{}', deleted='{}', additionalExclude='{}'",
-                datasetId, baseVersionId, newVersionId, addedItems.size(), editedItems.size(),
-                deletedIds.size(), additionalExcludeIds.size());
+        log.info(
+                "Applying delta for dataset '{}': newVersion='{}', copyFromDataset='{}', copyFromVersion='{}', "
+                        + "added='{}', edited='{}', deleted='{}', additionalExclude='{}'",
+                datasetId, newVersionId, copyFromDatasetId, copyFromVersionId, addedItems.size(),
+                editedItems.size(), deletedIds.size(), additionalExcludeIds.size());
 
         // Collect all stable item IDs that are being edited (so we don't copy them from base)
         Set<UUID> editedItemIds = editedItems.stream()
@@ -3097,8 +3126,12 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             // Step 2: Insert edited items (will sort after added due to middle UUIDs)
             Mono<Long> insertEdited = insertItems(datasetId, newVersionId, editedItems, workspaceId, userName);
 
-            // Step 3: Copy unchanged items (will sort last due to earliest/smallest UUIDs)
-            Mono<Long> copyUnchanged = copyUnchangedItems(datasetId, baseVersionId, newVersionId,
+            // Step 3: Copy unchanged items (will sort last due to earliest/smallest UUIDs).
+            // OPIK-6696: reads from caller-supplied source coordinates instead of destination prior version.
+            // Source coords = (copyFromDatasetId, copyFromVersionId); target coords = (datasetId, newVersionId).
+            Mono<Long> copyUnchanged = copyUnchangedItems(
+                    copyFromDatasetId, copyFromVersionId,
+                    datasetId, newVersionId,
                     excludedIds, unchangedUuids, workspaceId, userName);
 
             // Execute all operations and sum the results
@@ -3112,9 +3145,9 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
 
     @Override
     @WithSpan
-    public Mono<Long> editItemsViaSelectInsert(@NonNull UUID datasetId, @NonNull UUID baseVersionId,
-            @NonNull UUID newVersionId, @NonNull List<DatasetItemEdit> editedItems,
-            @NonNull List<UUID> newRowIds) {
+    public Mono<Long> editItemsViaSelectInsert(@NonNull UUID sourceDatasetId, @NonNull UUID sourceVersionId,
+            @NonNull UUID targetDatasetId, @NonNull UUID newVersionId,
+            @NonNull List<DatasetItemEdit> editedItems, @NonNull List<UUID> newRowIds) {
 
         if (editedItems.isEmpty()) {
             return Mono.just(0L);
@@ -3156,8 +3189,9 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
 
                     var statement = connection.createStatement(template.render())
                             .bind("workspace_id", workspaceId)
-                            .bind("datasetId", datasetId.toString())
-                            .bind("baseVersionId", baseVersionId.toString())
+                            .bind("sourceDatasetId", sourceDatasetId.toString())
+                            .bind("sourceVersionId", sourceVersionId.toString())
+                            .bind("targetDatasetId", targetDatasetId.toString())
                             .bind("newVersionId", newVersionId.toString())
                             .bind("datasetItemId", edit.id().toString())
                             .bind("newId", newRowId.toString())
@@ -3189,19 +3223,28 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                         .flatMap(Result::getRowsUpdated)
                         .reduce(0L, Long::sum)
                         .map(results -> itemCount)
-                        .doOnSuccess(count -> log.info("Edited '{}' items via SELECT INSERT for dataset '{}'",
-                                count, datasetId))
+                        .doOnSuccess(count -> log.info(
+                                "Edited '{}' items via SELECT INSERT from (dataset '{}', version '{}') into (dataset '{}', version '{}')",
+                                count, sourceDatasetId, sourceVersionId, targetDatasetId, newVersionId))
                         .doFinally(signalType -> endSegment(segment));
             });
         });
     }
 
-    private Mono<Long> copyUnchangedItems(UUID datasetId, UUID baseVersionId, UUID newVersionId,
+    /**
+     * OPIK-6696. Copies unchanged rows from a (sourceDatasetId, sourceVersionId) version into a
+     * destination (targetDatasetId, newVersionId) version. The SQL projects {@code :targetDatasetId}
+     * for the inserted rows' dataset_id so that cross-dataset copies (migrate replay reading from a
+     * source dataset and writing into a destination dataset) land in the correct dataset. When
+     * source == destination this is the legacy behavior.
+     */
+    private Mono<Long> copyUnchangedItems(UUID sourceDatasetId, UUID sourceVersionId,
+            UUID targetDatasetId, UUID newVersionId,
             Set<UUID> excludedIds, List<UUID> uuids, String workspaceId, String userName) {
 
         if (excludedIds.isEmpty()) {
             // Simple copy - no exclusions needed
-            return copyVersionItems(datasetId, baseVersionId, newVersionId, null, uuids)
+            return copyVersionItems(sourceDatasetId, sourceVersionId, targetDatasetId, newVersionId, null, uuids)
                     .contextWrite(ctx -> ctx
                             .put(RequestContext.WORKSPACE_ID, workspaceId)
                             .put(RequestContext.USER_NAME, userName));
@@ -3224,8 +3267,9 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             String query = template.render();
 
             var statement = connection.createStatement(query)
-                    .bind("datasetId", datasetId.toString())
-                    .bind("sourceVersionId", baseVersionId.toString())
+                    .bind("datasetId", sourceDatasetId.toString())
+                    .bind("sourceVersionId", sourceVersionId.toString())
+                    .bind("targetDatasetId", targetDatasetId.toString())
                     .bind("targetVersionId", newVersionId.toString())
                     .bind("excludedIds", excludedIdStrings)
                     .bind("uuids", uuidStrings)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionService.java
@@ -747,7 +747,7 @@ class DatasetVersionServiceImpl implements DatasetVersionService {
         List<UUID> uuids = generateUuidPool(idGenerator, sourceItemCount);
 
         return datasetItemVersionDAO
-                .copyVersionItems(datasetId, context.sourceVersionId, newVersionId, null, uuids)
+                .copyVersionItems(datasetId, context.sourceVersionId, datasetId, newVersionId, null, uuids)
                 .contextWrite(ctx -> ctx
                         .put(RequestContext.USER_NAME, context.userName)
                         .put(RequestContext.WORKSPACE_ID, context.workspaceId));

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -11064,6 +11064,47 @@ class DatasetsResourceTest {
                     .doesNotContain(destSeed.id())
                     .hasSize(4);
         }
+
+        @Test
+        @DisplayName("createOrUpdateDatasetItems: when copy_from points at a non-existent version, returns 404 instead of silently writing an empty version")
+        void createOrUpdate__copyFromMissingVersion__returns404() {
+            var workspaceName = UUID.randomUUID().toString();
+            var apiKey = UUID.randomUUID().toString();
+            var workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var dataset = buildDataset();
+            var datasetId = createAndAssert(dataset, apiKey, workspaceName);
+
+            // Seed v1 so the codepath reaches createVersionWithDelta (not createFirstVersion).
+            var seedItem = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder()
+                            .datasetName(dataset.name())
+                            .items(List.of(seedItem))
+                            .batchGroupId(UUID.randomUUID())
+                            .build(),
+                    workspaceName, apiKey);
+
+            var deltaItem = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
+            var bogusVersionId = UUID.randomUUID();
+
+            try (var response = client.target(BASE_RESOURCE_URI.formatted(baseURI))
+                    .path("items")
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, apiKey)
+                    .header(WORKSPACE_HEADER, workspaceName)
+                    .put(jakarta.ws.rs.client.Entity.json(
+                            DatasetItemBatch.builder()
+                                    .datasetName(dataset.name())
+                                    .items(List.of(deltaItem))
+                                    .batchGroupId(UUID.randomUUID())
+                                    .copyFromDatasetId(datasetId)
+                                    .copyFromVersionId(bogusVersionId)
+                                    .build()))) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(404);
+            }
+        }
     }
 
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -10974,6 +10974,90 @@ class DatasetsResourceTest {
         }
 
         @Test
+        @DisplayName("when chaining 3 snapshot-mode versions, each version's row set equals its payload (no leakage from prior versions)")
+        void snapshot__threeVersionChain__eachVersionEqualsItsPayload() {
+            var workspaceName = UUID.randomUUID().toString();
+            var apiKey = UUID.randomUUID().toString();
+            var workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var dataset = buildDataset();
+            var datasetId = createAndAssert(dataset, apiKey, workspaceName);
+
+            var itemA = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
+            var itemB = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
+            var itemC = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
+            var itemD = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
+
+            // v1 (first version, snapshot=true is a no-op here): {A, B}
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder()
+                            .datasetName(dataset.name())
+                            .items(List.of(itemA, itemB))
+                            .batchGroupId(UUID.randomUUID())
+                            .snapshot(true)
+                            .build(),
+                    workspaceName, apiKey);
+
+            // v2 (snapshot): drop B, add C → {A, C}
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder()
+                            .datasetName(dataset.name())
+                            .items(List.of(itemA, itemC))
+                            .batchGroupId(UUID.randomUUID())
+                            .snapshot(true)
+                            .build(),
+                    workspaceName, apiKey);
+
+            // v3 (snapshot): drop A, add B back, add D → {B, C, D}
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder()
+                            .datasetName(dataset.name())
+                            .items(List.of(itemB, itemC, itemD))
+                            .batchGroupId(UUID.randomUUID())
+                            .snapshot(true)
+                            .build(),
+                    workspaceName, apiKey);
+
+            var versions = datasetResourceClient.listVersions(datasetId, apiKey, workspaceName);
+            assertThat(versions.content()).hasSize(3);
+
+            // versions are sorted newest-first
+            var v3 = versions.content().get(0);
+            var v2 = versions.content().get(1);
+            var v1 = versions.content().get(2);
+
+            var v1Items = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 100, v1.versionHash(), apiKey, workspaceName);
+            assertThat(v1Items.content())
+                    .extracting(DatasetItem::id)
+                    .containsExactlyInAnyOrder(itemA.id(), itemB.id());
+            assertThat(v1.itemsTotal()).isEqualTo(2);
+
+            var v2Items = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 100, v2.versionHash(), apiKey, workspaceName);
+            assertThat(v2Items.content())
+                    .extracting(DatasetItem::id)
+                    .containsExactlyInAnyOrder(itemA.id(), itemC.id());
+            assertThat(v2.itemsTotal()).isEqualTo(2);
+
+            var v3Items = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 100, v3.versionHash(), apiKey, workspaceName);
+            assertThat(v3Items.content())
+                    .extracting(DatasetItem::id)
+                    .containsExactlyInAnyOrder(itemB.id(), itemC.id(), itemD.id());
+            assertThat(v3.itemsTotal()).isEqualTo(3);
+
+            // Per-item data payload round-trips across the chain. Pick one (itemC) present in both
+            // v2 and v3 to confirm the row content matches the original payload at both points, not
+            // a residual carry-forward.
+            var c2 = v2Items.content().stream().filter(i -> i.id().equals(itemC.id())).findFirst().orElseThrow();
+            var c3 = v3Items.content().stream().filter(i -> i.id().equals(itemC.id())).findFirst().orElseThrow();
+            assertThat(c2.data()).isEqualTo(itemC.data());
+            assertThat(c3.data()).isEqualTo(itemC.data());
+        }
+
+        @Test
         @DisplayName("when snapshot=true on first version (no base), then behaves like createFirstVersion")
         void snapshot__firstVersion__behavesLikeCreateFirstVersion() {
             var workspaceName = UUID.randomUUID().toString();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -10879,4 +10879,134 @@ class DatasetsResourceTest {
         }
     }
 
+    @Nested
+    @DisplayName("OPIK-6696: snapshot mode on createOrUpdateDatasetItems")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class CreateOrUpdateDatasetItemsSnapshotMode {
+
+        @Test
+        @DisplayName("when snapshot=true, then new version row set equals payload (removed items are dropped)")
+        void snapshot__newVersionRowSetEqualsPayload__removedItemDropped() {
+            var workspaceName = UUID.randomUUID().toString();
+            var apiKey = UUID.randomUUID().toString();
+            var workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var dataset = buildDataset();
+            var datasetId = createAndAssert(dataset, apiKey, workspaceName);
+
+            var itemA = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
+            var itemB = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
+            var itemC = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
+
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder()
+                            .datasetName(dataset.name())
+                            .items(List.of(itemA, itemB, itemC))
+                            .batchGroupId(UUID.randomUUID())
+                            .build(),
+                    workspaceName, apiKey);
+
+            // Snapshot-mode follow-up: payload omits itemC.
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder()
+                            .datasetName(dataset.name())
+                            .items(List.of(itemA, itemB))
+                            .batchGroupId(UUID.randomUUID())
+                            .snapshot(true)
+                            .build(),
+                    workspaceName, apiKey);
+
+            var versions = datasetResourceClient.listVersions(datasetId, apiKey, workspaceName);
+            assertThat(versions.content()).hasSize(2);
+
+            // versions are sorted newest-first
+            var snapshotVersion = versions.content().getFirst();
+            var snapshotItems = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 100, snapshotVersion.versionHash(), apiKey, workspaceName);
+            assertThat(snapshotItems.content())
+                    .extracting(DatasetItem::id)
+                    .containsExactlyInAnyOrder(itemA.id(), itemB.id());
+            assertThat(snapshotVersion.itemsTotal()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("when snapshot=false (default), then unchanged items are carried forward from base version")
+        void snapshot__default__carriesForwardUnchangedItems() {
+            var workspaceName = UUID.randomUUID().toString();
+            var apiKey = UUID.randomUUID().toString();
+            var workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var dataset = buildDataset();
+            var datasetId = createAndAssert(dataset, apiKey, workspaceName);
+
+            var itemA = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
+            var itemB = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
+            var itemC = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
+
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder()
+                            .datasetName(dataset.name())
+                            .items(List.of(itemA, itemB, itemC))
+                            .batchGroupId(UUID.randomUUID())
+                            .build(),
+                    workspaceName, apiKey);
+
+            // Default-mode follow-up: payload omits itemC but default mode carries it forward.
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder()
+                            .datasetName(dataset.name())
+                            .items(List.of(itemA, itemB))
+                            .batchGroupId(UUID.randomUUID())
+                            .build(),
+                    workspaceName, apiKey);
+
+            var versions = datasetResourceClient.listVersions(datasetId, apiKey, workspaceName);
+            assertThat(versions.content()).hasSize(2);
+
+            var defaultVersion = versions.content().getFirst();
+            var defaultItems = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 100, defaultVersion.versionHash(), apiKey, workspaceName);
+            assertThat(defaultItems.content())
+                    .extracting(DatasetItem::id)
+                    .containsExactlyInAnyOrder(itemA.id(), itemB.id(), itemC.id());
+        }
+
+        @Test
+        @DisplayName("when snapshot=true on first version (no base), then behaves like createFirstVersion")
+        void snapshot__firstVersion__behavesLikeCreateFirstVersion() {
+            var workspaceName = UUID.randomUUID().toString();
+            var apiKey = UUID.randomUUID().toString();
+            var workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var dataset = buildDataset();
+            var datasetId = createAndAssert(dataset, apiKey, workspaceName);
+
+            var itemA = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
+            var itemB = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
+
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder()
+                            .datasetName(dataset.name())
+                            .items(List.of(itemA, itemB))
+                            .batchGroupId(UUID.randomUUID())
+                            .snapshot(true)
+                            .build(),
+                    workspaceName, apiKey);
+
+            var versions = datasetResourceClient.listVersions(datasetId, apiKey, workspaceName);
+            assertThat(versions.content()).hasSize(1);
+
+            var v1 = versions.content().getFirst();
+            var v1Items = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 100, v1.versionHash(), apiKey, workspaceName);
+            assertThat(v1Items.content())
+                    .extracting(DatasetItem::id)
+                    .containsExactlyInAnyOrder(itemA.id(), itemB.id());
+            assertThat(v1.itemsTotal()).isEqualTo(2);
+        }
+    }
+
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -10880,59 +10880,83 @@ class DatasetsResourceTest {
     }
 
     @Nested
-    @DisplayName("OPIK-6696: snapshot mode on createOrUpdateDatasetItems")
+    @DisplayName("OPIK-6696: copy_from_dataset_id + copy_from_version_id on PUT /items and POST /items/changes")
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class CreateOrUpdateDatasetItemsSnapshotMode {
+    class CopyFromSourceVersion {
 
         @Test
-        @DisplayName("when snapshot=true, then new version row set equals payload (removed items are dropped)")
-        void snapshot__newVersionRowSetEqualsPayload__removedItemDropped() {
+        @DisplayName("createOrUpdateDatasetItems: when copy_from points at a separate source dataset's version, unchanged rows are copied from there (not destination)")
+        void createOrUpdate__copyFromSource__unchangedRowsCopiedFromSource() {
             var workspaceName = UUID.randomUUID().toString();
             var apiKey = UUID.randomUUID().toString();
             var workspaceId = UUID.randomUUID().toString();
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
-            var dataset = buildDataset();
-            var datasetId = createAndAssert(dataset, apiKey, workspaceName);
+            // Build the "source" dataset as a stable upstream (analog of source v_i in migrate replay)
+            var sourceDataset = buildDataset();
+            var sourceDatasetId = createAndAssert(sourceDataset, apiKey, workspaceName);
 
-            var itemA = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
-            var itemB = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
-            var itemC = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
-
+            var sourceItemA = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(sourceDatasetId)
+                    .build();
+            var sourceItemB = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(sourceDatasetId)
+                    .build();
+            var sourceItemC = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(sourceDatasetId)
+                    .build();
             datasetResourceClient.createDatasetItems(
                     DatasetItemBatch.builder()
-                            .datasetName(dataset.name())
-                            .items(List.of(itemA, itemB, itemC))
+                            .datasetName(sourceDataset.name())
+                            .items(List.of(sourceItemA, sourceItemB, sourceItemC))
+                            .batchGroupId(UUID.randomUUID())
+                            .build(),
+                    workspaceName, apiKey);
+            var sourceVersionId = datasetResourceClient.listVersions(sourceDatasetId, apiKey, workspaceName)
+                    .content().getFirst().id();
+
+            // Build the destination dataset and seed v1 with just one item (analog of dest v_(i-1)).
+            var destDataset = buildDataset();
+            var destDatasetId = createAndAssert(destDataset, apiKey, workspaceName);
+            var destSeedItem = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(destDatasetId)
+                    .build();
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder()
+                            .datasetName(destDataset.name())
+                            .items(List.of(destSeedItem))
                             .batchGroupId(UUID.randomUUID())
                             .build(),
                     workspaceName, apiKey);
 
-            // Snapshot-mode follow-up: payload omits itemC.
+            // OPIK-6696: submit a tiny "delta" payload to destination v_2, with copy_from pointing at
+            // the source dataset's version. The COPY of unchanged rows reads from the source, so the
+            // resulting destination v_2 should contain (delta) ∪ (source minus delta IDs).
+            var deltaItem = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(destDatasetId)
+                    .build();
             datasetResourceClient.createDatasetItems(
                     DatasetItemBatch.builder()
-                            .datasetName(dataset.name())
-                            .items(List.of(itemA, itemB))
+                            .datasetName(destDataset.name())
+                            .items(List.of(deltaItem))
                             .batchGroupId(UUID.randomUUID())
-                            .snapshot(true)
+                            .copyFromDatasetId(sourceDatasetId)
+                            .copyFromVersionId(sourceVersionId)
                             .build(),
                     workspaceName, apiKey);
 
-            var versions = datasetResourceClient.listVersions(datasetId, apiKey, workspaceName);
-            assertThat(versions.content()).hasSize(2);
+            var destVersions = datasetResourceClient.listVersions(destDatasetId, apiKey, workspaceName);
+            assertThat(destVersions.content()).hasSize(2);
 
-            // versions are sorted newest-first
-            var snapshotVersion = versions.content().getFirst();
-            var snapshotItems = datasetResourceClient.getDatasetItems(
-                    datasetId, 1, 100, snapshotVersion.versionHash(), apiKey, workspaceName);
-            assertThat(snapshotItems.content())
+            // newest-first → v2
+            var destV2 = destVersions.content().getFirst();
+            var destV2Items = datasetResourceClient.getDatasetItems(
+                    destDatasetId, 1, 100, destV2.versionHash(), apiKey, workspaceName);
+            assertThat(destV2Items.content())
                     .extracting(DatasetItem::id)
-                    .containsExactlyInAnyOrder(itemA.id(), itemB.id());
-            assertThat(snapshotVersion.itemsTotal()).isEqualTo(2);
+                    .containsExactlyInAnyOrder(
+                            deltaItem.id(),
+                            sourceItemA.id(), sourceItemB.id(), sourceItemC.id());
         }
 
         @Test
-        @DisplayName("when snapshot=false (default), then unchanged items are carried forward from base version")
-        void snapshot__default__carriesForwardUnchangedItems() {
+        @DisplayName("createOrUpdateDatasetItems: when copy_from is null, unchanged rows carry forward from destination prior version (regression)")
+        void createOrUpdate__noCopyFrom__carriesForwardFromDestination() {
             var workspaceName = UUID.randomUUID().toString();
             var apiKey = UUID.randomUUID().toString();
             var workspaceId = UUID.randomUUID().toString();
@@ -10943,17 +10967,6 @@ class DatasetsResourceTest {
 
             var itemA = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
             var itemB = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
-            var itemC = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
-
-            datasetResourceClient.createDatasetItems(
-                    DatasetItemBatch.builder()
-                            .datasetName(dataset.name())
-                            .items(List.of(itemA, itemB, itemC))
-                            .batchGroupId(UUID.randomUUID())
-                            .build(),
-                    workspaceName, apiKey);
-
-            // Default-mode follow-up: payload omits itemC but default mode carries it forward.
             datasetResourceClient.createDatasetItems(
                     DatasetItemBatch.builder()
                             .datasetName(dataset.name())
@@ -10962,134 +10975,94 @@ class DatasetsResourceTest {
                             .build(),
                     workspaceName, apiKey);
 
-            var versions = datasetResourceClient.listVersions(datasetId, apiKey, workspaceName);
-            assertThat(versions.content()).hasSize(2);
+            var itemC = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder()
+                            .datasetName(dataset.name())
+                            .items(List.of(itemC))
+                            .batchGroupId(UUID.randomUUID())
+                            .build(),
+                    workspaceName, apiKey);
 
-            var defaultVersion = versions.content().getFirst();
-            var defaultItems = datasetResourceClient.getDatasetItems(
-                    datasetId, 1, 100, defaultVersion.versionHash(), apiKey, workspaceName);
-            assertThat(defaultItems.content())
+            var v2 = datasetResourceClient.listVersions(datasetId, apiKey, workspaceName).content().getFirst();
+            var v2Items = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 100, v2.versionHash(), apiKey, workspaceName);
+            assertThat(v2Items.content())
                     .extracting(DatasetItem::id)
                     .containsExactlyInAnyOrder(itemA.id(), itemB.id(), itemC.id());
         }
 
         @Test
-        @DisplayName("when chaining 3 snapshot-mode versions, each version's row set equals its payload (no leakage from prior versions)")
-        void snapshot__threeVersionChain__eachVersionEqualsItsPayload() {
+        @DisplayName("applyDatasetItemChanges: when copy_from points at a source version, COPY + edit-via-SELECT-INSERT both read from there")
+        void applyChanges__copyFromSource__readsFromSource() {
             var workspaceName = UUID.randomUUID().toString();
             var apiKey = UUID.randomUUID().toString();
             var workspaceId = UUID.randomUUID().toString();
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
-            var dataset = buildDataset();
-            var datasetId = createAndAssert(dataset, apiKey, workspaceName);
-
-            var itemA = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
-            var itemB = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
-            var itemC = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
-            var itemD = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
-
-            // v1 (first version, snapshot=true is a no-op here): {A, B}
+            // Source dataset: stable v1 with {A, B, C}.
+            var sourceDataset = buildDataset();
+            var sourceDatasetId = createAndAssert(sourceDataset, apiKey, workspaceName);
+            var sourceItemA = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(sourceDatasetId)
+                    .build();
+            var sourceItemB = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(sourceDatasetId)
+                    .build();
+            var sourceItemC = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(sourceDatasetId)
+                    .build();
             datasetResourceClient.createDatasetItems(
                     DatasetItemBatch.builder()
-                            .datasetName(dataset.name())
-                            .items(List.of(itemA, itemB))
+                            .datasetName(sourceDataset.name())
+                            .items(List.of(sourceItemA, sourceItemB, sourceItemC))
                             .batchGroupId(UUID.randomUUID())
-                            .snapshot(true)
                             .build(),
                     workspaceName, apiKey);
+            var sourceVersionId = datasetResourceClient.listVersions(sourceDatasetId, apiKey, workspaceName)
+                    .content().getFirst().id();
 
-            // v2 (snapshot): drop B, add C → {A, C}
+            // Destination: empty (no prior version). First call mirrors source v1 via applyDatasetItemChanges,
+            // but with copy_from coords pointing at source. Result should be {A, B, C} in the destination.
+            var destDataset = buildDataset();
+            var destDatasetId = createAndAssert(destDataset, apiKey, workspaceName);
+
+            // Seed destination v1 with one row, so we have a base version on the destination side that
+            // applyDatasetItemChanges can chain onto.
+            var destSeed = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(destDatasetId).build();
             datasetResourceClient.createDatasetItems(
                     DatasetItemBatch.builder()
-                            .datasetName(dataset.name())
-                            .items(List.of(itemA, itemC))
+                            .datasetName(destDataset.name())
+                            .items(List.of(destSeed))
                             .batchGroupId(UUID.randomUUID())
-                            .snapshot(true)
                             .build(),
                     workspaceName, apiKey);
+            var destV1Id = datasetResourceClient.listVersions(destDatasetId, apiKey, workspaceName)
+                    .content().getFirst().id();
 
-            // v3 (snapshot): drop A, add B back, add D → {B, C, D}
-            datasetResourceClient.createDatasetItems(
-                    DatasetItemBatch.builder()
-                            .datasetName(dataset.name())
-                            .items(List.of(itemB, itemC, itemD))
-                            .batchGroupId(UUID.randomUUID())
-                            .snapshot(true)
-                            .build(),
-                    workspaceName, apiKey);
+            // Apply delta: delete the seed item, add one new "delta" item, copy unchanged from source.
+            var deltaItem = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(destDatasetId)
+                    .build();
+            var changes = com.comet.opik.api.DatasetItemChanges.builder()
+                    .baseVersion(destV1Id)
+                    .addedItems(List.of(deltaItem))
+                    .deletedIds(Set.of(destSeed.id()))
+                    .copyFromDatasetId(sourceDatasetId)
+                    .copyFromVersionId(sourceVersionId)
+                    .build();
+            datasetResourceClient.applyDatasetItemChanges(destDatasetId, changes, false, apiKey, workspaceName);
 
-            var versions = datasetResourceClient.listVersions(datasetId, apiKey, workspaceName);
-            assertThat(versions.content()).hasSize(3);
+            var destV2 = datasetResourceClient.listVersions(destDatasetId, apiKey, workspaceName).content().getFirst();
+            var destV2Items = datasetResourceClient.getDatasetItems(
+                    destDatasetId, 1, 100, destV2.versionHash(), apiKey, workspaceName);
 
-            // versions are sorted newest-first
-            var v3 = versions.content().get(0);
-            var v2 = versions.content().get(1);
-            var v1 = versions.content().get(2);
-
-            var v1Items = datasetResourceClient.getDatasetItems(
-                    datasetId, 1, 100, v1.versionHash(), apiKey, workspaceName);
-            assertThat(v1Items.content())
+            // applyDatasetItemChanges' prepareAddedItems regenerates the stable ID for added items, so
+            // we can't predict the delta item's final id. Assert: the destination contains source's
+            // three items (carry-forward from source COPY worked) plus exactly one extra (the new
+            // delta); destSeed was deleted; the COPY did NOT read from destination v_1 (it would have
+            // returned destSeed instead of source's items).
+            assertThat(destV2Items.content())
                     .extracting(DatasetItem::id)
-                    .containsExactlyInAnyOrder(itemA.id(), itemB.id());
-            assertThat(v1.itemsTotal()).isEqualTo(2);
-
-            var v2Items = datasetResourceClient.getDatasetItems(
-                    datasetId, 1, 100, v2.versionHash(), apiKey, workspaceName);
-            assertThat(v2Items.content())
-                    .extracting(DatasetItem::id)
-                    .containsExactlyInAnyOrder(itemA.id(), itemC.id());
-            assertThat(v2.itemsTotal()).isEqualTo(2);
-
-            var v3Items = datasetResourceClient.getDatasetItems(
-                    datasetId, 1, 100, v3.versionHash(), apiKey, workspaceName);
-            assertThat(v3Items.content())
-                    .extracting(DatasetItem::id)
-                    .containsExactlyInAnyOrder(itemB.id(), itemC.id(), itemD.id());
-            assertThat(v3.itemsTotal()).isEqualTo(3);
-
-            // Per-item data payload round-trips across the chain. Pick one (itemC) present in both
-            // v2 and v3 to confirm the row content matches the original payload at both points, not
-            // a residual carry-forward.
-            var c2 = v2Items.content().stream().filter(i -> i.id().equals(itemC.id())).findFirst().orElseThrow();
-            var c3 = v3Items.content().stream().filter(i -> i.id().equals(itemC.id())).findFirst().orElseThrow();
-            assertThat(c2.data()).isEqualTo(itemC.data());
-            assertThat(c3.data()).isEqualTo(itemC.data());
-        }
-
-        @Test
-        @DisplayName("when snapshot=true on first version (no base), then behaves like createFirstVersion")
-        void snapshot__firstVersion__behavesLikeCreateFirstVersion() {
-            var workspaceName = UUID.randomUUID().toString();
-            var apiKey = UUID.randomUUID().toString();
-            var workspaceId = UUID.randomUUID().toString();
-            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
-
-            var dataset = buildDataset();
-            var datasetId = createAndAssert(dataset, apiKey, workspaceName);
-
-            var itemA = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
-            var itemB = DatasetResourceClient.buildDatasetItem(factory).toBuilder().datasetId(datasetId).build();
-
-            datasetResourceClient.createDatasetItems(
-                    DatasetItemBatch.builder()
-                            .datasetName(dataset.name())
-                            .items(List.of(itemA, itemB))
-                            .batchGroupId(UUID.randomUUID())
-                            .snapshot(true)
-                            .build(),
-                    workspaceName, apiKey);
-
-            var versions = datasetResourceClient.listVersions(datasetId, apiKey, workspaceName);
-            assertThat(versions.content()).hasSize(1);
-
-            var v1 = versions.content().getFirst();
-            var v1Items = datasetResourceClient.getDatasetItems(
-                    datasetId, 1, 100, v1.versionHash(), apiKey, workspaceName);
-            assertThat(v1Items.content())
-                    .extracting(DatasetItem::id)
-                    .containsExactlyInAnyOrder(itemA.id(), itemB.id());
-            assertThat(v1.itemsTotal()).isEqualTo(2);
+                    .contains(sourceItemA.id(), sourceItemB.id(), sourceItemC.id())
+                    .doesNotContain(destSeed.id())
+                    .hasSize(4);
         }
     }
 


### PR DESCRIPTION
## Details

<img width="2160" height="3024" alt="image" src="https://github.com/user-attachments/assets/32b786db-cdae-4286-9ff7-c651fd470b06" />

**TL;DR — moves the `INSERT FROM SELECT` that copies unchanged rows from "destination's just-minted prior version" to "a caller-supplied stable upstream version."** That's the structural fix for the multi-replica read-after-write window that drives OPIK-6674's data loss and the `qa-v1-stress-*` regressions. Default behavior is unchanged when the new fields are null.

The change is exposed on the wire as two paired optional fields — `copy_from_dataset_id` + `copy_from_version_id` — on both `DatasetItemBatch` (PUT `/v1/private/datasets/items`) and `DatasetItemChanges` (POST `/v1/private/datasets/{id}/items/changes`). When set, the BE redirects all three reads that touched destination v_(i-1) to read from the caller-supplied source instead: the COPY (`copyUnchangedItems`), the edit-via-SELECT-INSERT (`editItemsViaSelectInsert`), and the classification SELECT (`getItemIdsAndHashes`). Payload stays O(delta) — the two UUIDs are the only addition.

The structural problem: `opik migrate` chains version writes against a destination that may not have replicated yet. `applyDelta`'s `copyUnchangedItems` step silently drops rows that haven't reached the SELECT-serving replica. `applyDatasetItemChanges` additionally runs `editItemsViaSelectInsert` and `countRowsInVersion` against the same destination version with the same exposure. For migrate the fix is straightforward — point copy-from at source v_i, which was written long ago and is fully replicated.

**Design pivot from earlier commits:** the first commits on this branch shipped a `snapshot: Boolean` field that made the payload the source of truth for the new version's row set. That doesn't scale for migrate — the SDK can't send 10k items on every call to keep an existing 10k+1k version. The latest commits replace `snapshot` with the copy-from coordinates approach: payload stays delta-sized, BE points at a stable upstream version for carry-forwards.

Implementation highlights:
- `DatasetItemBatch` / `DatasetItemChanges` gain `copyFromDatasetId` + `copyFromVersionId` (nullable, must be set together — validator + inline check enforce the pairing).
- When the new fields are set, the service validates the source version exists in the workspace AND belongs to `copy_from_dataset_id` — returns 404 on miss. Prevents silently writing an empty-carry-forwards version from a bogus or cross-workspace pair.
- `DatasetItemVersionDAO.applyDelta`, `editItemsViaSelectInsert`, `copyVersionItems` signatures take explicit source vs. target dataset_id.
- `COPY_VERSION_ITEMS` and `EDIT_ITEM_VIA_SELECT_INSERT` SQL templates project `:targetDatasetId` (was `src.dataset_id`, a latent bug that worked only because source always equaled target).
- `createVersionWithDelta`'s classification SELECT (`getItemIdsAndHashes`) also reads from copy-from coords — reading from a stale destination base could mis-route an "edit" as an "add" and produce duplicate stable IDs.
- Existing intra-dataset callers (`DatasetVersionService`, filter-based batch delete / update) pass `datasetId` as both source and target → behavior unchanged.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6696
- Blocks: OPIK-6697 (`[SDK] feat(migrate): use snapshot mode for dataset version replay`) — SDK side will set the copy-from coords when chaining replay calls

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation (DAO + service + DTOs + tests). Design pivoted mid-PR after the user surfaced the O(N²) scaling problem with the original snapshot-field approach
- Human verification: code review, scope refinement, test design review, local test run

## Testing

Ran the new `CopyFromSourceVersion` nested test class locally:

```
mvn test -Dtest='DatasetsResourceTest$CopyFromSourceVersion'
```

All 4 tests pass in ~1.8s:
- `createOrUpdate__copyFromSource__unchangedRowsCopiedFromSource` — a small delta sent to destination v_2 with copy_from pointing at a separate source dataset/version → destination v_2 contains the delta plus all of source's items.
- `createOrUpdate__noCopyFrom__carriesForwardFromDestination` — regression guard for the default path.
- `applyChanges__copyFromSource__readsFromSource` — same shape on the `/items/changes` endpoint, with a delete and an add, asserting source items appear in the destination and the destination's seed item is correctly deleted.
- `createOrUpdate__copyFromMissingVersion__returns404` — bogus `copy_from_version_id` returns 404 instead of silently writing an empty version.

Spotless clean. No frontend or SDK files changed. The migrate `qa-v1-stress-*` E2E depends on the SDK side (OPIK-6697) adopting the new fields; that will land on top.

## Documentation

N/A — the OpenAPI surface picks up the new fields automatically from Swagger annotations on `DatasetItemBatch` and `DatasetItemChanges`. The Fern regen workflow will publish them to the Python/TS SDKs on merge. Both endpoints' `@Operation` descriptions were updated to describe the copy-from semantics.
