### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -1833,6 +1833,11 @@ paths:
         - Returns 409 Conflict if baseVersion is stale and override is not set
 
         Use `override=true` query parameter to force version creation even with stale baseVersion.
+
+        Set 'copy_from_dataset_id' and 'copy_from_version_id' together on the request body to read
+        carry-forward rows from the supplied (dataset, version) pair instead of the destination's
+        prior version. When the fields are null, carry-forward rows are read from the destination's
+        prior version.
       operationId: applyDatasetItemChanges
       parameters:
       - name: id
@@ -1987,6 +1992,10 @@ paths:
         Create/update dataset items based on dataset item id.
         Each item's 'id' field is the stable identifier and upsert key.
         Provide it to update an existing item, or omit it to create a new one.
+
+        Set 'copy_from_dataset_id' and 'copy_from_version_id' together to read carry-forward rows
+        from the supplied (dataset, version) pair instead of the destination's prior version. When
+        the fields are null, carry-forward rows are read from the destination's prior version.
       operationId: createOrUpdateDatasetItems
       requestBody:
         content:
@@ -9378,6 +9387,11 @@ components:
           type: array
           items:
             type: string
+        annotators_per_item:
+          maximum: 1000
+          minimum: 1
+          type: integer
+          format: int32
         reviewers:
           type: array
           readOnly: true
@@ -9458,6 +9472,11 @@ components:
           type: array
           items:
             type: string
+        annotators_per_item:
+          maximum: 1000
+          minimum: 1
+          type: integer
+          format: int32
       description: List of annotation queues to create
     AnnotationQueueBatch:
       required:
@@ -9550,6 +9569,11 @@ components:
           type: array
           items:
             type: string
+        annotators_per_item:
+          maximum: 1000
+          minimum: 1
+          type: integer
+          format: int32
         reviewers:
           type: array
           readOnly: true
@@ -9607,6 +9631,11 @@ components:
           items:
             minLength: 1
             type: string
+        annotators_per_item:
+          maximum: 1000
+          minimum: 1
+          type: integer
+          format: int32
     AssertionResultBatch:
       required:
       - assertion_results
@@ -12445,6 +12474,17 @@ components:
             \ dataset version. If null, mutates the latest version instead of creating\
             \ a new one."
           format: uuid
+        copy_from_dataset_id:
+          type: string
+          description: "Optional. Dataset to read carry-forward rows from when materializing\
+            \ the new version. Required together with copy_from_version_id. When null,\
+            \ carry-forward rows are read from the destination dataset's prior version."
+          format: uuid
+        copy_from_version_id:
+          type: string
+          description: Optional. Version within copy_from_dataset_id to read carry-forward
+            rows from. Required together with copy_from_dataset_id.
+          format: uuid
     ExperimentItem:
       required:
       - dataset_item_id
@@ -12660,6 +12700,17 @@ components:
           description: "Optional batch group ID to group multiple batches into a single\
             \ dataset version. If null, mutates the latest version instead of creating\
             \ a new one."
+          format: uuid
+        copy_from_dataset_id:
+          type: string
+          description: "Optional. Dataset to read carry-forward rows from when materializing\
+            \ the new version. Required together with copy_from_version_id. When null,\
+            \ carry-forward rows are read from the destination dataset's prior version."
+          format: uuid
+        copy_from_version_id:
+          type: string
+          description: Optional. Version within copy_from_dataset_id to read carry-forward
+            rows from. Required together with copy_from_dataset_id.
           format: uuid
     DatasetItem_Write:
       required:
@@ -18296,11 +18347,16 @@ components:
           enum:
           - prompt_version
           - mask
-        environment:
-          maxLength: 150
-          minLength: 0
-          pattern: "^[A-Za-z0-9_-]+$"
-          type: string
+        environments:
+          maxItems: 100
+          minItems: 0
+          uniqueItems: true
+          type: array
+          items:
+            maxLength: 150
+            minLength: 0
+            pattern: "^[A-Za-z0-9_-]+$"
+            type: string
         change_description:
           type: string
         tags:
@@ -18425,11 +18481,16 @@ components:
           enum:
           - prompt_version
           - mask
-        environment:
-          maxLength: 150
-          minLength: 0
-          pattern: "^[A-Za-z0-9_-]+$"
-          type: string
+        environments:
+          maxItems: 100
+          minItems: 0
+          uniqueItems: true
+          type: array
+          items:
+            maxLength: 150
+            minLength: 0
+            pattern: "^[A-Za-z0-9_-]+$"
+            type: string
         change_description:
           type: string
         tags:
@@ -18612,11 +18673,16 @@ components:
           enum:
           - prompt_version
           - mask
-        environment:
-          maxLength: 150
-          minLength: 0
-          pattern: "^[A-Za-z0-9_-]+$"
-          type: string
+        environments:
+          maxItems: 100
+          minItems: 0
+          uniqueItems: true
+          type: array
+          items:
+            maxLength: 150
+            minLength: 0
+            pattern: "^[A-Za-z0-9_-]+$"
+            type: string
         change_description:
           type: string
         tags:
@@ -18691,18 +18757,26 @@ components:
             type: string
             format: uuid
     PromptVersionEnvironmentUpdate:
+      required:
+      - environments
       type: object
       properties:
-        environment:
-          maxLength: 150
-          minLength: 0
-          pattern: "^[A-Za-z0-9_-]+$"
-          type: string
+        environments:
+          maxItems: 100
+          minItems: 0
+          uniqueItems: true
+          type: array
+          items:
+            maxLength: 150
+            minLength: 0
+            pattern: "^[A-Za-z0-9_-]+$"
+            type: string
       description: |
-        Set or clear the environment owned by a prompt version.
-        - non-null name: maps the environment to this version; if another version of the same prompt currently owns the environment, ownership is moved atomically.
-        - null: clears the environment from this version.
-        The environment must already exist in the workspace registry; unknown names return 404.
+        Replace the full set of environments assigned to a prompt version.
+        The provided set becomes the new complete set of environments for this version.
+        - Non-empty set: assigns each environment to this version; if another version of the same prompt currently owns any of those environments, ownership is moved atomically.
+        - Empty set: clears all environments from this version.
+        All environments must already exist in the workspace registry; unknown names return 404.
     Prompt_Updatable:
       required:
       - name

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -1833,6 +1833,11 @@ paths:
         - Returns 409 Conflict if baseVersion is stale and override is not set
 
         Use `override=true` query parameter to force version creation even with stale baseVersion.
+
+        Set 'copy_from_dataset_id' and 'copy_from_version_id' together on the request body to read
+        carry-forward rows from the supplied (dataset, version) pair instead of the destination's
+        prior version. When the fields are null, carry-forward rows are read from the destination's
+        prior version.
       operationId: applyDatasetItemChanges
       parameters:
       - name: id
