### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -9378,6 +9378,11 @@ components:
           type: array
           items:
             type: string
+        annotators_per_item:
+          maximum: 1000
+          minimum: 1
+          type: integer
+          format: int32
         reviewers:
           type: array
           readOnly: true
@@ -9458,6 +9463,11 @@ components:
           type: array
           items:
             type: string
+        annotators_per_item:
+          maximum: 1000
+          minimum: 1
+          type: integer
+          format: int32
       description: List of annotation queues to create
     AnnotationQueueBatch:
       required:
@@ -9550,6 +9560,11 @@ components:
           type: array
           items:
             type: string
+        annotators_per_item:
+          maximum: 1000
+          minimum: 1
+          type: integer
+          format: int32
         reviewers:
           type: array
           readOnly: true
@@ -9607,6 +9622,11 @@ components:
           items:
             minLength: 1
             type: string
+        annotators_per_item:
+          maximum: 1000
+          minimum: 1
+          type: integer
+          format: int32
     AssertionResultBatch:
       required:
       - assertion_results

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -9378,6 +9378,11 @@ components:
           type: array
           items:
             type: string
+        annotators_per_item:
+          maximum: 1000
+          minimum: 1
+          type: integer
+          format: int32
         reviewers:
           type: array
           readOnly: true
@@ -9458,6 +9463,11 @@ components:
           type: array
           items:
             type: string
+        annotators_per_item:
+          maximum: 1000
+          minimum: 1
+          type: integer
+          format: int32
       description: List of annotation queues to create
     AnnotationQueueBatch:
       required:
@@ -9550,6 +9560,11 @@ components:
           type: array
           items:
             type: string
+        annotators_per_item:
+          maximum: 1000
+          minimum: 1
+          type: integer
+          format: int32
         reviewers:
           type: array
           readOnly: true
@@ -9607,6 +9622,11 @@ components:
           items:
             minLength: 1
             type: string
+        annotators_per_item:
+          maximum: 1000
+          minimum: 1
+          type: integer
+          format: int32
     AssertionResultBatch:
       required:
       - assertion_results

--- a/sdks/python/src/opik/rest_api/annotation_queues/client.py
+++ b/sdks/python/src/opik/rest_api/annotation_queues/client.py
@@ -112,6 +112,7 @@ class AnnotationQueuesClient:
         instructions: typing.Optional[str] = OMIT,
         comments_enabled: typing.Optional[bool] = OMIT,
         feedback_definition_names: typing.Optional[typing.Sequence[str]] = OMIT,
+        annotators_per_item: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -135,6 +136,8 @@ class AnnotationQueuesClient:
 
         feedback_definition_names : typing.Optional[typing.Sequence[str]]
 
+        annotators_per_item : typing.Optional[int]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -157,6 +160,7 @@ class AnnotationQueuesClient:
             instructions=instructions,
             comments_enabled=comments_enabled,
             feedback_definition_names=feedback_definition_names,
+            annotators_per_item=annotators_per_item,
             request_options=request_options,
         )
         return _response.data
@@ -256,6 +260,7 @@ class AnnotationQueuesClient:
         instructions: typing.Optional[str] = OMIT,
         comments_enabled: typing.Optional[bool] = OMIT,
         feedback_definition_names: typing.Optional[typing.Sequence[str]] = OMIT,
+        annotators_per_item: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -274,6 +279,8 @@ class AnnotationQueuesClient:
         comments_enabled : typing.Optional[bool]
 
         feedback_definition_names : typing.Optional[typing.Sequence[str]]
+
+        annotators_per_item : typing.Optional[int]
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -295,6 +302,7 @@ class AnnotationQueuesClient:
             instructions=instructions,
             comments_enabled=comments_enabled,
             feedback_definition_names=feedback_definition_names,
+            annotators_per_item=annotators_per_item,
             request_options=request_options,
         )
         return _response.data
@@ -432,6 +440,7 @@ class AsyncAnnotationQueuesClient:
         instructions: typing.Optional[str] = OMIT,
         comments_enabled: typing.Optional[bool] = OMIT,
         feedback_definition_names: typing.Optional[typing.Sequence[str]] = OMIT,
