### PR TITLE
[OPIK-6707] [CI] fix(e2e): tier-inclusive grep so t3 ⊇ t2 ⊇ t1

### DIFF
--- a/tests_end_to_end/e2e/package.json
+++ b/tests_end_to_end/e2e/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "playwright test --pass-with-no-tests",
     "test:t1": "playwright test --grep @t1-smoke",
-    "test:t2": "playwright test --grep @t2-cuj",
-    "test:t3": "playwright test --grep @t3-nightly",
+    "test:t2": "playwright test --grep \"@t1-smoke|@t2-cuj\"",
+    "test:t3": "playwright test --grep \"@t1-smoke|@t2-cuj|@t3-nightly\"",
     "test:headed": "playwright test --headed",
     "report": "playwright show-report"
   },


### PR DESCRIPTION
## Details

Fixes a semantic bug in the v2 tier definitions. The npm \`test:tN\` scripts previously matched only their own tag, so the tiers were disjoint sets. Today only \`@t1-smoke\` specs exist, so:

- \`npm run test:t2\` → 0 tests (matched nothing) — silently "passed"
- \`npm run test:t3\` → 0 tests (matched nothing) — silently "passed"

Tiers are now inclusive (t3 ⊇ t2 ⊇ t1), via a regex-union grep:
## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6707

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: Fix npm tier grep semantics. 1 file, 2 lines changed.
- Human verification: pending review + re-running \`workflow_dispatch\` of the v2 deployed-env / regression job with \`tier: t2\` and \`tier: t3\` to confirm 10 tests run.

## Testing

## Documentation