@@ -1987,6 +1992,10 @@ paths:
         Create/update dataset items based on dataset item id.
         Each item's 'id' field is the stable identifier and upsert key.
         Provide it to update an existing item, or omit it to create a new one.
+
+        Set 'copy_from_dataset_id' and 'copy_from_version_id' together to read carry-forward rows
+        from the supplied (dataset, version) pair instead of the destination's prior version. When
+        the fields are null, carry-forward rows are read from the destination's prior version.
       operationId: createOrUpdateDatasetItems
       requestBody:
         content:
@@ -9378,6 +9387,11 @@ components:
           type: array
           items:
             type: string
+        annotators_per_item:
+          maximum: 1000
+          minimum: 1
+          type: integer
+          format: int32
         reviewers:
           type: array
           readOnly: true
@@ -9458,6 +9472,11 @@ components:
           type: array
           items:
             type: string
+        annotators_per_item:
+          maximum: 1000
+          minimum: 1
+          type: integer
+          format: int32
       description: List of annotation queues to create
     AnnotationQueueBatch:
       required:
@@ -9550,6 +9569,11 @@ components:
           type: array
           items:
             type: string
+        annotators_per_item:
+          maximum: 1000
+          minimum: 1
+          type: integer
+          format: int32
         reviewers:
           type: array
           readOnly: true
@@ -9607,6 +9631,11 @@ components:
           items:
             minLength: 1
             type: string
+        annotators_per_item:
+          maximum: 1000
+          minimum: 1
+          type: integer
+          format: int32
     AssertionResultBatch:
       required:
       - assertion_results
@@ -12445,6 +12474,17 @@ components:
             \ dataset version. If null, mutates the latest version instead of creating\
             \ a new one."
           format: uuid
+        copy_from_dataset_id:
+          type: string
+          description: "Optional. Dataset to read carry-forward rows from when materializing\
+            \ the new version. Required together with copy_from_version_id. When null,\
+            \ carry-forward rows are read from the destination dataset's prior version."
+          format: uuid
+        copy_from_version_id:
+          type: string
+          description: Optional. Version within copy_from_dataset_id to read carry-forward
+            rows from. Required together with copy_from_dataset_id.
+          format: uuid
     ExperimentItem:
       required:
       - dataset_item_id
@@ -12660,6 +12700,17 @@ components:
           description: "Optional batch group ID to group multiple batches into a single\
             \ dataset version. If null, mutates the latest version instead of creating\
             \ a new one."
+          format: uuid
+        copy_from_dataset_id:
+          type: string
+          description: "Optional. Dataset to read carry-forward rows from when materializing\
+            \ the new version. Required together with copy_from_version_id. When null,\
+            \ carry-forward rows are read from the destination dataset's prior version."
+          format: uuid
+        copy_from_version_id:
+          type: string
+          description: Optional. Version within copy_from_dataset_id to read carry-forward
+            rows from. Required together with copy_from_dataset_id.
           format: uuid
     DatasetItem_Write:
       required:
@@ -18296,11 +18347,16 @@ components:
           enum:
           - prompt_version
           - mask
-        environment:
-          maxLength: 150
-          minLength: 0
-          pattern: "^[A-Za-z0-9_-]+$"
-          type: string
+        environments:
+          maxItems: 100
+          minItems: 0
+          uniqueItems: true
+          type: array
+          items:
+            maxLength: 150
+            minLength: 0
+            pattern: "^[A-Za-z0-9_-]+$"
+            type: string
         change_description:
           type: string
         tags:
@@ -18425,11 +18481,16 @@ components:
           enum:
           - prompt_version
           - mask
-        environment:
-          maxLength: 150
-          minLength: 0
-          pattern: "^[A-Za-z0-9_-]+$"
-          type: string
+        environments:
+          maxItems: 100
+          minItems: 0
+          uniqueItems: true
+          type: array
+          items:
+            maxLength: 150
+            minLength: 0
+            pattern: "^[A-Za-z0-9_-]+$"
+            type: string
         change_description:
           type: string
         tags:
@@ -18612,11 +18673,16 @@ components:
           enum:
           - prompt_version
           - mask
-        environment:
-          maxLength: 150
-          minLength: 0
-          pattern: "^[A-Za-z0-9_-]+$"
-          type: string
+        environments:
+          maxItems: 100
+          minItems: 0
+          uniqueItems: true
+          type: array
+          items:
+            maxLength: 150
+            minLength: 0
+            pattern: "^[A-Za-z0-9_-]+$"
+            type: string
         change_description:
           type: string
         tags:
@@ -18691,18 +18757,26 @@ components:
             type: string
             format: uuid
     PromptVersionEnvironmentUpdate:
+      required:
+      - environments
       type: object
       properties:
-        environment:
-          maxLength: 150
-          minLength: 0
-          pattern: "^[A-Za-z0-9_-]+$"
-          type: string
+        environments:
+          maxItems: 100
+          minItems: 0
+          uniqueItems: true
+          type: array
+          items:
+            maxLength: 150
+            minLength: 0
+            pattern: "^[A-Za-z0-9_-]+$"
+            type: string
       description: |
-        Set or clear the environment owned by a prompt version.
-        - non-null name: maps the environment to this version; if another version of the same prompt currently owns the environment, ownership is moved atomically.
-        - null: clears the environment from this version.
-        The environment must already exist in the workspace registry; unknown names return 404.
+        Replace the full set of environments assigned to a prompt version.
+        The provided set becomes the new complete set of environments for this version.
+        - Non-empty set: assigns each environment to this version; if another version of the same prompt currently owns any of those environments, ownership is moved atomically.
+        - Empty set: clears all environments from this version.
+        All environments must already exist in the workspace registry; unknown names return 404.
     Prompt_Updatable:
       required:
       - name

--- a/sdks/python/src/opik/rest_api/annotation_queues/client.py
+++ b/sdks/python/src/opik/rest_api/annotation_queues/client.py
@@ -112,6 +112,7 @@ class AnnotationQueuesClient:
         instructions: typing.Optional[str] = OMIT,
         comments_enabled: typing.Optional[bool] = OMIT,
         feedback_definition_names: typing.Optional[typing.Sequence[str]] = OMIT,
+        annotators_per_item: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -135,6 +136,8 @@ class AnnotationQueuesClient:
 
         feedback_definition_names : typing.Optional[typing.Sequence[str]]
 
+        annotators_per_item : typing.Optional[int]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -157,6 +160,7 @@ class AnnotationQueuesClient:
             instructions=instructions,
             comments_enabled=comments_enabled,
             feedback_definition_names=feedback_definition_names,
+            annotators_per_item=annotators_per_item,
             request_options=request_options,
         )
         return _response.data
@@ -256,6 +260,7 @@ class AnnotationQueuesClient:
         instructions: typing.Optional[str] = OMIT,
         comments_enabled: typing.Optional[bool] = OMIT,
         feedback_definition_names: typing.Optional[typing.Sequence[str]] = OMIT,
