### PR TITLE
[OPIK-6783] [DOCS] Use OPIK_WORKSPACE (optional) for opik-mcp instead of COMET_WORKSPACE

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/mcp-server.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/mcp-server.mdx
@@ -20,7 +20,7 @@ and ask Ollie investigative questions, all from the chat.
 You will need:
 
 - **`OPIK_API_KEY`** — generate one at [`comet.com/api/my/settings`](https://www.comet.com/api/my/settings/).
-- **`COMET_WORKSPACE`** — the lowercase workspace name from your Comet URL. For example, `https://www.comet.com/acme-ai/...` → `COMET_WORKSPACE=acme-ai`.
+- **`OPIK_WORKSPACE`** — the lowercase workspace name from your Comet URL. For example, `https://www.comet.com/acme-ai/...` → `OPIK_WORKSPACE=acme-ai`. Optional — defaults to `default` (the Opik SDK convention), which is correct for local/OSS installs; cloud users with a named workspace should set it. `COMET_WORKSPACE` is accepted as a deprecated alias (`OPIK_WORKSPACE` wins if both are set).
 - **[`uv`](https://docs.astral.sh/uv/)** installed locally. The fastest way is `brew install uv` (macOS) or `curl -LsSf https://astral.sh/uv/install.sh | sh`. `uvx` (bundled with `uv`) fetches and runs the latest published `opik-mcp` on demand — no global install required.
 
 <Tip>
@@ -31,6 +31,13 @@ PyPI release lands, replace `uvx opik-mcp` in any snippet on this page with
 
 ## Setting up the MCP server
 
+<Tip>
+`OPIK_WORKSPACE` is **optional** — you can omit the `OPIK_WORKSPACE` line/key
+entirely and the server uses the `default` workspace (correct for local/OSS
+installs). The snippets below include it for completeness; set it only if you
+connect to a named cloud workspace.
+</Tip>
+
 <Tabs>
     <Tab title="Claude Code">
 
@@ -39,7 +46,7 @@ PyPI release lands, replace `uvx opik-mcp` in any snippet on this page with
     ```bash
     claude mcp add --transport stdio opik-mcp \
       --env OPIK_API_KEY=<your-key> \
-      --env COMET_WORKSPACE=<your-workspace> \
+      --env OPIK_WORKSPACE=<your-workspace> \
       -- uvx opik-mcp
     ```
 
@@ -54,7 +61,7 @@ PyPI release lands, replace `uvx opik-mcp` in any snippet on this page with
           "args": ["opik-mcp"],
           "env": {
             "OPIK_API_KEY": "<your-key>",
-            "COMET_WORKSPACE": "<your-workspace>"
+            "OPIK_WORKSPACE": "<your-workspace>"
           }
         }
       }
@@ -79,7 +86,7 @@ PyPI release lands, replace `uvx opik-mcp` in any snippet on this page with
           "args": ["opik-mcp"],
           "env": {
             "OPIK_API_KEY": "<your-key>",
-            "COMET_WORKSPACE": "<your-workspace>"
+            "OPIK_WORKSPACE": "<your-workspace>"
           }
         }
       }
@@ -110,7 +117,7 @@ PyPI release lands, replace `uvx opik-mcp` in any snippet on this page with
           "args": ["opik-mcp"],
           "env": {
             "OPIK_API_KEY": "<your-key>",
-            "COMET_WORKSPACE": "<your-workspace>"
+            "OPIK_WORKSPACE": "<your-workspace>"
           }
         }
       }
@@ -126,7 +133,7 @@ PyPI release lands, replace `uvx opik-mcp` in any snippet on this page with
     For manual testing or debugging, run the inspector against `opik-mcp`:
 
     ```bash
-    OPIK_API_KEY=<your-key> COMET_WORKSPACE=<your-workspace> \
+    OPIK_API_KEY=<your-key> OPIK_WORKSPACE=<your-workspace> \
       npx @modelcontextprotocol/inspector uvx opik-mcp
     ```
 


### PR DESCRIPTION
## Details

Docs counterpart to comet-ml/opik-mcp#141 ([OPIK-6783](https://comet-ml.atlassian.net/browse/OPIK-6783)). The opik-mcp server now uses `OPIK_WORKSPACE` as the primary, `OPIK_`-prefixed env var for the workspace (matching the Opik SDK and the server's own `OPIK_API_KEY`). It is optional and defaults to `default`; `COMET_WORKSPACE` stays as a deprecated backward-compat alias (`OPIK_WORKSPACE` wins if both are set).

- `prompt_engineering/mcp-server.mdx`: "Before you start" description + all host setup snippets (Claude Code, Cursor, VS Code Copilot, MCP Inspector) now use `OPIK_WORKSPACE`.
- Adds an explicit tip that `OPIK_WORKSPACE` is optional and can be omitted (the server defaults to `default`); set it only for a named cloud workspace.
- No other docs reference the opik-mcp workspace env var (the legacy v1 JS-server page uses `--apiKey` CLI flags).

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6783
- Companion code PR: comet-ml/opik-mcp#141

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Documentation-only update mirroring the `OPIK_WORKSPACE` env-var change in comet-ml/opik-mcp#141 (one `.mdx` file).
- Human verification: author reviewed the rendered diff; the documented behavior was verified end-to-end against the running opik-mcp server in the companion PR.

## Testing

Docs-only change (single `.mdx` file), so no code/tests in this PR. Verified:
- `grep` confirms every opik-mcp workspace env reference on the page now uses `OPIK_WORKSPACE`; only the intentional deprecated-alias mention of `COMET_WORKSPACE` remains.
- The behavior being documented (OPIK_WORKSPACE primary / optional / defaults to `default`, COMET_WORKSPACE alias) was verified end-to-end against the running opik-mcp server in comet-ml/opik-mcp#141 (initialize handshake + a real tool call; all four env permutations resolved as documented).

## Documentation

This PR **is** the documentation update — `apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/mcp-server.mdx`.


[OPIK-6783]: https://comet-ml.atlassian.net/browse/OPIK-6783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