### PR TITLE
[OPIK-6626] [FE] feat: surface prompt environments across prompt UIs

### DIFF
--- a/apps/opik-frontend/src/api/prompts/useSetPromptVersionEnvironmentMutation.ts
+++ b/apps/opik-frontend/src/api/prompts/useSetPromptVersionEnvironmentMutation.ts
@@ -8,7 +8,7 @@ import { getApiErrorMessage } from "@/lib/api-error";
 type UseSetPromptVersionEnvironmentMutationParams = {
   versionId: string;
   promptId: string;
-  environment: string | null;
+  environments: string[];
 };
 
 const useSetPromptVersionEnvironmentMutation = () => {
@@ -18,11 +18,11 @@ const useSetPromptVersionEnvironmentMutation = () => {
   return useMutation({
     mutationFn: async ({
       versionId,
-      environment,
+      environments,
     }: UseSetPromptVersionEnvironmentMutationParams) => {
       await api.patch(
         `${PROMPTS_REST_ENDPOINT}versions/${versionId}/environments`,
-        { environment },
+        { environments },
       );
     },
     onError: (error: AxiosError) => {

--- a/apps/opik-frontend/src/hooks/useVisibleItemsByWidth.ts
+++ b/apps/opik-frontend/src/hooks/useVisibleItemsByWidth.ts
@@ -36,7 +36,9 @@ const calculateVisibleCount = (
     return 0;
   }
 
-  const itemListWidth = itemWidths.reduce((acc, w) => acc + w + itemGap, 0);
+  const itemListWidth =
+    itemWidths.reduce((acc, w) => acc + w, 0) +
+    Math.max(0, itemWidths.length - 1) * itemGap;
   const containerWidth = cellWidth - containerPadding;
 
   if (containerWidth >= itemListWidth) {
@@ -65,8 +67,7 @@ const calculateVisibleCount = (
   let availableWidth = containerWidth - counterTotalWidth;
 
   for (let idx = 0; idx <= lastIdx; idx++) {
-    const nextItemWidth =
-      itemWidths[idx] + (idx > 0 && idx < lastIdx ? itemGap * 2 : 0);
+    const nextItemWidth = itemWidths[idx] + (idx > 0 ? itemGap : 0);
 
     availableWidth -= nextItemWidth;
 

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadge.tsx
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadge.tsx
@@ -1,14 +1,25 @@
 import React from "react";
-import useEnvironmentsList from "@/api/environments/useEnvironmentsList";
 import { TagProps } from "@/ui/tag";
 import { cn } from "@/lib/utils";
-import { getContrastingTextColor, resolveEnvironmentColor } from "./helpers";
+import {
+  getContrastingTextColor,
+  getDefaultEnvironmentMeta,
+  resolveEnvironmentColor,
+} from "./helpers";
+import { useEnvironmentByName } from "./EnvironmentLabel";
 
 const SIZE_CLASSES: Record<NonNullable<TagProps["size"]>, string> = {
   default: "comet-body-xs h-5 px-2 leading-5 rounded-sm",
   sm: "comet-body-xs h-4 px-2 text-[11px] leading-4 rounded-sm",
   md: "comet-body-s h-6 px-1.5 leading-6 rounded-md",
   lg: "comet-body-s h-7 px-3 leading-7 rounded-md",
+};
+
+const ICON_SIZE_CLASSES: Record<NonNullable<TagProps["size"]>, string> = {
+  default: "size-3",
+  sm: "size-2.5",
+  md: "size-3",
+  lg: "size-3.5",
 };
 
 type EnvironmentBadgeProps = {
@@ -22,24 +33,31 @@ const EnvironmentBadge: React.FC<EnvironmentBadgeProps> = ({
   size = "sm",
   className,
 }) => {
-  const { data } = useEnvironmentsList();
+  const env = useEnvironmentByName(name);
 
   if (!name) return null;
 
-  const env = data?.content?.find((e) => e.name === name);
   const bg = resolveEnvironmentColor(env?.color);
   const text = getContrastingTextColor(bg);
+  const defaultMeta = getDefaultEnvironmentMeta(name);
+  const Icon = defaultMeta?.icon;
+  const resolvedSize = size ?? "sm";
 
   return (
     <div
       className={cn(
-        "inline-block max-w-[160px] truncate transition-colors",
-        SIZE_CLASSES[size ?? "sm"],
+        "inline-flex max-w-[160px] items-center gap-1 truncate transition-colors",
+        SIZE_CLASSES[resolvedSize],
         className,
       )}
       style={{ backgroundColor: bg, color: text }}
     >
-      {name}
+      {Icon && (
+        <Icon
+          className={cn("shrink-0 text-white", ICON_SIZE_CLASSES[resolvedSize])}
+        />
+      )}
+      <span className="truncate">{name}</span>
     </div>
   );
 };

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadgeList.tsx
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadgeList.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
 import { TagProps } from "@/ui/tag";
 import { cn } from "@/lib/utils";
 import { useVisibleItemsByWidth } from "@/hooks/useVisibleItemsByWidth";
@@ -50,6 +50,19 @@ const EnvironmentBadgeList: React.FC<EnvironmentBadgeListProps> = ({
     onMeasure,
   } = useVisibleItemsByWidth(list, OVERFLOW_CONFIG);
 
+  // Distinguish "not measured yet" (initial render, before ChildrenWidthMeasurer
+  // reports) from "measured and nothing fits" (truly narrow container). Without
+  // this flag the fallback below would keep rendering all items + the chip once
+  // the container is too narrow to fit even one — leaking clipped badges.
+  const [hasMeasured, setHasMeasured] = useState(false);
+  const handleMeasure = useCallback(
+    (widths: number[]) => {
+      onMeasure(widths);
+      setHasMeasured(true);
+    },
+    [onMeasure],
+  );
+
   if (list.length === 0) return null;
 
   const renderItem = (name: string) =>
@@ -72,7 +85,7 @@ const EnvironmentBadgeList: React.FC<EnvironmentBadgeListProps> = ({
     );
   }
 
-  const itemsToRender = visibleItems.length > 0 ? visibleItems : list;
+  const itemsToRender = hasMeasured ? visibleItems : list;
 
   return (
     <div
@@ -94,7 +107,7 @@ const EnvironmentBadgeList: React.FC<EnvironmentBadgeListProps> = ({
           maxWidth ? "w-[var(--env-list-width)]" : "inset-0",
         )}
       />
-      <ChildrenWidthMeasurer onMeasure={onMeasure}>
+      <ChildrenWidthMeasurer onMeasure={handleMeasure}>
         {list.map((name) => (
           <div key={name}>{renderItem(name)}</div>
         ))}

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadgeList.tsx
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadgeList.tsx
@@ -114,7 +114,7 @@ const EnvironmentBadgeList: React.FC<EnvironmentBadgeListProps> = ({
             className={cn(
               "flex shrink-0 items-center justify-center border border-border text-muted-slate",
               compact
-                ? "comet-body-xs h-4 min-w-4 px-1 text-[10px] leading-none rounded-[0.2rem]"
+                ? "comet-body-xs h-[18px] min-w-[18px] px-0.5 text-[10px] leading-none rounded-[0.2rem]"
                 : COUNTER_CLASSES[size ?? "sm"],
             )}
           >

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadgeList.tsx
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadgeList.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import { TagProps } from "@/ui/tag";
+import { cn } from "@/lib/utils";
+import { useVisibleItemsByWidth } from "@/hooks/useVisibleItemsByWidth";
+import ChildrenWidthMeasurer from "@/shared/ChildrenWidthMeasurer/ChildrenWidthMeasurer";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import EnvironmentBadge from "./EnvironmentBadge";
+import { EnvironmentSquareWithTooltip } from "./EnvironmentLabel";
+
+type EnvironmentBadgeListProps = {
+  names: string[] | null | undefined;
+  size?: TagProps["size"];
+  className?: string;
+  badgeClassName?: string;
+  withOverflow?: boolean;
+  maxWidth?: number;
+  compact?: boolean;
+};
+
+const COUNTER_CLASSES: Record<NonNullable<TagProps["size"]>, string> = {
+  default: "comet-body-xs h-5 px-1.5 leading-5 rounded-sm",
+  sm: "comet-body-xs h-4 px-1.5 text-[11px] leading-4 rounded-sm",
+  md: "comet-body-s h-6 px-1.5 leading-6 rounded-md",
+  lg: "comet-body-s h-7 px-2 leading-7 rounded-md",
+};
+
+const OVERFLOW_CONFIG = {
+  itemGap: 4,
+  counterWidth: 30,
+  containerPadding: 0,
+  minFirstItemWidth: 40,
+};
+
+const EnvironmentBadgeList: React.FC<EnvironmentBadgeListProps> = ({
+  names,
+  size = "sm",
+  className,
+  badgeClassName,
+  withOverflow = false,
+  maxWidth,
+  compact = false,
+}) => {
+  const list = names ?? [];
+  const {
+    cellRef,
+    visibleItems,
+    hiddenItems,
+    hasHiddenItems,
+    remainingCount,
+    onMeasure,
+  } = useVisibleItemsByWidth(list, OVERFLOW_CONFIG);
+
+  if (list.length === 0) return null;
+
+  const renderItem = (name: string) =>
+    compact ? (
+      <EnvironmentSquareWithTooltip key={name} name={name} />
+    ) : (
+      <EnvironmentBadge
+        key={name}
+        name={name}
+        size={size}
+        className={badgeClassName}
+      />
+    );
+
+  if (!withOverflow) {
+    return (
+      <div className={cn("flex flex-wrap items-center gap-1", className)}>
+        {list.map(renderItem)}
+      </div>
+    );
+  }
+
+  const itemsToRender = visibleItems.length > 0 ? visibleItems : list;
+
+  return (
+    <div
+      className={cn(
+        "relative flex min-w-0 items-center gap-1 overflow-hidden",
+        maxWidth && "max-w-[var(--env-list-width)]",
+        className,
+      )}
+      style={
+        maxWidth
+          ? ({ "--env-list-width": `${maxWidth}px` } as React.CSSProperties)
+          : undefined
+      }
+    >
+      <div
+        ref={cellRef}
+        className={cn(
+          "pointer-events-none invisible absolute",
+          maxWidth ? "w-[var(--env-list-width)]" : "inset-0",
+        )}
+      />
+      <ChildrenWidthMeasurer onMeasure={onMeasure}>
+        {list.map((name) => (
+          <div key={name}>{renderItem(name)}</div>
+        ))}
+      </ChildrenWidthMeasurer>
+      {itemsToRender.map(renderItem)}
+      {hasHiddenItems && (
+        <TooltipWrapper
+          content={
+            <div className="flex max-w-[300px] flex-wrap gap-1">
+              {hiddenItems.map((name) => (
+                <EnvironmentBadge key={name} name={name} size={size} />
+              ))}
+            </div>
+          }
+        >
+          <div
+            className={cn(
+              "flex shrink-0 items-center justify-center border border-border text-muted-slate",
+              compact
+                ? "comet-body-xs h-4 min-w-4 px-1 text-[10px] leading-none rounded-[0.2rem]"
+                : COUNTER_CLASSES[size ?? "sm"],
+            )}
+          >
+            +{remainingCount}
+          </div>
+        </TooltipWrapper>
+      )}
+    </div>
+  );
+};
+
+export default EnvironmentBadgeList;

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentLabel.tsx
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentLabel.tsx
@@ -1,17 +1,58 @@
 import React from "react";
 import useEnvironmentsList from "@/api/environments/useEnvironmentsList";
 import { cn } from "@/lib/utils";
-import { resolveEnvironmentColor } from "./helpers";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import { getDefaultEnvironmentMeta, resolveEnvironmentColor } from "./helpers";
+
+/**
+ * Looks up the environment definition (color, etc.) by display name from
+ * the workspace-level environments list. Shared by all components that need
+ * to render an environment given only its name.
+ */
+export const useEnvironmentByName = (name?: string | null) => {
+  const { data } = useEnvironmentsList();
+  if (!name) return undefined;
+  return data?.content?.find((e) => e.name === name);
+};
 
 export const EnvironmentSquare: React.FC<{
+  name?: string;
   color?: string;
   className?: string;
-}> = ({ color, className }) => (
-  <div
-    className={cn("size-2.5 shrink-0 rounded-[0.15rem]", className)}
-    style={{ backgroundColor: resolveEnvironmentColor(color) }}
-  />
-);
+}> = ({ name, color, className }) => {
+  const Icon = getDefaultEnvironmentMeta(name)?.icon;
+  const resolvedColor = resolveEnvironmentColor(color);
+
+  return (
+    <div
+      className={cn(
+        "flex size-4 shrink-0 items-center justify-center rounded-[0.2rem]",
+        className,
+      )}
+      style={{ backgroundColor: resolvedColor }}
+    >
+      {Icon && <Icon className="size-2.5 text-white" />}
+    </div>
+  );
+};
+
+/**
+ * Name-driven variant of EnvironmentSquare: resolves color by name and wraps
+ * the square in a tooltip that reveals the environment name on hover. Used in
+ * tight layouts where the name doesn't fit inline.
+ */
+export const EnvironmentSquareWithTooltip: React.FC<{ name: string }> = ({
+  name,
+}) => {
+  const env = useEnvironmentByName(name);
+  return (
+    <TooltipWrapper content={name}>
+      <span className="inline-flex">
+        <EnvironmentSquare name={name} color={env?.color} />
+      </span>
+    </TooltipWrapper>
+  );
+};
 
 type EnvironmentLabelProps = {
   name?: string;
@@ -22,17 +63,15 @@ const EnvironmentLabel: React.FC<EnvironmentLabelProps> = ({
   name,
   className,
 }) => {
-  const { data } = useEnvironmentsList();
+  const env = useEnvironmentByName(name);
 
   if (!name) {
     return <div className={cn("text-light-slate", className)}>-</div>;
   }
 
-  const env = data?.content?.find((e) => e.name === name);
-
   return (
     <div className={cn("flex min-w-0 items-center gap-1.5", className)}>
-      <EnvironmentSquare color={env?.color} />
+      <EnvironmentSquare name={name} color={env?.color} />
       <span className="truncate">{name}</span>
     </div>
   );

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentLabel.tsx
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentLabel.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import useEnvironmentsList from "@/api/environments/useEnvironmentsList";
 import { cn } from "@/lib/utils";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import { getDefaultEnvironmentMeta, resolveEnvironmentColor } from "./helpers";
+import {
+  getContrastingTextColor,
+  getDefaultEnvironmentMeta,
+  resolveEnvironmentColor,
+} from "./helpers";
 
 /**
  * Looks up the environment definition (color, etc.) by display name from
@@ -22,6 +26,7 @@ export const EnvironmentSquare: React.FC<{
 }> = ({ name, color, className }) => {
   const Icon = getDefaultEnvironmentMeta(name)?.icon;
   const resolvedColor = resolveEnvironmentColor(color);
+  const iconColor = getContrastingTextColor(resolvedColor);
 
   return (
     <div
@@ -29,9 +34,9 @@ export const EnvironmentSquare: React.FC<{
         "flex size-4 shrink-0 items-center justify-center rounded-[0.2rem]",
         className,
       )}
-      style={{ backgroundColor: resolvedColor }}
+      style={{ backgroundColor: resolvedColor, color: iconColor }}
     >
-      {Icon && <Icon className="size-2.5 text-white" />}
+      {Icon && <Icon className="size-2.5" />}
     </div>
   );
 };

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/helpers.ts
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/helpers.ts
@@ -1,3 +1,4 @@
+import { Code, FlaskRound, LucideIcon, Rocket } from "lucide-react";
 import { DEFAULT_HEX_COLOR, HEX_COLOR_REGEX } from "@/constants/colorVariants";
 
 export const resolveEnvironmentColor = (color: string | undefined) =>
@@ -10,3 +11,25 @@ export const getContrastingTextColor = (hex: string): string => {
   const luminance = (r * 299 + g * 587 + b * 114) / 1000;
   return luminance > 140 ? "#0f172a" : "#ffffff";
 };
+
+// Seeded server-side by migration 000066_seed_default_environments. Name +
+// color are kept in lock-step with the backend so the UI can recognize them
+// and protect their color from edits.
+type DefaultEnvironmentMeta = { color: string; icon: LucideIcon };
+
+const DEFAULT_ENVIRONMENTS: Record<string, DefaultEnvironmentMeta> = {
+  development: { color: "#EF6868", icon: Code },
+  staging: { color: "#F4B400", icon: FlaskRound },
+  production: { color: "#19A979", icon: Rocket },
+};
+
+const normalize = (name: string | undefined | null) =>
+  name?.trim().toLowerCase() ?? "";
+
+export const getDefaultEnvironmentMeta = (
+  name: string | undefined | null,
+): DefaultEnvironmentMeta | null =>
+  DEFAULT_ENVIRONMENTS[normalize(name)] ?? null;
+
+export const isDefaultEnvironmentName = (name: string | undefined | null) =>
+  normalize(name) in DEFAULT_ENVIRONMENTS;

--- a/apps/opik-frontend/src/types/prompts.ts
+++ b/apps/opik-frontend/src/types/prompts.ts
@@ -46,7 +46,7 @@ export interface PromptVersion {
   tags?: string[];
   type?: PROMPT_TYPE;
   version_type?: PROMPT_VERSION_TYPE;
-  environment?: string | null;
+  environments?: string[] | null;
 }
 
 export interface PromptCommitInfo {

--- a/apps/opik-frontend/src/v2/pages-shared/environments/AddEditEnvironmentDialog/AddEditEnvironmentDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/environments/AddEditEnvironmentDialog/AddEditEnvironmentDialog.tsx
@@ -1,9 +1,11 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { AxiosError } from "axios";
 
 import useEnvironmentCreateMutation from "@/api/environments/useEnvironmentCreateMutation";
 import useEnvironmentUpdateMutation from "@/api/environments/useEnvironmentUpdateMutation";
 import ColorPicker from "@/shared/ColorPicker/ColorPicker";
+import { getDefaultEnvironmentMeta } from "@/shared/EnvironmentLabel/helpers";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { Button } from "@/ui/button";
 import {
   Dialog,
@@ -72,6 +74,21 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
     }
     return "";
   }, [trimmedName]);
+
+  // Color is locked while the name matches a seeded default (development /
+  // staging / production) so the badge icon + color stay consistent with what
+  // the backend seeds in migration 000066. Renaming away from the default
+  // unlocks the picker.
+  const lockedDefault = getDefaultEnvironmentMeta(trimmedName);
+  const isColorLocked = lockedDefault !== null;
+
+  useEffect(() => {
+    if (lockedDefault && color !== lockedDefault.color) {
+      setColor(lockedDefault.color);
+    }
+  }, [lockedDefault, color]);
+
+  const LockedIcon = lockedDefault?.icon;
 
   const isEdit = mode === "edit";
   const title =
@@ -145,19 +162,31 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
           <div className="flex flex-col gap-2 pb-4">
             <Label htmlFor="environmentName">Name</Label>
             <div className="flex items-center">
-              <Popover>
-                <PopoverTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label="Change color"
-                    className="size-10 shrink-0 rounded-l-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
+              {isColorLocked ? (
+                <TooltipWrapper content="Color is reserved for the default environment">
+                  <div
+                    aria-label="Default environment color (locked)"
+                    className="flex size-10 shrink-0 cursor-not-allowed items-center justify-center rounded-l-md"
                     style={{ backgroundColor: color }}
-                  />
-                </PopoverTrigger>
-                <PopoverContent className="w-auto" align="start">
-                  <ColorPicker value={color} onChange={handleColorChange} />
-                </PopoverContent>
-              </Popover>
+                  >
+                    {LockedIcon && <LockedIcon className="size-5 text-white" />}
+                  </div>
+                </TooltipWrapper>
+              ) : (
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label="Change color"
+                      className="size-10 shrink-0 rounded-l-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
+                      style={{ backgroundColor: color }}
+                    />
+                  </PopoverTrigger>
+                  <PopoverContent className="w-auto" align="start">
+                    <ColorPicker value={color} onChange={handleColorChange} />
+                  </PopoverContent>
+                </Popover>
+              )}
               <Input
                 id="environmentName"
                 className="flex-1 rounded-l-none"

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
@@ -84,7 +84,9 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
   const resetKeyRef = useRef(0);
   const [open, setOpen] = useState<boolean | ConfirmType>(false);
   const selectedPromptIdRef = useRef<string | undefined>();
+  const selectedVersionIdRef = useRef<string | undefined>();
   const tempPromptIdRef = useRef<string | undefined>();
+  const tempVersionIdRef = useRef<string | undefined>();
   const isPromptSelectBoxOpenedRef = useRef<boolean>(false);
   const [showImproveWizard, setShowImproveWizard] = useState(false);
 
@@ -189,14 +191,16 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
   ]);
 
   const handleUpdateExternalPromptId = useCallback(
-    (selectedPromptId?: string) => {
+    (selectedPromptId?: string, selectedVersionId?: string) => {
       if (selectedPromptId) {
         selectedPromptIdRef.current = selectedPromptId;
+        selectedVersionIdRef.current = selectedVersionId;
         setIsLoading(true);
       }
 
       onChangeMessage({
         promptId: selectedPromptId,
+        promptVersionId: selectedVersionId,
       });
     },
     [onChangeMessage, setIsLoading],
@@ -250,7 +254,10 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
   const confirmConfig = useMemo(() => {
     return {
       onConfirm: () => {
-        handleUpdateExternalPromptId(tempPromptIdRef.current);
+        handleUpdateExternalPromptId(
+          tempPromptIdRef.current,
+          tempVersionIdRef.current,
+        );
       },
       title: "Load prompt",
       description:
@@ -267,10 +274,21 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
       selectedPromptIdRef.current === promptId &&
       selectedPromptIdRef.current === promptData?.id
     ) {
-      selectedPromptIdRef.current = undefined;
+      const requestedVersionId = selectedVersionIdRef.current;
+      // When a specific version was requested, wait until that version's data
+      // arrives so we apply its template — otherwise we'd briefly load latest.
+      if (requestedVersionId && loadedVersionData?.id !== requestedVersionId) {
+        return;
+      }
 
-      const template = promptData.latest_version?.template ?? "";
-      const versionId = promptData.latest_version?.id;
+      selectedPromptIdRef.current = undefined;
+      selectedVersionIdRef.current = undefined;
+
+      const sourceVersion = requestedVersionId
+        ? loadedVersionData
+        : promptData.latest_version;
+      const template = sourceVersion?.template ?? "";
+      const versionId = sourceVersion?.id;
       const isChatPrompt =
         promptData.template_structure === PROMPT_TEMPLATE_STRUCTURE.CHAT;
 
@@ -295,8 +313,8 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
         onClearOtherPromptLinks();
       }
       onChangeMessage({
-        content: parsePromptVersionContent(promptData.latest_version),
-        promptVersionId: promptData.latest_version?.id,
+        content: parsePromptVersionContent(sourceVersion),
+        promptVersionId: versionId,
         promptId: promptData.id,
       });
       setIsLoading(false);
@@ -305,6 +323,7 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
     onChangeMessage,
     promptData,
     promptId,
+    loadedVersionData,
     setIsLoading,
     onReplaceWithChatPrompt,
     onClearOtherPromptLinks,
@@ -346,17 +365,19 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
 
         <PromptsSelectBox
           compact
+          enableVersionSelect
           projectId={activeProjectId!}
           refetchOnMount
           value={promptId}
-          onValueChange={(id) => {
-            if (id !== promptId) {
+          onValueChange={(id, versionId) => {
+            if (id !== promptId || versionId !== promptVersionId) {
               if (content === "" || isUndefined(id)) {
-                handleUpdateExternalPromptId(id);
+                handleUpdateExternalPromptId(id, versionId);
               } else {
                 setOpen("load");
                 resetKeyRef.current = resetKeyRef.current + 1;
                 tempPromptIdRef.current = id;
+                tempVersionIdRef.current = versionId;
               }
             }
           }}

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
@@ -10,7 +10,7 @@ import SearchInput from "@/shared/SearchInput/SearchInput";
 import NoOptions from "@/shared/LoadableSelectBox/NoOptions";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import StageTag from "@/v2/pages-shared/version-history/StageTag";
-import EnvironmentBadge from "@/shared/EnvironmentLabel/EnvironmentBadge";
+import EnvironmentBadgeList from "@/shared/EnvironmentLabel/EnvironmentBadgeList";
 import useProjectPromptsList from "@/api/prompts/useProjectPromptsList";
 import usePromptVersionsById from "@/api/prompts/usePromptVersionsById";
 import { Prompt, PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
@@ -149,6 +149,7 @@ const PromptRow: React.FC<PromptRowProps> = ({
   const [hoverOpen, setHoverOpen] = useState(false);
 
   const latestStage = pickHighestStage(prompt.latest_version?.tags);
+  const latestEnvironments = prompt.latest_version?.environments;
   const latestLabel =
     prompt.version_count > 0 ? `v${prompt.version_count}` : "";
 
@@ -168,6 +169,13 @@ const PromptRow: React.FC<PromptRowProps> = ({
           </span>
         )}
         {latestStage && <StageTag value={latestStage} size="xs" />}
+        <EnvironmentBadgeList
+          names={latestEnvironments}
+          size="sm"
+          withOverflow
+          compact
+          maxWidth={80}
+        />
         {enableVersionSelect && (
           <ChevronRight className="size-3.5 shrink-0 text-light-slate" />
         )}
@@ -272,9 +280,13 @@ const PromptVersionsList: React.FC<PromptVersionsListProps> = ({
               {label}
             </span>
             {stage && <StageTag value={stage} size="xs" />}
-            {version.environment && (
-              <EnvironmentBadge name={version.environment} size="sm" />
-            )}
+            <EnvironmentBadgeList
+              names={version.environments}
+              size="sm"
+              withOverflow
+              compact
+              maxWidth={80}
+            />
             <TooltipWrapper
               content={`${formatDate(version.created_at, {
                 utc: true,

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
@@ -25,7 +25,7 @@ const NEW_PROMPT_VALUE = "new-prompt";
 interface PromptsSelectBoxProps {
   projectId: string;
   value?: string;
-  onValueChange: (value?: string) => void;
+  onValueChange: (value?: string, versionId?: string) => void;
   onClear?: () => void;
   onOpenChange?: (value: boolean) => void;
   clearable?: boolean;
@@ -37,6 +37,13 @@ interface PromptsSelectBoxProps {
   promptName?: string;
   loadedVersionId?: string;
   compact?: boolean;
+  /**
+   * Only meaningful in compact mode. When true, the prompt-library popover
+   * shows a hover submenu of versions and forwards the picked versionId via
+   * `onValueChange`. Default is false so callers that can't plumb versionId
+   * through their state don't silently drop the user's pick.
+   */
+  enableVersionSelect?: boolean;
 }
 
 const PromptsSelectBox: React.FC<PromptsSelectBoxProps> = ({
@@ -54,6 +61,7 @@ const PromptsSelectBox: React.FC<PromptsSelectBoxProps> = ({
   promptName,
   loadedVersionId,
   compact = false,
+  enableVersionSelect = false,
 }) => {
   const [open, setOpen] = useState(false);
   const [isLoadedMore, setIsLoadedMore] = useState(false);
@@ -168,12 +176,11 @@ const PromptsSelectBox: React.FC<PromptsSelectBoxProps> = ({
       <PromptLibraryMenu
         projectId={projectId}
         filterByTemplateStructure={filterByTemplateStructure}
-        onSelect={({ promptId }) => onValueChange(promptId)}
+        onSelect={({ promptId, versionId }) =>
+          onValueChange(promptId, versionId)
+        }
         onOpenChange={onOpenChangeHandler}
-        // Compact mode only forwards promptId to its callers, so we hide the
-        // version submenu — otherwise version picks would be silently dropped
-        // and the latest version would load instead.
-        enableVersionSelect={false}
+        enableVersionSelect={enableVersionSelect}
         trigger={
           <div>
             <TooltipWrapper content="Load prompt">

--- a/apps/opik-frontend/src/v2/pages-shared/traces/EnvironmentFilterSelect/EnvironmentFilterSelect.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/EnvironmentFilterSelect/EnvironmentFilterSelect.tsx
@@ -57,7 +57,10 @@ const EnvironmentFilterSelect: React.FC<EnvironmentFilterSelectProps> = ({
         >
           <span className="flex min-w-0 items-center gap-1.5 truncate">
             {selectedEnvironment && (
-              <EnvironmentSquare color={selectedEnvironment.color} />
+              <EnvironmentSquare
+                name={selectedEnvironment.name}
+                color={selectedEnvironment.color}
+              />
             )}
             {triggerLabel}
           </span>
@@ -89,7 +92,7 @@ const EnvironmentFilterSelect: React.FC<EnvironmentFilterSelectProps> = ({
               onSelect={() => onChange(env.name)}
             >
               <div className="flex min-w-0 items-center gap-2">
-                <EnvironmentSquare color={env.color} />
+                <EnvironmentSquare name={env.name} color={env.color} />
                 <span className="truncate">{env.name}</span>
               </div>
             </DropdownMenuItem>

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/PromptCard.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/PromptCard.tsx
@@ -32,6 +32,7 @@ import { useToast } from "@/ui/use-toast";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import DebounceInput from "@/shared/DebounceInput/DebounceInput";
+import EnvironmentBadgeList from "@/shared/EnvironmentLabel/EnvironmentBadgeList";
 import { useSyntaxHighlighterCode } from "@/shared/SyntaxHighlighter/hooks/useSyntaxHighlighterHooks";
 import { MODE_TYPE } from "@/shared/SyntaxHighlighter/constants";
 import CodeBlockBody from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/CodeBlock/CodeBlockBody";
@@ -113,15 +114,23 @@ const PromptCard: React.FC<PromptCardProps> = ({
   const { getDescriptor, isLoading: isVersionsLoading } =
     usePromptVersionsWithLabels(promptId);
 
-  const { versionLabel, stage } = useMemo(() => {
+  const { versionLabel, stage, environments } = useMemo(() => {
     const descriptor = getDescriptor(versionId);
     if (!descriptor) {
       const fallback = rawPrompt.version.commit
         ? rawPrompt.version.commit.slice(0, 7)
         : undefined;
-      return { versionLabel: fallback, stage: undefined };
+      return {
+        versionLabel: fallback,
+        stage: undefined,
+        environments: undefined,
+      };
     }
-    return { versionLabel: descriptor.label, stage: descriptor.stage };
+    return {
+      versionLabel: descriptor.label,
+      stage: descriptor.stage,
+      environments: descriptor.version.environments,
+    };
   }, [getDescriptor, versionId, rawPrompt.version.commit]);
 
   const messages = useMemo<ChatMessage[]>(
@@ -238,6 +247,13 @@ const PromptCard: React.FC<PromptCardProps> = ({
         ) : isVersionsLoading ? (
           <Skeleton className="h-3 w-8 shrink-0" />
         ) : null}
+        <EnvironmentBadgeList
+          names={environments}
+          size="sm"
+          withOverflow
+          compact
+          maxWidth={60}
+        />
 
         <div className="ml-auto flex shrink-0 items-center gap-1">
           <DropdownMenu>

--- a/apps/opik-frontend/src/v2/pages-shared/version-history/DiffVersionMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/version-history/DiffVersionMenu.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu";
+import EnvironmentBadgeList from "@/shared/EnvironmentLabel/EnvironmentBadgeList";
 import VersionTagList from "./VersionTagList";
 import type { VersionHistoryItem } from "./VersionHistoryTimeline";
 
@@ -58,6 +59,13 @@ const DiffVersionMenu: React.FC<DiffVersionMenuProps> = ({
                   {version.label}
                 </span>
                 <VersionTagList tags={version.tags} size="sm" maxWidth={120} />
+                <EnvironmentBadgeList
+                  names={version.environments}
+                  size="sm"
+                  withOverflow
+                  compact
+                  maxWidth={60}
+                />
               </div>
               <span className="comet-body-xs flex shrink-0 items-center gap-1 text-muted-slate">
                 <Clock className="size-3 shrink-0" />

--- a/apps/opik-frontend/src/v2/pages-shared/version-history/VersionHistoryTimeline.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/version-history/VersionHistoryTimeline.tsx
@@ -5,7 +5,7 @@ import { useInView } from "react-intersection-observer";
 import { cn } from "@/lib/utils";
 import DataTableNoData from "@/shared/DataTableNoData/DataTableNoData";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import EnvironmentBadge from "@/shared/EnvironmentLabel/EnvironmentBadge";
+import EnvironmentBadgeList from "@/shared/EnvironmentLabel/EnvironmentBadgeList";
 import VersionTagList from "./VersionTagList";
 import VersionMeta from "./VersionMeta";
 
@@ -16,7 +16,7 @@ export interface VersionHistoryItem {
   description?: string;
   created_at: string;
   created_by?: string;
-  environment?: string | null;
+  environments?: string[] | null;
 }
 
 interface VersionHistoryTimelineProps {
@@ -94,15 +94,17 @@ const VersionHistoryTimeline: React.FC<VersionHistoryTimelineProps> = ({
               )}
               onClick={() => onSelect(item)}
             >
-              <div className="flex items-center gap-1">
+              <div className="flex min-w-0 items-center gap-1">
                 <span className="comet-body-s-accented shrink-0">
                   {item.label}
                 </span>
                 <VersionTagList tags={item.tags} size="sm" maxWidth={200} />
-                <EnvironmentBadge
-                  name={item.environment}
+                <EnvironmentBadgeList
+                  names={item.environments}
                   size="sm"
-                  className="max-w-[120px]"
+                  badgeClassName="max-w-[120px]"
+                  withOverflow
+                  maxWidth={160}
                 />
               </div>
               {item.description && (

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerPromptCard.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerPromptCard.tsx
@@ -24,6 +24,7 @@ import {
 import { Skeleton } from "@/ui/skeleton";
 import { useToast } from "@/ui/use-toast";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import EnvironmentBadgeList from "@/shared/EnvironmentLabel/EnvironmentBadgeList";
 import StageTag from "@/v2/pages-shared/version-history/StageTag";
 import LLMPromptMessages from "@/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessages";
 import AutoResizeTextarea from "@/v2/pages-shared/agent-configuration/fields/AutoResizeTextarea";
@@ -324,10 +325,20 @@ const AgentRunnerPromptCard = forwardRef<
                 <GitCommitVertical className="size-3 text-muted-slate" />
               )}
               {selectedVersion?.label ?? "v?"}
+              <EnvironmentBadgeList
+                names={selectedVersion?.version.environments}
+                size="sm"
+                withOverflow
+                compact
+                maxWidth={60}
+              />
               <ChevronDown className="size-3" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="w-[220px]">
+          <DropdownMenuContent
+            align="start"
+            className="max-h-[40vh] w-[220px] overflow-y-auto"
+          >
             {descriptors.map(({ version, label, stage }) => {
               const isActive = version.id === selectedVersionId;
               return (
@@ -339,6 +350,13 @@ const AgentRunnerPromptCard = forwardRef<
                 >
                   <span className="comet-body-s">{label}</span>
                   {stage && <StageTag value={stage} size="xs" />}
+                  <EnvironmentBadgeList
+                    names={version.environments}
+                    size="sm"
+                    withOverflow
+                    compact
+                    maxWidth={60}
+                  />
                   <TooltipWrapper
                     content={`${formatDate(version.created_at, {
                       utc: true,

--- a/apps/opik-frontend/src/v2/pages/ConfigurationPage/EnvironmentsTab/EnvironmentNameCell.tsx
+++ b/apps/opik-frontend/src/v2/pages/ConfigurationPage/EnvironmentsTab/EnvironmentNameCell.tsx
@@ -19,7 +19,7 @@ const EnvironmentNameCell: React.FunctionComponent<
     >
       <TooltipWrapper content={name} stopClickPropagation>
         <div className="flex max-w-full items-center gap-1.5 rounded-md border border-transparent px-2">
-          <EnvironmentSquare color={color} />
+          <EnvironmentSquare name={name} color={color} />
           <div className="comet-body-xs-accented min-w-0 flex-1 truncate text-muted-slate">
             {name}
           </div>

--- a/apps/opik-frontend/src/v2/pages/PromptPage/CommitsTab/ComparePromptVersionDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/CommitsTab/ComparePromptVersionDialog.tsx
@@ -18,7 +18,7 @@ import { parseLLMMessageContent, parsePromptVersionContent } from "@/lib/llm";
 import MediaTagsList from "@/v2/pages-shared/llm/PromptMessageMediaTags/MediaTagsList";
 import VersionTagList from "@/v2/pages-shared/version-history/VersionTagList";
 import VersionMeta from "@/v2/pages-shared/version-history/VersionMeta";
-import EnvironmentBadge from "@/shared/EnvironmentLabel/EnvironmentBadge";
+import EnvironmentBadgeList from "@/shared/EnvironmentLabel/EnvironmentBadgeList";
 
 type VersionWithMaybeAuthor = PromptVersion & { created_by?: string };
 type DiffSide = "base" | "diff";
@@ -75,7 +75,12 @@ const ColumnHeader: React.FC<{ version: PromptVersion; label: string }> = ({
     <div className="flex h-8 min-w-0 items-center justify-between gap-2 bg-soft-background px-3">
       <div className="flex min-w-0 items-center gap-2">
         <span className="comet-body-xs shrink-0 text-muted-slate">{label}</span>
-        <EnvironmentBadge name={version.environment} size="sm" />
+        <EnvironmentBadgeList
+          names={version.environments}
+          size="sm"
+          withOverflow
+          maxWidth={200}
+        />
         <VersionTagList tags={version.tags ?? []} size="sm" />
       </div>
       <VersionMeta

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/DeployToEnvironmentMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/DeployToEnvironmentMenu.tsx
@@ -30,7 +30,7 @@ type DeployToEnvironmentMenuProps = {
   versionLabel: string;
   versions: PromptVersion[] | undefined;
   totalVersions: number;
-  activeEnvironment: string | null;
+  activeEnvironments: string[];
 };
 
 const DeployToEnvironmentMenu: React.FC<DeployToEnvironmentMenuProps> = ({
@@ -39,7 +39,7 @@ const DeployToEnvironmentMenu: React.FC<DeployToEnvironmentMenuProps> = ({
   versionLabel,
   versions,
   totalVersions,
-  activeEnvironment,
+  activeEnvironments,
 }) => {
   const { toast } = useToast();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
@@ -60,62 +60,63 @@ const DeployToEnvironmentMenu: React.FC<DeployToEnvironmentMenuProps> = ({
     [environmentsData?.content],
   );
 
+  const activeEnvSet = useMemo(
+    () => new Set(activeEnvironments),
+    [activeEnvironments],
+  );
+
   const environmentOwners = useMemo(() => {
     const map = new Map<string, { version: PromptVersion; index: number }>();
     // `versions` is newest-first; only keep the first writer per environment so
     // the "Currently vN" label reflects the newest version assigned to that env,
     // not whichever historical version was iterated last.
     versions?.forEach((v, index) => {
-      if (v.environment && !map.has(v.environment)) {
-        map.set(v.environment, { version: v, index });
-      }
+      v.environments?.forEach((env) => {
+        if (!map.has(env)) map.set(env, { version: v, index });
+      });
     });
     return map;
   }, [versions]);
 
-  const handleDeploy = useCallback(
-    (envName: string) => {
-      if (!canConfigureWorkspaceSettings) return;
-      if (activeEnvironment === envName) return;
+  const applyEnvironments = useCallback(
+    (next: string[], description: string) => {
       setVersionEnvironment(
-        { promptId, versionId, environment: envName },
-        {
-          onSuccess: () =>
-            toast({ description: `Deployed ${versionLabel} to ${envName}` }),
-        },
+        { promptId, versionId, environments: next },
+        { onSuccess: () => toast({ description }) },
       );
     },
+    [promptId, versionId, setVersionEnvironment, toast],
+  );
+
+  const handleToggle = useCallback(
+    (envName: string) => {
+      if (!canConfigureWorkspaceSettings) return;
+      if (activeEnvSet.has(envName)) {
+        const next = activeEnvironments.filter((e) => e !== envName);
+        applyEnvironments(next, `Removed ${versionLabel} from ${envName}`);
+      } else {
+        const next = [...activeEnvironments, envName];
+        applyEnvironments(next, `Deployed ${versionLabel} to ${envName}`);
+      }
+    },
     [
-      promptId,
-      versionId,
-      versionLabel,
-      activeEnvironment,
       canConfigureWorkspaceSettings,
-      setVersionEnvironment,
-      toast,
+      activeEnvSet,
+      activeEnvironments,
+      versionLabel,
+      applyEnvironments,
     ],
   );
 
-  const handleClear = useCallback(() => {
+  const handleClearAll = useCallback(() => {
     if (!canConfigureWorkspaceSettings) return;
-    if (!activeEnvironment) return;
-    setVersionEnvironment(
-      { promptId, versionId, environment: null },
-      {
-        onSuccess: () =>
-          toast({
-            description: `Removed ${versionLabel} from ${activeEnvironment}`,
-          }),
-      },
-    );
+    if (activeEnvironments.length === 0) return;
+    applyEnvironments([], `Removed ${versionLabel} from all environments`);
   }, [
-    promptId,
-    versionId,
-    versionLabel,
-    activeEnvironment,
     canConfigureWorkspaceSettings,
-    setVersionEnvironment,
-    toast,
+    activeEnvironments.length,
+    versionLabel,
+    applyEnvironments,
   ]);
 
   if (!canConfigureWorkspaceSettings) return null;
@@ -142,38 +143,39 @@ const DeployToEnvironmentMenu: React.FC<DeployToEnvironmentMenuProps> = ({
         ) : (
           environments.map((env) => {
             const owner = environmentOwners.get(env.name);
+            const isActiveHere = activeEnvSet.has(env.name);
             const ownerLabel =
-              owner && totalVersions > 0
-                ? `v${totalVersions - owner.index}`
+              !isActiveHere && owner && totalVersions > 0
+                ? `Currently v${totalVersions - owner.index}`
                 : "";
-            const isActiveHere = activeEnvironment === env.name;
             return (
               <DropdownMenuItem
                 key={env.id}
-                selected={isActiveHere}
-                disabled={isActiveHere}
-                onSelect={() => handleDeploy(env.name)}
+                onSelect={(e) => {
+                  e.preventDefault();
+                  handleToggle(env.name);
+                }}
               >
                 <div className="flex min-w-0 flex-1 items-center gap-2">
-                  <EnvironmentSquare color={env.color} />
+                  <EnvironmentSquare name={env.name} color={env.color} />
                   <span className="truncate">{env.name}</span>
                 </div>
                 <span className="comet-body-xs ml-3 shrink-0 text-light-slate">
                   {isActiveHere ? (
                     <Check className="size-3.5" />
                   ) : ownerLabel ? (
-                    `Currently ${ownerLabel}`
+                    ownerLabel
                   ) : null}
                 </span>
               </DropdownMenuItem>
             );
           })
         )}
-        {activeEnvironment && (
+        {activeEnvironments.length > 0 && (
           <>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={handleClear}>
-              Remove from {activeEnvironment}
+            <DropdownMenuItem onSelect={handleClearAll}>
+              Remove from all environments
             </DropdownMenuItem>
           </>
         )}

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
@@ -332,7 +332,10 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
               />
               {historyItems.length > 1 && (
                 <>
-                  <Separator orientation="vertical" className="mx-1 h-4 shrink-0" />
+                  <Separator
+                    orientation="vertical"
+                    className="mx-1 h-4 shrink-0"
+                  />
                   <DiffVersionMenu
                     currentItemId={effectiveVersionId}
                     versions={historyItems}

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
@@ -49,11 +49,12 @@ import usePromptVersionsById from "@/api/prompts/usePromptVersionsById";
 import usePromptVersionById, {
   useFetchPromptVersion,
 } from "@/api/prompts/usePromptVersionById";
-import EnvironmentBadge from "@/shared/EnvironmentLabel/EnvironmentBadge";
+import EnvironmentBadgeList from "@/shared/EnvironmentLabel/EnvironmentBadgeList";
 import ImproveInPlaygroundButton from "@/v2/pages/PromptPage/ImproveInPlaygroundButton";
 import useLoadPromptIntoPlayground from "@/v2/pages-shared/playground/useLoadPromptIntoPlayground";
 import { getTimeFromNow } from "@/lib/date";
 import { pickHighestStage } from "@/utils/version-stages";
+import DeployToEnvironmentMenu from "./DeployToEnvironmentMenu";
 import ChatPromptView from "./ChatPromptView";
 import TextPromptView from "./TextPromptView";
 import { usePermissions } from "@/contexts/PermissionsContext";
@@ -80,7 +81,7 @@ interface VersionWithMaybeAuthor extends PromptVersion {
 
 const PromptTab = ({ prompt }: PromptTabInterface) => {
   const {
-    permissions: { canUsePlayground },
+    permissions: { canUsePlayground, canConfigureWorkspaceSettings },
   } = usePermissions();
 
   const [openEditPrompt, setOpenEditPrompt] = useState(false);
@@ -124,7 +125,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
       description: v.change_description,
       created_at: v.created_at,
       created_by: v.created_by,
-      environment: v.environment ?? null,
+      environments: v.environments ?? [],
     }));
   }, [versions, total]);
 
@@ -154,7 +155,10 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
   const activeStage = pickHighestStage(activeVersion?.tags);
   const activeAuthor =
     (activeVersion as VersionWithMaybeAuthor | undefined)?.created_by ?? "";
-  const activeVersionEnvironment = activeVersion?.environment ?? null;
+  const activeVersionEnvironments = useMemo(
+    () => activeVersion?.environments ?? [],
+    [activeVersion?.environments],
+  );
 
   const isChatPrompt =
     prompt?.template_structure === PROMPT_TEMPLATE_STRUCTURE.CHAT;
@@ -259,12 +263,17 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
                 size="sm"
                 className="w-full justify-between font-normal"
               >
-                <span className="flex min-w-0 items-center gap-2 truncate">
-                  <span className="comet-body-s-accented text-foreground">
+                <span className="flex min-w-0 items-center gap-2">
+                  <span className="comet-body-s-accented shrink-0 text-foreground">
                     {activeVersionLabel || "v—"}
                   </span>
-                  <EnvironmentBadge name={activeVersionEnvironment} size="sm" />
-                  <span className="comet-body-xs text-muted-slate">
+                  <EnvironmentBadgeList
+                    names={activeVersionEnvironments}
+                    size="sm"
+                    withOverflow
+                    maxWidth={200}
+                  />
+                  <span className="comet-body-xs shrink-0 text-muted-slate">
                     {activeVersion?.created_at &&
                       getTimeFromNow(activeVersion.created_at)}
                   </span>
@@ -290,7 +299,13 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
                     <span className="comet-body-s-accented shrink-0">
                       {item.label}
                     </span>
-                    <EnvironmentBadge name={item.environment} size="sm" />
+                    <EnvironmentBadgeList
+                      names={item.environments}
+                      size="sm"
+                      withOverflow
+                      compact
+                      maxWidth={120}
+                    />
                   </div>
                   <span className="comet-body-xs text-muted-slate">
                     {getTimeFromNow(item.created_at)}
@@ -303,16 +318,21 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
         </div>
         <div className="rounded-md border bg-background">
           {/* Toolbar */}
-          <div className="flex flex-wrap items-center gap-2 px-4 pb-1.5 pt-3">
-            <div className="flex items-center gap-2">
-              <span className="comet-body-accented text-foreground">
+          <div className="flex items-center gap-2 px-4 pb-1.5 pt-3">
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              <span className="comet-body-accented shrink-0 text-foreground">
                 {activeVersionLabel || "v—"}
               </span>
               {activeStage && <StageTag value={activeStage} size="sm" />}
-              <EnvironmentBadge name={activeVersionEnvironment} size="sm" />
+              <EnvironmentBadgeList
+                names={activeVersionEnvironments}
+                size="sm"
+                withOverflow
+                maxWidth={320}
+              />
               {historyItems.length > 1 && (
                 <>
-                  <Separator orientation="vertical" className="mx-1 h-4" />
+                  <Separator orientation="vertical" className="mx-1 h-4 shrink-0" />
                   <DiffVersionMenu
                     currentItemId={effectiveVersionId}
                     versions={historyItems}
@@ -323,7 +343,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
               )}
             </div>
 
-            <div className="flex flex-wrap items-center gap-1 md:ml-auto">
+            <div className="flex shrink-0 flex-wrap items-center gap-1 md:ml-auto">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button variant="ghost" size="sm" className="px-0">
@@ -365,6 +385,20 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
                   <ImproveInPlaygroundButton
                     prompt={prompt}
                     activeVersion={activeVersion}
+                  />
+                </>
+              )}
+
+              {canConfigureWorkspaceSettings && (
+                <>
+                  <Separator orientation="vertical" className="mx-1 h-4" />
+                  <DeployToEnvironmentMenu
+                    promptId={prompt.id}
+                    versionId={effectiveVersionId}
+                    versionLabel={activeVersionLabel}
+                    versions={versions}
+                    totalVersions={total}
+                    activeEnvironments={activeVersionEnvironments}
                   />
                 </>
               )}


### PR DESCRIPTION
## Details

<img width="1507" height="691" alt="image" src="https://github.com/user-attachments/assets/38a0dfda-3178-4ed2-806b-5ba2c9edfb02" />
<img width="1498" height="737" alt="image" src="https://github.com/user-attachments/assets/fb45624b-0364-4a81-8ccd-fcece855f5dc" />
<img width="1443" height="679" alt="image" src="https://github.com/user-attachments/assets/28fecc54-6084-498c-9c2f-d08c5b4a3741" />
<img width="1506" height="733" alt="image" src="https://github.com/user-attachments/assets/d8fbd902-1139-48a4-a97e-449934555864" />


Bring multi-environment support to the prompt-facing surfaces of the frontend: render assigned environments next to every prompt-version reference, with a single-line `+N` overflow pattern that scales from the wide prompt page toolbar down to narrow dropdown rows.

- New `EnvironmentBadgeList` with three render modes: default flex-wrap, `withOverflow` + `maxWidth` for stable measurement (blueprint-style), and `compact` (colored squares with name tooltip + matching `+N` chip)
- Env badges wired into: prompt page toolbar (desktop + mobile), version history timeline, prompt library menu (rows + version submenu), compare-against popup, diff view column headers, agent runner prompt card (selector + dropdown), and the trace view prompt card
- Compact `PromptsSelectBox` now opt-in plumbs `versionId` through to `LLMPromptMessageActions`, so the playground text-prompt loader honors the version the user picked instead of always loading latest
- Fix off-by-one gap miscount in `useVisibleItemsByWidth` so a perfectly fitting container correctly reports all items as visible (also benefits `VersionTagList`)
- Agent runner version dropdown is scrollable (`max-h-[40vh]`); Deploy-to-environment menu drops the purple selected-row background
- Consolidate the env-by-name lookup into a shared `useEnvironmentByName` hook; `CompactEnvSquare` moved next to its sibling `EnvironmentSquare` and exported as `EnvironmentSquareWithTooltip`

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6626

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (claude.com/claude-code)
- Model(s): Claude Opus 4.7 (1M context)
- Scope: Implementation of UI changes, component refactor, and bug fix in `useVisibleItemsByWidth`. Author reviewed every diff and iterated on UX in the IDE.
- Human verification: Author iterated on layout/sizing in-browser; typecheck run after each change.

## Testing

- `npx tsc --project tsconfig.json --noEmit` — passes after every change
- Scenarios validated visually in the IDE/browser:
  - Prompt page toolbar: env badges fit on one line with overflow → `+N`; no gap between badges and the diff separator at any width
  - Version history timeline: per-version env list overflows correctly inside the narrow xl side panel
  - Prompt library menu: compact env squares in rows + version submenu (320px / 220px popovers)
  - Agent runner card: env squares on the version trigger and inside each dropdown row; long version lists scroll
  - Compare-against popup: env badges in each row (compact + tooltip)
  - Diff view column headers: full env badges with single-line overflow
  - Trace view prompt card: env badges next to the version label
  - Playground per-message text loader: version submenu now appears and selected version is actually applied (not silently dropped to latest)
- Tests not run: `npm test` / `npm run lint` — please confirm during CI


## Documentation
n/a