### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -18347,6 +18347,13 @@ components:
           enum:
           - prompt_version
           - mask
+        environment:
+          maxLength: 150
+          minLength: 0
+          pattern: "^[A-Za-z0-9_-]+$"
+          type: string
+          description: "Deprecated: use 'environments' instead"
+          deprecated: true
         environments:
           maxItems: 100
           minItems: 0
@@ -18481,6 +18488,13 @@ components:
           enum:
           - prompt_version
           - mask
+        environment:
+          maxLength: 150
+          minLength: 0
+          pattern: "^[A-Za-z0-9_-]+$"
+          type: string
+          description: "Deprecated: use 'environments' instead"
+          deprecated: true
         environments:
           maxItems: 100
           minItems: 0
@@ -18673,6 +18687,13 @@ components:
           enum:
           - prompt_version
           - mask
+        environment:
+          maxLength: 150
+          minLength: 0
+          pattern: "^[A-Za-z0-9_-]+$"
+          type: string
+          description: "Deprecated: use 'environments' instead"
+          deprecated: true
         environments:
           maxItems: 100
           minItems: 0

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -18347,6 +18347,13 @@ components:
           enum:
           - prompt_version
           - mask
+        environment:
+          maxLength: 150
+          minLength: 0
+          pattern: "^[A-Za-z0-9_-]+$"
+          type: string
+          description: "Deprecated: use 'environments' instead"
+          deprecated: true
         environments:
           maxItems: 100
           minItems: 0
@@ -18481,6 +18488,13 @@ components:
           enum:
           - prompt_version
           - mask
+        environment:
+          maxLength: 150
+          minLength: 0
+          pattern: "^[A-Za-z0-9_-]+$"
+          type: string
+          description: "Deprecated: use 'environments' instead"
+          deprecated: true
         environments:
           maxItems: 100
           minItems: 0
@@ -18673,6 +18687,13 @@ components:
           enum:
           - prompt_version
           - mask
+        environment:
+          maxLength: 150
+          minLength: 0
+          pattern: "^[A-Za-z0-9_-]+$"
+          type: string
+          description: "Deprecated: use 'environments' instead"
+          deprecated: true
         environments:
           maxItems: 100
           minItems: 0

--- a/sdks/python/src/opik/rest_api/types/prompt_version.py
+++ b/sdks/python/src/opik/rest_api/types/prompt_version.py
@@ -36,6 +36,11 @@ class PromptVersion(UniversalBaseModel):
     version type discriminator; defaults to prompt_version
     """
 
+    environment: typing.Optional[str] = pydantic.Field(default=None)
+    """
+    Deprecated: use 'environments' instead
+    """
+
     environments: typing.Optional[typing.List[str]] = None
     change_description: typing.Optional[str] = None
     tags: typing.Optional[typing.List[str]] = None

--- a/sdks/python/src/opik/rest_api/types/prompt_version_detail.py
+++ b/sdks/python/src/opik/rest_api/types/prompt_version_detail.py
@@ -36,6 +36,11 @@ class PromptVersionDetail(UniversalBaseModel):
     version type discriminator; defaults to prompt_version
     """
 
+    environment: typing.Optional[str] = pydantic.Field(default=None)
+    """
+    Deprecated: use 'environments' instead
+    """
+
     environments: typing.Optional[typing.List[str]] = None
     change_description: typing.Optional[str] = None
     tags: typing.Optional[typing.List[str]] = None

