### PR TITLE
[OPIK-6727] [BE] fix: aggregate experiment metrics across all referenced projects

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
@@ -84,6 +84,7 @@ import static com.comet.opik.domain.experiments.aggregations.ExperimentAggregate
 import static com.comet.opik.domain.experiments.aggregations.ExperimentAggregatesModel.SpanAggregations;
 import static com.comet.opik.domain.experiments.aggregations.ExperimentAggregatesModel.TraceAggregations;
 import static com.comet.opik.domain.experiments.aggregations.ExperimentAggregatesUtils.BatchResult;
+import static com.comet.opik.domain.experiments.aggregations.ExperimentAggregatesUtils.resolveLabelProjectId;
 import static com.comet.opik.domain.experiments.aggregations.ExperimentEntityData.ExperimentData;
 import static com.comet.opik.domain.experiments.aggregations.ExperimentSourceData.AssertionData;
 import static com.comet.opik.domain.experiments.aggregations.ExperimentSourceData.CommentsData;
@@ -97,9 +98,12 @@ public interface ExperimentAggregatesDAO {
 
     Mono<Void> populateExperimentAggregate(UUID experimentId);
 
-    Mono<UUID> getProjectId(UUID experimentId);
+    Mono<Set<UUID>> getProjectIds(UUID experimentId);
 
-    Mono<BatchResult> populateExperimentItemAggregates(UUID experimentId, UUID projectId, UUID cursor, int limit);
+    Mono<UUID> getExperimentProjectId(UUID experimentId);
+
+    Mono<BatchResult> populateExperimentItemAggregates(
+            UUID experimentId, Set<UUID> projectIds, UUID labelProjectId, UUID cursor, int limit);
 
     Mono<Experiment> getExperimentFromAggregates(UUID experimentId);
 
@@ -226,6 +230,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                 workspace_id,
                 id,
                 dataset_id,
+                project_id,
                 name,
                 created_at,
                 last_updated_at,
@@ -250,26 +255,29 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
             """;
 
     /**
-     * Get project_id from first experiment item trace
+     * Distinct project_ids this experiment's items reference, read from {@code traces} as the
+     * single source of truth. Drives the {@code project_id IN :project_ids} filter on every
+     * downstream aggregation query so totals cover all referenced projects while keeping
+     * partition pruning.
      */
-    private static final String GET_PROJECT_ID = """
-            WITH experiment_trace_items AS (
+    private static final String GET_PROJECT_IDS = """
+            SELECT groupUniqArrayIf(toString(project_id), project_id != '') AS project_ids
+            FROM traces
+            WHERE workspace_id = :workspace_id
+            AND id IN (
                 SELECT DISTINCT trace_id
                 FROM experiment_items
                 WHERE workspace_id = :workspace_id
                 AND experiment_id = :experiment_id
             )
-            SELECT DISTINCT project_id
-            FROM traces
-            INNER JOIN experiment_trace_items ON traces.id = experiment_trace_items.trace_id
-            WHERE workspace_id = :workspace_id
-            LIMIT 1
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
 
     /**
-     * Fetch trace aggregations for an experiment
+     * Fetch trace aggregations for an experiment. {@code project_id IN :project_ids} keeps
+     * partition pruning while covering every project the experiment's items reference;
+     * {@code :project_id} is the single label written to the aggregate row.
      */
     private static final String GET_TRACE_AGGREGATIONS = """
             WITH experiment_trace_items AS (
@@ -284,7 +292,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                 FROM traces
                 INNER JOIN experiment_trace_items ON traces.id = experiment_trace_items.trace_id
                 WHERE workspace_id = :workspace_id
-                AND project_id = :project_id
+                AND project_id IN :project_ids
                 ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
                 LIMIT 1 by id
             )
@@ -326,7 +334,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                     total_estimated_cost
                 FROM spans
                 WHERE workspace_id = :workspace_id
-                AND project_id = :project_id
+                AND project_id IN :project_ids
                 AND trace_id IN (SELECT trace_id FROM experiment_items)
                 ORDER BY (workspace_id, project_id, trace_id, parent_span_id, id) DESC, last_updated_at DESC
                 LIMIT 1 by id
@@ -390,7 +398,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                 FROM feedback_scores
                 WHERE entity_type = 'trace'
                 AND workspace_id = :workspace_id
-                AND project_id = :project_id
+                AND project_id IN :project_ids
                 UNION ALL
                 SELECT
                     entity_id,
@@ -399,7 +407,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                 FROM authored_feedback_scores
                 WHERE entity_type = 'trace'
                 AND workspace_id = :workspace_id
-                AND project_id = :project_id
+                AND project_id IN :project_ids
             ), feedback_scores_final AS (
                 SELECT
                     entity_id,
@@ -478,7 +486,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                     FROM assertion_results
                     WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
-                    AND project_id = :project_id
+                    AND project_id IN :project_ids
                     AND entity_id IN (SELECT trace_id FROM experiment_items_scope)
                     ORDER BY (workspace_id, project_id, entity_type, entity_id, author, name) ASC, last_updated_at DESC
                     LIMIT 1 BY workspace_id, project_id, entity_type, entity_id, author, name
@@ -543,7 +551,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                     FROM assertion_results
                     WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
-                    AND project_id = :project_id
+                    AND project_id IN :project_ids
                     AND entity_id IN (SELECT trace_id FROM experiment_items)
                     AND length(name) > 0
                     ORDER BY (workspace_id, project_id, entity_type, entity_id, author, name) ASC, last_updated_at DESC
@@ -696,7 +704,8 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
             """;
 
     /**
-     * Get trace data for experiment items batch identified by trace_ids
+     * Get trace data for an experiment-items batch, scoped to the projects the experiment
+     * references so partition pruning is preserved across multi-project experiments.
      */
     private static final String GET_TRACES_DATA = """
             SELECT
@@ -711,7 +720,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                 visibility_mode
             FROM traces
             WHERE workspace_id = :workspace_id
-            AND project_id = :project_id
+            AND project_id IN :project_ids
             AND id IN :trace_ids
             ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
             LIMIT 1 BY id
@@ -720,7 +729,8 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
             """;
 
     /**
-     * Get span data for experiment items batch identified by trace_ids
+     * Get span data for an experiment-items batch. See {@link #GET_TRACES_DATA} for the
+     * multi-project scoping.
      */
     private static final String GET_SPANS_DATA = """
             SELECT
@@ -732,7 +742,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                     trace_id, usage, total_estimated_cost
                 FROM spans
                 WHERE workspace_id = :workspace_id
-                AND project_id = :project_id
+                AND project_id IN :project_ids
                 AND trace_id IN :trace_ids
                 ORDER BY (workspace_id, project_id, trace_id, parent_span_id, id) DESC, last_updated_at DESC
                 LIMIT 1 BY id
@@ -777,7 +787,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                     FROM feedback_scores
                     WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
-                    AND project_id = :project_id
+                    AND project_id IN :project_ids
                     AND entity_id IN :trace_ids
                     UNION ALL
                     SELECT
@@ -797,7 +807,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                     FROM authored_feedback_scores
                     WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
-                    AND project_id = :project_id
+                    AND project_id IN :project_ids
                     AND entity_id IN :trace_ids
                 )
                 ORDER BY last_updated_at DESC
@@ -897,7 +907,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                     entity_id
                 FROM comments
                 WHERE workspace_id = :workspace_id
-                AND project_id = :project_id
+                AND project_id IN :project_ids
                 AND entity_id IN :trace_ids
                 ORDER BY (workspace_id, project_id, entity_id, id) DESC, last_updated_at DESC
                 LIMIT 1 BY id
@@ -930,7 +940,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                 FROM assertion_results
                 WHERE entity_type = 'trace'
                   AND workspace_id = :workspace_id
-                  AND project_id = :project_id
+                  AND project_id IN :project_ids
                   AND entity_id IN :trace_ids
                 ORDER BY (workspace_id, project_id, entity_type, entity_id, author, name) ASC, last_updated_at DESC
                 LIMIT 1 BY workspace_id, project_id, entity_type, entity_id, author, name
@@ -984,7 +994,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                         entity_id
                     FROM comments
                     WHERE workspace_id = :workspace_id
-                    AND project_id = :project_id
+                    AND project_id IN :project_ids
                     AND entity_id IN (SELECT trace_id FROM experiment_items)
                     ORDER BY (workspace_id, project_id, entity_id, id) DESC, last_updated_at DESC
                     LIMIT 1 BY id
@@ -1444,78 +1454,74 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
     public Mono<Void> populateExperimentAggregate(UUID experimentId) {
 
         return getExperimentData(experimentId)
-                .flatMap(experimentData -> {
-                    // First check if experiment has any items
-                    return getExperimentItemsCount(experimentId)
-                            .flatMap(itemsCount -> {
-                                if (itemsCount == 0) {
-                                    return insertExperimentAggregate(
-                                            experimentData,
-                                            createEmptyTraceAggregations(experimentId),
-                                            createEmptySpanAggregations(experimentId),
-                                            createEmptyFeedbackScoreAggregations(experimentId),
-                                            createEmptyPassRateAggregation(experimentId),
-                                            "[]",
-                                            0L,
-                                            createEmptyAssertionScoreAggregations(experimentId));
-                                }
+                .flatMap(experimentData ->
+                // First check if experiment has any items
+                getExperimentItemsCount(experimentId)
+                        .flatMap(itemsCount -> {
+                            if (itemsCount == 0) {
+                                return insertExperimentAggregate(
+                                        experimentData,
+                                        createEmptyTraceAggregations(experimentId),
+                                        createEmptySpanAggregations(experimentId),
+                                        createEmptyFeedbackScoreAggregations(experimentId),
+                                        createEmptyPassRateAggregation(experimentId),
+                                        "[]",
+                                        0L,
+                                        createEmptyAssertionScoreAggregations(experimentId));
+                            }
 
-                                return getProjectId(experimentId)
-                                        .map(Optional::of)
-                                        .defaultIfEmpty(Optional.empty())
-                                        .flatMap(projectIdOpt -> {
-                                            if (projectIdOpt.isEmpty()) {
-                                                return insertExperimentAggregate(
-                                                        experimentData,
-                                                        createEmptyTraceAggregations(experimentId),
-                                                        createEmptySpanAggregations(experimentId),
-                                                        createEmptyFeedbackScoreAggregations(experimentId),
-                                                        createEmptyPassRateAggregation(experimentId),
-                                                        EMPTY_ARRAY_STR,
-                                                        itemsCount,
-                                                        createEmptyAssertionScoreAggregations(experimentId));
-                                            }
+                            return getProjectIds(experimentId)
+                                    .flatMap(projectIds -> {
+                                        if (CollectionUtils.isEmpty(projectIds)) {
+                                            return insertExperimentAggregate(
+                                                    experimentData,
+                                                    createEmptyTraceAggregations(experimentId),
+                                                    createEmptySpanAggregations(experimentId),
+                                                    createEmptyFeedbackScoreAggregations(experimentId),
+                                                    createEmptyPassRateAggregation(experimentId),
+                                                    EMPTY_ARRAY_STR,
+                                                    itemsCount,
+                                                    createEmptyAssertionScoreAggregations(experimentId));
+                                        }
 
-                                            var projectId = projectIdOpt.get();
-                                            return Mono.zip(
-                                                    getTraceAggregations(experimentId, projectId),
-                                                    getSpanAggregations(experimentId, projectId),
-                                                    getFeedbackScoreAggregations(experimentId, projectId),
-                                                    getPassRateAggregation(experimentId, projectId)
-                                                            .defaultIfEmpty(
-                                                                    createEmptyPassRateAggregation(experimentId)),
-                                                    getCommentsAggregation(experimentId, projectId)
-                                                            .defaultIfEmpty(EMPTY_ARRAY_STR),
-                                                    getAssertionScoreAggregations(experimentId, projectId)
-                                                            .defaultIfEmpty(
-                                                                    createEmptyAssertionScoreAggregations(
-                                                                            experimentId)))
-                                                    .flatMap(tuple -> {
-                                                        var traceAgg = tuple.getT1();
-                                                        var spanAgg = tuple.getT2();
-                                                        var feedbackAgg = tuple.getT3();
-                                                        var passRateAgg = tuple.getT4();
-                                                        var commentsAgg = tuple.getT5();
-                                                        var assertionAgg = tuple.getT6();
+                                        var labelProjectId = resolveLabelProjectId(
+                                                experimentData.projectId(), projectIds);
+                                        return Mono.zip(
+                                                getTraceAggregations(experimentId, projectIds, labelProjectId),
+                                                getSpanAggregations(experimentId, projectIds),
+                                                getFeedbackScoreAggregations(experimentId, projectIds),
+                                                getPassRateAggregation(experimentId, projectIds)
+                                                        .defaultIfEmpty(createEmptyPassRateAggregation(experimentId)),
+                                                getCommentsAggregation(experimentId, projectIds)
+                                                        .defaultIfEmpty(EMPTY_ARRAY_STR),
+                                                getAssertionScoreAggregations(experimentId, projectIds)
+                                                        .defaultIfEmpty(
+                                                                createEmptyAssertionScoreAggregations(experimentId)))
+                                                .flatMap(tuple -> {
+                                                    var traceAgg = tuple.getT1();
+                                                    var spanAgg = tuple.getT2();
+                                                    var feedbackAgg = tuple.getT3();
+                                                    var passRateAgg = tuple.getT4();
+                                                    var commentsAgg = tuple.getT5();
+                                                    var assertionAgg = tuple.getT6();
 
-                                                        return insertExperimentAggregate(
-                                                                experimentData,
-                                                                traceAgg,
-                                                                spanAgg,
-                                                                feedbackAgg,
-                                                                passRateAgg,
-                                                                commentsAgg,
-                                                                itemsCount,
-                                                                assertionAgg);
-                                                    });
-                                        });
-                            });
-                });
+                                                    return insertExperimentAggregate(
+                                                            experimentData,
+                                                            traceAgg,
+                                                            spanAgg,
+                                                            feedbackAgg,
+                                                            passRateAgg,
+                                                            commentsAgg,
+                                                            itemsCount,
+                                                            assertionAgg);
+                                                });
+                                    });
+                        }));
     }
 
     @Override
-    public Mono<BatchResult> populateExperimentItemAggregates(UUID experimentId, UUID projectId, UUID cursorId,
-            int limit) {
+    public Mono<BatchResult> populateExperimentItemAggregates(
+            UUID experimentId, Set<UUID> projectIds, UUID labelProjectId, UUID cursorId, int limit) {
 
         return Mono.deferContextual(ctx -> {
             String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
@@ -1531,11 +1537,11 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                         var traceIds = items.stream().map(ExperimentItemData::traceId).toList();
 
                         return Mono.zip(
-                                getTracesData(workspaceId, experimentId, projectId, traceIds).collectList(),
-                                getSpansData(workspaceId, experimentId, projectId, traceIds).collectList(),
-                                getFeedbackScoresData(workspaceId, experimentId, projectId, traceIds).collectList(),
-                                getCommentsData(workspaceId, experimentId, projectId, traceIds).collectList(),
-                                getAssertionsData(workspaceId, experimentId, projectId, traceIds).collectList())
+                                getTracesData(workspaceId, experimentId, projectIds, traceIds).collectList(),
+                                getSpansData(workspaceId, experimentId, projectIds, traceIds).collectList(),
+                                getFeedbackScoresData(workspaceId, experimentId, projectIds, traceIds).collectList(),
+                                getCommentsData(workspaceId, experimentId, projectIds, traceIds).collectList(),
+                                getAssertionsData(workspaceId, experimentId, projectIds, traceIds).collectList())
                                 .flatMap(tuple -> {
                                     var tracesData = tuple.getT1();
                                     var spansData = tuple.getT2();
@@ -1544,7 +1550,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                                     var assertionsData = tuple.getT5();
 
                                     return insertExperimentItemAggregates(
-                                            projectId,
+                                            labelProjectId,
                                             items,
                                             tracesData,
                                             spansData,
@@ -1574,56 +1580,86 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
         }).singleOrEmpty());
     }
 
+    /**
+     * The experiment's stored {@code project_id}; emits {@link Mono#empty()} when unset or when
+     * the experiment doesn't exist, so callers can fall back via {@code .switchIfEmpty(...)}.
+     */
     @Override
-    public Mono<UUID> getProjectId(UUID experimentId) {
+    public Mono<UUID> getExperimentProjectId(@NonNull UUID experimentId) {
+        return getExperimentData(experimentId).mapNotNull(ExperimentData::projectId);
+    }
+
+    /**
+     * Distinct project_ids this experiment's items reference; always emits exactly one Set
+     * (possibly empty when no traces with project_id are found). See
+     * {@link #GET_PROJECT_IDS}.
+     */
+    @Override
+    public Mono<Set<UUID>> getProjectIds(UUID experimentId) {
         return asyncTemplate.nonTransaction(connection -> makeFluxContextAware((userName, workspaceId) -> {
-            var template = getSTWithLogComment(GET_PROJECT_ID,
-                    "getProjectId", workspaceId, userName, experimentId.toString());
+            var template = getSTWithLogComment(GET_PROJECT_IDS,
+                    "getProjectIds", workspaceId, userName, experimentId.toString());
 
             var statement = connection.createStatement(template.render())
                     .bind("workspace_id", workspaceId)
                     .bind("experiment_id", experimentId);
 
             return Flux.from(statement.execute())
-                    .flatMap(result -> result.map((row, metadata) -> UUID
-                            .fromString(row.get("project_id", String.class))));
-        }).singleOrEmpty());
+                    .flatMap(result -> result.map((row, metadata) -> Arrays
+                            .stream(row.get("project_ids", String[].class))
+                            .map(UUID::fromString)
+                            .collect(Collectors.toUnmodifiableSet())));
+        }).single());
     }
 
-    private Mono<TraceAggregations> getTraceAggregations(UUID experimentId, UUID projectId) {
+    private Mono<TraceAggregations> getTraceAggregations(UUID experimentId, Set<UUID> projectIds, UUID labelProjectId) {
         return queryExperimentAggregation(
-                GET_TRACE_AGGREGATIONS, "getTraceAggregations", experimentId, projectId,
+                GET_TRACE_AGGREGATIONS, "getTraceAggregations", experimentId, projectIds, labelProjectId,
                 this::mapTraceAggregations);
     }
 
-    private Mono<SpanAggregations> getSpanAggregations(UUID experimentId, UUID projectId) {
+    private Mono<SpanAggregations> getSpanAggregations(UUID experimentId, Set<UUID> projectIds) {
         return queryExperimentAggregation(
-                GET_SPAN_AGGREGATIONS, "getSpanAggregations", experimentId, projectId,
+                GET_SPAN_AGGREGATIONS, "getSpanAggregations", experimentId, projectIds,
                 this::mapSpanAggregations);
     }
 
-    private Mono<FeedbackScoreAggregations> getFeedbackScoreAggregations(UUID experimentId, UUID projectId) {
+    private Mono<FeedbackScoreAggregations> getFeedbackScoreAggregations(UUID experimentId, Set<UUID> projectIds) {
         return queryExperimentAggregation(
-                GET_FEEDBACK_SCORE_AGGREGATIONS, "getFeedbackScoreAggregations", experimentId, projectId,
+                GET_FEEDBACK_SCORE_AGGREGATIONS, "getFeedbackScoreAggregations", experimentId, projectIds,
                 this::mapFeedbackScoreAggregations);
     }
 
-    private Mono<PassRateAggregation> getPassRateAggregation(UUID experimentId, UUID projectId) {
+    private Mono<PassRateAggregation> getPassRateAggregation(UUID experimentId, Set<UUID> projectIds) {
         return queryExperimentAggregation(
-                GET_PASS_RATE_AGGREGATION, "getPassRateAggregation", experimentId, projectId,
+                GET_PASS_RATE_AGGREGATION, "getPassRateAggregation", experimentId, projectIds,
                 this::mapPassRateAggregation);
     }
 
     /**
-     * Executes a single-row aggregation query scoped to a workspace, experiment, and project.
-     * Handles the repeated context-aware execution, parameter binding, and singleOrEmpty pattern
-     * shared by getTraceAggregations, getSpanAggregations, and getFeedbackScoreAggregations.
+     * Single-row aggregation query scoped to one experiment and the set of projects its items
+     * reference. Delegates to the {@code labelProjectId}-aware overload with {@code null} for
+     * queries that don't need the label bind.
      */
     private <T> Mono<T> queryExperimentAggregation(
             String query,
             String logName,
             UUID experimentId,
-            UUID projectId,
+            Set<UUID> projectIds,
+            Function<Row, T> rowMapper) {
+        return queryExperimentAggregation(query, logName, experimentId, projectIds, null, rowMapper);
+    }
+
+    /**
+     * Overload for queries that additionally bind {@code :project_id} (the aggregate row's
+     * single-project label). Currently only {@link #GET_TRACE_AGGREGATIONS} needs it.
+     */
+    private <T> Mono<T> queryExperimentAggregation(
+            String query,
+            String logName,
+            UUID experimentId,
+            Set<UUID> projectIds,
+            UUID labelProjectId,
             Function<Row, T> rowMapper) {
         return asyncTemplate.nonTransaction(connection -> makeFluxContextAware((userName, workspaceId) -> {
             var template = getSTWithLogComment(query, logName, workspaceId, userName, experimentId.toString());
@@ -1631,7 +1667,10 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
             var statement = connection.createStatement(template.render())
                     .bind("workspace_id", workspaceId)
                     .bind("experiment_id", experimentId)
-                    .bind("project_id", projectId);
+                    .bind("project_ids", projectIds);
+            if (labelProjectId != null) {
+                statement.bind("project_id", labelProjectId);
+            }
 
             return Flux.from(statement.execute())
                     .flatMap(result -> result.map((row, metadata) -> rowMapper.apply(row)));
@@ -1671,7 +1710,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
             var experimentScoresArrays = mapToArrays(
                     ObjectUtils.getIfNull(experimentData.experimentScores(), Map.of()),
                     String[]::new, Double[]::new,
-                    v -> v.doubleValue());
+                    BigDecimal::doubleValue);
             var durationPercentilesArrays = mapToArrays(
                     ObjectUtils.getIfNull(traceAgg.durationPercentiles(), Map.of()),
                     String[]::new, Double[]::new,
@@ -1777,7 +1816,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
             String methodName,
             String workspaceId,
             UUID experimentId,
-            UUID projectId,
+            Set<UUID> projectIds,
             List<UUID> traceIds,
             Function<Row, T> rowMapper) {
 
@@ -1786,7 +1825,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
 
             var statement = connection.createStatement(template.render())
                     .bind("workspace_id", workspaceId)
-                    .bind("project_id", projectId)
+                    .bind("project_ids", projectIds)
                     .bind("trace_ids", traceIds.toArray(UUID[]::new));
 
             return Flux.from(statement.execute())
@@ -1794,48 +1833,48 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
         });
     }
 
-    private Flux<TraceData> getTracesData(String workspaceId, UUID experimentId, UUID projectId,
+    private Flux<TraceData> getTracesData(String workspaceId, UUID experimentId, Set<UUID> projectIds,
             List<UUID> traceIds) {
-        return streamWithTraceIds(GET_TRACES_DATA, "getTracesData", workspaceId, experimentId, projectId, traceIds,
+        return streamWithTraceIds(GET_TRACES_DATA, "getTracesData", workspaceId, experimentId, projectIds, traceIds,
                 this::mapTraceData);
     }
 
-    private Flux<SpanData> getSpansData(String workspaceId, UUID experimentId, UUID projectId,
+    private Flux<SpanData> getSpansData(String workspaceId, UUID experimentId, Set<UUID> projectIds,
             List<UUID> traceIds) {
-        return streamWithTraceIds(GET_SPANS_DATA, "getSpansData", workspaceId, experimentId, projectId, traceIds,
+        return streamWithTraceIds(GET_SPANS_DATA, "getSpansData", workspaceId, experimentId, projectIds, traceIds,
                 this::mapSpanData);
     }
 
-    private Flux<FeedbackScoreData> getFeedbackScoresData(String workspaceId, UUID experimentId, UUID projectId,
+    private Flux<FeedbackScoreData> getFeedbackScoresData(String workspaceId, UUID experimentId, Set<UUID> projectIds,
             List<UUID> traceIds) {
         return streamWithTraceIds(GET_FEEDBACK_SCORES_DATA, "getFeedbackScoresData", workspaceId, experimentId,
-                projectId, traceIds, this::mapFeedbackScoreData);
+                projectIds, traceIds, this::mapFeedbackScoreData);
     }
 
-    private Flux<CommentsData> getCommentsData(String workspaceId, UUID experimentId, UUID projectId,
+    private Flux<CommentsData> getCommentsData(String workspaceId, UUID experimentId, Set<UUID> projectIds,
             List<UUID> traceIds) {
-        return streamWithTraceIds(GET_COMMENTS_DATA, "getCommentsData", workspaceId, experimentId, projectId, traceIds,
+        return streamWithTraceIds(GET_COMMENTS_DATA, "getCommentsData", workspaceId, experimentId, projectIds, traceIds,
                 this::mapCommentsData);
     }
 
-    private Flux<AssertionData> getAssertionsData(String workspaceId, UUID experimentId, UUID projectId,
+    private Flux<AssertionData> getAssertionsData(String workspaceId, UUID experimentId, Set<UUID> projectIds,
             List<UUID> traceIds) {
-        return streamWithTraceIds(GET_ASSERTIONS_DATA, "getAssertionsData", workspaceId, experimentId, projectId,
+        return streamWithTraceIds(GET_ASSERTIONS_DATA, "getAssertionsData", workspaceId, experimentId, projectIds,
                 traceIds, this::mapAssertionData);
     }
 
-    private Mono<String> getCommentsAggregation(UUID experimentId, UUID projectId) {
+    private Mono<String> getCommentsAggregation(UUID experimentId, Set<UUID> projectIds) {
         return queryExperimentAggregation(
-                GET_COMMENTS_AGGREGATION, "getCommentsAggregation", experimentId, projectId,
+                GET_COMMENTS_AGGREGATION, "getCommentsAggregation", experimentId, projectIds,
                 row -> {
                     var value = row.get("comments_array_agg", String.class);
                     return StringUtils.isNotBlank(value) ? value : EMPTY_ARRAY_STR;
                 });
     }
 
-    private Mono<AssertionScoreAggregations> getAssertionScoreAggregations(UUID experimentId, UUID projectId) {
+    private Mono<AssertionScoreAggregations> getAssertionScoreAggregations(UUID experimentId, Set<UUID> projectIds) {
         return queryExperimentAggregation(
-                GET_ASSERTION_SCORE_AGGREGATIONS, "getAssertionScoreAggregations", experimentId, projectId,
+                GET_ASSERTION_SCORE_AGGREGATIONS, "getAssertionScoreAggregations", experimentId, projectIds,
                 this::mapAssertionScoreAggregations);
     }
 
@@ -1859,7 +1898,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
     }
 
     /**
-     * Serialise a single experiment-item row as a JSONEachRow object and append it to {@code out},
+     * Serialize a single experiment-item row as a JSONEachRow object and append it to {@code out},
      * terminated by {@code '\n'} — the format expected by ClickHouse v2 bulk insert
      * (see {@link #insertExperimentItemAggregates(UUID, List, List, List, List, List, List)}).
      *
@@ -1868,9 +1907,9 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
      * then handing off a single {@link java.io.ByteArrayInputStream} avoids per-row stream plumbing
      * and lets ClickHouse's HTTP layer compress + send the payload in one shot.
      *
-     * <p>Why {@link com.comet.opik.utils.JsonUtils#createObjectNode()}: keeps JSON serialisation on the
+     * <p>Why {@link com.comet.opik.utils.JsonUtils#createObjectNode()}: keeps JSON serialization on the
      * same Jackson {@code ObjectMapper} the rest of the backend uses (snake_case naming, BigDecimal
-     * handling, custom deserialisers). Using a local {@code new ObjectMapper()} would silently diverge
+     * handling, custom deserializers). Using a local {@code new ObjectMapper()} would silently diverge
      * from REST-side encoding and could reintroduce the NaN / precision / date-format mismatches that
      * the JSONEachRow path was designed to avoid.
      *
@@ -1977,7 +2016,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
      * <p>Why the v2 client + JSONEachRow (vs. the R2DBC path used elsewhere): this is the ONLY path
      * in the backend that uses the v2 client — we specifically chose it for this bulk-insert flow
      * because {@code EXPERIMENT_AGGREGATES_BATCH_SIZE} can be configured above 1k (e.g. {@code 10000}
-     * for workspaces with experiments of 1M+ items). R2DBC's bind-parameter serialisation scales
+     * for workspaces with experiments of 1M+ items). R2DBC's bind-parameter serialization scales
      * super-linearly once a single statement carries more than ~1k rows (per-row parameter map,
      * driver-side escaping, per-row round-trips), so at that batch size it becomes the dominant
      * cost of the aggregation job. The JSONEachRow bulk path is ~500× faster end-to-end on those
@@ -1989,7 +2028,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
      *
      * <p>Flow:
      * <ol>
-     *   <li>Materialise every item into a shared {@link StringBuilder} via
+     *   <li>Materialize every item into a shared {@link StringBuilder} via
      *       {@link #appendJsonRow} (one JSON object + newline per row).</li>
      *   <li>Convert to UTF-8 bytes and wrap in a {@link ByteArrayInputStream}.</li>
      *   <li>Attach a {@code log_comment} identifying the workspace / user / batch size so the query
@@ -2050,6 +2089,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                 .workspaceId(row.get("workspace_id", String.class))
                 .id(getUUID(row, "id"))
                 .datasetId(getUUID(row, "dataset_id"))
+                .projectId(getUUIDOrNull(row, "project_id"))
                 .name(row.get("name", String.class))
                 .createdAt(row.get("created_at", String.class))
                 .lastUpdatedAt(row.get("last_updated_at", String.class))
@@ -2468,25 +2508,25 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
         Optional.ofNullable(criteria.optimizationId())
                 .ifPresent(optimizationId -> template.add("optimization_id", optimizationId));
         Optional.ofNullable(criteria.types())
-                .filter(types -> types != null && !types.isEmpty())
+                .filter(types -> !types.isEmpty())
                 .ifPresent(types -> template.add("types", types));
         Optional.ofNullable(criteria.experimentIds())
-                .filter(experimentIds -> experimentIds != null && !experimentIds.isEmpty())
+                .filter(experimentIds -> !experimentIds.isEmpty())
                 .ifPresent(experimentIds -> template.add("experiment_ids", experimentIds));
 
         // Add regular experiment filters
         Optional.ofNullable(criteria.filters())
-                .flatMap(filters -> filterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.EXPERIMENT))
+                .flatMap(filters -> FilterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.EXPERIMENT))
                 .ifPresent(experimentFilters -> template.add("filters", experimentFilters));
 
         // Add aggregated feedback score filters (ONLY REFERENCED HERE in ExperimentAggregatesDAO)
         Optional.ofNullable(criteria.filters())
-                .flatMap(filters -> filterQueryBuilder.toAnalyticsDbFilters(filters,
+                .flatMap(filters -> FilterQueryBuilder.toAnalyticsDbFilters(filters,
                         FilterStrategy.FEEDBACK_SCORES_AGGREGATED))
                 .ifPresent(feedbackScoresAggregatedFilters -> template.add("feedback_scores_aggregated_filters",
                         feedbackScoresAggregatedFilters));
         Optional.ofNullable(criteria.filters())
-                .flatMap(filters -> filterQueryBuilder.toAnalyticsDbFilters(filters,
+                .flatMap(filters -> FilterQueryBuilder.toAnalyticsDbFilters(filters,
                         FilterStrategy.FEEDBACK_SCORES_AGGREGATED_IS_EMPTY))
                 .ifPresent(feedbackScoresAggregatedEmptyFilters -> template.add(
                         "feedback_scores_aggregated_empty_filters",
@@ -2494,12 +2534,12 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
 
         // Add experiment score filters
         Optional.ofNullable(criteria.filters())
-                .flatMap(filters -> filterQueryBuilder.toAnalyticsDbFilters(filters,
+                .flatMap(filters -> FilterQueryBuilder.toAnalyticsDbFilters(filters,
                         FilterStrategy.EXPERIMENT_SCORES))
                 .ifPresent(
                         experimentScoresFilters -> template.add("experiment_scores_filters", experimentScoresFilters));
         Optional.ofNullable(criteria.filters())
-                .flatMap(filters -> filterQueryBuilder.toAnalyticsDbFilters(filters,
+                .flatMap(filters -> FilterQueryBuilder.toAnalyticsDbFilters(filters,
                         FilterStrategy.EXPERIMENT_SCORES_IS_EMPTY))
                 .ifPresent(experimentScoresEmptyFilters -> template.add("experiment_scores_empty_filters",
                         experimentScoresEmptyFilters));
@@ -2648,7 +2688,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
 
             return Flux.from(statement.execute())
                     .flatMap(result -> result
-                            .map((row, rowMeta) -> DatasetItemResultMapper.buildItemFromRow(row, rowMeta)))
+                            .map(DatasetItemResultMapper::buildItemFromRow))
                     .collectList();
         }));
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesService.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static com.comet.opik.domain.experiments.aggregations.ExperimentAggregatesUtils.BatchResult;
+import static com.comet.opik.domain.experiments.aggregations.ExperimentAggregatesUtils.fallbackLabelProjectId;
 
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
@@ -88,34 +89,38 @@ public class ExperimentAggregatesService {
     }
 
     /**
-     * Populate experiment item aggregates in batches using cursor pagination with {@code Mono.expand()}.
-     *
-     * @param experimentId the experiment ID
-     * @param batchSize the number of items to process per batch
-     * @return Mono that completes when all batches are processed
+     * Populate experiment_item_aggregates in cursor-paginated batches. Resolves a single
+     * {@code labelProjectId} once per population (see
+     * {@link ExperimentAggregatesUtils#resolveLabelProjectId}) and threads it through every
+     * batch. Short-circuits when no project_ids resolve — nothing to aggregate.
      */
     private Mono<Void> populateExperimentItemsInBatches(UUID experimentId, int batchSize) {
-        return experimentAggregatesDAO.getProjectId(experimentId)
-                .flatMap(projectId -> experimentAggregatesDAO
-                        .populateExperimentItemAggregates(experimentId, projectId, null, batchSize)
-                        .expand(result -> {
-                            log.info("Processed experiment items in this batch, experimentId='{}', batchSize='{}'",
-                                    experimentId, result.processedCount());
-                            if (result.lastCursor() == null) {
-                                return Mono.empty();
-                            }
-                            log.debug(
-                                    "Batch processed, continuing with next batch, experimentId='{}', cursor='{}'",
-                                    experimentId, result.lastCursor());
-                            return experimentAggregatesDAO.populateExperimentItemAggregates(experimentId, projectId,
-                                    result.lastCursor(), batchSize);
-                        })
-                        .map(BatchResult::processedCount)
-                        .reduce(0L, Long::sum)
-                        .doOnSuccess(total -> log.info(
-                                "Finished processing all experiment items, experimentId='{}', totalProcessed='{}'",
-                                experimentId, total))
-                        .then());
+        return experimentAggregatesDAO.getProjectIds(experimentId)
+                .filter(CollectionUtils::isNotEmpty)
+                .flatMap(projectIds -> experimentAggregatesDAO.getExperimentProjectId(experimentId)
+                        .switchIfEmpty(Mono.fromSupplier(() -> fallbackLabelProjectId(projectIds)))
+                        .flatMap(labelProjectId -> experimentAggregatesDAO
+                                .populateExperimentItemAggregates(
+                                        experimentId, projectIds, labelProjectId, null, batchSize)
+                                .expand(result -> {
+                                    log.info(
+                                            "Processed experiment items in this batch, experimentId='{}', batchSize='{}'",
+                                            experimentId, result.processedCount());
+                                    if (result.lastCursor() == null) {
+                                        return Mono.empty();
+                                    }
+                                    log.debug(
+                                            "Batch processed, continuing with next batch, experimentId='{}', cursor='{}'",
+                                            experimentId, result.lastCursor());
+                                    return experimentAggregatesDAO.populateExperimentItemAggregates(
+                                            experimentId, projectIds, labelProjectId, result.lastCursor(), batchSize);
+                                })
+                                .map(BatchResult::processedCount)
+                                .reduce(0L, Long::sum)
+                                .doOnSuccess(total -> log.info(
+                                        "Finished processing all experiment items, experimentId='{}', totalProcessed='{}'",
+                                        experimentId, total))
+                                .then()));
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesUtils.java
@@ -1,7 +1,10 @@
 package com.comet.opik.domain.experiments.aggregations;
 
 import lombok.Builder;
+import lombok.NonNull;
 
+import java.util.Comparator;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -29,5 +32,27 @@ public class ExperimentAggregatesUtils {
      * @param <V>    Value type
      */
     public record MapArrays<K, V>(K[] keys, V[] values) {
+    }
+
+    /**
+     * Single project_id label written to {@code experiment_aggregates} /
+     * {@code experiment_item_aggregates} rows. Prefers the experiment's stored {@code project_id}
+     * (set at creation for V2-native experiments, set to the dominant project by the
+     * experiment-project migration for legacy ones); falls back to
+     * {@link #fallbackLabelProjectId(Set)} when null. The fallback window is transient:
+     * ReplacingMergeTree dedup overwrites the row once migration assigns a project.
+     */
+    public static UUID resolveLabelProjectId(UUID experimentProjectId, @NonNull Set<UUID> projectIds) {
+        return experimentProjectId != null ? experimentProjectId : fallbackLabelProjectId(projectIds);
+    }
+
+    /**
+     * Deterministic label for the unmigrated-V1 window: smallest project_id by lexicographic
+     * string comparison — the same ordering ClickHouse uses for {@code project_id ASC} on
+     * FixedString(36), so the system's "pick one project from a set" decisions all agree.
+     * Callers must ensure {@code projectIds} is non-empty.
+     */
+    public static UUID fallbackLabelProjectId(@NonNull Set<UUID> projectIds) {
+        return projectIds.stream().min(Comparator.comparing(UUID::toString)).orElseThrow();
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentEntityData.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentEntityData.java
@@ -39,6 +39,7 @@ public class ExperimentEntityData {
             String workspaceId,
             UUID id,
             UUID datasetId,
+            UUID projectId,
             String name,
             String createdAt,
             String lastUpdatedAt,

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
@@ -36,6 +36,8 @@ import com.comet.opik.api.resources.utils.MySQLContainerUtils;
 import com.comet.opik.api.resources.utils.RedisContainerUtils;
 import com.comet.opik.api.resources.utils.StatsUtils;
 import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
 import com.comet.opik.api.resources.utils.TestUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
 import com.comet.opik.api.resources.utils.resources.DatasetResourceClient;
@@ -76,6 +78,7 @@ import uk.co.jemos.podam.api.PodamFactory;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -96,13 +99,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(DropwizardAppExtensionProvider.class)
 class ExperimentAggregatesIntegrationTest {
 
-    // Fields to ignore in recursive comparison: id is a lookup key,
-    // timestamps differ due to timing, and the remaining fields are not stored
-    // in experiment_aggregates (they are computed/joined in the raw FIND path).
-    // The not-stored fields are explicitly asserted as null below.
+    /**
+     *  Fields ignored in recursive comparison: id (lookup key), createdAt/lastUpdatedAt
+     *  (precision drift between table schemas), projectId (label can diverge between raw and
+     *  aggregates paths — asserted explicitly via isIn(...) instead), and the remaining fields
+     *  which are computed/joined in the raw FIND path and not stored in experiment_aggregates.
+     *  The non-stored fields are explicitly asserted as null in assertExperimentMatches.
+     */
     private static final String[] EXPERIMENT_AGGREGATED_FIELDS_TO_IGNORE = new String[]{
             "id", "createdAt", "lastUpdatedAt",
-            "datasetName", "projectName", "promptVersion",
+            "datasetName", "projectId", "projectName", "promptVersion",
             "datasetVersionSummary", "datasetItemCount",
     };
 
@@ -125,7 +131,7 @@ class ExperimentAggregatesIntegrationTest {
             "lastUpdatedBy", "comments", "projectName", "executionPolicy"};
 
     @RegisterApp
-    private final TestDropwizardAppExtension APP;
+    private final TestDropwizardAppExtension app;
 
     private final WireMockUtils.WireMockRuntime wireMock;
 
@@ -140,8 +146,18 @@ class ExperimentAggregatesIntegrationTest {
         MigrationUtils.runMysqlDbMigration(MYSQL);
         MigrationUtils.runClickhouseDbMigration(CLICKHOUSE_CONTAINER);
 
-        APP = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
-                MYSQL.getJdbcUrl(), databaseAnalyticsFactory, wireMock.runtimeInfo(), REDIS.getRedisURI());
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .runtimeInfo(wireMock.runtimeInfo())
+                        .redisUrl(REDIS.getRedisURI())
+                        .customConfigs(List.of(
+                                // Override to a small value so the multi-project test (which creates ~15 traces)
+                                // covers the cursor-paginated expand() loop across several batches,
+                                // instead of completing in one.
+                                new CustomConfig("experimentAggregates.batchSize", "5")))
+                        .build());
     }
 
     private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
@@ -240,13 +256,12 @@ class ExperimentAggregatesIntegrationTest {
                 });
 
         // Populate aggregates
-        experiments.parallelStream().forEach(experiment -> {
-            experimentAggregatesService.populateAggregations(experiment.id())
-                    .contextWrite(ctx -> ctx
-                            .put(RequestContext.USER_NAME, USER)
-                            .put(RequestContext.WORKSPACE_ID, workspaceId))
-                    .block();
-        });
+        experiments.parallelStream()
+                .forEach(experiment -> experimentAggregatesService.populateAggregations(experiment.id())
+                        .contextWrite(ctx -> ctx
+                                .put(RequestContext.USER_NAME, USER)
+                                .put(RequestContext.WORKSPACE_ID, workspaceId))
+                        .block());
 
         // Build criteria using the provided function
         var testData = new CountTestData(
@@ -479,34 +494,81 @@ class ExperimentAggregatesIntegrationTest {
                         .put(RequestContext.WORKSPACE_ID, WORKSPACE_ID))
                 .block();
 
-        // Then: Verify raw calculation matches stored aggregates using recursive comparison
-        assertThat(experimentFromAggregates).as("Experiment from aggregates should not be null").isNotNull();
+        assertExperimentMatches(rawExperiment, experimentFromAggregates, projects.getFirst().id());
+    }
 
-        assertThat(experimentFromAggregates)
-                .usingRecursiveComparison(
-                        RecursiveComparisonConfiguration.builder()
-                                .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
-                                .build())
-                .ignoringFields(EXPERIMENT_AGGREGATED_FIELDS_TO_IGNORE)
-                .ignoringCollectionOrderInFields("experimentScores", "feedbackScores")
-                .isEqualTo(rawExperiment);
+    /**
+     * Multi-project correctness for the aggregation pipeline: one experiment whose
+     * {@code experiment_items} reference traces in two distinct projects, deliberately
+     * asymmetric (≈2:1 split), must produce an aggregate row where every metric covers
+     * traces from both projects — not just the larger side's subset. The {@code project_id}
+     * label is one of the referenced projects (raw and aggregates may pick different valid
+     * members). Compared against the raw FIND path via {@link #assertExperimentMatches}.
+     */
+    @Test
+    @DisplayName("Multi-project experiment aggregates cover every referenced project")
+    void multiProjectExperimentAggregatesCoverAllReferencedProjects() {
+        var workspaceName = UUID.randomUUID().toString();
+        var apiKey = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
-        // Fields not stored in experiment_aggregates table are expected to be null
-        assertThat(experimentFromAggregates.datasetName())
-                .as("datasetName is not stored in aggregates")
-                .isNull();
-        assertThat(experimentFromAggregates.projectName())
-                .as("projectName is not stored in aggregates")
-                .isNull();
-        assertThat(experimentFromAggregates.promptVersion())
-                .as("promptVersion is not stored in aggregates")
-                .isNull();
-        assertThat(experimentFromAggregates.datasetVersionSummary())
-                .as("datasetVersionSummary is not stored in aggregates")
-                .isNull();
-        assertThat(experimentFromAggregates.datasetItemCount())
-                .as("datasetItemCount is not stored in aggregates")
-                .isNull();
+        var projectA = createProject(apiKey, workspaceName);
+        var projectB = createProject(apiKey, workspaceName);
+        var dataset = createDataset(apiKey, workspaceName);
+        var experiment = createExperiment(dataset, apiKey, workspaceName);
+
+        // Asymmetric split (two batches in projectA, one in projectB) so the test fails
+        // distinctly if the aggregation pipeline were to silently drop the minority side.
+        List<String> feedbackScores = PodamFactoryUtils.manufacturePojoList(factory, String.class);
+        var itemsA1 = createExperimentItemWithData(
+                experiment.id(), dataset.id(), projectA.name(), feedbackScores, apiKey, workspaceName);
+        var itemsA2 = createExperimentItemWithData(
+                experiment.id(), dataset.id(), projectA.name(), feedbackScores, apiKey, workspaceName);
+        var itemsB = createExperimentItemWithData(
+                experiment.id(), dataset.id(), projectB.name(), feedbackScores, apiKey, workspaceName);
+        long projectACount = itemsA1.size() + itemsA2.size();
+        long projectBCount = itemsB.size();
+        long expectedTraceCount = projectACount + projectBCount;
+        assertThat(projectACount)
+                .as("test setup must create asymmetric counts to exercise the multi-project fix")
+                .isGreaterThan(projectBCount);
+
+        // Raw FIND path: ground truth that already accounts for both projects' traces.
+        var searchCriteria = ExperimentSearchCriteria.builder()
+                .experimentIds(Set.of(experiment.id()))
+                .entityType(EntityType.TRACE)
+                .sortingFields(List.of())
+                .build();
+
+        var beforeAggregation = experimentService.find(1, 10, searchCriteria)
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, workspaceId))
+                .block();
+
+        assertThat(beforeAggregation).isNotNull();
+        assertThat(beforeAggregation.content()).hasSize(1);
+        var rawExperiment = beforeAggregation.content().getFirst();
+        assertThat(rawExperiment.traceCount())
+                .as("raw FIND path must already cover traces from both projects")
+                .isEqualTo(expectedTraceCount);
+
+        // Populate aggregates and read them back.
+        experimentAggregatesService.populateAggregations(experiment.id())
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, workspaceId))
+                .block();
+
+        var experimentFromAggregates = experimentAggregatesService
+                .getExperimentFromAggregates(experiment.id())
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, workspaceId))
+                .block();
+
+        assertExperimentMatches(rawExperiment, experimentFromAggregates, projectA.id(), projectB.id());
     }
 
     @ParameterizedTest(name = "Group by {0}")
@@ -537,13 +599,11 @@ class ExperimentAggregatesIntegrationTest {
 
         // Create experiment items for each experiment
         List<String> feedbackScores = PodamFactoryUtils.manufacturePojoList(factory, String.class);
-        IntStream.range(0, numberOfItems).parallel().forEach(i -> {
-            createExperimentItemWithData(
-                    experiments.get(i).id(),
-                    datasets.get(i).id(),
-                    projects.get(i).name(),
-                    feedbackScores, apiKey, workspaceName);
-        });
+        IntStream.range(0, numberOfItems).parallel().forEach(i -> createExperimentItemWithData(
+                experiments.get(i).id(),
+                datasets.get(i).id(),
+                projects.get(i).name(),
+                feedbackScores, apiKey, workspaceName));
 
         // Populate aggregates for all experiments
         experiments.parallelStream()
@@ -612,13 +672,11 @@ class ExperimentAggregatesIntegrationTest {
 
         // Create experiment items for each experiment
         List<String> feedbackScores = PodamFactoryUtils.manufacturePojoList(factory, String.class);
-        IntStream.range(0, numberOfItems).parallel().forEach(i -> {
-            createExperimentItemWithData(
-                    experiments.get(i).id(),
-                    datasets.get(i).id(),
-                    projects.get(i).name(),
-                    feedbackScores, apiKey, workspaceName);
-        });
+        IntStream.range(0, numberOfItems).parallel().forEach(i -> createExperimentItemWithData(
+                experiments.get(i).id(),
+                datasets.get(i).id(),
+                projects.get(i).name(),
+                feedbackScores, apiKey, workspaceName));
 
         // Populate aggregates for all experiments
         experiments.forEach(experiment -> experimentAggregatesService.populateAggregations(experiment.id())
@@ -1025,8 +1083,7 @@ class ExperimentAggregatesIntegrationTest {
             DatasetItemCountTestData testData) {
     }
 
-    private AggregatesTestContext setupAggregatesTestData(
-            Function<DatasetItemCountTestData, DatasetItemSearchCriteria> criteriaBuilder) {
+    private AggregatesTestContext setupAggregatesTestData() {
         var workspaceName = UUID.randomUUID().toString();
         var apiKey = UUID.randomUUID().toString();
         var workspaceId = UUID.randomUUID().toString();
@@ -1090,7 +1147,7 @@ class ExperimentAggregatesIntegrationTest {
     void testDatasetItemCountWithAggregates(String scenarioName,
             Function<DatasetItemCountTestData, DatasetItemSearchCriteria> criteriaBuilder) {
 
-        var ctx = setupAggregatesTestData(criteriaBuilder);
+        var ctx = setupAggregatesTestData();
         var criteria = criteriaBuilder.apply(ctx.testData());
 
         // When: Get count from original service method
@@ -1266,7 +1323,7 @@ class ExperimentAggregatesIntegrationTest {
             String scenarioName,
             Function<DatasetItemCountTestData, DatasetItemSearchCriteria> criteriaBuilder) {
 
-        var ctx = setupAggregatesTestData(criteriaBuilder);
+        var ctx = setupAggregatesTestData();
         var criteria = criteriaBuilder.apply(ctx.testData());
 
         // When: Get items from original service method
@@ -1386,7 +1443,7 @@ class ExperimentAggregatesIntegrationTest {
     void getExperimentItemsStatsFromAggregates(String scenarioName,
             Function<DatasetItemCountTestData, DatasetItemSearchCriteria> criteriaBuilder) {
 
-        var ctx = setupAggregatesTestData(criteriaBuilder);
+        var ctx = setupAggregatesTestData();
         var criteria = criteriaBuilder.apply(ctx.testData());
 
         @SuppressWarnings("unchecked")
@@ -1716,7 +1773,7 @@ class ExperimentAggregatesIntegrationTest {
         var project = createProject(API_KEY, TEST_WORKSPACE);
         var dataset = createDataset(API_KEY, TEST_WORKSPACE);
 
-        // Create an test_suite experiment
+        // Create a test_suite experiment
         var experiment = experimentResourceClient.createPartialExperiment()
                 .datasetId(dataset.id())
                 .datasetName(dataset.name())
@@ -1733,7 +1790,7 @@ class ExperimentAggregatesIntegrationTest {
         // Log assertion scores with category_name="suite_assertion" on the first trace
         var traceId = experimentItems.getFirst().traceId();
         var assertionScores = List.of(
-                (FeedbackScoreBatchItem) factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
+                factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
                         .id(traceId)
                         .projectName(project.name())
                         .name("assertion-grounded")
@@ -1741,7 +1798,7 @@ class ExperimentAggregatesIntegrationTest {
                         .value(BigDecimal.ONE)
                         .source(ScoreSource.SDK)
                         .build(),
-                (FeedbackScoreBatchItem) factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
+                factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
                         .id(traceId)
                         .projectName(project.name())
                         .name("assertion-concise")
@@ -2216,7 +2273,7 @@ class ExperimentAggregatesIntegrationTest {
 
         var traceId = experimentItems.getFirst().traceId();
         var assertionScores = List.of(
-                (FeedbackScoreBatchItem) factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
+                factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
                         .id(traceId)
                         .projectName(project.name())
                         .name("assertion-grounded")
@@ -2225,7 +2282,7 @@ class ExperimentAggregatesIntegrationTest {
                         .reason("Grounded in context")
                         .source(ScoreSource.SDK)
                         .build(),
-                (FeedbackScoreBatchItem) factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
+                factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
                         .id(traceId)
                         .projectName(project.name())
                         .name("assertion-concise")
@@ -2305,7 +2362,7 @@ class ExperimentAggregatesIntegrationTest {
 
         var traceId = experimentItems.getFirst().traceId();
         var assertionScores = List.of(
-                (FeedbackScoreBatchItem) factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
+                factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
                         .id(traceId)
                         .projectName(project.name())
                         .name("assertion-grounded")
@@ -2314,7 +2371,7 @@ class ExperimentAggregatesIntegrationTest {
                         .reason("Grounded in context")
                         .source(ScoreSource.SDK)
                         .build(),
-                (FeedbackScoreBatchItem) factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
+                factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
                         .id(traceId)
                         .projectName(project.name())
                         .name("assertion-concise")
@@ -2462,7 +2519,7 @@ class ExperimentAggregatesIntegrationTest {
 
         experimentResourceClient.deleteExperimentItems(deletedItemIds, apiKey, workspaceName);
 
-        TestUtils.waitForMillis(1000); // Wait for the delete to be processed and the ExperimentItemsDeleted event to be published
+        TestUtils.waitForMillis(1000); // Wait for the deletion to be processed and the ExperimentItemsDeleted event to be published
 
         // Expected: beforeAggregation content with the deleted experiment items stripped out
         var expectedAfterDelete = beforeAggregation.content().stream()
@@ -2774,7 +2831,7 @@ class ExperimentAggregatesIntegrationTest {
                 .field("duration")
                 .direction(Direction.ASC)
                 .build());
-        var filters = List.<ExperimentsComparisonFilter>of(ExperimentsComparisonFilter.builder()
+        var filters = List.of(ExperimentsComparisonFilter.builder()
                 .field("duration")
                 .type(FieldType.NUMBER)
                 .operator(Operator.GREATER_THAN)
@@ -2834,7 +2891,7 @@ class ExperimentAggregatesIntegrationTest {
         // and exercises the `FROM dataset_item_versions FINAL` dedup across multiple
         // resolved versions, without relying on any per-item field generated randomly
         // by PodamFactory.
-        var filters = List.<ExperimentsComparisonFilter>of(ExperimentsComparisonFilter.builder()
+        var filters = List.of(ExperimentsComparisonFilter.builder()
                 .field("id")
                 .type(FieldType.STRING_EXACT)
                 .operator(Operator.NOT_EQUAL)
@@ -2886,7 +2943,7 @@ class ExperimentAggregatesIntegrationTest {
         // setup of multiVersionExperimentsFilterConsistentBeforeAndAfterAggregates above
         // but exercises an EIA-side (experiment_item_aggregates) filter rather than a
         // DI-side filter on `dataset_items_filtered_ids`. Catches regressions in the
-        // path OPIK-6311 optimised: experiment_item_filters clause + push_top_limit's
+        // path OPIK-6311 optimized: experiment_item_filters clause + push_top_limit's
         // top_dataset_items CTE rendering EIA filters with skip-index pushdown.
         var experiment1 = createExperimentPinnedToFreshDatasetVersion(dataset, project, feedbackScoreNames, apiKey,
                 workspaceName);
@@ -2899,7 +2956,7 @@ class ExperimentAggregatesIntegrationTest {
         // <if(experiment_item_filters)> clause to render in both top_dataset_items and the
         // outer SELECT, exercising eia.duration > 0 directly against the column (skip-index
         // friendly post-OPIK-6177 stable-id migration).
-        var filters = List.<ExperimentsComparisonFilter>of(ExperimentsComparisonFilter.builder()
+        var filters = List.of(ExperimentsComparisonFilter.builder()
                 .field(ExperimentsComparisonValidKnownField.DURATION.getQueryParamField())
                 .operator(Operator.GREATER_THAN)
                 .value("0")
@@ -3018,4 +3075,52 @@ class ExperimentAggregatesIntegrationTest {
         return experiment;
     }
 
+    /**
+     * Verify the aggregates-path Experiment matches the raw-FIND-path Experiment: row exists,
+     * stored metrics match (recursive comparison ignoring
+     * {@link #EXPERIMENT_AGGREGATED_FIELDS_TO_IGNORE}), and each ignored field is asserted
+     * explicitly: {@code id} equals the raw experiment's id; {@code projectId} is in
+     * {@code expectedProjectIdRange} (raw and aggregates use different valid heuristics and
+     * may pick different members of the referenced project set); {@code createdAt}/
+     * {@code lastUpdatedAt} are non-null (precision drift vs raw is tolerated); the rest are
+     * null (not stored in aggregates).
+     */
+    private void assertExperimentMatches(
+            Experiment rawExperiment, Experiment aggregatedExperiment, UUID... expectedProjectIdRange) {
+        assertThat(aggregatedExperiment)
+                .as("Aggregated Experiment should not be null")
+                .isNotNull();
+
+        assertThat(aggregatedExperiment)
+                .usingRecursiveComparison(
+                        RecursiveComparisonConfiguration.builder()
+                                .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
+                                .build())
+                .ignoringFields(EXPERIMENT_AGGREGATED_FIELDS_TO_IGNORE)
+                .ignoringCollectionOrderInFields("experimentScores", "feedbackScores")
+                .isEqualTo(rawExperiment);
+
+        assertThat(aggregatedExperiment.id())
+                .as("id must match the experiment we populated")
+                .isEqualTo(rawExperiment.id());
+        assertThat(aggregatedExperiment.createdAt())
+                .as("createdAt is stored in aggregates (precision drift vs raw is tolerated)")
+                .isNotNull();
+        assertThat(aggregatedExperiment.lastUpdatedAt())
+                .as("lastUpdatedAt is stored in aggregates (precision drift vs raw is tolerated)")
+                .isNotNull();
+        assertThat(aggregatedExperiment.datasetName())
+                .as("datasetName is not stored in aggregates").isNull();
+        assertThat(aggregatedExperiment.projectName())
+                .as("projectName is not stored in aggregates").isNull();
+        assertThat(aggregatedExperiment.promptVersion())
+                .as("promptVersion is not stored in aggregates").isNull();
+        assertThat(aggregatedExperiment.datasetVersionSummary())
+                .as("datasetVersionSummary is not stored in aggregates").isNull();
+        assertThat(aggregatedExperiment.datasetItemCount())
+                .as("datasetItemCount is not stored in aggregates").isNull();
+        assertThat(aggregatedExperiment.projectId())
+                .as("label projectId must be one of the referenced projects")
+                .isIn(Arrays.stream(expectedProjectIdRange).toList());
+    }
 }


### PR DESCRIPTION
## Details

Prefix carved out of OPIK-6727, shipping ahead of the upcoming experiment migration job. The migration job will assign each previously-ambiguous (multi-project) experiment a single dominant `project_id` and then trigger reaggregation. Before that lands, the aggregation pipeline must produce correct totals for experiments whose items reference traces in more than one project — otherwise the migration's first action (reaggregate the freshly assigned experiments) would persist undercounts.

Today `ExperimentAggregatesDAO` scopes every trace / span / feedback-score / comments / assertion query by a single `project_id` derived from one arbitrary referenced project. For multi-project experiments this silently drops the other projects' contributions. This PR replaces that single-project predicate with `project_id IN :project_ids` across all eleven fact-table queries, and discovers the referenced project set directly from the `traces` table (single source of truth — no dependency on the denormalized `experiment_items.project_id` backfill state). Partition pruning is preserved for the typical single-project case.

The aggregate row's single-column `project_id` label is resolved via a new `ExperimentAggregatesUtils.resolveLabelProjectId(...)` — prefers `experiments.project_id` (the migration will set this to the dominant project), falls back to the lex-smallest referenced `project_id` for the transient unmigrated-V1 window. The lex-min tiebreaker matches the `project_id ASC` ordering ClickHouse uses, so the label converges with whatever the migration eventually picks (ReplacingMergeTree dedup overwrites the transient label).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6727

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: assisted (analysis, refactor iterations, test scaffolding)
- Human verification: code review + manual verification of integration test logs (batch-size override, multi-batch pagination)

## Testing

Backend integration tests under `apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java`:

- `multiProjectExperimentAggregatesCoverAllReferencedProjects` — new. One experiment with items in two distinct projects, asymmetric ~2:1 split. Asserts the aggregate row matches the raw FIND ground truth via `usingRecursiveComparison` across every stored metric (trace count, duration percentiles, total cost, feedback aggregates, experiment scores, pass rate, assertion scores). Asserts the label `projectId` is one of the referenced projects via `isIn(...)`.
- `experimentDaoFindMatchesAggregates` — regression baseline. Single-project parity still holds; no metric drift.
- `experimentAggregates.batchSize` overridden to `5` via `customConfigs` in this test class only. The multi-project test (~15 traces) now exercises three real cursor-paginated batches, verified via the service log line `batchSize='5'` and three "Processed experiment items in this batch" lines.
- All other integration tests in the class (find / count / group / group-aggregations paths) continue to pass without modification.

Commands run locally:

```
mvn test -Dtest='ExperimentAggregatesIntegrationTest#multiProjectExperimentAggregatesCoverAllReferencedProjects'
mvn test -Dtest='ExperimentAggregatesIntegrationTest#experimentDaoFindMatchesAggregates'
```

Both pass.

## Documentation

N/A. Backend-internal correctness fix; no user-visible behavior change for V2-native single-project experiments. The upcoming migration-job PR will carry the Notion runbook and Grafana dashboard updates per OPIK-6727's full scope.