### PR TITLE
[OPIK-5988] [SDK] feat: add classification experiment scorers

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/overview.mdx
@@ -95,6 +95,7 @@ Opik helps you easily log, visualize, and evaluate everything from raw LLM calls
   <Card title="Novita AI" href="/integrations/novita-ai" />
   <Card title="Ollama" href="/integrations/ollama" />
   <Card title="OpenAI" href="/integrations/openai" />
+  <Card title="Qianfan" href="/integrations/qianfan" />
   <Card title="Predibase" href="/integrations/predibase" />
   <Card title="Together AI" href="/integrations/together-ai" />
   <Card title="WatsonX" href="/integrations/watsonx" />

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/qianfan.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/qianfan.mdx
@@ -1,0 +1,115 @@
+---
+description: Start here to integrate Opik into your Qianfan-based genai application
+  for end-to-end LLM observability, unit testing, and optimization.
+headline: Qianfan | Opik Documentation
+og:description: Learn to integrate Opik with Qianfan using the OpenAI SDK for
+  OpenAI-compatible endpoints.
+og:site_name: Opik Documentation
+og:title: Integrate Opik with Qianfan for AI Observability
+title: Observability for Qianfan with Opik
+---
+
+[Baidu Qianfan](https://cloud.baidu.com/doc/qianfan/index.html) provides OpenAI-compatible
+API endpoints for hosted model access. This guide shows how to use the OpenAI SDK with
+Opik to trace and evaluate Qianfan calls.
+
+## Getting started
+
+First, ensure you have both `opik` and `openai` packages installed:
+
+```bash
+pip install opik openai
+```
+
+You will need a Qianfan API key and an OpenAI-compatible base URL. The Qianfan
+OpenAI-compatible base URL is:
+
+`https://api.baiduqianfan.ai/v1`
+
+Refer to the [Qianfan documentation](https://intl.cloud.baidu.com/en/doc/qianfan/s/qm8qxemze-intl-en)
+for the latest setup steps and model list.
+
+## Tracking Qianfan API calls
+
+```python
+from opik.integrations.openai import track_openai
+from openai import OpenAI
+
+# Initialize the OpenAI client with your Qianfan base URL
+client = OpenAI(
+    base_url="https://api.baiduqianfan.ai/v1",
+    api_key="bce-v3/ALTAK-XXXXXXXX/XXXXXXXXXXXXXXXX",  # Qianfan bearer token
+    default_headers={"appid": "app-xxxxxx"}  # Optional Qianfan appid
+)
+client = track_openai(client)
+
+response = client.chat.completions.create(
+    model="ernie-4.0-turbo-8k",  # Use a model name from Qianfan
+    messages=[
+        {"role": "user", "content": "Hello, world!"}
+    ],
+    temperature=0.7,
+    max_tokens=100
+)
+
+print(response.choices[0].message.content)
+```
+
+## Advanced Usage
+
+### Using with @track decorator
+
+You can combine the tracked client with Opik's `@track` decorator for
+end-to-end tracing:
+
+```python
+from opik import track
+from opik.integrations.openai import track_openai
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.baiduqianfan.ai/v1",
+    api_key="bce-v3/ALTAK-XXXXXXXX/XXXXXXXXXXXXXXXX",  # Qianfan bearer token
+    default_headers={"appid": "app-xxxxxx"}  # Optional Qianfan appid
+)
+client = track_openai(client)
+
+@track
+def summarize_report(text: str) -> str:
+    response = client.chat.completions.create(
+        model="ernie-4.0-turbo-8k",
+        messages=[
+            {"role": "user", "content": text}
+        ]
+    )
+
+    return response.choices[0].message.content
+
+summary = summarize_report("Summarize this report in 3 bullets.")
+print(summary)
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Authentication Errors**: Confirm your API key is valid and has access to Qianfan
+2. **Model Not Found**: Verify the model name matches one available in Qianfan
+3. **Base URL Issues**: Ensure you are using the OpenAI-compatible endpoint from Qianfan
+
+### Getting Help
+
+- Review the [Qianfan documentation](https://cloud.baidu.com/doc/qianfan/index.html)
+- Check Opik tracing docs for setup details: [/tracing/advanced/sdk_configuration](/tracing/advanced/sdk_configuration)
+
+## Next Steps
+
+Once you have Qianfan integrated with Opik, you can:
+
+- [Evaluate your LLM applications](/evaluation/overview)
+- [Create datasets](/evaluation/advanced/manage_datasets)
+- [Collect feedback](/tracing/advanced/annotate_traces)
+- [Monitor traces](/tracing/concepts)
+
+For more information about OpenAI-compatible APIs, see the
+[OpenAI integration guide](/integrations/openai).

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/overview.mdx
@@ -95,6 +95,7 @@ Opik helps you easily log, visualize, and evaluate everything from raw LLM calls
   <Card title="Novita AI" href="/v1/integrations/novita-ai" />
   <Card title="Ollama" href="/v1/integrations/ollama" />
   <Card title="OpenAI" href="/v1/integrations/openai" />
+  <Card title="Qianfan" href="/v1/integrations/qianfan" />
   <Card title="Predibase" href="/v1/integrations/predibase" />
   <Card title="Together AI" href="/v1/integrations/together-ai" />
   <Card title="WatsonX" href="/v1/integrations/watsonx" />

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/qianfan.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/qianfan.mdx
@@ -38,8 +38,8 @@ from openai import OpenAI
 # Initialize the OpenAI client with your Qianfan base URL
 client = OpenAI(
     base_url="https://api.baiduqianfan.ai/v1",
-    api_key="bce-v3/ALTAK-XXXXXXXX/XXXXXXXXXXXXXXXX",  # Qianfan bearer token
-    default_headers={"appid": "app-xxxxxx"}  # Optional Qianfan appid
+    api_key="<QIANFAN_BEARER_TOKEN>",  # Qianfan bearer token
+    default_headers={"appid": "<QIANFAN_APP_ID>"}  # Optional Qianfan appid
 )
 client = track_openai(client)
 
@@ -69,8 +69,8 @@ from openai import OpenAI
 
 client = OpenAI(
     base_url="https://api.baiduqianfan.ai/v1",
-    api_key="bce-v3/ALTAK-XXXXXXXX/XXXXXXXXXXXXXXXX",  # Qianfan bearer token
-    default_headers={"appid": "app-xxxxxx"}  # Optional Qianfan appid
+    api_key="<QIANFAN_BEARER_TOKEN>",  # Qianfan bearer token
+    default_headers={"appid": "<QIANFAN_APP_ID>"}  # Optional Qianfan appid
 )
 client = track_openai(client)
 

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/qianfan.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/qianfan.mdx
@@ -1,0 +1,115 @@
+---
+description: Start here to integrate Opik into your Qianfan-based genai application
+  for end-to-end LLM observability, unit testing, and optimization.
+headline: Qianfan | Opik Documentation
+og:description: Learn to integrate Opik with Qianfan using the OpenAI SDK for
+  OpenAI-compatible endpoints.
+og:site_name: Opik Documentation
+og:title: Integrate Opik with Qianfan for AI Observability
+title: Observability for Qianfan with Opik
+---
+
+[Baidu Qianfan](https://cloud.baidu.com/doc/qianfan/index.html) provides OpenAI-compatible
+API endpoints for hosted model access. This guide shows how to use the OpenAI SDK with
+Opik to trace and evaluate Qianfan calls.
+
+## Getting started
+
+First, ensure you have both `opik` and `openai` packages installed:
+
+```bash
+pip install opik openai
+```
+
+You will need a Qianfan API key and an OpenAI-compatible base URL. The Qianfan
+OpenAI-compatible base URL is:
+
+`https://api.baiduqianfan.ai/v1`
+
+Refer to the [Qianfan documentation](https://intl.cloud.baidu.com/en/doc/qianfan/s/qm8qxemze-intl-en)
+for the latest setup steps and model list.
+
+## Tracking Qianfan API calls
+
+```python
+from opik.integrations.openai import track_openai
+from openai import OpenAI
+
+# Initialize the OpenAI client with your Qianfan base URL
+client = OpenAI(
+    base_url="https://api.baiduqianfan.ai/v1",
+    api_key="bce-v3/ALTAK-XXXXXXXX/XXXXXXXXXXXXXXXX",  # Qianfan bearer token
+    default_headers={"appid": "app-xxxxxx"}  # Optional Qianfan appid
+)
+client = track_openai(client)
+
+response = client.chat.completions.create(
+    model="ernie-4.0-turbo-8k",  # Use a model name from Qianfan
+    messages=[
+        {"role": "user", "content": "Hello, world!"}
+    ],
+    temperature=0.7,
+    max_tokens=100
+)
+
+print(response.choices[0].message.content)
+```
+
+## Advanced Usage
+
+### Using with @track decorator
+
+You can combine the tracked client with Opik's `@track` decorator for
+end-to-end tracing:
+
+```python
+from opik import track
+from opik.integrations.openai import track_openai
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.baiduqianfan.ai/v1",
+    api_key="bce-v3/ALTAK-XXXXXXXX/XXXXXXXXXXXXXXXX",  # Qianfan bearer token
+    default_headers={"appid": "app-xxxxxx"}  # Optional Qianfan appid
+)
+client = track_openai(client)
+
+@track
+def summarize_report(text: str) -> str:
+    response = client.chat.completions.create(
+        model="ernie-4.0-turbo-8k",
+        messages=[
+            {"role": "user", "content": text}
+        ]
+    )
+
+    return response.choices[0].message.content
+
+summary = summarize_report("Summarize this report in 3 bullets.")
+print(summary)
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Authentication Errors**: Confirm your API key is valid and has access to Qianfan
+2. **Model Not Found**: Verify the model name matches one available in Qianfan
+3. **Base URL Issues**: Ensure you are using the OpenAI-compatible endpoint from Qianfan
+
+### Getting Help
+
+- Review the [Qianfan documentation](https://cloud.baidu.com/doc/qianfan/index.html)
+- Check Opik tracing docs for setup details: [/v1/tracing/sdk_configuration](/v1/tracing/sdk_configuration)
+
+## Next Steps
+
+Once you have Qianfan integrated with Opik, you can:
+
+- [Evaluate your LLM applications](/v1/evaluation/overview)
+- [Create datasets](/v1/evaluation/manage_datasets)
+- [Collect feedback](/v1/tracing/annotate_traces)
+- [Monitor traces](/v1/tracing/concepts)
+
+For more information about OpenAI-compatible APIs, see the
+[OpenAI integration guide](/v1/integrations/openai).

--- a/apps/opik-documentation/documentation/fern/versions/latest.yml
+++ b/apps/opik-documentation/documentation/fern/versions/latest.yml
@@ -729,6 +729,9 @@ navigation:
               - page: OpenAI
                 path: ../docs-v2/integrations/openai.mdx
                 slug: openai
+              - page: Qianfan
+                path: ../docs-v2/integrations/qianfan.mdx
+                slug: qianfan
               - page: Predibase
                 path: ../docs-v2/integrations/predibase.mdx
                 slug: predibase

--- a/apps/opik-documentation/documentation/fern/versions/v1.yml
+++ b/apps/opik-documentation/documentation/fern/versions/v1.yml
@@ -552,6 +552,9 @@ navigation:
               - page: OpenAI
                 path: ../docs/tracing/integrations/openai.mdx
                 slug: openai
+              - page: Qianfan
+                path: ../docs/tracing/integrations/qianfan.mdx
+                slug: qianfan
               - page: Predibase
                 path: ../docs/tracing/integrations/predibase.mdx
                 slug: predibase

--- a/sdks/python/src/opik/evaluation/scoring_functions/__init__.py
+++ b/sdks/python/src/opik/evaluation/scoring_functions/__init__.py
@@ -1,0 +1,11 @@
+from .classification import (
+    classification_f1_score,
+    classification_precision_score,
+    classification_recall_score,
+)
+
+__all__ = [
+    "classification_f1_score",
+    "classification_precision_score",
+    "classification_recall_score",
+]

--- a/sdks/python/src/opik/evaluation/scoring_functions/classification.py
+++ b/sdks/python/src/opik/evaluation/scoring_functions/classification.py
@@ -1,0 +1,204 @@
+from typing import Any, List, Optional, Sequence, Tuple, Union
+
+from .. import test_case, test_result
+from ..metrics import score_result
+
+try:
+    from sklearn import metrics as sklearn_metrics
+except ImportError:  # pragma: no cover
+    sklearn_metrics = None
+
+_ALLOWED_AVERAGES = {"micro", "macro", "weighted"}
+_ZeroDivisionType = Union[int, float, str]
+
+
+def _require_sklearn() -> Any:
+    if sklearn_metrics is None:  # pragma: no cover
+        raise ImportError(
+            "scikit-learn is required for classification scoring functions. "
+            "Install it with 'pip install scikit-learn'."
+        )
+    return sklearn_metrics
+
+
+def _resolve_label_value(
+    case: test_case.TestCase,
+    key: str,
+) -> Tuple[bool, Any]:
+    mapped_inputs = case.mapped_scoring_inputs
+    if mapped_inputs is not None and key in mapped_inputs:
+        return True, mapped_inputs[key]
+
+    if key in case.task_output:
+        return True, case.task_output[key]
+
+    if key in case.dataset_item_content:
+        return True, case.dataset_item_content[key]
+
+    return False, None
+
+
+def _collect_labels(
+    test_results: List[test_result.TestResult],
+    prediction_key: str,
+    reference_key: str,
+) -> Tuple[List[Any], List[Any], int]:
+    y_true: List[Any] = []
+    y_pred: List[Any] = []
+    skipped = 0
+
+    for result in test_results:
+        case = result.test_case
+        has_pred, pred = _resolve_label_value(case, prediction_key)
+        has_ref, ref = _resolve_label_value(case, reference_key)
+
+        if not has_pred or not has_ref:
+            skipped += 1
+            continue
+
+        y_true.append(ref)
+        y_pred.append(pred)
+
+    return y_true, y_pred, skipped
+
+
+def _validate_average(average: str) -> None:
+    if average not in _ALLOWED_AVERAGES:
+        raise ValueError(
+            f"Unsupported average='{average}'. Expected one of: {sorted(_ALLOWED_AVERAGES)}."
+        )
+
+
+def _build_reason(metric_name: str, average: str, total: int, skipped: int) -> str:
+    reason = f"{metric_name} ({average}) over {total} samples"
+    if skipped:
+        reason += f"; skipped {skipped} missing labels"
+    return reason
+
+
+def _classification_score(
+    *,
+    metric_name: str,
+    metric_fn: Any,
+    test_results: List[test_result.TestResult],
+    average: str,
+    prediction_key: str,
+    reference_key: str,
+    labels: Optional[Sequence[Any]],
+    pos_label: Any,
+    zero_division: _ZeroDivisionType,
+    name: Optional[str],
+) -> List[score_result.ScoreResult]:
+    _validate_average(average)
+
+    y_true, y_pred, skipped = _collect_labels(
+        test_results=test_results,
+        prediction_key=prediction_key,
+        reference_key=reference_key,
+    )
+
+    if not y_true:
+        return []
+
+    value = metric_fn(
+        y_true,
+        y_pred,
+        average=average,
+        labels=labels,
+        pos_label=pos_label,
+        zero_division=zero_division,
+    )
+
+    result_name = name or f"{metric_name}_{average}"
+    return [
+        score_result.ScoreResult(
+            name=result_name,
+            value=float(value),
+            reason=_build_reason(metric_name, average, len(y_true), skipped),
+            metadata={
+                "average": average,
+                "samples": len(y_true),
+                "skipped": skipped,
+                "prediction_key": prediction_key,
+                "reference_key": reference_key,
+            },
+        )
+    ]
+
+
+def classification_f1_score(
+    test_results: List[test_result.TestResult],
+    *,
+    average: str = "macro",
+    prediction_key: str = "output",
+    reference_key: str = "reference",
+    labels: Optional[Sequence[Any]] = None,
+    pos_label: Any = 1,
+    zero_division: _ZeroDivisionType = 0.0,
+    name: Optional[str] = None,
+) -> List[score_result.ScoreResult]:
+    """Compute dataset-level F1 for classification tasks."""
+    return _classification_score(
+        metric_name="classification_f1",
+        metric_fn=_require_sklearn().f1_score,
+        test_results=test_results,
+        average=average,
+        prediction_key=prediction_key,
+        reference_key=reference_key,
+        labels=labels,
+        pos_label=pos_label,
+        zero_division=zero_division,
+        name=name,
+    )
+
+
+def classification_precision_score(
+    test_results: List[test_result.TestResult],
+    *,
+    average: str = "macro",
+    prediction_key: str = "output",
+    reference_key: str = "reference",
+    labels: Optional[Sequence[Any]] = None,
+    pos_label: Any = 1,
+    zero_division: _ZeroDivisionType = 0.0,
+    name: Optional[str] = None,
+) -> List[score_result.ScoreResult]:
+    """Compute dataset-level precision for classification tasks."""
+    return _classification_score(
+        metric_name="classification_precision",
+        metric_fn=_require_sklearn().precision_score,
+        test_results=test_results,
+        average=average,
+        prediction_key=prediction_key,
+        reference_key=reference_key,
+        labels=labels,
+        pos_label=pos_label,
+        zero_division=zero_division,
+        name=name,
+    )
+
+
+def classification_recall_score(
+    test_results: List[test_result.TestResult],
+    *,
+    average: str = "macro",
+    prediction_key: str = "output",
+    reference_key: str = "reference",
+    labels: Optional[Sequence[Any]] = None,
+    pos_label: Any = 1,
+    zero_division: _ZeroDivisionType = 0.0,
+    name: Optional[str] = None,
+) -> List[score_result.ScoreResult]:
+    """Compute dataset-level recall for classification tasks."""
+    return _classification_score(
+        metric_name="classification_recall",
+        metric_fn=_require_sklearn().recall_score,
+        test_results=test_results,
+        average=average,
+        prediction_key=prediction_key,
+        reference_key=reference_key,
+        labels=labels,
+        pos_label=pos_label,
+        zero_division=zero_division,
+        name=name,
+    )

--- a/sdks/python/tests/e2e/evaluation/test_experiment_scoring_functions.py
+++ b/sdks/python/tests/e2e/evaluation/test_experiment_scoring_functions.py
@@ -1,12 +1,19 @@
+import functools
 import statistics
-from typing import Dict, Any, List
+from typing import Any, Dict, List
 
 import pytest
+from sklearn import metrics as sklearn_metrics
 
 import opik
 from opik.evaluation import metrics
 from opik.evaluation import test_result
 from opik.evaluation.metrics import score_result
+from opik.evaluation.scoring_functions import (
+    classification_f1_score,
+    classification_precision_score,
+    classification_recall_score,
+)
 from .. import verifiers
 from ...testlib import generate_project_name
 
@@ -136,3 +143,87 @@ def test_experiment_scoring_functions__standard_deviation__computed_and_logged(
         f"Expected experiment score value {expected_stdev} in backend, but got {experiment_data.experiment_scores[0].value}. "
         f"Full score object: {experiment_data.experiment_scores[0]}"
     )
+
+
+def test_experiment_scoring_functions__classification_metrics__computed_and_logged(
+    opik_client: opik.Opik, dataset_name: str, experiment_name: str
+):
+    dataset = opik_client.create_dataset(dataset_name, project_name=PROJECT_NAME)
+
+    dataset.insert(
+        [
+            {"input": {"text": "first"}, "reference": "cat"},
+            {"input": {"text": "second"}, "reference": "dog"},
+            {"input": {"text": "third"}, "reference": "cat"},
+        ]
+    )
+
+    def task(item: Dict[str, Any]):
+        if item["input"] == {"text": "first"}:
+            return {"output": "cat"}
+        if item["input"] == {"text": "second"}:
+            return {"output": "cat"}
+        if item["input"] == {"text": "third"}:
+            return {"output": "cat"}
+
+        raise AssertionError(
+            f"Task received dataset item with an unexpected input: {item['input']}"
+        )
+
+    average = "macro"
+    f1_fn = functools.partial(classification_f1_score, average=average)
+    precision_fn = functools.partial(classification_precision_score, average=average)
+    recall_fn = functools.partial(classification_recall_score, average=average)
+
+    evaluation_result = opik.evaluate(
+        dataset=dataset,
+        task=task,
+        scoring_metrics=[],
+        experiment_name=experiment_name,
+        experiment_config={"model_name": "test-model"},
+        experiment_scoring_functions=[f1_fn, precision_fn, recall_fn],
+        project_name=PROJECT_NAME,
+    )
+
+    expected_y_true = ["cat", "dog", "cat"]
+    expected_y_pred = ["cat", "cat", "cat"]
+    expected_f1 = sklearn_metrics.f1_score(
+        expected_y_true,
+        expected_y_pred,
+        average=average,
+    )
+    expected_precision = sklearn_metrics.precision_score(
+        expected_y_true,
+        expected_y_pred,
+        average=average,
+    )
+    expected_recall = sklearn_metrics.recall_score(
+        expected_y_true,
+        expected_y_pred,
+        average=average,
+    )
+
+    assert len(evaluation_result.experiment_scores) == 3, (
+        f"Expected 3 experiment scores, got {len(evaluation_result.experiment_scores)}. "
+        f"Scores: {evaluation_result.experiment_scores}"
+    )
+
+    scores_by_name = {
+        score.name: score for score in evaluation_result.experiment_scores
+    }
+    assert scores_by_name["classification_f1_macro"].value == pytest.approx(
+        expected_f1, abs=0.0001
+    )
+    assert scores_by_name["classification_precision_macro"].value == pytest.approx(
+        expected_precision, abs=0.0001
+    )
+    assert scores_by_name["classification_recall_macro"].value == pytest.approx(
+        expected_recall, abs=0.0001
+    )
+
+    retrieved_experiment = opik_client.get_experiment_by_id(
+        evaluation_result.experiment_id
+    )
+    experiment_data = retrieved_experiment.get_experiment_data()
+    assert experiment_data.experiment_scores is not None
+    assert len(experiment_data.experiment_scores) == 3

--- a/sdks/python/tests/test_requirements.txt
+++ b/sdks/python/tests/test_requirements.txt
@@ -7,3 +7,4 @@ pytest-xdist
 deepdiff
 orderly_set==5.3.2  # Pinned version for stability
 pytest-deepassert==0.3.0
+scikit-learn


### PR DESCRIPTION
## Details\n\nAdd sklearn-backed experiment-level classification scorers (F1, precision, recall), expose them under opik.evaluation.scoring_functions, and add e2e coverage for evaluate() aggregation.\n\n## Change checklist\n\nUser facing\nDocumentation update\n\n## Issues\n\n27  Resolves #5988\n27 OPIK-NA\n\n## AI-WATERMARK\n\nAI-WATERMARK: yes\n\n27 Tools: GitHub Copilot\n27 Model(s): GPT-5.2-Codex\n27 Scope: Drafted classification scoring functions + e2e test updates\n27 Human verification: Manually reviewed the changes\n\n## Testing\n\nNot run (requires e2e backend).\n\n## Documentation\n\nNot required.