### PR TITLE
[OPIK-6727] [BE] feat: emit dominant project for multi-project orphan experiments

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -1802,7 +1802,7 @@ public class ExperimentDAO {
             SELECT
                 e.id AS experiment_id,
                 any(if(length(per_experiment_ranked.ranked) > 0, per_experiment_ranked.ranked[1].3, '')) AS project_id,
-                any(length(per_experiment_ranked.ranked)) AS distinct_project_count,
+                any(ifNull(length(per_experiment_ranked.ranked), 0)) AS distinct_project_count,
                 any(ifNull(per_experiment_ranked.project_breakdown, '')) AS project_breakdown
             FROM experiments e
             LEFT JOIN per_experiment_ranked ON e.id = per_experiment_ranked.experiment_id

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -1757,31 +1757,55 @@ public class ExperimentDAO {
             """;
 
     /**
-     * For each orphan experiment in a workspace, returns the trace-derived classification:
-     * {@code project_id} is any non-empty trace project_id (meaningful only when
-     * {@code project_count = 1}); {@code project_count} is the distinct count of non-empty trace
-     * project_ids — {@code 0} = no inference, {@code 1} = certain, {@code > 1} = ambiguous.
+     * For each orphan experiment in a workspace, returns the dominant project: {@code project_id}
+     * (empty when no traces are referenced), {@code distinct_project_count} ({@code 0} = no
+     * inference, {@code 1} = certain, {@code > 1} = dominant pick), and a {@code project_breakdown}
+     * ({@code projectId=count,...}) included in the per-assignment log line. Multi-project
+     * experiments are ranked by {@code (count DESC, last_activity DESC, project_id ASC)} so
+     * repeated runs produce the same result.
      *
-     * <p>The {@code CAST(t.project_id AS String)} converts away from {@code FixedString(36)},
-     * whose LEFT JOIN no-match default (36 NUL bytes, not {@code ''}) would slip past the
-     * {@code != ''} guard and trip the downstream UUID parser.
+     * <p>{@code CAST(t.project_id AS String)} converts away from {@code FixedString(36)}, whose
+     * default would slip past the {@code != ''} guard and trip the downstream UUID parser.
+     * {@code count(DISTINCT ei.trace_id)} counts in units of "distinct traces per project"
+     * (the natural unit for the dominant pick, since one trace lives in one project) and
+     * neutralizes join-output inflation from transient ReplacingMergeTree row versions on
+     * either side.
      */
     private static final String COMPUTE_EXPERIMENT_PROJECT_MAPPING = """
+            WITH per_experiment_ranked AS (
+                WITH arraySort(
+                        proj -> (-proj.1, -proj.2, proj.3),
+                        groupArray((per_proj_count, per_proj_last_activity_nanos, project_id))
+                    ) AS ranked
+                SELECT
+                    experiment_id,
+                    ranked,
+                    arrayStringConcat(
+                        arrayMap(proj -> concat(proj.3, '=', toString(proj.1)), ranked),
+                        ','
+                    ) AS project_breakdown
+                FROM (
+                    SELECT
+                        ei.experiment_id AS experiment_id,
+                        CAST(t.project_id AS String) AS project_id,
+                        count(DISTINCT ei.trace_id) AS per_proj_count,
+                        toUnixTimestamp64Nano(max(t.last_updated_at)) AS per_proj_last_activity_nanos
+                    FROM experiment_items ei
+                    INNER JOIN traces t
+                        ON ei.workspace_id = t.workspace_id AND ei.trace_id = t.id
+                    WHERE ei.workspace_id = :workspace_id
+                    GROUP BY ei.experiment_id, project_id
+                    HAVING project_id != ''
+                )
+                GROUP BY experiment_id
+            )
             SELECT
                 e.id AS experiment_id,
-                anyIf(et.project_id, et.project_id != '') AS project_id,
-                countDistinctIf(et.project_id, et.project_id != '') AS project_count
+                any(if(length(per_experiment_ranked.ranked) > 0, per_experiment_ranked.ranked[1].3, '')) AS project_id,
+                any(length(per_experiment_ranked.ranked)) AS distinct_project_count,
+                any(ifNull(per_experiment_ranked.project_breakdown, '')) AS project_breakdown
             FROM experiments e
-            LEFT JOIN (
-                SELECT
-                    ei.workspace_id,
-                    ei.experiment_id,
-                    CAST(t.project_id AS String) AS project_id
-                FROM experiment_items ei
-                INNER JOIN traces t
-                    ON ei.workspace_id = t.workspace_id AND ei.trace_id = t.id
-                WHERE ei.workspace_id = :workspace_id
-            ) et ON e.workspace_id = et.workspace_id AND e.id = et.experiment_id
+            LEFT JOIN per_experiment_ranked ON e.id = per_experiment_ranked.experiment_id
             WHERE e.workspace_id = :workspace_id
             AND e.name NOT IN :demo_experiment_names
             GROUP BY e.id
@@ -2968,7 +2992,8 @@ public class ExperimentDAO {
                                 .filter(StringUtils::isNotBlank)
                                 .map(UUID::fromString)
                                 .orElse(null))
-                        .projectCount(row.get("project_count", Long.class))
+                        .distinctProjectCount(row.get("distinct_project_count", Long.class))
+                        .projectBreakdown(row.get("project_breakdown", String.class))
                         .build()));
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMapping.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMapping.java
@@ -5,6 +5,24 @@ import lombok.NonNull;
 
 import java.util.UUID;
 
+/**
+ * Result of {@link ExperimentDAO#computeExperimentProjectMapping()}: one row per orphan
+ * experiment, holding the inferred {@code projectId} to assign.
+ *
+ * <p>{@code projectId} is the only nullable field — {@code null} means no inference was
+ * possible (no trace items reference any project, so {@code distinctProjectCount == 0}).
+ * When {@code distinctProjectCount == 1} it is the sole referenced project; when
+ * {@code > 1} it is the dominant project, chosen by
+ * {@code (count DESC, last_activity DESC, project_id ASC)}.
+ *
+ * <p>{@code projectBreakdown} lists the per-project trace counts in the same order (e.g.
+ * {@code "p1=5,p2=3,p3=1"}). Empty for no-inference rows and for Default-Project fallbacks
+ * synthesized by the service.
+ */
 @Builder(toBuilder = true)
