### PR TITLE
[OPIK-6652] [BE] fix: send Comet-Workspace header on Studio gateway LLM calls

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/jobs/optimizer_runner.py
+++ b/apps/opik-python-backend/src/opik_backend/jobs/optimizer_runner.py
@@ -9,6 +9,7 @@ All stdout/stderr from this script is captured by the parent process and
 streamed to Redis for S3 sync.
 """
 
+import functools
 import json
 import logging
 import os
@@ -114,6 +115,58 @@ def reconfigure_rich_console():
         logger.warning(f"Failed to reconfigure Rich console: {e}")
 
 
+def route_litellm_calls_through_gateway(workspace_name):
+    """Attach the ``Comet-Workspace`` header to gateway LLM calls.
+
+    Optimization Studio routes every LiteLLM completion through the Opik
+    backend gateway (``OPENAI_API_BASE``, set in optimizer.py). The gateway
+    authenticates each request per workspace, reading the ``Comet-Workspace``
+    header — the same header the SDK and playground send. LiteLLM's
+    OpenAI-compatible path only forwards ``Authorization`` by default, so
+    without this header the gateway rejects every call with
+    403 "Workspace name should be provided", regardless of project name.
+
+    The header is injected via ``extra_headers`` (which LiteLLM merges with the
+    auth header) by wrapping ``litellm.completion``/``litellm.acompletion``.
+    Both call sites in opik_optimizer resolve these attributes at call time, so
+    patching them before the optimization runs is sufficient. Guarded on
+    ``OPENAI_API_BASE`` so direct-provider calls are never touched.
+    """
+    if not workspace_name or not os.environ.get("OPENAI_API_BASE"):
+        return
+
+    import litellm
+
+    if getattr(litellm.completion, "_opik_gateway_workspace", None):
+        return
+
+    def _add_workspace_header(kwargs):
+        extra_headers = dict(kwargs.get("extra_headers") or {})
+        extra_headers.setdefault("Comet-Workspace", workspace_name)
+        kwargs["extra_headers"] = extra_headers
+        return kwargs
+
+    original_completion = litellm.completion
+    original_acompletion = litellm.acompletion
+
+    @functools.wraps(original_completion)
+    def completion_with_workspace(*args, **kwargs):
+        return original_completion(*args, **_add_workspace_header(kwargs))
+
+    @functools.wraps(original_acompletion)
+    async def acompletion_with_workspace(*args, **kwargs):
+        return await original_acompletion(*args, **_add_workspace_header(kwargs))
+
+    completion_with_workspace._opik_gateway_workspace = workspace_name
+    acompletion_with_workspace._opik_gateway_workspace = workspace_name
+
+    litellm.completion = completion_with_workspace
+    litellm.acompletion = acompletion_with_workspace
+    logger.debug(
+        "Routing LiteLLM calls through gateway with Comet-Workspace header"
+    )
+
+
 def main():
     """Main entry point for optimizer runner subprocess."""
     try:
@@ -152,6 +205,10 @@ def main():
         # Parse job context and config
         context = OptimizationJobContext.from_job_message(job_message)
         config = OptimizationConfig.from_dict(job_message.get("config", {}))
+
+        # Ensure every gateway-routed LLM call carries the workspace header so
+        # the backend can authenticate it (see optimizer.py for OPENAI_API_BASE).
+        route_litellm_calls_through_gateway(context.workspace_name)
 
         # Treat the Opik backend gateway as an OpenAI-compatible endpoint.
         # The "openai/" prefix tells LiteLLM to use its OpenAI handler, which

--- a/apps/opik-python-backend/src/opik_backend/jobs/optimizer_runner.py
+++ b/apps/opik-python-backend/src/opik_backend/jobs/optimizer_runner.py
@@ -77,6 +77,13 @@ warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")
 logger = logging.getLogger(__name__)
 logger.debug(f"TERMINAL_WIDTH: {TERMINAL_WIDTH}")
 
+# Opik backend gateway base URL for LLM calls. optimizer.py sets this in the
+# subprocess environment before spawning this runner whenever Optimization
+# Studio routes completions through the backend gateway, so it is read once at
+# import (mirrors OPIK_URL handling in studio/config.py).
+OPENAI_API_BASE = os.getenv("OPENAI_API_BASE")
+logger.debug(f"OPENAI_API_BASE configured: {bool(OPENAI_API_BASE)}")
+
 
 def reconfigure_rich_console():
     """Reconfigure Rich console to output to stderr so we can capture it.
