### PR TITLE
[OPIK-6385] [FE] revert: thread time range in ThreadDetailsPanel traces query

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel.tsx
@@ -241,11 +241,9 @@ const ThreadDetailsPanel: React.FC<ThreadDetailsPanelProps> = ({
       page: 1,
       size: 1000,
       truncate: false,
-      fromTime: thread?.start_time,
-      toTime: thread?.end_time,
     },
     {
-      enabled: Boolean(threadId) && Boolean(thread),
+      enabled: Boolean(threadId),
     },
   );
 


### PR DESCRIPTION
## Details

Reverts the time-range optimization introduced in #6949 (commit `0d5b6c25e5`).

#6949 made the v2 `ThreadDetailsPanel` pass the thread's `start_time`/`end_time` as `from_time`/`to_time` to the traces query; the backend converts those into UUIDv7 bounds on the `id` column. But `id` (UUIDv7) encodes the **id-mint time** while `start_time`/`end_time` are the traces' **event time**, and the SDK generates them independently — they only coincide for live SDK logging. This silently regressed valid data.

- For any trace where `start_time ≠ id-mint time` — backfilled / imported / replayed traces, user-supplied `id`s (`trace(id=...)`), or explicit historical `start_time` — the id-bounds miss the trace and the panel shows **0 traces**. The data is present, just unreachable.
- Hidden filter on a field we don't deterministically control → users log valid data that then silently doesn't appear, and it is very hard to debug.
- Inconsistent by construction: range comes from `start_time`/`end_time`, filtering happens on `id`, so an `id` minted 1ms before `start_time` drops the first message in the thread.
- This revert removes the `fromTime`/`toTime` props and restores the query gate to `enabled: Boolean(threadId)`. It **keeps** the orthogonal Revision-2 guard fix from #6949 (`if (!isThreadPending && !thread)`); a pure `git revert` would restore the old `isThreadPending || isTracesPending` guard and reintroduce a separate stuck-spinner bug. Net diff is the 4 lines that caused the regression.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6385
- Reverts #6949

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Revert of #6949 + merge-conflict resolution
- Human verification: Author requested the revert and reviewed the diff and rationale.

## Testing

- `bash scripts/dev-runner.sh --lint-fe` → ESLint, `tsc --noEmit`, and dependency-cruiser all pass.
- Diff verified to contain only the removal of `fromTime`/`toTime` and the `enabled` gate change in `ThreadDetailsPanel.tsx` (4 lines), with the Revision-2 `renderContent` guard intact.
- Behavior after revert: the thread panel's `useTracesList` filters by `thread_id` only (no time bounds), matching the pre-#6949 behavior so backfilled/imported/historical traces are reachable again.

> ⚠️ Known regression re-introduced by this revert (tracked on OPIK-6385): on very large projects the trace lookup again scans the full project (because `thread_id` is not part of the traces primary key `workspace_id, project_id, id`), which #6949 was trying to address. A different approach that doesn't depend on `id`↔`start_time` alignment is needed.

## Documentation

N/A — internal fix, no API or UX-visible change beyond load behavior.