### PR TITLE
[NA] [QA] feat: E2E failure investigation tooling (/comet:investigate-e2e-failure + debugging-e2e-tests skill)

### DIFF
--- a/.agents/commands/comet/investigate-e2e-failure.md
+++ b/.agents/commands/comet/investigate-e2e-failure.md
@@ -1,0 +1,31 @@
+# Investigate E2E Failure
+
+## Overview
+
+Investigate a failed Opik E2E test and propose a fix. The command gathers the evidence (trace, error, history), classifies the failure as a real regression, a flake, or environment/selector drift, and proposes a specific fix. **Read-only** — it diagnoses and proposes; it does not edit tests.
+
+---
+
+## Inputs
+
+- **Failure reference** (required) — any one of:
+  - A GitHub Actions run or a red `Run v2 suite` check (URL or run id).
+  - An Allure TestOps launch.
+  - A test name (e.g. `dataset-crud-smoke`) when you want its history / flake status.
+  - "The failure I just hit locally" — a test that failed in your local run.
+- **Optional** — the PR or branch involved, so the diagnosis can correlate the failure to recent changes.
+
+---
+
+## Instructions
+
+**Invoke the `debugging-e2e-tests` skill and follow it exactly.** It carries the loop — resolve the entry point → gather the trace + history → classify regression vs. flake → diagnose → report and propose — along with the evidence sources (the `allure-testops` MCP, `gh` artifacts, `npx playwright show-trace`) and the classification heuristics.
+
+---
+
+## Success criteria
+
+1. A **verdict**: regression / flake / environment-or-selector, with a confidence level.
+2. **Cited evidence**: the failing trace step, the error, the history pattern, and the correlated change (if any).
+3. A **specific proposed fix** (or, for a known flake, a poll/quarantine/no-fix recommendation).
+4. **No edits made** — to apply the fix, hand off to the `writing-e2e-tests` skill.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -5,6 +5,7 @@ Domain-specific agent skills for the Opik monorepo. Each skill provides patterns
 | Skill | Path | Description |
 |-------|------|-------------|
 | analytics-instrumentation | `analytics-instrumentation/` | Add analytics events to Opik features. Use when wiring PostHog events on the frontend or backend for product analytics tracking. |
+| debugging-e2e-tests | `debugging-e2e-tests/` | Investigate a failed Opik E2E test and propose a fix (read-only). Use when a test goes red in CI, a TestOps launch, or locally — gathers the trace + history, classifies regression vs. flake, proposes a fix. |
 | diagram-generation | `diagram-generation/` | Generate self-contained HTML architecture diagrams. Use when creating visual diagrams for PRs, task plans, or architectural explanations. |
 | documentation | `documentation/` | Feature documentation and release notes patterns. Use when documenting changes, writing PR descriptions, or preparing releases. |
 | local-dev | `local-dev/` | Local development environment setup and commands. Use when helping with dev server, Docker, or local testing. |

