### PR TITLE
[OPIK-6734] [BE] fix: resolve ClassCastException in thread-level online evaluation rules with filters

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TraceThreadOnlineScoringSamplerListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TraceThreadOnlineScoringSamplerListener.java
@@ -5,9 +5,6 @@ import com.comet.opik.api.TraceThreadSampling;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluator;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
 import com.comet.opik.api.events.TraceThreadsCreated;
-import com.comet.opik.api.filter.Field;
-import com.comet.opik.api.filter.TraceFilter;
-import com.comet.opik.api.filter.TraceThreadField;
 import com.comet.opik.api.filter.TraceThreadFilter;
 import com.comet.opik.domain.evaluators.AutomationRuleEvaluatorService;
 import com.comet.opik.domain.evaluators.TraceThreadFilterEvaluationService;
@@ -29,12 +26,10 @@ import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 
-import static com.comet.opik.api.filter.TraceThreadField.*;
 import static com.comet.opik.infrastructure.log.LogContextAware.wrapWithMdc;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
@@ -209,100 +204,13 @@ public class TraceThreadOnlineScoringSamplerListener {
         return acc;
     }
 
-    /**
-     * Determines if a thread should be sampled based on the rule's filters.
-     * Converts TraceFilter objects to TraceThreadFilter objects and evaluates them.
-     *
-     * @param evaluator the automation rule evaluator containing filters
-     * @param thread the thread to evaluate
-     * @return true if the thread matches all filters and should be sampled, false otherwise
-     */
+    @SuppressWarnings("unchecked")
     private boolean shouldSampleTraceThread(AutomationRuleEvaluator<?, ?> evaluator, TraceThreadModel thread) {
-        // Filter to only TraceFilter instances since TraceFilterEvaluationService expects TraceFilter
-        List<TraceFilter> traceFilters = (List<TraceFilter>) evaluator.getFilters();
-        if (traceFilters.isEmpty()) {
-            return true; // No filters mean all threads should be sampled
+        List<TraceThreadFilter> filters = (List<TraceThreadFilter>) evaluator.getFilters();
+        if (filters.isEmpty()) {
+            return true;
         }
-
-        // Convert TraceFilter to TraceThreadFilter
-        List<TraceThreadFilter> threadFilters = convertFilters(traceFilters);
-
-        // Evaluate filters against the thread
-        return filterEvaluationService.matchesAllFilters(threadFilters, thread);
-    }
-
-    /**
-     * Converts a list of TraceFilter objects to TraceThreadFilter objects.
-     * Maps trace fields to equivalent thread fields where possible.
-     */
-    private List<TraceThreadFilter> convertFilters(List<TraceFilter> traceFilters) {
-        return traceFilters.stream()
-                .map(this::convertFilter)
-                .filter(Objects::nonNull)
-                .toList();
-    }
-
-    /**
-     * Converts a single TraceFilter to TraceThreadFilter.
-     * Maps trace fields to equivalent thread fields.
-     */
-    private TraceThreadFilter convertFilter(TraceFilter traceFilter) {
-        TraceThreadField threadField = convertFieldToThreadField(traceFilter.field());
-        if (threadField == null) {
-            log.warn("Cannot convert trace field '{}' to thread field, skipping filter", traceFilter.field());
-            return null;
-        }
-
-        String value = traceFilter.value();
-
-        // Convert duration values from seconds to milliseconds for proper comparison
-        if (threadField == DURATION && value != null) {
-            try {
-                double seconds = Double.parseDouble(value);
-                long milliseconds = (long) (seconds * 1000);
-                log.info("Converting duration filter from {} seconds to {} milliseconds", seconds, milliseconds);
-                value = String.valueOf(milliseconds);
-            } catch (NumberFormatException e) {
-                log.warn("Invalid duration value '{}' for thread filter conversion", value);
-            }
-        }
-
-        return TraceThreadFilter.builder()
-                .field(threadField)
-                .operator(traceFilter.operator())
-                .key(traceFilter.key())
-                .value(value)
-                .build();
-    }
-
-    /**
-     * Maps TraceField to TraceThreadField where possible.
-     * Returns null for fields that don't have thread equivalents.
-     */
-    private TraceThreadField convertFieldToThreadField(Field traceField) {
-        return switch (traceField.toString()) {
-            case "ID" -> ID;
-            case "START_TIME" -> START_TIME;
-            case "END_TIME" -> END_TIME;
-            case "CREATED_AT" -> CREATED_AT;
-            case "LAST_UPDATED_AT" -> LAST_UPDATED_AT;
-            case "TAGS" -> TAGS;
-            case "STATUS" -> STATUS;
-            case "DURATION" -> DURATION;
-            case "FEEDBACK_SCORES" -> FEEDBACK_SCORES;
-            // Fields that don't have thread equivalents
-            case "NAME", "INPUT", "OUTPUT", "INPUT_JSON", "OUTPUT_JSON", "METADATA",
-                    "TOTAL_ESTIMATED_COST", "LLM_SPAN_COUNT", "USAGE_COMPLETION_TOKENS",
-                    "USAGE_PROMPT_TOKENS", "USAGE_TOTAL_TOKENS", "THREAD_ID", "GUARDRAILS",
-                    "VISIBILITY_MODE", "ERROR_INFO", "CUSTOM" -> {
-                log.debug("Trace field '{}' has no equivalent in thread model", traceField);
-                yield null;
-            }
-            default -> {
-                log.warn("Unknown trace field '{}' for conversion to thread field", traceField);
-                yield null;
-            }
-        };
+        return filterEvaluationService.matchesAllFilters(filters, thread);
     }
 
     private LogContextAware.Closable createThreadLoggingContext(String workspaceId,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TraceThreadOnlineScoringSamplerListenerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TraceThreadOnlineScoringSamplerListenerTest.java
@@ -4,6 +4,9 @@ import com.comet.opik.api.Source;
 import com.comet.opik.api.TraceThreadSampling;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadLlmAsJudge;
 import com.comet.opik.api.events.TraceThreadsCreated;
+import com.comet.opik.api.filter.Operator;
+import com.comet.opik.api.filter.TraceThreadField;
+import com.comet.opik.api.filter.TraceThreadFilter;
 import com.comet.opik.domain.evaluators.AutomationRuleEvaluatorService;
 import com.comet.opik.domain.evaluators.TraceThreadFilterEvaluationService;
 import com.comet.opik.domain.threads.TraceThreadModel;
@@ -182,19 +185,103 @@ class TraceThreadOnlineScoringSamplerListenerTest {
         }
     }
 
+    @Nested
+    class RuleFilteringTests {
+
+        @Test
+        void skipsDisabledEvaluators() {
+            var thread = createThread(Source.SDK);
+            var evaluator = createEvaluatorWithFilters(false, 1.0f, List.of());
+            var event = new TraceThreadsCreated(List.of(thread), projectId, workspaceId, userName);
+
+            doReturn(List.of(evaluator))
+                    .when(ruleEvaluatorService).findAll(projectId, workspaceId);
+            when(traceThreadService.updateThreadSampledValue(eq(projectId), any()))
+                    .thenReturn(Mono.empty());
+
+            listener.onTraceThreadOnlineScoringSampled(event);
+
+            ArgumentCaptor<List<TraceThreadSampling>> captor = ArgumentCaptor.forClass(List.class);
+            verify(traceThreadService).updateThreadSampledValue(eq(projectId), captor.capture());
+            assertThat(captor.getValue())
+                    .allSatisfy(sampling -> assertThat(sampling.samplingPerRule().values())
+                            .containsOnly(false));
+        }
+
+        @Test
+        void skipsThreadsThatDontMatchEvaluatorFilters() {
+            var thread = createThread(Source.SDK);
+            var nonMatchingFilter = TraceThreadFilter.builder()
+                    .field(TraceThreadField.DURATION)
+                    .operator(Operator.GREATER_THAN)
+                    .value("999999")
+                    .build();
+            var evaluator = createEvaluatorWithFilters(true, 1.0f, List.of(nonMatchingFilter));
+            var event = new TraceThreadsCreated(List.of(thread), projectId, workspaceId, userName);
+
+            doReturn(List.of(evaluator))
+                    .when(ruleEvaluatorService).findAll(projectId, workspaceId);
+            when(filterEvaluationService.matchesAllFilters(any(), any(TraceThreadModel.class)))
+                    .thenReturn(false);
+            when(traceThreadService.updateThreadSampledValue(eq(projectId), any()))
+                    .thenReturn(Mono.empty());
+
+            listener.onTraceThreadOnlineScoringSampled(event);
+
+            ArgumentCaptor<List<TraceThreadSampling>> captor = ArgumentCaptor.forClass(List.class);
+            verify(traceThreadService).updateThreadSampledValue(eq(projectId), captor.capture());
+            assertThat(captor.getValue())
+                    .allSatisfy(sampling -> assertThat(sampling.samplingPerRule().values())
+                            .containsOnly(false));
+        }
+
+        @Test
+        void processesThreadsThatMatchEvaluatorFilters() {
+            var thread = createThread(Source.SDK);
+            var matchingFilter = TraceThreadFilter.builder()
+                    .field(TraceThreadField.DURATION)
+                    .operator(Operator.GREATER_THAN)
+                    .value("0")
+                    .build();
+            var evaluator = createEvaluatorWithFilters(true, 1.0f, List.of(matchingFilter));
+            var event = new TraceThreadsCreated(List.of(thread), projectId, workspaceId, userName);
+
+            doReturn(List.of(evaluator))
+                    .when(ruleEvaluatorService).findAll(projectId, workspaceId);
+            when(filterEvaluationService.matchesAllFilters(any(), any(TraceThreadModel.class)))
+                    .thenReturn(true);
+            when(traceThreadService.updateThreadSampledValue(eq(projectId), any()))
+                    .thenReturn(Mono.empty());
+
+            listener.onTraceThreadOnlineScoringSampled(event);
+
+            ArgumentCaptor<List<TraceThreadSampling>> captor = ArgumentCaptor.forClass(List.class);
+            verify(traceThreadService).updateThreadSampledValue(eq(projectId), captor.capture());
+            assertThat(captor.getValue())
+                    .allSatisfy(sampling -> assertThat(sampling.samplingPerRule().get(evaluator.getId()))
+                            .isTrue());
+        }
+    }
+
     private TraceThreadModel createThread(Source source) {
         return podamFactory.manufacturePojo(TraceThreadModel.class).toBuilder()
                 .projectId(projectId)
                 .source(source)
+                .duration(30_000.0)
                 .build();
     }
 
     private AutomationRuleEvaluatorTraceThreadLlmAsJudge createEvaluator() {
+        return createEvaluatorWithFilters(true, 1.0f, List.of());
+    }
+
+    private AutomationRuleEvaluatorTraceThreadLlmAsJudge createEvaluatorWithFilters(
+            boolean enabled, float samplingRate, List<TraceThreadFilter> filters) {
         return podamFactory.manufacturePojo(AutomationRuleEvaluatorTraceThreadLlmAsJudge.class).toBuilder()
                 .projects(toProjects(Set.of(projectId)))
-                .samplingRate(1.0f)
-                .enabled(true)
-                .filters(List.of())
+                .samplingRate(samplingRate)
+                .enabled(enabled)
+                .filters(filters)
                 .build();
     }
 }


