### PR TITLE
[OPIK-6707] [CI] feat: v2 E2E post-merge workflow + deprecate v1 triggers

### DIFF
--- a/.github/workflows/e2e_tests_post_merge_v2.yml
+++ b/.github/workflows/e2e_tests_post_merge_v2.yml
@@ -1,32 +1,30 @@
-name: E2E Tests - Post Merge [DEPRECATED — v1]
-run-name: "E2E Tests v1 (${{ github.event.inputs.suite || 'happypaths' }}) - Manual run by @${{ github.actor }}"
-
-# DEPRECATED: replaced by e2e_tests_post_merge_v2.yml (OPIK-6707).
-# push-to-main and self-pull_request triggers removed; left dispatchable for
-# grace-period manual runs against the v1 suite.
+name: E2E Tests - Post Merge (v2)
+run-name: "E2E Tests v2 (${{ github.event.inputs.tier || 't1' }}) - ${{ github.event_name == 'push' && format('Post-merge {0}', github.sha) || format('Manual run by @{0}', github.actor) }}"
 
 on:
+  push:
+    branches:
+      - 'main'
+    # Skip workflow if only documentation or unrelated files changed
+    paths-ignore:
+      - '**.md'
+      - 'apps/opik-documentation/**'
+
+  pull_request:
+    paths:
+      - '.github/workflows/e2e_tests_post_merge_v2.yml'
+
   workflow_dispatch:
     inputs:
-      suite:
+      tier:
         type: choice
-        description: 'Test suite to run'
+        description: 'Which tag tier to run (t1=smoke, t2=cuj, t3=nightly)'
         required: true
-        default: 'happypaths'
+        default: 't1'
         options:
-          - sanity
-          - happypaths
-          - fullregression
-          - projects
-          - tracing
-          - threads
-          - attachments
-          - datasets
-          - experiments
-          - prompts
-          - playground
-          - feedbackscores
-          - onlinescores
+          - t1
+          - t2
+          - t3
       notify_on_success:
         type: boolean
         description: 'Send Slack notification even on success'
@@ -42,7 +40,7 @@ env:
   ALLURE_PROJECT_ID: 1
   ALLURE_RESULTS: allure-results
   ALLURE_JOB_RUN_ID: ${{ github.event.inputs.ALLURE_JOB_RUN_ID }}
-  
+
   OPIK_SENTRY_ENABLE: false
 
 permissions:
@@ -51,7 +49,7 @@ permissions:
 
 jobs:
   e2e-tests:
-    name: "🧪 E2E Tests (${{ github.event.inputs.suite || 'happypaths' }})"
+    name: "🧪 E2E v2 Tests (${{ github.event.inputs.tier || 't1' }})"
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -91,24 +89,25 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: tests_end_to_end/typescript-tests/package-lock.json
+          cache-dependency-path: tests_end_to_end/e2e/package-lock.json
 
       - name: "🐍 Setup Python"
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
-      - name: "📚 Install Opik Python SDK"
-        run: pip install ${{ github.workspace }}/sdks/python
+      - name: "⚡ Setup uv"
+        uses: astral-sh/setup-uv@v5
 
-      - name: "📚 Install Test Helper Service dependencies"
-        run: pip install -r ${{ github.workspace }}/tests_end_to_end/test-helper-service/requirements.txt
-
-      - name: "📚 Install TypeScript test dependencies"
-        working-directory: tests_end_to_end/typescript-tests
+      - name: "📚 Install E2E test dependencies"
+        working-directory: tests_end_to_end/e2e
         run: |
           npm ci
-          npx playwright install chromium
+          npx playwright install --with-deps chromium
+
+      - name: "📚 Sync bridge dependencies"
+        working-directory: tests_end_to_end/e2e/services/opik-sdk-driver
+        run: uv sync
 
       - name: "📊 Install allurectl"
         uses: allure-framework/setup-allurectl@v1
@@ -123,7 +122,7 @@ jobs:
         run: |
           echo "::group::Building Opik from branch: ${{ github.ref_name }}"
           cd ${{ github.workspace }}
-          TOGGLE_WELCOME_WIZARD_ENABLED="false" TOGGLE_FORCE_WORKSPACE_VERSION="version_1" ./opik.sh --build
+          TOGGLE_WELCOME_WIZARD_ENABLED="false" TOGGLE_FORCE_WORKSPACE_VERSION="version_2" ./opik.sh --build
           echo "::endgroup::"
           echo "✅ Opik build complete"
 
