### PR TITLE
[OPIK-5269] [DOCS] docs: add page on resuming interrupted evaluations

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/resume_evaluations.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/resume_evaluations.mdx
@@ -9,8 +9,7 @@ title: Resume an interrupted evaluation
 
 <Note>
   `evaluate_resume` is a Python SDK feature. It works on experiments created
-  with the Python SDK's `opik.evaluate(...)` (and `evaluate_prompt`,
-  `evaluate_optimization_trial`).
+  with the Python SDK's `opik.evaluate(...)`.
 </Note>
 
 Long evaluations are expensive. A 1,000-item dataset scored by an LLM judge can take an hour

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/resume_evaluations.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/resume_evaluations.mdx
@@ -8,18 +8,13 @@ title: Resume an interrupted evaluation
 ---
 
 <Note>
-  `evaluate_resume` is a Python SDK feature. It works on experiments created
-  with the Python SDK's `opik.evaluate(...)`.
+  `evaluate_resume` is a Python SDK feature for experiments created with
+  `opik.evaluate(...)`.
 </Note>
 
-Long evaluations are expensive. A 1,000-item dataset scored by an LLM judge can take an hour
-and burn real tokens. If the evaluation is interrupted halfway through — Ctrl-C, OOM, a
-network blip, a metric raising mid-scoring — the runs that did complete are still recorded
-on the backend, but a fresh `evaluate(...)` call would re-run every item from scratch.
-
-`opik.evaluate_resume(experiment_id, ...)` picks up where the original `evaluate(...)`
-stopped: runs that fully completed are reconstructed from the backend; runs that did not
-complete are replayed; everything is merged into one `EvaluationResult`.
+A long evaluation can be interrupted: Ctrl-C, OOM, a metric raising, a network blip.
+`opik.evaluate_resume(experiment_id, ...)` continues from where the original `evaluate(...)`
+stopped — replaying only the runs that didn't finish, keeping the runs that did.
 
 ## Quick start
 
@@ -35,129 +30,51 @@ result = opik.evaluate_resume(
     task=my_task,
     scoring_metrics=[Equals()],
 )
