### PR TITLE
[OPIK-6571] [FE] feat: update thread view UI to match trace/span panel

### DIFF
--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -104,7 +104,7 @@
     --thread-inactive: #e2effd;
     --thread-icon-background: #3438d0;
     --thread-icon-text: #ffffff;
-    --message-input-background: #e7ecff;
+    --message-input-background: #f2f2ff;
 
     /* Action cards */
     --action-card-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1),
@@ -916,6 +916,15 @@
   max-width: 100%;
   overflow-wrap: break-word;
   word-break: break-word;
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-medium;
+  }
 
   pre {
     color: hsl(var(--foreground));

--- a/apps/opik-frontend/src/shared/TagListRenderer/TagListRenderer.tsx
+++ b/apps/opik-frontend/src/shared/TagListRenderer/TagListRenderer.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Plus, Tag } from "lucide-react";
-import { Button } from "@/ui/button";
+import { Button, ButtonProps } from "@/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
 import { Input } from "@/ui/input";
 import { useToast } from "@/ui/use-toast";
@@ -9,13 +9,39 @@ import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { cn } from "@/lib/utils";
 import { TagProps } from "@/ui/tag";
 
+type TagListSize = "md" | "sm";
+
+type TagSizeConfig = {
+  iconClassName: string;
+  tagSize: TagProps["size"];
+  addButtonSize: ButtonProps["size"];
+  addButtonClassName?: string;
+  rowMinHeight: string;
+};
+
+const TAG_SIZE_CONFIG: Record<TagListSize, TagSizeConfig> = {
+  md: {
+    iconClassName: "mx-1 size-3.5",
+    tagSize: "md",
+    addButtonSize: "icon-2xs",
+    rowMinHeight: "min-h-6",
+  },
+  sm: {
+    iconClassName: "mx-1 size-3",
+    tagSize: "default",
+    addButtonSize: "icon-2xs",
+    addButtonClassName: "size-5",
+    rowMinHeight: "min-h-7",
+  },
+};
+
 export type TagListRendererProps = {
   tags: string[];
   immutableTags?: string[];
   onAddTag: (tag: string) => void;
   onDeleteTag: (tag: string) => void;
   align?: "start" | "end";
-  size?: "md" | "sm";
+  size?: TagListSize;
   className?: string;
   tooltipText?: string;
   placeholderText?: string;
@@ -46,7 +72,7 @@ const TagListRenderer: React.FC<TagListRendererProps> = ({
 
   const hasTags = tags.length > 0 || immutableTags.length > 0;
 
-  const tagMarginClass = size === "sm" ? "mx-0" : "mx-1";
+  const tagSizeConfig = TAG_SIZE_CONFIG[size];
 
   const isImmutableTag = (tag: string): boolean =>
     immutableTags.some((t) => t.toLowerCase() === tag.toLowerCase());
@@ -75,18 +101,19 @@ const TagListRenderer: React.FC<TagListRendererProps> = ({
   return (
     <div
       className={cn(
-        "flex min-h-7 w-full flex-wrap items-center gap-2 overflow-x-hidden",
+        "flex w-full flex-wrap items-center gap-2 overflow-x-hidden",
+        tagSizeConfig.rowMinHeight,
         className,
       )}
     >
       <TooltipWrapper content={tooltipText}>
-        <Tag className={`${tagMarginClass} size-3 text-muted-slate`} />
+        <Tag className={`${tagSizeConfig.iconClassName} text-muted-slate`} />
       </TooltipWrapper>
       {[...immutableTags].sort().map((tag) => (
         <RemovableTag
           label={tag}
           key={`immutable-${tag}`}
-          size="default"
+          size={tagSizeConfig.tagSize}
           variant={tagVariant}
         />
       ))}
@@ -94,7 +121,7 @@ const TagListRenderer: React.FC<TagListRendererProps> = ({
         <RemovableTag
           label={tag}
           key={tag}
-          size="default"
+          size={tagSizeConfig.tagSize}
           variant={tagVariant}
           onDelete={() => onDeleteTag(tag)}
         />
@@ -105,8 +132,8 @@ const TagListRenderer: React.FC<TagListRendererProps> = ({
             <Button
               data-testid="add-tag-button"
               variant="outline"
-              size="icon-2xs"
-              className="size-5"
+              size={tagSizeConfig.addButtonSize}
+              className={cn(tagSizeConfig.addButtonClassName)}
             >
               <Plus />
             </Button>

--- a/apps/opik-frontend/src/ui/tabs.tsx
+++ b/apps/opik-frontend/src/ui/tabs.tsx
@@ -30,21 +30,28 @@ const TabsTriggerVariants = cva(
     variants: {
       variant: {
         default:
-          "comet-body-s-accented justify-center rounded-md bg-transparent p-2 ring-offset-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:hover:bg-primary-hover data-[state=active]:hover:text-primary-foreground data-[state=active]:dark:text-primary-active",
+          "justify-center rounded-md bg-transparent p-2 font-medium ring-offset-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:hover:bg-primary-hover data-[state=active]:hover:text-primary-foreground data-[state=active]:dark:text-primary-active",
         underline:
-          "comet-body-s-accented border-b-2 border-transparent py-2 hover:text-foreground disabled:opacity-50 data-[state=active]:border-primary data-[state=active]:text-primary hover:data-[state=active]:text-primary-hover data-[state=active]:dark:border-primary-active data-[state=active]:dark:text-primary-active",
+          "border-b-2 border-transparent py-2 font-medium hover:text-foreground disabled:opacity-50 data-[state=active]:border-primary data-[state=active]:text-primary hover:data-[state=active]:text-primary-hover data-[state=active]:dark:border-primary-active data-[state=active]:dark:text-primary-active",
         segmented:
-          "comet-body-s justify-center gap-2 rounded px-2 py-1 text-foreground hover:text-foreground disabled:opacity-50 data-[state=active]:bg-slate-300/40 data-[state=active]:text-foreground",
+          "justify-center gap-2 rounded px-2 py-1 text-foreground hover:text-foreground disabled:opacity-50 data-[state=active]:bg-slate-300/40 data-[state=active]:text-foreground",
         "segmented-primary":
-          "comet-body-s-accented justify-center gap-2 rounded px-2 py-1 text-foreground hover:text-foreground disabled:opacity-50 data-[state=active]:bg-primary-100 data-[state=active]:text-primary",
+          "justify-center gap-2 rounded px-2 py-1 text-foreground hover:text-foreground disabled:opacity-50 data-[state=active]:bg-primary-100 data-[state=active]:text-primary",
       },
       size: {
-        default: "",
-        sm: " text-xs",
-        lg: "",
+        default: "comet-body-s",
+        sm: "comet-body-xs",
+        lg: "comet-body-s",
         icon: "size-9",
       },
     },
+    compoundVariants: [
+      {
+        variant: ["segmented", "segmented-primary"],
+        size: "sm",
+        class: "py-px",
+      },
+    ],
     defaultVariants: {
       variant: "default",
       size: "default",

--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadAnnotatePanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadAnnotatePanel.tsx
@@ -138,7 +138,7 @@ const ThreadAnnotatePanel: React.FC<ThreadAnnotatePanelProps> = ({
           onUpdateFeedbackScore={onUpdateFeedbackScore}
           onDeleteFeedbackScore={onDeleteFeedbackScore}
           className="mt-4 px-4"
-          header={<FeedbackScoresEditor.Header isThread={true} />}
+          header={<FeedbackScoresEditor.Header title="Human review" />}
           footer={<FeedbackScoresEditor.Footer entityCopy="threads" />}
         />
 

--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
@@ -494,22 +494,26 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
           </TabsList>
         </div>
         <TabsContent value="messages">
-          <MediaProvider media={media}>
-            {media.length > 0 && (
-              <div className="mb-4 px-4">
-                <Accordion type="multiple" defaultValue={["attachments"]}>
-                  <AttachmentsList media={media} />
-                </Accordion>
+          {isTracesPending ? (
+            <ThreadMessagesSkeleton />
+          ) : (
+            <MediaProvider media={media}>
+              {media.length > 0 && (
+                <div className="mb-4 px-4">
+                  <Accordion type="multiple" defaultValue={["attachments"]}>
+                    <AttachmentsList media={media} />
+                  </Accordion>
+                </div>
+              )}
+              <div style={bodyStyle}>
+                <TraceMessages
+                  traces={traces}
+                  handleOpenTrace={handleOpenTrace}
+                  traceId={traceId}
+                />
               </div>
-            )}
-            <div style={bodyStyle}>
-              <TraceMessages
-                traces={traces}
-                handleOpenTrace={handleOpenTrace}
-                traceId={traceId}
-              />
-            </div>
-          </MediaProvider>
+            </MediaProvider>
+          )}
         </TabsContent>
         <TabsContent value="feedback_scores">
           <div style={bodyStyle} className="overflow-y-auto px-4">
@@ -540,9 +544,7 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
   };
 
   const renderContent = () => {
-    const isLoading = isThreadPending || (Boolean(thread) && isTracesPending);
-
-    if (!isLoading && !thread) {
+    if (!isThreadPending && !thread) {
       return <NoData />;
     }
 
@@ -563,7 +565,7 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
                     dataType="threads"
                     buttonVariant="ghost"
                     buttonSize="2xs"
-                    disabled={isLoading}
+                    disabled={isThreadPending}
                   />
                 )}
                 {canAnnotateTraceSpanThread && !hideAnnotateActions && (
@@ -580,10 +582,10 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
               </div>
               <div ref={ref} className="relative min-h-0 flex-auto">
                 <div className="p-4" data-panel-header="true">
-                  {isLoading ? <ThreadHeaderSkeleton /> : renderHeader()}
+                  {isThreadPending ? <ThreadHeaderSkeleton /> : renderHeader()}
                 </div>
                 <div data-panel-body="true">
-                  {isLoading ? <ThreadMessagesSkeleton /> : renderBody()}
+                  {isThreadPending ? <ThreadMessagesSkeleton /> : renderBody()}
                 </div>
               </div>
             </div>

--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
@@ -10,6 +10,7 @@ import {
   Hash,
   MessagesSquare,
   MoreHorizontal,
+  PenLine,
   Share,
   Trash,
 } from "lucide-react";
@@ -34,14 +35,16 @@ import {
 } from "@/lib/traces/exportUtils";
 import { Trace } from "@/types/traces";
 import { Filter } from "@/types/filters";
+import { cn } from "@/lib/utils";
 import { formatDate, formatDuration } from "@/lib/date";
 import { formatCost } from "@/lib/money";
 import { manageToolFilter } from "@/v2/pages-shared/traces/spanTypeFilter";
 import useAppStore from "@/store/AppStore";
 import { usePermissions } from "@/contexts/PermissionsContext";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import Loader from "@/shared/Loader/Loader";
 import NoData from "@/shared/NoData/NoData";
+import { Skeleton } from "@/ui/skeleton";
+import FeedbackScoreHoverCard from "@/shared/FeedbackScoreTag/FeedbackScoreHoverCard";
 import ResizableSidePanel from "@/shared/ResizableSidePanel/ResizableSidePanel";
 import ResizableSidePanelTopBar from "@/shared/ResizableSidePanel/ResizableSidePanelTopBar";
 import ResizableSidePanelArrowNavigation from "@/shared/ResizableSidePanel/ResizableSidePanelArrowNavigation";
@@ -104,6 +107,50 @@ export type ThreadDetailsPanelProps = {
 };
 
 const DEFAULT_TAB = "messages";
+
+const ThreadHeaderSkeleton: React.FC = () => (
+  <div className="flex flex-col gap-2">
+    <div className="flex flex-wrap gap-2">
+      <Skeleton className="h-5 w-40" />
+      <Skeleton className="h-5 w-24" />
+      <Skeleton className="h-5 w-16" />
+      <Skeleton className="h-5 w-20" />
+    </div>
+    <div className="flex gap-2">
+      <Skeleton className="h-6 w-[72px]" />
+      <Skeleton className="h-6 w-[72px]" />
+      <Skeleton className="h-6 w-[72px]" />
+    </div>
+  </div>
+);
+
+const MESSAGE_SKELETON_ROWS = [
+  { align: "end", width: "55%", height: 56 },
+  { align: "start", width: "80%", height: 96 },
+  { align: "end", width: "45%", height: 56 },
+  { align: "start", width: "75%", height: 160 },
+  { align: "end", width: "60%", height: 56 },
+  { align: "start", width: "70%", height: 128 },
+] as const;
+
+const ThreadMessagesSkeleton: React.FC = () => (
+  <div className="flex flex-col gap-4 px-6 pt-2">
+    {MESSAGE_SKELETON_ROWS.map((row, i) => (
+      <div
+        key={i}
+        className={cn(
+          "flex",
+          row.align === "end" ? "justify-end" : "justify-start",
+        )}
+      >
+        <Skeleton
+          className="rounded-xl"
+          style={{ width: row.width, height: row.height }}
+        />
+      </div>
+    ))}
+  </div>
+);
 
 const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
   projectId,
@@ -369,37 +416,27 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
   };
 
   const renderHeader = () => {
-    if (isThreadPending) {
-      return <Loader />;
-    }
-
     return (
-      <div className="flex flex-col gap-1">
-        <div className=" flex w-full items-center gap-3 overflow-x-hidden py-1">
+      <div className="flex flex-col gap-2">
+        <div className="comet-body-s flex w-full flex-wrap items-center gap-3 pl-1 text-foreground">
           <TooltipWrapper content="Thread start time">
-            <div className="flex flex-nowrap items-center gap-x-1.5 px-1 text-muted-slate">
-              <Calendar className="size-4 shrink-0" />
-              <span className="comet-body-s truncate">
-                {thread?.start_time ? formatDate(thread?.start_time) : "NA"}
-              </span>
+            <div className="flex items-center gap-1">
+              <Calendar className="size-3.5 shrink-0 text-muted-slate" />
+              {thread?.start_time ? formatDate(thread?.start_time) : "NA"}
             </div>
           </TooltipWrapper>
           <TooltipWrapper content="Number of messages in the thread">
-            <div className="flex flex-nowrap items-center gap-x-1.5 px-1 text-muted-slate">
-              <Hash className="size-4 shrink-0" />
-              <span className="comet-body-s truncate">
-                {thread?.number_of_messages
-                  ? `${thread.number_of_messages} messages`
-                  : "NA"}
-              </span>
+            <div className="flex items-center gap-1">
+              <Hash className="size-3.5 shrink-0 text-muted-slate" />
+              {thread?.number_of_messages
+                ? `${thread.number_of_messages} messages`
+                : "NA"}
             </div>
           </TooltipWrapper>
           <TooltipWrapper content="Thread duration">
-            <div className="flex flex-nowrap items-center gap-x-1.5 px-1 text-muted-slate">
-              <Clock className="size-4 shrink-0" />
-              <span className="comet-body-s truncate">
-                {formatDuration(thread?.duration, false)}
-              </span>
+            <div className="flex items-center gap-1">
+              <Clock className="size-3.5 shrink-0 text-muted-slate" />
+              {formatDuration(thread?.duration, false)}
             </div>
           </TooltipWrapper>
           {!isUndefined(thread?.total_estimated_cost) && (
@@ -409,13 +446,19 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
                 { modifier: "full" },
               )}`}
             >
-              <div className="flex flex-nowrap items-center gap-x-1.5 px-1 text-muted-slate">
-                <Coins className="size-4 shrink-0" />
-                <span className="comet-body-s truncate">
-                  {formatCost(thread?.total_estimated_cost)}
-                </span>
+              <div className="flex items-center gap-1">
+                <Coins className="size-3.5 shrink-0 text-muted-slate" />
+                {formatCost(thread?.total_estimated_cost)}
               </div>
             </TooltipWrapper>
+          )}
+          {Boolean(threadFeedbackScores.length) && (
+            <FeedbackScoreHoverCard scores={threadFeedbackScores}>
+              <div className="flex items-center gap-1">
+                <PenLine className="size-3.5 shrink-0 text-muted-slate" />
+                {threadFeedbackScores.length} scores
+              </div>
+            </FeedbackScoreHoverCard>
           )}
         </div>
         {thread && (
@@ -430,10 +473,6 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
   };
 
   const renderBody = () => {
-    if (isTracesPending) {
-      return <Loader />;
-    }
-
     return (
       <Tabs
         defaultValue="messages"
@@ -441,11 +480,15 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
         onValueChange={setActiveTab}
       >
         <div className="mx-4" data-panel-tabs="true">
-          <TabsList variant="underline">
-            <TabsTrigger variant="underline" value="messages">
+          <TabsList variant="segmented-primary">
+            <TabsTrigger variant="segmented-primary" size="sm" value="messages">
               Messages
             </TabsTrigger>
-            <TabsTrigger variant="underline" value="feedback_scores">
+            <TabsTrigger
+              variant="segmented-primary"
+              size="sm"
+              value="feedback_scores"
+            >
               Feedback scores
             </TabsTrigger>
           </TabsList>
@@ -497,11 +540,9 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
   };
 
   const renderContent = () => {
-    if (isThreadPending) {
-      return <Loader />;
-    }
+    const isLoading = isThreadPending || (Boolean(thread) && isTracesPending);
 
-    if (!thread) {
+    if (!isLoading && !thread) {
       return <NoData />;
     }
 
@@ -522,6 +563,7 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
                     dataType="threads"
                     buttonVariant="ghost"
                     buttonSize="2xs"
+                    disabled={isLoading}
                   />
                 )}
                 {canAnnotateTraceSpanThread && !hideAnnotateActions && (
@@ -537,36 +579,40 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
                 )}
               </div>
               <div ref={ref} className="relative min-h-0 flex-auto">
-                <div className="px-4 pb-6 pt-4" data-panel-header="true">
-                  {renderHeader()}
+                <div className="p-4" data-panel-header="true">
+                  {isLoading ? <ThreadHeaderSkeleton /> : renderHeader()}
                 </div>
-                <div data-panel-body="true">{renderBody()}</div>
+                <div data-panel-body="true">
+                  {isLoading ? <ThreadMessagesSkeleton /> : renderBody()}
+                </div>
               </div>
             </div>
           </ResizablePanel>
-          {Boolean(currentActiveSection) && canAnnotateTraceSpanThread && (
-            <>
-              <ResizableHandle />
-              <ResizablePanel
-                id="thread-last-section-viewer"
-                defaultSize={30}
-                minSize={30}
-              >
-                {currentActiveSection === DetailsActionSection.Annotate && (
-                  <ThreadAnnotatePanel
-                    threadId={threadId}
-                    threadModelId={thread.thread_model_id}
-                    projectId={projectId}
-                    projectName={projectName}
-                    activeSection={activeSection}
-                    setActiveSection={setActiveSection}
-                    feedbackScores={threadFeedbackScores}
-                    comments={threadComments}
-                  />
-                )}
-              </ResizablePanel>
-            </>
-          )}
+          {Boolean(currentActiveSection) &&
+            canAnnotateTraceSpanThread &&
+            thread && (
+              <>
+                <ResizableHandle />
+                <ResizablePanel
+                  id="thread-last-section-viewer"
+                  defaultSize={30}
+                  minSize={30}
+                >
+                  {currentActiveSection === DetailsActionSection.Annotate && (
+                    <ThreadAnnotatePanel
+                      threadId={threadId}
+                      threadModelId={thread.thread_model_id}
+                      projectId={projectId}
+                      projectName={projectName}
+                      activeSection={activeSection}
+                      setActiveSection={setActiveSection}
+                      feedbackScores={threadFeedbackScores}
+                      comments={threadComments}
+                    />
+                  )}
+                </ResizablePanel>
+              </>
+            )}
         </ResizablePanelGroup>
       </div>
     );

--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsTags.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsTags.tsx
@@ -51,7 +51,8 @@ const ThreadDetailsTags: React.FunctionComponent<ThreadDetailsTagsProps> = ({
       onAddTag={handleAddTag}
       onDeleteTag={handleDeleteTag}
       canAdd={canLogTraceSpanThread}
-      tagVariant="gray"
+      size="md"
+      tagVariant="green"
     />
   );
 };

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TagList/TagList.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TagList/TagList.tsx
@@ -83,7 +83,7 @@ const TagList: React.FunctionComponent<TagListProps> = ({
       {...tagsProps}
       onAddTag={handleAddTag}
       onDeleteTag={handleDeleteTag}
-      size="sm"
+      size="md"
       className={className}
       canAdd={canLogTraceSpanThread}
       tagVariant={tagVariant}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -260,16 +260,24 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
           value={selectedTab!}
           onValueChange={setTab}
         >
-          <TabsList variant="segmented">
+          <TabsList variant="segmented-primary">
             {canShowMessagesTab && (
-              <TabsTrigger variant="segmented" value="messages">
+              <TabsTrigger
+                variant="segmented-primary"
+                size="sm"
+                value="messages"
+              >
                 Messages
               </TabsTrigger>
             )}
-            <TabsTrigger variant="segmented" value="details">
+            <TabsTrigger variant="segmented-primary" size="sm" value="details">
               Details
             </TabsTrigger>
-            <TabsTrigger variant="segmented" value="feedback_scores">
+            <TabsTrigger
+              variant="segmented-primary"
+              size="sm"
+              value="feedback_scores"
+            >
               Feedback scores
               <ExplainerIcon
                 className="ml-1"
@@ -277,12 +285,16 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
               />
             </TabsTrigger>
             {hasPrompts && (
-              <TabsTrigger variant="segmented" value="prompts">
+              <TabsTrigger
+                variant="segmented-primary"
+                size="sm"
+                value="prompts"
+              >
                 Prompts
               </TabsTrigger>
             )}
             {hasSpanAgentGraph && (
-              <TabsTrigger variant="segmented" value="graph">
+              <TabsTrigger variant="segmented-primary" size="sm" value="graph">
                 Agent graph
               </TabsTrigger>
             )}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceMessages/LikeFeedback.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceMessages/LikeFeedback.tsx
@@ -50,7 +50,7 @@ const LikeFeedback: React.FC<LikeFeedbackProps> = ({ state, traceId }) => {
         {state === USER_FEEDBACK_SCORE.like ? (
           <ThumbUpFilled className="text-muted-slate" />
         ) : (
-          <ThumbsUp />
+          <ThumbsUp className="text-muted-slate" />
         )}
       </Button>
       <Button
@@ -65,7 +65,7 @@ const LikeFeedback: React.FC<LikeFeedbackProps> = ({ state, traceId }) => {
         {state === USER_FEEDBACK_SCORE.dislike ? (
           <ThumbDownFilled className="text-muted-slate" />
         ) : (
-          <ThumbsDown />
+          <ThumbsDown className="text-muted-slate" />
         )}
       </Button>
     </div>

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceMessages/TraceMessage.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceMessages/TraceMessage.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import JsonView from "react18-json-view";
 import isObject from "lodash/isObject";
 import isUndefined from "lodash/isUndefined";
+import { ArrowUpRight } from "lucide-react";
 
 import { Trace, USER_FEEDBACK_SCORE } from "@/types/traces";
 import MarkdownPreview from "@/shared/MarkdownPreview/MarkdownPreview";
@@ -12,7 +13,6 @@ import { USER_FEEDBACK_NAME } from "@/constants/shared";
 import { prettifyMessage } from "@/lib/traces";
 import { toString } from "@/lib/utils";
 import { useJsonViewTheme } from "@/hooks/useJsonViewTheme";
-import { Hammer, ListTree } from "lucide-react";
 
 type TraceMessageProps = {
   trace: Trace;
@@ -72,38 +72,38 @@ const TraceMessage: React.FC<TraceMessageProps> = ({
   }, [trace.output, jsonViewTheme]);
 
   return (
-    <div className="border-b pt-4 first:pt-0" data-trace-message-id={trace.id}>
-      <div key={`${trace.id}_input`} className="mb-4 flex justify-end">
-        <div className="relative min-w-[20%] max-w-[90%] rounded-t-xl rounded-bl-xl bg-[var(--message-input-background)] px-4 py-2">
+    <div className="flex flex-col gap-2" data-trace-message-id={trace.id}>
+      <div className="flex justify-end pl-16">
+        <div className="rounded-t-xl rounded-bl-xl bg-[var(--message-input-background)] px-4 py-2">
           {input}
         </div>
       </div>
-      <div key={`${trace.id}_output`} className="flex justify-start">
-        <div className="relative min-w-[20%] max-w-[90%] rounded-t-xl rounded-br-xl bg-primary-foreground px-4 py-2 dark:bg-secondary">
-          {output}
-        </div>
-      </div>
-      <div className="mb-2 mt-1 flex items-center gap-0.5 p-0.5">
-        <LikeFeedback state={userFeedback} traceId={trace.id} />
-        <Separator orientation="vertical" className="mx-1 h-3" />
-        <Button
-          variant="ghost"
-          size="2xs"
-          onClick={() => handleOpenTrace(trace.id, false)}
-        >
-          <ListTree className="mr-1 size-3" />
-          View trace
-        </Button>
-        {trace.has_tool_spans && (
+      <div className="flex flex-col gap-1 pr-16">
+        <div className="pt-3">{output}</div>
+        <div className="flex items-center gap-0.5 p-0.5">
+          <LikeFeedback state={userFeedback} traceId={trace.id} />
+          <Separator orientation="vertical" className="mx-1 h-3" />
           <Button
             variant="ghost"
             size="2xs"
-            onClick={() => handleOpenTrace(trace.id, true)}
+            className="text-muted-slate"
+            onClick={() => handleOpenTrace(trace.id, false)}
           >
-            <Hammer className="mr-1 size-3" />
-            View tool calls
+            Trace
+            <ArrowUpRight className="ml-1 size-3" />
           </Button>
-        )}
+          {trace.has_tool_spans && (
+            <Button
+              variant="ghost"
+              size="2xs"
+              className="text-muted-slate"
+              onClick={() => handleOpenTrace(trace.id, true)}
+            >
+              Tool calls
+              <ArrowUpRight className="ml-1 size-3" />
+            </Button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceMessages/TraceMessages.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceMessages/TraceMessages.tsx
@@ -34,7 +34,7 @@ const TraceMessages: React.FC<TraceMessagesProps> = ({
 
   return (
     <div
-      className="relative flex size-full justify-center overflow-y-auto px-6"
+      className="relative flex size-full justify-center overflow-y-auto px-4"
       ref={setRef}
     >
       <div className="flex w-full flex-col gap-2">

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTagsList.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTagsList.tsx
@@ -39,6 +39,7 @@ const PromptTagsList: React.FC<PromptTagsListProps> = ({
       onAddTag={handleAddTag}
       onDeleteTag={handleDeleteTag}
       align="start"
+      size="sm"
       tagVariant="lavender"
     />
   );


### PR DESCRIPTION
## Details

<img width="1665" height="927" alt="image" src="https://github.com/user-attachments/assets/bdec650f-bc3f-457e-8034-8d75e6dc9a84" />
<img width="1660" height="928" alt="image" src="https://github.com/user-attachments/assets/21d09a95-38f9-4d0d-9b73-e272c979c157" />
<img width="1662" height="929" alt="image" src="https://github.com/user-attachments/assets/e13b77d5-6081-4e8a-862e-d88e505805bd" />


Aligns the thread detail sidebar with the updated trace/span panel (OPIK-6571). Replaces the loading spinner with shimmer skeletons, restyles the header stats and tags, modernizes the tabs, and redesigns the conversation messages to match the Figma. FE-only, no backend or data changes.

- Skeleton loaders for the thread sidebar (header chips + alternating chat-bubble body) instead of a spinner
- Header stats restyled to the trace visual language (date, messages, duration, cost) + a feedback-scores count
- Thread tags use the green variant with a size-aware tag list (24px) and aligned add button
- Tabs: primary segmented (blue active) style on the trace + thread sidebars; refactored `ui/tabs` so `size` owns typography and `variant` owns colors
- Conversation redesign: assistant turns render as plain full-width content (no bubble), per-message dividers removed, 64px insets, restyled action row (Trace / Tool calls with arrow-up-right)
- Markdown heading weight reduced to medium; message-input bubble token updated to `#f2f2ff`
- Annotate panel feedback editor header reads "Human review"

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6571

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: full implementation (design comparison + implementation)
  - Human verification: code review + manual visual QA

## Testing

- `bash scripts/dev-runner.sh --lint-fe` (ESLint + `tsc --noEmit` + dependency-cruiser) — all pass
- Shared-component changes verified against existing consumers: `ui/tabs` (all tab variants render identically at default size; only the trace/thread sidebars adopt the blue segmented style), `TagListRenderer` (default tag size unchanged for datasets/prompts/experiments), `MarkdownPreview` (heading weight only).
- Manual visual QA recommended: thread sidebar (Logs → Threads → open a thread), SME annotation thread view, Prompt page tabs (now regular weight), and dark mode.

## Documentation

N/A