### PR TITLE
[OPIK-6482] [BE] fix: fetch dashboards page in two steps to avoid filesort OOM on JSON config

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardDAO.java
@@ -20,6 +20,7 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.stringtemplate4.UseStringTemplateEngine;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -103,7 +104,20 @@ public interface DashboardDAO {
             @Define("filters") String filters,
             @BindMap Map<String, Object> filterMapping);
 
-    @SqlQuery("SELECT * FROM dashboards " +
+    /**
+     * Returns the ordered ids for a single page, selecting only {@code id} so the sort stays narrow.
+     * <p>
+     * Part of the two-step page fetch (OPIK-6482): this query does the ordering and pagination, then
+     * {@link #findByIds(Collection, String)} loads the row bodies. Selecting the large JSON
+     * {@code config} column here would make MySQL 8.0.20+ pack it into the filesort addon and raise
+     * {@code ER_OUT_OF_SORTMEMORY} (HTTP 500) once a single {@code config} exceeds
+     * {@code sort_buffer_size}; selecting only {@code id} keeps the sort buffer narrow regardless of
+     * config size.
+     *
+     * @return the page's ids in the requested order; the caller must preserve this order when
+     *         assembling the result
+     */
+    @SqlQuery("SELECT id FROM dashboards " +
             "WHERE workspace_id = :workspaceId " +
             "<if(search)> AND name like concat('%', :search, '%') <endif> " +
             "<if(project_id)> AND project_id = :projectId <endif>" +
@@ -113,7 +127,7 @@ public interface DashboardDAO {
             "LIMIT :limit OFFSET :offset")
     @UseStringTemplateEngine
     @AllowUnusedBindings
-    List<Dashboard> find(@Bind("workspaceId") String workspaceId,
+    List<UUID> findPageIdsSorted(@Bind("workspaceId") String workspaceId,
             @Define("search") @Bind("search") String search,
             @Define("project_id") @Bind("projectId") UUID projectId,
             @Define("scope") @Bind("scope") String scope,
@@ -122,6 +136,19 @@ public interface DashboardDAO {
             @Define("sort_fields") String sortingFields,
             @Bind("limit") int limit,
             @Bind("offset") int offset);
+
+    /**
+     * Loads the full row bodies for a page of ids, without an {@code ORDER BY}.
+     * <p>
+     * The caller re-orders the result by the id list from
+     * {@link #findPageIdsSorted(String, String, UUID, String, String, Map, String, int, int)}, so the
+     * JSON {@code config} column never passes through a sort. Callers must skip this call when
+     * {@code ids} is empty, as {@code IN ()} is invalid SQL.
+     */
+    @SqlQuery("SELECT * FROM dashboards WHERE workspace_id = :workspaceId AND id IN (<ids>)")
+    @UseStringTemplateEngine
+    @AllowUnusedBindings
+    List<Dashboard> findByIds(@BindList("ids") Collection<UUID> ids, @Bind("workspaceId") String workspaceId);
 
     @SqlQuery("SELECT COUNT(*) FROM dashboards WHERE workspace_id = :workspaceId AND slug LIKE concat(:slugPrefix, '%')")
     long countBySlugPrefix(@Bind("workspaceId") String workspaceId, @Bind("slugPrefix") String slugPrefix);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardService.java
@@ -30,9 +30,12 @@ import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
@@ -192,8 +195,21 @@ class DashboardServiceImpl implements DashboardService {
             int offset = (page - 1) * size;
 
             long total = dao.findCount(workspaceId, nameTerm, projectId, scope.getValue(), filtersSql, filterMapping);
-            List<Dashboard> dashboards = dao.find(workspaceId, nameTerm, projectId, scope.getValue(), filtersSql,
-                    filterMapping, sortingFieldsSql, size, offset);
+
+            // Two-step fetch (OPIK-6482): order and paginate on id only, then load the page bodies and
+            // re-order them in memory. This keeps the large JSON `config` column out of every sort
+            // buffer, which otherwise triggers ER_OUT_OF_SORTMEMORY on the filesort.
+            List<UUID> pageIds = dao.findPageIdsSorted(workspaceId, nameTerm, projectId, scope.getValue(),
+                    filtersSql, filterMapping, sortingFieldsSql, size, offset);
+
+            List<Dashboard> dashboards;
+            if (pageIds.isEmpty()) {
+                dashboards = List.of();
+            } else {
+                Map<UUID, Dashboard> byId = dao.findByIds(pageIds, workspaceId).stream()
+                        .collect(Collectors.toMap(Dashboard::id, Function.identity()));
+                dashboards = pageIds.stream().map(byId::get).filter(Objects::nonNull).toList();
+            }
 
             log.info("Found '{}' dashboards with scope '{}' in workspace '{}'", total, scope, workspaceId);
             return DashboardPage.builder()

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardService.java
@@ -30,7 +30,6 @@ import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -208,7 +207,7 @@ class DashboardServiceImpl implements DashboardService {
             } else {
                 Map<UUID, Dashboard> byId = dao.findByIds(pageIds, workspaceId).stream()
                         .collect(Collectors.toMap(Dashboard::id, Function.identity()));
-                dashboards = pageIds.stream().map(byId::get).filter(Objects::nonNull).toList();
+                dashboards = pageIds.stream().map(byId::get).toList();
             }
 
             log.info("Found '{}' dashboards with scope '{}' in workspace '{}'", total, scope, workspaceId);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DashboardsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DashboardsResourceTest.java
@@ -733,6 +733,49 @@ class DashboardsResourceTest {
         }
 
         @Test
+        @DisplayName("Sort by name with pagination returns every page's content in order")
+        void findDashboards__whenSortingByNameWithPagination__thenReturnEachPageContentInSortedOrder() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            // Random names (from the generated dashboards) mean the name order differs from id/creation
+            // order, so the two-step fetch's in-memory reorder is exercised under a non-id sort (OPIK-6482).
+            // Creation order is irrelevant (results are re-sorted by name), so create in parallel.
+            List<Dashboard> created = PodamFactoryUtils.manufacturePojoList(podamFactory, Dashboard.class)
+                    .parallelStream()
+                    .map(generated -> dashboardResourceClient.createPartialDashboard().name(generated.name()).build())
+                    .map(dashboard -> {
+                        var id = dashboardResourceClient.create(dashboard, apiKey, workspaceName);
+                        return dashboardResourceClient.get(id, apiKey, workspaceName, HttpStatus.SC_OK);
+                    })
+                    .toList();
+
+            List<Dashboard> sortedByName = created.stream()
+                    .sorted(Comparator.comparing(Dashboard::name, String.CASE_INSENSITIVE_ORDER))
+                    .toList();
+
+            var sorting = SortingField.builder().field("name").direction(Direction.ASC).build();
+
+            // Traverse the whole result set page by page; assert each page's full content (recursive
+            // comparison, not just ids) matches the corresponding slice of the name-sorted list.
+            int size = 2;
+            int totalPages = (sortedByName.size() + size - 1) / size;
+            for (int page = 1; page <= totalPages; page++) {
+                List<Dashboard> expectedPage = sortedByName.stream()
+                        .skip((long) (page - 1) * size)
+                        .limit(size)
+                        .toList();
+
+                var resultPage = dashboardResourceClient.find(apiKey, workspaceName, page, size, null,
+                        List.of(sorting), HttpStatus.SC_OK);
+
+                assertDashboardPage(resultPage, page, expectedPage.size(), expectedPage);
+            }
+        }
+
+        @Test
         @DisplayName("Default sorting without sorting parameter")
         void defaultSortingWithoutSortingParameter() {
             String apiKey = UUID.randomUUID().toString();


### PR DESCRIPTION
## Details

The dashboards list endpoint can return HTTP 500 (`java.sql.SQLException: Out of sort memory`) on workspaces with enough dashboards. The list query does `SELECT * ... ORDER BY id DESC` and, when the optimizer cannot satisfy the ordering from an index, falls back to a filesort. On MySQL 8.0.20+ the filesort uses the addon-fields algorithm, which packs the **selected columns** — including the large JSON `config` column — into the sort buffer; once a single row's `config` exceeds `sort_buffer_size`, MySQL raises `ER_OUT_OF_SORTMEMORY`. `max_length_for_sort_data` no longer forces the rowid algorithm in 8.0.20+, so the only reliable control is to keep `config` out of the sorted projection.

This fetches the page in two steps, so the JSON column never passes through a sort buffer, regardless of config size or sort field:
- `findPageIdsSorted` — orders and paginates, selecting only `id` (a narrow sort that cannot exceed `sort_buffer_size`).
- `findByIds` — loads the row bodies for that page with no `ORDER BY`; `DashboardService` restores the order in memory from the id list.

Follows the same "defer wide-column reads past pagination" pattern already used for the traces/spans list queries.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6482

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Implementation of the two-step fetch (DAO + service) and supporting query/plan analysis, under the author's direction.
  - Human verification: Author proposed the two-step solution and conducted the evidence-based analysis — reproducing `ER_OUT_OF_SORTMEMORY` and validating that the two-step plan removes the filesort via `EXPLAIN ANALYZE` — and reviewed the diff.

## Testing

- `mvn -o compile` in `apps/opik-backend` — BUILD SUCCESS.
- Reproduced the failure and validated the fix against two live environments (call them **environment A** and **environment B**), MySQL 8.0.42:
  - In **environment A**, the optimizer chose a `workspace_id`-only index and filesorted; the original query raised `ER_OUT_OF_SORTMEMORY` once a single `config` exceeded `sort_buffer_size`. In **environment B**, the optimizer used a composite index (reverse scan, no filesort) and never errored — confirming the bug is optimizer/data-distribution dependent and not reliably fixed by an index alone.
  - `EXPLAIN ANALYZE` confirms step 1 sorts only `id` (narrow) and step 2 has no sort node; the two-step succeeds even with `sort_buffer_size` forced to the 32 KB minimum against a >100 KB `config` row, where the original query fails.
-  `DashboardsResourceTest` integration suite passed.

## Documentation

No user-facing documentation changes.