### PR TITLE
[NA] [INFRA] ci: add Scout feedback-sync workflow

### DIFF
--- a/.github/workflows/scout-feedback.yml
+++ b/.github/workflows/scout-feedback.yml
@@ -1,0 +1,37 @@
+name: Scout Feedback Sync
+
+on:
+  # GitHub emits no event for comment reactions, so poll on a schedule.
+  schedule:
+    - cron: '*/30 * * * *'  # every 30 minutes
+  # Allow manual runs (and an optional wider scan window for backfills).
+  workflow_dispatch:
+    inputs:
+      since_days:
+        description: How many days back to scan issues for reactions
+        required: false
+        default: '7'
+        type: string
+
+# Don't let overlapping syncs double up.
+concurrency:
+  group: scout-feedback-sync
+  cancel-in-progress: false
+
+jobs:
+  sync-feedback:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      issues: read
+      contents: read
+
+    steps:
+      - name: Sync reactions to Opik
+        uses: comet-ml/scout-repo-agent/actions/feedback@main
+        with:
+          github_token: ${{ github.token }}
+          since_days: ${{ github.event.inputs.since_days || '7' }}
+        env:
+          OPIK_API_KEY: ${{ secrets.SCOUT_OPIK_API_KEY }}
+          OPIK_WORKSPACE: ${{ vars.SCOUT_OPIK_WORKSPACE }}

--- a/.github/workflows/scout-feedback.yml
+++ b/.github/workflows/scout-feedback.yml
@@ -3,7 +3,7 @@ name: Scout Feedback Sync
 on:
   # GitHub emits no event for comment reactions, so poll on a schedule.
   schedule:
-    - cron: '*/30 * * * *'  # every 30 minutes
+    - cron: '0 * * * *'  # hourly
   # Allow manual runs (and an optional wider scan window for backfills).
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Details

Adds a scheduled workflow that syncs 👍/👎 reactions on Scout's issue comments to Opik as `user_feedback` scores (every 30 min, plus manual `workflow_dispatch` with an adjustable scan window). It uses the new reusable `feedback` action published from `comet-ml/scout-repo-agent` (`actions/feedback`), so there is no checkout/pip here — just `uses:` + the same Scout credentials already configured for the triage workflow (`scout.yml`).
- Reads `secrets.SCOUT_OPIK_API_KEY` and `vars.SCOUT_OPIK_WORKSPACE` — identical naming to the existing `scout.yml`, so no new repo config is required.
- Depends on comet-ml/scout-repo-agent#26 (which publishes the `actions/feedback` action).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Authored `.github/workflows/scout-feedback.yml` in full.
- Human verification: Confirmed the workflow mirrors the equivalent scout-test-repo PR (comet-ml/scout-test-repo#35) and matches opik's existing `scout.yml` secret/variable names; confirmed the `actions/feedback` action it references is the one added in comet-ml/scout-repo-agent#26.

## Testing

- Validated the workflow YAML parses.
- Cross-checked secret/variable references against `.github/workflows/scout.yml` (`SCOUT_OPIK_API_KEY` secret, `SCOUT_OPIK_WORKSPACE` variable) — both already exist in this repo.
- Not run end-to-end: the referenced `comet-ml/scout-repo-agent/actions/feedback@main` action does not exist until comet-ml/scout-repo-agent#26 merges. Once it does, a manual `workflow_dispatch` run will exercise it.

## Documentation

n/a — internal CI workflow.