@@ -146,46 +145,38 @@ jobs:
       # ========================================
       # PHASE 3: Run E2E Tests
       # ========================================
-      - name: "🔍 Smoke test - Verify UI accessibility"
-        working-directory: tests_end_to_end/typescript-tests
-        env:
-          OPIK_BASE_URL: http://localhost:5173
-          OPIK_TEST_WORKSPACE: default
-          OPIK_TEST_PROJECT_NAME: automated_tests_project
-        run: |
-          echo "Running quick smoke test to verify UI is accessible..."
-          npx playwright test --grep "Projects created via SDK are visible" --reporter=list
-          echo "✅ UI is accessible and responding"
-
       - name: "🧪 Run E2E test suite"
         id: run-tests
-        working-directory: tests_end_to_end/typescript-tests
+        working-directory: tests_end_to_end/e2e
         env:
+          OPIK_DEPLOYMENT: oss
           OPIK_BASE_URL: http://localhost:5173
-          OPIK_TEST_WORKSPACE: default
-          OPIK_TEST_PROJECT_NAME: automated_tests_project
+          OPIK_WORKSPACE: default
+          WORKERS: 2
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          TEST_SUITE: ${{ github.event.inputs.suite || 'happypaths' }}
+          ALLURE_LAUNCH_NAME: "Opik v2 Post-Merge ${{ github.event.inputs.tier || 't1' }} - ${{ github.run_id }}"
         run: |
+          TIER="${{ github.event.inputs.tier || 't1' }}"
           echo "========================================"
-          echo "🧪 Running test suite: $TEST_SUITE"
+          echo "🧪 Running v2 tier: $TIER"
           echo "========================================"
           echo ""
-          
-          # Configure Allure results directory
-          export ALLURE_RESULTS="${{ github.workspace }}/tests_end_to_end/typescript-tests/${{ env.ALLURE_RESULTS }}"
-          
+
+          # Point both the allure-playwright reporter and allurectl at the same
+          # absolute results dir, then stream results to TestOps via allurectl watch.
+          export ALLURE_RESULTS="${{ github.workspace }}/tests_end_to_end/e2e/${{ env.ALLURE_RESULTS }}"
+
           # Create .allure directory to prevent testplan.json error
           mkdir -p .allure
-          
-          # Run tests with allurectl for TestOps integration
+
+          # Run tests with allurectl watch for TestOps integration
           # Capture output to extract the direct report URL
           set +e
-          allurectl watch -- npx playwright test 2>&1 | tee allure_output.log
+          allurectl watch -- npm run test:${TIER} 2>&1 | tee allure_output.log
           TEST_EXIT_CODE=${PIPESTATUS[0]}
           set -e
-          
+
           # Extract the direct job run URL from allurectl output
           if grep -q "Report link:" allure_output.log; then
             REPORT_URL=$(grep "Report link:" allure_output.log | head -1 | sed 's/.*Report link:[[:space:]]*//' | awk '{print $1}')
@@ -195,13 +186,12 @@ jobs:
             echo "allure_report_url=" >> "$GITHUB_OUTPUT"
             echo "⚠️ Could not capture direct report URL from allurectl output"
           fi
-          
+
           echo ""
           echo "========================================"
           echo "Test run completed with exit code: $TEST_EXIT_CODE"
           echo "========================================"
-          
-          # Exit with the test exit code to properly report success/failure
+
           exit "$TEST_EXIT_CODE"
 
       # ========================================
@@ -210,10 +200,10 @@ jobs:
       - name: "📊 Parse test results"
         id: parse-results
         if: always()
-        working-directory: tests_end_to_end/typescript-tests
+        working-directory: tests_end_to_end/e2e
         run: |
           echo "::group::Parsing test results"
-          
+
           if [ -f "test-results/results.json" ]; then
             echo "Found results.json, parsing..."
             TOTAL=$(jq '.stats.expected + .stats.unexpected + .stats.flaky + .stats.skipped' test-results/results.json 2>/dev/null || echo "0")
@@ -221,7 +211,7 @@ jobs:
             FAILED=$(jq '.stats.unexpected' test-results/results.json 2>/dev/null || echo "0")
             SKIPPED=$(jq '.stats.skipped' test-results/results.json 2>/dev/null || echo "0")
             FLAKY=$(jq '.stats.flaky' test-results/results.json 2>/dev/null || echo "0")
-            
+
             echo "Results: Total=$TOTAL, Passed=$PASSED, Failed=$FAILED, Skipped=$SKIPPED, Flaky=$FLAKY"
           else
             echo "⚠️ results.json not found, using defaults"