+        annotators_per_item: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -274,6 +279,8 @@ class AnnotationQueuesClient:
         comments_enabled : typing.Optional[bool]
 
         feedback_definition_names : typing.Optional[typing.Sequence[str]]
+
+        annotators_per_item : typing.Optional[int]
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -295,6 +302,7 @@ class AnnotationQueuesClient:
             instructions=instructions,
             comments_enabled=comments_enabled,
             feedback_definition_names=feedback_definition_names,
+            annotators_per_item=annotators_per_item,
             request_options=request_options,
         )
         return _response.data
@@ -432,6 +440,7 @@ class AsyncAnnotationQueuesClient:
         instructions: typing.Optional[str] = OMIT,
         comments_enabled: typing.Optional[bool] = OMIT,
         feedback_definition_names: typing.Optional[typing.Sequence[str]] = OMIT,
+        annotators_per_item: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -454,6 +463,8 @@ class AsyncAnnotationQueuesClient:
         comments_enabled : typing.Optional[bool]
 
         feedback_definition_names : typing.Optional[typing.Sequence[str]]
+
+        annotators_per_item : typing.Optional[int]
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -480,6 +491,7 @@ class AsyncAnnotationQueuesClient:
             instructions=instructions,
             comments_enabled=comments_enabled,
             feedback_definition_names=feedback_definition_names,
+            annotators_per_item=annotators_per_item,
             request_options=request_options,
         )
         return _response.data
@@ -588,6 +600,7 @@ class AsyncAnnotationQueuesClient:
         instructions: typing.Optional[str] = OMIT,
         comments_enabled: typing.Optional[bool] = OMIT,
         feedback_definition_names: typing.Optional[typing.Sequence[str]] = OMIT,
+        annotators_per_item: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -606,6 +619,8 @@ class AsyncAnnotationQueuesClient:
         comments_enabled : typing.Optional[bool]
 
         feedback_definition_names : typing.Optional[typing.Sequence[str]]
+
+        annotators_per_item : typing.Optional[int]
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -630,6 +645,7 @@ class AsyncAnnotationQueuesClient:
             instructions=instructions,
             comments_enabled=comments_enabled,
             feedback_definition_names=feedback_definition_names,
+            annotators_per_item=annotators_per_item,
             request_options=request_options,
         )
         return _response.data

--- a/sdks/python/src/opik/rest_api/annotation_queues/raw_client.py
+++ b/sdks/python/src/opik/rest_api/annotation_queues/raw_client.py
@@ -148,6 +148,7 @@ class RawAnnotationQueuesClient:
         instructions: typing.Optional[str] = OMIT,
         comments_enabled: typing.Optional[bool] = OMIT,
         feedback_definition_names: typing.Optional[typing.Sequence[str]] = OMIT,
+        annotators_per_item: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[None]:
         """
@@ -171,6 +172,8 @@ class RawAnnotationQueuesClient:
 
         feedback_definition_names : typing.Optional[typing.Sequence[str]]
 
+        annotators_per_item : typing.Optional[int]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -190,6 +193,7 @@ class RawAnnotationQueuesClient:
                 "scope": scope,
                 "comments_enabled": comments_enabled,
                 "feedback_definition_names": feedback_definition_names,
+                "annotators_per_item": annotators_per_item,
             },
             headers={
                 "content-type": "application/json",
@@ -409,6 +413,7 @@ class RawAnnotationQueuesClient:
         instructions: typing.Optional[str] = OMIT,
         comments_enabled: typing.Optional[bool] = OMIT,
         feedback_definition_names: typing.Optional[typing.Sequence[str]] = OMIT,
+        annotators_per_item: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[None]:
         """
@@ -428,6 +433,8 @@ class RawAnnotationQueuesClient:
 
         feedback_definition_names : typing.Optional[typing.Sequence[str]]
 
+        annotators_per_item : typing.Optional[int]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -444,6 +451,7 @@ class RawAnnotationQueuesClient:
                 "instructions": instructions,
                 "comments_enabled": comments_enabled,
                 "feedback_definition_names": feedback_definition_names,
+                "annotators_per_item": annotators_per_item,
             },
             headers={
                 "content-type": "application/json",
@@ -646,6 +654,7 @@ class AsyncRawAnnotationQueuesClient:
         instructions: typing.Optional[str] = OMIT,
         comments_enabled: typing.Optional[bool] = OMIT,
         feedback_definition_names: typing.Optional[typing.Sequence[str]] = OMIT,
+        annotators_per_item: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[None]:
         """
@@ -669,6 +678,8 @@ class AsyncRawAnnotationQueuesClient:
 
         feedback_definition_names : typing.Optional[typing.Sequence[str]]
 
+        annotators_per_item : typing.Optional[int]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -688,6 +699,7 @@ class AsyncRawAnnotationQueuesClient:
                 "scope": scope,
                 "comments_enabled": comments_enabled,
                 "feedback_definition_names": feedback_definition_names,
+                "annotators_per_item": annotators_per_item,
             },
             headers={
                 "content-type": "application/json",
@@ -907,6 +919,7 @@ class AsyncRawAnnotationQueuesClient:
         instructions: typing.Optional[str] = OMIT,
         comments_enabled: typing.Optional[bool] = OMIT,
         feedback_definition_names: typing.Optional[typing.Sequence[str]] = OMIT,
+        annotators_per_item: typing.Optional[int] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[None]:
         """
@@ -926,6 +939,8 @@ class AsyncRawAnnotationQueuesClient:
 
         feedback_definition_names : typing.Optional[typing.Sequence[str]]
 
+        annotators_per_item : typing.Optional[int]
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -942,6 +957,7 @@ class AsyncRawAnnotationQueuesClient:
                 "instructions": instructions,
                 "comments_enabled": comments_enabled,
                 "feedback_definition_names": feedback_definition_names,
+                "annotators_per_item": annotators_per_item,
             },
             headers={
                 "content-type": "application/json",

--- a/sdks/python/src/opik/rest_api/datasets/client.py
+++ b/sdks/python/src/opik/rest_api/datasets/client.py
@@ -70,6 +70,11 @@ class DatasetsClient:
 
         Use `override=true` query parameter to force version creation even with stale baseVersion.
 
+        Set 'copy_from_dataset_id' and 'copy_from_version_id' together on the request body to read
+        carry-forward rows from the supplied (dataset, version) pair instead of the destination's
+        prior version. When the fields are null, carry-forward rows are read from the destination's
+        prior version.
+
         Parameters
         ----------
         id : str
@@ -286,12 +291,18 @@ class DatasetsClient:
         project_name: typing.Optional[str] = OMIT,
         project_id: typing.Optional[str] = OMIT,
         batch_group_id: typing.Optional[str] = OMIT,
+        copy_from_dataset_id: typing.Optional[str] = OMIT,
+        copy_from_version_id: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
         Create/update dataset items based on dataset item id.
         Each item's 'id' field is the stable identifier and upsert key.
         Provide it to update an existing item, or omit it to create a new one.
+
+        Set 'copy_from_dataset_id' and 'copy_from_version_id' together to read carry-forward rows
+        from the supplied (dataset, version) pair instead of the destination's prior version. When
+        the fields are null, carry-forward rows are read from the destination's prior version.
 
         Parameters
         ----------
@@ -311,6 +322,12 @@ class DatasetsClient:
 
         batch_group_id : typing.Optional[str]
             Optional batch group ID to group multiple batches into a single dataset version. If null, mutates the latest version instead of creating a new one.
+
+        copy_from_dataset_id : typing.Optional[str]
+            Optional. Dataset to read carry-forward rows from when materializing the new version. Required together with copy_from_version_id. When null, carry-forward rows are read from the destination dataset's prior version.
+
+        copy_from_version_id : typing.Optional[str]
+            Optional. Version within copy_from_dataset_id to read carry-forward rows from. Required together with copy_from_dataset_id.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -334,6 +351,8 @@ class DatasetsClient:
             project_name=project_name,
             project_id=project_id,
             batch_group_id=batch_group_id,
+            copy_from_dataset_id=copy_from_dataset_id,
+            copy_from_version_id=copy_from_version_id,
             request_options=request_options,
         )
         return _response.data