--- a/.agents/skills/debugging-e2e-tests/SKILL.md
+++ b/.agents/skills/debugging-e2e-tests/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: debugging-e2e-tests
+description: Use when an Opik E2E test has failed and a developer wants it investigated — e.g. "why did this e2e test fail?", "investigate the failing run on my PR", "is dataset-crud-smoke flaky?", "the nightly e2e suite went red". Takes a failure from a CI check, a TestOps launch, a test name, or a local run; gathers the trace and history, classifies regression vs. flake, and proposes a fix. Read-only — it diagnoses and proposes, it does not edit tests.
+---
+
+# Debugging E2E Tests
+
+This skill investigates a failed test in the Opik E2E suite (`tests_end_to_end/e2e/`). You give it a failure from wherever you noticed it; it gathers the evidence, decides whether it's a real regression or a flake, and proposes a fix.
+
+**Announce at start:** "I'm using the debugging-e2e-tests skill to investigate X."
+
+## What this does — and doesn't
+
+- It **diagnoses and proposes**, grounded in cited evidence (the trace, the error, the history). It is **read-only**: it does not edit tests, and it does not re-run the suite as part of investigating.
+- To **apply** a proposed fix, hand off to the `writing-e2e-tests` skill (or just say "apply it") — that's a separate, deliberate act with its own run-until-green loop.
+
+## Where the evidence lives
+
+- **Local run** — traces under `tests_end_to_end/e2e/test-results/` (retained on failure), Allure results under `allure-results/`.
+- **CI run** — the suite uploads three artifacts per run (7-day retention): `test-results-v2` (Playwright traces + videos), `playwright-report-v2` (the HTML report), `allure-results-v2`. Download with `gh run download <run-id> -n test-results-v2 -D <dir>`.
+- **Allure TestOps** (`comet.testops.cloud`, project id `1`) — results stream live during CI. Launches are named `Opik v2 … <tier> - <run_id>` (the trailing number is the GitHub Actions run id; the env segment varies — `E2E`, `Post-Merge`, `Local`, `staging`, `production`).
+
+## Tooling
+
+- **`allure-testops` MCP** (already connected) — the richest source. Validated calls:
+  - `list_launches(projectId: 1, search: "<run_id or name fragment>", sort: ["createdDate,DESC"])` or `search_launches(rql: …)` — find the launch.
+  - `list_test_results(launchId)` — per-test `name`, `fullName` (spec path + line, e.g. `datasets/dataset-crud-smoke.spec.ts:8:7`), `status`, a TestOps-computed **`flaky`** flag, `muted`/`known`, `tags`, `jobRun.url` (the GitHub Actions run), and the result `id`. Use `search` to filter to the failing test.
+  - `get_test_result_history(id)` — the pass/fail timeline for that test across recent launches. This is the flake signal.
+- **`gh`** — `gh run view <run-id>` to find the failed job; `gh run download <run-id> -n test-results-v2 -D <dir>` for the trace artifact. A launch's `jobRun.url` gives you the run id.
+- **`npx playwright show-trace <trace.zip>`** (from `tests_end_to_end/e2e/`) — open the trace to see the exact step that failed, the DOM snapshot, and console/network at that moment.
+- **`git`** — diff the suspected change against the failing test's code path.
+
+## The loop
+
+```dot
+digraph debugging_e2e {
+    rankdir=TB;
+    "1. Resolve entry point" [shape=box];
+    "2. Gather evidence" [shape=box];
+    "3. Classify" [shape=box];
+    "4. Diagnose" [shape=box];
+    "5. Report + propose (no edits)" [shape=box];
+
+    "1. Resolve entry point" -> "2. Gather evidence";
+    "2. Gather evidence" -> "3. Classify";
+    "3. Classify" -> "4. Diagnose";
+    "4. Diagnose" -> "5. Report + propose (no edits)";
+}
+```
+
+### Step 1 — Resolve the entry point
+
+Normalize whatever you were given into "a failed test + where its evidence lives":
+
+- **A red CI check / Actions run** — take the run id. `gh run view <run-id>` for the failed job; find the matching launch via `list_launches(projectId: 1, search: "<run-id>")`; the trace is in the `test-results-v2` artifact (`gh run download`).
+- **A TestOps launch** — query it directly: `list_test_results(launchId)`, filter to the failed results.
+- **A test name** — `list_test_results` with `search` across a recent launch, or search launches, to find the result `id`; then pull its history.
+- **A local failure** — use the local `test-results/` trace and `allure-results/` directly; TestOps may have nothing for an uncommitted local run, which is fine.
+
+### Step 2 — Gather evidence
+
+- The failed assertion and error message (from the trace, the report, or the TestOps result).
+- The **trace**: `npx playwright show-trace` on the retained/downloaded `.zip`. Read the failing step, the DOM snapshot at that point, and console/network around it.
+- Screenshot / video if present (`only-on-failure` / `retain-on-failure`).
+- The test's **history** via `get_test_result_history(id)`, plus the TestOps `flaky` flag on the result. **Skip history gracefully** when TestOps isn't reachable (e.g. a purely local run) and fall back to trace + diff reasoning.
+
+### Step 3 — Classify
+
+Decide: **real regression**, **flake**, or **environment / selector drift**.
+
+- **History when available:** a clean pass streak that broke right after a related change → lean regression. Intermittent pass/fail with no related change, or a TestOps `flaky: true` → lean flake.
+- **Diff correlation:** does a recent change touch the code path the failed assertion exercises (the page/component, the POM method, the fixture)? If yes → regression is likely. If the failed area is untouched → flake or environment is likely.
+- **Default to "flake / uncertain"** when history is intermittent and no related diff exists — don't over-call a regression without evidence.
+
+### Step 4 — Diagnose
+
+Root cause, grounded in cited evidence (the specific trace step, the error, the history pattern) — not speculation. Apply the suite's lenses:
+
+- **Verify the test render before blaming the backend.** A "X didn't appear" failure is often a DOM race (a loading spinner still up, an eventually-consistent write not yet landed), not a backend regression. Check the trace's DOM snapshot at the failing step.
+- **Selector drift** — the FE changed an accessible name / removed a `data-testid`, so a locator no longer resolves.
+- **Eventually-consistent state** — async scoring/ingestion that needed a poll, not a fixed wait.
+- **Fixture seed-shape mismatch** — the page rendered an empty/partial state because the seed didn't match what the assertion expects.
+
+### Step 5 — Report + propose (no edits)
+
+Produce:
+
+- **Verdict** — classification (regression / flake / environment-or-selector) + a confidence level.
+- **Evidence** — the trace step, the error, the history pattern, and the correlated change (if any), each cited.
+- **Proposed fix** — specific. For a regression: the code/selector/poll change to make. For a flake: a poll instead of a fixed wait, a quarantine, or "no code fix — known flaky, retry." 
+
+Do **not** edit anything. If the developer wants the fix applied, hand off to `writing-e2e-tests`.
+
+## Boundaries
+
+- Read-only: no test edits, no investigation-driven re-runs.
+- Works from all four entry points; degrades gracefully without TestOps (local failures use the trace + diff alone).
+- Distinct from authoring: `writing-e2e-tests` makes a new test; this explains a red one.


### PR DESCRIPTION
## Details

Adds a read-only companion to the test-authoring tooling: when an Opik E2E test goes red, a developer types `/comet:investigate-e2e-failure` (or just describes the failure) and the agent gathers the evidence, classifies it as a real regression / flake / environment-or-selector drift, and proposes a fix — without editing anything. Applying a fix is a deliberate hand-off to the `writing-e2e-tests` skill.

- New `debugging-e2e-tests` skill carries the loop: resolve the entry point → gather the Playwright trace + Allure history → classify regression vs. flake → diagnose with the suite's lenses (DOM-race vs. backend, selector drift, eventually-consistent state, fixture seed-shape) → report + propose, all read-only.
- Handles four entry points: a red CI check / Actions run, an Allure TestOps launch, a test name (for history / flake status), or a local failure.
- New `/comet:investigate-e2e-failure` command is the muscle-memory entry point.
- Leans on tooling that already exists: the connected `allure-testops` MCP (launches, per-test results, history, the TestOps-computed `flaky` flag), `gh` for CI artifacts (`test-results-v2` traces), `npx playwright show-trace`, and `git` diff correlation. No new MCP or CI changes.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: full implementation (skill, command, index)
  - Human verification: design + plan approved interactively; the Allure TestOps MCP flow was validated with a live read-only probe (listed launches, fetched a launch's results, pulled a test's history) before the skill was written; runtime confirmed loading the new skill + command

## Testing

This change is agent-config + docs only (no application code), so the standard backend/frontend/SDK suites don't apply. Validation was:

- Ran a read-only probe against Allure TestOps project 1 to confirm the skill describes real MCP capabilities, not assumed ones: `list_launches` returns recent launches (names follow `Opik v2 … <tier> - <run_id>`); `list_test_results(launchId)` returns per-test name, spec path, status, the `flaky` flag, tags, and the GitHub Actions run URL; `get_test_result_history(id)` returns the pass/fail timeline across launches. No assumed query was unsupported.
- Confirmed the new `debugging-e2e-tests` skill and `/comet:investigate-e2e-failure` command load live in Claude Code (they appear in the skill/command registry with the correct descriptions).
- Swept the committed files for stray references.

## Documentation

- `.agents/skills/debugging-e2e-tests/SKILL.md` (new) — the investigation procedure.
- `.agents/skills/README.md` — indexed the new skill.

## Picking it up

`.agents/` is the committed source; `.claude/` (and `.cursor`) are the local runtime views, gitignored. After this merges, run `make claude` (or `make cursor` for Cursor) to materialize the command + skill locally — same one-step sync as every other `comet:*` command. A plain `git pull` alone won't surface them, since `.claude/` isn't tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
