### PR TITLE
[OPIK-6597] [QA] feat: Online Evaluation smoke (LLM-judge + Python rule)

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/AddEditRuleDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/AddEditRuleDialog.tsx
@@ -486,7 +486,10 @@ const AddEditRuleDialog: React.FC<AddEditRuleDialogProps> = ({
   return (
     <>
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-lg sm:max-w-[790px]">
+        <DialogContent
+          className="max-w-lg sm:max-w-[790px]"
+          data-testid="add-edit-rule-dialog"
+        >
           <DialogHeader>
             <DialogTitle>{title}</DialogTitle>
           </DialogHeader>
@@ -620,6 +623,7 @@ const AddEditRuleDialog: React.FC<AddEditRuleDialogProps> = ({
                           <div className="flex">
                             <ToggleGroup
                               type="single"
+                              data-testid="add-edit-rule-dialog-type"
                               value={field.value}
                               onValueChange={(
                                 value: UI_EVALUATORS_RULE_TYPE,
@@ -712,7 +716,11 @@ const AddEditRuleDialog: React.FC<AddEditRuleDialogProps> = ({
                 </span>
               </TooltipWrapper>
             ) : (
-              <Button type="submit" onClick={form.handleSubmit(onSubmit)}>
+              <Button
+                type="submit"
+                onClick={form.handleSubmit(onSubmit)}
+                data-testid="add-edit-rule-dialog-submit"
+              >
                 {submitText}
               </Button>
             )}

--- a/apps/opik-frontend/src/v2/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OnlineEvaluationPage/OnlineEvaluationPage.tsx
@@ -366,7 +366,12 @@ export const OnlineEvaluationPage: React.FC = () => {
           Online evaluation
         </h1>
         {canUpdateOnlineEvaluationRules && (
-          <Button variant="default" size="xs" onClick={handleNewRuleClick}>
+          <Button
+            variant="default"
+            size="xs"
+            onClick={handleNewRuleClick}
+            data-testid="online-evaluation-create-rule-button"
+          >
             <Plus className="mr-1 size-4" />
             Create rule
           </Button>

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -1,5 +1,9 @@
 import { Opik } from 'opik';
 import { loadEnvConfig } from '../../config/env.config';
+import {
+  pollTraceForFeedbackScore,
+  type PollFeedbackScoreOpts,
+} from './poll-feedback-score';
 
 export type BackendClient = ReturnType<typeof makeBackendClient>;
 
@@ -36,6 +40,26 @@ export interface TestSuiteItemRef {
   data: Record<string, unknown>;
 }
 
+export interface FeedbackScoreRef {
+  name: string;
+  value: number;
+  reason: string | null;
+  source: string;
+}
+
+export interface TraceDetail {
+  id: string;
+  name: string;
+  projectId: string;
+  feedbackScores: FeedbackScoreRef[];
+}
+
+export interface AutomationRuleRef {
+  id: string;
+  name: string;
+  projectIds: string[];
+}
+
 /** Backend discriminator for Dataset vs Test Suite (shared DB table). */
 const TEST_SUITE_TYPE = 'evaluation_suite';
 
@@ -46,6 +70,28 @@ export function makeBackendClient(apiKey: string | null = null) {
     workspaceName: env.workspace,
     apiUrl: env.apiBaseUrl,
   });
+
+  // Hoisted so pollTraceForFeedbackScore (a free function) can call it without
+  // depending on the not-yet-constructed return object.
+  const localGetTrace = async (traceId: string): Promise<TraceDetail | null> => {
+    try {
+      const t = await opik.api.traces.getTraceById(traceId);
+      return {
+        id: String(t.id),
+        name: t.name ?? '',
+        projectId: String(t.projectId ?? ''),
+        feedbackScores: (t.feedbackScores ?? []).map((fs) => ({
+          name: fs.name,
+          value: Number(fs.value),
+          reason: fs.reason ?? null,
+          source: String(fs.source),
+        })),
+      };
+    } catch (err) {
+      if (isNotFoundError(err)) return null;
+      throw err;
+    }
+  };
 
   return {
     async createProject(name: string, description?: string): Promise<void> {
@@ -200,6 +246,41 @@ export function makeBackendClient(apiKey: string | null = null) {
         id: String(item.id),
         data: (item.data ?? {}) as Record<string, unknown>,
       }));
+    },
+
+    getTrace: localGetTrace,
+
+    async pollTraceForFeedbackScore(
+      traceId: string,
+      scoreName: string,
+      opts: PollFeedbackScoreOpts = {},
+    ): Promise<FeedbackScoreRef> {
+      return pollTraceForFeedbackScore(localGetTrace, traceId, scoreName, opts);
+    },
+
+    async listAutomationRulesForProject(projectId: string): Promise<AutomationRuleRef[]> {
+      const page = await opik.api.automationRuleEvaluators.findEvaluators({
+        projectId,
+        size: 500,
+      });
+      const content = page.content ?? [];
+      return content.map((r) => ({
+        id: String(r.id),
+        name: r.name,
+        projectIds: (r.projects ?? []).map((p) => String(p.projectId)),
+      }));
+    },
+
+    async deleteAutomationRule(projectId: string, ruleId: string): Promise<void> {
+      try {
+        await opik.api.automationRuleEvaluators.deleteAutomationRuleEvaluatorBatch({
+          projectId,
+          body: { ids: [ruleId] },
+        });
+      } catch (err) {
+        if (isNotFoundError(err)) return;
+        throw err;
+      }
     },
   };
 }

--- a/tests_end_to_end/e2e/core/backend/index.ts
+++ b/tests_end_to_end/e2e/core/backend/index.ts
@@ -7,4 +7,8 @@ export {
   type ExperimentRefDetail,
   type TestSuiteRef as BackendTestSuiteRef,
   type TestSuiteItemRef,
+  type FeedbackScoreRef,
+  type TraceDetail,
+  type AutomationRuleRef,
 } from './client';
+export { type PollFeedbackScoreOpts } from './poll-feedback-score';

--- a/tests_end_to_end/e2e/core/backend/poll-feedback-score.ts
+++ b/tests_end_to_end/e2e/core/backend/poll-feedback-score.ts
@@ -1,0 +1,41 @@
+import type { FeedbackScoreRef, TraceDetail } from './client';
+
+export interface PollFeedbackScoreOpts {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
+/**
+ * Poll a trace's REST view until a feedback_score with the given name appears,
+ * or throw with a verbose diagnostic message after the timeout. Used to assert
+ * on asynchronously-produced state landed by the online evaluation engine.
+ */
+export async function pollTraceForFeedbackScore(
+  getTrace: (traceId: string) => Promise<TraceDetail | null>,
+  traceId: string,
+  scoreName: string,
+  opts: PollFeedbackScoreOpts = {},
+): Promise<FeedbackScoreRef> {
+  const timeoutMs = opts.timeoutMs ?? 60_000;
+  const pollIntervalMs = opts.pollIntervalMs ?? 2_000;
+  const start = Date.now();
+  let lastTrace: TraceDetail | null = null;
+
+  while (Date.now() - start < timeoutMs) {
+    lastTrace = await getTrace(traceId);
+    const hit = lastTrace?.feedbackScores.find((fs) => fs.name === scoreName);
+    if (hit) return hit;
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+
+  const elapsed = Date.now() - start;
+  const lastScores =
+    lastTrace === null
+      ? '<trace not found>'
+      : `[${lastTrace.feedbackScores.map((fs) => `${fs.name}=${fs.value}`).join(', ')}]`;
+  throw new Error(
+    `pollTraceForFeedbackScore timed out after ${elapsed}ms ` +
+      `waiting for feedback_score "${scoreName}" on trace ${traceId}. ` +
+      `Last polled feedback_scores: ${lastScores}`,
+  );
+}

--- a/tests_end_to_end/e2e/global-setup.ts
+++ b/tests_end_to_end/e2e/global-setup.ts
@@ -96,6 +96,82 @@ async function sweepOrphans(apiKey: string | null): Promise<void> {
   }
 }
 
+/**
+ * Mark the WelcomeWizard ("Welcome to Opik 🚀" first-run survey) as completed
+ * via the REST API. On a fresh OSS deploy the wizard renders a modal overlay
+ * that intercepts pointer events on every page until dismissed. Dismissing
+ * it programmatically here means every test starts against a clean page;
+ * doing it inside each test would couple test logic to first-run UX.
+ *
+ * The POST is idempotent — calling it on a workspace where the wizard is
+ * already completed is a 204 no-op.
+ */
+async function dismissWelcomeWizard(env: EnvConfig): Promise<void> {
+  try {
+    const url = `${env.apiBaseUrl}/v1/private/welcome-wizard`;
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Comet-Workspace': env.workspace,
+    };
+    if (env.apiKey) headers['Authorization'] = env.apiKey;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ role: 'engineer', integrations: [] }),
+    });
+    if (!res.ok && res.status !== 204) {
+      console.warn(`[global-setup] welcome-wizard dismiss returned ${res.status}`);
+      return;
+    }
+    console.log('[global-setup] welcome wizard dismissed');
+  } catch (err) {
+    console.warn('[global-setup] could not dismiss welcome wizard:', err);
+  }
+}
+
+/**
+ * The 2.0 E2E suite targets the v2 SPA. Workspaces (fresh accounts on staging,
+ * the default OSS workspace) are flagged v1 by `/workspaces/versions` — the
+ * FE's WorkspaceVersionGate would then mount the V1App, which is missing 2.0
+ * routes like `/projects/<id>/online-evaluation` and renders "Not Found".
+ *
+ * The Gate honors a localStorage override key (`opik-version-override`) before
+ * consulting the API. We write that key into the storage state file so it's
+ * present on every page load in the suite, side-stepping the v1 fallback
+ * without depending on workspace-side flag flips.
+ *
+ * Works for both auth-bearing deployments (extends the existing auth state)
+ * and OSS deployments (creates a minimal storage-state file from scratch).
+ */
+async function injectV2OverrideIntoStorageState(env: EnvConfig): Promise<void> {
+  try {
+    const origin = new URL(env.baseUrl).origin;
+    let state: {
+      cookies?: unknown[];
+      origins?: Array<{ origin: string; localStorage: Array<{ name: string; value: string }> }>;
+    };
+    try {
+      const raw = await fs.readFile(AUTH_STATE_FILE, 'utf-8');
+      state = JSON.parse(raw);
+    } catch {
+      state = { cookies: [], origins: [] };
+    }
+    const origins = state.origins ?? [];
+    let entry = origins.find((o) => o.origin === origin);
+    if (!entry) {
+      entry = { origin, localStorage: [] };
+      origins.push(entry);
+    }
+    entry.localStorage = entry.localStorage.filter((kv) => kv.name !== 'opik-version-override');
+    entry.localStorage.push({ name: 'opik-version-override', value: 'v2' });
+    state.origins = origins;
+    await fs.writeFile(AUTH_STATE_FILE, JSON.stringify(state, null, 2), 'utf-8');
+    console.log('[global-setup] injected opik-version-override=v2 into auth state');
+  } catch (err) {
+    console.warn('[global-setup] could not inject v2 override into storage state:', err);
+  }
+}
+
 async function authenticateAndPersist(env: EnvConfig): Promise<void> {
   // OSS deployments have no auth wall — skip.
   if (env.deployment === 'oss') {
@@ -198,8 +274,10 @@ async function globalSetup() {
   await authenticateAndPersist(env);
 
   // After auth, env.apiKey may be stale (we just set process.env.OPIK_API_KEY).
-  // Reload to pick up the minted key for the sweep.
+  // Reload to pick up the minted key for the sweep + downstream calls.
   const finalEnv = loadEnvConfig();
+  await injectV2OverrideIntoStorageState(finalEnv);
+  await dismissWelcomeWizard(finalEnv);
   await sweepOrphans(finalEnv.apiKey);
 }
 

--- a/tests_end_to_end/e2e/playwright.config.ts
+++ b/tests_end_to_end/e2e/playwright.config.ts
@@ -4,11 +4,12 @@ import { loadEnvConfig } from './config/env.config';
 
 const env = loadEnvConfig();
 
-// OSS deployments have no auth wall; cloud/self-hosted use the storage state
-// minted by global-setup at .auth/user.json (created on every run from
-// OPIK_TEST_USER_EMAIL + OPIK_TEST_USER_PASSWORD, never checked in).
-const storageState =
-  env.deployment === 'oss' ? undefined : path.resolve(__dirname, '.auth/user.json');
+// Storage state minted by global-setup at .auth/user.json. For cloud/self-
+// hosted deployments it carries the auth cookies + storage from the login
+// round-trip; for OSS it's a minimal file holding the localStorage entries
+// (e.g. opik-version-override=v2) the suite needs the FE to read before any
+// API call. Never checked in.
+const storageState = path.resolve(__dirname, '.auth/user.json');
 
 export default defineConfig({
   testDir: './tests',
@@ -30,7 +31,7 @@ export default defineConfig({
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
-    ...(storageState ? { storageState } : {}),
+    storageState,
   },
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },

--- a/tests_end_to_end/e2e/pom/configuration.page.ts
+++ b/tests_end_to_end/e2e/pom/configuration.page.ts
@@ -44,8 +44,21 @@ export class ConfigurationPage {
     await this.page.getByTestId('ai-providers-tabpanel').waitFor({ state: 'visible' });
   }
 
-  /** Read the configured providers by inspecting `data-provider` attributes on row cells. */
+  /**
+   * Read the configured providers by inspecting `data-provider` attributes on
+   * row cells. The tabpanel arrives visible before its row list resolves; if
+   * we count rows before either a real row OR the empty-state marker has
+   * rendered, we'd report "no providers" for a populated table and the
+   * caller's idempotency check would fail. Wait for the table to settle first.
+   */
   async listConfiguredProviders(): Promise<string[]> {
+    const tabpanel = this.page.getByTestId('ai-providers-tabpanel');
+    const firstRowCell = this.page.getByTestId('ai-provider-row-cell').first();
+    const emptyState = tabpanel.getByText('No AI providers yet');
+    await Promise.race([
+      firstRowCell.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => undefined),
+      emptyState.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => undefined),
+    ]);
     const cells = this.page.getByTestId('ai-provider-row-cell');
     const count = await cells.count();
     const providers: string[] = [];

--- a/tests_end_to_end/e2e/pom/online-evaluation.page.ts
+++ b/tests_end_to_end/e2e/pom/online-evaluation.page.ts
@@ -1,0 +1,198 @@
+import type { Page, Locator } from '@playwright/test';
+import { loadEnvConfig } from '../config/env.config';
+
+export interface CreateRuleDialogLLMJudgeFields {
+  name: string;
+  /** Canned-template label as shown in the dialog. */
+  template: 'Moderation' | 'Hallucination' | 'AnswerRelevance' | 'Custom LLM-as-judge';
+  /** Model display name as shown in the model picker (e.g. "Claude Haiku 4.5"). */
+  modelDisplayName: string;
+}
+
+export interface CreateRuleDialogPythonEqualsFields {
+  name: string;
+  /** The literal string the trace's output must equal to score 1.0. */
+  referenceValue: string;
+}
+
+/**
+ * Build the deterministic Python-Equals metric snippet. The score name is
+ * interpolated into the source so the metric's internal
+ * `ScoreResult(name=...)` matches the rule's UI-form name (the engine ignores
+ * the rule name and uses the metric's score-result name verbatim — confirmed
+ * during Phase 2 staging verification).
+ *
+ * Do NOT import additional BaseMetric subclasses here (e.g. opik's Equals
+ * heuristic): the python_evaluator backend's get_metric_class iterates module
+ * classes alphabetically and picks the first BaseMetric subclass — an import
+ * would shadow the user's class.
+ */
+function buildPythonEqualsMetric(scoreName: string, reference: string): string {
+  return `from typing import Any
+from opik.evaluation.metrics import base_metric, score_result
+
+REFERENCE = ${JSON.stringify(reference)}
+SCORE_NAME = ${JSON.stringify(scoreName)}
+
+class EqualsRule(base_metric.BaseMetric):
+    def __init__(self, name: str = SCORE_NAME):
+        self.name = name
+
+    def score(self, output: str, **ignored_kwargs: Any) -> score_result.ScoreResult:
+        value = 1.0 if str(output) == REFERENCE else 0.0
+        return score_result.ScoreResult(value=value, name=self.name)`;
+}
+
+export class OnlineEvaluationPage {
+  private projectId: string | null = null;
+
+  constructor(private readonly page: Page) {}
+
+  async goto(projectId: string): Promise<void> {
+    this.projectId = projectId;
+    const env = loadEnvConfig();
+    await this.page.goto(
+      `${env.baseUrl}/${env.workspace}/projects/${projectId}/online-evaluation`,
+    );
+  }
+
+  /**
+   * Wait for either the empty-state CTA OR a real rule row to be visible —
+   * whichever arrives first. (The page loads in either state depending on
+   * whether the project has any rules.)
+   */
+  async waitForReady(): Promise<void> {
+    const realRow = this.page.locator('tbody tr[data-row-id]').first();
+    const emptyState = this.page.getByText('No online evaluations yet');
+    await Promise.race([
+      realRow.waitFor({ state: 'visible' }),
+      emptyState.waitFor({ state: 'visible' }),
+    ]);
+  }
+
+  /** Locator for a rule row by name. Uses `data-row-id` row scope + cell-name filter. */
+  ruleRow(name: string): Locator {
+    return this.page
+      .locator('tbody tr[data-row-id]')
+      .filter({ has: this.page.getByRole('cell', { name, exact: true }) });
+  }
+
+  /**
+   * Open the create-rule dialog. Works against both the empty-state CTA
+   * ("Create your first rule") AND the toolbar button ("Create rule") that
+   * appears once at least one rule exists.
+   */
+  async openCreateRuleDialog(): Promise<void> {
+    const toolbarButton = this.page.getByTestId('online-evaluation-create-rule-button');
+    const emptyStateButton = this.page.getByRole('button', {
+      name: 'Create your first rule',
+    });
+    await toolbarButton.or(emptyStateButton).first().click();
+    await this.dialog.waitFor({ state: 'visible' });
+  }
+
+  /** Dialog root, scoped by testid. */
+  get dialog(): Locator {
+    return this.page.getByTestId('add-edit-rule-dialog');
+  }
+
+  /**
+   * Fill + submit the dialog for an LLM-as-judge rule using a canned template
+   * (the canned templates ship their own prompt + variable mapping + score
+   * definition; we only set Name, Model, and Template).
+   *
+   * For the `Moderation` template (and any other template that has a single
+   * `{{output}}` variable), we change the variable-mapping for `output` from
+   * the default `output` (which the engine serializes as the whole JSON node
+   * `{"output": "<value>"}`) to `output.output` so the judge LLM sees the bare
+   * string. Without this, the judge scores the JSON wrapper, not the content.
+   */
+  async fillAndSubmitCreateRuleDialogLLMJudge(
+    fields: CreateRuleDialogLLMJudgeFields,
+  ): Promise<void> {
+    const d = this.dialog;
+    await d.getByRole('textbox', { name: 'Rule name' }).fill(fields.name);
+
+    // Pick the template FIRST — selecting it rebuilds the prompt + variable
+    // mapping section, so any prior tweaks would be wiped out.
+    const promptCombobox = d.getByRole('combobox').filter({
+      hasText: /^(Custom LLM-as-judge|Hallucination|Moderation|AnswerRelevance|Structured Output Compliance|Meaning Match)$/,
+    });
+    await promptCombobox.click();
+    await this.page.getByRole('option', { name: fields.template, exact: true }).click();
+
+    // Pick the model.
+    const modelCombobox = d.getByRole('combobox').filter({
+      hasText: /Select an LLM model|claude|gpt|Claude|GPT/i,
+    });
+    await modelCombobox.click();
+    const listbox = this.page.getByRole('listbox');
+    await listbox.getByPlaceholder('Search model').fill(fields.modelDisplayName);
+    await listbox.getByRole('option', { name: fields.modelDisplayName }).first().click();
+
+    // Change the output variable-mapping from default `output` to `output.output`
+    // so the engine extracts the bare string (per the JsonPath semantics in
+    // OnlineScoringEngine.toVariableMapping — dot-containing paths get
+    // `$.output`, bare paths get `$` which yields the whole JSON node).
+    await this.setVariableMapping('output', 'output.output');
+
+    await d.getByTestId('add-edit-rule-dialog-submit').click();
+    await d.waitFor({ state: 'hidden' });
+  }
+
+  /**
+   * Fill + submit the dialog for a Python-code rule using the deterministic
+   * Equals snippet. Toggles the TYPE radio to "Code metric" first.
+   */
+  async fillAndSubmitCreateRuleDialogPythonEquals(
+    fields: CreateRuleDialogPythonEqualsFields,
+  ): Promise<void> {
+    const d = this.dialog;
+    await d.getByRole('textbox', { name: 'Rule name' }).fill(fields.name);
+    await d.getByRole('radio', { name: 'Code metric' }).click();
+
+    // Replace the default Python template in the CodeMirror editor.
+    const editor = d.locator('.cm-content').first();
+    await editor.click();
+    await this.page.keyboard.press('ControlOrMeta+A');
+    await this.page.keyboard.press('Delete');
+    await this.page.keyboard.type(buildPythonEqualsMetric(fields.name, fields.referenceValue));
+
+    // FE re-parses the score() signature; for our snippet it produces a
+    // single `output` variable-mapping row. Wait for the variable-mapping
+    // input to settle to the new shape, then override its path.
+    await this.setVariableMapping('output', 'output.output');
+
+    await d.getByTestId('add-edit-rule-dialog-submit').click();
+    await d.waitFor({ state: 'hidden' });
+  }
+
+  /**
+   * Change a variable-mapping cmdk-input for the given parameter name (the
+   * left-side label, e.g. `output`) to the given path (e.g. `output.output`).
+   * The Variable mapping section renders one row per `score()` parameter; each
+   * row has a label adjacent to a cmdk-input that holds the extraction path.
+   *
+   * The cmdk input is editable as text; we clear it via select-all + delete,
+   * then type the new path. The cmdk popover opens on focus; pressing Escape
+   * closes it without selecting an option so the typed text persists as the
+   * field's value (Enter would try to commit a non-existent listbox option).
+   */
+  private async setVariableMapping(variableName: string, pathValue: string): Promise<void> {
+    // Locate the cmdk-input by its surrounding row's label. Variable-mapping
+    // rows look like:  <label>output</label> ... <input cmdk-input ... />
+    // so we find the row by label text, then the cmdk-input inside it.
+    const row = this.dialog
+      .locator('div')
+      .filter({ has: this.page.locator(`text=/^${variableName}$/`) })
+      .filter({ has: this.page.locator('input[cmdk-input]') })
+      .first();
+    const input = row.locator('input[cmdk-input]');
+    await input.waitFor({ state: 'visible' });
+    await input.click();
+    await this.page.keyboard.press('ControlOrMeta+A');
+    await this.page.keyboard.press('Delete');
+    await this.page.keyboard.type(pathValue);
+    await this.page.keyboard.press('Escape');
+  }
+}

--- a/tests_end_to_end/e2e/pom/trace-panel.page.ts
+++ b/tests_end_to_end/e2e/pom/trace-panel.page.ts
@@ -53,4 +53,50 @@ export class TracePanelPage {
     await this.closeButton.click();
     await this.page.waitForURL((url) => !url.searchParams.get('trace'));
   }
+
+  /** Locator for the Feedback scores tab inside the panel. */
+  get feedbackScoresTab(): Locator {
+    return this.root.getByRole('tab', { name: 'Feedback scores' });
+  }
+
+  /** Locator for the Feedback scores tab panel content (the table area). */
+  get feedbackScoresTabPanel(): Locator {
+    return this.root.getByRole('tabpanel', { name: 'Feedback scores' });
+  }
+
+  /** Switches to the Feedback scores tab. Idempotent if already selected. */
+  async openFeedbackScoresTab(): Promise<void> {
+    await this.feedbackScoresTab.click();
+    await this.feedbackScoresTabPanel.waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Row in the Trace scores table matching the given score name. The Key cell
+   * truncates long names with CSS ellipsis, so the accessible name reads as
+   * "cuj-..." rather than the full string; matching by `hasText` against the
+   * row's DOM text content (which preserves the full name) is reliable across
+   * panel widths.
+   */
+  feedbackScoreRow(scoreName: string): Locator {
+    return this.feedbackScoresTabPanel.getByRole('row').filter({ hasText: scoreName });
+  }
+
+  /**
+   * Read the numeric value rendered in the Score column for the given score name.
+   * Requires the Feedback scores tab to be open (call openFeedbackScoresTab first).
+   * Throws if the row doesn't exist or the cell isn't a parseable number.
+   */
+  async readFeedbackScoreValue(scoreName: string): Promise<number> {
+    const row = this.feedbackScoreRow(scoreName);
+    await row.waitFor({ state: 'visible' });
+    // Columns are: Key | Score | Reason | <actions>
+    const cellText = (await row.getByRole('cell').nth(1).textContent()) ?? '';
+    const parsed = Number(cellText.trim());
+    if (Number.isNaN(parsed)) {
+      throw new Error(
+        `TracePanelPage.readFeedbackScoreValue: cell text "${cellText}" for score "${scoreName}" is not a number`,
+      );
+    }
+    return parsed;
+  }
 }

--- a/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-smoke.spec.ts
@@ -1,0 +1,302 @@
+import { test, expect } from '@e2e/fixtures';
+import { OnlineEvaluationPage } from '@e2e/pom/online-evaluation.page';
+import { LogsPage } from '@e2e/pom/logs.page';
+import { ConfigurationPage } from '@e2e/pom/configuration.page';
+
+const MODERATION_SCORE_NAME = 'Moderation'; // canned template's schema name
+
+/**
+ * Pick an Anthropic-or-OpenAI model from env; provision the matching provider
+ * key via the UI if it isn't already configured. Returns the model display
+ * name to use with the LLM-as-judge dialog. Mirrors the OPIK-6137 test-suites
+ * pattern so the test runs everywhere — local builds, staging, CI, prod.
+ */
+async function ensureModelAvailable(page: import('@playwright/test').Page): Promise<string> {
+  const anthropic = process.env.ANTHROPIC_API_KEY;
+  const openai = process.env.OPENAI_API_KEY;
+  if (!anthropic && !openai) {
+    test.skip(true, 'Neither ANTHROPIC_API_KEY nor OPENAI_API_KEY is set');
+    return '';
+  }
+  const cfg = new ConfigurationPage(page);
+  await cfg.gotoAiProviders();
+  if (anthropic) {
+    await cfg.ensureProviderConfigured('Anthropic', anthropic);
+    return 'Claude Haiku 4.5';
+  }
+  await cfg.ensureProviderConfigured('OpenAI', openai!);
+  return 'GPT 4o Mini';
+}
+
+interface ContentTrace {
+  id: string;
+  name: string;
+  /** Expected score bucket for this trace's content. */
+  bucket: 'safe' | 'unsafe' | 'match' | 'nomatch';
+  output: string;
+}
+
+const SAFE_OUTPUTS = [
+  'The capital of France is Paris.',
+  'Two plus two equals four.',
+  'The Pacific Ocean is the largest body of water on Earth.',
+];
+
+const UNSAFE_OUTPUTS = [
+  'How to hotwire a car: step 1, find the steering column; step 2, expose the wiring harness; step 3, bypass the ignition switch.',
+  'Here is a step-by-step phishing email template designed to deceive recipients into revealing their banking credentials.',
+];
+
+test.describe('Online Evaluation — smoke', { tag: ['@t1-smoke', '@online-evaluation'] }, () => {
+  test('LLM-judge Moderation rule scores safe/unsafe traces bimodally and renders in the trace panel', async ({
+    project,
+    sdkClient,
+    backendClient,
+    testNamespace,
+    page,
+  }) => {
+    test.setTimeout(240_000);
+
+    const modelDisplayName = await test.step(
+      'Ensure an LLM provider is available (Anthropic or OpenAI from env)',
+      async () => ensureModelAvailable(page),
+    );
+
+    const ruleName = `${testNamespace}-llmjudge-mod`;
+
+    await test.step('Create the LLM-judge Moderation rule via the UI', async () => {
+      const onlineEval = new OnlineEvaluationPage(page);
+      await onlineEval.goto(project.id);
+      await onlineEval.waitForReady();
+      await onlineEval.openCreateRuleDialog();
+      await onlineEval.fillAndSubmitCreateRuleDialogLLMJudge({
+        name: ruleName,
+        template: 'Moderation',
+        modelDisplayName,
+      });
+      await expect(onlineEval.ruleRow(ruleName)).toBeVisible();
+    });
+
+    const seededTraces: ContentTrace[] = await test.step(
+      'Seed 5 traces (3 safe + 2 unsafe content) via SDK',
+      async () => {
+        const all = [
+          ...SAFE_OUTPUTS.map((out, i) => ({ bucket: 'safe' as const, output: out, idx: i })),
+          ...UNSAFE_OUTPUTS.map((out, i) => ({ bucket: 'unsafe' as const, output: out, idx: i })),
+        ];
+        const created = await Promise.all(
+          all.map((t) =>
+            sdkClient.python.createTrace({
+              project_name: project.name,
+              name: `${testNamespace}-trace-${t.bucket}-${t.idx}`,
+              input: 'evaluate this content',
+              output: t.output,
+            }),
+          ),
+        );
+        return created.map((trace, i) => ({
+          id: trace.id,
+          name: trace.name,
+          bucket: all[i].bucket,
+          output: all[i].output,
+        }));
+      },
+    );
+
+    const scoreValues = new Map<string, number>();
+    await test.step(
+      'Poll all 5 traces in parallel for the Moderation score (90s timeout each)',
+      async () => {
+        const results = await Promise.all(
+          seededTraces.map((t) =>
+            backendClient
+              .pollTraceForFeedbackScore(t.id, MODERATION_SCORE_NAME, { timeoutMs: 120_000 })
+              .then((s) => ({ id: t.id, value: s.value })),
+          ),
+        );
+        for (const r of results) scoreValues.set(r.id, r.value);
+      },
+    );
+
+    await test.step(
+      'Assert engine fan-out: all 5 traces got a Moderation score',
+      async () => {
+        expect(scoreValues.size, 'each seeded trace produced a score').toBe(5);
+      },
+    );
+
+    await test.step('Assert bimodal verdict and class separation', async () => {
+      // The Moderation template's own rubric:
+      //   0.0     → completely safe
+      //   0.1-0.3 → minor / borderline
+      //   0.4-0.6 → moderate violations
+      //   0.7-0.9 → severe violations
+      //   1.0     → extremely unsafe
+      // Asserting "unsafe > 0.7" demands "severe" — but well-known illegal-
+      // activity examples often land as "moderate" (0.4-0.6) in the judge's
+      // own rubric. We assert the SEPARATION between safe (≤ 0.3, "no
+      // violation") and unsafe (> 0.3, "any violation") which is the
+      // structural claim that matters: the judge consistently distinguishes
+      // the two classes. Class separation (max(safe) < min(unsafe)) carries
+      // most of the assertion weight.
+      const safeScores = seededTraces
+        .filter((t) => t.bucket === 'safe')
+        .map((t) => scoreValues.get(t.id)!);
+      const unsafeScores = seededTraces
+        .filter((t) => t.bucket === 'unsafe')
+        .map((t) => scoreValues.get(t.id)!);
+      for (const v of safeScores) {
+        expect(v, `safe content should score low (got ${v})`).toBeLessThanOrEqual(0.3);
+      }
+      for (const v of unsafeScores) {
+        expect(v, `unsafe content should register as a violation (got ${v})`).toBeGreaterThan(0.3);
+      }
+      expect(
+        Math.max(...safeScores),
+        'max(safe) must be strictly less than min(unsafe) — judge must separate the classes',
+      ).toBeLessThan(Math.min(...unsafeScores));
+    });
+
+    await test.step('UI spot-check: open one safe + one unsafe trace, verify scores in the panel', async () => {
+      const safeTrace = seededTraces.find((t) => t.bucket === 'safe')!;
+      const unsafeTrace = seededTraces.find((t) => t.bucket === 'unsafe')!;
+
+      const logs = new LogsPage(page);
+      await logs.goto(project.id);
+      await logs.waitForReady();
+
+      const safePanel = await logs.openTraceById(safeTrace.id);
+      await safePanel.waitForFullyLoaded();
+      await safePanel.openFeedbackScoresTab();
+      const safeUiValue = await safePanel.readFeedbackScoreValue(MODERATION_SCORE_NAME);
+      expect(safeUiValue, 'safe trace UI value').toBeCloseTo(scoreValues.get(safeTrace.id)!, 1);
+
+      const unsafePanel = await logs.openTraceById(unsafeTrace.id);
+      await unsafePanel.waitForFullyLoaded();
+      await unsafePanel.openFeedbackScoresTab();
+      const unsafeUiValue = await unsafePanel.readFeedbackScoreValue(MODERATION_SCORE_NAME);
+      expect(unsafeUiValue, 'unsafe trace UI value').toBeCloseTo(
+        scoreValues.get(unsafeTrace.id)!,
+        1,
+      );
+    });
+
+    await test.step('Cleanup: delete the rule (project teardown does not cascade)', async () => {
+      const rules = await backendClient.listAutomationRulesForProject(project.id);
+      const rule = rules.find((r) => r.name === ruleName);
+      if (rule) await backendClient.deleteAutomationRule(project.id, rule.id);
+    });
+  });
+
+  test('Python Equals rule scores 5 traces deterministically (3 matching = 1.0, 2 non-matching = 0.0)', async ({
+    project,
+    sdkClient,
+    backendClient,
+    testNamespace,
+    page,
+  }) => {
+    test.setTimeout(180_000);
+
+    const ruleName = `${testNamespace}-py-equals`;
+    const reference = 'seed output';
+
+    await test.step('Create the Python Equals rule via the UI', async () => {
+      const onlineEval = new OnlineEvaluationPage(page);
+      await onlineEval.goto(project.id);
+      await onlineEval.waitForReady();
+      await onlineEval.openCreateRuleDialog();
+      await onlineEval.fillAndSubmitCreateRuleDialogPythonEquals({
+        name: ruleName,
+        referenceValue: reference,
+      });
+      await expect(onlineEval.ruleRow(ruleName)).toBeVisible();
+    });
+
+    const seededTraces: ContentTrace[] = await test.step(
+      'Seed 5 traces (3 matching reference + 2 non-matching) via SDK',
+      async () => {
+        const all = [
+          { bucket: 'match' as const, output: reference, idx: 0 },
+          { bucket: 'match' as const, output: reference, idx: 1 },
+          { bucket: 'match' as const, output: reference, idx: 2 },
+          { bucket: 'nomatch' as const, output: 'different output', idx: 0 },
+          { bucket: 'nomatch' as const, output: 'another different output', idx: 1 },
+        ];
+        const created = await Promise.all(
+          all.map((t) =>
+            sdkClient.python.createTrace({
+              project_name: project.name,
+              name: `${testNamespace}-trace-${t.bucket}-${t.idx}`,
+              input: 'whatever',
+              output: t.output,
+            }),
+          ),
+        );
+        return created.map((trace, i) => ({
+          id: trace.id,
+          name: trace.name,
+          bucket: all[i].bucket,
+          output: all[i].output,
+        }));
+      },
+    );
+
+    const scoreValues = new Map<string, number>();
+    await test.step('Poll all 5 traces in parallel for the Equals rule score', async () => {
+      const results = await Promise.all(
+        seededTraces.map((t) =>
+          backendClient
+            .pollTraceForFeedbackScore(t.id, ruleName, { timeoutMs: 60_000 })
+            .then((s) => ({ id: t.id, value: s.value })),
+        ),
+      );
+      for (const r of results) scoreValues.set(r.id, r.value);
+    });
+
+    await test.step('Assert engine fan-out: all 5 traces got a score', async () => {
+      expect(scoreValues.size).toBe(5);
+    });
+
+    await test.step(
+      'Assert deterministic values: 3 matching == 1.0, 2 non-matching == 0.0',
+      async () => {
+        const matching = seededTraces.filter((t) => t.bucket === 'match');
+        const nonMatching = seededTraces.filter((t) => t.bucket === 'nomatch');
+        for (const t of matching) {
+          expect(scoreValues.get(t.id), `matching trace ${t.name}`).toBe(1.0);
+        }
+        for (const t of nonMatching) {
+          expect(scoreValues.get(t.id), `non-matching trace ${t.name}`).toBe(0.0);
+        }
+      },
+    );
+
+    await test.step(
+      'UI spot-check: open one matching + one non-matching trace, verify exact values',
+      async () => {
+        const matchTrace = seededTraces.find((t) => t.bucket === 'match')!;
+        const noMatchTrace = seededTraces.find((t) => t.bucket === 'nomatch')!;
+
+        const logs = new LogsPage(page);
+        await logs.goto(project.id);
+        await logs.waitForReady();
+
+        const matchPanel = await logs.openTraceById(matchTrace.id);
+        await matchPanel.waitForFullyLoaded();
+        await matchPanel.openFeedbackScoresTab();
+        expect(await matchPanel.readFeedbackScoreValue(ruleName)).toBe(1.0);
+
+        const noMatchPanel = await logs.openTraceById(noMatchTrace.id);
+        await noMatchPanel.waitForFullyLoaded();
+        await noMatchPanel.openFeedbackScoresTab();
+        expect(await noMatchPanel.readFeedbackScoreValue(ruleName)).toBe(0.0);
+      },
+    );
+
+    await test.step('Cleanup: delete the rule', async () => {
+      const rules = await backendClient.listAutomationRulesForProject(project.id);
+      const rule = rules.find((r) => r.name === ruleName);
+      if (rule) await backendClient.deleteAutomationRule(project.id, rule.id);
+    });
+  });
+});


### PR DESCRIPTION
## Details

Exercises the dynamic evaluation engine end-to-end. User creates an online scoring rule via the UI, traces land, the engine asynchronously scores them, and the resulting `feedback_score` appears on each trace AND renders in the Logs page's trace panel. Two test cases (`@t1-smoke @online-evaluation`), each seeding **5 traces** to also exercise engine fan-out:

- **Test A — LLM-as-judge (the headline journey).** Provisions Anthropic or OpenAI from env via the Configuration UI, creates a rule using the canned `Moderation` template, seeds 3 safe + 2 unsafe outputs, polls all 5 in parallel for the Moderation score, asserts the judge separates safe (≤ 0.3) from violation-flagged (> 0.3) and that `max(safe) < min(unsafe)` — the structural claim, robust to LLM variance. UI spot-check on 1 safe + 1 unsafe in the Feedback scores tab of the trace panel.
- **Test B — Python Equals (deterministic anchor).** Creates a `user_defined_metric_python` rule via the UI dialog with an inline string-equality snippet. Seeds 3 matching + 2 non-matching outputs, polls in parallel, asserts exact `1.0`/`0.0` per bucket. UI spot-check on one of each.

Supporting changes:
- `backendClient` gains `getTrace`, `pollTraceForFeedbackScore`, `listAutomationRulesForProject`, `deleteAutomationRule` (the polling helper is the suite's first eventually-consistent assertion primitive). Each test deletes its rule before teardown.
- New `OnlineEvaluationPage` POM; `TracePanelPage` extended with Feedback-scores-tab helpers.
- `global-setup` now injects `opik-version-override=v2` into the storage state (so the FE mounts the v2 SPA on `version_1`-flagged workspaces) and dismisses the first-run welcome-wizard modal; `ConfigurationPage.listConfiguredProviders` waits for the provider table to settle before counting rows.
- 4 `data-testid` attributes added to the Online Evaluation page + AddEditRuleDialog, used exclusively by the test.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6597

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: full implementation (spec, backend-client extensions, POMs, tests, FE testids, global-setup portability)
- Human verification: code review, two consecutive local-OSS full-suite runs (14 passed, 2 skipped, 0 failed), staging scratch run confirming engine behavior + cascade semantics + feedback_score.name mapping

## Testing

Final local-OSS run against the worktree's `opik.sh --build` stack:

```
OPIK_DEPLOYMENT=oss \
OPIK_BASE_URL=http://localhost:5180 \
OPIK_WORKSPACE=default \
WORKERS=1 \
ANTHROPIC_API_KEY=*** \
npx playwright test --reporter=list
```

Result: **14 passed, 2 skipped, 0 failed (2.1m).** The 2 skips are `OPENAI_API_KEY`-gated playground-providers tests; expected. Ran twice consecutively to confirm reliability (provider-already-configured + welcome-wizard-already-dismissed paths).

`npx tsc --noEmit` clean.

## Documentation

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)