### PR TITLE
[OPIK-6781] Fix level enum typo (WARM→WARN) on automation_rule_evaluator_logs

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000086_fix_automation_rule_evaluator_logs_level_enum.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000086_fix_automation_rule_evaluator_logs_level_enum.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+--changeset yarivhashai:000086_fix_automation_rule_evaluator_logs_level_enum
+--comment: Fix level enum typo 'WARM' -> 'WARN' on automation_rule_evaluator_logs (OPIK-6781). The column was created in 000010/000017 as Enum8(...,'WARM'=3,...) but the application emits 'WARN', so every WARN-level log insert was rejected (UNKNOWN_ELEMENT_OF_ENUM / async-insert parse failures). Renaming the label for value 3 is a metadata-only change; the on-disk Int8 representation and all existing values are preserved.
+
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.automation_rule_evaluator_logs ON CLUSTER '{cluster}'
+    MODIFY COLUMN level Enum8('TRACE' = 0, 'DEBUG' = 1, 'INFO' = 2, 'WARN' = 3, 'ERROR' = 4);
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.automation_rule_evaluator_logs ON CLUSTER '{cluster}' MODIFY COLUMN level Enum8('TRACE' = 0, 'DEBUG' = 1, 'INFO' = 2, 'WARM' = 3, 'ERROR' = 4);

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000087_fix_automation_rule_evaluator_logs_level_enum.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000087_fix_automation_rule_evaluator_logs_level_enum.sql
@@ -1,5 +1,5 @@
 --liquibase formatted sql
---changeset yarivhashai:000086_fix_automation_rule_evaluator_logs_level_enum
+--changeset yarivhashai:000087_fix_automation_rule_evaluator_logs_level_enum
 --comment: Fix level enum typo 'WARM' -> 'WARN' on automation_rule_evaluator_logs (OPIK-6781). The column was created in 000010/000017 as Enum8(...,'WARM'=3,...) but the application emits 'WARN', so every WARN-level log insert was rejected (UNKNOWN_ELEMENT_OF_ENUM / async-insert parse failures). Renaming the label for value 3 is a metadata-only change; the on-disk Int8 representation and all existing values are preserved.
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.automation_rule_evaluator_logs ON CLUSTER '{cluster}'


### PR DESCRIPTION
## Details

Fixes a typo in the `level` enum of the `automation_rule_evaluator_logs` ClickHouse table: it was created (migration `000010`, carried into `000017`) as `Enum8('TRACE'=0,'DEBUG'=1,'INFO'=2,'WARM'=3,'ERROR'=4)`, but the application emits `'WARN'` (`LogItem.LogLevel.WARN`), so every WARN-level log insert was rejected. A forward migration renames the value-3 label `WARM`→`WARN` via `ALTER TABLE ... MODIFY COLUMN` (metadata-only — preserves the on-disk Int8 representation and all existing values; no data rewrite).

- This single typo is the root cause of **all three** errors reported in OPIK-6781: `691 UNKNOWN_ELEMENT_OF_ENUM`, `27 CANNOT_PARSE_INPUT_ASSERTION_FAILED`, and `43 ILLEGAL_TYPE_OF_ARGUMENT (now64)`.
- The 27/43 are **not** a separate "malformed INSERT" bug — they're how ClickHouse's async-insert / `Values` parser surfaces the rejected enum (it wraps each column in `if(isNull(dummy), defaultValueOfTypeName(...), value)`; the bad `'WARN'` fails the whole row parse). Verified in prod: 641/641 recent async-insert failures for this table are enum-related, 0 are a standalone `now64`/parse error.
- No application code change needed — the code already emits/expects `WARN`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6781

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Root-cause analysis (read-only prod ClickHouse investigation) and the migration fix; authored `000086` and the validation. No application code modified.
  - Human verification: Reproduced the exact prod error and the fix at the SQL level; reviewed the migration and ran the integration test below.

## Testing

- **SQL-level (ClickHouse 25.3, `clickhouse-local`):** inserting `'WARN'` into the old `WARM` enum fails with the exact prod error (`691 ... Unknown element 'WARN', maybe you meant: ['WARM']`); after `ALTER TABLE ... MODIFY COLUMN level Enum8(...,'WARN'=3,...)` the `WARN` insert succeeds, and `INFO`/`ERROR` are unaffected.
- **Integration:** `mvn test -Dtest=OnlineScoringEngineTest` — green. Confirms migration `000086` applies cleanly on a fresh ClickHouse (Testcontainers runs all Liquibase migrations at startup) and the rule-logs write/read path works.
- **Prod (read-only) scope check:** `system.asynchronous_insert_log` over 24h shows the only failing async inserts are this table, all enum-related (641/641) — confirming the fix covers all three error codes with no residual `now64` source.

## Documentation

N/A — internal ClickHouse schema fix; no user-facing API/UI or docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)