@@ -115,6 +122,12 @@ def reconfigure_rich_console():
         logger.warning(f"Failed to reconfigure Rich console: {e}")
 
 
+# Workspace the gateway wrappers inject into the Comet-Workspace header. Held in
+# a mutable container so the (single) set of wrappers always reflects the latest
+# workspace without needing to be torn down and rebuilt.
+_gateway_workspace = {"name": None}
+
+
 def route_litellm_calls_through_gateway(workspace_name):
     """Attach the ``Comet-Workspace`` header to gateway LLM calls.
 
@@ -131,18 +144,27 @@ def route_litellm_calls_through_gateway(workspace_name):
     Both call sites in opik_optimizer resolve these attributes at call time, so
     patching them before the optimization runs is sufficient. Guarded on
     ``OPENAI_API_BASE`` so direct-provider calls are never touched.
+
+    Idempotent: the wrappers are installed at most once. Calling again with a
+    different ``workspace_name`` updates the injected value in place rather than
+    stacking another wrapper.
     """
-    if not workspace_name or not os.environ.get("OPENAI_API_BASE"):
+    if not workspace_name or not OPENAI_API_BASE:
         return
 
     import litellm
 
-    if getattr(litellm.completion, "_opik_gateway_workspace", None):
+    # Always reflect the latest workspace; the wrappers read this dynamically.
+    _gateway_workspace["name"] = workspace_name
+
+    # Install the wrappers only once — they pick up workspace changes via the
+    # shared container above.
+    if getattr(litellm.completion, "_opik_gateway_wrapped", False):
         return
 
     def _add_workspace_header(kwargs):
         extra_headers = dict(kwargs.get("extra_headers") or {})
-        extra_headers.setdefault("Comet-Workspace", workspace_name)
+        extra_headers.setdefault("Comet-Workspace", _gateway_workspace["name"])
         kwargs["extra_headers"] = extra_headers
         return kwargs
 
@@ -157,8 +179,8 @@ def route_litellm_calls_through_gateway(workspace_name):
     async def acompletion_with_workspace(*args, **kwargs):
         return await original_acompletion(*args, **_add_workspace_header(kwargs))
 
-    completion_with_workspace._opik_gateway_workspace = workspace_name
-    acompletion_with_workspace._opik_gateway_workspace = workspace_name
+    completion_with_workspace._opik_gateway_wrapped = True
+    acompletion_with_workspace._opik_gateway_wrapped = True
 
     litellm.completion = completion_with_workspace
     litellm.acompletion = acompletion_with_workspace

--- a/apps/opik-python-backend/tests/test_studio_gateway_workspace_header.py
+++ b/apps/opik-python-backend/tests/test_studio_gateway_workspace_header.py
@@ -14,7 +14,14 @@ import types
 
 import pytest
 
+from opik_backend.jobs import optimizer_runner
 from opik_backend.jobs.optimizer_runner import route_litellm_calls_through_gateway
+
+
+@pytest.fixture(autouse=True)
+def reset_gateway_state(monkeypatch):
+    """Isolate the module-level workspace container between tests."""
+    monkeypatch.setattr(optimizer_runner, "_gateway_workspace", {"name": None})
 
 
 @pytest.fixture
