### PR TITLE
[NA] [SDK] fix: bump retired vertex_ai/gemini-2.0-flash test model to 2.5-flash

### DIFF
--- a/sdks/python/tests/library_integration/openai/agents_tests/test_opik_tracing_processor.py
+++ b/sdks/python/tests/library_integration/openai/agents_tests/test_opik_tracing_processor.py
@@ -5,6 +5,7 @@ from agents import Agent, Runner, set_trace_processors, function_tool, trace
 import opik
 from opik.integrations.openai.agents import OpikTracingProcessor
 from ..constants import MODEL_FOR_TESTS, EXPECTED_OPENAI_USAGE_LOGGED_FORMAT
+from ....llm_constants import LITELLM_VERTEX_GEMINI_FLASH
 from ....testlib import (
     ANY_BUT_NONE,
     ANY_LIST,
@@ -899,7 +900,7 @@ def test_opik_tracing_processor__litellm_vertex_ai_model__provider_is_google_ver
 
     input_message = "Write a haiku about recursion in programming."
     project_name = "opik-test-openai-agents"
-    litellm_model_id = "vertex_ai/gemini-2.0-flash"
+    litellm_model_id = LITELLM_VERTEX_GEMINI_FLASH
 
     set_trace_processors(processors=[OpikTracingProcessor(project_name)])
 

--- a/sdks/python/tests/llm_constants.py
+++ b/sdks/python/tests/llm_constants.py
@@ -66,6 +66,8 @@ AISUITE_ANTHROPIC_CLAUDE_SONNET = f"anthropic:{ANTHROPIC_CLAUDE_SONNET}"
 # Current default: Gemini 2.5 Flash — cheap, fast, widely supported.
 GEMINI_FLASH = "gemini-2.5-flash"
 
+LITELLM_VERTEX_GEMINI_FLASH = f"vertex_ai/{GEMINI_FLASH}"
+
 # ---------------------------------------------------------------------------
 # AWS Bedrock
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Details

The `openai-agents` integration suite's Vertex AI provider-inference test (`test_opik_tracing_processor__litellm_vertex_ai_model__provider_is_google_vertexai`) hardcoded `vertex_ai/gemini-2.0-flash`, which Google has retired from the test GCP project. The call now returns a 404 `NotFoundError`, failing the OpenAI tests CI job (all other OpenAI tests pass — this is the only failure, and it is a Vertex model-retirement issue, not an OpenAI/dependency version regression).

This routes the test through the centralized `GEMINI_FLASH` (`gemini-2.5-flash`) constant — the version the rest of the suite already uses — via a new `LITELLM_VERTEX_GEMINI_FLASH` entry, so future model bumps remain a one-line change.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- N/A (CI test fix, no ticket)

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: full implementation
  - Human verification: code review

## Testing

- Verified the new constant resolves: `vertex_ai/gemini-2.5-flash`
- Verified the test file parses (`ast.parse`) and the relative import resolves
- The integration test itself requires GCP/Vertex credentials and makes a live model call, so it runs in CI (SDK Lib OpenAI Tests workflow) rather than locally

## Documentation

N/A