@@ -231,7 +221,7 @@ jobs:
             SKIPPED="0"
             FLAKY="0"
           fi
-          
+
           {
             echo "total=$TOTAL"
             echo "passed=$PASSED"
@@ -239,7 +229,7 @@ jobs:
             echo "skipped=$SKIPPED"
             echo "flaky=$FLAKY"
           } >> "$GITHUB_OUTPUT"
-          
+
           echo "::endgroup::"
 
       - name: "🔗 Set output URLs"
@@ -248,7 +238,7 @@ jobs:
         run: |
           # Use direct report URL if captured, otherwise fall back to launches page
           DIRECT_URL="${{ steps.run-tests.outputs.allure_report_url }}"
-          
+
           if [ -n "$DIRECT_URL" ]; then
             TESTOPS_URL="$DIRECT_URL"
             echo "📊 Using direct TestOps report URL"
@@ -256,7 +246,7 @@ jobs:
             TESTOPS_URL="${{ env.ALLURE_ENDPOINT }}project/${{ env.ALLURE_PROJECT_ID }}/launches"
             echo "📊 Using fallback launches page URL"
           fi
-          
+
           echo "testops_url=$TESTOPS_URL" >> "$GITHUB_OUTPUT"
 
       # ========================================
@@ -265,7 +255,7 @@ jobs:
       - name: "📋 Generate job summary"
         if: always()
         run: |
-          SUITE="${{ github.event.inputs.suite || 'happypaths' }}"
+          TIER="${{ github.event.inputs.tier || 't1' }}"
           TESTOPS_URL="${{ steps.set-outputs.outputs.testops_url }}"
 
           TOTAL="${{ steps.parse-results.outputs.total }}"
@@ -277,7 +267,7 @@ jobs:
           exec >> "$GITHUB_STEP_SUMMARY"
 
           # Header
-          echo "# 🧪 E2E Test Results"
+          echo "# 🧪 E2E v2 Test Results"
           echo ""
 
           # Status banner
@@ -295,7 +285,7 @@ jobs:
           echo ""
           echo "| Property | Value |"
           echo "|----------|-------|"
-          echo "| **Suite** | \`$SUITE\` |"
+          echo "| **Tier** | \`$TIER\` |"
           echo "| **Branch** | \`${{ github.ref_name }}\` |"
           echo "| **Commit** | [\`${GITHUB_SHA:0:7}\`](https://github.com/${{ github.repository }}/commit/${{ github.sha }}) |"
           echo "| **Trigger** | ${{ github.event_name == 'push' && 'Post-merge (push to main)' || 'Manual dispatch' }} |"
@@ -320,7 +310,6 @@ jobs:
           echo "|----------|------|"
           echo "| 📊 **TestOps Dashboard** | [View detailed results, traces & history]($TESTOPS_URL) |"
           echo "| 📄 **Playwright Report** | [Download from Artifacts below](#artifacts) |"
-          echo "| 📚 **E2E Test Guide** | [Quickstart documentation](https://github.com/${{ github.repository }}/blob/main/tests_end_to_end/QUICKSTART.md) |"
           echo ""
 
           # Debugging section (only on failure)
@@ -332,10 +321,9 @@ jobs:
             echo "1. **Open TestOps** → Click the link above to see detailed failure traces, screenshots, and video recordings"
             echo "2. **Download Playwright Report** → The HTML report includes step-by-step traces for each test"
             echo "3. **Check test logs** → Expand the 'Run E2E test suite' step above for console output"
-            echo "4. **Run locally** → See the [Quickstart Guide](https://github.com/${{ github.repository }}/blob/main/tests_end_to_end/QUICKSTART.md) for local debugging"
             echo ""
             echo "### Common failure causes:"
-            echo "- UI element selectors changed"
+            echo "- UI element selectors changed (missing data-testid)"
             echo "- API response format changed"
             echo "- Timing/race conditions"
             echo "- New feature requiring test updates"
@@ -348,27 +336,27 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: allure-results
-          path: tests_end_to_end/typescript-tests/allure-results
+          name: allure-results-v2
+          path: tests_end_to_end/e2e/allure-results
           retention-days: 14
 
       - name: "📤 Upload Playwright report"
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-report
-          path: tests_end_to_end/typescript-tests/playwright-report
+          name: playwright-report-v2
+          path: tests_end_to_end/e2e/playwright-report
           retention-days: 14
 
       - name: "📤 Upload test results JSON"
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: test-results-json
-          path: tests_end_to_end/typescript-tests/test-results/results.json
+          name: test-results-json-v2
+          path: tests_end_to_end/e2e/test-results/results.json
           retention-days: 14
           if-no-files-found: ignore
