### PR TITLE
[OPIK-6769] [BE] feat: exclude demo data from prompt version creation BI event

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DemoData.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DemoData.java
@@ -50,7 +50,8 @@ public class DemoData {
     /** MySQL (utf8mb4_unicode_ci) — matching is case-insensitive, no need for case variants. */
     public static final List<String> PROMPTS = List.of(
             "Demo - Opik SDK Assistant - System Prompt",
-            "Q&A Prompt");
+            "Q&A Prompt",
+            "support-agent-system");
 
     /** ClickHouse — matching is case-sensitive, list every known casing explicitly. */
     public static final List<String> OPTIMIZATIONS = List.of("ivory_berm_3833");

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -208,7 +208,7 @@ class PromptServiceImpl implements PromptService {
                 .build();
 
         return withPromptVersionLock(workspaceId, createdPrompt.id(),
-                () -> savePromptVersion(workspaceId, createdPrompt.projectId(), promptVersion));
+                () -> savePromptVersion(workspaceId, createdPrompt.projectId(), promptVersion, createdPrompt.name()));
     }
 
     private Prompt savePrompt(String workspaceId, Prompt prompt) {
@@ -366,7 +366,7 @@ class PromptServiceImpl implements PromptService {
                         .commit(commit)
                         .build();
 
-                var savedPromptVersion = savePromptVersion(workspaceId, projectId, promptVersion);
+                var savedPromptVersion = savePromptVersion(workspaceId, projectId, promptVersion, prompt.name());
                 postPromptCommittedEvent(savedPromptVersion, workspaceId, workspaceName, userName, projectId);
 
                 return savedPromptVersion;
@@ -407,7 +407,7 @@ class PromptServiceImpl implements PromptService {
                 .environments(environments)
                 .build();
 
-        var saved = savePromptVersion(workspaceId, projectId, promptVersion);
+        var saved = savePromptVersion(workspaceId, projectId, promptVersion, prompt.name());
         postPromptCommittedEvent(saved, workspaceId, workspaceName, userName, projectId);
         return saved;
     }
@@ -511,12 +511,13 @@ class PromptServiceImpl implements PromptService {
                     .commit(CommitUtils.getCommit(newId))
                     .build();
 
-            return savePromptVersion(workspaceId, prompt.projectId(), promptVersion);
+            return savePromptVersion(workspaceId, prompt.projectId(), promptVersion, prompt.name());
 
         }).withRetry(3, this::newVersionConflict);
     }
 
