### PR TITLE
[OPIK-6810] [BE] add project_name to experiment_items_bulk to avoid Default Project fallback

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentItemBulkUpload.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentItemBulkUpload.java
@@ -11,12 +11,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.List;
 import java.util.UUID;
+
+import static com.comet.opik.utils.ValidationUtils.NULL_OR_NOT_BLANK;
 
 /**
  * Request object for bulk uploading experiment items.
@@ -35,9 +38,12 @@ public record ExperimentItemBulkUpload(
                 "provided, items will be added to the existing experiment and experimentName will be ignored. If not " +
                 "provided or experiment with that ID doesn't exist, a new experiment will be created with the given " +
                 "experimentName") UUID experimentId,
-        @JsonView({View.ExperimentItemBulkWriteView.class}) @Schema(description = "Project for traces auto-created " +
-                "from items that provide evaluate_task_result (i.e. without an explicit trace). If null, the default " +
-                "project is used; relying on this fallback is deprecated, please provide project_name explicitly.") String projectName,
+        @JsonView({
+                View.ExperimentItemBulkWriteView.class}) @Pattern(regexp = NULL_OR_NOT_BLANK, message = "must not be blank") @Schema(description = "Project for traces auto-created "
+                        +
+                        "from items that provide evaluate_task_result (i.e. without an explicit trace). If null, the default "
+                        +
+                        "project is used; relying on this fallback is deprecated, please provide project_name explicitly.") String projectName,
         @JsonView({
                 View.ExperimentItemBulkWriteView.class}) @NotNull @Size(min = 1, max = 1000, message = "Experiment items list size must be between 1 and 1000") @Valid List<ExperimentItemBulkRecord> items)
         implements

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentItemBulkUpload.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ExperimentItemBulkUpload.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api;
 
+import com.comet.opik.api.validation.ExperimentItemBulkUploadValidation;
 import com.comet.opik.api.validation.MaxRequestSize;
 import com.comet.opik.infrastructure.ratelimit.RateEventContainer;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -25,6 +26,7 @@ import java.util.UUID;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @MaxRequestSize // 4MB limit
+@ExperimentItemBulkUploadValidation
 public record ExperimentItemBulkUpload(
         @JsonView({
                 View.ExperimentItemBulkWriteView.class}) @NotBlank String experimentName,
@@ -33,6 +35,9 @@ public record ExperimentItemBulkUpload(
                 "provided, items will be added to the existing experiment and experimentName will be ignored. If not " +
                 "provided or experiment with that ID doesn't exist, a new experiment will be created with the given " +
                 "experimentName") UUID experimentId,
+        @JsonView({View.ExperimentItemBulkWriteView.class}) @Schema(description = "Project for traces auto-created " +
+                "from items that provide evaluate_task_result (i.e. without an explicit trace). If null, the default " +
+                "project is used; relying on this fallback is deprecated, please provide project_name explicitly.") String projectName,
         @JsonView({
                 View.ExperimentItemBulkWriteView.class}) @NotNull @Size(min = 1, max = 1000, message = "Experiment items list size must be between 1 and 1000") @Valid List<ExperimentItemBulkRecord> items)
         implements

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentItemBulkMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentItemBulkMapper.java
@@ -40,7 +40,6 @@ class ExperimentItemBulkMapper {
 
                         if (span.traceId() == null && finalTrace != null) {
                             builder.traceId(finalTrace.id());
-                            builder.projectName(finalTrace.projectName());
                         }
 
                         return builder.build();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
@@ -38,6 +38,7 @@ import com.comet.opik.domain.ExperimentItemService;
 import com.comet.opik.domain.ExperimentService;
 import com.comet.opik.domain.FeedbackScoreService;
 import com.comet.opik.domain.IdGenerator;
+import com.comet.opik.domain.ProjectService;
 import com.comet.opik.domain.Streamer;
 import com.comet.opik.domain.workspaces.WorkspaceMetadataService;
 import com.comet.opik.infrastructure.auth.RequestContext;
@@ -79,6 +80,7 @@ import jakarta.ws.rs.core.UriInfo;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.glassfish.jersey.server.ChunkedOutput;
 
 import java.util.Collections;
@@ -539,7 +541,7 @@ public class ExperimentsResource {
                 .name(request.experimentName())
                 .build();
 
-        experimentItemBulkIngestionService.ingest(experiment, items)
+        experimentItemBulkIngestionService.ingest(experiment, request.projectName(), items)
                 .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, userName)
                         .put(RequestContext.WORKSPACE_ID, workspaceId))
                 .retryWhen(RetryUtils.handleConnectionError())
@@ -548,7 +550,21 @@ public class ExperimentsResource {
         log.info("Recorded experiment items in bulk, count '{}', experimentId '{}'", request.items().size(),
                 request.experimentId());
 
-        return Response.noContent().build();
+        Response.ResponseBuilder responseBuilder = Response.noContent();
+        // Warn only when a fallback to the default project actually happened: no request-level project_name AND
+        // at least one item without its own project (no trace, or a trace with a blank project_name).
+        boolean usedDefaultProjectFallback = StringUtils.isBlank(request.projectName())
+                && items.stream().anyMatch(
+                        item -> item.trace() == null || StringUtils.isBlank(item.trace().projectName()));
+        if (usedDefaultProjectFallback) {
+            // Nudge clients to set project_name so experiments stay in their intended project.
+            responseBuilder.header(RequestContext.WORKSPACE_FALLBACK_HEADER,
+                    ("project_name was not provided; traces without a project were placed in the default project "
+                            + "'%s'. This fallback is deprecated, please provide project_name.")
+                            .formatted(ProjectService.DEFAULT_PROJECT));
+        }
+
+        return responseBuilder.build();
     }
 
     @GET

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
@@ -512,7 +512,7 @@ public class ExperimentsResource {
             "Maximum request size is 4MB.", responses = {
                     @ApiResponse(responseCode = "204", description = "No content"),
                     @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
-                    @ApiResponse(responseCode = "409", description = "Experiment dataset mismatch", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
+                    @ApiResponse(responseCode = "409", description = "Conflict", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
                     @ApiResponse(responseCode = "422", description = "Unprocessable Content", content = @Content(schema = @Schema(implementation = com.comet.opik.api.error.ErrorMessage.class))),
             })
     @RateLimited

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
@@ -539,6 +539,7 @@ public class ExperimentsResource {
                 .id(request.experimentId())
                 .datasetName(request.datasetName())
                 .name(request.experimentName())
+                .projectName(request.projectName())
                 .build();
 
         experimentItemBulkIngestionService.ingest(experiment, request.projectName(), items)

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/validate/ExperimentItemBulkValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/validate/ExperimentItemBulkValidator.java
@@ -11,12 +11,13 @@ public class ExperimentItemBulkValidator {
     public static void validate(ExperimentItemBulkRecord item) {
         if (item.trace() == null && !CollectionUtils.isEmpty(item.spans())) {
             throw new BadRequestException("Trace is required when spans are provided");
-        } else if (item.trace() != null && !CollectionUtils.isEmpty(item.spans()) && hasMatchingTraceId(item)) {
+        } else if (item.trace() != null && hasMismatchingTraceId(item)) {
             throw new BadRequestException("Trace ID must match the span's trace ID");
         }
     }
 
-    private static boolean hasMatchingTraceId(ExperimentItemBulkRecord item) {
-        return item.spans().stream().anyMatch(span -> !item.trace().id().equals(span.traceId()));
+    private static boolean hasMismatchingTraceId(ExperimentItemBulkRecord item) {
+        return !CollectionUtils.isEmpty(item.spans())
+                && item.spans().stream().anyMatch(span -> !item.trace().id().equals(span.traceId()));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/validate/ExperimentItemBulkValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/validate/ExperimentItemBulkValidator.java
@@ -11,7 +11,7 @@ public class ExperimentItemBulkValidator {
     public static void validate(ExperimentItemBulkRecord item) {
         if (item.trace() == null && !CollectionUtils.isEmpty(item.spans())) {
             throw new BadRequestException("Trace is required when spans are provided");
-        } else if (item.trace() != null && hasMatchingTraceId(item)) {
+        } else if (item.trace() != null && !CollectionUtils.isEmpty(item.spans()) && hasMatchingTraceId(item)) {
             throw new BadRequestException("Trace ID must match the span's trace ID");
         }
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ExperimentItemBulkUploadValidation.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ExperimentItemBulkUploadValidation.java
@@ -1,0 +1,24 @@
+package com.comet.opik.api.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {ExperimentItemBulkUploadValidator.class})
+@Documented
+public @interface ExperimentItemBulkUploadValidation {
+
+    String message() default "trace project_name must match the request project_name";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ExperimentItemBulkUploadValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ExperimentItemBulkUploadValidator.java
@@ -1,0 +1,50 @@
+package com.comet.opik.api.validation;
+
+import com.comet.opik.api.ExperimentItemBulkRecord;
+import com.comet.opik.api.ExperimentItemBulkUpload;
+import com.comet.opik.api.Trace;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Objects;
+
+public class ExperimentItemBulkUploadValidator
+        implements
+            ConstraintValidator<ExperimentItemBulkUploadValidation, ExperimentItemBulkUpload> {
+
+    private volatile ExperimentItemBulkUploadValidation constraintAnnotation;
+
+    @Override
+    public void initialize(ExperimentItemBulkUploadValidation constraintAnnotation) {
+        this.constraintAnnotation = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(ExperimentItemBulkUpload upload, ConstraintValidatorContext context) {
+        // No request-level project_name: item-level trace projects are unconstrained.
+        if (upload == null || StringUtils.isBlank(upload.projectName()) || CollectionUtils.isEmpty(upload.items())) {
+            return true;
+        }
+
+        // When a request-level project_name is provided, it is authoritative for the whole upload.
+        // An item-level trace pointing at a different project would split the experiment's traces across
+        // projects, so reject the contradiction.
+        boolean hasMismatch = upload.items().stream()
+                .map(ExperimentItemBulkRecord::trace)
+                .filter(Objects::nonNull)
+                .map(Trace::projectName)
+                .filter(StringUtils::isNotBlank)
+                .anyMatch(traceProjectName -> !traceProjectName.equalsIgnoreCase(upload.projectName()));
+
+        if (hasMismatch) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(constraintAnnotation.message())
+                    .addPropertyNode("items")
+                    .addConstraintViolation();
+        }
+
+        return !hasMismatch;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
@@ -22,6 +22,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple3;
@@ -35,6 +36,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
 
@@ -45,10 +47,12 @@ public interface ExperimentItemBulkIngestionService {
      * Ingests a batch of experiment items.
      *
      * @param experiment the experiment to add items to
+     * @param projectName the project for traces auto-created from items that provide evaluate_task_result
+     *                    (i.e. without an explicit trace); when blank, the default project is used
      * @param items the list of experiment items to ingest
      * @return a list of feedback score batch items
      */