@@ -1511,6 +1530,11 @@ class AsyncDatasetsClient:
 
         Use `override=true` query parameter to force version creation even with stale baseVersion.
 
+        Set 'copy_from_dataset_id' and 'copy_from_version_id' together on the request body to read
+        carry-forward rows from the supplied (dataset, version) pair instead of the destination's
+        prior version. When the fields are null, carry-forward rows are read from the destination's
+        prior version.
+
         Parameters
         ----------
         id : str
@@ -1739,12 +1763,18 @@ class AsyncDatasetsClient:
         project_name: typing.Optional[str] = OMIT,
         project_id: typing.Optional[str] = OMIT,
         batch_group_id: typing.Optional[str] = OMIT,
+        copy_from_dataset_id: typing.Optional[str] = OMIT,
+        copy_from_version_id: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
         Create/update dataset items based on dataset item id.
         Each item's 'id' field is the stable identifier and upsert key.
         Provide it to update an existing item, or omit it to create a new one.
+
+        Set 'copy_from_dataset_id' and 'copy_from_version_id' together to read carry-forward rows
+        from the supplied (dataset, version) pair instead of the destination's prior version. When
+        the fields are null, carry-forward rows are read from the destination's prior version.
 
         Parameters
         ----------
@@ -1764,6 +1794,12 @@ class AsyncDatasetsClient:
 
         batch_group_id : typing.Optional[str]
             Optional batch group ID to group multiple batches into a single dataset version. If null, mutates the latest version instead of creating a new one.
+
+        copy_from_dataset_id : typing.Optional[str]
+            Optional. Dataset to read carry-forward rows from when materializing the new version. Required together with copy_from_version_id. When null, carry-forward rows are read from the destination dataset's prior version.
+
+        copy_from_version_id : typing.Optional[str]
+            Optional. Version within copy_from_dataset_id to read carry-forward rows from. Required together with copy_from_dataset_id.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -1790,6 +1826,8 @@ class AsyncDatasetsClient:
             project_name=project_name,
             project_id=project_id,
             batch_group_id=batch_group_id,
+            copy_from_dataset_id=copy_from_dataset_id,
+            copy_from_version_id=copy_from_version_id,
             request_options=request_options,
         )
         return _response.data

--- a/sdks/python/src/opik/rest_api/datasets/raw_client.py
+++ b/sdks/python/src/opik/rest_api/datasets/raw_client.py
@@ -68,6 +68,11 @@ class RawDatasetsClient:
 
         Use `override=true` query parameter to force version creation even with stale baseVersion.
 
+        Set 'copy_from_dataset_id' and 'copy_from_version_id' together on the request body to read
+        carry-forward rows from the supplied (dataset, version) pair instead of the destination's
+        prior version. When the fields are null, carry-forward rows are read from the destination's
+        prior version.
+
         Parameters
         ----------
         id : str
@@ -374,12 +379,18 @@ class RawDatasetsClient:
         project_name: typing.Optional[str] = OMIT,
         project_id: typing.Optional[str] = OMIT,
         batch_group_id: typing.Optional[str] = OMIT,
+        copy_from_dataset_id: typing.Optional[str] = OMIT,
+        copy_from_version_id: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[None]:
         """
         Create/update dataset items based on dataset item id.
         Each item's 'id' field is the stable identifier and upsert key.
         Provide it to update an existing item, or omit it to create a new one.
+
+        Set 'copy_from_dataset_id' and 'copy_from_version_id' together to read carry-forward rows
+        from the supplied (dataset, version) pair instead of the destination's prior version. When
+        the fields are null, carry-forward rows are read from the destination's prior version.
 
         Parameters
         ----------
@@ -400,6 +411,12 @@ class RawDatasetsClient:
         batch_group_id : typing.Optional[str]
             Optional batch group ID to group multiple batches into a single dataset version. If null, mutates the latest version instead of creating a new one.
 
+        copy_from_dataset_id : typing.Optional[str]
+            Optional. Dataset to read carry-forward rows from when materializing the new version. Required together with copy_from_version_id. When null, carry-forward rows are read from the destination dataset's prior version.
+
+        copy_from_version_id : typing.Optional[str]
+            Optional. Version within copy_from_dataset_id to read carry-forward rows from. Required together with copy_from_dataset_id.
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -419,6 +436,8 @@ class RawDatasetsClient:
                     object_=items, annotation=typing.Sequence[DatasetItemWrite], direction="write"
                 ),
                 "batch_group_id": batch_group_id,
+                "copy_from_dataset_id": copy_from_dataset_id,
+                "copy_from_version_id": copy_from_version_id,
             },
             headers={
                 "content-type": "application/json",
@@ -2148,6 +2167,11 @@ class AsyncRawDatasetsClient:
 
         Use `override=true` query parameter to force version creation even with stale baseVersion.
 
+        Set 'copy_from_dataset_id' and 'copy_from_version_id' together on the request body to read
+        carry-forward rows from the supplied (dataset, version) pair instead of the destination's
+        prior version. When the fields are null, carry-forward rows are read from the destination's
+        prior version.
+
         Parameters
         ----------
         id : str
@@ -2454,12 +2478,18 @@ class AsyncRawDatasetsClient:
         project_name: typing.Optional[str] = OMIT,
         project_id: typing.Optional[str] = OMIT,
         batch_group_id: typing.Optional[str] = OMIT,
+        copy_from_dataset_id: typing.Optional[str] = OMIT,
+        copy_from_version_id: typing.Optional[str] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[None]:
         """
         Create/update dataset items based on dataset item id.
         Each item's 'id' field is the stable identifier and upsert key.
         Provide it to update an existing item, or omit it to create a new one.
