### PR TITLE
[OPIK-6813] [BE] feat: online-scoring overload protection (payload-size metric + consumption bound + per-workspace quota)

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -556,6 +556,18 @@ onlineScoring:
   #   trace_thread_llm_as_judge messages (their Redis payload carries only thread IDs, so the heavy context
   #   is fetched while scoring and can't be measured at admission).
   avgThreadBytes: ${REDIS_SCORING_AVG_THREAD_BYTES:-256000}
+  # Per-workspace producer quota: caps how many scoring evals a single workspace may enqueue per window
+  #   (fleet-wide, via the distributed rate limiter), so one workspace's rules can't flood the shared
+  #   scoring streams and starve other tenants. Applied after the per-rule sampling rate; over-quota evals
+  #   are dropped at the producer (never deferred). Drops are visible via the online_scoring_quota_dropped
+  #   metric (tagged evaluator_type + workspace_id + rule_id).
+  perWorkspaceQuota:
+    # Default: false. Master switch — when false the quota is not applied (current behavior).
+    enabled: ${ONLINE_SCORING_PER_WORKSPACE_QUOTA_ENABLED:-false}
+    # Default: 0. Max scoring evals a workspace may enqueue per durationInSeconds window (only used when enabled).
+    limit: ${ONLINE_SCORING_PER_WORKSPACE_QUOTA_LIMIT:-0}
+    # Default: 60. Length of the quota window in seconds.
+    durationInSeconds: ${ONLINE_SCORING_PER_WORKSPACE_QUOTA_DURATION_SECONDS:-60}
   ## scorer: options from AutomationRuleEvaluatorType
   ## streamName: the name of the stream in redis
   ## codec: 'json' when there are non-java consumers, 'java' for java consumers only

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -545,6 +545,17 @@ onlineScoring:
   #   length. 4 ≈ natural-language English. Lower for code/JSON-heavy workloads (≈ 2) — yields a more
   #   pessimistic estimate so the agentic-tools path engages earlier.
   agenticToolsCharsPerToken: ${ONLINE_SCORING_AGENTIC_TOOLS_CHARS_PER_TOKEN:-4}
+  # Default: 0 (disabled)
+  # Description: Memory-aware admission gate budget — the max estimated in-flight payload (bytes) a single
+  #   consumer processes concurrently. 0 disables the gate. Only consulted when the
+  #   memoryAwareScoringBoundEnabled service toggle is on. Can be overridden per stream. Size it from the
+  #   per-eval sizes the online_scoring_llm_*_chars metric reports in production.
+  maxInFlightBytes: ${REDIS_SCORING_MAX_IN_FLIGHT_BYTES:-0}
+  # Default: 256000
+  # Description: Estimated bytes one thread contributes to the in-flight payload, used to weight
+  #   trace_thread_llm_as_judge messages (their Redis payload carries only thread IDs, so the heavy context
+  #   is fetched while scoring and can't be measured at admission).
+  avgThreadBytes: ${REDIS_SCORING_AVG_THREAD_BYTES:-256000}
   ## scorer: options from AutomationRuleEvaluatorType
   ## streamName: the name of the stream in redis
   ## codec: 'json' when there are non-java consumers, 'java' for java consumers only
@@ -1055,6 +1066,12 @@ serviceToggles:
   # Description: Master switch for the agentic-tools path on LLM-as-judge online scoring. When false, the
   #   inline path is used regardless of context size. Threshold lives under onlineScoring.agenticToolsThresholdTokens.
   agenticToolsEnabled: ${TOGGLE_AGENTIC_TOOLS_ENABLED:-"false"}
+  # Default: false
+  # Description: Master switch for the memory-aware admission gate on online scoring. When false, the
+  #   consumer keeps its count-only concurrency (current behavior). When true, the consumer also bounds
+  #   concurrent in-flight evals by onlineScoring.maxInFlightBytes so overflow waits in Redis instead
+  #   of filling heap. Flip off to instantly revert in production.
+  memoryAwareScoringBoundEnabled: ${TOGGLE_MEMORY_AWARE_SCORING_BOUND_ENABLED:-"false"}
   # Default: "" (empty, no allowlisted workspaces)
   # Description: Comma-separated list of workspace IDs that should always receive V2 navigation.
   # Valid values: comma-separated workspace IDs (e.g. "ws-id-1,ws-id-2"), or "" (empty, disabled).

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -545,17 +545,19 @@ onlineScoring:
   #   length. 4 ≈ natural-language English. Lower for code/JSON-heavy workloads (≈ 2) — yields a more
   #   pessimistic estimate so the agentic-tools path engages earlier.
   agenticToolsCharsPerToken: ${ONLINE_SCORING_AGENTIC_TOOLS_CHARS_PER_TOKEN:-4}
-  # Default: 0 (disabled)
+  # Default: 6442450944 (6 GiB). Pre-sized for rollout but INERT until the memoryAwareScoringBoundEnabled
+  #   service toggle is turned on — flip that toggle to activate the gate with this budget already in place.
+  #   0 disables the gate regardless of the toggle.
   # Description: Memory-aware admission gate budget — the max estimated in-flight payload (bytes) a single
-  #   consumer processes concurrently. 0 disables the gate. Only consulted when the
-  #   memoryAwareScoringBoundEnabled service toggle is on. Can be overridden per stream. Size it from the
-  #   per-eval sizes the online_scoring_llm_*_chars metric reports in production.
-  maxInFlightBytes: ${REDIS_SCORING_MAX_IN_FLIGHT_BYTES:-0}
-  # Default: 256000
+  #   consumer processes concurrently. Sized for the ~8 GiB prod scoring heap (~6 concurrent thread-evals at
+  #   ~1 GiB each); lower it for smaller pods before enabling. Can be overridden per stream.
+  maxInFlightBytes: ${REDIS_SCORING_MAX_IN_FLIGHT_BYTES:-6442450944}
+  # Default: 1073741824 (1 GiB) — the measured real per-eval heap from the incident, not the raw payload size.
+  #   Only consulted when the byte gate is active (toggle on), so this stays inert until then.
   # Description: Estimated bytes one thread contributes to the in-flight payload, used to weight
   #   trace_thread_llm_as_judge messages (their Redis payload carries only thread IDs, so the heavy context
   #   is fetched while scoring and can't be measured at admission).
-  avgThreadBytes: ${REDIS_SCORING_AVG_THREAD_BYTES:-256000}
+  avgThreadBytes: ${REDIS_SCORING_AVG_THREAD_BYTES:-1073741824}
   # Per-workspace producer quota: caps how many scoring evals a single workspace may enqueue per window
   #   (fleet-wide, via the distributed rate limiter), so one workspace's rules can't flood the shared
   #   scoring streams and starve other tenants. Applied after the per-rule sampling rate; over-quota evals
@@ -564,8 +566,10 @@ onlineScoring:
   perWorkspaceQuota:
     # Default: false. Master switch — when false the quota is not applied (current behavior).
     enabled: ${ONLINE_SCORING_PER_WORKSPACE_QUOTA_ENABLED:-false}
-    # Default: 0. Max scoring evals a workspace may enqueue per durationInSeconds window (only used when enabled).
-    limit: ${ONLINE_SCORING_PER_WORKSPACE_QUOTA_LIMIT:-0}
+    # Default: 250. Max scoring evals a workspace may enqueue per durationInSeconds window. Pre-sized for
+    #   rollout (≈ drain capacity, generous headroom over the busiest legit workspace) but INERT until
+    #   enabled above — flip the enabled toggle to activate the quota with this limit already in place.
+    limit: ${ONLINE_SCORING_PER_WORKSPACE_QUOTA_LIMIT:-250}
     # Default: 60. Length of the quota window in seconds.
     durationInSeconds: ${ONLINE_SCORING_PER_WORKSPACE_QUOTA_DURATION_SECONDS:-60}
   ## scorer: options from AutomationRuleEvaluatorType
@@ -610,7 +614,10 @@ onlineScoring:
       # Optional per stream configuration (falls back to global if not specified)
       poolingInterval: ${REDIS_SCORING_TRACE_THREAD_LLM_AS_JUDGE_CONSUMER_POOL_INTERVAL:-}
       longPollingDuration: ${REDIS_SCORING_TRACE_THREAD_LLM_AS_JUDGE_LONG_POLLING_DURATION:-}
-      consumerBatchSize: ${REDIS_SCORING_TRACE_THREAD_LLM_AS_JUDGE_CONSUMER_BATCH_SIZE:-}
+      # Hard count cap on concurrent trace-thread messages (heap safety, ~6 GiB target). NOTE: NOT gated by
+      # the memory-aware toggle — this takes effect as soon as it ships (previously fell back to the global
+      # default of 10). Lower it for smaller pods.
+      consumerBatchSize: ${REDIS_SCORING_TRACE_THREAD_LLM_AS_JUDGE_CONSUMER_BATCH_SIZE:-6}
       claimIntervalRatio: ${REDIS_SCORING_TRACE_THREAD_LLM_AS_JUDGE_CLAIM_INTERVAL_RATIO:-}
       pendingMessageDuration: ${REDIS_SCORING_TRACE_THREAD_LLM_AS_JUDGE_PENDING_MESSAGE_DURATION:-}
       maxRetries: ${REDIS_SCORING_TRACE_THREAD_LLM_AS_JUDGE_MAX_RETRIES:-}
@@ -1081,8 +1088,9 @@ serviceToggles:
   # Default: false
   # Description: Master switch for the memory-aware admission gate on online scoring. When false, the
   #   consumer keeps its count-only concurrency (current behavior). When true, the consumer also bounds
-  #   concurrent in-flight evals by onlineScoring.maxInFlightBytes so overflow waits in Redis instead
-  #   of filling heap. Flip off to instantly revert in production.
+  #   concurrent in-flight evals by onlineScoring.maxInFlightBytes (pre-sized to 6 GiB) so overflow waits in
+  #   Redis instead of filling heap. The byte budget is already sized — flipping this to true is all that is
+  #   needed to activate B1. Flip off to instantly revert in production.
   memoryAwareScoringBoundEnabled: ${TOGGLE_MEMORY_AWARE_SCORING_BOUND_ENABLED:-"false"}
   # Default: "" (empty, no allowlisted workspaces)
   # Description: Comma-separated list of workspace IDs that should always receive V2 navigation.

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
@@ -583,12 +583,18 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
      */
     private Mono<Void> withAdmissionControl(M message, Mono<Void> work) {
         var budget = admissionBudget;
-        if (budget == null) {
+        // budget == null: gate off. message == null: a malformed entry (e.g. a missing payload field)
+        // that nothing can be estimated from — bypass the gate so it flows through the work path
+        // exactly as when the gate is off (handled by processEvent), instead of NPEing in the estimator.
+        if (budget == null || message == null) {
             return work;
         }
-        int permits = Math.min(maxInFlightPermits, toPermits(estimateInFlightBytes(message)));
-        long bytes = (long) permits * BYTES_PER_PERMIT;
         return Mono.fromCallable(() -> {
+            // Estimate inside the callable (not eagerly) so any unexpected estimator failure surfaces as
+            // an onError on the worker scheduler and flows through the normal failure path
+            // (onErrorResume/postProcessFailureMessages) rather than throwing synchronously and bypassing
+            // it. No permit is acquired if the estimate throws.
+            int permits = Math.min(maxInFlightPermits, toPermits(estimateInFlightBytes(message)));
             if (!budget.tryAcquire(permits)) {
                 // Build the metric attributes only on the contention path — the steady-state hot
                 // path (budget available) skips this allocation entirely.
@@ -598,13 +604,13 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
                 budget.acquire(permits);
                 admissionWaitTime.record(System.currentTimeMillis() - waitStartMillis, attributes);
             }
-            addInFlightBytes(bytes);
+            addInFlightBytes((long) permits * BYTES_PER_PERMIT);
             return permits;
         })
                 .subscribeOn(workersScheduler)
                 .flatMap(acquired -> work.doFinally(signalType -> {
                     budget.release(acquired);
-                    addInFlightBytes(-bytes);
+                    addInFlightBytes(-((long) acquired * BYTES_PER_PERMIT));
                 }));
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
@@ -121,6 +121,7 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
     private final LongCounter listPendingErrors;
     private final LongHistogram listPendingTime;
     private final LongCounter unexpectedErrors;
+    private final LongCounter deadLettered;
     private final LongHistogram admissionWaitTime;
     private final LongCounter admissionWaits;
     private final DoubleGauge inFlightBytesGauge;
@@ -226,6 +227,10 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
         this.unexpectedErrors = meter
                 .counterBuilder("%s_%s_unexpected_errors".formatted(metricNamespace, metricsBaseName))
                 .setDescription("Unexpected errors caught")
+                .build();
+        this.deadLettered = meter
+                .counterBuilder("%s_%s_dead_lettered_total".formatted(metricNamespace, metricsBaseName))
+                .setDescription("Messages permanently dropped: non-retryable, or retryable past maxRetries")
                 .build();
         this.admissionWaitTime = meter
                 .histogramBuilder("%s_%s_admission_wait_time".formatted(metricNamespace, metricsBaseName))
@@ -681,9 +686,15 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
                 .filter(this::maxRetriesReached)
                 .map(this::handleMaxRetriesReached)
                 .collectList() // Emits an empty list if the sequence is empty
-                .flatMap(maxRetries ->
-                // Delete all non-retryable combined with max retries reached
-                ackAndRemoveMessages(Stream.concat(nonRetryable.stream(), maxRetries.stream()).toList()))
+                .flatMap(maxRetries -> {
+                    // Delete all non-retryable combined with max retries reached — these leave the stream
+                    // for good, so count them as dead-lettered (the silent-loss signal).
+                    var deadLetteredIds = Stream.concat(nonRetryable.stream(), maxRetries.stream()).toList();
+                    if (!deadLetteredIds.isEmpty()) {
+                        deadLettered.add(deadLetteredIds.size());
+                    }
+                    return ackAndRemoveMessages(deadLetteredIds);
+                })
                 .thenReturn(processingResults);
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
@@ -81,6 +82,14 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
     private static final int BOUNDED_ELASTIC_SCHEDULER_TTL_SECONDS = 60;
 
     /**
+     * Granularity of the memory-aware admission gate: one semaphore permit per KiB of estimated
+     * in-flight payload. {@link Semaphore} permits are an {@code int}, so a byte-per-permit scheme
+     * would overflow above ~2 GiB; KiB permits push the ceiling to ~2 TiB while keeping the budget
+     * arithmetic exact enough for a coarse heap bound.
+     */
+    private static final int BYTES_PER_PERMIT = 1024;
+
+    /**
      * Logger for the actual subclass, in order to have the correct class name in the logs.
      */
     private final Logger log = LoggerFactory.getLogger(getClass());
@@ -111,12 +120,25 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
     private final LongCounter listPendingErrors;
     private final LongHistogram listPendingTime;
     private final LongCounter unexpectedErrors;
+    private final LongHistogram admissionWaitTime;
+    private final LongCounter admissionWaits;
+    private final DoubleGauge inFlightBytesGauge;
+    private final DoubleGauge streamLength;
 
     private volatile RStreamReactive<String, M> stream;
     private volatile Disposable streamSubscription;
     private volatile Scheduler timerScheduler;
     private volatile Scheduler consumerScheduler;
     private volatile Scheduler workersScheduler;
+
+    /**
+     * Memory-aware admission gate. Non-null only while the gate is active (subclass opts in via
+     * {@link #isAdmissionControlEnabled()} AND {@code maxInFlightBytes > 0}). When null the consumer
+     * keeps its count-only concurrency — identical to the pre-gate behavior.
+     */
+    private volatile Semaphore admissionBudget;
+    private volatile int maxInFlightPermits;
+    private final AtomicLong inFlightBytes = new AtomicLong();
 
     protected BaseRedisSubscriber(
             @NonNull StreamConfiguration config,
@@ -204,6 +226,53 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
                 .counterBuilder("%s_%s_unexpected_errors".formatted(metricNamespace, metricsBaseName))
                 .setDescription("Unexpected errors caught")
                 .build();
+        this.admissionWaitTime = meter
+                .histogramBuilder("%s_%s_admission_wait_time".formatted(metricNamespace, metricsBaseName))
+                .setDescription("Time a message waited on the memory-aware admission gate before processing")
+                .setUnit("ms")
+                .ofLongs()
+                .build();
+        this.admissionWaits = meter
+                .counterBuilder("%s_%s_admission_waits".formatted(metricNamespace, metricsBaseName))
+                .setDescription("Number of messages that had to wait for in-flight budget before processing")
+                .build();
+        this.inFlightBytesGauge = meter
+                .gaugeBuilder("%s_%s_in_flight_bytes".formatted(metricNamespace, metricsBaseName))
+                .setDescription("Estimated in-flight payload bytes currently admitted for processing")
+                .setUnit("bytes")
+                .build();
+        this.streamLength = meter
+                .gaugeBuilder("%s_%s_stream_length".formatted(metricNamespace, metricsBaseName))
+                .setDescription("Number of entries currently in the Redis stream (backlog)")
+                .build();
+    }
+
+    /**
+     * Estimated in-flight payload size, in bytes, the given message will hold while being processed.
+     * Drives the memory-aware admission gate. Base returns {@code 0} (no weight) so subscribers that
+     * don't opt in are unaffected; online-scoring scorers override it per message type.
+     */
+    protected long estimateInFlightBytes(M message) {
+        return 0;
+    }
+
+    /**
+     * Whether the memory-aware admission gate is active for this subscriber. Base returns
+     * {@code false} (gate off); online-scoring scorers override it from the service toggle so it can
+     * be flipped off in production to revert to the count-only concurrency behavior.
+     */
+    protected boolean isAdmissionControlEnabled() {
+        return false;
+    }
+
+    /**
+     * Whether to sample the Redis stream backlog (XLEN) for observability on each poll tick. Base
+     * returns {@code false} so the extra round-trip isn't imposed on subscribers that don't need it;
+     * online scoring overrides it to {@code true} so backlog is observable independently of the gate
+     * toggle (e.g. to size the budget before enabling the gate).
+     */
+    protected boolean isStreamLengthSamplingEnabled() {
+        return false;
     }
 
     @Override
@@ -239,6 +308,14 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
                             config.getConsumerGroupName(), config.getStreamName()),
                     BOUNDED_ELASTIC_SCHEDULER_TTL_SECONDS,
                     true);