-    private PromptVersion savePromptVersion(String workspaceId, UUID projectId, PromptVersion promptVersion) {
+    private PromptVersion savePromptVersion(String workspaceId, UUID projectId, PromptVersion promptVersion,
+            String promptName) {
         log.info("Creating prompt version for prompt id '{}'", promptVersion.promptId());
 
         IdGenerator.validateVersion(promptVersion.id(), "prompt version");
@@ -549,11 +550,15 @@ class PromptServiceImpl implements PromptService {
         log.info("Created Prompt version for prompt id '{}'", promptVersion.promptId());
 
         PromptVersion savedVersion = getById(workspaceId, promptVersion.id());
-        trackPromptVersionCreated(savedVersion, projectId, workspaceId);
+        trackPromptVersionCreated(savedVersion, projectId, workspaceId, promptName);
         return savedVersion;
     }
 
-    private void trackPromptVersionCreated(PromptVersion promptVersion, UUID projectId, String workspaceId) {
+    private void trackPromptVersionCreated(PromptVersion promptVersion, UUID projectId, String workspaceId,
+            String promptName) {
+        if (DemoData.PROMPTS.contains(promptName)) {
+            return;
+        }
         Schedulers.boundedElastic().schedule(() -> {
             Map<String, String> properties = new HashMap<>();
             properties.put("prompt_version_id", Objects.toString(promptVersion.id(), ""));
@@ -935,7 +940,7 @@ class PromptServiceImpl implements PromptService {
 
         PromptVersion restoredVersion = withPromptVersionLock(workspaceId, promptId,
                 () -> EntityConstraintHandler
-                        .handle(() -> savePromptVersion(workspaceId, prompt.projectId(), newVersion))
+                        .handle(() -> savePromptVersion(workspaceId, prompt.projectId(), newVersion, prompt.name()))
                         .onErrorDo(() -> retryableCreateVersion(workspaceId,
                                 CreatePromptVersion.builder()
                                         .name(prompt.name())

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -37,6 +37,7 @@ import com.comet.opik.api.resources.utils.resources.PromptVersionResourceClient;
 import com.comet.opik.api.sorting.Direction;
 import com.comet.opik.api.sorting.SortableFields;
 import com.comet.opik.api.sorting.SortingField;
+import com.comet.opik.domain.DemoData;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;
@@ -973,6 +974,10 @@ class PromptResourceTest {
                 }
             }
         }
+    }
+
+    static Stream<String> demoPromptNames() {
+        return DemoData.PROMPTS.stream();
     }
 
     private UUID createPrompt(Prompt prompt, String apiKey, String workspaceName) {
@@ -2054,6 +2059,60 @@ class PromptResourceTest {
             assertPromptVersion(actualPromptVersion, expectedPromptVersion, promptId);
 
             assertPromptVersionCreatedEvent(promptId, actualPromptVersion.id(), WORKSPACE_ID, USER);
+        }
+
+        @ParameterizedTest
+        @MethodSource("com.comet.opik.api.resources.v1.priv.PromptResourceTest#demoPromptNames")
+        @DisplayName("Success: demo prompt does not emit prompt_version_created event")
+        void shouldCreatePromptVersion__whenDemoPrompt__thenDoesNotEmitEvent(String demoPromptName) {
+
+            var demoPrompt = buildPrompt()
+                    .name(demoPromptName)
+                    .lastUpdatedBy(USER)
+                    .createdBy(USER)
+                    .template(null)
+                    .build();
+
+            UUID demoPromptId = createPrompt(demoPrompt, API_KEY, TEST_WORKSPACE);
+
+            var demoVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER)
+                    .commit(null)
+                    .id(null)
+                    .versionType(PromptVersionType.PROMPT_VERSION)
+                    .build();
+
+            wireMock.server().resetRequests();
+
+            createPromptVersion(createPromptVersionRequest(demoPrompt.name(), demoVersion,
+                    demoPrompt.templateStructure()), API_KEY, TEST_WORKSPACE);
+
+            // Sentinel: a regular prompt version is created after the demo one and goes through the same async
+            // pipeline. Once its event arrives, the demo event would also have arrived if it were ever emitted.
+            var sentinelPrompt = buildPrompt()
+                    .lastUpdatedBy(USER)
+                    .createdBy(USER)
+                    .template(null)
+                    .build();
+
+            UUID sentinelPromptId = createPrompt(sentinelPrompt, API_KEY, TEST_WORKSPACE);
+
+            var sentinelVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
+                    .createdBy(USER)
+                    .commit(null)
+                    .id(null)
+                    .versionType(PromptVersionType.PROMPT_VERSION)
+                    .build();
+
+            PromptVersion createdSentinel = createPromptVersion(createPromptVersionRequest(sentinelPrompt.name(),
+                    sentinelVersion, sentinelPrompt.templateStructure()), API_KEY, TEST_WORKSPACE);
+
+            assertPromptVersionCreatedEvent(sentinelPromptId, createdSentinel.id(), WORKSPACE_ID, USER);
+
+            wireMock.server().verify(0, postRequestedFor(urlPathEqualTo("/v1/notify/event"))
+                    .withRequestBody(matchingJsonPath("$.event_type",
+                            equalTo(AnalyticsService.EVENT_PREFIX + "prompt_version_created"))
+                            .and(matchingJsonPath("$.event_properties.prompt_id", equalTo(demoPromptId.toString())))));
         }
 
         @Test


### PR DESCRIPTION
## Details
Prompt version creation emits a `prompt_version_created` BI event used for product analytics. Versions created for built-in demo prompts were inflating these metrics. This change skips the event when the prompt name matches a known demo prompt, so analytics reflect only real user activity.

- Threads the prompt name through `savePromptVersion` into `trackPromptVersionCreated`, which now returns early when the name is in `DemoData.PROMPTS`.
- Adds `support-agent-system` to the demo prompt list.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6769

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Implementation and tests
- Human verification: Author reviewed diff and test coverage

## Testing
- Added parameterized test `shouldCreatePromptVersion__whenDemoPrompt__thenDoesNotEmitEvent` (one case per demo prompt name) in `PromptResourceTest`, verifying no `prompt_version_created` event is emitted for demo prompts. A sentinel real prompt is created afterward through the same async pipeline; once its event arrives, the absence of the demo event is conclusive.
- Run: `mvn test -Dtest=PromptResourceTest`

## Documentation
N/A
