### PR TITLE
[OPIK-6737] [FE] Add Ability to Evaluate Experiment Traces from UI

### DIFF
--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
@@ -28,6 +28,7 @@ import {
   COLUMN_USAGE_ID,
 } from "@/types/shared";
 import {
+  COMPARE_EXPERIMENTS_MAX_PAGE_SIZE,
   EXPERIMENT_ITEM_OUTPUT_PREFIX,
   EXPERIMENT_ITEM_DATASET_PREFIX,
 } from "@/constants/experiments";
@@ -106,8 +107,6 @@ type CompareExperimentsActionsPanelProps = {
   experiments?: Experiment[];
 };
 
-const EVALUATE_FETCH_PAGE_SIZE = 10000;
-
 const CompareExperimentsActionsPanel: React.FC<
   CompareExperimentsActionsPanelProps
 > = ({ getDataForExport, selectedRows = [], columnsToExport, experiments }) => {
@@ -145,7 +144,7 @@ const CompareExperimentsActionsPanel: React.FC<
             experimentsIds: [singleExperiment.id],
             truncate: true,
             page: 1,
-            size: EVALUATE_FETCH_PAGE_SIZE,
+            size: COMPARE_EXPERIMENTS_MAX_PAGE_SIZE,
           },
         );
       const traceIds = uniq(

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
@@ -1,17 +1,12 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import get from "lodash/get";
 import slugify from "slugify";
 import uniq from "lodash/uniq";
 import first from "lodash/first";
 
 import CompareExperimentsButton from "@/v2/pages/CompareExperimentsPage/CompareExperimentsButton/CompareExperimentsButton";
+import EvaluateExperimentTracesButton from "@/v2/pages/CompareExperimentsPage/EvaluateExperimentTracesButton/EvaluateExperimentTracesButton";
 import ExportToButton from "@/shared/ExportToButton/ExportToButton";
-import EvaluateButton from "@/v2/pages-shared/automations/EvaluateButton/EvaluateButton";
-import RunEvaluationDialog from "@/v2/pages-shared/automations/RunEvaluationDialog/RunEvaluationDialog";
-import useFilteredRulesList from "@/api/automations/useFilteredRulesList";
-import { getCompareExperimentsList } from "@/api/datasets/useCompareExperimentsList";
-import useAppStore from "@/store/AppStore";
-import { useToast } from "@/ui/use-toast";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
 import {
@@ -28,7 +23,6 @@ import {
   COLUMN_USAGE_ID,
 } from "@/types/shared";
 import {
-  COMPARE_EXPERIMENTS_MAX_PAGE_SIZE,
   EXPERIMENT_ITEM_OUTPUT_PREFIX,
   EXPERIMENT_ITEM_DATASET_PREFIX,
 } from "@/constants/experiments";
@@ -113,68 +107,8 @@ const CompareExperimentsActionsPanel: React.FC<
   const disabled = !selectedRows?.length;
   const isExportEnabled = useIsFeatureEnabled(FeatureToggleKeys.EXPORT_ENABLED);
 
-  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
-  const { toast } = useToast();
-
   const singleExperiment =
     experiments?.length === 1 ? experiments[0] : undefined;
-  const evaluateProjectId = singleExperiment?.project_id ?? "";
-  const evaluateEnabled = Boolean(singleExperiment && evaluateProjectId);
-
-  const [evaluateOpen, setEvaluateOpen] = useState(false);
-  const [evaluateTraceIds, setEvaluateTraceIds] = useState<string[]>([]);
-  const [isFetchingTraces, setIsFetchingTraces] = useState(false);
-
-  const { rules, isLoading: isRulesLoading } = useFilteredRulesList({
-    projectId: evaluateProjectId,
-    entityType: "trace",
-    enabled: evaluateEnabled,
-  });
-
-  const handleEvaluateClick = useCallback(async () => {
-    if (!singleExperiment?.dataset_id) return;
-    setIsFetchingTraces(true);
-    try {
-      const data: { content?: ExperimentsCompare[] } =
-        await getCompareExperimentsList(
-          {},
-          {
-            workspaceName,
-            datasetId: singleExperiment.dataset_id,
-            experimentsIds: [singleExperiment.id],
-            truncate: true,
-            page: 1,
-            size: COMPARE_EXPERIMENTS_MAX_PAGE_SIZE,
-          },
-        );
-      const traceIds = uniq(
-        (data?.content ?? [])
-          .flatMap((row) => row.experiment_items ?? [])
-          .map((item) => item.trace_id)
-          .filter((id): id is string => Boolean(id)),
-      );
-
-      if (!traceIds.length) {
-        toast({
-          title: "Nothing to evaluate",
-          description: "No traces are associated with this experiment.",
-          variant: "destructive",
-        });
-        return;
-      }
-
-      setEvaluateTraceIds(traceIds);
-      setEvaluateOpen(true);
-    } catch (error) {
-      toast({
-        title: "Error",
-        description: "Failed to load experiment traces for evaluation.",
-        variant: "destructive",
-      });
-    } finally {
-      setIsFetchingTraces(false);
-    }
-  }, [singleExperiment, workspaceName, toast]);
 
   const mapRowData = useCallback(async () => {
     if (!columnsToExport || !getDataForExport) return [];
@@ -261,25 +195,7 @@ const CompareExperimentsActionsPanel: React.FC<
   return (
     <div className="flex items-center gap-2">
       <CompareExperimentsButton />
-      {evaluateEnabled && (
-        <>
-          <RunEvaluationDialog
-            open={evaluateOpen}
-            setOpen={setEvaluateOpen}
-            projectId={evaluateProjectId}
-            entityIds={evaluateTraceIds}
-            entityType="trace"
-            rules={rules}
-            isLoading={isRulesLoading}
-          />
-          <EvaluateButton
-            isNoRules={!rules?.length}
-            disabled={isFetchingTraces}
-            label="Evaluate"
-            onClick={handleEvaluateClick}
-          />
-        </>
-      )}
+      <EvaluateExperimentTracesButton experiment={singleExperiment} />
       {columnsToExport && (
         <>
           <Separator orientation="vertical" className="mx-2 h-4" />

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import get from "lodash/get";
 import slugify from "slugify";
 import uniq from "lodash/uniq";
@@ -6,6 +6,12 @@ import first from "lodash/first";
 
 import CompareExperimentsButton from "@/v2/pages/CompareExperimentsPage/CompareExperimentsButton/CompareExperimentsButton";
 import ExportToButton from "@/shared/ExportToButton/ExportToButton";
+import EvaluateButton from "@/v2/pages-shared/automations/EvaluateButton/EvaluateButton";
+import RunEvaluationDialog from "@/v2/pages-shared/automations/RunEvaluationDialog/RunEvaluationDialog";
+import useFilteredRulesList from "@/api/automations/useFilteredRulesList";
+import { getCompareExperimentsList } from "@/api/datasets/useCompareExperimentsList";
+import useAppStore from "@/store/AppStore";
+import { useToast } from "@/ui/use-toast";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
 import {
@@ -100,11 +106,76 @@ type CompareExperimentsActionsPanelProps = {
   experiments?: Experiment[];
 };
 
+const EVALUATE_FETCH_PAGE_SIZE = 10000;
+
 const CompareExperimentsActionsPanel: React.FC<
   CompareExperimentsActionsPanelProps
 > = ({ getDataForExport, selectedRows = [], columnsToExport, experiments }) => {
   const disabled = !selectedRows?.length;
   const isExportEnabled = useIsFeatureEnabled(FeatureToggleKeys.EXPORT_ENABLED);
+
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const { toast } = useToast();
+
+  const singleExperiment =
+    experiments?.length === 1 ? experiments[0] : undefined;
+  const evaluateProjectId = singleExperiment?.project_id ?? "";
+  const evaluateEnabled = Boolean(singleExperiment && evaluateProjectId);
+
+  const [evaluateOpen, setEvaluateOpen] = useState(false);
+  const [evaluateTraceIds, setEvaluateTraceIds] = useState<string[]>([]);
+  const [isFetchingTraces, setIsFetchingTraces] = useState(false);
+
+  const { rules, isLoading: isRulesLoading } = useFilteredRulesList({
+    projectId: evaluateProjectId,
+    entityType: "trace",
+    enabled: evaluateEnabled,
+  });
+
+  const handleEvaluateClick = useCallback(async () => {
+    if (!singleExperiment?.dataset_id) return;
+    setIsFetchingTraces(true);
+    try {
+      const data: { content?: ExperimentsCompare[] } =
+        await getCompareExperimentsList(
+          {},
+          {
+            workspaceName,
+            datasetId: singleExperiment.dataset_id,
+            experimentsIds: [singleExperiment.id],
+            truncate: true,
+            page: 1,
+            size: EVALUATE_FETCH_PAGE_SIZE,
+          },
+        );
+      const traceIds = uniq(
+        (data?.content ?? [])
+          .flatMap((row) => row.experiment_items ?? [])
+          .map((item) => item.trace_id)
+          .filter((id): id is string => Boolean(id)),
+      );
+
+      if (!traceIds.length) {
+        toast({
+          title: "Nothing to evaluate",
+          description: "No traces are associated with this experiment.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      setEvaluateTraceIds(traceIds);
+      setEvaluateOpen(true);
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "Failed to load experiment traces for evaluation.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsFetchingTraces(false);
+    }
+  }, [singleExperiment, workspaceName, toast]);
 
   const mapRowData = useCallback(async () => {
     if (!columnsToExport || !getDataForExport) return [];
@@ -191,6 +262,25 @@ const CompareExperimentsActionsPanel: React.FC<
   return (
     <div className="flex items-center gap-2">
       <CompareExperimentsButton />
+      {evaluateEnabled && (
+        <>
+          <RunEvaluationDialog
+            open={evaluateOpen}
+            setOpen={setEvaluateOpen}
+            projectId={evaluateProjectId}
+            entityIds={evaluateTraceIds}
+            entityType="trace"
+            rules={rules}
+            isLoading={isRulesLoading}
+          />
+          <EvaluateButton
+            isNoRules={!rules?.length}
+            disabled={isFetchingTraces}
+            label="Evaluate"
+            onClick={handleEvaluateClick}
+          />
+        </>
+      )}
       {columnsToExport && (
         <>
           <Separator orientation="vertical" className="mx-2 h-4" />

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/EvaluateExperimentTracesButton/EvaluateExperimentTracesButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/EvaluateExperimentTracesButton/EvaluateExperimentTracesButton.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+import EvaluateButton from "@/v2/pages-shared/automations/EvaluateButton/EvaluateButton";
+import RunEvaluationDialog from "@/v2/pages-shared/automations/RunEvaluationDialog/RunEvaluationDialog";
+import { Experiment } from "@/types/datasets";
+import useEvaluateExperimentTraces from "./useEvaluateExperimentTraces";
+
+type EvaluateExperimentTracesButtonProps = {
+  experiment?: Experiment;
+};
+
+const EvaluateExperimentTracesButton: React.FC<
+  EvaluateExperimentTracesButtonProps
+> = ({ experiment }) => {
+  if (!experiment?.project_id) return null;
+
+  return (
+    <Inner experiment={experiment} projectId={experiment.project_id} />
+  );
+};
+
+const Inner: React.FC<{ experiment: Experiment; projectId: string }> = ({
+  experiment,
+  projectId,
+}) => {
+  const {
+    open,
+    setOpen,
+    traceIds,
+    isFetching,
+    rules,
+    isRulesLoading,
+    handleClick,
+  } = useEvaluateExperimentTraces({ experiment });
+
+  return (
+    <>
+      <RunEvaluationDialog
+        open={open}
+        setOpen={setOpen}
+        projectId={projectId}
+        entityIds={traceIds}
+        entityType="trace"
+        rules={rules}
+        isLoading={isRulesLoading}
+      />
+      <EvaluateButton
+        isNoRules={!rules?.length}
+        disabled={isFetching}
+        label="Evaluate"
+        onClick={handleClick}
+      />
+    </>
+  );
+};
+
+export default EvaluateExperimentTracesButton;

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/EvaluateExperimentTracesButton/useEvaluateExperimentTraces.ts
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/EvaluateExperimentTracesButton/useEvaluateExperimentTraces.ts
@@ -1,0 +1,94 @@
+import { useCallback, useState } from "react";
+import uniq from "lodash/uniq";
+
+import useAppStore from "@/store/AppStore";
+import { useToast } from "@/ui/use-toast";
+import useFilteredRulesList from "@/api/automations/useFilteredRulesList";
+import { getCompareExperimentsList } from "@/api/datasets/useCompareExperimentsList";
+import { COMPARE_EXPERIMENTS_MAX_PAGE_SIZE } from "@/constants/experiments";
+import {
+  Experiment,
+  ExperimentItem,
+  ExperimentsCompare,
+} from "@/types/datasets";
+
+type UseEvaluateExperimentTracesParams = {
+  experiment: Experiment;
+};
+
+const useEvaluateExperimentTraces = ({
+  experiment,
+}: UseEvaluateExperimentTracesParams) => {
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const { toast } = useToast();
+
+  const projectId = experiment.project_id ?? "";
+
+  const [open, setOpen] = useState(false);
+  const [traceIds, setTraceIds] = useState<string[]>([]);
+  const [isFetching, setIsFetching] = useState(false);
+
+  const { rules, isLoading: isRulesLoading } = useFilteredRulesList({
+    projectId,
+    entityType: "trace",
+    enabled: Boolean(projectId),
+  });
+
+  const handleClick = useCallback(async () => {
+    if (!experiment.dataset_id) return;
+    setIsFetching(true);
+    try {
+      const data: { content?: ExperimentsCompare[] } =
+        await getCompareExperimentsList(
+          {},
+          {
+            workspaceName,
+            datasetId: experiment.dataset_id,
+            experimentsIds: [experiment.id],
+            truncate: true,
+            page: 1,
+            size: COMPARE_EXPERIMENTS_MAX_PAGE_SIZE,
+          },
+        );
+      const ids = uniq(
+        (data?.content ?? [])
+          .flatMap((row) => row.experiment_items ?? [])
+          .map((item: ExperimentItem) => item.trace_id)
+          .filter((id): id is string => Boolean(id)),
+      );
+
+      if (!ids.length) {
+        toast({
+          title: "Nothing to evaluate",
+          description: "No traces are associated with this experiment.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      setTraceIds(ids);
+      setOpen(true);
+    } catch {
+      toast({
+        title: "Error",
+        description: "Failed to load experiment traces for evaluation.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsFetching(false);
+    }
+  }, [experiment.dataset_id, experiment.id, workspaceName, toast]);
+
+  return {
+    projectId,
+    open,
+    setOpen,
+    traceIds,
+    isFetching,
+    rules,
+    isRulesLoading,
+    handleClick,
+  };
+};
+
+export default useEvaluateExperimentTraces;


### PR DESCRIPTION
## Details
Currently, from logs you can trigger online eval rules for traces that have been logged.

## Summary

Adds an "Evaluate" action (brain icon) to the experiment items table header on the Compare Experiments page, allowing users to run online evaluation rules across all traces of the currently viewed experiment.

## Changes by Component

### Frontend
- `CompareExperimentsActionsPanel`: render a new `EvaluateButton` immediately after the Compare button when a single experiment is in view and it has a `project_id`.
- On click, fetch all experiment items for that experiment (using `COMPARE_EXPERIMENTS_MAX_PAGE_SIZE` and `truncate: true`), collect unique `trace_id`s, and open the existing `RunEvaluationDialog` scoped to `entityType: "trace"` and the experiment's project.
- Pre-load available trace evaluation rules via `useFilteredRulesList` so the button shows the standard "no rules" tooltip when none exist.
- Toast a destructive error if the fetch fails or no traces are associated with the experiment; hide the button on multi-experiment compare views to avoid cross-project ambiguity.

## Files Changed

```
 .../CompareExperimentsActionsPanel.tsx             | 91 +++++++++++++++++++++-
 1 file changed, 90 insertions(+), 1 deletion(-)
```

## The feature demonstration

https://github.com/user-attachments/assets/aaa96981-99e2-42b1-83f9-a38bce4a5df4


## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6737

## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
Manual testing performed

## Documentation
NA