### PR TITLE
[NA] [DOCS] Improve docs-v2 home page and quickstart content

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/development/optimization-runs/algorithms/parameter_optimizer.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/development/optimization-runs/algorithms/parameter_optimizer.mdx
@@ -56,7 +56,6 @@ The optimizer intelligently balances exploration (trying diverse parameters) wit
 <Tip>
   The core of this optimizer relies on robust evaluation where each parameter configuration is assessed using your `metric` against the `dataset`. Understanding Opik's evaluation platform is key to effective use:
   - [Evaluation Overview](/evaluation/overview)
-  - [Evaluate Prompts](/v1/evaluation/evaluate_prompt)
   - [Metrics Overview](/evaluation/metrics/overview)
 </Tip>
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/development/optimization-runs/optimization/optimize_multimodal.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/development/optimization-runs/optimization/optimize_multimodal.mdx
@@ -23,8 +23,6 @@ Use optimizers that can forward OpenAI-style content parts (string or an array o
 | Parameter Optimizer | ✓ | Tunes parameters only, but supports multimodal prompts for evaluation. |
 | GEPA Optimizer | ✓ | Uses content parts; requires a multimodal-capable model for evaluation. |
 
-See also: [Evaluate multimodal](/v1/evaluation/evaluate_multimodal) for model-family guidance and content block format.
-
 ## Dataset design
 
 - Store image, audio, or video references as signed URLs in your dataset items (for example `metadata["image_url"]`, `metadata["audio_url"]`, or `metadata["video_url"]`).

--- a/apps/opik-documentation/documentation/fern/docs-v2/development/optimization-runs/quickstart.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/development/optimization-runs/quickstart.mdx
@@ -9,10 +9,6 @@ og:title: Optimize Prompts with Opik Agent Optimizer
 title: Quickstart
 ---
 
-<Note>
-  In Opik 2.0, datasets and experiments are project-scoped. Make sure to specify a `project_name` when creating datasets and running experiments so they are associated with the correct project.
-</Note>
-
 **Opik Agent Optimizer Quickstart** gives you the fastest path from “hello world” to a successful optimization run. If you already walked through the main [Opik Quickstart](/quickstart) (tracing + evaluation), this is the next stop—it layers on the `opik-optimizer` SDK so you can automatically improve prompts and agents. Prefer a UI workflow? Use [Optimization Studio](/development/optimization-runs/optimization_studio) instead.
 
 ## Why Opik Agent Optimizer?

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/evaluate_your_llm.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/evaluate_your_llm.mdx
@@ -14,12 +14,6 @@ title: Evaluate your agent
 
 Evaluating your LLM application allows you to have confidence in the performance of your LLM application. In this guide, we will walk through the process of evaluating complex applications like LLM chains or agents.
 
-<Tip>
-  In this guide, we will focus on evaluating complex LLM applications. If you
-  are looking at evaluating single prompts you can refer to the [Evaluate A
-  Prompt](/v1/evaluation/evaluate_prompt) guide.
-</Tip>
-
 The evaluation is done in five steps:
 
 1. Add tracing to your LLM application
@@ -365,7 +359,7 @@ evaluation = evaluate(
 
 ### Linking prompts to experiments
 
-The [Opik prompt library](/v1/prompt_engineering/prompt_management) can be used to version your prompt templates.
+The [Opik prompt library](/prompt-library/getting-started) can be used to version your prompt templates.
 
 When creating an Experiment, you can link the Experiment to a specific prompt version:
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/log_experiments_with_rest_api.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/log_experiments_with_rest_api.mdx
@@ -19,8 +19,7 @@ already computed.
 
 <Tip>
   This guide focuses on logging pre-computed evaluation results. If you're looking to run evaluations with Opik
-  computing the metrics, refer to the [Evaluate your agent](/evaluation/advanced/evaluate_your_llm) and [Evaluate single
-  prompts](/v1/evaluation/evaluate_prompt) guides.
+  computing the metrics, refer to the [Evaluate your agent](/evaluation/advanced/evaluate_your_llm) guide.
 </Tip>
 
 The process involves these key steps:

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/evaluate_agents.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/evaluate_agents.mdx
@@ -21,11 +21,6 @@ To ship production-grade agents, teams need a clear path from development to dep
 
 This guide walks you through the agent lifecycle and shows how Opik helps at every stage.
 
-<Tip>
-  In this guide, we will focus on evaluating complex agentic applications. If you are looking at evaluating single
-  prompts you can refer to the [Evaluate A Prompt](/v1/evaluation/evaluate_prompt) guide.
-</Tip>
-
 ### 1. Start with Observability
 
 The first step in agent development is making its behavior transparent. From day one, you should instrument your agent with trace logging — capturing inputs, intermediate steps, tool calls, outputs, and errors.

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/metrics/structure_output_compliance.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/metrics/structure_output_compliance.mdx
@@ -42,7 +42,7 @@ Asynchronous scoring is also supported with the `ascore` method.
 
 ## Prompt Template
 
-Opik uses an LLM as a Judge to evaluate the structural compliance. The default model used is `gpt-4o`, but this can be changed to any model supported by [LiteLLM](https://docs.litellm.ai/docs/providers). You can learn more about customizing models in the [Customize models for LLM as a Judge metrics](/v1/evaluation/metrics/custom_model) section.
+Opik uses an LLM as a Judge to evaluate the structural compliance. The default model used is `gpt-4o`, but this can be changed to any model supported by [LiteLLM](https://docs.litellm.ai/docs/providers).
 
 The prompt used by the LLM looks like this:
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/home.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/home.mdx
@@ -1,69 +1,29 @@
 ---
 title: Home
-headline: Opik Documentation - Open-Source LLM Observability & Optimization
+headline: Opik Documentation - Open-Source LLM Tracing, Evaluation & Optimization
 og:site_name: Opik Documentation
-og:title: "Opik - Open-Source LLM Observability & Agent Optimization"
-og:description: "Build, test, and optimize GenAI apps from prototype to production. Comprehensive tracing, evaluation, and prompt optimization for RAG, agents, and more."
+og:title: "Opik - Open-Source LLM Tracing, Evaluation & Prompt Optimization"
+og:description: "Trace every LLM call, run automated evaluations with 30+ metrics, and optimize prompts automatically. Open-source platform built for production AI applications."
 ---
 
-Opik is an [open-source](https://github.com/comet-ml/opik) logging, debugging, and optimization
-platform for AI agents and LLM applications. If you're building AI features, you know it's easy to
-spin up a working prototype but harder to log, test, iterate, and monitor to meet production
-requirements.
-
-Opik gives you all the tools you need to go from LLM observability to action across your AI
-application footprint and dev cycle. Ship measurable improvements with gorgeous logs, annotation and
-scoring functions, pre-configured LLM-as-a-judge [eval metrics](/evaluation/metrics/overview), and
-even [automated agent optimization algorithms](/development/optimization-runs/overview) to maximize performance. 
-
-<Note>
-  **Upgrading from Opik 1.x?** Opik 2.0 reorganized everything around projects — datasets,
-  prompts, and experiments are now scoped to a project. See [Upgrading to Opik 2.0](/opik-v2-upgrade)
-  for what changed, how to update your code, and where your existing data moved.
-</Note>
-
-## End-to-End AI Engineering
-
-<Frame>
-  <img src="/img/home/EndToEnd-Engineering-Diagram.jpg" />
-</Frame>
-
-<Tip>
-  Opik is Open Source! You can find the full source code on [GitHub](https://github.com/comet-ml/opik) and the complete
-  self-hosting guide can be found [here](/self-host/local_deployment).
-</Tip>
-
-## Core Functions
+Opik is an open-source platform for tracing, evaluating, and optimizing LLM applications — from first prototype to production. [Get started in minutes →](/quickstart)
 
 <CardGroup cols={2}>
-  <Card title="Quickstart Guide" href="/quickstart" icon="fa-solid fa-rocket" iconPosition="left">
-    Opik integrates with your existing AI stack through your model provider or LLM framework.
+  <Card title="Trace my LLM calls" href="/tracing/getting-started" icon="fa-solid fa-eye" iconPosition="left">
+    See every LLM call, tool invocation, and span in real time. Debug failures, track token costs, and understand exactly what your agent is doing at every step.
   </Card>
-  <Card title="LLM Observability - Log LLM Traces" href="/tracing/advanced/log_traces" icon="fa-solid fa-eye" iconPosition="left">
-    Traces give you instant visibility into what's working, what's not, and why and includes
-    advanced analysis and debugging features built in. 
+  <Card title="Evaluate my agent's quality" href="/evaluation/getting-started" icon="fa-solid fa-chart-line" iconPosition="left">
+    Run automated evaluations with LLM-as-a-judge and 30+ pre-built metrics. Build test suites from real production failures and catch regressions before they ship.
   </Card>
-  <Card title="Evaluation - Score Performance" href="/evaluation/overview" icon="fa-solid fa-chart-line" iconPosition="left">
-    Use LLM-as-a-judge and heuristic eval metrics to score your app or agent on hallucination,
-    context recall, and more. 
+  <Card title="Optimize my prompts automatically" href="/optimization-runs/quickstart" icon="fa-solid fa-brain" iconPosition="left">
+    Use six optimization algorithms to auto-generate and score better prompts for every step of your agentic system — no manual tuning required.
   </Card>
-  <Card title="Agent Optimization" href="/development/optimization-runs/overview" icon="fa-solid fa-brain" iconPosition="left">
-    Choose from six advanced optimization algorithms to auto-generate and score the best prompts for
-    the steps in your agentic system. 
-  </Card>
-  <Card title="Prompt Engineering" href="/v1/prompt_engineering/prompt_management" icon="fa-solid fa-wand-magic-sparkles" iconPosition="left">
-    Store and version system prompts, compare results live in the [Prompt Playground](/v1/prompt_engineering/playground),
-    and experiment with different models with our LLM proxy. 
-  </Card>
-  <Card title="Self-hosting Opik" href="/self-host/overview" icon="fa-solid fa-server" iconPosition="left">
-    Deploy Opik on your own infrastructure with local or Kubernetes deployment options.
+  <Card title="Run Opik on my own infrastructure" href="/self-host/overview" icon="fa-solid fa-server" iconPosition="left">
+    Deploy with Docker locally or Kubernetes at scale. Full control over your data with no cloud dependency.
   </Card>
 </CardGroup>
 
-## Video Tutorials
-
-Prefer a visual guide ? Follow along as we cover everything from basic setup and trace logging to
-LLM evaluation metrics, production monitoring, and more.
+## See it in action
 
 <Frame>
   <iframe
@@ -78,17 +38,5 @@ LLM evaluation metrics, production monitoring, and more.
 </Frame>
 
 <Tip>
-  You can find a full set of video tutorials in the [Opik University](/v1/opik-university/overview).
+  More video walkthroughs are in [Opik University](/v1/opik-university/overview). Opik is open source — browse the code on [GitHub](https://github.com/comet-ml/opik) or follow the [self-hosting guide](/self-host/local_deployment) to run it yourself.
 </Tip>
-
-## Open-Source access meets enterprise performance
-
-All Opik versions ([cloud](https://www.comet.com/signup?from=llm),
-[open source](https://github.com/comet-ml/opik), and
-[enterprise](https://www.comet.com/site/pricing/)) include the full AI engineering featureset
-and run on the Comet platform, with proven performance at scale supporting many of the world's
-largest organizations. 
-
-Compare Opik to other LLM observability tools and you'll find that traces populate faster,
-evaluations run smoother, and reliability comes standard — even for complex agentic systems serving
-millions of users in production. 

--- a/apps/opik-documentation/documentation/fern/docs-v2/home.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/home.mdx
@@ -37,6 +37,10 @@ Opik is an open-source platform for tracing, evaluating, and optimizing LLM appl
   ></iframe>
 </Frame>
 
-<Tip>
-  More video walkthroughs are in [Opik University](/v1/opik-university/overview). Opik is open source — browse the code on [GitHub](https://github.com/comet-ml/opik) or follow the [self-hosting guide](/self-host/local_deployment) to run it yourself.
-</Tip>
+## Open-source access meets enterprise performance
+
+All Opik versions ([cloud](https://www.comet.com/signup?from=llm),
+[open source](https://github.com/comet-ml/opik), and
+[enterprise](https://www.comet.com/site/pricing/)) include the full AI engineering feature set
+and run on the Comet platform, with proven performance at scale supporting many of the world's
+largest organizations.

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/adk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/adk.mdx
@@ -606,7 +606,7 @@ opik_tracer.flush()
 
 ## Prompts integration
 
-The `OpikTracer` can be used together with the [OPIK prompts library](/v1/prompt_engineering/prompt_management)
+The `OpikTracer` can be used together with the [Opik prompt library](/prompt-library/getting-started)
 to easily access your existing prompts or create new ones, and then associate them with traces or spans within an ADK agent flow.
 
 ```python

--- a/apps/opik-documentation/documentation/fern/docs-v2/quickstart.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/quickstart.mdx
@@ -288,8 +288,6 @@ stack and follow the three steps to log your first trace:
 
 After running your application, you will start seeing your traces in Opik and you can use Ollie to analyze them and improve your agent.
 
-{/* [text](TODO: Update video) */}
-
 <video
   src="/img/tracing/quickstart.mp4"
   width="854"
@@ -305,9 +303,7 @@ If you don't see traces appearing, reach out to us on [Slack](https://chat.comet
 
 ## Next steps
 
-{/* [text](TODO: Update links and next steps) */}
-
-Now that you have logged your first Agent calls to, why not check out:
+Now that you have logged your first traces, here's what to explore next:
 
 1. [In depth guide on agent observability](/tracing/advanced/log_traces): Learn how to customize the data
    that is logged to Opik and how to log conversations.

--- a/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/annotate_traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/annotate_traces.mdx
@@ -168,10 +168,8 @@ This gives you the flexibility to evaluate exactly what you need, when you need 
 
 You can go one step further and:
 
-1. [Create an offline evaluation](/v1/evaluation/evaluate_prompt) to evaluate your agent before it is
-   deployed to production
-2. [Score your agent in production](/production/online-evaluation/rules) to track and catch specific issues with your
+1. [Score your agent in production](/production/online-evaluation/rules) to track and catch specific issues with your
    agent
-3. [Use annotation queues](/evaluation/advanced/annotation_queues) to organize your traces for review and
+2. [Use annotation queues](/evaluation/advanced/annotation_queues) to organize your traces for review and
    labeling by your team of experts
-4. [Checkout our LLM as a Judge metrics](/evaluation/metrics/overview)
+3. [Checkout our LLM as a Judge metrics](/evaluation/metrics/overview)

--- a/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/cost_tracking.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/cost_tracking.mdx
@@ -46,7 +46,7 @@ Track your overall project costs in:
 
 ## Retrieving Costs Programmatically
 
-You can retrieve the estimated cost programmatically for both spans and traces. Note that the cost will be `None` if the span or trace used an unsupported model. See [Exporting Traces and Spans](/v1/tracing/export_data) for more ways of exporting traces and spans.
+You can retrieve the estimated cost programmatically for both spans and traces. Note that the cost will be `None` if the span or trace used an unsupported model.
 
 ### Retrieving Span Costs
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/log_traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/log_traces.mdx
@@ -408,9 +408,6 @@ agent calls in Opik. In the Opik UI, you can review each agent call, see the
   <img src="/img/tracing/tracing_agent_overview.png" />
 </Frame>
 
-As a next step, you can create an [offline evaluation](/v1/evaluation/evaluate_prompt) to evaluate your
-agent's performance on a fixed set of samples.
-
 ## Advanced usage
 
 ### Using function decorators

--- a/apps/opik-documentation/documentation/fern/docs-v2/tracing/concepts.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/tracing/concepts.mdx
@@ -1,75 +1,64 @@
 ---
 description: Learn about the core concepts of Opik's tracing system, including traces,
-  spans, threads, and how they work together to provide comprehensive observability
+  spans, and threads, and how they work together to provide comprehensive observability
   for your LLM applications.
-headline: Concepts | Opik Documentation
-og:description: Learn to monitor and optimize LLM applications with Opik's tracing.
-  Understand key concepts to leverage your observability effectively.
+headline: Tracing Concepts | Opik Documentation
+og:description: Understand traces, spans, and threads — the building blocks of Opik's
+  observability system for LLM applications and agents.
 og:site_name: Opik Documentation
-og:title: Tracing Concepts in Opik - Enhance Observability
+og:title: Tracing Concepts in Opik - Traces, Spans & Threads
 subtitle: Understanding the fundamental concepts behind Opik's tracing platform
 title: Tracing Core Concepts
 ---
 
 <Tip>
-  If you want to jump straight to logging traces, you can head to the [Log traces](/tracing/advanced/log_traces) or [Log agents](/tracing/advanced/log_traces) guides.
+  Ready to start logging? Head to [Log traces](/tracing/advanced/log_traces) or [Log agents](/tracing/advanced/log_agent_graphs).
 </Tip>
 
-Tracing is the foundation of observability in Opik. It allows you to monitor, debug, and optimize your LLM applications by capturing detailed information about their execution. Understanding these core concepts is essential for effectively using Opik's tracing capabilities.
+Opik's tracing system gives you full visibility into what your LLM application or agent is doing — every call, every step, every intermediate result. There are three building blocks you need to understand:
 
-## Overview
-
-When working with LLM applications, understanding what's happening under the hood is crucial for debugging issues, optimizing performance, and ensuring reliability. Opik's tracing system provides comprehensive observability by capturing detailed execution information at multiple levels.
-
-In order to effectively use Opik's tracing capabilities, it's important to understand these key concepts:
-
-1. **Trace**: A complete execution path representing a single interaction with an LLM or agent
-2. **Span**: Individual operations or steps within a trace that represent specific actions or computations
-3. **Thread**: A collection of related traces that form a coherent conversation or workflow
-4. **Metric**: Quantitative measurements that provide objective assessments of your AI models' performance
-5. **Optimization**: The systematic process of refining and evaluating LLM prompts and configurations
-6. **Evaluation**: A framework for systematically testing your prompts and models against datasets
+1. **Trace**: A complete execution path for a single interaction with an LLM or agent
+2. **Span**: An individual operation or step within a trace
+3. **Thread**: A collection of related traces that form a conversation or multi-turn workflow
 
 ## Traces
 
-A **trace** represents a complete execution path for a single interaction with an LLM or agent. Think of it as a detailed record of everything that happened during one request-response cycle. Each trace captures the full context of the interaction, including inputs, outputs, timing, and any intermediate steps.
+A **trace** represents a complete execution path for a single interaction with an LLM or agent. Think of it as a detailed record of everything that happened during one request-response cycle — inputs, outputs, timing, token usage, and any intermediate steps.
 
-### Key Characteristics of Traces:
+### Key characteristics
 
-- **Unique Identity**: Each trace has a unique identifier that allows you to track and reference it
-- **Complete Context**: Contains all the information needed to understand what happened during the interaction
-- **Timing Information**: Records when the interaction started, ended, and how long each part took
-- **Input/Output Data**: Captures the exact prompts sent to the LLM and the responses received
-- **Metadata**: Includes additional context like model used, temperature settings, and custom tags
+- **Unique identity**: Each trace has a unique identifier for tracking and referencing
+- **Complete context**: All information needed to understand what happened during the interaction
+- **Timing information**: When the interaction started, ended, and how long each part took
+- **Input/output data**: The exact prompts sent to the LLM and the responses received
+- **Metadata**: Model used, temperature settings, custom tags, and more
 
-### Example Use Cases:
+### Common uses
 
-- **Debugging**: When an LLM produces unexpected output, you can examine the trace to understand what went wrong
-- **Performance Analysis**: Identify bottlenecks and slow operations by analyzing trace timing
-- **Cost Tracking**: Monitor token usage and associated costs for each interaction
-- **Quality Assurance**: Review traces to ensure your application is behaving as expected
+- **Debugging**: When an LLM produces unexpected output, examine the trace to understand what went wrong
+- **Performance analysis**: Identify slow operations by analyzing trace timing
+- **Cost tracking**: Monitor token usage and costs for each interaction
+- **Quality assurance**: Review traces to ensure expected behavior
 
 ## Spans
 
-A **span** represents an individual operation or step within a trace. While a trace shows the complete picture, spans break down the execution into granular, measurable components. This hierarchical structure allows you to understand both the high-level flow and the detailed operations within your LLM application.
+A **span** represents an individual operation or step within a trace. While a trace shows the complete picture, spans break it down into measurable components. Spans are hierarchical — they can contain other spans, creating a tree structure within the trace.
 
-### Key Characteristics of Spans:
+### Key characteristics
 
-- **Hierarchical Structure**: Spans can contain other spans, creating a tree-like structure within a trace
-- **Specific Operations**: Each span represents a distinct action, such as a function call, API request, or data processing step
-- **Detailed Timing**: Precise start and end times for each operation
-- **Context Preservation**: Maintains the relationship between parent and child operations
-- **Custom Attributes**: Can include additional metadata specific to the operation
+- **Hierarchical structure**: Spans can contain child spans, forming a tree within a trace
+- **Specific operations**: Each span represents a distinct action — an API call, a function, a data transformation
+- **Precise timing**: Start and end times for each operation
+- **Custom attributes**: Additional metadata specific to the operation
 
-### Common Span Types:
+### Common span types
 
 - **LLM Calls**: Individual requests to language models
 - **Function Calls**: Tool or function invocations within an agent
 - **Data Processing**: Transformations or manipulations of data
 - **External API Calls**: Requests to third-party services
-- **Custom Operations**: Any user-defined operation you want to track
 
-### Example Span Hierarchy:
+### Example span hierarchy
 
 ```
 Trace: "Customer Support Chat"
@@ -85,129 +74,59 @@ Trace: "Customer Support Chat"
 
 ## Threads
 
-A **thread** is a collection of related traces that form a coherent conversation or workflow. Threads are essential for understanding multi-turn interactions and maintaining context across multiple LLM calls. They provide a way to group related traces together, making it easier to analyze conversational patterns and user journeys.
+A **thread** is a collection of related traces that form a coherent conversation or multi-turn workflow. Threads are essential for chat applications and agents where context evolves across multiple interactions.
 
-### Key Characteristics of Threads:
+### Key characteristics
 
-- **Conversation Context**: Maintains the flow of multi-turn interactions
-- **Trace Grouping**: Organizes related traces under a single thread identifier
-- **Temporal Ordering**: Traces within a thread are ordered chronologically
-- **Shared Context**: Allows you to see how context evolves throughout a conversation
-- **Cross-Trace Analysis**: Enables analysis of patterns across multiple related interactions
+- **Conversation context**: Maintains the flow of multi-turn interactions
+- **Trace grouping**: Organizes related traces under a single thread identifier
+- **Chronological ordering**: Traces within a thread are ordered by time
+- **Cross-trace analysis**: Enables analysis of patterns across related interactions
 
-### When to Use Threads:
+### When to use threads
 
-- **Chat Applications**: Group all messages in a conversation
-- **Multi-Step Workflows**: Track complex processes that span multiple LLM calls
-- **User Sessions**: Organize all interactions from a single user session
-- **Agent Conversations**: Follow the complete interaction between an agent and a user
+- **Chat applications**: Group all messages in a conversation
+- **Multi-step workflows**: Track complex processes that span multiple LLM calls
+- **User sessions**: Organize all interactions from a single user session
+- **Agent conversations**: Follow the complete interaction between an agent and a user
 
-### Thread Management:
+Threads are created by setting a `thread_id` on your traces:
 
-Threads are created by defining a `thread_id` and referencing it in your traces. This allows you to:
+```python
+import opik
 
-- **Maintain Context**: Keep track of conversation history and user state
-- **Debug Conversations**: Understand how a conversation evolved over time
-- **Analyze Patterns**: Identify common conversation flows and user behaviors
-- **Optimize Performance**: Find bottlenecks in multi-turn interactions
+client = opik.Opik()
+client.trace(
+    name="chat-turn-1",
+    thread_id="user-session-abc123",
+    input={"message": "Hello"},
+    output={"response": "Hi! How can I help?"},
+)
+```
 
-## Metrics
-
-**Metrics** provide quantitative assessments of your AI models' outputs, enabling objective comparisons and performance tracking over time. They are essential for understanding how well your LLM applications are performing and identifying areas for improvement.
-
-### Key Characteristics of Metrics:
-
-- **Quantitative Measurement**: Provide numerical scores that can be compared and tracked
-- **Objective Assessment**: Remove subjective bias from performance evaluation
-- **Trend Analysis**: Enable tracking of performance changes over time
-- **Comparative Analysis**: Allow comparison between different models, prompts, or configurations
-- **Automated Evaluation**: Can be computed automatically without human intervention
-
-### Common Metric Types:
-
-- **Accuracy Metrics**: Measure how often the model produces correct outputs
-- **Quality Metrics**: Assess the quality of generated text (e.g., coherence, relevance)
-- **Efficiency Metrics**: Track performance characteristics like latency and throughput
-- **Cost Metrics**: Monitor token usage and associated costs
-- **Custom Metrics**: Domain-specific measurements tailored to your use case
-
-## Optimization
-
-**Optimization** is the systematic process of refining and evaluating LLM prompts and configurations to improve performance. It involves iteratively testing different approaches and using data-driven insights to make improvements.
-
-### Key Aspects of Optimization:
-
-- **Prompt Engineering**: Refining the instructions given to LLMs
-- **Parameter Tuning**: Adjusting model settings like temperature, top-p, and max tokens
-- **Few-shot Learning**: Optimizing example selection for in-context learning
-- **Tool Integration**: Improving how LLMs interact with external tools and functions
-- **Performance Monitoring**: Tracking improvements and regressions over time
-
-## Evaluation
-
-**Evaluation** provides a framework for systematically testing your prompts and models against datasets using various metrics to measure performance. It's the foundation for making data-driven decisions about your LLM applications.
-
-### Key Components of Evaluation:
-
-- **Datasets**: Collections of test cases with inputs and expected outputs
-- **Experiments**: Individual evaluation runs that test specific configurations
-- **Metrics**: Quantitative measures of performance
-- **Comparative Analysis**: Side-by-side comparison of different approaches
-- **Statistical Significance**: Ensuring results are reliable and reproducible
-
-## Learn More
-
-Now that you understand the core concepts, explore these resources to dive deeper:
-
-### Tracing and Observability:
-- [Log traces](/tracing/advanced/log_traces) - Learn how to capture traces in your applications
-- [Log agents](/tracing/advanced/log_traces) - Understand how to trace agent-based applications
-- [Annotate traces](/tracing/advanced/annotate_traces) - Add custom metadata to your traces
-- [Cost tracking](/tracing/advanced/cost_tracking) - Monitor and analyze costs
-
-### Evaluation and Testing:
-- [Evaluation concepts](/evaluation/concepts) - Deep dive into evaluation concepts
-- [Evaluate prompts](/v1/evaluation/evaluate_prompt) - Test and compare different prompts
-- [Evaluate agents](/evaluation/evaluate_agents) - Evaluate complex agent systems
-- [Metrics overview](/evaluation/metrics/overview) - Available evaluation metrics
-
-### Optimization:
-- [Agent Optimization concepts](/development/optimization-runs/optimization/concepts) - Core optimization concepts
-- [Optimization algorithms](/development/optimization-runs/overview) - Available optimization strategies
-- [Best practices](/development/optimization-runs/overview) - Optimization best practices
-
-### Integration Guides:
-- [SDK Configuration](/tracing/advanced/sdk_configuration) - Configure Opik in your applications
-- [Supported Models](/tracing/advanced/cost_tracking) - Models compatible with Opik
-- [Integrations](/integrations/overview) - Framework-specific integration guides
-
-## Best Practices for Tracing
+## Best practices
 
 <Steps>
-  <Step title="1. Start with Clear Trace Boundaries">
-    Define clear boundaries for what constitutes a single trace. Typically, this should align with a complete user interaction or business operation.
+  <Step title="Define clear trace boundaries">
+    A trace should represent a complete user interaction or business operation — not a single function call and not an entire session.
   </Step>
-  <Step title="2. Use Meaningful Span Names">
-    Choose descriptive names for your spans that clearly indicate what operation is being performed. This makes debugging much easier.
+  <Step title="Use meaningful span names">
+    Descriptive span names make debugging much easier. Name spans after what they do: `search_vector_db`, `call_gpt4`, `rank_results`.
   </Step>
-  <Step title="3. Leverage Thread IDs for Conversations">
-    Use consistent thread IDs for related interactions. This is especially important for chat applications and multi-step workflows.
+  <Step title="Use thread IDs for conversations">
+    Assign a consistent `thread_id` to all traces from the same conversation or session. This is especially important for chat applications.
   </Step>
-  <Step title="4. Add Relevant Metadata">
-    Include custom attributes and metadata that will be useful for analysis. Consider adding user IDs, session information, and business context.
+  <Step title="Add relevant metadata">
+    Include custom attributes that will be useful for analysis — user IDs, session context, model versions, experiment names.
   </Step>
-  <Step title="5. Monitor Performance Continuously">
-    Set up alerts and dashboards to monitor trace performance, error rates, and costs. This helps you catch issues early.
-  </Step>
-  <Step title="6. Use Traces for Optimization">
-    Regularly analyze your traces to identify optimization opportunities, such as reducing latency or improving prompt effectiveness.
+  <Step title="Be careful with sensitive data">
+    Avoid logging personally identifiable information (PII) or sensitive business data in your traces. Use Opik's data filtering capabilities to protect sensitive information.
   </Step>
 </Steps>
 
-<Tip>
-  **Pro Tip**: Start with basic tracing and gradually add more detailed spans as you identify areas that need deeper observability. Don't try to trace everything at once - focus on the most critical paths first.
-</Tip>
+## Next steps
 
-<Warning>
-  **Important**: Be mindful of sensitive data when tracing. Avoid logging personally identifiable information (PII) or sensitive business data in your traces. Use Opik's data filtering capabilities to protect sensitive information.
-</Warning>
+- [Log traces](/tracing/advanced/log_traces) — Capture traces in your application
+- [Log agent graphs](/tracing/advanced/log_agent_graphs) — Trace agent-based applications with full span trees
+- [Annotate traces](/tracing/advanced/annotate_traces) — Add scores and feedback to traces
+- [Cost tracking](/tracing/advanced/cost_tracking) — Monitor token usage and costs

--- a/apps/opik-documentation/documentation/fern/docs-v2/tracing/dashboards/production_monitoring.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/tracing/dashboards/production_monitoring.mdx
@@ -73,7 +73,7 @@ traces = opik_client.search_traces(
 
 <Tip>
 
-The `search_traces` method allows you to fetch traces based on any of trace attributes, you can learn more about the different search parameters in the [search traces documentation](/v1/tracing/export_data).
+The `search_traces` method allows you to fetch traces based on any trace attribute.
 
 </Tip>
 

--- a/apps/opik-documentation/documentation/fern/docs.yml
+++ b/apps/opik-documentation/documentation/fern/docs.yml
@@ -24,8 +24,6 @@ favicon: img/logo.svg
 js:
   - path: ./add_cookbook_banner.js
     strategy: afterInteractive
-  - path: ./v1_noindex.js
-    strategy: afterInteractive
 css: ./styles.css
 
 analytics:

--- a/apps/opik-documentation/documentation/fern/docs.yml
+++ b/apps/opik-documentation/documentation/fern/docs.yml
@@ -453,7 +453,7 @@ redirects:
     permanent: true
   # Agent optimization restructuring redirects
   - source: "/docs/opik/agent_optimization/opik_optimizer/quickstart"
-    destination: "/docs/opik/development/optimization-runs/overview"
+    destination: "/docs/opik/development/optimization-runs/quickstart"
     permanent: true
   - source: "/docs/opik/agent_optimization/opik_optimizer/datasets"
     destination: "/docs/opik/development/optimization-runs/overview"

--- a/apps/opik-documentation/documentation/fern/docs.yml
+++ b/apps/opik-documentation/documentation/fern/docs.yml
@@ -24,6 +24,8 @@ favicon: img/logo.svg
 js:
   - path: ./add_cookbook_banner.js
     strategy: afterInteractive
+  - path: ./v1_noindex.js
+    strategy: afterInteractive
 css: ./styles.css
 
 analytics:

--- a/apps/opik-documentation/documentation/fern/docs/administration/admin-dashboard/organization_settings.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/admin-dashboard/organization_settings.mdx
@@ -5,6 +5,7 @@ og:site_name: Opik Documentation
 og:title: 'Opik Organization Settings: Configure Your Organization'
 subtitle: Manage organization-wide configuration
 title: Organization Settings
+canonical-url: https://www.comet.com/docs/opik/administration/admin-dashboard/organization_settings
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/administration/admin-dashboard/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/admin-dashboard/overview.mdx
@@ -5,6 +5,7 @@ og:site_name: Opik Documentation
 og:title: 'Opik Admin Dashboard: Access and Navigation Guide'
 subtitle: How to access and use the organization administration dashboard
 title: Admin Dashboard
+canonical-url: https://www.comet.com/docs/opik/administration/admin-dashboard/overview
 ---
 
 The Admin Dashboard is the central hub for managing your organization in Opik. From here, organization administrators can manage users, workspaces, authentication settings, and more.

--- a/apps/opik-documentation/documentation/fern/docs/administration/admin-dashboard/service_accounts.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/admin-dashboard/service_accounts.mdx
@@ -5,6 +5,7 @@ og:site_name: Opik Documentation
 og:title: 'Opik Service Accounts: Programmatic API Access'
 subtitle: Creating and managing service accounts for automated systems and integrations
 title: Service Accounts
+canonical-url: https://www.comet.com/docs/opik/administration/admin-dashboard/service_accounts
 ---
 
 Service accounts provide programmatic access to Opik for automated systems, CI/CD pipelines, and integrations. Unlike user accounts, service accounts use API keys for authentication and don't require interactive login.

--- a/apps/opik-documentation/documentation/fern/docs/administration/admin-dashboard/users.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/admin-dashboard/users.mdx
@@ -5,6 +5,7 @@ og:site_name: Opik Documentation
 og:title: 'Opik Users: Managing Organization Access'
 subtitle: Manage users and organization roles
 title: Users
+canonical-url: https://www.comet.com/docs/opik/administration/admin-dashboard/users
 ---
 
 The Users section in the Admin Dashboard allows organization administrators to view all users, change organization roles, and remove users from the organization.

--- a/apps/opik-documentation/documentation/fern/docs/administration/admin-dashboard/workspaces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/admin-dashboard/workspaces.mdx
@@ -5,6 +5,7 @@ og:site_name: Opik Documentation
 og:title: 'Managing Workspaces in Opik'
 subtitle: Create and manage workspaces within your organization
 title: Workspaces
+canonical-url: https://www.comet.com/docs/opik/administration/admin-dashboard/workspaces
 ---
 
 Workspaces group related projects together within your organization. Each workspace has its own members, roles, and isolated data (traces, experiments, datasets).

--- a/apps/opik-documentation/documentation/fern/docs/administration/authentication/jwt.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/authentication/jwt.mdx
@@ -5,6 +5,7 @@ og:site_name: Opik Documentation
 og:title: 'Configure JWT Authentication in Opik: API Access Guide'
 subtitle: Setting up JWT token authentication for programmatic and service access
 title: JWT Authentication
+canonical-url: https://www.comet.com/docs/opik/administration/authentication/jwt
 ---
 
 JWT (JSON Web Token) authentication enables programmatic access to Opik using externally issued tokens. This is ideal for service-to-service authentication, custom auth flows, and integration with existing JWT-based systems.

--- a/apps/opik-documentation/documentation/fern/docs/administration/authentication/oidc.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/authentication/oidc.mdx
@@ -5,6 +5,7 @@ og:site_name: Opik Documentation
 og:title: 'Configure OIDC SSO in Opik: Step-by-Step Guide'
 subtitle: Setting up OpenID Connect authentication with your identity provider
 title: OIDC SSO
+canonical-url: https://www.comet.com/docs/opik/administration/authentication/oidc
 ---
 
 OpenID Connect (OIDC) is a modern authentication protocol built on OAuth 2.0. This guide walks you through configuring OIDC SSO for your Opik organization.

--- a/apps/opik-documentation/documentation/fern/docs/administration/authentication/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/authentication/overview.mdx
@@ -5,6 +5,7 @@ og:site_name: Opik Documentation
 og:title: 'Opik Authentication: SSO and JWT Configuration Guide'
 subtitle: Understanding authentication options and choosing the right approach
 title: Authentication Overview
+canonical-url: https://www.comet.com/docs/opik/administration/authentication/overview
 ---
 
 Opik supports multiple authentication methods to integrate with your organization's identity management infrastructure. This guide helps you understand the available options and choose the right approach for your needs.

--- a/apps/opik-documentation/documentation/fern/docs/administration/authentication/saml.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/authentication/saml.mdx
@@ -5,6 +5,7 @@ og:site_name: Opik Documentation
 og:title: 'Configure SAML SSO in Opik: Step-by-Step Guide'
 subtitle: Setting up SAML-based single sign-on with your identity provider
 title: SAML SSO
+canonical-url: https://www.comet.com/docs/opik/administration/authentication/saml
 ---
 
 SAML (Security Assertion Markup Language) SSO allows your users to authenticate using your organization's identity provider (IdP). This guide walks you through configuring SAML SSO for your Opik organization.

--- a/apps/opik-documentation/documentation/fern/docs/administration/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/overview.mdx
@@ -5,6 +5,7 @@ og:site_name: Opik Documentation
 og:title: 'Opik Administration: Managing Users, Workspaces, and Permissions'
 subtitle: Multi-user collaboration with enterprise-grade access control
 title: Overview
+canonical-url: https://www.comet.com/docs/opik/administration/overview
 ---
 
 Opik Cloud and Enterprise include administration features for teams and organizations, including:

--- a/apps/opik-documentation/documentation/fern/docs/administration/roles_and_permissions.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/roles_and_permissions.mdx
@@ -5,6 +5,7 @@ og:site_name: Opik Documentation
 og:title: 'Opik Roles and Permissions: Workspace Access Control'
 subtitle: Understanding and configuring workspace roles and the permission model
 title: Roles and Permissions
+canonical-url: https://www.comet.com/docs/opik/administration/roles_and_permissions
 ---
 
 Opik uses a role-based access control (RBAC) system that allows you to define what users can do within workspaces. This guide explains how roles and permissions work, the default roles available, and how to create custom roles.

--- a/apps/opik-documentation/documentation/fern/docs/administration/workspace-settings/ai_providers.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/workspace-settings/ai_providers.mdx
@@ -6,6 +6,7 @@ og:description: Configure connections to various LLMs in Opik, manage integratio
 og:site_name: Opik Documentation
 og:title: Configure AI Providers in Opik
 title: AI Providers
+canonical-url: https://www.comet.com/docs/opik/administration/workspace-settings/ai_providers
 ---
 
 AI Providers let you connect LLMs for use in the Playground and Online Evaluation.

--- a/apps/opik-documentation/documentation/fern/docs/administration/workspace-settings/feedback_definitions.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/workspace-settings/feedback_definitions.mdx
@@ -6,6 +6,7 @@ og:description: Create and manage custom labels to systematically collect and an
 og:site_name: Opik Documentation
 og:title: Feedback Definitions - Opik
 title: Feedback Definitions
+canonical-url: https://www.comet.com/docs/opik/administration/workspace-settings/feedback_definitions
 ---
 
 Feedback definitions allow you to create custom labels to systematically collect and analyze structured feedback on your LLM outputs.

--- a/apps/opik-documentation/documentation/fern/docs/administration/workspace-settings/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/workspace-settings/overview.mdx
@@ -5,6 +5,7 @@ og:site_name: Opik Documentation
 og:title: 'Opik Workspace Settings: Configure Your Workspace'
 subtitle: Understanding workspace-level configuration options in Opik
 title: Overview
+canonical-url: https://www.comet.com/docs/opik/administration/workspace-settings/overview
 ---
 
 Workspace settings allow you to configure options that apply to your entire workspace. These settings are managed separately from organization-level administration features.

--- a/apps/opik-documentation/documentation/fern/docs/administration/workspace-settings/workspace_members.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/workspace-settings/workspace_members.mdx
@@ -5,6 +5,7 @@ og:site_name: Opik Documentation
 og:title: 'Opik Workspace Members: Managing Workspace Access'
 subtitle: Invite users, manage members, and control workspace-level access
 title: Workspace Members
+canonical-url: https://www.comet.com/docs/opik/administration/workspace-settings/workspace_members
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/administration/workspace-settings/workspace_preferences.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/administration/workspace-settings/workspace_preferences.mdx
@@ -5,6 +5,7 @@ og:site_name: Opik Documentation
 og:title: 'Opik Workspace Preferences: Customize Your Workspace Behavior'
 subtitle: Configure workspace-wide behavior settings
 title: Workspace Preferences
+canonical-url: https://www.comet.com/docs/opik/administration/workspace-settings/workspace_preferences
 ---
 
 Workspace preferences let workspace owners configure behavior settings that apply across the entire workspace.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/advanced/chaining_optimizers.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/advanced/chaining_optimizers.mdx
@@ -6,6 +6,7 @@ og:description: Learn to optimize workflows by chaining MetaPrompt and Parameter
 og:site_name: Opik Documentation
 og:title: Chaining Optimizers - Opik
 title: Chaining optimizers
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/advanced/chaining_optimizers
 ---
 
 Some projects benefit from running two or more optimizers back-to-back. For example, use MetaPrompt to improve wording, then Parameter optimizer to fine-tune sampling settings. This guide explains why you might chain runs, the trade-offs, and the APIs you use to pass prompts and metadata between stages.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/advanced/custom_metrics.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/advanced/custom_metrics.mdx
@@ -7,6 +7,7 @@ og:description: Explore custom metrics in Opik to enhance evaluations with domai
 og:site_name: Opik Documentation
 og:title: Custom Metrics for Evaluation - Opik
 title: Custom metrics
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/advanced/custom_metrics
 ---
 
 Use custom metrics when built-in metrics are not enough (domain-specific scoring, precise safety checks, unique multimodal checks). Start with the core Opik evaluation docs so you know what already exists:

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/advanced/multiple_completions.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/advanced/multiple_completions.mdx
@@ -2,6 +2,7 @@
 title: "Multiple Completions (n parameter)"
 subtitle: "Introduce variety at each trial with pass@k evaluation"
 description: "Learn how to use the n parameter to generate multiple candidate outputs per evaluation, reducing variance and improving optimization results through best-of-k selection."
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/advanced/multiple_completions
 ---
 
 When optimizing prompts, single-sample evaluation can be noisy - a good prompt might fail on a particular trial due to LLM stochasticity. The `n` parameter lets you generate **multiple candidate outputs per evaluation** and select the best one, introducing variety and reducing evaluation variance.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/advanced/n_samples.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/advanced/n_samples.mdx
@@ -2,6 +2,7 @@
 title: "Sampling controls"
 subtitle: "Balance dataset subsampling and multi-completion evaluation"
 description: "Use n_samples, n_samples_minibatch, and the n parameter to trade cost for stability and exploration."
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/advanced/n_samples
 ---
 
 When optimizing prompts, there are two independent sampling layers you can control:

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/advanced/prompt_customization.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/advanced/prompt_customization.mdx
@@ -2,6 +2,7 @@
 title: "Custom Optimizer Prompts"
 subtitle: "Customize the internal prompts used by optimizers"
 description: "Learn how to override and customize the internal prompt templates used by Opik optimizers to add domain constraints, safety requirements, or custom formatting."
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/advanced/prompt_customization
 ---
 
 The Opik Optimizer uses a **PromptLibrary** system that lets you customize the internal prompts used by each optimizer. This is useful when you need to:

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/benchmarks.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/benchmarks.mdx
@@ -7,6 +7,7 @@ og:description: Evaluate optimizer performance using Opik's datasets and scripts
 og:site_name: Opik Documentation
 og:title: Benchmarking Optimization Algorithms with Opik
 title: Optimizer benchmarks
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/algorithms/benchmarks
 ---
 
 We regularly evaluate every optimizer against shared datasets so you can make informed trade-offs. This page summarizes the latest results and explains how to reproduce them with the public benchmark scripts.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/evolutionary_optimizer.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/evolutionary_optimizer.mdx
@@ -9,6 +9,7 @@ og:site_name: Opik Documentation
 og:title: Evolutionary Optimization Algorithms with Opik
 subtitle: Discover optimal prompts with genetic algorithms and multi-objective optimization.
 title: 'Evolutionary Optimizer: Genetic Algorithms'
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/algorithms/evolutionary_optimizer
 ---
 
 The `EvolutionaryOptimizer` uses genetic algorithms to refine and discover effective prompts. It

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/extending_optimizers.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/extending_optimizers.mdx
@@ -8,6 +8,7 @@ og:site_name: Opik Documentation
 og:title: Extending Optimizers - Opik
 subtitle: Extend Opik with custom optimization algorithms and contributions.
 title: Extending Optimizers
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/advanced/extending_optimizers
 ---
 
 Opik Agent Optimizer is designed to be a flexible framework for prompt and agent optimization. While

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/fewshot_bayesian_optimizer.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/fewshot_bayesian_optimizer.mdx
@@ -8,6 +8,7 @@ og:site_name: Opik Documentation
 og:title: Few-Shot Bayesian Optimization Techniques - Opik
 subtitle: Optimize few-shot examples for chat prompts with Bayesian techniques.
 title: Few-Shot Bayesian Optimizer
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/algorithms/fewshot_bayesian_optimizer
 ---
 
 The FewShotBayesianOptimizer is a sophisticated prompt optimization tool adds relevant examples from

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/gepa_optimizer.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/gepa_optimizer.mdx
@@ -8,6 +8,7 @@ og:site_name: Opik Documentation
 og:title: Optimize Single-Turn Tasks with Opik - GEPA
 subtitle: Single-turn system prompt optimization with reflection
 title: GEPA Optimizer
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/algorithms/gepa_optimizer
 ---
 
 `GepaOptimizer` wraps the external [GEPA](https://github.com/gepa-ai/gepa) package to optimize a

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/hierarchical_reflective_optimizer.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/hierarchical_reflective_optimizer.mdx
@@ -8,6 +8,7 @@ og:site_name: Opik Documentation
 og:title: HRPO (Hierarchical Reflective Prompt Optimizer) - Opik
 subtitle: Hierarchical root cause analysis for targeted prompt improvement
 title: HRPO (Hierarchical Reflective Prompt Optimizer)
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/algorithms/hierarchical_adaptive_optimizer
 ---
 
 `HRPO` (Hierarchical Reflective Prompt Optimizer) uses hierarchical root cause analysis to identify and address

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/metaprompt_optimizer.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/metaprompt_optimizer.mdx
@@ -8,6 +8,7 @@ og:site_name: Opik Documentation
 og:title: Enhance Prompt Effectiveness with Opik
 subtitle: Refine and improve LLM prompts with systematic analysis.
 title: MetaPrompt Optimizer
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/algorithms/metaprompt_optimizer
 ---
 
 The MetaPrompter is a specialized optimizer designed for meta-prompt optimization. It focuses on

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/optimizer_parameters_guide.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/optimizer_parameters_guide.mdx
@@ -2,6 +2,7 @@
 title: "Optimizer Parameters Guide"
 subtitle: "Complete reference for all optimizer-specific parameters and their use cases"
 description: "Comprehensive guide to all parameters available for each optimizer, including usage recommendations and best practices."
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/algorithms/overview
 ---
 
 This guide provides a complete reference for all optimizer-specific parameters, their use cases, and best practices for tuning them effectively.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/overview.mdx
@@ -6,6 +6,7 @@ og:description: Explore and select the right optimizer in Opik to enhance your p
 og:site_name: Opik Documentation
 og:title: Overview of Optimization Algorithms - Opik
 title: Optimization algorithms overview
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/algorithms/overview
 ---
 
 The Opik Optimizer SDK wraps a mix of in-house algorithms (MetaPrompt, HRPO) and external research projects (e.g., GEPA). Each optimizer follows the same API (`optimize_prompt`, `OptimizationResult`) so you can swap them without rewriting your pipeline. Use this page to quickly decide which optimizer to run before diving into the detailed guides.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/parameter_optimizer.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/parameter_optimizer.mdx
@@ -8,6 +8,7 @@ og:site_name: Opik Documentation
 og:title: Optimize Parameters with Opik - Enhance LLM Performance
 subtitle: Optimize LLM parameters like temperature and top_p with Bayesian techniques.
 title: 'Parameter Optimizer: Bayesian Parameter Tuning'
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/algorithms/parameter_optimizer
 ---
 
 The `ParameterOptimizer` uses Bayesian optimization to tune LLM call parameters such as temperature, top_p, frequency_penalty, and other sampling parameters. Unlike other optimizers that modify the prompt itself, this optimizer keeps your prompt unchanged and focuses solely on finding the best parameter configuration for your specific task.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/tool_optimization.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/tool_optimization.mdx
@@ -8,6 +8,7 @@ og:site_name: Opik Documentation
 og:title: Optimize Prompts with Opik - Tool Optimization
 subtitle: Optimize prompts that use external tools and function calls
 title: Tool Optimization (MCP & Function Calling)
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/algorithms/tool_optimization
 ---
 
 Tool optimization is a specialized feature that allows you to optimize prompts that use external tools and the Model Context Protocol (MCP). This capability is supported by all optimizers **except** `FewShotBayesianOptimizer`, `ParameterOptimizer`, and `GepaOptimizer`.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/best_practices/prompt_engineering.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/best_practices/prompt_engineering.mdx
@@ -2,6 +2,7 @@
 title: "Advanced Prompt Engineering Best Practices"
 subtitle: "Learn the best approaches to prompt engineering"
 description: "Learn advanced prompt engineering techniques and how to apply them systematically using Opik Agent Optimizer for improved LLM performance."
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/overview
 ---
 
 Improving the performance of your LLM application and agent often requires improving the quality

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/cookbook/arc_agi_optimizer_cookbook.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/cookbook/arc_agi_optimizer_cookbook.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: ARC-AGI Optimization Tutorial
 subtitle: Tutorial example using ARC-AGI style code tasks
 title: ARC-AGI Optimization Tutorial
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/overview
 ---
 
 This guide introduces ARC-AGI, why it is a strong fit for optimizer-driven prompt iteration, and where to find the full, runnable implementation in the SDK.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/cookbook/multimodal_agent_optimizer_cookbook.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/cookbook/multimodal_agent_optimizer_cookbook.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Multimodal Agent Optimization Tutorial
 subtitle: Tutorial example inspired by a self-driving car vision agent
 title: Multimodal Agent Optimization Tutorial
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/overview
 ---
 
 This tutorial outlines how to optimize a multimodal agent (vision + text) and links to the full walkthrough for a self-driving car scenario. The SDK already includes a working example script and dataset you can run locally.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/cookbook/optimizer_introduction_cookbook.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/cookbook/optimizer_introduction_cookbook.mdx
@@ -8,6 +8,7 @@ og:site_name: Opik Documentation
 og:title: End-to-End Prompt Optimization with Opik
 subtitle: Quick example notebook using HotPotQA dataset
 title: Optimizer Introduction Cookbook
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/overview
 ---
 
 <Info>

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/cookbook/synthetic_data_optimizer_cookbook.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/cookbook/synthetic_data_optimizer_cookbook.mdx
@@ -8,6 +8,7 @@ og:site_name: Opik Documentation
 og:title: Optimize Synthetic Data Generation with Opik
 subtitle: Advanced example notebook using synthetic datasets
 title: Synthetic Data Optimizer Cookbook
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/overview
 ---
 
 <Info>

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/getting_started/changelog.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/getting_started/changelog.mdx
@@ -6,6 +6,7 @@ og:description: Monitor Opik updates to stay informed about new features, improv
 og:site_name: Opik Documentation
 og:title: Changelog - Opik Updates and Enhancements
 title: Changelog
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/changelog
 ---
 
 Stay current on Agent Optimizer updates. Each entry below reflects a version bump in `sdks/opik_optimizer/pyproject.toml` on `main`. The compare links jump straight to the commits that landed in that release. As Opik is a monorepo, you will see other non-optimizer related changes in the commit links below.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/getting_started/quickstart.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/getting_started/quickstart.mdx
@@ -7,6 +7,7 @@ og:description: Learn to enhance your workflows with Opik Agent Optimizer for au
 og:site_name: Opik Documentation
 og:title: Optimize Prompts with Opik Agent Optimizer
 title: Quickstart
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/quickstart
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/known_issues.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/known_issues.mdx
@@ -2,6 +2,7 @@
 description: Known runtime issues when running Opik Optimizer with current dependencies.
 headline: Known Issues
 title: Known Issues
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/known_issues
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/opik_optimizer/concepts.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/opik_optimizer/concepts.mdx
@@ -9,6 +9,7 @@ og:site_name: Opik Documentation
 og:title: Master Optimization Concepts with Opik
 subtitle: Common terminology and how we optimize
 title: Opik Agent Optimizer Core Concepts
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/optimization/concepts
 ---
 
 ## Overview

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/opik_optimizer/configure_models.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/opik_optimizer/configure_models.mdx
@@ -8,6 +8,7 @@ og:site_name: Opik Documentation
 og:title: Configure LLM Providers - Opik
 subtitle: Use any LLM provider with the Opik Optimizer
 title: Configuring LLM Providers
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/optimization/configure_models
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/opik_optimizer/faq.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/opik_optimizer/faq.mdx
@@ -8,6 +8,7 @@ og:site_name: Opik Documentation
 og:title: Optimize Your Agents with Opik
 subtitle: Common questions about the Opik Agent Optimizer
 title: Optimizer Frequently Asked Questions
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/faq
 ---
 
 ## Getting started

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/opik_optimizer/reference.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/opik_optimizer/reference.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Opik Agent Optimizer API Reference"
 subtitle: "Technical SDK reference guide"
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/advanced/api_reference
 ---
 
 The Opik Agent Optimizer SDK provides a comprehensive set of tools for optimizing LLM prompts and agents. This reference guide documents the standardized API that all optimizers follow, ensuring consistency and interoperability across different optimization algorithms.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/optimization/dashboard_results.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/optimization/dashboard_results.mdx
@@ -6,6 +6,7 @@ og:description: Explore optimization results in Opik. Understand changes after e
 og:site_name: Opik Documentation
 og:title: Dashboard Results - Opik
 title: Dashboard results
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/optimization/dashboard_results
 ---
 
 After each optimization run, visit the Opik dashboard to understand what changed and decide whether to ship the new prompt.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/optimization/define_datasets.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/optimization/define_datasets.mdx
@@ -6,6 +6,7 @@ og:description: Learn how to define and manage datasets in Opik to effectively s
 og:site_name: Opik Documentation
 og:title: Define Datasets in Opik - Essential for Optimization
 title: Define datasets
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/optimization/define_datasets
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/optimization/define_metrics.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/optimization/define_metrics.mdx
@@ -7,6 +7,7 @@ og:description: Learn to leverage metrics for optimizer decisions with Opik. Dis
 og:site_name: Opik Documentation
 og:title: Define Metrics for Optimization - Opik
 title: Define metrics
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/optimization/define_metrics
 ---
 
 Metrics drive optimizer decisions. This guide highlights the fastest way to pick proven presets from Opik’s evaluation catalog, then shows how to extend them when your use case demands it. If you need the full theory, see [Evaluation concepts](/v1/evaluation/concepts) and the [metrics overview](/v1/evaluation/metrics/overview).

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/optimization/optimization_studio.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/optimization/optimization_studio.mdx
@@ -5,6 +5,7 @@ headline: Optimization Studio | Opik Documentation
 og:description: Run prompt optimizations from the Opik UI with datasets, metrics, and visual progress tracking.
 og:site_name: Opik Documentation
 og:title: Optimization Studio - Opik
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/optimization_studio
 ---
 
 Optimization Studio helps you improve prompts without writing code. You bring a prompt, define what “good” looks like, and Opik tests variations to find a better version you can ship with confidence. Teams like it because it shortens the loop from idea to evidence: you see scores and examples, not just a hunch. If you prefer a programmatic workflow, use the [Optimize prompts](/v1/agent_optimization/optimization/optimize_prompts) guide.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/optimization/optimize_agents/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/optimization/optimize_agents/overview.mdx
@@ -6,6 +6,7 @@ og:description: Learn to enhance agent frameworks using Opik's Agent Optimizer f
 og:site_name: Opik Documentation
 og:title: Optimize Agents with Opik
 title: Optimize agents
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/optimization/optimize_agents
 ---
 
 The Opik Agent Optimizer can optimize both simple prompts and complex agent workflows. For most use cases, you can optimize prompts directly using `ChatPrompt`. When you need multi-prompt workflows, agent orchestration, or custom execution logic, you'll use `OptimizableAgent` to create a custom agent class.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/optimization/optimize_multimodal.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/optimization/optimize_multimodal.mdx
@@ -6,6 +6,7 @@ og:description: Optimize your multimodal agents to effectively handle text, imag
 og:site_name: Opik Documentation
 og:title: Optimize multimodal performance with Opik
 title: Optimize multimodal prompts
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/optimization/optimize_multimodal
 ---
 
 Multimodal agents often juggle text instructions, images, audio, video, and structured outputs. Opik’s optimizers can work with any model that LiteLLM supports for non-text modalities (GPT-4o, Gemini, Claude 3.5 Sonnet vision, etc.). Make sure that both the optimizer’s `model` and your `ChatPrompt.model` accept the modality you plan to optimize. Otherwise, the run will fail or silently ignore the media.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/optimization/optimize_prompts.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/optimization/optimize_prompts.mdx
@@ -6,6 +6,7 @@ og:description: Learn to enhance your prompt optimization process using proven t
 og:site_name: Opik Documentation
 og:title: Optimize prompts effectively with Opik
 title: Optimize prompts
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/optimization/optimize_prompts
 ---
 
 Use this playbook whenever you need to improve a prompt (single-turn or agentic) and want a repeatable process rather than manual tweaks.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/optimization/optimize_tools.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/optimization/optimize_tools.mdx
@@ -1,6 +1,7 @@
 ---
 title: Optimize tools (MCP)
 description: Improve MCP tool and parameter descriptions without changing prompt text.
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/optimization/optimize_tools
 ---
 
 Use this guide when you want to optimize **tool signatures** (descriptions + parameter descriptions) separately from prompt text or agent logic.

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/overview.mdx
@@ -11,6 +11,7 @@ og:image: /img/agent_optimization/introducing.png
 og:site_name: Opik Documentation
 og:title: Optimize Prompts with Opik Agent Optimizer
 title: Agent Optimization
+canonical-url: https://www.comet.com/docs/opik/development/optimization-runs/overview
 ---
 
 **Opik Agent Optimizer** is a turnkey, open-source agent and prompt optimization SDK. It automatically tunes prompts, tools, and agent workflows using the datasets, metrics, and traces you already log to Opik. Instead of hand-editing instructions and re-running evaluations, pick an optimizer (MetaPrompt, HRPO, Evolutionary, GEPA, etc.) and let it iterate for you online or fully offline inside Docker and Kubernetes.

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2024-09-30.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2024-09-30.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2024-09-30
+---
+
 **Opik Dashboard**:
 
 - Added option to delete experiments from the UI

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2024-10-07.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2024-10-07.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2024-10-07
+---
+
 **Opik Dashboard**:
 
 - Added `Updated At` column in the project page

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2024-10-14.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2024-10-14.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2024-10-14
+---
+
 **Opik Dashboard**:
 
 - Fix handling of large experiment names in breadcrumbs and popups

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2024-10-18.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2024-10-18.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2024-10-18
+---
+
 **Opik Dashboard**:
 
 - Added a new `Feedback modal` in the UI so you can easily provide feedback on any parts of the platform.

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2024-10-21.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2024-10-21.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2024-10-21
+---
+
 **Opik Dashboard**:
 
 - Added the option to download traces and LLM calls as CSV files from the UI:

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2024-11-04.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2024-11-04.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2024-11-04
+---
+
 **Opik Dashboard**:
 
 - Added a new `Prompt library` page to manage your prompts in the UI.

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2024-11-11.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2024-11-11.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2024-11-11
+---
+
 **Opik Dashboard**:
 
 - Added the option to sort the projects table by `Last updated`, `Created at` and `Name` columns.

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2024-11-18.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2024-11-18.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2024-11-18
+---
+
 **Opik Dashboard**:
 
 - Updated the majority of tables to increase the information density, it is now easier to review many traces at once.

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2024-11-25.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2024-11-25.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2024-11-25
+---
+
 **Opik Dashboard**:
 
 - Feedback scores are now displayed as separate columns in the traces and spans table

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2024-12-02.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2024-12-02.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2024-12-02
+---
+
 **Opik Dashboard**:
 
 - Added a new `created_by` column for each table to indicate who created the record

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2024-12-09.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2024-12-09.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2024-12-09
+---
+
 **Opik Dashboard**:
 
 - Updated the experiments pages to make it easier to analyze the results of each experiment. Columns are now organized based on where they came from (dataset, evaluation task, etc) and output keys are now displayed in multiple columns to make it easier to review

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2024-12-16.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2024-12-16.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2024-12-16
+---
+
 **Opik Dashboard**:
 
 - The Opik playground is now in public preview

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2024-12-23.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2024-12-23.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2024-12-23
+---
+
 **SDK**:
 
 - Improved error messages when getting a rate limit when using the `evaluate` method

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2024-12-30.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2024-12-30.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2024-12-30
+---
+
 **Opik Dashboard**:
 
 - Added duration chart to the project dashboard

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-01-06.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-01-06.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-01-06
+---
+
 **Opik Dashboard**:
 
 - Fixed an issue with the trace viewer in Safari

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-01-13.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-01-13.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-01-13
+---
+
 **Opik Dashboard**:
 
 - Datasets are now supported in the playground allowing you to quickly evaluate prompts on multiple samples

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-01-20.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-01-20.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-01-20
+---
+
 **Opik Dashboard**:
 
 - Added logs for online evaluation rules so that you can more easily ensure your online evaluation metrics are working as expected

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-01-27.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-01-27.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-01-27
+---
+
 **Opik Dashboard**:
 
 - Performance improvements for workspaces with 100th of millions of traces

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-02-03.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-02-03.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-02-03
+---
+
 **Opik Dashboard**:
 
 - You can now view feedback scores for your projects in the Opik home page

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-02-10.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-02-10.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-02-10
+---
+
 **Opik Dashboard**:
 
 - Added support for local models in the Opik playground

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-02-17.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-02-17.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-02-17
+---
+
 **Opik Dashboard**:
 
 - Improved the UX when navigating between the project list page and the traces page

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-02-24.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-02-24.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-02-24
+---
+
 **Opik Dashboard**:
 
 - You can now add comments to your traces allowing for better collaboration:

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-03-03.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-03-03.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-03-03
+---
+
 **Opik Dashboard**:
 
 - Chat conversations can now be reviewed in the platform

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-03-10.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-03-10.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-03-10
+---
+
 **Opik Dashboard:**
 
 - Add CSV export for the experiment comparison page

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-03-17.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-03-17.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-03-17
+---
+
 **Opik Dashboard:**
 
 - We have revamped the traces table, the header row is now sticky at the top of

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-03-24.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-03-24.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-03-24
+---
+
 **General**
 
 - Introduced a new `.opik.sh` installation script

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-03-31.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-03-31.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-03-31
+---
+
 **Opik Dashboard:**
 
 - Render markdown in experiment output sidebar

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-04-07.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-04-07.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-04-07
+---
+
 **Opik Dashboard:**
 
 - Added search to codeblocks in the input and output fields.

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-04-14.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-04-14.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-04-14
+---
+
 **Opik Dashboard:**
 
 - Updated the feedback scores UI in the experiment page to make it easier to

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-04-21.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-04-21.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-04-21
+---
+
 **Opik Dashboard**:
 
 - Released Python code metrics for online evaluations for both Opik Cloud and

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-04-28.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-04-28.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-04-28
+---
+
 **Opik Dashboard**:
 
 - Updated the experiment page charts to better handle nulls, all metric values

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-05-05.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-05-05.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-05-05
+---
+
 **Opik Dashboard**:
 
 **Python and JS / TS SDK**:

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-05-23.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-05-23.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-05-23
+---
+
 ## ✨ New Features
 
 - **Opik Agent Optimizer**: A comprehensive toolkit designed to enhance the performance and efficiency of your Large Language Model (LLM) applications. [Read more](/v1/agent_optimization/overview)

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-06-06.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-06-06.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-06-06
+---
+
 ## 💡 Product Enhancements
 - Ability to upload **CSV datasets** directly through the user interface
 - Add **experiment cost tracking** to the Experiments table

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-06-20.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-06-20.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-06-20
+---
+
 ## 🔌 Integrations and SDK
 - Added **CloudFlare's WorkersAI** integration ([docs](/v1/integrations/cloudflare-workers-ai))
 - **Google ADK** integration: tracing is now automatically propagated to all sub-agents in agentic systems with the new `track_adk_agent_recursive` feature, eliminating the need to manually add tracing to each sub-agent.

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-07-04.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-07-04.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-07-04
+---
+
 ## 🛠 Agent Optimizer 1.0 released!
 
 The Opik Agent Optimizer now supports full agentic systems and not just single prompts.

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-07-18.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-07-18.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-07-18
+---
+
 ## 🧵 Thread-level LLMs-as-Judge
 
 We now support **thread-level LLMs-as-a-Judge metrics**! 

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-08-01.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-08-01.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-08-01
+---
+
 ## 🎯 Advanced Filtering & Search Capabilities
 
 We've expanded filtering and search capabilities to help you find and analyze data more effectively:

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-08-22.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-08-22.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-08-22
+---
+
 Here are the most relevant improvements we've made in the last couple of weeks:
 
 ## 🧪 Experiment Grouping 

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-09-05.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-09-05.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-09-05
+---
+
 Here are the most relevant improvements we've made since the last release:
 
 ## 🔍 Opik Trace Analyzer Beta is Live! 

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-10-03.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-10-03.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-10-03
+---
+
 Here are the most relevant improvements we've made since the last release:
 
 ## 📝 Multi-Value Feedback Scores & Annotation Queues

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-10-21.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-10-21.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-10-21
+---
+
 Here are the most relevant improvements we've made since the last release:
 
 ## 🚨 Alerts

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-11-04.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-11-04.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-11-04
+---
+
 Here are the most relevant improvements we've made since the last release:
 
 ## 🚨 Native Slack and PagerDuty Alerts

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-11-18.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-11-18.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-11-18
+---
+
 Here are the most relevant improvements we've made since the last release:
 
 ## 📊 More Metrics!

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-12-09.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-12-09.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-12-09
+---
+
 Here are the most relevant improvements we've made since the last release:
 
 ## 📊 Dataset Improvements

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2025-12-18.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2025-12-18.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2025-12-18
+---
+
 Here are the most relevant improvements we've made since the last release:
 
 ## 📊 Custom Dashboards (Beta)

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-01-13.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-01-13.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2026-01-13
+---
+
 Here are the most relevant improvements we've made since the last release:
 
 ## 🔌 Playground & Provider Enhancements

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-01-27.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-01-27.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2026-01-27
+---
+
 Here are the most relevant improvements we've made since the last release:
 
 ## 🚀 Optimization Studio

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-02-10.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-02-10.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2026-02-10
+---
+
 Here are the most relevant improvements we've made since the last release:
 
 ## 🛠️ SDK Improvements

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-03-03.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-03-03.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2026-03-03
+---
+
 Here are the most relevant improvements we've made since the last release:
 
 ## 🦞 Native OpenClaw Observability with Opik

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-05.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-05.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2026-05-05
+---
+
 This is our biggest release yet! A fundamental rethink of how you build, debug, and improve AI agents with Opik. Three major new feature groups (Ollie, Test Suites, and the Agent Playground) work together to close the loop from observing a problem to shipping a fix, all without leaving the platform. Alongside them, we've reorganized everything around projects, redesigned the core trace experience, and rebuilt the navigation to match. Here's what's new:
 
 ## 🤖 Ollie & Opik Connect

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-12.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-12.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2026-05-12
+---
+
 Here are the most relevant improvements we've made since the last release:
 
 ## 🌍 Environment Tracking for Traces, Spans & Threads

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-19.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-19.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2026-05-19
+---
+
 ## 🚀 Client-Side Prompt Caching (Python & TypeScript SDKs)
 
 `client.get_prompt()` and `client.get_chat_prompt()` now cache results in-process, so repeated calls inside a hot path skip the network round-trip entirely. Pinned commits are cached indefinitely; latest-version lookups use a 5-minute TTL that refreshes in the background so your code always gets a reasonably fresh value without blocking.

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-26.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-05-26.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog/2026-05-26
+---
+
 ## AND/OR Condition Grouping in Alerts
 
 Alert rules now support structured condition grouping: conditions within a group are evaluated with AND, while groups themselves are combined with OR. This makes it possible to express logic such as "flag a trace if (hallucination score > 0.8 AND relevance score < 0.3) OR (toxicity score > 0.5)".

--- a/apps/opik-documentation/documentation/fern/docs/contributing/agent-optimizer-sdk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/contributing/agent-optimizer-sdk.mdx
@@ -5,6 +5,7 @@ og:description: Contribute effectively to the Agent Optimizer SDK and enhance mo
 og:site_name: Opik Documentation
 og:title: Contribute to the Agent Optimizer - Opik
 title: Opik Optimizer
+canonical-url: https://www.comet.com/docs/opik/contributing/guides/agent-optimizer-sdk
 ---
 
 # Contributing to the Agent Optimizer SDK

--- a/apps/opik-documentation/documentation/fern/docs/contributing/backend.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/contributing/backend.mdx
@@ -5,6 +5,7 @@ og:description: Learn how to contribute to the Opik backend, enhancing data hand
 og:site_name: Opik Documentation
 og:title: Contribute to the Opik Backend Development
 title: Backend
+canonical-url: https://www.comet.com/docs/opik/contributing/guides/backend
 ---
 
 # Contributing to the Backend

--- a/apps/opik-documentation/documentation/fern/docs/contributing/bounties.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/contributing/bounties.mdx
@@ -5,6 +5,7 @@ og:description: Participate in the Opik Bounty Program to enhance the platform, 
 og:site_name: Opik Documentation
 og:title: Join the Opik Bounty Program to Contribute
 title: Bounty Program
+canonical-url: https://www.comet.com/docs/opik/contributing/developer-programs/bounties
 ---
 
 # Opik Bounty Program

--- a/apps/opik-documentation/documentation/fern/docs/contributing/documentation.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/contributing/documentation.mdx
@@ -5,6 +5,7 @@ og:description: Learn how to contribute effectively to Opik's documentation, inc
 og:site_name: Opik Documentation
 og:title: Contributing to Documentation - Opik
 title: Documentation
+canonical-url: https://www.comet.com/docs/opik/contributing/guides/documentation
 ---
 
 # Contributing to Documentation

--- a/apps/opik-documentation/documentation/fern/docs/contributing/frontend.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/contributing/frontend.mdx
@@ -5,6 +5,7 @@ og:description: Learn how to contribute to the Opik frontend project by reviewin
 og:site_name: Opik Documentation
 og:title: Contributing to the Opik Frontend
 title: Frontend
+canonical-url: https://www.comet.com/docs/opik/contributing/guides/frontend
 ---
 
 # Contributing to the Frontend

--- a/apps/opik-documentation/documentation/fern/docs/contributing/local-development.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/contributing/local-development.mdx
@@ -6,6 +6,7 @@ og:description: Configure your local Opik environment effectively. Learn to choo
 og:site_name: Opik Documentation
 og:title: Local Development Setup - Opik
 title: Local Development Setup
+canonical-url: https://www.comet.com/docs/opik/contributing/guides/local-development
 ---
 
 This guide provides detailed instructions for setting up your local Opik development environment. We offer multiple development modes optimized for different workflows.

--- a/apps/opik-documentation/documentation/fern/docs/contributing/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/contributing/overview.mdx
@@ -5,6 +5,7 @@ og:description: Contribute to Opik by submitting bug reports, suggesting feature
 og:site_name: Opik Documentation
 og:title: Contributing to Opik - Join Our Open Source Community
 title: Contribution Overview
+canonical-url: https://www.comet.com/docs/opik/contributing/overview
 ---
 
 # Contributing to Opik

--- a/apps/opik-documentation/documentation/fern/docs/contributing/python-sdk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/contributing/python-sdk.mdx
@@ -5,6 +5,7 @@ og:description: Learn how to contribute to the Opik Python SDK, enabling seamles
 og:site_name: Opik Documentation
 og:title: Contributing to the Opik Python SDK
 title: Python SDK
+canonical-url: https://www.comet.com/docs/opik/contributing/guides/python-sdk
 ---
 
 # Contributing to the Opik Python SDK

--- a/apps/opik-documentation/documentation/fern/docs/contributing/typescript-sdk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/contributing/typescript-sdk.mdx
@@ -5,6 +5,7 @@ og:description: Learn how to contribute effectively to the Opik TypeScript SDK b
 og:site_name: Opik Documentation
 og:title: Contribute to the TypeScript SDK - Opik
 title: TypeScript SDK
+canonical-url: https://www.comet.com/docs/opik/contributing/guides/typescript-sdk
 ---
 
 # Contributing to the TypeScript SDK

--- a/apps/opik-documentation/documentation/fern/docs/cookbook/OpikOptimizerIntro.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/cookbook/OpikOptimizerIntro.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/
+---
+
 # Introduction to Opik Agent Optimizers
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/cookbook/dynamic_tracing_cookbook.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/cookbook/dynamic_tracing_cookbook.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/
+---
+
 ```python
 import time
 import random

--- a/apps/opik-documentation/documentation/fern/docs/cookbook/evaluate_hallucination_metric.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/cookbook/evaluate_hallucination_metric.mdx
@@ -5,6 +5,7 @@ og:description: Learn to evaluate the Hallucination metric using the LLM Evaluat
 og:site_name: Opik Documentation
 og:title: Evaluate Hallucination Metric with Opik
 title: Cookbook - Evaluate hallucination metric
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 # Evaluating Opik's Hallucination Metric

--- a/apps/opik-documentation/documentation/fern/docs/cookbook/evaluate_moderation_metric.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/cookbook/evaluate_moderation_metric.mdx
@@ -5,6 +5,7 @@ og:description: Evaluate the Moderation metric in the LLM Evaluation SDK to enha
 og:site_name: Opik Documentation
 og:title: Evaluate Moderation Metric with Opik
 title: Cookbook - Evaluate moderation metric
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 # Evaluating Opik's Moderation Metric

--- a/apps/opik-documentation/documentation/fern/docs/cookbook/optimizer_notebook.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/cookbook/optimizer_notebook.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/
+---
+
 # Introduction to Opik Agent Optimizer
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/cookbook/quickstart_notebook.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/cookbook/quickstart_notebook.mdx
@@ -5,6 +5,7 @@ og:description: Learn to automate LLM workflow evaluation and track calls with O
 og:site_name: Opik Documentation
 og:title: Quickstart Notebook for LLM Tracking - Opik
 title: Quickstart notebook
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 # Quickstart notebook - Summarization

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/annotation_queues.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/annotation_queues.mdx
@@ -7,6 +7,7 @@ og:title: Streamline Annotation Queues with Opik
 subtitle: Enable subject matter experts to review and annotate agent outputs with
   easy queues,  invitations, and a clean annotation UI
 title: Annotation Queues
+canonical-url: https://www.comet.com/docs/opik/evaluation/advanced/annotation_queues
 ---
 
 Involving subject matter experts in AI projects is essential because they provide the domain knowledge and contextual judgment that ensures model outputs are accurate, relevant, and aligned with real-world expectations. Annotation Queues in Opik make it simple for subject matter experts (SMEs) to review and annotate agent outputs. This feature streamlines the human-in-the-loop process by providing easy queue management, simple invitation flows, and a distraction-free annotation experience designed for non-technical users.

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/concepts.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/concepts.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Evaluate LLM Applications Efficiently - Opik
 subtitle: Introduces the concepts behind Opik's evaluation platform
 title: Concepts
+canonical-url: https://www.comet.com/docs/opik/evaluation/concepts
 ---
 
 <Tip>

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_agent_trajectory.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_agent_trajectory.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Evaluate Agent Trajectories Effectively - Opik
 subtitle: Step-by-step guide to evaluate agent trajectories
 title: Evaluate agent trajectories
+canonical-url: https://www.comet.com/docs/opik/evaluation/advanced/evaluate_agent_trajectory
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_agents.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_agents.mdx
@@ -7,6 +7,7 @@ og:title: Evaluate AI Agents Efficiently - Opik
 subtitle: Step-by-step guide on how to evaluate and optimize AI agents throughout
   their lifecycle
 title: Best practices for evaluating agents
+canonical-url: https://www.comet.com/docs/opik/evaluation/evaluate_agents
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_multi_turn_agents.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_multi_turn_agents.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Evaluate Multi-Turn Agents Effectively - Opik
 subtitle: Step-by-step guide to evaluate multi-turn agents
 title: Evaluate multi-turn agents
+canonical-url: https://www.comet.com/docs/opik/evaluation/advanced/evaluate_multi_turn_agents
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_multimodal.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_multimodal.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Evaluate Multimodal Traces with Opik
 subtitle: Evaluate prompts that include images
 title: Evaluate multimodal traces
+canonical-url: https://www.comet.com/docs/opik/evaluation/overview
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_prompt.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_prompt.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Evaluate Single Prompts Effectively - Opik
 subtitle: Step by step guide on how to evaluate LLM prompts
 title: Evaluate single prompts
+canonical-url: https://www.comet.com/docs/opik/evaluation/getting-started
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_threads.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_threads.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Evaluate Threads Effectively - Opik
 subtitle: Step-by-step guide on how to evaluate conversation threads
 title: Evaluate threads
+canonical-url: https://www.comet.com/docs/opik/evaluation/evaluate_threads
 ---
 
 When you are running multi-turn conversations using frameworks that support LLM agents, the Opik integration will

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_your_llm.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/evaluate_your_llm.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Evaluate Your Agent with Opik
 subtitle: Step by step guide on how to evaluate your LLM application
 title: Evaluate your agent
+canonical-url: https://www.comet.com/docs/opik/evaluation/advanced/evaluate_your_llm
 ---
 
 <Tip>

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/log_experiments_with_rest_api.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/log_experiments_with_rest_api.mdx
@@ -7,6 +7,7 @@ og:title: Manually Logging Experiments - Opik
 subtitle: Step by step guide to logging evaluation results using Python SDK and REST
   API
 title: Manually logging experiments
+canonical-url: https://www.comet.com/docs/opik/evaluation/advanced/log_experiments_with_rest_api
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/manage_datasets.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/manage_datasets.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Manage datasets effectively with Opik
 subtitle: Guides you through the process of creating and managing datasets
 title: Manage datasets
+canonical-url: https://www.comet.com/docs/opik/evaluation/advanced/manage_datasets
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/advanced_configuration.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/advanced_configuration.mdx
@@ -7,6 +7,7 @@ og:description: Configure Opik's metrics with power-user controls for tailored e
 og:site_name: Opik Documentation
 og:title: Advanced Configuration - Opik
 title: Advanced configuration
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/advanced_configuration
 ---
 
 # Advanced configuration

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/agent_task_completion.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/agent_task_completion.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate agent performance effectively by using the AgentTaskCom
 og:site_name: Opik Documentation
 og:title: Agent Task Completion with Opik
 title: Agent task completion
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/agent_task_completion
 ---
 
 # Agent Task Completion Judge

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/agent_tool_correctness.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/agent_tool_correctness.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate agent tool usage accuracy to enhance API interaction an
 og:site_name: Opik Documentation
 og:title: Agent Tool Correctness with Opik
 title: Agent tool correctness
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/agent_tool_correctness
 ---
 
 # Agent Tool Correctness Judge

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/answer_relevance.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/answer_relevance.mdx
@@ -6,6 +6,7 @@ og:description: Assess how relevant LLM responses are to input questions with th
 og:site_name: Opik Documentation
 og:title: Evaluate Answer Relevance - Opik
 title: Answer relevance
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/answer_relevance
 ---
 
 The Answer Relevance metric allows you to evaluate how relevant and appropriate the LLM's response is to the given input question or prompt. To assess the relevance of the answer, you will need to provide the LLM input (question or prompt) and the LLM output (generated answer). Unlike the Hallucination metric, the Answer Relevance metric focuses on the appropriateness and pertinence of the response rather than factual accuracy.

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/compliance_risk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/compliance_risk.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate assistant responses for compliance risks efficiently us
 og:site_name: Opik Documentation
 og:title: Compliance Risk Evaluation with Opik
 title: Compliance risk
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/compliance_risk
 ---
 
 # Compliance Risk Judge

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/context_precision.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/context_precision.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate the accuracy of LLM responses with Context Precision me
 og:site_name: Opik Documentation
 og:title: Context Precision Metrics - Opik
 title: Context precision
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/context_precision
 ---
 
 The context precision metric evaluates the accuracy and relevance of an LLM's response based on provided context, helping to identify potential hallucinations or misalignments with the given information.

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/context_recall.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/context_recall.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate the accuracy of LLM responses using the Context Recall 
 og:site_name: Opik Documentation
 og:title: Context Recall Metric - Opik
 title: Context recall
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/context_recall
 ---
 
 The context recall metric evaluates the accuracy and relevance of an LLM's response based on provided context, helping to identify potential hallucinations or misalignments with the given information.

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/conversation_threads_metrics.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/conversation_threads_metrics.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate the quality of conversational threads with Opik's metri
 og:site_name: Opik Documentation
 og:title: Conversational Metrics for Analysis - Opik
 title: Conversational metrics
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/conversation_threads_metrics
 ---
 
 The conversational metrics can be used to score the quality of conversational threads collected by Opik through multiple traces. They also apply to conversations sourced outside of Opik when you want to analyse the performance of an assistant across turns.

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/custom_conversation_metric.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/custom_conversation_metric.mdx
@@ -7,6 +7,7 @@ og:site_name: Opik Documentation
 og:title: Custom Conversation Metrics - Opik
 title: Custom conversation metric
 toc_max_heading_level: 4
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/custom_conversation_metric
 ---
 
 # Custom Conversation (Multi-turn) Metrics

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/custom_metric.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/custom_metric.mdx
@@ -8,6 +8,7 @@ og:site_name: Opik Documentation
 og:title: Custom Metrics in Opik for Tailored Insights
 title: Custom metric
 toc_max_heading_level: 4
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/custom_metric
 ---
 
 # Custom Metric

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/custom_model.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/custom_model.mdx
@@ -8,6 +8,7 @@ og:site_name: Opik Documentation
 og:title: Custom Model Metrics - Opik
 title: Custom model
 toc_max_heading_level: 4
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/custom_model
 ---
 
 Opik provides a set of LLM as a Judge metrics that are designed to be model-agnostic and can be used with any LLM. In order to achieve this, we use the [LiteLLM library](https://github.com/BerriAI/litellm) to abstract the LLM calls.

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/dialogue_helpfulness.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/dialogue_helpfulness.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate dialogue effectiveness with Opik's Dialogue Helpfulness
 og:site_name: Opik Documentation
 og:title: Dialogue Helpfulness with Opik - Enhance User Support
 title: Dialogue helpfulness
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/dialogue_helpfulness
 ---
 
 # Dialogue Helpfulness Judge

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/g_eval.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/g_eval.mdx
@@ -7,6 +7,7 @@ og:description: Evaluate tasks using G-Eval, a LLM-as-a-judge metric. Specify ta
 og:site_name: Opik Documentation
 og:title: G-Eval Metrics - Opik for Task Evaluation
 title: G-Eval
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/g_eval
 ---
 
 G-Eval is a task-agnostic LLM-as-a-judge metric that allows you to specify a task description and evaluation criteria. The model first drafts step-by-step evaluation instructions and then produces a score between 0 and 1. You can learn more about G-Eval in the [original paper](https://arxiv.org/abs/2303.16634).

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/g_eval_conversation_metrics.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/g_eval_conversation_metrics.mdx
@@ -1,6 +1,7 @@
 ---
 title: Conversation-level GEval Metrics
 description: How to run GEval-based judges on full conversations
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/g_eval_conversation_metrics
 ---
 
 # Conversation-level GEval Metrics

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/hallucination.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/hallucination.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate LLM responses for hallucinated information using Opik's
 og:site_name: Opik Documentation
 og:title: Hallucination Metric - Opik
 title: Hallucination
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/hallucination
 ---
 
 The hallucination metric allows you to check if the LLM response contains any hallucinated information. In order to check for hallucination, you will need to provide the LLM input, LLM output. If the context is provided, this will also be used to check for hallucinations.

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/heuristic_metrics.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/heuristic_metrics.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate language model outputs with heuristic metrics to ensure
 og:site_name: Opik Documentation
 og:title: Heuristic Metrics for Language Models - Opik
 title: Heuristic metrics
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/heuristic_metrics
 ---
 
 Heuristic metrics are rule-based evaluation methods that allow you to check specific aspects of language model outputs. These metrics use predefined criteria or patterns to assess the quality, consistency, or characteristics of generated text. They come in two flavours:

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/llm_juries.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/llm_juries.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate multiple judge metrics effectively, combining quality d
 og:site_name: Opik Documentation
 og:title: 'LLM Juries: Ensemble Scoring with Opik'
 title: LLM Juries
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/llm_juries
 ---
 
 # LLM Juries Judge

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/meaning_match.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/meaning_match.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate LLM outputs with Meaning Match to ensure semantic accur
 og:site_name: Opik Documentation
 og:title: Meaning Match Metric - Opik
 title: Meaning Match
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/meaning_match
 ---
 
 # Meaning Match

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/moderation.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/moderation.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate the appropriateness of LLM responses using Moderation m
 og:site_name: Opik Documentation
 og:title: Moderation Metrics with Opik - Evaluate LLM Responses
 title: Moderation
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/moderation
 ---
 
 The Moderation metric allows you to evaluate the appropriateness of the LLM's response to the given LLM output. It does this by asking the LLM to rate the appropriateness of the response on a scale of 1 to 10, where 1 is the least appropriate and 10 is the most appropriate.

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/overview.mdx
@@ -6,6 +6,7 @@ og:description: Explore Opik's evaluation metrics to assess LLM behavior with he
 og:site_name: Opik Documentation
 og:title: Evaluation Metrics Overview - Opik
 title: Overview
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/overview
 ---
 
 # Overview

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/prompt_diagnostics.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/prompt_diagnostics.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate risky user requests with Opik's PromptUncertaintyJudge 
 og:site_name: Opik Documentation
 og:title: Prompt Uncertainty Scoring - Opik
 title: Prompt uncertainty
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/prompt_diagnostics
 ---
 
 # Prompt Uncertainty

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/structure_output_compliance.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/structure_output_compliance.mdx
@@ -1,5 +1,6 @@
 ---
 description: Describes the StructuredOutputCompliance metric
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/structure_output_compliance
 ---
 
 The `StructuredOutputCompliance` metric allows you to verify whether a given LLM output is valid JSON and adheres to an expected schema. You can optionally provide a Pydantic schema to validate the structure and types of the fields.

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/summarization_coherence.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/summarization_coherence.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate summary clarity and structure with Opik's Summarization
 og:site_name: Opik Documentation
 og:title: Summarization Coherence Metric - Opik
 title: Summarization coherence
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/summarization_coherence
 ---
 
 # Summarization Coherence Judge

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/summarization_consistency.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/summarization_consistency.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate the fidelity of generated summaries against originals u
 og:site_name: Opik Documentation
 og:title: Summarization Consistency with Opik
 title: Summarization consistency
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/summarization_consistency
 ---
 
 # Summarization Consistency Judge

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/sycophancy_evaluation.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/sycophancy_evaluation.mdx
@@ -2,6 +2,7 @@
 description: Describes SycEval metric for evaluating sycophantic behavior
 
 pytest_codeblocks_skip: true
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/sycophancy_evaluation
 ---
 
 The SycEval metric evaluates sycophantic behavior in large language models by testing their susceptibility to rebuttals. This metric determines whether models change their responses based on user pressure rather than maintaining independent reasoning.

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/task_span_metrics.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/task_span_metrics.mdx
@@ -8,6 +8,7 @@ og:site_name: Opik Documentation
 og:title: Task Span Metrics in Opik - Evaluate Execution Context
 title: Task span metrics
 toc_max_heading_level: 4
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/task_span_metrics
 ---
 
 # Task Span Metrics

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/trajectory_accuracy.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/trajectory_accuracy.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate and audit agent performance with Trajectory Accuracy to
 og:site_name: Opik Documentation
 og:title: Trajectory Accuracy Metrics - Opik
 title: Trajectory accuracy
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/trajectory_accuracy
 ---
 
 # Trajectory Accuracy

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/usefulness.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/usefulness.mdx
@@ -6,6 +6,7 @@ og:description: Evaluate the usefulness of LLM responses with Opik's metric, sco
 og:site_name: Opik Documentation
 og:title: Evaluate Usefulness with Opik Metrics
 title: Usefulness
+canonical-url: https://www.comet.com/docs/opik/evaluation/metrics/usefulness
 ---
 
 # Usefulness

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/overview.mdx
@@ -7,6 +7,7 @@ og:title: Evaluate LLM Outputs with Opik's Framework
 subtitle: A high-level overview on how to use Opik's evaluation features including
   some code snippets
 title: Overview
+canonical-url: https://www.comet.com/docs/opik/evaluation/overview
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/update_existing_experiment.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/update_existing_experiment.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: 'Re-running Experiments in Opik: Update Names & Scores'
 subtitle: Guides you through the process of updating an existing experiment
 title: Re-running an existing experiment
+canonical-url: https://www.comet.com/docs/opik/evaluation/advanced/evaluate_your_llm
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/faq.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/faq.mdx
@@ -5,6 +5,7 @@ og:description: Explore common questions about Opik, learn how to get started, a
 og:site_name: Opik Documentation
 og:title: 'FAQ - Opik: Your Guide to Getting Started'
 title: FAQ
+canonical-url: https://www.comet.com/docs/opik/faq
 ---
 
 These FAQs are a collection of the most common questions that we've received from our users. If you

--- a/apps/opik-documentation/documentation/fern/docs/home.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/home.mdx
@@ -4,6 +4,7 @@ headline: Opik Documentation - Open-Source LLM Observability & Optimization
 og:site_name: Opik Documentation
 og:title: "Opik - Open-Source LLM Observability & Agent Optimization"
 og:description: "Build, test, and optimize GenAI apps from prototype to production. Comprehensive tracing, evaluation, and prompt optimization for RAG, agents, and more."
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 Opik is an [open-source](https://github.com/comet-ml/opik) logging, debugging, and optimization

--- a/apps/opik-documentation/documentation/fern/docs/opik-university/1_intro/1.1-intro-opik-overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/opik-university/1_intro/1.1-intro-opik-overview.mdx
@@ -5,6 +5,7 @@ og:description: Explore Opik's capabilities to enhance your workflow and maximiz
 og:site_name: Opik Documentation
 og:title: Opik Overview - Discover Key Features and Benefits
 title: Opik Overview
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 <div style={{

--- a/apps/opik-documentation/documentation/fern/docs/opik-university/1_intro/1.2-intro-next-steps-set-expectations.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/opik-university/1_intro/1.2-intro-next-steps-set-expectations.mdx
@@ -5,6 +5,7 @@ og:description: Learn to set clear expectations for your project with Opik, ensu
 og:site_name: Opik Documentation
 og:title: 'Next Steps in Opik: Set Clear Expectations'
 title: Next steps / Set expectations
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 <div style={{

--- a/apps/opik-documentation/documentation/fern/docs/opik-university/2_observability/2.1-observability-log-traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/opik-university/2_observability/2.1-observability-log-traces.mdx
@@ -5,6 +5,7 @@ og:description: Monitor and analyze log traces effectively with Opik to improve 
 og:site_name: Opik Documentation
 og:title: Log Traces for Enhanced Observability - Opik
 title: Log Traces
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 <div

--- a/apps/opik-documentation/documentation/fern/docs/opik-university/2_observability/2.2-observability-annotate-traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/opik-university/2_observability/2.2-observability-annotate-traces.mdx
@@ -5,6 +5,7 @@ og:description: Learn to effectively annotate traces in Opik to improve observab
 og:site_name: Opik Documentation
 og:title: Annotate Traces with Opik for Enhanced Observability
 title: Annotate Traces
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 <div

--- a/apps/opik-documentation/documentation/fern/docs/opik-university/3_evaluation/3.1-evaluation-concepts-overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/opik-university/3_evaluation/3.1-evaluation-concepts-overview.mdx
@@ -5,6 +5,7 @@ og:description: Explore evaluation concepts in Opik to enhance your understandin
 og:site_name: Opik Documentation
 og:title: Evaluation Concepts Overview - Opik
 title: Evaluation Concepts and Overview
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 <div style={{

--- a/apps/opik-documentation/documentation/fern/docs/opik-university/3_evaluation/3.2-evaluation-create-datasets.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/opik-university/3_evaluation/3.2-evaluation-create-datasets.mdx
@@ -5,6 +5,7 @@ og:description: Build and manage evaluation datasets effectively using Opik's to
 og:site_name: Opik Documentation
 og:title: Create Evaluation Datasets with Opik
 title: Create Evaluation Datasets
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 <div style={{

--- a/apps/opik-documentation/documentation/fern/docs/opik-university/3_evaluation/3.3-evaluation-define-metrics.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/opik-university/3_evaluation/3.3-evaluation-define-metrics.mdx
@@ -5,6 +5,7 @@ og:description: Learn to define and implement effective evaluation metrics in Op
 og:site_name: Opik Documentation
 og:title: Define Evaluation Metrics in Opik - Enhance Your Analysis
 title: Define Evaluation Metrics
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 <div style={{

--- a/apps/opik-documentation/documentation/fern/docs/opik-university/3_evaluation/3.4-evaluation-evaluate-llm-application.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/opik-university/3_evaluation/3.4-evaluation-evaluate-llm-application.mdx
@@ -5,6 +5,7 @@ og:description: Evaluate your LLM application effectively with Opik's comprehens
 og:site_name: Opik Documentation
 og:title: Evaluate your LLM Application with Opik
 title: Evaluate your LLM Application
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 <div style={{

--- a/apps/opik-documentation/documentation/fern/docs/opik-university/3_evaluation/3.5-evaluation-ui-workflow.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/opik-university/3_evaluation/3.5-evaluation-ui-workflow.mdx
@@ -5,6 +5,7 @@ og:description: Evaluate LLM performance effortlessly with Opik's no-code workfl
 og:site_name: Opik Documentation
 og:title: No-code LLM Evaluation Workflow - Opik
 title: No-code LLM Evaluation Workflow
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 <div style={{

--- a/apps/opik-documentation/documentation/fern/docs/opik-university/4_prompt-engineering/4.1-prompt-engineering-management.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/opik-university/4_prompt-engineering/4.1-prompt-engineering-management.mdx
@@ -5,6 +5,7 @@ og:description: Learn to effectively manage and optimize prompts in Opik to enha
 og:site_name: Opik Documentation
 og:title: Master Prompt Management - Opik
 title: Prompt Management
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 <div style={{

--- a/apps/opik-documentation/documentation/fern/docs/opik-university/4_prompt-engineering/4.2-prompt-engineering-playground.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/opik-university/4_prompt-engineering/4.2-prompt-engineering-playground.mdx
@@ -5,6 +5,7 @@ og:description: Learn to craft effective prompts for AI interactions in Opik's P
 og:site_name: Opik Documentation
 og:title: Explore Prompt Playground - Opik
 title: Prompt Playground
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 <div style={{

--- a/apps/opik-documentation/documentation/fern/docs/opik-university/5_testing/5.1-testing-pytest-integration.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/opik-university/5_testing/5.1-testing-pytest-integration.mdx
@@ -5,6 +5,7 @@ og:description: Learn to seamlessly integrate PyTest in Opik to enhance your tes
 og:site_name: Opik Documentation
 og:title: Integrate PyTest with Opik for Efficient Testing
 title: PyTest Integration
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 <div style={{

--- a/apps/opik-documentation/documentation/fern/docs/opik-university/6_production-monitoring/6.1-production-monitoring-online-evaluation-rules.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/opik-university/6_production-monitoring/6.1-production-monitoring-online-evaluation-rules.mdx
@@ -5,6 +5,7 @@ og:description: Monitor and evaluate production processes effectively with Opik'
 og:site_name: Opik Documentation
 og:title: Online Evaluation Rules - Opik
 title: Online Evaluation Rules
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 <div style={{

--- a/apps/opik-documentation/documentation/fern/docs/opik-university/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/opik-university/overview.mdx
@@ -5,6 +5,7 @@ og:description: Master Opik's features through structured video tutorials, enhan
 og:site_name: Opik Documentation
 og:title: Learn Observability Skills with Opik
 title: Overview
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 # Welcome to Opik University

--- a/apps/opik-documentation/documentation/fern/docs/production/alerts.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/production/alerts.mdx
@@ -7,6 +7,7 @@ og:description: Configure automated webhook notifications in Opik for critical e
 og:site_name: Opik Documentation
 og:title: Alerts Configuration - Opik
 title: Alerts
+canonical-url: https://www.comet.com/docs/opik/production/alerts/alerts
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/production/anonymizers.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/production/anonymizers.mdx
@@ -5,6 +5,7 @@ og:description: Protect sensitive information in your LLM applications with Opik
 og:site_name: Opik Documentation
 og:title: Anonymizers - Opik for Secure LLM Applications
 title: Anonymizers
+canonical-url: https://www.comet.com/docs/opik/production/gateway-guardrails/anonymizers
 ---
 
 <Tip>

--- a/apps/opik-documentation/documentation/fern/docs/production/dashboards.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/production/dashboards.mdx
@@ -5,6 +5,7 @@ og:description: Build and customize dashboards in Opik to track project metrics,
 og:site_name: Opik Documentation
 og:title: Dashboards - Opik
 title: Dashboards
+canonical-url: https://www.comet.com/docs/opik/tracing/dashboards/dashboards
 ---
 
 Dashboards allow you to create customizable views for monitoring your LLM applications. You can track project metrics like trace volume, cost, latency, and feedback scores, as well as compare experiment results across different runs.

--- a/apps/opik-documentation/documentation/fern/docs/production/gateway.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/production/gateway.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: LLM Gateway for Seamless Integration - Opik
 subtitle: Overview of LLM gateway integrations available with Opik
 title: Gateway
+canonical-url: https://www.comet.com/docs/opik/production/gateway-guardrails/gateway
 ---
 
 An LLM gateway is a proxy server that forwards requests to an LLM API and returns the response. This is useful for when you want to centralize the access to LLM providers or when you want to be able to query multiple LLM providers from a single endpoint using a consistent request and response format.

--- a/apps/opik-documentation/documentation/fern/docs/production/guardrails.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/production/guardrails.mdx
@@ -5,6 +5,7 @@ og:description: Monitor your LLM calls with guardrails in Opik to prevent risks 
 og:site_name: Opik Documentation
 og:title: Guardrails for LLMs - Opik
 title: Guardrails
+canonical-url: https://www.comet.com/docs/opik/production/gateway-guardrails/guardrails
 ---
 
 <Tip>

--- a/apps/opik-documentation/documentation/fern/docs/production/production_monitoring.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/production/production_monitoring.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: 'Production Monitoring with Opik: Optimize Performance'
 subtitle: Describes how to monitor your LLM applications in production using Opik
 title: Production monitoring
+canonical-url: https://www.comet.com/docs/opik/tracing/dashboards/production_monitoring
 ---
 
 Opik has been designed from the ground up to support high volumes of traces making it the ideal tool for monitoring your production LLM applications.

--- a/apps/opik-documentation/documentation/fern/docs/production/rules.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/production/rules.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Online Evaluation Rules - Opik
 subtitle: Describes how to define scoring rules for production traces
 title: Online Evaluation rules
+canonical-url: https://www.comet.com/docs/opik/production/online-evaluation/rules
 ---
 
 <Tip>

--- a/apps/opik-documentation/documentation/fern/docs/prompt_engineering/improve.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/prompt_engineering/improve.mdx
@@ -5,6 +5,7 @@ og:description: Enhance your prompt quality using Opik's AI tools for efficient 
 og:site_name: Opik Documentation
 og:title: Boost Your Prompts with Opik's Generator & Improver
 title: Prompt Generator and Improver
+canonical-url: https://www.comet.com/docs/opik/development/prompt-library/overview
 ---
 
 Opik provides two AI-powered features to help you create and refine prompts: Prompt Generator and Prompt Improver. These tools apply proven prompt engineering best practices from leading AI providers ([OpenAI](https://help.openai.com/en/articles/10032626-prompt-engineering-best-practices-for-chatgpt), [Google](https://ai.google.dev/gemini-api/docs/prompting-strategies), [Anthropic](https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/overview)) automatically.

--- a/apps/opik-documentation/documentation/fern/docs/prompt_engineering/mcp_server.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/prompt_engineering/mcp_server.mdx
@@ -5,6 +5,7 @@ og:description: Configure Opik's MCP server with Cursor IDE to manage prompts an
 og:site_name: Opik Documentation
 og:title: Integrate with Opik's MCP server for prompt engineering
 title: Opik's MCP server
+canonical-url: https://www.comet.com/docs/opik/development/prompt-library/mcp-server
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/prompt_engineering/playground.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/prompt_engineering/playground.mdx
@@ -5,6 +5,7 @@ og:description: Experiment with LLM prompts in Opik's playground to evaluate per
 og:site_name: Opik Documentation
 og:title: Explore Prompt Playground - Opik
 title: Prompt Playground
+canonical-url: https://www.comet.com/docs/opik/development/prompt-playground
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/prompt_engineering/prompt_management.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/prompt_engineering/prompt_management.mdx
@@ -5,6 +5,7 @@ og:description: Learn to utilize Opik's prompt library for versioning, reusing, 
 og:site_name: Opik Documentation
 og:title: Manage Prompts Effectively with Opik
 title: Prompt management
+canonical-url: https://www.comet.com/docs/opik/development/prompt-library/getting-started
 ---
 
 Opik provides a prompt library that you can use to manage your prompts. Storing

--- a/apps/opik-documentation/documentation/fern/docs/quickstart.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/quickstart.mdx
@@ -5,6 +5,7 @@ og:description: Integrate Opik with your LLM application to log calls and chains
 og:site_name: Opik Documentation
 og:title: Quickstart Guide - Opik Integration
 title: Quickstart
+canonical-url: https://www.comet.com/docs/opik/quickstart
 ---
 
 This guide helps you integrate the Opik platform with your existing LLM application. The goal of

--- a/apps/opik-documentation/documentation/fern/docs/reference/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/overview.mdx
@@ -5,6 +5,7 @@ og:description: Explore comprehensive SDK reference documentation with Opik to e
 og:site_name: Opik Documentation
 og:title: SDK Reference Overview - Opik
 title: Overview
+canonical-url: https://www.comet.com/docs/opik/reference/overview
 ---
 
 Opik provides in-depth reference documentation for all its SDKs. If you are looking for

--- a/apps/opik-documentation/documentation/fern/docs/reference/python-sdk/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/python-sdk/overview.mdx
@@ -5,4 +5,5 @@ og:description: Build powerful applications with Opik's Python SDK, enabling sea
 og:site_name: Opik Documentation
 og:title: Opik Python SDK - Simplify Your Python Development
 title: Overview
+canonical-url: https://www.comet.com/docs/opik/reference/overview
 ---

--- a/apps/opik-documentation/documentation/fern/docs/reference/python-sdk/rest-api.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/python-sdk/rest-api.mdx
@@ -5,6 +5,7 @@ og:description: Access all Opik platform functionality with the Python SDK's RES
 og:site_name: Opik Documentation
 og:title: REST API Client - Opik Python SDK
 title: REST API Client
+canonical-url: https://www.comet.com/docs/opik/reference/python-sdk/rest-api
 ---
 
 The Opik Python SDK includes a complete REST API client that provides direct access to all Opik platform functionality. This low-level client is available through the `rest_client` property and is useful for advanced operations, custom integrations, and scenarios where the high-level SDK doesn't provide the needed functionality.

--- a/apps/opik-documentation/documentation/fern/docs/reference/python-sdk/troubleshooting/batching-and-updates.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/python-sdk/troubleshooting/batching-and-updates.mdx
@@ -4,6 +4,7 @@ og:description: Understand how batching affects update operations and how to avo
 og:site_name: Opik Documentation
 og:title: Batching and Update Operations
 title: Batching and update operations
+canonical-url: https://www.comet.com/docs/opik/reference/python-sdk/troubleshooting/batching-and-updates
 ---
 
 By default, the Opik Python SDK batches create requests for traces and spans to improve ingestion throughput. While this is the recommended setting for most use cases, it can cause issues when you update a span or trace shortly after creating it.

--- a/apps/opik-documentation/documentation/fern/docs/reference/rest-api/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/rest-api/overview.mdx
@@ -5,6 +5,7 @@ og:description: Explore the Opik REST API to integrate seamlessly with Open-Sour
 og:site_name: Opik Documentation
 og:title: Overview of the Opik REST API
 title: Overview
+canonical-url: https://www.comet.com/docs/opik/reference/rest-api/overview
 ---
 
 The Rest API can be used with both the Open-Source platform and Opik Cloud. The main differences are related to the URL

--- a/apps/opik-documentation/documentation/fern/docs/reference/ruby-otel-sdk/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/ruby-otel-sdk/overview.mdx
@@ -5,6 +5,7 @@ og:description: Configure OpenTelemetry SDK in your Ruby app to send telemetry d
 og:site_name: Opik Documentation
 og:title: OpenTelemetry Ruby SDK Integration with Opik
 title: OpenTelemetry Ruby SDK
+canonical-url: https://www.comet.com/docs/opik/integrations/opentelemetry-ruby-sdk
 ---
 
 ## Integration with Opik

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/datasets.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/datasets.mdx
@@ -5,6 +5,7 @@ og:description: Learn to create and manage datasets in Opik for effective evalua
 og:site_name: Opik Documentation
 og:title: Manage Datasets with Opik TypeScript SDK
 title: Datasets
+canonical-url: https://www.comet.com/docs/opik/reference/typescript-sdk/evaluation/datasets
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/evaluate.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/evaluate.mdx
@@ -5,6 +5,7 @@ og:description: Evaluate LLM tasks against datasets using customizable metrics w
 og:site_name: Opik Documentation
 og:title: Evaluate Function - Opik
 title: Evaluate Function
+canonical-url: https://www.comet.com/docs/opik/reference/typescript-sdk/evaluation/evaluate_function
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/evaluatePrompt.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/evaluatePrompt.mdx
@@ -5,6 +5,7 @@ og:description: Evaluate prompt templates against datasets effortlessly with Opi
 og:site_name: Opik Documentation
 og:title: Evaluate Prompt Function - Opik
 title: evaluatePrompt Function
+canonical-url: https://www.comet.com/docs/opik/reference/typescript-sdk/evaluation/evaluate_prompt_function
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/experiments.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/experiments.mdx
@@ -5,6 +5,7 @@ og:description: Evaluate and compare LLM applications with Opik by linking execu
 og:site_name: Opik Documentation
 og:title: Experiments in Opik for LLM Performance Evaluation
 title: Experiments
+canonical-url: https://www.comet.com/docs/opik/reference/typescript-sdk/evaluation/experiments
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/metrics.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/metrics.mdx
@@ -5,6 +5,7 @@ og:description: Evaluate AI model performance with Opik metrics to ensure accura
 og:site_name: Opik Documentation
 og:title: Understanding Metrics in Opik
 title: Evaluation Metrics
+canonical-url: https://www.comet.com/docs/opik/reference/typescript-sdk/evaluation/metrics
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/models.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/models.mdx
@@ -5,6 +5,7 @@ og:description: Configure models for evaluation using the TypeScript SDK with Op
 og:site_name: Opik Documentation
 og:title: Model Configuration in Opik AI
 title: Models
+canonical-url: https://www.comet.com/docs/opik/reference/typescript-sdk/evaluation/models
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/overview.mdx
@@ -5,6 +5,7 @@ og:description: Evaluate your LLM applications effectively using Opik's TypeScri
 og:site_name: Opik Documentation
 og:title: Evaluate LLM Applications with Opik's TypeScript SDK
 title: Evaluation
+canonical-url: https://www.comet.com/docs/opik/reference/typescript-sdk/evaluation/overview
 ---
 
 The TypeScript SDK provides a streamlined approach to evaluating your LLM applications with the `evaluate` function that handles various evaluation scenarios.

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/quick-start.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/quick-start.mdx
@@ -5,6 +5,7 @@ og:description: Evaluate your AI models effectively. Learn to create datasets an
 og:site_name: Opik Documentation
 og:title: Quick Start Guide for AI Evaluation - Opik
 title: Quick Start
+canonical-url: https://www.comet.com/docs/opik/reference/typescript-sdk/evaluation/quick-start
 ---
 
 **In just 15 minutes**, learn how to evaluate your AI models with Opik's TypeScript SDK. This guide will walk you through creating a dataset, defining an evaluation task, and analyzing results with built-in metrics – everything you need to start making data-driven decisions about your AI systems.

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/opik-query-language.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/opik-query-language.mdx
@@ -5,6 +5,7 @@ og:description: Learn to use OQL for powerful data filtering in Opik with SQL-li
 og:site_name: Opik Documentation
 og:title: Opik Query Language (OQL) - Opik
 title: Opik Query Language (OQL)
+canonical-url: https://www.comet.com/docs/opik/reference/typescript-sdk/opik-query-language
 ---
 
 OQL provides a powerful, SQL-like syntax for filtering data in Opik. It's used with various SDK methods like `searchPrompts()`, `searchTraces()`, and `searchThreads()` to find exactly the data you need using expressive filter conditions.

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/opik-ts.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/opik-ts.mdx
@@ -7,6 +7,7 @@ og:description: Configure Opik observability in Node.js apps effortlessly. Detec
 og:site_name: Opik Documentation
 og:title: Streamline Node.js with Opik TS SDK
 title: Opik TS - Interactive Setup Tool
+canonical-url: https://www.comet.com/docs/opik/reference/typescript-sdk/opik-ts
 ---
 
 The Opik TS is an interactive command-line tool that streamlines the process of adding Opik observability to your Node.js and TypeScript applications. It automatically detects your project setup, installs dependencies, and configures tracing for your LLM integrations.

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/overview.mdx
@@ -5,6 +5,7 @@ og:description: Monitor and debug your JavaScript/TypeScript apps with Opik's SD
 og:site_name: Opik Documentation
 og:title: Opik TypeScript SDK - Powerful Observability Tools
 title: Opik TypeScript SDK
+canonical-url: https://www.comet.com/docs/opik/reference/typescript-sdk/overview
 ---
 
 The Opik TypeScript SDK provides a powerful and easy-to-use interface for tracing, monitoring, and debugging your JavaScript and TypeScript applications. It offers comprehensive observability for LLM applications, agent workflows, and AI-powered systems.

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/prompts.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/prompts.mdx
@@ -5,6 +5,7 @@ og:description: Learn to version, store, and format LLM prompt templates using t
 og:site_name: Opik Documentation
 og:title: Manage Prompts Efficiently with Opik
 title: Prompts
+canonical-url: https://www.comet.com/docs/opik/reference/typescript-sdk/prompts
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/roadmap.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/roadmap.mdx
@@ -5,6 +5,7 @@ og:description: Explore Opik's evolving roadmap and contribute ideas to enhance 
 og:site_name: Opik Documentation
 og:title: Roadmap for Opik - Open-Source Development Insights
 title: Roadmap
+canonical-url: https://www.comet.com/docs/opik/
 ---
 
 Opik is [Open-Source](https://github.com/comet-ml/opik) and is under very active development. We use the feedback from the Opik community to drive the roadmap, this is very much a living document that will change as we release new features and learn about new ways to improve the product.

--- a/apps/opik-documentation/documentation/fern/docs/self-host/architecture.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/architecture.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Platform Architecture - Opik
 subtitle: High-level overview on Opik's Platform Architecture
 title: Platform Architecture
+canonical-url: https://www.comet.com/docs/opik/self-host/architecture
 ---
 
 Opik's architecture consists of multiple services that each handle a specific role, including:

--- a/apps/opik-documentation/documentation/fern/docs/self-host/backup.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/backup.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Advanced ClickHouse Backup Options - Opik
 subtitle: Comprehensive guide for ClickHouse backup options in Opik Kubernetes deployments
 title: Advanced clickhouse backup
+canonical-url: https://www.comet.com/docs/opik/self-host/backup
 ---
 
 # ClickHouse Backup Guide

--- a/apps/opik-documentation/documentation/fern/docs/self-host/configure/anonymous_usage_statistics.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/configure/anonymous_usage_statistics.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Anonymous Usage Statistics in Opik
 subtitle: Describes the usage statistics that are collected by Opik
 title: Anonymous usage statistics
+canonical-url: https://www.comet.com/docs/opik/self-host/configure/anonymous_usage_statistics
 ---
 
 Opik includes a system that optionally sends anonymous reports non-sensitive, non-personally identifiable information about the usage of the Opik platform. This information is used to help us understand how the Opik platform is being used and to identify areas for improvement.

--- a/apps/opik-documentation/documentation/fern/docs/self-host/configure/dataset_versioning_migration.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/configure/dataset_versioning_migration.mdx
@@ -5,6 +5,7 @@ og:site_name: Opik Documentation
 og:title: Dataset Versioning Migration in Opik
 subtitle: Understanding the automated dataset versioning migration process
 title: Dataset versioning migration
+canonical-url: https://www.comet.com/docs/opik/self-host/configure/dataset_versioning_migration
 ---
 
 # Dataset Versioning Migration

--- a/apps/opik-documentation/documentation/fern/docs/self-host/configure/large_csv_uploads.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/configure/large_csv_uploads.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Enable Large CSV Uploads with Opik
 subtitle: Configure Opik to support large CSV file uploads for datasets
 title: Large CSV uploads
+canonical-url: https://www.comet.com/docs/opik/self-host/configure/large_csv_uploads
 ---
 
 # Enabling Large CSV Uploads

--- a/apps/opik-documentation/documentation/fern/docs/self-host/configure/llm-model-registry.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/configure/llm-model-registry.mdx
@@ -1,3 +1,7 @@
+---
+canonical-url: https://www.comet.com/docs/opik/self-host/configure/llm-model-registry
+---
+
 # LLM Model Registry Configuration
 
 The list of LLM models that appear in Opik's dropdowns (Playground, LLM-as-Judge, Automation Rules, Optimization Studio) is served by the backend from a YAML registry. The registry is composed from up to three sources, merged in this order:

--- a/apps/opik-documentation/documentation/fern/docs/self-host/helm.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/helm.mdx
@@ -5,6 +5,7 @@ og:site_name: Opik Documentation
 og:title: 'Migrating from Bitnami to Opik Helm Chart'
 subtitle: Guide for migrating from Bitnami charts and images
 title: Migrating from Bitnami Charts and Images
+canonical-url: https://www.comet.com/docs/opik/self-host/helm
 ---
 
 > **Important:** If you're using or looking to use Opik or Comet enterprise version please reach out to Sales@comet.com to gain access to the correct deployment documentation.

--- a/apps/opik-documentation/documentation/fern/docs/self-host/kubernetes.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/kubernetes.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: 'Deploying with Opik: Kubernetes Made Easy'
 subtitle: Describes how to run Opik on a Kubernetes cluster
 title: Kubernetes deployment
+canonical-url: https://www.comet.com/docs/opik/self-host/kubernetes
 ---
 
 > **Important:** If you're using or looking to use Opik or Comet enterprise version please reach out to Sales@comet.com to gain access to the correct deployment documentation.

--- a/apps/opik-documentation/documentation/fern/docs/self-host/local_deployment.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/local_deployment.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Local Deployment with Opik - Self-Host Guide
 subtitle: Describes how to run Opik locally using Docker Compose
 title: Local deployment
+canonical-url: https://www.comet.com/docs/opik/self-host/local_deployment
 ---
 
 > **Important:** If you're using or looking to use Opik or Comet enterprise version please reach out to Sales@comet.com to gain access to the correct deployment documentation.

--- a/apps/opik-documentation/documentation/fern/docs/self-host/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/overview.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: 'Self-Hosting Opik: Deployment Options and Features'
 subtitle: High-level overview on how to self-host Opik
 title: Overview
+canonical-url: https://www.comet.com/docs/opik/self-host/overview
 ---
 
 You can use Opik through [Comet's Managed Cloud offering](https://comet.com) or you can self-host Opik on your own infrastructure. When choosing to self-host Opik, you get access to all Opik features including tracing, evaluation, etc but without user management features.

--- a/apps/opik-documentation/documentation/fern/docs/self-host/scaling.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/scaling.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Scaling Opik for High-Volume Deployments
 subtitle: Comprehensive guide for scaling Opik in production environments
 title: Scaling Opik
+canonical-url: https://www.comet.com/docs/opik/self-host/scaling
 ---
 
 Opik is built to power mission-critical workloads at scale. Whether you're running a small proof of concept or a high-volume enterprise deployment, Opik adapts seamlessly to your needs. Its stateless architecture and powerful ClickHouse backed storage make it highly resilient, horizontally scalable, and future-proof for your data growth.

--- a/apps/opik-documentation/documentation/fern/docs/self-host/troubleshooting.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/troubleshooting.mdx
@@ -7,6 +7,7 @@ og:description: Learn to resolve common issues in self-hosted Opik deployments, 
 og:site_name: Opik Documentation
 og:title: Troubleshooting Self-Hosted Opik Deployments
 title: Troubleshooting
+canonical-url: https://www.comet.com/docs/opik/self-host/troubleshooting
 ---
 
 This guide covers common troubleshooting scenarios for self-hosted Opik deployments.

--- a/apps/opik-documentation/documentation/fern/docs/testing/pytest_integration.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/testing/pytest_integration.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Testing with Pytest - Opik
 subtitle: Describes how to use Opik with Pytest to write LLM unit tests
 title: Pytest integration
+canonical-url: https://www.comet.com/docs/opik/evaluation/overview
 ---
 
 Ensuring your LLM applications is working as expected is a crucial step before deploying to production. Opik provides a Pytest integration so that you can easily track the overall pass / fail rates of your tests as well as the individual pass / fail rates of each test.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/annotate_traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/annotate_traces.mdx
@@ -5,6 +5,7 @@ og:description: Capture user feedback and track performance metrics to enhance y
 og:site_name: Opik Documentation
 og:title: Log User Feedback Effectively - Opik
 title: Log user feedback
+canonical-url: https://www.comet.com/docs/opik/tracing/advanced/annotate_traces
 ---
 
 Logging user feedback and scoring traces is a crucial aspect of evaluating and improving your agent.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/concepts.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/concepts.mdx
@@ -9,6 +9,7 @@ og:site_name: Opik Documentation
 og:title: Tracing Concepts in Opik - Enhance Observability
 subtitle: Understanding the fundamental concepts behind Opik's tracing platform
 title: Tracing Core Concepts
+canonical-url: https://www.comet.com/docs/opik/tracing/concepts
 ---
 
 <Tip>

--- a/apps/opik-documentation/documentation/fern/docs/tracing/cost_tracking.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/cost_tracking.mdx
@@ -5,6 +5,7 @@ og:description: Monitor and analyze cost patterns in your LLM apps using Opik's 
 og:site_name: Opik Documentation
 og:title: Cost Tracking with Opik for LLM Applications
 title: Cost tracking
+canonical-url: https://www.comet.com/docs/opik/tracing/advanced/cost_tracking
 ---
 
 Opik has been designed to track and monitor costs for your LLM applications by measuring token usage across all traces. Using the Opik dashboard, you can analyze spending patterns and quickly identify cost anomalies. All costs across Opik are estimated and displayed in USD.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/export_data.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/export_data.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Export Data Efficiently with Opik
 title: Export by SDK, REST, and UI
 toc_max_heading_level: 4
+canonical-url: https://www.comet.com/docs/opik/tracing/advanced/export-data
 ---
 
 When working with Opik, it is important to be able to export traces, spans, and threads so that you can use them to fine-tune your models or run deeper analysis.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
@@ -6,6 +6,7 @@ og:site_name: Opik Documentation
 og:title: Import/Export Data with Opik - Command Line Guide
 title: Import/Export by command line
 toc_max_heading_level: 4
+canonical-url: https://www.comet.com/docs/opik/tracing/advanced/migrate-data
 ---
 
 The export/import command-line functions enable you to:

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/adk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/adk.mdx
@@ -7,6 +7,7 @@ og:description: Build flexible AI agents using Google ADK, integrating easily wi
 og:site_name: Opik Documentation
 og:title: Develop AI Agents with Google ADK - Opik
 title: Observability for Google Agent Development Kit (Python) with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/adk
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/ag2.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/ag2.mdx
@@ -7,6 +7,7 @@ og:description: Build advanced AI agents with AG2 to facilitate multi-agent coll
 og:site_name: Opik Documentation
 og:title: AG2 Framework - Build AI Agents with Opik
 title: Observability for AG2 with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/ag2
 ---
 
 [AG2](https://ag2.ai/) is an open-source programming framework for building AI agents and facilitating cooperation among multiple agents to solve tasks.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/agentspec.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/agentspec.mdx
@@ -6,6 +6,7 @@ og:description: Trace Agent Spec workflows in Opik to debug and optimize agent e
 og:site_name: Opik Documentation
 og:title: Agent Spec - Opik
 title: Observability for Agent Spec with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/agentspec
 ---
 
 [Open Agent Specification](https://github.com/oracle/agent-spec) is a portable

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/agno.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/agno.mdx
@@ -7,6 +7,7 @@ og:description: Build high-performance AI agents with Agno in Opik. Learn to int
 og:site_name: Opik Documentation
 og:title: Agno Framework for AI Agents - Opik
 title: Observability for Agno with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/agno
 ---
 
 [Agno](https://github.com/agno-agi/agno) is a lightweight, high-performance library for building AI agents.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/aisuite.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/aisuite.mdx
@@ -7,6 +7,7 @@ og:description: Learn to integrate Opik with aisuite SDK to track API calls, log
 og:site_name: Opik Documentation
 og:title: Integrate AISuite with Opik for Seamless Tracking
 title: Observability for AISuite with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/aisuite
 ---
 
 This guide explains how to integrate Opik with the aisuite Python SDK. By using the `track_aisuite` method provided by opik, you can easily track and evaluate your aisuite API calls within your Opik projects as Opik will automatically log the input prompt, model used, token usage, and response generated.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/anannas.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/anannas.mdx
@@ -5,6 +5,7 @@ og:description: Learn to integrate Anannas AI with Opik using the OpenAI SDK wra
 og:site_name: Opik Documentation
 og:title: Integrate Anannas AI with Opik for Unified LLM Access
 title: Observability for Anannas AI with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/anannas
 ---
 
 [Anannas AI](https://anannas.ai) is a unified inference gateway providing access to 500+ models (OpenAI, Anthropic, Mistral, Gemini, DeepSeek, and more) through an OpenAI-compatible API.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/anthropic.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/anthropic.mdx
@@ -7,6 +7,7 @@ og:description: Track and evaluate your Anthropic API calls with Opik's `track_a
 og:site_name: Opik Documentation
 og:title: Integrate Opik with Anthropic for Enhanced AI Tracking
 title: Observability for Anthropic with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/anthropic
 ---
 
 [Anthropic](https://www.anthropic.com/) is an AI safety and research company that's working to build reliable, interpretable, and steerable AI systems.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/autogen.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/autogen.mdx
@@ -7,6 +7,7 @@ og:description: Build robust AI agents using Autogen's enterprise-ready framewor
 og:site_name: Opik Documentation
 og:title: Build AI Agents with Autogen - Opik
 title: Observability for AutoGen with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/autogen
 ---
 
 [Autogen](https://microsoft.github.io/autogen/stable/) is a framework for building AI agents and applications built and maintained by Microsoft.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/bedrock.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/bedrock.mdx
@@ -7,6 +7,7 @@ og:description: Learn to integrate Opik with the Bedrock Python SDK to track and
 og:site_name: Opik Documentation
 og:title: Integrate Bedrock with Opik for Enhanced AI Models
 title: Observability for AWS Bedrock with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/bedrock
 ---
 
 [AWS Bedrock](https://aws.amazon.com/bedrock/) is a fully managed service that provides access to high-performing foundation models (FMs) from leading AI companies like AI21 Labs, Anthropic, Cohere, Meta, Mistral AI, Stability AI, and Amazon through a single API.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/beeai-typescript.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/beeai-typescript.mdx
@@ -7,6 +7,7 @@ og:description: Simplify AI agent development with BeeAI's lightweight framework
 og:site_name: Opik Documentation
 og:title: Build AI agents effortlessly with Opik
 title: Observability for BeeAI (TypeScript) with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/beeai-typescript
 ---
 
 [BeeAI](https://beeai.dev/) is an agent framework designed to simplify the development of AI agents with a focus on simplicity and performance. It provides a clean API for building agents with built-in support for tool usage, conversation management, and extensible architecture.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/beeai.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/beeai.mdx
@@ -7,6 +7,7 @@ og:description: Build efficient AI agents with BeeAI's lightweight framework, le
 og:site_name: Opik Documentation
 og:title: BeeAI Framework - Build AI Agents with Opik
 title: Observability for BeeAI (Python) with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/beeai
 ---
 
 [BeeAI](https://beeai.dev/) is an agent framework designed to simplify the development of AI agents with a focus on simplicity and performance. It provides a clean API for building agents with built-in support for tool usage, conversation management, and extensible architecture.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/byteplus.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/byteplus.mdx
@@ -7,6 +7,7 @@ og:description: Learn to integrate Opik with BytePlus using the OpenAI SDK for s
 og:site_name: Opik Documentation
 og:title: Integrate Opik with BytePlus for AI Solutions
 title: Observability for BytePlus with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/byteplus
 ---
 
 [BytePlus](https://www.byteplus.com/) is ByteDance's AI-native enterprise platform offering ModelArk, a comprehensive Platform-as-a-Service (PaaS) solution for deploying and utilizing powerful large language models. It provides access to SkyLark models, DeepSeek V3.1, Kimi-K2, and other cutting-edge AI models with enterprise-grade security and scalability.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/claude-agent-sdk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/claude-agent-sdk.mdx
@@ -5,6 +5,7 @@ og:description: Claude telemetry is configured with environment variables; this 
 og:site_name: Opik Documentation
 og:title: Claude Agent SDK Integration - Opik
 title: Observability for Claude Agent SDK with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/claude-agent-sdk
 ---
 
 Claude Code telemetry is configured through environment variables.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/cloudflare-workers-ai.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/cloudflare-workers-ai.mdx
@@ -7,6 +7,7 @@ og:description: Monitor and debug your Cloudflare Workers AI applications with O
 og:site_name: Opik Documentation
 og:title: Optimize Cloudflare Workers AI Tracing - Opik
 title: Observability for Cloudflare Workers AI with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/cloudflare-workers-ai
 ---
 
 Opik provides seamless integration with [Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/) allowing you to trace, monitor, and debug your Cloudflare Workers AI applications.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/cohere.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/cohere.mdx
@@ -7,6 +7,7 @@ og:description: Learn to integrate Opik with Cohere using OpenAI SDK for efficie
 og:site_name: Opik Documentation
 og:title: Integrate Cohere Models with Opik for Enhanced Tracking
 title: Observability for Cohere with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/cohere
 ---
 
 [Cohere](https://cohere.com/) provides state-of-the-art large language models that excel at text generation, summarization, classification, and retrieval-augmented generation.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/crewai.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/crewai.mdx
@@ -7,6 +7,7 @@ og:description: Build intelligent AI teams with CrewAI and monitor their perform
 og:site_name: Opik Documentation
 og:title: Elevate CrewAI Framework with Opik Integration
 title: Observability for CrewAI with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/crewai
 ---
 
 [CrewAI](https://www.crewai.com/) is a cutting-edge framework for orchestrating autonomous AI agents.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/cursor.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/cursor.mdx
@@ -7,6 +7,7 @@ og:description: Explore how to integrate Opik with your agent using cursor and a
 og:site_name: Opik Documentation
 og:title: Integrate Cursor with Opik for Seamless Onboarding
 title: Observability for Cursor with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/cursor
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/deepseek.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/deepseek.mdx
@@ -7,6 +7,7 @@ og:description: Learn how to track DeepSeek calls using Opik with multiple hosti
 og:site_name: Opik Documentation
 og:title: Integrate DeepSeek with Opik for Enhanced Tracking
 title: Observability for DeepSeek with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/deepseek
 ---
 
 Deepseek is an Open-Source LLM model that rivals o1 from OpenAI. You can learn more about DeepSeek on [Github](https://github.com/deepseek-ai/DeepSeek-R1) or

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/dify.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/dify.mdx
@@ -7,6 +7,7 @@ og:description: Learn how to connect Dify with Opik to monitor your applications
 og:site_name: Opik Documentation
 og:title: Connect Dify with Opik - Monitor Your Apps
 title: Observability for Dify with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/dify
 ---
 
 Learn how to connect Opik with Dify to monitor your applications' performance.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/dspy.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/dspy.mdx
@@ -7,6 +7,7 @@ og:description: Learn to integrate Opik with DSPy for detailed logging of all DS
 og:site_name: Opik Documentation
 og:title: Integrate DSPy with Opik for Enhanced Logging
 title: Observability for DSPy with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/dspy
 ---
 
 [DSPy](https://dspy.ai/) is the framework for programming—rather than prompting—language models.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/fireworks-ai.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/fireworks-ai.mdx
@@ -7,6 +7,7 @@ og:description: Learn to integrate Fireworks AI's fast inference models with Opi
 og:site_name: Opik Documentation
 og:title: Integrate Fireworks AI with Opik - Opik
 title: Observability for Fireworks AI with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/fireworks-ai
 ---
 
 [Fireworks AI](https://fireworks.ai/) provides fast inference for popular open-source models, offering high-performance API access to models like Llama, Mistral, and Qwen with optimized inference infrastructure.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/flowise.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/flowise.mdx
@@ -7,6 +7,7 @@ og:description: Create AI agents using Flowise's drag-and-drop interface. Levera
 og:site_name: Opik Documentation
 og:title: Build AI Workflows with Opik - Flowise
 title: Observability for Flowise with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/flowise
 ---
 
 Flowise AI is a visual LLM builder that allows you to create AI agents and workflows through a drag-and-drop interface. With Opik integration, you can analyze and troubleshoot your chatflows and agentflows to improve performance and user experience.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/gemini-typescript.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/gemini-typescript.mdx
@@ -7,6 +7,7 @@ og:description: Integrate Opik with Google Generative AI SDK to trace and monito
 og:site_name: Opik Documentation
 og:title: Seamless Integration with Opik for Gemini API
 title: Observability for Google Gemini (TypeScript) with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/gemini-typescript
 ---
 
 Opik provides seamless integration with the [Google Generative AI Node.js SDK](https://github.com/googleapis/js-genai) (`@google/genai`) through the `opik-gemini` package, allowing you to trace, monitor, and debug your Gemini API calls.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/gemini.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/gemini.mdx
@@ -7,6 +7,7 @@ og:description: Explore how to integrate Gemini models with Opik using Google Ve
 og:site_name: Opik Documentation
 og:title: Gemini Models in VertexAI - Opik Integration
 title: Observability for Google Gemini (Python) with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/gemini
 ---
 
 [Gemini](https://aistudio.google.com/welcome) is a family of multimodal large language models developed by Google DeepMind.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/groq.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/groq.mdx
@@ -7,6 +7,7 @@ og:description: Learn to set up your Groq account on Opik and get started with A
 og:site_name: Opik Documentation
 og:title: Fast AI Inference with Groq - Opik Model Providers
 title: Observability for Groq with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/groq
 ---
 
 [Groq](https://groq.com/) is Fast AI Inference.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/guardrails-ai.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/guardrails-ai.mdx
@@ -7,6 +7,7 @@ og:description: Learn to log Guardrails validation steps to Opik, enhancing your
 og:site_name: Opik Documentation
 og:title: Validate Inputs with Guardrails AI - Opik
 title: Validation Tracking for Guardrails AI with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/guardrails-ai
 ---
 
 [Guardrails AI](https://github.com/guardrails-ai/guardrails) is a framework for validating the inputs and outputs

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/harbor.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/harbor.mdx
@@ -7,6 +7,7 @@ og:description: Evaluate autonomous LLM agents on coding tasks using Harbor's be
 og:site_name: Opik Documentation
 og:title: Evaluate LLM Agents with Harbor - Opik
 title: Observability for Harbor with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/harbor
 ---
 
 [Harbor](https://github.com/laude-institute/harbor) is a benchmark evaluation framework for autonomous LLM agents. It provides standardized infrastructure for running agents against benchmarks like SWE-bench, LiveCodeBench, Terminal-Bench, and others.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/haystack.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/haystack.mdx
@@ -7,6 +7,7 @@ og:description: Learn to integrate Opik with Haystack for logging all calls as t
 og:site_name: Opik Documentation
 og:title: Integrate Opik with Haystack - Opik
 title: Observability for Haystack with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/haystack
 ---
 
 [Haystack](https://docs.haystack.deepset.ai/docs/intro) is an open-source framework for building production-ready LLM applications, retrieval-augmented generative pipelines and state-of-the-art search systems that work intelligently over large document collections.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/helicone.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/helicone.mdx
@@ -5,6 +5,7 @@ og:description: Learn to integrate Helicone with Opik using the OpenAI SDK wrapp
 og:site_name: Opik Documentation
 og:title: Integrate Helicone with Opik for LLM Observability
 title: Observability for Helicone with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/helicone
 ---
 
 [Helicone](https://www.helicone.ai/) is an open-source LLM observability platform that provides monitoring, logging, and analytics for LLM applications. It acts as a proxy layer between your application and LLM providers, offering features like request logging, caching, rate limiting, and cost tracking.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/huggingface-datasets.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/huggingface-datasets.mdx
@@ -7,6 +7,7 @@ og:description: Learn how to convert and import datasets from Hugging Face into 
 og:site_name: Opik Documentation
 og:title: Integrate Hugging Face Datasets with Opik
 title: Observability for Hugging Face Datasets with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/huggingface-datasets
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/instructor.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/instructor.mdx
@@ -7,6 +7,7 @@ og:description: Learn to integrate Opik with Instructor to log all calls as trac
 og:site_name: Opik Documentation
 og:title: Integrate Instructor with Opik for Enhanced Tracing
 title: Structured Output Tracking for Instructor with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/instructor
 ---
 
 [Instructor](https://github.com/instructor-ai/instructor) is a Python library for working with structured outputs

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/kong-ai-gateway.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/kong-ai-gateway.mdx
@@ -7,6 +7,7 @@ og:description: Learn to integrate Kong AI Gateway with Opik using the Opik Kong
 og:site_name: Opik Documentation
 og:title: Integrate Kong AI Gateway with Opik for Production LLM Gateway
 title: Observability for Kong AI Gateway with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/kong-ai-gateway
 ---
 
 [Kong](https://docs.konghq.com/gateway/latest/) is a popular open-source API gateway that has an AI Gateway. 

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/langchain.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/langchain.mdx
@@ -7,6 +7,7 @@ og:description: Capture detailed insights and track costs in your LangChain appl
 og:site_name: Opik Documentation
 og:title: Unlock LangChain's Potential with Opik
 title: Observability for LangChain (Python) with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/langchain
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/langchainjs.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/langchainjs.mdx
@@ -7,6 +7,7 @@ og:description: Monitor and debug your LangChain applications effortlessly with 
 og:site_name: Opik Documentation
 og:title: Enhance LangChain Applications - Opik
 title: Observability for LangChain (JavaScript) with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/langchainjs
 ---
 
 Opik provides seamless integration with [LangChain](https://js.langchain.com/) through the `opik-langchain` package, allowing you to trace, monitor, and debug your LangChain applications.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/langflow.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/langflow.mdx
@@ -7,6 +7,7 @@ og:description: Monitor and trace your AI workflows with Opik's seamless integra
 og:site_name: Opik Documentation
 og:title: Build AI Apps with Langflow - Opik Integration
 title: Observability for Langflow with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/langflow
 ---
 
 [Langflow](https://www.langflow.org/) is an open-source, low-code platform for building AI applications using a visual flow-based interface. It enables developers and non-developers alike to create complex LLM applications through drag-and-drop components, making it easier to prototype, test, and deploy AI workflows.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/langgraph.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/langgraph.mdx
@@ -7,6 +7,7 @@ og:description: Capture detailed insights of your LangGraph applications effortl
 og:site_name: Opik Documentation
 og:title: Integrate LangGraph with Opik for Seamless Tracing
 title: Observability for LangGraph with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/langgraph
 ---
 
 Opik provides a seamless integration with LangGraph, allowing you to easily log and trace your LangGraph-based applications. By using the `OpikTracer` callback, you can automatically capture detailed information about your LangGraph graph executions during both development and production.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/langserve.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/langserve.mdx
@@ -5,6 +5,7 @@ og:description: LangServe has no standalone OTEL bootstrap; instrument the hosti
 og:site_name: Opik Documentation
 og:title: LangServe Integration - Opik
 title: Observability for LangServe with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/langserve
 ---
 
 [LangServe](https://github.com/langchain-ai/langserve) does not define its own standalone OpenTelemetry bootstrap. Instrumentation is configured at the host app/runtime layer (typically FastAPI + LangChain components).

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/litellm.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/litellm.mdx
@@ -7,6 +7,7 @@ og:description: Learn to call LLM APIs with LiteLLM using OpenAI format. Configu
 og:site_name: Opik Documentation
 og:title: LiteLLM Gateways - Opik Integration
 title: Observability for LiteLLM with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/litellm
 ---
 
 [LiteLLM](https://github.com/BerriAI/litellm) allows you to call all LLM APIs using the OpenAI format [Bedrock, Huggingface, VertexAI, TogetherAI, Azure, OpenAI, Groq etc.]. There are two main ways to use LiteLLM:

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/livekit.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/livekit.mdx
@@ -7,6 +7,7 @@ og:description: Build production-grade multimodal and voice AI agents using Live
 og:site_name: Opik Documentation
 og:title: Build AI Agents with Opik - LiveKit Agents
 title: Observability for LiveKit with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/livekit
 ---
 
 LiveKit Agents is an open-source Python framework for building production-grade multimodal and voice AI agents. It provides a complete set of tools and abstractions for feeding realtime media through AI pipelines, supporting both high-performance STT-LLM-TTS voice pipelines and speech-to-speech models.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/llama_index.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/llama_index.mdx
@@ -7,6 +7,7 @@ og:description: Build powerful LLM applications using LlamaIndex to easily conne
 og:site_name: Opik Documentation
 og:title: 'Llama Index: Build LLM Apps with Opik Frameworks'
 title: Observability for LlamaIndex with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/llama_index
 ---
 
 [LlamaIndex](https://github.com/run-llama/llama_index) is a flexible data framework for building LLM applications:

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/mastra.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/mastra.mdx
@@ -7,6 +7,7 @@ og:description: Build AI applications with Mastra's TypeScript framework. Captur
 og:site_name: Opik Documentation
 og:title: 'Mastra: AI Agent Framework - Opik'
 title: Observability for Mastra with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/mastra
 ---
 
 Mastra is the TypeScript agent framework designed to provide the essential primitives for building AI applications. It enables developers to create AI agents with memory and tool-calling capabilities, implement deterministic LLM workflows, and leverage RAG for knowledge integration.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/microsoft-agent-framework-dotnet.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/microsoft-agent-framework-dotnet.mdx
@@ -7,6 +7,7 @@ og:description: Build and deploy AI agents with the Microsoft Agent Framework, f
 og:site_name: Opik Documentation
 og:title: Microsoft Agent Framework for AI Development - Opik
 title: Observability for Microsoft Agent Framework (.NET) with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/microsoft-agent-framework-dotnet
 ---
 
 [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) is a comprehensive multi-language framework for building, orchestrating, and deploying AI agents and multi-agent workflows with support for both Python and .NET implementations.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/microsoft-agent-framework.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/microsoft-agent-framework.mdx
@@ -7,6 +7,7 @@ og:description: Build and deploy AI agents with the Microsoft Agent Framework, f
 og:site_name: Opik Documentation
 og:title: Microsoft Agent Framework - Opik Integration
 title: Observability for Microsoft Agent Framework (Python) with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/microsoft-agent-framework
 ---
 
 [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) is a comprehensive multi-language framework for building, orchestrating, and deploying AI agents and multi-agent workflows with support for both Python and .NET implementations.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/mistral.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/mistral.mdx
@@ -7,6 +7,7 @@ og:description: Learn to integrate Mistral AI with Opik via LiteLLM to track and
 og:site_name: Opik Documentation
 og:title: Integrate Mistral AI with Opik - Streamline Your Workflow
 title: Observability for Mistral AI with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/mistral
 ---
 
 [Mistral AI](https://mistral.ai/) provides cutting-edge large language models with excellent performance for text generation, reasoning, and specialized tasks like code generation.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/n8n.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/n8n.mdx
@@ -7,6 +7,7 @@ og:description: Connect services and automate tasks visually with n8n. Learn to 
 og:site_name: Opik Documentation
 og:title: Automate Workflows with n8n - Opik
 title: Observability for n8n with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/n8n
 ---
 
 [n8n](https://n8n.io) is a powerful workflow automation platform that allows you to connect various services and automate tasks through a visual interface. With the `n8n-observability` package, you can automatically trace workflow executions and node operations using OpenTelemetry.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/novita-ai.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/novita-ai.mdx
@@ -7,6 +7,7 @@ og:description: Learn to integrate Opik with Novita AI using LiteLLM to track an
 og:site_name: Opik Documentation
 og:title: Integrate Novita AI Models with Opik - Opik
 title: Observability for Novita AI with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/novita-ai
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/ollama.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/ollama.mdx
@@ -7,6 +7,7 @@ og:description: Deploy and interact with AI models on your machine using Ollama'
 og:site_name: Opik Documentation
 og:title: Run AI Models Locally with Ollama - Opik
 title: Observability for Ollama with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/ollama
 ---
 
 [Ollama](https://ollama.com/) allows users to run, interact with, and deploy AI models locally on their machines without the need for complex infrastructure or cloud dependencies.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openai-codex.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openai-codex.mdx
@@ -5,6 +5,7 @@ og:description: OpenAI Codex supports opt-in OpenTelemetry export via config.tom
 og:site_name: Opik Documentation
 og:title: OpenAI Codex Integration - Opik
 title: Observability for OpenAI Codex with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/openai-codex
 ---
 
 [OpenAI Codex](https://developers.openai.com/codex) supports opt-in OpenTelemetry export through Codex configuration files.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openai-typescript.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openai-typescript.mdx
@@ -7,6 +7,7 @@ og:description: Monitor and debug OpenAI API calls effortlessly using Opik's tra
 og:site_name: Opik Documentation
 og:title: Seamless OpenAI Integration - Opik
 title: Observability for OpenAI (TypeScript) with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/openai-typescript
 ---
 
 Opik provides seamless integration with the official [OpenAI Node.js SDK](https://github.com/openai/openai-node) through the `opik-openai` package, allowing you to trace, monitor, and debug your OpenAI API calls.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openai.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openai.mdx
@@ -7,6 +7,7 @@ og:description: Learn how to seamlessly track and evaluate OpenAI API calls in y
 og:site_name: Opik Documentation
 og:title: Integrate OpenAI with Opik for Effective Tracking
 title: Observability for OpenAI (Python) with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/openai
 ---
 
 <Tip>

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openai_agents.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openai_agents.mdx
@@ -7,6 +7,7 @@ og:description: Build advanced AI applications with OpenAI Agents, leveraging po
 og:site_name: Opik Documentation
 og:title: Explore OpenAI Agents Framework - Opik
 title: Observability for OpenAI Agents with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/openai_agents
 ---
 
 OpenAI released an agentic framework aptly named [Agents](https://platform.openai.com/docs/guides/agents). What

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openclaw.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openclaw.mdx
@@ -6,6 +6,7 @@ og:description: Connect OpenClaw to Opik with the @opik/opik-openclaw plugin.
 og:site_name: Opik Documentation
 og:title: OpenClaw Integration - Opik
 title: Observability for OpenClaw with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/openclaw
 ---
 
 [OpenClaw](https://github.com/openclaw/openclaw) can send trace data to Opik through the community plugin package `@opik/opik-openclaw`.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openrouter.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openrouter.mdx
@@ -7,6 +7,7 @@ og:description: Learn to integrate Opik with OpenRouter using OpenAI SDK for sea
 og:site_name: Opik Documentation
 og:title: Integrate OpenRouter with Opik Easily
 title: Observability for OpenRouter with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/openrouter
 ---
 
 This guide explains how to integrate Opik with OpenRouter using the OpenAI SDK. OpenRouter provides a unified API for accessing hundreds of AI models through a single OpenAI-compatible interface.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openwebui.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/openwebui.mdx
@@ -7,6 +7,7 @@ og:description: Monitor and enhance OpenWebUI using Opik for application traces 
 og:site_name: Opik Documentation
 og:title: Optimize OpenWebUI Performance with Opik
 title: Observability for OpenWebUI with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/openwebui
 ---
 
 [OpenWebUI](https://openwebui.com/) is a self-hosted WebUI that operates offline and supports various LLM runners, including Ollama and OpenAI-compatible APIs. OpenWebUI is open source and can easily be deployed on your own infrastructure.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/opik-llm-gateway.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/opik-llm-gateway.mdx
@@ -7,6 +7,7 @@ og:description: Learn to use the Opik LLM Gateway to centralize access to multip
 og:site_name: Opik Documentation
 og:title: Integrate Opik LLM Gateway for Centralized LLM Access
 title: Observability for Opik LLM Gateway with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/opik-llm-gateway
 ---
 
 The Opik LLM Gateway is a light-weight proxy server that can be used to query different LLM APIs using the OpenAI format. It's designed for **development and testing purposes** and provides a centralized way to access multiple LLM providers through a single endpoint.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/overview.mdx
@@ -6,6 +6,7 @@ og:description: Explore how to log, visualize, and evaluate LLM calls and RAG pi
 og:site_name: Opik Documentation
 og:title: 'Integrate with Opik: Overview of Capabilities'
 title: Overview
+canonical-url: https://www.comet.com/docs/opik/integrations/overview
 ---
 
 Opik helps you easily log, visualize, and evaluate everything from raw LLM calls to advanced RAG pipelines and complex agentic systems through a robust set of integrations with popular frameworks and tools.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/pipecat.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/pipecat.mdx
@@ -7,6 +7,7 @@ og:description: Learn to integrate Opik with Pipecat for real-time monitoring an
 og:site_name: Opik Documentation
 og:title: Integrate Opik with Pipecat for Enhanced AI
 title: Observability for Pipecat with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/pipecat
 ---
 
 [Pipecat](https://github.com/pipecat-ai/pipecat) is an open-source Python framework for building real-time voice and multimodal conversational AI agents. Developed by Daily, it enables fully programmable AI voice agents and supports multimodal interactions, positioning itself as a flexible solution for developers looking to build conversational AI systems.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/portkey.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/portkey.mdx
@@ -5,6 +5,7 @@ og:description: Learn to integrate Portkey with Opik using the OpenAI SDK wrappe
 og:site_name: Opik Documentation
 og:title: Integrate Portkey with Opik for Enterprise LLM Gateway
 title: Observability for Portkey with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/portkey
 ---
 
 [Portkey](https://portkey.ai/) is an enterprise-grade AI gateway that provides a unified interface to access 200+ LLMs with advanced features like smart routing, automatic fallbacks, load balancing, and comprehensive observability.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/predibase.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/predibase.mdx
@@ -7,6 +7,7 @@ og:description: Learn to set up your account on Predibase to fine-tune and serve
 og:site_name: Opik Documentation
 og:title: Fine-tune LLMs with Opik on Predibase
 title: Observability for Predibase with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/predibase
 ---
 
 Predibase is a platform for fine-tuning and serving open-source Large Language Models (LLMs). It's built on top of open-source [LoRAX](https://loraexchange.ai/).

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/prompt-flow.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/prompt-flow.mdx
@@ -5,6 +5,7 @@ og:description: Prompt Flow controls tracing via its own APIs; Opik export is co
 og:site_name: Opik Documentation
 og:title: Prompt Flow Integration - Opik
 title: Observability for Prompt Flow with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/prompt-flow
 ---
 
 [Prompt Flow](https://microsoft.github.io/promptflow/) enables tracing through Prompt Flow APIs and uses OpenTelemetry export settings for outbound telemetry.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/pydantic-ai.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/pydantic-ai.mdx
@@ -7,6 +7,7 @@ og:description: Build reliable AI applications using Pydantic AI's type-safe dat
 og:site_name: Opik Documentation
 og:title: Build AI Applications with Pydantic - Opik
 title: Observability for Pydantic AI with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/pydantic-ai
 ---
 
 [Pydantic AI](https://ai.pydantic.dev/) is a Python agent framework designed to

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/quarkus-langchain4j.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/quarkus-langchain4j.mdx
@@ -5,6 +5,7 @@ og:description: Quarkus LangChain4j uses Quarkus OTEL properties; this guide map
 og:site_name: Opik Documentation
 og:title: Quarkus LangChain4j Integration - Opik
 title: Observability for Quarkus LangChain4j with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/quarkus-langchain4j
 ---
 
 [Quarkus LangChain4j](https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html) uses Quarkus OpenTelemetry configuration in `application.properties`.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/ragas.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/ragas.mdx
@@ -7,6 +7,7 @@ og:description: Learn to integrate Ragas with Opik for efficient evaluation of R
 og:site_name: Opik Documentation
 og:title: Evaluate RAG Systems with Opik
 title: Evaluate LLM Applications with Ragas Metrics in Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/ragas
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/semantic-kernel.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/semantic-kernel.mdx
@@ -7,6 +7,7 @@ og:description: Leverage Semantic Kernel to integrate LLMs with languages like C
 og:site_name: Opik Documentation
 og:title: Build AI Applications with Semantic Kernel - Opik
 title: Observability for Semantic Kernel (Python) with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/semantic-kernel
 ---
 
 [Semantic Kernel](https://github.com/microsoft/semantic-kernel) is a powerful open-source SDK from Microsoft. It facilitates the combination of LLMs with popular programming languages like C#, Python, and Java. Semantic Kernel empowers developers to build sophisticated AI applications by seamlessly integrating AI services, data sources, and custom logic, accelerating the delivery of enterprise-grade AI solutions.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/smolagents.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/smolagents.mdx
@@ -7,6 +7,7 @@ og:description: Create powerful AI agents using Smolagents with Opik. Build, con
 og:site_name: Opik Documentation
 og:title: Build AI Agents with Smolagents - Opik
 title: Observability for Smolagents with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/smolagents
 ---
 
 [Smolagents](https://huggingface.co/docs/smolagents/en/index) is a framework from HuggingFace that allows you to create AI agents with various capabilities.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/spring-ai.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/spring-ai.mdx
@@ -7,6 +7,7 @@ og:description: Build intelligent applications with Spring AI, leveraging AI mod
 og:site_name: Opik Documentation
 og:title: Simplify AI Integration in Spring - Opik
 title: Observability for Spring AI (Java) with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/spring-ai
 ---
 
 Spring AI is a framework designed to simplify the integration of AI and machine learning capabilities into Spring applications. It provides a familiar Spring-based programming model for working with AI models, vector stores, and AI-powered features, making it easier to build intelligent applications within the Spring ecosystem.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/strands-agents.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/strands-agents.mdx
@@ -7,6 +7,7 @@ og:description: Explore how to build scalable AI agents with Strands Agents SDK,
 og:site_name: Opik Documentation
 og:title: Build AI Agents with Strands - Opik
 title: Observability for Strands Agents with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/strands-agents
 ---
 
 [Strands Agents](https://github.com/strands-agents/sdk-python) is a simple yet powerful SDK that takes a model-driven approach to building and running AI agents.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/temporal.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/temporal.mdx
@@ -5,6 +5,7 @@ og:description: Temporal Python SDK uses TracingInterceptor; this guide clarifie
 og:site_name: Opik Documentation
 og:title: Temporal Integration - Opik
 title: Observability for Temporal with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/temporal
 ---
 
 [Temporal](https://temporal.io/) Python SDK integrates with OpenTelemetry through `TracingInterceptor`.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/together-ai.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/together-ai.mdx
@@ -7,6 +7,7 @@ og:description: Configure Opik to track Together AI calls, enabling easy evaluat
 og:site_name: Opik Documentation
 og:title: Integrate Together AI with Opik - Fast Inference
 title: Observability for Together AI with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/together-ai
 ---
 
 [Together AI](https://www.together.ai/) provides fast inference for leading open-source models including Llama, Mistral, Qwen, and many others.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/truefoundry.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/truefoundry.mdx
@@ -5,6 +5,7 @@ og:description: Learn to integrate TrueFoundry with Opik using the OpenAI SDK wr
 og:site_name: Opik Documentation
 og:title: Integrate TrueFoundry with Opik for Enterprise MLOps
 title: Observability for TrueFoundry with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/truefoundry
 ---
 
 [TrueFoundry](https://www.truefoundry.com/) is an enterprise MLOps platform that provides a unified interface for deploying and managing ML models, including LLMs. It offers features like model deployment, monitoring, A/B testing, and cost optimization.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/vercel-ai-gateway.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/vercel-ai-gateway.mdx
@@ -5,6 +5,7 @@ og:description: Learn to integrate Vercel AI Gateway with Opik using the OpenAI 
 og:site_name: Opik Documentation
 og:title: Integrate Vercel AI Gateway with Opik for Edge-Optimized AI
 title: Observability for Vercel AI Gateway with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/vercel-ai-gateway
 ---
 
 [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) provides a unified interface to access multiple AI providers with edge-optimized performance, built-in caching, and comprehensive analytics. It's designed to work seamlessly with Vercel's edge infrastructure.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/vercel-ai-sdk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/vercel-ai-sdk.mdx
@@ -7,6 +7,7 @@ og:description: Enable tracing with Vercel AI SDK using OpikExporter for efficie
 og:site_name: Opik Documentation
 og:title: Vercel AI SDK Setup - Opik Integration
 title: Observability for Vercel AI SDK with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/vercel-ai-sdk
 ---
 
 ## Setup

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/voltagent.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/voltagent.mdx
@@ -7,6 +7,7 @@ og:description: Build and manage AI agents effectively with VoltAgent, leveragin
 og:site_name: Opik Documentation
 og:title: VoltAgent Framework - Build AI Agents with Opik
 title: Observability for VoltAgent with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/voltagent
 ---
 
 VoltAgent is an agent framework designed to simplify the creation and management of AI agents with built-in support for tool usage, memory management, and multi-agent coordination. It provides a flexible architecture for building production-ready AI agent systems.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/watsonx.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/watsonx.mdx
@@ -7,6 +7,7 @@ og:description: Build and deploy AI models effectively with WatsonX using Opik f
 og:site_name: Opik Documentation
 og:title: Train AI Models with Opik - WatsonX Model Providers
 title: Observability for IBM watsonx with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/watsonx
 ---
 
 [watsonx](https://www.ibm.com/products/watsonx-ai) is a next generation enterprise studio for AI builders to train, validate, tune and deploy AI models.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/xai-grok.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/xai-grok.mdx
@@ -7,6 +7,7 @@ og:description: Learn to integrate Opik with xAI Grok via LiteLLM to efficiently
 og:site_name: Opik Documentation
 og:title: Integrate xAI Grok with Opik for Enhanced AI Tracking
 title: Observability for xAI Grok with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/xai-grok
 ---
 
 <Note>

--- a/apps/opik-documentation/documentation/fern/docs/tracing/log_agent_graph.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/log_agent_graph.mdx
@@ -5,6 +5,7 @@ og:description: Learn to log agent execution graphs in Opik for enhanced debuggi
 og:site_name: Opik Documentation
 og:title: Visualize Agent Graphs with Opik
 title: Log Agent Graphs
+canonical-url: https://www.comet.com/docs/opik/tracing/advanced/log_agent_graphs
 ---
 
 Agent Graphs are a great way to visualize the flow of an agent and simplifies it's debugging.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/log_chat_conversations.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/log_chat_conversations.mdx
@@ -5,6 +5,7 @@ og:description: Capture and analyze chat conversations on Opik, enabling better 
 og:site_name: Opik Documentation
 og:title: Log Conversations Effectively - Opik
 title: Log conversations
+canonical-url: https://www.comet.com/docs/opik/tracing/advanced/log_chat_conversations
 ---
 
 You can log chat conversations to the Opik platform and track the full conversations

--- a/apps/opik-documentation/documentation/fern/docs/tracing/log_distributed_traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/log_distributed_traces.mdx
@@ -5,6 +5,7 @@ og:description: Learn to track distributed traces in complex LLM applications us
 og:site_name: Opik Documentation
 og:title: Log Distributed Traces with Opik
 title: Log distributed traces
+canonical-url: https://www.comet.com/docs/opik/tracing/advanced/log_distributed_traces
 ---
 
 When working with complex LLM applications, it is common to need to track a traces across multiple services. Opik supports distributed tracing out of the box when integrating using function decorators using a mechanism that is similar to how OpenTelemetry implements distributed tracing.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/log_multimodal_traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/log_multimodal_traces.mdx
@@ -5,6 +5,7 @@ og:description: Capture multimodal traces in Opik by logging images, videos, and
 og:site_name: Opik Documentation
 og:title: Log Media & Attachments with Opik
 title: Log media & attachments
+canonical-url: https://www.comet.com/docs/opik/tracing/advanced/log_multimodal_traces
 ---
 
 Opik supports multimodal traces allowing you to track not just the text input

--- a/apps/opik-documentation/documentation/fern/docs/tracing/log_traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/log_traces.mdx
@@ -5,6 +5,7 @@ og:description: Monitor the flow of your LLM applications with tracing to identi
 og:site_name: Opik Documentation
 og:title: Log Traces with Opik - Enhance Observability
 title: Log traces
+canonical-url: https://www.comet.com/docs/opik/tracing/advanced/log_traces
 ---
 
 <Tip>

--- a/apps/opik-documentation/documentation/fern/docs/tracing/offline_fallback.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/offline_fallback.mdx
@@ -6,6 +6,7 @@ og:description: Keep your tracing data intact during network outages with Opik's
 og:site_name: Opik Documentation
 og:title: Offline Fallback & Message Replay - Opik Python SDK
 title: Offline fallback and message replay
+canonical-url: https://www.comet.com/docs/opik/tracing/advanced/offline_fallback
 ---
 
 # Offline fallback and message replay

--- a/apps/opik-documentation/documentation/fern/docs/tracing/opentelemetry/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/opentelemetry/overview.mdx
@@ -7,6 +7,7 @@ og:title: Get Started with OpenTelemetry - Opik
 subtitle: Describes how to send data to Opik using OpenTelemetry
 title: OpenTelemetry
 toc_max_heading_level: 4
+canonical-url: https://www.comet.com/docs/opik/integrations/opentelemetry
 ---
 
 # Get Started with OpenTelemetry

--- a/apps/opik-documentation/documentation/fern/docs/tracing/opentelemetry/python-sdk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/opentelemetry/python-sdk.mdx
@@ -7,6 +7,7 @@ og:title: Instrument Your Python Apps with OpenTelemetry - Opik
 subtitle: How to send data to Opik using the OpenTelemetry Python SDK
 title: OpenTelemetry Python SDK
 toc_max_heading_level: 4
+canonical-url: https://www.comet.com/docs/opik/integrations/opentelemetry-python-sdk
 ---
 
 # Using the OpenTelemetry Python SDK

--- a/apps/opik-documentation/documentation/fern/docs/tracing/opik_assist.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/opik_assist.mdx
@@ -6,6 +6,7 @@ og:description: Explore Opik Assist to debug and enhance your LLM application tr
 og:site_name: Opik Documentation
 og:title: Analyze and Optimize with Opik Assist
 title: ✨ Opik Assist (Beta)
+canonical-url: https://www.comet.com/docs/opik/ollie
 ---
 
 <img src="/img/tracing/trace_inspector_with_response.png" alt="Opik Assist AI response with recommendations" />

--- a/apps/opik-documentation/documentation/fern/docs/tracing/sdk_configuration.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/sdk_configuration.mdx
@@ -5,6 +5,7 @@ og:description: Configure Python and TypeScript SDKs effectively. Set up your AP
 og:site_name: Opik Documentation
 og:title: SDK Configuration Guide - Opik
 title: SDK configuration
+canonical-url: https://www.comet.com/docs/opik/tracing/advanced/sdk_configuration
 ---
 
 # SDK Configuration

--- a/apps/opik-documentation/documentation/fern/docs/tracing/supported_models.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/supported_models.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Supported Models for Cost Tracking"
 description: "Complete list of models supported for automatic cost tracking in Opik"
+canonical-url: https://www.comet.com/docs/opik/tracing/advanced/cost_tracking
 ---
 
 # Supported Models for Cost Tracking

--- a/apps/opik-documentation/documentation/fern/v1_noindex.js
+++ b/apps/opik-documentation/documentation/fern/v1_noindex.js
@@ -1,10 +1,29 @@
-// Prevent v1 documentation pages from being indexed by search engines.
-// v1 content is preserved for users who need it via the version switcher,
-// but should not compete with latest docs in search results.
+// Inject canonical links on v1 documentation pages pointing to their latest equivalents.
+// Prevents duplicate content penalties while consolidating link equity onto the latest docs.
 (function () {
-  if (!window.location.pathname.match(/\/docs\/opik\/v1(\/|$)/)) return;
-  var meta = document.createElement("meta");
-  meta.name = "robots";
-  meta.content = "noindex,follow";
-  document.head.appendChild(meta);
+  var path = window.location.pathname;
+  var match = path.match(/^(\/docs\/opik)\/v1(\/.*)?$/);
+  if (!match) return;
+
+  var base = match[1]; // /docs/opik
+  var rest = match[2] || "/"; // everything after /v1
+
+  var canonical;
+
+  // Sections whose URL structure changed between v1 and latest
+  if (/^\/agent_optimization/.test(rest)) {
+    canonical = base + "/development/optimization-runs/overview";
+  } else if (/^\/prompt_engineering/.test(rest)) {
+    canonical = base + "/prompt-library/getting-started";
+  } else if (/^\/opik-university/.test(rest)) {
+    canonical = base + "/";
+  } else {
+    // Tracing, evaluation, self-host, integrations, reference — same URL structure
+    canonical = base + rest;
+  }
+
+  var link = document.createElement("link");
+  link.rel = "canonical";
+  link.href = "https://www.comet.com" + canonical;
+  document.head.appendChild(link);
 })();

--- a/apps/opik-documentation/documentation/fern/v1_noindex.js
+++ b/apps/opik-documentation/documentation/fern/v1_noindex.js
@@ -1,0 +1,10 @@
+// Prevent v1 documentation pages from being indexed by search engines.
+// v1 content is preserved for users who need it via the version switcher,
+// but should not compete with latest docs in search results.
+(function () {
+  if (!window.location.pathname.match(/\/docs\/opik\/v1(\/|$)/)) return;
+  var meta = document.createElement("meta");
+  meta.name = "robots";
+  meta.content = "noindex,follow";
+  document.head.appendChild(meta);
+})();


### PR DESCRIPTION
## Details

- **Home page rewrite**: Removed the "Upgrading from Opik 1.x" migration note (not relevant to current users), the generic architecture diagram, and the enterprise marketing paragraph. Replaced 6 generic feature cards with 4 intent-based scenario cards ("Trace my LLM calls", "Evaluate my agent's quality", "Optimize my prompts automatically", "Run Opik on my own infrastructure"). Fixed stale link pointing to `/v1/prompt_engineering/playground`. Simplified intro to a single sentence with a quickstart CTA.
- **Quickstart fixes**: Removed two `TODO` comment placeholders left in JSX. Fixed truncated "Next steps" sentence ("logged your first Agent calls to" was missing "Opik").
- **Optimization quickstart**: Removed "In Opik 2.0, datasets and experiments are project-scoped" callout — we don't reference version numbers in docs aimed at current users.
- **Tracing concepts rewrite**: Scoped the page to only the three tracing primitives (Traces, Spans, Threads). Removed off-topic Metrics, Optimization, and Evaluation sections that belong to their own pages. Fixed broken link to `/v1/evaluation/evaluate_prompt` and duplicate "Log traces"/"Log agents" links that both pointed to the same URL.
- **Redirect fix**: `/docs/opik/agent_optimization/opik_optimizer/quickstart` was redirecting to the overview page — corrected to point to the quickstart page.

## Change checklist

- [x] Home page removes all version-specific language
- [x] All card links verified against latest.yml slugs
- [x] Tracing concepts page links to `log_traces` and `log_agent_graphs` (not the same URL twice)
- [x] No TODO comments remain in quickstart.mdx
- [x] Redirect destination updated in docs.yml

## Issues

N/A

## AI-WATERMARK

This PR was created with AI assistance.

## Testing

Docs changes — verify by running the Fern docs dev server and checking:
1. Home page renders 4 cards with correct links
2. Quickstart next steps section is complete
3. Tracing concepts page no longer includes Metrics/Optimization/Evaluation sections
4. Old agent_optimization/quickstart URL redirects to the quickstart page

## Documentation

This PR _is_ the documentation change.