### PR TITLE
[OPIK-6813] [BE] feat: add online-scoring LLM payload size metric

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -328,8 +328,13 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
      * pin the per-stream worker scheduler thread (OPIK-6308).
      */
     private Mono<ChatResponse> scoreTraceReactive(ChatRequest request, TraceToScoreLlmAsJudge message) {
-        return Mono.fromCallable(() -> aiProxyService.scoreTrace(
-                request, message.llmAsJudgeCode().model(), message.workspaceId()))
+        return Mono.fromCallable(() -> {
+            var response = aiProxyService.scoreTrace(
+                    request, message.llmAsJudgeCode().model(), message.workspaceId());
+            OnlineScoringLlmMetrics.record(message.workspaceId(), message.ruleId().toString(),
+                    Constants.LLM_AS_JUDGE, message.llmAsJudgeCode().model().name(), request, response);
+            return response;
+        })
                 .subscribeOn(Schedulers.boundedElastic());
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmMetrics.java
@@ -1,0 +1,118 @@
+package com.comet.opik.api.resources.v1.events;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.Meter;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Records the approximate payload size (in characters) of LLM-as-judge online-scoring calls.
+ * <p>
+ * This is the observability piece of OPIK-6813: during a high-volume scoring surge the backend heap
+ * fills with in-flight eval state (rendered prompt + LLM response), but there was previously no way to
+ * see how much memory an eval costs. These histograms let us size the in-flight memory budget for the
+ * consumption-bounding work and spot heavy eval workloads.
+ * <p>
+ * Recorded at the per-call site (inside the reactive {@code scoreTrace} wrapper), so agentic multi-turn
+ * tool loops are captured per round-trip, not just once per eval.
+ * <p>
+ * Metric attributes are intentionally limited to {@code evaluator_type} and {@code model} to stay well
+ * within the configured OTel metric cardinality limit. Per-workspace / per-rule attribution is emitted on
+ * the log line instead (queryable via Loki), since {@code rule_id} is unbounded and would explode metric
+ * cardinality.
+ */
+@UtilityClass
+@Slf4j
+public class OnlineScoringLlmMetrics {
+
+    private static final String METER_NAME = "opik.online_scoring";
+
+    private static final Meter METER = GlobalOpenTelemetry.getMeter(METER_NAME);
+
+    private static final LongHistogram INPUT_CHARS = METER.histogramBuilder("online_scoring_llm_input_chars")
+            .setDescription("Approx. characters in an LLM-as-judge request payload (proxy for heap held per eval)")
+            .setUnit("characters")
+            .ofLongs()
+            .build();
+
+    private static final LongHistogram OUTPUT_CHARS = METER.histogramBuilder("online_scoring_llm_output_chars")
+            .setDescription("Approx. characters in an LLM-as-judge response payload")
+            .setUnit("characters")
+            .ofLongs()
+            .build();
+
+    /**
+     * Records the request/response payload size for a single LLM-as-judge call. Best-effort: any failure to
+     * compute or record is swallowed so telemetry never breaks scoring.
+     */
+    public void record(
+            String workspaceId,
+            String ruleId,
+            String evaluatorType,
+            String model,
+            ChatRequest request,
+            ChatResponse response) {
+        try {
+            long in = approxChars(request);
+            long out = approxChars(response);
+
+            Attributes attributes = Attributes.builder()
+                    .put("evaluator_type", evaluatorType)
+                    .put("model", model)
+                    .build();
+
+            INPUT_CHARS.record(in, attributes);
+            OUTPUT_CHARS.record(out, attributes);
+
+            // Per-workspace / per-rule attribution lives on the log line (not the metric) to bound cardinality.
+            log.info(
+                    "Online scoring LLM payload: workspaceId='{}', ruleId='{}', type='{}', model='{}', inputChars={}, outputChars={}",
+                    workspaceId, ruleId, evaluatorType, model, in, out);
+        } catch (RuntimeException exception) {
+            log.debug("Failed to record online-scoring LLM payload metric", exception);
+        }
+    }
+
+    private long approxChars(ChatRequest request) {
+        if (request == null || request.messages() == null) {
+            return 0L;
+        }
+        long total = 0L;
+        for (ChatMessage message : request.messages()) {
+            total += textLength(message);
+        }
+        return total;
+    }
+
+    private long approxChars(ChatResponse response) {
+        if (response == null || response.aiMessage() == null || response.aiMessage().text() == null) {
+            return 0L;
+        }
+        return response.aiMessage().text().length();
+    }
+
+    private long textLength(ChatMessage message) {
+        return switch (message) {
+            case SystemMessage systemMessage -> systemMessage.text() == null ? 0L : systemMessage.text().length();
+            case AiMessage aiMessage -> aiMessage.text() == null ? 0L : aiMessage.text().length();
+            case UserMessage userMessage -> {
+                try {
+                    String text = userMessage.singleText();
+                    yield text == null ? 0L : text.length();
+                } catch (RuntimeException notSingleText) {
+                    // Multimodal / multi-part content: fall back to the rendered form length.
+                    yield String.valueOf(userMessage).length();
+                }
+            }
+            default -> message == null ? 0L : String.valueOf(message).length();
+        };
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
@@ -121,6 +121,8 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
 
             var score = aiProxyService.scoreTrace(
                     scoreRequest, message.llmAsJudgeCode().model(), message.workspaceId());
+            OnlineScoringLlmMetrics.record(message.workspaceId(), message.ruleId().toString(),
+                    Constants.SPAN_LLM_AS_JUDGE, message.llmAsJudgeCode().model().name(), scoreRequest, score);
             userFacingLogger.info("Received response for spanId '{}':\n\n{}", span.id(), score);
 
             var parsed = OnlineScoringEngine.toFeedbackScores(score);

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -400,8 +400,13 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
      * per-stream worker scheduler thread (OPIK-6308). Mirrors the trace scorer.
      */
     private Mono<ChatResponse> scoreTraceReactive(ChatRequest request, TraceThreadToScoreLlmAsJudge message) {
-        return Mono.fromCallable(() -> aiProxyService.scoreTrace(
-                request, message.code().model(), message.workspaceId()))
+        return Mono.fromCallable(() -> {
+            var response = aiProxyService.scoreTrace(
+                    request, message.code().model(), message.workspaceId());
+            OnlineScoringLlmMetrics.record(message.workspaceId(), message.ruleId().toString(),
+                    Constants.TRACE_THREAD_LLM_AS_JUDGE, message.code().model().name(), request, response);
+            return response;
+        })
                 .subscribeOn(Schedulers.boundedElastic());
     }
 


### PR DESCRIPTION
## Details

Adds an OTel metric for the approximate payload size (characters) of every LLM-as-judge online-scoring call, so we can size the in-flight memory budget for upcoming consumption-bounding work and spot heavy eval workloads. This is **C1**, the observability first-step of OPIK-6813 (the 2026-06-06 prod incident where a scoring surge filled the backend heap and there was no way to measure per-eval memory).

- New `OnlineScoringLlmMetrics` utility: histograms `online_scoring_llm_input_chars` / `online_scoring_llm_output_chars`.
- Recorded inside the reactive `scoreTrace` wrapper of each LLM-judge scorer (trace / span / trace-thread), so agentic `ToolCallLoop` multi-turn calls are captured per round-trip.
- Metric tags limited to `{evaluator_type, model}` to stay within the OTel cardinality limit; per-workspace / per-rule attribution is on the log line (queryable via Loki), since `rule_id` is unbounded.
- Best-effort: any failure to compute/record is swallowed so telemetry never breaks scoring.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6813

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Design and full implementation of the metric utility and scorer wiring; PR authored from an incident investigation.
  - Human verification: Author review of the diff; local `mvn compile` + `test-compile` verified green; full test suite via CI; behavioral validation of the emitted metric/log pending prod deploy.

## Testing
<!-- additive change: new static metric call + log line, no signature or behavior changes -->

- Exact commands run (local, `apps/opik-backend`):
  - `mvn -o compile -DskipTests` → BUILD SUCCESS
  - `mvn -o test-compile -DskipTests` → BUILD SUCCESS (confirms existing scorer tests still compile against the change)
- Scenarios validated: change is additive (records a metric + log after the existing `scoreTrace` call); no signatures or control flow changed, so existing scorer/engine tests are unaffected.
- Tests not run locally: full unit/integration suite (requires testcontainers/Docker) — deferred to CI.
- Environment: local JDK 21 (Corretto), offline Maven build.

## Documentation

N/A — internal telemetry. Metric names and tags are documented in the `OnlineScoringLlmMetrics` class javadoc.