### PR TITLE
[OPIK-6838] [FE] fix: link Playground prompt versions to experiments and traces

### DIFF
--- a/apps/opik-frontend/src/api/playground/promptLinkage.test.ts
+++ b/apps/opik-frontend/src/api/playground/promptLinkage.test.ts
@@ -1,11 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   collectPromptVersionRefs,
   buildPromptLibraryMetadata,
+  resolvePromptVersionForLink,
 } from "./promptLinkage";
 import { PlaygroundPromptType } from "@/types/playground";
 import { LLMMessage, LLM_MESSAGE_ROLE } from "@/types/llm";
-import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
+import { PROMPT_TEMPLATE_STRUCTURE, PromptVersion } from "@/types/prompts";
 
 const message = (overrides: Partial<LLMMessage> = {}): LLMMessage => ({
   id: "m1",
@@ -44,6 +45,21 @@ describe("collectPromptVersionRefs", () => {
       }),
     );
     expect(result).toEqual([{ id: "V2", promptId: "P2" }]);
+  });
+
+  it("collects multiple message-level versions in order", () => {
+    const result = collectPromptVersionRefs(
+      prompt({
+        messages: [
+          message({ id: "m1", promptId: "PA", promptVersionId: "VA" }),
+          message({ id: "m2", promptId: "PB", promptVersionId: "VB" }),
+        ],
+      }),
+    );
+    expect(result).toEqual([
+      { id: "VA", promptId: "PA" },
+      { id: "VB", promptId: "PB" },
+    ]);
   });
 
   it("collects both CHAT and message-level versions, CHAT first", () => {
@@ -135,5 +151,65 @@ describe("buildPromptLibraryMetadata", () => {
       false,
     );
     expect(result.version.template).toBe("not { json");
+  });
+
+  it("includes version.metadata when present", () => {
+    const result = buildPromptLibraryMetadata(
+      { name: "n", id: "P1" },
+      { id: "V1", template: "t", metadata: { key: "val" } },
+      false,
+    );
+    expect(result.version.metadata).toEqual({ key: "val" });
+  });
+});
+
+describe("resolvePromptVersionForLink", () => {
+  const version = (id: string): PromptVersion =>
+    ({ id, template: "t", commit: id.slice(-8) }) as PromptVersion;
+
+  it("returns the explicitly requested version", async () => {
+    const fetchVersion = vi.fn(async ({ versionId }) => version(versionId));
+    const result = await resolvePromptVersionForLink(
+      { latest_version: version("LATEST") },
+      "EXPLICIT",
+      fetchVersion,
+    );
+    expect(fetchVersion).toHaveBeenCalledWith({ versionId: "EXPLICIT" });
+    expect(result?.id).toBe("EXPLICIT");
+  });
+
+  it("returns the embedded latest_version without fetching when no explicit version is supplied", async () => {
+    const fetchVersion = vi.fn(async ({ versionId }) => version(versionId));
+    const latest = version("LATEST");
+    const result = await resolvePromptVersionForLink(
+      { latest_version: latest },
+      undefined,
+      fetchVersion,
+    );
+    expect(fetchVersion).not.toHaveBeenCalled();
+    expect(result).toBe(latest);
+  });
+
+  it("returns undefined when an explicit version cannot be fetched", async () => {
+    const fetchVersion = vi.fn(async () => {
+      throw new Error("404");
+    });
+    const result = await resolvePromptVersionForLink(
+      { latest_version: version("LATEST") },
+      "EXPLICIT",
+      fetchVersion,
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when there is no version to anchor to", async () => {
+    const fetchVersion = vi.fn();
+    const result = await resolvePromptVersionForLink(
+      {},
+      undefined,
+      fetchVersion,
+    );
+    expect(fetchVersion).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
   });
 });

--- a/apps/opik-frontend/src/api/playground/promptLinkage.test.ts
+++ b/apps/opik-frontend/src/api/playground/promptLinkage.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectPromptVersionRefs,
+  buildPromptLibraryMetadata,
+} from "./promptLinkage";
+import { PlaygroundPromptType } from "@/types/playground";
+import { LLMMessage, LLM_MESSAGE_ROLE } from "@/types/llm";
+import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
+
+const message = (overrides: Partial<LLMMessage> = {}): LLMMessage => ({
+  id: "m1",
+  role: LLM_MESSAGE_ROLE.user,
+  content: "hello",
+  ...overrides,
+});
+
+const prompt = (
+  overrides: Partial<PlaygroundPromptType> = {},
+): PlaygroundPromptType => ({
+  name: "p",
+  id: "prompt-state-id",
+  messages: [],
+  model: "",
+  provider: "",
+  configs: {},
+  ...overrides,
+});
+
+describe("collectPromptVersionRefs", () => {
+  it("collects the loaded CHAT prompt version", () => {
+    const result = collectPromptVersionRefs(
+      prompt({
+        loadedChatPromptId: "P1",
+        loadedChatPromptVersionId: "V1",
+      }),
+    );
+    expect(result).toEqual([{ id: "V1", promptId: "P1" }]);
+  });
+
+  it("collects message-level TEXT prompt versions", () => {
+    const result = collectPromptVersionRefs(
+      prompt({
+        messages: [message({ promptId: "P2", promptVersionId: "V2" })],
+      }),
+    );
+    expect(result).toEqual([{ id: "V2", promptId: "P2" }]);
+  });
+
+  it("collects both CHAT and message-level versions, CHAT first", () => {
+    const result = collectPromptVersionRefs(
+      prompt({
+        loadedChatPromptId: "P1",
+        loadedChatPromptVersionId: "V1",
+        messages: [message({ promptId: "P2", promptVersionId: "V2" })],
+      }),
+    );
+    expect(result).toEqual([
+      { id: "V1", promptId: "P1" },
+      { id: "V2", promptId: "P2" },
+    ]);
+  });
+
+  it("deduplicates repeated version ids", () => {
+    const result = collectPromptVersionRefs(
+      prompt({
+        loadedChatPromptId: "P1",
+        loadedChatPromptVersionId: "V1",
+        messages: [message({ promptId: "P1", promptVersionId: "V1" })],
+      }),
+    );
+    expect(result).toEqual([{ id: "V1", promptId: "P1" }]);
+  });
+
+  it("skips entries missing a version id or prompt id", () => {
+    const result = collectPromptVersionRefs(
+      prompt({
+        loadedChatPromptId: "P1", // no version id
+        messages: [message({ promptVersionId: "V2" })], // no prompt id
+      }),
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("returns an empty array for an ad-hoc prompt", () => {
+    expect(collectPromptVersionRefs(prompt())).toEqual([]);
+  });
+});
+
+describe("buildPromptLibraryMetadata", () => {
+  it("parses a JSON template and passes through the modified flag", () => {
+    const result = buildPromptLibraryMetadata(
+      { name: "n", id: "P1", template_structure: "chat" },
+      {
+        id: "V1",
+        template: '[{"role":"system","content":"hi"}]',
+        commit: "abc1234",
+      },
+      true,
+    );
+    expect(result).toEqual({
+      name: "n",
+      id: "P1",
+      template_structure: PROMPT_TEMPLATE_STRUCTURE.CHAT,
+      modified: true,
+      version: {
+        id: "V1",
+        template: [{ role: "system", content: "hi" }],
+        commit: "abc1234",
+      },
+    });
+  });
+
+  it("defaults template_structure to TEXT and omits commit/metadata when absent", () => {
+    const result = buildPromptLibraryMetadata(
+      { name: "n", id: "P1" },
+      { id: "V1", template: "plain text" },
+      false,
+    );
+    expect(result).toEqual({
+      name: "n",
+      id: "P1",
+      template_structure: PROMPT_TEMPLATE_STRUCTURE.TEXT,
+      modified: false,
+      version: {
+        id: "V1",
+        template: "plain text",
+      },
+    });
+  });
+
+  it("falls back to raw string when template is not valid JSON", () => {
+    const result = buildPromptLibraryMetadata(
+      { name: "n", id: "P1" },
+      { id: "V1", template: "not { json" },
+      false,
+    );
+    expect(result.version.template).toBe("not { json");
+  });
+});

--- a/apps/opik-frontend/src/api/playground/promptLinkage.ts
+++ b/apps/opik-frontend/src/api/playground/promptLinkage.ts
@@ -1,4 +1,7 @@
-import { PlaygroundPromptType, PromptLibraryMetadata } from "@/types/playground";
+import {
+  PlaygroundPromptType,
+  PromptLibraryMetadata,
+} from "@/types/playground";
 import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
 
 export interface PromptVersionRef {

--- a/apps/opik-frontend/src/api/playground/promptLinkage.ts
+++ b/apps/opik-frontend/src/api/playground/promptLinkage.ts
@@ -2,7 +2,7 @@ import {
   PlaygroundPromptType,
   PromptLibraryMetadata,
 } from "@/types/playground";
-import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
+import { PROMPT_TEMPLATE_STRUCTURE, PromptVersion } from "@/types/prompts";
 
 export interface PromptVersionRef {
   id: string;
@@ -77,3 +77,36 @@ export const buildPromptLibraryMetadata = (
     ...(version.metadata && { metadata: version.metadata }),
   },
 });
+
+type FetchPromptVersion = (params: {
+  versionId: string;
+}) => Promise<PromptVersion>;
+
+/**
+ * Resolve which Prompt Library version a loaded prompt should link to. Shared
+ * by the CHAT and TEXT paths in useHydratePromptMetadata so the resolution
+ * rules can't drift between them. Anchors to the explicitly-loaded version when
+ * present, otherwise the prompt's latest version. Returns undefined when there
+ * is no safe anchor — either no version exists, or an explicit version was
+ * requested but could not be fetched (in which case we must not silently
+ * compare against the wrong version).
+ */
+export const resolvePromptVersionForLink = async (
+  promptData: { latest_version?: PromptVersion } | undefined,
+  explicitVersionId: string | undefined,
+  fetchPromptVersion: FetchPromptVersion,
+): Promise<PromptVersion | undefined> => {
+  // No explicit version requested: the prompt's embedded latest_version already
+  // satisfies the link, so avoid an extra network round-trip (matches the
+  // pre-refactor behavior). Resolves to undefined when there is no version.
+  if (!explicitVersionId) return promptData?.latest_version;
+
+  // An explicit version was requested. Fetch it; if it can't be fetched
+  // (deleted, or a transient error — we intentionally don't distinguish), bail
+  // rather than silently anchor to the wrong version.
+  try {
+    return await fetchPromptVersion({ versionId: explicitVersionId });
+  } catch {
+    return undefined;
+  }
+};

--- a/apps/opik-frontend/src/api/playground/promptLinkage.ts
+++ b/apps/opik-frontend/src/api/playground/promptLinkage.ts
@@ -1,0 +1,76 @@
+import { PlaygroundPromptType, PromptLibraryMetadata } from "@/types/playground";
+import { PROMPT_TEMPLATE_STRUCTURE } from "@/types/prompts";
+
+export interface PromptVersionRef {
+  id: string;
+  promptId: string;
+}
+
+/**
+ * Single source of truth for resolving which Prompt Library version(s) a
+ * playground prompt is linked to. Used by BOTH the experiment-execute path
+ * (test suites) and the experiment-log path (datasets / direct runs) so the
+ * two can never drift apart again (the drift was the root cause of OPIK-6838).
+ *
+ * Collects, de-duplicated, in priority order:
+ *  - the CHAT prompt version the prompt was loaded from (loadedChatPromptVersionId)
+ *  - any per-message TEXT prompt versions (msg.promptVersionId)
+ */
+export const collectPromptVersionRefs = (
+  prompt: PlaygroundPromptType,
+): PromptVersionRef[] => {
+  const refs: PromptVersionRef[] = [];
+  const seen = new Set<string>();
+
+  const add = (versionId?: string, promptId?: string) => {
+    if (!versionId || !promptId || seen.has(versionId)) return;
+    seen.add(versionId);
+    refs.push({ id: versionId, promptId });
+  };
+
+  add(prompt.loadedChatPromptVersionId, prompt.loadedChatPromptId);
+  prompt.messages.forEach((msg) => add(msg.promptVersionId, msg.promptId));
+
+  return refs;
+};
+
+const parseTemplateJson = (template?: string): unknown => {
+  if (!template) return null;
+  try {
+    return JSON.parse(template);
+  } catch {
+    return template;
+  }
+};
+
+interface VersionData {
+  id: string;
+  template?: string;
+  commit?: string;
+  metadata?: object;
+}
+
+/**
+ * IO-free builder for the `opik_prompts` trace-metadata entry. Kept separate
+ * from the fetching hook so the transform (and the `modified` flag) is unit
+ * testable. `modified` is true when the current playground prompt has diverged
+ * from the library version it was loaded from.
+ */
+export const buildPromptLibraryMetadata = (
+  promptData: { name: string; id: string; template_structure?: string },
+  version: VersionData,
+  modified: boolean,
+): PromptLibraryMetadata => ({
+  name: promptData.name,
+  id: promptData.id,
+  template_structure:
+    (promptData.template_structure as PROMPT_TEMPLATE_STRUCTURE) ??
+    PROMPT_TEMPLATE_STRUCTURE.TEXT,
+  modified,
+  version: {
+    template: parseTemplateJson(version.template),
+    id: version.id,
+    ...(version.commit && { commit: version.commit }),
+    ...(version.metadata && { metadata: version.metadata }),
+  },
+});

--- a/apps/opik-frontend/src/api/playground/useRunExperimentExecution.ts
+++ b/apps/opik-frontend/src/api/playground/useRunExperimentExecution.ts
@@ -3,6 +3,7 @@ import get from "lodash/get";
 import api, { EXPERIMENT_EXECUTION_REST_ENDPOINT } from "@/api/api";
 import { sanitizeConfigForRequest } from "@/lib/modelUtils";
 import { snakeCaseObj } from "@/lib/utils";
+import { collectPromptVersionRefs } from "@/api/playground/promptLinkage";
 import { PlaygroundPromptType } from "@/types/playground";
 import { useToast } from "@/ui/use-toast";
 import { AxiosError } from "axios";
@@ -26,28 +27,6 @@ interface UseRunExperimentExecutionParams {
   projectName?: string;
 }
 
-interface PromptVersionRef {
-  id: string;
-  prompt_id: string;
-}
-
-const collectPromptVersions = (
-  prompt: PlaygroundPromptType,
-): PromptVersionRef[] | undefined => {
-  const refs: PromptVersionRef[] = [];
-  const seen = new Set<string>();
-  const add = (versionId?: string, promptId?: string) => {
-    if (!versionId || !promptId || seen.has(versionId)) return;
-    seen.add(versionId);
-    refs.push({ id: versionId, prompt_id: promptId });
-  };
-
-  add(prompt.loadedChatPromptVersionId, prompt.loadedChatPromptId);
-  prompt.messages.forEach((msg) => add(msg.promptVersionId, msg.promptId));
-
-  return refs.length > 0 ? refs : undefined;
-};
-
 const runExperimentExecution = async ({
   datasetName,
   datasetVersionId,
@@ -57,6 +36,8 @@ const runExperimentExecution = async ({
   projectName,
 }: UseRunExperimentExecutionParams): Promise<ExperimentExecutionResponse> => {
   const promptVariants = prompts.map((prompt) => {
+    const versionRefs = collectPromptVersionRefs(prompt);
+
     return {
       model: prompt.model,
       messages: prompt.messages.map((msg) => snakeCaseObj(msg)),
@@ -64,7 +45,10 @@ const runExperimentExecution = async ({
         prompt.model,
         prompt.configs as Record<string, unknown>,
       ),
-      prompt_versions: collectPromptVersions(prompt),
+      prompt_versions:
+        versionRefs.length > 0
+          ? versionRefs.map((ref) => ({ id: ref.id, prompt_id: ref.promptId }))
+          : undefined,
     };
   });
 

--- a/apps/opik-frontend/src/api/playground/useRunExperimentExecution.ts
+++ b/apps/opik-frontend/src/api/playground/useRunExperimentExecution.ts
@@ -37,6 +37,9 @@ const runExperimentExecution = async ({
 }: UseRunExperimentExecutionParams): Promise<ExperimentExecutionResponse> => {
   const promptVariants = prompts.map((prompt) => {
     const versionRefs = collectPromptVersionRefs(prompt);
+    const promptVersions = versionRefs.length
+      ? versionRefs.map((ref) => ({ id: ref.id, prompt_id: ref.promptId }))
+      : undefined;
 
     return {
       model: prompt.model,
@@ -45,10 +48,7 @@ const runExperimentExecution = async ({
         prompt.model,
         prompt.configs as Record<string, unknown>,
       ),
-      prompt_versions:
-        versionRefs.length > 0
-          ? versionRefs.map((ref) => ({ id: ref.id, prompt_id: ref.promptId }))
-          : undefined,
+      prompt_versions: promptVersions,
     };
   });
 

--- a/apps/opik-frontend/src/types/playground.ts
+++ b/apps/opik-frontend/src/types/playground.ts
@@ -15,6 +15,7 @@ export interface PromptLibraryMetadata {
   name: string;
   id: string;
   template_structure?: PROMPT_TEMPLATE_STRUCTURE;
+  modified?: boolean;
   version: {
     template: unknown;
     commit?: string;

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/PromptCard.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/PromptCard.tsx
@@ -247,6 +247,13 @@ const PromptCard: React.FC<PromptCardProps> = ({
         ) : isVersionsLoading ? (
           <Skeleton className="h-3 w-8 shrink-0" />
         ) : null}
+        {rawPrompt.modified && (
+          <TooltipWrapper content="This run was edited after loading from the linked library version">
+            <span className="comet-body-xs shrink-0 rounded bg-muted px-1.5 text-light-slate">
+              modified
+            </span>
+          </TooltipWrapper>
+        )}
         <EnvironmentBadgeList
           names={environments}
           size="sm"

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
@@ -195,6 +195,7 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
               id={pv.prompt_id}
               name={`${pv.prompt_name}${pv.commit ? ` (${pv.commit})` : ""}`}
               resource={RESOURCE_TYPE.prompt}
+              search={{ activeVersionId: pv.id }}
             />
           ))}
         </div>

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
@@ -22,6 +22,8 @@ import PageBodyStickyTableWrapper from "@/v2/layout/PageBodyStickyTableWrapper/P
 import ExplainerCallout from "@/shared/ExplainerCallout/ExplainerCallout";
 import { convertColumnDataToColumn } from "@/lib/table";
 import SearchInput from "@/shared/SearchInput/SearchInput";
+import NavigationTag from "@/shared/NavigationTag";
+import { RESOURCE_TYPE } from "@/shared/ResourceLink/ResourceLink";
 import { Experiment } from "@/types/datasets";
 import { Switch } from "@/ui/switch";
 import { Label } from "@/ui/label";
@@ -63,6 +65,11 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
   });
 
   const isCompare = experimentsIds.length > 1;
+
+  const promptVersions =
+    !isCompare && experiments[0]?.prompt_versions?.length
+      ? experiments[0].prompt_versions
+      : [];
 
   const [columnsWidth, setColumnsWidth] = useLocalStorageState<
     Record<string, number>
@@ -174,7 +181,7 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
         direction="bidirectional"
         limitWidth
       >
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <SearchInput
             searchText={search as string}
             setSearchText={setSearch}
@@ -182,6 +189,14 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
             className="w-[320px]"
             dimension="sm"
           ></SearchInput>
+          {promptVersions.map((pv) => (
+            <NavigationTag
+              key={pv.id}
+              id={pv.prompt_id}
+              name={`${pv.prompt_name}${pv.commit ? ` (${pv.commit})` : ""}`}
+              resource={RESOURCE_TYPE.prompt}
+            />
+          ))}
         </div>
         <div className="flex items-center gap-2">
           <CompareExperimentsActionsPanel />

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
@@ -66,10 +66,9 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
 
   const isCompare = experimentsIds.length > 1;
 
-  const promptVersions =
-    !isCompare && experiments[0]?.prompt_versions?.length
-      ? experiments[0].prompt_versions
-      : [];
+  // Prompt-version links only make sense for a single experiment; in compare
+  // mode we don't show them. An empty array simply renders nothing.
+  const promptVersions = isCompare ? [] : experiments[0]?.prompt_versions ?? [];
 
   const [columnsWidth, setColumnsWidth] = useLocalStorageState<
     Record<string, number>

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/useHydratePromptMetadata.ts
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/useHydratePromptMetadata.ts
@@ -5,12 +5,14 @@ import {
   PlaygroundPromptType,
   PromptLibraryMetadata,
 } from "@/types/playground";
-import { PromptVersion } from "@/types/prompts";
 import { parsePromptVersionContent } from "@/lib/llm";
 import { useFetchPrompt } from "@/api/prompts/usePromptById";
 import { useFetchPromptVersion } from "@/api/prompts/usePromptVersionById";
 import { serializeChatTemplate, chatTemplatesEqual } from "@/lib/chatTemplate";
-import { buildPromptLibraryMetadata } from "@/api/playground/promptLinkage";
+import {
+  buildPromptLibraryMetadata,
+  resolvePromptVersionForLink,
+} from "@/api/playground/promptLinkage";
 
 export function useHydratePromptMetadata() {
   const fetchPrompt = useFetchPrompt();
@@ -29,27 +31,11 @@ export function useHydratePromptMetadata() {
         }));
         try {
           const promptData = await fetchPrompt({ promptId: chatPromptId });
-          const explicitVersionId = prompt.loadedChatPromptVersionId;
-          const targetVersionId =
-            explicitVersionId ?? promptData?.latest_version?.id;
-          if (!targetVersionId) return undefined;
-
-          let versionData: PromptVersion | undefined;
-          try {
-            versionData = await fetchPromptVersion({
-              versionId: targetVersionId,
-            });
-          } catch {
-            // Only fall back to latest_version when no explicit version was
-            // requested. Otherwise we'd compare against the wrong version
-            // and silently drop the library link.
-          }
-
-          // When an explicit version was selected but we couldn't fetch it,
-          // there's no safe anchor — bail rather than mismatch.
-          if (explicitVersionId && !versionData) return undefined;
-
-          const sourceVersion = versionData ?? promptData?.latest_version;
+          const sourceVersion = await resolvePromptVersionForLink(
+            promptData,
+            prompt.loadedChatPromptVersionId,
+            fetchPromptVersion,
+          );
           if (!sourceVersion?.template) return undefined;
 
           // Keep the library link even when the user edited the prompt after
@@ -63,12 +49,7 @@ export function useHydratePromptMetadata() {
 
           return buildPromptLibraryMetadata(
             promptData,
-            {
-              id: sourceVersion.id,
-              template: sourceVersion.template,
-              commit: sourceVersion.commit,
-              metadata: sourceVersion.metadata,
-            },
+            sourceVersion,
             modified,
           );
         } catch {
@@ -87,36 +68,18 @@ export function useHydratePromptMetadata() {
 
         try {
           const promptData = await fetchPrompt({ promptId: message.promptId });
-
-          const explicitVersionId = message.promptVersionId;
-          const targetVersionId =
-            explicitVersionId ?? promptData?.latest_version?.id;
-          if (!targetVersionId) continue;
-
-          let versionData: PromptVersion | undefined;
-          try {
-            versionData = await fetchPromptVersion({
-              versionId: targetVersionId,
-            });
-          } catch {
-            // Only fall back to latest_version when no explicit version was
-            // requested; otherwise bail rather than compare the wrong version.
-          }
-          if (explicitVersionId && !versionData) continue;
-
-          const sourceVersion = versionData ?? promptData?.latest_version;
+          const sourceVersion = await resolvePromptVersionForLink(
+            promptData,
+            message.promptVersionId,
+            fetchPromptVersion,
+          );
           if (!sourceVersion) continue;
 
           const libraryContent = parsePromptVersionContent(sourceVersion);
           const modified = !isEqual(message.content, libraryContent);
           const metadata = buildPromptLibraryMetadata(
             promptData,
-            {
-              id: sourceVersion.id,
-              template: sourceVersion.template,
-              commit: sourceVersion.commit,
-              metadata: sourceVersion.metadata,
-            },
+            sourceVersion,
             modified,
           );
 

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/useHydratePromptMetadata.ts
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/useHydratePromptMetadata.ts
@@ -76,7 +76,9 @@ export function useHydratePromptMetadata() {
         }
       }
 
-      // For TEXT prompts - check message-level library link. Prefer an exact
+      // For TEXT prompts - check message-level library link. Anchor to the
+      // specific version the message was loaded from (message.promptVersionId),
+      // not necessarily the latest, mirroring the CHAT branch. Prefer an exact
       // (unmodified) match; otherwise keep the first edited library-linked
       // message and mark it modified (OPIK-6838 #4) rather than dropping it.
       let fallback: PromptLibraryMetadata | undefined;
@@ -86,19 +88,34 @@ export function useHydratePromptMetadata() {
         try {
           const promptData = await fetchPrompt({ promptId: message.promptId });
 
-          if (!promptData?.latest_version) continue;
+          const explicitVersionId = message.promptVersionId;
+          const targetVersionId =
+            explicitVersionId ?? promptData?.latest_version?.id;
+          if (!targetVersionId) continue;
 
-          const libraryContent = parsePromptVersionContent(
-            promptData.latest_version,
-          );
+          let versionData: PromptVersion | undefined;
+          try {
+            versionData = await fetchPromptVersion({
+              versionId: targetVersionId,
+            });
+          } catch {
+            // Only fall back to latest_version when no explicit version was
+            // requested; otherwise bail rather than compare the wrong version.
+          }
+          if (explicitVersionId && !versionData) continue;
+
+          const sourceVersion = versionData ?? promptData?.latest_version;
+          if (!sourceVersion) continue;
+
+          const libraryContent = parsePromptVersionContent(sourceVersion);
           const modified = !isEqual(message.content, libraryContent);
           const metadata = buildPromptLibraryMetadata(
             promptData,
             {
-              id: promptData.latest_version.id,
-              template: promptData.latest_version.template,
-              commit: promptData.latest_version.commit,
-              metadata: promptData.latest_version.metadata,
+              id: sourceVersion.id,
+              template: sourceVersion.template,
+              commit: sourceVersion.commit,
+              metadata: sourceVersion.metadata,
             },
             modified,
           );

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/useHydratePromptMetadata.ts
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/useHydratePromptMetadata.ts
@@ -5,44 +5,12 @@ import {
   PlaygroundPromptType,
   PromptLibraryMetadata,
 } from "@/types/playground";
-import { PROMPT_TEMPLATE_STRUCTURE, PromptVersion } from "@/types/prompts";
+import { PromptVersion } from "@/types/prompts";
 import { parsePromptVersionContent } from "@/lib/llm";
 import { useFetchPrompt } from "@/api/prompts/usePromptById";
 import { useFetchPromptVersion } from "@/api/prompts/usePromptVersionById";
 import { serializeChatTemplate, chatTemplatesEqual } from "@/lib/chatTemplate";
-
-const parseTemplateJson = (template: string | undefined): unknown => {
-  if (!template) return null;
-  try {
-    return JSON.parse(template);
-  } catch {
-    return template;
-  }
-};
-
-interface VersionData {
-  id: string;
-  template?: string;
-  commit?: string;
-  metadata?: object;
-}
-
-const buildMetadata = (
-  promptData: { name: string; id: string; template_structure?: string },
-  versionData: VersionData,
-): PromptLibraryMetadata => ({
-  name: promptData.name,
-  id: promptData.id,
-  template_structure:
-    (promptData.template_structure as PROMPT_TEMPLATE_STRUCTURE) ??
-    PROMPT_TEMPLATE_STRUCTURE.TEXT,
-  version: {
-    template: parseTemplateJson(versionData.template),
-    id: versionData.id,
-    ...(versionData.commit && { commit: versionData.commit }),
-    ...(versionData.metadata && { metadata: versionData.metadata }),
-  },
-});
+import { buildPromptLibraryMetadata } from "@/api/playground/promptLinkage";
 
 export function useHydratePromptMetadata() {
   const fetchPrompt = useFetchPrompt();
@@ -52,14 +20,13 @@ export function useHydratePromptMetadata() {
     async (
       prompt: PlaygroundPromptType,
     ): Promise<PromptLibraryMetadata | undefined> => {
-      const currentMessages = prompt.messages.map((m) => ({
-        role: m.role,
-        content: m.content,
-      }));
-
       // Loaded from a CHAT prompt in the library
       const chatPromptId = prompt.loadedChatPromptId;
       if (chatPromptId) {
+        const currentMessages = prompt.messages.map((m) => ({
+          role: m.role,
+          content: m.content,
+        }));
         try {
           const promptData = await fetchPrompt({ promptId: chatPromptId });
           const explicitVersionId = prompt.loadedChatPromptVersionId;
@@ -85,26 +52,34 @@ export function useHydratePromptMetadata() {
           const sourceVersion = versionData ?? promptData?.latest_version;
           if (!sourceVersion?.template) return undefined;
 
-          if (
-            !chatTemplatesEqual(
-              serializeChatTemplate(currentMessages),
-              sourceVersion.template,
-            )
-          )
-            return undefined;
+          // Keep the library link even when the user edited the prompt after
+          // loading it — mark it modified rather than silently dropping the
+          // reference (OPIK-6838 #4). Truly ad-hoc prompts never reach here
+          // because they have no loadedChatPromptId.
+          const modified = !chatTemplatesEqual(
+            serializeChatTemplate(currentMessages),
+            sourceVersion.template,
+          );
 
-          return buildMetadata(promptData, {
-            id: sourceVersion.id,
-            template: sourceVersion.template,
-            commit: sourceVersion.commit,
-            metadata: sourceVersion.metadata,
-          });
+          return buildPromptLibraryMetadata(
+            promptData,
+            {
+              id: sourceVersion.id,
+              template: sourceVersion.template,
+              commit: sourceVersion.commit,
+              metadata: sourceVersion.metadata,
+            },
+            modified,
+          );
         } catch {
           return undefined;
         }
       }
 
-      // For TEXT prompts - check message-level library link
+      // For TEXT prompts - check message-level library link. Prefer an exact
+      // (unmodified) match; otherwise keep the first edited library-linked
+      // message and mark it modified (OPIK-6838 #4) rather than dropping it.
+      let fallback: PromptLibraryMetadata | undefined;
       for (const message of prompt.messages) {
         if (!message.promptId) continue;
 
@@ -113,24 +88,29 @@ export function useHydratePromptMetadata() {
 
           if (!promptData?.latest_version) continue;
 
-          // Parse the library content for comparison
           const libraryContent = parsePromptVersionContent(
             promptData.latest_version,
           );
-          if (!isEqual(message.content, libraryContent)) continue; // Edited
+          const modified = !isEqual(message.content, libraryContent);
+          const metadata = buildPromptLibraryMetadata(
+            promptData,
+            {
+              id: promptData.latest_version.id,
+              template: promptData.latest_version.template,
+              commit: promptData.latest_version.commit,
+              metadata: promptData.latest_version.metadata,
+            },
+            modified,
+          );
 
-          return buildMetadata(promptData, {
-            id: promptData.latest_version.id,
-            template: promptData.latest_version.template,
-            commit: promptData.latest_version.commit,
-            metadata: promptData.latest_version.metadata,
-          });
+          if (!modified) return metadata;
+          fallback ??= metadata;
         } catch {
           continue;
         }
       }
 
-      return undefined;
+      return fallback;
     },
     [fetchPrompt, fetchPromptVersion],
   );

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/usePromptDatasetItemCombination.ts
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/usePromptDatasetItemCombination.ts
@@ -28,6 +28,7 @@ import isNumber from "lodash/isNumber";
 import { parseCompletionOutput } from "@/lib/playground";
 import { useHydrateDatasetItemData } from "@/v2/pages/PlaygroundPage/useHydrateDatasetItemData";
 import { useHydratePromptMetadata } from "@/v2/pages/PlaygroundPage/useHydratePromptMetadata";
+import { collectPromptVersionRefs } from "@/api/playground/promptLinkage";
 import { getTextFromMessageContent } from "@/lib/llm";
 
 export interface DatasetItemPromptCombination {
@@ -219,13 +220,14 @@ const usePromptDatasetItemCombination = ({
           transformMessageIntoProviderMessage(m, datasetItemData),
         );
 
-        const promptLibraryVersions = (
-          prompt.messages
-            .map((m) => m.promptVersionId)
-            .filter(Boolean) as string[]
-        ).map((id) => ({
-          id,
-        }));
+        // Single source of truth shared with the execute path: includes the
+        // CHAT prompt version (loadedChatPromptVersionId) that the old
+        // message-only collection silently dropped — the root cause of
+        // OPIK-6838 #1 (empty "Prompt commit" column) and #3 (dataset
+        // experiments missing from the prompt's Experiments tab).
+        const promptLibraryVersions = collectPromptVersionRefs(prompt).map(
+          (ref) => ({ id: ref.id }),
+        );
 
         // Calculate prompt library metadata at execution time
         // This checks React Query cache to determine if prompt is unchanged from library


### PR DESCRIPTION
## Details
Experiments and traces created from the Playground over a regular **Dataset** (or via a direct run) silently lost their Prompt Library version link, while runs over a **Test Suite** kept it. Root cause: the dataset/"log" path collected only per-message TEXT prompt versions and ignored the loaded CHAT prompt version (`loadedChatPromptVersionId`), whereas the test-suite/"execute" path collected both. This produced an empty "Prompt commit" column, dataset experiments missing from a prompt's Experiments tab, and no prompt reference in the single-experiment view.

This PR removes that drift by introducing one shared version collector used by both paths, surfaces the prompt-version link in the Configuration tab, and keeps the trace↔prompt reference even after a loaded prompt is edited. Frontend-only — no backend, migrations, or `v1` changes.

- Extract `collectPromptVersionRefs` + `buildPromptLibraryMetadata` into a shared, unit-tested `src/api/playground/promptLinkage.ts` (single source of truth); reuse it in both the execute and log paths.
- Dataset/log path now links CHAT prompt versions → fixes the empty "Prompt commit" column and dataset experiments missing from the prompt's Experiments tab.
- Add a prompt-version link in the single-experiment **Configuration** tab (deep-links to the experiment's exact version via `activeVersionId`).
- Trace linkage (`metadata.opik_prompts`, a frontend-only field) now keeps the reference for edited prompts with a `modified` flag, plus a "modified" badge on the trace's Prompts card; TEXT path anchors to the message's own version instead of latest.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6838

## AI-WATERMARK

AI-WATERMARK: yes

  - Tools: Claude-Code
  - Model: Opus-4.8
  - Scope: All files
  - Human verification: Yes — reproduced all 4 issues as broken on `main`, then verified each fixed in the running app (local, OpenAI provider, Chrome).

## Testing
Commands (from `apps/opik-frontend`):
- `npm run typecheck` — clean (project-wide)
- `npm run lint` — 0 warnings (project-wide)
- `npm run test -- src/api/playground` — pass, including new `promptLinkage.test.ts` (9 cases)
- `npx vitest run` (full suite) — 1751 passed. The only failures (23 in `src/lib/ls-migrations/*`) are a pre-existing happy-dom `localStorage.clear` env issue, unrelated to this change (they fail in isolation and touch none of the changed files).

Manual UI (local process mode, OpenAI provider, Chrome) — loaded a CHAT library prompt into the Playground and ran an experiment over a regular Dataset:
- #1 "Prompt commit" column populated with the version commit (was `-`).
- #3 the dataset experiment now appears under the prompt's Experiments tab.
- #2 the single-experiment Configuration tab shows a prompt-version link.
- #4 the resulting trace carries `opik_prompts` (with the new `modified` field) and renders the prompt card on the Prompts tab.
Confirmed all four reproduce as broken on `main`.

Not run: a live screenshot of the `modified: true` badge — local ClickHouse trace-list ingestion lag prevented surfacing the edited-run trace in time. The `modified` flag is confirmed present in trace metadata and the badge rendering is covered by code review.

## Documentation
N/A — no user-facing docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
