### PR TITLE
[NA] [BE] fix: update PromptVersionInfo constructor in test for versionNumber field

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentExecutionServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentExecutionServiceTest.java
@@ -574,7 +574,8 @@ class ExperimentExecutionServiceTest {
                     .thenReturn(Mono.just(Map.of(versionId, version)));
             when(promptService.getVersionsInfoByVersionsIds(Set.of(versionId)))
                     .thenReturn(Mono.just(Map.of(versionId,
-                            new PromptVersionInfo(versionId, version.commit(), resolvedName))));
+                            new PromptVersionInfo(versionId, version.commit(), version.versionNumber(),
+                                    resolvedName))));
 
             executeRequest(request);
 


### PR DESCRIPTION
## Details

Follow-up to #6894, which added a `versionNumber` field to the `PromptVersionInfo` record but missed updating one call site in `ExperimentExecutionServiceTest`. The 3-arg constructor no longer exists, so the backend Docker build fails at `testCompile` (which runs even with `-DskipTests`).

- One-line test fix: pass `version.versionNumber()` as the new third argument

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7
- Scope: identified the broken call site from the Docker build error, applied the single-line constructor fix, and verified locally with `mvn test-compile`
- Human verification: petrot reviewed and approved the change before push

## Testing

- `mvn test-compile` under `apps/opik-backend/` — compiles clean (was failing before fix)
- No behavioral change to the test; only adapts the constructor signature to match the updated record

## Documentation

N/A — internal test fix, no user-facing changes.