### PR TITLE
[OPIK-6727] [FE] fix: drop active-project filter from Trial Page constituent experiments fetch

### DIFF
--- a/apps/opik-frontend/src/v2/pages/TrialPage/TrialPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/TrialPage/TrialPage.tsx
@@ -14,7 +14,7 @@ import useExperimentsList from "@/api/datasets/useExperimentsList";
 import useDeepMemo from "@/hooks/useDeepMemo";
 import { Experiment, EXPERIMENT_TYPE } from "@/types/datasets";
 import useOptimizationById from "@/api/optimizations/useOptimizationById";
-import useAppStore, { useActiveProjectId } from "@/store/AppStore";
+import useAppStore from "@/store/AppStore";
 import { checkIsTestSuite } from "@/lib/optimizations";
 import { getObjectiveScoreValue } from "@/lib/feedback-scores";
 import { keepPreviousData } from "@tanstack/react-query";
@@ -24,7 +24,6 @@ import { MAX_EXPERIMENTS_LOADED } from "@/lib/optimizations";
 
 const TrialPage: React.FunctionComponent = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
-  const activeProjectId = useActiveProjectId();
   const {
     permissions: { canViewDatasets },
   } = usePermissions();
@@ -58,7 +57,6 @@ const TrialPage: React.FunctionComponent = () => {
   const { data: optimizationExperimentsData } = useExperimentsList(
     {
       workspaceName,
-      projectId: activeProjectId ?? undefined,
       optimizationId,
       types: [EXPERIMENT_TYPE.TRIAL],
       page: 1,


### PR DESCRIPTION
## Details

Third and final carve-out of OPIK-6727, following the aggregation-fix carve-out (#6912, merged) and the migration-job carve-out (#6923, in review). The V2 Trial Page lives under a project-scoped route (`/projects/$projectId/optimizations/$optimizationId/trials`) and was passing the URL's `activeProjectId` into the `useExperimentsList` lookup that loads the optimization's constituent trials. This silently dropped any trial whose `project_id` differed from the URL's project — a regression vector that becomes load-bearing once the migration-job PR assigns multi-project experiments to a single dominant project per trial.

After this change the lookup is scoped by `optimizationId` only: every experiment belongs to exactly one optimization, so the optimization id is a sufficient and correct filter. The backend API already accepts the unscoped form (the hook conditionally selects between the project-scoped and the generic experiments endpoint based on whether `projectId` is passed); no backend change needed. The V1 Trial Page has always called the hook this way — V2 now aligns.

The change is three lines: drop the `useActiveProjectId` named import, drop the local `const activeProjectId = useActiveProjectId();`, drop the `projectId: activeProjectId ?? undefined` parameter from the `useExperimentsList(...)` call. No new component, no new branch, no new state.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6727

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: assisted (analysis, code review, PR description)
- Human verification: code review + manual verification of typecheck and lint locally

## Testing

Pre-flight checks run locally on the FE workspace:

```
npm run typecheck  # clean
npm run lint       # clean
```

No FE unit tests exist for the Trial Page (either v1 or v2 variant) — page-level entry components in this codebase are not unit-tested by convention; tests live one layer down (utilities in `lib/`, hooks, shared/redirect components). Adding a test for this three-line removal would require mocking ~6 hooks plus four sub-components for a single "this parameter is absent" assertion — disproportionate to the change and inconsistent with the existing v2 page-component pattern.

Manual operational verification per the OPIK-6727 ticket: with a synthetic optimization whose constituent experiments span ≥ 2 projects, verify the Trial Page lists every constituent regardless of which project the URL is scoped to. This becomes naturally exercisable once the migration-job PR (#6923) ships and assigns multi-project orphans to their dominant projects.

## Documentation

N/A. Backend-internal correctness fix; no user-visible behavior change for single-project optimizations. Multi-project optimizations now correctly show every trial on the Trial Page after this fix lands and the migration job assigns dominant projects.