### PR TITLE
[NA] [QA] docs: self-serve E2E test authoring (/add-e2e-test + writing-e2e-tests skill)

### DIFF
--- a/.agents/commands/comet/add-e2e-test.md
+++ b/.agents/commands/comet/add-e2e-test.md
@@ -1,0 +1,56 @@
+# Add E2E Test
+
+## Overview
+
+Add a working, locally-verified Playwright end-to-end test for an Opik feature in `tests_end_to_end/e2e/`. The command runs the full loop — analyze the feature and frontend code, explore the live UI, write the Page Object Model + spec, and run it locally until it passes.
+
+---
+
+## Inputs
+
+- **Feature to test** (required): a plain-English description of the flow. The more specific, the better — name the page, the actions, and what should be true at the end. Examples:
+  - "Add an e2e test for the dataset items page: SDK-seed a dataset, open it, verify the items render."
+  - "Cover the experiments comparison page — two experiments on one dataset, open the comparison view, verify both columns show."
+  - "Write a test for the feature I just built on this branch."
+- **Optional context** that helps the agent focus (it explores the live UI regardless):
+  - A specific page URL (e.g. `localhost:5173/default/projects/<id>/experiments`).
+  - A PR or branch to read the diff from.
+  - An existing test to extend.
+
+---
+
+## Safety: verify local config
+
+The default target is local OSS (`http://localhost:5173`). The Python SDK behind the bridge reads `~/.opik.config`; if it points at a cloud environment, seeding would create real data there.
+
+```bash
+cat ~/.opik.config
+```
+
+If `url_override` is anything other than `http://localhost:5173/api`, back it up and point it local, then restore it when done:
+
+```bash
+cp ~/.opik.config ~/.opik.config.bak 2>/dev/null || true
+cat > ~/.opik.config << 'EOF'
+[opik]
+url_override = http://localhost:5173/api
+workspace = default
+EOF
+```
+
+Restore afterward: `cp ~/.opik.config.bak ~/.opik.config`. If it already points local, skip this.
+
+---
+
+## Instructions
+
+**Invoke the `writing-e2e-tests` skill and follow it exactly.** It carries the full procedure — scope, analyze the feature + frontend code, explore the live UI with the Playwright MCP (delegating selector discovery to `playwright-pom-discovery`), write the POM + spec, and run until green — plus the suite's conventions.
+
+---
+
+## Success criteria
+
+1. A POM (`pom/*.page.ts`) and spec (`tests/<feature>/<name>.spec.ts`) added under `tests_end_to_end/e2e/`.
+2. Correct tier + feature tags on the spec; `test.step()` wrapping in the spec and POM methods.
+3. The test runs **green locally**, with the actual run output reported.
+4. Any brittle selector backed by a `data-testid` added to the frontend component in the same change.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -11,7 +11,9 @@ Domain-specific agent skills for the Opik monorepo. Each skill provides patterns
 | opik-backend | `opik-backend/` | Java backend patterns for Opik. Use when working in `apps/opik-backend`, designing APIs, database operations, or services. |
 | opik-frontend | `opik-frontend/` | React frontend patterns for Opik. Use when working in `apps/opik-frontend`, on components, state, or data fetching. |
 | playwright-e2e | `playwright-e2e/` | Playwright E2E test generation workflow. Use when generating, fixing, or planning automated tests in `tests_end_to_end/`. |
+| playwright-pom-discovery | `playwright-pom-discovery/` | Choose stable selectors against the live UI when building a Page Object Model for the E2E suite (`tests_end_to_end/e2e/pom/`). Used as the discovery sub-step by `writing-e2e-tests`. |
 | python-sdk | `python-sdk/` | Python SDK patterns for Opik. Use when working in `sdks/python`, on SDK APIs, integrations, or message processing. |
 | typescript-sdk | `typescript-sdk/` | TypeScript SDK patterns for Opik. Use when working in `sdks/typescript`. |
+| writing-e2e-tests | `writing-e2e-tests/` | Add an end-to-end test for an Opik feature in `tests_end_to_end/e2e/`. Use when a developer wants to write a test for a feature, page, or branch — runs the full loop: analyze, explore the live UI, write the POM + spec, and run it locally until green. |
 
 Each skill directory contains a `SKILL.md` entry point plus supporting documents (testing, code quality, patterns, etc.).

--- a/.agents/skills/playwright-pom-discovery/SKILL.md
+++ b/.agents/skills/playwright-pom-discovery/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: playwright-pom-discovery
+description: Use when building or extending a Page Object Model (POM) for the Opik E2E suite (under `tests_end_to_end/e2e/pom/`) and you need to choose stable selectors against the live UI. Walks through seeding required state, exploring the running page with the Playwright MCP (accessibility snapshot + data-testid enumeration), picking the most stable locator for each element, and verifying it before committing. Used as the discovery sub-step by the `writing-e2e-tests` skill.
+---
+
+# Playwright POM Discovery
+
+This skill is the **how** of choosing selectors for a POM in the Opik E2E suite. You already know which POM you're building; this skill tells you how to figure out what's on the page, what selectors are stable, and how to verify your method actually works before checking it in.
+
+**Announce at start:** "I'm using the playwright-pom-discovery skill to build the X page object."
+
+## When this skill applies
+
+- You're touching anything under `tests_end_to_end/e2e/pom/`.
+- You need to write a `data-testid` selector, a `getByRole`, or any other Playwright locator targeting the live Opik UI.
+- You're adding a method to an existing POM that interacts with a new element you haven't seen before.
+
+It does NOT apply to:
+
+- Pure fixture work (no UI interaction).
+- Matchers / type-only changes.
+
+## The procedure
+
+```dot
+digraph pom_discovery {
+    rankdir=TB;
+    "Identify target page + entity preconditions" [shape=box];
+    "Seed required state (project, dataset, trace, etc.)?" [shape=diamond];
+    "Create state via SDK / bridge before opening UI" [shape=box];
+    "Open page via browser_navigate (with auth)" [shape=box];
+    "browser_snapshot to get accessibility tree" [shape=box];
+    "browser_evaluate to enumerate data-testids" [shape=box];
+    "Pick selector preference (testid > role > label > css)" [shape=box];
+    "Write POM method" [shape=box];
+    "Verify via browser_generate_locator and test_run" [shape=box];
+    "Method works?" [shape=diamond];
+    "Selector unstable or missing?" [shape=diamond];
+    "Flag for FE data-testid addition" [shape=box];
+    "Commit POM method" [shape=box];
+
+    "Identify target page + entity preconditions" -> "Seed required state (project, dataset, trace, etc.)?";
+    "Seed required state (project, dataset, trace, etc.)?" -> "Create state via SDK / bridge before opening UI" [label="yes"];
+    "Create state via SDK / bridge before opening UI" -> "Open page via browser_navigate (with auth)";
+    "Seed required state (project, dataset, trace, etc.)?" -> "Open page via browser_navigate (with auth)" [label="no — stateless page"];
+    "Open page via browser_navigate (with auth)" -> "browser_snapshot to get accessibility tree";
+    "browser_snapshot to get accessibility tree" -> "browser_evaluate to enumerate data-testids";
+    "browser_evaluate to enumerate data-testids" -> "Pick selector preference (testid > role > label > css)";
+    "Pick selector preference (testid > role > label > css)" -> "Write POM method";
+    "Write POM method" -> "Verify via browser_generate_locator and test_run";
+    "Verify via browser_generate_locator and test_run" -> "Method works?";
+    "Method works?" -> "Commit POM method" [label="yes"];
+    "Method works?" -> "Selector unstable or missing?" [label="no"];
+    "Selector unstable or missing?" -> "Flag for FE data-testid addition" [label="yes"];
+    "Selector unstable or missing?" -> "browser_snapshot to get accessibility tree" [label="no, try different selector"];
+    "Flag for FE data-testid addition" -> "Pick selector preference (testid > role > label > css)";
+}
+```
+
+## Step-by-step
+
+### 1. Identify target page + preconditions
+
+Before opening the browser, answer in writing:
+
+- **What page** does the POM model? E.g., `LogsPage` models `/<workspace>/projects/<projectId>/logs`. Get the route from the FE source under `apps/opik-frontend/src/v2/pages/` — each page has a directory matching its name.
+- **What entities must exist** for the page to show real data? Examples:
+  - `LogsPage` — needs a project AND at least one trace under it. An empty project shows only the empty state.
+  - `DatasetItemsPage` — needs a dataset AND at least one item. Empty datasets show only the "Create item" CTA.
+  - `TestSuitesPage` — needs at least one test suite to show row interactions.
+  - `OnlineEvaluationPage` — works empty, but creating a rule shows the rule list.
+- **What auth state** does the page need? The browser session needs the workspace authenticated. See the auth setup below.
+
+If the page genuinely is stateless (e.g., an empty list page), skip seeding and go straight to step 3. If it's not, seed first — exploring an empty-state UI will lead you to write a POM that only ever sees the empty state.
+
+### 2. Seed required state via SDK / bridge
+
+**Never** click-create state through the UI just to populate the page you're exploring. Two reasons:
+
+1. The page you're exploring may itself BE the UI-create flow you're trying to model — you'd be using the UI to test the UI.
+2. UI-create is slower and flakier than SDK-create.
+
+Instead, use the bridge or the TS SDK to seed before opening the browser. For the discovery phase, a one-off seed script is fine — you don't need to wire it into the test suite yet (the test's fixture handles that later).
+
+**Example seed for `LogsPage` discovery:**
+
+```ts
+// scratch script, not committed
+import { Opik } from 'opik';
+const opik = new Opik({
+  apiKey: process.env.OPIK_API_KEY,
+  workspaceName: process.env.OPIK_WORKSPACE,
+  apiUrl: process.env.OPIK_BASE_URL + '/api',
+});
+
+// project + a few traces with structure variety
+const projectName = `discovery-logs-${Date.now()}`;
+await opik.api.projects.createProject({ name: projectName });
+
+import { track } from 'opik';
+const decoratedFn = track({ name: 'discovery-trace', projectName }, async (input: string) => {
+  return `output for ${input}`;
+});
+await decoratedFn('hello');
+await decoratedFn('world');
+await opik.flush();
+
+console.log(`Discovery project: ${projectName}`);
+```
+
+Run it locally with staging or local-dev creds, note the project name, then navigate the UI to that project's logs page in the next step. Tear it down by hand at the end of the discovery session (`backendClient.deleteProject` if it's wired up, or `curl` otherwise) — discovery state should never accumulate.
+
+**Reusable seed patterns by page family:**
+
+| Page being built | Seed via | Why |
+|---|---|---|
+| `LogsPage`, `TracePanelPage` | `opik.track` decorator + at least one call | Empty projects show only the empty state |
+| `DatasetsPage` | `opik.api.datasets.createDataset({...})` for ~3 datasets with different shapes | List interactions need multiple rows |
+| `DatasetItemsPage` | `opik.Dataset(name).insert([...])` with 3+ items | Item-table interactions need data |
+| `TestSuitesPage`, `TestSuitePage` | `opik.TestSuite(...)` with items + evaluator + run | Suite states (running/completed/failed) need a real run |
+| `ExperimentsPage` | `experiment.evaluate(...)` against a dataset | Experiment rows need a completed run |
+| `OnlineEvaluationPage` | (works empty for rule list); seed a rule via UI once during discovery | Rule list shows after at least one rule exists |
+| `AnnotationQueuesPage`, `AnnotationQueuePage` | `opik.TracesAnnotationQueue(...)` with 3+ traces | Reviewer flow needs items to score |
+
+Common gotchas:
+
+- **Trace ingestion is eventually consistent.** After `opik.flush()`, the trace may take 1–3 seconds to appear in the Logs page. If you snapshot too fast, you'll see the empty state. Wait or refresh.
+- **Online scoring rules apply asynchronously** — if you seed a trace and then snapshot the Online Evaluation page, scores may not have landed yet.
+- **Dataset items have a slight delay** between insert and table-render — usually ms, but watch for it.
+
+### 3. Open the page with an authed browser session
+
+**Auth setup once per discovery session:**
+
+The browser MCP needs an authenticated page. Against local OSS (`http://localhost:5173`, workspace `default`) there's no login wall — navigate straight to the page. Against an authenticated deployment, reuse the suite's storage state: `global-setup` mints `.auth/user.json` the first time you run a Playwright test, and the browser MCP can load it as its `storageState`. Don't script a full login flow during discovery — it's a distraction.
+
+**Standard discovery navigation:**
+
+```
+mcp__Playwright__browser_navigate(url="http://localhost:5173/...")
+```
+
+Get the exact route from the FE source — `apps/opik-frontend/src/v2/router.tsx` for the route table, or the page directory under `apps/opik-frontend/src/v2/pages/<PageName>/`. Most data pages are project-scoped, e.g. `/{workspace}/projects/{projectId}/datasets/` or `/{workspace}/projects/{projectId}/logs`. Confirm against the router rather than guessing — routes change.
+
+### 4. Snapshot the accessibility tree
+
+```
+mcp__Playwright__browser_snapshot()
+```
+
+This returns the **structured accessibility tree**, not pixels. Each interactive element has:
+
+- A role (`button`, `textbox`, `link`, `combobox`, `row`, etc.)
+- An accessible name (the visible text or `aria-label`)
+- A stable `ref` ID you can use with `browser_click(ref="...")` to interact
+
+Why this is the right primitive: Playwright's `getByRole(...)` selectors map 1:1 to what the snapshot shows. If you see `button "Create suite"` in the snapshot, you can confidently write `page.getByRole('button', { name: 'Create suite' })`.
+
+**Read the snapshot before writing any selector.** Don't guess. Don't grep the FE source for what you think the button is called — the rendered DOM is the only source of truth that matters.
+
+### 5. Enumerate `data-testid`s
+
+The snapshot tells you what's interactive but not what's been explicitly marked stable by the FE team. For that:
+
+```
+mcp__Playwright__browser_evaluate(function="""() => {
+  return Array.from(document.querySelectorAll('[data-testid]'))
+    .map(e => ({
+      testid: e.getAttribute('data-testid'),
+      tag: e.tagName.toLowerCase(),
+      text: (e.textContent || '').slice(0, 60).trim(),
+      visible: e.offsetParent !== null,
+    }))
+    .filter(e => e.visible);
+}""")
+```
+
+This returns every test id currently rendered on the page, with enough context to know what each one is. **Test ids are the preferred selector** — they're the FE team's contract for "this won't change." Use them when they exist.
+
+### 6. Pick the right selector
+
+In priority order:
+
+1. **`data-testid`** — most stable. `page.getByTestId('create-suite-button')`. If a test id exists, use it.
+2. **`getByRole(name)`** — stable across most refactors as long as the accessible name doesn't change. `page.getByRole('button', { name: 'Create suite' })`.
+3. **`getByLabel`** for form inputs that have a label. `page.getByLabel('Dataset name')`.
+4. **`getByText`** — fragile if the text is dynamic or i18n'd. Use only for truly static labels.
+5. **CSS / XPath selectors** — **last resort**. Use only when no test id and no accessible name exists, and leave a comment explaining why: `// no test id; FE team to add — link to ticket`.
+
+**The decision is binary at write time, not runtime.** Pick one selector and commit to it — write deterministic selectors, not runtime-healing ones.
+
+### 7. Use `browser_generate_locator` when you're unsure
+
+If the accessibility tree shows three buttons with similar names, or the element has both a test id and a role and you're not sure which is canonical:
+
+```
+mcp__Playwright__browser_snapshot()  # to find the ref of the element
+mcp__playwright-test__browser_generate_locator(ref="<the-ref>")
+```
+
+This returns the locator code **Playwright itself would generate** if you used `codegen` against this element. Trust that output — Playwright's locator selection logic is well-tuned for resilience.
+
+If you don't have access to `mcp__playwright-test__` tools, fall back to writing the selector manually based on the snapshot + test id list, then verify in step 8.
+
+### 8. Verify by running
+
+After writing the POM method, the verification loop is:
+
+```ts
+// scratch test, not committed
+import { test, expect } from '@playwright/test';
+import { LogsPage } from '../pom/logs.page';
+
+test('discovery: LogsPage.filterByProject works', async ({ page }) => {
+  await page.goto('http://localhost:5173/<workspace>/projects/<seed-project-id>/logs');
+  const logs = new LogsPage(page);
+  await logs.filterByProject('discovery-logs-...');
+  expect(await logs.countTraces()).toBeGreaterThan(0);
+});
+```
+
+Run it through:
+
+```
+mcp__playwright-test__test_run(testPath="path/to/scratch.spec.ts")
+```
+
+If it passes, the POM method works against the live page. If it fails, **read the failure trace** (Playwright's artifacts), don't just adjust selectors blindly. Common failures:
+
+- **Timeout waiting for element** — selector is wrong. Re-snapshot and pick a different one.
+- **Element resolved but assertion failed** — the POM method's logic is wrong, not the selector. Fix the method, not the selector.
+- **Multiple elements matched** — selector isn't specific enough. Add a parent scope or use a more precise role.
+
+### 9. When a stable selector doesn't exist
+
+If after all of the above the only working selector is a CSS path like `.MuiTable-root > tbody > tr:nth-child(2)`, **stop and flag it**. The missing-data-testid protocol:
+
+- **Default:** add a `data-testid` to the FE component in the **same change** as your POM. Find the component under `apps/opik-frontend/src/v2/pages/<Page>/...` or its shared-component dependency, add `data-testid="<descriptive-name>"`, then use that in the POM.
+- **Fallback:** if blocked from touching the FE, use `getByRole` with explicit accessible name (survives most refactors).
+- **Last resort:** structural CSS selector with a comment explaining why it's necessary and that a `data-testid` should be added.
+
+The `data-testid` naming convention is kebab-case, descriptive, scoped to the page/component: `dataset-items-table`, `create-suite-button`, `trace-row-{traceId}`. Avoid generic names like `submit-button` that conflict across pages.
+
+### 10. Commit and move on
+
+Once the POM method works against the live UI:
+
+- The POM file change goes in with the test that uses it.
+- Any FE `data-testid` additions go in the **same** change (cross-package is fine; reviewers expect it for test-enablement work).
+- Any scratch seed script and scratch test file are **NOT** committed. Delete them first.
+- Tear down any state you created during discovery (`backendClient.deleteProject(...)` or `curl -X DELETE ...`).
+
+## Anti-patterns
+
+These are red flags that mean you skipped a step:
+
+| Symptom | What you skipped |
+|---|---|
+| "Let me look at the FE source to find the right selector" | Step 4 — snapshot the rendered DOM, not the source. Components compose; what renders is what matters. |
+| "I'll write the POM method and check if it works when the test runs" | Step 8 — verify in isolation before committing. Iterating inside a full run is slower. |
+| "The page is empty, so I'll just check the empty state" | Step 2 — seed real data. An empty-state-only POM never exercises the row template, the open-detail action, etc. |
+| "I'll use `page.locator('.button:nth-child(3)')` — it's fine" | Step 9 — flag missing testids and add them to the FE. Brittle selectors are the #1 source of E2E flake. |
+| "The test id I see is generic, like `button-1` — I'll use that" | Step 5 + 9 — generic test ids are nearly as bad as no test id. Rename it to something descriptive in the same change. |
+| "I'll add the POM but skip the seed because the test will create state" | Step 2 — even during the test, you're now writing untested POM code against a page state you've never seen. |
+
+## Where this fits
+
+This is the discovery sub-step of writing an E2E test. The `writing-e2e-tests` skill invokes it once it has scoped the test and analyzed the feature: you seed the page's state, explore the live UI, and come back with the selectors each POM method will use plus any `data-testid`s the FE needs. The test and POM get written and run from there.

--- a/.agents/skills/writing-e2e-tests/SKILL.md
+++ b/.agents/skills/writing-e2e-tests/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: writing-e2e-tests
+description: Use when a developer wants to add, write, or create an end-to-end test for an Opik feature, page, or branch — e.g. "add an e2e test for the experiments comparison page", "write a test for the feature I just built", "e2e test for this branch", "cover the dataset items flow with a test". Runs the full loop in tests_end_to_end/e2e/ — analyze the feature and frontend code, explore the live UI with the Playwright MCP, write the Page Object Model + spec, and run it locally until green.
+---
+
+# Writing E2E Tests
+
+This skill is how we add an end-to-end test to the Opik E2E suite. You give it a feature, page, or branch; it runs a proven loop end-to-end and leaves you with a working, locally-verified Playwright test.
+
+**Announce at start:** "I'm using the writing-e2e-tests skill to add an E2E test for X."
+
+## Where tests live
+
+The suite is at `tests_end_to_end/e2e/`. Inside it:
+
+- **Specs:** `tests/<feature>/<name>.spec.ts` — one feature directory per page family (`datasets`, `trace-explore`, `experiments`, `test-suites`, `online-evaluation`, …).
+- **Page Object Models:** `pom/<name>.page.ts` — one class per page, methods for the interactions a test needs.
+- **Fixtures:** `fixtures/<name>.fixture.ts` — seed entities (project, dataset, trace, experiment, testSuite) and tear them down. Composed in a chain; re-exported from `fixtures/index.ts`.
+- **SDK clients:** `core/sdk/` — `sdkClient.python` (HTTP wrapper over the bridge) and `sdkClient.typescript` (direct `new Opik({...})`) for seeding. `core/backend/` holds the typed REST client for inspection + teardown.
+- **Bridge:** `services/opik-sdk-driver/` — a FastAPI app (run with `uv`) wrapping the Python SDK, exposing routes the TS clients call. Playwright's `webServer` directive auto-spawns it during a test run; you don't start it by hand.
+
+Specs and POMs import through path aliases: `import { test, expect } from '@e2e/fixtures'` and `import { LogsPage } from '@e2e/pom/logs.page'`.
+
+## Tooling — already set up
+
+- The **`Playwright` MCP** (live-UI exploration) and the **`playwright-test` MCP** (`browser_generate_locator`) are already configured in the repo's `.mcp.json`. No setup step.
+- Tests run via the plain Playwright CLI from `tests_end_to_end/e2e/`. The `webServer` directive spawns the bridge automatically.
+
+## Conventions
+
+Read [conventions.md](conventions.md) before writing any POM or spec. It carries the rules that keep tests legible and stable: mandatory `test.step()` wrapping, UI-first assertions, selector preference, public-SDK-only seeding, fixture seed shapes, and the tag taxonomy. They aren't optional polish — each prevents a class of failure.
+
+## The loop
+
+```dot
+digraph writing_e2e {
+    rankdir=TB;
+    "1. Scope (GATE)" [shape=box];
+    "2. Analyze feature + FE code" [shape=box];
+    "3. Discover live UI (GATE)" [shape=box];
+    "4. Write POM + spec" [shape=box];
+    "5. Run until green" [shape=box];
+    "Green?" [shape=diamond];
+
+    "1. Scope (GATE)" -> "2. Analyze feature + FE code";
+    "2. Analyze feature + FE code" -> "3. Discover live UI (GATE)";
+    "3. Discover live UI (GATE)" -> "4. Write POM + spec";
+    "4. Write POM + spec" -> "5. Run until green";
+    "5. Run until green" -> "Green?";
+    "Green?" -> "4. Write POM + spec" [label="no — fix"];
+    "Green?" -> "done" [label="yes"];
+}
+```
+
+### Step 1 — Scope (gate, lightweight)
+
+Work out, from the request:
+
+- **What flow / feature** the test covers, and **which page** it lives on. If the dev pointed at a branch or PR, read the diff to find what changed.
+- **The target.** Default is local OSS at `http://localhost:5173` (`OPIK_DEPLOYMENT=oss`, workspace `default`) — the natural target for "test the feature I just built." Only use another target if the dev asks.
+- **Tags** — pick a tier (`@t1-smoke` / `@t2-cuj` / `@t3-nightly`) and a feature tag, per [conventions.md](conventions.md).
+
+Run the **safety check** (below) before any seeding. Then confirm the scope in one short message — feature, page, target, tags — and proceed. Don't write a formal spec document.
+
+### Step 2 — Analyze the feature and frontend code
+
+Before touching the browser:
+
+- Read the page's FE source under `apps/opik-frontend/src/v2/pages/<Page>/` — the route it renders at, the components it composes, and any `data-testid` attributes already present. The route shape is what your POM's `goto()` will use.
+- Identify the **entity preconditions**: what must exist for the page to render real data (an empty project shows only the empty state). Decide how to seed it — which fixture fits, or which bridge/SDK call. Seed via the SDK/bridge, never by click-creating through the UI.
+- Check `fixtures/` for an existing fixture that already seeds the shape you need; reuse it before writing a new one.
+
+### Step 3 — Discover the live UI (gate, lightweight)
+
+**Invoke the `playwright-pom-discovery` skill** (via the Skill tool). It walks the live page with the Playwright MCP: seed state, navigate authed, snapshot the accessibility tree, enumerate `data-testid`s, pick the most stable selector for each element you'll target, and flag any element that has no stable selector (needs a FE `data-testid` added in this change).
+
+When discovery is done, report a short summary — the selectors you'll use per element, and any missing testids you'll add — and confirm before writing code. Don't write anything under `pom/` before this step.
+
+### Step 4 — Write the POM + spec
+
+- Write or extend the POM in `pom/<name>.page.ts` using the selectors from discovery. Each method wraps its body in `test.step()` and returns through the callback (see [conventions.md](conventions.md)).
+- Write the spec in `tests/<feature>/<name>.spec.ts`: tier + feature tag on the describe block, coarse `test.step()` phases, UI-first assertions.
+- If discovery flagged a missing/brittle selector, add a descriptive `data-testid` to the FE component in the **same change**.
+
+### Step 5 — Run until green
+
+From `tests_end_to_end/e2e/`:
+
+```bash
+npx playwright test tests/<feature>/<name>.spec.ts --reporter=list
+```
+
+The bridge auto-spawns (you'll see its startup line in the output). If a test fails, **read the failure trace** (`npx playwright show-trace`) rather than adjusting selectors blindly — see "verify the test render before blaming the backend" in [conventions.md](conventions.md). Fix and re-run until green. Report the actual run output.
+
+## Safety: verify local config before seeding
+
+The Python SDK behind the bridge reads `~/.opik.config`. If it points at a cloud environment, seeding would create real data there. Before any seed against a local target:
+
+```bash
+cat ~/.opik.config
+```
+
+If `url_override` is anything other than `http://localhost:5173/api`, back it up and point it local:
+
+```bash
+cp ~/.opik.config ~/.opik.config.bak 2>/dev/null || true
+cat > ~/.opik.config << 'EOF'
+[opik]
+url_override = http://localhost:5173/api
+workspace = default
+EOF
+```
+
+When the work is done, remind the dev to restore: `cp ~/.opik.config.bak ~/.opik.config`. If it already points local, skip this.
+
+## Anti-patterns
+
+| Symptom | What you skipped |
+|---|---|
+| "Let me read the FE source to find the selector" | Discovery — snapshot the rendered DOM. What renders is the only source of truth for selectors. |
+| "I'll explore the empty page and figure out the rows later" | Seeding — an empty-state-only POM never exercises the row template or open-detail actions. |
+| "I'll write the POM and find out if it works when the whole suite runs" | Run-until-green in isolation — iterate on the one spec, don't debug it inside a full suite run. |
+| "`page.locator('tbody tr:nth-child(3)')` is fine" | Flagging the missing testid — brittle structural selectors are the top source of flake; add a `data-testid`. |
+| "I'll create the dataset through the UI so the page has data" | SDK/bridge seeding — UI-create is what the test exercises, not how you set up. |

--- a/.agents/skills/writing-e2e-tests/conventions.md
+++ b/.agents/skills/writing-e2e-tests/conventions.md
@@ -1,0 +1,102 @@
+# E2E Test Conventions
+
+These are the durable conventions for the Opik E2E suite (`tests_end_to_end/e2e/`). Read this before writing any Page Object Model or spec. They aren't style preferences — each one prevents a class of failure or makes failures legible.
+
+## `test.step()` wrapping is mandatory
+
+Wrap logical phases at the test level, and wrap each POM method body in a `test.step()` that returns through the callback. This is what makes the Playwright trace viewer and the Allure timeline readable — without it, a failure is a flat wall of actions with no narrative.
+
+Granularity: a "phase" is something you'd describe in a complete sentence ("seed three traces", "open the trace and verify the panel").
+
+In the test:
+
+```ts
+import { test, expect } from '@e2e/fixtures';
+import { LogsPage } from '@e2e/pom/logs.page';
+
+test('Logs view shows seeded traces in order', async ({ project, sdkClient, page }) => {
+  await test.step('Seed traces via the Python SDK', async () => {
+    await sdkClient.python.createTrace({ project_name: project.name, name: 'a', input: 'i', output: 'o' });
+  });
+
+  await test.step('Open Logs and verify', async () => {
+    const logs = new LogsPage(page);
+    await logs.goto(project.id);
+    await logs.waitForReady();
+    expect(await logs.countTraces()).toBe(1);
+  });
+});
+```
+
+In a POM method — wrap the body and return through the step callback:
+
+```ts
+async openDatasetByName(name: string): Promise<DatasetItemsPage> {
+  return test.step(`open dataset "${name}"`, async () => {
+    const row = this.datasetRow(name);
+    await row.waitFor({ state: 'visible' });
+    await row.getByRole('cell', { name, exact: true }).click();
+    return new DatasetItemsPage(this.page, this.projectId, datasetId);
+  });
+}
+```
+
+## UI-first assertions by default
+
+Assert on what the user sees, using Playwright's built-in locator assertions:
+
+```ts
+await expect(panel.traceNameInHeader(trace.name)).toBeVisible();
+await expect(logs.row(name)).toHaveCount(1);
+await expect(panel.errorBadge).toBeHidden();
+```
+
+Don't register custom matchers. Touch `matchers/register.ts` only if you've identified a specific assertion the built-in locator assertions genuinely can't express — and if you do, the test you ship must actually use it. A registered-but-unused matcher is dead code.
+
+When you need to confirm something the UI doesn't surface (e.g. a feedback score landed on a source trace after an async rule), read it back through the suite's SDK client — but prefer a UI assertion whenever the UI shows the fact.
+
+## Selector preference
+
+Pick the most stable locator available, in this order:
+
+1. **`getByTestId('descriptive-name')`** — the FE team's stability contract. Use it whenever it exists.
+2. **`getByRole('button', { name: 'Create dataset' })`** — survives most refactors as long as the accessible name holds.
+3. **`getByLabel('Dataset name')`** — for labelled form inputs.
+4. **`getByText(...)`** — only for truly static, non-i18n text.
+5. **CSS / XPath** — last resort.
+
+If the only working selector is a structural CSS path (`tbody > tr:nth-child(2)`), stop: add a descriptive kebab-case `data-testid` to the FE component (under `apps/opik-frontend/src/v2/pages/<Page>/...` or its shared dependency) in the **same change** as the POM. Name it for the page/element (`create-dataset-sidebar`, `dataset-items-table`), never generically (`button-1`, `submit`). If you genuinely can't touch the FE, leave a comment explaining why the CSS selector is necessary and that a `data-testid` should be added.
+
+## Public SDK surface only
+
+Seed and inspect through the suite's SDK clients and the public `Opik` class. Never deep-import REST internals (`opik/rest_api/*`). The public surface is the contract; internals move.
+
+## Seed state via the SDK/bridge, not the UI
+
+Create the state a page needs through the bridge or SDK before you open the browser. UI-create is what the *test* exercises — it's not how you set up for exploration or for a precondition. UI-create is also slower and flakier as a setup step.
+
+## Fixture seed shapes must match what the page renders
+
+An empty project shows only the empty state; a dataset with no items shows only the "create item" CTA. If your page needs rows, sort order, or a pass/fail mix to be meaningful, the fixture must seed that shape. Reuse existing fixtures (`project`, `dataset`, `trace`, `experiment`, `testSuite`) where they fit; add a new one only when the shape genuinely differs. Verify teardown: some entities cascade with the project, some need explicit deletion — check and clean up what you create.
+
+## Verify the test render before blaming the backend
+
+When something "isn't appearing," the usual cause is a DOM race (a loading spinner still up, an eventually-consistent write not yet landed), not a backend regression. Read the failure trace artifact first — `npx playwright show-trace` — and confirm the page actually finished rendering before concluding the data is missing. For genuinely async state (online scoring rules, ingestion lag), poll with `expect.poll(...)` rather than a fixed `setTimeout`.
+
+## Tags
+
+Every test carries a tier tag and a feature tag. Tiers are inclusive: `test:t2` runs `@t1-smoke|@t2-cuj`, `test:t3` runs all three.
+
+- `@t1-smoke` — fast, deterministic, always-on core checks.
+- `@t2-cuj` — core user journeys; multi-step flows.
+- `@t3-nightly` — broader / slower coverage.
+
+Apply them on the describe block alongside the feature tag:
+
+```ts
+test.describe('Dataset CRUD — smoke', { tag: ['@t1-smoke', '@datasets'] }, () => {
+  // ...
+});
+```
+
+Pick the tier by what the test costs and how core it is; pick the feature tag to match the page family (`@datasets`, `@trace-explore`, `@experiments`, …).

--- a/tests_end_to_end/e2e/AGENTIC.md
+++ b/tests_end_to_end/e2e/AGENTIC.md
@@ -4,27 +4,14 @@ This suite is built to be extended by a coding agent. You describe the feature y
 
 ## Two ways to start
 
-1. **Type the command:** `/add-e2e-test` — then describe the flow you want covered.
+1. **Type the command:** `/comet:add-e2e-test` — then describe the flow you want covered.
 2. **Just ask in plain English:** tell Claude Code "add an e2e test for the experiments comparison page" (or "…for the feature I just built", or "…for this branch"). It routes to the same procedure.
 
 Both land in the `writing-e2e-tests` skill, which carries the full procedure and the suite's conventions.
 
 ## What the agent does
 
-A five-step loop, with two lightweight checkpoints where it confirms direction with you:
-
-1. **Scope** *(checkpoint)* — works out the flow, the page, the target (local by default), and the tags; confirms in one line.
-2. **Analyze** — reads the feature's frontend code and figures out what state the page needs to render real data.
-3. **Discover the live UI** *(checkpoint)* — explores the running page with the Playwright MCP, picks stable selectors, flags any missing `data-testid`s; confirms before writing code.
-4. **Write** — the Page Object Model + spec, plus any `data-testid` the frontend was missing.
-5. **Run until green** — runs the new test locally, reads failure traces, fixes, and re-runs until it passes.
-
-## Where things land
-
-- Specs: `tests/<feature>/<name>.spec.ts`
-- Page Object Models: `pom/<name>.page.ts`
-- Fixtures (seed + teardown): `fixtures/<name>.fixture.ts`
-- SDK bridge (auto-spawned during a run): `services/opik-sdk-driver/`
+A five-step loop — analyze the feature + frontend code → explore the live UI with the Playwright MCP → write the Page Object Model + spec → run it locally until green — with two lightweight checkpoints where it confirms direction with you (scope, and the live-UI discovery findings). The step-by-step is in the `writing-e2e-tests` skill.
 
 ## Prerequisites
 
@@ -33,4 +20,4 @@ A five-step loop, with two lightweight checkpoints where it confirms direction w
 
 ## Going deeper
 
-The procedure and conventions live in the `writing-e2e-tests` skill (`conventions.md` alongside it covers `test.step()` wrapping, assertion style, selector preference, seeding, and tags). The live-UI selector hunt is the `playwright-pom-discovery` skill. See [README.md](README.md) for the environment-variable surface and quick start.
+The procedure, conventions, and the map of where files land (`tests/`, `pom/`, `fixtures/`, the SDK bridge) live in the `writing-e2e-tests` skill and its `conventions.md`. The live-UI selector hunt is the `playwright-pom-discovery` skill. See [README.md](README.md) for the environment-variable surface and quick start.

--- a/tests_end_to_end/e2e/AGENTIC.md
+++ b/tests_end_to_end/e2e/AGENTIC.md
@@ -1,0 +1,36 @@
+# Adding E2E tests with an agent
+
+This suite is built to be extended by a coding agent. You describe the feature you want covered; the agent runs a proven loop and leaves you with a working, locally-verified Playwright test.
+
+## Two ways to start
+
+1. **Type the command:** `/add-e2e-test` — then describe the flow you want covered.
+2. **Just ask in plain English:** tell Claude Code "add an e2e test for the experiments comparison page" (or "…for the feature I just built", or "…for this branch"). It routes to the same procedure.
+
+Both land in the `writing-e2e-tests` skill, which carries the full procedure and the suite's conventions.
+
+## What the agent does
+
+A five-step loop, with two lightweight checkpoints where it confirms direction with you:
+
+1. **Scope** *(checkpoint)* — works out the flow, the page, the target (local by default), and the tags; confirms in one line.
+2. **Analyze** — reads the feature's frontend code and figures out what state the page needs to render real data.
+3. **Discover the live UI** *(checkpoint)* — explores the running page with the Playwright MCP, picks stable selectors, flags any missing `data-testid`s; confirms before writing code.
+4. **Write** — the Page Object Model + spec, plus any `data-testid` the frontend was missing.
+5. **Run until green** — runs the new test locally, reads failure traces, fixes, and re-runs until it passes.
+
+## Where things land
+
+- Specs: `tests/<feature>/<name>.spec.ts`
+- Page Object Models: `pom/<name>.page.ts`
+- Fixtures (seed + teardown): `fixtures/<name>.fixture.ts`
+- SDK bridge (auto-spawned during a run): `services/opik-sdk-driver/`
+
+## Prerequisites
+
+- Opik running locally (`./opik.sh`, frontend at `http://localhost:5173`). That's the default target.
+- The Playwright MCP servers ship in the repo's `.mcp.json` — no setup needed.
+
+## Going deeper
+
+The procedure and conventions live in the `writing-e2e-tests` skill (`conventions.md` alongside it covers `test.step()` wrapping, assertion style, selector preference, seeding, and tags). The live-UI selector hunt is the `playwright-pom-discovery` skill. See [README.md](README.md) for the environment-variable surface and quick start.


### PR DESCRIPTION
## Details

Turns the manually-driven E2E test-authoring workflow into first-class, self-serve developer tooling for `tests_end_to_end/e2e/`. A developer types `/comet:add-e2e-test` — or just describes the request in plain English ("add an e2e test for the experiments comparison page") — and the agent runs the full proven loop: analyze the feature + frontend code → explore the live UI with the Playwright MCP → write the Page Object Model + spec → run it locally until green. No knowledge of internal procedure required.

- New `writing-e2e-tests` skill carries the full loop with two lightweight gates (scope confirmation, live-UI discovery summary) and the local-OSS `~/.opik.config` safety check, plus a sibling `conventions.md` (mandatory `test.step()` wrapping, UI-first assertions, selector preference, public-SDK-only seeding, fixture seed shapes, tag taxonomy).
- New `/comet:add-e2e-test` command is the muscle-memory entry point; it runs the safety check and invokes the skill.
- `playwright-pom-discovery` skill (the live-UI selector-discovery sub-step) is genericized and committed to the source tree for the first time — it previously existed only as a local file, so it reached no other developer.
- Authored under `.agents/` (the committed source of truth) so it reaches everyone; the local runtime view is materialized from it. Adds a team-facing `tests_end_to_end/e2e/AGENTIC.md` overview and a skills-index entry.

## Picking it up

`.agents/` is the committed source; `.claude/` (and `.cursor`) are the local runtime views, gitignored. After this merges, run `make claude` (or `make cursor` for Cursor) to materialize the command + skills locally — same one-step sync as every other `comet:*` command in the repo. A plain `git pull` alone won't surface them, since `.claude/` isn't tracked.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: full implementation (skill, command, conventions, discovery-skill genericization, docs)
  - Human verification: design + plan approved interactively; full loop dry-run against local OSS produced a green Playwright test; runtime confirmed loading the new skill + command

## Testing

This change is agent-config + docs only (no application code), so the standard backend/frontend/SDK suites don't apply. Validation was:

- Confirmed the new `writing-e2e-tests` skill and `/comet:add-e2e-test` command load live in Claude Code (they appear in the skill/command registry with the correct descriptions).
- Dry-ran the full loop end-to-end against a local OSS instance (`./opik.sh`, `localhost:5173`) on a real flow. The agent walked scope → analyze → discover → write → run-until-green and produced a passing Playwright test; the SDK bridge auto-spawned and orphan teardown ran clean. The proof test and an incidental POM fix it surfaced were intentionally left out of this PR to keep it tooling-only.
- Verified the local-OSS `~/.opik.config` safety check fires (it caught a config pointing at a cloud environment before any seeding).
- Sanity-checked skill frontmatter validity and swept the committed files for stray references.

## Documentation

- `tests_end_to_end/e2e/AGENTIC.md` (new) — "two ways to add an E2E test" overview.
- `.agents/skills/writing-e2e-tests/conventions.md` (new) — the suite's E2E conventions.
- `.agents/skills/README.md` — indexed the new and discovery skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


