### PR TITLE
[OPIK-6633] [CI] Pin Docker release builds to tag + idempotent helm push

### DIFF
--- a/.github/workflows/publish_helm_chart.yaml
+++ b/.github/workflows/publish_helm_chart.yaml
@@ -143,8 +143,12 @@ jobs:
             git config user.email "actions@users.noreply.github.com"
             git ls-files -o --exclude-standard -z | xargs -0 -r git add
             git add "${INDEX_FILE}" README.md
-            git commit -m "Release Opik helm chart $VERSION"
-            git push   
+            if git diff --staged --quiet; then
+              echo "::warning title=helm publish::No changes to commit; chart ${VERSION} is already up to date in gh-pages."
+            else
+              git commit -m "Release Opik helm chart $VERSION"
+              git push
+            fi
 
         - name: Summary
           run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,7 @@ jobs:
     with:
       version: ${{needs.set-version.outputs.version}}
       is_release: true
+      ref: refs/tags/${{needs.set-version.outputs.version}}
 
   release-sdk:
     needs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,8 @@ jobs:
     with:
       version: ${{needs.set-version.outputs.version}}
       is_release: true
+      # Caller-passes ref: build_apps.yml already exposes a ref input (defaults to inputs.ref || github.ref).
+      # TS SDK workflows in OPIK-6627 used callee-derives because they lacked one. See OPIK-6633.
       ref: refs/tags/${{needs.set-version.outputs.version}}
 
   release-sdk:


### PR DESCRIPTION
## Details

Two latent fixes in the release pipeline, both forward-looking. Neither is currently broken; both close footguns surfaced while validating OPIK-6627 (PR #6800).

- **Docker builds now pinned to the tag.** `release.yaml`'s `release-apps` job now passes `ref: refs/tags/<version>` to `build_apps.yml`. Closes the same drift footgun OPIK-6627 fixed for SDK publishes — more dangerous here because GHCR/ECR silently allow tag overwrite, so a re-dispatch against `main` after `main` has moved past the tag would publish newer-main source under the released version with no error. `build_apps.yml` already accepts a `ref` input (`inputs.ref || github.ref`), so no changes are needed there.
- **Helm gh-pages push is now idempotent.** `publish_helm_chart.yaml`'s `Push New Files` step now guards `git commit` with `git diff --staged --quiet`. Today, replays only succeed because the timestamp-restoration dance leaves a tiny diff in `index.yaml`. If that ever becomes truly deterministic, `set -e` + `nothing to commit` would kill every replay. New behaviour: warn on no-op, commit + push on real diff.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6633

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: drafted ticket description, validated claims against current `origin/main`, applied the two edits, wrote PR description. All commands/diffs reviewed by author.
- Human verification: diffs reviewed before commit; YAML parsed locally with `python3 -c "import yaml; yaml.safe_load(...)"`. CI actionlint will give the final say.

## Testing

Local checks performed:
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yaml')); yaml.safe_load(open('.github/workflows/publish_helm_chart.yaml'))"` — both parse cleanly.
- `git diff` reviewed before commit (7 insertions, 2 deletions across 2 files).

Tests not run locally (covered by CI):
- `actionlint` — not installed locally; the existing workflow lint job in CI is authoritative.

Scenarios to validate on a release dispatch (post-merge):
- On a fresh release, Docker images are still built from the tag (in the `release-apps` job's checkout step, `ref` should resolve to `refs/tags/<version>`).
- Re-dispatch with `reuse_existing_tag=true` against an already-shipped version: Docker images build from the **tag** source, not current `main`. Image digests for components with no source change should match the original release.
- On a replay where helm artifacts are byte-identical, `publish-helm-chart` emits the `::warning title=helm publish::` line and the workflow continues green (instead of failing once timestamp restoration becomes deterministic).
- Normal release flow (real diff in `index.yaml`) still commits + pushes as before.

No video — workflow-only change with no UI surface.

## Documentation

No user-facing documentation changes. Both fixes are internal to the release pipeline.
