### PR TITLE
[OPIK-6542] [DOCS] docs: add opik migrate CLI documentation page

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/home.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/home.mdx
@@ -16,6 +16,12 @@ application footprint and dev cycle. Ship measurable improvements with gorgeous 
 scoring functions, pre-configured LLM-as-a-judge [eval metrics](/evaluation/metrics/overview), and
 even [automated agent optimization algorithms](/development/optimization-runs/overview) to maximize performance. 
 
+<Note>
+  **Upgrading from Opik 1.x?** Opik 2.0 reorganized everything around projects — datasets,
+  prompts, and experiments are now scoped to a project. See [Upgrading to Opik 2.0](/opik-v2-upgrade)
+  for what changed, how to update your code, and where your existing data moved.
+</Note>
+
 ## End-to-End AI Engineering
 
 <Frame>

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/migrate_data.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/migrate_data.mdx
@@ -1,0 +1,138 @@
+---
+headline: Migrate data between projects | Opik Documentation
+og:description: Move datasets and prompts — with their full version history and
+  attached data — between projects with the opik migrate CLI command.
+og:site_name: Opik Documentation
+og:title: Migrate data between projects with Opik
+title: Migrate data
+---
+
+`opik migrate` moves an entity — and everything attached to it — from one project to another **in the same workspace**. It copies the entity's full version history and its related data into the destination project.
+
+It has two subcommands:
+
+- **`opik migrate dataset`** — a dataset (or test suite) with its full version history, plus the experiments, traces, spans, feedback scores, assertion results, comments, and optimizations attached to it.
+- **`opik migrate prompt`** — a prompt and its full version history.
+
+Use it to consolidate or re-home an entity and its history under a different project.
+
+<Note>
+  These commands move data **between projects in a single workspace**. To move data between
+  separate Opik installations or environments, use [`opik export` / `opik import`](/tracing/advanced/export-data#command-line-tools) instead.
+</Note>
+
+<Warning>
+  The migration **renames the source** to `<name>_v1` and gives the destination the original
+  name. Preview with `--dry-run` first to see exactly what will change.
+</Warning>
+
+## Options
+
+The `--workspace` and `--api-key` flags go on the `opik migrate` group, **before** the subcommand. The rest are shared by both `dataset` and `prompt`.
+
+| Flag                       | Default                                         | Description                                                                                   |
+| -------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `NAME` (argument)          | —                                               | Exact name of the source dataset or prompt to migrate.                                        |
+| `--to-project`             | — (**required**)                                | Destination project. It must already exist — create it first if needed.                       |
+| `--from-project`           | whole workspace                                 | Optional hint for which project the source lives in. Omit to search the whole workspace.      |
+| `--dry-run`                | `false`                                         | Preview what would happen without making any changes. See [Previewing a migration](#previewing-a-migration). |
+| `--workspace` (group flag) | `OPIK_WORKSPACE` → `~/.opik.config` → `default` | Workspace to operate in.                                                                       |
+| `--api-key` (group flag)   | `OPIK_API_KEY` → `~/.opik.config`               | Opik API key.                                                                                  |
+
+## Previewing a migration
+
+Add `--dry-run` to any migration to see exactly what it would do **without changing anything** — nothing is renamed and nothing is copied. The command resolves the source, prints the plan it would run step by step, then exits.
+
+```bash
+opik migrate dataset "MyDataset" --to-project="production" --dry-run
+```
+
+Use the preview to confirm the source resolved to the right entity and that the destination project is correct. When the plan looks right, run the same command again without `--dry-run` to apply it.
+
+## `opik migrate dataset`
+
+```bash
+opik migrate dataset NAME --to-project=DESTINATION_PROJECT [OPTIONS]
+```
+
+`NAME` is the exact name of the source dataset. Both plain datasets and test suites are supported. [Preview with `--dry-run`](#previewing-a-migration) before applying.
+
+### What gets copied
+
+| Entity                | What comes across                                                                                  |
+| --------------------- | -------------------------------------------------------------------------------------------------- |
+| **Dataset**           | Name, description, visibility, tags, and type (dataset or test suite).                             |
+| **Version history**   | Every version, in order, with the same items and ordering as the source.                           |
+| **Items**             | Each item's data, description, tags, evaluators, execution policy, and source.                     |
+| **Experiments**       | Name, type, evaluation method, tags, and metadata.                                                 |
+| **Traces**            | Input, output, metadata, tags, timing, thread, errors, and environment.                            |
+| **Spans**             | The full span tree, inputs and outputs, metadata, model, provider, usage, cost, tags, and errors.  |
+| **Feedback scores**   | On traces and spans.                                                                               |
+| **Assertion results** | For test suites.                                                                                   |
+| **Comments**          | On traces and spans.                                                                               |
+| **Optimizations**     | Optimizations linked to the dataset, with their experiments re-linked on the destination.          |
+
+### What happens when you run it
+
+The same steps appear in the `--dry-run` plan:
+
+| #   | Step                  | What it does                                                          |
+| --- | --------------------- | -------------------------------------------------------------------- |
+| 1   | Rename source         | Renames the source to `<name>_v1` to free up its name.               |
+| 2   | Create destination    | Creates the dataset under `--to-project` with the original name.     |
+| 3   | Replay versions       | Replays every version onto the destination, in order.                |
+| 4   | Copy optimizations    | Recreates any optimizations linked to the dataset.                   |
+| 5   | Copy experiments      | Recreates the experiments, along with their traces and spans.        |
+
+### What is not copied
+
+- **Prompt snapshots on experiments** — migrate prompts separately with `opik migrate prompt`.
+- **Attachments on traces and spans** — files like images and audio are not copied.
+- **Thread tags, status, feedback scores, and comments** — the traces themselves (including their environment) do come across, but these thread-level fields don't yet.
+
+### Examples
+
+```bash
+# Migrate a dataset (with its experiments, traces, and spans)
+opik migrate dataset "MyDataset" --to-project="production"
+
+# Preview without making any changes
+opik migrate dataset "MyDataset" --to-project="production" --dry-run
+
+# Tell it which project the source is in
+opik migrate dataset "MyDataset" --to-project="production" --from-project="staging"
+```
+
+## `opik migrate prompt`
+
+```bash
+opik migrate prompt NAME --to-project=DESTINATION_PROJECT [OPTIONS]
+```
+
+`NAME` is the exact name of the source prompt. This subcommand migrates the prompt and its version history only — it does not copy experiments, traces, or spans. [Preview with `--dry-run`](#previewing-a-migration) before applying.
+
+### What gets copied
+
+- **Prompt** — name, description, tags, and template structure.
+- **Version history** — every version, oldest first, with its template, metadata, type, change description, and tags.
+- **Commit hashes** — each version's commit hash is preserved, so the history matches the source exactly.
+
+It renames the source to `<name>_v1`, creates the destination prompt under `--to-project`, and replays every version.
+
+### Examples
+
+```bash
+# Migrate a prompt and its full version history
+opik migrate prompt "MyPrompt" --to-project="production"
+
+# Preview without making any changes
+opik migrate prompt "MyPrompt" --to-project="production" --dry-run
+```
+
+## Troubleshooting
+
+- **Name already used** — the rename target `<name>_v1` already exists. Rename or delete the conflicting entity and re-run:
+
+  ```
+  Cannot rename source to 'MyDataset_v1' — that name is already used by a dataset in project 'staging'. Rename or delete the conflicting dataset and re-run.
+  ```

--- a/apps/opik-documentation/documentation/fern/docs-v2/opik_v2_upgrade.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/opik_v2_upgrade.mdx
@@ -47,81 +47,59 @@ Upgrade to the Opik SDK **2.0 or later**:
   </Tab>
 </Tabs>
 
-The main change is to **tell Opik which project you're working in**. New datasets, prompts, experiments, and traces are created inside that project. If you don't set one, they fall back to `Default Project`.
+The main change is to **pass the project to the method you're calling**. The create and search methods for datasets, prompts, and experiments all take a `project_name` argument. If you don't pass it, Opik uses the project from your environment (`OPIK_PROJECT_NAME`) or config, falling back to `Default Project`.
 
 <Tabs>
   <Tab title="Python">
     ```python
     import opik
 
-    # Set the project once for the client
-    client = opik.Opik(project_name="my-agent")
+    client = opik.Opik()
 
-    # Datasets, prompts, and experiments now live inside that project
-    dataset = client.create_dataset(name="qa-pairs")
-    prompt = client.create_prompt(name="assistant-prompt", prompt="Answer: {{question}}")
-
-    # The tracing decorator accepts a project too
-    @opik.track(project_name="my-agent")
-    def my_agent(question: str) -> str:
-        ...
+    # Pass the project to each call
+    dataset = client.create_dataset(name="qa-pairs", project_name="my-agent")
+    prompt = client.create_prompt(
+        name="assistant-prompt",
+        prompt="Answer: {{question}}",
+        project_name="my-agent",
+    )
     ```
 
-    Prefer to set it globally instead of per client? Use the `OPIK_PROJECT_NAME`
-    environment variable, or run `opik configure` to store `project_name` in
-    `~/.opik.config`. Most `create_*` / `search_*` methods also take a `project_name`
-    argument to override per call.
+    Omit `project_name` and Opik falls back to the `OPIK_PROJECT_NAME` environment
+    variable (or your `~/.opik.config`), and finally to `Default Project`.
   </Tab>
   <Tab title="TypeScript">
     ```typescript
     import { Opik } from "opik";
 
-    // Set the project once for the client
-    const client = new Opik({ projectName: "my-agent" });
+    const client = new Opik();
 
-    // Datasets and prompts now live inside that project
-    const dataset = await client.getOrCreateDataset("qa-pairs");
+    // Pass the project to each call
+    const dataset = await client.getOrCreateDataset("qa-pairs", "QA pairs", "my-agent");
     const prompt = await client.createPrompt({
       name: "assistant-prompt",
       prompt: "Answer: {{question}}",
+      projectName: "my-agent",
     });
     ```
 
-    Prefer to set it globally instead? Use the `OPIK_PROJECT_NAME` environment variable.
-    `createDataset` / `createPrompt` and related methods also accept a `projectName` to
-    override per call.
+    Omit the project and Opik falls back to the `OPIK_PROJECT_NAME` environment variable
+    (or your config), and finally to `Default Project`.
   </Tab>
 </Tabs>
 
-## Where your existing data went
+## Where your existing data lands
 
-When your workspace upgraded to 2.0, Opik **automatically moved your workspace-scoped 1.x data** — datasets, prompts, experiments, and optimizations — into projects. You don't need to migrate anything by hand.
+While upgrading your workspace to 2.0, Opik **automatically moves your workspace-scoped 1.x data** — datasets, prompts, experiments, and optimizations — into projects. You don't need to migrate anything by hand.
 
-Each item was placed in the project Opik could infer from the runs that used it. When there was nothing to infer from (no associated runs, or the original project had been deleted), the item was placed in your **`Default Project`**.
+Each item is placed in the project Opik can infer from the runs that used it. When there's nothing to infer from (no associated runs, or the original project had been deleted), the item is placed in your **`Default Project`**.
 
 So if you don't see a dataset, prompt, or experiment where you expected it, check the project its traces and experiments belong to — and check **`Default Project`**.
 
-## Self-hosted installations
-
-The automatic migration above runs on Opik Cloud. On self-hosted (open-source) deployments it is **off by default**, so your existing 1.x data is still at the workspace level and isn't attached to any project yet.
-
-Because 2.0 scopes these to a project, they can't stay at the workspace level — move each into the project it belongs to:
-
-- **Datasets** and **test suites**
-- **Prompts**
-- **Experiments** and **optimizations** (these come along automatically when you move their dataset)
-
-Move them with the [`opik migrate`](/tracing/advanced/migrate-data) CLI. Omit `--from-project` so it picks up the workspace-level entity, and point `--to-project` at the destination:
-
-```bash
-# A dataset brings its experiments, traces, spans, and optimizations along
-opik migrate dataset "my-dataset" --to-project="my-agent"
-
-# A prompt brings its full version history
-opik migrate prompt "my-prompt" --to-project="my-agent"
-```
-
-Preview with `--dry-run` first. See [Migrate data](/tracing/advanced/migrate-data) for the full guide.
+<Note>
+  On open-source installations, a workspace is promoted to 2.0 automatically as soon as its
+  blocking workspace-level (orphan) data has been migrated into projects.
+</Note>
 
 ## Moving data to a different project
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/opik_v2_upgrade.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/opik_v2_upgrade.mdx
@@ -47,7 +47,9 @@ Upgrade to the Opik SDK **2.0 or later**:
   </Tab>
 </Tabs>
 
-The main change is to **pass the project to the method you're calling**. The create and search methods for datasets, prompts, and experiments all take a `project_name` argument. If you don't pass it, Opik uses the project from your environment (`OPIK_PROJECT_NAME`) or config, falling back to `Default Project`.
+The main change is to **pass the project to the methods you call**. The dataset, prompt, experiment, and optimization APIs all take a `project_name` (`projectName` in TypeScript). Omit it and Opik uses the project from the `OPIK_PROJECT_NAME` environment variable or your config, falling back to `Default Project`.
+
+All snippets below assume a client:
 
 <Tabs>
   <Tab title="Python">
@@ -55,38 +57,99 @@ The main change is to **pass the project to the method you're calling**. The cre
     import opik
 
     client = opik.Opik()
-
-    # Pass the project to each call
-    dataset = client.create_dataset(name="qa-pairs", project_name="my-agent")
-    prompt = client.create_prompt(
-        name="assistant-prompt",
-        prompt="Answer: {{question}}",
-        project_name="my-agent",
-    )
     ```
-
-    Omit `project_name` and Opik falls back to the `OPIK_PROJECT_NAME` environment
-    variable (or your `~/.opik.config`), and finally to `Default Project`.
   </Tab>
   <Tab title="TypeScript">
     ```typescript
     import { Opik } from "opik";
 
     const client = new Opik();
+    ```
+  </Tab>
+</Tabs>
 
-    // Pass the project to each call
-    const dataset = await client.getOrCreateDataset("qa-pairs", "QA pairs", "my-agent");
-    const prompt = await client.createPrompt({
-      name: "assistant-prompt",
+### Datasets
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    client.create_dataset(name="qa-pairs", project_name="my-agent")
+    client.get_dataset(name="qa-pairs", project_name="my-agent")
+    client.get_or_create_dataset(name="qa-pairs", project_name="my-agent")
+    client.get_datasets(project_name="my-agent")
+    client.delete_dataset(name="qa-pairs", project_name="my-agent")
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    await client.createDataset("qa-pairs", "QA pairs", "my-agent");
+    await client.getDataset("qa-pairs", "my-agent");
+    await client.getOrCreateDataset("qa-pairs", "QA pairs", "my-agent");
+    await client.getDatasets(100, "my-agent");
+    await client.deleteDataset("qa-pairs", "my-agent");
+    ```
+  </Tab>
+</Tabs>
+
+### Prompts
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    client.create_prompt(name="assistant", prompt="Answer: {{question}}", project_name="my-agent")
+    client.get_prompt(name="assistant", project_name="my-agent")
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    await client.createPrompt({
+      name: "assistant",
       prompt: "Answer: {{question}}",
       projectName: "my-agent",
     });
+    await client.getPrompt({ name: "assistant", projectName: "my-agent" });
     ```
-
-    Omit the project and Opik falls back to the `OPIK_PROJECT_NAME` environment variable
-    (or your config), and finally to `Default Project`.
   </Tab>
 </Tabs>
+
+### Experiments
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    client.create_experiment(dataset_name="qa-pairs", name="run-1", project_name="my-agent")
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    await client.createExperiment({
+      datasetName: "qa-pairs",
+      name: "run-1",
+      projectName: "my-agent",
+    });
+    ```
+  </Tab>
+</Tabs>
+
+<Tip>
+  When you run an evaluation with `opik.evaluate(...)`, the experiment is created in its
+  dataset's project automatically — create the dataset in the right project and the
+  experiment follows it.
+</Tip>
+
+### Optimizations
+
+Optimizations are available in the Python SDK:
+
+```python
+client.create_optimization(
+    dataset_name="qa-pairs",
+    objective_name="accuracy",
+    project_name="my-agent",
+)
+```
+
+If you use the Opik Optimizer, pass `project_name` to `optimize_prompt(...)` so its runs land in the right project.
 
 ## Where your existing data lands
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/opik_v2_upgrade.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/opik_v2_upgrade.mdx
@@ -18,15 +18,16 @@ Opik 2.0 reorganized the product around **projects**. A project now maps to a si
 
 ## What changed: projects are the home for everything
 
-In Opik 1.x, traces lived in projects, but **datasets, prompts, and experiments were shared across the whole workspace**. In 2.0, a project maps to one agent or app and scopes all of its work.
+In Opik 1.x, traces and threads lived in projects, but **datasets, prompts, experiments, optimizations, automation rules, alerts, and dashboards were workspace-wide**. In 2.0, a project maps to one agent or app and scopes all of its work.
 
-These are now **scoped to a project**:
+These entities are now **scoped to a project**:
 
-- Traces and threads
 - Datasets and test suites
 - Experiments and optimizations
 - Prompts
-- Alerts and dashboards
+- Automation rules — in 1.x a rule could target multiple projects; in 2.0 a rule is scoped to a single project
+- Alerts
+- Dashboards — workspace-level dashboards remain supported through a dedicated view
 
 You also get a workspace-level project selector, project-scoped navigation across the app, a unified Logs page (threads, traces, and spans in one place), and a redesigned trace view. The result is a focused view of everything tied to a single agent. See the [2.0 release notes](/changelog) for the full picture.
 
@@ -189,15 +190,23 @@ An experiment — and **every trace, span, and feedback score it produces** — 
 
 ## Where your existing data lands
 
-While upgrading your workspace to 2.0, Opik **automatically moves your workspace-scoped 1.x data** — datasets, prompts, experiments, and optimizations — into projects. You don't need to migrate anything by hand.
+When your workspace is upgraded to 2.0, your workspace-scoped 1.x data — datasets, prompts, experiments, and optimizations — is **moved into projects**.
 
 Each item is placed in the project Opik can infer from the runs that used it. When there's nothing to infer from (no associated runs, or the original project had been deleted), the item is placed in your **`Default Project`**.
 
 So if you don't see a dataset, prompt, or experiment where you expected it, check the project its traces and experiments belong to — and check **`Default Project`**.
 
 <Note>
-  On open-source installations, a workspace is promoted to 2.0 automatically as soon as its
-  blocking workspace-level (orphan) data has been migrated into projects.
+  **Opik Cloud (Comet-hosted):** the move runs automatically — there is nothing to start by hand.
+  A workspace is promoted to 2.0 as soon as its blocking workspace-level (orphan) data has been
+  migrated into projects.
+</Note>
+
+<Note>
+  **Self-hosted Opik:** the same move is available as backend migration jobs that you run yourself
+  before promoting a workspace to 2.0. Dedicated runbooks for those jobs will be published under
+  [self-host configuration](/self-host/overview); until then, see the [2.0 release notes](/changelog)
+  for the current upgrade procedure.
 </Note>
 
 ## Moving data to a different project

--- a/apps/opik-documentation/documentation/fern/docs-v2/opik_v2_upgrade.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/opik_v2_upgrade.mdx
@@ -49,6 +49,12 @@ Upgrade to the Opik SDK **2.0 or later**:
 
 The main change is to **pass the project to the methods you call**. The dataset, test suite, prompt, and experiment APIs all take a `project_name` (`projectName` in TypeScript). Omit it and Opik uses the project from the `OPIK_PROJECT_NAME` environment variable or your config, falling back to `Default Project`.
 
+<Tip>
+  Running `opik configure` now also prompts you to pick a project — it suggests your most
+  recent one and stores your choice as `project_name` in `~/.opik.config`, so you only pass
+  `project_name` on a call when you want to override that default.
+</Tip>
+
 All snippets below assume a client:
 
 <Tabs>

--- a/apps/opik-documentation/documentation/fern/docs-v2/opik_v2_upgrade.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/opik_v2_upgrade.mdx
@@ -1,0 +1,135 @@
+---
+headline: Upgrading to Opik 2.0 | Opik Documentation
+og:description: What changed in Opik 2.0 — everything is now organized around
+  projects — how to update your SDK code, where your existing data was moved, and
+  how to relocate it if needed.
+og:site_name: Opik Documentation
+og:title: Upgrading to Opik 2.0
+title: Upgrading to Opik 2.0
+---
+
+Opik 2.0 reorganized the product around **projects**. A project now maps to a single agent or app and is the home for everything related to it. This page explains what changed, how to work with the SDK from now on, where your existing data was moved, and how to relocate it if it didn't land where you want.
+
+<Note>
+  If you started on Opik 2.0, there's nothing to do here — projects are the default. This
+  guide is for users upgrading from Opik 1.x. For the full list of new features, see the
+  [2.0 release notes](/changelog).
+</Note>
+
+## What changed: projects are the home for everything
+
+In Opik 1.x, traces lived in projects, but **datasets, prompts, and experiments were shared across the whole workspace**. In 2.0, a project maps to one agent or app and scopes all of its work.
+
+These are now **scoped to a project**:
+
+- Traces and threads
+- Datasets and test suites
+- Experiments and optimizations
+- Prompts
+- Alerts and dashboards
+
+You also get a workspace-level project selector, project-scoped navigation across the app, a unified Logs page (threads, traces, and spans in one place), and a redesigned trace view. The result is a focused view of everything tied to a single agent. See the [2.0 release notes](/changelog) for the full picture.
+
+## How to work now
+
+Upgrade to the Opik SDK **2.0 or later**:
+
+<Tabs>
+  <Tab title="Python">
+    ```bash
+    pip install --upgrade "opik>=2.0.0"
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```bash
+    npm install opik@latest
+    ```
+  </Tab>
+</Tabs>
+
+The main change is to **tell Opik which project you're working in**. New datasets, prompts, experiments, and traces are created inside that project. If you don't set one, they fall back to `Default Project`.
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import opik
+
+    # Set the project once for the client
+    client = opik.Opik(project_name="my-agent")
+
+    # Datasets, prompts, and experiments now live inside that project
+    dataset = client.create_dataset(name="qa-pairs")
+    prompt = client.create_prompt(name="assistant-prompt", prompt="Answer: {{question}}")
+
+    # The tracing decorator accepts a project too
+    @opik.track(project_name="my-agent")
+    def my_agent(question: str) -> str:
+        ...
+    ```
+
+    Prefer to set it globally instead of per client? Use the `OPIK_PROJECT_NAME`
+    environment variable, or run `opik configure` to store `project_name` in
+    `~/.opik.config`. Most `create_*` / `search_*` methods also take a `project_name`
+    argument to override per call.
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import { Opik } from "opik";
+
+    // Set the project once for the client
+    const client = new Opik({ projectName: "my-agent" });
+
+    // Datasets and prompts now live inside that project
+    const dataset = await client.getOrCreateDataset("qa-pairs");
+    const prompt = await client.createPrompt({
+      name: "assistant-prompt",
+      prompt: "Answer: {{question}}",
+    });
+    ```
+
+    Prefer to set it globally instead? Use the `OPIK_PROJECT_NAME` environment variable.
+    `createDataset` / `createPrompt` and related methods also accept a `projectName` to
+    override per call.
+  </Tab>
+</Tabs>
+
+## Where your existing data went
+
+When your workspace upgraded to 2.0, Opik **automatically moved your workspace-scoped 1.x data** — datasets, prompts, experiments, and optimizations — into projects. You don't need to migrate anything by hand.
+
+Each item was placed in the project Opik could infer from the runs that used it. When there was nothing to infer from (no associated runs, or the original project had been deleted), the item was placed in your **`Default Project`**.
+
+So if you don't see a dataset, prompt, or experiment where you expected it, check the project its traces and experiments belong to — and check **`Default Project`**.
+
+## Self-hosted installations
+
+The automatic migration above runs on Opik Cloud. On self-hosted (open-source) deployments it is **off by default**, so your existing 1.x data is still at the workspace level and isn't attached to any project yet.
+
+Because 2.0 scopes these to a project, they can't stay at the workspace level — move each into the project it belongs to:
+
+- **Datasets** and **test suites**
+- **Prompts**
+- **Experiments** and **optimizations** (these come along automatically when you move their dataset)
+
+Move them with the [`opik migrate`](/tracing/advanced/migrate-data) CLI. Omit `--from-project` so it picks up the workspace-level entity, and point `--to-project` at the destination:
+
+```bash
+# A dataset brings its experiments, traces, spans, and optimizations along
+opik migrate dataset "my-dataset" --to-project="my-agent"
+
+# A prompt brings its full version history
+opik migrate prompt "my-prompt" --to-project="my-agent"
+```
+
+Preview with `--dry-run` first. See [Migrate data](/tracing/advanced/migrate-data) for the full guide.
+
+## Moving data to a different project
+
+If something landed in a project you don't want, you can move it with the [`opik migrate`](/tracing/advanced/migrate-data) CLI. It relocates a dataset (with its experiments, traces, and spans) or a prompt (with its full version history) into another project.
+
+```bash
+# Move a dataset that landed in Default Project into your agent's project
+opik migrate dataset "qa-pairs" --to-project="my-agent"
+```
+
+Preview any move with `--dry-run` first. See [Migrate data](/tracing/advanced/migrate-data) for the full guide — what's copied, the options, and troubleshooting.

--- a/apps/opik-documentation/documentation/fern/docs-v2/opik_v2_upgrade.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/opik_v2_upgrade.mdx
@@ -47,7 +47,7 @@ Upgrade to the Opik SDK **2.0 or later**:
   </Tab>
 </Tabs>
 
-The main change is to **pass the project to the methods you call**. The dataset, prompt, experiment, and optimization APIs all take a `project_name` (`projectName` in TypeScript). Omit it and Opik uses the project from the `OPIK_PROJECT_NAME` environment variable or your config, falling back to `Default Project`.
+The main change is to **pass the project to the methods you call**. The dataset, prompt, and experiment APIs all take a `project_name` (`projectName` in TypeScript). Omit it and Opik uses the project from the `OPIK_PROJECT_NAME` environment variable or your config, falling back to `Default Project`.
 
 All snippets below assume a client:
 
@@ -133,20 +133,6 @@ An experiment — and **every trace, span, and feedback score it produces** — 
     ```
   </Tab>
 </Tabs>
-
-### Optimizations
-
-Optimizations are available in the Python SDK:
-
-```python
-client.create_optimization(
-    dataset_name="qa-pairs",
-    objective_name="accuracy",
-    project_name="my-agent",
-)
-```
-
-If you use the Opik Optimizer, pass `project_name` to `optimize_prompt(...)` so its runs land in the right project.
 
 ## Where your existing data lands
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/opik_v2_upgrade.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/opik_v2_upgrade.mdx
@@ -47,7 +47,7 @@ Upgrade to the Opik SDK **2.0 or later**:
   </Tab>
 </Tabs>
 
-The main change is to **pass the project to the methods you call**. The dataset, prompt, and experiment APIs all take a `project_name` (`projectName` in TypeScript). Omit it and Opik uses the project from the `OPIK_PROJECT_NAME` environment variable or your config, falling back to `Default Project`.
+The main change is to **pass the project to the methods you call**. The dataset, test suite, prompt, and experiment APIs all take a `project_name` (`projectName` in TypeScript). Omit it and Opik uses the project from the `OPIK_PROJECT_NAME` environment variable or your config, falling back to `Default Project`.
 
 All snippets below assume a client:
 
@@ -78,6 +78,7 @@ All snippets below assume a client:
     client.get_or_create_dataset(name="qa-pairs", project_name="my-agent")
     client.get_datasets(project_name="my-agent")
     client.delete_dataset(name="qa-pairs", project_name="my-agent")
+    client.get_dataset_experiments(dataset_name="qa-pairs", project_name="my-agent")
     ```
   </Tab>
   <Tab title="TypeScript">
@@ -87,6 +88,32 @@ All snippets below assume a client:
     await client.getOrCreateDataset("qa-pairs", "QA pairs", "my-agent");
     await client.getDatasets(100, "my-agent");
     await client.deleteDataset("qa-pairs", "my-agent");
+    await client.getDatasetExperiments("qa-pairs", 100, "my-agent");
+    ```
+  </Tab>
+</Tabs>
+
+### Test suites
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    client.create_test_suite(name="qa-suite", project_name="my-agent")
+    client.get_test_suite(name="qa-suite", project_name="my-agent")
+    client.get_or_create_test_suite(name="qa-suite", project_name="my-agent")
+    client.get_test_suites(project_name="my-agent")
+    client.delete_test_suite(name="qa-suite", project_name="my-agent")
+    client.get_test_suite_experiments(name="qa-suite", project_name="my-agent")
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    await client.createTestSuite({ name: "qa-suite", projectName: "my-agent" });
+    await client.getTestSuite("qa-suite", "my-agent");
+    await client.getOrCreateTestSuite({ name: "qa-suite", projectName: "my-agent" });
+    await client.getTestSuites(1000, "my-agent");
+    await client.deleteTestSuite("qa-suite", "my-agent");
+    await client.getTestSuiteExperiments("qa-suite", 100, "my-agent");
     ```
   </Tab>
 </Tabs>
@@ -97,7 +124,17 @@ All snippets below assume a client:
   <Tab title="Python">
     ```python
     client.create_prompt(name="assistant", prompt="Answer: {{question}}", project_name="my-agent")
+    client.create_chat_prompt(
+        name="assistant-chat",
+        messages=[{"role": "user", "content": "{{question}}"}],
+        project_name="my-agent",
+    )
     client.get_prompt(name="assistant", project_name="my-agent")
+    client.get_chat_prompt(name="assistant-chat", project_name="my-agent")
+    client.get_prompt_history(name="assistant", project_name="my-agent")
+    client.get_chat_prompt_history(name="assistant-chat", project_name="my-agent")
+    client.get_all_prompts(name="assistant", project_name="my-agent")
+    client.search_prompts(project_name="my-agent")
     ```
   </Tab>
   <Tab title="TypeScript">
@@ -107,7 +144,13 @@ All snippets below assume a client:
       prompt: "Answer: {{question}}",
       projectName: "my-agent",
     });
+    await client.createChatPrompt({
+      name: "assistant-chat",
+      messages: [{ role: "user", content: "{{question}}" }],
+      projectName: "my-agent",
+    });
     await client.getPrompt({ name: "assistant", projectName: "my-agent" });
+    await client.getChatPrompt({ name: "assistant-chat", projectName: "my-agent" });
     ```
   </Tab>
 </Tabs>
@@ -121,6 +164,8 @@ An experiment — and **every trace, span, and feedback score it produces** — 
     ```python
     # project_name must be the dataset's project — the experiment and its data land there
     client.create_experiment(dataset_name="qa-pairs", name="run-1", project_name="my-agent")
+    client.get_experiment_by_name(name="run-1", project_name="my-agent")
+    client.get_experiments_by_name(name="run-1", project_name="my-agent")
     ```
   </Tab>
   <Tab title="TypeScript">
@@ -130,6 +175,8 @@ An experiment — and **every trace, span, and feedback score it produces** — 
       name: "run-1",
       projectName: "my-agent", // the dataset's project
     });
+    await client.getExperiment("run-1", "my-agent");
+    await client.getExperimentsByName("run-1", "my-agent");
     ```
   </Tab>
 </Tabs>

--- a/apps/opik-documentation/documentation/fern/docs-v2/opik_v2_upgrade.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/opik_v2_upgrade.mdx
@@ -114,9 +114,12 @@ All snippets below assume a client:
 
 ### Experiments
 
+An experiment — and **every trace, span, and feedback score it produces** — always lands in the **same project as the dataset it runs against**. You don't scope an experiment separately: put the dataset in the project you want, and each run of it follows. This holds whether you call `opik.evaluate(...)` or create the experiment directly.
+
 <Tabs>
   <Tab title="Python">
     ```python
+    # project_name must be the dataset's project — the experiment and its data land there
     client.create_experiment(dataset_name="qa-pairs", name="run-1", project_name="my-agent")
     ```
   </Tab>
@@ -125,17 +128,11 @@ All snippets below assume a client:
     await client.createExperiment({
       datasetName: "qa-pairs",
       name: "run-1",
-      projectName: "my-agent",
+      projectName: "my-agent", // the dataset's project
     });
     ```
   </Tab>
 </Tabs>
-
-<Tip>
-  When you run an evaluation with `opik.evaluate(...)`, the experiment is created in its
-  dataset's project automatically — create the dataset in the right project and the
-  experiment follows it.
-</Tip>
 
 ### Optimizations
 

--- a/apps/opik-documentation/documentation/fern/versions/latest.yml
+++ b/apps/opik-documentation/documentation/fern/versions/latest.yml
@@ -33,6 +33,10 @@ navigation:
             path: ../docs-v2/quickstart.mdx
             slug: /quickstart
             icon: fa-regular fa-bolt
+          - page: Upgrading to Opik 2.0
+            path: ../docs-v2/opik_v2_upgrade.mdx
+            slug: /opik-v2-upgrade
+            icon: fa-regular fa-circle-up
           - page: Ollie Agent
             path: ../docs-v2/ollie.mdx
             slug: ollie

--- a/apps/opik-documentation/documentation/fern/versions/latest.yml
+++ b/apps/opik-documentation/documentation/fern/versions/latest.yml
@@ -87,6 +87,9 @@ navigation:
               - page: Export data
                 path: ../docs-v2/observability/export_data.mdx
                 slug: export-data
+              - page: Migrate data
+                path: ../docs-v2/observability/migrate_data.mdx
+                slug: migrate-data
               - page: SDK configuration
                 path: ../docs-v2/tracing/advanced/sdk_configuration.mdx
                 slug: sdk_configuration


### PR DESCRIPTION
## Details

Adds a public Fern documentation page for the `opik migrate` CLI command, the final piece of the SDK migration-tool epic. The page documents both subcommands — `opik migrate dataset` and `opik migrate prompt` — as well as the shared options and the `--dry-run` preview workflow.

- **`opik migrate dataset`**: what gets copied (full version history, items, experiments, traces, spans, feedback scores, assertion results, comments, optimizations), what is not copied (prompt snapshots, attachments, thread-level fields), and the step-by-step plan.
- **`opik migrate prompt`**: prompt and full version history with commit hashes preserved.
- **Previewing a migration**: a dedicated `--dry-run` section, referenced from both subcommand sections and the options table.
- **Troubleshooting**: the common name-collision failure and how to resolve it.
- Registers the page in the docs navigation under Observability → Advanced, alongside "Export data".

Written to be user-guiding rather than an implementation explainer. Every command, flag, the dry-run plan output, and the error messages were verified against a local Opik backend.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-6542

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: Authored the docs page and navigation entry; verified the documented commands/flags/plan/errors against a local backend.
- Human verification: Author reviewed and iterated on the content; `fern check` passes with 0 errors.

## Testing

- `fern check` — 0 errors (4 pre-existing global warnings unrelated to this page).
- Verified the documented behavior against a local Opik backend: `opik migrate dataset` / `opik migrate prompt` `--help`, the `--dry-run` plan, a real dataset migration (rename → create → replay → optimizations → experiments cascade), a real prompt migration (commit hashes preserved), and the project-not-found / source-not-found / rename-collision error messages.

## Documentation

- New page: `apps/opik-documentation/documentation/fern/docs-v2/observability/migrate_data.mdx`
- Navigation: registered in `apps/opik-documentation/documentation/fern/versions/latest.yml` (Observability → Advanced → "Migrate data").
