### PR TITLE
[OPIK-6781] [DOCS] Migration rule: empty rollback for in-place column changes

### DIFF
--- a/.agents/skills/opik-backend/migrations.md
+++ b/.agents/skills/opik-backend/migrations.md
@@ -63,6 +63,28 @@ ORDER BY (workspace_id, event_type, id);
 
 ```
 
+## Rollback: Additive vs In-Place Changes
+
+The kind of change decides whether a rollback is allowed:
+
+- **Additive / structural changes → provide a rollback** that undoes them (new table → `DROP TABLE`, new column → `DROP COLUMN`, new index → `DROP INDEX`). Dropping what was just added is safe.
+- **In-place changes to an existing column → rollback MUST be empty (`--rollback empty`)**: enum modify/rename, type or precision changes, default/codec changes. Reverting them (1) often reintroduces the bug the migration fixed, and (2) is lossy or fails once new data is written under the new definition — they are effectively irreversible.
+
+```sql
+-- ✅ Additive change → real rollback
+ALTER TABLE events ON CLUSTER '{cluster}' ADD COLUMN IF NOT EXISTS source String DEFAULT '';
+--rollback ALTER TABLE events ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS source;
+
+-- ✅ In-place enum change → empty rollback
+ALTER TABLE events ON CLUSTER '{cluster}' MODIFY COLUMN level Enum8('TRACE' = 0, 'INFO' = 2, 'WARN' = 3, 'ERROR' = 4);
+--rollback empty
+
+-- ❌ In-place enum change → reverting reintroduces the old (buggy) label and breaks rows already written
+--rollback ALTER TABLE events ON CLUSTER '{cluster}' MODIFY COLUMN level Enum8('TRACE' = 0, 'INFO' = 2, 'WARM' = 3, 'ERROR' = 4);
+```
+
+Always declare an intentionally empty rollback explicitly as `--rollback empty` (see `000029_add_thread_enum_value_to_feedback_scores.sql`) — never just omit it.
+
 ## Rollback Dependency Order
 
 Rollback statements run in the order they appear. When columns have dependencies (e.g. a `MATERIALIZED` column that references another column), **drop dependent columns first** — the reverse of creation order.


### PR DESCRIPTION
## Details

Codifies the migration-rollback convention surfaced while fixing #6962 / #6965. The high-level rule: the *kind* of change decides whether a rollback is allowed.

- **Additive / structural changes** (new table, new column, new index) → provide a real rollback that drops what was added (safe to reverse).
- **In-place changes to an existing column** (enum modify/rename, type/precision changes, default/codec changes) → rollback **must be empty** (`--rollback empty`). Reverting them (1) reintroduces the bug the migration fixed and (2) is lossy or fails once new data is written under the new definition — they are effectively irreversible.

Updates the version-controlled backend migration skill (`.agents/skills/opik-backend/migrations.md`) with a new "Rollback: Additive vs In-Place Changes" section, alongside the existing rollback-ordering guidance.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-6781

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Documentation-only change to the backend migration skill.
  - Human verification: Reviewed against the real cases (#6962/#6965 enum fix) and the existing `000029` empty-rollback precedent.

## Testing

N/A — documentation-only change (migration authoring guidance). No code or schema affected.

## Documentation

This PR *is* the documentation change: adds the additive-vs-in-place rollback rule to `.agents/skills/opik-backend/migrations.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)