### PR TITLE
[OPIK-4909] [BE] fix: use pre-computed gen_ai.usage.cost from OTel

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static com.comet.opik.domain.mapping.OpenTelemetryEventsMapper.processEvents;
+import static com.comet.opik.domain.mapping.OpenTelemetryMappingUtils.extractCost;
 import static com.comet.opik.domain.mapping.OpenTelemetryMappingUtils.extractTags;
 import static com.comet.opik.domain.mapping.OpenTelemetryMappingUtils.extractToJsonColumn;
 import static com.comet.opik.domain.mapping.OpenTelemetryMappingUtils.extractUsageField;
@@ -155,6 +156,10 @@ public class OpenTelemetryMapper {
 
                 case USAGE :
                     extractUsageField(usage, rule, key, value);
+                    break;
+
+                case COST :
+                    extractCost(value).ifPresent(spanBuilder::totalEstimatedCost);
                     break;
 
                 case INPUT :

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingRule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingRule.java
@@ -44,6 +44,7 @@ public class OpenTelemetryMappingRule {
         MODEL, // Attribute sets the model field
         PROVIDER, // Attribute sets the provider field
         USAGE, // Attribute contributes to usage map
+        COST, // Attribute sets the span's total estimated cost directly (authoritative, bypasses cost calculation)
         TAGS, // Attribute contributes to tag set
         THREAD_ID, // Attribute sets the threadId for trace grouping (e.g., gen_ai.conversation.id)
         DROP // Attribute should be ignored

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingUtils.java
@@ -112,11 +112,20 @@ public class OpenTelemetryMappingUtils {
      */
     public static Optional<BigDecimal> extractCost(@NonNull AnyValue value) {
         return switch (value.getValueCase()) {
-            case DOUBLE_VALUE -> Optional.of(BigDecimal.valueOf(value.getDoubleValue()));
+            case DOUBLE_VALUE -> {
+                // BigDecimal.valueOf throws NumberFormatException for NaN / Infinity, which would
+                // abort span enrichment for the whole batch. Treat non-finite values as unsupported.
+                double d = value.getDoubleValue();
+                if (!Double.isFinite(d)) {
+                    log.warn("Non-finite cost value, skipping: '{}'", d);
+                    yield Optional.empty();
+                }
+                yield Optional.of(BigDecimal.valueOf(d));
+            }
             case INT_VALUE -> Optional.of(BigDecimal.valueOf(value.getIntValue()));
             case STRING_VALUE -> parseCostString(value.getStringValue());
             default -> {
-                log.warn("Unsupported value type for cost extraction: {}", value.getValueCase());
+                log.warn("Unsupported value type for cost extraction: '{}'", value.getValueCase());
                 yield Optional.empty();
             }
         };

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingUtils.java
@@ -112,17 +112,8 @@ public class OpenTelemetryMappingUtils {
      */
     public static Optional<BigDecimal> extractCost(@NonNull AnyValue value) {
         return switch (value.getValueCase()) {
-            case DOUBLE_VALUE -> {
-                // BigDecimal.valueOf throws NumberFormatException for NaN / Infinity, which would
-                // abort span enrichment for the whole batch. Treat non-finite values as unsupported.
-                double d = value.getDoubleValue();
-                if (!Double.isFinite(d)) {
-                    log.warn("Non-finite cost value, skipping: '{}'", d);
-                    yield Optional.empty();
-                }
-                yield Optional.of(BigDecimal.valueOf(d));
-            }
-            case INT_VALUE -> Optional.of(BigDecimal.valueOf(value.getIntValue()));
+            case DOUBLE_VALUE -> parseCostDouble(value.getDoubleValue());
+            case INT_VALUE -> parseCostInt(value.getIntValue());
             case STRING_VALUE -> parseCostString(value.getStringValue());
             default -> {
                 log.warn("Unsupported value type for cost extraction: '{}'", value.getValueCase());
@@ -131,11 +122,31 @@ public class OpenTelemetryMappingUtils {
         };
     }
 
+    private static Optional<BigDecimal> parseCostDouble(double value) {
+        // BigDecimal.valueOf throws NumberFormatException for NaN / Infinity. Wider catch keeps
+        // cost extraction non-fatal regardless of how the conversion fails in the future.
+        try {
+            return Optional.of(BigDecimal.valueOf(value));
+        } catch (RuntimeException e) {
+            log.warn("Failed to parse cost double value '{}'", value);
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<BigDecimal> parseCostInt(long value) {
+        try {
+            return Optional.of(BigDecimal.valueOf(value));
+        } catch (RuntimeException e) {
+            log.warn("Failed to parse cost int value '{}'", value);
+            return Optional.empty();
+        }
+    }
+
     private static Optional<BigDecimal> parseCostString(String stringValue) {
         try {
-            return Optional.of(new BigDecimal(stringValue.trim()));
-        } catch (NumberFormatException e) {
-            log.debug("Failed to parse cost string value '{}' as a number", stringValue);
+            return Optional.of(new BigDecimal(stringValue.strip()));
+        } catch (RuntimeException e) {
+            log.warn("Failed to parse cost string value '{}' as a number", stringValue);
             return Optional.empty();
         }
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingUtils.java
@@ -9,9 +9,11 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.UncheckedIOException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -97,6 +99,35 @@ public class OpenTelemetryMappingUtils {
                 // extracting from a JSON object
                 tryExtractUsageFromJsonObject(usage, key, value.getStringValue());
             }
+        }
+    }
+
+    /**
+     * Extracts a pre-computed cost value from an AnyValue. Some integrations (e.g. LiteLLM) send the
+     * exact request cost as a float attribute; we use it as the authoritative cost instead of recalculating.
+     * Supports double, integer, and numeric string values.
+     *
+     * @param value the AnyValue containing the cost
+     * @return the parsed cost, or empty if the value is not a parseable number
+     */
+    public static Optional<BigDecimal> extractCost(@NonNull AnyValue value) {
+        return switch (value.getValueCase()) {
+            case DOUBLE_VALUE -> Optional.of(BigDecimal.valueOf(value.getDoubleValue()));
+            case INT_VALUE -> Optional.of(BigDecimal.valueOf(value.getIntValue()));
+            case STRING_VALUE -> parseCostString(value.getStringValue());
+            default -> {
+                log.warn("Unsupported value type for cost extraction: {}", value.getValueCase());
+                yield Optional.empty();
+            }
+        };
+    }
+
+    private static Optional<BigDecimal> parseCostString(String stringValue) {
+        try {
+            return Optional.of(new BigDecimal(stringValue.trim()));
+        } catch (NumberFormatException e) {
+            log.debug("Failed to parse cost string value '{}' as a number", stringValue);
+            return Optional.empty();
         }
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingUtils.java
@@ -127,8 +127,8 @@ public class OpenTelemetryMappingUtils {
         // cost extraction non-fatal regardless of how the conversion fails in the future.
         try {
             return Optional.of(BigDecimal.valueOf(value));
-        } catch (RuntimeException e) {
-            log.warn("Failed to parse cost double value '{}'", value);
+        } catch (RuntimeException exception) {
+            log.warn("Failed to parse cost double value '{}'", value, exception);
             return Optional.empty();
         }
     }
@@ -136,8 +136,8 @@ public class OpenTelemetryMappingUtils {
     private static Optional<BigDecimal> parseCostInt(long value) {
         try {
             return Optional.of(BigDecimal.valueOf(value));
-        } catch (RuntimeException e) {
-            log.warn("Failed to parse cost int value '{}'", value);
+        } catch (RuntimeException exception) {
+            log.warn("Failed to parse cost int value '{}'", value, exception);
             return Optional.empty();
         }
     }
@@ -145,8 +145,8 @@ public class OpenTelemetryMappingUtils {
     private static Optional<BigDecimal> parseCostString(String stringValue) {
         try {
             return Optional.of(new BigDecimal(stringValue.strip()));
-        } catch (RuntimeException e) {
-            log.warn("Failed to parse cost string value '{}' as a number", stringValue);
+        } catch (RuntimeException exception) {
+            log.warn("Failed to parse cost string value '{}' as a number", stringValue, exception);
             return Optional.empty();
         }
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/GenAIMappingRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/GenAIMappingRules.java
@@ -46,6 +46,9 @@ public final class GenAIMappingRules {
                     .rule("gen_ai.system").source(SOURCE).outcome(OpenTelemetryMappingRule.Outcome.PROVIDER)
                     .spanType(SpanType.llm).build(),
             OpenTelemetryMappingRule.builder()
+                    .rule("gen_ai.usage.cost").source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.COST).spanType(SpanType.llm).build(),
+            OpenTelemetryMappingRule.builder()
                     .rule("gen_ai.usage.").isPrefix(true).source(SOURCE)
                     .outcome(OpenTelemetryMappingRule.Outcome.USAGE).spanType(SpanType.llm).build(),
             OpenTelemetryMappingRule.builder()

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -225,56 +225,13 @@ class OpenTelemetryMapperTest {
     void genAiUsageCostExtractedIntoTotalEstimatedCost(String label, AnyValue costValue, BigDecimal expected) {
         // Pre-computed cost from gen_ai.usage.cost lands on the span's totalEstimatedCost for every
         // supported value shape. Malformed values (non-finite doubles, unparseable strings) are
-        // skipped so they never abort span enrichment.
+        // skipped so they never abort span enrichment. Sibling token attributes still populate the
+        // integer-only usage map without a 'cost' key — guarding against the original bug where the
+        // double cost was routed there and silently dropped.
         var attributes = List.of(
                 KeyValue.newBuilder()
                         .setKey("gen_ai.usage.cost")
                         .setValue(costValue)
-                        .build());
-
-        var spanBuilder = Span.builder()
-                .id(UUID.randomUUID())
-                .traceId(UUID.randomUUID())
-                .projectId(UUID.randomUUID())
-                .startTime(Instant.now());
-
-        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
-
-        var span = spanBuilder.build();
-
-        if (expected == null) {
-            assertThat(span.totalEstimatedCost()).isNull();
-        } else {
-            assertThat(span.totalEstimatedCost()).isEqualByComparingTo(expected);
-        }
-    }
-
-    static Stream<Arguments> genAiUsageCostCases() {
-        return Stream.of(
-                Arguments.of("double", AnyValue.newBuilder().setDoubleValue(0.001234).build(),
-                        new BigDecimal("0.001234")),
-                Arguments.of("int", AnyValue.newBuilder().setIntValue(1).build(),
-                        new BigDecimal("1")),
-                Arguments.of("numeric string", AnyValue.newBuilder().setStringValue("0.005").build(),
-                        new BigDecimal("0.005")),
-                Arguments.of("non-numeric string",
-                        AnyValue.newBuilder().setStringValue("not a number").build(), null),
-                Arguments.of("NaN", AnyValue.newBuilder().setDoubleValue(Double.NaN).build(), null),
-                Arguments.of("positive infinity",
-                        AnyValue.newBuilder().setDoubleValue(Double.POSITIVE_INFINITY).build(), null),
-                Arguments.of("negative infinity",
-                        AnyValue.newBuilder().setDoubleValue(Double.NEGATIVE_INFINITY).build(), null));
-    }
-
-    @Test
-    void testGenAiUsageCostDoesNotPolluteUsageMap() {
-        // Regression guard for the original bug: gen_ai.usage.cost (a double) used to be routed
-        // to the integer-only usage map and silently dropped. The cost goes to totalEstimatedCost
-        // while sibling token attributes still populate the usage map with no 'cost' key.
-        var attributes = List.of(
-                KeyValue.newBuilder()
-                        .setKey("gen_ai.usage.cost")
-                        .setValue(AnyValue.newBuilder().setDoubleValue(0.001234))
                         .build(),
                 KeyValue.newBuilder()
                         .setKey("gen_ai.usage.prompt_tokens")
@@ -285,20 +242,48 @@ class OpenTelemetryMapperTest {
                         .setValue(AnyValue.newBuilder().setIntValue(50))
                         .build());
 
-        var spanBuilder = Span.builder()
-                .id(UUID.randomUUID())
-                .traceId(UUID.randomUUID())
-                .projectId(UUID.randomUUID())
-                .startTime(Instant.now());
+        var spanBuilder = newSpanBuilder();
 
         OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
 
         var span = spanBuilder.build();
 
-        assertThat(span.totalEstimatedCost()).isEqualByComparingTo("0.001234");
+        if (expected == null) {
+            assertThat(span.totalEstimatedCost()).isNull();
+        } else {
+            assertThat(span.totalEstimatedCost()).isEqualByComparingTo(expected);
+        }
         assertThat(span.usage()).doesNotContainKey("cost");
         assertThat(span.usage().get("prompt_tokens")).isEqualTo(100);
         assertThat(span.usage().get("completion_tokens")).isEqualTo(50);
+    }
+
+    static Stream<Arguments> genAiUsageCostCases() {
+        return Stream.of(
+                Arguments.of("double", AnyValue.newBuilder().setDoubleValue(0.001234).build(),
+                        new BigDecimal("0.001234")),
+                Arguments.of("int", AnyValue.newBuilder().setIntValue(1).build(),
+                        new BigDecimal("1")),
+                Arguments.of("numeric string", AnyValue.newBuilder().setStringValue("0.005").build(),
+                        new BigDecimal("0.005")),
+                Arguments.of("numeric string with whitespace",
+                        AnyValue.newBuilder().setStringValue("  0.005  ").build(),
+                        new BigDecimal("0.005")),
+                Arguments.of("non-numeric string",
+                        AnyValue.newBuilder().setStringValue("not a number").build(), null),
+                Arguments.of("NaN", AnyValue.newBuilder().setDoubleValue(Double.NaN).build(), null),
+                Arguments.of("positive infinity",
+                        AnyValue.newBuilder().setDoubleValue(Double.POSITIVE_INFINITY).build(), null),
+                Arguments.of("negative infinity",
+                        AnyValue.newBuilder().setDoubleValue(Double.NEGATIVE_INFINITY).build(), null));
+    }
+
+    private static Span.SpanBuilder newSpanBuilder() {
+        return Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .startTime(Instant.now());
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1,6 +1,7 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.Span;
+import com.comet.opik.podam.PodamFactoryUtils;
 import com.fasterxml.uuid.Generators;
 import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 import com.google.protobuf.ByteString;
@@ -12,6 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.co.jemos.podam.api.PodamFactory;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -22,6 +24,8 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class OpenTelemetryMapperTest {
+
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
 
     @Test
     void testThreadIdMappingRule() {
@@ -278,12 +282,13 @@ class OpenTelemetryMapperTest {
                         AnyValue.newBuilder().setDoubleValue(Double.NEGATIVE_INFINITY).build(), null));
     }
 
-    private static Span.SpanBuilder newSpanBuilder() {
-        return Span.builder()
-                .id(UUID.randomUUID())
-                .traceId(UUID.randomUUID())
-                .projectId(UUID.randomUUID())
-                .startTime(Instant.now());
+    private Span.SpanBuilder newSpanBuilder() {
+        // PODAM fills in id / traceId / projectId / startTime and every other field with random
+        // values; null out totalEstimatedCost because enrich only sets it on successful extraction,
+        // so the malformed/non-finite cost cases would otherwise inherit PODAM's random BigDecimal.
+        return podamFactory.manufacturePojo(Span.class)
+                .toBuilder()
+                .totalEstimatedCost(null);
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -9,11 +9,15 @@ import io.opentelemetry.proto.common.v1.KeyValue;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -216,10 +220,57 @@ class OpenTelemetryMapperTest {
         assertThat(span.input()).isNull();
     }
 
+    @ParameterizedTest(name = "gen_ai.usage.cost as {0} -> {2}")
+    @MethodSource("genAiUsageCostCases")
+    void genAiUsageCostExtractedIntoTotalEstimatedCost(String label, AnyValue costValue, BigDecimal expected) {
+        // Pre-computed cost from gen_ai.usage.cost lands on the span's totalEstimatedCost for every
+        // supported value shape. Malformed values (non-finite doubles, unparseable strings) are
+        // skipped so they never abort span enrichment.
+        var attributes = List.of(
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.usage.cost")
+                        .setValue(costValue)
+                        .build());
+
+        var spanBuilder = Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .startTime(Instant.now());
+
+        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
+
+        var span = spanBuilder.build();
+
+        if (expected == null) {
+            assertThat(span.totalEstimatedCost()).isNull();
+        } else {
+            assertThat(span.totalEstimatedCost()).isEqualByComparingTo(expected);
+        }
+    }
+
+    static Stream<Arguments> genAiUsageCostCases() {
+        return Stream.of(
+                Arguments.of("double", AnyValue.newBuilder().setDoubleValue(0.001234).build(),
+                        new BigDecimal("0.001234")),
+                Arguments.of("int", AnyValue.newBuilder().setIntValue(1).build(),
+                        new BigDecimal("1")),
+                Arguments.of("numeric string", AnyValue.newBuilder().setStringValue("0.005").build(),
+                        new BigDecimal("0.005")),
+                Arguments.of("non-numeric string",
+                        AnyValue.newBuilder().setStringValue("not a number").build(), null),
+                Arguments.of("NaN", AnyValue.newBuilder().setDoubleValue(Double.NaN).build(), null),
+                Arguments.of("positive infinity",
+                        AnyValue.newBuilder().setDoubleValue(Double.POSITIVE_INFINITY).build(), null),
+                Arguments.of("negative infinity",
+                        AnyValue.newBuilder().setDoubleValue(Double.NEGATIVE_INFINITY).build(), null));
+    }
+
     @Test
-    void testGenAiUsageCostAsDoubleSetsTotalEstimatedCost() {
-        // LiteLLM sends the pre-computed cost as a float gen_ai.usage.cost; it must be used directly
-        // and must NOT be routed into the integer-only usage map (where it was previously dropped).
+    void testGenAiUsageCostDoesNotPolluteUsageMap() {
+        // Regression guard for the original bug: gen_ai.usage.cost (a double) used to be routed
+        // to the integer-only usage map and silently dropped. The cost goes to totalEstimatedCost
+        // while sibling token attributes still populate the usage map with no 'cost' key.
         var attributes = List.of(
                 KeyValue.newBuilder()
                         .setKey("gen_ai.usage.cost")
@@ -248,28 +299,6 @@ class OpenTelemetryMapperTest {
         assertThat(span.usage()).doesNotContainKey("cost");
         assertThat(span.usage().get("prompt_tokens")).isEqualTo(100);
         assertThat(span.usage().get("completion_tokens")).isEqualTo(50);
-    }
-
-    @Test
-    void testGenAiUsageCostAsStringSetsTotalEstimatedCost() {
-        // LiteLLM may serialize the cost as a string; it must still be parsed into totalEstimatedCost
-        var attributes = List.of(
-                KeyValue.newBuilder()
-                        .setKey("gen_ai.usage.cost")
-                        .setValue(AnyValue.newBuilder().setStringValue("0.001234"))
-                        .build());
-
-        var spanBuilder = Span.builder()
-                .id(UUID.randomUUID())
-                .traceId(UUID.randomUUID())
-                .projectId(UUID.randomUUID())
-                .startTime(Instant.now());
-
-        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
-
-        var span = spanBuilder.build();
-
-        assertThat(span.totalEstimatedCost()).isEqualByComparingTo("0.001234");
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -217,6 +217,62 @@ class OpenTelemetryMapperTest {
     }
 
     @Test
+    void testGenAiUsageCostAsDoubleSetsTotalEstimatedCost() {
+        // LiteLLM sends the pre-computed cost as a float gen_ai.usage.cost; it must be used directly
+        // and must NOT be routed into the integer-only usage map (where it was previously dropped).
+        var attributes = List.of(
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.usage.cost")
+                        .setValue(AnyValue.newBuilder().setDoubleValue(0.001234))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.usage.prompt_tokens")
+                        .setValue(AnyValue.newBuilder().setIntValue(100))
+                        .build(),
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.usage.completion_tokens")
+                        .setValue(AnyValue.newBuilder().setIntValue(50))
+                        .build());
+
+        var spanBuilder = Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .startTime(Instant.now());
+
+        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
+
+        var span = spanBuilder.build();
+
+        assertThat(span.totalEstimatedCost()).isEqualByComparingTo("0.001234");
+        assertThat(span.usage()).doesNotContainKey("cost");
+        assertThat(span.usage().get("prompt_tokens")).isEqualTo(100);
+        assertThat(span.usage().get("completion_tokens")).isEqualTo(50);
+    }
+
+    @Test
+    void testGenAiUsageCostAsStringSetsTotalEstimatedCost() {
+        // LiteLLM may serialize the cost as a string; it must still be parsed into totalEstimatedCost
+        var attributes = List.of(
+                KeyValue.newBuilder()
+                        .setKey("gen_ai.usage.cost")
+                        .setValue(AnyValue.newBuilder().setStringValue("0.001234"))
+                        .build());
+
+        var spanBuilder = Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .startTime(Instant.now());
+
+        OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
+
+        var span = spanBuilder.build();
+
+        assertThat(span.totalEstimatedCost()).isEqualByComparingTo("0.001234");
+    }
+
+    @Test
     void testOldAndNewGenAiAttributesCoexist() {
         var attributes = List.of(
                 KeyValue.newBuilder()


### PR DESCRIPTION
## Details

<img width="1280" height="2400" alt="opik-4909-cost-flow" src="https://github.com/user-attachments/assets/07c4ded7-1600-4848-aa09-232d83977f72" />

Pre-computed `gen_ai.usage.cost` from LiteLLM (and similar OTel integrations) was silently dropped because it matched the broad `gen_ai.usage.` prefix rule and got routed to the integer-only usage map; Opik then recalculated cost from its own price table, diverging from what LiteLLM/Langfuse/PostHog report.

- Add new `Outcome.COST` and register an exact-match rule `gen_ai.usage.cost → COST` **before** the `gen_ai.usage.` prefix rule (`findRule()` returns the first match, so ordering is critical).
- `extractCost(AnyValue)` reads `DOUBLE_VALUE` / `INT_VALUE` / parseable `STRING_VALUE` into a `BigDecimal` and sets `spanBuilder.totalEstimatedCost(...)`; `SpanDAO` then stores the value as authoritative (`total_estimated_cost_version = ""`) and skips `calculateCost`.

<!-- diagram: drag-drop opik-4909-cost-flow.png here in the PR UI -->

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #5620
- OPIK-4909

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: implementation of the 4 backend edits, 2 unit tests, manual E2E verification (local + prod), and this PR description.
- Human verification: PR author reviewed the diff locally, ran the test suite, and performed manual end-to-end validation against both a local backend (with fix) and production (without fix) confirming the divergence.

## Testing

How you tested:

- `mvn test -Dtest='OpenTelemetryMapperTest,OpenTelemetryMappingUtilsTest'` (run from `apps/opik-backend`) — 51 + 40 tests, 0 failures, incl. 2 new `gen_ai.usage.cost` tests.
- `mvn spotless:apply` — clean, no formatting violations.
- Manual E2E **with fix** (local backend started via `./scripts/dev-runner.sh --restart`): POST an OTel span with `gen_ai.usage.cost = 0.424242`, `gen_ai.request.model = gpt-4o`, 100 prompt + 50 completion tokens to `http://localhost:8080/v1/private/otel/v1/traces`. Stored span: `total_estimated_cost = 0.424242`, `total_estimated_cost_version = ""` (authoritative); usage map = `{prompt_tokens: 100, completion_tokens: 50, total_tokens: 150}` (no `cost` key — confirms it did not leak into the integer usage map).
- Manual E2E **without fix** (production, against author's personal workspace): identical payload → stored `total_estimated_cost = 0.000750`, exactly Opik's bundled gpt-4o recalculation (`100 × $2.50/1M + 50 × $10/1M = $0.000750`). This confirms the bug today and that the fix changes the behavior.
- Scenarios validated: cost as `DOUBLE_VALUE`, cost as numeric `STRING_VALUE`, cost does not pollute the usage map, sibling token attributes preserved, `total_tokens` auto-computation still works.
- Environment: local process mode (backend Java + frontend Vite) via `dev-runner.sh`, plus a cloud comparison against production over HTTPS.
- Not run: the full containerized integration test suite for the backend (Testcontainers heavyweight; this change is purely additive in the attribute mapper and is fully covered by the unit tests above).

Video evidence: N/A (backend-only data-mapping fix; values verified by API readback shown above).

## Documentation

No user-facing documentation changes required. The OTel integration page already lists `gen_ai.usage.cost` as a supported attribute; this PR makes that attribute respected rather than dropped, with no API surface change.