### PR TITLE
[OPIK-6779] [BE] [DOCS] feat: default Opik V2 for open source

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1071,14 +1071,14 @@ serviceToggles:
   # Use case: customer-driven V1 stickiness — pin specific workspaces to legacy navigation without affecting the rest of the deployment.
   # Operational impact: empty/missing means no allowlisting. Non-allowlisted workspaces are unaffected.
   v1WorkspaceAllowlist: ${TOGGLE_V1_WORKSPACE_ALLOWLIST:-""}
-  # Default: disabled
+  # Default: version_2
   # Description: Forces ALL workspaces to a specific navigation version.
   # Valid values: "disabled" (use version 1 entity check), "version_1" (force legacy), "version_2" (force project-first).
   # Scope: Global — applies to all workspaces regardless of their entity state.
   # Priority: Third — overridden by v2WorkspaceAllowlist and v1WorkspaceAllowlist for listed workspaces.
   # Overrides: When not "disabled", overrides the version entity check and auth gate entirely.
-  # Operational impact: Default is "disabled" (entity-based determination). Override to "version_1" or "version_2" if global enforcement is needed.
-  forceWorkspaceVersion: ${TOGGLE_FORCE_WORKSPACE_VERSION:-"disabled"}
+  # Operational impact: Default is "version_2". Override to "disabled" (entity-based determination) or "version_1" if global enforcement is needed.
+  forceWorkspaceVersion: ${TOGGLE_FORCE_WORKSPACE_VERSION:-"version_2"}
   # Default: 100
   # Description: Deployment-level default rows-per-page for UI tables (experiments v1/v2).
   #              Lower this value to reduce initial render cost for high-volume workspaces.

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/OpikVersion.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/OpikVersion.java
@@ -24,6 +24,15 @@ public enum OpikVersion {
      */
     public static final String UNKNOWN = "unknown";
 
+    /**
+     * Sentinel value for the {@code TOGGLE_FORCE_WORKSPACE_VERSION} feature flag meaning "no global force";
+     * version determination falls through to the auth gate and the entity check. (Workspace allowlists are
+     * evaluated before this flag and are unaffected by it.) Declared here as a {@code String} (not an enum
+     * constant) because it is a toggle-config marker, not a workspace version, and must never serialize on
+     * the {@code OpikVersion} public API.
+     */
+    public static final String DISABLED = "disabled";
+
     @JsonValue
     private final String value;
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static com.comet.opik.infrastructure.ServiceTogglesConfig.FORCE_WORKSPACE_VERSION_DISABLED;
+import static com.comet.opik.api.OpikVersion.DISABLED;
 import static com.comet.opik.infrastructure.auth.RequestContext.SYSTEM_USER;
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
 
@@ -44,9 +44,12 @@ import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONL
  * <ol>
  *   <li><b>V2 workspace allowlist</b> ({@code TOGGLE_V2_WORKSPACE_ALLOWLIST}) — comma-separated workspace IDs
  *       that always receive {@code version_2}. Highest priority, all deployment modes.</li>
+ *   <li><b>V1 workspace allowlist</b> ({@code TOGGLE_V1_WORKSPACE_ALLOWLIST}) — comma-separated workspace IDs
+ *       that always receive {@code version_1}. Overridden by the V2 allowlist; overrides the force flag and
+ *       all subsequent steps. Defensive rollback layer for customers pinned to legacy navigation.</li>
  *   <li><b>Feature flag override</b> ({@code TOGGLE_FORCE_WORKSPACE_VERSION}) — if set to a valid
  *       {@link OpikVersion} value ({@code "version_1"} or {@code "version_2"}), that version is returned
- *       unconditionally. Value {@code "disabled"} means no override.</li>
+ *       unconditionally. Value {@code "disabled"} means no override. Defaults to {@code "version_2"}.</li>
  *   <li><b>Auth one-way V2 gate</b> (authenticated mode only) — if auth metadata indicates the workspace
  *       was created post-launch ({@code version_2}), always return {@code version_2}.
  *       Prevents V2 to V1 demotion. Defensive: gracefully degrades when auth service doesn't
@@ -281,12 +284,13 @@ abstract class AbstractWorkspaceVersionService implements WorkspaceVersionServic
 
     private Optional<OpikVersion> getForcedVersion() {
         var forced = serviceTogglesConfig.getForceWorkspaceVersion();
-        if (StringUtils.isBlank(forced) || FORCE_WORKSPACE_VERSION_DISABLED.equalsIgnoreCase(forced)) {
+        if (DISABLED.equalsIgnoreCase(forced)) {
             return Optional.empty();
         }
         var version = OpikVersion.findByValue(forced);
         if (version.isEmpty()) {
-            log.warn("Invalid forceWorkspaceVersion config value: '{}', ignoring", forced);
+            log.warn("Invalid forceWorkspaceVersion config value: '{}', defaulting to version_2", forced);
+            return Optional.of(OpikVersion.VERSION_2);
         }
         return version;
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
@@ -18,8 +18,6 @@ import java.util.stream.Collectors;
 @Data
 public class ServiceTogglesConfig {
 
-    public static final String FORCE_WORKSPACE_VERSION_DISABLED = "disabled";
-
     @Valid @JsonProperty
     @NotNull boolean pythonEvaluatorEnabled;
     @JsonProperty
@@ -92,7 +90,7 @@ public class ServiceTogglesConfig {
                 .orElse(Set.of());
     }
 
-    @NotBlank String forceWorkspaceVersion = FORCE_WORKSPACE_VERSION_DISABLED;
+    @NotBlank String forceWorkspaceVersion;
 
     @JsonProperty
     @Min(5) @Max(100) int defaultPageSize;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
@@ -43,7 +43,6 @@ import com.comet.opik.api.resources.utils.resources.ProjectMetricsResourceClient
 import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
 import com.comet.opik.api.resources.utils.resources.SpanResourceClient;
 import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
-import com.comet.opik.api.resources.utils.resources.WorkspaceResourceClient;
 import com.comet.opik.api.resources.utils.spans.SpanAssertions;
 import com.comet.opik.api.resources.utils.traces.TraceAssertions;
 import com.comet.opik.domain.EntityType;
@@ -132,7 +131,6 @@ class MultiValueFeedbackScoresE2ETest {
     private DatasetResourceClient datasetResourceClient;
     private OptimizationResourceClient optimizationResourceClient;
     private ProjectMetricsResourceClient projectMetricsResourceClient;
-    private WorkspaceResourceClient workspaceResourceClient;
     private FeedbackScoreDAO feedbackScoreDAO;
 
     @BeforeAll
@@ -150,7 +148,6 @@ class MultiValueFeedbackScoresE2ETest {
         this.datasetResourceClient = new DatasetResourceClient(client, baseURI);
         this.optimizationResourceClient = new OptimizationResourceClient(client, baseURI, factory);
         this.projectMetricsResourceClient = new ProjectMetricsResourceClient(client, baseURI);
-        this.workspaceResourceClient = new WorkspaceResourceClient(client, baseURI, factory);
         this.feedbackScoreDAO = feedbackScoreDAO;
     }
 
@@ -988,10 +985,6 @@ class MultiValueFeedbackScoresE2ETest {
                         .put(RequestContext.WORKSPACE_ID, workspaceId))
                 .block();
 
-        // Trigger the natural workspace-version determination flow so the legacy-scores probe
-        // runs against actual ClickHouse state and the workspace flag is set accordingly.
-        workspaceResourceClient.getWorkspaceVersion(apiKey, workspaceName);
-
         var expected = traceResourceClient.getById(traceId, workspaceName, apiKey).toBuilder()
                 .feedbackScores(List.of(
                         FeedbackScore.builder().name(authoredScore.name()).value(authoredScore.value()).build(),
@@ -1033,8 +1026,6 @@ class MultiValueFeedbackScoresE2ETest {
                         .put(RequestContext.USER_NAME, USER1)
                         .put(RequestContext.WORKSPACE_ID, workspaceId))
                 .block();
-
-        workspaceResourceClient.getWorkspaceVersion(apiKey, workspaceName);
 
         var expected = spanResourceClient.getById(spanId, workspaceName, apiKey).toBuilder()
                 .feedbackScores(List.of(

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -41,7 +41,6 @@ import com.comet.opik.api.resources.utils.resources.GuardrailsResourceClient;
 import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
 import com.comet.opik.api.resources.utils.resources.SpanResourceClient;
 import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
-import com.comet.opik.api.resources.utils.resources.WorkspaceResourceClient;
 import com.comet.opik.api.sorting.Direction;
 import com.comet.opik.api.sorting.SortableFields;
 import com.comet.opik.api.sorting.SortingField;
@@ -193,7 +192,6 @@ class ProjectsResourceTest {
     private ProjectResourceClient projectResourceClient;
     private GuardrailsResourceClient guardrailsResourceClient;
     private GuardrailsGenerator guardrailsGenerator;
-    private WorkspaceResourceClient workspaceResourceClient;
 
     @BeforeAll
     void setUpAll(ClientSupport client, ProjectService projectService) {
@@ -211,7 +209,6 @@ class ProjectsResourceTest {
         this.projectResourceClient = new ProjectResourceClient(this.client, baseURI, factory);
         this.guardrailsResourceClient = new GuardrailsResourceClient(this.client, baseURI);
         this.guardrailsGenerator = new GuardrailsGenerator();
-        this.workspaceResourceClient = new WorkspaceResourceClient(this.client, baseURI, factory);
     }
 
     private void mockTargetWorkspace(String apiKey, String workspaceName, String workspaceId) {
@@ -1462,10 +1459,6 @@ class ProjectsResourceTest {
                             .put(RequestContext.USER_NAME, USER)
                             .put(RequestContext.WORKSPACE_ID, workspaceId))
                     .block();
-
-            // Trigger the natural workspace-version determination flow so the legacy-scores
-            // probe runs against actual ClickHouse state and persists the workspace flag.
-            workspaceResourceClient.getWorkspaceVersion(apiKey, workspaceName);
 
             var expectedFeedback = new ArrayList<>(seeded.feedbackScores());
             expectedFeedback.add(FeedbackScoreAverage.builder()

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/WorkspaceVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/WorkspaceVersionResourceTest.java
@@ -403,7 +403,9 @@ class WorkspaceVersionResourceTest {
                             .runtimeInfo(wireMock.runtimeInfo())
                             .usageReportUrl("%s%s".formatted(wireMock.runtimeInfo().getHttpBaseUrl(), ANALYTICS_PATH))
                             .usageReportEnabled(true)
-                            .customConfigs(List.of(new CustomConfig("analytics.enabled", "true")))
+                            .customConfigs(List.of(
+                                    new CustomConfig("serviceToggles.forceWorkspaceVersion", "disabled"),
+                                    new CustomConfig("analytics.enabled", "true")))
                             .build());
         }
 
@@ -638,6 +640,7 @@ class WorkspaceVersionResourceTest {
                             .databaseAnalyticsFactory(databaseAnalyticsFactory)
                             .redisUrl(REDIS.getRedisURI())
                             .customConfigs(List.of(
+                                    new CustomConfig("serviceToggles.forceWorkspaceVersion", "disabled"),
                                     new CustomConfig("cacheManager.enabled", "true"),
                                     new CustomConfig("cacheManager.caches.workspace_version", "PT1S")))
                             .build());

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetProjectMigrationJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetProjectMigrationJobTest.java
@@ -90,6 +90,9 @@ class DatasetProjectMigrationJobTest {
                         .runtimeInfo(wireMock.runtimeInfo())
                         .redisUrl(REDIS.getRedisURI())
                         .customConfigs(List.of(
+                                // Entity-based determination required so the migration's V1 -> V2 transition
+                                // is observable.
+                                new CustomConfig("serviceToggles.forceWorkspaceVersion", "disabled"),
                                 new CustomConfig("datasetProjectMigration.enabled", "true"),
                                 // Cache enabled with the production TTL so only the migration's
                                 // evictCache can flip a cached V1 to V2 within the test windows.

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetProjectMigrationServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetProjectMigrationServiceTest.java
@@ -90,6 +90,9 @@ class DatasetProjectMigrationServiceTest {
                         .runtimeInfo(wireMock.runtimeInfo())
                         .redisUrl(REDIS.getRedisURI())
                         .customConfigs(List.of(
+                                // Entity-based determination required so the migration's V1 -> V2 transition
+                                // is observable.
+                                new CustomConfig("serviceToggles.forceWorkspaceVersion", "disabled"),
                                 new CustomConfig("migration.excludedWorkspaceIds",
                                         "%s,%s".formatted(EXCLUDED_WORKSPACE_ID_1, EXCLUDED_WORKSPACE_ID_2)),
                                 // Cache enabled with the production TTL so only the migration's

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentProjectMigrationJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentProjectMigrationJobTest.java
@@ -85,6 +85,9 @@ class ExperimentProjectMigrationJobTest {
                         .runtimeInfo(wireMock.runtimeInfo())
                         .redisUrl(REDIS.getRedisURI())
                         .customConfigs(List.of(
+                                // Entity-based determination required so the migration's V1 -> V2 transition
+                                // is observable.
+                                new CustomConfig("serviceToggles.forceWorkspaceVersion", "disabled"),
                                 new CustomConfig("experimentProjectMigration.enabled", "true"),
                                 // Cache enabled with the production TTL so only the migration's
                                 // evictCache can flip a cached V1 to V2 within the test windows.

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentProjectMigrationServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentProjectMigrationServiceTest.java
@@ -87,6 +87,9 @@ class ExperimentProjectMigrationServiceTest {
                         .runtimeInfo(wireMock.runtimeInfo())
                         .redisUrl(REDIS.getRedisURI())
                         .customConfigs(List.of(
+                                // Entity-based determination required so the migration's V1 -> V2 transition
+                                // is observable.
+                                new CustomConfig("serviceToggles.forceWorkspaceVersion", "disabled"),
                                 new CustomConfig("migration.excludedWorkspaceIds",
                                         "%s,%s".formatted(EXCLUDED_WORKSPACE_ID_1, EXCLUDED_WORKSPACE_ID_2)),
                                 // Cache enabled with the production TTL so only the migration's

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OptimizationProjectMigrationServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OptimizationProjectMigrationServiceTest.java
@@ -91,6 +91,9 @@ class OptimizationProjectMigrationServiceTest {
                         .runtimeInfo(wireMock.runtimeInfo())
                         .redisUrl(REDIS.getRedisURI())
                         .customConfigs(List.of(
+                                // Entity-based determination required so the migration's V1 -> V2 transition
+                                // is observable.
+                                new CustomConfig("serviceToggles.forceWorkspaceVersion", "disabled"),
                                 new CustomConfig("migration.excludedWorkspaceIds", EXCLUDED_WORKSPACE_ID),
                                 // Cache enabled with the production TTL so only the migration's
                                 // evictCache can flip a cached V1 to V2 between assertions.

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -630,14 +630,14 @@ serviceToggles:
   # Use case: gradual V2 rollout — allowlist specific workspace IDs for V2 while the rest use entity-based determination.
   # Operational impact: empty/missing means no allowlisting. Non-allowlisted workspaces are unaffected.
   v2WorkspaceAllowlist: ""
-  # Default: disabled
+  # Default: version_2
   # Description: Forces ALL workspaces to a specific navigation version.
   # Valid values: "disabled" (use version 1 entity check), "version_1" (force legacy), "version_2" (force project-first).
   # Scope: Global — applies to all workspaces regardless of their entity state.
-  # Priority: Second highest — overridden by v2WorkspaceAllowlist for listed workspaces.
+  # Priority: Third — overridden by v2WorkspaceAllowlist and v1WorkspaceAllowlist for listed workspaces.
   # Overrides: When not "disabled", overrides the version entity check and auth gate entirely.
-  # Operational impact: Default is "disabled" (entity-based determination). Override to "version_1" or "version_2" if global enforcement is needed.
-  forceWorkspaceVersion: "disabled"
+  # Operational impact: Default is "version_2". Override to "disabled" (entity-based determination) or "version_1" if global enforcement is needed.
+  forceWorkspaceVersion: "version_2"
   # Default: 100
   # Description: Deployment-level default rows-per-page for UI tables (experiments v1/v2).
   #              Lower this value to reduce initial render cost for high-volume workspaces.

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/v1_to_v2_migration.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/v1_to_v2_migration.mdx
@@ -9,6 +9,10 @@ title: Migrating to Opik 2.0
 
 Opik 2.0 organizes everything around **projects**. Data created after upgrading is automatically project-scoped. Data created on Opik 1.x — datasets, prompts, experiments, optimizations, automation rules, and alerts — requires six background jobs to assign each item to the right project. This page walks you through running those jobs.
 
+<Warning>
+  **Upgrading from Opik 1.x with existing data?** Recent Opik images default `TOGGLE_FORCE_WORKSPACE_VERSION` to `version_2`, which loads the Opik 2.0 UI globally regardless of your existing entities. 1.x entities that have not yet been assigned to a project (no `project_id`) will not be visible in the 2.0 UI until you run the migration jobs below.
+</Warning>
+
 ## Before you start
 
 1. **Update to the latest Opik image.** All six migration jobs ship with the 2.0 release. Make sure your `opik-backend` is running the 2.0 image before enabling any flag.

--- a/apps/opik-documentation/documentation/fern/openapi/ai_examples_override.yml
+++ b/apps/opik-documentation/documentation/fern/openapi/ai_examples_override.yml
@@ -3609,7 +3609,7 @@ paths:
               customllmProviderEnabled: true
               ollamaProviderEnabled: false
               collaboratorsTabEnabled: true
-              forceWorkspaceVersion: disabled
+              forceWorkspaceVersion: version_2
   /v1/private/experiments/batch:
     patch:
       x-fern-examples:

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
       - clickhouse-config:/config
     command: |
       sh -c "
-        cp -r /clickhouse_config_files/* /config/ && 
+        cp -r /clickhouse_config_files/* /config/ &&
         chown -R 1000:1000 /config
       "
   clickhouse:
@@ -131,7 +131,7 @@ services:
       sleep 10s;
       /usr/bin/mc alias set s3 http://minio:9000 ${MINIO_ROOT_USER:-THAAIOSFODNN7EXAMPLE} ${MINIO_ROOT_PASSWORD:-LESlrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY} --api S3v4 ;
       /usr/bin/mc mb --ignore-existing s3/public;
-      /usr/bin/mc anonymous set download s3/public/;       
+      /usr/bin/mc anonymous set download s3/public/;
       "
 
   backend:
@@ -190,7 +190,7 @@ services:
       TOGGLE_GUARDRAILS_ENABLED: ${TOGGLE_GUARDRAILS_ENABLED:-"false"}
       TOGGLE_OPTIMIZATION_STUDIO_ENABLED: ${TOGGLE_OPTIMIZATION_STUDIO_ENABLED:-"false"}
       TOGGLE_WELCOME_WIZARD_ENABLED: ${TOGGLE_WELCOME_WIZARD_ENABLED:-"true"}
-      TOGGLE_FORCE_WORKSPACE_VERSION: ${TOGGLE_FORCE_WORKSPACE_VERSION:-"disabled"}
+      TOGGLE_FORCE_WORKSPACE_VERSION: ${TOGGLE_FORCE_WORKSPACE_VERSION:-"version_2"}
       LLM_MODEL_REGISTRY_DEFAULT_RESOURCE: ${LLM_MODEL_REGISTRY_DEFAULT_RESOURCE:-llm-models-default.yaml}
       LLM_MODEL_REGISTRY_LOCAL_OVERRIDE_PATH: ${LLM_MODEL_REGISTRY_LOCAL_OVERRIDE_PATH:-}
       LLM_MODEL_REGISTRY_REMOTE_ENABLED: ${LLM_MODEL_REGISTRY_REMOTE_ENABLED:-"false"}
@@ -356,7 +356,7 @@ services:
       OTEL_COLLECTOR_PORT: ${OTEL_COLLECTOR_PORT:-4317}
       # NGINX_EXTRA_ACCESS_LOG: access_log syslog:server=otel-collector:5140 logger-json;
       # NGINX_EXTRA_ERROR_LOG: error_log syslog:server=otel-collector:5140 error;
-      
+
   # Jaeger - receives traces via OTLP
   jaeger:
     image: jaegertracing/all-in-one:latest

--- a/scripts/dev-runner.ps1
+++ b/scripts/dev-runner.ps1
@@ -23,11 +23,12 @@ if ($env:DEBUG_MODE -eq "true") {
     $script:DEBUG_MODE = $true
 }
 
-# Force-v2 workspace gate for local dev so a fresh worktree's empty backend
-# doesn't trip the "Workspace upgrade required" pairing screen. Propagated
-# into both the JAR-mode backend and the docker-compose backend (see
-# docker-compose.yaml `TOGGLE_FORCE_WORKSPACE_VERSION`). Override by setting
-# `$env:TOGGLE_FORCE_WORKSPACE_VERSION = "disabled"` before invoking.
+# Local dev defaults to version_2 (matches the bundled config.yml and
+# docker-compose defaults) so a fresh worktree's empty backend doesn't trip
+# the "Workspace upgrade required" pairing screen. Exported here so the
+# JAR-mode backend and docker-compose backend inherit the same value.
+# Override by setting `$env:TOGGLE_FORCE_WORKSPACE_VERSION = "disabled"`
+# before invoking.
 if (-not $env:TOGGLE_FORCE_WORKSPACE_VERSION) {
     $env:TOGGLE_FORCE_WORKSPACE_VERSION = "version_2"
 }

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -8,10 +8,10 @@ set -euo pipefail
 DEBUG_MODE=${DEBUG_MODE:-false}
 ORIGINAL_COMMAND="$0 $@"
 
-# Force-v2 workspace gate for local dev so a fresh worktree's empty backend
-# doesn't trip the "Workspace upgrade required" pairing screen. Propagated
-# into both the JAR-mode backend (start_backend) and the docker-compose
-# backend (see docker-compose.yaml `TOGGLE_FORCE_WORKSPACE_VERSION`).
+# Local dev defaults to version_2 (matches the bundled config.yml and
+# docker-compose defaults) so a fresh worktree's empty backend doesn't trip
+# the "Workspace upgrade required" pairing screen. Exported here so the
+# JAR-mode backend (start_backend) inherits the same value as docker-compose.
 # Override by exporting TOGGLE_FORCE_WORKSPACE_VERSION=disabled (or
 # version_1) before invoking the script.
 export TOGGLE_FORCE_WORKSPACE_VERSION="${TOGGLE_FORCE_WORKSPACE_VERSION:-version_2}"


### PR DESCRIPTION
## Details

Make Opik V2 the global default for open-source and self-hosted deployments by flipping `TOGGLE_FORCE_WORKSPACE_VERSION` from `"disabled"` to `"version_2"` in `apps/opik-backend/config.yml`, the bundled `docker-compose.yaml`, the dev-runner scripts, and `config-test.yml`. This is the in-repo follow-up to the SaaS rollout finalised under OPIK-6779.

- Backend: removed `ServiceTogglesConfig.FORCE_WORKSPACE_VERSION_DISABLED`, introduced `OpikVersion.DISABLED` as the toggle sentinel co-located with `findByValue`, tightened `WorkspaceVersionService#getForcedVersion()` (defensive `VERSION_2` fallback on unrecognized values), and updated the class-level Javadoc to include the V1 workspace allowlist in the priority order and document the new default.
- Self-host docs: added a `<Warning>` callout to the V1→V2 migration guide so upgraders with V1 entities know the navigation now defaults to V2 globally.
- Tests: pinned the five project-migration suites (Dataset/Experiment/Optimization × Service + Dataset/Experiment × Job) to entity-based determination via an explicit `serviceToggles.forceWorkspaceVersion=disabled` override so their V1→V2 transition assertions remain observable. Removed the now-redundant `getWorkspaceVersion` probe-trigger from two legacy-scores tests (`MultiValueFeedbackScoresE2ETest`, `ProjectsResourceTest`) — those tests rely on `WorkspacesService.hasLegacyScores().orElse(true)`, which is the documented production safety net, so the probe-via-version-determination coupling was never necessary.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6779

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: assisted (review iterations, test fixes, doc polishing)
- Human verification: multi-pass code review + targeted `mvn test` runs on every impacted suite

## Testing

Verified locally with `mvn test` on every test class that touches workspace-version semantics:

- `WorkspaceVersionResourceTest` — 18 tests across 6 nested classes (V2/V1 allowlist, ForceV1/V2, Entity, Cache)
- 5 migration suites — 38 tests total: `DatasetProjectMigrationServiceTest` (13), `DatasetProjectMigrationJobTest` (1), `ExperimentProjectMigrationServiceTest` (10), `ExperimentProjectMigrationJobTest` (1), `OptimizationProjectMigrationServiceTest` (13)
- 3 legacy-scores tests — `MultiValueFeedbackScoresE2ETest#testTraceStats_/#testSpanStats_legacyFeedbackScoresSurfacedWhenPresent`, `ProjectsResourceTest$FindProject#getProjects__whenLegacyScoresHasData__thenStatsIncludeThem`

All 59 tests pass. `mvn compile` and `mvn test-compile` clean. Remaining quality checks left to CI.

## Documentation

- `apps/opik-documentation/documentation/fern/docs-v2/self-host/v1_to_v2_migration.mdx` — added `<Warning>` callout for upgraders with V1 entities.
- `apps/opik-backend/config.yml` and `apps/opik-backend/src/test/resources/config-test.yml` — comment blocks (header `# Default:`, body operational-impact, priority order) updated to match new default.
- `apps/opik-documentation/documentation/fern/openapi/ai_examples_override.yml` — OpenAPI example value updated.
- `apps/opik-backend/src/main/java/com/comet/opik/api/OpikVersion.java` — Javadoc on the new `DISABLED` constant.
- `apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceVersionService.java` — class Javadoc priority order updated to include V1 allowlist and note the new default.
- `scripts/dev-runner.sh` / `dev-runner.ps1` — comments rewritten now that v2 is the global default rather than a local-dev-only override.