### PR TITLE
[OPIK-6781] [BE] Make enum-fix migration rollback empty

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000087_fix_automation_rule_evaluator_logs_level_enum.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000087_fix_automation_rule_evaluator_logs_level_enum.sql
@@ -5,4 +5,4 @@
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.automation_rule_evaluator_logs ON CLUSTER '{cluster}'
     MODIFY COLUMN level Enum8('TRACE' = 0, 'DEBUG' = 1, 'INFO' = 2, 'WARN' = 3, 'ERROR' = 4);
 
---rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.automation_rule_evaluator_logs ON CLUSTER '{cluster}' MODIFY COLUMN level Enum8('TRACE' = 0, 'DEBUG' = 1, 'INFO' = 2, 'WARM' = 3, 'ERROR' = 4);
+--rollback empty


### PR DESCRIPTION
## Details

Follow-up to #6962 (already merged) addressing @andrescrz's review feedback.

The migration `000087_fix_automation_rule_evaluator_logs_level_enum.sql` shipped with a rollback that reverted the `level` enum from `WARN` back to `WARM`. That rollback is wrong on two counts:

1. **It reintroduces the exact typo** the migration was created to fix.
2. **Enum changes can't be safely rolled back** once new data is inserted under the new label — these expansion/rename statements shouldn't have a rollback at all.

This PR replaces the rollback with `--rollback empty`, matching the established pattern for enum changes (e.g. `000029_add_thread_enum_value_to_feedback_scores.sql`).

```sql
ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.automation_rule_evaluator_logs ON CLUSTER '{cluster}'
    MODIFY COLUMN level Enum8('TRACE' = 0, 'DEBUG' = 1, 'INFO' = 2, 'WARN' = 3, 'ERROR' = 4);

--rollback empty
```

> ⚠️ Note: this edits an already-merged changeset, so its Liquibase checksum changes. Fine if 000087 hasn't been applied to long-lived environments yet; otherwise a `clearCheckSums` / `validCheckSum` may be needed on deploy.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6781

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: One-line migration rollback change addressing review feedback.
  - Human verification: Verified the rollback line and confirmed the `--rollback empty` convention against existing enum migrations.

## Testing

N/A — single-line change to a migration rollback directive; the forward migration and its integration coverage are unchanged from #6962.

## Documentation

N/A — internal ClickHouse migration rollback fix; no user-facing API/UI or docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)