### PR TITLE
[OPIK-6813] [BE] feat: add online-scoring eval payload-size metric

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -74,6 +74,7 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
     private final OpikConfiguration opikConfiguration;
     private final OnlineScoringConfig onlineScoringConfig;
     private final ServiceTogglesConfig serviceTogglesConfig;
+    private final OnlineScoringMetrics onlineScoringMetrics;
 
     @Inject
     public OnlineScoringLlmAsJudgeScorer(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
@@ -88,7 +89,8 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
             @NonNull ToolRegistry toolRegistry,
             @NonNull TraceCompressor traceCompressor,
             @NonNull WorkspaceNameService workspaceNameService,
-            @NonNull OpikConfiguration opikConfiguration) {
+            @NonNull OpikConfiguration opikConfiguration,
+            @NonNull OnlineScoringMetrics onlineScoringMetrics) {
         super(config, redisson, feedbackScoreService, traceService,
                 LLM_AS_JUDGE, Constants.LLM_AS_JUDGE);
         this.aiProxyService = aiProxyService;
@@ -102,6 +104,7 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
         this.opikConfiguration = opikConfiguration;
         this.onlineScoringConfig = config;
         this.serviceTogglesConfig = serviceTogglesConfig;
+        this.onlineScoringMetrics = onlineScoringMetrics;
     }
 
     /**
@@ -328,9 +331,13 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
      * pin the per-stream worker scheduler thread (OPIK-6308).
      */
     private Mono<ChatResponse> scoreTraceReactive(ChatRequest request, TraceToScoreLlmAsJudge message) {
-        return Mono.fromCallable(() -> aiProxyService.scoreTrace(
-                request, message.llmAsJudgeCode().model(), message.workspaceId()))
-                .subscribeOn(Schedulers.boundedElastic());
+        return Mono.fromCallable(() -> {
+            var response = aiProxyService.scoreTrace(
+                    request, message.llmAsJudgeCode().model(), message.workspaceId());
+            onlineScoringMetrics.recordPayloadSize(request, response, type,
+                    message.llmAsJudgeCode().model().name(), message.workspaceId(), message.ruleId());
+            return response;
+        }).subscribeOn(Schedulers.boundedElastic());
     }
 
     private static boolean shouldUseTools(TraceToScoreLlmAsJudge message) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringMetrics.java
