### PR TITLE
[OPIK-5435] [FE] fix: show trace logs inline on annotation queue page

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
@@ -99,6 +99,7 @@ export type ThreadDetailsPanelProps = {
   open: boolean;
   onClose: () => void;
   onRowChange?: (shift: number) => void;
+  container?: HTMLElement | null;
   hideAnnotateActions?: boolean;
 };
 
@@ -115,6 +116,7 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
   open,
   onClose,
   onRowChange,
+  container,
   hideAnnotateActions,
 }) => {
   const navigate = useNavigate();
@@ -707,6 +709,7 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
       initialWidth={0.5}
       minWidth={700}
       horizontalNavigation={horizontalNavigation}
+      container={container}
     >
       {renderContent()}
     </ResizableSidePanel>

--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
@@ -88,7 +88,7 @@ import { FeatureToggleKeys } from "@/types/feature-toggles";
 import { LOGS_TYPE } from "@/constants/traces";
 import { useHotkeys } from "react-hotkeys-hook";
 
-type ThreadDetailsPanelProps = {
+export type ThreadDetailsPanelProps = {
   projectId: string;
   projectName: string;
   threadId: string;

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel.tsx
@@ -88,7 +88,7 @@ const TraceDataSkeleton: React.FC = () => (
   </div>
 );
 
-type TraceDetailsPanelProps = {
+export type TraceDetailsPanelProps = {
   projectId?: string;
   traceId: string;
   spanId: string;

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
@@ -757,7 +757,12 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
     return allRows.filter((row) => selectedIds.includes(row.id)) as Trace[];
   }, [refetchExportData, rowSelection]);
 
-  const { traceId, handleRowClick, panels } = useTraceThreadPanelsState<Trace>({
+  const {
+    traceId,
+    handleRowClick,
+    handleClose: clearPanelsState,
+    panels,
+  } = useTraceThreadPanelsState<Trace>({
     rows,
     type: "trace",
     queryPrefix: TLS_QUERY_PREFIX,
@@ -818,10 +823,11 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
   const handleOpenChange = useCallback(
     (isOpen: boolean) => {
       if (!isOpen) {
+        clearPanelsState();
         onClose();
       }
     },
-    [onClose],
+    [clearPanelsState, onClose],
   );
 
   const sortConfig = useMemo(

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
@@ -763,6 +763,11 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
     queryPrefix: TLS_QUERY_PREFIX,
     manageLastSection: true,
     traceDetailsPanelProps: { projectId, container: sheetContentRef },
+    threadDetailsPanelProps: {
+      projectId,
+      projectName,
+      container: sheetContentRef,
+    },
   });
 
   const columns = useMemo(() => {

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebar.tsx
@@ -11,7 +11,6 @@ import {
   ColumnSort,
   RowSelectionState,
 } from "@tanstack/react-table";
-import findIndex from "lodash/findIndex";
 import isObject from "lodash/isObject";
 import isNumber from "lodash/isNumber";
 import isArray from "lodash/isArray";
@@ -78,7 +77,6 @@ import CommentsCell from "@/shared/DataTableCells/CommentsCell";
 import FeedbackScoreHeader from "@/shared/DataTableHeaders/FeedbackScoreHeader";
 import { formatScoreDisplay } from "@/lib/feedback-scores";
 import DataTableStateHandler from "@/shared/DataTableStateHandler/DataTableStateHandler";
-import TraceDetailsPanel from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel";
 import TracesOrSpansPathsAutocomplete from "@/v2/pages-shared/traces/TracesOrSpansPathsAutocomplete/TracesOrSpansPathsAutocomplete";
 import TracesOrSpansFeedbackScoresSelect from "@/v2/pages-shared/traces/TracesOrSpansFeedbackScoresSelect/TracesOrSpansFeedbackScoresSelect";
 import ErrorTypeAutocomplete from "@/v2/pages-shared/traces/ErrorTypeAutocomplete/ErrorTypeAutocomplete";
@@ -89,10 +87,7 @@ import useTracesStatistic from "@/api/traces/useTracesStatistic";
 import { useDynamicColumnsCache } from "@/hooks/useDynamicColumnsCache";
 import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
-import {
-  DetailsActionSectionParam,
-  DetailsActionSectionValue,
-} from "@/v2/pages-shared/traces/DetailsActionSection";
+import useTraceThreadPanelsState from "@/v2/pages-shared/traces/useTraceThreadPanelsState";
 import { Filter } from "@/types/filters";
 import { useTruncationEnabled } from "@/contexts/server-sync-provider";
 
@@ -424,22 +419,6 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
     null,
   );
 
-  const [traceId = "", setTraceId] = useQueryParam(
-    `${TLS_QUERY_PREFIX}trace`,
-    StringParam,
-    {
-      updateType: "replaceIn",
-    },
-  );
-
-  const [spanId = "", setSpanId] = useQueryParam(
-    `${TLS_QUERY_PREFIX}span`,
-    StringParam,
-    {
-      updateType: "replaceIn",
-    },
-  );
-
   const [page = 1, setPage] = useQueryParam(
     `${TLS_QUERY_PREFIX}page`,
     NumberParam,
@@ -457,14 +436,6 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
     queryParamConfig: NumberParam,
     syncQueryWithLocalStorageOnInit: true,
   });
-
-  const [, setLastSection] = useQueryParam(
-    `${TLS_QUERY_PREFIX}lastSection`,
-    DetailsActionSectionParam,
-    {
-      updateType: "replaceIn",
-    },
-  );
 
   const [height, setHeight] = useQueryParamAndLocalStorageState<
     string | null | undefined
@@ -786,18 +757,13 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
     return allRows.filter((row) => selectedIds.includes(row.id)) as Trace[];
   }, [refetchExportData, rowSelection]);
 
-  const handleRowClick = useCallback(
-    (row?: Trace, lastSection?: DetailsActionSectionValue) => {
-      if (!row) return;
-      setTraceId((state) => (row.id === state ? "" : row.id));
-      setSpanId("");
-
-      if (lastSection) {
-        setLastSection(lastSection);
-      }
-    },
-    [setTraceId, setSpanId, setLastSection],
-  );
+  const { traceId, handleRowClick, panels } = useTraceThreadPanelsState<Trace>({
+    rows,
+    type: "trace",
+    queryPrefix: TLS_QUERY_PREFIX,
+    manageLastSection: true,
+    traceDetailsPanelProps: { projectId, container: sheetContentRef },
+  });
 
   const columns = useMemo(() => {
     return [
@@ -843,20 +809,6 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
   }, [columns, selectedColumns]);
 
   const activeRowId = traceId;
-  const rowIndex = findIndex(rows, (row) => activeRowId === row.id);
-
-  const hasNext = rowIndex >= 0 ? rowIndex < rows.length - 1 : false;
-  const hasPrevious = rowIndex >= 0 ? rowIndex > 0 : false;
-
-  const handleRowChange = useCallback(
-    (shift: number) => handleRowClick(rows[rowIndex + shift]),
-    [handleRowClick, rowIndex, rows],
-  );
-
-  const handleClose = useCallback(() => {
-    setTraceId("");
-    setSpanId("");
-  }, [setSpanId, setTraceId]);
 
   const handleOpenChange = useCallback(
     (isOpen: boolean) => {
@@ -1053,18 +1005,7 @@ const TraceLogsSidebar: React.FunctionComponent<TraceLogsSidebarProps> = ({
             />
           </div>
         </div>
-        <TraceDetailsPanel
-          projectId={projectId}
-          traceId={traceId!}
-          spanId={spanId!}
-          setSpanId={setSpanId}
-          hasPreviousRow={hasPrevious}
-          hasNextRow={hasNext}
-          open={Boolean(traceId)}
-          onClose={handleClose}
-          onRowChange={handleRowChange}
-          container={sheetContentRef}
-        />
+        {panels}
       </SheetContent>
     </Sheet>
   );

--- a/apps/opik-frontend/src/v2/pages-shared/traces/useTraceThreadPanelsState.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/useTraceThreadPanelsState.tsx
@@ -1,0 +1,165 @@
+import React, { useCallback, useMemo } from "react";
+import { StringParam, useQueryParam } from "use-query-params";
+import findIndex from "lodash/findIndex";
+
+import TraceDetailsPanel, {
+  TraceDetailsPanelProps,
+} from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel";
+import ThreadDetailsPanel, {
+  ThreadDetailsPanelProps,
+} from "@/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel";
+import {
+  DetailsActionSectionParam,
+  DetailsActionSectionValue,
+} from "@/v2/pages-shared/traces/DetailsActionSection";
+
+type UseTraceThreadPanelsStateOpts<TRow extends { id: string }> = {
+  rows: TRow[];
+  type: "trace" | "thread";
+  traceDetailsPanelProps: Partial<TraceDetailsPanelProps>;
+  threadDetailsPanelProps?: Partial<ThreadDetailsPanelProps> &
+    Pick<ThreadDetailsPanelProps, "projectId" | "projectName">;
+  queryPrefix?: string;
+  manageLastSection?: boolean;
+};
+
+const useTraceThreadPanelsState = <TRow extends { id: string }>({
+  rows,
+  type,
+  traceDetailsPanelProps,
+  threadDetailsPanelProps,
+  queryPrefix = "",
+  manageLastSection = false,
+}: UseTraceThreadPanelsStateOpts<TRow>) => {
+  const [traceId = "", setTraceId] = useQueryParam(
+    `${queryPrefix}trace`,
+    StringParam,
+    { updateType: "replaceIn" },
+  );
+
+  const [spanId = "", setSpanId] = useQueryParam(
+    `${queryPrefix}span`,
+    StringParam,
+    { updateType: "replaceIn" },
+  );
+
+  const [threadId = "", setThreadId] = useQueryParam(
+    `${queryPrefix}thread`,
+    StringParam,
+    { updateType: "replaceIn" },
+  );
+
+  const [, setLastSection] = useQueryParam(
+    `${queryPrefix}lastSection`,
+    DetailsActionSectionParam,
+    { updateType: "replaceIn" },
+  );
+
+  const handleRowClick = useCallback(
+    (row?: TRow, lastSection?: DetailsActionSectionValue) => {
+      if (!row) return;
+
+      if (type === "trace") {
+        setTraceId((state) => (row.id === state ? "" : row.id));
+        setSpanId("");
+      } else {
+        setThreadId((state) => (row.id === state ? "" : row.id));
+      }
+
+      if (manageLastSection && lastSection) {
+        setLastSection(lastSection);
+      }
+    },
+    [
+      type,
+      manageLastSection,
+      setTraceId,
+      setSpanId,
+      setThreadId,
+      setLastSection,
+    ],
+  );
+
+  const handleThreadIdClick = useCallback(
+    (row?: { id: string; thread_id?: string }) => {
+      if (!row || !row.thread_id) return;
+      setThreadId(row.thread_id);
+      setTraceId(row.id);
+    },
+    [setThreadId, setTraceId],
+  );
+
+  const activeRowId = type === "trace" ? traceId ?? "" : threadId ?? "";
+
+  const rowIndex = useMemo(
+    () => findIndex(rows, (row) => row.id === activeRowId),
+    [rows, activeRowId],
+  );
+
+  const hasNext = rowIndex >= 0 ? rowIndex < rows.length - 1 : false;
+  const hasPrevious = rowIndex >= 0 ? rowIndex > 0 : false;
+
+  const handleRowChange = useCallback(
+    (shift: number) => handleRowClick(rows[rowIndex + shift]),
+    [handleRowClick, rowIndex, rows],
+  );
+
+  const handleClose = useCallback(() => {
+    setTraceId("");
+    setSpanId("");
+    setThreadId("");
+  }, [setTraceId, setSpanId, setThreadId]);
+
+  const renderThreadPanel = Boolean(threadDetailsPanelProps);
+
+  const panels = (
+    <>
+      <TraceDetailsPanel
+        {...traceDetailsPanelProps}
+        traceId={traceId ?? ""}
+        spanId={spanId ?? ""}
+        setSpanId={setSpanId}
+        setThreadId={renderThreadPanel ? setThreadId : undefined}
+        hasPreviousRow={type === "trace" ? hasPrevious : undefined}
+        hasNextRow={type === "trace" ? hasNext : undefined}
+        onRowChange={type === "trace" ? handleRowChange : undefined}
+        open={
+          renderThreadPanel ? Boolean(traceId) && !threadId : Boolean(traceId)
+        }
+        onClose={handleClose}
+      />
+      {threadDetailsPanelProps && (
+        <ThreadDetailsPanel
+          {...threadDetailsPanelProps}
+          traceId={traceId ?? ""}
+          threadId={threadId ?? ""}
+          setTraceId={setTraceId}
+          hasPreviousRow={type === "thread" ? hasPrevious : undefined}
+          hasNextRow={type === "thread" ? hasNext : undefined}
+          onRowChange={type === "thread" ? handleRowChange : undefined}
+          open={Boolean(threadId)}
+          onClose={handleClose}
+        />
+      )}
+    </>
+  );
+
+  return {
+    traceId: traceId ?? "",
+    spanId: spanId ?? "",
+    threadId: threadId ?? "",
+    setTraceId,
+    setSpanId,
+    setThreadId,
+    activeRowId,
+    hasNext,
+    hasPrevious,
+    handleRowClick,
+    handleThreadIdClick,
+    handleRowChange,
+    handleClose,
+    panels,
+  };
+};
+
+export default useTraceThreadPanelsState;

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
@@ -9,6 +9,7 @@ import { useAnnotationQueueIdFromURL } from "@/v2/pages/AnnotationQueuePage/useA
 import DateTag from "@/shared/DateTag/DateTag";
 import { RESOURCE_TYPE } from "@/shared/ResourceLink/ResourceLink";
 import NavigationTag from "@/shared/NavigationTag";
+import TraceLogsSidebarButton from "@/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebarButton";
 import FeedbackScoresList from "@/v2/pages-shared/FeedbackScoresList/FeedbackScoresList";
 import ConfigurationTab from "@/v2/pages/AnnotationQueuePage/ConfigurationTab/ConfigurationTab";
 import QueueItemsTab from "@/v2/pages/AnnotationQueuePage/QueueItemsTab/QueueItemsTab";
@@ -113,23 +114,26 @@ const AnnotationQueuePage: React.FunctionComponent = () => {
               resource={RESOURCE_TYPE.annotationQueue}
             />
           )}
-          {annotationQueue?.scope && annotationQueue?.project_id && (
-            <NavigationTag
-              resource={
-                annotationQueue.scope === ANNOTATION_QUEUE_SCOPE.TRACE
-                  ? RESOURCE_TYPE.traces
-                  : RESOURCE_TYPE.threads
-              }
-              id={annotationQueue.project_id}
-              name={
-                annotationQueue.scope === ANNOTATION_QUEUE_SCOPE.TRACE
-                  ? "Go to traces"
-                  : "Go to threads"
-              }
-              search={annotationQueueSearch}
-              tooltipContent={`View all ${annotationQueue.scope}s for this queue`}
-            />
-          )}
+          {annotationQueue?.scope === ANNOTATION_QUEUE_SCOPE.TRACE &&
+            annotationQueue?.project_id && (
+              <TraceLogsSidebarButton
+                projectId={annotationQueue.project_id}
+                sourceFilters={generateAnnotationQueueIdFilter(
+                  annotationQueue.id,
+                )}
+                title="Logs"
+              />
+            )}
+          {annotationQueue?.scope === ANNOTATION_QUEUE_SCOPE.THREAD &&
+            annotationQueue?.project_id && (
+              <NavigationTag
+                resource={RESOURCE_TYPE.threads}
+                id={annotationQueue.project_id}
+                name="Go to threads"
+                search={annotationQueueSearch}
+                tooltipContent="View all threads for this queue"
+              />
+            )}
           {annotationQueue?.project_id && (
             <NavigationTag
               id={annotationQueue.project_id}

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import {
   JsonParam,
   NumberParam,
@@ -62,7 +62,7 @@ import { ExternalLink } from "lucide-react";
 import { LOGS_TYPE } from "@/constants/traces";
 import useThreadsList from "@/api/traces/useThreadsList";
 import TimeCell from "@/shared/DataTableCells/TimeCell";
-import { generateTracesURL } from "@/lib/annotation-queues";
+import useTraceThreadPanelsState from "@/v2/pages-shared/traces/useTraceThreadPanelsState";
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import useAppStore from "@/store/AppStore";
 import { generateAnnotationQueueIdFilter } from "@/lib/filters";
@@ -405,21 +405,16 @@ const ThreadQueueItemsTab: React.FunctionComponent<
     return rows.filter((row) => rowSelection[row.id]);
   }, [rowSelection, rows]);
 
-  // TODO: Temporary workaround to open in new tab until sidebars are integrated in the page
-  const handleRowClick = useCallback(
-    (row: Thread) => {
-      if (!row) return;
-
-      const url = generateTracesURL(
-        workspaceName,
-        annotationQueue.project_id,
-        "threads",
-        row.id,
-      );
-      window.open(url, "_blank");
-    },
-    [workspaceName, annotationQueue.project_id],
-  );
+  const { threadId, handleRowClick, panels } =
+    useTraceThreadPanelsState<Thread>({
+      rows,
+      type: "thread",
+      traceDetailsPanelProps: { projectId: annotationQueue.project_id },
+      threadDetailsPanelProps: {
+        projectId: annotationQueue.project_id,
+        projectName: annotationQueue.project_name,
+      },
+    });
 
   const columns = useMemo(() => {
     const convertedColumns = convertColumnDataToColumn<Thread, Thread>(
@@ -533,6 +528,7 @@ const ThreadQueueItemsTab: React.FunctionComponent<
         columns={columns}
         data={rows}
         onRowClick={handleRowClick}
+        activeRowId={threadId}
         sortConfig={sortConfig}
         resizeConfig={resizeConfig}
         selectionConfig={{
@@ -583,6 +579,7 @@ const ThreadQueueItemsTab: React.FunctionComponent<
           truncationEnabled={truncationEnabled}
         />
       </PageBodyStickyContainer>
+      {panels}
     </>
   );
 };

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import {
   JsonParam,
   NumberParam,
@@ -74,7 +74,7 @@ import useTracesList from "@/api/traces/useTracesList";
 import { formatDuration } from "@/lib/date";
 import { formatCost } from "@/lib/money";
 import TimeCell from "@/shared/DataTableCells/TimeCell";
-import { generateTracesURL } from "@/lib/annotation-queues";
+import useTraceThreadPanelsState from "@/v2/pages-shared/traces/useTraceThreadPanelsState";
 import useTracesStatistic from "@/api/traces/useTracesStatistic";
 import useAppStore from "@/store/AppStore";
 import { generateAnnotationQueueIdFilter } from "@/lib/filters";
@@ -482,36 +482,16 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
     return rows.filter((row) => rowSelection[row.id]);
   }, [rowSelection, rows]);
 
-  // TODO: Temporary workaround to open in new tab until sidebars are integrated in the page
-  const handleRowClick = useCallback(
-    (row: Trace) => {
-      if (!row) return;
-
-      const url = generateTracesURL(
-        workspaceName,
-        annotationQueue.project_id,
-        "traces",
-        row.id,
-      );
-      window.open(url, "_blank");
-    },
-    [workspaceName, annotationQueue.project_id],
-  );
-
-  const handleThreadIdClick = useCallback(
-    (row: Trace) => {
-      if (!row || !row.thread_id) return;
-
-      const url = generateTracesURL(
-        workspaceName,
-        annotationQueue.project_id,
-        "threads",
-        row.thread_id,
-      );
-      window.open(url, "_blank");
-    },
-    [workspaceName, annotationQueue.project_id],
-  );
+  const { traceId, handleRowClick, handleThreadIdClick, panels } =
+    useTraceThreadPanelsState<Trace>({
+      rows,
+      type: "trace",
+      traceDetailsPanelProps: { projectId: annotationQueue.project_id },
+      threadDetailsPanelProps: {
+        projectId: annotationQueue.project_id,
+        projectName: annotationQueue.project_name,
+      },
+    });
 
   const columns = useMemo(() => {
     const convertedColumns = convertColumnDataToColumn<Trace, Trace>(
@@ -631,6 +611,7 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
         columnsStatistic={columnsStatistic}
         data={rows}
         onRowClick={handleRowClick}
+        activeRowId={traceId}
         sortConfig={sortConfig}
         resizeConfig={resizeConfig}
         selectionConfig={{
@@ -681,6 +662,7 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
           truncationEnabled={truncationEnabled}
         />
       </PageBodyStickyContainer>
+      {panels}
     </>
   );
 };


### PR DESCRIPTION
## Details


https://github.com/user-attachments/assets/1994a4f6-52b3-41ed-a4da-609d42b280f0


Fix OPIK-5435 — "Go to traces" on annotation queue pages opened the project Logs view filtered by the queue id, but Logs hides experiment/playground/optimization-source traces by design, so users adding experiment traces to a queue saw an empty list. The header tag is now an inline TraceLogsSidebar (no source filter), and trace/thread detail viewers open inline on the queue tabs instead of opening new browser tabs.

- Replace the broken "Go to traces" header tag with `<TraceLogsSidebarButton>` on the annotation queue page
- Open `TraceDetailsPanel` / `ThreadDetailsPanel` inline on queue trace and thread tabs (with cross-navigation) instead of `window.open`
- Extract `useTraceThreadPanelsState` hook used by `TraceLogsSidebar` and both annotation queue tabs
- Enable thread side panel inside `TraceLogsSidebar` (drill from trace → thread now works inside the sheet)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-5435

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: assisted
- Human verification: code review + manual testing

## Testing

- `bash scripts/dev-runner.sh --lint-fe` — eslint, prettier, tsc, depcruise pass on the changed files
- Manual smoke (recommended):
  - Create an annotation queue, add a trace from an experiment, open the queue
  - Click the "Go to logs" header tag → sidebar opens, experiment trace is visible
  - Click a trace row → inline `TraceDetailsPanel` opens; click again → closes
  - Click the `thread_id` cell on a trace → `ThreadDetailsPanel` opens with drill-back to the trace
  - On thread queue tab, click a thread row → inline `ThreadDetailsPanel` opens; drill into a trace → `TraceDetailsPanel` opens
  - Inside `TraceLogsSidebar`, click a trace row's `thread_id` → `ThreadDetailsPanel` opens within the sheet
- A pre-existing lint error in `MetricsSummary.tsx` (`previousValue` unused-var) exists on `main` (introduced by #6866) and is unrelated to this change

## Documentation

N/A