-          
+
       - name: "🧹 Stop Opik server"
         if: always()
         run: |
@@ -381,7 +369,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: e2e-tests
     if: |
-      always() && 
+      always() &&
       needs.e2e-tests.result != 'cancelled' &&
       (needs.e2e-tests.result == 'failure' || github.event.inputs.notify_on_success == 'true')
 
@@ -428,7 +416,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           TEST_RESULT: ${{ needs.e2e-tests.result }}
-          SUITE_NAME: ${{ github.event.inputs.suite || 'happypaths' }}
+          SUITE_NAME: "v2 ${{ github.event.inputs.tier || 't1' }}"
           PASSED_TESTS: ${{ needs.e2e-tests.outputs.passed_tests }}
           FAILED_TESTS: ${{ needs.e2e-tests.outputs.failed_tests }}
           TESTOPS_URL: ${{ needs.e2e-tests.outputs.testops_url }}

--- a/.github/workflows/end2end_suites_typescript.yml
+++ b/.github/workflows/end2end_suites_typescript.yml
@@ -1,4 +1,9 @@
-name: Application E2E Tests (TypeScript)
+name: Application E2E Tests (TypeScript) [DEPRECATED — v1]
+
+# DEPRECATED: replaced by end2end_suites_v2.yml (OPIK-6707).
+# PR/auto triggers removed; left dispatchable for grace-period manual runs.
+# The v2 PR-gate covers tests_end_to_end/e2e/** paths.
+
 env:
   OPIK_SENTRY_ENABLE: False
   ALLURE_TOKEN: ${{ secrets.ALLURE_TOKEN }}
@@ -34,11 +39,6 @@ on:
                 description: ALLURE_JOB_RUN_ID service parameter. Leave blank.
             ALLURE_USERNAME:
                 description: ALLURE_USERNAME service parameter. Leave blank.
-
-    pull_request:
-      paths:
-        - 'sdks/code_generation/fern/openapi/openapi.yaml'
-        - 'tests_end_to_end/**'
 
 
 concurrency:


### PR DESCRIPTION
## Details

Cutover step 1 of 2 (companion PR in comet-automation-tests). Replaces the v1 push-to-main E2E gate with a v2 equivalent and disables the auto-triggers on the v1 workflows.

- **New**: \`e2e_tests_post_merge_v2.yml\` — push-to-main + manual-dispatch E2E gate for the v2 suite (\`tests_end_to_end/e2e/\`). Mirrors the v1 \`e2e_tests_post_merge.yml\` shape (Allure TestOps streaming, Slack notification, results parsing, GH step summary, debugging-guide block on failure). Builds Opik locally with \`TOGGLE_FORCE_WORKSPACE_VERSION=version_2\`, runs \`@t1-smoke\` by default; \`tier\` input (t1/t2/t3) replaces v1's \`suite\` choice. Reuses the existing \`.github/scripts/notify-slack-e2e-post-merge.sh\` unchanged (the script is reporter-agnostic).
- **Deprecated**: \`end2end_suites_typescript.yml\` and \`e2e_tests_post_merge.yml\` — auto-triggers stripped (no more \`pull_request\` / \`push\` / cosmetic-self-PR). Both remain dispatchable for the cutover grace period; planned for full removal once v2 has soaked.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6707

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: New v2 post-merge workflow + trigger-strip on two v1 workflows.
- Human verification: pending review + first post-merge run on \`main\`.

## Testing

Local verification:
- \`actionlint\` clean on all three modified workflow files.
- Confirmed Slack script \`.github/scripts/notify-slack-e2e-post-merge.sh\` exists on \`main\` and is reporter-agnostic (takes counts + URL via env).
- The new workflow uses the same lockfile/cache path, \`setup-uv\`, bridge \`uv sync\`, and \`allurectl watch\` pattern as the merged \`end2end_suites_v2.yml\` PR-gate (proven on real runs).

Not run: the workflow end-to-end (requires GitHub Actions runner + Docker build). Will validate via the first push-to-main after merge.

## Sequencing

- This PR is safe to merge before the comet-automation-tests companion PR — the two repos are independent at the GitHub level.
- After merge: confirm one post-merge run on \`main\` produces a green TestOps launch named \`Opik v2 Post-Merge t1 - <run_id>\`. Then it's safe to start deleting the v1 files entirely.

## Documentation