### PR DESCRIPTION
## Details

Thread-level LLM-as-judge online evaluation rules (`trace_thread_llm_as_judge`) silently stopped producing scores when filters were configured. The root cause was a `ClassCastException` in `TraceThreadOnlineScoringSamplerListener.shouldSampleTraceThread()` — it incorrectly cast the evaluator's `List<TraceThreadFilter>` to `List<TraceFilter>`, then attempted to convert them back. This conversion code was correct when originally written (OPIK-1454), but was never updated after the filters architecture refactor (#4311) changed the evaluator's generic type from `TraceFilter` to `TraceThreadFilter`.

Wrote a regression test that reproduces the exact production error first, then applied the fix: removed the dead conversion pipeline and cast directly to the correct `TraceThreadFilter` type.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6734

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Opus 4.6
- Scope: assisted implementation
- Human verification: directed test-first approach, reviewed root cause analysis, guided local verification against running backend, code review

## Testing

**Unit tests:**

```bash
cd apps/opik-backend && mvn test -Dtest="TraceThreadOnlineScoringSamplerListenerTest"
```

- `RuleFilteringTests.skipsDisabledEvaluators` — disabled rule with filters produces `sampled=false`
- `RuleFilteringTests.skipsThreadsThatDontMatchEvaluatorFilters` — enabled rule with non-matching filter produces `sampled=false`
- `RuleFilteringTests.processesThreadsThatMatchEvaluatorFilters` — enabled rule with matching filter produces `sampled=true`

All 11 tests pass (3 new + 8 existing).

**Local manual testing against running backend:**

1. Started the backend service locally
2. Created a `trace_thread_user_defined_metric_python` rule with a `duration > 0` filter on a test project
3. Created a second rule with a `status = ACTIVE` filter on the same project
4. Sent traces with `thread_id` via `POST /v1/private/traces` to trigger thread creation and the evaluation pipeline
5. Tailed `/tmp/opik-opik-backend.log` — confirmed no `ClassCastException`, filter evaluation ran correctly (`TraceThreadFilterEvaluationService` evaluated duration and status filters), and thread sampling values were updated successfully

## Documentation

N/A