@@ -1,0 +1,131 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongHistogram;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.UUID;
+
+/**
+ * Records the approximate character size of each online-scoring LLM round-trip so we can size the
+ * memory an evaluation holds while blocked on the provider (OPIK-6813) and spot heavy workloads.
+ * Stateful — owns the OTel instruments — so it is injected as a {@code @Singleton} rather than a
+ * static utility.
+ *
+ * <p>The histograms are tagged with {@code evaluator_type} and {@code model} only: {@code rule_id}
+ * and {@code workspace_id} are unbounded and would blow the prod metrics cardinality limit, so they
+ * are emitted on a log line instead (sizes only — never the rendered content).
+ */
+@Singleton
+@Slf4j
+public class OnlineScoringMetrics {
+
+    private static final String METER_NAME = "opik.online_scoring";
+    private static final AttributeKey<String> EVALUATOR_TYPE_KEY = AttributeKey.stringKey("evaluator_type");
+    private static final AttributeKey<String> MODEL_KEY = AttributeKey.stringKey("model");
+
+    private final LongHistogram inputChars;
+    private final LongHistogram outputChars;
+
+    @Inject
+    public OnlineScoringMetrics() {
+        var meter = GlobalOpenTelemetry.get().getMeter(METER_NAME);
+        this.inputChars = meter.histogramBuilder("online_scoring_llm_input_chars")
+                .ofLongs()
+                .setDescription("Approximate character count of the LLM-as-judge request messages per round-trip")
+                .setUnit("chars")
+                .build();
+        this.outputChars = meter.histogramBuilder("online_scoring_llm_output_chars")
+                .ofLongs()
+                .setDescription("Approximate character count of the LLM-as-judge response text per round-trip")
+                .setUnit("chars")
+                .build();
+    }
+
+    /**
+     * Records one LLM round-trip's input/output sizes. Called per provider call — including each
+     * agentic tool-loop round — so multi-turn evaluations are captured turn by turn.
+     */
+    public void recordPayloadSize(@NonNull ChatRequest request, @NonNull ChatResponse response,
+            @NonNull AutomationRuleEvaluatorType evaluatorType, @NonNull String model,
+            @NonNull String workspaceId, @NonNull UUID ruleId) {
+        long input = inputChars(request);
+        long output = outputChars(response);
+
+        var attributes = buildAttributes(evaluatorType, model);
+        inputChars.record(input, attributes);
+        outputChars.record(output, attributes);
+
+        log.debug(
+                "Online scoring LLM payload size: evaluatorType '{}', model '{}', workspaceId '{}', ruleId '{}', inputChars '{}', outputChars '{}'",
+                evaluatorType.getType(), model, workspaceId, ruleId, input, output);
+    }
+
+    /**
+     * Sums the character length of every message in the request. Switches on the message type and
+     * reads the already-materialized text rather than calling {@code toString()} on the message —
+     * stringifying a multi-MB rendered prompt just to measure it would roughly double the per-eval
+     * heap churn (the same reason {@link OnlineScoringEngine#summarizeRequest} avoids it). Non-text
+     * (image / audio / video) content parts are skipped.
+     */
+    /**
+     * Builds the histogram tag set: {@code evaluator_type} and {@code model} only. {@code rule_id}
+     * and {@code workspace_id} are deliberately excluded — they are unbounded and would breach the
+     * prod metrics cardinality limit. Kept package-private so the cardinality contract is locked in
+     * by a unit test.
+     */
+    static Attributes buildAttributes(AutomationRuleEvaluatorType evaluatorType, String model) {
+        return Attributes.of(EVALUATOR_TYPE_KEY, evaluatorType.getType(), MODEL_KEY, model);
+    }
+
+    static long inputChars(ChatRequest request) {
+        if (request == null || request.messages() == null) {
+            return 0L;
+        }
+        return request.messages().stream()
+                .mapToLong(OnlineScoringMetrics::messageChars)
+                .sum();
+    }
+
+    static long messageChars(ChatMessage message) {
+        return switch (message) {
+            case null -> 0L;
+            case SystemMessage systemMessage -> length(systemMessage.text());
+            case UserMessage userMessage -> userMessage.contents() == null
+                    ? 0L
+                    : userMessage.contents().stream()
+                            .mapToLong(content -> content instanceof TextContent textContent
+                                    ? length(textContent.text())
+                                    : 0L)
+                            .sum();
+            case AiMessage aiMessage -> length(aiMessage.text());
+            case ToolExecutionResultMessage toolResult -> length(toolResult.text());
+            default -> 0L;
+        };
+    }
+
+    static long outputChars(ChatResponse response) {
+        if (response == null || response.aiMessage() == null) {
+            return 0L;
+        }
+        return length(response.aiMessage().text());
+    }
+
+    private static long length(String value) {
+        return value == null ? 0L : value.length();
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
@@ -42,6 +42,7 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
     private final ChatCompletionService aiProxyService;
     private final Logger userFacingLogger;
     private final LlmProviderFactory llmProviderFactory;
+    private final OnlineScoringMetrics onlineScoringMetrics;
 
     @Inject
     public OnlineScoringSpanLlmAsJudgeScorer(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
@@ -50,12 +51,14 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
             @NonNull FeedbackScoreService feedbackScoreService,
             @NonNull ChatCompletionService aiProxyService,
             @NonNull TraceService traceService,
-            @NonNull LlmProviderFactory llmProviderFactory) {
+            @NonNull LlmProviderFactory llmProviderFactory,
+            @NonNull OnlineScoringMetrics onlineScoringMetrics) {
         super(config, redisson, feedbackScoreService, traceService, SPAN_LLM_AS_JUDGE, Constants.SPAN_LLM_AS_JUDGE);
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.aiProxyService = aiProxyService;
         this.userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringSpanLlmAsJudgeScorer.class);
         this.llmProviderFactory = llmProviderFactory;
+        this.onlineScoringMetrics = onlineScoringMetrics;
     }
 
     @Override
@@ -121,6 +124,8 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
 
             var score = aiProxyService.scoreTrace(
                     scoreRequest, message.llmAsJudgeCode().model(), message.workspaceId());
+            onlineScoringMetrics.recordPayloadSize(scoreRequest, score, type,
+                    message.llmAsJudgeCode().model().name(), message.workspaceId(), message.ruleId());
             userFacingLogger.info("Received response for spanId '{}':\n\n{}", span.id(), score);
 
             var parsed = OnlineScoringEngine.toFeedbackScores(score);

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -72,6 +72,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
     private final OnlineScoringConfig onlineScoringConfig;
     private final ServiceTogglesConfig serviceTogglesConfig;
     private final SpanService spanService;
+    private final OnlineScoringMetrics onlineScoringMetrics;
 
     @Inject
     public OnlineScoringTraceThreadLlmAsJudgeScorer(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
@@ -85,7 +86,8 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
             @NonNull ProjectService projectService,
             @NonNull AutomationRuleEvaluatorService automationRuleEvaluatorService,
             @NonNull ToolRegistry toolRegistry,
-            @NonNull SpanService spanService) {
+            @NonNull SpanService spanService,
+            @NonNull OnlineScoringMetrics onlineScoringMetrics) {
         super(config, redisson, feedbackScoreService, traceService, TRACE_THREAD_LLM_AS_JUDGE,
                 Constants.TRACE_THREAD_LLM_AS_JUDGE);
         this.aiProxyService = aiProxyService;
@@ -97,6 +99,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         this.onlineScoringConfig = config;
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.spanService = spanService;
+        this.onlineScoringMetrics = onlineScoringMetrics;
         this.userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringTraceThreadLlmAsJudgeScorer.class);
     }
 
