### PR TITLE
[NA] [BE][FE] feat: surface prompt version_number, rename "commit" to "version" in prompt UI

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Experiment.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Experiment.java
@@ -107,6 +107,8 @@ public record Experiment(
     public record PromptVersionLink(@JsonView({
             Experiment.View.Public.class, Experiment.View.Write.class}) @NotNull UUID id,
             @JsonView({Experiment.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String commit,
+            @JsonView({
+                    Experiment.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "sequential version number in the format v<N>; null for masks") String versionNumber,
             @JsonView({Experiment.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) UUID promptId,
             @JsonView({
                     Experiment.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String promptName) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentService.java
@@ -258,6 +258,7 @@ public class ExperimentService {
         return new PromptVersionLink(
                 version.id(),
                 info != null ? info.commit() : null,
+                info != null ? info.versionNumber() : null,
                 version.promptId(),
                 info != null ? info.promptName() : null);
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptVersionDAO.java
@@ -318,7 +318,7 @@ interface PromptVersionDAO {
     }
 
     @SqlQuery("""
-            SELECT pv.id, pv.commit, p.name AS prompt_name
+            SELECT pv.id, pv.commit, pv.version_number, p.name AS prompt_name
             FROM prompt_versions pv
             INNER JOIN prompts p ON pv.prompt_id = p.id
             WHERE pv.id IN (<ids>) AND pv.workspace_id = :workspace_id

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptVersionInfo.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptVersionInfo.java
@@ -2,5 +2,5 @@ package com.comet.opik.domain;
 
 import java.util.UUID;
 
-public record PromptVersionInfo(UUID id, String commit, String promptName) {
+public record PromptVersionInfo(UUID id, String commit, String versionNumber, String promptName) {
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -3186,6 +3186,7 @@ class DatasetsResourceTest {
                                                 .promptId(promptVersion.promptId())
                                                 .id(promptVersion.id())
                                                 .commit(promptVersion.commit())
+                                                .versionNumber(promptVersion.versionNumber())
                                                 .build())
                                 .build();
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceFindProjectExperimentsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceFindProjectExperimentsTest.java
@@ -157,6 +157,7 @@ class ExperimentsResourceFindProjectExperimentsTest {
         return PromptVersionLink.builder()
                 .id(promptVersion.id())
                 .commit(promptVersion.commit())
+                .versionNumber(promptVersion.versionNumber())
                 .promptId(promptVersion.promptId())
                 .promptName(promptName)
                 .build();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -4059,6 +4059,7 @@ class ExperimentsResourceTest {
         return PromptVersionLink.builder()
                 .id(promptVersion.id())
                 .commit(promptVersion.commit())
+                .versionNumber(promptVersion.versionNumber())
                 .promptId(promptVersion.promptId())
                 .promptName(promptName)
                 .build();
@@ -4750,7 +4751,7 @@ class ExperimentsResourceTest {
             var promptVersion = promptResourceClient.createPromptVersion(prompt, API_KEY, TEST_WORKSPACE);
 
             var versionLink = new PromptVersionLink(promptVersion.id(), promptVersion.commit(),
-                    promptVersion.promptId(), promptName);
+                    promptVersion.versionNumber(), promptVersion.promptId(), promptName);
 
             var expectedExperiment = experimentResourceClient.createPartialExperiment()
                     .promptVersion(versionLink)
@@ -4818,7 +4819,8 @@ class ExperimentsResourceTest {
         @Test
         void createWithInvalidPromptVersionId() {
             var experiment = experimentResourceClient.createPartialExperiment()
-                    .promptVersion(new PromptVersionLink(GENERATOR.generate(), null, GENERATOR.generate(), null))
+                    .promptVersion(
+                            new PromptVersionLink(GENERATOR.generate(), null, null, GENERATOR.generate(), null))
                     .datasetVersionId(null)
                     .datasetVersionSummary(null)
                     .build();

--- a/apps/opik-frontend/src/types/datasets.ts
+++ b/apps/opik-frontend/src/types/datasets.ts
@@ -120,6 +120,7 @@ export interface ExperimentOutputColumn {
 export interface ExperimentPromptVersion {
   id: string;
   commit: string;
+  version_number?: string;
   prompt_id: string;
   prompt_name: string;
 }

--- a/apps/opik-frontend/src/types/prompts.ts
+++ b/apps/opik-frontend/src/types/prompts.ts
@@ -39,6 +39,7 @@ export interface PromptVersion {
   template: string;
   metadata: object;
   commit: string;
+  version_number?: string;
   change_description?: string;
   prompt_id: string;
   created_at: string;

--- a/apps/opik-frontend/src/v2/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
@@ -37,6 +37,7 @@ import { transformExperimentScores } from "@/lib/feedback-scores";
 import useGroupedExperimentsList, {
   GroupedExperiment,
 } from "@/hooks/useGroupedExperimentsList";
+import { ExperimentPromptVersion } from "@/types/datasets";
 import {
   COLUMN_DATASET_ID,
   COLUMN_METADATA_ID,
@@ -179,10 +180,16 @@ const ExperimentsTab: React.FC<ExperimentsTabProps> = ({ promptId }) => {
         id: "prompt",
         label: "Prompt version",
         type: COLUMN_TYPE.list,
-        accessorFn: (row) => get(row, ["prompt_versions"], []),
+        accessorFn: (row) =>
+          (get(row, ["prompt_versions"], []) as ExperimentPromptVersion[]).map(
+            (v) => ({
+              ...v,
+              version_label: v.version_number ?? v.commit,
+            }),
+          ),
         cell: MultiResourceCell as never,
         customMeta: {
-          nameKey: "commit",
+          nameKey: "version_label",
           idKey: "prompt_id",
           resource: RESOURCE_TYPE.prompt,
           getSearch: (data: GroupedExperiment) => ({

--- a/apps/opik-frontend/src/v2/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/ExperimentsTab/ExperimentsTab.tsx
@@ -177,7 +177,7 @@ const ExperimentsTab: React.FC<ExperimentsTabProps> = ({ promptId }) => {
       },
       {
         id: "prompt",
-        label: "Prompt commit",
+        label: "Prompt version",
         type: COLUMN_TYPE.list,
         accessorFn: (row) => get(row, ["prompt_versions"], []),
         cell: MultiResourceCell as never,
@@ -189,7 +189,6 @@ const ExperimentsTab: React.FC<ExperimentsTabProps> = ({ promptId }) => {
             activeVersionId: get(data, "id", null),
           }),
         },
-        explainer: EXPLAINERS_MAP[EXPLAINER_ID.whats_a_prompt_commit],
       },
       {
         id: COLUMN_ID_ID,

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/EditPromptSheet.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/EditPromptSheet.tsx
@@ -155,7 +155,7 @@ const EditPromptSheet: React.FC<EditPromptSheetProps> = ({
             disabled={!isValid || isSaving}
             onClick={handleClickEditPrompt}
           >
-            Create new commit
+            Create new version
           </Button>
         </div>
       </SheetContent>


### PR DESCRIPTION
## Details

User-facing rename of "commit" → "version" in the prompt UI, plus the BE plumbing needed to display real version labels (`v1`, `v2`, …) instead of commit hashes in the prompt-page Experiments tab.

**Frontend:**
- `EditPromptSheet`: "Create new commit" button → "Create new version"
- `PromptPage → Experiments` tab: column header `Prompt commit` → `Prompt version`, and the cell now renders `version_number` (falls back to commit hash when null, i.e. for masks). Removes the now-redundant `whats_a_prompt_commit` explainer on that column.
- Type additions for `version_number` on `ExperimentPromptVersion` and `PromptVersion`.

**Backend:**
- `Experiment.PromptVersionLink` record gains a `versionNumber` field (read-only, snake-cased to `version_number` in the JSON response).
- `PromptVersionInfo` + `PromptVersionDAO.findPromptVersionInfoByVersionsIds` now select and carry `pv.version_number`.
- `ExperimentService#enrichPromptVersionLink` passes the value through.
- Test helpers/builders (`ExperimentsResourceTest`, `ExperimentsResourceFindProjectExperimentsTest`, `DatasetsResourceTest`) populate `versionNumber` so recursive-comparison assertions stay green.


<img width="544" height="195" alt="Screenshot 2026-05-28 at 11 18 23" src="https://github.com/user-attachments/assets/96ad083a-8f60-4401-9c93-e35f9d00f892" />



## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: assisted (string edits, BE record/DAO plumbing, audit of remaining "commit" references)
- Human verification: code review + manual UI check pending

## Testing

- `npm run lint` and `npm run typecheck` (FE) — pass
- `mvn -DskipTests compile` and `mvn -DskipTests test-compile` (BE) — pass
- Manual UI verification: BE restart required to see `version_number` in the Experiments tab; label-rename surfaces verified locally before BE plumbing was added.

## Documentation

N/A — user-visible label change + additive API field.