-public record ExperimentProjectMapping(@NonNull UUID experimentId, UUID projectId, long projectCount) {
+public record ExperimentProjectMapping(
+        @NonNull UUID experimentId,
+        UUID projectId,
+        long distinctProjectCount,
+        @NonNull String projectBreakdown) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentProjectMigrationService.java
@@ -3,7 +3,6 @@ package com.comet.opik.domain;
 import com.comet.opik.api.Project;
 import com.comet.opik.domain.experiments.aggregations.ExperimentAggregationPublisher;
 import com.comet.opik.domain.workspaces.WorkspaceVersionService;
-import com.comet.opik.domain.workspaces.WorkspacesService;
 import com.comet.opik.infrastructure.ExperimentDenormalizationConfig;
 import com.comet.opik.infrastructure.ExperimentProjectMigrationConfig;
 import com.comet.opik.infrastructure.MigrationConfig;
@@ -48,32 +47,32 @@ public class ExperimentProjectMigrationService implements Managed {
 
     public static final Attributes RESULT_ERROR = Attributes.of(RESULT_KEY, "error");
 
-    private static final String REASON_ALL_AMBIGUOUS = "all_ambiguous";
-
     private static final Attributes RESULT_MIGRATED = Attributes.of(RESULT_KEY, "migrated");
     private static final Attributes RESULT_NO_CERTAIN = Attributes.of(RESULT_KEY, "no_certain_experiments");
-    private static final Attributes RESULT_ALL_AMBIGUOUS = Attributes.of(RESULT_KEY, "all_ambiguous");
 
     private static final Attributes REASON_NO_INFERENCE = Attributes.of(REASON_KEY, "no_inference");
     private static final Attributes REASON_DELETED_PROJECT = Attributes.of(REASON_KEY, "deleted_project");
-    private static final Attributes REASON_AMBIGUOUS = Attributes.of(REASON_KEY, "ambiguous");
+
+    /** Tags {@code experiments.assigned_to_dominant_project} by the source distinct project count. */
+    private static final AttributeKey<String> DISTINCT_PROJECT_COUNT_KEY = stringKey("distinct_project_count");
+
+    /** Cap on the {@link #DISTINCT_PROJECT_COUNT_KEY} label value to bound metric cardinality. */
+    private static final int DISTINCT_PROJECT_COUNT_MAX = 50;
 
     private final @NonNull ExperimentDAO experimentDAO;
     private final @NonNull ExperimentItemService experimentItemService;
     private final @NonNull ProjectService projectService;
     private final @NonNull ExperimentAggregationPublisher experimentAggregationPublisher;
     private final @NonNull WorkspaceVersionService workspaceVersionService;
-    private final @NonNull WorkspacesService workspacesService;
     private final @NonNull ExperimentProjectMigrationConfig config;
     private final @NonNull MigrationConfig migrationConfig;
     private final @NonNull ExperimentDenormalizationConfig denormalizationConfig;
 
     private final LongHistogram cycleEligibleWorkspaces;
-    private final LongGauge cycleTrappedWorkspaces;
     private final LongGauge cycleEnvExcludedWorkspaces;
     private final LongHistogram workspaceDuration;
-    private final LongCounter experimentsSkipped;
     private final LongCounter experimentsAssignedToDefault;
+    private final LongCounter experimentsAssignedToDominantProject;
     private final LongHistogram batchSize;
 
     /**
@@ -91,7 +90,6 @@ public class ExperimentProjectMigrationService implements Managed {
             @NonNull ProjectService projectService,
             @NonNull ExperimentAggregationPublisher experimentAggregationPublisher,
             @NonNull WorkspaceVersionService workspaceVersionService,
-            @NonNull WorkspacesService workspacesService,
             @NonNull @Config("experimentProjectMigration") ExperimentProjectMigrationConfig config,
             @NonNull @Config("migration") MigrationConfig migrationConfig,
             @NonNull @Config("experimentDenormalization") ExperimentDenormalizationConfig denormalizationConfig) {
@@ -100,7 +98,6 @@ public class ExperimentProjectMigrationService implements Managed {
         this.projectService = projectService;
         this.experimentAggregationPublisher = experimentAggregationPublisher;
         this.workspaceVersionService = workspaceVersionService;
-        this.workspacesService = workspacesService;
         this.config = config;
         this.migrationConfig = migrationConfig;
         this.denormalizationConfig = denormalizationConfig;
@@ -111,31 +108,27 @@ public class ExperimentProjectMigrationService implements Managed {
                 .setDescription("Number of workspaces with eligible experiments found per cycle")
                 .ofLongs()
                 .build();
-        this.cycleTrappedWorkspaces = meter
-                .gaugeBuilder("%s.cycle.trapped_workspaces".formatted(METRIC_NAMESPACE))
-                .setDescription(
-                        "Number of workspaces locally skipped because all their remaining experiments are ambiguous")
-                .ofLongs()
-                .build();
         this.cycleEnvExcludedWorkspaces = meter
                 .gaugeBuilder("%s.cycle.env_excluded_workspaces".formatted(METRIC_NAMESPACE))
                 .setDescription(
-                        "Number of workspaces excluded from migration via the MIGRATION_EXCLUDED_WORKSPACE_IDS env var. Mirrors trapped_workspaces so the dashboard can show both exclusion paths side by side.")
+                        "Number of workspaces excluded from migration via the MIGRATION_EXCLUDED_WORKSPACE_IDS env var.")
                 .ofLongs()
                 .build();
         this.workspaceDuration = meter
                 .histogramBuilder("%s.workspace.duration".formatted(METRIC_NAMESPACE))
-                .setDescription("Duration of a single workspace migration, tagged by result")
+                .setDescription(
+                        "Duration of a single workspace migration, tagged by result (migrated / no_certain_experiments / error)")
                 .setUnit("ms")
                 .ofLongs()
-                .build();
-        this.experimentsSkipped = meter
-                .counterBuilder("%s.experiments.skipped".formatted(METRIC_NAMESPACE))
-                .setDescription("Total number of experiments skipped during migration, tagged by reason")
                 .build();
         this.experimentsAssignedToDefault = meter
                 .counterBuilder("%s.experiments.assigned_to_default".formatted(METRIC_NAMESPACE))
                 .setDescription("Total number of experiments assigned to the Default Project")
+                .build();
+        this.experimentsAssignedToDominantProject = meter
+                .counterBuilder("%s.experiments.assigned_to_dominant_project".formatted(METRIC_NAMESPACE))
+                .setDescription(
+                        "Total number of orphan experiments that referenced multiple projects and were assigned to the dominant one (most referencing traces). Tagged by distinct_project_count for the multi-project distribution.")
                 .build();
         this.batchSize = meter
                 .histogramBuilder("%s.batch.size".formatted(METRIC_NAMESPACE))
@@ -169,18 +162,12 @@ public class ExperimentProjectMigrationService implements Managed {
 
     public Mono<Void> runMigrationCycle() {
         return Mono.fromCallable(() -> {
-            var skippedWorkspaceIds = workspacesService.findExperimentProjectMigrationSkippedWorkspaceIds();
             var envExcludedWorkspaceIds = migrationConfig.getExcludedWorkspaceIds();
-            cycleTrappedWorkspaces.set(skippedWorkspaceIds.size());
             cycleEnvExcludedWorkspaces.set(envExcludedWorkspaceIds.size());
             log.info(
-                    "Starting experiment project migration cycle, workspacesPerRun='{}', batchSize='{}', trappedWorkspaces='{}', envExcludedWorkspaces='{}'",
-                    config.workspacesPerRun(), config.experimentBatchSize(), skippedWorkspaceIds.size(),
-                    envExcludedWorkspaceIds.size());
-            return Stream.concat(
-                    envExcludedWorkspaceIds.stream(),
-                    skippedWorkspaceIds.stream())
-                    .collect(Collectors.toUnmodifiableSet());
+                    "Starting experiment project migration cycle, workspacesPerRun='{}', batchSize='{}', envExcludedWorkspaces='{}'",
+                    config.workspacesPerRun(), config.experimentBatchSize(), envExcludedWorkspaceIds.size());
+            return envExcludedWorkspaceIds;
         })
                 .subscribeOn(migrationScheduler)
                 .flatMapMany(excludedWorkspaceIds -> experimentDAO
@@ -243,14 +230,11 @@ public class ExperimentProjectMigrationService implements Managed {
 
     private Mono<Boolean> migrateValidatedMappings(
             String workspaceId, List<ExperimentProjectMapping> mappings, int batchSize, long workspaceStartMillis) {
-        var ambiguous = mappings.stream()
-                .filter(mapping -> mapping.projectCount() > 1)
-                .toList();
         var noInference = mappings.stream()
-                .filter(mapping -> mapping.projectCount() == 0)
+                .filter(mapping -> mapping.distinctProjectCount() == 0)
                 .toList();
         var withInferred = mappings.stream()
-                .filter(mapping -> mapping.projectCount() == 1 && mapping.projectId() != null)
+                .filter(mapping -> mapping.distinctProjectCount() >= 1 && mapping.projectId() != null)
                 .toList();
 
         var inferredProjectIds = withInferred.stream()
@@ -269,15 +253,17 @@ public class ExperimentProjectMigrationService implements Managed {
                             .filter(mapping -> !validProjectIds.contains(mapping.projectId()))
                             .toList();
 
-                    logAndEmitMetrics(workspaceId, ambiguous, certainDeleted, noInference);
+                    recordDominantAssignments(workspaceId, certain);
+                    logAndEmitDefaultProjectMetrics(workspaceId, certainDeleted, noInference);
 
                     var defaultAssigned = getDefaultAssigned(workspaceId, certainDeleted, noInference);
                     var validated = Stream.concat(certain.stream(), defaultAssigned).toList();
                     if (CollectionUtils.isEmpty(validated)) {
-                        log.info(
-                                "All remaining experiments are ambiguous, marking workspace as trapped, workspaceId='{}'",
-                                workspaceId);
-                        return markMigrationSkipped(workspaceId, workspaceStartMillis, Mono.empty());
+                        var duration = Duration.ofMillis(System.currentTimeMillis() - workspaceStartMillis);
+                        log.info("No experiments to migrate after classification, workspaceId='{}', duration='{}'",
+                                workspaceId, duration);
+                        recordWorkspaceDuration(RESULT_NO_CERTAIN, workspaceStartMillis);
+                        return Mono.just(false);
                     }
                     var byProject = validated.stream()
                             .collect(Collectors.groupingBy(ExperimentProjectMapping::projectId));
@@ -292,13 +278,7 @@ public class ExperimentProjectMigrationService implements Managed {
                                     workspaceId, byProject.size()))
                             .then(triggerReaggregation(workspaceId, validated))
                             .then(evictWorkspaceVersionCache(workspaceId))
-                            .then(Mono.defer(() -> {
-                                if (!ambiguous.isEmpty()) {
-                                    log.info(
-                                            "Migration completed with remaining ambiguous experiments, marking workspace as trapped, workspaceId='{}', migrated='{}', ambiguous='{}'",
-                                            workspaceId, validated.size(), ambiguous.size());
-                                    return markMigrationSkipped(workspaceId, workspaceStartMillis, Mono.just(false));
-                                }
+                            .then(Mono.fromCallable(() -> {
                                 var duration = Duration
                                         .ofMillis(System.currentTimeMillis() - workspaceStartMillis);
                                 log.info(
@@ -306,7 +286,7 @@ public class ExperimentProjectMigrationService implements Managed {
                                         workspaceId, validated.size(), certainDeleted.size(), noInference.size(),
                                         duration);
                                 recordWorkspaceDuration(RESULT_MIGRATED, workspaceStartMillis);
-                                return Mono.just(true);
+                                return true;
                             }));
                 });
     }
@@ -315,16 +295,30 @@ public class ExperimentProjectMigrationService implements Managed {
         workspaceDuration.record(System.currentTimeMillis() - startMillis, resultAttributes);
     }
 
-    private void logAndEmitMetrics(
+    /**
+     * Bumps {@code experiments.assigned_to_dominant_project} and logs the chosen project plus its
+     * per-project trace breakdown for each validated multi-project experiment. Single-project rows
+     * are skipped — they're the unambiguous case where no dominant decision was made.
+     */
+    private void recordDominantAssignments(String workspaceId, List<ExperimentProjectMapping> certain) {
+        for (var mapping : certain) {
+            if (mapping.distinctProjectCount() <= 1) {
+                continue;
+            }
+            long boundedCount = Math.min(mapping.distinctProjectCount(), DISTINCT_PROJECT_COUNT_MAX);
+            experimentsAssignedToDominantProject.add(1,
+                    Attributes.of(DISTINCT_PROJECT_COUNT_KEY, Long.toString(boundedCount)));
+            log.info(
+                    "Assigning dominant project to experiment, workspaceId='{}', experimentId='{}', chosenProjectId='{}', distinctProjectCount='{}', projectBreakdown='{}'",
+                    workspaceId, mapping.experimentId(), mapping.projectId(), mapping.distinctProjectCount(),
+                    mapping.projectBreakdown());
+        }
+    }
+
+    private void logAndEmitDefaultProjectMetrics(
             String workspaceId,
-            List<ExperimentProjectMapping> ambiguous,
             List<ExperimentProjectMapping> certainDeleted,
             List<ExperimentProjectMapping> noInference) {
-        if (!ambiguous.isEmpty()) {
-            log.info("Skipping ambiguous experiments, workspaceId='{}', count='{}'",
-                    workspaceId, ambiguous.size());
-            experimentsSkipped.add(ambiguous.size(), REASON_AMBIGUOUS);
-        }
         if (!certainDeleted.isEmpty()) {
             log.info("Assigning certain but deleted experiments to Default Project, workspaceId='{}', count='{}'",
                     workspaceId, certainDeleted.size());
@@ -355,15 +349,6 @@ public class ExperimentProjectMigrationService implements Managed {
                         .map(mapping -> mapping.toBuilder()
                                 .projectId(defaultProjectId)
                                 .build());
-    }
-
-    private Mono<Boolean> markMigrationSkipped(String workspaceId, long workspaceStartMillis, Mono<Boolean> result) {
-        return Mono
-                .fromRunnable(() -> workspacesService.markExperimentProjectMigrationSkipped(
-                        workspaceId, REASON_ALL_AMBIGUOUS))
-                .subscribeOn(migrationScheduler)
-                .doFinally(signalType -> recordWorkspaceDuration(RESULT_ALL_AMBIGUOUS, workspaceStartMillis))
-                .then(result);
     }
 
     private Mono<Long> batchUpdateProjectId(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/Workspace.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/Workspace.java
@@ -20,8 +20,6 @@ public record Workspace(
         String lastKnownVersion,
         Instant versionDeterminedAt,
         Instant firstTraceReportedAt,
-        Instant experimentProjectMigrationSkippedAt,
-        String experimentProjectMigrationSkipReason,
         Instant promptProjectMigrationSkippedAt,
         String promptProjectMigrationSkipReason,
         boolean hasLegacyScores,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesDAO.java
@@ -57,43 +57,8 @@ public interface WorkspacesDAO {
             @Bind("userName") String userName);
 
     /**
-     * Atomic NULL → timestamp transition for the experiment-project-migration-skipped flag.
-     * Returns 1 only when this caller flipped the column from NULL; returns 0 if no row exists
-     * or the column was already non-null. Pair with {@link #insertExperimentProjectMigrationSkipped}
-     * for the missing-row case.
-     */
-    @SqlUpdate("""
-            UPDATE workspaces
-            SET experiment_project_migration_skipped_at = :skippedAt,
-                experiment_project_migration_skip_reason = :reason,
-                last_updated_by = :userName
-            WHERE id = :id AND experiment_project_migration_skipped_at IS NULL
-            """)
-    int updateExperimentProjectMigrationSkippedIfNull(@Bind("id") String id,
-            @Bind("skippedAt") Instant skippedAt,
-            @Bind("reason") String reason,
-            @Bind("userName") String userName);
-
-    /**
-     * Plain INSERT (no upsert). Throws on duplicate-key — caller handles the "row already exists"
-     * branch via the {@link #updateExperimentProjectMigrationSkippedIfNull} attempt that precedes it.
-     */
-    @SqlUpdate("""
-            INSERT INTO workspaces (id, experiment_project_migration_skipped_at, experiment_project_migration_skip_reason, created_by, last_updated_by)
-            VALUES (:id, :skippedAt, :reason, :userName, :userName)
-            """)
-    void insertExperimentProjectMigrationSkipped(@Bind("id") String id,
-            @Bind("skippedAt") Instant skippedAt,
-            @Bind("reason") String reason,
-            @Bind("userName") String userName);
-
-    @SqlQuery("SELECT id FROM workspaces WHERE experiment_project_migration_skipped_at IS NOT NULL")
-    List<String> findExperimentProjectMigrationSkippedWorkspaceIds();
-
-    /**
-     * Atomic NULL → timestamp transition for the prompt-project-migration trap flag. Parallel to
-     * {@link #updateExperimentProjectMigrationSkippedIfNull} but scoped to the prompt cycle's own
-     * column so the two migrations record their traps independently.
+     * Atomic NULL → timestamp transition for the prompt-project-migration trap flag. Scoped to the
+     * prompt cycle's own column so its trap state is recorded independently of any other migration.
      */
     @SqlUpdate("""
             UPDATE workspaces
@@ -109,7 +74,7 @@ public interface WorkspacesDAO {
 
     /**
      * Plain INSERT (no upsert). Paired with {@link #updatePromptProjectMigrationSkippedIfNull}
-     * for the missing-row case, mirroring {@link #insertExperimentProjectMigrationSkipped}.
+     * for the missing-row case.
      */
     @SqlUpdate("""
             INSERT INTO workspaces (

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesService.java
@@ -45,18 +45,7 @@ public interface WorkspacesService {
     /**
      * Idempotent: subsequent calls do not overwrite the original timestamp/reason. Audit columns
      * are stamped with the system user — this is the migration job's call site, never a direct
-     * user action.
-     *
-     * @return {@code true} when this caller flipped the flag; {@code false} when it was already set
-     */
-    boolean markExperimentProjectMigrationSkipped(String workspaceId, String reason);
-
-    List<String> findExperimentProjectMigrationSkippedWorkspaceIds();
-
-    /**
-     * Prompt-cycle parallel of {@link #markExperimentProjectMigrationSkipped}, recording the trap
-     * in the dedicated {@code prompt_project_migration_skipped_at} column so the experiment trap
-     * state isn't disturbed.
+     * user action. Recorded in the dedicated {@code prompt_project_migration_skipped_at} column.
      */
     boolean markPromptProjectMigrationSkipped(String workspaceId, String reason);
 
@@ -134,39 +123,6 @@ class WorkspacesServiceImpl implements WorkspacesService {
                 throw exception;
             }
         });
-    }
-
-    /**
-     * Same UPDATE-then-INSERT-then-retry-UPDATE flow as {@link #markFirstTraceReported}, applied
-     * to the {@code experiment_project_migration_skipped_at} flag. Idempotent: returns
-     * {@code false} when this caller loses the race or the workspace was already trapped.
-     */
-    @Override
-    public boolean markExperimentProjectMigrationSkipped(@NonNull String workspaceId, @NonNull String reason) {
-        return transactionTemplate.inTransaction(WRITE, handle -> {
-            var dao = handle.attach(WorkspacesDAO.class);
-            var now = Instant.now();
-            if (dao.updateExperimentProjectMigrationSkippedIfNull(workspaceId, now, reason, SYSTEM_USER) > 0) {
-                return true;
-            }
-            try {
-                dao.insertExperimentProjectMigrationSkipped(workspaceId, now, reason, SYSTEM_USER);
-                return true;
-            } catch (UnableToExecuteStatementException exception) {
-                if (exception.getCause() instanceof SQLException sql
-                        && SQL_STATE_INTEGRITY_CONSTRAINT_VIOLATION.equals(sql.getSQLState())) {
-                    return dao.updateExperimentProjectMigrationSkippedIfNull(workspaceId, now, reason,
-                            SYSTEM_USER) > 0;
-                }
-                throw exception;
-            }
-        });
-    }
-
-    @Override
-    public List<String> findExperimentProjectMigrationSkippedWorkspaceIds() {
-        return transactionTemplate.inTransaction(READ_ONLY,
-                handle -> handle.attach(WorkspacesDAO.class).findExperimentProjectMigrationSkippedWorkspaceIds());
     }
 
     @Override

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000078_drop_experiment_migration_columns_from_workspaces.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000078_drop_experiment_migration_columns_from_workspaces.sql
@@ -1,0 +1,14 @@
+--liquibase formatted sql
+--changeset andrescrz:000078_drop_experiment_migration_columns_from_workspaces
+--comment: Drop the experiment-project migration trap columns and index from workspaces. The job now assigns multi-project orphans to a dominant project, so the trap state is unreachable. Prompt trap columns (000076) are untouched.
+
+DROP INDEX workspaces_exp_proj_migration_skipped_idx ON workspaces;
+
+ALTER TABLE workspaces
+    DROP COLUMN experiment_project_migration_skipped_at,
+    DROP COLUMN experiment_project_migration_skip_reason;
+
+--rollback ALTER TABLE workspaces
+--rollback     ADD COLUMN experiment_project_migration_skipped_at TIMESTAMP(6) NULL AFTER first_trace_reported_at,
+--rollback     ADD COLUMN experiment_project_migration_skip_reason VARCHAR(255) NULL AFTER experiment_project_migration_skipped_at;
+--rollback CREATE INDEX workspaces_exp_proj_migration_skipped_idx ON workspaces (experiment_project_migration_skipped_at);

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentProjectMigrationServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentProjectMigrationServiceTest.java
@@ -20,7 +20,6 @@ import com.comet.opik.api.resources.utils.resources.ExperimentResourceClient;
 import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
 import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
 import com.comet.opik.api.resources.utils.resources.WorkspaceResourceClient;
-import com.comet.opik.domain.workspaces.WorkspacesService;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.auth.RequestContext;
@@ -209,25 +208,14 @@ class ExperimentProjectMigrationServiceTest {
     }
 
     /**
-     * Single workspace covering all four classifier buckets in one cycle:
-     * <ul>
-     *   <li><b>certain</b> — one trace in a single alive project => migrates to inferred project.</li>
-     *   <li><b>certain-deleted</b> — one trace in a project later deleted in MySQL => migrates to
-     *       Default Project.</li>
-     *   <li><b>no-inference</b> — orphan experiment with no experiment_items => migrates to Default
-     *       Project.</li>
-     *   <li><b>ambiguous</b> — two traces in two different projects => skipped.</li>
-     * </ul>
-     * Also covers the demo-name filter: an experiment named like a demo is eligible-shaped but
-     * filtered by {@code WHERE e.name NOT IN :demo_experiment_names} in {@code FIND_ELIGIBLE} and
-     * {@code COMPUTE_MAPPING}; demo data is invisible to the V1 entity check, so the gap can only
-     * be detected at the experiment level.
-     *
-     * <p>Outcome: workspace stays V1 because of the remaining ambiguous orphan, gets trapped with
-     * {@code all_ambiguous}, and the demo experiment's empty project_id is preserved.
+     * One workspace exercising all migration buckets: certain (single project), multi-project
+     * resolved by dominant assignment, certain-deleted, no-inference, demo. No bucket traps the
+     * workspace — every non-demo orphan is migrated, the workspace flips to V2, and the demo
+     * experiment is left untouched (filtered out at the {@code WHERE e.name NOT IN
+     * :demo_experiment_names} guard before it can reach the classifier).
      */
     @Test
-    void mixedWorkspaceMigratesAcrossBucketsAndTrapsOnAmbiguous(WorkspacesService workspacesService) {
+    void mixedWorkspaceMigratesAllBucketsIncludingMultiProjectAsDominant() {
         var apiKey = randomName("api-key");
         var workspaceName = randomName("workspace");
         var workspaceId = UUID.randomUUID().toString();
@@ -242,19 +230,21 @@ class ExperimentProjectMigrationServiceTest {
         var certainExperimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
         linkExperimentToTraces(apiKey, workspaceName, certainExperimentId, certainTraceId);
 
-        // Ambiguous: two traces in two different projects => skipped.
-        var ambiguousProjectName1 = randomName("project");
-        var ambiguousProjectName2 = randomName("project");
-        createProject(apiKey, workspaceName, ambiguousProjectName1);
-        createProject(apiKey, workspaceName, ambiguousProjectName2);
-        var ambiguousTrace1Id = createTrace(apiKey, workspaceName, ambiguousProjectName1);
-        var ambiguousTrace2Id = createTrace(apiKey, workspaceName, ambiguousProjectName2);
-        var ambiguousExperimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
-        linkExperimentToTraces(apiKey, workspaceName, ambiguousExperimentId,
-                ambiguousTrace1Id, ambiguousTrace2Id);
+        // Multi-project (dominant): two traces in the winner, one in the runner-up => migrates to the
+        // winner. Previously this bucket was the "ambiguous" trap source.
+        var dominantProjectName = randomName("project");
+        var dominantProjectId = createProject(apiKey, workspaceName, dominantProjectName);
+        var runnerUpProjectName = randomName("project");
+        createProject(apiKey, workspaceName, runnerUpProjectName);
+        var dominantTrace1Id = createTrace(apiKey, workspaceName, dominantProjectName);
+        var dominantTrace2Id = createTrace(apiKey, workspaceName, dominantProjectName);
+        var runnerUpTraceId = createTrace(apiKey, workspaceName, runnerUpProjectName);
+        var dominantExperimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+        linkExperimentToTraces(apiKey, workspaceName, dominantExperimentId,
+                dominantTrace1Id, dominantTrace2Id, runnerUpTraceId);
 
-        // Certain-deleted: one trace in a single project that is then deleted in MySQL.
-        // Was: skipped. Now: migrates to Default Project.
+        // Certain-deleted: one trace in a single project that is then deleted in MySQL =>
+        // migrates to Default Project.
         var deletedProjectName = randomName("project");
         var deletedProjectId = createProject(apiKey, workspaceName, deletedProjectName);
         var deletedTraceId = createTrace(apiKey, workspaceName, deletedProjectName);
@@ -277,7 +267,7 @@ class ExperimentProjectMigrationServiceTest {
         linkExperimentToTraces(apiKey, workspaceName, demoExperimentId, demoTraceId);
 
         var certainBefore = experimentResourceClient.getExperiment(certainExperimentId, apiKey, workspaceName);
-        var ambiguousBefore = experimentResourceClient.getExperiment(ambiguousExperimentId, apiKey, workspaceName);
+        var dominantBefore = experimentResourceClient.getExperiment(dominantExperimentId, apiKey, workspaceName);
         var deletedBefore = experimentResourceClient.getExperiment(deletedExperimentId, apiKey, workspaceName);
         var noInferenceBefore = experimentResourceClient.getExperiment(
                 noInferenceExperimentId, apiKey, workspaceName);
@@ -285,18 +275,16 @@ class ExperimentProjectMigrationServiceTest {
 
         migrationService.runMigrationCycle().block();
 
-        // Ambiguous keeps the workspace pinned to V1; the cycle migrates the other three buckets
-        // and traps the workspace with all_ambiguous.
-        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_1);
+        // Every non-demo orphan resolves to a project this cycle; workspace flips to V2.
+        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_2);
 
         assertExperimentMigrated(apiKey, workspaceName, certainExperimentId, certainBefore,
                 certainProjectId, certainProjectName);
+        assertExperimentMigrated(apiKey, workspaceName, dominantExperimentId, dominantBefore,
+                dominantProjectId, dominantProjectName);
         assertExperimentMigratedToDefault(apiKey, workspaceName, deletedExperimentId, deletedBefore);
         assertExperimentMigratedToDefault(apiKey, workspaceName, noInferenceExperimentId, noInferenceBefore);
-        assertExperimentUnchanged(apiKey, workspaceName, ambiguousExperimentId, ambiguousBefore);
         assertExperimentUnchanged(apiKey, workspaceName, demoExperimentId, demoBefore);
-
-        assertWorkspaceTrapped(workspacesService, workspaceId, "all_ambiguous");
     }
 
     @Test
@@ -348,58 +336,159 @@ class ExperimentProjectMigrationServiceTest {
     }
 
     /**
-     * Workspace whose only orphan is ambiguous: the early {@code validated.isEmpty()} short-circuit
-     * in {@code migrateValidatedMappings} traps the workspace before any writes happen. Distinct
-     * from the post-write trap covered by {@link #mixedWorkspaceMigratesAcrossBucketsAndTrapsOnAmbiguous},
-     * which goes through the full batch-update / reaggregation / cache-evict chain first.
+     * Dominant-project assignment by trace count: the project with more referencing traces wins.
+     * Verifies the primary key of the SQL ranker ({@code count DESC}).
      */
     @Test
-    void trapWorkspaceWithOnlyAmbiguousExperiments(WorkspacesService workspacesService) {
+    void migrateMultiProjectExperimentToDominantProjectByCount() {
         var apiKey = randomName("api-key");
         var workspaceName = randomName("workspace");
         var workspaceId = UUID.randomUUID().toString();
         mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
 
-        var projectName1 = randomName("project");
-        var projectName2 = randomName("project");
-        createProject(apiKey, workspaceName, projectName1);
-        createProject(apiKey, workspaceName, projectName2);
+        var dominantProjectName = randomName("project");
+        var dominantProjectId = createProject(apiKey, workspaceName, dominantProjectName);
+        var runnerUpProjectName = randomName("project");
+        createProject(apiKey, workspaceName, runnerUpProjectName);
+
         var datasetName = randomName("dataset");
-        createDatasetWithProject(apiKey, workspaceName, datasetName,
-                createProject(apiKey, workspaceName, randomName("project")));
-        var trace1Id = createTrace(apiKey, workspaceName, projectName1);
-        var trace2Id = createTrace(apiKey, workspaceName, projectName2);
+        createDatasetWithProject(apiKey, workspaceName, datasetName, dominantProjectId);
+
+        var dominantTraceA = createTrace(apiKey, workspaceName, dominantProjectName);
+        var dominantTraceB = createTrace(apiKey, workspaceName, dominantProjectName);
+        var runnerUpTrace = createTrace(apiKey, workspaceName, runnerUpProjectName);
+
         var experimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
-        linkExperimentToTraces(apiKey, workspaceName, experimentId, trace1Id, trace2Id);
+        linkExperimentToTraces(apiKey, workspaceName, experimentId,
+                dominantTraceA, dominantTraceB, runnerUpTrace);
 
         var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
 
         migrationService.runMigrationCycle().block();
 
-        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_1);
-        assertExperimentUnchanged(apiKey, workspaceName, experimentId, beforeMigration);
-        assertWorkspaceTrapped(workspacesService, workspaceId, "all_ambiguous");
+        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_2);
+        assertExperimentMigrated(apiKey, workspaceName, experimentId, beforeMigration,
+                dominantProjectId, dominantProjectName);
     }
 
+    /**
+     * Dominant-project recency tiebreaker: equal trace counts across two projects, the
+     * most-recently-updated trace's project wins ({@code last_activity DESC}).
+     */
     @Test
-    void skipPreMarkedTrappedWorkspaces(WorkspacesService workspacesService) {
-        // Explicitly tests the trap exclusion: pre-mark a workspace as skipped, seed an eligible
-        // experiment, run the cycle, and assert it was excluded (V1 + unchanged).
+    void migrateMultiProjectExperimentToMostRecentProjectWhenCountTies() {
         var apiKey = randomName("api-key");
         var workspaceName = randomName("workspace");
         var workspaceId = UUID.randomUUID().toString();
         mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
 
-        workspacesService.markExperimentProjectMigrationSkipped(workspaceId, "test-pre-marked-trap");
+        var olderProjectName = randomName("project");
+        createProject(apiKey, workspaceName, olderProjectName);
+        var recentProjectName = randomName("project");
+        var recentProjectId = createProject(apiKey, workspaceName, recentProjectName);
 
-        var seeded = seedCertainExperiment(apiKey, workspaceName, randomName("project"));
-        var experimentId = seeded.getLeft();
+        var datasetName = randomName("dataset");
+        createDatasetWithProject(apiKey, workspaceName, datasetName, recentProjectId);
+
+        var olderTrace = createTrace(apiKey, workspaceName, olderProjectName);
+        // Cushion against batched writes sharing an insert tick — keeps the recency contrast unambiguous.
+        TestUtils.waitForMillis(20);
+        var recentTrace = createTrace(apiKey, workspaceName, recentProjectName);
+
+        var experimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+        linkExperimentToTraces(apiKey, workspaceName, experimentId, olderTrace, recentTrace);
+
         var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
 
         migrationService.runMigrationCycle().block();
 
-        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_1);
-        assertExperimentUnchanged(apiKey, workspaceName, experimentId, beforeMigration);
+        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_2);
+        assertExperimentMigrated(apiKey, workspaceName, experimentId, beforeMigration,
+                recentProjectId, recentProjectName);
+    }
+
+    /**
+     * Dominant project is deleted before the cycle runs: validation drops it and the experiment
+     * falls back to Default Project — it is not reassigned to the surviving lower-count project,
+     * and it does not count as a dominant assignment.
+     */
+    @Test
+    void migrateMultiProjectExperimentToDefaultProjectWhenDominantProjectWasDeleted() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var dominantProjectName = randomName("project");
+        var dominantProjectId = createProject(apiKey, workspaceName, dominantProjectName);
+        var minorityProjectName = randomName("project");
+        createProject(apiKey, workspaceName, minorityProjectName);
+
+        var datasetName = randomName("dataset");
+        createDatasetWithProject(apiKey, workspaceName, datasetName, dominantProjectId);
+
+        var experimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+        linkExperimentToTraces(apiKey, workspaceName, experimentId,
+                createTrace(apiKey, workspaceName, dominantProjectName),
+                createTrace(apiKey, workspaceName, dominantProjectName),
+                createTrace(apiKey, workspaceName, minorityProjectName));
+
+        // Delete the dominant project: the query still infers it, but validation drops it.
+        projectResourceClient.deleteProject(dominantProjectId, apiKey, workspaceName);
+
+        var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_2);
+        assertExperimentMigratedToDefault(apiKey, workspaceName, experimentId, beforeMigration);
+    }
+
+    /**
+     * Re-running the cycle on an already-migrated multi-project experiment is a no-op:
+     * eligibility query reports no orphans, and the {@code project_id = ''} guard on
+     * {@code BATCH_SET_PROJECT_ID} would block a write even if reached. {@code lastUpdatedAt}
+     * stability confirms idempotency.
+     */
+    @Test
+    void multiProjectExperimentSecondCycleIsNoop() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var dominantProjectName = randomName("project");
+        var dominantProjectId = createProject(apiKey, workspaceName, dominantProjectName);
+        var runnerUpProjectName = randomName("project");
+        createProject(apiKey, workspaceName, runnerUpProjectName);
+
+        var datasetName = randomName("dataset");
+        createDatasetWithProject(apiKey, workspaceName, datasetName, dominantProjectId);
+
+        linkExperimentToTraces(apiKey, workspaceName,
+                createOrphanExperiment(apiKey, workspaceName, datasetName),
+                createTrace(apiKey, workspaceName, dominantProjectName),
+                createTrace(apiKey, workspaceName, dominantProjectName),
+                createTrace(apiKey, workspaceName, runnerUpProjectName));
+
+        var experimentId = createOrphanExperiment(apiKey, workspaceName, datasetName);
+        linkExperimentToTraces(apiKey, workspaceName, experimentId,
+                createTrace(apiKey, workspaceName, dominantProjectName),
+                createTrace(apiKey, workspaceName, dominantProjectName),
+                createTrace(apiKey, workspaceName, runnerUpProjectName));
+
+        var beforeMigration = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+        migrationService.runMigrationCycle().block();
+        var afterFirstCycle = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+        assertExperimentMigrated(apiKey, workspaceName, experimentId, beforeMigration,
+                dominantProjectId, dominantProjectName);
+
+        migrationService.runMigrationCycle().block();
+        var afterSecondCycle = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
+
+        assertThat(afterSecondCycle.lastUpdatedAt()).isEqualTo(afterFirstCycle.lastUpdatedAt());
+        assertExperimentEqual(afterSecondCycle, afterFirstCycle);
+        assertWorkspaceVersion(apiKey, workspaceName, OpikVersion.VERSION_2);
     }
 
     @Test
@@ -518,11 +607,5 @@ class ExperimentProjectMigrationServiceTest {
         var actual = experimentResourceClient.getExperiment(experimentId, apiKey, workspaceName);
         assertExperimentEqual(actual, beforeMigration);
         assertThat(actual.lastUpdatedAt()).isEqualTo(beforeMigration.lastUpdatedAt());
-    }
-
-    private void assertWorkspaceTrapped(WorkspacesService workspacesService, String workspaceId, String reason) {
-        assertThat(workspacesService.findExperimentProjectMigrationSkippedWorkspaceIds()).contains(workspaceId);
-        assertThat(workspacesService.findById(workspaceId))
-                .hasValueSatisfying(w -> assertThat(w.experimentProjectMigrationSkipReason()).isEqualTo(reason));
     }
 }


### PR DESCRIPTION
## Details

Migration-job carve-out of OPIK-6727, following the aggregation-fix carve-out that already shipped in #6912. The aggregation pipeline now correctly handles multi-project experiments, which unblocks this PR: the experiment migration job can safely assign a single dominant project to formerly-ambiguous orphan experiments without triggering metric undercounts at the reaggregation that follows.

The `COMPUTE_EXPERIMENT_PROJECT_MAPPING` ClickHouse query is extended so that for every workspace-scoped orphan experiment it returns the **dominant** referenced project (the one with the most distinct trace items), with deterministic tiebreakers `(count DESC, last_activity DESC, project_id ASC)`. The service-level classifier folds what was previously the AMBIGUOUS bucket into the validated-certain set. Migrated experiments still flow through the existing Default-Project provisioning for the certain-deleted and no-inference buckets, and `triggerReaggregation` runs on every migrated row to refresh `experiment_aggregates`.

The workspace-trap mechanism for this job is removed end-to-end: Liquibase migration `000078` drops the two trap columns and the index on the `workspaces` table (reversible rollback included); the DAO/service helpers that read or write the trap state are deleted; the `cycle.trapped_workspaces` gauge and the `experiments.skipped{reason=ambiguous}` counter are retired together with the bucket they observed. After this PR, no code path in the experiment cycle can emit a trap reason. The prompt-cycle trap (column `prompt_project_migration_skipped_at`) is intentionally untouched.

A new counter `experiments.assigned_to_dominant_project` is emitted on every dominant assignment, tagged by `distinct_project_count` (capped at 50 to bound metric cardinality), and a structured log line per assignment names the chosen project, the per-project trace breakdown in rank order, and the experiment id.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6727

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: assisted (analysis, SQL ranker design iterations, test scaffolding, code review)
- Human verification: code review + integration test runs locally

## Testing

Integration tests in `ExperimentProjectMigrationServiceTest` cover:

- **Dominant by count** (`migrateMultiProjectExperimentToDominantProjectByCount`) — two traces in winner project, one in runner-up; experiment migrates to the winner.
- **Recency tiebreaker** (`migrateMultiProjectExperimentToMostRecentProjectWhenCountTies`) — equal counts; the project whose latest trace was updated most recently wins.
- **Dominant project deleted before cycle** (`migrateMultiProjectExperimentToDefaultProjectWhenDominantProjectWasDeleted`) — validation drops the dominant pick and the experiment falls back to Default Project rather than being reassigned to the surviving runner-up.
- **Idempotency on re-run** (`secondCycleIsNoopAfterSuccessfulMigration`, `multiProjectExperimentSecondCycleIsNoop`) — once an experiment is migrated, subsequent cycles do not touch it (eligibility query reports no orphans; `BATCH_SET_PROJECT_ID` carries a `WHERE project_id = ''` guard as a second safety net). Verified via `lastUpdatedAt` stability.
- **Mixed-bucket workspace** (`mixedWorkspaceMigratesAllBucketsIncludingMultiProjectAsDominant`) — one workspace seeded with a certain row, a multi-project dominant row, a certain-deleted row, a no-inference row, and a demo experiment. Every non-demo orphan migrates, workspace flips V1→V2, demo experiment stays untouched.
- **No trap emission** — asserted by contradiction in the mixed test: under the old code the multi-project row would have trapped the workspace under `all_ambiguous`; under this PR it migrates and the workspace flips to V2.
- **Existing certain / certain-deleted / no-inference paths** continue to pass without modification.

Commands run locally (all pass):

```
mvn test -Dtest='ExperimentProjectMigrationServiceTest'
```

## Documentation

N/A in this PR. The runbook and Grafana dashboard updates that the full OPIK-6727 scope calls for are operator follow-ups carried by the ticket.