@@ -400,9 +403,13 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
      * per-stream worker scheduler thread (OPIK-6308). Mirrors the trace scorer.
      */
     private Mono<ChatResponse> scoreTraceReactive(ChatRequest request, TraceThreadToScoreLlmAsJudge message) {
-        return Mono.fromCallable(() -> aiProxyService.scoreTrace(
-                request, message.code().model(), message.workspaceId()))
-                .subscribeOn(Schedulers.boundedElastic());
+        return Mono.fromCallable(() -> {
+            var response = aiProxyService.scoreTrace(
+                    request, message.code().model(), message.workspaceId());
+            onlineScoringMetrics.recordPayloadSize(request, response, type,
+                    message.code().model().name(), message.workspaceId(), message.ruleId());
+            return response;
+        }).subscribeOn(Schedulers.boundedElastic());
     }
 
     // Package-private for unit tests.

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
@@ -88,6 +88,8 @@ class OnlineScoringLlmAsJudgeScorerTest {
     private WorkspaceNameService workspaceNameService;
     @Mock
     private OpikConfiguration opikConfiguration;
+    @Mock
+    private OnlineScoringMetrics onlineScoringMetrics;
 
     private MockedStatic<UserFacingLoggingFactory> mockedFactory;
     private OnlineScoringLlmAsJudgeScorer scorer;
@@ -137,7 +139,7 @@ class OnlineScoringLlmAsJudgeScorerTest {
                 traceCompressor,
                 workspaceNameService,
                 opikConfiguration,
-                new OnlineScoringMetrics());
+                onlineScoringMetrics);
     }
 
     @AfterEach

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
@@ -136,7 +136,8 @@ class OnlineScoringLlmAsJudgeScorerTest {
                 toolRegistry,
                 traceCompressor,
                 workspaceNameService,
-                opikConfiguration);
+                opikConfiguration,
+                new OnlineScoringMetrics());
     }
 
     @AfterEach

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringMetricsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringMetricsTest.java
@@ -1,0 +1,131 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import io.opentelemetry.api.common.AttributeKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+@DisplayName("OnlineScoringMetrics char-sizing")
+class OnlineScoringMetricsTest {
+
+    @Test
+    void messageCharsForSystemMessage() {
+        assertThat(OnlineScoringMetrics.messageChars(SystemMessage.from("system prompt"))).isEqualTo(13L);
+    }
+
+    @Test
+    void messageCharsForUserMessageWithText() {
+        assertThat(OnlineScoringMetrics.messageChars(UserMessage.from("hello world"))).isEqualTo(11L);
+    }
+
+    @Test
+    void messageCharsForUserMessageCountsOnlyTextParts() {
+        var userMessage = UserMessage.from(
+                TextContent.from("hello"),
+                ImageContent.from("https://example.com/image.png"),
+                TextContent.from("!"));
+
+        // Only the two text parts are counted; the image URL is skipped.
+        assertThat(OnlineScoringMetrics.messageChars(userMessage)).isEqualTo(6L);
+    }
+
+    @Test
+    void messageCharsForAiMessage() {
+        assertThat(OnlineScoringMetrics.messageChars(AiMessage.from("scored"))).isEqualTo(6L);
+    }
+
+    @Test
+    void messageCharsForAiMessageWithoutText() {
+        var aiMessage = AiMessage.builder()
+                .toolExecutionRequests(List.of(ToolExecutionRequest.builder()
+                        .id("1").name("read").arguments("{}").build()))
+                .build();
+
+        assertThat(OnlineScoringMetrics.messageChars(aiMessage)).isZero();
+    }
+
+    @Test
+    void messageCharsForToolExecutionResult() {
+        assertThat(OnlineScoringMetrics.messageChars(
+                ToolExecutionResultMessage.from("1", "read", "result"))).isEqualTo(6L);
+    }
+
+    @Test
+    void messageCharsForNullMessageIsZero() {
+        assertThat(OnlineScoringMetrics.messageChars(null)).isZero();
+    }
+
+    @Test
+    void inputCharsSumsAllMessages() {
+        var request = ChatRequest.builder()
+                .messages(SystemMessage.from("abc"), UserMessage.from("de"), AiMessage.from("f"))
+                .build();
+
+        assertThat(OnlineScoringMetrics.inputChars(request)).isEqualTo(6L);
+    }
+
+    @Test
+    void inputCharsForNullRequestIsZero() {
+        assertThat(OnlineScoringMetrics.inputChars(null)).isZero();
+    }
+
+    @Test
+    void outputCharsForResponseText() {
+        var response = ChatResponse.builder().aiMessage(AiMessage.from("a response")).build();
+
+        assertThat(OnlineScoringMetrics.outputChars(response)).isEqualTo(10L);
+    }
+
+    @Test
+    void outputCharsForResponseWithoutTextIsZero() {
+        var response = ChatResponse.builder()
+                .aiMessage(AiMessage.builder()
+                        .toolExecutionRequests(List.of(ToolExecutionRequest.builder()
+                                .id("1").name("read").arguments("{}").build()))
+                        .build())
+                .build();
+
+        assertThat(OnlineScoringMetrics.outputChars(response)).isZero();
+    }
+
+    @Test
+    void outputCharsForNullResponseIsZero() {
+        assertThat(OnlineScoringMetrics.outputChars(null)).isZero();
+    }
+
+    @Test
+    void buildAttributesTagsEvaluatorTypeAndModelValues() {
+        var attributes = OnlineScoringMetrics.buildAttributes(
+                AutomationRuleEvaluatorType.TRACE_THREAD_LLM_AS_JUDGE, "gpt-4o");
+
+        assertThat(attributes.asMap())
+                .containsOnly(
+                        entry(AttributeKey.stringKey("evaluator_type"), "trace_thread_llm_as_judge"),
+                        entry(AttributeKey.stringKey("model"), "gpt-4o"));
+    }
+
+    @Test
+    void buildAttributesNeverTagsUnboundedIdentifiers() {
+        var attributes = OnlineScoringMetrics.buildAttributes(
+                AutomationRuleEvaluatorType.LLM_AS_JUDGE, "gpt-4o");
+
+        // Cardinality guard: rule_id / workspace_id must never become histogram tags.
+        assertThat(attributes.asMap().keySet())
+                .extracting(AttributeKey::getKey)
+                .containsExactlyInAnyOrder("evaluator_type", "model");
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -144,7 +144,8 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
                 projectService,
                 automationRuleEvaluatorService,
                 toolRegistry,
-                spanService);
+                spanService,
+                new OnlineScoringMetrics());
 
         projectId = UUID.randomUUID();
         ruleId = UUID.randomUUID();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -92,6 +92,8 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
     private com.comet.opik.api.resources.v1.events.tools.ToolRegistry toolRegistry;
     @Mock
     private com.comet.opik.domain.SpanService spanService;
