### PR TITLE
[OPIK-6844] [QA] feat: deeper tracing & spans E2E coverage

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow.tsx
@@ -190,6 +190,7 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
           placeholder="Score"
           type="number"
           value={value}
+          data-testid="annotate-score-input"
         />
       );
     }
@@ -341,6 +342,7 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
       <div
         className="flex items-center overflow-hidden border-t border-border p-1"
         data-test-value={name}
+        data-testid={`annotate-score-row-${name}`}
       >
         {feedbackDefinition ? (
           <div className="min-w-0 flex-1 overflow-auto">
@@ -355,6 +357,7 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
           <Button
             variant="minimal"
             size="icon-xs"
+            aria-label="Clear score"
             onClick={deleteFeedbackScore}
           >
             <X />

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceTreeViewer/VirtualizedTreeViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceTreeViewer/VirtualizedTreeViewer.tsx
@@ -437,6 +437,7 @@ const VirtualizedTreeViewer: React.FC<VirtualizedTreeViewerProps> = ({
               key={node.id}
               ref={rowVirtualizer.measureElement}
               data-index={virtualRow.index}
+              data-testid={`trace-tree-node-${name}`}
               className={cn(
                 "absolute left-0 flex w-full flex-col py-1 pl-2 pr-4 cursor-pointer border-l-8 border-transparent",
                 "hover:bg-[var(--row-bg)]",
@@ -496,6 +497,7 @@ const VirtualizedTreeViewer: React.FC<VirtualizedTreeViewerProps> = ({
                       variant="ghost"
                       size="icon-3xs"
                       className="ml-1"
+                      aria-label="Expand or collapse span"
                       onClick={(e) => {
                         e.stopPropagation();
                         toggleExpand(node.id);

--- a/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
+++ b/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
@@ -7,6 +7,36 @@ export interface PythonSdkClient {
     output: string;
     workspace?: string;
   }): Promise<{ id: string; name: string; project_id: string }>;
+  createNestedTrace(args: {
+    project_name: string;
+    name: string;
+    input?: Record<string, unknown>;
+    output?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
+    tags?: string[];
+    thread_id?: string;
+    feedback_scores?: Array<{ name: string; value: number; reason?: string }>;
+    spans: Array<{
+      name: string;
+      type?: 'general' | 'llm' | 'tool';
+      input?: Record<string, unknown>;
+      output?: Record<string, unknown>;
+      metadata?: Record<string, unknown>;
+      model?: string;
+      provider?: string;
+      usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+      total_cost?: number;
+      parent_index?: number;
+    }>;
+    workspace?: string;
+  }): Promise<{ id: string; name: string; project_id: string; span_count: number }>;
+  createFeedbackDefinition(args: {
+    name: string;
+    min?: number;
+    max?: number;
+    workspace?: string;
+  }): Promise<{ id: string; name: string }>;
+  deleteFeedbackDefinition(args: { id: string; workspace?: string }): Promise<void>;
   createDataset(args: {
     name: string;
     project_name: string;
@@ -149,6 +179,19 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
     },
     async createTrace(args) {
       return request<{ id: string; name: string; project_id: string }>('POST', '/traces', args);
+    },
+    async createNestedTrace(args) {
+      return request<{ id: string; name: string; project_id: string; span_count: number }>(
+        'POST',
+        '/traces/nested',
+        args,
+      );
+    },
+    async createFeedbackDefinition(args) {
+      return request<{ id: string; name: string }>('POST', '/feedback-definitions', args);
+    },
+    async deleteFeedbackDefinition({ id }) {
+      await request<{ deleted: boolean }>('DELETE', `/feedback-definitions/${id}`);
     },
     async createDataset(args) {
       return request<{ id: string; name: string }>('POST', '/datasets', args);

--- a/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
+++ b/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
@@ -36,7 +36,9 @@ export interface PythonSdkClient {
     max?: number;
     workspace?: string;
   }): Promise<{ id: string; name: string }>;
-  deleteFeedbackDefinition(args: { id: string; workspace?: string }): Promise<void>;
+  // Workspace is resolved from the bridge's env (OPIK_WORKSPACE), the same as
+  // createFeedbackDefinition, so both operate on one workspace per run.
+  deleteFeedbackDefinition(args: { id: string }): Promise<void>;
   createDataset(args: {
     name: string;
     project_name: string;

--- a/tests_end_to_end/e2e/fixtures/feedback-definition.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/feedback-definition.fixture.ts
@@ -1,0 +1,48 @@
+import { test as baseTest } from './test-suite.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+
+export interface FeedbackDefinitionRef {
+  id: string;
+  name: string;
+  min: number;
+  max: number;
+}
+
+export interface FeedbackDefinitionFixtures {
+  feedbackDefinition: FeedbackDefinitionRef;
+}
+
+const MIN = 0;
+const MAX = 1;
+
+/**
+ * A numerical feedback definition, the precondition for the trace panel's
+ * manual named-score editor (the UI only renders an editable score control for
+ * definitions that exist in the workspace). Workspace-scoped, so it does not
+ * cascade with a project — this fixture deletes it explicitly on teardown. The
+ * name is namespaced per test to avoid collisions across parallel workers.
+ */
+export const test = baseTest.extend<FeedbackDefinitionFixtures>({
+  feedbackDefinition: async ({ sdkClient, testNamespace }, use, testInfo) => {
+    const name = `${testNamespace}-quality`;
+    const created = await sdkClient.python.createFeedbackDefinition({ name, min: MIN, max: MAX });
+
+    const ref: FeedbackDefinitionRef = { id: created.id, name: created.name, min: MIN, max: MAX };
+    await testInfo.attach('opik.feedbackDefinition', {
+      body: JSON.stringify(ref, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use(ref);
+
+    if (!shouldLeaveArtifacts(testInfo)) {
+      try {
+        await sdkClient.python.deleteFeedbackDefinition({ id: created.id });
+      } catch (err) {
+        console.warn(`[feedbackDefinition fixture] delete warning for ${name}:`, err);
+      }
+    }
+  },
+});
+
+export { expect } from './test-suite.fixture';

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-export { test, expect } from './test-suite.fixture';
+export { test, expect } from './traced-agent.fixture';
 export type { ProjectFixtures } from './project.fixture';
 export type { ScratchDir, ScratchDirFixtures } from './scratch-dir.fixture';
 export type {
@@ -20,4 +20,13 @@ export type {
   TestSuiteFixtures,
   TestSuiteItemSeed,
 } from './test-suite.fixture';
+export type {
+  FeedbackDefinitionRef,
+  FeedbackDefinitionFixtures,
+} from './feedback-definition.fixture';
+export type {
+  TracedAgentRef,
+  TracedAgentSpanRef,
+  TracedAgentFixtures,
+} from './traced-agent.fixture';
 export type { ProjectRef } from '../core/backend';

--- a/tests_end_to_end/e2e/fixtures/traced-agent.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/traced-agent.fixture.ts
@@ -1,0 +1,98 @@
+import { test as baseTest } from './feedback-definition.fixture';
+
+export interface TracedAgentSpanRef {
+  name: string;
+  type: 'general' | 'llm' | 'tool';
+  /** Index into `spans` of this span's parent; null for a root span. */
+  parentIndex: number | null;
+}
+
+export interface TracedAgentRef {
+  id: string;
+  name: string;
+  projectId: string;
+  projectName: string;
+  tags: string[];
+  feedbackScore: { name: string; value: number };
+  /** The LLM span's cost/token expectations, surfaced in span detail. */
+  llmSpan: { name: string; model: string; totalTokens: number; totalCost: number };
+  spans: TracedAgentSpanRef[];
+  spanCount: number;
+}
+
+export interface TracedAgentFixtures {
+  tracedAgent: TracedAgentRef;
+}
+
+/**
+ * A small agent-shaped trace: a `plan` (general) root span fanning out to an
+ * `llm-call` (llm, with model/usage/cost) and a `search-tool` (tool). Nested
+ * two levels deep so the span tree, expand/collapse, span types, and LLM
+ * token/cost detail all have real data to assert against. Seeded entirely
+ * through the public SDK so the same shape lands on OSS and Cloud.
+ */
+const ROOT_SPAN = 'plan';
+const LLM_SPAN = 'llm-call';
+const TOOL_SPAN = 'search-tool';
+const LLM_MODEL = 'gpt-4o';
+const LLM_TOTAL_TOKENS = 15;
+const LLM_TOTAL_COST = 0.00042;
+const FEEDBACK_SCORE = { name: 'relevance', value: 0.9 };
+const TRACE_TAGS = ['e2e', 'nested'];
+
+export const test = baseTest.extend<TracedAgentFixtures>({
+  tracedAgent: async ({ sdkClient, project, testNamespace }, use, testInfo) => {
+    const name = `${testNamespace}-agent`;
+
+    const created = await sdkClient.python.createNestedTrace({
+      project_name: project.name,
+      name,
+      input: { question: 'What is the capital of France?' },
+      output: { answer: 'Paris' },
+      metadata: { agent: 'researcher' },
+      tags: TRACE_TAGS,
+      feedback_scores: [{ name: FEEDBACK_SCORE.name, value: FEEDBACK_SCORE.value, reason: 'on topic' }],
+      spans: [
+        { name: ROOT_SPAN, type: 'general', input: { goal: 'answer geography q' }, output: { steps: 2 } },
+        {
+          name: LLM_SPAN,
+          type: 'llm',
+          parent_index: 0,
+          model: LLM_MODEL,
+          provider: 'openai',
+          input: { prompt: 'capital of France?' },
+          output: { completion: 'Paris' },
+          usage: { prompt_tokens: 12, completion_tokens: 3, total_tokens: LLM_TOTAL_TOKENS },
+          total_cost: LLM_TOTAL_COST,
+        },
+        { name: TOOL_SPAN, type: 'tool', parent_index: 0, input: { query: 'France capital' }, output: { hit: 'Paris' } },
+      ],
+    });
+
+    const ref: TracedAgentRef = {
+      id: created.id,
+      name: created.name,
+      projectId: created.project_id,
+      projectName: project.name,
+      tags: TRACE_TAGS,
+      feedbackScore: FEEDBACK_SCORE,
+      llmSpan: { name: LLM_SPAN, model: LLM_MODEL, totalTokens: LLM_TOTAL_TOKENS, totalCost: LLM_TOTAL_COST },
+      spans: [
+        { name: ROOT_SPAN, type: 'general', parentIndex: null },
+        { name: LLM_SPAN, type: 'llm', parentIndex: 0 },
+        { name: TOOL_SPAN, type: 'tool', parentIndex: 0 },
+      ],
+      spanCount: created.span_count,
+    };
+
+    await testInfo.attach('opik.tracedAgent', {
+      body: JSON.stringify(ref, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use(ref);
+    // No explicit teardown — the project fixture's deleteProject cascades.
+  },
+});
+
+export { expect } from './feedback-definition.fixture';

--- a/tests_end_to_end/e2e/pom/trace-panel.page.ts
+++ b/tests_end_to_end/e2e/pom/trace-panel.page.ts
@@ -41,6 +41,123 @@ export class TracePanelPage {
     return this.root.getByText(new RegExp(`^Spans\\s*\\(${n}\\)$`)).first();
   }
 
+  /** A node in the span tree, keyed by the span/trace name. */
+  spanTreeNode(name: string): Locator {
+    return this.root.getByTestId(`trace-tree-node-${name}`);
+  }
+
+  /** The expand/collapse toggle within a given tree node. */
+  spanTreeToggle(name: string): Locator {
+    return this.spanTreeNode(name).getByRole('button', { name: 'Expand or collapse span' });
+  }
+
+  /** Collapse a span tree node by clicking its toggle. */
+  async collapseSpan(name: string): Promise<void> {
+    return test.step(`Collapse span "${name}"`, async () => {
+      await this.spanTreeToggle(name).click();
+    });
+  }
+
+  /** Expand a span tree node by clicking its toggle. */
+  async expandSpan(name: string): Promise<void> {
+    return test.step(`Expand span "${name}"`, async () => {
+      await this.spanTreeToggle(name).click();
+    });
+  }
+
+  /** Select a span in the tree, opening its detail in the inspect area. */
+  async selectSpan(name: string): Promise<void> {
+    return test.step(`Select span "${name}"`, async () => {
+      await this.spanTreeNode(name).click();
+      await this.page.waitForURL((url) => (url.searchParams.get('span') ?? '') !== '');
+    });
+  }
+
+  /** The provider/model chip shown in the inspect header for an LLM span. */
+  get spanModelChip(): Locator {
+    return this.root.getByTestId('data-viewer-provider-model');
+  }
+
+  /** Text within the panel — use to assert token usage / cost values render. */
+  panelText(value: string | RegExp): Locator {
+    return this.root.getByText(value);
+  }
+
+  // --- Tags ---
+
+  get addTagButton(): Locator {
+    return this.root.getByTestId('add-tag-button');
+  }
+
+  /** A rendered tag chip matching the given tag text. */
+  tagChip(tag: string): Locator {
+    return this.root.getByText(tag, { exact: true });
+  }
+
+  /** Add a tag via the add-tag popover input. */
+  async addTag(tag: string): Promise<void> {
+    return test.step(`Add tag "${tag}"`, async () => {
+      await this.addTagButton.click();
+      const input = this.page.getByPlaceholder('New tag');
+      await input.waitFor({ state: 'visible' });
+      await input.fill(tag);
+      await input.press('Enter');
+      await this.page.keyboard.press('Escape');
+    });
+  }
+
+  // --- Annotate panel: manual feedback scores ---
+
+  /** Open the Annotate panel section. Idempotent. */
+  async openAnnotate(): Promise<void> {
+    return test.step('Open Annotate panel', async () => {
+      await this.root.getByRole('button', { name: /Annotate/ }).click();
+      await this.page.waitForURL((url) => url.searchParams.get('lastSection') === 'annotate');
+    });
+  }
+
+  /** The annotate score row for a named feedback definition. */
+  annotateScoreRow(definitionName: string): Locator {
+    return this.root.getByTestId(`annotate-score-row-${definitionName}`);
+  }
+
+  /** Set (or change) the numeric value in a named annotate score row. */
+  async setAnnotateScore(definitionName: string, value: number): Promise<void> {
+    return test.step(`Set ${definitionName} score to ${value}`, async () => {
+      const input = this.annotateScoreRow(definitionName).getByTestId('annotate-score-input');
+      await input.fill(String(value));
+      // The score input debounces; blur to flush the write.
+      await input.blur();
+    });
+  }
+
+  /**
+   * Clear the score in a named annotate score row. The clear button sits in a
+   * grid cell that is a sibling of the score-input cell (the one carrying the
+   * row testid), not a descendant — so it's scoped to the panel root. With a
+   * single seeded definition this is unambiguous; the void param documents
+   * which score the call clears.
+   */
+  async clearAnnotateScore(definitionName: string): Promise<void> {
+    return test.step(`Clear ${definitionName} score`, async () => {
+      await this.root.getByRole('button', { name: 'Clear score' }).click();
+    });
+  }
+
+  /** A rendered feedback score tag matching the given score name. */
+  feedbackScoreTag(scoreName: string): Locator {
+    return this.root
+      .getByTestId('feedback-score-tag')
+      .filter({ has: this.page.getByTestId('feedback-score-tag-label').filter({ hasText: scoreName }) });
+  }
+
+  /** Read the value rendered on a feedback score tag by score name. */
+  async readFeedbackScoreTagValue(scoreName: string): Promise<string> {
+    const tag = this.feedbackScoreTag(scoreName);
+    await tag.waitFor({ state: 'visible' });
+    return (await tag.getByTestId('feedback-score-tag-value').textContent())?.trim() ?? '';
+  }
+
   /** Rendered input text inside the panel's Details tab. */
   inputValue(value: string): Locator {
     return this.root.getByText(value, { exact: true }).first();

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/main.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/main.py
@@ -2,7 +2,15 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from opik.rest_api.core.api_error import ApiError
 
-from .routes import datasets, experiments, health, projects, test_suites, traces
+from .routes import (
+    datasets,
+    experiments,
+    feedback_definitions,
+    health,
+    projects,
+    test_suites,
+    traces,
+)
 
 app = FastAPI(title="opik-sdk-driver", version="0.0.1")
 
@@ -18,6 +26,7 @@ async def _api_error_handler(_request: Request, exc: ApiError) -> JSONResponse:
 app.include_router(health.router)
 app.include_router(projects.router)
 app.include_router(traces.router)
+app.include_router(feedback_definitions.router)
 app.include_router(datasets.router)
 app.include_router(experiments.router)
 app.include_router(test_suites.router)

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/feedback_definitions.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/feedback_definitions.py
@@ -50,11 +50,12 @@ def create_feedback_definition(
 def delete_feedback_definition(
     definition_id: str,
     x_opik_api_key: str | None = Header(default=None),
-    workspace: str | None = Header(default=None, alias="X-Opik-Workspace"),
 ) -> dict[str, bool]:
-    # Returns a JSON body (not 204) so the TS bridge client, which parses every
-    # successful response as JSON, doesn't choke on an empty body.
-    client = make_opik_client(workspace=workspace, api_key=x_opik_api_key)
+    # Workspace is resolved from the bridge env (same as create), so the delete
+    # always targets the workspace the definition was created in. Returns a JSON
+    # body (not 204) so the TS client, which parses every success as JSON,
+    # doesn't choke on an empty body.
+    client = make_opik_client(api_key=x_opik_api_key)
     try:
         client._rest_client.feedback_definitions.delete_feedback_definition_by_id(
             definition_id

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/feedback_definitions.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/feedback_definitions.py
@@ -1,0 +1,65 @@
+import atexit
+
+from fastapi import APIRouter, Header, HTTPException
+from opik.rest_api.types import (
+    FeedbackCreate_Numerical,
+    NumericalFeedbackDetailCreate,
+)
+
+from ..opik_factory import make_opik_client
+from ..schemas import FeedbackDefinitionCreate, FeedbackDefinitionResponse
+
+router = APIRouter(prefix="/feedback-definitions", tags=["feedback-definitions"])
+
+
+@router.post("", response_model=FeedbackDefinitionResponse, status_code=201)
+def create_feedback_definition(
+    body: FeedbackDefinitionCreate,
+    x_opik_api_key: str | None = Header(default=None),
+) -> FeedbackDefinitionResponse:
+    # _rest_client because opik.Opik() doesn't expose a public
+    # create_feedback_definition(); a numerical definition is the precondition
+    # for the UI's manual named-score editor. Workspace-scoped, so the caller
+    # is responsible for deletion (no project cascade). ApiError is translated
+    # to HTTP by the app-wide exception handler.
+    client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
+    try:
+        client._rest_client.feedback_definitions.create_feedback_definition(
+            request=FeedbackCreate_Numerical(
+                name=body.name,
+                details=NumericalFeedbackDetailCreate(min=body.min, max=body.max),
+            )
+        )
+        page = client._rest_client.feedback_definitions.find_feedback_definitions(
+            name=body.name, page=1, size=1
+        )
+    finally:
+        client.end(flush=False)
+        atexit.unregister(client.end)
+    if not page.content:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Feedback definition {body.name} not visible after create",
+        )
+    return FeedbackDefinitionResponse(
+        id=str(page.content[0].id), name=page.content[0].name
+    )
+
+
+@router.delete("/{definition_id}")
+def delete_feedback_definition(
+    definition_id: str,
+    x_opik_api_key: str | None = Header(default=None),
+    workspace: str | None = Header(default=None, alias="X-Opik-Workspace"),
+) -> dict[str, bool]:
+    # Returns a JSON body (not 204) so the TS bridge client, which parses every
+    # successful response as JSON, doesn't choke on an empty body.
+    client = make_opik_client(workspace=workspace, api_key=x_opik_api_key)
+    try:
+        client._rest_client.feedback_definitions.delete_feedback_definition_by_id(
+            definition_id
+        )
+    finally:
+        client.end(flush=False)
+        atexit.unregister(client.end)
+    return {"deleted": True}

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/traces.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/traces.py
@@ -86,12 +86,12 @@ def create_nested_trace(
             if span_seed.parent_index is None:
                 parent = trace
             else:
-                if span_seed.parent_index >= index:
+                if not (0 <= span_seed.parent_index < index):
                     raise HTTPException(
                         status_code=422,
                         detail=(
                             f"span[{index}] parent_index {span_seed.parent_index} "
-                            "must reference an earlier span"
+                            "must reference an earlier span (0 <= parent_index < index)"
                         ),
                     )
                 parent = created[span_seed.parent_index]
@@ -114,16 +114,19 @@ def create_nested_trace(
             created.append(span)
 
         opik.flush_tracker()
+        # Confirm visibility by the trace's own id (unique), not by name — trace
+        # names are not unique within a project, so a name filter could return a
+        # different, older trace and make the response point at the wrong spans.
         traces = client.search_traces(
             project_name=body.project_name,
-            filter_string=f'name = "{body.name}"',
+            filter_string=f'id = "{trace.id}"',
             max_results=1,
             wait_for_at_least=1,
         )
         if not traces:
             raise HTTPException(
                 status_code=500,
-                detail=f"Trace {body.name} not visible after create + flush",
+                detail=f"Trace {trace.id} not visible after create + flush",
             )
         found = traces[0]
         # Block until every span is queryable, not just the trace. The trace row

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/traces.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/traces.py
@@ -4,7 +4,12 @@ import opik
 from fastapi import APIRouter, Header, HTTPException
 
 from ..opik_factory import make_opik_client
-from ..schemas import TraceCreate, TraceResponse
+from ..schemas import (
+    NestedTraceCreate,
+    NestedTraceResponse,
+    TraceCreate,
+    TraceResponse,
+)
 
 router = APIRouter(prefix="/traces", tags=["traces"])
 
@@ -50,4 +55,96 @@ def create_trace(
         id=str(trace.id),
         name=trace.name,
         project_id=str(trace.project_id),
+    )
+
+
+@router.post("/nested", response_model=NestedTraceResponse, status_code=201)
+def create_nested_trace(
+    body: NestedTraceCreate,
+    x_opik_api_key: str | None = Header(default=None),
+) -> NestedTraceResponse:
+    # Build a multi-span trace explicitly through the public SDK (client.trace
+    # + trace.span/span.span), rather than via @opik.track which only emits a
+    # single root span. Spans are ordered parent-before-child, so a span's
+    # parent_index always points at an already-created span. ApiError from the
+    # SDK is translated to HTTP by the app-wide exception handler.
+    client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
+    try:
+        trace = client.trace(
+            project_name=body.project_name,
+            name=body.name,
+            input=body.input,
+            output=body.output,
+            metadata=body.metadata,
+            tags=body.tags,
+            thread_id=body.thread_id,
+            feedback_scores=body.feedback_scores,
+        )
+
+        created: list = []
+        for index, span_seed in enumerate(body.spans):
+            if span_seed.parent_index is None:
+                parent = trace
+            else:
+                if span_seed.parent_index >= index:
+                    raise HTTPException(
+                        status_code=422,
+                        detail=(
+                            f"span[{index}] parent_index {span_seed.parent_index} "
+                            "must reference an earlier span"
+                        ),
+                    )
+                parent = created[span_seed.parent_index]
+            # The create call carries the full span payload. We deliberately do
+            # NOT call span.end()/trace.end() afterwards: with batching enabled
+            # an immediate end() update races the create in the same batch and
+            # clobbers the rich fields (name/input/output/usage/model/cost) with
+            # nulls. See the SDK note on batching-and-updates.
+            span = parent.span(
+                name=span_seed.name,
+                type=span_seed.type,
+                input=span_seed.input,
+                output=span_seed.output,
+                metadata=span_seed.metadata,
+                model=span_seed.model,
+                provider=span_seed.provider,
+                usage=span_seed.usage,
+                total_cost=span_seed.total_cost,
+            )
+            created.append(span)
+
+        opik.flush_tracker()
+        traces = client.search_traces(
+            project_name=body.project_name,
+            filter_string=f'name = "{body.name}"',
+            max_results=1,
+            wait_for_at_least=1,
+        )
+        if not traces:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Trace {body.name} not visible after create + flush",
+            )
+        found = traces[0]
+        # Block until every span is queryable, not just the trace. The trace row
+        # and its spans land on separate eventually-consistent paths; without
+        # this, a consumer that opens the trace right after seeding can see
+        # Spans (0) and null fields. wait_for_at_least makes the seed return a
+        # fully materialized trace.
+        if body.spans:
+            client.search_spans(
+                project_name=body.project_name,
+                trace_id=str(found.id),
+                max_results=len(body.spans),
+                wait_for_at_least=len(body.spans),
+            )
+    finally:
+        client.end(flush=False)
+        atexit.unregister(client.end)
+
+    return NestedTraceResponse(
+        id=str(found.id),
+        name=body.name,
+        project_id=str(found.project_id),
+        span_count=len(body.spans),
     )

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
@@ -33,6 +33,65 @@ class TraceResponse(BaseModel):
     project_id: str
 
 
+class SpanSeed(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    type: str = "general"
+    input: dict[str, Any] | None = None
+    output: dict[str, Any] | None = None
+    metadata: dict[str, Any] | None = None
+    # LLM-span fields. usage keys follow the OpenAI shape (prompt_tokens,
+    # completion_tokens, total_tokens) so the UI renders token counts; model +
+    # provider + total_cost drive the cost cell.
+    model: str | None = None
+    provider: str | None = None
+    usage: dict[str, int] | None = None
+    total_cost: float | None = None
+    # Index into the same request's spans list identifying this span's parent.
+    # None means the span is a direct child of the trace (a root span).
+    parent_index: int | None = None
+
+
+class NestedTraceCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    project_name: str
+    name: str
+    input: dict[str, Any] | None = None
+    output: dict[str, Any] | None = None
+    metadata: dict[str, Any] | None = None
+    tags: list[str] | None = None
+    thread_id: str | None = None
+    feedback_scores: list[dict[str, Any]] | None = None
+    spans: list[SpanSeed]
+    workspace: str | None = None
+
+
+class NestedTraceResponse(BaseModel):
+    id: str
+    name: str
+    project_id: str
+    span_count: int
+
+
+class FeedbackDefinitionCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    # Numerical definition bounds. The UI's manual-score editor only renders a
+    # named-score control once a matching feedback definition exists in the
+    # workspace, so tests seed one before annotating through the panel.
+    min: float = 0.0
+    max: float = 1.0
+    workspace: str | None = None
+
+
+class FeedbackDefinitionResponse(BaseModel):
+    id: str
+    name: str
+
+
 class DatasetCreate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-spans-depth.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-spans-depth.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '@e2e/fixtures';
+import { LogsPage } from '@e2e/pom/logs.page';
+
+test.describe('Trace spans — panel depth', { tag: ['@t2-cuj', '@trace-explore'] }, () => {
+  test('Span tree renders the seeded nested hierarchy with working expand/collapse', async ({
+    tracedAgent,
+    project,
+    page,
+  }) => {
+    const logs = new LogsPage(page);
+
+    const panel = await test.step('Open the seeded multi-span trace', async () => {
+      await logs.goto(project.id);
+      const panel = await logs.openTraceById(tracedAgent.id);
+      await panel.waitForFullyLoaded();
+      return panel;
+    });
+
+    await test.step('Verify the span count and the nested tree nodes', async () => {
+      await expect(panel.spansCountLabel(tracedAgent.spanCount)).toBeVisible();
+      // Root span and its two children are all visible in the tree.
+      await expect(panel.spanTreeNode('plan')).toBeVisible();
+      await expect(panel.spanTreeNode('llm-call')).toBeVisible();
+      await expect(panel.spanTreeNode('search-tool')).toBeVisible();
+    });
+
+    await test.step('Collapsing the root span hides its children, expanding restores them', async () => {
+      await panel.collapseSpan('plan');
+      await expect(panel.spanTreeNode('llm-call')).toBeHidden();
+      await expect(panel.spanTreeNode('search-tool')).toBeHidden();
+
+      await panel.expandSpan('plan');
+      await expect(panel.spanTreeNode('llm-call')).toBeVisible();
+      await expect(panel.spanTreeNode('search-tool')).toBeVisible();
+    });
+  });
+
+  test('Selecting the LLM span shows its model, token usage, and cost', async ({
+    tracedAgent,
+    project,
+    page,
+  }) => {
+    const logs = new LogsPage(page);
+
+    const panel = await test.step('Open the trace and select the LLM span', async () => {
+      await logs.goto(project.id);
+      const panel = await logs.openTraceById(tracedAgent.id);
+      await panel.waitForFullyLoaded();
+      await panel.selectSpan(tracedAgent.llmSpan.name);
+      return panel;
+    });
+
+    await test.step('Verify the LLM span detail surfaces model, tokens, and cost', async () => {
+      await expect(panel.spanModelChip).toContainText(tracedAgent.llmSpan.model);
+      // Token usage renders the seeded total in the Token usage section. Anchor
+      // to the whole line so it doesn't also match `original_usage.total_tokens`.
+      await expect(
+        panel.panelText(new RegExp(`^total_tokens: ${tracedAgent.llmSpan.totalTokens}$`)),
+      ).toBeVisible();
+      // The seeded cost is small; the UI rounds it to "<$0.01" rather than $0.
+      await expect(panel.panelText('<$0.01').first()).toBeVisible();
+    });
+  });
+
+  test('A tag can be added to a trace from the panel and removed', async ({
+    tracedAgent,
+    project,
+    page,
+  }) => {
+    const logs = new LogsPage(page);
+    const newTag = 'reviewed';
+
+    const panel = await test.step('Open the trace', async () => {
+      await logs.goto(project.id);
+      const panel = await logs.openTraceById(tracedAgent.id);
+      await panel.waitForFullyLoaded();
+      return panel;
+    });
+
+    await test.step('Add a tag and verify the chip appears', async () => {
+      // Seeded tags are already present; the new one is added alongside them.
+      await expect(panel.tagChip(tracedAgent.tags[0])).toBeVisible();
+      await panel.addTag(newTag);
+      await expect(panel.tagChip(newTag)).toBeVisible();
+    });
+  });
+
+  test('A manual feedback score can be added, edited, and deleted from the Annotate panel', async ({
+    tracedAgent,
+    feedbackDefinition,
+    project,
+    page,
+  }) => {
+    const logs = new LogsPage(page);
+    const scoreName = feedbackDefinition.name;
+
+    const panel = await test.step('Open the trace and the Annotate panel', async () => {
+      await logs.goto(project.id);
+      const panel = await logs.openTraceById(tracedAgent.id);
+      await panel.waitForFullyLoaded();
+      await panel.openAnnotate();
+      return panel;
+    });
+
+    await test.step('Add a score and verify it renders', async () => {
+      await panel.setAnnotateScore(scoreName, 0.7);
+      await expect.poll(() => panel.readFeedbackScoreTagValue(scoreName)).toBe('0.7');
+    });
+
+    await test.step('Edit the score and verify the new value', async () => {
+      await panel.setAnnotateScore(scoreName, 0.3);
+      await expect.poll(() => panel.readFeedbackScoreTagValue(scoreName)).toBe('0.3');
+    });
+
+    await test.step('Delete the score and verify the tag disappears', async () => {
+      await panel.clearAnnotateScore(scoreName);
+      await expect(panel.feedbackScoreTag(scoreName)).toBeHidden();
+    });
+  });
+});


### PR DESCRIPTION
## Details

Trace/span E2E coverage was previously two `@t1-smoke` specs (list count/order and a single root-span panel check). The deeper trace surface — nested span trees, per-span input/output, token usage and cost, manual feedback scores, and tags — was untested, because the SDK bridge could only seed a single root span with string-only I/O.

This PR removes that bottleneck and lands the first wave of depth tests on top of it:

- **Seeding harness** (`services/opik-sdk-driver`): a `POST /traces/nested` route builds a realistic agent-shaped trace through the **public SDK** — nested child spans (`general`/`llm`/`tool`), per-span input/output, token usage, cost, metadata, plus trace-level tags and feedback scores. A `POST /feedback-definitions` route seeds the numerical feedback definition the UI requires before its manual named-score editor renders.
- **Fixtures**: `tracedAgent` (the multi-span trace) and `feedbackDefinition` (a numerical definition with explicit teardown, namespaced per test).
- **POM**: `TracePanelPage` extended with span-tree, span-detail, tags, and annotate-score (add/edit/delete) interactions.
- **Specs** (`tests/trace-explore/trace-spans-depth.spec.ts`, `@t2-cuj @trace-explore`): span-tree hierarchy + expand/collapse, LLM span detail (model/tokens/cost), tag add, and manual feedback score add/edit/delete.
- **Frontend**: minimal `data-testid` / `aria-label` additions to back stable selectors (`trace-tree-node-*`, `annotate-score-row-*`, `annotate-score-input`, expand/collapse-span, clear-score). No behavior change.

Seeding uses only the public `Opik` surface (the one exception, feedback-definition create, mirrors the existing project-create route's `_rest_client` usage), so the same shapes seed identically on OSS and Cloud.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6844

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: full implementation (analysis, bridge/fixture/POM/specs, FE testids)
  - Human verification: code review + local test runs

## Testing

Ran the new spec file against a from-source frontend (FE on :5174, backend on :8080) seeded via the auto-spawned bridge:

```
OPIK_BASE_URL=http://localhost:5174 OPIK_DEPLOYMENT=oss WORKERS=2 \
  npx playwright test tests/trace-explore/trace-spans-depth.spec.ts --reporter=list
```

- All 4 specs pass (green twice consecutively at `WORKERS=2`, the CI default; also green at `WORKERS=1`), ~20s.
- Scenarios validated: span-tree hierarchy renders + expand/collapse toggles children; LLM span detail surfaces model/token-usage/cost; tag add shows a chip; manual feedback score add → edit → delete round-trips through the Annotate panel.
- Regression: the existing `trace-explore-smoke.spec.ts` (shares the extended POM and fixture chain) still passes.
- Quality gates: frontend `npm run typecheck` and ESLint clean; e2e `tsc --noEmit` clean.
- Note: the Vite dev server (used only for local from-source verification) contends under the suite's 4-worker default; CI runs at `WORKERS=2` against a prebuilt frontend, where this does not occur.

## Documentation

N/A