+        annotators_per_item: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -454,6 +463,8 @@ class AsyncAnnotationQueuesClient:
         comments_enabled : typing.Optional[bool]
 
         feedback_definition_names : typing.Optional[typing.Sequence[str]]
+
+        annotators_per_item : typing.Optional[int]
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -480,6 +491,7 @@ class AsyncAnnotationQueuesClient:
             instructions=instructions,
             comments_enabled=comments_enabled,
             feedback_definition_names=feedback_definition_names,
+            annotators_per_item=annotators_per_item,
             request_options=request_options,
         )
         return _response.data
@@ -588,6 +600,7 @@ class AsyncAnnotationQueuesClient:
         instructions: typing.Optional[str] = OMIT,
         comments_enabled: typing.Optional[bool] = OMIT,
         feedback_definition_names: typing.Optional[typing.Sequence[str]] = OMIT,
+        annotators_per_item: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -606,6 +619,8 @@ class AsyncAnnotationQueuesClient:
         comments_enabled : typing.Optional[bool]
 
         feedback_definition_names : typing.Optional[typing.Sequence[str]]
+
+        annotators_per_item : typing.Optional[int]
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -630,6 +645,7 @@ class AsyncAnnotationQueuesClient:
             instructions=instructions,
             comments_enabled=comments_enabled,
             feedback_definition_names=feedback_definition_names,
+            annotators_per_item=annotators_per_item,
             request_options=request_options,
         )
         return _response.data

--- a/sdks/python/src/opik/rest_api/annotation_queues/raw_client.py
+++ b/sdks/python/src/opik/rest_api/annotation_queues/raw_client.py
@@ -148,6 +148,7 @@ class RawAnnotationQueuesClient:
         instructions: typing.Optional[str] = OMIT,
         comments_enabled: typing.Optional[bool] = OMIT,
         feedback_definition_names: typing.Optional[typing.Sequence[str]] = OMIT,
+        annotators_per_item: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[None]:
         """
@@ -171,6 +172,8 @@ class RawAnnotationQueuesClient:
 
         feedback_definition_names : typing.Optional[typing.Sequence[str]]
 
+        annotators_per_item : typing.Optional[int]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -190,6 +193,7 @@ class RawAnnotationQueuesClient:
                 "scope": scope,
                 "comments_enabled": comments_enabled,
                 "feedback_definition_names": feedback_definition_names,
+                "annotators_per_item": annotators_per_item,
             },
             headers={
                 "content-type": "application/json",
@@ -409,6 +413,7 @@ class RawAnnotationQueuesClient:
         instructions: typing.Optional[str] = OMIT,
         comments_enabled: typing.Optional[bool] = OMIT,
         feedback_definition_names: typing.Optional[typing.Sequence[str]] = OMIT,
+        annotators_per_item: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[None]:
         """
@@ -428,6 +433,8 @@ class RawAnnotationQueuesClient:
 
         feedback_definition_names : typing.Optional[typing.Sequence[str]]
 
+        annotators_per_item : typing.Optional[int]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -444,6 +451,7 @@ class RawAnnotationQueuesClient:
                 "instructions": instructions,
                 "comments_enabled": comments_enabled,
                 "feedback_definition_names": feedback_definition_names,
