### PR TITLE
[NA] [QA] docs: share agentic workflow artifacts for Opik 2.0 E2E

### DIFF
--- a/.agents/skills/playwright-pom-discovery/SKILL.md
+++ b/.agents/skills/playwright-pom-discovery/SKILL.md
@@ -1,0 +1,352 @@
+---
+name: playwright-pom-discovery
+description: Use whenever the user wants to build, write, add, or modify automated CUJ / E2E tests for the Opik 2.0 suite under `tests_end_to_end/e2e/`. Triggers on natural-language requests like "write a test for the agent-config switcher flow", "we need automated tests for experiments", "can you cover the X journey with an E2E test", as well as on explicit work touching POMs, fixtures, bridge routes, or test files in that directory. Handles both ticket-anchored work (Jira key provided) and ticketless natural-language requests (the skill scopes the work itself via a brief adaptive conversation). Walks the agent through live-UI exploration with the Playwright MCP, seeding required state, choosing stable selectors, and verifying methods against the running page. Bundles cumulative retro lessons from prior CUJ tickets (matchers default off, UI-first assertions, `test.step()` mandatory, FE testid policy, cascade verification, fixture-seed-shape considerations). NOT for the 1.0 suite at `tests_end_to_end/typescript-tests/`.
+---
+
+# Playwright POM Discovery (Opik 2.0 E2E CUJ workflow)
+
+This skill is the **how** of writing CUJ tests for the Opik 2.0 E2E suite. The ticket scope tells you WHICH test to build; this skill tells you how to figure out what's on the page, what selectors are stable, and how to verify your method actually works before checking it in. It also carries the accumulated retro lessons from prior CUJ tickets — patterns the team has learned to follow (and anti-patterns to avoid).
+
+**Announce at start:** "I'm using the playwright-pom-discovery skill to work on the [ticket / area]."
+
+## Required reading on invocation
+
+Before writing any code, read the supplementary file:
+
+- **[retro-lessons.md](retro-lessons.md)** — cumulative lessons from previously-shipped CUJ tests. Covers UI-first assertions, matcher policy, `test.step()` discipline, FE testid policy, cascade verification, fixture-seed-shape considerations, and more. Read it once at the start of every CUJ ticket; it's the team contract.
+
+## Triage: ticket-anchored OR natural-language request?
+
+Before doing anything else, figure out which of these you're in. Branch the conversation accordingly.
+
+### Path A — ticket-anchored work
+
+The user gave you a Jira ticket key (e.g., "OPIK-XXXX") or pasted the kickoff prompt at `tests_end_to_end/e2e/.agentic/cuj-test-kickoff.md` with a TICKET line filled in. Standard 5-phase flow:
+
+1. Read the Jira ticket via the Atlassian MCP.
+2. Read the closest-shape merged PR (see the kickoff prompt's per-ticket cheat sheet for which one).
+3. Draft a spec at `docs/superpowers/specs/<DATE>-<ticket-key-lowercased>-<slug>-design.md` (local-only, never `git add`).
+4. Stop at the Phase 1 spec gate for user approval.
+5. Proceed through Phase 2 (bridge/fixture), Phase 3 (UI discovery — see procedure below), Phase 4 (POMs + test), Phase 5 (PR + Jira transition).
+
+Skip to the "Step-by-step" section for Phase 3 mechanics.
+
+### Path B — natural-language request, no ticket
+
+The user said something like "we need tests for the agent-config switcher flow" or "write E2E coverage for experiments" with no Jira key. Don't ask them to file a ticket first — scope the work in conversation:
+
+**Step 1: Adaptive scoping (1-5 questions max, depending on how complete the initial request was).**
+
+Read what they said. Ask ONLY the questions that aren't already answered. Cap at 5 total; aim for 1-3 if their initial message was concrete. Pull from this question pool, in priority order:
+
+1. **Flow walkthrough** (almost always ask): "Walk me through the happy path you want covered, as a user clicking through the UI. Where do they start, what do they do, what should they see at the end?"
+2. **Preconditions** (ask if not obvious): "What state needs to exist before the test starts? (e.g., a project with N traces, a dataset with items, a configured runner)"
+3. **Red-path / failure cases** (ask if happy-path-only would leave coverage thin): "Do we want to assert anything about the failure path too — e.g., what happens with invalid input, a missing dependency, a server error?"
+4. **Out of scope** (ask if the user's request was broad): "What edge cases or related flows would you defer to a follow-up rather than bundle into this test?"
+5. **Tier** (ask if not obvious from context): "Is this T1 (must run on every deploy, blocks if red), T2 (CUJ-cadence, runs on schedule), or T3 (nightly)?"
+
+If the user's request was already detailed (multi-paragraph with preconditions + happy path + edge cases), skip to step 2 with as few questions as possible — they've front-loaded the scoping. Don't make them repeat themselves.
+
+**Step 2: Jira decision.** Once scope is clear, ask ONE question:
+
+> "Should I file a Jira ticket for this under OPIK-6107 (CUJ epic) for tracking, or ship as a `[NA]` PR with no ticket reference? Both are normal in this repo."
+
+Default to `[NA]` if the user says "just ship it" or doesn't seem to care. If they want Jira tracking, file the ticket via the Atlassian MCP (cloud id `70d91365-5d13-4b02-b353-de8a8e8ee962`) with the user as reporter, parent OPIK-6107, summary derived from the scoped flow.
+
+**Step 3: One-pager spec.** Draft a one-pager spec at `docs/superpowers/specs/<DATE>-natural-<short-slug>-design.md` (or `<DATE>-opik-XXXX-<slug>-design.md` if a Jira ticket was filed). Same shape as the per-ticket specs documented in the kickoff prompt at `tests_end_to_end/e2e/.agentic/cuj-test-kickoff.md` §7.1, but shorter — for natural-language work the spec only needs to cover:
+
+- Why this test exists (1 paragraph, derived from the user's request)
+- Scope: in / out of scope (bullet lists)
+- Component design: what fixture (extends what), what bridge route (if any new one), what POMs (estimated names), what test cases (2-3 typically)
+- Acceptance criteria (4-6 checkboxes)
+
+Local-only. Never `git add`. Report the file path back to the user.
+
+**Step 4: User approves the spec.** Stop here. The user reads (~5 min), then approves or redirects.
+
+**Step 5+: From here, the natural-language path joins the standard 5-phase flow.** Phase 2 (bridge/fixture), Phase 3 (UI discovery via the procedure below), Phase 4 (POMs + test), Phase 5 (PR).
+
+For Phase 5's PR title, use `[NA] [QA] test: <short description>` if no Jira ticket; otherwise `[OPIK-XXXX] [QA] test: <short description>`. Branch name follows the same shape (`andreic/NA-<slug>` or `andreic/OPIK-XXXX-<slug>` — use the actual username if you're not Andrei).
+
+## When this skill applies
+
+- You're touching anything under `tests_end_to_end/e2e/pom/`.
+- You're writing or modifying tests under `tests_end_to_end/e2e/tests/`.
+- You're adding fixtures under `tests_end_to_end/e2e/fixtures/` for CUJ test consumption.
+- You need to write a `data-testid` selector, a `getByRole`, or any other Playwright locator targeting the live Opik UI.
+- You're adding a method to an existing POM that interacts with a new element you haven't seen before.
+
+It does NOT apply to:
+
+- The OLD `tests_end_to_end/typescript-tests/` suite — that's covered by the `playwright-e2e` skill.
+- Pure fixture work (no UI interaction) — see the spec for the ticket.
+- Matchers / type-only changes.
+
+## The procedure
+
+```dot
+digraph pom_discovery {
+    rankdir=TB;
+    "Identify target page + entity preconditions" [shape=box];
+    "Seed required state (project, dataset, trace, etc.)?" [shape=diamond];
+    "Create state via SDK / bridge before opening UI" [shape=box];
+    "Open page via browser_navigate (with auth)" [shape=box];
+    "browser_snapshot to get accessibility tree" [shape=box];
+    "browser_evaluate to enumerate data-testids" [shape=box];
+    "Pick selector preference (testid > role > label > css)" [shape=box];
+    "Write POM method" [shape=box];
+    "Verify via browser_generate_locator and test_run" [shape=box];
+    "Method works?" [shape=diamond];
+    "Selector unstable or missing?" [shape=diamond];
+    "Flag for FE data-testid addition" [shape=box];
+    "Commit POM method" [shape=box];
+
+    "Identify target page + entity preconditions" -> "Seed required state (project, dataset, trace, etc.)?";
+    "Seed required state (project, dataset, trace, etc.)?" -> "Create state via SDK / bridge before opening UI" [label="yes"];
+    "Create state via SDK / bridge before opening UI" -> "Open page via browser_navigate (with auth)";
+    "Seed required state (project, dataset, trace, etc.)?" -> "Open page via browser_navigate (with auth)" [label="no — stateless page"];
+    "Open page via browser_navigate (with auth)" -> "browser_snapshot to get accessibility tree";
+    "browser_snapshot to get accessibility tree" -> "browser_evaluate to enumerate data-testids";
+    "browser_evaluate to enumerate data-testids" -> "Pick selector preference (testid > role > label > css)";
+    "Pick selector preference (testid > role > label > css)" -> "Write POM method";
+    "Write POM method" -> "Verify via browser_generate_locator and test_run";
+    "Verify via browser_generate_locator and test_run" -> "Method works?";
+    "Method works?" -> "Commit POM method" [label="yes"];
+    "Method works?" -> "Selector unstable or missing?" [label="no"];
+    "Selector unstable or missing?" -> "Flag for FE data-testid addition" [label="yes"];
+    "Selector unstable or missing?" -> "browser_snapshot to get accessibility tree" [label="no, try different selector"];
+    "Flag for FE data-testid addition" -> "Pick selector preference (testid > role > label > css)";
+}
+```
+
+## Step-by-step
+
+### 1. Identify target page + preconditions
+
+Before opening the browser, answer in writing:
+
+- **What page** does the POM model? E.g., `LogsPage` models `/<workspace>/projects/<projectId>/logs`. Get the route from the FE source under `apps/opik-frontend/src/v2/pages/` — each page has a directory matching its name.
+- **What entities must exist** for the page to show real data? Examples:
+  - `LogsPage` — needs a project AND at least one trace under it. An empty project shows only the empty state.
+  - `DatasetItemsPage` — needs a dataset AND at least one item. Empty datasets show only the "Create item" CTA.
+  - `TestSuitesPage` — needs at least one test suite to show row interactions.
+  - `OnlineEvaluationPage` — works empty, but creating a rule shows the rule list.
+- **What auth state** does the page need? The 2.0 suite uses API-key auth; the browser session needs the workspace cookie set. See the auth setup below.
+
+If the page genuinely is stateless (e.g., an empty list page), skip seeding and go straight to step 3. If it's not, seed first — exploring an empty-state UI will lead you to write a POM that only ever sees the empty state.
+
+### 2. Seed required state via SDK / bridge
+
+**Never** click-create state through the UI just to populate the page you're exploring. Two reasons:
+
+1. The page you're exploring may itself BE the UI-create flow you're trying to model — you'd be using the UI to test the UI.
+2. UI-create is slower and flakier than SDK-create.
+
+Instead, use the bridge or the TS SDK to seed before opening the browser. For the POM-discovery phase, a one-off seed script is fine (don't wire it into the test suite yet — that's for the test ticket itself).
+
+**Example seed for `LogsPage` discovery:**
+
+```ts
+// scratch script, not committed
+import { Opik } from 'opik';
+const opik = new Opik({
+  apiKey: process.env.OPIK_API_KEY,
+  workspaceName: process.env.OPIK_WORKSPACE,
+  apiUrl: process.env.OPIK_BASE_URL + '/api',
+});
+
+// project + a few traces with structure variety
+const projectName = `discovery-logs-${Date.now()}`;
+await opik.api.projects.createProject({ name: projectName });
+
+import { track } from 'opik';
+const decoratedFn = track({ name: 'discovery-trace', projectName }, async (input: string) => {
+  return `output for ${input}`;
+});
+await decoratedFn('hello');
+await decoratedFn('world');
+await opik.flush();
+
+console.log(`Discovery project: ${projectName}`);
+```
+
+Run it locally with staging or local-dev creds, note the project name, then navigate the UI to that project's logs page in the next step. Tear it down by hand at the end of the discovery session (`backendClient.deleteProject` if it's wired up, or `curl` otherwise) — discovery state should never accumulate.
+
+**Reusable seed patterns by page family:**
+
+| Page being built | Seed via | Why |
+|---|---|---|
+| `LogsPage`, `TracePanelPage` | `opik.track` decorator + at least one call | Empty projects show only the empty state |
+| `DatasetsPage` | `opik.api.datasets.createDataset({...})` for ~3 datasets with different shapes | List interactions need multiple rows |
+| `DatasetItemsPage` | `opik.Dataset(name).insert([...])` with 3+ items | Item-table interactions need data |
+| `TestSuitesPage`, `TestSuitePage` | `opik.TestSuite(...)` with items + evaluator + run | Suite states (running/completed/failed) need a real run |
+| `ExperimentsPage` | `experiment.evaluate(...)` against a dataset | Experiment rows need a completed run |
+| `OnlineEvaluationPage` | (works empty for rule list); seed a rule via UI once during discovery | Rule list shows after at least one rule exists |
+| `AnnotationQueuesPage`, `AnnotationQueuePage` | `opik.TracesAnnotationQueue(...)` with 3+ traces | Reviewer flow needs items to score |
+
+Common gotchas:
+
+- **Trace ingestion is eventually consistent.** After `opik.flush()`, the trace may take 1–3 seconds to appear in the Logs page. If you snapshot too fast, you'll see the empty state. Wait or refresh.
+- **Online scoring rules apply asynchronously** — if you seed a trace and then snapshot the Online Evaluation page, scores may not have landed yet.
+- **Dataset items have a slight delay** between insert and table-render — usually ms, but watch for it.
+
+### 3. Open the page with an authed browser session
+
+**Auth setup once per discovery session:**
+
+The 2.0 suite uses API-key auth. The browser MCP needs an authed page. The simplest path during discovery: navigate to the login page, log in via UI once, then `browser_storage_state` to save cookies, then reuse that state for the discovery session.
+
+**Even simpler for early POM work:** ask the user to provide their browser's storage state JSON, or to log in interactively in the MCP-controlled browser, then proceed. Don't try to script the full login flow during POM discovery — it's a distraction.
+
+**Standard discovery navigation:**
+
+```
+mcp__Playwright__browser_navigate(url="https://staging.dev.comet.com/opik/...")
+```
+
+URL templates (substitute `{workspace}` and IDs as needed):
+
+- Datasets list: `/{workspace}/datasets`
+- Dataset items: `/{workspace}/datasets/{id}/items`
+- Test Suites list: `/{workspace}/test-suites`
+- Test Suite detail: `/{workspace}/test-suites/{id}`
+- Test Suite items: `/{workspace}/test-suites/{id}/items`
+- Logs (project): `/{workspace}/projects/{projectId}/logs`
+- Experiments: `/{workspace}/experiments`
+- Online evaluation: `/{workspace}/projects/{projectId}/online-evaluation`
+- Annotation queues: `/{workspace}/annotation-queues`
+
+Confirm route shape by inspecting `apps/opik-frontend/src/v2/router.tsx` or the page directory under `apps/opik-frontend/src/v2/pages/<PageName>/` if the route is wrong.
+
+### 4. Snapshot the accessibility tree
+
+```
+mcp__Playwright__browser_snapshot()
+```
+
+This returns the **structured accessibility tree**, not pixels. Each interactive element has:
+
+- A role (`button`, `textbox`, `link`, `combobox`, `row`, etc.)
+- An accessible name (the visible text or `aria-label`)
+- A stable `ref` ID you can use with `browser_click(ref="...")` to interact
+
+Why this is the right primitive: Playwright's `getByRole(...)` selectors map 1:1 to what the snapshot shows. If you see `button "Create suite"` in the snapshot, you can confidently write `page.getByRole('button', { name: 'Create suite' })`.
+
+**Read the snapshot before writing any selector.** Don't guess. Don't grep the FE source for what you think the button is called — the rendered DOM is the only source of truth that matters.
+
+### 5. Enumerate `data-testid`s
+
+The snapshot tells you what's interactive but not what's been explicitly marked stable by the FE team. For that:
+
+```
+mcp__Playwright__browser_evaluate(function="""() => {
+  return Array.from(document.querySelectorAll('[data-testid]'))
+    .map(e => ({
+      testid: e.getAttribute('data-testid'),
+      tag: e.tagName.toLowerCase(),
+      text: (e.textContent || '').slice(0, 60).trim(),
+      visible: e.offsetParent !== null,
+    }))
+    .filter(e => e.visible);
+}""")
+```
+
+This returns every test id currently rendered on the page, with enough context to know what each one is. **Test ids are the preferred selector** — they're the FE team's contract for "this won't change." Use them when they exist.
+
+### 6. Pick the right selector
+
+In priority order:
+
+1. **`data-testid`** — most stable. `page.getByTestId('create-suite-button')`. If a test id exists, use it.
+2. **`getByRole(name)`** — stable across most refactors as long as the accessible name doesn't change. `page.getByRole('button', { name: 'Create suite' })`.
+3. **`getByLabel`** for form inputs that have a label. `page.getByLabel('Dataset name')`.
+4. **`getByText`** — fragile if the text is dynamic or i18n'd. Use only for truly static labels.
+5. **CSS / XPath selectors** — **last resort**. Use only when no test id and no accessible name exists, and leave a comment explaining why: `// no test id; FE team to add — link to ticket`.
+
+**The decision is binary at write time, not runtime.** Pick one selector and commit to it. The "heal at runtime" pattern (Seam 3 in the parent design) is reserved for future C-scope work; B-scope (where we are) writes deterministic selectors.
+
+### 7. Use `browser_generate_locator` when you're unsure
+
+If the accessibility tree shows three buttons with similar names, or the element has both a test id and a role and you're not sure which is canonical:
+
+```
+mcp__Playwright__browser_snapshot()  # to find the ref of the element
+mcp__playwright-test__browser_generate_locator(ref="<the-ref>")
+```
+
+This returns the locator code **Playwright itself would generate** if you used `codegen` against this element. Trust that output — Playwright's locator selection logic is well-tuned for resilience.
+
+If you don't have access to `mcp__playwright-test__` tools, fall back to writing the selector manually based on the snapshot + test id list, then verify in step 8.
+
+### 8. Verify by running
+
+After writing the POM method, the verification loop is:
+
+```ts
+// scratch test, not committed
+import { test, expect } from '@playwright/test';
+import { LogsPage } from '../pom/logs.page';
+
+test('discovery: LogsPage.filterByProject works', async ({ page }) => {
+  await page.goto('https://staging.dev.comet.com/opik/<workspace>/projects/<seed-project-id>/logs');
+  const logs = new LogsPage(page);
+  await logs.filterByProject('discovery-logs-...');
+  expect(await logs.countTraces()).toBeGreaterThan(0);
+});
+```
+
+Run it through:
+
+```
+mcp__playwright-test__test_run(testPath="path/to/scratch.spec.ts")
+```
+
+If it passes, the POM method works against the live page. If it fails, **read the failure trace** (Playwright's artifacts), don't just adjust selectors blindly. Common failures:
+
+- **Timeout waiting for element** — selector is wrong. Re-snapshot and pick a different one.
+- **Element resolved but assertion failed** — the POM method's logic is wrong, not the selector. Fix the method, not the selector.
+- **Multiple elements matched** — selector isn't specific enough. Add a parent scope or use a more precise role.
+
+### 9. When a stable selector doesn't exist
+
+If after all of the above the only working selector is a CSS path like `.MuiTable-root > tbody > tr:nth-child(2)`, **stop and flag it**. Per the parent design `2026-04-23-opik-2.0-e2e-infrastructure-design.md` §10.4 "Missing data-testid protocol":
+
+- **Default:** add a `data-testid` to the FE component in the **same PR** as your POM. The QA team has explicit permission for this. Find the component under `apps/opik-frontend/src/v2/pages/<Page>/...` or its shared-component dependency, add `data-testid="<descriptive-name>"`, then use that in the POM.
+- **Fallback:** if blocked from touching the FE, use `getByRole` with explicit accessible name (survives most refactors).
+- **Last resort:** structural CSS selector with a `// TODO(OPIK-####): awaits testid` comment linking to a ticket. Lint flags unticketed CSS selectors.
+
+The `data-testid` naming convention is kebab-case, descriptive, scoped to the page/component: `dataset-items-table`, `create-suite-button`, `trace-row-{traceId}`. Avoid generic names like `submit-button` that conflict across pages.
+
+### 10. Commit and move on
+
+Once the POM method works against the live UI:
+
+- The POM file change goes in the test ticket's PR.
+- Any FE `data-testid` additions go in the **same** PR (cross-package change is fine; reviewers expect it for test-enablement work).
+- The scratch seed script and scratch test file are **NOT** committed. Delete them before the commit.
+- Tear down any state you created during discovery (`backendClient.deleteProject(...)` or `curl -X DELETE ...`).
+
+## Anti-patterns
+
+These are red flags that mean you skipped a step:
+
+| Symptom | What you skipped |
+|---|---|
+| "Let me look at the FE source to find the right selector" | Step 4 — snapshot the rendered DOM, not the source. Components compose; what renders is what matters. |
+| "I'll write the POM method and check if it works when the test runs" | Step 8 — verify in isolation before committing. The test ticket will be slower to iterate on. |
+| "The page is empty, so I'll just check the empty state" | Step 2 — seed real data. An empty-state-only POM never exercises the row template, the open-detail action, etc. |
+| "I'll use `page.locator('.button:nth-child(3)')` — it's fine" | Step 9 — flag missing testids and add them to the FE. Brittle selectors are the #1 source of E2E flake. |
+| "The test id I see is generic, like `button-1` — I'll use that" | Step 5 + 9 — generic test ids are nearly as bad as no test id. Ask the FE team to rename it to something descriptive in the same PR. |
+| "I'll add the POM but skip the seed because the test will create state" | Step 2 — even during the test, you're now writing untested POM code against a page state you've never seen. |
+
+## Integration with the broader workflow
+
+This skill sits inside the `superpowers:subagent-driven-development` workflow. When an implementer subagent is dispatched for a POM-introducing task (e.g., the POM portion of OPIK-6128), the dispatch prompt should invoke this skill at the start:
+
+> Before writing `LogsPage`, use the `playwright-pom-discovery` skill to explore the live Logs page on staging. Specifically: seed a project + a few traces via the bridge, navigate to the page, snapshot the accessibility tree, enumerate test ids, then write the POM method. Report what test ids you found, what selectors you chose for each method, and which (if any) elements required `data-testid` additions to the FE.
+
+That dispatch text + this skill = the agent has a clear procedure to follow without me writing per-ticket instructions.
+
+## Reserved for future expansion
+
+When the suite gains the `LogsPage`, `TracePanelPage`, etc., POMs from OPIK-6128 onwards, a follow-up update to this skill should add a **page-object-catalog.md** sibling file (similar to the existing `playwright-e2e/page-object-catalog.md`) listing each POM, its key methods, and the data preconditions for using it in tests. Don't write that file yet — it'd be speculative; populate it as POMs land.

--- a/.agents/skills/playwright-pom-discovery/retro-lessons.md
+++ b/.agents/skills/playwright-pom-discovery/retro-lessons.md
@@ -1,0 +1,163 @@
+# CUJ Test Retro Lessons (Opik 2.0 E2E)
+
+Supplementary reading for the `playwright-pom-discovery` skill. Captures lessons from previously-shipped CUJ tests under `tests_end_to_end/e2e/tests/` (Opik 2.0 suite, not the 1.0 suite at `tests_end_to_end/typescript-tests/`). Read this once when invoking the skill on a new CUJ ticket.
+
+## Lessons from OPIK-6595 (Dataset CRUD, PR #6851)
+
+### 7. Bridge routes now use `opik_factory.make_opik_client(...)`, not `opik.Opik(...)` direct
+
+OPIK-6595 introduced `services/opik-sdk-driver/src/opik_sdk_driver/opik_factory.py` with a `make_opik_client(workspace=..., api_key=...)` helper. New bridge routes follow this pattern.
+
+### 8. Bridge routes can accept per-request auth via `X-Opik-Api-Key` header
+
+OPIK-6595's `POST /datasets` route signature:
+
+```python
+def create_dataset(body: ..., x_opik_api_key: str | None = Header(default=None)) -> ...:
+    client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
+```
+
+Tests can pass per-request auth this way. Match the pattern for new bridge routes.
+
+### 9. Cascade behavior is per-entity — verify in Phase 2
+
+OPIK-6595 discovered that **datasets do NOT cascade-delete with their parent project** — explicit teardown is required. Don't assume project deletion cleans up child entities. During Phase 2, after creating an entity via the bridge route, verify whether deleting the project cleans it up. If not, the fixture needs explicit teardown AND `global-teardown.ts` needs an entity-specific sweep added BEFORE the project sweep (datasets-before-projects is the established order).
+
+### 10. The fixture composition chain is growing — pick the right parent
+
+As of OPIK-6595, the chain is:
+
+```
+base → project → scratch-dir → failure-artifacts → trace → dataset → ...
+```
+
+Each new fixture extends the highest-level ancestor it actually needs (so transitively gets everything below). For OPIK-6596 (Experiments), the question is whether to extend `dataset` (if experiments always need a dataset) or `trace` (if some experiment flows don't need datasets). Pick based on dependency, not on "extend the latest."
+
+### 11. The test discovered a UI feature that wasn't in the spec — that's fine
+
+OPIK-6595's spec didn't predict that "commit changes" creates a new dataset version (v2, v3). The agent discovered this during Phase 3 discovery and the test now asserts on version labels. This is the kind of discovery the 5-phase model is designed to surface. Future agents: if Phase 3 reveals UI behavior the spec didn't anticipate, flag it; if it makes the test more meaningful, incorporate it; if it's tangential, defer.
+
+### 12. Reusing an earlier fixture means inheriting its seed shape — check that fits the new ticket's assertions
+
+OPIK-6595's `dataset.fixture` seeds 3 items, all happy-path (`input` / `expected_output` matched). That's perfect for "list page shows 3 rows" but useless for "experiment evaluator caught a failure on item 3."
+
+When OPIK-6596 (Experiments) reuses `dataset.fixture`, it inherits happy-path-only seed data and can only assert on happy paths. **Red-path coverage matters** — an evaluator that silently scores everything as 1.0 should fail the test. The fix: OPIK-6596's `experiment.fixture` seeds its OWN dataset with a 2-pass-1-fail item shape, deliberately not reusing `dataset.fixture`.
+
+**The general principle:** when a new ticket reuses a fixture, look at its seed data and ask "does this shape let me assert on both the success AND failure surfaces of my CUJ?" If the answer is "only success," seed your own shape — even if it means writing a similar-looking fixture. The maintenance cost of two fixtures is less than the regression cost of a test that can't see failure.
+
+This applies broadly:
+- Online evaluation (OPIK-6597): the `trace` fixture seeds one happy trace. To test "rule fires and scores match/no-match correctly," the test creates additional traces inline (one matching, one not) — don't try to make the `trace` fixture parameterized.
+- Annotation queue (OPIK-6598): seed traces include at least one that the test will score, one that it'll skip, and one that it'll mark as failing.
+- Any future ticket reusing existing fixtures: same question.
+
+### 13. Wrap test phases in `test.step(...)` — Allure + trace-viewer rely on it
+
+Every CUJ test from OPIK-6596 onwards MUST wrap its logical phases in `await test.step('description', async () => { ... })`. This is non-negotiable for two reasons:
+
+1. **Allure integration is in flight** (parent design §14 Phase 4). When allure-playwright ships, each `test.step()` becomes a labeled row in the test timeline. A flat test renders as one opaque block; debugging requires watching the video. Tests written without steps now will need painful refactor when Allure lands.
+2. **Playwright's own trace viewer** (`npx playwright show-trace`) renders steps as collapsible timeline blocks. Steps are a usability win locally even before Allure.
+
+**What counts as a "phase":** a logical block you'd describe with a complete sentence. Examples (good granularity):
+
+- `await test.step('seed three traces with sequential timestamps', async () => { ... })`
+- `await test.step('navigate to Logs and verify trace count', async () => { ... })`
+- `await test.step('open first trace and assert panel renders', async () => { ... })`
+- `await test.step('UI-create dataset via dialog', async () => { ... })`
+- `await test.step('verify dataset via SDK roundtrip', async () => { ... })`
+
+**Bad granularity** (don't do these):
+
+- Wrapping every line in its own step (`test.step('click button')`, `test.step('wait for visible')`) — overkill, makes the timeline noisy.
+- Wrapping nothing (the current OPIK-6128 / OPIK-6595 shape) — see the rationale above.
+- Wrapping fixture setup from within the fixture itself — fixtures already attach `testInfo` annotations; leaking fixture internals into the test report just adds noise.
+
+**POM methods also get steps**, with a different granularity:
+
+```ts
+async openTraceById(traceId: string): Promise<TracePanelPage> {
+  return test.step(`open trace ${traceId}`, async () => {
+    // ... existing implementation
+  });
+}
+```
+
+POM steps are the FINE-grained "click row", "wait for panel ready" level; the test's steps are the COARSE-grained "open trace and verify panel" level. Nested steps in the Allure / trace viewer give you both granularities — the user-journey narrative AND the locator-level detail when you drill in. Each POM method does exactly one user-visible action AND wraps its body in `test.step()`.
+
+**Returning from a stepped POM method:**
+The `test.step()` callback must return whatever the POM method returns:
+
+```ts
+async openTraceById(traceId: string): Promise<TracePanelPage> {
+  return test.step(`open trace ${traceId}`, async () => {
+    await this.page.goto(/* ... */);
+    return new TracePanelPage(this.page, traceId);
+  });
+}
+```
+
+**Existing tests (OPIK-6128, OPIK-6595):** retrofit is not required mid-wave. New tests onward (OPIK-6596+) MUST follow this. The two existing tests get a step-wrapping cleanup ticket filed later (low priority, can land alongside the Allure wiring).
+
+## Lessons from OPIK-6128 (Trace Explore, merged 2026-05-25, PR #6823)
+
+These are enforceable defaults. If you deviate, name the reason in the implementation.
+
+### 1. Default to UI-first assertions with Playwright built-ins
+
+Assert what the user sees in the rendered DOM, not what the REST API returns. Use Playwright's built-in locator assertions: `await expect(locator).toBeVisible()`, `await expect(locator).toHaveCount(n)`, `await expect(locator).toHaveText(...)`, `await expect(locator).toBeHidden()`. These cover essentially every CUJ assertion the data-plane suite needs.
+
+**Do NOT add to `matchers/register.ts`** by default. The file exists from OPIK-6128 but its six exports are dead code — none are consumed by the merged test. Custom matcher registration is an opt-in decision that requires explicit justification AND actual consumption in the test you ship.
+
+When you might genuinely need a custom matcher:
+
+- Asserting against data that the UI doesn't render but the user's journey depends on (e.g., a hidden span-tree shape that's accessed via REST after a UI action).
+- Asserting against a structural shape that would be very verbose to express with built-ins (e.g., "spans form a tree where every llm-typed node has a tool-typed parent").
+
+When you don't:
+
+- "I want a nicer error message" — write a clearer Playwright assertion with a custom locator name instead.
+- "I want this matcher available for future tests" — YAGNI. Add it when the future test ships.
+- "The OPIK-6128 matcher file already exists, I'll just extend it" — no. Extending dead code propagates the dead code.
+
+**Anti-pattern from OPIK-6128:** six matchers (`toHaveSpanOfType`, `toHaveSpanCount`, `toHaveAtLeastSpanCount`, `toHaveValidInput`, `toHaveValidOutput`, `toHaveNoErrors`) were built during Phase 4 then orphaned when the test refactored to UI-first assertions. The file is in the repo, untouched, doing nothing. Don't repeat this.
+
+### 2. Auth is owned by `global-setup.ts`, not by `.auth/` symlinks
+
+The Opik 2.0 E2E suite logs in via HTTP POST to `<rootBase>/api/auth/login` during `global-setup`, captures the API key from the response, mints `.auth/user.json` storage state at runtime, and propagates the API key to workers via `process.env`.
+
+This means:
+
+- **Don't symlink** `.auth/staging.json` between worktrees — there's no such file. The file is `.auth/user.json` and global-setup creates it fresh each run.
+- **Cloud auth requires `OPIK_TEST_USER_EMAIL` + `OPIK_TEST_USER_PASSWORD`** in env. See `.env.cloud.example` for the full env-var shape.
+- **`OPIK_API_KEY` alone is not enough** for UI tests — global-setup needs to be able to log in to mint storage state. Power-user shortcut: set `OPIK_API_KEY` AND pre-populate `.auth/user.json` and global-setup will trust both and skip the login.
+- **OSS deployments skip auth** — `global-setup` short-circuits when `deployment=oss`.
+
+### 3. Inspection methods on `backendClient` are pre-blessed
+
+Per parent design §7.4, `core/backend/client.ts` is for inspection + teardown only. Adding read methods (`getProject`, `getTrace`, `getTraceSpans`, `findDatasetByName`, etc.) is expected and welcome — not scope creep. If your test needs to inspect backend state during development or during a verification gate, add the wrapper method. Don't add WRITE methods (create/update) — those belong in `sdkClient` per the SDK-first principle.
+
+### 4. FE `data-testid` additions in the same PR, default
+
+When Phase 3 discovery finds an element you'd need a brittle selector for (CSS path, `:nth-child`, regex body-text parse), the default is to **add a `data-testid` to the FE component in the SAME PR**. The QA team has explicit permission for cross-package changes per parent design §10.4.
+
+Fallback selectors (`getByRole`, `getByText`, deterministic class/role combinations) are only acceptable when there's a named reason: FE owner unreachable, the element is third-party (Radix/Shadcn), or the testid would be too generic to be useful.
+
+**Don't ship body-text regex parsing** like `document.body.innerText.match(/Traces (\d+)/)` without a paired FE testid PR. That's a workaround, not a selector, and it accumulates fragility across tickets.
+
+### 5. Spec case counts are tentative
+
+If the spec proposes 3 test cases and you find two of them are redundant (one is a subset of the other), STOP, flag it to the user, and propose collapsing to fewer cases. The spec is a starting point. Don't ship 3 cases just because the spec said 3.
+
+OPIK-6128 was specced with 3 cases and shipped with 2 after a refactor commit collapsed the redundant one.
+
+### 6. Don't refactor adjacent code mid-ticket
+
+If during a CUJ ticket you notice that `core/sdk/`, `core/backend/`, `fixtures/`, or the bridge needs improvement that's outside the ticket's scope — STOP and file it as a separate ticket. Do not bundle the refactor into the CUJ PR. The PR review focus dilutes; the diff gets harder to reason about.
+
+**OPIK-6128 exception:** the global-setup auth flow rewrite was substantial and unplanned, but it's structurally part of the CUJ test (you can't run the test without auth, and the old approach was broken). That's the bar: the refactor must be load-bearing for the ticket's own functionality, not just adjacent improvement.
+
+## Things that are NOT lessons (in case the agent guesses)
+
+- **The `playwright-pom-discovery` skill is correct as-is.** Use it before any POM selector work. It enforced good discipline on OPIK-6128.
+- **The 5-phase model is correct.** Plan → bridge+SDK+fixture → discovery → POM+test → PR. Don't compress phases unless a phase is genuinely empty for the ticket.
+- **`comet:create-pr` skill works.** Use it for the PR. Don't hand-roll `gh pr create` unless the skill fails.
+- **Worktree pattern `.worktrees/<branch>` is correct.** The parent repo's `.git/info/exclude` already ignores `.worktrees/`.

--- a/.claude/rules/playwright-pom.md
+++ b/.claude/rules/playwright-pom.md
@@ -1,0 +1,24 @@
+---
+---
+# Opik 2.0 E2E CUJ test workflow
+
+**Invoke the `playwright-pom-discovery` skill via the `Skill` tool** whenever any of these trigger:
+
+- The user mentions `tests_end_to_end/e2e/`, "CUJ" tests, or "E2E test" in their message.
+- The user describes a feature flow they want test coverage for (e.g., "we need automated tests for the agent-config switcher flow", "can you write tests for the experiments page").
+- You're about to create or modify any file under `tests_end_to_end/e2e/` — POMs, tests, fixtures, or bridge routes for the Opik 2.0 E2E suite.
+
+Invoke the skill BEFORE writing any code or asking detailed clarifying questions. The skill itself handles scoping (it'll ask up to ~3 questions adaptively if there's no spec or ticket to anchor on).
+
+The skill carries:
+
+- The 10-step UI discovery procedure (live `browser_snapshot`, `data-testid` enumeration, selector preference order, FE testid policy).
+- A supplementary `retro-lessons.md` with cumulative lessons from prior CUJ tickets (matchers default off, UI-first assertions, `test.step()` mandatory, cascade verification, fixture-seed-shape rules, and more).
+- A "no-ticket entry point" for natural-language requests — the skill scopes the work itself and offers to file a Jira ticket OR ship as `[NA]`.
+- Anti-patterns and red flags to avoid.
+
+Does NOT apply to:
+- `tests_end_to_end/typescript-tests/**` — the 1.0 suite, owned by the `playwright-e2e` skill.
+- Non-test code paths under `tests_end_to_end/e2e/` (e.g., the bridge service's pure Python code).
+
+Read `tests_end_to_end/e2e/AGENTIC.md` for the team workflow overview if you're new to this directory.

--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,13 @@ sdks/python/uv.lock
 .vscode
 
 # Claude Code
-.claude/
+# Selectively ignore personal/volatile parts of .claude/.
+# Shared rules (.claude/rules/) ARE tracked so teammates auto-load them.
+.claude/agents/
+.claude/commands/
+.claude/skills/
+.claude/worktrees/
+.claude/settings.local.json
 .mcp.json
 CLAUDE.md
 .codex

--- a/tests_end_to_end/e2e/.agentic/cuj-test-kickoff.md
+++ b/tests_end_to_end/e2e/.agentic/cuj-test-kickoff.md
@@ -1,0 +1,261 @@
+# Universal CUJ Kickoff Prompt (Opik 2.0 E2E)
+
+**How to use this:** open a fresh Claude Code session in the opik repo root. Either:
+
+- **Have a Jira ticket?** Edit the `TICKET` line below to the ticket key (e.g., `TICKET: OPIK-6595`). Paste everything from the horizontal rule down.
+- **No ticket — just a natural-language request?** You don't even need this prompt. Just say what you want in plain English ("write tests for the agent-config switcher flow" / "we need E2E coverage for experiments"). The `playwright-pom-discovery` skill auto-triggers on phrases like that, handles the scoping conversation, and asks if you want it to file a Jira ticket or ship as `[NA]`. See `tests_end_to_end/e2e/AGENTIC.md` for examples.
+
+Either way the agent stops at the Phase 1 spec gate, the Phase 3 discovery gate, and (if anything goes sideways) at any escalation point.
+
+**This prompt is the shared team contract for the data-plane CUJ test sequence.** It lives in `tests_end_to_end/e2e/.agentic/` and is updated when patterns shift (after each CUJ ticket lands). See `tests_end_to_end/e2e/AGENTIC.md` for the onboarding overview.
+
+---
+
+TICKET: <<<EDIT THIS — e.g. OPIK-6595, or leave blank/replace with a natural-language description of the flow you want tested>>>
+
+You're picking up the work above. It's a CUJ test (or test family) for the Opik 2.0 E2E suite. This is your only piece of work for this session — finish it, ship the PR, then stop. Don't pick up another one.
+
+**If the TICKET line above is a Jira key (`OPIK-XXXX`):** proceed via the ticket-anchored path — fetch the ticket via the Atlassian MCP, use the cheat-sheet table below for known gotchas, drive the 5-phase model.
+
+**If the TICKET line is blank, says "no ticket", or contains a natural-language description:** invoke the `playwright-pom-discovery` skill immediately. It has a "Path B" entry point for natural-language requests — handles scoping in 1-5 adaptive questions, asks about Jira vs `[NA]`, drafts a one-pager spec, then joins the standard 5-phase model from Phase 2 onwards.
+
+# What you're walking into
+
+The Opik 2.0 E2E test suite lives at `tests_end_to_end/e2e/` (separate from the 1.0 suite at `tests_end_to_end/typescript-tests/`). The infrastructure is built and merged on `main`:
+
+- **OPIK-6126** — env config, global setup/teardown, orphan project sweep.
+- **OPIK-6498** — FastAPI bridge at `localhost:5175` (Python SDK wrapper) with `health` + `projects` routes.
+- **OPIK-6499** — TypeScript SDK clients: `sdkClient.python` (HTTP wrapper over bridge), `sdkClient.typescript` (direct `new Opik({...})`), `backendClient` (cutover to public `Opik().api.*` for inspection/teardown).
+- **OPIK-6500** — base fixtures: `base`, `project`, `scratchDir`, `failureArtifacts`; `playwright.config.ts` `webServer` directive auto-spawns the bridge during tests.
+- **OPIK-6128** — first CUJ test (Trace Explore). PR #6823 is the reference shape for everything you'll build. Read it.
+
+The current session's first task is to read three things:
+
+1. **The Jira ticket description** — via the Atlassian MCP. The ticket carries the scope contract.
+
+2. **The closest-shape merged PR for your ticket** — fetch via `gh pr view <number> --json files,commits` and read the test file, POMs, bridge route, fixture. Recent examples on `main`:
+   - **OPIK-6128 (PR #6823)** — Trace Explore. SDK-create + UI-verify. Reference for fixture extending `failure-artifacts`, POM patterns, UI-first assertions.
+   - **OPIK-6595 (PR #6851)** — Dataset CRUD. SDK-create + UI-create pair pattern. Reference for `opik_factory.make_opik_client`, `X-Opik-Api-Key` header, explicit teardown for non-cascading entities, FE testid additions in same PR.
+   - Newer CUJs as they land. Find the merged precedents under `tests_end_to_end/e2e/tests/<feature>/` on `main`.
+
+3. **The CUJ retro lessons** at `.agents/skills/playwright-pom-discovery/retro-lessons.md` — supplementary to the `playwright-pom-discovery` skill. Read it once at the start; it captures hard-won lessons from prior CUJ tickets (matchers default off, UI-first assertions, FE testid policy, `test.step()` mandatory, cascade verification, fixture-seed-shape considerations, etc.).
+
+# The per-ticket cheat sheet
+
+Find your ticket below. The cheat-sheet line is opinion, not gospel — the spec you write in Phase 1 is where you commit to design choices.
+
+| Ticket | Entity / fixture | Bridge route(s) | POMs | Key gotchas |
+|---|---|---|---|---|
+| **OPIK-6595** | `dataset` fixture, depends on `project` | `POST /datasets` (create with N items); add `GET /datasets/by-name` only if Phase 4 tests need it | `DatasetsPage` (list + create dialog), `DatasetItemsPage` (item table + add/edit/delete) | Dataset and TestSuite share the `Dataset` DB table with a `DatasetType` discriminator (`DATASET` vs `TEST_SUITE`). Different user-level entity, different fixture, different POMs. Don't reuse the future `testSuite` fixture. First ticket exercising the SDK-create + UI-create pair-in-one-PR pattern. |
+| **OPIK-6137** | `testSuite` fixture, depends on `project` | `POST /test-suites` (create with items + deterministic evaluator) | `TestSuitesPage` (list + create dialog), `TestSuitePage` (suite detail with run trigger), `TestSuiteItemsPage` (per-item results) | Separate entity from Dataset at the user level. Python SDK class is `opik.TestSuite`, NOT `opik.Dataset`. Backend `DatasetType.TEST_SUITE` enum value is the string `evaluation_suite` (pending OPIK-5795 rename). Trigger-run-via-UI is part of the journey per parent §11.2 — don't trigger run via SDK. |
+| **OPIK-6596** | `experiment` fixture, depends on `project` directly (NOT on `dataset.fixture`) — seeds its OWN dataset with a 2-pass + 1-fail shape, see notes below | `POST /experiments/evaluate` (with deterministic scorer) | `ExperimentsPage` (list), `ExperimentDetailPage` (per-item metric values, status) | T1 = deterministic evaluator ONLY (`Equals`, `Contains`, etc.). No LLM judges — those reintroduce non-determinism the smoke can't tolerate. **Do NOT extend `dataset.fixture` from OPIK-6595** — its 3 items are all happy-path. Experiments need red-path coverage. Instead, the `experiment` fixture seeds its own dataset shaped: <br>• `{ input: "X", expected_output: "Y" }` where the task returns `"Y"` → score 1.0 <br>• `{ input: "A", expected_output: "B" }` where the task returns `"B"` → score 1.0 <br>• `{ input: "Q", expected_output: "Z" }` where the task returns `"WRONG"` → score 0.0 <br>The evaluator is `Equals` (or similar deterministic exact-match). Test assertions verify: experiment row appears in list with status COMPLETED; detail page shows 3 items; 2 marked passed, 1 marked failed; aggregate score = 2/3. Bridge route uses `opik_factory.make_opik_client(...)` per OPIK-6595's pattern, accepts `x_opik_api_key` header. UI-create-experiment flow is multi-step (select dataset + evaluator + target); defer to T2 follow-up, only ship SDK-create + UI-verify here. **Verify cascade behavior**: do experiments delete with their parent dataset? Their parent project? Check during Phase 2; if not cascading, add explicit teardown to fixture AND an experiments sweep to `global-teardown.ts` BEFORE the dataset sweep (dependency order: experiments → datasets → projects). |
+| **OPIK-6597** | reuses `trace` fixture from OPIK-6128 | (reuses `POST /traces`) | `OnlineEvaluationPage` (rule list + create dialog) | First test in the suite that asserts on eventually-consistent state. Rules apply asynchronously — assertion shape is "wait up to 30s for feedback score to land." Build a polling helper (e.g., `LogsPage.waitForFeedbackScore(traceId, ruleName)`), not a `setTimeout` race. Use Playwright's built-in `expect.poll(...)` if it fits. Confirmed by user: online evals enabled by default in every environment. |
+| **OPIK-6598** | `annotationQueue` fixture, depends on `project` + traces | `POST /annotation-queues` (with trace IDs) | `AnnotationQueuesPage` (list + create), `AnnotationQueuePage` (per-queue reviewer view with score entry / reason / skip / save) | **T2, not T1** — tag `@t2-cuj`, not `@t1-smoke`. Multi-step UI flow with persistence across two entity types (queue + source traces). Verify feedback scores landed on the source traces via `sdkClient.python` after UI scoring. SDK exports are `opik.TracesAnnotationQueue` (Python top-level) — use that, not the rest_api internals. |
+
+# Standing rules (apply to every phase)
+
+Most of these are auto-loaded from `.claude/rules/*.md`. Restating the critical ones here:
+
+- **`playwright-pom-discovery` skill is mandatory before any POM selector work.** The `.claude/rules/playwright-pom.md` rule enforces this. Phase 3 invokes the skill explicitly.
+- **CUJ retro lessons from OPIK-6128.** Bundled with the skill at `.agents/skills/playwright-pom-discovery/retro-lessons.md`. Read those before writing the spec. Key points: UI-first assertions by default; FE testid in same PR; spec case counts are tentative; inspection methods on `backendClient` are pre-blessed.
+- **Public SDK surface only.** No deep imports into `opik/rest_api/*`. Use `new Opik({...}).api.*` for the typed REST surface from TS; use `opik.Opik(...)` / decorators for Python.
+- **SDK-first, REST-fallback.** State creation through `sdkClient.python` (bridge) or `sdkClient.typescript` (direct). REST via `backendClient` is inspection + teardown only.
+- **No meta-smoke tests.** Don't create `<entity>-lifecycle.spec.ts` that tests fixture wiring in isolation. The CUJ test itself validates the fixture.
+- **No ticket numbers in source comments.** Git blame surfaces history.
+- **No GPG signing.** Use `git -c commit.gpgsign=false commit ...` on every commit.
+- **Per-ticket work-log docs are local-only.** When you write a spec, plan, or discovery report for THIS ticket, put it under `docs/superpowers/specs/`, `docs/superpowers/plans/`, `docs/superpowers/discovery/` respectively. Never `git add` anything under `docs/superpowers/`. Verify before each commit via `git status` and after the final push via `git log origin/main..HEAD --stat -- 'docs/superpowers/'` (must be empty). Reusable team artifacts (this prompt, the rules, the skill, the AGENTIC.md doc) DO live in the tracked repo — don't confuse them with per-ticket work-logs.
+- **Worktree pattern.** `.worktrees/<branch-name>`. Already in `.git/info/exclude`. Worktree the work off `origin/main`.
+
+# Phase 0 — Setup (no gate)
+
+1. Read the `TICKET:` line above. If it's a Jira key (`OPIK-XXXX`), proceed via Path A (ticket-anchored, this prompt). If it's blank, says "no ticket", or contains a natural-language description, **stop following this prompt** and invoke the `playwright-pom-discovery` skill — it has a Path B entry point that handles scoping for ticketless work. Don't try to ask the user to file a ticket; that's the skill's job to handle (or skip).
+2. Fetch the Jira ticket description via the Atlassian MCP (`mcp__claude_ai_Atlassian__getJiraIssue`, cloud id `70d91365-5d13-4b02-b353-de8a8e8ee962`). Read it.
+3. Read the three required files listed in "What you're walking into" above.
+4. Create the worktree:
+   ```
+   git fetch origin
+   git worktree add -b andreic/<TICKET-KEY>-<short-slug> .worktrees/<TICKET-KEY>-<short-slug> origin/main
+   cd .worktrees/<TICKET-KEY>-<short-slug>
+   ```
+   Short slug examples: `dataset-crud`, `test-suites`, `experiments`, `online-eval`, `annotation-queue`.
+5. Run `npx tsc --noEmit` from `tests_end_to_end/e2e/` to confirm baseline is clean.
+
+# Phase 1 — Spec (STOP for user gate)
+
+Write a spec at `docs/superpowers/specs/<DATE>-<TICKET-KEY-LOWERCASE>-<short-slug>-design.md` (local-only, never `git add`). Date format: `YYYY-MM-DD`.
+
+Use OPIK-6128's PR (#6823) as the spec-shape reference — read its description and the test file it shipped. Mirror the section structure for your ticket; swap the scope. Sections expected:
+
+- §1 Why this exists
+- §2 Scope (in / out / explicit non-decisions)
+- §3 Architectural fit
+- §4 Component design (bridge route, SDK method, fixture, POMs, test file shape). Do NOT include a "matchers" subsection by default — see the assertion-style guidance below.
+- §5 Phased delivery — direct port of OPIK-6128's §5
+- §6 Pre-work / shared resources — direct port
+- §7 Acceptance criteria
+- §8 Risks and mitigations
+- §9 Non-scope reminders
+
+**Critical things to get right in §4 (component design):**
+
+- **Test case count is TENTATIVE.** Propose 2-3 cases for the UI-create+SDK-verify pair (when applicable) or 2 cases for SDK-only journeys. If you suspect a case is redundant, name it and propose collapsing.
+- **Don't pre-specify custom Jest/Playwright matchers** (`expect.extend(...)` registrations under `matchers/register.ts`). Default assertion style is UI-first using Playwright's built-in locator assertions: `await expect(panel.spansCountLabel(1)).toBeVisible()`, `await expect(logs.row(name)).toHaveCount(1)`, `await expect(panel.errorBadge).toBeHidden()`. These are sufficient for everything the data-plane CUJ suite needs.
+
+  Touching `matchers/register.ts` is an explicit decision, not a default: do it only if you've identified a specific assertion the test needs that the built-in locator assertions genuinely can't express. If you do touch it, the assertion must be USED by the test you ship — OPIK-6128's six dead matchers are the cautionary tale (none consumed in the final test). The current state of `matchers/register.ts` is dead code from OPIK-6128; you're allowed to ignore it.
+- **Identify FE `data-testid`s likely needed.** Best guess based on the cheat-sheet POM list and the OPIK-6128 reference. Phase 3 confirms via live inspection.
+- **For OPIK-6595, OPIK-6137, OPIK-6598:** both SDK-create and UI-create tests in the spec. For OPIK-6596 and OPIK-6597: SDK-create only (UI-create deferred to T2).
+
+Report back when the spec is written:
+
+- Spec file path.
+- 1-paragraph summary of scope: "this ticket adds X bridge route, Y fixture, Z POMs, with N test cases asserting [...]."
+- Any design decisions you're uncertain about, called out explicitly.
+
+**STOP.** Do not start Phase 2 until the user reads the spec and approves.
+
+# Phase 2 — Bridge route + SDK client method + fixture
+
+Only after Phase 1 spec approval.
+
+Scope per the spec's §4. Verification gate:
+
+- `npx tsc --noEmit` clean.
+- Scratch script (NOT committed) that creates the entity via the new bridge route against staging, verifies it's visible via the appropriate `backendClient` method (add the inspection method to `backendClient` if needed — per the retro lessons, this is pre-blessed), then deletes the parent (which cascades). Report the actual command + actual stdout, not a narrative.
+- Delete the scratch script before commit.
+
+Use the `superpowers:test-driven-development` skill for the scratch verification (write the scratch first, watch it fail because the route doesn't exist, implement, watch it pass).
+
+Commits at this phase, in order:
+- `feat(bridge): add POST /<route> route`
+- `feat(sdk): add <methodName> on PythonSdkClient`
+- `feat(fixtures): add <entity> fixture extending failure-artifacts`
+- `feat(backend-client): add <inspectionMethod(s)>` (if needed)
+
+Report when done. STOP only if you hit something the spec didn't predict. Otherwise proceed to Phase 3.
+
+# Phase 3 — UI discovery (STOP for user gate)
+
+**Invoke the `playwright-pom-discovery` skill via the `Skill` tool.** The 10-step procedure is in the skill. Don't write any code under `pom/` before completing this phase.
+
+Use a long-lived pinned discovery scratch project in your staging workspace (convention: name it something like `discovery-scratch-pinned`, seed it once with example entities of varied shape, leave it long-lived for reuse). The user will tell you the project name and workspace at kickoff if you need to confirm. If your CUJ needs entity shapes that aren't in the pinned project, seed additional state via Phase 2's bridge route. Do not click-create state through the UI for discovery setup — UI-create is what the test exercises, not what the discovery uses.
+
+Storage state for the browser MCP: `global-setup` will mint `.auth/user.json` for you the first time you run a Playwright test, OR you can capture it manually via `npx playwright codegen --save-storage=.auth/user.json https://staging.dev.comet.com/opik/`. The browser MCP loads it via `storageState: '.auth/user.json'` in the navigation config.
+
+Deliverable (THE GATE): a discovery report at `docs/superpowers/discovery/<DATE>-<TICKET-KEY-LOWERCASE>-<short-slug>.md` (local-only). Same shape as a `playwright-pom-discovery` skill output. Must include:
+
+- URLs explored, entity preconditions for each page.
+- Per-element table: description, chosen selector, fallback if selector is fragile.
+- **List of `data-testid`s missing from the FE that you'll add in this PR.** Per retro lesson #4, default is to add them — flag any element where the chosen selector is brittle (CSS path, body text regex, nth-child, etc.) AND propose a testid name. Don't ship workarounds without paired FE testid additions.
+- UI behavior notes that affect test design (pagination defaults, sort order, dialog modal vs side-pane behavior, etc.).
+
+Report back with the path to the discovery report. **STOP.** Do not start Phase 4 until the user reads it and approves.
+
+# Phase 4 — POMs + test file + FE testids
+
+Only after Phase 3 discovery approval.
+
+Scope per the spec's §4. The POMs you write must use the selectors confirmed in the discovery report. FE `data-testid` additions go in THIS PR (cross-package, QA has permission per parent design §10.4).
+
+**`test.step()` wrapping is mandatory.** Per retro lesson #13 (in `.agents/skills/playwright-pom-discovery/retro-lessons.md`), every test body wraps its logical phases in `await test.step('description', async () => { ... })`, and every POM method wraps its body in a `test.step()` returning the method's result. This is non-negotiable for Allure compatibility (the data-plane suite's eventual reporter) and pays back immediately in `npx playwright show-trace` debugging. Granularity: a "phase" is something you'd describe with a complete sentence ("seed three traces", "open trace and verify panel"). Read lesson #13 in full before writing the test file or POM methods.
+
+Verification gate (use `superpowers:verification-before-completion`):
+
+Run from the worktree's `tests_end_to_end/e2e/` directory:
+
+```bash
+OPIK_DEPLOYMENT=cloud \
+  OPIK_API_KEY=<staging api key from user> \
+  OPIK_BASE_URL=https://staging.dev.comet.com/opik \
+  OPIK_TEST_USER_EMAIL=<staging email from user> \
+  OPIK_TEST_USER_PASSWORD=<staging password from user> \
+  OPIK_WORKSPACE=<your-workspace> \
+  OPIK_TEST_USER_NAME=<your-workspace> \
+  WORKERS=1 \
+  npx playwright test tests/_seed/ tests/<feature-dir>/ --reporter=list
+```
+
+Expected: ALL tests pass — OPIK-6499 `sdk-clients.spec.ts`, OPIK-6128 `trace-explore-smoke.spec.ts`, and your new tests. Confirm `[WebServer] INFO: Uvicorn running on http://127.0.0.1:5175` in stdout (proves bridge auto-spawned). After the run, confirm zero orphans:
+
+```bash
+curl -sS "https://staging.dev.comet.com/opik/api/v1/private/projects?name=cuj-<RUN_ID>-" \
+  -H "Authorization: $OPIK_API_KEY" -H "Comet-Workspace: <your-workspace>" | jq '.total'
+```
+
+Should print `0`.
+
+**REPORT THE ACTUAL STDOUT VERBATIM.** Not a summary. Not "tests passed." The user reads the output to verify the gate. If the chat can't hold the output, save to `/tmp/<TICKET-KEY>-phase4.log` and tell the user the path.
+
+If any test fails, debug it. Don't proceed to Phase 5 with red tests.
+
+# Phase 5 — PR
+
+Push the branch:
+
+```bash
+git push -u origin andreic/<TICKET-KEY>-<short-slug>
+```
+
+Verify no `docs/superpowers/` files in the diff:
+
+```bash
+git log origin/main..HEAD --stat -- 'docs/superpowers/'
+```
+
+Must print nothing. If anything appears, STOP and remove the file(s) from the branch.
+
+Open the PR via the `comet:create-pr` skill. Title format: `[<TICKET-KEY>] [QA] feat: <short summary>`. Body shape follows OPIK-6128's PR (#6823). Include:
+
+- The Phase 4 stdout verbatim as evidence.
+- A summary of FE `data-testid` additions, if any.
+- Cross-link to OPIK-6128 / OPIK-6500 if relevant.
+- AI watermark filled in.
+
+After the PR is open, transition the Jira ticket to "In Review" via Atlassian MCP. Post a progress comment to the Jira ticket using REAL newlines in the body (NOT literal `\n` strings — per the `feedback_jira_comment_newlines` memory).
+
+Report PR URL + Jira comment URL back to the user. Then stop.
+
+# When you're stuck
+
+Escalate (don't silently work around) if:
+
+- The Jira ticket description disagrees with this prompt's cheat-sheet line.
+- The pinned discovery scratch project is missing or empty on staging.
+- Storage state minting fails in `global-setup`.
+- Phase 3 reveals the page is structured fundamentally differently from what the spec assumed.
+- FE owners decline cross-package testid PRs and the fallback selector strategy isn't viable.
+- A Phase 4 staging run fails for a reason that isn't selector-fixable.
+- You notice an adjacent file needs improvement that's tempting to bundle into this PR (per retro lesson #6, file a separate ticket instead).
+
+Don't proceed past a failing or unclear gate. Don't compress the 5-phase model. Don't expand scope.
+
+# Reference
+
+- OPIK-6128 PR for shape: https://github.com/comet-ml/opik/pull/6823
+- OPIK-6500 PR for fixture pattern: https://github.com/comet-ml/opik/pull/6770
+- OPIK-6499 PR for bridge-route pattern: https://github.com/comet-ml/opik/pull/6768
+- Architectural-decision references: PR #6677 (OPIK-6126 foundation), PR #6770 (OPIK-6500 base fixtures), PR #6823 (OPIK-6128 first CUJ), PR #6851 (OPIK-6595 Dataset CRUD with UI-create pair) — read the descriptions on these to absorb the architectural decisions.
+- `playwright-pom-discovery` skill: invoked via the `Skill` tool by name
+- Retro lessons rule: `.agents/skills/playwright-pom-discovery/retro-lessons.md` (bundled with the skill)
+- POM discovery rule: `.claude/rules/playwright-pom.md` (bundled with the skill)
+
+# Credentials
+
+The user will provide staging credentials in their next message after pasting this prompt. Expected env vars:
+
+- `OPIK_API_KEY` — staging API key
+- `OPIK_TEST_USER_EMAIL` — login email
+- `OPIK_TEST_USER_PASSWORD` — login password
+- `OPIK_WORKSPACE` — your staging workspace name
+- `OPIK_BASE_URL` — currently `https://staging.dev.comet.com/opik`
+
+Do not log these credentials anywhere they could be captured (PR descriptions, Jira comments, commit messages, file contents). They're for runtime use during Phase 2 and Phase 4 verification only.
+
+**Defensive fix that should ride along with this PR if it hasn't landed yet:** `tests_end_to_end/e2e/.gitignore` is missing entries for `.env.cloud` and `.env.local` (the real-credentials files; the `.example` templates are checked in but the real files aren't gitignored). Check `git show origin/main:tests_end_to_end/e2e/.gitignore | grep -E '\\.env'` — if there's no `.env` line, add the 2-line entry to your branch's `.gitignore`:
+
+```
+# Local credentials (templates checked in, real values gitignored)
+.env.local
+.env.cloud
+```
+
+Include in Phase 5 PR as a small defensive fix. Per the retro lesson on adjacent refactors: this is load-bearing for the workflow (anyone using the `.env.cloud.example` template needs to know their real file is safe from accidental commit), not adjacent improvement. **Skip if already on main.**

--- a/tests_end_to_end/e2e/AGENTIC.md
+++ b/tests_end_to_end/e2e/AGENTIC.md
@@ -1,0 +1,102 @@
+# Writing Opik 2.0 E2E Tests with Claude Code
+
+This directory is the Opik 2.0 E2E test suite. The data-plane CUJ tests (Trace Explore, Datasets, Test Suites, Experiments, Prompt Playground, Online Scoring, Annotation Queue) are written using a structured Claude Code workflow.
+
+## TL;DR — two ways to start
+
+### Way 1: just describe what you want, in plain English
+
+Open a fresh **Claude Code** session in the opik repo root and say what you want. For example:
+
+> "Write automated tests in `tests_end_to_end/e2e/` for the agent-config switcher flow."
+
+> "We need E2E coverage for the experiments comparison page."
+
+> "Can you add CUJ tests for online scoring rules?"
+
+The agent picks up an auto-loaded rule (`.claude/rules/playwright-pom.md`) that triggers on phrases like these. It invokes the `playwright-pom-discovery` skill, which scopes the work in 1-5 adaptive questions (what's the happy path, what state needs to exist, what's out of scope), asks if you want it to file a Jira ticket under OPIK-6107 or ship as `[NA]`, drafts a one-pager spec for your approval, then runs the standard 5-phase model end-to-end.
+
+You don't need to know about the kickoff prompt or any files. This is the easy path.
+
+### Way 2: you already have a Jira ticket
+
+Open a fresh Claude Code session. Open `tests_end_to_end/e2e/.agentic/cuj-test-kickoff.md`. Edit the `TICKET:` line at the top to your Jira key (e.g. `TICKET: OPIK-XXXX`). Copy everything from the horizontal rule down, paste into the session. The agent reads the ticket, drafts a spec, runs the 5-phase model.
+
+This is the heavier-context path. Useful when the ticket carries detailed scope that the agent should anchor against.
+
+---
+
+Either way: the agent stops at gates (Phase 1 spec, Phase 3 discovery report) for your review (~5 min each). Expected human time per test: ~15 minutes total. Expected wall-clock: a few hours of agent runtime.
+
+## What's set up for you, in the repo
+
+| Artifact | Path | What it does |
+|---|---|---|
+| **CUJ workflow skill** | `.agents/skills/playwright-pom-discovery/` (SKILL.md + retro-lessons.md) | The procedure the agent follows on any CUJ ticket: 10-step UI discovery, selector preference order, FE testid policy, plus the cumulative retro lessons from prior tickets (matchers default off, UI-first assertions, `test.step()` mandatory, cascade verification, fixture-seed-shape considerations, etc.). Invoked via the `Skill` tool. |
+| **Workflow auto-load rule** | `.claude/rules/playwright-pom.md` | Auto-loads in every Claude Code session under this repo. ~15 lines pointing the agent at the skill above when work touches `tests_end_to_end/e2e/`. |
+| **Universal kickoff prompt** | `tests_end_to_end/e2e/.agentic/cuj-test-kickoff.md` | The one prompt you paste per ticket. Reads the Jira ticket, picks the right shape, drives 5 phases (spec → bridge/fixture → UI discovery → POMs+tests → PR). Gates at Phase 1 and Phase 3 for your review. |
+
+You don't need to install or invoke anything separately — Claude Code picks up all of these automatically when you open a session in this repo. The only thing you paste is the kickoff prompt.
+
+## The 5-phase model
+
+The kickoff prompt drives the agent through five phases. You gate the workflow at two of them:
+
+| Phase | Agent does | You |
+|---|---|---|
+| 1. Plan | Reads Jira ticket + relevant merged PRs + the rules. Drafts a spec under `docs/superpowers/specs/` (your local machine; not committed). | **Read the spec** (~5 min). Approve or redirect. |
+| 2. Bridge route + SDK client + fixture | Adds the FastAPI bridge route, the `PythonSdkClient` method, the fixture. Runs a scratch verification against staging. | (auto-proceed; review the verification output if interested) |
+| 3. UI discovery | Invokes the POM-discovery skill. Uses Playwright MCP to snapshot the live UI, enumerate testids, propose POM selectors. Drafts a discovery report under `docs/superpowers/discovery/`. | **Read the discovery report** (~5 min). Confirm selectors / approve FE testid additions. |
+| 4. POMs + tests + FE testids | Writes the POMs against the confirmed selectors, writes the tests, adds any FE testids needed, runs the full suite against staging. | (auto-proceed; review the staging stdout) |
+| 5. PR | Pushes branch, opens PR via `comet:create-pr`, transitions Jira to "In Review". | Review the PR like any other. |
+
+The agent stops between phases. Don't dispatch the next phase yourself — the agent prompts you when each gate needs your input.
+
+## Credentials
+
+The kickoff prompt's last section tells the agent to wait for credentials. After pasting the prompt, your follow-up message provides them. Either:
+
+**Option A (per-session paste):**
+
+```
+Staging credentials:
+
+OPIK_API_KEY=<your staging API key>
+OPIK_TEST_USER_EMAIL=<your staging email>
+OPIK_TEST_USER_PASSWORD=<your staging password>
+OPIK_WORKSPACE=<your workspace>
+OPIK_TEST_USER_NAME=<your workspace>
+OPIK_BASE_URL=https://staging.dev.comet.com/opik
+OPIK_DEPLOYMENT=cloud
+```
+
+**Option B (persistent `.env.cloud`):** create `tests_end_to_end/e2e/.env.cloud` (gitignored, won't be committed) with the env-var lines, and tell the agent "source .env.cloud before running tests." The agent then runs `set -a; source /full/path/to/tests_end_to_end/e2e/.env.cloud; set +a` before staging verification.
+
+Option B saves typing across multiple tickets; Option A is fine for one-off tickets.
+
+The `.env.cloud.example` file in this directory documents the full env-var shape.
+
+### Credential hygiene (read before your first run)
+
+- `.env.cloud` is gitignored. Never `git add` it. Never copy its contents into a PR description, Jira comment, screenshot, or any chat message outside the Claude Code session you're driving.
+- The agent is instructed not to log credentials, but the human in the loop is the last line of defence. If you see a credential about to surface in a PR body or a public artifact, redact it before sending.
+- If a staging credential ever leaks (committed, screenshotted, posted publicly), rotate it immediately via the Comet staging admin and tell the team — don't wait to see if anyone noticed.
+
+## Per-ticket work-log conventions
+
+Specs, plans, and discovery reports the agent writes for YOUR ticket are work-logs, not team artifacts. They live under `docs/superpowers/specs/`, `docs/superpowers/plans/`, `docs/superpowers/discovery/` on your local machine and are **gitignored** — they never enter PRs.
+
+The reusable team artifacts (the kickoff prompt, the rules, the skill, this doc) DO live in the tracked repo. The agent knows the difference.
+
+## Asking for help
+
+If the agent gets stuck or surprises you (e.g., proposes scope creep, picks the wrong fixture parent, writes selectors against FE source without inspecting the DOM) — that's a signal worth surfacing. Retro lessons grow from these moments. If you spot a class of mistake that's likely to recur, post in the QA channel; we'll either tighten the rule, sharpen the kickoff prompt, or both.
+
+## What's NOT here yet
+
+This workflow currently covers the **data-plane CUJ tests** (the 6 tickets listed at the top). It does NOT yet cover:
+
+- The agent-side CUJs (Agent Configuration, Playground Pairing, Ollie Instrument, Skills Instrument) — those depend on `goldenAgent` / `localRunner` / `ollieSession` / `claudeCodeAgent` fixtures that aren't built yet. When that work starts, this doc and the kickoff prompt will be updated.
+- AI-augmented capabilities (LLM-as-judge matchers, self-healing selectors, AI failure summaries) — Layer B / Layer C work, future scope.
+
+For anything outside the data-plane CUJ scope, fall back to the general Claude Code workflow (skills, brainstorming, etc.) rather than this kickoff prompt.


### PR DESCRIPTION
## Details

Promote the Claude Code workflow artifacts for Opik 2.0 E2E CUJ tests from local-only to tracked so the team can use the same loop. Six files: gitignore flip (selective `.claude/` ignore), the CUJ workflow skill + its supplementary retro-lessons file under `.agents/skills/playwright-pom-discovery/`, a thin auto-loaded rule pointing at the skill, the universal kickoff prompt, and an onboarding doc.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: assisted (workflow design + drafting)
- Human verification: locally inspected each file; tested gitignore selectivity via \`git check-ignore\`

## Testing

No source changes — docs + gitignore only. \`git check-ignore\` confirms \`.claude/rules/\` is now trackable while \`.claude/skills/\`, \`.claude/worktrees/\`, \`.claude/agents/\`, \`.claude/commands/\`, \`.claude/settings.local.json\` remain ignored. End-to-end smoke against a real teammate's fresh Claude Code session is deferred to the next CUJ ticket assignment.

## Documentation

This PR IS the documentation: \`tests_end_to_end/e2e/AGENTIC.md\` (onboarding) and \`tests_end_to_end/e2e/.agentic/cuj-test-kickoff.md\` (per-ticket kickoff prompt).