@@ -40,7 +47,9 @@ def fake_litellm(monkeypatch):
 
 @pytest.fixture
 def gateway_env(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_BASE", "http://gateway/v1/private")
+    monkeypatch.setattr(
+        optimizer_runner, "OPENAI_API_BASE", "http://gateway/v1/private"
+    )
 
 
 class TestRouteLitellmCallsThroughGateway:
@@ -81,7 +90,7 @@ class TestRouteLitellmCallsThroughGateway:
         assert fake_litellm.calls[-1]["extra_headers"]["Comet-Workspace"] == "explicit-ws"
 
     def test_noop_when_gateway_not_active(self, fake_litellm, monkeypatch):
-        monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+        monkeypatch.setattr(optimizer_runner, "OPENAI_API_BASE", None)
 
         route_litellm_calls_through_gateway("my-workspace")
         fake_litellm.completion(messages=[])
@@ -128,3 +137,15 @@ class TestRouteLitellmCallsThroughGateway:
         fake_litellm.completion(messages=[])
         # Header injected exactly once (no nested extra_headers stacking).
         assert fake_litellm.calls[-1]["extra_headers"] == {"Comet-Workspace": "my-workspace"}
+
+    def test_updates_workspace_without_rewrapping(self, fake_litellm, gateway_env):
+        route_litellm_calls_through_gateway("workspace-a")
+        wrapped_once = fake_litellm.completion
+
+        route_litellm_calls_through_gateway("workspace-b")
+
+        # Same wrapper object (no nested re-wrap)...
+        assert fake_litellm.completion is wrapped_once
+        # ...but it now injects the updated workspace.
+        fake_litellm.completion(messages=[])
+        assert fake_litellm.calls[-1]["extra_headers"] == {"Comet-Workspace": "workspace-b"}

--- a/apps/opik-python-backend/tests/test_studio_gateway_workspace_header.py
+++ b/apps/opik-python-backend/tests/test_studio_gateway_workspace_header.py
@@ -1,0 +1,130 @@
+"""Tests that gateway-routed LLM calls carry the Comet-Workspace header.
+
+Optimization Studio routes every LiteLLM completion through the Opik backend
+gateway (OPENAI_API_BASE, set in optimizer.py). The gateway authenticates each
+request per workspace via the Comet-Workspace header, so the subprocess runner
+must attach it to every completion and async completion. Without it the gateway
+rejects every call with 403 "Workspace name should be provided". These tests
+cover the wrapping seam in optimizer_runner.
+"""
+
+import asyncio
+import sys
+import types
+
+import pytest
+
+from opik_backend.jobs.optimizer_runner import route_litellm_calls_through_gateway
+
+
+@pytest.fixture
+def fake_litellm(monkeypatch):
+    """Install a stub `litellm` module that records the kwargs it receives."""
+    calls = []
+
+    def completion(*args, **kwargs):
+        calls.append(kwargs)
+        return "sync-response"
+
+    async def acompletion(*args, **kwargs):
+        calls.append(kwargs)
+        return "async-response"
+
+    module = types.ModuleType("litellm")
+    module.completion = completion
+    module.acompletion = acompletion
+    module.calls = calls
+    monkeypatch.setitem(sys.modules, "litellm", module)
+    return module
+
+
+@pytest.fixture
+def gateway_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_BASE", "http://gateway/v1/private")
+
+
+class TestRouteLitellmCallsThroughGateway:
+    def test_injects_workspace_header_on_completion(self, fake_litellm, gateway_env):
+        route_litellm_calls_through_gateway("my-workspace")
+
+        result = fake_litellm.completion(model="openai/gpt-4o-mini", messages=[])
+
+        assert result == "sync-response"
+        assert fake_litellm.calls[-1]["extra_headers"]["Comet-Workspace"] == "my-workspace"
+
+    def test_injects_workspace_header_on_acompletion(self, fake_litellm, gateway_env):
+        route_litellm_calls_through_gateway("my-workspace")
+
+        result = asyncio.run(
+            fake_litellm.acompletion(model="openai/gpt-4o-mini", messages=[])
+        )
+
+        assert result == "async-response"
+        assert fake_litellm.calls[-1]["extra_headers"]["Comet-Workspace"] == "my-workspace"
+
+    def test_preserves_existing_extra_headers(self, fake_litellm, gateway_env):
+        route_litellm_calls_through_gateway("my-workspace")
+
+        fake_litellm.completion(messages=[], extra_headers={"X-Custom": "1"})
+
+        extra_headers = fake_litellm.calls[-1]["extra_headers"]
+        assert extra_headers["X-Custom"] == "1"
+        assert extra_headers["Comet-Workspace"] == "my-workspace"
+
+    def test_does_not_override_explicit_workspace_header(self, fake_litellm, gateway_env):
+        route_litellm_calls_through_gateway("my-workspace")
+
+        fake_litellm.completion(
+            messages=[], extra_headers={"Comet-Workspace": "explicit-ws"}
+        )
+
+        assert fake_litellm.calls[-1]["extra_headers"]["Comet-Workspace"] == "explicit-ws"
+
+    def test_noop_when_gateway_not_active(self, fake_litellm, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+
+        route_litellm_calls_through_gateway("my-workspace")
+        fake_litellm.completion(messages=[])
+
+        assert "extra_headers" not in fake_litellm.calls[-1]
+
+    def test_noop_when_workspace_missing(self, fake_litellm, gateway_env):
+        route_litellm_calls_through_gateway("")
+        fake_litellm.completion(messages=[])
+
+        assert "extra_headers" not in fake_litellm.calls[-1]
+
+    @pytest.mark.parametrize(
+        "workspace_name",
+        [
+            "scout:comet-ml/scout-test-repo",  # colon + slash (Scout-style)
+            "team space",  # whitespace
+            "wß-üñïçødé",  # non-ascii
+            "a+b%c&d",  # url-reserved characters
+        ],
+    )
+    def test_injects_special_character_workspace_verbatim(
+        self, fake_litellm, gateway_env, workspace_name
+    ):
+        # The workspace name is the only value flowing into the gateway path;
+        # it must reach the Comet-Workspace header unchanged (no encoding or
+        # truncation) so the backend can match it exactly.
+        route_litellm_calls_through_gateway(workspace_name)
+
+        fake_litellm.completion(messages=[])
+
+        assert (
+            fake_litellm.calls[-1]["extra_headers"]["Comet-Workspace"]
+            == workspace_name
+        )
+
+    def test_is_idempotent(self, fake_litellm, gateway_env):
+        route_litellm_calls_through_gateway("my-workspace")
+        wrapped_once = fake_litellm.completion
+        route_litellm_calls_through_gateway("my-workspace")
+
+        assert fake_litellm.completion is wrapped_once
+
+        fake_litellm.completion(messages=[])
+        # Header injected exactly once (no nested extra_headers stacking).
+        assert fake_litellm.calls[-1]["extra_headers"] == {"Comet-Workspace": "my-workspace"}


### PR DESCRIPTION
## Details

Optimization Studio routes every LiteLLM completion through the Opik backend gateway (`OPENAI_API_BASE`, added in #6830). The gateway authenticates each request per workspace via the `Comet-Workspace` header, but LiteLLM's OpenAI-compatible path forwards only `Authorization` — so the gateway received no workspace and rejected every server-side optimization run with `403 "Workspace name should be provided"`. This wraps `litellm.completion`/`litellm.acompletion` in the optimizer runner to inject the workspace header.

- Header value is sourced from the job's workspace name (`context.workspace_name`), independent of the project name.
- Guarded on `OPENAI_API_BASE` so direct-provider calls are never touched; idempotent and won't override a caller-supplied `Comet-Workspace`.
- Covers both optimizer and metric-judge LLM calls (both resolve `litellm.completion`/`acompletion` at call time).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6652

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8 (1M context)
  - Scope: Root-cause investigation, the fix in `optimizer_runner.py`, and the new unit tests.
  - Human verification: Author traced the gateway auth path (`RemoteAuthService`, `ChatCompletionsResource`) and LiteLLM header handling, reviewed the diff, and ran the test suite locally.

## Testing

Added `apps/opik-python-backend/tests/test_studio_gateway_workspace_header.py` (11 cases): header injection on sync + async completions, preserving existing `extra_headers`, not overriding an explicit `Comet-Workspace`, no-op when the gateway is inactive or workspace is empty, idempotency, and special-character workspace names (colon+slash, whitespace, non-ASCII, URL-reserved) passed through verbatim.

Commands run (Python 3.11 venv with `tests/test_requirements.txt` + `requirements.txt`):

```
cd apps/opik-python-backend
PYTHONPATH=src python -m pytest tests/test_studio_gateway_workspace_header.py tests/test_studio_project_name.py -q
# 11 passed (gateway header) + studio project-name tests pass
```

Not run: full backend/E2E cloud gateway run (requires a live Opik Cloud workspace + AI provider keys). The fix mirrors the exact header the SDK/playground already send (`Comet-Workspace`), verified against the LLM-gateway docs and `RemoteAuthService` auth path.

## Documentation

N/A — internal Optimization Studio gateway wiring; no user-facing API or docs change.