-
-print(f"Total test results: {len(result.test_results)}")
-print(f"Experiment URL: {result.experiment_url}")
 ```
 
-The returned `EvaluationResult` has the same shape as `evaluate()`. Its `test_results` covers
-the **whole** experiment — reconstructed prior runs plus runs this call executed.
+The returned `EvaluationResult` covers the **whole** experiment, not just the runs this call
+executed. You don't pass `dataset`, `nb_samples`, or `experiment_name` — resume reads them
+back from the experiment.
 
-## When you can resume an experiment
+## What resume does
 
-Two requirements:
+- **Keeps every run that already completed.** Outputs and feedback scores are preserved
+  as-is; the task is not re-invoked for them.
+- **Replays only the runs that didn't complete.** Failed task, failed scoring, never-reached
+  items, and missing runs for items with `trial_count > 1` all replay.
+- **Returns one merged result.** `EvaluationResult.test_results` covers both the kept runs
+  and the freshly replayed ones.
 
-- The experiment was created by an SDK version that supports resume.
-- The dataset had at least one version at the time of the original `evaluate(...)`.
+## Requirements
 
-If either is missing, `evaluate_resume` raises `opik.exceptions.ExperimentNotResumable` with
-the reason. Resume always iterates against the dataset **version** that was pinned at the
-moment of the original call — even if the dataset has grown or been mutated since.
+To call `evaluate_resume`, the experiment must have been created by:
 
-## What gets replayed vs reconstructed
+- A Python SDK version that supports resume.
+- An `evaluate(...)` call against a **versioned dataset**.
 
-`evaluate_resume` looks at each run the original evaluation produced and asks: did it
-complete cleanly? A run is **completed** when its trace has an `output` set — the engine
-writes the trace's `output` only at the end of the happy path, after the task ran and every
-metric scored cleanly.
+If either condition isn't met, `evaluate_resume` raises
+`opik.exceptions.ExperimentNotResumable`.
 
-| Outcome of the original run | What resume does |
-|---|---|
-| Task ran, scoring finished cleanly | **Reconstruct** from the stored experiment item — no re-run, no new feedback scores. |
-| Task ran but scoring crashed (e.g. metric raised `BaseException`, Ctrl-C between task and score-log) | **Replay** — the task is invoked again and metrics are scored against the new run. |
-| Task failed | **Replay** — the task is invoked again. |
-| Item was never reached | **Run fresh** — task + scoring run from scratch. |
+## Running on the same machine as the original `evaluate()`
 
-Runs of the same item are independent: when an item was set up with multiple runs
-(`trial_count > 1`) and only some completed, resume replays **only the missing ones**. The
-completed runs are reconstructed from the backend untouched, so a 3-run item that finished
-1 of 3 ends up with 1 reconstructed run + 2 freshly replayed runs in the returned
-`EvaluationResult`.
+If the original `evaluate(...)` used a custom `dataset_sampler` or explicit
+`dataset_item_ids`, resume needs a local checkpoint that was written next to the experiment
+id. Run resume from the same machine that ran the original call — otherwise
+`opik.exceptions.LocalCheckpointMissing` is raised.
 
-## Custom samplers and explicit `dataset_item_ids`
-
-Most evaluations iterate the dataset deterministically — apply the dataset filter, optionally
-cap at `nb_samples`, walk the items. That recipe is fully captured in the resume blob.
-
-Two cases need a little more: a **custom `dataset_sampler`** (non-deterministic by design)
-and **explicit `dataset_item_ids`** (an arbitrary list of ids that isn't recoverable from the
-filter alone). In these cases the SDK writes a small local checkpoint next to the experiment
-id containing the resolved ids the engine actually iterated, so the resume call can
-reproduce the same iteration.
-
-This means: if you used a sampler or explicit ids when calling `evaluate(...)`, **resume
-must run on the same machine** that wrote the checkpoint. If you've moved hosts, the checkpoint
-file isn't there:
-
-```python
-import opik
-from opik import exceptions
-
-try:
-    opik.evaluate_resume(experiment_id="<id>", task=my_task)
-except exceptions.LocalCheckpointMissing as exc:
-    # The original run used a sampler or explicit dataset_item_ids.
-    # Resume from the original machine, or start a fresh evaluate()
-    # with the same explicit dataset_item_ids.
-    print(f"Checkpoint not found: {exc}")
-```
-
-## Putting it together
-
-A typical pattern: a script that starts the evaluation and a separate script that resumes it.
-
-```python title="start_evaluation.py" language="python"
-import opik
-from opik.evaluation.metrics import Equals
-
-dataset = opik.Opik().get_or_create_dataset("my-dataset")
-
-def my_task(item):
-    return {"output": call_my_model(item["input"])}
-
-result = opik.evaluate(
-    dataset=dataset,
-    task=my_task,
-    scoring_metrics=[Equals()],
-    experiment_name="my-experiment",
-)
-print(f"Experiment id: {result.experiment_id}")
-```
-
-If the script above crashes or is interrupted, look up the partially-completed experiment id
-and run:
-
-```python title="resume_evaluation.py" language="python"
-import opik
-from opik.evaluation.metrics import Equals
-
-def my_task(item):
-    return {"output": call_my_model(item["input"])}
-
-result = opik.evaluate_resume(
-    experiment_id="<id from start_evaluation.py>",
-    task=my_task,
-    scoring_metrics=[Equals()],
-)
-print(f"Resumed. Total test results: {len(result.test_results)}")
-```
-
-You don't need to pass `dataset`, `dataset_filter_string`, `nb_samples`, or `experiment_name`
-— resume reads those back from the experiment.
+Evaluations without a sampler or explicit ids do **not** need to run on the same machine.
 
 ## When `evaluate_resume` is the wrong tool
 
-- **You only want to re-score an existing experiment with new metrics.** Use
-  `opik.evaluate_experiment(...)` instead — it walks the existing completed runs and
-  computes new feedback scores without re-running the task.
-- **You want to extend the experiment with more items.** Resume only iterates the same set
-  the original evaluation saw. To add items, start a fresh evaluation against the larger
-  dataset.
-- **You changed the task implementation between calls.** Resume calls your new `task` for
-  the missing runs, but already-completed runs keep their original outputs. If the change
-  should affect every run, start a fresh `evaluate()` instead.
+- **You want to re-score an existing experiment with new metrics.** Use
+  `opik.evaluate_experiment(...)` — it scores existing runs without re-running the task.
+- **You want to add more items to the experiment.** Resume only iterates the items the
+  original evaluation saw. Start a fresh `evaluate()` against the larger dataset.
+- **You changed the `task` implementation between calls.** Resume calls your new `task`
+  only for the missing runs; already-completed runs keep their original outputs. If the
+  change should affect every run, start a fresh `evaluate()`.
 
 ## Reference
 
-- Python: `opik.evaluate_resume`
-- Exceptions: `opik.exceptions.ExperimentNotResumable`, `opik.exceptions.LocalCheckpointMissing`
+- `opik.evaluate_resume`
+- `opik.exceptions.ExperimentNotResumable`, `opik.exceptions.LocalCheckpointMissing`

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/resume_evaluations.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/resume_evaluations.mdx
@@ -45,16 +45,6 @@ back from the experiment.
 - **Returns one merged result.** `EvaluationResult.test_results` covers both the kept runs
   and the freshly replayed ones.
 
-## Requirements
-
-To call `evaluate_resume`, the experiment must have been created by:
-
-- A Python SDK version that supports resume.
-- An `evaluate(...)` call against a **versioned dataset**.
-
-If either condition isn't met, `evaluate_resume` raises
-`opik.exceptions.ExperimentNotResumable`.
-
 ## When `evaluate_resume` is the wrong tool
 
 - **You want to re-score an existing experiment with new metrics.** Use
@@ -68,11 +58,18 @@ If either condition isn't met, `evaluate_resume` raises
   already-completed runs keep their original outputs and feedback scores. If the change
   should affect every run, start a fresh `evaluate()`.
 
-## Running on the same machine as the original `evaluate()`
+## Requirements
+
+To call `evaluate_resume`, the experiment must have been created by:
+
+- A Python SDK version that supports resume.
+- An `evaluate(...)` call against a **versioned dataset**.
+
+If either condition isn't met, `evaluate_resume` raises
+`opik.exceptions.ExperimentNotResumable`.
 
 If the original `evaluate(...)` used a custom `dataset_sampler` or explicit
-`dataset_item_ids`, resume needs a local checkpoint that was written next to the experiment
-id. Run resume from the same machine that ran the original call — otherwise
-`opik.exceptions.LocalCheckpointMissing` is raised.
-
-Evaluations without a sampler or explicit ids do **not** need to run on the same machine.
+`dataset_item_ids`, resume also needs a local checkpoint that was written next to the
+experiment id. Run resume from the same machine that ran the original call — otherwise
+`opik.exceptions.LocalCheckpointMissing` is raised. Evaluations without a sampler or
+explicit ids do **not** need to run on the same machine.

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/resume_evaluations.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/resume_evaluations.mdx
@@ -55,15 +55,6 @@ To call `evaluate_resume`, the experiment must have been created by:
 If either condition isn't met, `evaluate_resume` raises
 `opik.exceptions.ExperimentNotResumable`.
 
-## Running on the same machine as the original `evaluate()`
-
-If the original `evaluate(...)` used a custom `dataset_sampler` or explicit
-`dataset_item_ids`, resume needs a local checkpoint that was written next to the experiment
-id. Run resume from the same machine that ran the original call — otherwise
-`opik.exceptions.LocalCheckpointMissing` is raised.
-
-Evaluations without a sampler or explicit ids do **not** need to run on the same machine.
-
 ## When `evaluate_resume` is the wrong tool
 
 - **You want to re-score an existing experiment with new metrics.** Use
@@ -73,6 +64,15 @@ Evaluations without a sampler or explicit ids do **not** need to run on the same
 - **You changed the `task` implementation between calls.** Resume calls your new `task`
   only for the missing runs; already-completed runs keep their original outputs. If the
   change should affect every run, start a fresh `evaluate()`.
+
+## Running on the same machine as the original `evaluate()`
+
+If the original `evaluate(...)` used a custom `dataset_sampler` or explicit
+`dataset_item_ids`, resume needs a local checkpoint that was written next to the experiment
+id. Run resume from the same machine that ran the original call — otherwise
+`opik.exceptions.LocalCheckpointMissing` is raised.
+
+Evaluations without a sampler or explicit ids do **not** need to run on the same machine.
 
 ## Reference
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/resume_evaluations.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/resume_evaluations.mdx
@@ -1,0 +1,178 @@
+---
+headline: Resume an interrupted evaluation | Opik Documentation
+og:description: Continue a long-running Opik evaluation after a crash, network blip, or Ctrl-C — replaying only the trials that didn't finish.
+og:site_name: Opik Documentation
+og:title: Resume an interrupted evaluation - Opik
+subtitle: Continue an evaluation from where it stopped
+title: Resume an interrupted evaluation
+---
+
+<Note>
+  `evaluate_resume` is a Python SDK feature. It works on experiments created
+  with the Python SDK's `opik.evaluate(...)` (and `evaluate_prompt`,
+  `evaluate_optimization_trial`).
+</Note>
+
+Long evaluations are expensive. A 1,000-item dataset scored by an LLM judge can take an hour
+and burn real tokens. If the run is interrupted halfway through — Ctrl-C, OOM, a network blip,
+a metric raising mid-scoring — the trials that did complete are still on the backend, but a
+fresh `evaluate(...)` call would re-run every item from scratch.
+
+`opik.evaluate_resume(experiment_id, ...)` picks up where the original `evaluate(...)` stopped:
+trials that fully completed are reconstructed from the backend; trials that did not complete
+are replayed; everything is merged into one `EvaluationResult`.
+
+## Quick start
+
+```python title="Python" language="python"
+import opik
+from opik.evaluation.metrics import Equals
+
+def my_task(item):
+    return {"output": call_my_model(item["input"])}
+
+result = opik.evaluate_resume(
+    experiment_id="<id of the experiment to resume>",
+    task=my_task,
+    scoring_metrics=[Equals()],
+)
+
+print(f"Total test results: {len(result.test_results)}")
+print(f"Experiment URL: {result.experiment_url}")
+```
+
+The returned `EvaluationResult` has the same shape as `evaluate()`. Its `test_results` covers
+the **whole** experiment — reconstructed prior trials plus trials this call executed.
+
+## When you can resume an experiment
+
+`evaluate_resume` only works on experiments that were created by a Python SDK version that
+knows how to record resume state. When `opik.evaluate(...)` runs, it embeds a small JSON blob
+in the experiment's `experiment_config` capturing the pinned dataset version, the iteration
+knobs (`dataset_filter_string`, `nb_samples`), and the default per-item trial count. On
+resume, that blob is read back to reproduce the exact same iteration.
+
+If the experiment was created with an older SDK — or by a path that didn't pin a dataset
+version — `evaluate_resume` will refuse to continue, with a clear error:
+
+```python
+import opik
+from opik import exceptions
+
+try:
+    opik.evaluate_resume(experiment_id="<some old experiment id>", task=my_task)
+except exceptions.ExperimentNotResumable as exc:
+    # The original evaluate() did not record enough state for safe resume.
+    # Iterating against a moving dataset HEAD would break the resume contract.
+    print(f"Cannot resume: {exc}")
+```
+
+The dataset is pinned by version at the moment of the original `evaluate()`. That means
+resume always re-iterates against the same set of items the first run saw, even if the
+dataset has grown or been mutated since.
+
+## What gets replayed vs reconstructed
+
+`evaluate_resume` looks at each trial that the original run produced and asks: did it fully
+complete? A trial is **fully completed** when its trace has an `output` set — the engine
+writes the trace's `output` only at the end of the happy path, after the task ran and every
+metric scored cleanly.
+
+| Outcome of the original trial | What resume does |
+|---|---|
+| Task ran, scoring finished cleanly | **Reconstruct** from the stored experiment item — no re-run, no new feedback scores. |
+| Task ran but scoring crashed (e.g. metric raised `BaseException`, Ctrl-C between task and score-log) | **Replay** — the task is invoked again and metrics are scored against the new run. |
+| Task failed | **Replay** — the task is invoked again. |
+| Item was never reached | **Run fresh** — task + scoring run from scratch. |
+
+When an item was set up with multiple trials (`trial_count > 1`) and only some completed,
+resume **redoes all** trials for that item — not just the missing ones. This is intentional:
+trial outputs depend on the task / metric state at the time they ran, so mixing partial old
+trials with new ones could produce internally inconsistent results.
+
+## Custom samplers and explicit `dataset_item_ids`
+
+Most evaluations iterate the dataset deterministically — apply the dataset filter, optionally
+cap at `nb_samples`, walk the items. That recipe is fully captured in the resume blob.
+
+Two cases need a little more: a **custom `dataset_sampler`** (non-deterministic by design)
+and **explicit `dataset_item_ids`** (an arbitrary list of ids that isn't recoverable from the
+filter alone). In these cases the SDK writes a small local checkpoint next to the experiment
+id containing the resolved ids the engine actually iterated, so the resume call can
+reproduce the same iteration.
+
+This means: if you used a sampler or explicit ids when calling `evaluate(...)`, **resume
+must run on the same machine** that wrote the checkpoint. If you've moved hosts, the checkpoint
+file isn't there:
+
+```python
+import opik
+from opik import exceptions
+
+try:
+    opik.evaluate_resume(experiment_id="<id>", task=my_task)
+except exceptions.LocalCheckpointMissing as exc:
+    # The original run used a sampler or explicit dataset_item_ids.
+    # Resume from the original machine, or start a fresh evaluate()
+    # with the same explicit dataset_item_ids.
+    print(f"Checkpoint not found: {exc}")
+```
+
+## Putting it together
+
+A typical pattern: a script that starts the evaluation and a separate script that resumes it.
+
+```python title="start_evaluation.py" language="python"
+import opik
+from opik.evaluation.metrics import Equals
+
+dataset = opik.Opik().get_or_create_dataset("my-dataset")
+
+def my_task(item):
+    return {"output": call_my_model(item["input"])}
+
+result = opik.evaluate(
+    dataset=dataset,
+    task=my_task,
+    scoring_metrics=[Equals()],
+    experiment_name="my-experiment",
+)
+print(f"Experiment id: {result.experiment_id}")
+```
+
+If the script above crashes or is interrupted, look up the partially-completed experiment id
+and run:
+
+```python title="resume_evaluation.py" language="python"
+import opik
+from opik.evaluation.metrics import Equals
+
+def my_task(item):
+    return {"output": call_my_model(item["input"])}
+
+result = opik.evaluate_resume(
+    experiment_id="<id from start_evaluation.py>",
+    task=my_task,
+    scoring_metrics=[Equals()],
+)
+print(f"Resumed. Total test results: {len(result.test_results)}")
+```
+
+You don't need to pass `dataset`, `dataset_filter_string`, `nb_samples`, or `experiment_name`
+— resume reads those back from the experiment.
+
+## When `evaluate_resume` is the wrong tool
+
+- **You only want to re-score an existing run with new metrics.** Use `opik.evaluate_experiment(...)`
+  instead — it walks completed trials and computes new feedback scores without re-running the
+  task.
+- **You want to extend the experiment with more items.** Resume only iterates the same set
+  the original run saw. To add items, start a fresh evaluation against the larger dataset.
+- **You want to change the task implementation between runs.** Resume calls your new `task`
+  for replayed items, but reconstructed items keep the old run's outputs. If you've changed
+  the task in a way that should affect every item, start a fresh `evaluate()` instead.
+
+## Reference
+
+- Python: `opik.evaluate_resume`
+- Exceptions: `opik.exceptions.ExperimentNotResumable`, `opik.exceptions.LocalCheckpointMissing`

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/resume_evaluations.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/resume_evaluations.mdx
@@ -1,6 +1,6 @@
 ---
 headline: Resume an interrupted evaluation | Opik Documentation
-og:description: Continue a long-running Opik evaluation after a crash, network blip, or Ctrl-C — replaying only the trials that didn't finish.
+og:description: Continue a long-running Opik evaluation after a crash, network blip, or Ctrl-C — replaying only the runs that didn't finish.
 og:site_name: Opik Documentation
 og:title: Resume an interrupted evaluation - Opik
 subtitle: Continue an evaluation from where it stopped
@@ -13,13 +13,13 @@ title: Resume an interrupted evaluation
 </Note>
 
 Long evaluations are expensive. A 1,000-item dataset scored by an LLM judge can take an hour
-and burn real tokens. If the run is interrupted halfway through — Ctrl-C, OOM, a network blip,
-a metric raising mid-scoring — the trials that did complete are still on the backend, but a
-fresh `evaluate(...)` call would re-run every item from scratch.
+and burn real tokens. If the evaluation is interrupted halfway through — Ctrl-C, OOM, a
+network blip, a metric raising mid-scoring — the runs that did complete are still recorded
+on the backend, but a fresh `evaluate(...)` call would re-run every item from scratch.
 
-`opik.evaluate_resume(experiment_id, ...)` picks up where the original `evaluate(...)` stopped:
-trials that fully completed are reconstructed from the backend; trials that did not complete
-are replayed; everything is merged into one `EvaluationResult`.
+`opik.evaluate_resume(experiment_id, ...)` picks up where the original `evaluate(...)`
+stopped: runs that fully completed are reconstructed from the backend; runs that did not
+complete are replayed; everything is merged into one `EvaluationResult`.
 
 ## Quick start
 
@@ -41,53 +41,38 @@ print(f"Experiment URL: {result.experiment_url}")
 ```
 
 The returned `EvaluationResult` has the same shape as `evaluate()`. Its `test_results` covers
-the **whole** experiment — reconstructed prior trials plus trials this call executed.
+the **whole** experiment — reconstructed prior runs plus runs this call executed.
 
 ## When you can resume an experiment
 
-`evaluate_resume` only works on experiments that were created by a Python SDK version that
-knows how to record resume state. When `opik.evaluate(...)` runs, it embeds a small JSON blob
-in the experiment's `experiment_config` capturing the pinned dataset version, the iteration
-knobs (`dataset_filter_string`, `nb_samples`), and the default per-item trial count. On
-resume, that blob is read back to reproduce the exact same iteration.
+Two requirements:
 
-If the experiment was created with an older SDK — or by a path that didn't pin a dataset
-version — `evaluate_resume` will refuse to continue, with a clear error:
+- The experiment was created by an SDK version that supports resume.
+- The dataset had at least one version at the time of the original `evaluate(...)`.
 
-```python
-import opik
-from opik import exceptions
-
-try:
-    opik.evaluate_resume(experiment_id="<some old experiment id>", task=my_task)
-except exceptions.ExperimentNotResumable as exc:
-    # The original evaluate() did not record enough state for safe resume.
-    # Iterating against a moving dataset HEAD would break the resume contract.
-    print(f"Cannot resume: {exc}")
-```
-
-The dataset is pinned by version at the moment of the original `evaluate()`. That means
-resume always re-iterates against the same set of items the first run saw, even if the
-dataset has grown or been mutated since.
+If either is missing, `evaluate_resume` raises `opik.exceptions.ExperimentNotResumable` with
+the reason. Resume always iterates against the dataset **version** that was pinned at the
+moment of the original call — even if the dataset has grown or been mutated since.
 
 ## What gets replayed vs reconstructed
 
-`evaluate_resume` looks at each trial that the original run produced and asks: did it fully
-complete? A trial is **fully completed** when its trace has an `output` set — the engine
+`evaluate_resume` looks at each run the original evaluation produced and asks: did it
+complete cleanly? A run is **completed** when its trace has an `output` set — the engine
 writes the trace's `output` only at the end of the happy path, after the task ran and every
 metric scored cleanly.
 
-| Outcome of the original trial | What resume does |
+| Outcome of the original run | What resume does |
 |---|---|
 | Task ran, scoring finished cleanly | **Reconstruct** from the stored experiment item — no re-run, no new feedback scores. |
 | Task ran but scoring crashed (e.g. metric raised `BaseException`, Ctrl-C between task and score-log) | **Replay** — the task is invoked again and metrics are scored against the new run. |
 | Task failed | **Replay** — the task is invoked again. |
 | Item was never reached | **Run fresh** — task + scoring run from scratch. |
 
-When an item was set up with multiple trials (`trial_count > 1`) and only some completed,
-resume **redoes all** trials for that item — not just the missing ones. This is intentional:
-trial outputs depend on the task / metric state at the time they ran, so mixing partial old
-trials with new ones could produce internally inconsistent results.
+Runs of the same item are independent: when an item was set up with multiple runs
+(`trial_count > 1`) and only some completed, resume replays **only the missing ones**. The
+completed runs are reconstructed from the backend untouched, so a 3-run item that finished
+1 of 3 ends up with 1 reconstructed run + 2 freshly replayed runs in the returned
+`EvaluationResult`.
 
 ## Custom samplers and explicit `dataset_item_ids`
 
@@ -162,14 +147,15 @@ You don't need to pass `dataset`, `dataset_filter_string`, `nb_samples`, or `exp
 
 ## When `evaluate_resume` is the wrong tool
 
-- **You only want to re-score an existing run with new metrics.** Use `opik.evaluate_experiment(...)`
-  instead — it walks completed trials and computes new feedback scores without re-running the
-  task.
+- **You only want to re-score an existing experiment with new metrics.** Use
+  `opik.evaluate_experiment(...)` instead — it walks the existing completed runs and
+  computes new feedback scores without re-running the task.
 - **You want to extend the experiment with more items.** Resume only iterates the same set
-  the original run saw. To add items, start a fresh evaluation against the larger dataset.
-- **You want to change the task implementation between runs.** Resume calls your new `task`
-  for replayed items, but reconstructed items keep the old run's outputs. If you've changed
-  the task in a way that should affect every item, start a fresh `evaluate()` instead.
+  the original evaluation saw. To add items, start a fresh evaluation against the larger
+  dataset.
+- **You changed the task implementation between calls.** Resume calls your new `task` for
+  the missing runs, but already-completed runs keep their original outputs. If the change
+  should affect every run, start a fresh `evaluate()` instead.
 
 ## Reference
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/resume_evaluations.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/resume_evaluations.mdx
@@ -58,12 +58,15 @@ If either condition isn't met, `evaluate_resume` raises
 ## When `evaluate_resume` is the wrong tool
 
 - **You want to re-score an existing experiment with new metrics.** Use
-  `opik.evaluate_experiment(...)` — it scores existing runs without re-running the task.
+  [`opik.evaluate_experiment(...)`](https://www.comet.com/docs/opik/python-sdk-reference/evaluation/evaluate_experiment.html)
+  — it scores existing runs without re-running the task.
 - **You want to add more items to the experiment.** Resume only iterates the items the
   original evaluation saw. Start a fresh `evaluate()` against the larger dataset.
-- **You changed the `task` implementation between calls.** Resume calls your new `task`
-  only for the missing runs; already-completed runs keep their original outputs. If the
-  change should affect every run, start a fresh `evaluate()`.
+- **You changed the `task` implementation or the metrics between calls.** Providing the
+  same `task` and `scoring_metrics` you used originally is the caller's responsibility.
+  Resume calls your new `task` and runs your new metrics only for the missing runs;
+  already-completed runs keep their original outputs and feedback scores. If the change
+  should affect every run, start a fresh `evaluate()`.
 
 ## Running on the same machine as the original `evaluate()`
 
@@ -73,8 +76,3 @@ id. Run resume from the same machine that ran the original call — otherwise
 `opik.exceptions.LocalCheckpointMissing` is raised.
 
 Evaluations without a sampler or explicit ids do **not** need to run on the same machine.
-
-## Reference
-
-- `opik.evaluate_resume`
-- `opik.exceptions.ExperimentNotResumable`, `opik.exceptions.LocalCheckpointMissing`

--- a/apps/opik-documentation/documentation/fern/versions/latest.yml
+++ b/apps/opik-documentation/documentation/fern/versions/latest.yml
@@ -320,6 +320,9 @@ navigation:
               - page: Datasets & Experiments
                 path: ../docs-v2/evaluation/advanced/evaluate_your_llm.mdx
                 slug: evaluate_your_llm
+              - page: Resume an interrupted evaluation
+                path: ../docs-v2/evaluation/advanced/resume_evaluations.mdx
+                slug: resume_evaluations
               - page: Manage datasets
                 path: ../docs-v2/evaluation/advanced/manage_datasets.mdx
                 slug: manage_datasets


### PR DESCRIPTION
## Details

Adds a docs page for `opik.evaluate_resume(...)` — the SDK feature shipping in #6941 — under **Evaluation → Advanced**, between *Datasets & Experiments* and *Manage datasets*.

The page is written to be scanned, not read top-to-bottom:

1. **One-paragraph intro** — what the function does and the failure modes it targets (Ctrl-C, OOM, metric raising, network blip).
2. **Quick start** — minimal `evaluate_resume(experiment_id, task, scoring_metrics=[...])` call.
3. **What resume does** — three short bullets: keeps completed runs, replays only the missing ones, returns one merged `EvaluationResult`.
4. **When `evaluate_resume` is the wrong tool** — points users at [`evaluate_experiment`](https://www.comet.com/docs/opik/python-sdk-reference/evaluation/evaluate_experiment.html) for re-scoring, fresh `evaluate()` for new items, and notes that providing the same `task` + `scoring_metrics` between calls is the caller's responsibility.
5. **Requirements** — resume-aware SDK + versioned dataset → `ExperimentNotResumable`. Same section also explains the sampler / explicit-ids case → must run on the original machine, else `LocalCheckpointMissing`.

Page is 78 lines. Guidance is at the top, gotchas/requirements at the bottom.

`fern check` reports 0 errors.

## Change checklist
- [X] User facing
- [X] Documentation update

## Issues

- OPIK-5269

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7
- Scope: assisted (page drafting, nav placement, terminology + structure iterations against author feedback)
- Human verification: page reviewed iteratively for tone, scannability, and accuracy against the SDK behavior shipping in #6941. `fern check` from `apps/opik-documentation/documentation/fern` returns 0 errors.

## Testing

- `fern check` from `apps/opik-documentation/documentation/fern` → 0 errors, 4 unrelated `logo.href` warnings (pre-existing).
- Cross-references (`opik.evaluate_resume`, `opik.exceptions.ExperimentNotResumable`, `opik.exceptions.LocalCheckpointMissing`, `opik.evaluate_experiment`) match the symbols on the SDK branch.

## Documentation

This **is** the documentation. Pairs with #6941 (the SDK feature). Order:
- Merge #6941 first (the SDK ships the API the page documents).
- Then merge this PR.

## Related
- #6941 — `[OPIK-5269] [SDK] feat: add evaluate_resume to continue interrupted evaluations`


[OPIK-5269]: https://comet-ml.atlassian.net/browse/OPIK-5269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