### PR TITLE
[OPIK-6640] [FE] fix: resolve MetricsSummary lint errors

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/traces/MetricsSummary/MetricsSummary.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/MetricsSummary/MetricsSummary.tsx
@@ -57,7 +57,7 @@ const METRIC_CARDS: MetricCardDef[] = [
     icon: AlertTriangle,
     label: "Error rate",
     formatter: (v: number) =>
-      `${parseFloat((v < 1 ? v.toFixed(2) : v.toFixed(1)))}%`,
+      `${parseFloat(v < 1 ? v.toFixed(2) : v.toFixed(1))}%`,
     trend: "inverted",
     deltaUnit: "pp",
   },
@@ -201,6 +201,17 @@ const getCardMode = (perCardWidth: number): CardMode => {
   return "icon-only";
 };
 
+// Raw current/previous values feed the period-over-period delta in MetricCard.
+// While there's no data, return undefined so the delta is hidden instead of
+// being computed against empty values.
+const getDeltaValue = (
+  showData: boolean,
+  value: number | null | undefined,
+): number | null | undefined => {
+  if (!showData) return undefined;
+  return value ?? null;
+};
+
 export type MetricsSummaryProps = {
   projectId: string;
   entityType: KpiEntityType;
@@ -330,7 +341,6 @@ const MetricsSummary: React.FC<MetricsSummaryProps> = ({
         {filteredCards.map((card, index) => {
           const metric = metricsMap.get(card.type);
           const currentValue = metric?.current_value ?? 0;
-          const previousValue = metric?.previous_value ?? 0;
           const label = card.type === "count" ? countLabel : card.label;
           const isFirst = index === 0;
           const isLast = index === filteredCards.length - 1;
@@ -341,8 +351,8 @@ const MetricsSummary: React.FC<MetricsSummaryProps> = ({
               icon={card.icon}
               label={label}
               value={showData ? card.formatter(currentValue) : "N/A"}
-              currentRaw={showData ? (metric?.current_value ?? null) : undefined}
-              previousRaw={showData ? (metric?.previous_value ?? null) : undefined}
+              currentRaw={getDeltaValue(showData, metric?.current_value)}
+              previousRaw={getDeltaValue(showData, metric?.previous_value)}
               trend={card.trend}
               selected={showData && selectedMetric === card.type}
               onClick={() => handleSelectMetric(card.type)}


### PR DESCRIPTION
## Details

Fixes the ESLint/Prettier errors in `MetricsSummary.tsx` (surfaced by CI lint on the OPIK-6640 changes) and cleans up the raw-value gating logic:

- **Prettier** — removed the redundant parens in the `parseFloat(...)` error-rate formatter and around the `?? null` JSX props.
- **`@typescript-eslint/no-unused-vars`** — removed the unused `previousValue` variable.
- **Cleanup** — extracted the duplicated `showData ? value ?? null : undefined` ternary into a module-level pure helper `getDeltaValue(showData, value)` (matching the existing `getCardMode`/`getChartConfig` pattern), so it's no longer an inline ternary nor a function defined inside the component.

Behavior is unchanged: `undefined` while there's no data (so `MetricCard` hides the period-over-period delta), otherwise the value normalized to `number | null`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6640

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Fixed the 4 reported lint errors and refactored the raw-value gating into a module-level helper.
- Human verification: lint + typecheck reviewed; behavior preserved.

## Testing

- `npx eslint src/v2/pages-shared/traces/MetricsSummary/MetricsSummary.tsx --max-warnings=0` — passes (exit 0).
- `npx tsc --project tsconfig.json --noEmit` — no errors for the changed file.

## Documentation

N/A