### PR TITLE
[BE] fix: discount cached tokens for Claude on Vertex AI

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -49,7 +49,8 @@ public class CostService {
                     "bedrock", SpanCostCalculator::textGenerationWithCacheCostBedrock,
                     "bedrock_converse", SpanCostCalculator::textGenerationWithCacheCostBedrock,
                     "vertex_ai-language-models", SpanCostCalculator::textGenerationWithCacheCostGoogle,
-                    "gemini", SpanCostCalculator::textGenerationWithCacheCostGoogle);
+                    "gemini", SpanCostCalculator::textGenerationWithCacheCostGoogle,
+                    "vertex_ai-anthropic_models", SpanCostCalculator::textGenerationWithCacheCostAnthropic);
 
     static {
         try {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -39,6 +39,31 @@ class CostServiceTest {
     }
 
     @Test
+    void calculateCostUsesAnthropicCacheCalculatorForClaudeOnVertexAI() {
+        // Claude models hosted on Google Vertex AI ship under the litellm_provider
+        // "vertex_ai-anthropic_models" (canonical provider "anthropic_vertexai"), separate from
+        // the bare-Anthropic and Bedrock paths. Without an entry in PROVIDERS_CACHE_COST_CALCULATOR
+        // these requests fell through to textGenerationCost, so prompt-cache tokens were billed
+        // at the full input rate instead of the configured cache-read rate.
+        Map<String, Integer> usage = Map.of(
+                "prompt_tokens", 1000,
+                "completion_tokens", 100,
+                "original_usage.input_tokens", 1000,
+                "original_usage.output_tokens", 100,
+                "original_usage.cache_read_input_tokens", 200,
+                "original_usage.cache_creation_input_tokens", 50);
+
+        BigDecimal cost = CostService.calculateCost("vertex_ai/claude-haiku-4-5", "anthropic_vertexai", usage, null);
+
+        // vertex_ai/claude-haiku-4-5 (vertex_ai-anthropic_models):
+        // input 1e-6, output 5e-6, cache_read 1e-7, cache_creation 1.25e-6
+        // Anthropic shape: prompt_tokens EXCLUDES cached tokens, so we sum each bucket at its own rate.
+        // 1000*1e-6 + 100*5e-6 + 50*1.25e-6 + 200*1e-7
+        // = 0.001 + 0.0005 + 0.0000625 + 0.00002 = 0.0015825
+        assertThat(cost).isEqualByComparingTo("0.0015825");
+    }
+
+    @Test
     void calculateCostUsesGoogleCacheCalculatorWhenCachePricesConfigured_issue6976() {
         Map<String, Integer> usage = Map.of(
                 "prompt_tokens", 1000,


### PR DESCRIPTION
## Details

Follow-up to #6980. While fixing the Google/Gemini cache gap I noted in the PR body that the canonical provider `anthropic_vertexai` (Claude models hosted on Google Vertex AI) had the same hole in `CostService.PROVIDERS_CACHE_COST_CALCULATOR`. This PR closes it.

`CostService.PROVIDERS_CACHE_COST_CALCULATOR` is keyed by the **raw LiteLLM provider** (e.g. `bedrock_converse` for the Bedrock Converse path, `vertex_ai-language-models` for Gemini). The raw provider for Claude-on-Vertex is `vertex_ai-anthropic_models` (canonical `anthropic_vertexai`, see `PROVIDERS_MAPPING`), and that entry was missing — so when `resolveCalculator()` is called for one of these models it does `getOrDefault(provider, textGenerationCost)` and falls back to the no-cache calculator. Result: prompt-cache tokens are billed at the full input rate instead of the discounted cache-read rate, over-reporting `total_estimated_cost` on cache-heavy calls.

This is visible in the pricing data: `vertex_ai/claude-haiku-4-5`, `vertex_ai/claude-sonnet-4-5` and `vertex_ai/claude-opus-4-1` all carry `cache_read_input_token_cost` / `cache_creation_input_token_cost` and `supports_prompt_caching: true`. For example `vertex_ai/claude-haiku-4-5` has `cache_read_input_token_cost: 1e-07` (10× cheaper than `input_cost_per_token: 1e-06`) — so cached tokens were being over-billed 10×.

Claude-on-Vertex reports the Anthropic usage shape (`input_tokens` / `output_tokens` / `cache_read_input_tokens` / `cache_creation_input_tokens`), so `textGenerationWithCacheCostAnthropic` is the correct calculator to wire in — same handler the bare `anthropic` provider already uses.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (CLI)
- Model(s): Claude Opus 4.7
- Scope: assisted in identifying the missing provider entry, the calculator routing and the regression test.
- Human verification: traced the raw/canonical provider mapping, confirmed Vertex-Anthropic models in `model_prices_and_context_window.json` carry cache pricing, and ran the affected backend tests locally (see Testing).

## Testing

Ran the affected backend tests locally (Windows, JDK 24 + Maven 3.9.9):

- `mvn -f apps/opik-backend/pom.xml -Dtest=CostServiceTest test` — added a `vertex_ai/claude-haiku-4-5` integration case (`calculateCostUsesAnthropicCacheCalculatorForClaudeOnVertexAI`) that exercises the real `model_prices_and_context_window.json` entry. Without this PR the test computes `0.0015` (cache portion ignored); with the fix it computes `0.0015825`. **61 tests, 0 failures.**
- `mvn -f apps/opik-backend/pom.xml -Dtest=SpanCostCalculatorTest test` — regression check on the calculator itself (unchanged). **16 tests, 0 failures.**

The existing `anthropic` / `openai` / `bedrock` / `bedrock_converse` / `vertex_ai-language-models` / `gemini` routes are unchanged.

## Documentation

No docs change — internal cost-calculation fix with no API/user-facing surface change.
