### PR TITLE
[issue-6721] [DOCS] docs: add qianfan integration docs

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/overview.mdx
@@ -95,6 +95,7 @@ Opik helps you easily log, visualize, and evaluate everything from raw LLM calls
   <Card title="Novita AI" href="/integrations/novita-ai" />
   <Card title="Ollama" href="/integrations/ollama" />
   <Card title="OpenAI" href="/integrations/openai" />
+  <Card title="Qianfan" href="/integrations/qianfan" />
   <Card title="Predibase" href="/integrations/predibase" />
   <Card title="Together AI" href="/integrations/together-ai" />
   <Card title="WatsonX" href="/integrations/watsonx" />

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/qianfan.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/qianfan.mdx
@@ -1,0 +1,115 @@
+---
+description: Start here to integrate Opik into your Qianfan-based genai application
+  for end-to-end LLM observability, unit testing, and optimization.
+headline: Qianfan | Opik Documentation
+og:description: Learn to integrate Opik with Qianfan using the OpenAI SDK for
+  OpenAI-compatible endpoints.
+og:site_name: Opik Documentation
+og:title: Integrate Opik with Qianfan for AI Observability
+title: Observability for Qianfan with Opik
+---
+
+[Baidu Qianfan](https://cloud.baidu.com/doc/qianfan/index.html) provides OpenAI-compatible
+API endpoints for hosted model access. This guide shows how to use the OpenAI SDK with
+Opik to trace and evaluate Qianfan calls.
+
+## Getting started
+
+First, ensure you have both `opik` and `openai` packages installed:
+
+```bash
+pip install opik openai
+```
+
+You will need a Qianfan API key and an OpenAI-compatible base URL. The Qianfan
+OpenAI-compatible base URL is:
+
+`https://api.baiduqianfan.ai/v1`
+
+Refer to the [Qianfan documentation](https://intl.cloud.baidu.com/en/doc/qianfan/s/qm8qxemze-intl-en)
+for the latest setup steps and model list.
+
+## Tracking Qianfan API calls
+
+```python
+from opik.integrations.openai import track_openai
+from openai import OpenAI
+
+# Initialize the OpenAI client with your Qianfan base URL
+client = OpenAI(
+    base_url="https://api.baiduqianfan.ai/v1",
+    api_key="bce-v3/ALTAK-XXXXXXXX/XXXXXXXXXXXXXXXX",  # Qianfan bearer token
+    default_headers={"appid": "app-xxxxxx"}  # Optional Qianfan appid
+)
+client = track_openai(client)
+
+response = client.chat.completions.create(
+    model="ernie-4.0-turbo-8k",  # Use a model name from Qianfan
+    messages=[
+        {"role": "user", "content": "Hello, world!"}
+    ],
+    temperature=0.7,
+    max_tokens=100
+)
+
+print(response.choices[0].message.content)
+```
+
+## Advanced Usage
+
+### Using with @track decorator
+
+You can combine the tracked client with Opik's `@track` decorator for
+end-to-end tracing:
+
+```python
+from opik import track
+from opik.integrations.openai import track_openai
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.baiduqianfan.ai/v1",
+    api_key="bce-v3/ALTAK-XXXXXXXX/XXXXXXXXXXXXXXXX",  # Qianfan bearer token
+    default_headers={"appid": "app-xxxxxx"}  # Optional Qianfan appid
+)
+client = track_openai(client)
+
+@track
+def summarize_report(text: str) -> str:
+    response = client.chat.completions.create(
+        model="ernie-4.0-turbo-8k",
+        messages=[
+            {"role": "user", "content": text}
+        ]
+    )
+
+    return response.choices[0].message.content
+
+summary = summarize_report("Summarize this report in 3 bullets.")
+print(summary)
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Authentication Errors**: Confirm your API key is valid and has access to Qianfan
+2. **Model Not Found**: Verify the model name matches one available in Qianfan
+3. **Base URL Issues**: Ensure you are using the OpenAI-compatible endpoint from Qianfan
+
+### Getting Help
+
+- Review the [Qianfan documentation](https://cloud.baidu.com/doc/qianfan/index.html)
+- Check Opik tracing docs for setup details: [/tracing/advanced/sdk_configuration](/tracing/advanced/sdk_configuration)
+
+## Next Steps
+
+Once you have Qianfan integrated with Opik, you can:
+
+- [Evaluate your LLM applications](/evaluation/overview)
+- [Create datasets](/evaluation/advanced/manage_datasets)
+- [Collect feedback](/tracing/advanced/annotate_traces)
+- [Monitor traces](/tracing/concepts)
+
+For more information about OpenAI-compatible APIs, see the
+[OpenAI integration guide](/integrations/openai).

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/overview.mdx
@@ -95,6 +95,7 @@ Opik helps you easily log, visualize, and evaluate everything from raw LLM calls
   <Card title="Novita AI" href="/v1/integrations/novita-ai" />
   <Card title="Ollama" href="/v1/integrations/ollama" />
   <Card title="OpenAI" href="/v1/integrations/openai" />
+  <Card title="Qianfan" href="/v1/integrations/qianfan" />
   <Card title="Predibase" href="/v1/integrations/predibase" />
   <Card title="Together AI" href="/v1/integrations/together-ai" />
   <Card title="WatsonX" href="/v1/integrations/watsonx" />

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/qianfan.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/qianfan.mdx
@@ -38,8 +38,8 @@ from openai import OpenAI
 # Initialize the OpenAI client with your Qianfan base URL
 client = OpenAI(
     base_url="https://api.baiduqianfan.ai/v1",
-    api_key="bce-v3/ALTAK-XXXXXXXX/XXXXXXXXXXXXXXXX",  # Qianfan bearer token
-    default_headers={"appid": "app-xxxxxx"}  # Optional Qianfan appid
+    api_key="<QIANFAN_BEARER_TOKEN>",  # Qianfan bearer token
+    default_headers={"appid": "<QIANFAN_APP_ID>"}  # Optional Qianfan appid
 )
 client = track_openai(client)
 
@@ -69,8 +69,8 @@ from openai import OpenAI
 
 client = OpenAI(
     base_url="https://api.baiduqianfan.ai/v1",
-    api_key="bce-v3/ALTAK-XXXXXXXX/XXXXXXXXXXXXXXXX",  # Qianfan bearer token
-    default_headers={"appid": "app-xxxxxx"}  # Optional Qianfan appid
+    api_key="<QIANFAN_BEARER_TOKEN>",  # Qianfan bearer token
+    default_headers={"appid": "<QIANFAN_APP_ID>"}  # Optional Qianfan appid
 )
 client = track_openai(client)
 

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/qianfan.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/qianfan.mdx
@@ -1,0 +1,115 @@
+---
+description: Start here to integrate Opik into your Qianfan-based genai application
+  for end-to-end LLM observability, unit testing, and optimization.
+headline: Qianfan | Opik Documentation
+og:description: Learn to integrate Opik with Qianfan using the OpenAI SDK for
+  OpenAI-compatible endpoints.
+og:site_name: Opik Documentation
+og:title: Integrate Opik with Qianfan for AI Observability
+title: Observability for Qianfan with Opik
+---
+
+[Baidu Qianfan](https://cloud.baidu.com/doc/qianfan/index.html) provides OpenAI-compatible
+API endpoints for hosted model access. This guide shows how to use the OpenAI SDK with
+Opik to trace and evaluate Qianfan calls.
+
+## Getting started
+
+First, ensure you have both `opik` and `openai` packages installed:
+
+```bash
+pip install opik openai
+```
+
+You will need a Qianfan API key and an OpenAI-compatible base URL. The Qianfan
+OpenAI-compatible base URL is:
+
+`https://api.baiduqianfan.ai/v1`
+
+Refer to the [Qianfan documentation](https://intl.cloud.baidu.com/en/doc/qianfan/s/qm8qxemze-intl-en)
+for the latest setup steps and model list.
+
+## Tracking Qianfan API calls
+
+```python
+from opik.integrations.openai import track_openai
+from openai import OpenAI
+
+# Initialize the OpenAI client with your Qianfan base URL
+client = OpenAI(
+    base_url="https://api.baiduqianfan.ai/v1",
+    api_key="bce-v3/ALTAK-XXXXXXXX/XXXXXXXXXXXXXXXX",  # Qianfan bearer token
+    default_headers={"appid": "app-xxxxxx"}  # Optional Qianfan appid
+)
+client = track_openai(client)
+
+response = client.chat.completions.create(
+    model="ernie-4.0-turbo-8k",  # Use a model name from Qianfan
+    messages=[
+        {"role": "user", "content": "Hello, world!"}
+    ],
+    temperature=0.7,
+    max_tokens=100
+)
+
+print(response.choices[0].message.content)
+```
+
+## Advanced Usage
+
+### Using with @track decorator
+
+You can combine the tracked client with Opik's `@track` decorator for
+end-to-end tracing:
+
+```python
+from opik import track
+from opik.integrations.openai import track_openai
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.baiduqianfan.ai/v1",
+    api_key="bce-v3/ALTAK-XXXXXXXX/XXXXXXXXXXXXXXXX",  # Qianfan bearer token
+    default_headers={"appid": "app-xxxxxx"}  # Optional Qianfan appid
+)
+client = track_openai(client)
+
+@track
+def summarize_report(text: str) -> str:
+    response = client.chat.completions.create(
+        model="ernie-4.0-turbo-8k",
+        messages=[
+            {"role": "user", "content": text}
+        ]
+    )
+
+    return response.choices[0].message.content
+
+summary = summarize_report("Summarize this report in 3 bullets.")
+print(summary)
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Authentication Errors**: Confirm your API key is valid and has access to Qianfan
+2. **Model Not Found**: Verify the model name matches one available in Qianfan
+3. **Base URL Issues**: Ensure you are using the OpenAI-compatible endpoint from Qianfan
+
+### Getting Help
+
+- Review the [Qianfan documentation](https://cloud.baidu.com/doc/qianfan/index.html)
+- Check Opik tracing docs for setup details: [/v1/tracing/sdk_configuration](/v1/tracing/sdk_configuration)
+
+## Next Steps
+
+Once you have Qianfan integrated with Opik, you can:
+
+- [Evaluate your LLM applications](/v1/evaluation/overview)
+- [Create datasets](/v1/evaluation/manage_datasets)
+- [Collect feedback](/v1/tracing/annotate_traces)
+- [Monitor traces](/v1/tracing/concepts)
+
+For more information about OpenAI-compatible APIs, see the
+[OpenAI integration guide](/v1/integrations/openai).

--- a/apps/opik-documentation/documentation/fern/versions/latest.yml
+++ b/apps/opik-documentation/documentation/fern/versions/latest.yml
@@ -729,6 +729,9 @@ navigation:
               - page: OpenAI
                 path: ../docs-v2/integrations/openai.mdx
                 slug: openai
+              - page: Qianfan
+                path: ../docs-v2/integrations/qianfan.mdx
+                slug: qianfan
               - page: Predibase
                 path: ../docs-v2/integrations/predibase.mdx
                 slug: predibase

--- a/apps/opik-documentation/documentation/fern/versions/v1.yml
+++ b/apps/opik-documentation/documentation/fern/versions/v1.yml
@@ -552,6 +552,9 @@ navigation:
               - page: OpenAI
                 path: ../docs/tracing/integrations/openai.mdx
                 slug: openai
+              - page: Qianfan
+                path: ../docs/tracing/integrations/qianfan.mdx
+                slug: qianfan
               - page: Predibase
                 path: ../docs/tracing/integrations/predibase.mdx
                 slug: predibase


### PR DESCRIPTION
## Details
Add Qianfan integration docs for OpenAI-compatible tracing and wire them into the integrations overview and navigation for both v1 and v2 docs.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- Resolves #6721
- OPIK-NA

## AI-WATERMARK
AI-WATERMARK: yes

- Tools: GitHub Copilot
- Model(s): GPT-5.2-Codex
- Scope: Drafted Qianfan integration docs and navigation updates
- Human verification: Manually reviewed the changes

## Testing
Not run (docs project has no test script in package.json).

## Documentation
Added Qianfan integration docs (v1 and v2) and linked them in integrations overview and navigation.