### PR TITLE
[OPIK-6384] [FE] fix: update outdated Optimization Studio code snippets

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/development/optimization-runs/algorithms/gepa_optimizer.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/development/optimization-runs/algorithms/gepa_optimizer.mdx
@@ -62,8 +62,7 @@ prompt = ChatPrompt(
 optimizer = GepaOptimizer(
     model="openai/gpt-4o-mini",
     n_threads=6,
-    temperature=0.2,
-    max_tokens=200,
+    model_parameters={"temperature": 0.2, "max_tokens": 200},
 )
 
 result = optimizer.optimize_prompt(

--- a/apps/opik-documentation/documentation/fern/docs-v2/development/optimization-runs/algorithms/tool_optimization.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/development/optimization-runs/algorithms/tool_optimization.mdx
@@ -207,8 +207,7 @@ Always cite your sources and be thorough in your research."""
 
 # Initialize the optimizer
 optimizer = MetaPromptOptimizer(
-    model="openai/gpt-5-nano",
-    reasoning_model="openai/gpt-5.2"
+    model="openai/gpt-5-nano"
 )
 
 # Define evaluation metric
@@ -224,7 +223,7 @@ result = optimizer.optimize_prompt(
     dataset=research_dataset,
     metric=research_quality_metric,
     n_samples=100,
-    max_rounds=5
+    max_trials=5
 )
 
 print("Optimized prompt with tools:")

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/gepa_optimizer.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/gepa_optimizer.mdx
@@ -62,8 +62,7 @@ prompt = ChatPrompt(
 optimizer = GepaOptimizer(
     model="openai/gpt-4o-mini",
     n_threads=6,
-    temperature=0.2,
-    max_tokens=200,
+    model_parameters={"temperature": 0.2, "max_tokens": 200},
 )
 
 result = optimizer.optimize_prompt(

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/optimizer_parameters_guide.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/optimizer_parameters_guide.mdx
@@ -88,12 +88,13 @@ All optimizers support these parameters in their `optimize_prompt()` method:
 **Purpose**: Uses meta-prompting to iteratively refine prompts through LLM-driven analysis.
 
 **Specific Parameters:**
-- **`reasoning_model`** (str, optional): Separate model for generating prompt suggestions
-- **`max_rounds`** (int, default: 3): Number of optimization rounds
-- **`num_prompts_per_round`** (int, default: 4): Number of candidates generated per round
-- **`initial_trials_per_candidate`** (int, default: 1): Initial evaluations per candidate
-- **`max_trials_per_candidate`** (int, default: 3): Maximum evaluations per promising candidate
-- **`improvement_threshold`** (float, default: 0.01): Minimum improvement to continue optimization
+- **`prompts_per_round`** (int, default: 4): Number of candidate prompts generated per round
+- **`enable_context`** (bool, default: True): Include dataset/task context when generating candidates
+- **`num_task_examples`** (int, default: 5): Number of dataset examples included as context
+- **`model_parameters`** (dict, optional): LiteLLM parameters (e.g. `temperature`, `max_tokens`) for the optimizer's reasoning model
+
+**Optimization Parameters (via optimize_prompt kwargs):**
+- **`max_trials`** (int, default: 10): Total number of candidate evaluations across rounds
 
 **Use Cases:**
 - General-purpose prompt improvement
@@ -101,9 +102,9 @@ All optimizers support these parameters in their `optimize_prompt()` method:
 - Tasks where prompt wording and structure matter significantly
 
 **Parameter Tuning:**
-- **Reasoning Model**: Use more capable models (gpt-4, claude-3) for better suggestions
-- **Max Rounds**: More rounds (5-10) for thorough refinement, fewer (2-3) for quick improvement
+- **Model**: Use more capable models (gpt-4o, claude-3.5-sonnet) for better prompt suggestions
 - **Prompts Per Round**: More candidates (6-8) for exploration, fewer (2-4) for focused refinement
+- **Max Trials**: More trials for thorough refinement, fewer for quick improvement
 
 ### HRPO (Hierarchical Reflective Prompt Optimizer)
 
@@ -138,8 +139,9 @@ All optimizers support these parameters in their `optimize_prompt()` method:
 **Purpose**: Wraps the GEPA package for single-turn system prompt optimization with reflection.
 
 **Specific Parameters:**
-- **`reflection_model`** (str, optional): Model for reflection (defaults to main model)
 - **`verbose`** (int, default: 1): Verbosity level (0=off, 1=on, 2=debug)
+
+Reflection is handled internally; there is no separate `reflection_model` argument to set.
 
 **Optimization Parameters (via optimize_prompt kwargs):**
 - **`max_metric_calls`** (int): Effective metric budget used by GEPA (`max_trials × evaluated_samples`). The Opik wrapper still runs its own baseline/final rescoring outside this budget, so plan for those extra evaluations when sizing API usage.
@@ -209,7 +211,7 @@ All optimizers support these parameters in their `optimize_prompt()` method:
 
 **Limited Computational Resources:**
 - Use `FewShotBayesianOptimizer` with lower `n_iterations`
-- Use `MetaPromptOptimizer` with fewer `max_rounds`
+- Use `MetaPromptOptimizer` with fewer `max_trials`
 - Use `MiproOptimizer` with `auto="light"`
 
 **Abundant Computational Resources:**

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/tool_optimization.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/algorithms/tool_optimization.mdx
@@ -207,8 +207,7 @@ Always cite your sources and be thorough in your research."""
 
 # Initialize the optimizer
 optimizer = MetaPromptOptimizer(
-    model="openai/gpt-5-nano",
-    reasoning_model="openai/gpt-5.2"
+    model="openai/gpt-5-nano"
 )
 
 # Define evaluation metric
@@ -224,7 +223,7 @@ result = optimizer.optimize_prompt(
     dataset=research_dataset,
     metric=research_quality_metric,
     n_samples=100,
-    max_rounds=5
+    max_trials=5
 )
 
 print("Optimized prompt with tools:")

--- a/apps/opik-documentation/documentation/fern/docs/agent_optimization/best_practices/prompt_engineering.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/agent_optimization/best_practices/prompt_engineering.mdx
@@ -130,9 +130,7 @@ Prompt engineering is rarely a one-shot process. Continuous iteration is key. A 
 
   prompter = MetaPromptOptimizer( # Note: often aliased as 'prompter' in examples
       model="openai/gpt-4", # Evaluation model
-      reasoning_model="openai/gpt-4-turbo", # Model for generating prompt suggestions
-      max_rounds=5,
-      num_prompts_per_round=3
+      prompts_per_round=3
   )
   ```
 

--- a/apps/opik-frontend/src/v1/pages/OptimizationsPage/AddOptimizationDialog/AddOptimizationDialog.tsx
+++ b/apps/opik-frontend/src/v1/pages/OptimizationsPage/AddOptimizationDialog/AddOptimizationDialog.tsx
@@ -82,12 +82,10 @@ def levenshtein_ratio(dataset_item, llm_output):
 # Run the optimization
 optimizer = MetaPromptOptimizer(
     model="openai/gpt-4o-mini",  # Task model (LiteLLM name)
-    reasoning_model="openai/gpt-4o",  # Optional reasoning model
-    rounds=3,
-    num_prompts_per_round=4,
+    model_parameters={"temperature": 0.0},
+    prompts_per_round=4,
     n_threads=8,
     enable_context=True,
-    temperature=0.0,
     seed=42,
 )
 
@@ -238,9 +236,7 @@ def levenshtein_ratio(dataset_item, llm_output):
 # Run the optimization
 optimizer = GepaOptimizer(
     model="openai/gpt-4o-mini",  # Task model (LiteLLM name)
-    reflection_model="openai/gpt-4o",  # Reflection model for re-ranking
-    temperature=0.0,
-    max_tokens=400,
+    model_parameters={"temperature": 0.0, "max_tokens": 400},
 )
 
 result = optimizer.optimize_prompt(

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/AddOptimizationDialog/AddOptimizationDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/AddOptimizationDialog/AddOptimizationDialog.tsx
@@ -82,12 +82,10 @@ def levenshtein_ratio(dataset_item, llm_output):
 # Run the optimization
 optimizer = MetaPromptOptimizer(
     model="openai/gpt-4o-mini",  # Task model (LiteLLM name)
-    reasoning_model="openai/gpt-4o",  # Optional reasoning model
-    rounds=3,
-    num_prompts_per_round=4,
+    model_parameters={"temperature": 0.0},
+    prompts_per_round=4,
     n_threads=8,
     enable_context=True,
-    temperature=0.0,
     seed=42,
 )
 
@@ -238,9 +236,7 @@ def levenshtein_ratio(dataset_item, llm_output):
 # Run the optimization
 optimizer = GepaOptimizer(
     model="openai/gpt-4o-mini",  # Task model (LiteLLM name)
-    reflection_model="openai/gpt-4o",  # Reflection model for re-ranking
-    temperature=0.0,
-    max_tokens=400,
+    model_parameters={"temperature": 0.0, "max_tokens": 400},
 )
 
 result = optimizer.optimize_prompt(


### PR DESCRIPTION
## Details

The "Start optimization run" dialog's hardcoded Python snippets for `MetaPromptOptimizer` and `GepaOptimizer` were written for the pre-v3 `opik_optimizer` API and fail at construction time with `TypeError` (`unexpected keyword argument 'reasoning_model'` / `'reflection_model'`). Updated both snippets to the current SDK shape and brought matching doc examples in line.

- Meta: drop `reasoning_model` + `rounds`, rename `num_prompts_per_round` → `prompts_per_round`, move `temperature` into `model_parameters`.
- GEPA: drop `reflection_model`, move `temperature` + `max_tokens` into `model_parameters`.
- Docs: aligned `gepa_optimizer.mdx`, `tool_optimization.mdx`, `best_practices/prompt_engineering.mdx`, and the prose `optimizer_parameters_guide.mdx` across both the live `docs-v2/` tree and the legacy `docs/` tree. Auto-generated `reference.mdx` / `api_reference.mdx` are intentionally untouched — they regenerate from the SDK via `scripts/generate_fern_docs.py`.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6384

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: full implementation
- Human verification: code review + end-to-end manual run of both Meta and GEPA snippets from the Studio dialog

## Testing

- Reproduced the original `TypeError` with the broken kwargs against installed `opik_optimizer 3.1.1`, then verified clean construction with the corrected kwargs:
  - `MetaPromptOptimizer(model="openai/gpt-4o-mini", model_parameters={"temperature": 0.0}, prompts_per_round=4, n_threads=8, enable_context=True, seed=42)` — OK
  - `GepaOptimizer(model="openai/gpt-4o-mini", model_parameters={"temperature": 0.0, "max_tokens": 400})` — OK
- Ran both algorithms end-to-end from the Studio dialog UI against a real Opik dataset (workspace `agents`, project `playground`) — both pass the constructor and proceed into `optimize_prompt`/baseline evaluation.
- FE quality checks via `scripts/dev-runner.sh --lint-fe`: ESLint, Stylelint, TypeScript typecheck, dependency-cruiser — all green.
- Repo-wide regrep confirmed no remaining failure-causing constructor kwargs for `MetaPromptOptimizer` / `GepaOptimizer` in non-generated files. Remaining `reflection_model` mentions in docs are the intentional "there is no separate `reflection_model` argument" notes.

## Documentation

- `algorithms/gepa_optimizer.mdx` (both trees) — moved top-level `temperature` / `max_tokens` into `model_parameters`.
- `algorithms/tool_optimization.mdx` (both trees) — dropped `reasoning_model` from the `MetaPromptOptimizer(...)` call; renamed `max_rounds` → `max_trials` in the trailing `optimize_prompt(...)` call.
- `best_practices/prompt_engineering.mdx` (legacy tree only) — dropped `reasoning_model` + `max_rounds`, renamed `num_prompts_per_round` → `prompts_per_round`.
- `algorithms/optimizer_parameters_guide.mdx` (legacy tree only) — rewrote the MetaPrompt "Specific Parameters" list grounded in the current constructor + constants, removed GEPA `reflection_model`, and updated tuning prose (`max_rounds` → `max_trials`).