### PR TITLE
[NA] fix: preserve selected model provider in rule editor

### DIFF
--- a/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
@@ -186,17 +186,16 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
                 <div className="flex h-10 items-center justify-center gap-2">
                   <PromptModelSelect
                     value={model}
-                    onChange={(m) => {
+                    onChange={(m, resolvedProvider) => {
                       if (m) {
                         field.onChange(m);
                         // Update config to ensure reasoning models have temperature >= 1.0
-                        const newProvider = calculateModelProvider(m);
                         const currentConfig = form.getValues(
                           "llmJudgeDetails.config",
                         );
                         const adjustedConfig = updateProviderConfig(
                           currentConfig,
-                          { model: m, provider: newProvider },
+                          { model: m, provider: resolvedProvider },
                         );
                         if (
                           adjustedConfig &&

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.test.tsx
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+import { PROVIDER_MODEL_TYPE, PROVIDER_TYPE } from "@/types/providers";
+import LLMJudgeRuleDetails from "./LLMJudgeRuleDetails";
+
+const setValue = vi.fn();
+const getValues = vi.fn(() => ({ temperature: 0, maxCompletionTokens: 1024 }));
+const fieldOnChange = vi.fn();
+let promptModelSelectProps: {
+  onChange: (model: PROVIDER_MODEL_TYPE, provider: PROVIDER_TYPE) => void;
+};
+let promptModelConfigsProvider: string | undefined;
+const updateProviderConfig = vi.fn(
+  (config: Record<string, unknown>, params: { provider: PROVIDER_TYPE }) => ({
+    ...config,
+    providerSeen: params.provider,
+  }),
+);
+
+vi.mock("@/hooks/useLLMProviderModelsData", () => ({
+  default: () => ({
+    calculateModelProvider: vi.fn(() => PROVIDER_TYPE.GEMINI),
+    calculateDefaultModel: vi.fn(
+      () => PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_2_5_PRO,
+    ),
+  }),
+}));
+
+vi.mock("@/contexts/feature-toggles-provider", () => ({
+  useIsFeatureEnabled: () => false,
+}));
+
+vi.mock("@/v2/pages-shared/llm/PromptModelSelect/PromptModelSelect", () => ({
+  default: (props: typeof promptModelSelectProps) => {
+    promptModelSelectProps = props;
+    return (
+      <button
+        onClick={() =>
+          props.onChange(
+            PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_2_5_PRO,
+            PROVIDER_TYPE.VERTEX_AI,
+          )
+        }
+      >
+        Select Vertex model
+      </button>
+    );
+  },
+}));
+
+vi.mock("@/v2/pages-shared/llm/PromptModelSettings/PromptModelConfigs", () => ({
+  default: (props: { provider: string }) => {
+    promptModelConfigsProvider = props.provider;
+    return null;
+  },
+}));
+vi.mock("@/lib/modelUtils", () => ({
+  updateProviderConfig: (...args: Parameters<typeof updateProviderConfig>) =>
+    updateProviderConfig(...args),
+}));
+
+vi.mock("@/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessages", () => ({
+  default: () => null,
+}));
+vi.mock(
+  "@/v2/pages-shared/llm/LLMPromptMessagesVariables/LLMPromptMessagesVariables",
+  () => ({ default: () => null }),
+);
+vi.mock("@/v2/pages-shared/llm/LLMJudgeScores/LLMJudgeScores", () => ({
+  default: () => null,
+}));
+vi.mock("@/shared/ExplainerIcon/ExplainerIcon", () => ({
+  default: () => null,
+}));
+vi.mock("@/shared/TooltipWrapper/TooltipWrapper", () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("@/shared/SelectBox/SelectBox", () => ({ default: () => null }));
+
+const form = {
+  control: {},
+  watch: vi.fn((name: string) => {
+    if (name === "scope") {
+      return "trace";
+    }
+    return "";
+  }),
+  getValues,
+  setValue,
+} as never;
+
+vi.mock("@/ui/form", () => ({
+  FormControl: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  FormItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  FormMessage: () => null,
+  FormField: ({
+    render,
+    name,
+  }: {
+    render: (args: unknown) => React.ReactNode;
+    name: string;
+  }) =>
+    render({
+      field: {
+        value: name === "llmJudgeDetails.model" ? "" : undefined,
+        onChange: fieldOnChange,
+      },
+      formState: { errors: {} },
+    }),
+}));
+
+describe("LLMJudgeRuleDetails", () => {
+  it("uses the provider resolved by PromptModelSelect when updating model config", () => {
+    render(<LLMJudgeRuleDetails workspaceName="workspace" form={form} />);
+
+    expect(promptModelConfigsProvider).toBe(PROVIDER_TYPE.GEMINI);
+
+    fireEvent.click(screen.getByText("Select Vertex model"));
+
+    expect(fieldOnChange).toHaveBeenCalledWith(
+      PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_2_5_PRO,
+    );
+    expect(updateProviderConfig).toHaveBeenCalledWith(
+      { temperature: 0, maxCompletionTokens: 1024 },
+      {
+        model: PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_2_5_PRO,
+        provider: PROVIDER_TYPE.VERTEX_AI,
+      },
+    );
+    expect(setValue).toHaveBeenCalledWith("llmJudgeDetails.config", {
+      temperature: 0,
+      maxCompletionTokens: 1024,
+      providerSeen: PROVIDER_TYPE.VERTEX_AI,
+    });
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
@@ -184,17 +184,16 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
                 <div className="flex h-10 items-center justify-center gap-2">
                   <PromptModelSelect
                     value={model}
-                    onChange={(m) => {
+                    onChange={(m, resolvedProvider) => {
                       if (m) {
                         field.onChange(m);
                         // Update config to ensure reasoning models have temperature >= 1.0
-                        const newProvider = calculateModelProvider(m);
                         const currentConfig = form.getValues(
                           "llmJudgeDetails.config",
                         );
                         const adjustedConfig = updateProviderConfig(
                           currentConfig,
-                          { model: m, provider: newProvider },
+                          { model: m, provider: resolvedProvider },
                         );
                         if (
                           adjustedConfig &&


### PR DESCRIPTION
## Details

Online evaluation rule edits re-derived the model provider from the model id, so a Vertex AI selection that maps to an underlying Gemini model was rewritten as a direct Gemini provider. This change uses the provider already resolved by `PromptModelSelect` when updating the LLM judge config, so ambiguous Vertex AI / Gemini picks keep the provider the user selected.

- Use the provider resolved by `PromptModelSelect` when rule model selections update LLM judge config.
- Apply the same fix to the v1 and v2 rule editor components.
- Add a regression test covering the ambiguous Vertex AI / Gemini selection path.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #6928

## AI-WATERMARK

AI-WATERMARK: no

## Testing

From `apps/opik-frontend`:

- `npx vitest run src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.test.tsx`
- `npx eslint src/v1/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.test.tsx`
- `npm run typecheck`
- `git diff --check`

Scenarios validated: selecting a Vertex AI model that resolves to a Gemini model keeps the Vertex AI provider; selecting a direct Gemini model is unchanged; switching providers updates config as before.

## Documentation

No documentation changes required; this is a bug fix with no user-facing API or UI surface changes.


<!-- metadata refreshed for PR linter on 2026-06-05 -->