-    Mono<Void> ingest(Experiment experiment, List<ExperimentItemBulkRecord> items);
+    Mono<Void> ingest(Experiment experiment, String projectName, List<ExperimentItemBulkRecord> items);
 }
 
 @Singleton
@@ -72,11 +76,18 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
      * @return a list of feedback score batch items
      */
     @Override
-    public Mono<Void> ingest(Experiment experiment, List<ExperimentItemBulkRecord> items) {
+    public Mono<Void> ingest(Experiment experiment, String projectName, List<ExperimentItemBulkRecord> items) {
 
         return Mono.deferContextual(ctx -> {
 
             String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
+
+            // Project applied to traces that don't carry their own project: traces auto-created from
+            // evaluate_task_result items, and explicit traces with a blank project_name. When the request
+            // does not specify one, fall back to the default project (deprecated behavior).
+            String bulkProjectName = StringUtils.isNotBlank(projectName)
+                    ? projectName
+                    : ProjectService.DEFAULT_PROJECT;
 
             return validateExperimentConsistency(experiment, workspaceId)
                     .then(experimentService.create(experiment))
@@ -85,11 +96,15 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
                         log.info("Using experiment with id '{}', name '{}', datasetName '{}', workspaceId '{}'",
                                 experimentId, experiment.name(), experiment.datasetName(), workspaceId);
 
-                        // Collect unique project names from all traces
-                        List<String> projectNames = items.stream()
-                                .map(ExperimentItemBulkRecord::trace)
-                                .filter(Objects::nonNull)
-                                .map(Trace::projectName)
+                        // Collect unique project names: the bulk project (for auto-created traces and
+                        // traces without a project), plus any project specified on item-level traces.
+                        List<String> projectNames = Stream.concat(
+                                Stream.of(bulkProjectName),
+                                items.stream()
+                                        .map(ExperimentItemBulkRecord::trace)
+                                        .filter(Objects::nonNull)
+                                        .map(Trace::projectName)
+                                        .filter(StringUtils::isNotBlank))
                                 .distinct()
                                 .toList();
 
@@ -111,7 +126,8 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
                                             experimentItems,
                                             spans,
                                             feedbackScores,
-                                            projectNameToIdMap);
+                                            projectNameToIdMap,
+                                            bulkProjectName);
 
                                     return experimentItemService.create(experimentItems)
                                             .then(saveAll(traces, spans, feedbackScores))
@@ -185,7 +201,8 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
             Set<ExperimentItem> experimentItems,
             List<Span> spans,
             List<FeedbackScoreBatchItem> feedbackScores,
-            Map<String, UUID> projectNameToIdMap) {
+            Map<String, UUID> projectNameToIdMap,
+            String bulkProjectName) {
 
         for (ExperimentItemBulkRecord item : items) {
             Trace trace;
@@ -195,7 +212,7 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
                 Instant now = Instant.now();
                 trace = Trace.builder()
                         .id(idGenerator.generateId())
-                        .projectName(ProjectService.DEFAULT_PROJECT)
+                        .projectName(bulkProjectName)
                         .output(item.evaluateTaskResult())
                         .startTime(now)
                         .endTime(now)
@@ -203,9 +220,13 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
                         .source(Source.EXPERIMENT)
                         .build();
             } else {
-                trace = item.trace().toBuilder()
-                        .source(Source.EXPERIMENT)
-                        .build();
+                var traceBuilder = item.trace().toBuilder()
+                        .source(Source.EXPERIMENT);
+                // An explicit trace without its own project inherits the bulk project.
+                if (StringUtils.isBlank(item.trace().projectName())) {
+                    traceBuilder.projectName(bulkProjectName);
+                }
+                trace = traceBuilder.build();
             }
 
             traces.add(trace);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
@@ -89,12 +89,14 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
                     ? projectName
                     : ProjectService.DEFAULT_PROJECT;
 
-            return validateExperimentConsistency(experiment, workspaceId)
+            return validateExperimentConsistency(experiment)
                     .then(experimentService.create(experiment))
                     .retryWhen(RetryUtils.handleConnectionError())
                     .flatMap(experimentId -> {
-                        log.info("Using experiment with id '{}', name '{}', datasetName '{}', workspaceId '{}'",
-                                experimentId, experiment.name(), experiment.datasetName(), workspaceId);
+                        log.info(
+                                "Using experiment with id '{}', name '{}', datasetName '{}', projectName '{}', workspaceId '{}'",
+                                experimentId, experiment.name(), experiment.datasetName(), experiment.projectName(),
+                                workspaceId);
 
                         // Collect unique project names: the bulk project (for auto-created traces and
                         // traces without a project), plus any project specified on item-level traces.
@@ -146,7 +148,7 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
         });
     }
 
-    private Mono<Void> validateExperimentConsistency(Experiment experiment, String workspaceId) {
+    private Mono<Void> validateExperimentConsistency(Experiment experiment) {
         if (experiment.id() == null) {
             return Mono.empty(); // New experiment, no validation needed
         }
@@ -245,8 +247,13 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
             experimentItems.add(build);
 
             if (CollectionUtils.isNotEmpty(item.spans())) {
+                // Spans belong to the item's trace (enforced by ExperimentItemBulkValidator), so they must
+                // share its resolved project — otherwise span data would diverge from the trace's project.
                 List<Span> experimentSpans = item.spans().stream()
-                        .map(span -> span.toBuilder().source(Source.EXPERIMENT).build())
+                        .map(span -> span.toBuilder()
+                                .source(Source.EXPERIMENT)
+                                .projectName(trace.projectName())
+                                .build())
                         .toList();
 
                 spans.addAll(experimentSpans);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
@@ -160,6 +161,23 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
                         String errorMessage = "Experiment '%s' belongs to dataset '%s', but request specifies dataset '%s'"
                                 .formatted(experiment.id(), existingExperiment.datasetName(), experiment.datasetName());
                         return Mono.error(new ClientErrorException(errorMessage, Response.Status.CONFLICT));
+                    }
+
+                    // Validate project consistency: a request-level project_name must match the existing
+                    // experiment's project, otherwise items would be split across projects.
+                    if (StringUtils.isNotBlank(experiment.projectName())) {
+                        return projectService.resolveProjectId(experiment.projectName())
+                                .flatMap(resolvedProjectId -> {
+                                    if (!Optional.ofNullable(existingExperiment.projectId())
+                                            .equals(resolvedProjectId)) {
+                                        String errorMessage = "Experiment '%s' belongs to project '%s', but request specifies project_name '%s'"
+                                                .formatted(experiment.id(), existingExperiment.projectName(),
+                                                        experiment.projectName());
+                                        return Mono.<Void>error(
+                                                new ClientErrorException(errorMessage, Response.Status.CONFLICT));
+                                    }
+                                    return Mono.<Void>empty();
+                                });
                     }
 
                     return Mono.<Void>empty();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ExperimentTestAssertions.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ExperimentTestAssertions.java
@@ -7,8 +7,10 @@ import com.comet.opik.api.resources.utils.CommentAssertionUtils;
 import com.comet.opik.api.resources.utils.StatsUtils;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,6 +20,13 @@ public class ExperimentTestAssertions {
             "feedbackScores.createdAt", "feedbackScores.lastUpdatedAt", "comments.createdAt", "comments.lastUpdatedAt",
             "feedbackScores.valueByAuthor", "projectName"
     };
+
+    // Experiment items returned by the bulk endpoint get server-generated ids/traceId/experimentId, so those
+    // are ignored on top of the base ignored fields. projectId is intentionally NOT ignored — it is asserted.
+    public static final String[] BULK_EXPERIMENT_ITEMS_IGNORED_FIELDS = Stream.concat(
+            Arrays.stream(EXPERIMENT_ITEMS_IGNORED_FIELDS),
+            Stream.of("traceId", "id", "experimentId"))
+            .toArray(String[]::new);
 
     public static final String[] EXPERIMENT_IGNORED_FIELDS = new String[]{
             "id", "datasetId", "name", "feedbackScores", "assertionScores", "traceCount", "createdAt",

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -6895,11 +6895,12 @@ class ExperimentsResourceTest {
                     actualExperimentItems.getFirst().experimentId(), API_KEY, TEST_WORKSPACE);
             assertThat(experiment.projectId()).isEqualTo(projectId);
 
-            // the dataset was created
+            // the dataset was created in the requested project
             Dataset dataset = datasetResourceClient.getDatasetByIdentifier(
                     DatasetIdentifier.builder().datasetName(datasetName).build(), API_KEY, TEST_WORKSPACE);
             assertThat(dataset).isNotNull();
             assertThat(dataset.name()).isEqualTo(datasetName);
+            assertThat(dataset.projectId()).isEqualTo(projectId);
 
             // and the auto-created trace landed in the same project
             Trace trace = traceResourceClient.getById(actualExperimentItems.getFirst().traceId(), TEST_WORKSPACE,
@@ -6961,6 +6962,60 @@ class ExperimentsResourceTest {
 
             Span actualSpan = spanResourceClient.getById(span.id(), TEST_WORKSPACE, API_KEY);
             assertThat(actualSpan.projectId()).isEqualTo(projectId);
+        }
+
+        @Test
+        @DisplayName("when experimentId points to an existing experiment and a different project_name is provided, then return conflict")
+        void experimentItemsBulk__whenExistingExperimentAndMismatchedProjectName__thenReturnConflict() {
+            // given
+            var dataset = buildDataset();
+            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
+            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
+                    .datasetId(datasetId)
+                    .build();
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder().datasetName(dataset.name())
+                            .items(List.of(datasetItem)).build(),
+                    TEST_WORKSPACE, API_KEY);
+
+            var projectA = "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
+            var projectB = "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
+            projectResourceClient.createProject(projectB, API_KEY, TEST_WORKSPACE);
+
+            var experimentId = podamFactory.manufacturePojo(UUID.class);
+            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+
+            // create the experiment in project A via a first bulk upload
+            experimentResourceClient.bulkUploadExperimentItem(
+                    ExperimentItemBulkUpload.builder()
+                            .experimentId(experimentId)
+                            .experimentName(experimentName)
+                            .datasetName(dataset.name())
+                            .projectName(projectA)
+                            .items(List.of(ExperimentItemBulkRecord.builder()
+                                    .datasetItemId(datasetItem.id())
+                                    .evaluateTaskResult(JsonUtils.readTree("{\"answer\": \"42\"}"))
+                                    .build()))
+                            .build(),
+                    API_KEY, TEST_WORKSPACE);
+
+            // when — upload again to the same experiment but with a different project
+            var mismatched = ExperimentItemBulkUpload.builder()
+                    .experimentId(experimentId)
+                    .experimentName(experimentName)
+                    .datasetName(dataset.name())
+                    .projectName(projectB)
+                    .items(List.of(ExperimentItemBulkRecord.builder()
+                            .datasetItemId(datasetItem.id())
+                            .evaluateTaskResult(JsonUtils.readTree("{\"answer\": \"43\"}"))
+                            .build()))
+                    .build();
+
+            try (var response = experimentResourceClient.callExperimentItemBulkUpload(mismatched, API_KEY,
+                    TEST_WORKSPACE)) {
+                // then
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
+            }
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -4,6 +4,7 @@ import com.comet.opik.api.AssertionResult;
 import com.comet.opik.api.AssertionScoreAverage;
 import com.comet.opik.api.Comment;
 import com.comet.opik.api.Dataset;
+import com.comet.opik.api.DatasetIdentifier;
 import com.comet.opik.api.DatasetItem;
 import com.comet.opik.api.DatasetItemBatch;
 import com.comet.opik.api.DatasetItemChanges;
@@ -6854,6 +6855,56 @@ class ExperimentsResourceTest {
             Trace actualTrace = traceResourceClient.getById(actualExperimentItems.getFirst().traceId(), TEST_WORKSPACE,
                     API_KEY);
             assertThat(actualTrace.projectId()).isEqualTo(projectId);
+        }
+
+        @Test
+        @DisplayName("when project_name is provided and the experiment and dataset don't exist, then both are created in that project")
+        void experimentItemsBulk__whenProjectNameProvidedAndExperimentAndDatasetDoNotExist__thenBothCreatedInProject() {
+            // given — project exists (so we know its id), but dataset and experiment do not
+            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
+            UUID projectId = projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
+
+            var datasetName = "dataset-" + RandomStringUtils.secure().nextAlphanumeric(20);
+            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+
+            var bulkUploadRequest = ExperimentItemBulkUpload.builder()
+                    .experimentName(experimentName)
+                    .datasetName(datasetName)
+                    .projectName(projectName)
+                    .items(List.of(ExperimentItemBulkRecord.builder()
+                            .datasetItemId(podamFactory.manufacturePojo(UUID.class))
+                            .evaluateTaskResult(JsonUtils.readTree("{\"answer\": \"42\"}"))
+                            .feedbackScores(List.of(createScore()))
+                            .build()))
+                    .build();
+
+            // when
+            try (var response = experimentResourceClient.callExperimentItemBulkUpload(bulkUploadRequest, API_KEY,
+                    TEST_WORKSPACE)) {
+                // then
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+                assertThat(response.getHeaderString(RequestContext.WORKSPACE_FALLBACK_HEADER)).isNull();
+            }
+
+            List<ExperimentItem> actualExperimentItems = experimentResourceClient.getExperimentItems(experimentName,
+                    API_KEY, TEST_WORKSPACE);
+            assertThat(actualExperimentItems).hasSize(1);
+
+            // the experiment was created in the requested project
+            Experiment experiment = experimentResourceClient.getExperiment(
+                    actualExperimentItems.getFirst().experimentId(), API_KEY, TEST_WORKSPACE);
+            assertThat(experiment.projectId()).isEqualTo(projectId);
+
+            // the dataset was created
+            Dataset dataset = datasetResourceClient.getDatasetByIdentifier(
+                    DatasetIdentifier.builder().datasetName(datasetName).build(), API_KEY, TEST_WORKSPACE);
+            assertThat(dataset).isNotNull();
+            assertThat(dataset.name()).isEqualTo(datasetName);
+
+            // and the auto-created trace landed in the same project
+            Trace trace = traceResourceClient.getById(actualExperimentItems.getFirst().traceId(), TEST_WORKSPACE,
+                    API_KEY);
+            assertThat(trace.projectId()).isEqualTo(projectId);
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -6908,6 +6908,62 @@ class ExperimentsResourceTest {
         }
 
         @Test
+        @DisplayName("when project_name is provided and an item has spans, then the spans land in the request project (same as their trace)")
+        void experimentItemsBulk__whenProjectNameProvidedAndItemHasSpans__thenSpansLandInRequestProject() {
+            // given
+            var dataset = buildDataset();
+            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
+            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
+                    .datasetId(datasetId)
+                    .build();
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder().datasetName(dataset.name())
+                            .items(List.of(datasetItem)).build(),
+                    TEST_WORKSPACE, API_KEY);
+
+            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
+            UUID projectId = projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
+
+            // trace and span without their own project — both should inherit the request project
+            var trace = createTrace().toBuilder()
+                    .projectName(null)
+                    .projectId(null)
+                    .build();
+            var span = creatrSpan().toBuilder()
+                    .traceId(trace.id())
+                    .projectName(null)
+                    .projectId(null)
+                    .build();
+
+            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+            var bulkUploadRequest = ExperimentItemBulkUpload.builder()
+                    .experimentName(experimentName)
+                    .datasetName(dataset.name())
+                    .projectName(projectName)
+                    .items(List.of(ExperimentItemBulkRecord.builder()
+                            .datasetItemId(datasetItem.id())
+                            .trace(trace)
+                            .spans(List.of(span))
+                            .build()))
+                    .build();
+
+            // when
+            try (var response = experimentResourceClient.callExperimentItemBulkUpload(bulkUploadRequest, API_KEY,
+                    TEST_WORKSPACE)) {
+                // then
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+                assertThat(response.getHeaderString(RequestContext.WORKSPACE_FALLBACK_HEADER)).isNull();
+            }
+
+            // both the trace and its span land in the request project
+            Trace actualTrace = traceResourceClient.getById(trace.id(), TEST_WORKSPACE, API_KEY);
+            assertThat(actualTrace.projectId()).isEqualTo(projectId);
+
+            Span actualSpan = spanResourceClient.getById(span.id(), TEST_WORKSPACE, API_KEY);
+            assertThat(actualSpan.projectId()).isEqualTo(projectId);
+        }
+
+        @Test
         void experimentItemsBulk__whenProcessingBatchWithExceedLimit__thenReturnBadRequest() {
             // given
             var dataset = buildDataset();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -71,9 +71,11 @@ import com.comet.opik.api.sorting.SortableFields;
 import com.comet.opik.api.sorting.SortingField;
 import com.comet.opik.domain.DatasetEventInfoHolder;
 import com.comet.opik.domain.FeedbackScoreMapper;
+import com.comet.opik.domain.ProjectService;
 import com.comet.opik.domain.SpanType;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.auth.WorkspaceUserPermission;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.infrastructure.usagelimit.Quota;
@@ -6556,19 +6558,302 @@ class ExperimentsResourceTest {
             List<ExperimentItem> actualExperimentItems = experimentResourceClient.getExperimentItems(experimentName,
                     API_KEY, TEST_WORKSPACE);
 
-            String[] ignoringFields = Stream
-                    .concat(Arrays.stream(ExperimentTestAssertions.EXPERIMENT_ITEMS_IGNORED_FIELDS),
-                            Stream.of("traceId", "id", "experimentId"))
-                    .toArray(String[]::new);
+            // No project_name on the request: the auto-created trace and its experiment item land in the default project.
+            UUID defaultProjectId = projectResourceClient.getByName(ProjectService.DEFAULT_PROJECT, API_KEY,
+                    TEST_WORKSPACE).id();
+            expectedItems = expectedItems.stream()
+                    .map(item -> item.toBuilder().projectId(defaultProjectId).build())
+                    .toList();
 
             ExperimentTestAssertions.assertExperimentResultsIgnoringFields(actualExperimentItems, expectedItems,
-                    ignoringFields);
+                    ExperimentTestAssertions.BULK_EXPERIMENT_ITEMS_IGNORED_FIELDS);
 
             Trace trace = traceResourceClient.getById(actualExperimentItems.getFirst().traceId(), TEST_WORKSPACE,
                     API_KEY);
 
             assertThat(trace).isNotNull();
             assertThat(trace.visibilityMode()).isEqualTo(VisibilityMode.HIDDEN);
+        }
+
+        @Test
+        @DisplayName("when items have no trace and project_name is provided, then auto-created traces use that project without a deprecation header")
+        void experimentItemsBulk__whenNoTraceAndProjectNameProvided__thenTracesUseProjectAndNoDeprecationHeader() {
+            // given
+            var dataset = buildDataset();
+            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
+            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
+                    .datasetId(datasetId)
+                    .build();
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder().datasetName(dataset.name())
+                            .items(List.of(datasetItem)).build(),
+                    TEST_WORKSPACE, API_KEY);
+
+            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
+            UUID projectId = projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
+
+            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+            var bulkItemRecord = ExperimentItemBulkRecord.builder()
+                    .datasetItemId(datasetItem.id())
+                    .evaluateTaskResult(JsonUtils.readTree("{\"answer\": \"42\"}"))
+                    .feedbackScores(List.of(createScore()))
+                    .build();
+            var bulkUploadRequest = ExperimentItemBulkUpload.builder()
+                    .experimentName(experimentName)
+                    .datasetName(dataset.name())
+                    .projectName(projectName)
+                    .items(List.of(bulkItemRecord))
+                    .build();
+
+            // when
+            try (var response = experimentResourceClient.callExperimentItemBulkUpload(bulkUploadRequest, API_KEY,
+                    TEST_WORKSPACE)) {
+                // then
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+                assertThat(response.getHeaderString(RequestContext.WORKSPACE_FALLBACK_HEADER)).isNull();
+            }
+
+            List<ExperimentItem> actualExperimentItems = experimentResourceClient.getExperimentItems(experimentName,
+                    API_KEY, TEST_WORKSPACE);
+            assertThat(actualExperimentItems).hasSize(1);
+
+            Trace trace = traceResourceClient.getById(actualExperimentItems.getFirst().traceId(), TEST_WORKSPACE,
+                    API_KEY);
+            assertThat(trace.projectId()).isEqualTo(projectId);
+            assertThat(trace.visibilityMode()).isEqualTo(VisibilityMode.HIDDEN);
+        }
+
+        @Test
+        @DisplayName("when items have no trace and no project_name, then auto-created traces use the default project and a deprecation header is returned")
+        void experimentItemsBulk__whenNoTraceAndNoProjectName__thenDefaultProjectAndDeprecationHeader() {
+            // given
+            var dataset = buildDataset();
+            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
+            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
+                    .datasetId(datasetId)
+                    .build();
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder().datasetName(dataset.name())
+                            .items(List.of(datasetItem)).build(),
+                    TEST_WORKSPACE, API_KEY);
+
+            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+            var bulkItemRecord = ExperimentItemBulkRecord.builder()
+                    .datasetItemId(datasetItem.id())
+                    .evaluateTaskResult(JsonUtils.readTree("{\"answer\": \"42\"}"))
+                    .feedbackScores(List.of(createScore()))
+                    .build();
+            var bulkUploadRequest = ExperimentItemBulkUpload.builder()
+                    .experimentName(experimentName)
+                    .datasetName(dataset.name())
+                    .items(List.of(bulkItemRecord))
+                    .build();
+
+            // when
+            try (var response = experimentResourceClient.callExperimentItemBulkUpload(bulkUploadRequest, API_KEY,
+                    TEST_WORKSPACE)) {
+                // then
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+                assertThat(response.getHeaderString(RequestContext.WORKSPACE_FALLBACK_HEADER))
+                        .isNotNull()
+                        .contains(ProjectService.DEFAULT_PROJECT);
+            }
+
+            List<ExperimentItem> actualExperimentItems = experimentResourceClient.getExperimentItems(experimentName,
+                    API_KEY, TEST_WORKSPACE);
+            assertThat(actualExperimentItems).hasSize(1);
+
+            Project defaultProject = projectResourceClient.getByName(ProjectService.DEFAULT_PROJECT, API_KEY,
+                    TEST_WORKSPACE);
+            Trace trace = traceResourceClient.getById(actualExperimentItems.getFirst().traceId(), TEST_WORKSPACE,
+                    API_KEY);
+            assertThat(trace.projectId()).isEqualTo(defaultProject.id());
+        }
+
+        @Test
+        @DisplayName("when project_name is provided on the request but not on an item trace, then the trace inherits the request project")
+        void experimentItemsBulk__whenProjectNameOnRequestButNotOnTrace__thenTraceInheritsRequestProject() {
+            // given
+            var dataset = buildDataset();
+            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
+            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
+                    .datasetId(datasetId)
+                    .build();
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder().datasetName(dataset.name())
+                            .items(List.of(datasetItem)).build(),
+                    TEST_WORKSPACE, API_KEY);
+
+            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
+            UUID projectId = projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
+
+            // explicit trace without its own project_name
+            var trace = createTrace().toBuilder()
+                    .projectName(null)
+                    .projectId(null)
+                    .build();
+
+            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+            var bulkItemRecord = ExperimentItemBulkRecord.builder()
+                    .datasetItemId(datasetItem.id())
+                    .trace(trace)
+                    .feedbackScores(List.of(createScore()))
+                    .build();
+            var bulkUploadRequest = ExperimentItemBulkUpload.builder()
+                    .experimentName(experimentName)
+                    .datasetName(dataset.name())
+                    .projectName(projectName)
+                    .items(List.of(bulkItemRecord))
+                    .build();
+
+            // when
+            try (var response = experimentResourceClient.callExperimentItemBulkUpload(bulkUploadRequest, API_KEY,
+                    TEST_WORKSPACE)) {
+                // then
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+                assertThat(response.getHeaderString(RequestContext.WORKSPACE_FALLBACK_HEADER)).isNull();
+            }
+
+            List<ExperimentItem> actualExperimentItems = experimentResourceClient.getExperimentItems(experimentName,
+                    API_KEY, TEST_WORKSPACE);
+            assertThat(actualExperimentItems).hasSize(1);
+
+            Trace actualTrace = traceResourceClient.getById(actualExperimentItems.getFirst().traceId(), TEST_WORKSPACE,
+                    API_KEY);
+            assertThat(actualTrace.projectId()).isEqualTo(projectId);
+        }
+
+        @Test
+        @DisplayName("when an item trace project_name differs from the request project_name, then return unprocessable entity")
+        void experimentItemsBulk__whenTraceProjectNameMismatchesRequestProjectName__thenReturnUnprocessableEntity() {
+            // given
+            var requestProjectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
+            var trace = createTrace().toBuilder()
+                    .projectName("other-" + RandomStringUtils.secure().nextAlphanumeric(20))
+                    .build();
+
+            var bulkUploadRequest = ExperimentItemBulkUpload.builder()
+                    .experimentName("Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(8))
+                    .datasetName("Test Dataset")
+                    .projectName(requestProjectName)
+                    .items(List.of(ExperimentItemBulkRecord.builder()
+                            .datasetItemId(UUID.randomUUID())
+                            .trace(trace)
+                            .build()))
+                    .build();
+
+            // when
+            try (var response = experimentResourceClient.callExperimentItemBulkUpload(bulkUploadRequest, API_KEY,
+                    TEST_WORKSPACE)) {
+                // then
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+                var errorMessage = response.readEntity(com.comet.opik.api.error.ErrorMessage.class);
+                assertThat(errorMessage.errors())
+                        .contains("items trace project_name must match the request project_name");
+            }
+        }
+
+        @Test
+        @DisplayName("when no project_name and an item trace has no project, then the trace lands in the default project with a deprecation header")
+        void experimentItemsBulk__whenNoProjectNameAndTraceWithoutProject__thenDefaultProjectAndDeprecationHeader() {
+            // given
+            var dataset = buildDataset();
+            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
+            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
+                    .datasetId(datasetId)
+                    .build();
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder().datasetName(dataset.name())
+                            .items(List.of(datasetItem)).build(),
+                    TEST_WORKSPACE, API_KEY);
+
+            // explicit trace without its own project_name and no request-level project_name
+            var trace = createTrace().toBuilder()
+                    .projectName(null)
+                    .projectId(null)
+                    .build();
+
+            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+            var bulkUploadRequest = ExperimentItemBulkUpload.builder()
+                    .experimentName(experimentName)
+                    .datasetName(dataset.name())
+                    .items(List.of(ExperimentItemBulkRecord.builder()
+                            .datasetItemId(datasetItem.id())
+                            .trace(trace)
+                            .feedbackScores(List.of(createScore()))
+                            .build()))
+                    .build();
+
+            // when
+            try (var response = experimentResourceClient.callExperimentItemBulkUpload(bulkUploadRequest, API_KEY,
+                    TEST_WORKSPACE)) {
+                // then
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+                assertThat(response.getHeaderString(RequestContext.WORKSPACE_FALLBACK_HEADER))
+                        .isNotNull()
+                        .contains(ProjectService.DEFAULT_PROJECT);
+            }
+
+            List<ExperimentItem> actualExperimentItems = experimentResourceClient.getExperimentItems(experimentName,
+                    API_KEY, TEST_WORKSPACE);
+            assertThat(actualExperimentItems).hasSize(1);
+
+            Project defaultProject = projectResourceClient.getByName(ProjectService.DEFAULT_PROJECT, API_KEY,
+                    TEST_WORKSPACE);
+            Trace actualTrace = traceResourceClient.getById(actualExperimentItems.getFirst().traceId(), TEST_WORKSPACE,
+                    API_KEY);
+            assertThat(actualTrace.projectId()).isEqualTo(defaultProject.id());
+        }
+
+        @Test
+        @DisplayName("when no project_name but an item trace has its own project, then the trace keeps its project and no deprecation header is returned")
+        void experimentItemsBulk__whenNoProjectNameButTraceHasOwnProject__thenTraceKeepsProjectAndNoDeprecationHeader() {
+            // given
+            var dataset = buildDataset();
+            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
+            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
+                    .datasetId(datasetId)
+                    .build();
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder().datasetName(dataset.name())
+                            .items(List.of(datasetItem)).build(),
+                    TEST_WORKSPACE, API_KEY);
+
+            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
+            UUID projectId = projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
+
+            // trace carries its own project and there is no request-level project_name -> no fallback, no warning
+            var trace = createTrace().toBuilder()
+                    .projectName(projectName)
+                    .projectId(null)
+                    .build();
+
+            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+            var bulkUploadRequest = ExperimentItemBulkUpload.builder()
+                    .experimentName(experimentName)
+                    .datasetName(dataset.name())
+                    .items(List.of(ExperimentItemBulkRecord.builder()
+                            .datasetItemId(datasetItem.id())
+                            .trace(trace)
+                            .feedbackScores(List.of(createScore()))
+                            .build()))
+                    .build();
+
+            // when
+            try (var response = experimentResourceClient.callExperimentItemBulkUpload(bulkUploadRequest, API_KEY,
+                    TEST_WORKSPACE)) {
+                // then
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+                assertThat(response.getHeaderString(RequestContext.WORKSPACE_FALLBACK_HEADER)).isNull();
+            }
+
+            List<ExperimentItem> actualExperimentItems = experimentResourceClient.getExperimentItems(experimentName,
+                    API_KEY, TEST_WORKSPACE);
+            assertThat(actualExperimentItems).hasSize(1);
+
+            Trace actualTrace = traceResourceClient.getById(actualExperimentItems.getFirst().traceId(), TEST_WORKSPACE,
+                    API_KEY);
+            assertThat(actualTrace.projectId()).isEqualTo(projectId);
         }
 
         @Test
@@ -6812,13 +7097,15 @@ class ExperimentsResourceTest {
             List<ExperimentItem> actualExperimentItems = experimentResourceClient.getExperimentItems(experimentName,
                     API_KEY, TEST_WORKSPACE);
 
-            String[] ignoringFields = Stream
-                    .concat(Arrays.stream(ExperimentTestAssertions.EXPERIMENT_ITEMS_IGNORED_FIELDS),
-                            Stream.of("traceId", "id", "experimentId"))
-                    .toArray(String[]::new);
+            // No project_name on the request: the auto-created trace and its experiment item land in the default project.
+            UUID defaultProjectId = projectResourceClient.getByName(ProjectService.DEFAULT_PROJECT, API_KEY,
+                    TEST_WORKSPACE).id();
+            expectedItems = expectedItems.stream()
+                    .map(item -> item.toBuilder().projectId(defaultProjectId).build())
+                    .toList();
 
             ExperimentTestAssertions.assertExperimentResultsIgnoringFields(actualExperimentItems, expectedItems,
-                    ignoringFields);
+                    ExperimentTestAssertions.BULK_EXPERIMENT_ITEMS_IGNORED_FIELDS);
 
             Trace trace = traceResourceClient.getById(actualExperimentItems.getFirst().traceId(), TEST_WORKSPACE,
                     API_KEY);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -6495,6 +6495,30 @@ class ExperimentsResourceTest {
                     .build();
         }
 
+        private record BulkDataset(String datasetName, DatasetItem item) {
+        }
+
+        private BulkDataset createDatasetWithItem() {
+            var dataset = buildDataset();
+            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
+            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
+                    .datasetId(datasetId)
+                    .build();
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder().datasetName(dataset.name())
+                            .items(List.of(datasetItem)).build(),
+                    TEST_WORKSPACE, API_KEY);
+            return new BulkDataset(dataset.name(), datasetItem);
+        }
+
+        private String newExperimentName() {
+            return "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+        }
+
+        private String newProjectName() {
+            return "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
+        }
+
         private Span creatrSpan() {
             Instant now = Instant.now();
             return podamFactory.manufacturePojo(Span.class).toBuilder()
@@ -6522,33 +6546,21 @@ class ExperimentsResourceTest {
         @Test
         void experimentItemsBulk__whenProcessingBatchWithNoTraceButWithFeedbackScores__thenReturnNoContent() {
             // given
-            var dataset = buildDataset();
-            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
-            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
-                    .datasetId(datasetId)
-                    .build();
-
-            datasetResourceClient.createDatasetItems(
-                    DatasetItemBatch.builder().datasetName(dataset.name())
-                            .items(List.of(datasetItem)).build(),
-                    TEST_WORKSPACE,
-                    API_KEY);
-
-            // Create a bulk upload request with a single item
+            var datasetWithItem = createDatasetWithItem();
 
             var feedbackScore = createScore();
 
-            List<ExperimentItem> expectedItems = getExpectedItem(datasetItem, null, feedbackScore, null);
+            List<ExperimentItem> expectedItems = getExpectedItem(datasetWithItem.item(), null, feedbackScore, null);
 
-            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+            var experimentName = newExperimentName();
             var bulkItemRecord = ExperimentItemBulkRecord.builder()
-                    .datasetItemId(datasetItem.id())
+                    .datasetItemId(datasetWithItem.item().id())
                     .feedbackScores(List.of(feedbackScore))
                     .build();
 
             var bulkUploadRequest = ExperimentItemBulkUpload.builder()
                     .experimentName(experimentName)
-                    .datasetName(dataset.name())
+                    .datasetName(datasetWithItem.datasetName())
                     .items(List.of(bulkItemRecord))
                     .build();
 
@@ -6580,28 +6592,20 @@ class ExperimentsResourceTest {
         @DisplayName("when items have no trace and project_name is provided, then auto-created traces use that project without a deprecation header")
         void experimentItemsBulk__whenNoTraceAndProjectNameProvided__thenTracesUseProjectAndNoDeprecationHeader() {
             // given
-            var dataset = buildDataset();
-            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
-            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
-                    .datasetId(datasetId)
-                    .build();
-            datasetResourceClient.createDatasetItems(
-                    DatasetItemBatch.builder().datasetName(dataset.name())
-                            .items(List.of(datasetItem)).build(),
-                    TEST_WORKSPACE, API_KEY);
+            var datasetWithItem = createDatasetWithItem();
 
-            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
+            var projectName = newProjectName();
             UUID projectId = projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
 
-            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+            var experimentName = newExperimentName();
             var bulkItemRecord = ExperimentItemBulkRecord.builder()
-                    .datasetItemId(datasetItem.id())
+                    .datasetItemId(datasetWithItem.item().id())
                     .evaluateTaskResult(JsonUtils.readTree("{\"answer\": \"42\"}"))
                     .feedbackScores(List.of(createScore()))
                     .build();
             var bulkUploadRequest = ExperimentItemBulkUpload.builder()
                     .experimentName(experimentName)
-                    .datasetName(dataset.name())
+                    .datasetName(datasetWithItem.datasetName())
                     .projectName(projectName)
                     .items(List.of(bulkItemRecord))
                     .build();
@@ -6628,25 +6632,17 @@ class ExperimentsResourceTest {
         @DisplayName("when items have no trace and no project_name, then auto-created traces use the default project and a deprecation header is returned")
         void experimentItemsBulk__whenNoTraceAndNoProjectName__thenDefaultProjectAndDeprecationHeader() {
             // given
-            var dataset = buildDataset();
-            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
-            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
-                    .datasetId(datasetId)
-                    .build();
-            datasetResourceClient.createDatasetItems(
-                    DatasetItemBatch.builder().datasetName(dataset.name())
-                            .items(List.of(datasetItem)).build(),
-                    TEST_WORKSPACE, API_KEY);
+            var datasetWithItem = createDatasetWithItem();
 
-            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+            var experimentName = newExperimentName();
             var bulkItemRecord = ExperimentItemBulkRecord.builder()
-                    .datasetItemId(datasetItem.id())
+                    .datasetItemId(datasetWithItem.item().id())
                     .evaluateTaskResult(JsonUtils.readTree("{\"answer\": \"42\"}"))
                     .feedbackScores(List.of(createScore()))
                     .build();
             var bulkUploadRequest = ExperimentItemBulkUpload.builder()
                     .experimentName(experimentName)
-                    .datasetName(dataset.name())
+                    .datasetName(datasetWithItem.datasetName())
                     .items(List.of(bulkItemRecord))
                     .build();
 
@@ -6675,17 +6671,9 @@ class ExperimentsResourceTest {
         @DisplayName("when project_name is provided on the request but not on an item trace, then the trace inherits the request project")
         void experimentItemsBulk__whenProjectNameOnRequestButNotOnTrace__thenTraceInheritsRequestProject() {
             // given
-            var dataset = buildDataset();
-            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
-            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
-                    .datasetId(datasetId)
-                    .build();
-            datasetResourceClient.createDatasetItems(
-                    DatasetItemBatch.builder().datasetName(dataset.name())
-                            .items(List.of(datasetItem)).build(),
-                    TEST_WORKSPACE, API_KEY);
+            var datasetWithItem = createDatasetWithItem();
 
-            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
+            var projectName = newProjectName();
             UUID projectId = projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
 
             // explicit trace without its own project_name
@@ -6694,15 +6682,15 @@ class ExperimentsResourceTest {
                     .projectId(null)
                     .build();
 
-            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+            var experimentName = newExperimentName();
             var bulkItemRecord = ExperimentItemBulkRecord.builder()
-                    .datasetItemId(datasetItem.id())
+                    .datasetItemId(datasetWithItem.item().id())
                     .trace(trace)
                     .feedbackScores(List.of(createScore()))
                     .build();
             var bulkUploadRequest = ExperimentItemBulkUpload.builder()
                     .experimentName(experimentName)
-                    .datasetName(dataset.name())
+                    .datasetName(datasetWithItem.datasetName())
                     .projectName(projectName)
                     .items(List.of(bulkItemRecord))
                     .build();
@@ -6728,17 +6716,17 @@ class ExperimentsResourceTest {
         @DisplayName("when an item trace project_name differs from the request project_name, then return unprocessable entity")
         void experimentItemsBulk__whenTraceProjectNameMismatchesRequestProjectName__thenReturnUnprocessableEntity() {
             // given
-            var requestProjectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
+            var requestProjectName = newProjectName();
             var trace = createTrace().toBuilder()
                     .projectName("other-" + RandomStringUtils.secure().nextAlphanumeric(20))
                     .build();
 
             var bulkUploadRequest = ExperimentItemBulkUpload.builder()
-                    .experimentName("Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(8))
+                    .experimentName(newExperimentName())
                     .datasetName("Test Dataset")
                     .projectName(requestProjectName)
                     .items(List.of(ExperimentItemBulkRecord.builder()
-                            .datasetItemId(UUID.randomUUID())
+                            .datasetItemId(podamFactory.manufacturePojo(UUID.class))
                             .trace(trace)
                             .build()))
                     .build();
@@ -6758,15 +6746,7 @@ class ExperimentsResourceTest {
         @DisplayName("when no project_name and an item trace has no project, then the trace lands in the default project with a deprecation header")
         void experimentItemsBulk__whenNoProjectNameAndTraceWithoutProject__thenDefaultProjectAndDeprecationHeader() {
             // given
-            var dataset = buildDataset();
-            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
-            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
-                    .datasetId(datasetId)
-                    .build();
-            datasetResourceClient.createDatasetItems(
-                    DatasetItemBatch.builder().datasetName(dataset.name())
-                            .items(List.of(datasetItem)).build(),
-                    TEST_WORKSPACE, API_KEY);
+            var datasetWithItem = createDatasetWithItem();
 
             // explicit trace without its own project_name and no request-level project_name
             var trace = createTrace().toBuilder()
@@ -6774,12 +6754,12 @@ class ExperimentsResourceTest {
                     .projectId(null)
                     .build();
 
-            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+            var experimentName = newExperimentName();
             var bulkUploadRequest = ExperimentItemBulkUpload.builder()
                     .experimentName(experimentName)
-                    .datasetName(dataset.name())
+                    .datasetName(datasetWithItem.datasetName())
                     .items(List.of(ExperimentItemBulkRecord.builder()
-                            .datasetItemId(datasetItem.id())
+                            .datasetItemId(datasetWithItem.item().id())
                             .trace(trace)
                             .feedbackScores(List.of(createScore()))
                             .build()))
@@ -6810,17 +6790,9 @@ class ExperimentsResourceTest {
         @DisplayName("when no project_name but an item trace has its own project, then the trace keeps its project and no deprecation header is returned")
         void experimentItemsBulk__whenNoProjectNameButTraceHasOwnProject__thenTraceKeepsProjectAndNoDeprecationHeader() {
             // given
-            var dataset = buildDataset();
-            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
-            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
-                    .datasetId(datasetId)
-                    .build();
-            datasetResourceClient.createDatasetItems(
-                    DatasetItemBatch.builder().datasetName(dataset.name())
-                            .items(List.of(datasetItem)).build(),
-                    TEST_WORKSPACE, API_KEY);
+            var datasetWithItem = createDatasetWithItem();
 
-            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
+            var projectName = newProjectName();
             UUID projectId = projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
 
             // trace carries its own project and there is no request-level project_name -> no fallback, no warning
@@ -6829,12 +6801,12 @@ class ExperimentsResourceTest {
                     .projectId(null)
                     .build();
 
-            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+            var experimentName = newExperimentName();
             var bulkUploadRequest = ExperimentItemBulkUpload.builder()
                     .experimentName(experimentName)
-                    .datasetName(dataset.name())
+                    .datasetName(datasetWithItem.datasetName())
                     .items(List.of(ExperimentItemBulkRecord.builder()
-                            .datasetItemId(datasetItem.id())
+                            .datasetItemId(datasetWithItem.item().id())
                             .trace(trace)
                             .feedbackScores(List.of(createScore()))
                             .build()))
@@ -6861,11 +6833,11 @@ class ExperimentsResourceTest {
         @DisplayName("when project_name is provided and the experiment and dataset don't exist, then both are created in that project")
         void experimentItemsBulk__whenProjectNameProvidedAndExperimentAndDatasetDoNotExist__thenBothCreatedInProject() {
             // given — project exists (so we know its id), but dataset and experiment do not
-            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
+            var projectName = newProjectName();
             UUID projectId = projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
 
             var datasetName = "dataset-" + RandomStringUtils.secure().nextAlphanumeric(20);
-            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+            var experimentName = newExperimentName();
 
             var bulkUploadRequest = ExperimentItemBulkUpload.builder()
                     .experimentName(experimentName)
@@ -6912,17 +6884,9 @@ class ExperimentsResourceTest {
         @DisplayName("when project_name is provided and an item has spans, then the spans land in the request project (same as their trace)")
         void experimentItemsBulk__whenProjectNameProvidedAndItemHasSpans__thenSpansLandInRequestProject() {
             // given
-            var dataset = buildDataset();
-            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
-            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
-                    .datasetId(datasetId)
-                    .build();
-            datasetResourceClient.createDatasetItems(
-                    DatasetItemBatch.builder().datasetName(dataset.name())
-                            .items(List.of(datasetItem)).build(),
-                    TEST_WORKSPACE, API_KEY);
+            var datasetWithItem = createDatasetWithItem();
 
-            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
+            var projectName = newProjectName();
             UUID projectId = projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
 
             // trace and span without their own project — both should inherit the request project
@@ -6936,13 +6900,13 @@ class ExperimentsResourceTest {
                     .projectId(null)
                     .build();
 
-            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+            var experimentName = newExperimentName();
             var bulkUploadRequest = ExperimentItemBulkUpload.builder()
                     .experimentName(experimentName)
-                    .datasetName(dataset.name())
+                    .datasetName(datasetWithItem.datasetName())
                     .projectName(projectName)
                     .items(List.of(ExperimentItemBulkRecord.builder()
-                            .datasetItemId(datasetItem.id())
+                            .datasetItemId(datasetWithItem.item().id())
                             .trace(trace)
                             .spans(List.of(span))
                             .build()))
@@ -6968,32 +6932,24 @@ class ExperimentsResourceTest {
         @DisplayName("when experimentId points to an existing experiment and a different project_name is provided, then return conflict")
         void experimentItemsBulk__whenExistingExperimentAndMismatchedProjectName__thenReturnConflict() {
             // given
-            var dataset = buildDataset();
-            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
-            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
-                    .datasetId(datasetId)
-                    .build();
-            datasetResourceClient.createDatasetItems(
-                    DatasetItemBatch.builder().datasetName(dataset.name())
-                            .items(List.of(datasetItem)).build(),
-                    TEST_WORKSPACE, API_KEY);
+            var datasetWithItem = createDatasetWithItem();
 
-            var projectA = "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
-            var projectB = "project-" + RandomStringUtils.secure().nextAlphanumeric(20);
+            var projectA = newProjectName();
+            var projectB = newProjectName();
             projectResourceClient.createProject(projectB, API_KEY, TEST_WORKSPACE);
 
             var experimentId = podamFactory.manufacturePojo(UUID.class);
-            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+            var experimentName = newExperimentName();
 
             // create the experiment in project A via a first bulk upload
             experimentResourceClient.bulkUploadExperimentItem(
                     ExperimentItemBulkUpload.builder()
                             .experimentId(experimentId)
                             .experimentName(experimentName)
-                            .datasetName(dataset.name())
+                            .datasetName(datasetWithItem.datasetName())
                             .projectName(projectA)
                             .items(List.of(ExperimentItemBulkRecord.builder()
-                                    .datasetItemId(datasetItem.id())
+                                    .datasetItemId(datasetWithItem.item().id())
                                     .evaluateTaskResult(JsonUtils.readTree("{\"answer\": \"42\"}"))
                                     .build()))
                             .build(),
@@ -7003,10 +6959,10 @@ class ExperimentsResourceTest {
             var mismatched = ExperimentItemBulkUpload.builder()
                     .experimentId(experimentId)
                     .experimentName(experimentName)
-                    .datasetName(dataset.name())
+                    .datasetName(datasetWithItem.datasetName())
                     .projectName(projectB)
                     .items(List.of(ExperimentItemBulkRecord.builder()
-                            .datasetItemId(datasetItem.id())
+                            .datasetItemId(datasetWithItem.item().id())
                             .evaluateTaskResult(JsonUtils.readTree("{\"answer\": \"43\"}"))
                             .build()))
                     .build();
@@ -7220,37 +7176,28 @@ class ExperimentsResourceTest {
         @Test
         void experimentItemsBulk__whenOnlyEvaluateTaskResultProvided__thenSucceed() {
             // given
-            var dataset = buildDataset();
-            var datasetId = datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
-            var datasetItem = podamFactory.manufacturePojo(DatasetItem.class).toBuilder()
-                    .datasetId(datasetId)
-                    .build();
-
-            datasetResourceClient.createDatasetItems(
-                    DatasetItemBatch.builder().datasetName(dataset.name())
-                            .items(List.of(datasetItem)).build(),
-                    TEST_WORKSPACE,
-                    API_KEY);
+            var datasetWithItem = createDatasetWithItem();
 
             // Create a bulk upload request with only evaluateTaskResult
             var evaluateTaskResult = podamFactory.manufacturePojo(JsonNode.class);
-            var experimentName = "Test Experiment " + RandomStringUtils.secure().nextAlphanumeric(20);
+            var experimentName = newExperimentName();
 
             var feedbackScore = createScore();
 
             var bulkItemRecord = ExperimentItemBulkRecord.builder()
-                    .datasetItemId(datasetItem.id())
+                    .datasetItemId(datasetWithItem.item().id())
                     .evaluateTaskResult(evaluateTaskResult)
                     .feedbackScores(List.of(feedbackScore))
                     .build();
 
             var bulkUploadRequest = ExperimentItemBulkUpload.builder()
                     .experimentName(experimentName)
-                    .datasetName(dataset.name())
+                    .datasetName(datasetWithItem.datasetName())
                     .items(List.of(bulkItemRecord))
                     .build();
 
-            List<ExperimentItem> expectedItems = getExpectedItem(datasetItem, null, feedbackScore, evaluateTaskResult);
+            List<ExperimentItem> expectedItems = getExpectedItem(datasetWithItem.item(), null, feedbackScore,
+                    evaluateTaskResult);
 
             // when
             experimentResourceClient.bulkUploadExperimentItem(bulkUploadRequest, API_KEY, TEST_WORKSPACE);


### PR DESCRIPTION
## Details

`experiment_items_bulk` items that use `evaluate_task_result` (no trace) had their auto-created hidden traces hardcoded to the Default Project, while the experiment lived in its own project. The async aggregation job then derived the aggregate's `project_id` from those traces, and the find query served the experiment from the aggregate path filtered by that project — so the experiment disappeared from its own project's view (and from `get_experiments_by_name(project_name=...)`) a few minutes after upload.

This PR adds an optional `project_name` on `ExperimentItemBulkUpload` and routes the whole bulk under one project — the experiment, the dataset (if created), the traces, and the spans.

- Add optional `project_name` on `ExperimentItemBulkUpload` (validated `@Pattern(NULL_OR_NOT_BLANK)`).
- Use it to create the experiment and the dataset (if they don't exist) in that project.
- Apply it to traces that don't carry their own project (auto-created, or explicit traces with a blank `project_name`); spans always inherit their trace's resolved project.
- Keep the Default-Project fallback when `project_name` is omitted, but return an `X-Opik-Deprecation` header only when a fallback actually occurred.
- Reject (422) a mismatch between request `project_name` and an item trace's `project_name` (bean-validation annotation).
- Reject (409) when `experimentId` targets an existing experiment whose project differs from a non-blank request `project_name`.
- Fix a pre-existing NPE in bulk validation when a trace is present with `null` spans.
- Experiment items now carry the resolved `project_id` (was `null` on the no-trace path).

Trace routing matrix:

| request `project_name` | item shape | trace lands in | `X-Opik-Deprecation` header? |
|---|---|---|---|
| set | no trace (`evaluate_task_result`) | request project | no |
| set | trace without a project | request project (inherited) | no |
| set | trace with a *different* project | — rejected (422) | — |
| (blank) | no trace | Default Project | yes |
| (blank) | trace without a project | Default Project (inherited) | yes |
| (blank) | trace with its own project | its own project | no |

Note: the SDK `experiment_items_bulk(project_name=...)` parameter follows from Fern regeneration of the backend OpenAPI.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6810

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: investigation, backend implementation, tests, PR description
- Human verification: behavior confirmed against live data; tests run locally (see Testing)

## Testing

`mvn test -Dtest='ExperimentsResourceTest$BulkUpload'` — 21/21 green (Testcontainers: ClickHouse/MySQL/Redis, local). `mvn spotless:check` clean; `mvn compile` / `test-compile` green.

Scenarios covered:

Project routing (with `project_name`):
- no-trace items (`evaluate_task_result`) → auto-created trace lands in the request project; no deprecation header.
- explicit trace without its own project → trace inherits the request project.
- item with spans → spans land in the request project (same as their trace).
- experiment and dataset don't exist → both created in the request project (asserts experiment `project_id`, dataset `project_id`, and trace `project_id`).

Fallback / deprecation (no `project_name`):
- no-trace items → Default Project + `X-Opik-Deprecation` header.
- explicit trace without its own project → Default Project (inherited) + `X-Opik-Deprecation` header.
- explicit trace with its own project → stays in its own project; no header (no fallback occurred).
- legacy no-trace round-trips (`evaluate_task_result` / feedback scores) → experiment items now carry the resolved `project_id`.

Rejections:
- item trace `project_name` differs from request `project_name` → 422 (bean validation).
- `experimentId` targets an existing experiment whose project differs from a non-blank request `project_name` → 409.

Regression:
- trace present with `null` spans no longer NPEs (pre-existing bug surfaced by the inherit path).

## Documentation

- The new request field is self-documented in the OpenAPI spec via the `@Schema` description on `ExperimentItemBulkUpload.projectName` (notes the Default-Project fallback is deprecated).
- Python/TS SDK reference for `experiment_items_bulk(project_name=...)` regenerates from the backend OpenAPI via Fern (follow-up).
- No separate docs-site (`apps/opik-documentation`) change required.