+
+        Set 'copy_from_dataset_id' and 'copy_from_version_id' together to read carry-forward rows
+        from the supplied (dataset, version) pair instead of the destination's prior version. When
+        the fields are null, carry-forward rows are read from the destination's prior version.
 
         Parameters
         ----------
@@ -2480,6 +2510,12 @@ class AsyncRawDatasetsClient:
         batch_group_id : typing.Optional[str]
             Optional batch group ID to group multiple batches into a single dataset version. If null, mutates the latest version instead of creating a new one.
 
+        copy_from_dataset_id : typing.Optional[str]
+            Optional. Dataset to read carry-forward rows from when materializing the new version. Required together with copy_from_version_id. When null, carry-forward rows are read from the destination dataset's prior version.
+
+        copy_from_version_id : typing.Optional[str]
+            Optional. Version within copy_from_dataset_id to read carry-forward rows from. Required together with copy_from_dataset_id.
+
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
 
@@ -2499,6 +2535,8 @@ class AsyncRawDatasetsClient:
                     object_=items, annotation=typing.Sequence[DatasetItemWrite], direction="write"
                 ),
                 "batch_group_id": batch_group_id,
+                "copy_from_dataset_id": copy_from_dataset_id,
+                "copy_from_version_id": copy_from_version_id,
             },
             headers={
                 "content-type": "application/json",

--- a/sdks/python/src/opik/rest_api/prompts/client.py
+++ b/sdks/python/src/opik/rest_api/prompts/client.py
@@ -669,7 +669,7 @@ class PromptsClient:
         self,
         version_id: str,
         *,
-        environment: typing.Optional[str] = OMIT,
+        environments: typing.Sequence[str],
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -683,7 +683,7 @@ class PromptsClient:
         ----------
         version_id : str
 
-        environment : typing.Optional[str]
+        environments : typing.Sequence[str]
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -696,10 +696,10 @@ class PromptsClient:
         --------
         from Opik import OpikApi
         client = OpikApi(api_key="YOUR_API_KEY", workspace_name="YOUR_WORKSPACE_NAME", )
-        client.prompts.set_prompt_version_environment(version_id='versionId', )
+        client.prompts.set_prompt_version_environment(version_id='versionId', environments=['environments'], )
         """
         _response = self._raw_client.set_prompt_version_environment(
-            version_id, environment=environment, request_options=request_options
+            version_id, environments=environments, request_options=request_options
         )
         return _response.data
 
@@ -1403,7 +1403,7 @@ class AsyncPromptsClient:
         self,
         version_id: str,
         *,
-        environment: typing.Optional[str] = OMIT,
+        environments: typing.Sequence[str],
         request_options: typing.Optional[RequestOptions] = None,
     ) -> None:
         """
@@ -1417,7 +1417,7 @@ class AsyncPromptsClient:
         ----------
         version_id : str
 
-        environment : typing.Optional[str]
+        environments : typing.Sequence[str]
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -1432,10 +1432,10 @@ class AsyncPromptsClient:
         import asyncio
         client = AsyncOpikApi(api_key="YOUR_API_KEY", workspace_name="YOUR_WORKSPACE_NAME", )
         async def main() -> None:
-            await client.prompts.set_prompt_version_environment(version_id='versionId', )
+            await client.prompts.set_prompt_version_environment(version_id='versionId', environments=['environments'], )
         asyncio.run(main())
         """
         _response = await self._raw_client.set_prompt_version_environment(
-            version_id, environment=environment, request_options=request_options
+            version_id, environments=environments, request_options=request_options
         )
         return _response.data

--- a/sdks/python/src/opik/rest_api/prompts/raw_client.py
+++ b/sdks/python/src/opik/rest_api/prompts/raw_client.py
@@ -1137,7 +1137,7 @@ class RawPromptsClient:
         self,
         version_id: str,
         *,
-        environment: typing.Optional[str] = OMIT,
+        environments: typing.Sequence[str],
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[None]:
         """
@@ -1151,7 +1151,7 @@ class RawPromptsClient:
         ----------
         version_id : str
 
-        environment : typing.Optional[str]
+        environments : typing.Sequence[str]
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -1164,7 +1164,7 @@ class RawPromptsClient:
             f"v1/private/prompts/versions/{jsonable_encoder(version_id)}/environments",
             method="PATCH",
             json={
-                "environment": environment,
+                "environments": environments,
             },
             headers={
                 "content-type": "application/json",
@@ -2313,7 +2313,7 @@ class AsyncRawPromptsClient:
         self,
         version_id: str,
         *,
-        environment: typing.Optional[str] = OMIT,
+        environments: typing.Sequence[str],
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[None]:
         """
@@ -2327,7 +2327,7 @@ class AsyncRawPromptsClient:
         ----------
         version_id : str
 
-        environment : typing.Optional[str]
+        environments : typing.Sequence[str]
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -2340,7 +2340,7 @@ class AsyncRawPromptsClient:
             f"v1/private/prompts/versions/{jsonable_encoder(version_id)}/environments",
             method="PATCH",
             json={
-                "environment": environment,
+                "environments": environments,
             },
             headers={
                 "content-type": "application/json",

--- a/sdks/python/src/opik/rest_api/types/annotation_queue.py
+++ b/sdks/python/src/opik/rest_api/types/annotation_queue.py
@@ -24,6 +24,7 @@ class AnnotationQueue(UniversalBaseModel):
     scope: AnnotationQueueScope
     comments_enabled: typing.Optional[bool] = None
     feedback_definition_names: typing.Optional[typing.List[str]] = None
+    annotators_per_item: typing.Optional[int] = None
     reviewers: typing.Optional[typing.List[AnnotationQueueReviewer]] = None
     feedback_scores: typing.Optional[typing.List[FeedbackScoreAverage]] = None
     items_count: typing.Optional[int] = None

--- a/sdks/python/src/opik/rest_api/types/annotation_queue_public.py
+++ b/sdks/python/src/opik/rest_api/types/annotation_queue_public.py
@@ -20,6 +20,7 @@ class AnnotationQueuePublic(UniversalBaseModel):
     scope: AnnotationQueuePublicScope
     comments_enabled: typing.Optional[bool] = None
     feedback_definition_names: typing.Optional[typing.List[str]] = None
+    annotators_per_item: typing.Optional[int] = None
     reviewers: typing.Optional[typing.List[AnnotationQueueReviewerPublic]] = None
     feedback_scores: typing.Optional[typing.List[FeedbackScoreAveragePublic]] = None
     items_count: typing.Optional[int] = None

--- a/sdks/python/src/opik/rest_api/types/annotation_queue_write.py
+++ b/sdks/python/src/opik/rest_api/types/annotation_queue_write.py
@@ -20,6 +20,7 @@ class AnnotationQueueWrite(UniversalBaseModel):
     scope: AnnotationQueueWriteScope
     comments_enabled: typing.Optional[bool] = None
     feedback_definition_names: typing.Optional[typing.List[str]] = None
+    annotators_per_item: typing.Optional[int] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/dataset_item_batch.py
+++ b/sdks/python/src/opik/rest_api/types/dataset_item_batch.py
@@ -34,6 +34,16 @@ class DatasetItemBatch(UniversalBaseModel):
     Optional batch group ID to group multiple batches into a single dataset version. If null, mutates the latest version instead of creating a new one.
     """
 
+    copy_from_dataset_id: typing.Optional[str] = pydantic.Field(default=None)
+    """
+    Optional. Dataset to read carry-forward rows from when materializing the new version. Required together with copy_from_version_id. When null, carry-forward rows are read from the destination dataset's prior version.
+    """
+
+    copy_from_version_id: typing.Optional[str] = pydantic.Field(default=None)
+    """
+    Optional. Version within copy_from_dataset_id to read carry-forward rows from. Required together with copy_from_dataset_id.
+    """
+
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
     else:

--- a/sdks/python/src/opik/rest_api/types/prompt_version.py
+++ b/sdks/python/src/opik/rest_api/types/prompt_version.py
@@ -36,7 +36,7 @@ class PromptVersion(UniversalBaseModel):
     version type discriminator; defaults to prompt_version
     """
 
-    environment: typing.Optional[str] = None
+    environments: typing.Optional[typing.List[str]] = None
     change_description: typing.Optional[str] = None
     tags: typing.Optional[typing.List[str]] = None
     variables: typing.Optional[typing.List[str]] = None

--- a/sdks/python/src/opik/rest_api/types/prompt_version_detail.py
+++ b/sdks/python/src/opik/rest_api/types/prompt_version_detail.py
@@ -36,7 +36,7 @@ class PromptVersionDetail(UniversalBaseModel):
     version type discriminator; defaults to prompt_version
     """
 
-    environment: typing.Optional[str] = None
+    environments: typing.Optional[typing.List[str]] = None
     change_description: typing.Optional[str] = None
     tags: typing.Optional[typing.List[str]] = None
     variables: typing.Optional[typing.List[str]] = None

--- a/sdks/python/src/opik/rest_api/types/prompt_version_public.py
+++ b/sdks/python/src/opik/rest_api/types/prompt_version_public.py
@@ -36,7 +36,7 @@ class PromptVersionPublic(UniversalBaseModel):
     version type discriminator; defaults to prompt_version
     """
 
-    environment: typing.Optional[str] = None
+    environments: typing.Optional[typing.List[str]] = None
     change_description: typing.Optional[str] = None
     tags: typing.Optional[typing.List[str]] = None
     template_structure: typing.Optional[PromptVersionPublicTemplateStructure] = None

--- a/sdks/typescript/src/opik/rest_api/api/resources/annotationQueues/client/requests/AnnotationQueueUpdate.ts
+++ b/sdks/typescript/src/opik/rest_api/api/resources/annotationQueues/client/requests/AnnotationQueueUpdate.ts
@@ -10,4 +10,5 @@ export interface AnnotationQueueUpdate {
     instructions?: string;
     commentsEnabled?: boolean;
     feedbackDefinitionNames?: string[];
+    annotatorsPerItem?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/api/resources/datasets/client/Client.ts
+++ b/sdks/typescript/src/opik/rest_api/api/resources/datasets/client/Client.ts
@@ -37,6 +37,11 @@ export class DatasetsClient {
      *
      * Use `override=true` query parameter to force version creation even with stale baseVersion.
      *
+     * Set 'copy_from_dataset_id' and 'copy_from_version_id' together on the request body to read
+     * carry-forward rows from the supplied (dataset, version) pair instead of the destination's
+     * prior version. When the fields are null, carry-forward rows are read from the destination's
+     * prior version.
+     *
      * @param {string} id
      * @param {OpikApi.ApplyDatasetItemChangesRequest} request
      * @param {DatasetsClient.RequestOptions} requestOptions - Request-specific configuration.
@@ -368,6 +373,10 @@ export class DatasetsClient {
      * Create/update dataset items based on dataset item id.
      * Each item's 'id' field is the stable identifier and upsert key.
      * Provide it to update an existing item, or omit it to create a new one.
+     *
+     * Set 'copy_from_dataset_id' and 'copy_from_version_id' together to read carry-forward rows
+     * from the supplied (dataset, version) pair instead of the destination's prior version. When
+     * the fields are null, carry-forward rows are read from the destination's prior version.
      *
      * @param {OpikApi.DatasetItemBatchWrite} request
      * @param {DatasetsClient.RequestOptions} requestOptions - Request-specific configuration.

--- a/sdks/typescript/src/opik/rest_api/api/resources/datasets/client/requests/DatasetItemBatchWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/api/resources/datasets/client/requests/DatasetItemBatchWrite.ts
@@ -25,4 +25,8 @@ export interface DatasetItemBatchWrite {
     items: OpikApi.DatasetItemWrite[];
     /** Optional batch group ID to group multiple batches into a single dataset version. If null, mutates the latest version instead of creating a new one. */
     batchGroupId?: string;
+    /** Optional. Dataset to read carry-forward rows from when materializing the new version. Required together with copy_from_version_id. When null, carry-forward rows are read from the destination dataset's prior version. */
+    copyFromDatasetId?: string;
+    /** Optional. Version within copy_from_dataset_id to read carry-forward rows from. Required together with copy_from_dataset_id. */
+    copyFromVersionId?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/api/resources/prompts/client/Client.ts
+++ b/sdks/typescript/src/opik/rest_api/api/resources/prompts/client/Client.ts
@@ -1381,11 +1381,13 @@ export class PromptsClient {
      * @throws {@link OpikApi.NotFoundError}
      *
      * @example
-     *     await client.prompts.setPromptVersionEnvironment("versionId")
+     *     await client.prompts.setPromptVersionEnvironment("versionId", {
+     *         environments: ["environments"]
+     *     })
      */
     public setPromptVersionEnvironment(
         versionId: string,
-        request: OpikApi.PromptVersionEnvironmentUpdate = {},
+        request: OpikApi.PromptVersionEnvironmentUpdate,
         requestOptions?: PromptsClient.RequestOptions,
     ): core.HttpResponsePromise<void> {
         return core.HttpResponsePromise.fromPromise(
@@ -1395,7 +1397,7 @@ export class PromptsClient {
 
     private async __setPromptVersionEnvironment(
         versionId: string,
-        request: OpikApi.PromptVersionEnvironmentUpdate = {},
+        request: OpikApi.PromptVersionEnvironmentUpdate,
         requestOptions?: PromptsClient.RequestOptions,
     ): Promise<core.WithRawResponse<void>> {
         const _headers: core.Fetcher.Args["headers"] = mergeHeaders(

--- a/sdks/typescript/src/opik/rest_api/api/resources/prompts/client/requests/PromptVersionEnvironmentUpdate.ts
+++ b/sdks/typescript/src/opik/rest_api/api/resources/prompts/client/requests/PromptVersionEnvironmentUpdate.ts
@@ -2,8 +2,10 @@
 
 /**
  * @example
- *     {}
+ *     {
+ *         environments: ["environments"]
+ *     }
  */
 export interface PromptVersionEnvironmentUpdate {
-    environment?: string;
+    environments: string[];
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/AnnotationQueue.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/AnnotationQueue.ts
@@ -15,6 +15,7 @@ export interface AnnotationQueue {
     scope: OpikApi.AnnotationQueueScope;
     commentsEnabled?: boolean;
     feedbackDefinitionNames?: string[];
+    annotatorsPerItem?: number;
     reviewers?: OpikApi.AnnotationQueueReviewer[];
     feedbackScores?: OpikApi.FeedbackScoreAverage[];
     itemsCount?: number;

--- a/sdks/typescript/src/opik/rest_api/api/types/AnnotationQueuePublic.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/AnnotationQueuePublic.ts
@@ -12,6 +12,7 @@ export interface AnnotationQueuePublic {
     scope: OpikApi.AnnotationQueuePublicScope;
     commentsEnabled?: boolean;
     feedbackDefinitionNames?: string[];
+    annotatorsPerItem?: number;
     reviewers?: OpikApi.AnnotationQueueReviewerPublic[];
     feedbackScores?: OpikApi.FeedbackScoreAveragePublic[];
     itemsCount?: number;

--- a/sdks/typescript/src/opik/rest_api/api/types/AnnotationQueueWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/AnnotationQueueWrite.ts
@@ -14,4 +14,5 @@ export interface AnnotationQueueWrite {
     scope: OpikApi.AnnotationQueueWriteScope;
     commentsEnabled?: boolean;
     feedbackDefinitionNames?: string[];
+    annotatorsPerItem?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/DatasetItemBatch.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/DatasetItemBatch.ts
@@ -14,4 +14,8 @@ export interface DatasetItemBatch {
     items: OpikApi.DatasetItem[];
     /** Optional batch group ID to group multiple batches into a single dataset version. If null, mutates the latest version instead of creating a new one. */
     batchGroupId?: string;
+    /** Optional. Dataset to read carry-forward rows from when materializing the new version. Required together with copy_from_version_id. When null, carry-forward rows are read from the destination dataset's prior version. */
+    copyFromDatasetId?: string;
+    /** Optional. Version within copy_from_dataset_id to read carry-forward rows from. Required together with copy_from_dataset_id. */
+    copyFromVersionId?: string;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/PromptVersion.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/PromptVersion.ts
@@ -15,7 +15,7 @@ export interface PromptVersion {
     type?: OpikApi.PromptVersionType;
     /** version type discriminator; defaults to prompt_version */
     versionType?: OpikApi.PromptVersionVersionType;
-    environment?: string;
+    environments?: string[];
     changeDescription?: string;
     tags?: string[];
     variables?: string[];

--- a/sdks/typescript/src/opik/rest_api/api/types/PromptVersionDetail.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/PromptVersionDetail.ts
@@ -15,7 +15,7 @@ export interface PromptVersionDetail {
     type?: OpikApi.PromptVersionDetailType;
     /** version type discriminator; defaults to prompt_version */
     versionType?: OpikApi.PromptVersionDetailVersionType;
-    environment?: string;
+    environments?: string[];
     changeDescription?: string;
     tags?: string[];
     variables?: string[];

--- a/sdks/typescript/src/opik/rest_api/api/types/PromptVersionPublic.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/PromptVersionPublic.ts
@@ -15,7 +15,7 @@ export interface PromptVersionPublic {
     type?: OpikApi.PromptVersionPublicType;
     /** version type discriminator; defaults to prompt_version */
     versionType?: OpikApi.PromptVersionPublicVersionType;
-    environment?: string;
+    environments?: string[];
     changeDescription?: string;
     tags?: string[];
     templateStructure?: OpikApi.PromptVersionPublicTemplateStructure;

--- a/sdks/typescript/src/opik/rest_api/serialization/resources/annotationQueues/client/requests/AnnotationQueueUpdate.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/resources/annotationQueues/client/requests/AnnotationQueueUpdate.ts
@@ -16,6 +16,7 @@ export const AnnotationQueueUpdate: core.serialization.Schema<
         "feedback_definition_names",
         core.serialization.list(core.serialization.string()).optional(),
     ),
+    annotatorsPerItem: core.serialization.property("annotators_per_item", core.serialization.number().optional()),
 });
 
 export declare namespace AnnotationQueueUpdate {
@@ -25,5 +26,6 @@ export declare namespace AnnotationQueueUpdate {
         instructions?: string | null;
         comments_enabled?: boolean | null;
         feedback_definition_names?: string[] | null;
+        annotators_per_item?: number | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/resources/datasets/client/requests/DatasetItemBatchWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/resources/datasets/client/requests/DatasetItemBatchWrite.ts
@@ -15,6 +15,8 @@ export const DatasetItemBatchWrite: core.serialization.Schema<
     projectId: core.serialization.property("project_id", core.serialization.string().optional()),
     items: core.serialization.list(DatasetItemWrite),
     batchGroupId: core.serialization.property("batch_group_id", core.serialization.string().optional()),
+    copyFromDatasetId: core.serialization.property("copy_from_dataset_id", core.serialization.string().optional()),
+    copyFromVersionId: core.serialization.property("copy_from_version_id", core.serialization.string().optional()),
 });
 
 export declare namespace DatasetItemBatchWrite {
@@ -25,5 +27,7 @@ export declare namespace DatasetItemBatchWrite {
         project_id?: string | null;
         items: DatasetItemWrite.Raw[];
         batch_group_id?: string | null;
+        copy_from_dataset_id?: string | null;
+        copy_from_version_id?: string | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/resources/prompts/client/requests/PromptVersionEnvironmentUpdate.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/resources/prompts/client/requests/PromptVersionEnvironmentUpdate.ts
@@ -8,11 +8,11 @@ export const PromptVersionEnvironmentUpdate: core.serialization.Schema<
     serializers.PromptVersionEnvironmentUpdate.Raw,
     OpikApi.PromptVersionEnvironmentUpdate
 > = core.serialization.object({
-    environment: core.serialization.string().optional(),
+    environments: core.serialization.list(core.serialization.string()),
 });
 
 export declare namespace PromptVersionEnvironmentUpdate {
     export interface Raw {
-        environment?: string | null;
+        environments: string[];
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/AnnotationQueue.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/AnnotationQueue.ts
@@ -23,6 +23,7 @@ export const AnnotationQueue: core.serialization.ObjectSchema<
         "feedback_definition_names",
         core.serialization.list(core.serialization.string()).optional(),
     ),
+    annotatorsPerItem: core.serialization.property("annotators_per_item", core.serialization.number().optional()),
     reviewers: core.serialization.list(AnnotationQueueReviewer).optional(),
     feedbackScores: core.serialization.property(
         "feedback_scores",
@@ -46,6 +47,7 @@ export declare namespace AnnotationQueue {
         scope: AnnotationQueueScope.Raw;
         comments_enabled?: boolean | null;
         feedback_definition_names?: string[] | null;
+        annotators_per_item?: number | null;
         reviewers?: AnnotationQueueReviewer.Raw[] | null;
         feedback_scores?: FeedbackScoreAverage.Raw[] | null;
         items_count?: number | null;

--- a/sdks/typescript/src/opik/rest_api/serialization/types/AnnotationQueuePublic.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/AnnotationQueuePublic.ts
@@ -23,6 +23,7 @@ export const AnnotationQueuePublic: core.serialization.ObjectSchema<
         "feedback_definition_names",
         core.serialization.list(core.serialization.string()).optional(),
     ),
+    annotatorsPerItem: core.serialization.property("annotators_per_item", core.serialization.number().optional()),
     reviewers: core.serialization.list(AnnotationQueueReviewerPublic).optional(),
     feedbackScores: core.serialization.property(
         "feedback_scores",
@@ -46,6 +47,7 @@ export declare namespace AnnotationQueuePublic {
         scope: AnnotationQueuePublicScope.Raw;
         comments_enabled?: boolean | null;
         feedback_definition_names?: string[] | null;
+        annotators_per_item?: number | null;
         reviewers?: AnnotationQueueReviewerPublic.Raw[] | null;
         feedback_scores?: FeedbackScoreAveragePublic.Raw[] | null;
         items_count?: number | null;

--- a/sdks/typescript/src/opik/rest_api/serialization/types/AnnotationQueueWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/AnnotationQueueWrite.ts
@@ -20,6 +20,7 @@ export const AnnotationQueueWrite: core.serialization.ObjectSchema<
         "feedback_definition_names",
         core.serialization.list(core.serialization.string()).optional(),
     ),
+    annotatorsPerItem: core.serialization.property("annotators_per_item", core.serialization.number().optional()),
 });
 
 export declare namespace AnnotationQueueWrite {
@@ -32,5 +33,6 @@ export declare namespace AnnotationQueueWrite {
         scope: AnnotationQueueWriteScope.Raw;
         comments_enabled?: boolean | null;
         feedback_definition_names?: string[] | null;
+        annotators_per_item?: number | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/DatasetItemBatch.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/DatasetItemBatch.ts
@@ -15,6 +15,8 @@ export const DatasetItemBatch: core.serialization.ObjectSchema<
     projectId: core.serialization.property("project_id", core.serialization.string().optional()),
     items: core.serialization.list(DatasetItem),
     batchGroupId: core.serialization.property("batch_group_id", core.serialization.string().optional()),
+    copyFromDatasetId: core.serialization.property("copy_from_dataset_id", core.serialization.string().optional()),
+    copyFromVersionId: core.serialization.property("copy_from_version_id", core.serialization.string().optional()),
 });
 
 export declare namespace DatasetItemBatch {
@@ -25,5 +27,7 @@ export declare namespace DatasetItemBatch {
         project_id?: string | null;
         items: DatasetItem.Raw[];
         batch_group_id?: string | null;
+        copy_from_dataset_id?: string | null;
+        copy_from_version_id?: string | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/PromptVersion.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/PromptVersion.ts
@@ -18,7 +18,7 @@ export const PromptVersion: core.serialization.ObjectSchema<serializers.PromptVe
         metadata: JsonNode.optional(),
         type: PromptVersionType.optional(),
         versionType: core.serialization.property("version_type", PromptVersionVersionType.optional()),
-        environment: core.serialization.string().optional(),
+        environments: core.serialization.list(core.serialization.string()).optional(),
         changeDescription: core.serialization.property("change_description", core.serialization.string().optional()),
         tags: core.serialization.list(core.serialization.string()).optional(),
         variables: core.serialization.list(core.serialization.string()).optional(),
@@ -37,7 +37,7 @@ export declare namespace PromptVersion {
         metadata?: JsonNode.Raw | null;
         type?: PromptVersionType.Raw | null;
         version_type?: PromptVersionVersionType.Raw | null;
-        environment?: string | null;
+        environments?: string[] | null;
         change_description?: string | null;
         tags?: string[] | null;
         variables?: string[] | null;

--- a/sdks/typescript/src/opik/rest_api/serialization/types/PromptVersionDetail.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/PromptVersionDetail.ts
@@ -20,7 +20,7 @@ export const PromptVersionDetail: core.serialization.ObjectSchema<
     metadata: JsonNodeDetail.optional(),
     type: PromptVersionDetailType.optional(),
     versionType: core.serialization.property("version_type", PromptVersionDetailVersionType.optional()),
-    environment: core.serialization.string().optional(),
+    environments: core.serialization.list(core.serialization.string()).optional(),
     changeDescription: core.serialization.property("change_description", core.serialization.string().optional()),
     tags: core.serialization.list(core.serialization.string()).optional(),
     variables: core.serialization.list(core.serialization.string()).optional(),
@@ -42,7 +42,7 @@ export declare namespace PromptVersionDetail {
         metadata?: JsonNodeDetail.Raw | null;
         type?: PromptVersionDetailType.Raw | null;
         version_type?: PromptVersionDetailVersionType.Raw | null;
-        environment?: string | null;
+        environments?: string[] | null;
         change_description?: string | null;
         tags?: string[] | null;
         variables?: string[] | null;

--- a/sdks/typescript/src/opik/rest_api/serialization/types/PromptVersionPublic.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/PromptVersionPublic.ts
@@ -20,7 +20,7 @@ export const PromptVersionPublic: core.serialization.ObjectSchema<
     metadata: JsonNodePublic.optional(),
     type: PromptVersionPublicType.optional(),
     versionType: core.serialization.property("version_type", PromptVersionPublicVersionType.optional()),
-    environment: core.serialization.string().optional(),
+    environments: core.serialization.list(core.serialization.string()).optional(),
     changeDescription: core.serialization.property("change_description", core.serialization.string().optional()),
     tags: core.serialization.list(core.serialization.string()).optional(),
     templateStructure: core.serialization.property(
@@ -41,7 +41,7 @@ export declare namespace PromptVersionPublic {
         metadata?: JsonNodePublic.Raw | null;
         type?: PromptVersionPublicType.Raw | null;
         version_type?: PromptVersionPublicVersionType.Raw | null;
-        environment?: string | null;
+        environments?: string[] | null;
         change_description?: string | null;
         tags?: string[] | null;
         template_structure?: PromptVersionPublicTemplateStructure.Raw | null;


### PR DESCRIPTION
## Details
Automated update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

**Triggered by BE merge:** https://github.com/comet-ml/opik/pull/6873

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate