### PR TITLE
[OPIK-6754] [FE] polish: env pill sizing, deploy menu UX, playground hover fix

### DIFF
--- a/apps/opik-frontend/src/api/environments/useEnvironmentsList.ts
+++ b/apps/opik-frontend/src/api/environments/useEnvironmentsList.ts
@@ -5,7 +5,7 @@ import api, {
   QueryConfig,
 } from "@/api/api";
 import { Environment } from "@/types/environments";
-import { sortEnvironments } from "@/shared/EnvironmentLabel/helpers";
+import { sortEnvironments } from "@/utils/environments";
 
 export type UseEnvironmentsListResponse = {
   content: Environment[];

--- a/apps/opik-frontend/src/api/environments/useEnvironmentsList.ts
+++ b/apps/opik-frontend/src/api/environments/useEnvironmentsList.ts
@@ -5,6 +5,7 @@ import api, {
   QueryConfig,
 } from "@/api/api";
 import { Environment } from "@/types/environments";
+import { sortEnvironments } from "@/shared/EnvironmentLabel/helpers";
 
 export type UseEnvironmentsListResponse = {
   content: Environment[];
@@ -20,7 +21,7 @@ const getEnvironmentsList = async ({ signal }: QueryFunctionContext) => {
     { signal },
   );
 
-  return data;
+  return { ...data, content: sortEnvironments(data.content) };
 };
 
 export default function useEnvironmentsList(

--- a/apps/opik-frontend/src/api/environments/useEnvironmentsList.ts
+++ b/apps/opik-frontend/src/api/environments/useEnvironmentsList.ts
@@ -21,7 +21,7 @@ const getEnvironmentsList = async ({ signal }: QueryFunctionContext) => {
     { signal },
   );
 
-  return { ...data, content: sortEnvironments(data.content) };
+  return { ...data, content: sortEnvironments(data.content ?? []) };
 };
 
 export default function useEnvironmentsList(

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadge.tsx
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadge.tsx
@@ -8,19 +8,19 @@ import {
 } from "./helpers";
 import { useEnvironmentByName } from "./EnvironmentLabel";
 
-// `promptPill` is a project-specific variant used across prompt-version
+// `pill` is a project-specific variant used across prompt-version
 // surfaces (prompt detail header, mobile version picker, version history
 // timeline, +N overflow tooltip): 20px tall with a 10px label and asymmetric
 // padding so the leading env icon hugs the left edge while the text gets a
 // little more breathing room on the right.
-export type EnvironmentBadgeSize = NonNullable<TagProps["size"]> | "promptPill";
+export type EnvironmentBadgeSize = NonNullable<TagProps["size"]> | "pill";
 
 const SIZE_CLASSES: Record<EnvironmentBadgeSize, string> = {
   default: "comet-body-xs h-5 px-2 leading-5 rounded-sm",
   sm: "comet-body-xs h-4 px-2 text-[11px] leading-4 rounded-sm",
   md: "comet-body-s h-6 px-1.5 leading-6 rounded-md",
   lg: "comet-body-s h-7 px-3 leading-7 rounded-md",
-  promptPill: "h-5 pl-1.5 pr-2 text-[10px] leading-5 rounded-sm",
+  pill: "h-5 pl-1.5 pr-2 text-[10px] leading-5 rounded-sm",
 };
 
 const ICON_SIZE_CLASSES: Record<EnvironmentBadgeSize, string> = {
@@ -28,7 +28,7 @@ const ICON_SIZE_CLASSES: Record<EnvironmentBadgeSize, string> = {
   sm: "size-2.5",
   md: "size-3",
   lg: "size-3.5",
-  promptPill: "size-2.5",
+  pill: "size-2.5",
 };
 
 type EnvironmentBadgeProps = {

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadge.tsx
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadge.tsx
@@ -8,30 +8,32 @@ import {
 } from "./helpers";
 import { useEnvironmentByName } from "./EnvironmentLabel";
 
-const SIZE_CLASSES: Record<NonNullable<TagProps["size"]>, string> = {
+// `promptPill` is a project-specific variant used across prompt-version
+// surfaces (prompt detail header, mobile version picker, version history
+// timeline, +N overflow tooltip): 20px tall with a 10px label and asymmetric
+// padding so the leading env icon hugs the left edge while the text gets a
+// little more breathing room on the right.
+export type EnvironmentBadgeSize = NonNullable<TagProps["size"]> | "promptPill";
+
+const SIZE_CLASSES: Record<EnvironmentBadgeSize, string> = {
   default: "comet-body-xs h-5 px-2 leading-5 rounded-sm",
   sm: "comet-body-xs h-4 px-2 text-[11px] leading-4 rounded-sm",
   md: "comet-body-s h-6 px-1.5 leading-6 rounded-md",
   lg: "comet-body-s h-7 px-3 leading-7 rounded-md",
+  promptPill: "h-5 pl-1.5 pr-2 text-[10px] leading-5 rounded-sm",
 };
 
-const ICON_SIZE_CLASSES: Record<NonNullable<TagProps["size"]>, string> = {
+const ICON_SIZE_CLASSES: Record<EnvironmentBadgeSize, string> = {
   default: "size-3",
   sm: "size-2.5",
   md: "size-3",
   lg: "size-3.5",
+  promptPill: "size-2.5",
 };
-
-// Asymmetric pill spec used across prompt-version surfaces (prompt detail
-// header, mobile version picker, version history timeline, +N overflow
-// tooltip). Pass as `badgeClassName` on EnvironmentBadgeList — tailwind-merge
-// resolves the conflicts against SIZE_CLASSES["sm"].
-export const ENV_BADGE_PROMPT_PILL_CLASS =
-  "h-5 pl-1.5 pr-2 text-[10px] leading-5";
 
 type EnvironmentBadgeProps = {
   name?: string | null;
-  size?: TagProps["size"];
+  size?: EnvironmentBadgeSize;
   className?: string;
 };
 

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadge.tsx
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadge.tsx
@@ -8,11 +8,6 @@ import {
 } from "./helpers";
 import { useEnvironmentByName } from "./EnvironmentLabel";
 
-// `pill` is a project-specific variant used across prompt-version
-// surfaces (prompt detail header, mobile version picker, version history
-// timeline, +N overflow tooltip): 20px tall with a 10px label and asymmetric
-// padding so the leading env icon hugs the left edge while the text gets a
-// little more breathing room on the right.
 export type EnvironmentBadgeSize = NonNullable<TagProps["size"]> | "pill";
 
 const SIZE_CLASSES: Record<EnvironmentBadgeSize, string> = {

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadge.tsx
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadge.tsx
@@ -22,6 +22,13 @@ const ICON_SIZE_CLASSES: Record<NonNullable<TagProps["size"]>, string> = {
   lg: "size-3.5",
 };
 
+// Asymmetric pill spec used across prompt-version surfaces (prompt detail
+// header, mobile version picker, version history timeline, +N overflow
+// tooltip). Pass as `badgeClassName` on EnvironmentBadgeList — tailwind-merge
+// resolves the conflicts against SIZE_CLASSES["sm"].
+export const ENV_BADGE_PROMPT_PILL_CLASS =
+  "h-5 pl-1.5 pr-2 text-[10px] leading-5";
+
 type EnvironmentBadgeProps = {
   name?: string | null;
   size?: TagProps["size"];

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadge.tsx
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadge.tsx
@@ -15,7 +15,7 @@ const SIZE_CLASSES: Record<EnvironmentBadgeSize, string> = {
   sm: "comet-body-xs h-4 px-2 text-[11px] leading-4 rounded-sm",
   md: "comet-body-s h-6 px-1.5 leading-6 rounded-md",
   lg: "comet-body-s h-7 px-3 leading-7 rounded-md",
-  pill: "h-5 pl-1.5 pr-2 text-[10px] leading-5 rounded-sm",
+  pill: "comet-body-xs h-5 pl-1.5 pr-2 text-[10px] leading-5 rounded-sm",
 };
 
 const ICON_SIZE_CLASSES: Record<EnvironmentBadgeSize, string> = {

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadgeList.tsx
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadgeList.tsx
@@ -1,15 +1,14 @@
 import React, { useCallback, useState } from "react";
-import { TagProps } from "@/ui/tag";
 import { cn } from "@/lib/utils";
 import { useVisibleItemsByWidth } from "@/hooks/useVisibleItemsByWidth";
 import ChildrenWidthMeasurer from "@/shared/ChildrenWidthMeasurer/ChildrenWidthMeasurer";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import EnvironmentBadge from "./EnvironmentBadge";
+import EnvironmentBadge, { EnvironmentBadgeSize } from "./EnvironmentBadge";
 import { EnvironmentSquareWithTooltip } from "./EnvironmentLabel";
 
 type EnvironmentBadgeListProps = {
   names: string[] | null | undefined;
-  size?: TagProps["size"];
+  size?: EnvironmentBadgeSize;
   className?: string;
   badgeClassName?: string;
   withOverflow?: boolean;
@@ -17,11 +16,12 @@ type EnvironmentBadgeListProps = {
   compact?: boolean;
 };
 
-const COUNTER_CLASSES: Record<NonNullable<TagProps["size"]>, string> = {
+const COUNTER_CLASSES: Record<EnvironmentBadgeSize, string> = {
   default: "comet-body-xs h-5 px-1.5 leading-5 rounded-sm",
   sm: "comet-body-xs h-4 px-1.5 text-[11px] leading-4 rounded-sm",
   md: "comet-body-s h-6 px-1.5 leading-6 rounded-md",
   lg: "comet-body-s h-7 px-2 leading-7 rounded-md",
+  promptPill: "h-5 px-1.5 text-[10px] leading-5 rounded-sm",
 };
 
 const OVERFLOW_CONFIG = {

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadgeList.tsx
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadgeList.tsx
@@ -118,7 +118,12 @@ const EnvironmentBadgeList: React.FC<EnvironmentBadgeListProps> = ({
           content={
             <div className="flex max-w-[300px] flex-wrap gap-1">
               {hiddenItems.map((name) => (
-                <EnvironmentBadge key={name} name={name} size={size} />
+                <EnvironmentBadge
+                  key={name}
+                  name={name}
+                  size={size}
+                  className={badgeClassName}
+                />
               ))}
             </div>
           }

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadgeList.tsx
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadgeList.tsx
@@ -21,7 +21,7 @@ const COUNTER_CLASSES: Record<EnvironmentBadgeSize, string> = {
   sm: "comet-body-xs h-4 px-1.5 text-[11px] leading-4 rounded-sm",
   md: "comet-body-s h-6 px-1.5 leading-6 rounded-md",
   lg: "comet-body-s h-7 px-2 leading-7 rounded-md",
-  pill: "h-5 px-1.5 text-[10px] leading-5 rounded-sm",
+  pill: "comet-body-xs h-5 px-1.5 text-[10px] leading-5 rounded-sm",
 };
 
 const OVERFLOW_CONFIG = {

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadgeList.tsx
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/EnvironmentBadgeList.tsx
@@ -21,7 +21,7 @@ const COUNTER_CLASSES: Record<EnvironmentBadgeSize, string> = {
   sm: "comet-body-xs h-4 px-1.5 text-[11px] leading-4 rounded-sm",
   md: "comet-body-s h-6 px-1.5 leading-6 rounded-md",
   lg: "comet-body-s h-7 px-2 leading-7 rounded-md",
-  promptPill: "h-5 px-1.5 text-[10px] leading-5 rounded-sm",
+  pill: "h-5 px-1.5 text-[10px] leading-5 rounded-sm",
 };
 
 const OVERFLOW_CONFIG = {

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/helpers.ts
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/helpers.ts
@@ -33,3 +33,17 @@ export const getDefaultEnvironmentMeta = (
 
 export const isDefaultEnvironmentName = (name: string | undefined | null) =>
   normalize(name) in DEFAULT_ENVIRONMENTS;
+
+const DEFAULT_ENV_SORT_PRIORITY: Record<string, number> = {
+  production: 0,
+  staging: 1,
+  development: 2,
+};
+
+export const sortEnvironments = <T extends { name: string }>(envs: T[]): T[] =>
+  envs.slice().sort((a, b) => {
+    const aPriority = DEFAULT_ENV_SORT_PRIORITY[normalize(a.name)] ?? Infinity;
+    const bPriority = DEFAULT_ENV_SORT_PRIORITY[normalize(b.name)] ?? Infinity;
+    if (aPriority !== bPriority) return aPriority - bPriority;
+    return a.name.localeCompare(b.name);
+  });

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/helpers.ts
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/helpers.ts
@@ -1,5 +1,9 @@
 import { Code, FlaskRound, LucideIcon, Rocket } from "lucide-react";
 import { DEFAULT_HEX_COLOR, HEX_COLOR_REGEX } from "@/constants/colorVariants";
+import {
+  DEFAULT_ENVIRONMENT_NAMES,
+  DefaultEnvironmentName,
+} from "@/utils/environments";
 
 export const resolveEnvironmentColor = (color: string | undefined) =>
   color && HEX_COLOR_REGEX.test(color) ? color : DEFAULT_HEX_COLOR;
@@ -12,24 +16,34 @@ export const getContrastingTextColor = (hex: string): string => {
   return luminance > 140 ? "#0f172a" : "#ffffff";
 };
 
-// Seeded server-side by migration 000066_seed_default_environments. Name +
-// color are kept in lock-step with the backend so the UI can recognize them
-// and protect their color from edits.
+// Seeded server-side by migration 000066_seed_default_environments. The set of
+// names is the source of truth in `utils/environments.ts`
+// (DEFAULT_ENVIRONMENT_NAMES); TypeScript enforces this map carries one entry
+// per default env so adding a new default forces editing both color/icon and
+// sort priority together.
 type DefaultEnvironmentMeta = { color: string; icon: LucideIcon };
 
-const DEFAULT_ENVIRONMENTS: Record<string, DefaultEnvironmentMeta> = {
-  development: { color: "#EF6868", icon: Code },
-  staging: { color: "#F4B400", icon: FlaskRound },
+const DEFAULT_ENVIRONMENTS: Record<
+  DefaultEnvironmentName,
+  DefaultEnvironmentMeta
+> = {
   production: { color: "#19A979", icon: Rocket },
+  staging: { color: "#F4B400", icon: FlaskRound },
+  development: { color: "#EF6868", icon: Code },
 };
 
-const normalize = (name: string | undefined | null) =>
+const normalize = (name: string | undefined | null): string =>
   name?.trim().toLowerCase() ?? "";
+
+const isDefaultName = (name: string): name is DefaultEnvironmentName =>
+  (DEFAULT_ENVIRONMENT_NAMES as readonly string[]).includes(name);
 
 export const getDefaultEnvironmentMeta = (
   name: string | undefined | null,
-): DefaultEnvironmentMeta | null =>
-  DEFAULT_ENVIRONMENTS[normalize(name)] ?? null;
+): DefaultEnvironmentMeta | null => {
+  const normalized = normalize(name);
+  return isDefaultName(normalized) ? DEFAULT_ENVIRONMENTS[normalized] : null;
+};
 
 export const isDefaultEnvironmentName = (name: string | undefined | null) =>
-  normalize(name) in DEFAULT_ENVIRONMENTS;
+  isDefaultName(normalize(name));

--- a/apps/opik-frontend/src/shared/EnvironmentLabel/helpers.ts
+++ b/apps/opik-frontend/src/shared/EnvironmentLabel/helpers.ts
@@ -33,17 +33,3 @@ export const getDefaultEnvironmentMeta = (
 
 export const isDefaultEnvironmentName = (name: string | undefined | null) =>
   normalize(name) in DEFAULT_ENVIRONMENTS;
-
-const DEFAULT_ENV_SORT_PRIORITY: Record<string, number> = {
-  production: 0,
-  staging: 1,
-  development: 2,
-};
-
-export const sortEnvironments = <T extends { name: string }>(envs: T[]): T[] =>
-  envs.slice().sort((a, b) => {
-    const aPriority = DEFAULT_ENV_SORT_PRIORITY[normalize(a.name)] ?? Infinity;
-    const bPriority = DEFAULT_ENV_SORT_PRIORITY[normalize(b.name)] ?? Infinity;
-    if (aPriority !== bPriority) return aPriority - bPriority;
-    return a.name.localeCompare(b.name);
-  });

--- a/apps/opik-frontend/src/utils/environments.ts
+++ b/apps/opik-frontend/src/utils/environments.ts
@@ -1,0 +1,15 @@
+const DEFAULT_ENV_SORT_PRIORITY: Record<string, number> = {
+  production: 0,
+  staging: 1,
+  development: 2,
+};
+
+export const sortEnvironments = <T extends { name: string }>(envs: T[]): T[] =>
+  envs.slice().sort((a, b) => {
+    const aKey = a.name.trim().toLowerCase();
+    const bKey = b.name.trim().toLowerCase();
+    const aPriority = DEFAULT_ENV_SORT_PRIORITY[aKey] ?? Infinity;
+    const bPriority = DEFAULT_ENV_SORT_PRIORITY[bKey] ?? Infinity;
+    if (aPriority !== bPriority) return aPriority - bPriority;
+    return a.name.localeCompare(b.name);
+  });

--- a/apps/opik-frontend/src/utils/environments.ts
+++ b/apps/opik-frontend/src/utils/environments.ts
@@ -1,8 +1,18 @@
-const DEFAULT_ENV_SORT_PRIORITY: Record<string, number> = {
-  production: 0,
-  staging: 1,
-  development: 2,
-};
+// Canonical list of default environment names seeded by backend migration
+// 000066. The order here drives the sort priority below AND the icon/color
+// lookup in shared/EnvironmentLabel/helpers.ts — keep both in lock-step by
+// editing this list, not its consumers.
+export const DEFAULT_ENVIRONMENT_NAMES = [
+  "production",
+  "staging",
+  "development",
+] as const;
+
+export type DefaultEnvironmentName = (typeof DEFAULT_ENVIRONMENT_NAMES)[number];
+
+const DEFAULT_ENV_SORT_PRIORITY: Record<string, number> = Object.fromEntries(
+  DEFAULT_ENVIRONMENT_NAMES.map((name, index) => [name, index]),
+);
 
 export const sortEnvironments = <T extends { name: string }>(envs: T[]): T[] =>
   envs.slice().sort((a, b) => {

--- a/apps/opik-frontend/src/v2/pages-shared/environments/AddEditEnvironmentDialog/AddEditEnvironmentDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/environments/AddEditEnvironmentDialog/AddEditEnvironmentDialog.tsx
@@ -55,6 +55,7 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
       : DEFAULT_HEX_COLOR,
   );
   const [submitError, setSubmitError] = useState<string>("");
+  const [colorPopoverOpen, setColorPopoverOpen] = useState(false);
 
   const { mutate: createMutation } = useEnvironmentCreateMutation({
     showErrorToast: false,
@@ -152,6 +153,16 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
     setOpen,
   ]);
 
+  const handleBodyKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        submitHandler();
+      }
+    },
+    [submitHandler],
+  );
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent className="max-w-lg sm:max-w-[560px]">
@@ -159,64 +170,77 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
         <DialogAutoScrollBody>
-          <div className="flex flex-col gap-2 pb-4">
-            <Label htmlFor="environmentName">Name</Label>
-            <div className="flex items-center">
-              {isColorLocked ? (
-                <TooltipWrapper content="Color is reserved for the default environment">
-                  <div
-                    aria-label="Default environment color (locked)"
-                    className="flex size-10 shrink-0 cursor-not-allowed items-center justify-center rounded-l-md"
-                    style={{ backgroundColor: color }}
-                  >
-                    {LockedIcon && <LockedIcon className="size-5 text-white" />}
-                  </div>
-                </TooltipWrapper>
-              ) : (
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <button
-                      type="button"
-                      aria-label="Change color"
-                      className="size-10 shrink-0 rounded-l-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
+          <div onKeyDown={handleBodyKeyDown}>
+            <div className="flex flex-col gap-2 pb-4">
+              <Label htmlFor="environmentName">Name</Label>
+              <div className="flex items-center">
+                {isColorLocked ? (
+                  <TooltipWrapper content="Color is reserved for the default environment">
+                    <div
+                      aria-label="Default environment color (locked)"
+                      className="flex size-10 shrink-0 cursor-not-allowed items-center justify-center rounded-l-md"
                       style={{ backgroundColor: color }}
-                    />
-                  </PopoverTrigger>
-                  <PopoverContent className="w-auto" align="start">
-                    <ColorPicker value={color} onChange={handleColorChange} />
-                  </PopoverContent>
-                </Popover>
+                    >
+                      {LockedIcon && (
+                        <LockedIcon className="size-5 text-white" />
+                      )}
+                    </div>
+                  </TooltipWrapper>
+                ) : (
+                  <Popover
+                    open={colorPopoverOpen}
+                    onOpenChange={setColorPopoverOpen}
+                  >
+                    <PopoverTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label="Change color"
+                        className="size-10 shrink-0 rounded-l-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
+                        style={{ backgroundColor: color }}
+                      />
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto" align="start">
+                      <ColorPicker
+                        value={color}
+                        onChange={handleColorChange}
+                        onPresetSelect={() => setColorPopoverOpen(false)}
+                      />
+                    </PopoverContent>
+                  </Popover>
+                )}
+                <Input
+                  id="environmentName"
+                  className="flex-1 rounded-l-none"
+                  placeholder="e.g. staging"
+                  value={name}
+                  onChange={(event) => handleNameChange(event.target.value)}
+                  maxLength={ENVIRONMENT_NAME_MAX_LENGTH}
+                />
+              </div>
+              {nameError || submitError ? (
+                <p className="comet-body-xs text-destructive">
+                  {nameError || submitError}
+                </p>
+              ) : (
+                <p className="comet-body-xs text-light-slate">
+                  Use letters, numbers, dashes, or underscores. Must be unique
+                  within the workspace.
+                </p>
               )}
-              <Input
-                id="environmentName"
-                className="flex-1 rounded-l-none"
-                placeholder="e.g. staging"
-                value={name}
-                onChange={(event) => handleNameChange(event.target.value)}
-                maxLength={ENVIRONMENT_NAME_MAX_LENGTH}
+            </div>
+            <div className="flex flex-col gap-2 pb-4">
+              <Label htmlFor="environmentDescription">Description</Label>
+              <Textarea
+                id="environmentDescription"
+                placeholder="Optional description"
+                className="min-h-20"
+                value={description}
+                onChange={(event) =>
+                  handleDescriptionChange(event.target.value)
+                }
+                maxLength={ENVIRONMENT_DESCRIPTION_MAX_LENGTH}
               />
             </div>
-            {nameError || submitError ? (
-              <p className="comet-body-xs text-destructive">
-                {nameError || submitError}
-              </p>
-            ) : (
-              <p className="comet-body-xs text-light-slate">
-                Use letters, numbers, dashes, or underscores. Must be unique
-                within the workspace.
-              </p>
-            )}
-          </div>
-          <div className="flex flex-col gap-2 pb-4">
-            <Label htmlFor="environmentDescription">Description</Label>
-            <Textarea
-              id="environmentDescription"
-              placeholder="Optional description"
-              className="min-h-20"
-              value={description}
-              onChange={(event) => handleDescriptionChange(event.target.value)}
-              maxLength={ENVIRONMENT_DESCRIPTION_MAX_LENGTH}
-            />
           </div>
         </DialogAutoScrollBody>
         <DialogFooter>

--- a/apps/opik-frontend/src/v2/pages-shared/environments/AddEditEnvironmentDialog/AddEditEnvironmentDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/environments/AddEditEnvironmentDialog/AddEditEnvironmentDialog.tsx
@@ -20,7 +20,7 @@ import { Input } from "@/ui/input";
 import { Label } from "@/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
 import { Textarea } from "@/ui/textarea";
-import { DEFAULT_HEX_COLOR, HEX_COLOR_REGEX } from "@/constants/colorVariants";
+import { HEX_COLOR_REGEX, PRESET_HEX_COLORS } from "@/constants/colorVariants";
 import {
   ENVIRONMENT_DESCRIPTION_MAX_LENGTH,
   ENVIRONMENT_NAME_MAX_LENGTH,
@@ -49,10 +49,10 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
   const [description, setDescription] = useState<string>(
     environment?.description ?? "",
   );
-  const [color, setColor] = useState<string>(
+  const [color, setColor] = useState<string>(() =>
     environment?.color && HEX_COLOR_REGEX.test(environment.color)
       ? environment.color
-      : DEFAULT_HEX_COLOR,
+      : PRESET_HEX_COLORS[Math.floor(Math.random() * PRESET_HEX_COLORS.length)],
   );
   const [submitError, setSubmitError] = useState<string>("");
   const [colorPopoverOpen, setColorPopoverOpen] = useState(false);

--- a/apps/opik-frontend/src/v2/pages-shared/environments/AddEditEnvironmentDialog/AddEditEnvironmentDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/environments/AddEditEnvironmentDialog/AddEditEnvironmentDialog.tsx
@@ -57,12 +57,15 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
   const [submitError, setSubmitError] = useState<string>("");
   const [colorPopoverOpen, setColorPopoverOpen] = useState(false);
 
-  const { mutate: createMutation } = useEnvironmentCreateMutation({
-    showErrorToast: false,
-  });
-  const { mutate: updateMutation } = useEnvironmentUpdateMutation({
-    showErrorToast: false,
-  });
+  const { mutate: createMutation, isPending: isCreating } =
+    useEnvironmentCreateMutation({
+      showErrorToast: false,
+    });
+  const { mutate: updateMutation, isPending: isUpdating } =
+    useEnvironmentUpdateMutation({
+      showErrorToast: false,
+    });
+  const isSubmitting = isCreating || isUpdating;
 
   const trimmedName = name.trim();
   const nameError = useMemo(() => {
@@ -118,7 +121,7 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
   }, []);
 
   const submitHandler = useCallback(() => {
-    if (!isValid) return;
+    if (!isValid || isSubmitting) return;
 
     const payload = {
       name: trimmedName,
@@ -143,6 +146,7 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
     }
   }, [
     isValid,
+    isSubmitting,
     trimmedName,
     description,
     color,
@@ -218,7 +222,7 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
                 />
               </div>
               {nameError || submitError ? (
-                <p className="comet-body-xs text-destructive">
+                <p role="alert" className="comet-body-xs text-destructive">
                   {nameError || submitError}
                 </p>
               ) : (
@@ -247,7 +251,11 @@ const AddEditEnvironmentDialog: React.FunctionComponent<
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>
           </DialogClose>
-          <Button type="submit" disabled={!isValid} onClick={submitHandler}>
+          <Button
+            type="submit"
+            disabled={!isValid || isSubmitting}
+            onClick={submitHandler}
+          >
             {submitText}
           </Button>
         </DialogFooter>

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LoadedPromptDisplay/LoadedPromptDisplay.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LoadedPromptDisplay/LoadedPromptDisplay.tsx
@@ -8,6 +8,7 @@ import {
 
 import { Button } from "@/ui/button";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import EnvironmentBadgeList from "@/shared/EnvironmentLabel/EnvironmentBadgeList";
 import StageTag from "@/v2/pages-shared/version-history/StageTag";
 import { pickHighestStage } from "@/utils/version-stages";
 import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
@@ -18,6 +19,7 @@ type LoadedPromptDisplayProps = {
   templateStructure?: PROMPT_TEMPLATE_STRUCTURE;
   versionLabel?: string;
   versionTags?: string[];
+  versionEnvironments?: string[] | null;
   hasUnsavedChanges?: boolean;
   onClear?: () => void;
 };
@@ -27,6 +29,7 @@ const LoadedPromptDisplay: React.FC<LoadedPromptDisplayProps> = ({
   templateStructure,
   versionLabel,
   versionTags,
+  versionEnvironments,
   hasUnsavedChanges = false,
   onClear,
 }) => {
@@ -57,6 +60,14 @@ const LoadedPromptDisplay: React.FC<LoadedPromptDisplayProps> = ({
         </span>
       )}
       {stage && <StageTag value={stage} size="xs" />}
+      <EnvironmentBadgeList
+        names={versionEnvironments}
+        className="ml-1"
+        size="sm"
+        withOverflow
+        compact
+        maxWidth={60}
+      />
       {onClear && (
         <TooltipWrapper content="Detach loaded prompt">
           <Button

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LoadedPromptDisplay/LoadedPromptDisplay.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LoadedPromptDisplay/LoadedPromptDisplay.tsx
@@ -54,7 +54,7 @@ const LoadedPromptDisplay: React.FC<LoadedPromptDisplayProps> = ({
         </div>
       </TooltipWrapper>
       {versionLabel && (
-        <span className="ml-1.5 flex shrink-0 items-center text-light-slate">
+        <span className="mx-1.5 flex shrink-0 items-center text-light-slate">
           <GitCommitVertical className="size-3 shrink-0" />
           {versionLabel}
         </span>

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
@@ -64,8 +64,8 @@ const PromptLibraryMenu: React.FC<PromptLibraryMenuProps> = ({
     const allPrompts = data?.content ?? [];
     const byStructure = filterByTemplateStructure
       ? allPrompts.filter(
-          (p) => p.template_structure === filterByTemplateStructure,
-        )
+        (p) => p.template_structure === filterByTemplateStructure,
+      )
       : allPrompts;
     if (!search) return byStructure;
     const q = toLower(search);
@@ -84,10 +84,6 @@ const PromptLibraryMenu: React.FC<PromptLibraryMenuProps> = ({
   const handleSelect = useCallback(
     (selection: PromptLibrarySelection) => {
       onSelect(selection);
-      // Route through handleOpenChange so subscribers (e.g. the playground's
-      // `isChatLibraryOpen` hover-strip pin) see the close. Calling setOpen
-      // directly updates internal state but Radix doesn't re-fire
-      // onOpenChange when the controlled value flips externally.
       handleOpenChange(false);
     },
     [onSelect, handleOpenChange],

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
@@ -109,7 +109,7 @@ const PromptLibraryMenu: React.FC<PromptLibraryMenuProps> = ({
             setSearchText={setSearch}
             placeholder="Search"
             variant="ghost"
-            size="sm"
+            dimension="sm"
           />
         </div>
         <Separator className="my-1" />

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
@@ -64,8 +64,8 @@ const PromptLibraryMenu: React.FC<PromptLibraryMenuProps> = ({
     const allPrompts = data?.content ?? [];
     const byStructure = filterByTemplateStructure
       ? allPrompts.filter(
-        (p) => p.template_structure === filterByTemplateStructure,
-      )
+          (p) => p.template_structure === filterByTemplateStructure,
+        )
       : allPrompts;
     if (!search) return byStructure;
     const q = toLower(search);

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
@@ -175,7 +175,7 @@ const PromptRow: React.FC<PromptRowProps> = ({
           size="sm"
           withOverflow
           compact
-          maxWidth={80}
+          maxWidth={60}
         />
         {enableVersionSelect && (
           <ChevronRight className="size-3.5 shrink-0 text-light-slate" />
@@ -281,7 +281,7 @@ const PromptVersionsList: React.FC<PromptVersionsListProps> = ({
               size="sm"
               withOverflow
               compact
-              maxWidth={80}
+              maxWidth={60}
             />
             <TooltipWrapper
               content={`${formatDate(version.created_at, {

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
@@ -109,6 +109,7 @@ const PromptLibraryMenu: React.FC<PromptLibraryMenuProps> = ({
             setSearchText={setSearch}
             placeholder="Search"
             variant="ghost"
+            size="sm"
           />
         </div>
         <Separator className="my-1" />
@@ -266,17 +267,12 @@ const PromptVersionsList: React.FC<PromptVersionsListProps> = ({
             role="button"
             tabIndex={0}
             className={cn(
-              "comet-body-s flex h-9 cursor-pointer items-center gap-2 rounded-md px-2 hover:bg-primary-foreground",
+              "comet-body-s flex h-8 cursor-pointer items-center gap-2 rounded-md px-3 hover:bg-primary-foreground",
               isActive && "bg-primary-100 text-primary",
             )}
             onClick={() => onSelect(version.id)}
           >
-            <span
-              className={cn(
-                "comet-body-s-accented shrink-0",
-                isActive && "text-primary",
-              )}
-            >
+            <span className={cn("shrink-0", isActive && "text-primary")}>
               {label}
             </span>
             {stage && <StageTag value={stage} size="xs" />}

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
@@ -84,9 +84,13 @@ const PromptLibraryMenu: React.FC<PromptLibraryMenuProps> = ({
   const handleSelect = useCallback(
     (selection: PromptLibrarySelection) => {
       onSelect(selection);
-      setOpen(false);
+      // Route through handleOpenChange so subscribers (e.g. the playground's
+      // `isChatLibraryOpen` hover-strip pin) see the close. Calling setOpen
+      // directly updates internal state but Radix doesn't re-fire
+      // onOpenChange when the controlled value flips externally.
+      handleOpenChange(false);
     },
-    [onSelect],
+    [onSelect, handleOpenChange],
   );
 
   return (

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
@@ -266,13 +266,14 @@ const CompactLoadedPrompt: React.FC<CompactLoadedPromptProps> = ({
     data?.version_count,
   );
 
-  // Look up the selected version's tags so the stage badge reflects what's
-  // actually loaded; otherwise we'd show `latest_version.tags` for older picks.
+  // Look up the selected version's tags + environments so the chip reflects
+  // what's actually loaded; otherwise we'd show `latest_version` data for
+  // older picks.
   const { getDescriptor } = usePromptVersionsWithLabels(promptId, {
     enabled: Boolean(versionId),
   });
-  const selectedVersionTags = versionId
-    ? getDescriptor(versionId)?.version.tags
+  const selectedVersion = versionId
+    ? getDescriptor(versionId)?.version
     : undefined;
 
   return (
@@ -280,7 +281,10 @@ const CompactLoadedPrompt: React.FC<CompactLoadedPromptProps> = ({
       name={displayName}
       templateStructure={data?.template_structure}
       versionLabel={versionLabel}
-      versionTags={selectedVersionTags ?? data?.latest_version?.tags}
+      versionTags={selectedVersion?.tags ?? data?.latest_version?.tags}
+      versionEnvironments={
+        selectedVersion?.environments ?? data?.latest_version?.environments
+      }
       hasUnsavedChanges={hasUnsavedChanges}
       onClear={onClear}
     />

--- a/apps/opik-frontend/src/v2/pages-shared/traces/EnvironmentFilterSelect/EnvironmentFilterSelect.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/EnvironmentFilterSelect/EnvironmentFilterSelect.tsx
@@ -35,7 +35,7 @@ const EnvironmentFilterSelect: React.FC<EnvironmentFilterSelectProps> = ({
   const { data } = useEnvironmentsList();
 
   const environments = useMemo<Environment[]>(
-    () => (data?.content ?? []).slice().sort((a, b) => a.position - b.position),
+    () => data?.content ?? [],
     [data?.content],
   );
 

--- a/apps/opik-frontend/src/v2/pages-shared/traces/EnvironmentFilterSelect/EnvironmentFilterSelect.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/EnvironmentFilterSelect/EnvironmentFilterSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { ChevronDown, SlidersHorizontal } from "lucide-react";
+import { ChevronDown, Settings2 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 
 import {
@@ -72,12 +72,14 @@ const EnvironmentFilterSelect: React.FC<EnvironmentFilterSelectProps> = ({
         className="min-w-[var(--radix-dropdown-menu-trigger-width)]"
       >
         <DropdownMenuItem
+          size="sm"
           selected={value === ALL_ENVIRONMENTS_VALUE}
           onSelect={() => onChange(ALL_ENVIRONMENTS_VALUE)}
         >
           {ALL_ENVIRONMENTS_LABEL}
         </DropdownMenuItem>
         <DropdownMenuItem
+          size="sm"
           selected={value === ENVIRONMENT_UNTAGGED_VALUE}
           onSelect={() => onChange(ENVIRONMENT_UNTAGGED_VALUE)}
         >
@@ -88,6 +90,7 @@ const EnvironmentFilterSelect: React.FC<EnvironmentFilterSelectProps> = ({
           {environments.map((env) => (
             <DropdownMenuItem
               key={env.id}
+              size="sm"
               selected={value === env.name}
               onSelect={() => onChange(env.name)}
             >
@@ -99,13 +102,13 @@ const EnvironmentFilterSelect: React.FC<EnvironmentFilterSelectProps> = ({
           ))}
         </div>
         <DropdownMenuSeparator />
-        <DropdownMenuItem asChild>
+        <DropdownMenuItem size="sm" asChild>
           <Link
             to="/$workspaceName/configuration"
             params={{ workspaceName }}
             search={{ tab: CONFIGURATION_TABS.ENVIRONMENTS }}
           >
-            <SlidersHorizontal className="mr-2 size-3.5 shrink-0 text-muted-slate" />
+            <Settings2 className="mr-2 size-3.5 shrink-0 text-muted-slate" />
             Manage environments
           </Link>
         </DropdownMenuItem>

--- a/apps/opik-frontend/src/v2/pages-shared/version-history/VersionHistoryTimeline.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/version-history/VersionHistoryTimeline.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import DataTableNoData from "@/shared/DataTableNoData/DataTableNoData";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import EnvironmentBadgeList from "@/shared/EnvironmentLabel/EnvironmentBadgeList";
+import { ENV_BADGE_PROMPT_PILL_CLASS } from "@/shared/EnvironmentLabel/EnvironmentBadge";
 import VersionTagList from "./VersionTagList";
 import VersionMeta from "./VersionMeta";
 
@@ -102,7 +103,10 @@ const VersionHistoryTimeline: React.FC<VersionHistoryTimelineProps> = ({
                 <EnvironmentBadgeList
                   names={item.environments}
                   size="sm"
-                  badgeClassName="max-w-[120px]"
+                  badgeClassName={cn(
+                    ENV_BADGE_PROMPT_PILL_CLASS,
+                    "max-w-[120px]",
+                  )}
                   withOverflow
                   maxWidth={160}
                 />

--- a/apps/opik-frontend/src/v2/pages-shared/version-history/VersionHistoryTimeline.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/version-history/VersionHistoryTimeline.tsx
@@ -6,7 +6,6 @@ import { cn } from "@/lib/utils";
 import DataTableNoData from "@/shared/DataTableNoData/DataTableNoData";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import EnvironmentBadgeList from "@/shared/EnvironmentLabel/EnvironmentBadgeList";
-import { ENV_BADGE_PROMPT_PILL_CLASS } from "@/shared/EnvironmentLabel/EnvironmentBadge";
 import VersionTagList from "./VersionTagList";
 import VersionMeta from "./VersionMeta";
 
@@ -102,11 +101,8 @@ const VersionHistoryTimeline: React.FC<VersionHistoryTimelineProps> = ({
                 <VersionTagList tags={item.tags} size="sm" maxWidth={200} />
                 <EnvironmentBadgeList
                   names={item.environments}
-                  size="sm"
-                  badgeClassName={cn(
-                    ENV_BADGE_PROMPT_PILL_CLASS,
-                    "max-w-[120px]",
-                  )}
+                  size="promptPill"
+                  badgeClassName="max-w-[120px]"
                   withOverflow
                   maxWidth={160}
                 />

--- a/apps/opik-frontend/src/v2/pages-shared/version-history/VersionHistoryTimeline.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/version-history/VersionHistoryTimeline.tsx
@@ -101,7 +101,7 @@ const VersionHistoryTimeline: React.FC<VersionHistoryTimelineProps> = ({
                 <VersionTagList tags={item.tags} size="sm" maxWidth={200} />
                 <EnvironmentBadgeList
                   names={item.environments}
-                  size="promptPill"
+                  size="pill"
                   badgeClassName="max-w-[120px]"
                   withOverflow
                   maxWidth={160}

--- a/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerPromptCard.tsx
+++ b/apps/opik-frontend/src/v2/pages/AgentRunnerPage/AgentRunnerPromptCard.tsx
@@ -344,6 +344,7 @@ const AgentRunnerPromptCard = forwardRef<
               return (
                 <DropdownMenuItem
                   key={version.id}
+                  size="sm"
                   selected={isActive}
                   onClick={() => setPickedVersionId(version.id)}
                   className="flex items-center gap-2"

--- a/apps/opik-frontend/src/v2/pages/ConfigurationPage/EnvironmentsTab/EnvironmentNameCell.tsx
+++ b/apps/opik-frontend/src/v2/pages/ConfigurationPage/EnvironmentsTab/EnvironmentNameCell.tsx
@@ -18,7 +18,7 @@ const EnvironmentNameCell: React.FunctionComponent<
       className="gap-1.5"
     >
       <TooltipWrapper content={name} stopClickPropagation>
-        <div className="flex max-w-full items-center gap-1.5 rounded-md border border-transparent px-2">
+        <div className="flex max-w-full items-center gap-1.5">
           <EnvironmentSquare name={name} color={color} />
           <div className="comet-body-xs-accented min-w-0 flex-1 truncate text-muted-slate">
             {name}

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -28,7 +28,7 @@ import usePromptBadgeColor from "@/v2/pages/PlaygroundPage/PlaygroundPrompts/use
 import { generateDefaultLLMPromptMessage, getNextMessageType } from "@/lib/llm";
 import LLMPromptMessages from "@/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessages";
 import PromptModelSelect from "@/v2/pages-shared/llm/PromptModelSelect/PromptModelSelect";
-import { getAlphabetLetter } from "@/lib/utils";
+import { cn, getAlphabetLetter } from "@/lib/utils";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import PromptModelConfigs from "@/v2/pages-shared/llm/PromptModelSettings/PromptModelConfigs";
 import {
@@ -111,6 +111,10 @@ const PlaygroundPrompt = ({
     useState(false);
   const [lastImportedPromptName, setLastImportedPromptName] =
     useState<string>("");
+  // Pin the hover-revealed actions strip open while the library popover is up:
+  // otherwise moving the mouse off the trigger collapses the strip to max-w-0,
+  // and the Popover re-anchors to a zero-width origin and visibly shifts.
+  const [isChatLibraryOpen, setIsChatLibraryOpen] = useState(false);
 
   const selectedChatPromptId = prompt?.loadedChatPromptId;
   const selectedChatPromptVersionId = prompt?.loadedChatPromptVersionId;
@@ -371,7 +375,13 @@ const PlaygroundPrompt = ({
           />
         </div>
 
-        <div className="flex min-w-0 items-center overflow-hidden pl-4 [@media(hover:hover)]:max-w-0 [@media(hover:hover)]:pl-0 [@media(hover:hover)]:group-hover/prompt:max-w-none [@media(hover:hover)]:group-hover/prompt:pl-4">
+        <div
+          className={cn(
+            "flex min-w-0 items-center overflow-hidden pl-4",
+            !isChatLibraryOpen &&
+              "[@media(hover:hover)]:max-w-0 [@media(hover:hover)]:pl-0 [@media(hover:hover)]:group-hover/prompt:max-w-none [@media(hover:hover)]:group-hover/prompt:pl-4",
+          )}
+        >
           {selectedChatPromptId ? (
             <LoadedPromptDisplay
               name={chatPromptData?.name}
@@ -380,6 +390,10 @@ const PlaygroundPrompt = ({
               versionTags={
                 chatPromptVersionData?.tags ??
                 chatPromptData?.latest_version?.tags
+              }
+              versionEnvironments={
+                chatPromptVersionData?.environments ??
+                chatPromptData?.latest_version?.environments
               }
               hasUnsavedChanges={hasUnsavedChatPromptChanges}
               onClear={() => handleImportChatPrompt(undefined, undefined)}
@@ -391,6 +405,7 @@ const PlaygroundPrompt = ({
               onSelect={({ promptId: pId, versionId }) =>
                 handleImportChatPrompt(pId, versionId)
               }
+              onOpenChange={setIsChatLibraryOpen}
               trigger={
                 <div>
                   <TooltipWrapper content="Load prompt">

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -111,9 +111,6 @@ const PlaygroundPrompt = ({
     useState(false);
   const [lastImportedPromptName, setLastImportedPromptName] =
     useState<string>("");
-  // Pin the hover-revealed actions strip open while the library popover is up:
-  // otherwise moving the mouse off the trigger collapses the strip to max-w-0,
-  // and the Popover re-anchors to a zero-width origin and visibly shifts.
   const [isChatLibraryOpen, setIsChatLibraryOpen] = useState(false);
 
   const selectedChatPromptId = prompt?.loadedChatPromptId;
@@ -379,7 +376,7 @@ const PlaygroundPrompt = ({
           className={cn(
             "flex min-w-0 items-center overflow-hidden pl-4",
             !isChatLibraryOpen &&
-              "[@media(hover:hover)]:max-w-0 [@media(hover:hover)]:pl-0 [@media(hover:hover)]:group-hover/prompt:max-w-none [@media(hover:hover)]:group-hover/prompt:pl-4",
+            "[@media(hover:hover)]:max-w-0 [@media(hover:hover)]:pl-0 [@media(hover:hover)]:group-hover/prompt:max-w-none [@media(hover:hover)]:group-hover/prompt:pl-4",
           )}
         >
           {selectedChatPromptId ? (

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -376,7 +376,7 @@ const PlaygroundPrompt = ({
           className={cn(
             "flex min-w-0 items-center overflow-hidden pl-4",
             !isChatLibraryOpen &&
-            "[@media(hover:hover)]:max-w-0 [@media(hover:hover)]:pl-0 [@media(hover:hover)]:group-hover/prompt:max-w-none [@media(hover:hover)]:group-hover/prompt:pl-4",
+              "[@media(hover:hover)]:max-w-0 [@media(hover:hover)]:pl-0 [@media(hover:hover)]:group-hover/prompt:max-w-none [@media(hover:hover)]:group-hover/prompt:pl-4",
           )}
         >
           {selectedChatPromptId ? (

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/DeployToEnvironmentMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/DeployToEnvironmentMenu.tsx
@@ -53,10 +53,7 @@ const DeployToEnvironmentMenu: React.FC<DeployToEnvironmentMenuProps> = ({
     useSetPromptVersionEnvironmentMutation();
 
   const environments = useMemo(
-    () =>
-      (environmentsData?.content ?? [])
-        .slice()
-        .sort((a, b) => a.position - b.position),
+    () => environmentsData?.content ?? [],
     [environmentsData?.content],
   );
 

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/DeployToEnvironmentMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/DeployToEnvironmentMenu.tsx
@@ -3,7 +3,7 @@ import {
   ChevronDown,
   Check,
   CircleFadingArrowUp,
-  SlidersHorizontal,
+  Settings2,
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 
@@ -137,7 +137,7 @@ const DeployToEnvironmentMenu: React.FC<DeployToEnvironmentMenuProps> = ({
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-[220px]">
         {environments.length === 0 ? (
-          <DropdownMenuItem disabled>
+          <DropdownMenuItem size="sm" disabled>
             No environments configured
           </DropdownMenuItem>
         ) : (
@@ -151,6 +151,7 @@ const DeployToEnvironmentMenu: React.FC<DeployToEnvironmentMenuProps> = ({
             return (
               <DropdownMenuItem
                 key={env.id}
+                size="sm"
                 onSelect={(e) => {
                   e.preventDefault();
                   handleToggle(env.name);
@@ -174,19 +175,19 @@ const DeployToEnvironmentMenu: React.FC<DeployToEnvironmentMenuProps> = ({
         {activeEnvironments.length > 0 && (
           <>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={handleClearAll}>
+            <DropdownMenuItem size="sm" onSelect={handleClearAll}>
               Remove from all environments
             </DropdownMenuItem>
           </>
         )}
         <DropdownMenuSeparator />
-        <DropdownMenuItem asChild>
+        <DropdownMenuItem size="sm" asChild>
           <Link
             to="/$workspaceName/configuration"
             params={{ workspaceName }}
             search={{ tab: CONFIGURATION_TABS.ENVIRONMENTS }}
           >
-            <SlidersHorizontal className="mr-2 size-3.5 shrink-0 text-muted-slate" />
+            <Settings2 className="mr-2 size-3.5 shrink-0 text-muted-slate" />
             Manage environments
           </Link>
         </DropdownMenuItem>

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/DeployToEnvironmentMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/DeployToEnvironmentMenu.tsx
@@ -4,6 +4,7 @@ import {
   Check,
   CircleFadingArrowUp,
   Settings2,
+  X,
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 
@@ -173,7 +174,8 @@ const DeployToEnvironmentMenu: React.FC<DeployToEnvironmentMenuProps> = ({
           <>
             <DropdownMenuSeparator />
             <DropdownMenuItem size="sm" onSelect={handleClearAll}>
-              Remove from all environments
+              <X className="mr-2 size-3.5 shrink-0 text-muted-slate" />
+              Remove from all
             </DropdownMenuItem>
           </>
         )}

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
@@ -50,7 +50,6 @@ import usePromptVersionById, {
   useFetchPromptVersion,
 } from "@/api/prompts/usePromptVersionById";
 import EnvironmentBadgeList from "@/shared/EnvironmentLabel/EnvironmentBadgeList";
-import { ENV_BADGE_PROMPT_PILL_CLASS } from "@/shared/EnvironmentLabel/EnvironmentBadge";
 import ImproveInPlaygroundButton from "@/v2/pages/PromptPage/ImproveInPlaygroundButton";
 import useLoadPromptIntoPlayground from "@/v2/pages-shared/playground/useLoadPromptIntoPlayground";
 import { getTimeFromNow } from "@/lib/date";
@@ -270,8 +269,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
                   </span>
                   <EnvironmentBadgeList
                     names={activeVersionEnvironments}
-                    size="sm"
-                    badgeClassName={ENV_BADGE_PROMPT_PILL_CLASS}
+                    size="promptPill"
                     withOverflow
                     maxWidth={200}
                   />
@@ -328,8 +326,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
               {activeStage && <StageTag value={activeStage} size="sm" />}
               <EnvironmentBadgeList
                 names={activeVersionEnvironments}
-                size="sm"
-                badgeClassName={ENV_BADGE_PROMPT_PILL_CLASS}
+                size="promptPill"
                 withOverflow
                 maxWidth={320}
               />

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
@@ -269,7 +269,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
                   </span>
                   <EnvironmentBadgeList
                     names={activeVersionEnvironments}
-                    size="promptPill"
+                    size="pill"
                     withOverflow
                     maxWidth={200}
                   />
@@ -326,7 +326,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
               {activeStage && <StageTag value={activeStage} size="sm" />}
               <EnvironmentBadgeList
                 names={activeVersionEnvironments}
-                size="promptPill"
+                size="pill"
                 withOverflow
                 maxWidth={320}
               />

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
@@ -50,6 +50,7 @@ import usePromptVersionById, {
   useFetchPromptVersion,
 } from "@/api/prompts/usePromptVersionById";
 import EnvironmentBadgeList from "@/shared/EnvironmentLabel/EnvironmentBadgeList";
+import { ENV_BADGE_PROMPT_PILL_CLASS } from "@/shared/EnvironmentLabel/EnvironmentBadge";
 import ImproveInPlaygroundButton from "@/v2/pages/PromptPage/ImproveInPlaygroundButton";
 import useLoadPromptIntoPlayground from "@/v2/pages-shared/playground/useLoadPromptIntoPlayground";
 import { getTimeFromNow } from "@/lib/date";
@@ -270,6 +271,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
                   <EnvironmentBadgeList
                     names={activeVersionEnvironments}
                     size="sm"
+                    badgeClassName={ENV_BADGE_PROMPT_PILL_CLASS}
                     withOverflow
                     maxWidth={200}
                   />
@@ -327,6 +329,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
               <EnvironmentBadgeList
                 names={activeVersionEnvironments}
                 size="sm"
+                badgeClassName={ENV_BADGE_PROMPT_PILL_CLASS}
                 withOverflow
                 maxWidth={320}
               />


### PR DESCRIPTION
## Details

Follow-up polish on the prompt-environment surfaces shipped in [OPIK-6626 (#6892)](https://github.com/comet-ml/opik/pull/6892): tighten env-pill sizing, surface env icons on the Prompt playground chip, standardize dropdown-item heights, and fix a Playground hover-strip bug that caused the load-prompt popover to shift.

- Added a `pill` size variant on `EnvironmentBadge` / `EnvironmentBadgeList` (20px tall, 10px label, asymmetric pl-1.5/pr-2 to seat the leading env icon); used across the prompt detail header, mobile version picker, version history timeline, and the +N overflow chip
- `LoadedPromptDisplay` now surfaces env icons next to the version label, matching the Agent runner
- `DropdownMenuItem size="sm"` (h-8 / px-3) applied uniformly to `DeployToEnvironmentMenu`, `EnvironmentFilterSelect`, the Agent runner versions menu, and the `PromptLibraryMenu` version submenu (which also gets regular label weight and a 32px `dimension="sm"` SearchInput)
- `AddEditEnvironmentDialog`: color popover closes on preset click / Enter on a valid hex; Cmd/Ctrl+Enter saves the form
- `EnvironmentNameCell`: dropped extra `px-2 rounded-md border border-transparent` so content aligns with the column header like every other cell
- `PlaygroundPrompt`: pin the hover-revealed actions strip open while the chat prompt library popover is up — previously it collapsed to `max-w-0` when the mouse left the trigger, causing the popover to re-anchor and visibly shift

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6754

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: implementation of all listed bullets (component edits, refactor of the pill size variant, PR description)
- Human verification: changes manually reviewed by author; visual scenarios listed in Testing below to be exercised in dev server

## Testing

- `npx tsc --noEmit` and `npx eslint <changed files>` in `apps/opik-frontend` — both pass clean.
- Manual UI verification (in progress):
  - Prompt detail page: env pills render with the new pill size, +N overflow chip matches the pill height
  - Prompt playground (chat): chip shows env icons; opening the library popover keeps the load-prompt icon visible (no shift, no disappear) while the popover is open
  - Agent runner: version dropdown rows are 32px / 12px and labels are regular weight
  - Traces env filter dropdown: list items are 32px / 12px
  - Configuration → Environments tab: name cell content aligns with the "Name" column header
  - Edit environment dialog: clicking a preset color closes the popover; pressing Enter in the hex input with a valid value closes the popover; Cmd/Ctrl+Enter saves
  - Default-named envs (development/staging/production) keep the colored square + white icon everywhere

No tests added (no existing FE tests for these surfaces; changes are visual/interaction polish).

## Documentation

No documentation changes — internal FE polish only.