+                "annotators_per_item": annotators_per_item,
             },
             headers={
                 "content-type": "application/json",
@@ -646,6 +654,7 @@ class AsyncRawAnnotationQueuesClient:
         instructions: typing.Optional[str] = OMIT,
         comments_enabled: typing.Optional[bool] = OMIT,
         feedback_definition_names: typing.Optional[typing.Sequence[str]] = OMIT,
+        annotators_per_item: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[None]:
         """
@@ -669,6 +678,8 @@ class AsyncRawAnnotationQueuesClient:
 
         feedback_definition_names : typing.Optional[typing.Sequence[str]]
 
+        annotators_per_item : typing.Optional[int]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -688,6 +699,7 @@ class AsyncRawAnnotationQueuesClient:
                 "scope": scope,
                 "comments_enabled": comments_enabled,
                 "feedback_definition_names": feedback_definition_names,
+                "annotators_per_item": annotators_per_item,
             },
             headers={
                 "content-type": "application/json",
@@ -907,6 +919,7 @@ class AsyncRawAnnotationQueuesClient:
         instructions: typing.Optional[str] = OMIT,
         comments_enabled: typing.Optional[bool] = OMIT,
         feedback_definition_names: typing.Optional[typing.Sequence[str]] = OMIT,
+        annotators_per_item: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[None]:
         """
@@ -926,6 +939,8 @@ class AsyncRawAnnotationQueuesClient:
 
         feedback_definition_names : typing.Optional[typing.Sequence[str]]
 
+        annotators_per_item : typing.Optional[int]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -942,6 +957,7 @@ class AsyncRawAnnotationQueuesClient:
                 "instructions": instructions,
                 "comments_enabled": comments_enabled,
                 "feedback_definition_names": feedback_definition_names,
+                "annotators_per_item": annotators_per_item,
             },
             headers={
                 "content-type": "application/json",

--- a/sdks/python/src/opik/rest_api/types/annotation_queue.py
+++ b/sdks/python/src/opik/rest_api/types/annotation_queue.py
@@ -24,6 +24,7 @@ class AnnotationQueue(UniversalBaseModel):
     scope: AnnotationQueueScope
     comments_enabled: typing.Optional[bool] = None
     feedback_definition_names: typing.Optional[typing.List[str]] = None
+    annotators_per_item: typing.Optional[int] = None
     reviewers: typing.Optional[typing.List[AnnotationQueueReviewer]] = None
     feedback_scores: typing.Optional[typing.List[FeedbackScoreAverage]] = None
     items_count: typing.Optional[int] = None

--- a/sdks/python/src/opik/rest_api/types/annotation_queue_public.py
+++ b/sdks/python/src/opik/rest_api/types/annotation_queue_public.py
@@ -20,6 +20,7 @@ class AnnotationQueuePublic(UniversalBaseModel):
     scope: AnnotationQueuePublicScope
     comments_enabled: typing.Optional[bool] = None
     feedback_definition_names: typing.Optional[typing.List[str]] = None
+    annotators_per_item: typing.Optional[int] = None
     reviewers: typing.Optional[typing.List[AnnotationQueueReviewerPublic]] = None
     feedback_scores: typing.Optional[typing.List[FeedbackScoreAveragePublic]] = None
     items_count: typing.Optional[int] = None

--- a/sdks/python/src/opik/rest_api/types/annotation_queue_write.py
+++ b/sdks/python/src/opik/rest_api/types/annotation_queue_write.py
@@ -20,6 +20,7 @@ class AnnotationQueueWrite(UniversalBaseModel):
     scope: AnnotationQueueWriteScope
     comments_enabled: typing.Optional[bool] = None
     feedback_definition_names: typing.Optional[typing.List[str]] = None
+    annotators_per_item: typing.Optional[int] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/typescript/src/opik/rest_api/api/resources/annotationQueues/client/requests/AnnotationQueueUpdate.ts
+++ b/sdks/typescript/src/opik/rest_api/api/resources/annotationQueues/client/requests/AnnotationQueueUpdate.ts
@@ -10,4 +10,5 @@ export interface AnnotationQueueUpdate {
     instructions?: string;
     commentsEnabled?: boolean;
     feedbackDefinitionNames?: string[];
+    annotatorsPerItem?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/AnnotationQueue.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/AnnotationQueue.ts
@@ -15,6 +15,7 @@ export interface AnnotationQueue {
     scope: OpikApi.AnnotationQueueScope;
     commentsEnabled?: boolean;
     feedbackDefinitionNames?: string[];
+    annotatorsPerItem?: number;
     reviewers?: OpikApi.AnnotationQueueReviewer[];
     feedbackScores?: OpikApi.FeedbackScoreAverage[];
     itemsCount?: number;

--- a/sdks/typescript/src/opik/rest_api/api/types/AnnotationQueuePublic.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/AnnotationQueuePublic.ts
@@ -12,6 +12,7 @@ export interface AnnotationQueuePublic {
     scope: OpikApi.AnnotationQueuePublicScope;
     commentsEnabled?: boolean;
     feedbackDefinitionNames?: string[];
+    annotatorsPerItem?: number;
     reviewers?: OpikApi.AnnotationQueueReviewerPublic[];
     feedbackScores?: OpikApi.FeedbackScoreAveragePublic[];
     itemsCount?: number;

--- a/sdks/typescript/src/opik/rest_api/api/types/AnnotationQueueWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/AnnotationQueueWrite.ts
@@ -14,4 +14,5 @@ export interface AnnotationQueueWrite {
     scope: OpikApi.AnnotationQueueWriteScope;
     commentsEnabled?: boolean;
     feedbackDefinitionNames?: string[];
+    annotatorsPerItem?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/resources/annotationQueues/client/requests/AnnotationQueueUpdate.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/resources/annotationQueues/client/requests/AnnotationQueueUpdate.ts
@@ -16,6 +16,7 @@ export const AnnotationQueueUpdate: core.serialization.Schema<
         "feedback_definition_names",
         core.serialization.list(core.serialization.string()).optional(),
     ),
+    annotatorsPerItem: core.serialization.property("annotators_per_item", core.serialization.number().optional()),
 });
 
 export declare namespace AnnotationQueueUpdate {
@@ -25,5 +26,6 @@ export declare namespace AnnotationQueueUpdate {
         instructions?: string | null;
         comments_enabled?: boolean | null;
         feedback_definition_names?: string[] | null;
+        annotators_per_item?: number | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/AnnotationQueue.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/AnnotationQueue.ts
@@ -23,6 +23,7 @@ export const AnnotationQueue: core.serialization.ObjectSchema<
         "feedback_definition_names",
         core.serialization.list(core.serialization.string()).optional(),
     ),
+    annotatorsPerItem: core.serialization.property("annotators_per_item", core.serialization.number().optional()),
     reviewers: core.serialization.list(AnnotationQueueReviewer).optional(),
     feedbackScores: core.serialization.property(
         "feedback_scores",
@@ -46,6 +47,7 @@ export declare namespace AnnotationQueue {
         scope: AnnotationQueueScope.Raw;
         comments_enabled?: boolean | null;
         feedback_definition_names?: string[] | null;
+        annotators_per_item?: number | null;
         reviewers?: AnnotationQueueReviewer.Raw[] | null;
         feedback_scores?: FeedbackScoreAverage.Raw[] | null;
         items_count?: number | null;

--- a/sdks/typescript/src/opik/rest_api/serialization/types/AnnotationQueuePublic.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/AnnotationQueuePublic.ts
@@ -23,6 +23,7 @@ export const AnnotationQueuePublic: core.serialization.ObjectSchema<
         "feedback_definition_names",
         core.serialization.list(core.serialization.string()).optional(),
     ),
+    annotatorsPerItem: core.serialization.property("annotators_per_item", core.serialization.number().optional()),
     reviewers: core.serialization.list(AnnotationQueueReviewerPublic).optional(),
     feedbackScores: core.serialization.property(
         "feedback_scores",
@@ -46,6 +47,7 @@ export declare namespace AnnotationQueuePublic {
         scope: AnnotationQueuePublicScope.Raw;
         comments_enabled?: boolean | null;
         feedback_definition_names?: string[] | null;
+        annotators_per_item?: number | null;
         reviewers?: AnnotationQueueReviewerPublic.Raw[] | null;
         feedback_scores?: FeedbackScoreAveragePublic.Raw[] | null;
         items_count?: number | null;

--- a/sdks/typescript/src/opik/rest_api/serialization/types/AnnotationQueueWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/AnnotationQueueWrite.ts
@@ -20,6 +20,7 @@ export const AnnotationQueueWrite: core.serialization.ObjectSchema<
         "feedback_definition_names",
         core.serialization.list(core.serialization.string()).optional(),
     ),
+    annotatorsPerItem: core.serialization.property("annotators_per_item", core.serialization.number().optional()),
 });
 
 export declare namespace AnnotationQueueWrite {
@@ -32,5 +33,6 @@ export declare namespace AnnotationQueueWrite {
         scope: AnnotationQueueWriteScope.Raw;
         comments_enabled?: boolean | null;
         feedback_definition_names?: string[] | null;
+        annotators_per_item?: number | null;
     }
 }


### PR DESCRIPTION
## Details
Automated update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

**Triggered by BE merge:** https://github.com/comet-ml/opik/pull/6792

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate