### PR TITLE
[OPIK-6758] [BE] feat: assign multi-project prompts to dominant project, remove trap

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -1896,36 +1896,53 @@ public class ExperimentDAO {
             """;
 
     /**
-     * For one workspace and a set of orphan prompt IDs, returns the trace-derived classification
-     * for each prompt that has at least one referencing experiment: {@code project_id} is any
-     * non-orphan {@code project_id} of a referencing experiment (meaningful only when
-     * {@code project_count = 1}); {@code project_count} is the distinct count of non-orphan
-     * project_ids — {@code 0} = no inference, {@code 1} = certain, {@code > 1} = ambiguous.
-     * Same shape as {@link #COMPUTE_EXPERIMENT_PROJECT_MAPPING} so the prompt and experiment
-     * cycles classify the same way.
+     * For one workspace and a set of orphan prompt IDs, returns each referenced prompt's inferred
+     * {@code project_id}, the {@code distinct_project_count} of referencing projects, and a sorted
+     * {@code project_breakdown} ({@code projectId=count,...}) included in the dominant-assignment
+     * log entry. Same shape as {@link #COMPUTE_DATASET_PROJECT_MAPPING}: single-project rows are
+     * unambiguous; multi-project rows pick the dominant project by {@code (count DESC,
+     * last_activity DESC, project_id ASC)} so repeated runs produce the same result. Prompts whose
+     * only referencing experiments are still at {@code project_id = ''} are dropped by the inner
+     * {@code HAVING}; the caller treats absence as no-inference.
      *
-     * <p>{@code argMax(_, last_updated_at)} on the inner aggregate dedupes ReplacingMergeTree
-     * duplicates by picking the latest row per experiment id. Prompt references are immutable
-     * per the data contract but {@code project_id} can flip during the D1 migration, so the
-     * latest one is what the inference must observe. The outer {@code anyIf} / {@code countDistinctIf}
-     * then filter on {@code project_id != ''} so experiments still orphan post-D1 are correctly
-     * invisible to the inference.
+     * <p>{@code argMax(_, last_updated_at) GROUP BY id} dedupes ReplacingMergeTree row versions
+     * for in-flight experiment updates. {@code arrayDistinct} collapses experiments that reach
+     * the same prompt via both the legacy {@code prompt_id} column and the {@code prompt_versions}
+     * map, preventing {@code per_proj_count} inflation in the subsequent {@code ARRAY JOIN}.
+     * Demo-named experiments are filtered upstream so the seeded Demo Project cannot tilt the
+     * dominant choice for a user prompt that happens to be referenced by a demo experiment.
      */
     private static final String COMPUTE_PROMPT_PROJECT_CLASSIFICATION = """
+            WITH arraySort(proj -> (-proj.1, -proj.2, proj.3),
+                    groupArray((per_proj_count, per_proj_last_activity_nanos, experiment_project_id))) AS ranked
             SELECT
                 prompt_id_ref AS prompt_id,
-                anyIf(latest_project_id, latest_project_id != '') AS project_id,
-                countDistinctIf(latest_project_id, latest_project_id != '') AS project_count
+                length(ranked) AS distinct_project_count,
+                ranked[1].3 AS project_id,
+                arrayStringConcat(
+                    arrayMap(proj -> concat(proj.3, '=', toString(proj.1)), ranked), ','
+                ) AS project_breakdown
             FROM (
                 SELECT
-                    argMax(project_id, last_updated_at) AS latest_project_id,
-                    argMax(arrayConcat([prompt_id], mapKeys(prompt_versions)), last_updated_at) AS prompt_id_refs
-                FROM experiments
-                WHERE workspace_id = :workspace_id
-                GROUP BY id
+                    prompt_id_ref,
+                    experiment_project_id,
+                    count() AS per_proj_count,
+                    toUnixTimestamp64Nano(max(experiment_last_updated_at)) AS per_proj_last_activity_nanos
+                FROM (
+                    SELECT
+                        argMax(project_id, last_updated_at) AS experiment_project_id,
+                        argMax(arrayDistinct(arrayConcat([prompt_id], mapKeys(prompt_versions))), last_updated_at) AS prompt_id_refs,
+                        max(last_updated_at) AS experiment_last_updated_at
+                    FROM experiments
+                    WHERE workspace_id = :workspace_id
+                    AND name NOT IN :demo_experiment_names
+                    GROUP BY id
+                    HAVING experiment_project_id != ''
+                )
+                ARRAY JOIN prompt_id_refs AS prompt_id_ref
+                WHERE prompt_id_ref IN :prompt_ids
+                GROUP BY prompt_id_ref, experiment_project_id
             )
-            ARRAY JOIN prompt_id_refs AS prompt_id_ref
-            WHERE prompt_id_ref IN :prompt_ids
             GROUP BY prompt_id_ref
             SETTINGS log_comment = '<log_comment>'
             """;
@@ -3040,11 +3057,9 @@ public class ExperimentDAO {
     }
 
     /**
-     * Bulk classification for the prompt project migration. For the workspace from the request
-     * context and a set of orphan prompt IDs, returns one {@link PromptProjectClassification}
-     * per prompt that has at least one referencing experiment. Prompts absent from the result
-     * have no referencing experiments at all and the caller treats them the same as
-     * {@code projectCount = 0} — i.e. no-inference → Default Project.
+     * Bulk classification for the prompt project migration. Returns one
+     * {@link PromptProjectClassification} per referenced prompt with a usable inferred project;
+     * prompts absent from the result are treated as no-inference by the caller.
      */
     Flux<PromptProjectClassification> computePromptProjectClassification(Set<UUID> promptIds) {
         if (CollectionUtils.isEmpty(promptIds)) {
@@ -3055,16 +3070,19 @@ public class ExperimentDAO {
             var template = getSTWithLogComment(COMPUTE_PROMPT_PROJECT_CLASSIFICATION,
                     "compute_prompt_project_classification", workspaceId, userName, details);
             var statement = connection.createStatement(template.render())
-                    .bind("prompt_ids", promptIds);
+                    .bind("prompt_ids", promptIds)
+                    .bind("demo_experiment_names", DemoData.EXPERIMENTS);
             return bindWorkspaceIdToFlux(statement).subscriberContext(userName, workspaceId);
         }))
-                .flatMap(result -> result.map((row, metadata) -> PromptProjectClassification.builder()
-                        .promptId(UUID.fromString(row.get("prompt_id", String.class)))
-                        .projectId(Optional.ofNullable(row.get("project_id", String.class))
-                                .filter(StringUtils::isNotBlank)
-                                .map(UUID::fromString)
-                                .orElse(null))
-                        .projectCount(row.get("project_count", Long.class))
-                        .build()));
+                .flatMap(result -> result.map((row, metadata) -> Optional
+                        .ofNullable(row.get("project_id", String.class))
+                        .filter(StringUtils::isNotBlank)
+                        .map(projectId -> PromptProjectClassification.builder()
+                                .promptId(UUID.fromString(row.get("prompt_id", String.class)))
+                                .projectId(UUID.fromString(projectId))
+                                .distinctProjectCount(row.get("distinct_project_count", Long.class))
+                                .projectBreakdown(row.get("project_breakdown", String.class))
+                                .build())))
+                .flatMap(Mono::justOrEmpty);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptProjectClassification.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptProjectClassification.java
@@ -6,12 +6,19 @@ import lombok.NonNull;
 import java.util.UUID;
 
 /**
- * Per-prompt classification result, sister to {@link ExperimentProjectMapping}. {@code projectId}
- * is any non-orphan {@code project_id} of an experiment that references this prompt via either
- * the legacy {@code prompt_id} column or the {@code prompt_versions} map; meaningful only when
- * {@code projectCount = 1}. {@code projectCount} is the distinct count of such non-orphan
- * project_ids — {@code 0} = no inference, {@code 1} = certain, {@code > 1} = ambiguous.
+ * Result of {@link ExperimentDAO#computePromptProjectClassification(java.util.Set)}: one row per
+ * referenced prompt with a usable inferred project. Sister to {@link DatasetProjectMapping}.
+ *
+ * <p>When {@code distinctProjectCount == 1}, {@code projectId} is the sole referenced project;
+ * when {@code > 1}, it is the dominant project, chosen by {@code (count DESC, last_activity DESC,
+ * project_id ASC)}. {@code projectBreakdown} lists the per-project experiment counts in the same
+ * order (for example {@code "p1=5,p2=3,p3=1"}) and is included in the dominant-assignment log
+ * entry.
  */
 @Builder(toBuilder = true)
-public record PromptProjectClassification(@NonNull UUID promptId, UUID projectId, long projectCount) {
+public record PromptProjectClassification(
+        @NonNull UUID promptId,
+        @NonNull UUID projectId,
+        long distinctProjectCount,
+        @NonNull String projectBreakdown) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptProjectMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptProjectMigrationService.java
@@ -1,7 +1,6 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.Project;
-import com.comet.opik.domain.workspaces.WorkspacesService;
 import com.comet.opik.infrastructure.MigrationConfig;
 import com.comet.opik.infrastructure.PromptProjectMigrationConfig;
 import com.google.common.collect.Lists;
@@ -25,10 +24,12 @@ import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -40,12 +41,13 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 /**
  * D4 migration — assigns {@code project_id} to V1 (workspace-scoped) prompts. Sister to
- * {@link ExperimentProjectMigrationService}: same Quartz / Managed / scheduler-isolation shape
- * and the same four-bucket classification (certain / certain-deleted → Default Project /
- * no-inference → Default Project / ambiguous → skip). Differs only in the SQL — eligibility is
- * a pure MySQL scan of the {@code prompts} table, classification reads experiments in ClickHouse
- * to map each orphan prompt to a project via either the legacy {@code prompt_id} column or the
- * {@code prompt_versions} map.
+ * {@link ExperimentProjectMigrationService} and {@link DatasetProjectMigrationService}: same
+ * Quartz / Managed / scheduler-isolation shape and the same dominant-project classification
+ * (certain / certain-deleted → Default Project / no-inference → Default Project). Differs only in
+ * the SQL — eligibility is a pure MySQL scan of the {@code prompts} table, classification reads
+ * experiments in ClickHouse to map each orphan prompt to a project via either the legacy
+ * {@code prompt_id} column or the {@code prompt_versions} map, and ties across multiple projects
+ * are resolved by {@code (count DESC, last_activity DESC, project_id ASC)}.
  */
 @Slf4j
 @Singleton
@@ -58,41 +60,29 @@ public class PromptProjectMigrationService implements Managed {
 
     public static final Attributes RESULT_ERROR = Attributes.of(RESULT_KEY, "error");
 
-    private static final String REASON_ALL_AMBIGUOUS = "all_ambiguous";
-
     private static final Attributes RESULT_MIGRATED = Attributes.of(RESULT_KEY, "migrated");
     private static final Attributes RESULT_NO_ORPHAN_PROMPTS = Attributes.of(RESULT_KEY, "no_orphan_prompts");
-    private static final Attributes RESULT_ALL_AMBIGUOUS = Attributes.of(RESULT_KEY, "all_ambiguous");
 
-    private static final Attributes REASON_AMBIGUOUS = Attributes.of(REASON_KEY, "ambiguous");
     private static final Attributes REASON_DELETED_PROJECT = Attributes.of(REASON_KEY, "deleted_project");
     private static final Attributes REASON_NO_INFERENCE = Attributes.of(REASON_KEY, "no_inference");
 
-    /**
-     * Classifier output for a single orphan prompt. Maps directly to the {@code projectCount}
-     * column from the ClickHouse classification query — {@code 0} → no-inference (route to
-     * Default Project), {@code 1} → certain (assign inferred unless project deleted), anything
-     * higher → ambiguous (skip and trap on cycle exit).
-     */
-    private enum Bucket {
-        CERTAIN,
-        NO_INFERENCE,
-        AMBIGUOUS
-    }
+    /** Tags {@code prompts.assigned_to_dominant_project} by the source distinct project count. */
+    private static final AttributeKey<String> DISTINCT_PROJECT_COUNT_KEY = stringKey("distinct_project_count");
+
+    /** Cap on the {@link #DISTINCT_PROJECT_COUNT_KEY} label value to bound metric cardinality. */
+    private static final int DISTINCT_PROJECT_COUNT_MAX = 50;
 
     private final @NonNull TransactionTemplate transactionTemplate;
     private final @NonNull ExperimentDAO experimentDAO;
     private final @NonNull ProjectService projectService;
-    private final @NonNull WorkspacesService workspacesService;
     private final @NonNull PromptProjectMigrationConfig config;
     private final @NonNull MigrationConfig migrationConfig;
 
     private final LongHistogram cycleEligibleWorkspaces;
-    private final LongGauge cycleTrappedWorkspaces;
     private final LongGauge cycleEnvExcludedWorkspaces;
     private final LongHistogram workspaceDuration;
-    private final LongCounter promptsSkipped;
     private final LongCounter promptsAssignedToDefault;
+    private final LongCounter promptsAssignedToDominantProject;
     private final LongHistogram batchSize;
 
     /**
@@ -106,13 +96,11 @@ public class PromptProjectMigrationService implements Managed {
             @NonNull TransactionTemplate transactionTemplate,
             @NonNull ExperimentDAO experimentDAO,
             @NonNull ProjectService projectService,
-            @NonNull WorkspacesService workspacesService,
             @NonNull @Config("promptProjectMigration") PromptProjectMigrationConfig config,
             @NonNull @Config("migration") MigrationConfig migrationConfig) {
         this.transactionTemplate = transactionTemplate;
         this.experimentDAO = experimentDAO;
         this.projectService = projectService;
-        this.workspacesService = workspacesService;
         this.config = config;
         this.migrationConfig = migrationConfig;
 
@@ -120,12 +108,6 @@ public class PromptProjectMigrationService implements Managed {
         this.cycleEligibleWorkspaces = meter
                 .histogramBuilder("%s.cycle.eligible_workspaces".formatted(METRIC_NAMESPACE))
                 .setDescription("Number of workspaces with orphan prompts found per cycle")
-                .ofLongs()
-                .build();
-        this.cycleTrappedWorkspaces = meter
-                .gaugeBuilder("%s.cycle.trapped_workspaces".formatted(METRIC_NAMESPACE))
-                .setDescription(
-                        "Number of workspaces locally skipped because all their remaining prompts are ambiguous")
                 .ofLongs()
                 .build();
         this.cycleEnvExcludedWorkspaces = meter
@@ -140,13 +122,14 @@ public class PromptProjectMigrationService implements Managed {
                 .setUnit("ms")
                 .ofLongs()
                 .build();
-        this.promptsSkipped = meter
-                .counterBuilder("%s.prompts.skipped".formatted(METRIC_NAMESPACE))
-                .setDescription("Prompts skipped during migration, tagged by reason")
-                .build();
         this.promptsAssignedToDefault = meter
                 .counterBuilder("%s.prompts.assigned_to_default".formatted(METRIC_NAMESPACE))
                 .setDescription("Prompts re-routed to Default Project, tagged by reason")
+                .build();
+        this.promptsAssignedToDominantProject = meter
+                .counterBuilder("%s.prompts.assigned_to_dominant_project".formatted(METRIC_NAMESPACE))
+                .setDescription(
+                        "Total number of orphan prompts that referenced multiple projects and were assigned to the dominant one (most referencing experiments). Tagged by distinct_project_count for the multi-project distribution.")
                 .build();
         this.batchSize = meter
                 .histogramBuilder("%s.batch.size".formatted(METRIC_NAMESPACE))
@@ -180,18 +163,12 @@ public class PromptProjectMigrationService implements Managed {
 
     public Mono<Void> runMigrationCycle() {
         return Mono.fromCallable(() -> {
-            var skippedWorkspaceIds = workspacesService.findPromptProjectMigrationSkippedWorkspaceIds();
             var envExcludedWorkspaceIds = migrationConfig.getExcludedWorkspaceIds();
-            cycleTrappedWorkspaces.set(skippedWorkspaceIds.size());
             cycleEnvExcludedWorkspaces.set(envExcludedWorkspaceIds.size());
             log.info(
-                    "Starting prompt project migration cycle, workspacesPerRun='{}', promptBatchSize='{}', trappedWorkspaces='{}', envExcludedWorkspaces='{}'",
-                    config.workspacesPerRun(), config.promptBatchSize(), skippedWorkspaceIds.size(),
-                    envExcludedWorkspaceIds.size());
-            return Stream.concat(
-                    envExcludedWorkspaceIds.stream(),
-                    skippedWorkspaceIds.stream())
-                    .collect(Collectors.toUnmodifiableSet());
+                    "Starting prompt project migration cycle, workspacesPerRun='{}', promptBatchSize='{}', envExcludedWorkspaces='{}'",
+                    config.workspacesPerRun(), config.promptBatchSize(), envExcludedWorkspaceIds.size());
+            return envExcludedWorkspaceIds;
         })
                 .subscribeOn(migrationScheduler)
                 .flatMapMany(excludedWorkspaceIds -> Mono
@@ -250,169 +227,148 @@ public class PromptProjectMigrationService implements Managed {
                         workspaceId, orphanIds, classifications, batchSize, workspaceStartMillis));
     }
 
+    /**
+     * Splits the orphans into three groups: certain (the inferred project still exists, including
+     * the dominant project picked by the query for multi-project prompts), certain-deleted (the
+     * inferred project no longer exists in MySQL), and no-inference (no usable referencing
+     * experiment). Multi-project prompts flow through the certain path because the SQL already
+     * picked their dominant project; the dominant-assignment metric and log are emitted here, and
+     * the other two groups are routed to the workspace's Default Project.
+     */
     private Mono<Boolean> applyClassifications(
             String workspaceId,
             Set<UUID> orphanIds,
             List<PromptProjectClassification> classifications,
             int batchSize,
             long workspaceStartMillis) {
-        var classified = classifications.stream()
-                .collect(Collectors.toUnmodifiableMap(PromptProjectClassification::promptId, c -> c));
+        var classifiedByPrompt = classifications.stream()
+                .collect(Collectors.toUnmodifiableMap(PromptProjectClassification::promptId, Function.identity()));
 
-        var byBucket = orphanIds.stream()
-                .collect(Collectors.groupingBy(
-                        promptId -> bucketOf(classified.get(promptId)),
-                        Collectors.toUnmodifiableSet()));
-        var ambiguous = byBucket.getOrDefault(Bucket.AMBIGUOUS, Set.of());
-        var noInference = byBucket.getOrDefault(Bucket.NO_INFERENCE, Set.of());
-        var certainByProject = byBucket.getOrDefault(Bucket.CERTAIN, Set.of()).stream()
-                .collect(Collectors.groupingBy(
-                        promptId -> classified.get(promptId).projectId(),
-                        Collectors.toUnmodifiableSet()));
-
-        var existingProjectIds = certainByProject.isEmpty()
-                ? Set.<UUID>of()
-                : projectService.findByIds(workspaceId, certainByProject.keySet()).stream()
-                        .map(Project::id)
-                        .collect(Collectors.toUnmodifiableSet());
-        var certainAssignments = certainByProject.entrySet().stream()
-                .filter(entry -> existingProjectIds.contains(entry.getKey()))
-                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
-        var deletedPromptIds = certainByProject.entrySet().stream()
-                .filter(entry -> !existingProjectIds.contains(entry.getKey()))
-                .flatMap(entry -> entry.getValue().stream())
-                .collect(Collectors.toUnmodifiableSet());
-
-        logAndEmitMetrics(workspaceId, ambiguous, deletedPromptIds, noInference);
-
-        var assignments = mergeAssignments(certainAssignments,
-                getDefaultAssignments(workspaceId, deletedPromptIds, noInference));
-
-        // findOrphanPromptIds caps at batchSize, so the current view is only "the whole workspace"
-        // when the result came back short — a full-page result means more orphans may still exist
-        // and the trap decisions below must defer to a later cycle instead of permanently excluding
-        // the workspace based on a partial sample.
-        boolean isTailBatch = orphanIds.size() < batchSize;
-
-        if (assignments.isEmpty()) {
-            if (isTailBatch) {
-                log.info(
-                        "All remaining orphan prompts in workspace are ambiguous, trapping all_ambiguous, workspaceId='{}', count='{}'",
-                        workspaceId, ambiguous.size());
-                return markMigrationSkipped(workspaceId, workspaceStartMillis, Mono.empty());
+        var certainCandidates = new ArrayList<PromptProjectClassification>();
+        var noInferenceIds = new ArrayList<UUID>();
+        for (var promptId : orphanIds) {
+            var inferred = classifiedByPrompt.get(promptId);
+            if (inferred == null) {
+                noInferenceIds.add(promptId);
+            } else {
+                certainCandidates.add(inferred);
             }
-            log.info(
-                    "Current batch is fully ambiguous but workspace may have more orphans, deferring trap to next cycle, workspaceId='{}', batchAmbiguous='{}'",
-                    workspaceId, ambiguous.size());
-            recordWorkspaceDuration(RESULT_ALL_AMBIGUOUS, workspaceStartMillis);
-            return Mono.empty();
         }
 
-        return Flux.fromIterable(assignments.entrySet())
-                .publishOn(migrationScheduler)
-                .concatMap(entry -> batchUpdateProjectId(workspaceId, entry.getKey(), entry.getValue(), batchSize))
-                .reduce(0L, Long::sum)
-                .flatMap(totalUpdated -> {
-                    var duration = Duration.ofMillis(System.currentTimeMillis() - workspaceStartMillis);
-                    if (!ambiguous.isEmpty() && isTailBatch) {
-                        log.info(
-                                "Migration completed with remaining ambiguous prompts, marking workspace as trapped, workspaceId='{}', migrated='{}', ambiguous='{}', duration='{}'",
-                                workspaceId, totalUpdated, ambiguous.size(), duration);
-                        return markMigrationSkipped(workspaceId, workspaceStartMillis, Mono.just(false));
+        var inferredProjectIds = certainCandidates.stream()
+                .map(PromptProjectClassification::projectId)
+                .collect(Collectors.toUnmodifiableSet());
+        return Mono.fromCallable(() -> inferredProjectIds.isEmpty()
+                ? Set.<UUID>of()
+                : projectService.findByIds(workspaceId, inferredProjectIds).stream()
+                        .map(Project::id)
+                        .collect(Collectors.toUnmodifiableSet()))
+                .subscribeOn(migrationScheduler)
+                .flatMap(validProjectIds -> {
+                    var certain = certainCandidates.stream()
+                            .filter(classification -> validProjectIds.contains(classification.projectId()))
+                            .toList();
+                    var certainDeletedIds = certainCandidates.stream()
+                            .filter(classification -> !validProjectIds.contains(classification.projectId()))
+                            .map(PromptProjectClassification::promptId)
+                            .toList();
+
+                    recordDominantAssignments(workspaceId, certain);
+                    logAndEmitDefaultProjectMetrics(workspaceId, certainDeletedIds, noInferenceIds);
+
+                    var assignments = buildAssignments(workspaceId, certain, certainDeletedIds, noInferenceIds);
+                    if (assignments.isEmpty()) {
+                        log.info("No prompts to migrate after classification, workspaceId='{}'", workspaceId);
+                        recordWorkspaceDuration(RESULT_NO_ORPHAN_PROMPTS, workspaceStartMillis);
+                        return Mono.just(false);
                     }
-                    if (!ambiguous.isEmpty()) {
-                        log.info(
-                                "Batch migration completed; workspace has remaining orphans for next cycle, workspaceId='{}', migrated='{}', batchAmbiguous='{}', duration='{}'",
-                                workspaceId, totalUpdated, ambiguous.size(), duration);
-                    } else {
-                        log.info(
-                                "Workspace prompt migration completed, workspaceId='{}', migrated='{}', deletedProject='{}', noInference='{}', duration='{}'",
-                                workspaceId, totalUpdated, deletedPromptIds.size(), noInference.size(), duration);
-                    }
-                    recordWorkspaceDuration(RESULT_MIGRATED, workspaceStartMillis);
-                    return Mono.just(true);
+                    return Flux.fromIterable(assignments.entrySet())
+                            .publishOn(migrationScheduler)
+                            .concatMap(entry -> batchUpdateProjectId(
+                                    workspaceId, entry.getKey(), entry.getValue(), batchSize))
+                            .reduce(0L, Long::sum)
+                            .doOnSuccess(totalUpdated -> {
+                                var duration = Duration.ofMillis(System.currentTimeMillis() - workspaceStartMillis);
+                                log.info(
+                                        "Workspace prompt migration completed, workspaceId='{}', migrated='{}', certain='{}', certainDeleted='{}', noInference='{}', duration='{}'",
+                                        workspaceId, totalUpdated, certain.size(), certainDeletedIds.size(),
+                                        noInferenceIds.size(), duration);
+                                recordWorkspaceDuration(RESULT_MIGRATED, workspaceStartMillis);
+                            })
+                            .thenReturn(true);
                 });
     }
 
-    private Bucket bucketOf(PromptProjectClassification classification) {
-        if (classification == null || classification.projectCount() == 0) {
-            return Bucket.NO_INFERENCE;
+    /**
+     * Bumps {@code prompts.assigned_to_dominant_project} and logs the chosen project plus its
+     * per-project experiment breakdown for each validated multi-project prompt. Single-project
+     * rows are skipped — no dominant decision was made.
+     */
+    private void recordDominantAssignments(String workspaceId, List<PromptProjectClassification> certain) {
+        for (var classification : certain) {
+            if (classification.distinctProjectCount() <= 1) {
+                continue;
+            }
+            long boundedCount = Math.min(classification.distinctProjectCount(), DISTINCT_PROJECT_COUNT_MAX);
+            promptsAssignedToDominantProject.add(1,
+                    Attributes.of(DISTINCT_PROJECT_COUNT_KEY, Long.toString(boundedCount)));
+            log.info(
+                    "Assigning dominant project to prompt, workspaceId='{}', promptId='{}', chosenProjectId='{}', distinctProjectCount='{}', projectBreakdown='{}'",
+                    workspaceId, classification.promptId(), classification.projectId(),
+                    classification.distinctProjectCount(), classification.projectBreakdown());
         }
-        if (classification.projectCount() == 1 && classification.projectId() != null) {
-            return Bucket.CERTAIN;
-        }
-        return Bucket.AMBIGUOUS;
     }
 
-    private void logAndEmitMetrics(
+    private void logAndEmitDefaultProjectMetrics(
             String workspaceId,
-            Set<UUID> ambiguous,
-            Set<UUID> deletedPromptIds,
-            Set<UUID> noInference) {
-        if (!ambiguous.isEmpty()) {
-            log.info("Skipping ambiguous prompts, workspaceId='{}', count='{}'", workspaceId, ambiguous.size());
-            promptsSkipped.add(ambiguous.size(), REASON_AMBIGUOUS);
-        }
-        if (!deletedPromptIds.isEmpty()) {
+            List<UUID> certainDeletedIds,
+            List<UUID> noInferenceIds) {
+        if (!certainDeletedIds.isEmpty()) {
             log.info("Assigning deleted-project prompts to Default Project, workspaceId='{}', count='{}'",
-                    workspaceId, deletedPromptIds.size());
-            promptsAssignedToDefault.add(deletedPromptIds.size(), REASON_DELETED_PROJECT);
+                    workspaceId, certainDeletedIds.size());
+            promptsAssignedToDefault.add(certainDeletedIds.size(), REASON_DELETED_PROJECT);
         }
-        if (!noInference.isEmpty()) {
+        if (!noInferenceIds.isEmpty()) {
             log.info("Assigning no-inference prompts to Default Project, workspaceId='{}', count='{}'",
-                    workspaceId, noInference.size());
-            promptsAssignedToDefault.add(noInference.size(), REASON_NO_INFERENCE);
+                    workspaceId, noInferenceIds.size());
+            promptsAssignedToDefault.add(noInferenceIds.size(), REASON_NO_INFERENCE);
         }
     }
 
     /**
-     * Re-targets the certain-deleted and no-inference prompt sets to the workspace's Default
-     * Project. {@link ProjectService#getOrCreate} is the same path trace ingestion takes, so a
-     * missing Default Project is provisioned in-line rather than trapping the workspace. Returns
-     * an empty map when neither bucket has rows so the caller can skip the merge cheaply.
+     * Groups every actionable prompt by its destination {@code project_id} so the caller can
+     * issue one MySQL batch UPDATE per project. The Default Project is provisioned only when at
+     * least one prompt actually needs it. When an experiment legitimately references the Default
+     * Project, the certain-by-project key collides with the synthesized default-project key, and
+     * the merge function unions both prompt sets rather than letting either side shadow the
+     * other.
      */
-    private Map<UUID, Set<UUID>> getDefaultAssignments(
+    private Map<UUID, Set<UUID>> buildAssignments(
             String workspaceId,
-            Set<UUID> deletedPromptIds,
-            Set<UUID> noInference) {
-        if (deletedPromptIds.isEmpty() && noInference.isEmpty()) {
-            return Map.of();
+            List<PromptProjectClassification> certain,
+            List<UUID> certainDeletedIds,
+            List<UUID> noInferenceIds) {
+        var certainByProject = certain.stream()
+                .collect(Collectors.groupingBy(
+                        PromptProjectClassification::projectId,
+                        Collectors.mapping(PromptProjectClassification::promptId, Collectors.toUnmodifiableSet())));
+        if (certainDeletedIds.isEmpty() && noInferenceIds.isEmpty()) {
+            return certainByProject;
         }
         var defaultProjectId = projectService
                 .getOrCreate(workspaceId, ProjectService.DEFAULT_PROJECT, SYSTEM_USER)
                 .id();
-        var combined = Stream.concat(deletedPromptIds.stream(), noInference.stream())
+        var defaultPromptIds = Stream.concat(certainDeletedIds.stream(), noInferenceIds.stream())
                 .collect(Collectors.toUnmodifiableSet());
-        return Map.of(defaultProjectId, combined);
-    }
-
-    /**
-     * Merges two project_id → prompt_id bucket maps. The Default Project key could coincide with
-     * a {@code certainAssignments} key (an experiment legitimately points to the Default
-     * Project), so the merge combines the two prompt sets rather than letting either side
-     * shadow the other.
-     */
-    private Map<UUID, Set<UUID>> mergeAssignments(
-            Map<UUID, Set<UUID>> certainAssignments,
-            Map<UUID, Set<UUID>> defaultAssignments) {
-        return Stream.concat(certainAssignments.entrySet().stream(), defaultAssignments.entrySet().stream())
+        return Stream.concat(
+                certainByProject.entrySet().stream(),
+                Stream.of(Map.entry(defaultProjectId, defaultPromptIds)))
                 .collect(Collectors.toUnmodifiableMap(
                         Map.Entry::getKey,
                         Map.Entry::getValue,
-                        (certainPromptIds, defaultPromptIds) -> Stream
-                                .concat(certainPromptIds.stream(), defaultPromptIds.stream())
+                        (certainPromptIds, defaultPromptIdsForKey) -> Stream
+                                .concat(certainPromptIds.stream(), defaultPromptIdsForKey.stream())
                                 .collect(Collectors.toUnmodifiableSet())));
-    }
-
-    private Mono<Boolean> markMigrationSkipped(
-            String workspaceId,
-            long workspaceStartMillis,
-            Mono<Boolean> result) {
-        return Mono.fromRunnable(() -> workspacesService.markPromptProjectMigrationSkipped(
-                workspaceId, REASON_ALL_AMBIGUOUS))
-                .subscribeOn(migrationScheduler)
-                .doFinally(signalType -> recordWorkspaceDuration(RESULT_ALL_AMBIGUOUS, workspaceStartMillis))
-                .then(result);
     }
 
     private Mono<Long> batchUpdateProjectId(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/Workspace.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/Workspace.java
@@ -20,8 +20,6 @@ public record Workspace(
         String lastKnownVersion,
         Instant versionDeterminedAt,
         Instant firstTraceReportedAt,
-        Instant promptProjectMigrationSkippedAt,
-        String promptProjectMigrationSkipReason,
         boolean hasLegacyScores,
         Instant createdAt,
         String createdBy,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesDAO.java
@@ -6,7 +6,6 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 
 @RegisterConstructorMapper(Workspace.class)
@@ -55,50 +54,6 @@ public interface WorkspacesDAO {
     void insertFirstTrace(@Bind("id") String id,
             @Bind("reportedAt") Instant reportedAt,
             @Bind("userName") String userName);
-
-    /**
-     * Atomic NULL → timestamp transition for the prompt-project-migration trap flag. Scoped to the
-     * prompt cycle's own column so its trap state is recorded independently of any other migration.
-     */
-    @SqlUpdate("""
-            UPDATE workspaces
-            SET prompt_project_migration_skipped_at = :skippedAt,
-                prompt_project_migration_skip_reason = :reason,
-                last_updated_by = :userName
-            WHERE id = :id AND prompt_project_migration_skipped_at IS NULL
-            """)
-    int updatePromptProjectMigrationSkippedIfNull(@Bind("id") String id,
-            @Bind("skippedAt") Instant skippedAt,
-            @Bind("reason") String reason,
-            @Bind("userName") String userName);
-
-    /**
-     * Plain INSERT (no upsert). Paired with {@link #updatePromptProjectMigrationSkippedIfNull}
-     * for the missing-row case.
-     */
-    @SqlUpdate("""
-            INSERT INTO workspaces (
-                id,
-                prompt_project_migration_skipped_at,
-                prompt_project_migration_skip_reason,
-                created_by,
-                last_updated_by
-            )
-            VALUES (
-                :id,
-                :skippedAt,
-                :reason,
-                :userName,
-                :userName
-            )
-            """)
-    void insertPromptProjectMigrationSkipped(@Bind("id") String id,
-            @Bind("skippedAt") Instant skippedAt,
-            @Bind("reason") String reason,
-            @Bind("userName") String userName);
-
-    @SqlQuery("SELECT id FROM workspaces WHERE prompt_project_migration_skipped_at IS NOT NULL")
-    List<String> findPromptProjectMigrationSkippedWorkspaceIds();
 
     /**
      * Returns the workspace's legacy-feedback-scores flag. {@code Optional.empty()} when the

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspacesService.java
@@ -15,10 +15,8 @@ import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
 import java.sql.SQLException;
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 
-import static com.comet.opik.infrastructure.auth.RequestContext.SYSTEM_USER;
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
 
@@ -41,15 +39,6 @@ public interface WorkspacesService {
      * created the trace).
      */
     boolean markFirstTraceReported(String workspaceId, String userName);
-
-    /**
-     * Idempotent: subsequent calls do not overwrite the original timestamp/reason. Audit columns
-     * are stamped with the system user — this is the migration job's call site, never a direct
-     * user action. Recorded in the dedicated {@code prompt_project_migration_skipped_at} column.
-     */
-    boolean markPromptProjectMigrationSkipped(String workspaceId, String reason);
-
-    List<String> findPromptProjectMigrationSkippedWorkspaceIds();
 
     /**
      * Returns whether the workspace has data in the legacy {@code feedback_scores} ClickHouse
@@ -123,33 +112,6 @@ class WorkspacesServiceImpl implements WorkspacesService {
                 throw exception;
             }
         });
-    }
-
-    @Override
-    public boolean markPromptProjectMigrationSkipped(@NonNull String workspaceId, @NonNull String reason) {
-        return transactionTemplate.inTransaction(WRITE, handle -> {
-            var dao = handle.attach(WorkspacesDAO.class);
-            var now = Instant.now();
-            if (dao.updatePromptProjectMigrationSkippedIfNull(workspaceId, now, reason, SYSTEM_USER) > 0) {
-                return true;
-            }
-            try {
-                dao.insertPromptProjectMigrationSkipped(workspaceId, now, reason, SYSTEM_USER);
-                return true;
-            } catch (UnableToExecuteStatementException exception) {
-                if (exception.getCause() instanceof SQLException sql
-                        && SQL_STATE_INTEGRITY_CONSTRAINT_VIOLATION.equals(sql.getSQLState())) {
-                    return dao.updatePromptProjectMigrationSkippedIfNull(workspaceId, now, reason, SYSTEM_USER) > 0;
-                }
-                throw exception;
-            }
-        });
-    }
-
-    @Override
-    public List<String> findPromptProjectMigrationSkippedWorkspaceIds() {
-        return transactionTemplate.inTransaction(READ_ONLY,
-                handle -> handle.attach(WorkspacesDAO.class).findPromptProjectMigrationSkippedWorkspaceIds());
     }
 
     @Override

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000079_drop_prompt_migration_columns_from_workspaces.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000079_drop_prompt_migration_columns_from_workspaces.sql
@@ -1,0 +1,14 @@
+--liquibase formatted sql
+--changeset andrescrz:000079_drop_prompt_migration_columns_from_workspaces
+--comment: Drop the prompt-project migration trap columns and index from workspaces. The job now assigns multi-project orphans to a dominant project, so the trap state is unreachable.
+
+DROP INDEX workspaces_prompt_proj_migration_skipped_idx ON workspaces;
+
+ALTER TABLE workspaces
+    DROP COLUMN prompt_project_migration_skipped_at,
+    DROP COLUMN prompt_project_migration_skip_reason;
+
+--rollback ALTER TABLE workspaces
+--rollback     ADD COLUMN prompt_project_migration_skipped_at TIMESTAMP(6) NULL AFTER first_trace_reported_at,
+--rollback     ADD COLUMN prompt_project_migration_skip_reason VARCHAR(255) NULL AFTER prompt_project_migration_skipped_at;
+--rollback CREATE INDEX workspaces_prompt_proj_migration_skipped_idx ON workspaces (prompt_project_migration_skipped_at);

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/PromptProjectMigrationJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/PromptProjectMigrationJobTest.java
@@ -44,10 +44,10 @@ import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABA
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Wiring smoke test for the D4 Quartz job. The bucket logic, trap conditions, exclusion lists,
- * and idempotency live in {@link PromptProjectMigrationServiceTest} — this class only verifies
- * that the scheduler -> job -> service plumbing fires and a migration actually happens. Keep
- * scenarios here minimal so the Awaitility windows can stay short.
+ * Wiring smoke test for the D4 Quartz job. Classification logic, dominant-project assignment,
+ * exclusion lists, and idempotency live in {@link PromptProjectMigrationServiceTest} — this class
+ * only verifies that the scheduler -> job -> service plumbing fires and a migration actually
+ * happens. Keep scenarios here minimal so the Awaitility windows can stay short.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DropwizardAppExtensionProvider.class)

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/PromptProjectMigrationServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/PromptProjectMigrationServiceTest.java
@@ -19,7 +19,6 @@ import com.comet.opik.api.resources.utils.resources.ExperimentResourceClient;
 import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
 import com.comet.opik.api.resources.utils.resources.PromptResourceClient;
 import com.comet.opik.api.resources.utils.resources.PromptTestAssertions;
-import com.comet.opik.domain.workspaces.WorkspacesService;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.auth.RequestContext;
@@ -154,25 +153,22 @@ class PromptProjectMigrationServiceTest {
     }
 
     /**
-     * Single workspace covering all four classifier buckets in one cycle:
+     * Single workspace covering every post-classification path in one cycle:
      * <ul>
      *     <li><b>certain</b> — one referencing experiment in a single alive project => assigned.</li>
      *     <li><b>certain-deleted</b> — one referencing experiment in a project later deleted in
      *     MySQL => routed to Default Project.</li>
      *     <li><b>no-inference</b> — orphan prompt with no referencing experiment => routed to
      *     Default Project.</li>
-     *     <li><b>ambiguous</b> — referencing experiments in two distinct live projects => skipped.</li>
+     *     <li><b>multi-project (dominant)</b> — referencing experiments in two distinct live
+     *     projects with different counts => assigned to the dominant (higher-count) project.</li>
      * </ul>
      * Also covers the demo-name filter: a demo-named prompt is workspace-orphan but excluded from
      * the eligibility query, so it's invisible to the cycle even when other prompts in the
      * workspace migrate.
-     *
-     * <p>Outcome: workspace gets trapped with {@code all_ambiguous} because the ambiguous prompt
-     * is left behind; the other three buckets land on their assigned projects and the demo prompt
-     * stays orphan.
      */
     @Test
-    void mixedWorkspaceMigratesAcrossBucketsAndTrapsOnAmbiguous(WorkspacesService workspacesService) {
+    void mixedWorkspaceMigratesAcrossAllBuckets() {
         var apiKey = randomName("api-key");
         var workspaceName = randomName("workspace");
         var workspaceId = UUID.randomUUID().toString();
@@ -196,14 +192,17 @@ class PromptProjectMigrationServiceTest {
 
         var noInferenceLink = createOrphanPromptVersion(apiKey, workspaceName);
 
-        var secondAliveProjectName = randomName("project");
-        var secondAliveProjectId = createProject(apiKey, workspaceName, secondAliveProjectName);
-        var secondAliveDataset = createDatasetWithProject(apiKey, workspaceName, secondAliveProjectId);
-        var ambiguousLink = createOrphanPromptVersion(apiKey, workspaceName);
+        var minorityProjectName = randomName("project");
+        var minorityProjectId = createProject(apiKey, workspaceName, minorityProjectName);
+        var minorityDataset = createDatasetWithProject(apiKey, workspaceName, minorityProjectId);
+        var dominantLink = createOrphanPromptVersion(apiKey, workspaceName);
+        // Two experiments in aliveProject vs one in minorityProject — aliveProject wins by count.
         createExperimentInProject(apiKey, workspaceName, aliveDataset, aliveProjectId, aliveProjectName,
-                ambiguousLink, null);
-        createExperimentInProject(apiKey, workspaceName, secondAliveDataset, secondAliveProjectId,
-                secondAliveProjectName, ambiguousLink, null);
+                dominantLink, null);
+        createExperimentInProject(apiKey, workspaceName, aliveDataset, aliveProjectId, aliveProjectName,
+                dominantLink, null);
+        createExperimentInProject(apiKey, workspaceName, minorityDataset, minorityProjectId,
+                minorityProjectName, dominantLink, null);
 
         // Demo: eligible-shaped but excluded by the demo-name filter on the eligibility query.
         var demoName = DemoData.PROMPTS.getFirst();
@@ -216,7 +215,7 @@ class PromptProjectMigrationServiceTest {
         var certainBefore = promptResourceClient.getPrompt(certainLink.promptId(), apiKey, workspaceName);
         var deletedBefore = promptResourceClient.getPrompt(deletedLink.promptId(), apiKey, workspaceName);
         var noInferenceBefore = promptResourceClient.getPrompt(noInferenceLink.promptId(), apiKey, workspaceName);
-        var ambiguousBefore = promptResourceClient.getPrompt(ambiguousLink.promptId(), apiKey, workspaceName);
+        var dominantBefore = promptResourceClient.getPrompt(dominantLink.promptId(), apiKey, workspaceName);
         var demoBefore = promptResourceClient.getPrompt(demoLink.promptId(), apiKey, workspaceName);
 
         migrationService.runMigrationCycle().block();
@@ -224,10 +223,8 @@ class PromptProjectMigrationServiceTest {
         assertPromptMigratedTo(apiKey, workspaceName, certainLink.promptId(), certainBefore, aliveProjectId);
         assertPromptMigratedToDefault(apiKey, workspaceName, deletedLink.promptId(), deletedBefore);
         assertPromptMigratedToDefault(apiKey, workspaceName, noInferenceLink.promptId(), noInferenceBefore);
-        assertPromptUnchanged(apiKey, workspaceName, ambiguousLink.promptId(), ambiguousBefore);
+        assertPromptMigratedTo(apiKey, workspaceName, dominantLink.promptId(), dominantBefore, aliveProjectId);
         assertPromptUnchanged(apiKey, workspaceName, demoLink.promptId(), demoBefore);
-
-        assertWorkspaceTrapped(workspacesService, workspaceId, "all_ambiguous");
     }
 
     @Test
@@ -306,61 +303,37 @@ class PromptProjectMigrationServiceTest {
     }
 
     /**
-     * Workspace whose only orphan is ambiguous: the early {@code assignments.isEmpty()}
-     * short-circuit in {@code applyClassifications} traps the workspace before any writes happen.
-     * Distinct from the post-write trap exercised by
-     * {@link #mixedWorkspaceMigratesAcrossBucketsAndTrapsOnAmbiguous}, which goes through the
-     * full batch-update chain first.
+     * Multi-project orphan referenced by two equally-counted projects — the dominant query falls
+     * through the count tiebreaker to recency, picking the project of the more recently updated
+     * experiment. A small sleep between the two seed calls keeps the {@code last_updated_at}
+     * values distinguishable at ClickHouse's nanosecond precision.
      */
     @Test
-    void trapWorkspaceWithOnlyAmbiguousPrompts(WorkspacesService workspacesService) {
+    void migrateMultiProjectPromptToMostRecentProjectWhenCountTies() {
         var apiKey = randomName("api-key");
         var workspaceName = randomName("workspace");
         var workspaceId = UUID.randomUUID().toString();
         mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
 
-        var projectName1 = randomName("project");
-        var projectId1 = createProject(apiKey, workspaceName, projectName1);
-        var dataset1 = createDatasetWithProject(apiKey, workspaceName, projectId1);
-        var projectName2 = randomName("project");
-        var projectId2 = createProject(apiKey, workspaceName, projectName2);
-        var dataset2 = createDatasetWithProject(apiKey, workspaceName, projectId2);
+        var olderProjectName = randomName("project");
+        var olderProjectId = createProject(apiKey, workspaceName, olderProjectName);
+        var olderDataset = createDatasetWithProject(apiKey, workspaceName, olderProjectId);
+        var newerProjectName = randomName("project");
+        var newerProjectId = createProject(apiKey, workspaceName, newerProjectName);
+        var newerDataset = createDatasetWithProject(apiKey, workspaceName, newerProjectId);
 
         var promptLink = createOrphanPromptVersion(apiKey, workspaceName);
-        createExperimentInProject(apiKey, workspaceName, dataset1, projectId1, projectName1,
+        createExperimentInProject(apiKey, workspaceName, olderDataset, olderProjectId, olderProjectName,
                 promptLink, null);
-        createExperimentInProject(apiKey, workspaceName, dataset2, projectId2, projectName2,
+        TestUtils.waitForMillis(20);
+        createExperimentInProject(apiKey, workspaceName, newerDataset, newerProjectId, newerProjectName,
                 promptLink, null);
 
         var before = promptResourceClient.getPrompt(promptLink.promptId(), apiKey, workspaceName);
 
         migrationService.runMigrationCycle().block();
 
-        assertPromptUnchanged(apiKey, workspaceName, promptLink.promptId(), before);
-        assertWorkspaceTrapped(workspacesService, workspaceId, "all_ambiguous");
-    }
-
-    @Test
-    void skipPreMarkedTrappedWorkspaces(WorkspacesService workspacesService) {
-        var apiKey = randomName("api-key");
-        var workspaceName = randomName("workspace");
-        var workspaceId = UUID.randomUUID().toString();
-        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
-
-        workspacesService.markPromptProjectMigrationSkipped(workspaceId, "test-pre-marked-trap");
-
-        var projectName = randomName("project");
-        var projectId = createProject(apiKey, workspaceName, projectName);
-        var datasetName = createDatasetWithProject(apiKey, workspaceName, projectId);
-        var promptLink = createOrphanPromptVersion(apiKey, workspaceName);
-        createExperimentInProject(apiKey, workspaceName, datasetName, projectId, projectName,
-                promptLink, null);
-
-        var before = promptResourceClient.getPrompt(promptLink.promptId(), apiKey, workspaceName);
-
-        migrationService.runMigrationCycle().block();
-
-        assertPromptUnchanged(apiKey, workspaceName, promptLink.promptId(), before);
+        assertPromptMigratedTo(apiKey, workspaceName, promptLink.promptId(), before, newerProjectId);
     }
 
     @Test
@@ -465,110 +438,222 @@ class PromptProjectMigrationServiceTest {
     }
 
     /**
-     * Partial-batch all-ambiguous: a workspace with more orphans than {@code promptBatchSize}
-     * whose current batch happens to be entirely ambiguous must NOT be trapped on this cycle —
-     * the workspace may still have non-ambiguous orphans on the next page. Without the
-     * {@code isTailBatch} guard this is a silent data-loss path: workspace gets permanently
-     * excluded after cycle 1 and the remaining orphans are stranded.
-     *
-     * <p>Known residual: when every orphan in the workspace is genuinely ambiguous,
-     * {@code findOrphanPromptIds} keeps returning a full {@code BATCH_SIZE}-sized page each
-     * cycle so {@code isTailBatch} stays false forever and the workspace cycles indefinitely
-     * without trapping. The indefinite cycle is annoying (visible in metrics / logs) but is
-     * strictly better than the silent-data-loss alternative. Closing this cleanly requires
-     * {@code ORDER BY id ASC} + cursor-style spillover in {@code findOrphanPromptIds} and is
-     * a follow-up to this PR.
+     * Multi-project orphan referenced by experiments split across two projects with different
+     * counts — the dominant (higher-count) project wins by the {@code count DESC} step of the
+     * ranking. A second cycle is a no-op (re-runs are deterministic; same input → same
+     * assignment).
      */
     @Test
-    void partialBatchAllAmbiguousDoesNotTrap(WorkspacesService workspacesService) {
+    void migrateMultiProjectPromptToDominantProjectByCount() {
         var apiKey = randomName("api-key");
         var workspaceName = randomName("workspace");
         var workspaceId = UUID.randomUUID().toString();
         mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
 
-        // Two distinct alive projects shared across every ambiguous prompt so each prompt's
-        // classification has projectCount == 2 → AMBIGUOUS bucket.
-        var projectName1 = randomName("project");
-        var projectId1 = createProject(apiKey, workspaceName, projectName1);
-        var dataset1 = createDatasetWithProject(apiKey, workspaceName, projectId1);
-        var projectName2 = randomName("project");
-        var projectId2 = createProject(apiKey, workspaceName, projectName2);
-        var dataset2 = createDatasetWithProject(apiKey, workspaceName, projectId2);
+        var dominantProjectName = randomName("project");
+        var dominantProjectId = createProject(apiKey, workspaceName, dominantProjectName);
+        var dominantDataset = createDatasetWithProject(apiKey, workspaceName, dominantProjectId);
+        var minorityProjectName = randomName("project");
+        var minorityProjectId = createProject(apiKey, workspaceName, minorityProjectName);
+        var minorityDataset = createDatasetWithProject(apiKey, workspaceName, minorityProjectId);
 
-        // BATCH_SIZE + 2 ambiguous prompts: cycle 1 fetches BATCH_SIZE (non-tail, all-ambiguous),
-        // so the guard defers the trap. None get migrated either, so the workspace remains
-        // eligible — which is the correctness contract we're protecting.
-        var promptIds = new ArrayList<UUID>();
-        for (int i = 0; i < BATCH_SIZE + 2; i++) {
-            var link = createOrphanPromptVersion(apiKey, workspaceName);
-            createExperimentInProject(apiKey, workspaceName, dataset1, projectId1, projectName1, link, null);
-            createExperimentInProject(apiKey, workspaceName, dataset2, projectId2, projectName2, link, null);
-            promptIds.add(link.promptId());
-        }
+        var promptLink = createOrphanPromptVersion(apiKey, workspaceName);
+        // 3 experiments in the dominant project, 1 in the minority project.
+        createExperimentInProject(apiKey, workspaceName, dominantDataset, dominantProjectId, dominantProjectName,
+                promptLink, null);
+        createExperimentInProject(apiKey, workspaceName, dominantDataset, dominantProjectId, dominantProjectName,
+                promptLink, null);
+        createExperimentInProject(apiKey, workspaceName, dominantDataset, dominantProjectId, dominantProjectName,
+                promptLink, null);
+        createExperimentInProject(apiKey, workspaceName, minorityDataset, minorityProjectId, minorityProjectName,
+                promptLink, null);
+
+        var before = promptResourceClient.getPrompt(promptLink.promptId(), apiKey, workspaceName);
 
         migrationService.runMigrationCycle().block();
 
-        assertThat(countMigrated(apiKey, workspaceName, promptIds))
-                .as("cycle 1 must not migrate any ambiguous prompt")
-                .isZero();
-        assertWorkspaceNotTrapped(workspacesService, workspaceId);
+        assertPromptMigratedTo(apiKey, workspaceName, promptLink.promptId(), before, dominantProjectId);
+
+        var afterFirstCycle = promptResourceClient.getPrompt(promptLink.promptId(), apiKey, workspaceName);
+        migrationService.runMigrationCycle().block();
+        assertPromptUnchanged(apiKey, workspaceName, promptLink.promptId(), afterFirstCycle);
     }
 
     /**
-     * Partial-batch mixed buckets: a workspace with more orphans than {@code promptBatchSize}
-     * whose current batch contains both certain and ambiguous prompts must migrate the certain
-     * prompts and NOT trap on the post-write decision — the workspace still has more orphans
-     * (including the ambiguous remainder) for the next cycle. Without the {@code isTailBatch}
-     * guard the post-write trap fires and strands the rest.
+     * Multi-project orphan where one referencing experiment is itself still V1 ({@code
+     * project_id = ''}): the empty-project row is filtered out by the CH classifier's inner
+     * {@code HAVING experiment_project_id != ''}, and the dominant choice is made over the
+     * remaining V2 experiments only.
      */
     @Test
-    void partialBatchMixedAmbiguousAndCertainDoesNotTrap(WorkspacesService workspacesService) {
+    void multiProjectPromptIgnoresExperimentsWithEmptyProjectId() {
         var apiKey = randomName("api-key");
         var workspaceName = randomName("workspace");
         var workspaceId = UUID.randomUUID().toString();
         mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
 
-        // One alive project for the certain bucket, two alive projects for the ambiguous bucket.
-        var certainProjectName = randomName("project");
-        var certainProjectId = createProject(apiKey, workspaceName, certainProjectName);
-        var certainDataset = createDatasetWithProject(apiKey, workspaceName, certainProjectId);
-        var ambiguousProjectName1 = randomName("project");
-        var ambiguousProjectId1 = createProject(apiKey, workspaceName, ambiguousProjectName1);
-        var ambiguousDataset1 = createDatasetWithProject(apiKey, workspaceName, ambiguousProjectId1);
-        var ambiguousProjectName2 = randomName("project");
-        var ambiguousProjectId2 = createProject(apiKey, workspaceName, ambiguousProjectName2);
-        var ambiguousDataset2 = createDatasetWithProject(apiKey, workspaceName, ambiguousProjectId2);
+        var dominantProjectName = randomName("project");
+        var dominantProjectId = createProject(apiKey, workspaceName, dominantProjectName);
+        var dominantDataset = createDatasetWithProject(apiKey, workspaceName, dominantProjectId);
+        var minorityProjectName = randomName("project");
+        var minorityProjectId = createProject(apiKey, workspaceName, minorityProjectName);
+        var minorityDataset = createDatasetWithProject(apiKey, workspaceName, minorityProjectId);
 
-        // 51 certain + 51 ambiguous = BATCH_SIZE + 2 total. Pigeonhole: any 100-of-102 slice must
-        // include at least 49 of each bucket — cycle 1's batch is guaranteed to have both certain
-        // and ambiguous prompts regardless of MySQL fetch order.
-        int perBucket = (BATCH_SIZE + 2) / 2;
-        var certainPromptIds = new ArrayList<UUID>();
-        for (int i = 0; i < perBucket; i++) {
-            var link = createOrphanPromptVersion(apiKey, workspaceName);
-            createExperimentInProject(apiKey, workspaceName, certainDataset, certainProjectId, certainProjectName,
-                    link, null);
-            certainPromptIds.add(link.promptId());
-        }
-        var ambiguousPromptIds = new ArrayList<UUID>();
-        for (int i = 0; i < perBucket; i++) {
-            var link = createOrphanPromptVersion(apiKey, workspaceName);
-            createExperimentInProject(apiKey, workspaceName, ambiguousDataset1, ambiguousProjectId1,
-                    ambiguousProjectName1, link, null);
-            createExperimentInProject(apiKey, workspaceName, ambiguousDataset2, ambiguousProjectId2,
-                    ambiguousProjectName2, link, null);
-            ambiguousPromptIds.add(link.promptId());
-        }
+        var promptLink = createOrphanPromptVersion(apiKey, workspaceName);
+        createExperimentInProject(apiKey, workspaceName, dominantDataset, dominantProjectId, dominantProjectName,
+                promptLink, null);
+        createExperimentInProject(apiKey, workspaceName, dominantDataset, dominantProjectId, dominantProjectName,
+                promptLink, null);
+        createExperimentInProject(apiKey, workspaceName, minorityDataset, minorityProjectId, minorityProjectName,
+                promptLink, null);
+        // V1 experiment referencing the prompt without a project: filtered out by the HAVING
+        // clause, so the dominant tally only spans the three V2 experiments above.
+        var orphanDataset = randomName("dataset");
+        datasetResourceClient.createDataset(
+                factory.manufacturePojo(Dataset.class).toBuilder()
+                        .name(orphanDataset)
+                        .projectId(null)
+                        .projectName(null)
+                        .build(),
+                apiKey, workspaceName);
+        experimentResourceClient.create(
+                experimentResourceClient.createPartialExperiment()
+                        .id(null)
+                        .datasetName(orphanDataset)
+                        .promptVersion(promptLink)
+                        .build(),
+                apiKey, workspaceName);
+
+        var before = promptResourceClient.getPrompt(promptLink.promptId(), apiKey, workspaceName);
 
         migrationService.runMigrationCycle().block();
 
-        assertThat(countMigrated(apiKey, workspaceName, certainPromptIds))
-                .as("cycle 1 must migrate at least some certain prompts in the batch")
-                .isPositive();
-        assertThat(countMigrated(apiKey, workspaceName, ambiguousPromptIds))
-                .as("ambiguous prompts are never written by the cycle")
-                .isZero();
-        assertWorkspaceNotTrapped(workspacesService, workspaceId);
+        assertPromptMigratedTo(apiKey, workspaceName, promptLink.promptId(), before, dominantProjectId);
+    }
+
+    /**
+     * Multi-project prompt whose dominant project (the higher-count one the query chose) is
+     * deleted in MySQL before the cycle runs. Project-validation drops the now-missing dominant
+     * project, so the prompt falls back to the Default Project — it is not reassigned to the
+     * surviving lower-count project.
+     */
+    @Test
+    void migrateMultiProjectPromptToDefaultProjectWhenDominantProjectWasDeleted() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var dominantProjectName = randomName("project");
+        var dominantProjectId = createProject(apiKey, workspaceName, dominantProjectName);
+        var dominantDataset = createDatasetWithProject(apiKey, workspaceName, dominantProjectId);
+        var minorityProjectName = randomName("project");
+        var minorityProjectId = createProject(apiKey, workspaceName, minorityProjectName);
+        var minorityDataset = createDatasetWithProject(apiKey, workspaceName, minorityProjectId);
+
+        var promptLink = createOrphanPromptVersion(apiKey, workspaceName);
+        // Dominant project (2 experiments) beats the minority project (1) by count.
+        createExperimentInProject(apiKey, workspaceName, dominantDataset, dominantProjectId, dominantProjectName,
+                promptLink, null);
+        createExperimentInProject(apiKey, workspaceName, dominantDataset, dominantProjectId, dominantProjectName,
+                promptLink, null);
+        createExperimentInProject(apiKey, workspaceName, minorityDataset, minorityProjectId, minorityProjectName,
+                promptLink, null);
+
+        // Delete the dominant project: the query still infers it, but validation drops it.
+        projectResourceClient.deleteProject(dominantProjectId, apiKey, workspaceName);
+
+        var before = promptResourceClient.getPrompt(promptLink.promptId(), apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertPromptMigratedToDefault(apiKey, workspaceName, promptLink.promptId(), before);
+    }
+
+    /**
+     * Multi-project orphan referenced both via the legacy {@code experiments.prompt_id} column and
+     * via the {@code experiments.prompt_versions} map: both reference paths contribute to the
+     * dominant calculation via the {@code ARRAY JOIN} on the concatenated prompt-id array.
+     * Same-experiment duplicates (an experiment referencing the prompt through both columns at
+     * once) are absorbed by {@code arrayDistinct} so they don't inflate the count.
+     */
+    @Test
+    void multiProjectPromptViaLegacyAndModernRefsContributesToDominant() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var dominantProjectName = randomName("project");
+        var dominantProjectId = createProject(apiKey, workspaceName, dominantProjectName);
+        var dominantDataset = createDatasetWithProject(apiKey, workspaceName, dominantProjectId);
+        var minorityProjectName = randomName("project");
+        var minorityProjectId = createProject(apiKey, workspaceName, minorityProjectName);
+        var minorityDataset = createDatasetWithProject(apiKey, workspaceName, minorityProjectId);
+
+        var promptLink = createOrphanPromptVersion(apiKey, workspaceName);
+        // Dominant: one experiment via prompt_id, one via prompt_versions map only.
+        createExperimentInProject(apiKey, workspaceName, dominantDataset, dominantProjectId, dominantProjectName,
+                promptLink, null);
+        createExperimentInProject(apiKey, workspaceName, dominantDataset, dominantProjectId, dominantProjectName,
+                null, List.of(promptLink));
+        // Minority: one experiment with the prompt referenced via both columns redundantly. After
+        // arrayDistinct in the classifier, this counts as a single reference.
+        createExperimentInProject(apiKey, workspaceName, minorityDataset, minorityProjectId, minorityProjectName,
+                promptLink, List.of(promptLink));
+
+        var before = promptResourceClient.getPrompt(promptLink.promptId(), apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertPromptMigratedTo(apiKey, workspaceName, promptLink.promptId(), before, dominantProjectId);
+    }
+
+    /**
+     * Demo-named experiments must not influence the dominant-project choice for a non-demo prompt.
+     * The real experiment is created first in {@code realProject}; a demo-named experiment is
+     * then created in a different project that references the same prompt. Without the
+     * {@code AND name NOT IN :demo_experiment_names} filter on the classifier, both projects
+     * would tie at {@code distinctProjectCount=2} and the recency tiebreaker would assign the
+     * prompt to the demo experiment's project — leaking demo data into a real prompt's home.
+     * With the filter, only the real experiment contributes and the prompt lands on
+     * {@code realProject}.
+     */
+    @Test
+    void multiProjectPromptIgnoresDemoNamedExperiments() {
+        var apiKey = randomName("api-key");
+        var workspaceName = randomName("workspace");
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, randomName("user"));
+
+        var realProjectName = randomName("project");
+        var realProjectId = createProject(apiKey, workspaceName, realProjectName);
+        var realDataset = createDatasetWithProject(apiKey, workspaceName, realProjectId);
+        var demoSpyProjectName = randomName("project");
+        var demoSpyProjectId = createProject(apiKey, workspaceName, demoSpyProjectName);
+        var demoSpyDataset = createDatasetWithProject(apiKey, workspaceName, demoSpyProjectId);
+
+        var promptLink = createOrphanPromptVersion(apiKey, workspaceName);
+        createExperimentInProject(apiKey, workspaceName, realDataset, realProjectId, realProjectName,
+                promptLink, null);
+        // Wait so the demo experiment's last_updated_at is strictly newer; absent the filter the
+        // recency tiebreaker would pick demoSpyProject and the assertion below would fail.
+        TestUtils.waitForMillis(20);
+        var demoExperiment = experimentResourceClient.createPartialExperiment()
+                .id(null)
+                .name(DemoData.EXPERIMENTS.getFirst())
+                .datasetName(demoSpyDataset)
+                .projectId(demoSpyProjectId)
+                .projectName(demoSpyProjectName)
+                .promptVersion(promptLink)
+                .build();
+        experimentResourceClient.create(demoExperiment, apiKey, workspaceName);
+
+        var before = promptResourceClient.getPrompt(promptLink.promptId(), apiKey, workspaceName);
+
+        migrationService.runMigrationCycle().block();
+
+        assertPromptMigratedTo(apiKey, workspaceName, promptLink.promptId(), before, realProjectId);
     }
 
     /**
@@ -733,16 +818,6 @@ class PromptProjectMigrationServiceTest {
             Prompt beforeMigration) {
         var actual = promptResourceClient.getPrompt(promptId, apiKey, workspaceName);
         PromptTestAssertions.assertPromptEqual(actual, beforeMigration);
-    }
-
-    private void assertWorkspaceTrapped(WorkspacesService workspacesService, String workspaceId, String reason) {
-        assertThat(workspacesService.findPromptProjectMigrationSkippedWorkspaceIds()).contains(workspaceId);
-        assertThat(workspacesService.findById(workspaceId))
-                .hasValueSatisfying(w -> assertThat(w.promptProjectMigrationSkipReason()).isEqualTo(reason));
-    }
-
-    private void assertWorkspaceNotTrapped(WorkspacesService workspacesService, String workspaceId) {
-        assertThat(workspacesService.findPromptProjectMigrationSkippedWorkspaceIds()).doesNotContain(workspaceId);
     }
 
     private long countMigrated(String apiKey, String workspaceName, List<UUID> promptIds) {


### PR DESCRIPTION
## Details

Replaces the prompt-migration ambiguous bucket with the dominant-project pattern already shipped for the dataset job and for the experiment job. Multi-project orphans are now assigned the project with the most referencing experiments, breaking ties by recency then `project_id` ASC. After this lands, every previously-V1 prompt in every previously-trapped workspace gets a non-empty `project_id` — nothing left behind. Affected cohort is small (well under 1% of prompts in production telemetry).

- **Classifier (`ExperimentDAO.COMPUTE_PROMPT_PROJECT_CLASSIFICATION`)** now emits `(prompt_id, project_id=dominant, distinct_project_count, project_breakdown)`. `arrayDistinct` collapses redundant legacy+modern references on the same experiment; `HAVING experiment_project_id != ''` keeps V1 experiments out of the inference; `AND name NOT IN :demo_experiment_names` keeps demo-named experiments from tilting the dominant pick for user prompts. Same shape as `COMPUTE_DATASET_PROJECT_MAPPING`.
- **`PromptProjectClassification`** record updated to `distinctProjectCount` + `projectBreakdown`; `projectId` is `@NonNull` to match `DatasetProjectMapping`. DAO drops blank-`project_id` rows at the JDBC boundary.
- **Service (`PromptProjectMigrationService`)** collapses the three-bucket enum into a single validated path. Emits a new `prompts.assigned_to_dominant_project` counter tagged by `distinct_project_count` (capped at 50 for cardinality) plus a structured per-assignment log line naming chosen project, distinct project count, and the runner-up breakdown.
- **Trap mechanism fully removed.** Liquibase `000079_drop_prompt_migration_columns_from_workspaces.sql` drops the two trap columns and their index; `WorkspacesDAO`, `WorkspacesService`, and the `Workspace` record lose the trap methods/fields; `cycle.trapped_workspaces` and `prompts.skipped` metrics are retired.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6758

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: assisted — full implementation under reviewer-in-the-loop iteration; multiple rounds of justified push-back, SQL/correctness analysis, and review-focused passes
- Human verification: line-by-line code review, deep query/branch analysis, sibling-pattern cross-checks against the dataset/experiment migrations, integration-test suite green locally

## Testing

- `mvn test -Dtest='PromptProjectMigrationServiceTest,PromptProjectMigrationJobTest'` in `apps/opik-backend` — **17/17 green** (16 service tests + 1 smoke). CI will run the full backend suite.
- New tests added on top of the existing five:
  - `migrateMultiProjectPromptToDominantProjectByCount` — different counts → dominant wins; second cycle is a no-op (idempotency).
  - `migrateMultiProjectPromptToMostRecentProjectWhenCountTies` — equal counts → recency tiebreaker.
  - `multiProjectPromptIgnoresExperimentsWithEmptyProjectId` — V1 experiment dropped by `HAVING`; dominant tally spans only V2 experiments.
  - `multiProjectPromptViaLegacyAndModernRefsContributesToDominant` — locks in `arrayDistinct` correctness for legacy+modern reference paths on the same experiment.
  - `migrateMultiProjectPromptToDefaultProjectWhenDominantProjectWasDeleted` — dominant project deleted in MySQL after the cycle started → falls back to Default Project, not to the lower-count surviving project.
  - `multiProjectPromptIgnoresDemoNamedExperiments` — demo-named experiment in a different project doesn't tilt the dominant pick for a user prompt (without the filter, recency tiebreak would have flipped the assignment to the demo project).
- Existing `mixedWorkspaceMigratesAcrossBucketsAndTrapsOnAmbiguous` rewritten as `mixedWorkspaceMigratesAcrossAllBuckets` — covers certain / certain-deleted / no-inference / dominant in one workspace plus the demo-prompt eligibility filter.
- Removed trap-state helpers and the two partial-batch trap tests; the trap mechanism no longer exists.
- Two intentional coverage gaps (flagged during review, infeasible at integration level): equal-counts-equal-timestamps `project_id` ASC tiebreaker (clock-resolution prevents forced collisions) and direct OTel meter probes for the dominant counter and default-project counters (no precedent in sibling tests; behavior verified by outcome — prompt placements).

## Documentation

- Backend Javadoc tightened on `ExperimentDAO.COMPUTE_PROMPT_PROJECT_CLASSIFICATION`, `PromptProjectClassification`, and `PromptProjectMigrationService` to reflect the dominant-project shape and the tiebreaker chain.
- Liquibase changelog comment on `000079_drop_prompt_migration_columns_from_workspaces.sql` documents the trap-removal rationale.
- Out-of-scope (called out in OPIK-6758): the Grafana dashboard for this job needs trap-workspaces panels removed and the new `prompts.assigned_to_dominant_project` series surfaced; the Notion runbook needs the trap-detection / CLI-mandatory-cleanup sections rewritten to "dominant assignment + CLI as opt-in copy tool." Both tracked outside this PR.