+        }
+        if (admissionBudget == null && isAdmissionControlEnabled() && config.getMaxInFlightBytes() > 0) {
+            maxInFlightPermits = toPermits(config.getMaxInFlightBytes());
+            // Fair so a large, budget-clamped message admitted in order isn't starved by a steady
+            // stream of small ones.
+            admissionBudget = new Semaphore(maxInFlightPermits, true);
+            log.info("Memory-aware admission gate enabled: maxInFlightBytes='{}', permits='{}'",
+                    config.getMaxInFlightBytes(), maxInFlightPermits);
         }
         if (streamSubscription == null) {
             streamSubscription = setupStreamListener();
@@ -276,6 +353,7 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
         if (consumerScheduler != null && !consumerScheduler.isDisposed()) {
             consumerScheduler.dispose();
         }
+        admissionBudget = null;
     }
 
     /**
@@ -340,14 +418,14 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
                             i);
                 })
                 // ConcatMap ensures one readGroup/autoClaim at a time
-                .concatMap(i -> {
+                .concatMap(i -> sampleStreamLength().then(Mono.defer(() -> {
                     // Using our own counter to track real reads as ticks (i) might be dropped on backpressure
                     if (readCount.incrementAndGet() % config.getClaimIntervalRatio() == 0) {
                         return claimPendingMessages();
                     } else {
                         return readMessages();
                     }
-                })
+                })))
                 .flatMapIterable(Map::entrySet)
                 // Concurrency for processing messages
                 .flatMap(this::processMessage, config.getConsumerBatchSize())
@@ -459,7 +537,7 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
         }
         var startMillis = System.currentTimeMillis();
         // Deferring as processEvent is out of our control, it might not return a cold Mono
-        return Mono.defer(() -> processEvent(message))
+        return withAdmissionControl(message, Mono.defer(() -> processEvent(message)))
                 .subscribeOn(workersScheduler)
                 .thenReturn(ProcessingResult.builder()
                         .messageId(messageId)
@@ -477,6 +555,67 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
                             .ifPresent(messageMillis -> messageQueueDelay
                                     .record(System.currentTimeMillis() - messageMillis));
                 });
+    }
+
+    /**
+     * Wraps the processing work with the memory-aware admission gate. When the gate is off (base
+     * subscribers, or the toggle disabled) the work {@code Mono} is returned unchanged — zero
+     * overhead, byte-for-byte the prior behavior. When on, it acquires permits proportional to the
+     * estimated in-flight bytes (clamped to the whole budget so an oversized message runs alone
+     * rather than deadlocking), processes, then releases on any terminal signal. The acquire runs on
+     * the worker scheduler; a full budget parks that worker until capacity frees up, which
+     * propagates backpressure upstream so surplus messages stay unread in Redis instead of piling
+     * into heap. Acks/retries/auto-claim are unaffected: a message that waits here was already read,
+     * and one that can't even be read stays in the stream.
+     */
+    private Mono<Void> withAdmissionControl(M message, Mono<Void> work) {
+        var budget = admissionBudget;
+        if (budget == null) {
+            return work;
+        }
+        int permits = Math.min(maxInFlightPermits, toPermits(estimateInFlightBytes(message)));
+        long bytes = (long) permits * BYTES_PER_PERMIT;
+        return Mono.fromCallable(() -> {
+            if (!budget.tryAcquire(permits)) {
+                admissionWaits.add(1);
+                var waitStartMillis = System.currentTimeMillis();
+                budget.acquire(permits);
+                admissionWaitTime.record(System.currentTimeMillis() - waitStartMillis);
+            }
+            addInFlightBytes(bytes);
+            return permits;
+        })
+                .subscribeOn(workersScheduler)
+                .flatMap(acquired -> work.doFinally(signalType -> {
+                    budget.release(acquired);
+                    addInFlightBytes(-bytes);
+                }));
+    }
+
+    private int toPermits(long bytes) {
+        return (int) Math.max(1, Math.min(Integer.MAX_VALUE, bytes / BYTES_PER_PERMIT));
+    }
+
+    private void addInFlightBytes(long delta) {
+        inFlightBytesGauge.set(inFlightBytes.addAndGet(delta));
+    }
+
+    /**
+     * Best-effort sample of the Redis stream backlog for observability. Runs before each read tick;
+     * errors are swallowed so a failed sample never disrupts consumption.
+     */
+    private Mono<Void> sampleStreamLength() {
+        if (stream == null || !isStreamLengthSamplingEnabled()) {
+            return Mono.empty();
+        }
+        return stream.size()
+                .subscribeOn(consumerScheduler)
+                .doOnNext(size -> streamLength.set(Objects.requireNonNullElse(size, 0L).doubleValue()))
+                .onErrorResume(throwable -> {
+                    log.debug("Failed to sample stream length for stream '{}'", config.getStreamName(), throwable);
+                    return Mono.empty();
+                })
+                .then();
     }
 
     private Mono<List<ProcessingResult>> postProcessSuccessMessages(List<ProcessingResult> processingResults) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
