### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -17900,9 +17900,14 @@ components:
           - total_cost
         current_value:
           type: number
+          description: "Metric value for the current period. Unit depends on `type`:\
+            \ `count` is an integer count; `errors` is a percentage in [0, 100]; `avg_duration`\
+            \ is milliseconds; `total_cost` is in USD."
           format: double
         previous_value:
           type: number
+          description: Metric value for the immediately preceding period of equal
+            length. Same unit as `current_value`.
           format: double
     KpiCardRequest:
       required:

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -17900,9 +17900,14 @@ components:
           - total_cost
         current_value:
           type: number
+          description: "Metric value for the current period. Unit depends on `type`:\
+            \ `count` is an integer count; `errors` is a percentage in [0, 100]; `avg_duration`\
+            \ is milliseconds; `total_cost` is in USD."
           format: double
         previous_value:
           type: number
+          description: Metric value for the immediately preceding period of equal
+            length. Same unit as `current_value`.
           format: double
     KpiCardRequest:
       required:

--- a/sdks/python/src/opik/rest_api/types/kpi_metric.py
+++ b/sdks/python/src/opik/rest_api/types/kpi_metric.py
@@ -9,8 +9,15 @@ from .kpi_metric_type import KpiMetricType
 
 class KpiMetric(UniversalBaseModel):
     type: typing.Optional[KpiMetricType] = None
-    current_value: typing.Optional[float] = None
-    previous_value: typing.Optional[float] = None
+    current_value: typing.Optional[float] = pydantic.Field(default=None)
+    """
+    Metric value for the current period. Unit depends on `type`: `count` is an integer count; `errors` is a percentage in [0, 100]; `avg_duration` is milliseconds; `total_cost` is in USD.
+    """
+
+    previous_value: typing.Optional[float] = pydantic.Field(default=None)
+    """
+    Metric value for the immediately preceding period of equal length. Same unit as `current_value`.
+    """
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/typescript/src/opik/rest_api/api/types/KpiMetric.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/KpiMetric.ts
@@ -4,6 +4,8 @@ import type * as OpikApi from "../index.js";
 
 export interface KpiMetric {
     type?: OpikApi.KpiMetricType;
+    /** Metric value for the current period. Unit depends on `type`: `count` is an integer count; `errors` is a percentage in [0, 100]; `avg_duration` is milliseconds; `total_cost` is in USD. */
     currentValue?: number;
+    /** Metric value for the immediately preceding period of equal length. Same unit as `current_value`. */
     previousValue?: number;
 }


### PR DESCRIPTION
## Details
Automated update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

**Triggered by BE merge:** https://github.com/comet-ml/opik/pull/6912

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate