### PR TITLE
[OPIK-6702] [BE] fix: allow last_updated_at and created_at filters on Trace filters

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -559,6 +559,8 @@ public class FilterQueryBuilder {
                 TraceField.NAME,
                 TraceField.START_TIME,
                 TraceField.END_TIME,
+                TraceField.CREATED_AT,
+                TraceField.LAST_UPDATED_AT,
                 TraceField.INPUT,
                 TraceField.OUTPUT,
                 TraceField.INPUT_JSON,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
@@ -94,6 +94,7 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -4148,7 +4149,6 @@ class ProjectMetricsResourceTest {
                 int count, Integer firstThreadTraceCount) {
             List<String> threadIds = new ArrayList<>();
             List<Double> threadDurations = new ArrayList<>();
-            List<Trace> allTraces = new ArrayList<>();
 
             for (int i = 0; i < count; i++) {
                 String threadId = RandomStringUtils.secure().nextAlphabetic(10);
@@ -4172,11 +4172,23 @@ class ProjectMetricsResourceTest {
                         })
                         .toList();
 
-                allTraces.addAll(traces);
-                threadDurations.add(threadStartTime.until(threadEndTime, ChronoUnit.MICROS) / 1000.0);
+                // A thread's created_at is min(trace.created_at), and trace.created_at defaults to
+                // now64(9) evaluated once per insert block. Inserting all threads in one batch would
+                // give them the same created_at, making CREATED_AT filters match multiple threads.
+                // Insert each thread in its own batch so every thread gets a distinct created_at.
+                traceResourceClient.batchCreateTraces(traces, API_KEY, WORKSPACE_NAME);
+
+                // The backend computes thread duration as max(endTime) - min(startTime) across all
+                // traces. With small random durations an intermediate trace can end after the last
+                // one, so derive the expected duration from the actual trace bounds rather than
+                // assuming threadEndTime is the maximum.
+                Instant actualThreadEnd = traces.stream()
+                        .map(Trace::endTime)
+                        .max(Comparator.naturalOrder())
+                        .orElse(threadEndTime);
+                threadDurations.add(threadStartTime.until(actualThreadEnd, ChronoUnit.MICROS) / 1000.0);
             }
 
-            traceResourceClient.batchCreateTraces(allTraces, API_KEY, WORKSPACE_NAME);
             Mono.delay(Duration.ofMillis(100)).block();
             traceResourceClient.closeTraceThreads(Set.copyOf(threadIds), null, projectName, API_KEY, WORKSPACE_NAME);
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -7735,4 +7735,92 @@ class TracesResourceTest {
         }
     }
 
+    @Nested
+    @DisplayName("Filter traces by created_at / last_updated_at")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class FilterTracesByTimestamp {
+
+        private List<Trace> createPersistedTraces(String projectName, int count) {
+            List<Trace> persisted = new ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                        .projectName(projectName)
+                        .usage(null)
+                        .feedbackScores(null)
+                        .build();
+                UUID id = traceResourceClient.createTrace(trace, API_KEY, TEST_WORKSPACE);
+                persisted.add(traceResourceClient.getById(id, TEST_WORKSPACE, API_KEY));
+            }
+            return persisted;
+        }
+
+        private Instant timestamp(Trace trace, TraceField field) {
+            return field == TraceField.CREATED_AT ? trace.createdAt() : trace.lastUpdatedAt();
+        }
+
+        Stream<Arguments> timestampFilterCases() {
+            return Stream.of(TraceField.CREATED_AT, TraceField.LAST_UPDATED_AT)
+                    .flatMap(field -> Stream.of(
+                            arguments(field, Operator.GREATER_THAN_EQUAL, List.of(2, 1)),
+                            arguments(field, Operator.GREATER_THAN, List.of(2)),
+                            arguments(field, Operator.LESS_THAN, List.of(0)),
+                            arguments(field, Operator.LESS_THAN_EQUAL, List.of(1, 0)),
+                            arguments(field, Operator.EQUAL, List.of(1)),
+                            arguments(field, Operator.NOT_EQUAL, List.of(2, 0))));
+        }
+
+        @ParameterizedTest
+        @MethodSource("timestampFilterCases")
+        @DisplayName("honors all comparison operators against the persisted timestamp")
+        void filterByTimestampField(TraceField field, Operator operator, List<Integer> expectedIndexes) {
+            var projectName = "timestamp-filter-%s-%s-%s".formatted(field.name(), operator.name(), UUID.randomUUID());
+
+            var traces = createPersistedTraces(projectName, 3);
+            var boundary = timestamp(traces.get(1), field);
+
+            var filters = List.of(TraceFilter.builder()
+                    .field(field)
+                    .operator(operator)
+                    .value(boundary.toString())
+                    .build());
+
+            var page = traceResourceClient.getTraces(projectName, null, API_KEY, TEST_WORKSPACE,
+                    filters, List.of(), 10, Map.of());
+
+            var expected = expectedIndexes.stream().map(traces::get).toList();
+            var unexpected = IntStream.range(0, traces.size())
+                    .filter(i -> !expectedIndexes.contains(i))
+                    .mapToObj(traces::get)
+                    .toList();
+
+            TraceAssertions.assertTraces(page.content(), expected, unexpected, USER);
+        }
+
+        @Test
+        @DisplayName("supports a last_updated_at window combining lower and upper bounds")
+        void filterByLastUpdatedAtWindow() {
+            var projectName = "last-updated-window-" + UUID.randomUUID();
+
+            var traces = createPersistedTraces(projectName, 3);
+
+            var filters = List.of(
+                    TraceFilter.builder()
+                            .field(TraceField.LAST_UPDATED_AT)
+                            .operator(Operator.GREATER_THAN_EQUAL)
+                            .value(traces.get(1).lastUpdatedAt().toString())
+                            .build(),
+                    TraceFilter.builder()
+                            .field(TraceField.LAST_UPDATED_AT)
+                            .operator(Operator.LESS_THAN)
+                            .value(traces.get(2).lastUpdatedAt().toString())
+                            .build());
+
+            var page = traceResourceClient.getTraces(projectName, null, API_KEY, TEST_WORKSPACE,
+                    filters, List.of(), 10, Map.of());
+
+            TraceAssertions.assertTraces(page.content(), List.of(traces.get(1)),
+                    List.of(traces.get(0), traces.get(2)), USER);
+        }
+    }
+
 }


### PR DESCRIPTION
## Details

The `GET /v1/private/traces` endpoint accepted `filters` entries with `field: "last_updated_at"` or `field: "created_at"` without any validation error, but silently dropped them at SQL-build time and returned an unfiltered page. The fields were fully wired (declared as `DATE_TIME`, mapped to their analytics-db columns, all comparison operators templated) but were missing from `FilterStrategy.TRACE`'s allowlist, so `FilterQueryBuilder.toAnalyticsDbFilters` skipped them.

- Add `TraceField.LAST_UPDATED_AT` and `TraceField.CREATED_AT` to the `FilterStrategy.TRACE` set in `FilterQueryBuilder.createFilterStrategyMap()`. No other wiring changes were required.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6702

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Root-cause analysis, the one-line allowlist fix, and the new integration tests
  - Human verification: Author reviewed the fix and ran the new integration tests locally

## Testing

Added a `FilterTracesByTimestamp` nested class in `TracesResourceTest`:
- Parameterized coverage of all six comparison operators (`=`, `!=`, `>`, `>=`, `<`, `<=`) against both `created_at` and `last_updated_at`, asserting only the in-range traces are returned.
- A `last_updated_at` window test combining `>=` and `<` bounds (the incremental-polling use case).

Run with:
`mvn test -Dtest='TracesResourceTest$FilterTracesByTimestamp'`

## Documentation

N/A — no documentation changes.