@@ -3,6 +3,7 @@ package com.comet.opik.api.resources.v1.events;
 import com.comet.opik.infrastructure.StreamConfiguration;
 import io.dropwizard.lifecycle.Managed;
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleGauge;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongHistogram;
@@ -263,6 +264,18 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
      */
     protected boolean isAdmissionControlEnabled() {
         return false;
+    }
+
+    /**
+     * Attributes attached to the admission-contention metrics ({@code admission_waits} /
+     * {@code admission_wait_time}). Base returns {@link Attributes#empty()}; online-scoring scorers
+     * override it to tag waits with {@code workspace_id} + {@code rule_id} so it's visible in Grafana
+     * which tenants/rules are saturating the consumer's byte budget. Only the contention metrics
+     * carry these labels — they fire solely when the budget is full (a small set of offenders), so
+     * the per-tenant cardinality stays bounded; the per-pod gauges stay unlabelled.
+     */
+    protected Attributes admissionAttributes(M message) {
+        return Attributes.empty();
     }
 
     /**
@@ -577,10 +590,13 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
         long bytes = (long) permits * BYTES_PER_PERMIT;
         return Mono.fromCallable(() -> {
             if (!budget.tryAcquire(permits)) {
-                admissionWaits.add(1);
+                // Build the metric attributes only on the contention path — the steady-state hot
+                // path (budget available) skips this allocation entirely.
+                var attributes = admissionAttributes(message);
+                admissionWaits.add(1, attributes);
                 var waitStartMillis = System.currentTimeMillis();
                 budget.acquire(permits);
-                admissionWaitTime.record(System.currentTimeMillis() - waitStartMillis);
+                admissionWaitTime.record(System.currentTimeMillis() - waitStartMillis, attributes);
             }
             addInFlightBytes(bytes);
             return permits;

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
@@ -13,6 +13,8 @@ import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.infrastructure.OnlineScoringStreamConfigurationAdapter;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import jakarta.validation.constraints.NotNull;
 import lombok.NonNull;
 import org.redisson.api.RedissonReactiveClient;
@@ -90,6 +92,18 @@ public abstract class OnlineScoringBaseScorer<M> extends BaseRedisSubscriber<M> 
         // Online-scoring backlog is worth watching independently of the admission gate (e.g. to size
         // the budget before enabling it), so sampling is always on for scoring streams.
         return true;
+    }
+
+    private static final AttributeKey<String> WORKSPACE_ID_KEY = AttributeKey.stringKey("workspace_id");
+    private static final AttributeKey<String> RULE_ID_KEY = AttributeKey.stringKey("rule_id");
+
+    /**
+     * Tags for the admission-contention metrics: which workspace + rule was waiting on the byte
+     * budget. Leaf scorers pass these via {@link #admissionAttributes} so Grafana can show, per
+     * customer and per rule, who is saturating the consumer.
+     */
+    protected static Attributes scoringAttributes(String workspaceId, UUID ruleId) {
+        return Attributes.of(WORKSPACE_ID_KEY, workspaceId, RULE_ID_KEY, ruleId.toString());
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
@@ -103,6 +103,11 @@ public abstract class OnlineScoringBaseScorer<M> extends BaseRedisSubscriber<M> 
      * customer and per rule, who is saturating the consumer.
      */
     protected static Attributes scoringAttributes(String workspaceId, UUID ruleId) {
+        // Guard against legacy/replayed entries with missing identifiers: Attributes.of NPEs on a null
+        // value, which would fail the contention path before the metric is even emitted.
+        if (workspaceId == null || ruleId == null) {
+            return Attributes.empty();
+        }
         return Attributes.of(WORKSPACE_ID_KEY, workspaceId, RULE_ID_KEY, ruleId.toString());
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
@@ -54,11 +54,13 @@ public abstract class OnlineScoringBaseScorer<M> extends BaseRedisSubscriber<M> 
     protected final FeedbackScoreService feedbackScoreService;
     protected final TraceService traceService;
     protected final AutomationRuleEvaluatorType type;
+    protected final OnlineScoringMetrics onlineScoringMetrics;
 
     protected OnlineScoringBaseScorer(@NonNull @Config OnlineScoringConfig config,
             @NonNull RedissonReactiveClient redisson,
             @NonNull FeedbackScoreService feedbackScoreService,
             @NonNull TraceService traceService,
+            @NonNull OnlineScoringMetrics onlineScoringMetrics,
             @NonNull AutomationRuleEvaluatorType type,
             @NonNull String metricsBaseName) {
         super(OnlineScoringStreamConfigurationAdapter.create(config, type),
@@ -68,6 +70,7 @@ public abstract class OnlineScoringBaseScorer<M> extends BaseRedisSubscriber<M> 
                 metricsBaseName);
         this.feedbackScoreService = feedbackScoreService;
         this.traceService = traceService;
+        this.onlineScoringMetrics = onlineScoringMetrics;
         this.type = type;
     }
 
@@ -77,7 +80,9 @@ public abstract class OnlineScoringBaseScorer<M> extends BaseRedisSubscriber<M> 
      */
     @Override
     protected Mono<Void> processEvent(M message) {
-        return Mono.defer(() -> score(message));
+        return Mono.defer(() -> score(message))
+                .doOnError(error -> onlineScoringMetrics.recordEvalOutcome(type,
+                        OnlineScoringMetrics.EvalOutcome.ERROR));
     }
 
     /**
@@ -132,6 +137,8 @@ public abstract class OnlineScoringBaseScorer<M> extends BaseRedisSubscriber<M> 
             List<FeedbackScoreBatchItem> scores, Trace trace, String userName, String workspaceId) {
         log.info("Received '{}' scores for traceId '{}' in workspace '{}'. Storing them",
                 scores.size(), trace.id(), workspaceId);
+        onlineScoringMetrics.recordEvalOutcome(type, OnlineScoringMetrics.EvalOutcome.SCORED);
+        onlineScoringMetrics.recordScoresStored(type, scores.size());
         return feedbackScoreService.scoreBatchOfTraces(scores)
                 .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, userName)
                         .put(RequestContext.WORKSPACE_ID, workspaceId))
@@ -142,6 +149,8 @@ public abstract class OnlineScoringBaseScorer<M> extends BaseRedisSubscriber<M> 
             List<FeedbackScoreBatchItem> scores, com.comet.opik.api.Span span, String userName, String workspaceId) {
         log.info("Received '{}' scores for spanId '{}' in workspace '{}'. Storing them",
                 scores.size(), span.id(), workspaceId);
+        onlineScoringMetrics.recordEvalOutcome(type, OnlineScoringMetrics.EvalOutcome.SCORED);
+        onlineScoringMetrics.recordScoresStored(type, scores.size());
         return feedbackScoreService.scoreBatchOfSpans(scores)
                 .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, userName)
                         .put(RequestContext.WORKSPACE_ID, workspaceId))
@@ -152,6 +161,8 @@ public abstract class OnlineScoringBaseScorer<M> extends BaseRedisSubscriber<M> 
             List<FeedbackScoreBatchItemThread> scores, String threadId, String userName, String workspaceId) {
         log.info("Received '{}' scores for threadId '{}' in workspace '{}'. Storing them",
                 scores.size(), threadId, workspaceId);
+        onlineScoringMetrics.recordEvalOutcome(type, OnlineScoringMetrics.EvalOutcome.SCORED);
+        onlineScoringMetrics.recordScoresStored(type, scores.size());
         return feedbackScoreService.scoreBatchOfThreads(scores)
                 .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, userName)
                         .put(RequestContext.WORKSPACE_ID, workspaceId))

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
@@ -12,6 +12,7 @@ import com.comet.opik.domain.TraceService;
 import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.infrastructure.OnlineScoringStreamConfigurationAdapter;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.validation.constraints.NotNull;
 import lombok.NonNull;
 import org.redisson.api.RedissonReactiveClient;
@@ -83,6 +84,30 @@ public abstract class OnlineScoringBaseScorer<M> extends BaseRedisSubscriber<M> 
      * {@link #storeThreadScores}.
      */
     protected abstract Mono<Void> score(M message);
+
+    @Override
+    protected boolean isStreamLengthSamplingEnabled() {
+        // Online-scoring backlog is worth watching independently of the admission gate (e.g. to size
+        // the budget before enabling it), so sampling is always on for scoring streams.
+        return true;
+    }
+
+    /**
+     * Coarse byte estimate of one or more JSON payload fields, for the memory-aware admission gate.
+     * Uses {@code toString().length()} (chars ≈ bytes for the estimate) — the same size proxy
+     * {@code OnlineScoringEngine.estimateTokensFromJson} relies on. Allocates the string once per
+     * message at admission (then discarded); acceptable for a coarse weight that's calibrated from
+     * the {@code online_scoring_llm_*_chars} metric.
+     */
+    protected static long jsonSize(JsonNode... nodes) {
+        long total = 0;
+        for (var node : nodes) {
+            if (node != null) {
+                total += node.toString().length();
+            }
+        }
+        return total;
+    }
 
     protected Mono<Map<String, List<BigDecimal>>> storeScores(
             List<FeedbackScoreBatchItem> scores, Trace trace, String userName, String workspaceId) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -75,6 +75,7 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
     private final OpikConfiguration opikConfiguration;
     private final OnlineScoringConfig onlineScoringConfig;
     private final ServiceTogglesConfig serviceTogglesConfig;
+    private final OnlineScoringMetrics onlineScoringMetrics;
 
     @Inject
     public OnlineScoringLlmAsJudgeScorer(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
@@ -89,7 +90,8 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
             @NonNull ToolRegistry toolRegistry,
             @NonNull TraceCompressor traceCompressor,
             @NonNull WorkspaceNameService workspaceNameService,
-            @NonNull OpikConfiguration opikConfiguration) {
+            @NonNull OpikConfiguration opikConfiguration,
+            @NonNull OnlineScoringMetrics onlineScoringMetrics) {
         super(config, redisson, feedbackScoreService, traceService,
                 LLM_AS_JUDGE, Constants.LLM_AS_JUDGE);
         this.aiProxyService = aiProxyService;
@@ -103,6 +105,7 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
         this.opikConfiguration = opikConfiguration;
         this.onlineScoringConfig = config;
         this.serviceTogglesConfig = serviceTogglesConfig;
+        this.onlineScoringMetrics = onlineScoringMetrics;
     }
 
     @Override
@@ -345,9 +348,13 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
      * pin the per-stream worker scheduler thread (OPIK-6308).
      */
     private Mono<ChatResponse> scoreTraceReactive(ChatRequest request, TraceToScoreLlmAsJudge message) {
-        return Mono.fromCallable(() -> aiProxyService.scoreTrace(
-                request, message.llmAsJudgeCode().model(), message.workspaceId()))
-                .subscribeOn(Schedulers.boundedElastic());
+        return Mono.fromCallable(() -> {
+            var response = aiProxyService.scoreTrace(
+                    request, message.llmAsJudgeCode().model(), message.workspaceId());
+            onlineScoringMetrics.recordPayloadSize(request, response, type,
+                    message.llmAsJudgeCode().model().name(), message.workspaceId(), message.ruleId());
+            return response;
+        }).subscribeOn(Schedulers.boundedElastic());
     }
 
     private static boolean shouldUseTools(TraceToScoreLlmAsJudge message) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -75,7 +75,6 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
     private final OpikConfiguration opikConfiguration;
     private final OnlineScoringConfig onlineScoringConfig;
     private final ServiceTogglesConfig serviceTogglesConfig;
-    private final OnlineScoringMetrics onlineScoringMetrics;
 
     @Inject
     public OnlineScoringLlmAsJudgeScorer(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
@@ -92,7 +91,7 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
             @NonNull WorkspaceNameService workspaceNameService,
             @NonNull OpikConfiguration opikConfiguration,
             @NonNull OnlineScoringMetrics onlineScoringMetrics) {
-        super(config, redisson, feedbackScoreService, traceService,
+        super(config, redisson, feedbackScoreService, traceService, onlineScoringMetrics,
                 LLM_AS_JUDGE, Constants.LLM_AS_JUDGE);
         this.aiProxyService = aiProxyService;
         this.userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringLlmAsJudgeScorer.class);
@@ -105,7 +104,6 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
         this.opikConfiguration = opikConfiguration;
         this.onlineScoringConfig = config;
         this.serviceTogglesConfig = serviceTogglesConfig;
-        this.onlineScoringMetrics = onlineScoringMetrics;
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -28,6 +28,7 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import io.opentelemetry.api.common.Attributes;
 import jakarta.inject.Inject;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -113,6 +114,11 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
     protected long estimateInFlightBytes(TraceToScoreLlmAsJudge message) {
         var trace = message.trace();
         return jsonSize(trace.input(), trace.output(), trace.metadata());
+    }
+
+    @Override
+    protected Attributes admissionAttributes(TraceToScoreLlmAsJudge message) {
+        return scoringAttributes(message.workspaceId(), message.ruleId());
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -104,6 +104,17 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
         this.serviceTogglesConfig = serviceTogglesConfig;
     }
 
+    @Override
+    protected boolean isAdmissionControlEnabled() {
+        return serviceTogglesConfig.isMemoryAwareScoringBoundEnabled();
+    }
+
+    @Override
+    protected long estimateInFlightBytes(TraceToScoreLlmAsJudge message) {
+        var trace = message.trace();
+        return jsonSize(trace.input(), trace.output(), trace.metadata());
+    }
+
     /**
      * Resolves the workspaceName for the post-scoring chain. Needed because
      * {@link com.comet.opik.domain.ExperimentService#finishExperiments(Set)} reads

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringMetrics.java
@@ -12,6 +12,7 @@ import dev.langchain4j.model.chat.response.ChatResponse;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongHistogram;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -37,9 +38,37 @@ public class OnlineScoringMetrics {
     private static final String METER_NAME = "opik.online_scoring";
     private static final AttributeKey<String> EVALUATOR_TYPE_KEY = AttributeKey.stringKey("evaluator_type");
     private static final AttributeKey<String> MODEL_KEY = AttributeKey.stringKey("model");
+    private static final AttributeKey<String> DECISION_KEY = AttributeKey.stringKey("decision");
+    private static final AttributeKey<String> OUTCOME_KEY = AttributeKey.stringKey("outcome");
 
     private final LongHistogram inputChars;
     private final LongHistogram outputChars;
+    // End-to-end funnel counters (low cardinality: evaluator_type + a small fixed enum, never workspace_id).
+    private final LongCounter sampled;
+    private final LongCounter enqueued;
+    private final LongCounter evals;
+    private final LongCounter scoresStored;
+
+    /**
+     * Terminal outcome of one online-scoring eval, used as the bounded {@code outcome} label on
+     * {@link #recordEvalOutcome}. Kept a small fixed set so the counter stays low-cardinality.
+     */
+    public enum EvalOutcome {
+        SCORED("scored"),
+        SKIPPED_NO_TRACES("skipped_no_traces"),
+        SKIPPED_RULE_MISSING("skipped_rule_missing"),
+        ERROR("error");
+
+        private final String label;
+
+        EvalOutcome(String label) {
+            this.label = label;
+        }
+
+        public String label() {
+            return label;
+        }
+    }
 
     @Inject
     public OnlineScoringMetrics() {
@@ -54,6 +83,57 @@ public class OnlineScoringMetrics {
                 .setDescription("Approximate character count of the LLM-as-judge response text per round-trip")
                 .setUnit("chars")
                 .build();
+        this.sampled = meter.counterBuilder("online_scoring_sampled")
+                .setDescription("Traces evaluated against a rule's sampling rate, by decision (sampled|dropped)")
+                .build();
+        this.enqueued = meter.counterBuilder("online_scoring_enqueued")
+                .setDescription("Messages enqueued into the online-scoring Redis streams (post-sampling, post-quota)")
+                .build();
+        this.evals = meter.counterBuilder("online_scoring_eval")
+                .setDescription(
+                        "Online-scoring eval terminal outcomes (scored|skipped_no_traces|skipped_rule_missing|error)")
+                .build();
+        this.scoresStored = meter.counterBuilder("online_scoring_scores_stored")
+                .setDescription("Feedback scores produced and stored by online scoring")
+                .build();
+    }
+
+    /**
+     * Funnel top (B4): how many candidate traces a rule's sampling rate let through vs dropped.
+     */
+    public void recordSampled(@NonNull AutomationRuleEvaluatorType evaluatorType, long sampledIn, long dropped) {
+        var type = evaluatorType.getType();
+        if (sampledIn > 0) {
+            sampled.add(sampledIn, Attributes.of(EVALUATOR_TYPE_KEY, type, DECISION_KEY, "sampled"));
+        }
+        if (dropped > 0) {
+            sampled.add(dropped, Attributes.of(EVALUATOR_TYPE_KEY, type, DECISION_KEY, "dropped"));
+        }
+    }
+
+    /**
+     * Funnel middle (B5): messages actually enqueued into Redis for a given evaluator type.
+     */
+    public void recordEnqueued(@NonNull AutomationRuleEvaluatorType evaluatorType, long count) {
+        if (count > 0) {
+            enqueued.add(count, Attributes.of(EVALUATOR_TYPE_KEY, evaluatorType.getType()));
+        }
+    }
+
+    /**
+     * Funnel bottom (B2): the terminal outcome of one eval (scored / skipped / error).
+     */
+    public void recordEvalOutcome(@NonNull AutomationRuleEvaluatorType evaluatorType, @NonNull EvalOutcome outcome) {
+        evals.add(1, Attributes.of(EVALUATOR_TYPE_KEY, evaluatorType.getType(), OUTCOME_KEY, outcome.label()));
+    }
+
+    /**
+     * Funnel bottom (B2): feedback scores actually written for an eval.
+     */
+    public void recordScoresStored(@NonNull AutomationRuleEvaluatorType evaluatorType, long count) {
+        if (count > 0) {
+            scoresStored.add(count, Attributes.of(EVALUATOR_TYPE_KEY, evaluatorType.getType()));
+        }
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringMetrics.java
@@ -1,0 +1,131 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongHistogram;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.UUID;
+
+/**
+ * Records the approximate character size of each online-scoring LLM round-trip so we can size the
+ * memory an evaluation holds while blocked on the provider (OPIK-6813) and spot heavy workloads.
+ * Stateful — owns the OTel instruments — so it is injected as a {@code @Singleton} rather than a
+ * static utility.
+ *
+ * <p>The histograms are tagged with {@code evaluator_type} and {@code model} only: {@code rule_id}
+ * and {@code workspace_id} are unbounded and would blow the prod metrics cardinality limit, so they
+ * are emitted on a log line instead (sizes only — never the rendered content).
+ */
+@Singleton
+@Slf4j
+public class OnlineScoringMetrics {
+
+    private static final String METER_NAME = "opik.online_scoring";
+    private static final AttributeKey<String> EVALUATOR_TYPE_KEY = AttributeKey.stringKey("evaluator_type");
+    private static final AttributeKey<String> MODEL_KEY = AttributeKey.stringKey("model");
+
+    private final LongHistogram inputChars;
+    private final LongHistogram outputChars;
+
+    @Inject
+    public OnlineScoringMetrics() {
+        var meter = GlobalOpenTelemetry.get().getMeter(METER_NAME);
+        this.inputChars = meter.histogramBuilder("online_scoring_llm_input_chars")
+                .ofLongs()
+                .setDescription("Approximate character count of the LLM-as-judge request messages per round-trip")
+                .setUnit("chars")
+                .build();
+        this.outputChars = meter.histogramBuilder("online_scoring_llm_output_chars")
+                .ofLongs()
+                .setDescription("Approximate character count of the LLM-as-judge response text per round-trip")
+                .setUnit("chars")
+                .build();
+    }
+
+    /**
+     * Records one LLM round-trip's input/output sizes. Called per provider call — including each
+     * agentic tool-loop round — so multi-turn evaluations are captured turn by turn.
+     */
+    public void recordPayloadSize(@NonNull ChatRequest request, @NonNull ChatResponse response,
+            @NonNull AutomationRuleEvaluatorType evaluatorType, @NonNull String model,
+            @NonNull String workspaceId, @NonNull UUID ruleId) {
+        long input = inputChars(request);
+        long output = outputChars(response);
+
+        var attributes = buildAttributes(evaluatorType, model);
+        inputChars.record(input, attributes);
+        outputChars.record(output, attributes);
+
+        log.debug(
+                "Online scoring LLM payload size: evaluatorType '{}', model '{}', workspaceId '{}', ruleId '{}', inputChars '{}', outputChars '{}'",
+                evaluatorType.getType(), model, workspaceId, ruleId, input, output);
+    }
+
+    /**
+     * Sums the character length of every message in the request. Switches on the message type and
+     * reads the already-materialized text rather than calling {@code toString()} on the message —
+     * stringifying a multi-MB rendered prompt just to measure it would roughly double the per-eval
+     * heap churn (the same reason {@link OnlineScoringEngine#summarizeRequest} avoids it). Non-text
+     * (image / audio / video) content parts are skipped.
+     */
+    /**
+     * Builds the histogram tag set: {@code evaluator_type} and {@code model} only. {@code rule_id}
+     * and {@code workspace_id} are deliberately excluded — they are unbounded and would breach the
+     * prod metrics cardinality limit. Kept package-private so the cardinality contract is locked in
+     * by a unit test.
+     */
+    static Attributes buildAttributes(AutomationRuleEvaluatorType evaluatorType, String model) {
+        return Attributes.of(EVALUATOR_TYPE_KEY, evaluatorType.getType(), MODEL_KEY, model);
+    }
+
+    static long inputChars(ChatRequest request) {
+        if (request == null || request.messages() == null) {
+            return 0L;
+        }
+        return request.messages().stream()
+                .mapToLong(OnlineScoringMetrics::messageChars)
+                .sum();
+    }
+
+    static long messageChars(ChatMessage message) {
+        return switch (message) {
+            case null -> 0L;
+            case SystemMessage systemMessage -> length(systemMessage.text());
+            case UserMessage userMessage -> userMessage.contents() == null
+                    ? 0L
+                    : userMessage.contents().stream()
+                            .mapToLong(content -> content instanceof TextContent textContent
+                                    ? length(textContent.text())
+                                    : 0L)
+                            .sum();
+            case AiMessage aiMessage -> length(aiMessage.text());
+            case ToolExecutionResultMessage toolResult -> length(toolResult.text());
+            default -> 0L;
+        };
+    }
+
+    static long outputChars(ChatResponse response) {
+        if (response == null || response.aiMessage() == null) {
+            return 0L;
+        }
+        return length(response.aiMessage().text());
+    }
+
+    private static long length(String value) {
+        return value == null ? 0L : value.length();
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringQuotaService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringQuotaService.java
@@ -1,0 +1,109 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.infrastructure.OnlineScoringConfig;
+import com.comet.opik.infrastructure.ratelimit.RateLimitService;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.comet.opik.infrastructure.RateLimitConfig.LimitConfig;
+
+/**
+ * Per-workspace producer quota for online scoring (OPIK-6813 B2). Caps how many scoring evals a
+ * single workspace may enqueue per time window — fleet-wide, via the distributed
+ * {@link RateLimitService} — so one workspace's automation rules can't flood the shared Redis
+ * streams and starve other tenants. Applied at the producer, after the per-rule sampling rate, so
+ * the over-quota remainder is shed before it ever reaches Redis. Disabled by default.
+ */
+@Singleton
+@Slf4j
+public class OnlineScoringQuotaService {
+
+    private static final String BUCKET_NAME = "online_scoring_quota:%s";
+    private static final String METER_NAME = "opik.online_scoring";
+    private static final AttributeKey<String> EVALUATOR_TYPE_KEY = AttributeKey.stringKey("evaluator_type");
+    private static final AttributeKey<String> WORKSPACE_ID_KEY = AttributeKey.stringKey("workspace_id");
+    private static final AttributeKey<String> RULE_ID_KEY = AttributeKey.stringKey("rule_id");
+
+    private final RateLimitService rateLimitService;
+    private final OnlineScoringConfig.PerWorkspaceQuota quota;
+    private final LongCounter admittedEvals;
+    private final LongCounter droppedEvals;
+
+    @Inject
+    public OnlineScoringQuotaService(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
+            @NonNull RateLimitService rateLimitService) {
+        this.rateLimitService = rateLimitService;
+        this.quota = config.getPerWorkspaceQuota();
+        var meter = GlobalOpenTelemetry.get().getMeter(METER_NAME);
+        this.admittedEvals = meter
+                .counterBuilder("online_scoring_quota_admitted")
+                .setDescription("Online-scoring evals admitted under the per-workspace quota")
+                .build();
+        this.droppedEvals = meter
+                .counterBuilder("online_scoring_quota_dropped")
+                .setDescription("Online-scoring evals dropped because the per-workspace quota was exceeded")
+                .build();
+    }
+
+    /**
+     * Returns the sublist of {@code items} admitted under the workspace quota, dropping the
+     * over-quota remainder (best-effort: shed at the source, never deferred or retried). When the
+     * quota is disabled the input is returned unchanged. On any rate-limiter error it fails open
+     * (admits all) so a limiter hiccup never stops scoring.
+     */
+    public <T> List<T> admit(@NonNull String workspaceId, @NonNull UUID ruleId, @NonNull String evaluatorType,
+            @NonNull List<T> items) {
+        if (items.isEmpty() || !quota.isEnabled() || quota.getLimit() <= 0) {
+            return items;
+        }
+        int requested = items.size();
+        int admitted = tryAdmit(workspaceId, requested);
+        record(workspaceId, ruleId, evaluatorType, admitted, requested - admitted);
+        return admitted >= requested ? items : items.subList(0, admitted);
+    }
+
+    private int tryAdmit(String workspaceId, int requested) {
+        var bucket = BUCKET_NAME.formatted(workspaceId);
+        var limitConfig = new LimitConfig("NA", "online_scoring_quota", quota.getLimit(),
+                quota.getDurationInSeconds(), "");
+        try {
+            long available = rateLimitService.availableEvents(bucket, limitConfig).blockOptional().orElse(0L);
+            int toAdmit = (int) Math.min(available, requested);
+            if (toAdmit <= 0) {
+                return 0;
+            }
+            boolean exceeded = Boolean.TRUE.equals(
+                    rateLimitService.isLimitExceeded(toAdmit, bucket, limitConfig).block());
+            return exceeded ? 0 : toAdmit;
+        } catch (RuntimeException exception) {
+            // Fail open: a limiter hiccup must never stop scoring (the trace is already ingested).
+            log.warn("Online scoring quota check failed for workspaceId '{}', admitting all", workspaceId, exception);
+            return requested;
+        }
+    }
+
+    private void record(String workspaceId, UUID ruleId, String evaluatorType, int admitted, int dropped) {
+        if (admitted > 0) {
+            admittedEvals.add(admitted, Attributes.of(EVALUATOR_TYPE_KEY, evaluatorType));
+        }
+        if (dropped > 0) {
+            // workspace_id + rule_id ride only on the DROPPED counter: it fires solely for over-quota
+            // offenders (a small set), so the per-customer/per-rule labels stay within the metrics
+            // cardinality budget while giving full drop visibility in Grafana.
+            droppedEvals.add(dropped, Attributes.of(
+                    EVALUATOR_TYPE_KEY, evaluatorType, WORKSPACE_ID_KEY, workspaceId, RULE_ID_KEY, ruleId.toString()));
+            log.info("Online scoring quota dropped '{}' of '{}' evals for workspaceId '{}', ruleId '{}', type '{}'",
+                    dropped, admitted + dropped, workspaceId, ruleId, evaluatorType);
+        }
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
@@ -64,6 +64,7 @@ public class OnlineScoringSampler {
     private final Logger userFacingLogger;
     private final ServiceTogglesConfig serviceTogglesConfig;
     private final OnlineScorePublisher onlineScorePublisher;
+    private final OnlineScoringQuotaService quotaService;
 
     @Inject
     public OnlineScoringSampler(@NonNull @Config("serviceToggles") ServiceTogglesConfig serviceTogglesConfig,
@@ -71,13 +72,15 @@ public class OnlineScoringSampler {
             @NonNull TraceFilterEvaluationService filterEvaluationService,
             @NonNull OnlineScorePublisher onlineScorePublisher,
             @NonNull TraceService traceService,
-            @NonNull ProjectService projectService) throws NoSuchAlgorithmException {
+            @NonNull ProjectService projectService,
+            @NonNull OnlineScoringQuotaService quotaService) throws NoSuchAlgorithmException {
         this.ruleEvaluatorService = ruleEvaluatorService;
         this.filterEvaluationService = filterEvaluationService;
         this.onlineScorePublisher = onlineScorePublisher;
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.traceService = traceService;
         this.projectService = projectService;
+        this.quotaService = quotaService;
         secureRandom = SecureRandom.getInstanceStrong();
         userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringSampler.class);
     }
@@ -203,8 +206,10 @@ public class OnlineScoringSampler {
                                         (AutomationRuleEvaluatorLlmAsJudge) evaluator, trace))
                                 .toList();
                         logSampledTrace(evaluator, messages, scorableTraces.size());
-                        if (!messages.isEmpty()) {
-                            onlineScorePublisher.enqueueMessage(messages, AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+                        var admitted = quotaService.admit(workspaceId, evaluator.getId(),
+                                evaluator.getType().getType(), messages);
+                        if (!admitted.isEmpty()) {
+                            onlineScorePublisher.enqueueMessage(admitted, AutomationRuleEvaluatorType.LLM_AS_JUDGE);
                         }
                     }
                     case USER_DEFINED_METRIC_PYTHON -> {
@@ -214,8 +219,10 @@ public class OnlineScoringSampler {
                                             (AutomationRuleEvaluatorUserDefinedMetricPython) evaluator, trace))
                                     .toList();
                             logSampledTrace(evaluator, messages, scorableTraces.size());
-                            if (!messages.isEmpty()) {
-                                onlineScorePublisher.enqueueMessage(messages,
+                            var admitted = quotaService.admit(workspaceId, evaluator.getId(),
+                                    evaluator.getType().getType(), messages);
+                            if (!admitted.isEmpty()) {
+                                onlineScorePublisher.enqueueMessage(admitted,
                                         AutomationRuleEvaluatorType.USER_DEFINED_METRIC_PYTHON);
                             }
                         } else {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
@@ -65,6 +65,7 @@ public class OnlineScoringSampler {
     private final ServiceTogglesConfig serviceTogglesConfig;
     private final OnlineScorePublisher onlineScorePublisher;
     private final OnlineScoringQuotaService quotaService;
+    private final OnlineScoringMetrics onlineScoringMetrics;
 
     @Inject
     public OnlineScoringSampler(@NonNull @Config("serviceToggles") ServiceTogglesConfig serviceTogglesConfig,
@@ -73,7 +74,8 @@ public class OnlineScoringSampler {
             @NonNull OnlineScorePublisher onlineScorePublisher,
             @NonNull TraceService traceService,
             @NonNull ProjectService projectService,
-            @NonNull OnlineScoringQuotaService quotaService) throws NoSuchAlgorithmException {
+            @NonNull OnlineScoringQuotaService quotaService,
+            @NonNull OnlineScoringMetrics onlineScoringMetrics) throws NoSuchAlgorithmException {
         this.ruleEvaluatorService = ruleEvaluatorService;
         this.filterEvaluationService = filterEvaluationService;
         this.onlineScorePublisher = onlineScorePublisher;
@@ -81,6 +83,7 @@ public class OnlineScoringSampler {
         this.traceService = traceService;
         this.projectService = projectService;
         this.quotaService = quotaService;
+        this.onlineScoringMetrics = onlineScoringMetrics;
         secureRandom = SecureRandom.getInstanceStrong();
         userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringSampler.class);
     }
@@ -206,6 +209,8 @@ public class OnlineScoringSampler {
                                         (AutomationRuleEvaluatorLlmAsJudge) evaluator, trace))
                                 .toList();
                         logSampledTrace(evaluator, messages, scorableTraces.size());
+                        onlineScoringMetrics.recordSampled(evaluator.getType(), messages.size(),
+                                scorableTraces.size() - messages.size());
                         var admitted = quotaService.admit(workspaceId, evaluator.getId(),
                                 evaluator.getType().getType(), messages);
                         if (!admitted.isEmpty()) {
@@ -219,6 +224,8 @@ public class OnlineScoringSampler {
                                             (AutomationRuleEvaluatorUserDefinedMetricPython) evaluator, trace))
                                     .toList();
                             logSampledTrace(evaluator, messages, scorableTraces.size());
+                            onlineScoringMetrics.recordSampled(evaluator.getType(), messages.size(),
+                                    scorableTraces.size() - messages.size());
                             var admitted = quotaService.admit(workspaceId, evaluator.getId(),
                                     evaluator.getType().getType(), messages);
                             if (!admitted.isEmpty()) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
@@ -43,6 +43,7 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
     private final ChatCompletionService aiProxyService;
     private final Logger userFacingLogger;
     private final LlmProviderFactory llmProviderFactory;
+    private final OnlineScoringMetrics onlineScoringMetrics;
 
     @Inject
     public OnlineScoringSpanLlmAsJudgeScorer(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
@@ -51,12 +52,14 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
             @NonNull FeedbackScoreService feedbackScoreService,
             @NonNull ChatCompletionService aiProxyService,
             @NonNull TraceService traceService,
-            @NonNull LlmProviderFactory llmProviderFactory) {
+            @NonNull LlmProviderFactory llmProviderFactory,
+            @NonNull OnlineScoringMetrics onlineScoringMetrics) {
         super(config, redisson, feedbackScoreService, traceService, SPAN_LLM_AS_JUDGE, Constants.SPAN_LLM_AS_JUDGE);
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.aiProxyService = aiProxyService;
         this.userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringSpanLlmAsJudgeScorer.class);
         this.llmProviderFactory = llmProviderFactory;
+        this.onlineScoringMetrics = onlineScoringMetrics;
     }
 
     @Override
@@ -138,6 +141,8 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
 
             var score = aiProxyService.scoreTrace(
                     scoreRequest, message.llmAsJudgeCode().model(), message.workspaceId());
+            onlineScoringMetrics.recordPayloadSize(scoreRequest, score, type,
+                    message.llmAsJudgeCode().model().name(), message.workspaceId(), message.ruleId());
             userFacingLogger.info("Received response for spanId '{}':\n\n{}", span.id(), score);
 
             var parsed = OnlineScoringEngine.toFeedbackScores(score);

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
@@ -59,6 +59,17 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
     }
 
     @Override
+    protected boolean isAdmissionControlEnabled() {
+        return serviceTogglesConfig.isMemoryAwareScoringBoundEnabled();
+    }
+
+    @Override
+    protected long estimateInFlightBytes(SpanToScoreLlmAsJudge message) {
+        var span = message.span();
+        return jsonSize(span.input(), span.output(), span.metadata());
+    }
+
+    @Override
     public void start() {
         if (serviceTogglesConfig.isSpanLlmAsJudgeEnabled()) {
             super.start();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
@@ -43,7 +43,6 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
     private final ChatCompletionService aiProxyService;
     private final Logger userFacingLogger;
     private final LlmProviderFactory llmProviderFactory;
-    private final OnlineScoringMetrics onlineScoringMetrics;
 
     @Inject
     public OnlineScoringSpanLlmAsJudgeScorer(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
@@ -54,12 +53,12 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
             @NonNull TraceService traceService,
             @NonNull LlmProviderFactory llmProviderFactory,
             @NonNull OnlineScoringMetrics onlineScoringMetrics) {
-        super(config, redisson, feedbackScoreService, traceService, SPAN_LLM_AS_JUDGE, Constants.SPAN_LLM_AS_JUDGE);
+        super(config, redisson, feedbackScoreService, traceService, onlineScoringMetrics, SPAN_LLM_AS_JUDGE,
+                Constants.SPAN_LLM_AS_JUDGE);
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.aiProxyService = aiProxyService;
         this.userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringSpanLlmAsJudgeScorer.class);
         this.llmProviderFactory = llmProviderFactory;
-        this.onlineScoringMetrics = onlineScoringMetrics;
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
@@ -10,6 +10,7 @@ import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
 import dev.langchain4j.model.chat.request.ChatRequest;
+import io.opentelemetry.api.common.Attributes;
 import jakarta.inject.Inject;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -67,6 +68,11 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
     protected long estimateInFlightBytes(SpanToScoreLlmAsJudge message) {
         var span = message.span();
         return jsonSize(span.input(), span.output(), span.metadata());
+    }
+
+    @Override
+    protected Attributes admissionAttributes(SpanToScoreLlmAsJudge message) {
+        return scoringAttributes(message.workspaceId(), message.ruleId());
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSampler.java
@@ -55,18 +55,21 @@ public class OnlineScoringSpanSampler {
     private final ServiceTogglesConfig serviceTogglesConfig;
     private final OnlineScorePublisher onlineScorePublisher;
     private final OnlineScoringQuotaService quotaService;
+    private final OnlineScoringMetrics onlineScoringMetrics;
 
     @Inject
     public OnlineScoringSpanSampler(@NonNull @Config("serviceToggles") ServiceTogglesConfig serviceTogglesConfig,
             @NonNull AutomationRuleEvaluatorService ruleEvaluatorService,
             @NonNull SpanFilterEvaluationService filterEvaluationService,
             @NonNull OnlineScorePublisher onlineScorePublisher,
-            @NonNull OnlineScoringQuotaService quotaService) throws NoSuchAlgorithmException {
+            @NonNull OnlineScoringQuotaService quotaService,
+            @NonNull OnlineScoringMetrics onlineScoringMetrics) throws NoSuchAlgorithmException {
         this.ruleEvaluatorService = ruleEvaluatorService;
         this.filterEvaluationService = filterEvaluationService;
         this.onlineScorePublisher = onlineScorePublisher;
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.quotaService = quotaService;
+        this.onlineScoringMetrics = onlineScoringMetrics;
         secureRandom = SecureRandom.getInstanceStrong();
         userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringSpanSampler.class);
     }
@@ -142,6 +145,8 @@ public class OnlineScoringSpanSampler {
                                 .map(span -> toLlmAsJudgeMessage(spansBatch, rule, span))
                                 .toList();
                         logSampledSpan(evaluator, messages, scorableSpans.size());
+                        onlineScoringMetrics.recordSampled(rule.getType(), messages.size(),
+                                scorableSpans.size() - messages.size());
                         var admitted = quotaService.admit(spansBatch.workspaceId(), rule.getId(),
                                 rule.getType().getType(), messages);
                         if (!admitted.isEmpty()) {
@@ -169,6 +174,8 @@ public class OnlineScoringSpanSampler {
                                 .map(span -> toUserDefinedMetricPythonMessage(spansBatch, rule, span))
                                 .toList();
                         logSampledSpan(evaluator, messages, scorableSpans.size());
+                        onlineScoringMetrics.recordSampled(rule.getType(), messages.size(),
+                                scorableSpans.size() - messages.size());
                         var admitted = quotaService.admit(spansBatch.workspaceId(), rule.getId(),
                                 rule.getType().getType(), messages);
                         if (!admitted.isEmpty()) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSampler.java
@@ -54,16 +54,19 @@ public class OnlineScoringSpanSampler {
     private final Logger userFacingLogger;
     private final ServiceTogglesConfig serviceTogglesConfig;
     private final OnlineScorePublisher onlineScorePublisher;
+    private final OnlineScoringQuotaService quotaService;
 
     @Inject
     public OnlineScoringSpanSampler(@NonNull @Config("serviceToggles") ServiceTogglesConfig serviceTogglesConfig,
             @NonNull AutomationRuleEvaluatorService ruleEvaluatorService,
             @NonNull SpanFilterEvaluationService filterEvaluationService,
-            @NonNull OnlineScorePublisher onlineScorePublisher) throws NoSuchAlgorithmException {
+            @NonNull OnlineScorePublisher onlineScorePublisher,
+            @NonNull OnlineScoringQuotaService quotaService) throws NoSuchAlgorithmException {
         this.ruleEvaluatorService = ruleEvaluatorService;
         this.filterEvaluationService = filterEvaluationService;
         this.onlineScorePublisher = onlineScorePublisher;
         this.serviceTogglesConfig = serviceTogglesConfig;
+        this.quotaService = quotaService;
         secureRandom = SecureRandom.getInstanceStrong();
         userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringSpanSampler.class);
     }
@@ -139,8 +142,10 @@ public class OnlineScoringSpanSampler {
                                 .map(span -> toLlmAsJudgeMessage(spansBatch, rule, span))
                                 .toList();
                         logSampledSpan(evaluator, messages, scorableSpans.size());
-                        if (!messages.isEmpty()) {
-                            onlineScorePublisher.enqueueMessage(messages,
+                        var admitted = quotaService.admit(spansBatch.workspaceId(), rule.getId(),
+                                rule.getType().getType(), messages);
+                        if (!admitted.isEmpty()) {
+                            onlineScorePublisher.enqueueMessage(admitted,
                                     AutomationRuleEvaluatorType.SPAN_LLM_AS_JUDGE);
                         }
                     }
@@ -164,8 +169,10 @@ public class OnlineScoringSpanSampler {
                                 .map(span -> toUserDefinedMetricPythonMessage(spansBatch, rule, span))
                                 .toList();
                         logSampledSpan(evaluator, messages, scorableSpans.size());
-                        if (!messages.isEmpty()) {
-                            onlineScorePublisher.enqueueMessage(messages,
+                        var admitted = quotaService.admit(spansBatch.workspaceId(), rule.getId(),
+                                rule.getType().getType(), messages);
+                        if (!admitted.isEmpty()) {
+                            onlineScorePublisher.enqueueMessage(admitted,
                                     AutomationRuleEvaluatorType.SPAN_USER_DEFINED_METRIC_PYTHON);
                         }
                     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorer.java
@@ -50,9 +50,10 @@ public class OnlineScoringSpanUserDefinedMetricPythonScorer
             @NonNull RedissonReactiveClient redisson,
             @NonNull FeedbackScoreService feedbackScoreService,
             @NonNull TraceService traceService,
-            @NonNull PythonEvaluatorService pythonEvaluatorService) {
-        super(config, redisson, feedbackScoreService, traceService, SPAN_USER_DEFINED_METRIC_PYTHON,
-                Constants.SPAN_USER_DEFINED_METRIC_PYTHON);
+            @NonNull PythonEvaluatorService pythonEvaluatorService,
+            @NonNull OnlineScoringMetrics onlineScoringMetrics) {
+        super(config, redisson, feedbackScoreService, traceService, onlineScoringMetrics,
+                SPAN_USER_DEFINED_METRIC_PYTHON, Constants.SPAN_USER_DEFINED_METRIC_PYTHON);
         this.pythonEvaluatorService = pythonEvaluatorService;
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.userFacingLogger = UserFacingLoggingFactory

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -73,6 +73,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
     private final OnlineScoringConfig onlineScoringConfig;
     private final ServiceTogglesConfig serviceTogglesConfig;
     private final SpanService spanService;
+    private final OnlineScoringMetrics onlineScoringMetrics;
 
     @Inject
     public OnlineScoringTraceThreadLlmAsJudgeScorer(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
@@ -86,7 +87,8 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
             @NonNull ProjectService projectService,
             @NonNull AutomationRuleEvaluatorService automationRuleEvaluatorService,
             @NonNull ToolRegistry toolRegistry,
-            @NonNull SpanService spanService) {
+            @NonNull SpanService spanService,
+            @NonNull OnlineScoringMetrics onlineScoringMetrics) {
         super(config, redisson, feedbackScoreService, traceService, TRACE_THREAD_LLM_AS_JUDGE,
                 Constants.TRACE_THREAD_LLM_AS_JUDGE);
         this.aiProxyService = aiProxyService;
@@ -98,6 +100,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         this.onlineScoringConfig = config;
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.spanService = spanService;
+        this.onlineScoringMetrics = onlineScoringMetrics;
         this.userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringTraceThreadLlmAsJudgeScorer.class);
     }
 
@@ -424,9 +427,13 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
      * per-stream worker scheduler thread (OPIK-6308). Mirrors the trace scorer.
      */
     private Mono<ChatResponse> scoreTraceReactive(ChatRequest request, TraceThreadToScoreLlmAsJudge message) {
-        return Mono.fromCallable(() -> aiProxyService.scoreTrace(
-                request, message.code().model(), message.workspaceId()))
-                .subscribeOn(Schedulers.boundedElastic());
+        return Mono.fromCallable(() -> {
+            var response = aiProxyService.scoreTrace(
+                    request, message.code().model(), message.workspaceId());
+            onlineScoringMetrics.recordPayloadSize(request, response, type,
+                    message.code().model().name(), message.workspaceId(), message.ruleId());
+            return response;
+        }).subscribeOn(Schedulers.boundedElastic());
     }
 
     // Package-private for unit tests.

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -131,6 +131,11 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         log.info("Message received with projectId: '{}', ruleId: '{}', threadIds: '{}' for workspace '{}'",
                 message.projectId(), message.ruleId(), message.threadIds(), message.workspaceId());
 
+        // Follow-up (heap bound): threads are scored with Flux's default concurrency (256), unbounded here.
+        // The admission gate (maxInFlightBytes) and consumerBatchSize cap concurrent *messages*, not threads
+        // within a single message — so one message carrying many threads can exceed the in-flight heap budget
+        // regardless of those limits. If heap pressure recurs with the gate enabled, bound this fan-out
+        // (flatMap(..., K)) and align estimateInFlightBytes to min(threadIds.size(), K) * avgThreadBytes.
         return Flux.fromIterable(message.threadIds())
                 .flatMap(threadId -> processThreadScores(message, threadId))
                 .then(Mono.defer(

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -73,7 +73,6 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
     private final OnlineScoringConfig onlineScoringConfig;
     private final ServiceTogglesConfig serviceTogglesConfig;
     private final SpanService spanService;
-    private final OnlineScoringMetrics onlineScoringMetrics;
 
     @Inject
     public OnlineScoringTraceThreadLlmAsJudgeScorer(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
@@ -89,7 +88,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
             @NonNull ToolRegistry toolRegistry,
             @NonNull SpanService spanService,
             @NonNull OnlineScoringMetrics onlineScoringMetrics) {
-        super(config, redisson, feedbackScoreService, traceService, TRACE_THREAD_LLM_AS_JUDGE,
+        super(config, redisson, feedbackScoreService, traceService, onlineScoringMetrics, TRACE_THREAD_LLM_AS_JUDGE,
                 Constants.TRACE_THREAD_LLM_AS_JUDGE);
         this.aiProxyService = aiProxyService;
         this.llmProviderFactory = llmProviderFactory;
@@ -100,7 +99,6 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         this.onlineScoringConfig = config;
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.spanService = spanService;
-        this.onlineScoringMetrics = onlineScoringMetrics;
         this.userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringTraceThreadLlmAsJudgeScorer.class);
     }
 
@@ -170,6 +168,8 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                                     "No traces found for threadId '{}' in projectId '{}'. Skipping scoring.",
                                     currentThreadId, message.projectId());
                         }
+                        onlineScoringMetrics.recordEvalOutcome(type,
+                                OnlineScoringMetrics.EvalOutcome.SKIPPED_NO_TRACES);
                         return Mono.empty();
                     }
                     return traceThreadService.getThreadModelId(message.projectId(), currentThreadId)
@@ -179,6 +179,8 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                                             "Thread model not found for threadId '{}' in projectId '{}'. Skipping scoring.",
                                             currentThreadId, message.projectId());
                                 }
+                                onlineScoringMetrics.recordEvalOutcome(type,
+                                        OnlineScoringMetrics.EvalOutcome.SKIPPED_RULE_MISSING);
                                 return Mono.empty();
                             }))
                             .flatMap(threadModelId -> processScoring(message, traces, threadModelId,
@@ -224,6 +226,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                 log.warn(
                         "Automation rule with ID '{}' not found in projectId '{}' for workspace '{}'. Skipping scoring for threadId '{}'.",
                         message.ruleId(), message.projectId(), message.workspaceId(), threadId);
+                onlineScoringMetrics.recordEvalOutcome(type, OnlineScoringMetrics.EvalOutcome.SKIPPED_RULE_MISSING);
                 return Optional.empty();
             }
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -29,6 +29,7 @@ import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import io.opentelemetry.api.common.Attributes;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 import lombok.NonNull;
@@ -111,6 +112,11 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         // scoring, so it isn't measurable here. Weight by thread count × the configured per-thread
         // estimate. Calibrate avgThreadBytes from the online_scoring_llm_*_chars metric.
         return (long) message.threadIds().size() * onlineScoringConfig.getAvgThreadBytes();
+    }
+
+    @Override
+    protected Attributes admissionAttributes(TraceThreadToScoreLlmAsJudge message) {
+        return scoringAttributes(message.workspaceId(), message.ruleId());
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -100,6 +100,19 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         this.userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringTraceThreadLlmAsJudgeScorer.class);
     }
 
+    @Override
+    protected boolean isAdmissionControlEnabled() {
+        return serviceTogglesConfig.isMemoryAwareScoringBoundEnabled();
+    }
+
+    @Override
+    protected long estimateInFlightBytes(TraceThreadToScoreLlmAsJudge message) {
+        // The message carries only thread IDs — the heavy context (traces + spans) is fetched while
+        // scoring, so it isn't measurable here. Weight by thread count × the configured per-thread
+        // estimate. Calibrate avgThreadBytes from the online_scoring_llm_*_chars metric.
+        return (long) message.threadIds().size() * onlineScoringConfig.getAvgThreadBytes();
+    }
+
     /**
      * Use AI Proxy to score the trace thread and store it as a feedback scores.
      * If the evaluator has multiple score definitions, it calls the LLM once per score definition.

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
@@ -75,9 +75,10 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
             @NonNull TraceThreadService traceThreadService,
             @NonNull ProjectService projectService,
             @NonNull AutomationRuleEvaluatorService automationRuleEvaluatorService,
-            @NonNull SpanService spanService) {
-        super(config, redisson, feedbackScoreService, traceService, TRACE_THREAD_USER_DEFINED_METRIC_PYTHON,
-                Constants.TRACE_THREAD_USER_DEFINED_METRIC_PYTHON);
+            @NonNull SpanService spanService,
+            @NonNull OnlineScoringMetrics onlineScoringMetrics) {
+        super(config, redisson, feedbackScoreService, traceService, onlineScoringMetrics,
+                TRACE_THREAD_USER_DEFINED_METRIC_PYTHON, Constants.TRACE_THREAD_USER_DEFINED_METRIC_PYTHON);
         this.pythonEvaluatorService = pythonEvaluatorService;
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.traceThreadService = traceThreadService;

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorer.java
@@ -53,9 +53,10 @@ public class OnlineScoringUserDefinedMetricPythonScorer
             @NonNull FeedbackScoreService feedbackScoreService,
             @NonNull TraceService traceService,
             @NonNull SpanService spanService,
-            @NonNull PythonEvaluatorService pythonEvaluatorService) {
-        super(config, redisson, feedbackScoreService, traceService, USER_DEFINED_METRIC_PYTHON,
-                Constants.USER_DEFINED_METRIC_PYTHON);
+            @NonNull PythonEvaluatorService pythonEvaluatorService,
+            @NonNull OnlineScoringMetrics onlineScoringMetrics) {
+        super(config, redisson, feedbackScoreService, traceService, onlineScoringMetrics,
+                USER_DEFINED_METRIC_PYTHON, Constants.USER_DEFINED_METRIC_PYTHON);
         this.pythonEvaluatorService = pythonEvaluatorService;
         this.spanService = spanService;
         this.serviceTogglesConfig = serviceTogglesConfig;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/OnlineScorePublisher.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/OnlineScorePublisher.java
@@ -6,6 +6,7 @@ import com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadUserDefin
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
 import com.comet.opik.api.events.TraceThreadToScoreLlmAsJudge;
 import com.comet.opik.api.events.TraceThreadToScoreUserDefinedMetricPython;
+import com.comet.opik.api.resources.v1.events.OnlineScoringMetrics;
 import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.infrastructure.OnlineScoringStreamConfigurationAdapter;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
@@ -60,15 +61,18 @@ class OnlineScorePublisherImpl implements OnlineScorePublisher {
     private final AutomationRuleEvaluatorService automationRuleEvaluatorService;
     private final Map<AutomationRuleEvaluatorType, OnlineScoringStreamConfigurationAdapter> streamConfigurations;
     private final ServiceTogglesConfig serviceTogglesConfig;
+    private final OnlineScoringMetrics onlineScoringMetrics;
 
     @Inject
     public OnlineScorePublisherImpl(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
             @NonNull @Config("serviceToggles") ServiceTogglesConfig serviceTogglesConfig,
             @NonNull RedissonReactiveClient redisClient,
-            @NonNull AutomationRuleEvaluatorService automationRuleEvaluatorService) {
+            @NonNull AutomationRuleEvaluatorService automationRuleEvaluatorService,
+            @NonNull OnlineScoringMetrics onlineScoringMetrics) {
         this.redisClient = redisClient;
         this.automationRuleEvaluatorService = automationRuleEvaluatorService;
         this.serviceTogglesConfig = serviceTogglesConfig;
+        this.onlineScoringMetrics = onlineScoringMetrics;
         this.streamConfigurations = config.getStreams().stream()
                 .map(streamConfiguration -> {
                     var evaluatorType = AutomationRuleEvaluatorType.fromString(streamConfiguration.getScorer());
@@ -83,6 +87,7 @@ class OnlineScorePublisherImpl implements OnlineScorePublisher {
 
     public void enqueueMessage(List<?> messages, AutomationRuleEvaluatorType type) {
         var config = streamConfigurations.get(type);
+        onlineScoringMetrics.recordEnqueued(type, messages.size());
         var codec = config.getCodec();
         var stream = redisClient.getStream(config.getStreamName(), codec);
         Flux.fromIterable(messages)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadOnlineScorerPublisher.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadOnlineScorerPublisher.java
@@ -1,5 +1,6 @@
 package com.comet.opik.domain.threads;
 
+import com.comet.opik.api.resources.v1.events.OnlineScoringQuotaService;
 import com.comet.opik.domain.evaluators.OnlineScorePublisher;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.google.inject.Inject;
@@ -22,7 +23,10 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 class TraceThreadOnlineScorerPublisher {
 
+    private static final String THREAD_EVALUATOR_TYPE = "trace_thread";
+
     private final @NonNull OnlineScorePublisher onlineScorePublisher;
+    private final @NonNull OnlineScoringQuotaService quotaService;
 
     public Mono<Void> publish(@NonNull UUID projectId, @NonNull List<TraceThreadModel> closeThreads) {
         return Mono.deferContextual(ctx -> {
@@ -50,12 +54,18 @@ class TraceThreadOnlineScorerPublisher {
                         UUID ruleId = ruleIdToThreadIds.getKey();
                         Set<String> threadIds = ruleIdToThreadIds.getValue();
 
+                        var admittedThreadIds = quotaService.admit(workspaceId, ruleId, THREAD_EVALUATOR_TYPE,
+                                List.copyOf(threadIds));
+                        if (admittedThreadIds.isEmpty()) {
+                            return ruleId;
+                        }
+
                         log.info(
                                 "Enqueuing threads: '{}' trace threads for ruleId: '{}' in projectId '{}' for workspaceId '{}'",
-                                threadIds, ruleId, projectId, workspaceId);
+                                admittedThreadIds, ruleId, projectId, workspaceId);
 
                         onlineScorePublisher.enqueueThreadMessage(
-                                List.copyOf(threadIds),
+                                admittedThreadIds,
                                 ruleId,
                                 projectId,
                                 workspaceId,
@@ -63,7 +73,7 @@ class TraceThreadOnlineScorerPublisher {
 
                         log.info(
                                 "Enqueued threads: '{}' trace threads for ruleId: '{}' in projectId '{}' for workspaceId '{}'",
-                                threadIds, ruleId, projectId, workspaceId);
+                                admittedThreadIds, ruleId, projectId, workspaceId);
 
                         return ruleId;
                     }).subscribeOn(Schedulers.boundedElastic()))

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OnlineScoringConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OnlineScoringConfig.java
@@ -108,6 +108,45 @@ public class OnlineScoringConfig {
     @JsonProperty
     @Min(1) private long avgThreadBytes = 256_000;
 
+    /**
+     * Per-workspace producer quota for online scoring. Caps how many scoring evals a single
+     * workspace may enqueue per time window (fleet-wide, via the distributed rate limiter), so one
+     * workspace's automation rules can't flood the shared Redis streams and starve other tenants.
+     * Over-quota evals are shed at the producer (down-sampled / dropped — never deferred), after the
+     * per-rule sampling rate has already been applied. Disabled by default.
+     *
+     * <p>Field initializer (not {@code @Builder.Default}) so the default instance applies during
+     * Dropwizard's YAML deserialization (no-args constructor), not only via the builder.
+     */
+    @Valid @JsonProperty
+    @NotNull private PerWorkspaceQuota perWorkspaceQuota = new PerWorkspaceQuota();
+
+    @Data
+    @Builder(toBuilder = true)
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PerWorkspaceQuota {
+
+        @JsonProperty
+        @Builder.Default
+        private boolean enabled = false;
+
+        /**
+         * Max scoring evals a workspace may enqueue per {@link #durationInSeconds} window. Only
+         * consulted when {@link #enabled}. {@code 0} (the default) leaves the quota a no-op even
+         * when enabled — sizing the limit is required to actually cap; the quota fails open rather
+         * than dropping everything on a half-configured rule. Size it from the volumes the
+         * online-scoring metrics report.
+         */
+        @JsonProperty
+        @Builder.Default
+        @Min(0) private long limit = 0;
+
+        @JsonProperty
+        @Builder.Default
+        @Min(1) private long durationInSeconds = 60;
+    }
+
     @Data
     @Builder(toBuilder = true)
     @NoArgsConstructor

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OnlineScoringConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OnlineScoringConfig.java
@@ -86,6 +86,28 @@ public class OnlineScoringConfig {
     @JsonProperty
     @Min(1) private int agenticToolsCharsPerToken = 4;
 
+    /**
+     * Global default for the memory-aware admission gate: the maximum estimated in-flight payload,
+     * in bytes, a single consumer processes concurrently. {@code 0} (default) disables the gate, so
+     * the consumer keeps its count-only concurrency. Gated at runtime by the
+     * {@code memoryAwareScoringBoundEnabled} service toggle; this value is only consulted when that
+     * toggle is on. Can be overridden per stream.
+     *
+     * <p>Field initializer (not {@code @Builder.Default}) so the default applies during Dropwizard's
+     * YAML deserialization (no-args constructor), not only via the builder.
+     */
+    @JsonProperty
+    @Min(0) private long maxInFlightBytes = 0;
+
+    /**
+     * Estimated bytes a single thread contributes to the in-flight payload, used to weight
+     * {@code trace_thread_llm_as_judge} messages — their Redis payload carries only thread IDs, so
+     * the heavy context (traces + spans) is fetched while scoring and isn't measurable at admission.
+     * Calibrate from the per-eval sizes the {@code online_scoring_llm_*_chars} metric reports.
+     */
+    @JsonProperty
+    @Min(1) private long avgThreadBytes = 256_000;
+
     @Data
     @Builder(toBuilder = true)
     @NoArgsConstructor
@@ -127,5 +149,8 @@ public class OnlineScoringConfig {
 
         @JsonProperty
         @Min(0) @Max(10_000) private Integer streamTrimLimit;
+
+        @JsonProperty
+        @Min(0) private Long maxInFlightBytes;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OnlineScoringStreamConfigurationAdapter.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OnlineScoringStreamConfigurationAdapter.java
@@ -110,4 +110,12 @@ public class OnlineScoringStreamConfigurationAdapter implements StreamConfigurat
                 ? streamConfig.getStreamTrimLimit()
                 : onlineScoringConfig.getStreamTrimLimit();
     }
+
+    @Override
+    public long getMaxInFlightBytes() {
+        // Use stream-specific value if present, otherwise fall back to global value
+        return streamConfig.getMaxInFlightBytes() != null
+                ? streamConfig.getMaxInFlightBytes()
+                : onlineScoringConfig.getMaxInFlightBytes();
+    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
@@ -65,6 +65,8 @@ public class ServiceTogglesConfig {
     @NotNull boolean ollieEnabled;
     @JsonProperty
     @NotNull boolean agenticToolsEnabled;
+    @JsonProperty
+    @NotNull boolean memoryAwareScoringBoundEnabled;
 
     @NotNull Set<@NotBlank String> v2WorkspaceAllowlistIds = Set.of();
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/StreamConfiguration.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/StreamConfiguration.java
@@ -28,4 +28,13 @@ public interface StreamConfiguration {
     int getStreamMaxLen();
 
     int getStreamTrimLimit();
+
+    /**
+     * Upper bound, in bytes, on the estimated in-flight payload a single consumer may process
+     * concurrently. {@code 0} (the default) disables the memory-aware admission gate, preserving
+     * the count-only concurrency behavior. Only the online-scoring streams override this.
+     */
+    default long getMaxInFlightBytes() {
+        return 0;
+    }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
@@ -575,6 +575,35 @@ class BaseRedisSubscriberTest {
             assertThat(subscriber.getFailedMessageCount().get()).isZero();
         }
 
+        @Test
+        void handlesNullPayloadWhenGatedWithoutLeakingBudget() {
+            var nullCount = new AtomicInteger();
+            var gatedConfig = config.toBuilder().maxInFlightBytes(TWO_PERMIT_BUDGET).build();
+            // Estimator dereferences the message: a null (missing-payload) message must bypass the gate
+            // rather than NPE eagerly and escape the reactive failure path. Valid messages still flow
+            // through the gate, so a leaked budget would stall them.
+            var subscriber = trackSubscriber(TestRedisSubscriber.gatedSubscriber(gatedConfig, redissonClient,
+                    message -> {
+                        if (message == null) {
+                            nullCount.incrementAndGet();
+                        }
+                        return Mono.empty();
+                    },
+                    message -> (long) message.length()));
+            subscriber.start();
+
+            var malformedMessages = PodamFactoryUtils.manufacturePojoList(podamFactory, String.class);
+            var validMessages = PodamFactoryUtils.manufacturePojoList(podamFactory, String.class);
+            // Wrong field → null message; then a normal batch through the gate.
+            publishMessagesToStream("other-payload", malformedMessages);
+            publishMessagesToStream(validMessages);
+
+            waitForMessagesProcessed(subscriber, malformedMessages.size() + validMessages.size());
+            waitForMessagesAckedAndRemoved();
+            assertThat(nullCount.get()).isEqualTo(malformedMessages.size());
+            assertThat(subscriber.getFailedMessageCount().get()).isZero();
+        }
+
         private void awaitLatch(CountDownLatch latch) {
             try {
                 latch.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.redisson.Redisson;
 import org.redisson.api.RStreamReactive;
@@ -36,8 +37,10 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.comet.opik.api.resources.utils.TestUtils.waitForMillis;
@@ -435,6 +438,149 @@ class BaseRedisSubscriberTest {
             waitForMessagesAckedAndRemoved(newMessages.size());
             assertThat(subscriber.getSuccessMessageCount().get()).isEqualTo(processedCountBeforeStop);
             assertThat(subscriber.getFailedMessageCount().get()).isZero();
+        }
+    }
+
+    @Nested
+    class AdmissionControlTests {
+
+        // 2048 bytes / 1024 bytes-per-permit = 2 permits of budget.
+        private static final long TWO_PERMIT_BUDGET = 2048;
+        private static final long ONE_PERMIT_WEIGHT = 1024;
+
+        @Test
+        void shouldBoundConcurrencyByInFlightBytes() {
+            var current = new AtomicInteger();
+            var maxConcurrent = new AtomicInteger();
+            var release = new CountDownLatch(1);
+            var gatedConfig = config.toBuilder().maxInFlightBytes(TWO_PERMIT_BUDGET).build();
+            // 5 messages, each weighing 1 permit, against a 2-permit budget → at most 2 run at once.
+            var messages = List.of("m1", "m2", "m3", "m4", "m5");
+            var subscriber = trackSubscriber(TestRedisSubscriber.gatedSubscriber(gatedConfig, redissonClient,
+                    message -> Mono.fromRunnable(() -> {
+                        maxConcurrent.accumulateAndGet(current.incrementAndGet(), Math::max);
+                        awaitLatch(release);
+                        current.decrementAndGet();
+                    }),
+                    message -> ONE_PERMIT_WEIGHT));
+            subscriber.start();
+
+            publishMessagesToStream(messages);
+
+            // Two messages occupy the whole budget; the rest wait at the gate.
+            await().atMost(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertThat(current.get()).isEqualTo(2));
+
+            release.countDown();
+            waitForMessagesProcessed(subscriber, messages.size());
+            waitForMessagesAckedAndRemoved();
+            // The gate never let more than the 2-permit budget run concurrently.
+            assertThat(maxConcurrent.get()).isEqualTo(2);
+            assertThat(subscriber.getFailedMessageCount().get()).isZero();
+        }
+
+        @Test
+        void shouldProcessMessageLargerThanBudgetSolo() {
+            var current = new AtomicInteger();
+            var maxConcurrent = new AtomicInteger();
+            var release = new CountDownLatch(1);
+            var gatedConfig = config.toBuilder().maxInFlightBytes(TWO_PERMIT_BUDGET).build();
+            // Each message is far larger than the whole budget — clamped to the full budget, so each
+            // runs alone instead of deadlocking (liveness).
+            var messages = List.of("big1", "big2", "big3");
+            var subscriber = trackSubscriber(TestRedisSubscriber.gatedSubscriber(gatedConfig, redissonClient,
+                    message -> Mono.fromRunnable(() -> {
+                        maxConcurrent.accumulateAndGet(current.incrementAndGet(), Math::max);
+                        awaitLatch(release);
+                        current.decrementAndGet();
+                    }),
+                    message -> 1_000_000L));
+            subscriber.start();
+
+            publishMessagesToStream(messages);
+
+            await().atMost(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertThat(current.get()).isEqualTo(1));
+
+            release.countDown();
+            waitForMessagesProcessed(subscriber, messages.size());
+            waitForMessagesAckedAndRemoved();
+            // Each oversized message ran alone; all still completed.
+            assertThat(maxConcurrent.get()).isEqualTo(1);
+            assertThat(subscriber.getFailedMessageCount().get()).isZero();
+        }
+
+        @Test
+        void shouldNotBoundConcurrencyWhenBudgetDisabled() {
+            var current = new AtomicInteger();
+            var maxConcurrent = new AtomicInteger();
+            var release = new CountDownLatch(1);
+            // maxInFlightBytes = 0 (default) → gate disabled even though the subscriber opts in and
+            // weighs messages; concurrency is the count-only behavior (up to consumerBatchSize).
+            var messages = List.of("m1", "m2", "m3", "m4", "m5");
+            var subscriber = trackSubscriber(TestRedisSubscriber.gatedSubscriber(config, redissonClient,
+                    message -> Mono.fromRunnable(() -> {
+                        maxConcurrent.accumulateAndGet(current.incrementAndGet(), Math::max);
+                        awaitLatch(release);
+                        current.decrementAndGet();
+                    }),
+                    message -> ONE_PERMIT_WEIGHT));
+            subscriber.start();
+
+            publishMessagesToStream(messages);
+
+            // All messages run concurrently (consumerBatchSize = 5) — no byte bound applied.
+            await().atMost(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertThat(current.get()).isEqualTo(messages.size()));
+
+            release.countDown();
+            waitForMessagesProcessed(subscriber, messages.size());
+            waitForMessagesAckedAndRemoved();
+            assertThat(maxConcurrent.get()).isEqualTo(messages.size());
+            assertThat(subscriber.getFailedMessageCount().get()).isZero();
+        }
+
+        // Bytes-awareness: with the budget fixed at 4 permits (4096 bytes), the number of evals that
+        // may run concurrently is budget / per-message-weight. Heavier messages each consume more of
+        // the budget, so fewer run at once — this is what distinguishes the gate from a plain count.
+        @ParameterizedTest(name = "weight={0} permits/msg @ 4-permit budget -> max concurrency {1}")
+        @CsvSource({"1, 4", "2, 2", "4, 1"})
+        void concurrencyScalesInverselyWithPerMessageWeight(int weightPermits, int expectedConcurrent) {
+            long budgetBytes = 4 * ONE_PERMIT_WEIGHT;
+            long weightBytes = weightPermits * ONE_PERMIT_WEIGHT;
+            var current = new AtomicInteger();
+            var maxConcurrent = new AtomicInteger();
+            var release = new CountDownLatch(1);
+            // consumerBatchSize 8 > budget, so the byte budget — not the count — is the binding limit.
+            var gatedConfig = config.toBuilder().consumerBatchSize(8).maxInFlightBytes(budgetBytes).build();
+            var messages = IntStream.range(0, 8).mapToObj(i -> "m" + i).toList();
+            var subscriber = trackSubscriber(TestRedisSubscriber.gatedSubscriber(gatedConfig, redissonClient,
+                    message -> Mono.fromRunnable(() -> {
+                        maxConcurrent.accumulateAndGet(current.incrementAndGet(), Math::max);
+                        awaitLatch(release);
+                        current.decrementAndGet();
+                    }),
+                    message -> weightBytes));
+            subscriber.start();
+
+            publishMessagesToStream(messages);
+
+            await().atMost(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertThat(current.get()).isEqualTo(expectedConcurrent));
+
+            release.countDown();
+            waitForMessagesProcessed(subscriber, messages.size());
+            waitForMessagesAckedAndRemoved();
+            assertThat(maxConcurrent.get()).isEqualTo(expectedConcurrent);
+            assertThat(subscriber.getFailedMessageCount().get()).isZero();
+        }
+
+        private void awaitLatch(CountDownLatch latch) {
+            try {
+                latch.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
@@ -138,7 +138,8 @@ class OnlineScoringLlmAsJudgeScorerTest {
                 toolRegistry,
                 traceCompressor,
                 workspaceNameService,
-                opikConfiguration);
+                opikConfiguration,
+                new OnlineScoringMetrics());
     }
 
     @AfterEach

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
@@ -22,6 +22,7 @@ import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
+import com.comet.opik.utils.JsonUtils;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
@@ -543,6 +544,38 @@ class OnlineScoringLlmAsJudgeScorerTest {
                 return Mono.just(result);
             }
         };
+    }
+
+    @Nested
+    class AdmissionWeightTests {
+
+        @Test
+        void estimateInFlightBytesSumsTraceInputOutputAndMetadata() {
+            var input = JsonUtils.getJsonNodeFromString("{\"q\":\"hello\"}");
+            var output = JsonUtils.getJsonNodeFromString("{\"a\":\"world\"}");
+            var metadata = JsonUtils.getJsonNodeFromString("{\"m\":\"meta\"}");
+            Trace trace = Trace.builder()
+                    .id(UUID.randomUUID())
+                    .projectId(UUID.randomUUID())
+                    .name("t")
+                    .startTime(Instant.now())
+                    .input(input)
+                    .output(output)
+                    .metadata(metadata)
+                    .build();
+            var message = newMessageWithoutExperimentId(UUID.randomUUID()).toBuilder().trace(trace).build();
+
+            long expected = input.toString().length() + output.toString().length() + metadata.toString().length();
+            assertThat(scorer.estimateInFlightBytes(message)).isEqualTo(expected);
+        }
+
+        @Test
+        void admissionControlFollowsServiceToggle() {
+            assertThat(scorer.isAdmissionControlEnabled()).isFalse();
+
+            when(serviceTogglesConfig.isMemoryAwareScoringBoundEnabled()).thenReturn(true);
+            assertThat(scorer.isAdmissionControlEnabled()).isTrue();
+        }
     }
 
     private static TraceToScoreLlmAsJudge newMessage(UUID traceId) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
@@ -34,6 +34,7 @@ import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import io.dropwizard.util.Duration;
+import io.opentelemetry.api.common.AttributeKey;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -575,6 +576,16 @@ class OnlineScoringLlmAsJudgeScorerTest {
 
             when(serviceTogglesConfig.isMemoryAwareScoringBoundEnabled()).thenReturn(true);
             assertThat(scorer.isAdmissionControlEnabled()).isTrue();
+        }
+
+        @Test
+        void admissionAttributesTagWorkspaceAndRule() {
+            var message = newMessageWithoutExperimentId(UUID.randomUUID());
+
+            var attributes = scorer.admissionAttributes(message);
+
+            assertThat(attributes.get(AttributeKey.stringKey("workspace_id"))).isEqualTo(message.workspaceId());
+            assertThat(attributes.get(AttributeKey.stringKey("rule_id"))).isEqualTo(message.ruleId().toString());
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
@@ -90,6 +90,8 @@ class OnlineScoringLlmAsJudgeScorerTest {
     private WorkspaceNameService workspaceNameService;
     @Mock
     private OpikConfiguration opikConfiguration;
+    @Mock
+    private OnlineScoringMetrics onlineScoringMetrics;
 
     private MockedStatic<UserFacingLoggingFactory> mockedFactory;
     private OnlineScoringLlmAsJudgeScorer scorer;
@@ -139,7 +141,7 @@ class OnlineScoringLlmAsJudgeScorerTest {
                 traceCompressor,
                 workspaceNameService,
                 opikConfiguration,
-                new OnlineScoringMetrics());
+                onlineScoringMetrics);
     }
 
     @AfterEach

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringMetricsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringMetricsTest.java
@@ -1,0 +1,131 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import io.opentelemetry.api.common.AttributeKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+@DisplayName("OnlineScoringMetrics char-sizing")
+class OnlineScoringMetricsTest {
+
+    @Test
+    void messageCharsForSystemMessage() {
+        assertThat(OnlineScoringMetrics.messageChars(SystemMessage.from("system prompt"))).isEqualTo(13L);
+    }
+
+    @Test
+    void messageCharsForUserMessageWithText() {
+        assertThat(OnlineScoringMetrics.messageChars(UserMessage.from("hello world"))).isEqualTo(11L);
+    }
+
+    @Test
+    void messageCharsForUserMessageCountsOnlyTextParts() {
+        var userMessage = UserMessage.from(
+                TextContent.from("hello"),
+                ImageContent.from("https://example.com/image.png"),
+                TextContent.from("!"));
+
+        // Only the two text parts are counted; the image URL is skipped.
+        assertThat(OnlineScoringMetrics.messageChars(userMessage)).isEqualTo(6L);
+    }
+
+    @Test
+    void messageCharsForAiMessage() {
+        assertThat(OnlineScoringMetrics.messageChars(AiMessage.from("scored"))).isEqualTo(6L);
+    }
+
+    @Test
+    void messageCharsForAiMessageWithoutText() {
+        var aiMessage = AiMessage.builder()
+                .toolExecutionRequests(List.of(ToolExecutionRequest.builder()
+                        .id("1").name("read").arguments("{}").build()))
+                .build();
+
+        assertThat(OnlineScoringMetrics.messageChars(aiMessage)).isZero();
+    }
+
+    @Test
+    void messageCharsForToolExecutionResult() {
+        assertThat(OnlineScoringMetrics.messageChars(
+                ToolExecutionResultMessage.from("1", "read", "result"))).isEqualTo(6L);
+    }
+
+    @Test
+    void messageCharsForNullMessageIsZero() {
+        assertThat(OnlineScoringMetrics.messageChars(null)).isZero();
+    }
+
+    @Test
+    void inputCharsSumsAllMessages() {
+        var request = ChatRequest.builder()
+                .messages(SystemMessage.from("abc"), UserMessage.from("de"), AiMessage.from("f"))
+                .build();
+
+        assertThat(OnlineScoringMetrics.inputChars(request)).isEqualTo(6L);
+    }
+
+    @Test
+    void inputCharsForNullRequestIsZero() {
+        assertThat(OnlineScoringMetrics.inputChars(null)).isZero();
+    }
+
+    @Test
+    void outputCharsForResponseText() {
+        var response = ChatResponse.builder().aiMessage(AiMessage.from("a response")).build();
+
+        assertThat(OnlineScoringMetrics.outputChars(response)).isEqualTo(10L);
+    }
+
+    @Test
+    void outputCharsForResponseWithoutTextIsZero() {
+        var response = ChatResponse.builder()
+                .aiMessage(AiMessage.builder()
+                        .toolExecutionRequests(List.of(ToolExecutionRequest.builder()
+                                .id("1").name("read").arguments("{}").build()))
+                        .build())
+                .build();
+
+        assertThat(OnlineScoringMetrics.outputChars(response)).isZero();
+    }
+
+    @Test
+    void outputCharsForNullResponseIsZero() {
+        assertThat(OnlineScoringMetrics.outputChars(null)).isZero();
+    }
+
+    @Test
+    void buildAttributesTagsEvaluatorTypeAndModelValues() {
+        var attributes = OnlineScoringMetrics.buildAttributes(
+                AutomationRuleEvaluatorType.TRACE_THREAD_LLM_AS_JUDGE, "gpt-4o");
+
+        assertThat(attributes.asMap())
+                .containsOnly(
+                        entry(AttributeKey.stringKey("evaluator_type"), "trace_thread_llm_as_judge"),
+                        entry(AttributeKey.stringKey("model"), "gpt-4o"));
+    }
+
+    @Test
+    void buildAttributesNeverTagsUnboundedIdentifiers() {
+        var attributes = OnlineScoringMetrics.buildAttributes(
+                AutomationRuleEvaluatorType.LLM_AS_JUDGE, "gpt-4o");
+
+        // Cardinality guard: rule_id / workspace_id must never become histogram tags.
+        assertThat(attributes.asMap().keySet())
+                .extracting(AttributeKey::getKey)
+                .containsExactlyInAnyOrder("evaluator_type", "model");
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringQuotaServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringQuotaServiceTest.java
@@ -1,0 +1,146 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.infrastructure.OnlineScoringConfig;
+import com.comet.opik.infrastructure.ratelimit.RateLimitService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.comet.opik.infrastructure.RateLimitConfig.LimitConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OnlineScoringQuotaService")
+class OnlineScoringQuotaServiceTest {
+
+    private static final String WORKSPACE_ID = "workspace-x";
+    private static final String EVALUATOR_TYPE = "llm_as_judge";
+    private final UUID ruleId = UUID.randomUUID();
+
+    @Mock
+    private RateLimitService rateLimitService;
+
+    private OnlineScoringQuotaService service(boolean enabled, long limit) {
+        var config = new OnlineScoringConfig();
+        config.setPerWorkspaceQuota(OnlineScoringConfig.PerWorkspaceQuota.builder()
+                .enabled(enabled)
+                .limit(limit)
+                .durationInSeconds(60)
+                .build());
+        return new OnlineScoringQuotaService(config, rateLimitService);
+    }
+
+    @Test
+    void admitsAllWhenDisabled() {
+        var items = List.of("a", "b", "c");
+
+        var admitted = service(false, 0).admit(WORKSPACE_ID, ruleId, EVALUATOR_TYPE, items);
+
+        assertThat(admitted).isEqualTo(items);
+        verifyNoInteractions(rateLimitService);
+    }
+
+    @Test
+    void admitsAllWhenEnabledButLimitZero() {
+        // enabled with limit=0 (the default) is a no-op quota — fail open, never touch the limiter.
+        var items = List.of("a", "b", "c");
+
+        var admitted = service(true, 0).admit(WORKSPACE_ID, ruleId, EVALUATOR_TYPE, items);
+
+        assertThat(admitted).isEqualTo(items);
+        verifyNoInteractions(rateLimitService);
+    }
+
+    @Test
+    void admitsEmptyInputWithoutCallingLimiter() {
+        var admitted = service(true, 100).admit(WORKSPACE_ID, ruleId, EVALUATOR_TYPE, List.of());
+
+        assertThat(admitted).isEmpty();
+        verifyNoInteractions(rateLimitService);
+    }
+
+    @Test
+    void admitsAllWhenUnderLimit() {
+        when(rateLimitService.availableEvents(any(), any())).thenReturn(Mono.just(100L));
+        when(rateLimitService.isLimitExceeded(eq(3L), any(), any())).thenReturn(Mono.just(false));
+        var items = List.of("a", "b", "c");
+
+        var admitted = service(true, 100).admit(WORKSPACE_ID, ruleId, EVALUATOR_TYPE, items);
+
+        assertThat(admitted).isEqualTo(items);
+    }
+
+    @Test
+    void downSamplesToAvailableWhenOverLimit() {
+        // Only 2 permits remain in the window for 5 requested → admit the first 2, drop the rest.
+        when(rateLimitService.availableEvents(any(), any())).thenReturn(Mono.just(2L));
+        when(rateLimitService.isLimitExceeded(eq(2L), any(), any())).thenReturn(Mono.just(false));
+        var items = List.of("a", "b", "c", "d", "e");
+
+        var admitted = service(true, 100).admit(WORKSPACE_ID, ruleId, EVALUATOR_TYPE, items);
+
+        assertThat(admitted).containsExactly("a", "b");
+    }
+
+    @Test
+    void dropsAllWhenNoPermitsAvailable() {
+        when(rateLimitService.availableEvents(any(), any())).thenReturn(Mono.just(0L));
+        var items = List.of("a", "b", "c");
+
+        var admitted = service(true, 100).admit(WORKSPACE_ID, ruleId, EVALUATOR_TYPE, items);
+
+        assertThat(admitted).isEmpty();
+        // No point trying to consume when nothing is available.
+        verify(rateLimitService, never()).isLimitExceeded(anyLong(), any(), any());
+    }
+
+    @Test
+    void dropsAllWhenAcquireRaceLost() {
+        // availableEvents saw room, but another pod consumed it before we acquired.
+        when(rateLimitService.availableEvents(any(), any())).thenReturn(Mono.just(3L));
+        when(rateLimitService.isLimitExceeded(eq(3L), any(), any())).thenReturn(Mono.just(true));
+        var items = List.of("a", "b", "c");
+
+        var admitted = service(true, 100).admit(WORKSPACE_ID, ruleId, EVALUATOR_TYPE, items);
+
+        assertThat(admitted).isEmpty();
+    }
+
+    @Test
+    void failsOpenWhenLimiterErrors() {
+        // A limiter hiccup must never stop scoring — admit everything.
+        when(rateLimitService.availableEvents(any(), any()))
+                .thenReturn(Mono.error(new RuntimeException("redis unavailable")));
+        var items = List.of("a", "b", "c");
+
+        var admitted = service(true, 100).admit(WORKSPACE_ID, ruleId, EVALUATOR_TYPE, items);
+
+        assertThat(admitted).isEqualTo(items);
+    }
+
+    @Test
+    void usesPerWorkspaceBucket() {
+        when(rateLimitService.availableEvents(eq("online_scoring_quota:%s".formatted(WORKSPACE_ID)),
+                any(LimitConfig.class))).thenReturn(Mono.just(100L));
+        when(rateLimitService.isLimitExceeded(eq(1L),
+                eq("online_scoring_quota:%s".formatted(WORKSPACE_ID)), any(LimitConfig.class)))
+                .thenReturn(Mono.just(false));
+
+        var admitted = service(true, 100).admit(WORKSPACE_ID, ruleId, EVALUATOR_TYPE, List.of("a"));
+
+        assertThat(admitted).containsExactly("a");
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSamplerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSamplerTest.java
@@ -84,6 +84,9 @@ class OnlineScoringSamplerTest {
     @Mock
     private OnlineScoringQuotaService quotaService;
 
+    @Mock
+    private OnlineScoringMetrics onlineScoringMetrics;
+
     private OnlineScoringSampler onlineScoringSampler;
     private MockedStatic<UserFacingLoggingFactory> mockedFactory;
 
@@ -108,7 +111,8 @@ class OnlineScoringSamplerTest {
                 onlineScorePublisher,
                 traceService,
                 projectService,
-                quotaService);
+                quotaService,
+                onlineScoringMetrics);
 
         projectId = UUID.randomUUID();
         workspaceId = UUID.randomUUID().toString();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSamplerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSamplerTest.java
@@ -53,6 +53,7 @@ import static com.comet.opik.api.resources.utils.AutomationRuleEvaluatorTestUtil
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
@@ -80,6 +81,9 @@ class OnlineScoringSamplerTest {
     @Mock
     private ProjectService projectService;
 
+    @Mock
+    private OnlineScoringQuotaService quotaService;
+
     private OnlineScoringSampler onlineScoringSampler;
     private MockedStatic<UserFacingLoggingFactory> mockedFactory;
 
@@ -93,13 +97,18 @@ class OnlineScoringSamplerTest {
         mockedFactory.when(() -> UserFacingLoggingFactory.getLogger(any(Class.class)))
                 .thenReturn(mock(Logger.class));
 
+        // Quota disabled in these tests: admit() passes every message through unchanged.
+        lenient().when(quotaService.admit(any(), any(), any(), any()))
+                .thenAnswer(invocation -> invocation.getArgument(3));
+
         onlineScoringSampler = new OnlineScoringSampler(
                 serviceTogglesConfig,
                 ruleEvaluatorService,
                 new TraceFilterEvaluationService(),
                 onlineScorePublisher,
                 traceService,
-                projectService);
+                projectService,
+                quotaService);
 
         projectId = UUID.randomUUID();
         workspaceId = UUID.randomUUID().toString();
@@ -603,6 +612,40 @@ class OnlineScoringSamplerTest {
             onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
 
             verifyNoInteractions(projectService);
+        }
+    }
+
+    @Nested
+    class QuotaTests {
+
+        @Test
+        void doesNotEnqueueWhenQuotaDropsAll() {
+            var trace = createTrace(Source.SDK);
+            var evaluator = createLlmEvaluator(true, 1.0f, List.of());
+            whenFindAllLlmEvaluators(evaluator);
+            when(quotaService.admit(any(), any(), any(), any())).thenReturn(List.of());
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
+
+            verifyNoInteractions(onlineScorePublisher);
+        }
+
+        @Test
+        void enqueuesOnlyTheQuotaAdmittedSubset() {
+            var traceA = createTrace(Source.SDK);
+            var traceB = createTrace(Source.SDK);
+            var evaluator = createLlmEvaluator(true, 1.0f, List.of());
+            whenFindAllLlmEvaluators(evaluator);
+            // Quota admits only the first message of the batch; the rest is dropped at the producer.
+            when(quotaService.admit(any(), any(), any(), any()))
+                    .thenAnswer(invocation -> ((List<?>) invocation.getArgument(3)).subList(0, 1));
+
+            onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(traceA, traceB), workspaceId, userName));
+
+            ArgumentCaptor<List<TraceToScoreLlmAsJudge>> captor = ArgumentCaptor.forClass(List.class);
+            verify(onlineScorePublisher).enqueueMessage(captor.capture(),
+                    eq(AutomationRuleEvaluatorType.LLM_AS_JUDGE));
+            assertThat(captor.getValue()).hasSize(1);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorerTest.java
@@ -50,6 +50,8 @@ class OnlineScoringSpanLlmAsJudgeScorerTest {
     private TraceService traceService;
     @Mock
     private LlmProviderFactory llmProviderFactory;
+    @Mock
+    private OnlineScoringMetrics onlineScoringMetrics;
 
     private MockedStatic<UserFacingLoggingFactory> mockedFactory;
     private OnlineScoringSpanLlmAsJudgeScorer scorer;
@@ -69,7 +71,7 @@ class OnlineScoringSpanLlmAsJudgeScorerTest {
         lenient().when(onlineScoringConfig.getConsumerGroupName()).thenReturn("online_scoring");
 
         scorer = new OnlineScoringSpanLlmAsJudgeScorer(onlineScoringConfig, serviceTogglesConfig, redissonClient,
-                feedbackScoreService, aiProxyService, traceService, llmProviderFactory);
+                feedbackScoreService, aiProxyService, traceService, llmProviderFactory, onlineScoringMetrics);
     }
 
     @AfterEach

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorerTest.java
@@ -1,0 +1,116 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.Span;
+import com.comet.opik.api.events.SpanToScoreLlmAsJudge;
+import com.comet.opik.domain.FeedbackScoreService;
+import com.comet.opik.domain.TraceService;
+import com.comet.opik.domain.llm.ChatCompletionService;
+import com.comet.opik.domain.llm.LlmProviderFactory;
+import com.comet.opik.infrastructure.OnlineScoringConfig;
+import com.comet.opik.infrastructure.ServiceTogglesConfig;
+import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
+import com.comet.opik.utils.JsonUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RedissonReactiveClient;
+import org.slf4j.Logger;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OnlineScoringSpanLlmAsJudgeScorer admission weighting")
+class OnlineScoringSpanLlmAsJudgeScorerTest {
+
+    @Mock
+    private OnlineScoringConfig onlineScoringConfig;
+    @Mock
+    private ServiceTogglesConfig serviceTogglesConfig;
+    @Mock
+    private RedissonReactiveClient redissonClient;
+    @Mock
+    private FeedbackScoreService feedbackScoreService;
+    @Mock
+    private ChatCompletionService aiProxyService;
+    @Mock
+    private TraceService traceService;
+    @Mock
+    private LlmProviderFactory llmProviderFactory;
+
+    private MockedStatic<UserFacingLoggingFactory> mockedFactory;
+    private OnlineScoringSpanLlmAsJudgeScorer scorer;
+
+    @BeforeEach
+    void setUp() {
+        mockedFactory = mockStatic(UserFacingLoggingFactory.class);
+        mockedFactory.when(() -> UserFacingLoggingFactory.getLogger(any(Class.class)))
+                .thenReturn(mock(Logger.class));
+
+        var streamConfig = OnlineScoringConfig.StreamConfiguration.builder()
+                .scorer("span_llm_as_judge")
+                .streamName("stream_scoring_span_llm_as_judge")
+                .codec("java")
+                .build();
+        lenient().when(onlineScoringConfig.getStreams()).thenReturn(List.of(streamConfig));
+        lenient().when(onlineScoringConfig.getConsumerGroupName()).thenReturn("online_scoring");
+
+        scorer = new OnlineScoringSpanLlmAsJudgeScorer(onlineScoringConfig, serviceTogglesConfig, redissonClient,
+                feedbackScoreService, aiProxyService, traceService, llmProviderFactory);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (mockedFactory != null) {
+            mockedFactory.close();
+        }
+    }
+
+    @Test
+    void estimateInFlightBytesSumsSpanInputOutputAndMetadata() {
+        var input = JsonUtils.getJsonNodeFromString("{\"q\":\"hello\"}");
+        var output = JsonUtils.getJsonNodeFromString("{\"a\":\"world\"}");
+        var metadata = JsonUtils.getJsonNodeFromString("{\"m\":\"meta\"}");
+        var span = mock(Span.class);
+        when(span.input()).thenReturn(input);
+        when(span.output()).thenReturn(output);
+        when(span.metadata()).thenReturn(metadata);
+        var message = mock(SpanToScoreLlmAsJudge.class);
+        when(message.span()).thenReturn(span);
+
+        long expected = input.toString().length() + output.toString().length() + metadata.toString().length();
+        assertThat(scorer.estimateInFlightBytes(message)).isEqualTo(expected);
+    }
+
+    @Test
+    void estimateInFlightBytesSkipsNullMetadata() {
+        var input = JsonUtils.getJsonNodeFromString("{\"q\":\"hello\"}");
+        var span = mock(Span.class);
+        when(span.input()).thenReturn(input);
+        when(span.output()).thenReturn(null);
+        when(span.metadata()).thenReturn(null);
+        var message = mock(SpanToScoreLlmAsJudge.class);
+        when(message.span()).thenReturn(span);
+
+        assertThat(scorer.estimateInFlightBytes(message)).isEqualTo(input.toString().length());
+    }
+
+    @Test
+    void admissionControlFollowsServiceToggle() {
+        assertThat(scorer.isAdmissionControlEnabled()).isFalse();
+
+        when(serviceTogglesConfig.isMemoryAwareScoringBoundEnabled()).thenReturn(true);
+        assertThat(scorer.isAdmissionControlEnabled()).isTrue();
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorerTest.java
@@ -10,6 +10,7 @@ import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
 import com.comet.opik.utils.JsonUtils;
+import io.opentelemetry.api.common.AttributeKey;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +23,7 @@ import org.redisson.api.RedissonReactiveClient;
 import org.slf4j.Logger;
 
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -112,5 +114,18 @@ class OnlineScoringSpanLlmAsJudgeScorerTest {
 
         when(serviceTogglesConfig.isMemoryAwareScoringBoundEnabled()).thenReturn(true);
         assertThat(scorer.isAdmissionControlEnabled()).isTrue();
+    }
+
+    @Test
+    void admissionAttributesTagWorkspaceAndRule() {
+        var ruleId = UUID.randomUUID();
+        var message = mock(SpanToScoreLlmAsJudge.class);
+        when(message.workspaceId()).thenReturn("ws-1");
+        when(message.ruleId()).thenReturn(ruleId);
+
+        var attributes = scorer.admissionAttributes(message);
+
+        assertThat(attributes.get(AttributeKey.stringKey("workspace_id"))).isEqualTo("ws-1");
+        assertThat(attributes.get(AttributeKey.stringKey("rule_id"))).isEqualTo(ruleId.toString());
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSamplerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSamplerTest.java
@@ -78,6 +78,9 @@ class OnlineScoringSpanSamplerTest {
     @Mock
     private OnlineScoringQuotaService quotaService;
 
+    @Mock
+    private OnlineScoringMetrics onlineScoringMetrics;
+
     private OnlineScoringSpanSampler sampler;
     private MockedStatic<UserFacingLoggingFactory> mockedFactory;
 
@@ -101,7 +104,8 @@ class OnlineScoringSpanSamplerTest {
                 ruleEvaluatorService,
                 filterEvaluationService,
                 onlineScorePublisher,
-                quotaService);
+                quotaService,
+                onlineScoringMetrics);
 
         projectId = UUID.randomUUID();
         workspaceId = "workspace-123";

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSamplerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSamplerTest.java
@@ -75,6 +75,9 @@ class OnlineScoringSpanSamplerTest {
     @Mock
     private ServiceTogglesConfig serviceTogglesConfig;
 
+    @Mock
+    private OnlineScoringQuotaService quotaService;
+
     private OnlineScoringSpanSampler sampler;
     private MockedStatic<UserFacingLoggingFactory> mockedFactory;
 
@@ -89,11 +92,16 @@ class OnlineScoringSpanSamplerTest {
         mockedFactory.when(() -> UserFacingLoggingFactory.getLogger(any(Class.class)))
                 .thenReturn(mock(org.slf4j.Logger.class));
 
+        // Quota disabled in these tests: admit() passes every message through unchanged.
+        lenient().when(quotaService.admit(any(), any(), any(), any()))
+                .thenAnswer(invocation -> invocation.getArgument(3));
+
         sampler = new OnlineScoringSpanSampler(
                 serviceTogglesConfig,
                 ruleEvaluatorService,
                 filterEvaluationService,
-                onlineScorePublisher);
+                onlineScorePublisher,
+                quotaService);
 
         projectId = UUID.randomUUID();
         workspaceId = "workspace-123";
@@ -198,6 +206,51 @@ class OnlineScoringSpanSamplerTest {
             assertThat(messages).hasSize(1);
             assertThat(messages.getFirst().span()).isEqualTo(span);
             assertThat(messages.getFirst().ruleId()).isEqualTo(evaluator.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Per-workspace quota integration")
+    class QuotaTests {
+
+        @Test
+        void doesNotEnqueueWhenQuotaDropsAll() {
+            when(serviceTogglesConfig.isSpanLlmAsJudgeEnabled()).thenReturn(true);
+            when(serviceTogglesConfig.isSpanUserDefinedMetricPythonEnabled()).thenReturn(false);
+            Span span = createTestSpan(projectId, Source.SDK);
+            AutomationRuleEvaluatorSpanLlmAsJudge evaluator = createTestEvaluator(true, 1.0f, List.of());
+            when(ruleEvaluatorService.<SpanLlmAsJudgeCode, SpanFilter, AutomationRuleEvaluatorSpanLlmAsJudge>findAll(
+                    projectId, workspaceId, AutomationRuleEvaluatorType.SPAN_LLM_AS_JUDGE))
+                    .thenReturn(List.of(evaluator));
+            lenient().when(filterEvaluationService.matchesAllFilters(any(), any())).thenReturn(true);
+            when(quotaService.admit(any(), any(), any(), any())).thenReturn(List.of());
+
+            sampler.onSpansCreated(new SpansCreated(List.of(span), workspaceId, userName));
+
+            verify(onlineScorePublisher, never())
+                    .enqueueMessage(any(), eq(AutomationRuleEvaluatorType.SPAN_LLM_AS_JUDGE));
+        }
+
+        @Test
+        void enqueuesOnlyTheQuotaAdmittedSubset() {
+            when(serviceTogglesConfig.isSpanLlmAsJudgeEnabled()).thenReturn(true);
+            when(serviceTogglesConfig.isSpanUserDefinedMetricPythonEnabled()).thenReturn(false);
+            Span spanA = createTestSpan(projectId, Source.SDK);
+            Span spanB = createTestSpan(projectId, Source.SDK);
+            AutomationRuleEvaluatorSpanLlmAsJudge evaluator = createTestEvaluator(true, 1.0f, List.of());
+            when(ruleEvaluatorService.<SpanLlmAsJudgeCode, SpanFilter, AutomationRuleEvaluatorSpanLlmAsJudge>findAll(
+                    projectId, workspaceId, AutomationRuleEvaluatorType.SPAN_LLM_AS_JUDGE))
+                    .thenReturn(List.of(evaluator));
+            lenient().when(filterEvaluationService.matchesAllFilters(any(), any())).thenReturn(true);
+            when(quotaService.admit(any(), any(), any(), any()))
+                    .thenAnswer(invocation -> ((List<?>) invocation.getArgument(3)).subList(0, 1));
+
+            sampler.onSpansCreated(new SpansCreated(List.of(spanA, spanB), workspaceId, userName));
+
+            ArgumentCaptor<List<SpanToScoreLlmAsJudge>> captor = ArgumentCaptor.forClass(List.class);
+            verify(onlineScorePublisher).enqueueMessage(captor.capture(),
+                    eq(AutomationRuleEvaluatorType.SPAN_LLM_AS_JUDGE));
+            assertThat(captor.getValue()).hasSize(1);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorerTest.java
@@ -67,6 +67,9 @@ class OnlineScoringSpanUserDefinedMetricPythonScorerTest {
     @Mock
     private PythonEvaluatorService pythonEvaluatorService;
 
+    @Mock
+    private OnlineScoringMetrics onlineScoringMetrics;
+
     private OnlineScoringSpanUserDefinedMetricPythonScorer scorer;
     private MockedStatic<UserFacingLoggingFactory> mockedFactory;
 
@@ -105,7 +108,8 @@ class OnlineScoringSpanUserDefinedMetricPythonScorerTest {
                 redissonClient,
                 feedbackScoreService,
                 traceService,
-                pythonEvaluatorService);
+                pythonEvaluatorService,
+                onlineScoringMetrics);
     }
 
     @AfterEach

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -22,6 +22,7 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import io.dropwizard.util.Duration;
+import io.opentelemetry.api.common.AttributeKey;
 import jakarta.ws.rs.NotFoundException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -691,6 +692,19 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
 
             when(serviceTogglesConfig.isMemoryAwareScoringBoundEnabled()).thenReturn(true);
             assertThat(scorer.isAdmissionControlEnabled()).isTrue();
+        }
+
+        @Test
+        void admissionAttributesTagWorkspaceAndRule() {
+            var message = mock(TraceThreadToScoreLlmAsJudge.class);
+            var msgRuleId = UUID.randomUUID();
+            when(message.workspaceId()).thenReturn("ws-1");
+            when(message.ruleId()).thenReturn(msgRuleId);
+
+            var attributes = scorer.admissionAttributes(message);
+
+            assertThat(attributes.get(AttributeKey.stringKey("workspace_id"))).isEqualTo("ws-1");
+            assertThat(attributes.get(AttributeKey.stringKey("rule_id"))).isEqualTo(msgRuleId.toString());
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -672,6 +672,28 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
                 .build();
     }
 
+    @Nested
+    class AdmissionWeightTests {
+
+        @Test
+        void estimateInFlightBytesScalesWithThreadCount() {
+            var message = mock(TraceThreadToScoreLlmAsJudge.class);
+            when(message.threadIds()).thenReturn(List.of("t1", "t2", "t3"));
+            when(onlineScoringConfig.getAvgThreadBytes()).thenReturn(256_000L);
+
+            // The thread message carries only IDs, so weight is thread count × the configured estimate.
+            assertThat(scorer.estimateInFlightBytes(message)).isEqualTo(3L * 256_000L);
+        }
+
+        @Test
+        void admissionControlFollowsServiceToggle() {
+            assertThat(scorer.isAdmissionControlEnabled()).isFalse();
+
+            when(serviceTogglesConfig.isMemoryAwareScoringBoundEnabled()).thenReturn(true);
+            assertThat(scorer.isAdmissionControlEnabled()).isTrue();
+        }
+    }
+
     private FeedbackScoreBatchItemThread threadScore(String name, BigDecimal value, String reason, Project project) {
         return FeedbackScoreBatchItemThread.builder()
                 .id(threadModelId)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -93,6 +93,8 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
     private com.comet.opik.api.resources.v1.events.tools.ToolRegistry toolRegistry;
     @Mock
     private com.comet.opik.domain.SpanService spanService;
+    @Mock
+    private OnlineScoringMetrics onlineScoringMetrics;
 
     private OnlineScoringTraceThreadLlmAsJudgeScorer scorer;
     private MockedStatic<UserFacingLoggingFactory> mockedFactory;
@@ -146,7 +148,7 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
                 automationRuleEvaluatorService,
                 toolRegistry,
                 spanService,
-                new OnlineScoringMetrics());
+                onlineScoringMetrics);
 
         projectId = UUID.randomUUID();
         ruleId = UUID.randomUUID();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -145,7 +145,8 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
                 projectService,
                 automationRuleEvaluatorService,
                 toolRegistry,
-                spanService);
+                spanService,
+                new OnlineScoringMetrics());
 
         projectId = UUID.randomUUID();
         ruleId = UUID.randomUUID();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
@@ -87,6 +87,9 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
     @Mock
     private com.comet.opik.domain.SpanService spanService;
 
+    @Mock
+    private OnlineScoringMetrics onlineScoringMetrics;
+
     private OnlineScoringTraceThreadUserDefinedMetricPythonScorer scorer;
     private MockedStatic<UserFacingLoggingFactory> mockedFactory;
     private Logger userFacingLogger;
@@ -131,7 +134,8 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
                 traceThreadService,
                 projectService,
                 automationRuleEvaluatorService,
-                spanService);
+                spanService,
+                onlineScoringMetrics);
 
         projectId = UUID.randomUUID();
         ruleId = UUID.randomUUID();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorerTest.java
@@ -70,6 +70,9 @@ class OnlineScoringUserDefinedMetricPythonScorerTest {
     @Mock
     private PythonEvaluatorService pythonEvaluatorService;
 
+    @Mock
+    private OnlineScoringMetrics onlineScoringMetrics;
+
     private OnlineScoringUserDefinedMetricPythonScorer scorer;
     private MockedStatic<UserFacingLoggingFactory> mockedFactory;
     private Logger userFacingLogger;
@@ -110,7 +113,8 @@ class OnlineScoringUserDefinedMetricPythonScorerTest {
                 feedbackScoreService,
                 traceService,
                 spanService,
-                pythonEvaluatorService);
+                pythonEvaluatorService,
+                onlineScoringMetrics);
 
         projectId = UUID.randomUUID();
         traceId = UUID.randomUUID();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TestRedisSubscriber.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TestRedisSubscriber.java
@@ -26,13 +26,26 @@ public class TestRedisSubscriber extends BaseRedisSubscriber<String> {
     private final AtomicInteger failedMessageCount = new AtomicInteger(0);
 
     private final Function<String, Mono<Void>> processor;
+    private final boolean admissionControlEnabled;
+    private final Function<String, Long> weigher;
 
     public TestRedisSubscriber(
             @NonNull StreamConfiguration config,
             @NonNull RedissonReactiveClient redisson,
             @NonNull Function<String, Mono<Void>> processor) {
+        this(config, redisson, processor, false, message -> 0L);
+    }
+
+    public TestRedisSubscriber(
+            @NonNull StreamConfiguration config,
+            @NonNull RedissonReactiveClient redisson,
+            @NonNull Function<String, Mono<Void>> processor,
+            boolean admissionControlEnabled,
+            @NonNull Function<String, Long> weigher) {
         super(config, redisson, TestStreamConfiguration.PAYLOAD_FIELD, METRIC_NAMESPACE, METRICS_BASE_NAME);
         this.processor = processor;
+        this.admissionControlEnabled = admissionControlEnabled;
+        this.weigher = weigher;
     }
 
     @Override
@@ -40,6 +53,27 @@ public class TestRedisSubscriber extends BaseRedisSubscriber<String> {
         return processor.apply(message)
                 .doOnSuccess(unused -> successMessageCount.incrementAndGet())
                 .doOnError(throwable -> failedMessageCount.incrementAndGet());
+    }
+
+    @Override
+    protected boolean isAdmissionControlEnabled() {
+        return admissionControlEnabled;
+    }
+
+    @Override
+    protected long estimateInFlightBytes(String message) {
+        return weigher.apply(message);
+    }
+
+    /**
+     * Factory for a subscriber with the memory-aware admission gate enabled and a per-message weight.
+     */
+    public static TestRedisSubscriber gatedSubscriber(
+            StreamConfiguration config,
+            RedissonReactiveClient redisson,
+            Function<String, Mono<Void>> processor,
+            Function<String, Long> weigher) {
+        return new TestRedisSubscriber(config, redisson, processor, true, weigher);
     }
 
     /**

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TestStreamConfiguration.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TestStreamConfiguration.java
@@ -61,6 +61,9 @@ public class TestStreamConfiguration implements StreamConfiguration {
     private int streamTrimLimit = 100;
 
     @Builder.Default
+    private long maxInFlightBytes = 0;
+
+    @Builder.Default
     private Codec codec = RedisStreamCodec.JAVA.getCodec();
 
     public static TestStreamConfiguration create() {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/OnlineScorePublisherTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/OnlineScorePublisherTest.java
@@ -83,7 +83,8 @@ class OnlineScorePublisherTest {
         when(redisClient.getStream(anyString(), any())).thenReturn(stream);
         when(stream.add(any())).thenReturn(Mono.just(new StreamMessageId(System.currentTimeMillis(), 0)));
         return new OnlineScorePublisherImpl(
-                onlineScoringConfig, serviceTogglesConfig, redisClient, automationRuleEvaluatorService);
+                onlineScoringConfig, serviceTogglesConfig, redisClient, automationRuleEvaluatorService,
+                org.mockito.Mockito.mock(com.comet.opik.api.resources.v1.events.OnlineScoringMetrics.class));
     }
 
     private StreamAddParams<Object, Object> captureStreamAddParams() {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/threads/TraceThreadOnlineScorerPublisherTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/threads/TraceThreadOnlineScorerPublisherTest.java
@@ -1,0 +1,78 @@
+package com.comet.opik.domain.threads;
+
+import com.comet.opik.api.resources.v1.events.OnlineScoringQuotaService;
+import com.comet.opik.domain.evaluators.OnlineScorePublisher;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TraceThreadOnlineScorerPublisher per-workspace quota integration")
+class TraceThreadOnlineScorerPublisherTest {
+
+    @Mock
+    private OnlineScorePublisher onlineScorePublisher;
+    @Mock
+    private OnlineScoringQuotaService quotaService;
+
+    private TraceThreadOnlineScorerPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        publisher = new TraceThreadOnlineScorerPublisher(onlineScorePublisher, quotaService);
+    }
+
+    private void publish(UUID projectId, List<TraceThreadModel> threads) {
+        publisher.publish(projectId, threads)
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.WORKSPACE_ID, "ws-1")
+                        .put(RequestContext.USER_NAME, "user-1"))
+                .block();
+    }
+
+    @Test
+    void doesNotEnqueueWhenQuotaDropsAll() {
+        var projectId = UUID.randomUUID();
+        var ruleId = UUID.randomUUID();
+        var thread = TraceThreadModel.builder().threadId("t1").sampling(Map.of(ruleId, true)).build();
+        when(quotaService.admit(any(), any(), any(), any())).thenReturn(List.of());
+
+        publish(projectId, List.of(thread));
+
+        verifyNoInteractions(onlineScorePublisher);
+    }
+
+    @Test
+    void enqueuesOnlyTheQuotaAdmittedThreadIds() {
+        var projectId = UUID.randomUUID();
+        var ruleId = UUID.randomUUID();
+        var thread1 = TraceThreadModel.builder().threadId("t1").sampling(Map.of(ruleId, true)).build();
+        var thread2 = TraceThreadModel.builder().threadId("t2").sampling(Map.of(ruleId, true)).build();
+        // Quota admits only one of the two sampled threads.
+        when(quotaService.admit(any(), any(), any(), any()))
+                .thenAnswer(invocation -> ((List<?>) invocation.getArgument(3)).subList(0, 1));
+
+        publish(projectId, List.of(thread1, thread2));
+
+        ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+        verify(onlineScorePublisher).enqueueThreadMessage(
+                captor.capture(), eq(ruleId), eq(projectId), eq("ws-1"), eq("user-1"));
+        assertThat(captor.getValue()).hasSize(1);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/OnlineScoringStreamConfigurationAdapterTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/OnlineScoringStreamConfigurationAdapterTest.java
@@ -1,0 +1,53 @@
+package com.comet.opik.infrastructure;
+
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("OnlineScoringStreamConfigurationAdapter maxInFlightBytes resolution")
+class OnlineScoringStreamConfigurationAdapterTest {
+
+    private static final long GLOBAL_BYTES = 1_000;
+    private static final long STREAM_BYTES = 5_000;
+
+    @Test
+    void usesPerStreamOverrideWhenPresent() {
+        var config = configWith(OnlineScoringConfig.StreamConfiguration.builder()
+                .scorer("llm_as_judge")
+                .streamName("stream_scoring_llm_as_judge")
+                .codec("java")
+                .maxInFlightBytes(STREAM_BYTES)
+                .build());
+
+        var adapter = OnlineScoringStreamConfigurationAdapter.create(
+                config, AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+
+        assertThat(adapter.getMaxInFlightBytes()).isEqualTo(STREAM_BYTES);
+    }
+
+    @Test
+    void fallsBackToGlobalWhenStreamOverrideAbsent() {
+        var config = configWith(OnlineScoringConfig.StreamConfiguration.builder()
+                .scorer("llm_as_judge")
+                .streamName("stream_scoring_llm_as_judge")
+                .codec("java")
+                .maxInFlightBytes(null)
+                .build());
+
+        var adapter = OnlineScoringStreamConfigurationAdapter.create(
+                config, AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+
+        assertThat(adapter.getMaxInFlightBytes()).isEqualTo(GLOBAL_BYTES);
+    }
+
+    private OnlineScoringConfig configWith(OnlineScoringConfig.StreamConfiguration streamConfig) {
+        var config = new OnlineScoringConfig();
+        config.setMaxInFlightBytes(GLOBAL_BYTES);
+        config.setStreams(List.of(streamConfig));
+        return config;
+    }
+}

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -281,6 +281,11 @@ onlineScoring:
   # Default: 4
   # Description: Characters-per-token ratio used to estimate trace size from serialized JSON length.
   agenticToolsCharsPerToken: 4
+  # Per-workspace producer quota for online scoring (disabled by default).
+  perWorkspaceQuota:
+    enabled: false
+    limit: 0
+    durationInSeconds: 60
   ## scorer: options from AutomationRuleEvaluatorType
   ## streamName: the name of the stream in redis
   ## codec: 'json' when there are non-java consumers, 'java' for java consumers only

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -281,6 +281,12 @@ onlineScoring:
   # Default: 4
   # Description: Characters-per-token ratio used to estimate trace size from serialized JSON length.
   agenticToolsCharsPerToken: 4
+  # Default: 0 (gate disabled). Memory-aware admission gate budget in bytes. Kept at 0 so tests run
+  #   count-only by default; admission-control tests set their own budget via the config builder.
+  maxInFlightBytes: 0
+  # Default: 256000. Estimated bytes per thread for weighting trace_thread evals; only consulted when the
+  #   gate is enabled. Must be >= 1 (@Min(1)), so set it explicitly rather than relying on the POJO default.
+  avgThreadBytes: 256000
   # Per-workspace producer quota for online scoring (disabled by default).
   perWorkspaceQuota:
     enabled: false

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -622,6 +622,9 @@ serviceToggles:
   # Default: false
   # Description: Master switch for the agentic-tools path on LLM-as-judge online scoring.
   agenticToolsEnabled: "false"
+  # Default: false
+  # Description: Master switch for the memory-aware admission gate on online scoring.
+  memoryAwareScoringBoundEnabled: "false"
   # Default: "" (empty, no allowlisted workspaces)
   # Description: Comma-separated list of workspace IDs that should always receive V2 navigation.
   # Valid values: comma-separated workspace IDs (e.g. "ws-id-1,ws-id-2"), or "" (empty, disabled).


### PR DESCRIPTION
## Details

Two complementary, independently flag-gated controls (B1, B2) that protect online scoring from the overload that took the backend NotReady, plus the supporting eval payload-size metric (C1) — bundled in one PR so they deploy and get tested together (B1/B2 are still toggled separately in prod). **C1 was previously #6988, now combined into this PR.**

**C1 — eval payload-size metric (always-on observability).** Records each eval's LLM input/output character size as histograms (`online_scoring_llm_input_chars` / `online_scoring_llm_output_chars`, tagged `{evaluator_type, model}`) so the B1 byte budget and the B2 quota can be sized from *real* production payloads rather than guesses. Recorded by the three LLM-as-judge scorers; char-sizing avoids materializing `toString()`. Not flag-gated — it's measurement only.

**B1 — memory-aware consumption bound (consumer side).** Bounds the consumer on estimated in-flight payload **bytes**, not just message count, so a workload of large agentic evals can't fill a pod's heap; overflow waits in Redis (capped by the existing `MAXLEN` trim) instead of accumulating in heap. Adding pods doesn't help here — Redis Streams consumer groups assign each message to exactly one consumer (no cross-pod fan-out), so more replicas drain faster but each still runs up to `consumerBatchSize` concurrent evals and hits the same per-pod memory ceiling; the right lever is bounding per-pod in-flight memory.
- Fair per-stream `Semaphore` admission gate in `BaseRedisSubscriber` (KiB-granularity permits); acquires `min(weight, budget)` — clamped to the whole budget so an oversized eval runs alone rather than deadlocking — releases on the terminal signal; preserves ack/retry/auto-claim. Default-off via overridable hooks, so the other 5 subscribers are unchanged.
- Per-scorer weight: trace/span sum the carried entity's input/output/metadata JSON size; thread weights by `threadIds.size() × avgThreadBytes` (its message carries only IDs).
- Gated by the `memoryAwareScoringBoundEnabled` toggle; budget via `onlineScoring.maxInFlightBytes` (global + per-stream).

**B2 — per-workspace producer quota (producer side).** Caps how many scoring evals a single workspace may enqueue per window (fleet-wide, via the distributed `RateLimitService`), so one workspace's rules can't flood the shared streams and starve other tenants. Applied after the per-rule sampling rate; over-quota evals are shed at the producer (down-sampled, never deferred) so they never reach Redis. Wired into the automatic producers only (trace/span/thread); manual evaluation + test-suite assertions are exempt. Gated by `onlineScoring.perWorkspaceQuota.enabled` (default off).

**Observability (Grafana):**
- C1: `online_scoring_llm_input_chars` / `online_scoring_llm_output_chars` histograms `{evaluator_type, model}` — real per-eval payload sizes for tuning B1/B2.
- B1: `online_scoring_<type>_in_flight_bytes` + `_stream_length` gauges (per pod); `_admission_waits` + `_admission_wait_time` tagged `{workspace_id, rule_id}` — which tenant/rule is saturating a consumer.
- B2: `online_scoring_quota_admitted` `{evaluator_type}`; `online_scoring_quota_dropped` `{evaluator_type, workspace_id, rule_id}` — per-customer/per-rule drop visibility.
- Per-workspace/rule labels ride only the contention/drop metrics (they fire only for offenders), so cardinality stays bounded.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6813

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Full implementation of C1 + B1 + B2 (payload-size metric, gate, per-scorer weighting, per-workspace quota, config/flags, metrics, tests) under human direction; design decisions reviewed and approved by the author.
  - Human verification: Reviewed diffs; ran backend test suites + spotless; ran a local synthetic heap load test (in-flight heap held at the budget vs unbounded) and a local end-to-end run with the flags on/off validating live Grafana metrics; covered by `/comet-cra-review` with findings addressed.

## Testing

- `cd apps/opik-backend && mvn test -Dtest="OnlineScoringMetricsTest,OnlineScoringQuotaServiceTest,OnlineScoringSamplerTest,OnlineScoringSpanSamplerTest,TraceThreadOnlineScorerPublisherTest,OnlineScoringLlmAsJudgeScorerTest,OnlineScoringTraceThreadLlmAsJudgeScorerTest,OnlineScoringSpanLlmAsJudgeScorerTest,OnlineScoringStreamConfigurationAdapterTest,BaseRedisSubscriberTest"` — all green; `mvn spotless:check` clean.
- C1: `OnlineScoringMetrics` char-sizing + attribute-tagging unit tests; recording wired into the three LLM-as-judge scorers.
- B1: real-Redis gate tests (bounds concurrency to the byte budget; byte-awareness via inverse weight↔concurrency scaling; oversized-runs-solo liveness; disabled passthrough; malformed/null-message handled without leaking the budget); per-scorer weight + admission-attribute + adapter + toggle unit tests; local synthetic heap load test (in-flight heap held flat at the budget under load vs scaling with `consumerBatchSize × payload` unbounded).
- B2: quota service (under/over limit, partial down-sample, no-permits drop, acquire-race, fail-open, disabled, limit=0, empty input, per-workspace bucket); sampler + thread-publisher integration (admit→empty ⇒ no enqueue; admit→subset ⇒ only the subset enqueued).
- Both B1 and B2 are default-off, so the no-flag path is byte-for-byte current behavior.

## Documentation

No user-facing/SDK surface change — internal backend reliability controls gated by service toggles, with `onlineScoring.maxInFlightBytes` / `avgThreadBytes` / `perWorkspaceQuota.*` knobs documented inline in `config.yml`. No docs-site update required.
