### PR TITLE
[OPIK-6740] [FE] Fix experiment feedback score empty state copy

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTableNoData.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTableNoData.tsx
@@ -73,7 +73,8 @@ const FeedbackScoreTableNoData: React.FC<FeedbackScoreTableNoDataProps> = ({
                 Add human review
               </Button>
             )}
-            {(entityType === "experiment" || canUpdateOnlineEvaluationRules) && (
+            {(entityType === "experiment" ||
+              canUpdateOnlineEvaluationRules) && (
               <Button variant="secondary" size="sm" asChild>
                 <a
                   href={evaluationDocsLink}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTableNoData.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTableNoData.tsx
@@ -23,10 +23,24 @@ const FeedbackScoreTableNoData: React.FC<FeedbackScoreTableNoDataProps> = ({
   } = usePermissions();
 
   const evaluationDocsLink = buildDocsUrl(
-    "/production/online-evaluation/rules",
+    entityType === "experiment"
+      ? "/evaluation/overview"
+      : "/production/online-evaluation/rules",
   );
 
+  const evaluationDocsLabel =
+    entityType === "experiment"
+      ? "Learn about experiment scoring"
+      : "Learn about online evaluation";
+
   const getDescription = () => {
+    if (entityType === "experiment") {
+      if (canAnnotateTraceSpanThread) {
+        return "Use the SDK to automatically score your experiments, or manually annotate them with human review.";
+      }
+      return "Use the SDK to automatically score your experiments.";
+    }
+
     if (canUpdateOnlineEvaluationRules && canAnnotateTraceSpanThread) {
       return `Use the SDK or Online evaluation rules to automatically score your ${entityCopy[entityType]}, or manually annotate your ${entityCopy[entityType]} with human review.`;
     }
@@ -45,7 +59,9 @@ const FeedbackScoreTableNoData: React.FC<FeedbackScoreTableNoDataProps> = ({
   return (
     <div className="flex min-h-48 flex-col items-center justify-center gap-2 bg-background p-6">
       <div>No feedback scores yet</div>
-      {(canAnnotateTraceSpanThread || canUpdateOnlineEvaluationRules) && (
+      {(canAnnotateTraceSpanThread ||
+        canUpdateOnlineEvaluationRules ||
+        entityType === "experiment") && (
         <>
           <span className="max-w-[500px] whitespace-pre-wrap break-words text-center text-muted-slate">
             {getDescription()}
@@ -57,7 +73,7 @@ const FeedbackScoreTableNoData: React.FC<FeedbackScoreTableNoDataProps> = ({
                 Add human review
               </Button>
             )}
-            {canUpdateOnlineEvaluationRules && (
+            {(entityType === "experiment" || canUpdateOnlineEvaluationRules) && (
               <Button variant="secondary" size="sm" asChild>
                 <a
                   href={evaluationDocsLink}
@@ -65,7 +81,7 @@ const FeedbackScoreTableNoData: React.FC<FeedbackScoreTableNoDataProps> = ({
                   rel="noopener noreferrer"
                 >
                   <Book className="mr-2 size-4" />
-                  Learn about online evaluation
+                  {evaluationDocsLabel}
                 </a>
               </Button>
             )}


### PR DESCRIPTION
## Details

Online evaluation rules no longer run against experiments, but the `FeedbackScoreTableNoData` component was still referencing them in both the description copy and the CTA button when `entityType === "experiment"`.

Changes:
- For experiments: description now says "Use the SDK to automatically score your experiments, or manually annotate them with human review." — no mention of online evaluation rules.
- For experiments: docs CTA changes from "Learn about online evaluation" (linking to online evaluation rules docs) to "Learn about experiment scoring" (linking to `/evaluation/overview`).
- The docs CTA now always shows for experiments, regardless of the `canUpdateOnlineEvaluationRules` permission (which is specific to the online evaluation rules feature).
- All other entity types (trace, span, thread) are unaffected.

## Change checklist

- [x] No TypeScript errors
- [x] Only v2 components modified

## Issues

Closes [OPIK-6740](https://comet-ml.atlassian.net/browse/OPIK-6740)

## AI-WATERMARK

This PR was created with AI assistance.

## Testing

Open the feedback scores tab on an experiment item with no scores — verify the empty state shows the updated copy and CTA.

## Documentation

No documentation changes required.

[OPIK-6740]: https://comet-ml.atlassian.net/browse/OPIK-6740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