### PR TITLE
[NA] [BE][FE] chore: sync provider model definitions

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/AnthropicModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/AnthropicModelName.java
@@ -15,11 +15,11 @@ public enum AnthropicModelName implements StructuredOutputSupported {
     CLAUDE_OPUS_4_5("claude-opus-4-5-20251101"),
     CLAUDE_OPUS_4_6("claude-opus-4-6"),
     CLAUDE_OPUS_4_7("claude-opus-4-7"),
+    CLAUDE_OPUS_4_8("claude-opus-4-8"),
     CLAUDE_SONNET_4("claude-sonnet-4-20250514"),
     CLAUDE_SONNET_4_5("claude-sonnet-4-5"),
     CLAUDE_SONNET_4_5_20250929("claude-sonnet-4-5-20250929"),
-    CLAUDE_SONNET_4_6("claude-sonnet-4-6"),
-    CLAUDE_OPUS_4_8("claude-opus-4-8");
+    CLAUDE_SONNET_4_6("claude-sonnet-4-6");
 
     private final String value;
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/gemini/GeminiModelName.java
@@ -26,8 +26,10 @@ public enum GeminiModelName implements StructuredOutputSupported {
     GEMINI_2_5_FLASH_LITE("gemini-2.5-flash-lite", true),
     GEMINI_2_5_PRO("gemini-2.5-pro", true),
     GEMINI_3_FLASH("gemini-3-flash-preview", true),
+    GEMINI_3_PRO_IMAGE("gemini-3-pro-image", false),
     GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", true),
     GEMINI_3_PRO("gemini-3-pro-preview", true),
+    GEMINI_3_1_FLASH_IMAGE("gemini-3.1-flash-image", false),
     GEMINI_3_1_FLASH_IMAGE_PREVIEW("gemini-3.1-flash-image-preview", true),
     GEMINI_3_1_FLASH_LITE("gemini-3.1-flash-lite", false),
     GEMINI_3_1_FLASH_LITE_PREVIEW("gemini-3.1-flash-lite-preview", true),
@@ -40,9 +42,7 @@ public enum GeminiModelName implements StructuredOutputSupported {
     LYRIA_3_CLIP_PREVIEW("lyria-3-clip-preview", false),
     LYRIA_3_PRO_PREVIEW("lyria-3-pro-preview", false),
     NANO_BANANA_PRO_PREVIEW("nano-banana-pro-preview", false),
-    TEXT_EMBEDDING("text-embedding-004", false),
-    GEMINI_3_PRO_IMAGE("gemini-3-pro-image", false),
-    GEMINI_3_1_FLASH_IMAGE("gemini-3.1-flash-image", false);
+    TEXT_EMBEDDING("text-embedding-004", false);
 
     private static final String WARNING_UNKNOWN_MODEL = "could not find GeminiModelName with value '{}'";
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterModelName.java
@@ -220,6 +220,7 @@ public enum OpenRouterModelName implements StructuredOutputSupported {
     MINIMAX_MINIMAX_M2_5("minimax/minimax-m2.5"),
     MINIMAX_MINIMAX_M2_5_FREE("minimax/minimax-m2.5:free"),
     MINIMAX_MINIMAX_M2_7("minimax/minimax-m2.7"),
+    MINIMAX_MINIMAX_M3("minimax/minimax-m3"),
     MISTRALAI_CODESTRAL_2501("mistralai/codestral-2501"),
     MISTRALAI_CODESTRAL_2508("mistralai/codestral-2508"),
     MISTRALAI_DEVSTRAL_2512("mistralai/devstral-2512"),

--- a/apps/opik-backend/src/main/resources/llm-models-default.yaml
+++ b/apps/opik-backend/src/main/resources/llm-models-default.yaml
@@ -182,12 +182,6 @@ gemini:
   - id: "gemini-2.5-flash-lite"
     label: "Gemini 2.5 Flash-Lite"
     structuredOutput: true
-  - id: "gemini-2.0-flash"
-    label: "Gemini 2.0 Flash"
-    structuredOutput: true
-  - id: "gemini-2.0-flash-lite"
-    label: "Gemini 2.0 Flash-Lite"
-    structuredOutput: true
   - id: "gemma-4-26b-a4b-it"
     label: "Gemma 4 26B A4B IT"
   - id: "gemma-4-31b-it"
@@ -201,6 +195,10 @@ gemini:
   - id: "gemini-1.5-flash-latest"
     structuredOutput: true
   - id: "gemini-1.5-pro-latest"
+    structuredOutput: true
+  - id: "gemini-2.0-flash"
+    structuredOutput: true
+  - id: "gemini-2.0-flash-lite"
     structuredOutput: true
   - id: "gemini-2.5-flash-image"
     structuredOutput: true
@@ -489,9 +487,6 @@ openrouter:
     label: "eleutherai/llemma_7b"
   - id: "essentialai/rnj-1-instruct"
     label: "essentialai/rnj-1-instruct"
-  - id: "google/gemini-2.0-flash-001"
-    label: "google/gemini-2.0-flash-001"
-    structuredOutput: true
   - id: "google/gemini-2.0-flash-exp:free"
     label: "google/gemini-2.0-flash-exp:free"
     structuredOutput: true
@@ -709,6 +704,8 @@ openrouter:
     label: "minimax/minimax-m2.5:free"
   - id: "minimax/minimax-m2.7"
     label: "minimax/minimax-m2.7"
+  - id: "minimax/minimax-m3"
+    label: "minimax/minimax-m3"
   - id: "mistralai/codestral-2501"
     label: "mistralai/codestral-2501"
     structuredOutput: true
@@ -1386,3 +1383,5 @@ openrouter:
     label: "~openai/gpt-latest"
   - id: "~openai/gpt-mini-latest"
     label: "~openai/gpt-mini-latest"
+  - id: "google/gemini-2.0-flash-001"
+    structuredOutput: true

--- a/apps/opik-frontend/src/constants/providerModels.ts
+++ b/apps/opik-frontend/src/constants/providerModels.ts
@@ -551,10 +551,6 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       label: "essentialai/rnj-1-instruct",
     },
     {
-      value: PROVIDER_MODEL_TYPE.GOOGLE_GEMINI_2_0_FLASH_001,
-      label: "google/gemini-2.0-flash-001",
-    },
-    {
       value: PROVIDER_MODEL_TYPE.GOOGLE_GEMINI_2_0_FLASH_EXP_FREE,
       label: "google/gemini-2.0-flash-exp:free",
     },
@@ -949,6 +945,10 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
     {
       value: PROVIDER_MODEL_TYPE.MINIMAX_MINIMAX_M2_7,
       label: "minimax/minimax-m2.7",
+    },
+    {
+      value: PROVIDER_MODEL_TYPE.MINIMAX_MINIMAX_M3,
+      label: "minimax/minimax-m3",
     },
     {
       value: PROVIDER_MODEL_TYPE.MISTRALAI_CODESTRAL_2501,
@@ -2213,14 +2213,6 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
     {
       value: PROVIDER_MODEL_TYPE.GEMINI_2_5_FLASH_LITE,
       label: "Gemini 2.5 Flash-Lite",
-    },
-    {
-      value: PROVIDER_MODEL_TYPE.GEMINI_2_0_FLASH,
-      label: "Gemini 2.0 Flash",
-    },
-    {
-      value: PROVIDER_MODEL_TYPE.GEMINI_2_0_FLASH_LITE,
-      label: "Gemini 2.0 Flash-Lite",
     },
     {
       value: PROVIDER_MODEL_TYPE.GEMMA_4_26B_A4B_IT,

--- a/apps/opik-frontend/src/types/providers.ts
+++ b/apps/opik-frontend/src/types/providers.ts
@@ -102,11 +102,11 @@ export enum PROVIDER_MODEL_TYPE {
   CLAUDE_OPUS_4_5 = "claude-opus-4-5-20251101",
   CLAUDE_OPUS_4_6 = "claude-opus-4-6",
   CLAUDE_OPUS_4_7 = "claude-opus-4-7",
+  CLAUDE_OPUS_4_8 = "claude-opus-4-8",
   CLAUDE_SONNET_4 = "claude-sonnet-4-20250514",
   CLAUDE_SONNET_4_5 = "claude-sonnet-4-5",
   CLAUDE_SONNET_4_5_20250929 = "claude-sonnet-4-5-20250929",
   CLAUDE_SONNET_4_6 = "claude-sonnet-4-6",
-  CLAUDE_OPUS_4_8 = "claude-opus-4-8",
 
   //  <---- OpenRouter
   AI21_JAMBA_LARGE_1_7 = "ai21/jamba-large-1.7",
@@ -311,6 +311,7 @@ export enum PROVIDER_MODEL_TYPE {
   MINIMAX_MINIMAX_M2_5 = "minimax/minimax-m2.5",
   MINIMAX_MINIMAX_M2_5_FREE = "minimax/minimax-m2.5:free",
   MINIMAX_MINIMAX_M2_7 = "minimax/minimax-m2.7",
+  MINIMAX_MINIMAX_M3 = "minimax/minimax-m3",
   MISTRALAI_CODESTRAL_2501 = "mistralai/codestral-2501",
   MISTRALAI_CODESTRAL_2508 = "mistralai/codestral-2508",
   MISTRALAI_DEVSTRAL_2512 = "mistralai/devstral-2512",
@@ -631,8 +632,10 @@ export enum PROVIDER_MODEL_TYPE {
   GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite",
   GEMINI_2_5_PRO = "gemini-2.5-pro",
   GEMINI_3_FLASH = "gemini-3-flash-preview",
+  GEMINI_3_PRO_IMAGE = "gemini-3-pro-image",
   GEMINI_3_PRO_IMAGE_PREVIEW = "gemini-3-pro-image-preview",
   GEMINI_3_PRO = "gemini-3-pro-preview",
+  GEMINI_3_1_FLASH_IMAGE = "gemini-3.1-flash-image",
   GEMINI_3_1_FLASH_IMAGE_PREVIEW = "gemini-3.1-flash-image-preview",
   GEMINI_3_1_FLASH_LITE = "gemini-3.1-flash-lite",
   GEMINI_3_1_FLASH_LITE_PREVIEW = "gemini-3.1-flash-lite-preview",
@@ -646,8 +649,6 @@ export enum PROVIDER_MODEL_TYPE {
   LYRIA_3_PRO_PREVIEW = "lyria-3-pro-preview",
   NANO_BANANA_PRO_PREVIEW = "nano-banana-pro-preview",
   TEXT_EMBEDDING = "text-embedding-004",
-  GEMINI_3_PRO_IMAGE = "gemini-3-pro-image",
-  GEMINI_3_1_FLASH_IMAGE = "gemini-3.1-flash-image",
 
   //   <------ vertex ai
   VERTEX_AI_GEMINI_2_0_FLASH = "vertex_ai/gemini-2.0-flash-001",


### PR DESCRIPTION
## Details

Automated sync of LLM provider model definitions from source APIs and prices JSON.

**Sync summary:**
```
## Provider Model Sync

### Openrouter
- Added 1 model(s):
  + minimax/minimax-m3
- Stale 165 model(s) (not in source, manual review needed):
  ? ai21/jamba-mini-1.7
  ? alfredpros/codellama-7b-instruct-solidity
  ? alibaba/tongyi-deepresearch-30b-a3b
  ? alibaba/tongyi-deepresearch-30b-a3b:free
  ? allenai/molmo-2-8b
  ? allenai/olmo-2-0325-32b-instruct
  ? allenai/olmo-3-7b-instruct
  ? allenai/olmo-3-7b-think
  ? allenai/olmo-3.1-32b-instruct
  ? allenai/olmo-3.1-32b-think
  ? alpindale/goliath-120b
  ? anthropic/claude-3.5-sonnet
  ? anthropic/claude-3.7-sonnet
  ? anthropic/claude-3.7-sonnet:thinking
  ? arcee-ai/afm-4.5b
  ? arcee-ai/trinity-large-preview
  ? arcee-ai/trinity-large-preview:free
  ? arcee-ai/trinity-large-thinking:free
  ? arcee-ai/trinity-mini:free
  ? arliai/qwq-32b-arliai-rpr-v1
  ? arliai/qwq-32b-arliai-rpr-v1:free
  ? baidu/cobuddy:free
  ? baidu/ernie-4.5-21b-a3b
  ? baidu/ernie-4.5-21b-a3b-thinking
  ? baidu/qianfan-ocr-fast
  ? baidu/qianfan-ocr-fast:free
  ? deepcogito/cogito-v2-preview-deepseek-671b
  ? deepcogito/cogito-v2-preview-llama-109b-moe
  ? deepcogito/cogito-v2-preview-llama-405b
  ? deepcogito/cogito-v2-preview-llama-70b
  ? deepseek/deepseek-chat-v3-0324:free
  ? deepseek/deepseek-prover-v2
  ? deepseek/deepseek-r1-0528-qwen3-8b
  ? deepseek/deepseek-r1-0528-qwen3-8b:free
  ? deepseek/deepseek-r1-0528:free
  ? deepseek/deepseek-r1-distill-llama-70b:free
  ? deepseek/deepseek-r1-distill-qwen-14b
  ? deepseek/deepseek-r1:free
  ? deepseek/deepseek-v3.1-terminus:exacto
  ? deepseek/deepseek-v3.2-speciale
  ? deepseek/deepseek-v4-flash:free
  ? eleutherai/llemma_7b
  ? google/gemini-2.0-flash-exp:free
  ? google/gemini-2.5-flash-image-preview
  ? google/gemini-2.5-flash-preview-09-2025
  ? google/gemini-3-pro-preview
  ? google/gemma-2-9b-it
  ? google/gemma-3-12b-it:free
  ? google/gemma-3-27b-it:free
  ? google/gemma-3-4b-it:free
  ? google/gemma-3n-e2b-it:free
  ? google/gemma-3n-e4b-it:free
  ? inception/mercury
  ? inception/mercury-coder
  ? inclusionai/ling-2.6-1t:free
  ? inclusionai/ling-2.6-flash:free
  ? inclusionai/ring-2.6-1t:free
  ? kwaipilot/kat-coder-pro
  ? kwaipilot/kat-coder-pro:free
  ? liquid/lfm-2.2-6b
  ? liquid/lfm2-8b-a1b
  ? meituan/longcat-flash-chat
  ? meituan/longcat-flash-chat:free
  ? meta-llama/llama-3.1-405b
  ? meta-llama/llama-3.1-405b-instruct
  ? meta-llama/llama-3.2-90b-vision-instruct
  ? meta-llama/llama-guard-2-8b
  ? meta-llama/llama-guard-4-12b:free
  ? microsoft/mai-ds-r1
  ? microsoft/mai-ds-r1:free
  ? microsoft/phi-3-medium-128k-instruct
  ? microsoft/phi-3-mini-128k-instruct
  ? microsoft/phi-3.5-mini-128k-instruct
  ? microsoft/phi-4-multimodal-instruct
  ? microsoft/phi-4-reasoning-plus
  ? minimax/minimax-m2.5:free
  ? mistralai/codestral-2501
  ? mistralai/devstral-medium
  ? mistralai/devstral-small
  ? mistralai/devstral-small-2505
  ? mistralai/magistral-medium-2506
  ? mistralai/magistral-medium-2506:thinking
  ? mistralai/magistral-small-2506
  ? mistralai/ministral-3b
  ? mistralai/ministral-8b
  ? mistralai/mistral-7b-instruct
  ? mistralai/mistral-7b-instruct-v0.1
  ? mistralai/mistral-7b-instruct-v0.2
  ? mistralai/mistral-7b-instruct-v0.3
  ? mistralai/mistral-7b-instruct:free
  ? mistralai/mistral-large-2411
  ? mistralai/mistral-nemo:free
  ? mistralai/mistral-small
  ? mistralai/mistral-small-24b-instruct-2501:free
  ? mistralai/mistral-small-3.1-24b-instruct:free
  ? mistralai/mistral-small-3.2-24b-instruct:free
  ? mistralai/mistral-small-creative
  ? mistralai/mistral-tiny
  ? mistralai/mixtral-8x7b-instruct
  ? mistralai/pixtral-12b
  ? mistralai/pixtral-large-2411
  ? moonshotai/kimi-dev-72b
  ? moonshotai/kimi-k2-0905:exacto
  ? moonshotai/kimi-k2:free
  ? moonshotai/kimi-linear-48b-a3b-instruct
  ? neversleep/llama-3.1-lumimaid-8b
  ? neversleep/noromaid-20b
  ? nousresearch/deephermes-3-mistral-24b-preview
  ? nvidia/llama-3.1-nemotron-70b-instruct
  ? nvidia/llama-3.1-nemotron-ultra-253b-v1
  ? nvidia/nemotron-nano-12b-v2-vl
  ? openai/chatgpt-4o-latest
  ? openai/codex-mini
  ? openai/gpt-4o-audio-preview
  ? openai/gpt-4o:extended
  ? openai/gpt-5.2-chat-latest
  ? openai/gpt-oss-120b:exacto
  ? opengvlab/internvl3-78b
  ? openrouter/elephant-alpha
  ? openrouter/healer-alpha
  ? openrouter/hunter-alpha
  ? perplexity/sonar-reasoning
  ? qwen/qwen-2.5-72b-instruct:free
  ? qwen/qwen-2.5-coder-32b-instruct:free
  ? qwen/qwen-2.5-vl-7b-instruct
  ? qwen/qwen-max
  ? qwen/qwen-turbo
  ? qwen/qwen-vl-max
  ? qwen/qwen-vl-plus
  ? qwen/qwen2.5-coder-7b-instruct
  ? qwen/qwen2.5-vl-32b-instruct
  ? qwen/qwen2.5-vl-32b-instruct:free
  ? qwen/qwen3-14b:free
  ? qwen/qwen3-235b-a22b:free
  ? qwen/qwen3-30b-a3b:free
  ? qwen/qwen3-4b:free
  ? qwen/qwen3-coder:exacto
  ? qwen/qwen3.6-plus-preview:free
  ? qwen/qwen3.6-plus:free
  ? qwen/qwq-32b
  ? raifle/sorcererlm-8x22b
  ? reka/reka-edge
  ? stepfun-ai/step3
  ? stepfun/step-3.5-flash:free
  ? tencent/hy3-preview:free
  ? thedrummer/anubis-70b-v1.1
  ? thudm/glm-4.1v-9b-thinking
  ? tngtech/deepseek-r1t-chimera
  ? tngtech/deepseek-r1t-chimera:free
  ? tngtech/deepseek-r1t2-chimera
  ? tngtech/deepseek-r1t2-chimera:free
  ? x-ai/grok-3
  ? x-ai/grok-3-beta
  ? x-ai/grok-3-mini
  ? x-ai/grok-3-mini-beta
  ? x-ai/grok-4
  ? x-ai/grok-4-fast
  ? x-ai/grok-4.1-fast
  ? x-ai/grok-4.1-fast:free
  ? x-ai/grok-4.20-beta
  ? x-ai/grok-4.20-multi-agent-beta
  ? x-ai/grok-code-fast-1
  ? xiaomi/mimo-v2-omni
  ? xiaomi/mimo-v2-pro
  ? z-ai/glm-4.6:exacto
- Deprecated 1 model(s) (past deprecation_date, excluded from dropdown):
  ✗ google/gemini-2.0-flash-001
- Total models: 510 (dropdown: 509)

### Openai
- Stale 15 model(s) (not in source, manual review needed):
  ? chatgpt-4o-latest
  ? gpt-4-0125-preview
  ? gpt-4-0314
  ? gpt-4-1106-preview
  ? gpt-4-turbo-2024-04-09
  ? gpt-4-turbo-preview
  ? gpt-4o-2024-05-13
  ? gpt-4o-2024-08-06
  ? gpt-4o-2024-11-20
  ? gpt-4o-mini-2024-07-18
  ? o1-2024-12-17
  ? o1-mini
  ? o1-mini-2024-09-12
  ? o1-preview
  ? o1-preview-2024-09-12
- Deprecated 4 model(s) (past deprecation_date, excluded from dropdown):
  ✗ gpt-4-0125-preview
  ✗ gpt-4-0314
  ✗ gpt-4-0613
  ✗ gpt-4-1106-preview
- Total models: 65 (dropdown: 20)

### Anthropic
- Stale 2 model(s) (not in source, manual review needed):
  ? claude-3-7-sonnet-20250219
  ? claude-sonnet-4-5
- Deprecated 3 model(s) (past deprecation_date, excluded from dropdown):
  ✗ claude-3-7-sonnet-20250219
  ✗ claude-opus-4-20250514
  ✗ claude-sonnet-4-20250514
- Total models: 12 (dropdown: 8)

### Gemini
- Stale 6 model(s) (not in source, manual review needed):
  ? aqa
  ? gemini-1.0-pro
  ? gemini-1.5-flash-latest
  ? gemini-1.5-pro-latest
  ? gemini-pro-vision
  ? text-embedding-004
- Deprecated 4 model(s) (past deprecation_date, excluded from dropdown):
  ✗ gemini-2.0-flash
  ✗ gemini-2.0-flash-lite
  ✗ gemini-3-pro-preview
  ✗ text-embedding-004
- Total models: 28 (dropdown: 12)

### Vertexai
- Stale 9 model(s) (not in source, manual review needed):
  ? vertex_ai/gemini-2.0-flash-001
  ? vertex_ai/gemini-2.0-flash-lite-001
  ? vertex_ai/gemini-2.5-flash
  ? vertex_ai/gemini-2.5-flash-lite-preview-06-17
  ? vertex_ai/gemini-2.5-flash-preview-04-17
  ? vertex_ai/gemini-2.5-pro
  ? vertex_ai/gemini-2.5-pro-exp-03-25
  ? vertex_ai/gemini-2.5-pro-preview-03-25
  ? vertex_ai/gemini-2.5-pro-preview-05-06
- Total models: 13 (dropdown: 8)

```

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: GitHub Actions (`sync_provider_models.yml`)
  - Model(s): N/A (scripted automation)
  - Scope: Automated model list sync
  - Human verification: Requires manual review before merge

## Testing

- Script dry-run passed in CI
- Changes are add-only; stale/deprecated models flagged for manual review

## Documentation

N/A