### PR TITLE
[NA] [BE] fix: enforce project visibility when resolving thread by project name

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -803,10 +803,12 @@ class ProjectServiceImpl implements ProjectService {
             return get(projectId).id();
         }
 
-        // If the project name is provided, find the project by name
+        // If the project name is provided, find the project by name, then verify visibility so that
+        // public (unauthenticated) requests cannot reach non-public projects by name.
         return findByNames(workspaceId, List.of(projectName))
                 .stream()
                 .findFirst()
+                .flatMap(project -> verifyVisibility(project, requestContext.get().getVisibility()))
                 .orElseThrow(() -> ErrorUtils.failWithNotFoundName("Project", projectName))
                 .id();
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -798,6 +798,44 @@ class TracesResourceTest {
 
         @ParameterizedTest
         @MethodSource("publicCredentials")
+        void getTraceThreadByProjectName__whenApiKeyIsPresent__thenReturnProperResponse(String apiKey,
+                Visibility visibility, int expectedCode) {
+
+            var workspaceName = RandomStringUtils.secure().nextAlphanumeric(10);
+            var workspaceId = UUID.randomUUID().toString();
+
+            mockTargetWorkspace(okApikey, workspaceName, workspaceId);
+            mockGetWorkspaceIdByName(workspaceName, workspaceId);
+
+            Project project = factory.manufacturePojo(Project.class).toBuilder().name(DEFAULT_PROJECT)
+                    .visibility(visibility).build();
+            projectResourceClient.createProject(project, okApikey, workspaceName);
+
+            var threadId = UUID.randomUUID().toString();
+            var trace = createTrace()
+                    .toBuilder()
+                    .projectId(null)
+                    .threadId(threadId)
+                    .projectName(DEFAULT_PROJECT)
+                    .build();
+            create(trace, okApikey, workspaceName);
+
+            // Resolving the thread by project name must enforce visibility just like resolving by project id,
+            // otherwise unauthenticated public requests could read threads from non-public projects.
+            try (var actualResponse = traceResourceClient.callRetrieveThreadResponse(
+                    TraceThreadIdentifier.builder().projectName(DEFAULT_PROJECT).threadId(threadId).build(),
+                    apiKey, workspaceName)) {
+
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(expectedCode);
+                if (expectedCode == 404) {
+                    assertThat(actualResponse.readEntity(NotFoundException.class).getMessage())
+                            .isEqualTo(PROJECT_NAME_NOT_FOUND_MESSAGE.formatted(DEFAULT_PROJECT));
+                }
+            }
+        }
+
+        @ParameterizedTest
+        @MethodSource("publicCredentials")
         void get__whenApiKeyIsPresent__thenReturnSearchTrace(String apiKey,
                 Visibility visibility, int expectedCode) {
 
@@ -1196,6 +1234,40 @@ class TracesResourceTest {
                 if (expectedCode == 404) {
                     assertThat(actualResponse.readEntity(NotFoundException.class).getMessage())
                             .isEqualTo(PROJECT_NOT_FOUND_MESSAGE.formatted(projectId));
+                }
+            }
+        }
+
+        @ParameterizedTest
+        @MethodSource("publicCredentials")
+        void getTraceThreadByProjectName__whenSessionTokenIsPresent__thenReturnProperResponse(String sessionToken,
+                Visibility visibility,
+                String workspaceName, int expectedCode) {
+
+            mockTargetWorkspace(API_KEY, workspaceName, WORKSPACE_ID);
+            mockGetWorkspaceIdByName(workspaceName, WORKSPACE_ID);
+
+            Project project = factory.manufacturePojo(Project.class).toBuilder().visibility(visibility).build();
+            projectResourceClient.createProject(project, API_KEY, workspaceName);
+
+            var threadId = UUID.randomUUID().toString();
+            var trace = createTrace()
+                    .toBuilder()
+                    .projectId(null)
+                    .threadId(threadId)
+                    .projectName(project.name())
+                    .build();
+            create(trace, API_KEY, workspaceName);
+
+            // Resolving the thread by project name must enforce visibility just like resolving by project id.
+            try (var actualResponse = traceResourceClient.callRetrieveThreadResponseWithCookie(
+                    TraceThreadIdentifier.builder().projectName(project.name()).threadId(threadId).build(),
+                    sessionToken, workspaceName)) {
+
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(expectedCode);
+                if (expectedCode == 404) {
+                    assertThat(actualResponse.readEntity(NotFoundException.class).getMessage())
+                            .isEqualTo(PROJECT_NAME_NOT_FOUND_MESSAGE.formatted(project.name()));
                 }
             }
         }


### PR DESCRIPTION
## Details

ProjectService.validateProjectIdentifier verified project visibility only on the project-id branch (via get(projectId)); the project-name branch returned the project without the check, so the two identifier forms behaved inconsistently for public-visibility requests.

Apply the same verifyVisibility(...) on the project-name branch so both paths enforce visibility identically.

Add regression tests for thread retrieval by project name across the API-key and session-token public-access matrices — previously only the project-id branch was covered, which is why the gap went unnoticed.



## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- NA

## AI-WATERMARK

## Testing
Manual tests

## Documentation
N/A