+    @Mock
+    private OnlineScoringMetrics onlineScoringMetrics;
 
     private OnlineScoringTraceThreadLlmAsJudgeScorer scorer;
     private MockedStatic<UserFacingLoggingFactory> mockedFactory;
@@ -145,7 +147,7 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
                 automationRuleEvaluatorService,
                 toolRegistry,
                 spanService,
-                new OnlineScoringMetrics());
+                onlineScoringMetrics);
 
         projectId = UUID.randomUUID();
         ruleId = UUID.randomUUID();


### PR DESCRIPTION
## Details

Adds an observability metric (the **C1** piece of OPIK-6813) recording the approximate character size of each online-scoring LLM round-trip — input request messages + output response text — via OTel histograms, so we can size the heap an evaluation holds while blocked on the provider and spot heavy workloads. This is the measurement that informs the in-flight consumption bound (B1) and per-workspace quota (B2) that follow.

- New `OnlineScoringMetrics` `@Singleton` recorder owns two `LongHistogram`s (`online_scoring_llm_input_chars` / `online_scoring_llm_output_chars`, meter `opik.online_scoring`); wired into the trace, span and thread LLM-as-judge scorers. The reactive scorers record per provider round-trip, so agentic tool-loop turns are each captured.
- Histograms are tagged `{evaluator_type, model}` only; `workspaceId`/`ruleId` go on a debug log line to stay within the prod metrics cardinality limit.
- Char sizing sums per-message text length (never `toString()` on a multi-MB prompt) and skips non-text content; sizes only, never content/PII.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6813

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Full implementation (recorder + scorer wiring + unit tests) under human direction; design reviewed and approved.
  - Human verification: Reviewed diff, ran the backend test suites and spotless locally; verified cardinality/heap-churn/PII constraints.

## Testing

- `cd apps/opik-backend && mvn test -Dtest="OnlineScoringMetricsTest,OnlineScoringLlmAsJudgeScorerTest,OnlineScoringTraceThreadLlmAsJudgeScorerTest"` — all green (14 metrics tests + affected scorer suites).
- `mvn compile` and `mvn spotless:check` clean.
- Scenarios: char sizing for System/User (text-only + multimodal-skip)/Ai/ToolResult messages, null-safety, empty messages, and the `{evaluator_type, model}`-only cardinality contract (asserts `ruleId`/`workspaceId` are never tags).
- Environment: local backend process mode (macOS).
- Not run: no integration test asserting OTel emission end-to-end — would require the `opentelemetry-sdk-testing` dependency, avoided per the tech-stack rule; the recorder body is trivial pass-through and the cardinality contract is unit-tested via `buildAttributes`.

## Documentation

No user-facing or SDK surface change — internal backend observability metric only; no documentation update required.