### PR TITLE
[OPIK-6626] [BE] feat: support multiple environments per prompt version

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersion.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersion.java
@@ -50,7 +50,7 @@ public record PromptVersion(
         @JsonView({PromptVersion.View.Public.class, Prompt.View.Detail.class,
                 PromptVersion.View.Detail.class}) @Schema(description = "version type discriminator; defaults to prompt_version") PromptVersionType versionType,
         @JsonView({PromptVersion.View.Public.class, Prompt.View.Detail.class,
-                PromptVersion.View.Detail.class}) @Nullable @Pattern(regexp = Environment.NAME_PATTERN, message = Environment.NAME_PATTERN_MESSAGE) @Size(max = 150, message = "cannot exceed 150 characters") String environment,
+                PromptVersion.View.Detail.class}) @Nullable @Size(max = 100, message = "cannot exceed 100 environments") Set<@Pattern(regexp = Environment.NAME_PATTERN, message = Environment.NAME_PATTERN_MESSAGE) @Size(max = 150, message = "cannot exceed 150 characters") String> environments,
         @JsonView({PromptVersion.View.Public.class, Prompt.View.Detail.class,
                 PromptVersion.View.Detail.class}) String changeDescription,
         @JsonView({PromptVersion.View.Public.class, Prompt.View.Detail.class,
@@ -102,7 +102,7 @@ public record PromptVersion(
     }
 
     @JsonIgnore
-    @AssertTrue(message = "environment cannot be set on a mask version") public boolean isEnvironmentCompatibleWithVersionType() {
-        return environment == null || versionType() != PromptVersionType.MASK;
+    @AssertTrue(message = "environments cannot be set on a mask version") public boolean isEnvironmentCompatibleWithVersionType() {
+        return (environments == null || environments.isEmpty()) || versionType() != PromptVersionType.MASK;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersion.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersion.java
@@ -15,6 +15,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
+import org.apache.commons.collections4.CollectionUtils;
 import org.jdbi.v3.json.Json;
 
 import java.time.Instant;
@@ -103,6 +104,6 @@ public record PromptVersion(
 
     @JsonIgnore
     @AssertTrue(message = "environments cannot be set on a mask version") public boolean isEnvironmentCompatibleWithVersionType() {
-        return (environments == null || environments.isEmpty()) || versionType() != PromptVersionType.MASK;
+        return CollectionUtils.isEmpty(environments) || versionType() != PromptVersionType.MASK;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersionEnvironmentUpdate.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersionEnvironmentUpdate.java
@@ -4,20 +4,23 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
+
+import java.util.Set;
 
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Schema(description = """
-        Set or clear the environment owned by a prompt version.
-        - non-null name: maps the environment to this version; if another version of the same prompt currently owns the environment, ownership is moved atomically.
-        - null: clears the environment from this version.
-        The environment must already exist in the workspace registry; unknown names return 404.
+        Replace the full set of environments assigned to a prompt version.
+        The provided set becomes the new complete set of environments for this version.
+        - Non-empty set: assigns each environment to this version; if another version of the same prompt currently owns any of those environments, ownership is moved atomically.
+        - Empty set: clears all environments from this version.
+        All environments must already exist in the workspace registry; unknown names return 404.
         """)
 public record PromptVersionEnvironmentUpdate(
-        @Nullable @Pattern(regexp = Environment.NAME_PATTERN, message = Environment.NAME_PATTERN_MESSAGE) @Size(max = 150, message = "cannot exceed 150 characters") String environment) {
+        @NotNull @Size(max = 100, message = "cannot exceed 100 environments") Set<@Pattern(regexp = Environment.NAME_PATTERN, message = Environment.NAME_PATTERN_MESSAGE) @Size(max = 150, message = "cannot exceed 150 characters") String> environments) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
@@ -424,11 +424,11 @@ public class PromptResource {
     public Response setPromptVersionEnvironment(@PathParam("versionId") UUID versionId,
             @RequestBody(content = @Content(schema = @Schema(implementation = PromptVersionEnvironmentUpdate.class))) @Valid @NotNull PromptVersionEnvironmentUpdate request) {
         String workspaceId = requestContext.get().getWorkspaceId();
-        log.info("Setting environment '{}' on prompt version '{}' on workspace_id '{}'",
-                request.environment(), versionId, workspaceId);
-        promptService.setVersionEnvironment(versionId, request.environment());
-        log.info("Successfully set environment '{}' on prompt version '{}' on workspace_id '{}'",
-                request.environment(), versionId, workspaceId);
+        log.info("Setting environments '{}' on prompt version '{}' on workspace_id '{}'",
+                request.environments(), versionId, workspaceId);
+        promptService.setVersionEnvironment(versionId, request.environments());
+        log.info("Successfully set environments '{}' on prompt version '{}' on workspace_id '{}'",
+                request.environments(), versionId, workspaceId);
         return Response.noContent().build();
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
@@ -61,6 +61,10 @@ interface EnvironmentDAO {
     @SqlQuery("SELECT COUNT(*) FROM environments WHERE workspace_id = :workspaceId AND name = :name")
     long countByName(@Bind("workspaceId") String workspaceId, @Bind("name") String name);
 
+    @SqlQuery("SELECT name FROM environments WHERE workspace_id = :workspaceId AND name IN (<names>)")
+    Set<String> findExistingNames(@Bind("workspaceId") String workspaceId,
+            @BindList("names") Set<String> names);
+
     @SqlQuery("SELECT COUNT(*) FROM environments WHERE workspace_id = :workspaceId")
     long countByWorkspace(@Bind("workspaceId") String workspaceId);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
@@ -68,10 +68,6 @@ interface EnvironmentDAO {
         return findNames(workspaceId, null);
     }
 
-    default Set<String> findExistingNames(String workspaceId, Set<String> names) {
-        return findNames(workspaceId, names);
-    }
-
     @SqlQuery("SELECT COUNT(*) FROM environments WHERE workspace_id = :workspaceId AND name = :name")
     long countByName(@Bind("workspaceId") String workspaceId, @Bind("name") String name);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentDAO.java
@@ -4,12 +4,15 @@ import com.comet.opik.api.Environment;
 import com.comet.opik.infrastructure.db.UUIDArgumentFactory;
 import org.jdbi.v3.sqlobject.config.RegisterArgumentFactory;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
+import org.jdbi.v3.sqlobject.customizer.AllowUnusedBindings;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.BindMethods;
+import org.jdbi.v3.sqlobject.customizer.Define;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.stringtemplate4.UseStringTemplateEngine;
 
 import java.util.List;
 import java.util.Optional;
@@ -55,15 +58,22 @@ interface EnvironmentDAO {
     @SqlQuery("SELECT * FROM environments WHERE workspace_id = :workspaceId ORDER BY created_at ASC")
     List<Environment> findAll(@Bind("workspaceId") String workspaceId);
 
-    @SqlQuery("SELECT name FROM environments WHERE workspace_id = :workspaceId")
-    List<String> findAllNames(@Bind("workspaceId") String workspaceId);
+    @SqlQuery("SELECT name FROM environments WHERE workspace_id = :workspaceId <if(names)> AND name IN (<names>) <endif>")
+    @UseStringTemplateEngine
+    @AllowUnusedBindings
+    Set<String> findNames(@Bind("workspaceId") String workspaceId,
+            @Define("names") @BindList(onEmpty = BindList.EmptyHandling.NULL_VALUE, value = "names") Set<String> names);
+
+    default Set<String> findAllNames(String workspaceId) {
+        return findNames(workspaceId, null);
+    }
+
+    default Set<String> findExistingNames(String workspaceId, Set<String> names) {
+        return findNames(workspaceId, names);
+    }
 
     @SqlQuery("SELECT COUNT(*) FROM environments WHERE workspace_id = :workspaceId AND name = :name")
     long countByName(@Bind("workspaceId") String workspaceId, @Bind("name") String name);
-
-    @SqlQuery("SELECT name FROM environments WHERE workspace_id = :workspaceId AND name IN (<names>)")
-    Set<String> findExistingNames(@Bind("workspaceId") String workspaceId,
-            @BindList("names") Set<String> names);
 
     @SqlQuery("SELECT COUNT(*) FROM environments WHERE workspace_id = :workspaceId")
     long countByWorkspace(@Bind("workspaceId") String workspaceId);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
@@ -19,6 +19,7 @@ import jakarta.ws.rs.core.Response;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import reactor.core.publisher.Mono;
@@ -203,7 +204,7 @@ class EnvironmentServiceImpl implements EnvironmentService {
 
     @Override
     public Set<String> findExistingNames(@NonNull Set<String> names, @NonNull String workspaceId) {
-        if (names.isEmpty()) {
+        if (CollectionUtils.isEmpty(names)) {
             return Set.of();
         }
         return template.inTransaction(READ_ONLY, handle -> handle.attach(EnvironmentDAO.class)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
@@ -203,12 +203,12 @@ class EnvironmentServiceImpl implements EnvironmentService {
     }
 
     @Override
-    public Set<String> findExistingNames(@NonNull Set<String> names, @NonNull String workspaceId) {
+    public Set<String> findExistingNames(Set<String> names, @NonNull String workspaceId) {
         if (CollectionUtils.isEmpty(names)) {
             return Set.of();
         }
         return template.inTransaction(READ_ONLY, handle -> handle.attach(EnvironmentDAO.class)
-                .findExistingNames(workspaceId, names));
+                .findNames(workspaceId, names));
     }
 
     private void trackEnvironmentCreatedEvent(Environment environment, String workspaceId, String userName,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/EnvironmentService.java
@@ -57,6 +57,8 @@ public interface EnvironmentService {
 
     boolean existsByName(String name, String workspaceId);
 
+    Set<String> findExistingNames(Set<String> names, String workspaceId);
+
     Environment update(UUID id, EnvironmentUpdate environmentUpdate);
 
     Environment get(UUID id);
@@ -197,6 +199,15 @@ class EnvironmentServiceImpl implements EnvironmentService {
             var repository = handle.attach(EnvironmentDAO.class);
             return repository.countByName(workspaceId, name) > 0;
         });
+    }
+
+    @Override
+    public Set<String> findExistingNames(@NonNull Set<String> names, @NonNull String workspaceId) {
+        if (names.isEmpty()) {
+            return Set.of();
+        }
+        return template.inTransaction(READ_ONLY, handle -> handle.attach(EnvironmentDAO.class)
+                .findExistingNames(workspaceId, names));
     }
 
     private void trackEnvironmentCreatedEvent(Environment environment, String workspaceId, String userName,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptDAO.java
@@ -55,70 +55,81 @@ public interface PromptDAO {
     void save(@Bind("workspace_id") String workspaceId, @BindMethods("bean") Prompt prompt);
 
     @SqlQuery("""
+            WITH pv_for_prompt AS (
+                SELECT pv.*
+                FROM prompt_versions pv
+                WHERE pv.prompt_id = :id AND pv.workspace_id = :workspace_id
+            ), active_envs AS (
+                SELECT pve.version_id, pve.environment
+                FROM prompt_version_envs pve
+                INNER JOIN pv_for_prompt pfp ON pfp.id = pve.version_id
+                WHERE pve.workspace_id = :workspace_id AND pve.ended_at IS NULL
+            ), ver_envs AS (
+                SELECT version_id, JSON_ARRAYAGG(environment) AS environments
+                FROM active_envs
+                GROUP BY version_id
+            )
             SELECT
-                *,
+                p.*,
                 (
-                    SELECT COUNT(pv.id)
-                    FROM prompt_versions pv
-                    WHERE pv.prompt_id = p.id
-                    AND pv.workspace_id = p.workspace_id
-                    AND pv.version_type = 'prompt_version'
+                    SELECT COUNT(pfp.id)
+                    FROM pv_for_prompt pfp
+                    WHERE pfp.version_type = 'prompt_version'
                 ) AS version_count,
                 (
                     SELECT JSON_OBJECT(
-                        'id', pv.id,
-                        'prompt_id', pv.prompt_id,
-                        'commit', pv.commit,
-                        'version_number', pv.version_number,
-                        'template', pv.template,
-                        'metadata', pv.metadata,
-                        'change_description', pv.change_description,
-                        'type', pv.type,
-                        'version_type', pv.version_type,
-                        'environments', (SELECT JSON_ARRAYAGG(pve.environment) FROM prompt_version_envs pve WHERE pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id AND pve.ended_at IS NULL),
-                        'tags', pv.tags,
-                        'created_at', pv.created_at,
-                        'created_by', pv.created_by,
-                        'last_updated_at', pv.last_updated_at,
-                        'last_updated_by', pv.last_updated_by
+                        'id', pfp.id,
+                        'prompt_id', pfp.prompt_id,
+                        'commit', pfp.commit,
+                        'version_number', pfp.version_number,
+                        'template', pfp.template,
+                        'metadata', pfp.metadata,
+                        'change_description', pfp.change_description,
+                        'type', pfp.type,
+                        'version_type', pfp.version_type,
+                        'environments', ve.environments,
+                        'tags', pfp.tags,
+                        'created_at', pfp.created_at,
+                        'created_by', pfp.created_by,
+                        'last_updated_at', pfp.last_updated_at,
+                        'last_updated_by', pfp.last_updated_by
                     )
-                    FROM prompt_versions pv
-                    WHERE pv.prompt_id = p.id
-                    AND pv.workspace_id = p.workspace_id
-                    AND pv.version_type = 'prompt_version'
-                    ORDER BY pv.id DESC
+                    FROM pv_for_prompt pfp
+                    LEFT JOIN ver_envs ve ON ve.version_id = pfp.id
+                    WHERE pfp.version_type = 'prompt_version'
+                    ORDER BY pfp.id DESC
                     LIMIT 1
                 ) AS latest_version
                 <if(mask_id || environment)>
                 ,
                 (
                     SELECT JSON_OBJECT(
-                        'id', pv.id,
-                        'prompt_id', pv.prompt_id,
-                        'commit', pv.commit,
-                        'version_number', pv.version_number,
-                        'template', pv.template,
-                        'metadata', pv.metadata,
-                        'change_description', pv.change_description,
-                        'type', pv.type,
-                        'version_type', pv.version_type,
-                        'environments', (SELECT JSON_ARRAYAGG(pve.environment) FROM prompt_version_envs pve WHERE pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id AND pve.ended_at IS NULL),
-                        'tags', pv.tags,
-                        'created_at', pv.created_at,
-                        'created_by', pv.created_by,
-                        'last_updated_at', pv.last_updated_at,
-                        'last_updated_by', pv.last_updated_by
+                        'id', pfp.id,
+                        'prompt_id', pfp.prompt_id,
+                        'commit', pfp.commit,
+                        'version_number', pfp.version_number,
+                        'template', pfp.template,
+                        'metadata', pfp.metadata,
+                        'change_description', pfp.change_description,
+                        'type', pfp.type,
+                        'version_type', pfp.version_type,
+                        'environments', ve.environments,
+                        'tags', pfp.tags,
+                        'created_at', pfp.created_at,
+                        'created_by', pfp.created_by,
+                        'last_updated_at', pfp.last_updated_at,
+                        'last_updated_by', pfp.last_updated_by
                     )
-                    FROM prompt_versions pv
-                    WHERE pv.prompt_id = p.id
-                    AND pv.workspace_id = p.workspace_id
-                    <if(mask_id)> AND pv.id = :mask_id AND pv.version_type = 'mask' <endif>
-                    <if(environment)> AND EXISTS (SELECT 1 FROM prompt_version_envs pve WHERE pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id AND pve.environment = :environment AND pve.ended_at IS NULL) AND pv.version_type = 'prompt_version' <endif>
+                    FROM pv_for_prompt pfp
+                    LEFT JOIN ver_envs ve ON ve.version_id = pfp.id
+                    WHERE 1=1
+                    <if(mask_id)> AND pfp.id = :mask_id AND pfp.version_type = 'mask' <endif>
+                    <if(environment)> AND pfp.id IN (SELECT version_id FROM active_envs WHERE environment = :environment) AND pfp.version_type = 'prompt_version' <endif>
                 ) AS requested_version
                 <endif>
             FROM prompts p
-            WHERE id = :id
-            AND workspace_id = :workspace_id
+            WHERE p.id = :id
+            AND p.workspace_id = :workspace_id
             """)
     @UseStringTemplateEngine
     @AllowUnusedBindings
@@ -179,39 +190,44 @@ public interface PromptDAO {
             	FROM prompts AS p
             	WHERE workspace_id = :workspace_id
             	<if(ids)> AND id IN (<ids>) <endif>
+            ), pv_ranked AS (
+                SELECT pv.*,
+                    ROW_NUMBER() OVER (PARTITION BY pv.prompt_id ORDER BY pv.id DESC) AS rn
+                FROM prompt_versions pv
+                WHERE pv.workspace_id = :workspace_id AND pv.version_type = 'prompt_version'
+                <if(ids)> AND pv.prompt_id IN (<ids>) <endif>
+            ), active_envs AS (
+                SELECT pve.version_id, pve.environment
+                FROM prompt_version_envs pve
+                INNER JOIN pv_ranked pvr ON pvr.id = pve.version_id AND pvr.rn = 1
+                WHERE pve.workspace_id = :workspace_id AND pve.ended_at IS NULL
+            ), ver_envs AS (
+                SELECT version_id, JSON_ARRAYAGG(environment) AS environments
+                FROM active_envs
+                GROUP BY version_id
             ), latest_versions AS (
             	SELECT
               JSON_OBJECT(
-                'id', id,
-                'prompt_id', prompt_id,
-                'commit', commit,
-                'version_number', version_number,
-                'template', template,
-                'metadata', metadata,
-                'change_description', change_description,
-                'type', type,
-                'version_type', version_type,
-                'environments', (SELECT JSON_ARRAYAGG(pve.environment) FROM prompt_version_envs pve WHERE pve.workspace_id = ranked.workspace_id AND pve.version_id = ranked.id AND pve.ended_at IS NULL),
-                'tags', tags,
-                'created_at', created_at,
-                'created_by', created_by,
-                'last_updated_at', last_updated_at,
-                'last_updated_by', last_updated_by
+                'id', pvr.id,
+                'prompt_id', pvr.prompt_id,
+                'commit', pvr.commit,
+                'version_number', pvr.version_number,
+                'template', pvr.template,
+                'metadata', pvr.metadata,
+                'change_description', pvr.change_description,
+                'type', pvr.type,
+                'version_type', pvr.version_type,
+                'environments', ve.environments,
+                'tags', pvr.tags,
+                'created_at', pvr.created_at,
+                'created_by', pvr.created_by,
+                'last_updated_at', pvr.last_updated_at,
+                'last_updated_by', pvr.last_updated_by
               ) AS latest_version,
-              prompt_id
-              FROM (
-                SELECT
-                  pv.*,
-                  ROW_NUMBER() OVER (
-                    PARTITION BY pv.prompt_id
-                    ORDER BY pv.id DESC
-                  ) AS rn
-                FROM prompt_versions pv
-                WHERE pv.workspace_id = :workspace_id
-                  AND pv.version_type = 'prompt_version'
-                  <if(ids)> AND pv.prompt_id IN (<ids>) <endif>
-              ) ranked
-              WHERE ranked.rn = 1
+              pvr.prompt_id
+              FROM pv_ranked pvr
+              LEFT JOIN ver_envs ve ON ve.version_id = pvr.id
+              WHERE pvr.rn = 1
             )
             SELECT sp.*, lv.latest_version
             FROM selected_prompts sp
@@ -276,6 +292,20 @@ public interface PromptDAO {
             @Bind("lastUpdatedBy") String lastUpdatedBy);
 
     @SqlQuery("""
+            WITH pv_for_commit AS (
+                SELECT pv.*
+                FROM prompt_versions pv
+                WHERE pv.commit = :commit AND pv.workspace_id = :workspace_id AND pv.version_type = 'prompt_version'
+            ), active_envs AS (
+                SELECT pve.version_id, pve.environment
+                FROM prompt_version_envs pve
+                INNER JOIN pv_for_commit pvc ON pvc.id = pve.version_id
+                WHERE pve.workspace_id = :workspace_id AND pve.ended_at IS NULL
+            ), ver_envs AS (
+                SELECT version_id, JSON_ARRAYAGG(environment) AS environments
+                FROM active_envs
+                GROUP BY version_id
+            )
             SELECT
                 p.*,
                 (
@@ -286,27 +316,25 @@ public interface PromptDAO {
                     AND pv2.version_type = 'prompt_version'
                 ) AS version_count,
                 JSON_OBJECT(
-                    'id', pv.id,
-                    'prompt_id', pv.prompt_id,
-                    'commit', pv.commit,
-                    'version_number', pv.version_number,
-                    'template', pv.template,
-                    'metadata', pv.metadata,
-                    'change_description', pv.change_description,
-                    'type', pv.type,
-                    'version_type', pv.version_type,
-                    'environments', (SELECT JSON_ARRAYAGG(pve.environment) FROM prompt_version_envs pve WHERE pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id AND pve.ended_at IS NULL),
-                    'tags', pv.tags,
-                    'created_at', pv.created_at,
-                    'created_by', pv.created_by,
-                    'last_updated_at', pv.last_updated_at,
-                    'last_updated_by', pv.last_updated_by
+                    'id', pvc.id,
+                    'prompt_id', pvc.prompt_id,
+                    'commit', pvc.commit,
+                    'version_number', pvc.version_number,
+                    'template', pvc.template,
+                    'metadata', pvc.metadata,
+                    'change_description', pvc.change_description,
+                    'type', pvc.type,
+                    'version_type', pvc.version_type,
+                    'environments', ve.environments,
+                    'tags', pvc.tags,
+                    'created_at', pvc.created_at,
+                    'created_by', pvc.created_by,
+                    'last_updated_at', pvc.last_updated_at,
+                    'last_updated_by', pvc.last_updated_by
                 ) AS requested_version
-            FROM prompt_versions pv
-            INNER JOIN prompts p ON pv.prompt_id = p.id AND p.workspace_id = pv.workspace_id
-            WHERE pv.commit = :commit
-            AND pv.workspace_id = :workspace_id
-            AND pv.version_type = 'prompt_version'
+            FROM pv_for_commit pvc
+            INNER JOIN prompts p ON pvc.prompt_id = p.id AND p.workspace_id = pvc.workspace_id
+            LEFT JOIN ver_envs ve ON ve.version_id = pvc.id
             """)
     List<Prompt> findByCommit(@Bind("commit") String commit, @Bind("workspace_id") String workspaceId);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptDAO.java
@@ -75,7 +75,7 @@ public interface PromptDAO {
                         'change_description', pv.change_description,
                         'type', pv.type,
                         'version_type', pv.version_type,
-                        'environment', pv.environment,
+                        'environments', (SELECT JSON_ARRAYAGG(pve.environment) FROM prompt_version_envs pve WHERE pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id AND pve.ended_at IS NULL),
                         'tags', pv.tags,
                         'created_at', pv.created_at,
                         'created_by', pv.created_by,
@@ -102,7 +102,7 @@ public interface PromptDAO {
                         'change_description', pv.change_description,
                         'type', pv.type,
                         'version_type', pv.version_type,
-                        'environment', pv.environment,
+                        'environments', (SELECT JSON_ARRAYAGG(pve.environment) FROM prompt_version_envs pve WHERE pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id AND pve.ended_at IS NULL),
                         'tags', pv.tags,
                         'created_at', pv.created_at,
                         'created_by', pv.created_by,
@@ -113,7 +113,7 @@ public interface PromptDAO {
                     WHERE pv.prompt_id = p.id
                     AND pv.workspace_id = p.workspace_id
                     <if(mask_id)> AND pv.id = :mask_id AND pv.version_type = 'mask' <endif>
-                    <if(environment)> AND pv.environment = :environment AND pv.version_type = 'prompt_version' <endif>
+                    <if(environment)> AND EXISTS (SELECT 1 FROM prompt_version_envs pve WHERE pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id AND pve.environment = :environment AND pve.ended_at IS NULL) AND pv.version_type = 'prompt_version' <endif>
                 ) AS requested_version
                 <endif>
             FROM prompts p
@@ -191,7 +191,7 @@ public interface PromptDAO {
                 'change_description', change_description,
                 'type', type,
                 'version_type', version_type,
-                'environment', environment,
+                'environments', (SELECT JSON_ARRAYAGG(pve.environment) FROM prompt_version_envs pve WHERE pve.workspace_id = ranked.workspace_id AND pve.version_id = ranked.id AND pve.ended_at IS NULL),
                 'tags', tags,
                 'created_at', created_at,
                 'created_by', created_by,
@@ -295,7 +295,7 @@ public interface PromptDAO {
                     'change_description', pv.change_description,
                     'type', pv.type,
                     'version_type', pv.version_type,
-                    'environment', pv.environment,
+                    'environments', (SELECT JSON_ARRAYAGG(pve.environment) FROM prompt_version_envs pve WHERE pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id AND pve.ended_at IS NULL),
                     'tags', pv.tags,
                     'created_at', pv.created_at,
                     'created_by', pv.created_by,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -800,11 +800,22 @@ class PromptServiceImpl implements PromptService {
 
         withPromptVersionLock(workspaceId, promptId, () -> transactionTemplate.inTransaction(WRITE, handle -> {
             PromptVersionDAO dao = handle.attach(PromptVersionDAO.class);
-            dao.closeVersionEnvironments(versionId, workspaceId);
-            if (!CollectionUtils.isEmpty(envs)) {
-                dao.closeEnvOwnershipsForPrompt(promptId, workspaceId, envs);
-                List<UUID> envIds = envs.stream().map(ignored -> idGenerator.generateId()).toList();
-                dao.saveEnvironments(envIds, workspaceId, promptId, versionId, envs, userName);
+
+            Set<String> currentEnvs = dao.findVersionEnvironments(versionId, workspaceId);
+
+            Set<String> toAdd = new HashSet<>(envs);
+            toAdd.removeAll(currentEnvs);
+
+            Set<String> toRemove = new HashSet<>(currentEnvs);
+            toRemove.removeAll(envs);
+
+            if (!CollectionUtils.isEmpty(toRemove)) {
+                dao.closeVersionEnvironmentsForNames(versionId, workspaceId, toRemove);
+            }
+            if (!CollectionUtils.isEmpty(toAdd)) {
+                dao.closeEnvOwnershipsForPrompt(promptId, workspaceId, toAdd);
+                List<UUID> envIds = toAdd.stream().map(ignored -> idGenerator.generateId()).toList();
+                dao.saveEnvironments(envIds, workspaceId, promptId, versionId, toAdd, userName);
             }
             return null;
         }));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -33,11 +33,13 @@ import jakarta.ws.rs.NotFoundException;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -55,6 +57,7 @@ import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
 import static com.comet.opik.utils.AsyncUtils.makeMonoContextAware;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
 
 @ImplementedBy(PromptServiceImpl.class)
 public interface PromptService {
@@ -337,9 +340,9 @@ class PromptServiceImpl implements PromptService {
                 : createPromptVersion.version().environments().stream()
                         .filter(StringUtils::isNotBlank)
                         .map(String::trim)
-                        .collect(java.util.stream.Collectors.toSet());
+                        .collect(toSet());
 
-        if (!environments.isEmpty()) {
+        if (!CollectionUtils.isEmpty(environments)) {
             environmentService.bulkCreate(environments, workspaceId, userName);
         }
 
@@ -525,8 +528,11 @@ class PromptServiceImpl implements PromptService {
             }
 
             promptVersionDAO.save(workspaceId, toSave);
-            promptVersionDAO.saveEnvironments(workspaceId, toSave.promptId(), toSave.id(),
-                    toSave.environments(), toSave.createdBy());
+            if (!CollectionUtils.isEmpty(toSave.environments())) {
+                List<UUID> envIds = toSave.environments().stream().map(ignored -> idGenerator.generateId()).toList();
+                promptVersionDAO.saveEnvironments(envIds, workspaceId, toSave.promptId(), toSave.id(),
+                        toSave.environments(), toSave.createdBy());
+            }
             if (toSave.versionType() != PromptVersionType.MASK) {
                 promptDAO.updateLastUpdatedAt(toSave.promptId(), workspaceId, toSave.createdBy());
             }
@@ -772,7 +778,7 @@ class PromptServiceImpl implements PromptService {
                 : environments.stream()
                         .filter(StringUtils::isNotBlank)
                         .map(String::trim)
-                        .collect(java.util.stream.Collectors.toSet());
+                        .collect(toSet());
 
         PromptVersion version = getVersionById(versionId);
 
@@ -780,12 +786,12 @@ class PromptServiceImpl implements PromptService {
             throw new BadRequestException(MASK_ENV_NOT_ALLOWED);
         }
 
-        if (!envs.isEmpty()) {
+        if (!CollectionUtils.isEmpty(envs)) {
             Set<String> existing = environmentService.findExistingNames(envs, workspaceId);
             if (existing.size() != envs.size()) {
-                Set<String> missing = new java.util.HashSet<>(envs);
+                Set<String> missing = new HashSet<>(envs);
                 missing.removeAll(existing);
-                throw new NotFoundException(
+                throw new ConflictException(
                         "Environments do not exist in the workspace: '%s'".formatted(missing));
             }
         }
@@ -795,10 +801,11 @@ class PromptServiceImpl implements PromptService {
         withPromptVersionLock(workspaceId, promptId, () -> transactionTemplate.inTransaction(WRITE, handle -> {
             PromptVersionDAO dao = handle.attach(PromptVersionDAO.class);
             dao.closeVersionEnvironments(versionId, workspaceId);
-            if (!envs.isEmpty()) {
+            if (!CollectionUtils.isEmpty(envs)) {
                 dao.closeEnvOwnershipsForPrompt(promptId, workspaceId, envs);
+                List<UUID> envIds = envs.stream().map(ignored -> idGenerator.generateId()).toList();
+                dao.saveEnvironments(envIds, workspaceId, promptId, versionId, envs, userName);
             }
-            dao.saveEnvironments(workspaceId, promptId, versionId, envs, userName);
             return null;
         }));
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -77,7 +77,7 @@ public interface PromptService {
 
     Prompt getById(UUID id, UUID maskId, String environment);
 
-    void setVersionEnvironment(UUID versionId, String environment);
+    void setVersionEnvironment(UUID versionId, Set<String> environments);
 
     List<Prompt> getByIds(Set<UUID> ids);
 
@@ -332,16 +332,21 @@ class PromptServiceImpl implements PromptService {
         Prompt prompt = getOrCreatePrompt(workspaceId, createPromptVersion.name(), userName, templateStructure,
                 projectId);
 
-        String environment = StringUtils.trimToNull(createPromptVersion.version().environment());
+        Set<String> environments = createPromptVersion.version().environments() == null
+                ? Set.of()
+                : createPromptVersion.version().environments().stream()
+                        .filter(StringUtils::isNotBlank)
+                        .map(String::trim)
+                        .collect(java.util.stream.Collectors.toSet());
 
-        if (environment != null) {
-            environmentService.bulkCreate(Set.of(environment), workspaceId, userName);
+        if (!environments.isEmpty()) {
+            environmentService.bulkCreate(environments, workspaceId, userName);
         }
 
         return withPromptVersionLock(workspaceId, prompt.id(), () -> {
-            if (environment != null) {
+            if (!environments.isEmpty()) {
                 return createVersionWithEnvironment(workspaceId, workspaceName, userName, projectId, prompt,
-                        createPromptVersion, id, commit, environment);
+                        createPromptVersion, id, commit, environments);
             }
 
             EntityConstraintHandler<PromptVersion> handler = EntityConstraintHandler.handle(() -> {
@@ -375,15 +380,14 @@ class PromptServiceImpl implements PromptService {
 
     private PromptVersion createVersionWithEnvironment(String workspaceId, String workspaceName, String userName,
             UUID projectId, Prompt prompt, CreatePromptVersion createPromptVersion, UUID id, String commit,
-            String environment) {
-        PromptVersion existing = transactionTemplate.inTransaction(READ_ONLY, handle -> {
+            Set<String> environments) {
+        Set<String> takenEnvs = transactionTemplate.<Set<String>>inTransaction(READ_ONLY, handle -> {
             PromptVersionDAO dao = handle.attach(PromptVersionDAO.class);
-            return dao.findByEnvironment(prompt.id(), environment, workspaceId);
+            return dao.findTakenEnvironments(prompt.id(), workspaceId, environments);
         });
-        if (existing != null) {
+        if (!takenEnvs.isEmpty()) {
             throw new EntityAlreadyExistsException(new ErrorMessage(409,
-                    "Environment '%s' is already mapped to version '%s'"
-                            .formatted(environment, existing.commit())));
+                    "Environments already mapped to another version: '%s'".formatted(takenEnvs)));
         }
 
         PromptVersion promptVersion = createPromptVersion.version().toBuilder()
@@ -391,6 +395,7 @@ class PromptServiceImpl implements PromptService {
                 .createdBy(userName)
                 .id(id)
                 .commit(commit)
+                .environments(environments)
                 .build();
 
         var saved = savePromptVersion(workspaceId, promptVersion);
@@ -520,6 +525,8 @@ class PromptServiceImpl implements PromptService {
             }
 
             promptVersionDAO.save(workspaceId, toSave);
+            promptVersionDAO.saveEnvironments(workspaceId, toSave.promptId(), toSave.id(),
+                    toSave.environments(), toSave.createdBy());
             if (toSave.versionType() != PromptVersionType.MASK) {
                 promptDAO.updateLastUpdatedAt(toSave.promptId(), workspaceId, toSave.createdBy());
             }
@@ -756,9 +763,16 @@ class PromptServiceImpl implements PromptService {
     }
 
     @Override
-    public void setVersionEnvironment(@NonNull UUID versionId, String environment) {
+    public void setVersionEnvironment(@NonNull UUID versionId, Set<String> environments) {
         String workspaceId = requestContext.get().getWorkspaceId();
-        String env = StringUtils.trimToNull(environment);
+        String userName = requestContext.get().getUserName();
+
+        Set<String> envs = environments == null
+                ? Set.of()
+                : environments.stream()
+                        .filter(StringUtils::isNotBlank)
+                        .map(String::trim)
+                        .collect(java.util.stream.Collectors.toSet());
 
         PromptVersion version = getVersionById(versionId);
 
@@ -766,26 +780,29 @@ class PromptServiceImpl implements PromptService {
             throw new BadRequestException(MASK_ENV_NOT_ALLOWED);
         }
 
-        UUID promptId = version.promptId();
-
-        if (env != null && !environmentService.existsByName(env, workspaceId)) {
-            throw new NotFoundException(
-                    "Environment '%s' does not exist in the workspace".formatted(env));
+        if (!envs.isEmpty()) {
+            Set<String> existing = environmentService.findExistingNames(envs, workspaceId);
+            if (existing.size() != envs.size()) {
+                Set<String> missing = new java.util.HashSet<>(envs);
+                missing.removeAll(existing);
+                throw new NotFoundException(
+                        "Environments do not exist in the workspace: '%s'".formatted(missing));
+            }
         }
+
+        UUID promptId = version.promptId();
 
         withPromptVersionLock(workspaceId, promptId, () -> transactionTemplate.inTransaction(WRITE, handle -> {
             PromptVersionDAO dao = handle.attach(PromptVersionDAO.class);
-            if (env != null) {
-                dao.clearEnvironment(promptId, workspaceId, env);
+            dao.closeVersionEnvironments(versionId, workspaceId);
+            if (!envs.isEmpty()) {
+                dao.closeEnvOwnershipsForPrompt(promptId, workspaceId, envs);
             }
-            int updated = dao.updateEnvironment(versionId, workspaceId, env);
-            if (updated == 0) {
-                throw new NotFoundException(PROMPT_VERSION_NOT_FOUND);
-            }
-            return updated;
+            dao.saveEnvironments(workspaceId, promptId, versionId, envs, userName);
+            return null;
         }));
 
-        log.info("Set environment '{}' on prompt version '{}'", env, versionId);
+        log.info("Set environments '{}' on prompt version '{}'", envs, versionId);
     }
 
     @Override
@@ -869,7 +886,7 @@ class PromptServiceImpl implements PromptService {
                 .createdBy(userName)
                 .changeDescription("Restored from version " + versionRef)
                 .tags(null) // Don't propagate tags to restored version
-                .environment(null) // Don't propagate environment ownership to restored version
+                .environments(null) // Don't propagate environment ownership to restored version
                 .build();
 
         PromptVersion restoredVersion = withPromptVersionLock(workspaceId, promptId,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -339,7 +339,7 @@ class PromptServiceImpl implements PromptService {
                 ? Set.of()
                 : createPromptVersion.version().environments().stream()
                         .filter(StringUtils::isNotBlank)
-                        .map(String::trim)
+                        .map(String::strip)
                         .collect(toSet());
 
         if (!CollectionUtils.isEmpty(environments)) {
@@ -777,7 +777,7 @@ class PromptServiceImpl implements PromptService {
                 ? Set.of()
                 : environments.stream()
                         .filter(StringUtils::isNotBlank)
-                        .map(String::trim)
+                        .map(String::strip)
                         .collect(toSet());
 
         PromptVersion version = getVersionById(versionId);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptVersionDAO.java
@@ -65,21 +65,22 @@ interface PromptVersionDAO {
 
     @SqlBatch("""
             INSERT INTO prompt_version_envs (id, workspace_id, prompt_id, version_id, environment, created_by)
-            VALUES (UUID(), :workspace_id, :prompt_id, :version_id, :environment, :created_by)
+            VALUES (:id, :workspace_id, :prompt_id, :version_id, :environment, :created_by)
             """)
     void saveEnvironments(
+            @Bind("id") List<UUID> ids,
             @Bind("workspace_id") String workspaceId,
             @Bind("prompt_id") UUID promptId,
             @Bind("version_id") UUID versionId,
             @Bind("environment") List<String> environments,
             @Bind("created_by") String createdBy);
 
-    default void saveEnvironments(String workspaceId, UUID promptId, UUID versionId, Set<String> environments,
-            String createdBy) {
+    default void saveEnvironments(List<UUID> ids, String workspaceId, UUID promptId, UUID versionId,
+            Set<String> environments, String createdBy) {
         if (environments == null || environments.isEmpty()) {
             return;
         }
-        saveEnvironments(workspaceId, promptId, versionId, List.copyOf(environments), createdBy);
+        saveEnvironments(ids, workspaceId, promptId, versionId, List.copyOf(environments), createdBy);
     }
 
     @SqlUpdate("""
@@ -105,18 +106,29 @@ interface PromptVersionDAO {
             @BindList("environments") Set<String> environments);
 
     @SqlQuery("""
-            SELECT pv.*,
-                p.template_structure,
-                (SELECT JSON_ARRAYAGG(pve.environment) FROM prompt_version_envs pve WHERE pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id AND pve.ended_at IS NULL) AS environments
-            FROM prompt_versions pv
-            INNER JOIN prompts p ON pv.prompt_id = p.id
-            WHERE pv.workspace_id = :workspace_id
-            <if(ids)> AND pv.id IN (<ids>) <endif>
-            <if(prompt_id)> AND pv.prompt_id = :prompt_id AND pv.version_type = 'prompt_version' <endif>
-            <if(search)> AND (pv.template LIKE CONCAT('%', :search, '%') OR pv.change_description LIKE CONCAT('%', :search, '%')) <endif>
-            <if(filters)> AND <filters> <endif>
+            WITH paginated AS (
+                SELECT pv.*,
+                    p.template_structure
+                FROM prompt_versions pv
+                INNER JOIN prompts p ON pv.prompt_id = p.id
+                WHERE pv.workspace_id = :workspace_id
+                <if(ids)> AND pv.id IN (<ids>) <endif>
+                <if(prompt_id)> AND pv.prompt_id = :prompt_id AND pv.version_type = 'prompt_version' <endif>
+                <if(search)> AND (pv.template LIKE CONCAT('%', :search, '%') OR pv.change_description LIKE CONCAT('%', :search, '%')) <endif>
+                <if(filters)> AND <filters> <endif>
+                ORDER BY <if(sort_fields)><sort_fields>, <endif>pv.id DESC
+                <if(limit)> LIMIT :limit OFFSET :offset <endif>
+            ), ver_envs AS (
+                SELECT pve.version_id, JSON_ARRAYAGG(pve.environment) AS environments
+                FROM prompt_version_envs pve
+                INNER JOIN paginated pv ON pv.id = pve.version_id
+                WHERE pve.workspace_id = :workspace_id AND pve.ended_at IS NULL
+                GROUP BY pve.version_id
+            )
+            SELECT pv.*, ve.environments
+            FROM paginated pv
+            LEFT JOIN ver_envs ve ON ve.version_id = pv.id
             ORDER BY <if(sort_fields)><sort_fields>, <endif>pv.id DESC
-            <if(limit)> LIMIT :limit OFFSET :offset <endif>
             """)
     @UseStringTemplateEngine
     @AllowUnusedBindings

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptVersionDAO.java
@@ -13,6 +13,7 @@ import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.BindMap;
 import org.jdbi.v3.sqlobject.customizer.BindMethods;
 import org.jdbi.v3.sqlobject.customizer.Define;
+import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.stringtemplate4.UseStringTemplateEngine;
@@ -41,7 +42,6 @@ interface PromptVersionDAO {
                 change_description,
                 type,
                 version_type,
-                environment,
                 tags,
                 created_by,
                 workspace_id
@@ -56,7 +56,6 @@ interface PromptVersionDAO {
                 :bean.changeDescription,
                 :bean.type,
                 :bean.versionType,
-                :bean.environment,
                 :bean.tags,
                 :bean.createdBy,
                 :workspace_id
@@ -64,8 +63,51 @@ interface PromptVersionDAO {
             """)
     void save(@Bind("workspace_id") String workspaceId, @BindMethods("bean") PromptVersion prompt);
 
+    @SqlBatch("""
+            INSERT INTO prompt_version_envs (id, workspace_id, prompt_id, version_id, environment, created_by)
+            VALUES (UUID(), :workspace_id, :prompt_id, :version_id, :environment, :created_by)
+            """)
+    void saveEnvironments(
+            @Bind("workspace_id") String workspaceId,
+            @Bind("prompt_id") UUID promptId,
+            @Bind("version_id") UUID versionId,
+            @Bind("environment") List<String> environments,
+            @Bind("created_by") String createdBy);
+
+    default void saveEnvironments(String workspaceId, UUID promptId, UUID versionId, Set<String> environments,
+            String createdBy) {
+        if (environments == null || environments.isEmpty()) {
+            return;
+        }
+        saveEnvironments(workspaceId, promptId, versionId, List.copyOf(environments), createdBy);
+    }
+
+    @SqlUpdate("""
+            UPDATE prompt_version_envs
+            SET ended_at = CURRENT_TIMESTAMP(6)
+            WHERE workspace_id = :workspace_id AND version_id = :version_id AND ended_at IS NULL
+            """)
+    void closeVersionEnvironments(@Bind("version_id") UUID versionId, @Bind("workspace_id") String workspaceId);
+
+    @SqlUpdate("""
+            UPDATE prompt_version_envs
+            SET ended_at = CURRENT_TIMESTAMP(6)
+            WHERE workspace_id = :workspace_id AND prompt_id = :prompt_id AND environment IN (<environments>) AND ended_at IS NULL
+            """)
+    void closeEnvOwnershipsForPrompt(@Bind("prompt_id") UUID promptId, @Bind("workspace_id") String workspaceId,
+            @BindList("environments") Set<String> environments);
+
     @SqlQuery("""
-            SELECT pv.*, p.template_structure
+            SELECT environment FROM prompt_version_envs
+            WHERE workspace_id = :workspace_id AND prompt_id = :prompt_id AND environment IN (<environments>) AND ended_at IS NULL
+            """)
+    Set<String> findTakenEnvironments(@Bind("prompt_id") UUID promptId, @Bind("workspace_id") String workspaceId,
+            @BindList("environments") Set<String> environments);
+
+    @SqlQuery("""
+            SELECT pv.*,
+                p.template_structure,
+                (SELECT JSON_ARRAYAGG(pve.environment) FROM prompt_version_envs pve WHERE pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id AND pve.ended_at IS NULL) AS environments
             FROM prompt_versions pv
             INNER JOIN prompts p ON pv.prompt_id = p.id
             WHERE pv.workspace_id = :workspace_id
@@ -142,7 +184,9 @@ interface PromptVersionDAO {
     }
 
     @SqlQuery("""
-            SELECT pv.*, p.template_structure
+            SELECT pv.*,
+                p.template_structure,
+                (SELECT JSON_ARRAYAGG(pve.environment) FROM prompt_version_envs pve WHERE pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id AND pve.ended_at IS NULL) AS environments
             FROM prompt_versions pv
             INNER JOIN prompts p ON pv.prompt_id = p.id
             WHERE pv.prompt_id = :prompt_id AND pv.commit = :commit AND pv.workspace_id = :workspace_id
@@ -152,7 +196,9 @@ interface PromptVersionDAO {
             @Bind("workspace_id") String workspaceId);
 
     @SqlQuery("""
-            SELECT pv.*, p.template_structure
+            SELECT pv.*,
+                p.template_structure,
+                (SELECT JSON_ARRAYAGG(pve.environment) FROM prompt_version_envs pve WHERE pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id AND pve.ended_at IS NULL) AS environments
             FROM prompt_versions pv
             INNER JOIN prompts p ON pv.prompt_id = p.id
             WHERE pv.prompt_id = :prompt_id
@@ -223,28 +269,15 @@ interface PromptVersionDAO {
     @SqlUpdate("DELETE FROM prompt_versions WHERE prompt_id = :prompt_id AND workspace_id = :workspace_id")
     int deleteByPromptId(@Bind("prompt_id") UUID promptId, @Bind("workspace_id") String workspaceId);
 
-    @SqlUpdate("""
-            UPDATE prompt_versions
-            SET environment = :environment
-            WHERE id = :id AND workspace_id = :workspace_id AND version_type = 'prompt_version'
-            """)
-    int updateEnvironment(@Bind("id") UUID id, @Bind("workspace_id") String workspaceId,
-            @Bind("environment") String environment);
-
-    @SqlUpdate("""
-            UPDATE prompt_versions
-            SET environment = NULL
-            WHERE prompt_id = :prompt_id AND workspace_id = :workspace_id AND environment = :environment
-            """)
-    int clearEnvironment(@Bind("prompt_id") UUID promptId, @Bind("workspace_id") String workspaceId,
-            @Bind("environment") String environment);
-
     @SqlQuery("""
-            SELECT pv.*, p.template_structure
+            SELECT pv.*,
+                p.template_structure,
+                (SELECT JSON_ARRAYAGG(pve2.environment) FROM prompt_version_envs pve2 WHERE pve2.workspace_id = pv.workspace_id AND pve2.version_id = pv.id AND pve2.ended_at IS NULL) AS environments
             FROM prompt_versions pv
             INNER JOIN prompts p ON pv.prompt_id = p.id
-            WHERE pv.prompt_id = :prompt_id AND pv.environment = :environment AND pv.workspace_id = :workspace_id
-            AND pv.version_type = 'prompt_version'
+            INNER JOIN prompt_version_envs pve ON pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id
+            WHERE pv.prompt_id = :prompt_id AND pve.environment = :environment AND pv.workspace_id = :workspace_id
+            AND pv.version_type = 'prompt_version' AND pve.ended_at IS NULL
             """)
     PromptVersion findByEnvironment(@Bind("prompt_id") UUID promptId, @Bind("environment") String environment,
             @Bind("workspace_id") String workspaceId);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptVersionDAO.java
@@ -4,6 +4,7 @@ import com.comet.opik.api.PromptVersion;
 import com.comet.opik.api.PromptVersionBatchUpdate;
 import com.comet.opik.infrastructure.db.SetFlatArgumentFactory;
 import com.comet.opik.infrastructure.db.UUIDArgumentFactory;
+import org.apache.commons.collections4.CollectionUtils;
 import org.jdbi.v3.sqlobject.config.RegisterArgumentFactory;
 import org.jdbi.v3.sqlobject.config.RegisterColumnMapper;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
@@ -77,7 +78,7 @@ interface PromptVersionDAO {
 
     default void saveEnvironments(List<UUID> ids, String workspaceId, UUID promptId, UUID versionId,
             Set<String> environments, String createdBy) {
-        if (environments == null || environments.isEmpty()) {
+        if (CollectionUtils.isEmpty(environments)) {
             return;
         }
         saveEnvironments(ids, workspaceId, promptId, versionId, List.copyOf(environments), createdBy);
@@ -85,39 +86,52 @@ interface PromptVersionDAO {
 
     @SqlQuery("""
             SELECT environment FROM prompt_version_envs
-            WHERE workspace_id = :workspace_id AND version_id = :version_id AND ended_at IS NULL
+            WHERE workspace_id = :workspace_id
+            <if(version_id)> AND version_id = :version_id <endif>
+            <if(prompt_id)> AND prompt_id = :prompt_id <endif>
+            <if(environments)> AND environment IN (<environments>) <endif>
+            AND ended_at IS NULL
             """)
-    Set<String> findVersionEnvironments(@Bind("version_id") UUID versionId, @Bind("workspace_id") String workspaceId);
+    @UseStringTemplateEngine
+    @AllowUnusedBindings
+    Set<String> findActiveEnvironments(
+            @Bind("workspace_id") String workspaceId,
+            @Define("version_id") @Bind("version_id") UUID versionId,
+            @Define("prompt_id") @Bind("prompt_id") UUID promptId,
+            @Define("environments") @BindList(onEmpty = BindList.EmptyHandling.NULL_VALUE, value = "environments") Set<String> environments);
+
+    default Set<String> findVersionEnvironments(UUID versionId, String workspaceId) {
+        return findActiveEnvironments(workspaceId, versionId, null, null);
+    }
+
+    default Set<String> findTakenEnvironments(UUID promptId, String workspaceId, Set<String> environments) {
+        return findActiveEnvironments(workspaceId, null, promptId, environments);
+    }
 
     @SqlUpdate("""
             UPDATE prompt_version_envs
             SET ended_at = CURRENT_TIMESTAMP(6)
-            WHERE workspace_id = :workspace_id AND version_id = :version_id AND ended_at IS NULL
+            WHERE workspace_id = :workspace_id
+            <if(version_id)> AND version_id = :version_id <endif>
+            <if(prompt_id)> AND prompt_id = :prompt_id <endif>
+            <if(environments)> AND environment IN (<environments>) <endif>
+            AND ended_at IS NULL
             """)
-    void closeVersionEnvironments(@Bind("version_id") UUID versionId, @Bind("workspace_id") String workspaceId);
+    @UseStringTemplateEngine
+    @AllowUnusedBindings
+    void closeEnvironmentAssignments(
+            @Bind("workspace_id") String workspaceId,
+            @Define("version_id") @Bind("version_id") UUID versionId,
+            @Define("prompt_id") @Bind("prompt_id") UUID promptId,
+            @Define("environments") @BindList(onEmpty = BindList.EmptyHandling.NULL_VALUE, value = "environments") Set<String> environments);
 
-    @SqlUpdate("""
-            UPDATE prompt_version_envs
-            SET ended_at = CURRENT_TIMESTAMP(6)
-            WHERE workspace_id = :workspace_id AND version_id = :version_id AND environment IN (<environments>) AND ended_at IS NULL
-            """)
-    void closeVersionEnvironmentsForNames(@Bind("version_id") UUID versionId, @Bind("workspace_id") String workspaceId,
-            @BindList("environments") Set<String> environments);
+    default void closeVersionEnvironmentsForNames(UUID versionId, String workspaceId, Set<String> environments) {
+        closeEnvironmentAssignments(workspaceId, versionId, null, environments);
+    }
 
-    @SqlUpdate("""
-            UPDATE prompt_version_envs
-            SET ended_at = CURRENT_TIMESTAMP(6)
-            WHERE workspace_id = :workspace_id AND prompt_id = :prompt_id AND environment IN (<environments>) AND ended_at IS NULL
-            """)
-    void closeEnvOwnershipsForPrompt(@Bind("prompt_id") UUID promptId, @Bind("workspace_id") String workspaceId,
-            @BindList("environments") Set<String> environments);
-
-    @SqlQuery("""
-            SELECT environment FROM prompt_version_envs
-            WHERE workspace_id = :workspace_id AND prompt_id = :prompt_id AND environment IN (<environments>) AND ended_at IS NULL
-            """)
-    Set<String> findTakenEnvironments(@Bind("prompt_id") UUID promptId, @Bind("workspace_id") String workspaceId,
-            @BindList("environments") Set<String> environments);
+    default void closeEnvOwnershipsForPrompt(UUID promptId, String workspaceId, Set<String> environments) {
+        closeEnvironmentAssignments(workspaceId, null, promptId, environments);
+    }
 
     @SqlQuery("""
             WITH paginated AS (
@@ -215,26 +229,30 @@ interface PromptVersionDAO {
                 (SELECT JSON_ARRAYAGG(pve.environment) FROM prompt_version_envs pve WHERE pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id AND pve.ended_at IS NULL) AS environments
             FROM prompt_versions pv
             INNER JOIN prompts p ON pv.prompt_id = p.id
-            WHERE pv.prompt_id = :prompt_id AND pv.commit = :commit AND pv.workspace_id = :workspace_id
+            <if(environment)>
+            INNER JOIN prompt_version_envs pve ON pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id AND pve.environment = :environment AND pve.ended_at IS NULL
+            <endif>
+            WHERE pv.prompt_id = :prompt_id AND pv.workspace_id = :workspace_id
             AND pv.version_type = 'prompt_version'
+            <if(commit)> AND pv.commit = :commit <endif>
+            <if(version_number)> AND pv.version_number = :version_number <endif>
             """)
-    PromptVersion findByCommit(@Bind("prompt_id") UUID promptId, @Bind("commit") String commit,
-            @Bind("workspace_id") String workspaceId);
+    @UseStringTemplateEngine
+    @AllowUnusedBindings
+    PromptVersion findSingleVersion(
+            @Bind("prompt_id") UUID promptId,
+            @Bind("workspace_id") String workspaceId,
+            @Define("commit") @Bind("commit") String commit,
+            @Define("version_number") @Bind("version_number") String versionNumber,
+            @Define("environment") @Bind("environment") String environment);
 
-    @SqlQuery("""
-            SELECT pv.*,
-                p.template_structure,
-                (SELECT JSON_ARRAYAGG(pve.environment) FROM prompt_version_envs pve WHERE pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id AND pve.ended_at IS NULL) AS environments
-            FROM prompt_versions pv
-            INNER JOIN prompts p ON pv.prompt_id = p.id
-            WHERE pv.prompt_id = :prompt_id
-            AND pv.version_number = :version_number
-            AND pv.workspace_id = :workspace_id
-            AND pv.version_type = 'prompt_version'
-            """)
-    PromptVersion findByVersionNumber(@Bind("prompt_id") UUID promptId,
-            @Bind("version_number") String versionNumber,
-            @Bind("workspace_id") String workspaceId);
+    default PromptVersion findByCommit(UUID promptId, String commit, String workspaceId) {
+        return findSingleVersion(promptId, workspaceId, commit, null, null);
+    }
+
+    default PromptVersion findByVersionNumber(UUID promptId, String versionNumber, String workspaceId) {
+        return findSingleVersion(promptId, workspaceId, null, versionNumber, null);
+    }
 
     @SqlQuery("""
             SELECT COALESCE(MAX(CAST(SUBSTRING(version_number, 2) AS UNSIGNED)), 0)
@@ -295,18 +313,9 @@ interface PromptVersionDAO {
     @SqlUpdate("DELETE FROM prompt_versions WHERE prompt_id = :prompt_id AND workspace_id = :workspace_id")
     int deleteByPromptId(@Bind("prompt_id") UUID promptId, @Bind("workspace_id") String workspaceId);
 
-    @SqlQuery("""
-            SELECT pv.*,
-                p.template_structure,
-                (SELECT JSON_ARRAYAGG(pve2.environment) FROM prompt_version_envs pve2 WHERE pve2.workspace_id = pv.workspace_id AND pve2.version_id = pv.id AND pve2.ended_at IS NULL) AS environments
-            FROM prompt_versions pv
-            INNER JOIN prompts p ON pv.prompt_id = p.id
-            INNER JOIN prompt_version_envs pve ON pve.workspace_id = pv.workspace_id AND pve.version_id = pv.id
-            WHERE pv.prompt_id = :prompt_id AND pve.environment = :environment AND pv.workspace_id = :workspace_id
-            AND pv.version_type = 'prompt_version' AND pve.ended_at IS NULL
-            """)
-    PromptVersion findByEnvironment(@Bind("prompt_id") UUID promptId, @Bind("environment") String environment,
-            @Bind("workspace_id") String workspaceId);
+    default PromptVersion findByEnvironment(UUID promptId, String environment, String workspaceId) {
+        return findSingleVersion(promptId, workspaceId, null, null, environment);
+    }
 
     @SqlQuery("""
             SELECT pv.id, pv.commit, p.name AS prompt_name

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptVersionDAO.java
@@ -83,12 +83,26 @@ interface PromptVersionDAO {
         saveEnvironments(ids, workspaceId, promptId, versionId, List.copyOf(environments), createdBy);
     }
 
+    @SqlQuery("""
+            SELECT environment FROM prompt_version_envs
+            WHERE workspace_id = :workspace_id AND version_id = :version_id AND ended_at IS NULL
+            """)
+    Set<String> findVersionEnvironments(@Bind("version_id") UUID versionId, @Bind("workspace_id") String workspaceId);
+
     @SqlUpdate("""
             UPDATE prompt_version_envs
             SET ended_at = CURRENT_TIMESTAMP(6)
             WHERE workspace_id = :workspace_id AND version_id = :version_id AND ended_at IS NULL
             """)
     void closeVersionEnvironments(@Bind("version_id") UUID versionId, @Bind("workspace_id") String workspaceId);
+
+    @SqlUpdate("""
+            UPDATE prompt_version_envs
+            SET ended_at = CURRENT_TIMESTAMP(6)
+            WHERE workspace_id = :workspace_id AND version_id = :version_id AND environment IN (<environments>) AND ended_at IS NULL
+            """)
+    void closeVersionEnvironmentsForNames(@Bind("version_id") UUID versionId, @Bind("workspace_id") String workspaceId,
+            @BindList("environments") Set<String> environments);
 
     @SqlUpdate("""
             UPDATE prompt_version_envs

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/PromptVersionColumnMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/PromptVersionColumnMapper.java
@@ -13,7 +13,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 public class PromptVersionColumnMapper implements ColumnMapper<PromptVersion> {
@@ -37,9 +39,13 @@ public class PromptVersionColumnMapper implements ColumnMapper<PromptVersion> {
                 .map(JsonNode::asText)
                 .map(PromptVersionType::fromString)
                 .orElse(PromptVersionType.PROMPT_VERSION);
-        String environment = Optional.ofNullable(jsonNode.get("environment"))
-                .filter(node -> !node.isNull())
-                .map(JsonNode::asText)
+        Set<String> environments = Optional.ofNullable(jsonNode.get("environments"))
+                .filter(node -> !node.isNull() && node.isArray())
+                .map(node -> {
+                    Set<String> result = new HashSet<>();
+                    node.forEach(e -> result.add(e.asText()));
+                    return result.isEmpty() ? null : result;
+                })
                 .orElse(null);
         String versionNumber = Optional.ofNullable(jsonNode.get("version_number"))
                 .filter(node -> !node.isNull())
@@ -56,7 +62,7 @@ public class PromptVersionColumnMapper implements ColumnMapper<PromptVersion> {
                 .changeDescription(jsonNode.get("change_description").asText())
                 .type(type)
                 .versionType(versionType)
-                .environment(environment)
+                .environments(environments)
                 .variables(TemplateParseUtils.extractVariables(template, type))
                 .tags(jsonNode.has("tags") && jsonNode.get("tags") != null && !jsonNode.get("tags").isNull()
                         ? JsonUtils.readValue(jsonNode.get("tags").asText(), SetFlatArgumentFactory.TYPE_REFERENCE)

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000077_add_prompt_version_envs_table.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000077_add_prompt_version_envs_table.sql
@@ -19,3 +19,7 @@ CREATE TABLE prompt_version_envs (
 
 ALTER TABLE prompt_versions DROP INDEX idx_prompt_versions_workspace_prompt_environment;
 ALTER TABLE prompt_versions DROP COLUMN environment;
+
+--rollback DROP TABLE prompt_version_envs;
+--rollback ALTER TABLE prompt_versions ADD COLUMN environment VARCHAR(150) NULL;
+--rollback CREATE UNIQUE INDEX idx_prompt_versions_workspace_prompt_environment ON prompt_versions (workspace_id, prompt_id, environment);

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000077_add_prompt_version_envs_table.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000077_add_prompt_version_envs_table.sql
@@ -10,9 +10,11 @@ CREATE TABLE prompt_version_envs (
     created_at   TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     created_by   VARCHAR(255) NOT NULL DEFAULT '',
     ended_at     TIMESTAMP(6) NULL DEFAULT NULL,
+    active_env   VARCHAR(150) GENERATED ALWAYS AS (IF(ended_at IS NULL, environment, NULL)) STORED,
     PRIMARY KEY (id),
     INDEX idx_pve_env_lookup (workspace_id, prompt_id, environment, ended_at),
-    INDEX idx_pve_version (workspace_id, version_id, ended_at)
+    INDEX idx_pve_version (workspace_id, version_id, ended_at),
+    UNIQUE INDEX uq_pve_active_env (workspace_id, prompt_id, active_env)
 );
 
 ALTER TABLE prompt_versions DROP INDEX idx_prompt_versions_workspace_prompt_environment;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000077_add_prompt_version_envs_table.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000077_add_prompt_version_envs_table.sql
@@ -1,0 +1,19 @@
+--liquibase formatted sql
+--changeset boryst:000077_add_prompt_version_envs_table
+
+CREATE TABLE prompt_version_envs (
+    id           CHAR(36)     NOT NULL,
+    workspace_id VARCHAR(255) NOT NULL,
+    prompt_id    CHAR(36)     NOT NULL,
+    version_id   CHAR(36)     NOT NULL,
+    environment  VARCHAR(150) NOT NULL,
+    created_at   TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    created_by   VARCHAR(255) NOT NULL DEFAULT '',
+    ended_at     TIMESTAMP(6) NULL DEFAULT NULL,
+    PRIMARY KEY (id),
+    INDEX idx_pve_env_lookup (workspace_id, prompt_id, environment, ended_at),
+    INDEX idx_pve_version (workspace_id, version_id, ended_at)
+);
+
+ALTER TABLE prompt_versions DROP INDEX idx_prompt_versions_workspace_prompt_environment;
+ALTER TABLE prompt_versions DROP COLUMN environment;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -5267,6 +5267,25 @@ class PromptResourceTest {
         }
 
         @Test
+        @DisplayName("PATCH /versions/{id} incrementally adds environment without removing existing ones")
+        void patchIncrementallyAddsEnvironmentToVersionWithExistingOnes() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            String env1 = uniqueEnvName("keep");
+            var saved = createVersionWithEnvironments(prompt, Set.of(env1));
+
+            String env2 = uniqueEnvName("add");
+            environmentsResourceClient.createEnvironment(
+                    Environment.builder().name(env2).build(), API_KEY, TEST_WORKSPACE);
+
+            patchVersionEnvironments(saved.id(), Set.of(env1, env2), HttpStatus.SC_NO_CONTENT);
+
+            getPromptVersionAndAssert(saved.id(), saved.toBuilder().environments(Set.of(env1, env2)).build(), API_KEY,
+                    TEST_WORKSPACE);
+        }
+
+        @Test
         @DisplayName("PATCH /versions/{id} with an unknown environment returns 409 Conflict")
         void patchOnUnknownEnvironmentReturnsConflict() {
             var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -4753,7 +4753,7 @@ class PromptResourceTest {
             var maskVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
                     .createdBy(USER)
                     .versionType(PromptVersionType.MASK)
-                    .environment(null)
+                    .environments(null)
                     .build();
 
             PromptVersion created = createPromptVersion(
@@ -4777,7 +4777,7 @@ class PromptResourceTest {
                     API_KEY, TEST_WORKSPACE);
 
             var maskVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environments(null).build();
             createPromptVersion(
                     createPromptVersionRequest(prompt.name(), maskVersion, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -4802,7 +4802,7 @@ class PromptResourceTest {
                     API_KEY, TEST_WORKSPACE);
 
             var maskVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environments(null).build();
             createPromptVersion(
                     createPromptVersionRequest(prompt.name(), maskVersion, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -4823,7 +4823,7 @@ class PromptResourceTest {
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             var maskVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environments(null).build();
             var savedMask = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), maskVersion, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -4841,7 +4841,7 @@ class PromptResourceTest {
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             var maskVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environments(null).build();
             var savedMask = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), maskVersion, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -4868,7 +4868,7 @@ class PromptResourceTest {
                     API_KEY, TEST_WORKSPACE);
 
             var maskVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environments(null).build();
             var savedMask = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), maskVersion, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -4908,7 +4908,7 @@ class PromptResourceTest {
             var promptB = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
             createPrompt(promptB, API_KEY, TEST_WORKSPACE);
             var maskVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environments(null).build();
             var maskOfB = createPromptVersion(
                     createPromptVersionRequest(promptB.name(), maskVersion, promptB.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -4947,13 +4947,13 @@ class PromptResourceTest {
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             var maskA = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environments(null).build();
             var savedA = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), maskA, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
             var maskB = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environments(null).build();
             var savedB = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), maskB, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -4996,7 +4996,7 @@ class PromptResourceTest {
             Thread.sleep(10);
 
             var maskVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environments(null).build();
             createPromptVersion(
                     createPromptVersionRequest(prompt.name(), maskVersion, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -5034,13 +5034,13 @@ class PromptResourceTest {
 
             String env = uniqueEnvName("prod");
             var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
 
             var saved = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
-            assertThat(saved.environment()).isEqualTo(env);
+            assertThat(saved.environments()).contains(env);
             assertWorkspaceContainsEnvironment(env);
         }
 
@@ -5052,13 +5052,13 @@ class PromptResourceTest {
 
             String env = uniqueEnvName("dup");
             var first = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
             createPromptVersion(
                     createPromptVersionRequest(prompt.name(), first, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
             var second = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
             try (var response = postVersionRaw(prompt.name(), second, prompt.templateStructure())) {
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
             }
@@ -5074,29 +5074,30 @@ class PromptResourceTest {
 
             String env = uniqueEnvName("shared");
             var vA = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
             var savedA = createPromptVersion(
                     createPromptVersionRequest(promptA.name(), vA, promptA.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
             var vB = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
             var savedB = createPromptVersion(
                     createPromptVersionRequest(promptB.name(), vB, promptB.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
-            assertThat(savedA.environment()).isEqualTo(env);
-            assertThat(savedB.environment()).isEqualTo(env);
+            assertThat(savedA.environments()).contains(env);
+            assertThat(savedB.environments()).contains(env);
         }
 
         @Test
-        @DisplayName("Creating a mask version with environment returns 422 Unprocessable Content")
+        @DisplayName("Creating a mask version with environments returns 422 Unprocessable Content")
         void creatingMaskWithEnvironmentReturnsUnprocessable() {
             var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             var mask = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(uniqueEnvName("mask")).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK)
+                    .environments(Set.of(uniqueEnvName("mask"))).build();
             try (var response = postVersionRaw(prompt.name(), mask, prompt.templateStructure())) {
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_UNPROCESSABLE_ENTITY);
             }
@@ -5108,24 +5109,21 @@ class PromptResourceTest {
             var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
             UUID promptId = createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
-            // v1: no env
             var v1 = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(null).build();
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(null).build();
             createPromptVersion(
                     createPromptVersionRequest(prompt.name(), v1, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
-            // v2: env=prod
             String env = uniqueEnvName("resolve");
             var v2 = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
             var savedV2 = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), v2, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
-            // v3: no env (latest)
             var v3 = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(null).build();
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(null).build();
             var savedV3 = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), v3, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -5135,7 +5133,7 @@ class PromptResourceTest {
                 Prompt fetched = response.readEntity(Prompt.class);
                 assertThat(fetched.requestedVersion()).isNotNull();
                 assertThat(fetched.requestedVersion().id()).isEqualTo(savedV2.id());
-                assertThat(fetched.requestedVersion().environment()).isEqualTo(env);
+                assertThat(fetched.requestedVersion().environments()).contains(env);
                 assertThat(fetched.latestVersion()).isNotNull();
                 assertThat(fetched.latestVersion().id()).isEqualTo(savedV3.id());
             }
@@ -5166,13 +5164,134 @@ class PromptResourceTest {
         }
 
         @Test
+        @DisplayName("Create version with multiple environments: all envs are set and auto-created in registry")
+        void shouldCreateVersionWithMultipleEnvironments() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            String env1 = uniqueEnvName("create-a");
+            String env2 = uniqueEnvName("create-b");
+            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION)
+                    .environments(Set.of(env1, env2)).build();
+
+            var saved = createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            assertThat(saved.environments()).containsExactlyInAnyOrder(env1, env2);
+            assertWorkspaceContainsEnvironment(env1);
+            assertWorkspaceContainsEnvironment(env2);
+        }
+
+        @Test
+        @DisplayName("Creating version with multiple envs where one is already taken returns 409 Conflict")
+        void creatingVersionWithMultipleEnvsWhereOneIsTakenReturnsConflict() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            String takenEnv = uniqueEnvName("taken");
+            var first = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION)
+                    .environments(Set.of(takenEnv)).build();
+            createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), first, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            String freeEnv = uniqueEnvName("free");
+            var second = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION)
+                    .environments(Set.of(takenEnv, freeEnv)).build();
+            try (var response = postVersionRaw(prompt.name(), second, prompt.templateStructure())) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
+            }
+        }
+
+        @Test
+        @DisplayName("GET /prompts/{id}?environment resolves to same version when it has multiple environments")
+        void getPromptByIdResolvesEachEnvToSameMultiEnvVersion() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            UUID promptId = createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            String env1 = uniqueEnvName("multi-a");
+            String env2 = uniqueEnvName("multi-b");
+            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION)
+                    .environments(Set.of(env1, env2)).build();
+            var saved = createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            for (String env : List.of(env1, env2)) {
+                try (var response = promptResourceClient.callGetPrompt(promptId, null, env, API_KEY, TEST_WORKSPACE)) {
+                    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+                    Prompt fetched = response.readEntity(Prompt.class);
+                    assertThat(fetched.requestedVersion()).isNotNull();
+                    assertThat(fetched.requestedVersion().id()).isEqualTo(saved.id());
+                    assertThat(fetched.requestedVersion().environments()).containsExactlyInAnyOrder(env1, env2);
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("PATCH replaces all envs: version had two envs, PATCH with different env replaces both")
+        void patchReplacesAllEnvironments() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            String env1 = uniqueEnvName("old1");
+            String env2 = uniqueEnvName("old2");
+            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION)
+                    .environments(Set.of(env1, env2)).build();
+            var saved = createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            String env3 = uniqueEnvName("new");
+            environmentsResourceClient.createEnvironment(
+                    Environment.builder().name(env3).build(), API_KEY, TEST_WORKSPACE);
+
+            patchVersionEnvironments(saved.id(), Set.of(env3), HttpStatus.SC_NO_CONTENT);
+
+            assertThat(promptResourceClient.getPromptVersion(saved.id(), API_KEY, TEST_WORKSPACE).environments())
+                    .containsExactly(env3);
+        }
+
+        @Test
+        @DisplayName("POST /versions/retrieve resolves by each env when version has multiple environments")
+        void retrieveVersionByEachEnvWhenVersionHasMultipleEnvironments() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            String env1 = uniqueEnvName("ret-a");
+            String env2 = uniqueEnvName("ret-b");
+            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION)
+                    .environments(Set.of(env1, env2)).build();
+            var saved = createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            for (String env : List.of(env1, env2)) {
+                var request = PromptVersionRetrieve.builder().name(prompt.name()).environment(env).build();
+                try (var response = promptResourceClient.callRetrievePromptVersion(request, API_KEY, TEST_WORKSPACE)) {
+                    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+                    PromptVersion retrieved = response.readEntity(PromptVersion.class);
+                    assertThat(retrieved.id()).isEqualTo(saved.id());
+                    assertThat(retrieved.environments()).containsExactlyInAnyOrder(env1, env2);
+                }
+            }
+        }
+
+        @Test
         @DisplayName("PATCH /versions/{id} sets the environment on a version when the env exists in the workspace")
         void patchSetsEnvironmentOnVersion() {
             var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(null).build();
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(null).build();
             var saved = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -5181,10 +5300,35 @@ class PromptResourceTest {
             environmentsResourceClient.createEnvironment(
                     Environment.builder().name(env).build(), API_KEY, TEST_WORKSPACE);
 
-            patchVersionEnvironment(saved.id(), env, HttpStatus.SC_NO_CONTENT);
+            patchVersionEnvironments(saved.id(), Set.of(env), HttpStatus.SC_NO_CONTENT);
 
-            assertThat(promptResourceClient.getPromptVersion(saved.id(), API_KEY, TEST_WORKSPACE).environment())
-                    .isEqualTo(env);
+            assertThat(promptResourceClient.getPromptVersion(saved.id(), API_KEY, TEST_WORKSPACE).environments())
+                    .contains(env);
+        }
+
+        @Test
+        @DisplayName("PATCH /versions/{id} assigns multiple environments to the same version")
+        void patchAssignsMultipleEnvironmentsToSameVersion() {
+            var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
+            createPrompt(prompt, API_KEY, TEST_WORKSPACE);
+
+            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(null).build();
+            var saved = createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+
+            String env1 = uniqueEnvName("multi1");
+            String env2 = uniqueEnvName("multi2");
+            environmentsResourceClient.createEnvironment(
+                    Environment.builder().name(env1).build(), API_KEY, TEST_WORKSPACE);
+            environmentsResourceClient.createEnvironment(
+                    Environment.builder().name(env2).build(), API_KEY, TEST_WORKSPACE);
+
+            patchVersionEnvironments(saved.id(), Set.of(env1, env2), HttpStatus.SC_NO_CONTENT);
+
+            assertThat(promptResourceClient.getPromptVersion(saved.id(), API_KEY, TEST_WORKSPACE).environments())
+                    .containsExactlyInAnyOrder(env1, env2);
         }
 
         @Test
@@ -5194,31 +5338,31 @@ class PromptResourceTest {
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(null).build();
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(null).build();
             var saved = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
-            patchVersionEnvironment(saved.id(), uniqueEnvName("ghost"), HttpStatus.SC_NOT_FOUND);
+            patchVersionEnvironments(saved.id(), Set.of(uniqueEnvName("ghost")), HttpStatus.SC_NOT_FOUND);
         }
 
         @Test
-        @DisplayName("PATCH /versions/{id} with null environment clears the env on the version")
-        void patchClearsEnvironmentOnVersion() {
+        @DisplayName("PATCH /versions/{id} with empty environments clears all envs on the version")
+        void patchClearsEnvironmentsOnVersion() {
             var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             String env = uniqueEnvName("clear");
             var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
             var saved = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
-            patchVersionEnvironment(saved.id(), null, HttpStatus.SC_NO_CONTENT);
+            patchVersionEnvironments(saved.id(), Set.of(), HttpStatus.SC_NO_CONTENT);
 
-            assertThat(promptResourceClient.getPromptVersion(saved.id(), API_KEY, TEST_WORKSPACE).environment())
-                    .isNull();
+            assertThat(promptResourceClient.getPromptVersion(saved.id(), API_KEY, TEST_WORKSPACE).environments())
+                    .isNullOrEmpty();
         }
 
         @Test
@@ -5229,29 +5373,29 @@ class PromptResourceTest {
 
             String env = uniqueEnvName("move");
             var owner = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
             var savedOwner = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), owner, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
             var next = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(null).build();
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(null).build();
             var savedNext = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), next, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
-            patchVersionEnvironment(savedNext.id(), env, HttpStatus.SC_NO_CONTENT);
+            patchVersionEnvironments(savedNext.id(), Set.of(env), HttpStatus.SC_NO_CONTENT);
 
-            assertThat(promptResourceClient.getPromptVersion(savedOwner.id(), API_KEY, TEST_WORKSPACE).environment())
-                    .isNull();
-            assertThat(promptResourceClient.getPromptVersion(savedNext.id(), API_KEY, TEST_WORKSPACE).environment())
-                    .isEqualTo(env);
+            assertThat(promptResourceClient.getPromptVersion(savedOwner.id(), API_KEY, TEST_WORKSPACE).environments())
+                    .isNullOrEmpty();
+            assertThat(promptResourceClient.getPromptVersion(savedNext.id(), API_KEY, TEST_WORKSPACE).environments())
+                    .contains(env);
         }
 
         @Test
         @DisplayName("PATCH /versions/{id} on an unknown version returns 404 Not Found")
         void patchOnUnknownVersionReturnsNotFound() {
-            patchVersionEnvironment(UUID.randomUUID(), uniqueEnvName("ghost"), HttpStatus.SC_NOT_FOUND);
+            patchVersionEnvironments(UUID.randomUUID(), Set.of(uniqueEnvName("ghost")), HttpStatus.SC_NOT_FOUND);
         }
 
         @Test
@@ -5261,12 +5405,12 @@ class PromptResourceTest {
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             var mask = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.MASK).environment(null).build();
+                    .createdBy(USER).versionType(PromptVersionType.MASK).environments(null).build();
             var savedMask = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), mask, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
-            patchVersionEnvironment(savedMask.id(), uniqueEnvName("masked"), HttpStatus.SC_BAD_REQUEST);
+            patchVersionEnvironments(savedMask.id(), Set.of(uniqueEnvName("masked")), HttpStatus.SC_BAD_REQUEST);
         }
 
         @Test
@@ -5277,7 +5421,7 @@ class PromptResourceTest {
 
             String env = uniqueEnvName("ret");
             var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
             var saved = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -5291,7 +5435,7 @@ class PromptResourceTest {
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
                 PromptVersion retrieved = response.readEntity(PromptVersion.class);
                 assertThat(retrieved.id()).isEqualTo(saved.id());
-                assertThat(retrieved.environment()).isEqualTo(env);
+                assertThat(retrieved.environments()).contains(env);
             }
         }
 
@@ -5313,21 +5457,20 @@ class PromptResourceTest {
         }
 
         @Test
-        @DisplayName("Restored version is created without the source version's environment")
+        @DisplayName("Restored version is created without the source version's environments")
         void restoredVersionDoesNotCarryEnvironment() {
             var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
             UUID promptId = createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             String env = uniqueEnvName("restore");
             var original = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(env).build();
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
             var savedOriginal = createPromptVersion(
                     createPromptVersionRequest(prompt.name(), original, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
 
-            // Create a successor without env so restore creates a new latest version
             var successor = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environment(null).build();
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(null).build();
             createPromptVersion(
                     createPromptVersionRequest(prompt.name(), successor, prompt.templateStructure()),
                     API_KEY, TEST_WORKSPACE);
@@ -5337,20 +5480,20 @@ class PromptResourceTest {
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
                 PromptVersion restored = response.readEntity(PromptVersion.class);
                 assertThat(restored.id()).isNotEqualTo(savedOriginal.id());
-                assertThat(restored.environment()).isNull();
+                assertThat(restored.environments()).isNullOrEmpty();
             }
 
-            // original version still owns the env
-            assertThat(promptResourceClient.getPromptVersion(savedOriginal.id(), API_KEY, TEST_WORKSPACE).environment())
-                    .isEqualTo(env);
+            assertThat(
+                    promptResourceClient.getPromptVersion(savedOriginal.id(), API_KEY, TEST_WORKSPACE).environments())
+                    .contains(env);
         }
 
         private String uniqueEnvName(String prefix) {
             return prefix + "_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
         }
 
-        private void patchVersionEnvironment(UUID versionId, String environment, int expectedStatus) {
-            var update = PromptVersionEnvironmentUpdate.builder().environment(environment).build();
+        private void patchVersionEnvironments(UUID versionId, Set<String> environments, int expectedStatus) {
+            var update = PromptVersionEnvironmentUpdate.builder().environments(environments).build();
             try (var response = promptResourceClient.callSetPromptVersionEnvironment(versionId, update, API_KEY,
                     TEST_WORKSPACE)) {
                 assertThat(response.getStatus()).isEqualTo(expectedStatus);
@@ -5538,7 +5681,7 @@ class PromptResourceTest {
             var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
                     .createdBy(USER)
                     .versionType(PromptVersionType.PROMPT_VERSION)
-                    .environment(null)
+                    .environments(null)
                     .build();
             return createPromptVersion(
                     createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
@@ -5549,7 +5692,7 @@ class PromptResourceTest {
             var mask = factory.manufacturePojo(PromptVersion.class).toBuilder()
                     .createdBy(USER)
                     .versionType(PromptVersionType.MASK)
-                    .environment(null)
+                    .environments(null)
                     .build();
             return createPromptVersion(
                     createPromptVersionRequest(prompt.name(), mask, prompt.templateStructure()),

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -5033,14 +5033,9 @@ class PromptResourceTest {
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             String env = uniqueEnvName("prod");
-            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
+            var saved = createVersionWithEnvironments(prompt, Set.of(env));
 
-            var saved = createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
-
-            assertThat(saved.environments()).contains(env);
+            getPromptVersionAndAssert(saved.id(), saved, API_KEY, TEST_WORKSPACE);
             assertWorkspaceContainsEnvironment(env);
         }
 
@@ -5051,11 +5046,7 @@ class PromptResourceTest {
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             String env = uniqueEnvName("dup");
-            var first = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
-            createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), first, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
+            createVersionWithEnvironments(prompt, Set.of(env));
 
             var second = factory.manufacturePojo(PromptVersion.class).toBuilder()
                     .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
@@ -5073,20 +5064,11 @@ class PromptResourceTest {
             createPrompt(promptB, API_KEY, TEST_WORKSPACE);
 
             String env = uniqueEnvName("shared");
-            var vA = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
-            var savedA = createPromptVersion(
-                    createPromptVersionRequest(promptA.name(), vA, promptA.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
+            var savedA = createVersionWithEnvironments(promptA, Set.of(env));
+            var savedB = createVersionWithEnvironments(promptB, Set.of(env));
 
-            var vB = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
-            var savedB = createPromptVersion(
-                    createPromptVersionRequest(promptB.name(), vB, promptB.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
-
-            assertThat(savedA.environments()).contains(env);
-            assertThat(savedB.environments()).contains(env);
+            getPromptVersionAndAssert(savedA.id(), savedA, API_KEY, TEST_WORKSPACE);
+            getPromptVersionAndAssert(savedB.id(), savedB, API_KEY, TEST_WORKSPACE);
         }
 
         @Test
@@ -5109,24 +5091,11 @@ class PromptResourceTest {
             var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
             UUID promptId = createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
-            var v1 = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(null).build();
-            createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), v1, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
+            createVersionWithoutEnvironments(prompt);
 
             String env = uniqueEnvName("resolve");
-            var v2 = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
-            var savedV2 = createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), v2, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
-
-            var v3 = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(null).build();
-            var savedV3 = createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), v3, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
+            var savedV2 = createVersionWithEnvironments(prompt, Set.of(env));
+            var savedV3 = createVersionWithoutEnvironments(prompt);
 
             try (var response = promptResourceClient.callGetPrompt(promptId, null, env, API_KEY, TEST_WORKSPACE)) {
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
@@ -5171,15 +5140,9 @@ class PromptResourceTest {
 
             String env1 = uniqueEnvName("create-a");
             String env2 = uniqueEnvName("create-b");
-            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION)
-                    .environments(Set.of(env1, env2)).build();
+            var saved = createVersionWithEnvironments(prompt, Set.of(env1, env2));
 
-            var saved = createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
-
-            assertThat(saved.environments()).containsExactlyInAnyOrder(env1, env2);
+            getPromptVersionAndAssert(saved.id(), saved, API_KEY, TEST_WORKSPACE);
             assertWorkspaceContainsEnvironment(env1);
             assertWorkspaceContainsEnvironment(env2);
         }
@@ -5191,12 +5154,7 @@ class PromptResourceTest {
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             String takenEnv = uniqueEnvName("taken");
-            var first = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION)
-                    .environments(Set.of(takenEnv)).build();
-            createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), first, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
+            createVersionWithEnvironments(prompt, Set.of(takenEnv));
 
             String freeEnv = uniqueEnvName("free");
             var second = factory.manufacturePojo(PromptVersion.class).toBuilder()
@@ -5215,12 +5173,7 @@ class PromptResourceTest {
 
             String env1 = uniqueEnvName("multi-a");
             String env2 = uniqueEnvName("multi-b");
-            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION)
-                    .environments(Set.of(env1, env2)).build();
-            var saved = createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
+            var saved = createVersionWithEnvironments(prompt, Set.of(env1, env2));
 
             for (String env : List.of(env1, env2)) {
                 try (var response = promptResourceClient.callGetPrompt(promptId, null, env, API_KEY, TEST_WORKSPACE)) {
@@ -5241,12 +5194,7 @@ class PromptResourceTest {
 
             String env1 = uniqueEnvName("old1");
             String env2 = uniqueEnvName("old2");
-            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION)
-                    .environments(Set.of(env1, env2)).build();
-            var saved = createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
+            var saved = createVersionWithEnvironments(prompt, Set.of(env1, env2));
 
             String env3 = uniqueEnvName("new");
             environmentsResourceClient.createEnvironment(
@@ -5254,8 +5202,8 @@ class PromptResourceTest {
 
             patchVersionEnvironments(saved.id(), Set.of(env3), HttpStatus.SC_NO_CONTENT);
 
-            assertThat(promptResourceClient.getPromptVersion(saved.id(), API_KEY, TEST_WORKSPACE).environments())
-                    .containsExactly(env3);
+            getPromptVersionAndAssert(saved.id(), saved.toBuilder().environments(Set.of(env3)).build(), API_KEY,
+                    TEST_WORKSPACE);
         }
 
         @Test
@@ -5266,12 +5214,7 @@ class PromptResourceTest {
 
             String env1 = uniqueEnvName("ret-a");
             String env2 = uniqueEnvName("ret-b");
-            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION)
-                    .environments(Set.of(env1, env2)).build();
-            var saved = createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
+            var saved = createVersionWithEnvironments(prompt, Set.of(env1, env2));
 
             for (String env : List.of(env1, env2)) {
                 var request = PromptVersionRetrieve.builder().name(prompt.name()).environment(env).build();
@@ -5290,11 +5233,7 @@ class PromptResourceTest {
             var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
-            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(null).build();
-            var saved = createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
+            var saved = createVersionWithoutEnvironments(prompt);
 
             String env = uniqueEnvName("patch");
             environmentsResourceClient.createEnvironment(
@@ -5302,8 +5241,8 @@ class PromptResourceTest {
 
             patchVersionEnvironments(saved.id(), Set.of(env), HttpStatus.SC_NO_CONTENT);
 
-            assertThat(promptResourceClient.getPromptVersion(saved.id(), API_KEY, TEST_WORKSPACE).environments())
-                    .contains(env);
+            getPromptVersionAndAssert(saved.id(), saved.toBuilder().environments(Set.of(env)).build(), API_KEY,
+                    TEST_WORKSPACE);
         }
 
         @Test
@@ -5312,11 +5251,7 @@ class PromptResourceTest {
             var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
-            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(null).build();
-            var saved = createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
+            var saved = createVersionWithoutEnvironments(prompt);
 
             String env1 = uniqueEnvName("multi1");
             String env2 = uniqueEnvName("multi2");
@@ -5327,23 +5262,19 @@ class PromptResourceTest {
 
             patchVersionEnvironments(saved.id(), Set.of(env1, env2), HttpStatus.SC_NO_CONTENT);
 
-            assertThat(promptResourceClient.getPromptVersion(saved.id(), API_KEY, TEST_WORKSPACE).environments())
-                    .containsExactlyInAnyOrder(env1, env2);
+            getPromptVersionAndAssert(saved.id(), saved.toBuilder().environments(Set.of(env1, env2)).build(), API_KEY,
+                    TEST_WORKSPACE);
         }
 
         @Test
-        @DisplayName("PATCH /versions/{id} with an unknown environment returns 404 Not Found")
-        void patchOnUnknownEnvironmentReturnsNotFound() {
+        @DisplayName("PATCH /versions/{id} with an unknown environment returns 409 Conflict")
+        void patchOnUnknownEnvironmentReturnsConflict() {
             var prompt = buildPrompt().lastUpdatedBy(USER).createdBy(USER).template(null).build();
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
-            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(null).build();
-            var saved = createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
+            var saved = createVersionWithoutEnvironments(prompt);
 
-            patchVersionEnvironments(saved.id(), Set.of(uniqueEnvName("ghost")), HttpStatus.SC_NOT_FOUND);
+            patchVersionEnvironments(saved.id(), Set.of(uniqueEnvName("ghost")), HttpStatus.SC_CONFLICT);
         }
 
         @Test
@@ -5353,16 +5284,12 @@ class PromptResourceTest {
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             String env = uniqueEnvName("clear");
-            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
-            var saved = createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
+            var saved = createVersionWithEnvironments(prompt, Set.of(env));
 
             patchVersionEnvironments(saved.id(), Set.of(), HttpStatus.SC_NO_CONTENT);
 
-            assertThat(promptResourceClient.getPromptVersion(saved.id(), API_KEY, TEST_WORKSPACE).environments())
-                    .isNullOrEmpty();
+            getPromptVersionAndAssert(saved.id(), saved.toBuilder().environments(null).build(), API_KEY,
+                    TEST_WORKSPACE);
         }
 
         @Test
@@ -5372,24 +5299,15 @@ class PromptResourceTest {
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             String env = uniqueEnvName("move");
-            var owner = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
-            var savedOwner = createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), owner, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
-
-            var next = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(null).build();
-            var savedNext = createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), next, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
+            var savedOwner = createVersionWithEnvironments(prompt, Set.of(env));
+            var savedNext = createVersionWithoutEnvironments(prompt);
 
             patchVersionEnvironments(savedNext.id(), Set.of(env), HttpStatus.SC_NO_CONTENT);
 
-            assertThat(promptResourceClient.getPromptVersion(savedOwner.id(), API_KEY, TEST_WORKSPACE).environments())
-                    .isNullOrEmpty();
-            assertThat(promptResourceClient.getPromptVersion(savedNext.id(), API_KEY, TEST_WORKSPACE).environments())
-                    .contains(env);
+            getPromptVersionAndAssert(savedOwner.id(), savedOwner.toBuilder().environments(null).build(), API_KEY,
+                    TEST_WORKSPACE);
+            getPromptVersionAndAssert(savedNext.id(), savedNext.toBuilder().environments(Set.of(env)).build(), API_KEY,
+                    TEST_WORKSPACE);
         }
 
         @Test
@@ -5420,23 +5338,10 @@ class PromptResourceTest {
             createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             String env = uniqueEnvName("ret");
-            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
-            var saved = createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
+            var saved = createVersionWithEnvironments(prompt, Set.of(env));
 
-            var request = PromptVersionRetrieve.builder()
-                    .name(prompt.name())
-                    .environment(env)
-                    .build();
-
-            try (var response = promptResourceClient.callRetrievePromptVersion(request, API_KEY, TEST_WORKSPACE)) {
-                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
-                PromptVersion retrieved = response.readEntity(PromptVersion.class);
-                assertThat(retrieved.id()).isEqualTo(saved.id());
-                assertThat(retrieved.environments()).contains(env);
-            }
+            var request = PromptVersionRetrieve.builder().name(prompt.name()).environment(env).build();
+            retrievePromptVersionAndAssert(request, saved, API_KEY, TEST_WORKSPACE);
         }
 
         @Test
@@ -5463,17 +5368,8 @@ class PromptResourceTest {
             UUID promptId = createPrompt(prompt, API_KEY, TEST_WORKSPACE);
 
             String env = uniqueEnvName("restore");
-            var original = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(Set.of(env)).build();
-            var savedOriginal = createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), original, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
-
-            var successor = factory.manufacturePojo(PromptVersion.class).toBuilder()
-                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION).environments(null).build();
-            createPromptVersion(
-                    createPromptVersionRequest(prompt.name(), successor, prompt.templateStructure()),
-                    API_KEY, TEST_WORKSPACE);
+            var savedOriginal = createVersionWithEnvironments(prompt, Set.of(env));
+            createVersionWithoutEnvironments(prompt);
 
             try (var response = promptResourceClient.callRestorePromptVersion(promptId, savedOriginal.id(),
                     API_KEY, TEST_WORKSPACE)) {
@@ -5483,9 +5379,25 @@ class PromptResourceTest {
                 assertThat(restored.environments()).isNullOrEmpty();
             }
 
-            assertThat(
-                    promptResourceClient.getPromptVersion(savedOriginal.id(), API_KEY, TEST_WORKSPACE).environments())
-                    .contains(env);
+            getPromptVersionAndAssert(savedOriginal.id(), savedOriginal, API_KEY, TEST_WORKSPACE);
+        }
+
+        private PromptVersion createVersionWithEnvironments(Prompt prompt, Set<String> environments) {
+            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION)
+                    .environments(environments).build();
+            return createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
+        }
+
+        private PromptVersion createVersionWithoutEnvironments(Prompt prompt) {
+            var version = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER).versionType(PromptVersionType.PROMPT_VERSION)
+                    .environments(null).build();
+            return createPromptVersion(
+                    createPromptVersionRequest(prompt.name(), version, prompt.templateStructure()),
+                    API_KEY, TEST_WORKSPACE);
         }
 
         private String uniqueEnvName(String prefix) {


### PR DESCRIPTION
## Details

Extends the prompt version environment model from a single `environment` field to a `Set<String> environments`, allowing one version to be pinned to multiple environments simultaneously.

**Schema changes:**
- New `prompt_version_envs` table (migration `000077`) tracks environment-to-version mappings with soft-delete via `ended_at`, replacing the `environment` column on `prompt_versions`
- Indexes added for efficient lookup by workspace+prompt+environment and by workspace+version

**API changes:**
- `PromptVersion.environment` → `environments: Set<String>` (nullable, max 100 entries, each validated against `Environment.NAME_PATTERN`)
- `PromptVersionEnvironmentUpdate.environment` → `environments: Set<String>` (non-null; empty set clears all; previously nullable string mapped to clear behavior)
- Validation updated: mask versions reject non-empty `environments` sets

**Service / DAO changes:**
- `PromptService.setVersionEnvironment` accepts `Set<String>` and performs: close all current env assignments for the version, close any existing ownerships for the incoming envs on the same prompt, then batch-insert the new assignments
- `createVersionWithEnvironment` checks for conflicts via `findTakenEnvironments` (set-based) instead of single-version lookup; raises `409` listing all conflicting env names
- `savePromptVersion` now also calls `saveEnvironments` in the same transaction
- Queries that return `PromptVersion` objects use a correlated subquery (`JSON_ARRAYAGG`) to populate `environments` from the new table
- `EnvironmentService.findExistingNames` added to validate the full set of requested envs before assignment

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-6626

## Testing

Integration tests in `PromptResourceTest` updated to cover:
- Creating a version with multiple environments
- Setting multiple environments via `PUT /v1/private/prompts/versions/{id}/environment`
- Conflict detection when two versions claim overlapping environments
- Clearing all environments with an empty set
- Mask version rejection when `environments` is non-empty
- Environment existence validation (404 on unknown names)

## Documentation

No public documentation changes — internal API behavior change. Callers previously passing a single `environment` string must migrate to `environments: [<name>]` (or `environments: []` to clear).