--- a/sdks/python/src/opik/rest_api/types/prompt_version_public.py
+++ b/sdks/python/src/opik/rest_api/types/prompt_version_public.py
@@ -36,6 +36,11 @@ class PromptVersionPublic(UniversalBaseModel):
     version type discriminator; defaults to prompt_version
     """
 
+    environment: typing.Optional[str] = pydantic.Field(default=None)
+    """
+    Deprecated: use 'environments' instead
+    """
+
     environments: typing.Optional[typing.List[str]] = None
     change_description: typing.Optional[str] = None
     tags: typing.Optional[typing.List[str]] = None

--- a/sdks/typescript/src/opik/rest_api/api/types/PromptVersion.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/PromptVersion.ts
@@ -15,6 +15,8 @@ export interface PromptVersion {
     type?: OpikApi.PromptVersionType;
     /** version type discriminator; defaults to prompt_version */
     versionType?: OpikApi.PromptVersionVersionType;
+    /** Deprecated: use 'environments' instead */
+    environment?: string;
     environments?: string[];
     changeDescription?: string;
     tags?: string[];

--- a/sdks/typescript/src/opik/rest_api/api/types/PromptVersionDetail.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/PromptVersionDetail.ts
@@ -15,6 +15,8 @@ export interface PromptVersionDetail {
     type?: OpikApi.PromptVersionDetailType;
     /** version type discriminator; defaults to prompt_version */
     versionType?: OpikApi.PromptVersionDetailVersionType;
+    /** Deprecated: use 'environments' instead */
+    environment?: string;
     environments?: string[];
     changeDescription?: string;
     tags?: string[];

--- a/sdks/typescript/src/opik/rest_api/api/types/PromptVersionPublic.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/PromptVersionPublic.ts
@@ -15,6 +15,8 @@ export interface PromptVersionPublic {
     type?: OpikApi.PromptVersionPublicType;
     /** version type discriminator; defaults to prompt_version */
     versionType?: OpikApi.PromptVersionPublicVersionType;
+    /** Deprecated: use 'environments' instead */
+    environment?: string;
     environments?: string[];
     changeDescription?: string;
     tags?: string[];

--- a/sdks/typescript/src/opik/rest_api/serialization/types/PromptVersion.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/PromptVersion.ts
@@ -18,6 +18,7 @@ export const PromptVersion: core.serialization.ObjectSchema<serializers.PromptVe
         metadata: JsonNode.optional(),
         type: PromptVersionType.optional(),
         versionType: core.serialization.property("version_type", PromptVersionVersionType.optional()),
+        environment: core.serialization.string().optional(),
         environments: core.serialization.list(core.serialization.string()).optional(),
         changeDescription: core.serialization.property("change_description", core.serialization.string().optional()),
         tags: core.serialization.list(core.serialization.string()).optional(),
@@ -37,6 +38,7 @@ export declare namespace PromptVersion {
         metadata?: JsonNode.Raw | null;
         type?: PromptVersionType.Raw | null;
         version_type?: PromptVersionVersionType.Raw | null;
+        environment?: string | null;
         environments?: string[] | null;
         change_description?: string | null;
         tags?: string[] | null;

--- a/sdks/typescript/src/opik/rest_api/serialization/types/PromptVersionDetail.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/PromptVersionDetail.ts
@@ -20,6 +20,7 @@ export const PromptVersionDetail: core.serialization.ObjectSchema<
     metadata: JsonNodeDetail.optional(),
     type: PromptVersionDetailType.optional(),
     versionType: core.serialization.property("version_type", PromptVersionDetailVersionType.optional()),
+    environment: core.serialization.string().optional(),
     environments: core.serialization.list(core.serialization.string()).optional(),
     changeDescription: core.serialization.property("change_description", core.serialization.string().optional()),
     tags: core.serialization.list(core.serialization.string()).optional(),
@@ -42,6 +43,7 @@ export declare namespace PromptVersionDetail {
         metadata?: JsonNodeDetail.Raw | null;
         type?: PromptVersionDetailType.Raw | null;
         version_type?: PromptVersionDetailVersionType.Raw | null;
+        environment?: string | null;
         environments?: string[] | null;
         change_description?: string | null;
         tags?: string[] | null;

--- a/sdks/typescript/src/opik/rest_api/serialization/types/PromptVersionPublic.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/PromptVersionPublic.ts
@@ -20,6 +20,7 @@ export const PromptVersionPublic: core.serialization.ObjectSchema<
     metadata: JsonNodePublic.optional(),
     type: PromptVersionPublicType.optional(),
     versionType: core.serialization.property("version_type", PromptVersionPublicVersionType.optional()),
+    environment: core.serialization.string().optional(),
     environments: core.serialization.list(core.serialization.string()).optional(),
     changeDescription: core.serialization.property("change_description", core.serialization.string().optional()),
     tags: core.serialization.list(core.serialization.string()).optional(),
@@ -41,6 +42,7 @@ export declare namespace PromptVersionPublic {
         metadata?: JsonNodePublic.Raw | null;
         type?: PromptVersionPublicType.Raw | null;
         version_type?: PromptVersionPublicVersionType.Raw | null;
+        environment?: string | null;
         environments?: string[] | null;
         change_description?: string | null;
         tags?: string[] | null;


### PR DESCRIPTION
## Details
Automated update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

**Triggered by commit:** https://github.com/comet-ml/opik/commit/e77e7fa338cb6a1436255caab04aff1d20debc54

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate