### PR TITLE
[OPIK-6694] [SDK] feat: preserve environment ownership on prompt migrate

### DIFF
--- a/sdks/python/src/opik/cli/migrate/prompts/version_replay.py
+++ b/sdks/python/src/opik/cli/migrate/prompts/version_replay.py
@@ -178,8 +178,8 @@ def replay_all_prompt_versions(
                 "source_commit": commit,
                 "target_version_id": new_version_id,
                 "target_commit": getattr(created, "commit", None),
-                "source_environments": sorted(environments) if environments else None,
-                "target_environments": sorted(target_environments)
+                "source_environments": environments if environments else None,
+                "target_environments": target_environments
                 if target_environments
                 else None,
             },

--- a/sdks/python/src/opik/cli/migrate/prompts/version_replay.py
+++ b/sdks/python/src/opik/cli/migrate/prompts/version_replay.py
@@ -8,8 +8,9 @@ the destination prompt has a fresh id.
 
 Stays on the low-level ``OpikApi`` (Fern) client so we can read every
 field the BE persists per version (``template``, ``metadata``, ``type``,
-``commit``, ``change_description``, ``tags``, ``template_structure``)
-without going through the high-level ``opik.api_objects.prompt`` wrapper.
+``commit``, ``change_description``, ``tags``, ``environments``,
+``template_structure``) without going through the high-level
+``opik.api_objects.prompt`` wrapper.
 Every call site is wrapped with
 ``ensure_rest_api_call_respecting_rate_limit``.
 
@@ -128,6 +129,15 @@ def replay_all_prompt_versions(
         if progress_callback is not None:
             progress_callback(index, total, label)
 
+        # ``environments`` (the set of environments this version owns) is
+        # carried verbatim. The BE accepts it inline on
+        # ``create_prompt_version`` and moves env ownership atomically
+        # (PromptService.createVersionWithEnvironment). ``get_prompt_versions``
+        # only reports active ownership (``ended_at IS NULL``), so each env is
+        # owned by exactly one source version and no collision occurs when the
+        # destination versions are minted oldest-first.
+        environments = getattr(source_version, "environments", None)
+
         version_payload = PromptVersionDetail(
             template=source_version.template,
             metadata=getattr(source_version, "metadata", None),
@@ -135,6 +145,7 @@ def replay_all_prompt_versions(
             commit=commit,
             change_description=getattr(source_version, "change_description", None),
             tags=getattr(source_version, "tags", None),
+            environments=environments,
         )
 
         create_kwargs: Dict[str, Any] = {
@@ -157,6 +168,7 @@ def replay_all_prompt_versions(
 
         result.versions_replayed += 1
 
+        target_environments = getattr(created, "environments", None)
         audit.record(
             type="replay_prompt_version",
             status="ok",
@@ -166,6 +178,10 @@ def replay_all_prompt_versions(
                 "source_commit": commit,
                 "target_version_id": new_version_id,
                 "target_commit": getattr(created, "commit", None),
+                "source_environments": sorted(environments) if environments else None,
+                "target_environments": sorted(target_environments)
+                if target_environments
+                else None,
             },
         )
 

--- a/sdks/python/tests/e2e/cli/test_migrate_prompt_e2e.py
+++ b/sdks/python/tests/e2e/cli/test_migrate_prompt_e2e.py
@@ -77,6 +77,7 @@ def _seed_source_prompt_with_versions(
             type=spec.get("type"),
             change_description=spec.get("change_description"),
             tags=spec.get("tags"),
+            environments=spec.get("environments"),
         )
         created = rest_client.prompts.create_prompt_version(
             name=name,
@@ -156,3 +157,73 @@ class TestMigratePromptE2E:
         ]
         assert len(replay_records) == len(source_commits)
         assert all(a["status"] == "ok" for a in replay_records)
+
+    def test_environment_ownership_round_trips(
+        self,
+        opik_client: opik.Opik,
+        source_project_name: str,
+        target_project_name: str,
+        prompt_name: str,
+        tmp_path: Path,
+    ) -> None:
+        # A version that owns an environment on the source must own the
+        # same environment on the destination after migration. The BE
+        # accepts ``environments`` inline on create_prompt_version and
+        # auto-registers unknown names in the workspace registry, so the
+        # replay carries the set verbatim without a follow-up PATCH.
+        rest = opik_client.rest_client
+        environment_name = f"prod-{random_chars()}"
+        source_commits = _seed_source_prompt_with_versions(
+            rest,
+            name=prompt_name,
+            project_name=source_project_name,
+            version_specs=[
+                {"template": "hi {{name}}", "type": "mustache"},
+                {"template": "hello {{name}}", "type": "mustache"},
+                {
+                    "template": "greetings {{name}}",
+                    "type": "mustache",
+                    "environments": [environment_name],
+                },
+            ],
+        )
+
+        audit_log_path = tmp_path / "audit.json"
+        result = run_migrate_cli(
+            ["prompt", prompt_name, "--to-project", target_project_name],
+            audit_log_path=str(audit_log_path),
+        )
+        assert result.returncode == 0, (
+            f"migrate prompt failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+
+        dest_page = rest.prompts.get_prompts(name=prompt_name, size=10)
+        assert dest_page.content, "destination prompt not found at original name"
+        dest_prompt = dest_page.content[0]
+
+        dest_versions_page = rest.prompts.get_prompt_versions(
+            id=dest_prompt.id, page=1, size=100
+        )
+        dest_versions = list(reversed(dest_versions_page.content or []))
+        dest_commits = [v.commit for v in dest_versions]
+        assert dest_commits == source_commits
+
+        # Exactly one destination version owns the environment, and it is
+        # the last one (the source owner), proving ownership round-tripped
+        # without leaking onto the env-less versions.
+        owners = [
+            v.commit
+            for v in dest_versions
+            if environment_name in (v.environments or [])
+        ]
+        assert owners == [source_commits[-1]]
+
+        audit = json.loads(audit_log_path.read_text())
+        env_records = [
+            a
+            for a in audit["actions"]
+            if a["type"] == "replay_prompt_version" and a.get("source_environments")
+        ]
+        assert len(env_records) == 1
+        assert env_records[0]["source_environments"] == [environment_name]
+        assert env_records[0]["target_environments"] == [environment_name]

--- a/sdks/python/tests/unit/cli/_migrate_prompt_helpers.py
+++ b/sdks/python/tests/unit/cli/_migrate_prompt_helpers.py
@@ -40,7 +40,7 @@ class _PromptVersionRow:
 
     Field set mirrors the Fern model: ``id``, ``prompt_id``, ``commit``,
     ``template`` (required), plus optional metadata / type / change_description
-    / tags / template_structure.
+    / tags / environments / template_structure.
     """
 
     def __init__(
@@ -54,6 +54,7 @@ class _PromptVersionRow:
         type: Optional[str] = None,
         change_description: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        environments: Optional[List[str]] = None,
         template_structure: Optional[str] = "text",
     ) -> None:
         self.id = id
@@ -64,6 +65,7 @@ class _PromptVersionRow:
         self.type = type
         self.change_description = change_description
         self.tags = tags
+        self.environments = environments
         self.template_structure = template_structure
 
 

--- a/sdks/python/tests/unit/cli/test_migrate_prompt_executor.py
+++ b/sdks/python/tests/unit/cli/test_migrate_prompt_executor.py
@@ -34,6 +34,7 @@ def _client_with_rest_mock(version_pages: List[_Page]) -> Any:
         side_effect=lambda **kw: MagicMock(
             id=f"dest-version-{kw['version'].commit}",
             commit=kw["version"].commit,
+            environments=kw["version"].environments,
         )
     )
     rest_client.prompts.get_prompt_versions.side_effect = version_pages
@@ -168,6 +169,55 @@ class TestExecuteActions:
         assert second_version.commit == "bbbbbbbb"
         assert first_version.template == "hello {{name}}"
         assert second_version.template == "hello {{name}} v2"
+
+    def test_replay_versions__carries_environments_verbatim(self) -> None:
+        # Environment ownership is per-version data the BE accepts inline on
+        # create_prompt_version. A version that owns environments on the
+        # source must carry them onto the destination; one that owns none
+        # must pass environments=None so the BE assigns no ownership.
+        v1 = _PromptVersionRow(
+            id="src-v-1",
+            prompt_id="src-1",
+            commit="aaaaaaaa",
+            template="hello",
+        )
+        v2 = _PromptVersionRow(
+            id="src-v-2",
+            prompt_id="src-1",
+            commit="bbbbbbbb",
+            template="hi",
+            environments=["production", "staging"],
+        )
+        client, rest_client = _client_with_rest_mock([_Page([v2, v1])])
+        plan = _make_plan()
+        audit = AuditLog(command="opik migrate prompt", args={})
+
+        executor_module.execute_plan(client, plan, audit)
+
+        calls = rest_client.prompts.create_prompt_version.call_args_list
+        first_version = calls[0].kwargs["version"]
+        second_version = calls[1].kwargs["version"]
+        assert first_version.environments is None
+        assert second_version.environments == ["production", "staging"]
+
+    def test_replay_versions__records_environments_in_audit(self) -> None:
+        v1 = _PromptVersionRow(
+            id="src-v-1",
+            prompt_id="src-1",
+            commit="aaaaaaaa",
+            template="hello",
+            environments=["staging", "production"],
+        )
+        client, _ = _client_with_rest_mock([_Page([v1])])
+        plan = _make_plan()
+        audit = AuditLog(command="opik migrate prompt", args={})
+
+        executor_module.execute_plan(client, plan, audit)
+
+        record = next(a for a in audit.actions if a["type"] == "replay_prompt_version")
+        # Sorted for stable audit output regardless of source set ordering.
+        assert record["source_environments"] == ["production", "staging"]
+        assert record["target_environments"] == ["production", "staging"]
 
     def test_replay_versions__populates_prompt_version_id_remap(self) -> None:
         # Slice 7 (OPIK-6575) reads ``plan.prompt_version_id_remap`` to

--- a/sdks/python/tests/unit/cli/test_migrate_prompt_executor.py
+++ b/sdks/python/tests/unit/cli/test_migrate_prompt_executor.py
@@ -172,9 +172,10 @@ class TestExecuteActions:
 
     def test_replay_versions__carries_environments_verbatim(self) -> None:
         # Environment ownership is per-version data the BE accepts inline on
-        # create_prompt_version. A version that owns environments on the
-        # source must carry them onto the destination; one that owns none
-        # must pass environments=None so the BE assigns no ownership.
+        # create_prompt_version. The history mixes an env-less version, a
+        # non-latest version owning a single env, and a latest version owning
+        # multiple envs — proving single + multi env work and that a
+        # non-latest version's env is preserved (not just the newest one's).
         v1 = _PromptVersionRow(
             id="src-v-1",
             prompt_id="src-1",
@@ -186,19 +187,26 @@ class TestExecuteActions:
             prompt_id="src-1",
             commit="bbbbbbbb",
             template="hi",
+            environments=["development"],
+        )
+        v3 = _PromptVersionRow(
+            id="src-v-3",
+            prompt_id="src-1",
+            commit="cccccccc",
+            template="hey",
             environments=["production", "staging"],
         )
-        client, rest_client = _client_with_rest_mock([_Page([v2, v1])])
+        # BE returns newest-first; the loop reverses to oldest-first.
+        client, rest_client = _client_with_rest_mock([_Page([v3, v2, v1])])
         plan = _make_plan()
         audit = AuditLog(command="opik migrate prompt", args={})
 
         executor_module.execute_plan(client, plan, audit)
 
         calls = rest_client.prompts.create_prompt_version.call_args_list
-        first_version = calls[0].kwargs["version"]
-        second_version = calls[1].kwargs["version"]
-        assert first_version.environments is None
-        assert second_version.environments == ["production", "staging"]
+        assert calls[0].kwargs["version"].environments is None
+        assert calls[1].kwargs["version"].environments == ["development"]
+        assert calls[2].kwargs["version"].environments == ["production", "staging"]
 
     def test_replay_versions__records_environments_in_audit(self) -> None:
         v1 = _PromptVersionRow(
@@ -215,9 +223,10 @@ class TestExecuteActions:
         executor_module.execute_plan(client, plan, audit)
 
         record = next(a for a in audit.actions if a["type"] == "replay_prompt_version")
-        # Sorted for stable audit output regardless of source set ordering.
-        assert record["source_environments"] == ["production", "staging"]
-        assert record["target_environments"] == ["production", "staging"]
+        # Environments are recorded verbatim (order is irrelevant), so compare
+        # order-insensitively.
+        assert sorted(record["source_environments"]) == ["production", "staging"]
+        assert sorted(record["target_environments"]) == ["production", "staging"]
 
     def test_replay_versions__populates_prompt_version_id_remap(self) -> None:
         # Slice 7 (OPIK-6575) reads ``plan.prompt_version_id_remap`` to


### PR DESCRIPTION
## Details

`opik migrate prompt` dropped each source version's environment ownership during version replay — the destination payload was built from a fixed allowlist that omitted `environments`. This carries the `environments` set through verbatim, inline on `create_prompt_version` (the backend accepts it on creation and moves env ownership atomically, so no follow-up PATCH is needed). Per-version audit entries now record `source_environments` / `target_environments`.

- `version_type` / mask round-trip is intentionally **out of scope**: `get_prompt_versions` filters `version_type = 'prompt_version'` server-side, so masks are never read by the replay loop, and there is no endpoint to enumerate masks per prompt. Carrying masks would require separate backend work and is noted on the ticket.
- The schema referenced in the ticket (singular `environment` column) has since moved to a multi-environment `environments` set backed by `prompt_version_envs` (OPIK-6626), so "preserve environment" maps to carrying `environments`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6694

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8 (1M context)
  - Scope: full implementation
  - Human verification: code review + unit tests

## Testing

- Unit: `pytest tests/unit/cli/test_migrate_prompt_executor.py` — 8 passed, including 2 new cases: `test_replay_versions__carries_environments_verbatim` (env-owning version carries `environments`, env-less version passes `None`) and `test_replay_versions__records_environments_in_audit`.
- Lint/type: SDK pre-commit hooks (`ruff`, `ruff format`, `mypy`) pass on all changed files.
- E2E: added `test_environment_ownership_round_trips` (seeds a prompt whose latest version owns an environment, runs the CLI, asserts exactly that version owns the env on the destination and the audit records it). Requires a live backend — not executed locally; will run in CI.

## Documentation

N/A
