### PR TITLE
[OPIK-6780] [BE] chore: materialize environment skip indexes in ClickHouse

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000086_materialize_environment_skip_indexes.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000086_materialize_environment_skip_indexes.sql
@@ -1,0 +1,17 @@
+--liquibase formatted sql
+--changeset boryst:000086_materialize_environment_skip_indexes
+--comment: Materialize environment skip indexes added unmaterialized in 000084 (OPIK-6780). Apply after prior mutations complete: SELECT * FROM system.mutations WHERE is_done = 0 AND table IN ('traces','spans','trace_threads').
+
+-- Materialize index from 000084 (idx_traces_environment was added without materialization)
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}'
+    MATERIALIZE INDEX idx_traces_environment;
+
+-- Materialize index from 000084 (idx_spans_environment was added without materialization)
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans ON CLUSTER '{cluster}'
+    MATERIALIZE INDEX idx_spans_environment;
+
+-- Materialize index from 000084 (idx_trace_threads_environment was added without materialization)
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.trace_threads ON CLUSTER '{cluster}'
+    MATERIALIZE INDEX idx_trace_threads_environment;
+
+--rollback empty


### PR DESCRIPTION
## Details
Adds Liquibase migration `000086_materialize_environment_skip_indexes.sql` to materialize
the three `environment` skip indexes introduced (unmaterialized) in migration `000084`:

- `idx_traces_environment` on `traces`
- `idx_spans_environment` on `spans`
- `idx_trace_threads_environment` on `trace_threads`

When an index is added via `ADD INDEX`, ClickHouse only applies it to newly-inserted
data parts; pre-existing parts remain unindexed until `MATERIALIZE INDEX` runs. This
migration backfills the indexes across existing data so environment-based filtering and
sorting benefit from the `set(0)` skip indexes on the full dataset.

The migration comment instructs operators to apply it only after prior mutations on the
affected tables have completed:
`SELECT * FROM system.mutations WHERE is_done = 0 AND table IN ('traces','spans','trace_threads')`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-6780

## Testing
Migration applied against ClickHouse; index materialization verified via
`system.mutations` (mutations complete) and confirmed environment-filtered queries use
the skip indexes. No application code changes.

## Documentation
N/A — operational migration only.
