### PR TITLE
[OPIK-0000][BE] Add environment to promptVersion for backward compatibility

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersion.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersion.java
@@ -51,6 +51,8 @@ public record PromptVersion(
         @JsonView({PromptVersion.View.Public.class, Prompt.View.Detail.class,
                 PromptVersion.View.Detail.class}) @Schema(description = "version type discriminator; defaults to prompt_version") PromptVersionType versionType,
         @JsonView({PromptVersion.View.Public.class, Prompt.View.Detail.class,
+                PromptVersion.View.Detail.class}) @Deprecated @Schema(deprecated = true, description = "Deprecated: use 'environments' instead") @Nullable @Pattern(regexp = Environment.NAME_PATTERN, message = Environment.NAME_PATTERN_MESSAGE) @Size(max = 150, message = "cannot exceed 150 characters") String environment,
+        @JsonView({PromptVersion.View.Public.class, Prompt.View.Detail.class,
                 PromptVersion.View.Detail.class}) @Nullable @Size(max = 100, message = "cannot exceed 100 environments") Set<@Pattern(regexp = Environment.NAME_PATTERN, message = Environment.NAME_PATTERN_MESSAGE) @Size(max = 150, message = "cannot exceed 150 characters") String> environments,
         @JsonView({PromptVersion.View.Public.class, Prompt.View.Detail.class,
                 PromptVersion.View.Detail.class}) String changeDescription,


### PR DESCRIPTION
## Details
Add environment to promptVersion for backward compatibility

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-0000

## AI-WATERMARK

AI-WATERMARK: no

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
<!--
REPLACE ME WITH:

How you tested

Include:
- Exact commands run (for example: `mvn test`, `npm run lint && npm run test`, `pytest ...`)
- Scenarios validated (happy path, edge cases, regressions)
- Environment/context used (local process mode vs Docker, OS/browser when relevant)
- Any tests not run, with reason
- Relevant logs/artifacts links if available

Video evidence:
- External contributors: include a short recording for all contributions where possible.
- Internal contributors: include a short recording for complex changes where possible.
-->

## Documentation
