### PR TITLE
[OPIK-6761] [FE] feat: rework Optimization runs empty state to match Figma

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/optimizations/StudioTemplates/StudioTemplates.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/optimizations/StudioTemplates/StudioTemplates.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { useNavigate } from "@tanstack/react-router";
 import { SquareDashedMousePointer, MessageSquare } from "lucide-react";
-import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import { OPTIMIZATION_DEMO_TEMPLATES } from "@/constants/optimizations";
+import useNavigateToOptimizationStudio from "@/v2/pages-shared/optimizations/useNavigateToOptimizationStudio";
 import OptimizationTemplateCard from "./OptimizationTemplateCard";
 
 const TEMPLATE_ICONS: Record<
@@ -16,17 +15,7 @@ const TEMPLATE_ICONS: Record<
 };
 
 const StudioTemplates: React.FC = () => {
-  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
-  const activeProjectId = useActiveProjectId();
-  const navigate = useNavigate();
-
-  const handleTemplateClick = (templateId?: string) => {
-    navigate({
-      to: "/$workspaceName/projects/$projectId/optimizations/new",
-      params: { workspaceName, projectId: activeProjectId! },
-      search: templateId ? { template: templateId } : undefined,
-    });
-  };
+  const handleTemplateClick = useNavigateToOptimizationStudio();
 
   return (
     <div className="pt-4">

--- a/apps/opik-frontend/src/v2/pages-shared/optimizations/useNavigateToOptimizationStudio.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/optimizations/useNavigateToOptimizationStudio.ts
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+import { useNavigate } from "@tanstack/react-router";
+
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
+
+/**
+ * Shared navigation into the Optimization Studio wizard (project-scoped
+ * `/optimizations/new`), optionally pre-filling a demo template. Used by both
+ * the optimizations empty state and the studio templates row so the routing
+ * lives in a single place.
+ */
+const useNavigateToOptimizationStudio = () => {
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
+  const navigate = useNavigate();
+
+  return useCallback(
+    (templateId?: string) => {
+      navigate({
+        to: "/$workspaceName/projects/$projectId/optimizations/new",
+        params: { workspaceName, projectId: activeProjectId! },
+        search: templateId ? { template: templateId } : undefined,
+      });
+    },
+    [navigate, workspaceName, activeProjectId],
+  );
+};
+
+export default useNavigateToOptimizationStudio;

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsEmptyState.tsx
@@ -1,5 +1,10 @@
 import React from "react";
-import { SquareDashedMousePointer, Bot, ExternalLink } from "lucide-react";
+import {
+  BotMessageSquare,
+  SquareDashedMousePointer,
+  FileSliders,
+  ExternalLink,
+} from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { Button } from "@/ui/button";
@@ -11,11 +16,11 @@ import emptyOptStudioLightUrl from "/images/empty-optimization-studio-light.svg"
 import emptyOptStudioDarkUrl from "/images/empty-optimization-studio-dark.svg";
 
 type OptimizationsEmptyStateProps = {
-  onOptimizeClick: () => void;
+  onOptimizeViaSdkClick: () => void;
 };
 
 const OptimizationsEmptyState: React.FC<OptimizationsEmptyStateProps> = ({
-  onOptimizeClick,
+  onOptimizeViaSdkClick,
 }) => {
   const { themeMode } = useTheme();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
@@ -26,58 +31,72 @@ const OptimizationsEmptyState: React.FC<OptimizationsEmptyStateProps> = ({
       ? emptyOptStudioDarkUrl
       : emptyOptStudioLightUrl;
 
-  const handleDemoTemplateClick = () => {
+  const navigateToStudio = (templateId?: string) => {
     navigate({
       to: "/$workspaceName/projects/$projectId/optimizations/new",
       params: { workspaceName, projectId: activeProjectId! },
-      search: { template: "opik-chatbot" },
+      search: templateId ? { template: templateId } : undefined,
     });
   };
 
   return (
     <div className="flex min-h-full flex-1 items-center justify-center gap-16 px-6">
-      <div className="flex w-full max-w-lg flex-col gap-6">
+      <div className="flex w-full max-w-[480px] flex-col gap-4">
+        <h2 className="comet-title-s text-foreground">
+          No optimization runs yet
+        </h2>
+        <p className="comet-body-s text-muted-slate">
+          Try different prompt versions and see what performs best. Optimization
+          runs help you improve accuracy, consistency, and user experience.
+        </p>
         <div className="flex flex-col gap-2">
-          <h2 className="comet-title-s text-foreground">
-            No optimization runs yet
-          </h2>
-          <p className="comet-body-s text-muted-slate">
-            Try different prompt versions and see what performs best.
-            Optimization runs help you improve accuracy, consistency, and user
-            experience.
-          </p>
-        </div>
-        <div className="flex flex-col gap-3">
           <button
             type="button"
-            onClick={onOptimizeClick}
-            className="flex items-start gap-3 rounded-md border p-4 text-left transition-colors hover:border-primary hover:bg-primary-100"
+            onClick={() => navigateToStudio("opik-chatbot")}
+            className="flex flex-col gap-1 rounded-md border p-4 text-left transition-colors hover:border-primary hover:bg-primary-100"
           >
-            <SquareDashedMousePointer className="mt-0.5 size-5 shrink-0 text-chart-green" />
-            <div className="flex flex-col gap-0.5">
+            <span className="flex items-center gap-2">
+              <BotMessageSquare className="size-4 shrink-0 text-chart-blue" />
               <span className="comet-body-s-accented text-foreground">
-                Optimize your prompt
+                Run a demo example
               </span>
-              <span className="comet-body-s text-muted-slate">
-                Start from scratch and configure your own optimization setting
-              </span>
-            </div>
+            </span>
+            <span className="comet-body-xs text-muted-slate">
+              Start with a pre-configured optimization example for a support
+              chatbot.
+            </span>
           </button>
           <button
             type="button"
-            onClick={handleDemoTemplateClick}
-            className="flex items-start gap-3 rounded-md border p-4 text-left transition-colors hover:border-primary hover:bg-primary-100"
+            onClick={() => navigateToStudio()}
+            className="flex flex-col gap-1 rounded-md border p-4 text-left transition-colors hover:border-primary hover:bg-primary-100"
           >
-            <Bot className="mt-0.5 size-5 shrink-0 text-chart-burgundy" />
-            <div className="flex flex-col gap-0.5">
+            <span className="flex items-center gap-2">
+              <SquareDashedMousePointer className="size-4 shrink-0 text-chart-purple" />
               <span className="comet-body-s-accented text-foreground">
-                Try demo template
+                Use the Optimization Studio
               </span>
-              <span className="comet-body-s text-muted-slate">
-                Train a chatbot to answer questions about Opik and decline
-                off-topic requests.
+            </span>
+            <span className="comet-body-xs text-muted-slate">
+              Create a custom optimization workflow to test and improve your
+              prompts.
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={onOptimizeViaSdkClick}
+            className="flex flex-col gap-1 rounded-md border p-4 text-left transition-colors hover:border-primary hover:bg-primary-100"
+          >
+            <span className="flex items-center gap-2">
+              <FileSliders className="size-4 shrink-0 text-chart-burgundy" />
+              <span className="comet-body-s-accented text-foreground">
+                Optimize via SDK
               </span>
-            </div>
+            </span>
+            <span className="comet-body-xs text-muted-slate">
+              Generate starter code for running a custom optimization
+              programmatically.
+            </span>
           </button>
         </div>
         <div>

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsEmptyState.tsx
@@ -4,10 +4,12 @@ import {
   SquareDashedMousePointer,
   FileSliders,
   ExternalLink,
+  type LucideIcon,
 } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { Button } from "@/ui/button";
+import { cn } from "@/lib/utils";
 import { buildDocsUrl } from "@/v2/lib/utils";
 import { useTheme } from "@/contexts/theme-provider";
 import { THEME_MODE } from "@/constants/theme";
@@ -18,6 +20,34 @@ import emptyOptStudioDarkUrl from "/images/empty-optimization-studio-dark.svg";
 type OptimizationsEmptyStateProps = {
   onOptimizeViaSdkClick: () => void;
 };
+
+type ActionCardConfig = {
+  icon: LucideIcon;
+  iconClassName: string;
+  title: string;
+  description: string;
+  onClick: () => void;
+};
+
+const ActionCard: React.FC<ActionCardConfig> = ({
+  icon: Icon,
+  iconClassName,
+  title,
+  description,
+  onClick,
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="flex flex-col gap-1 rounded-md border p-4 text-left transition-colors hover:border-primary hover:bg-primary-100"
+  >
+    <span className="flex items-center gap-2">
+      <Icon className={cn("size-4 shrink-0", iconClassName)} />
+      <span className="comet-body-s-accented text-foreground">{title}</span>
+    </span>
+    <span className="comet-body-xs text-muted-slate">{description}</span>
+  </button>
+);
 
 const OptimizationsEmptyState: React.FC<OptimizationsEmptyStateProps> = ({
   onOptimizeViaSdkClick,
@@ -39,6 +69,33 @@ const OptimizationsEmptyState: React.FC<OptimizationsEmptyStateProps> = ({
     });
   };
 
+  const actionCards: ActionCardConfig[] = [
+    {
+      icon: BotMessageSquare,
+      iconClassName: "text-chart-blue",
+      title: "Run a demo example",
+      description:
+        "Start with a pre-configured optimization example for a support chatbot.",
+      onClick: () => navigateToStudio("opik-chatbot"),
+    },
+    {
+      icon: SquareDashedMousePointer,
+      iconClassName: "text-chart-purple",
+      title: "Use the Optimization Studio",
+      description:
+        "Create a custom optimization workflow to test and improve your prompts.",
+      onClick: () => navigateToStudio(),
+    },
+    {
+      icon: FileSliders,
+      iconClassName: "text-chart-burgundy",
+      title: "Optimize via SDK",
+      description:
+        "Generate starter code for running a custom optimization programmatically.",
+      onClick: onOptimizeViaSdkClick,
+    },
+  ];
+
   return (
     <div className="flex min-h-full flex-1 items-center justify-center gap-16 px-6">
       <div className="flex w-full max-w-[480px] flex-col gap-4">
@@ -50,54 +107,9 @@ const OptimizationsEmptyState: React.FC<OptimizationsEmptyStateProps> = ({
           runs help you improve accuracy, consistency, and user experience.
         </p>
         <div className="flex flex-col gap-2">
-          <button
-            type="button"
-            onClick={() => navigateToStudio("opik-chatbot")}
-            className="flex flex-col gap-1 rounded-md border p-4 text-left transition-colors hover:border-primary hover:bg-primary-100"
-          >
-            <span className="flex items-center gap-2">
-              <BotMessageSquare className="size-4 shrink-0 text-chart-blue" />
-              <span className="comet-body-s-accented text-foreground">
-                Run a demo example
-              </span>
-            </span>
-            <span className="comet-body-xs text-muted-slate">
-              Start with a pre-configured optimization example for a support
-              chatbot.
-            </span>
-          </button>
-          <button
-            type="button"
-            onClick={() => navigateToStudio()}
-            className="flex flex-col gap-1 rounded-md border p-4 text-left transition-colors hover:border-primary hover:bg-primary-100"
-          >
-            <span className="flex items-center gap-2">
-              <SquareDashedMousePointer className="size-4 shrink-0 text-chart-purple" />
-              <span className="comet-body-s-accented text-foreground">
-                Use the Optimization Studio
-              </span>
-            </span>
-            <span className="comet-body-xs text-muted-slate">
-              Create a custom optimization workflow to test and improve your
-              prompts.
-            </span>
-          </button>
-          <button
-            type="button"
-            onClick={onOptimizeViaSdkClick}
-            className="flex flex-col gap-1 rounded-md border p-4 text-left transition-colors hover:border-primary hover:bg-primary-100"
-          >
-            <span className="flex items-center gap-2">
-              <FileSliders className="size-4 shrink-0 text-chart-burgundy" />
-              <span className="comet-body-s-accented text-foreground">
-                Optimize via SDK
-              </span>
-            </span>
-            <span className="comet-body-xs text-muted-slate">
-              Generate starter code for running a custom optimization
-              programmatically.
-            </span>
-          </button>
+          {actionCards.map((card) => (
+            <ActionCard key={card.title} {...card} />
+          ))}
         </div>
         <div>
           <Button variant="outline" size="sm" asChild>

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsEmptyState.tsx
@@ -6,14 +6,12 @@ import {
   ExternalLink,
   type LucideIcon,
 } from "lucide-react";
-import { useNavigate } from "@tanstack/react-router";
-
 import { Button } from "@/ui/button";
 import { cn } from "@/lib/utils";
 import { buildDocsUrl } from "@/v2/lib/utils";
 import { useTheme } from "@/contexts/theme-provider";
 import { THEME_MODE } from "@/constants/theme";
-import useAppStore, { useActiveProjectId } from "@/store/AppStore";
+import useNavigateToOptimizationStudio from "@/v2/pages-shared/optimizations/useNavigateToOptimizationStudio";
 import emptyOptStudioLightUrl from "/images/empty-optimization-studio-light.svg";
 import emptyOptStudioDarkUrl from "/images/empty-optimization-studio-dark.svg";
 
@@ -53,21 +51,11 @@ const OptimizationsEmptyState: React.FC<OptimizationsEmptyStateProps> = ({
   onOptimizeViaSdkClick,
 }) => {
   const { themeMode } = useTheme();
-  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
-  const activeProjectId = useActiveProjectId();
-  const navigate = useNavigate();
+  const navigateToStudio = useNavigateToOptimizationStudio();
   const imageUrl =
     themeMode === THEME_MODE.DARK
       ? emptyOptStudioDarkUrl
       : emptyOptStudioLightUrl;
-
-  const navigateToStudio = (templateId?: string) => {
-    navigate({
-      to: "/$workspaceName/projects/$projectId/optimizations/new",
-      params: { workspaceName, projectId: activeProjectId! },
-      search: templateId ? { template: templateId } : undefined,
-    });
-  };
 
   const actionCards: ActionCardConfig[] = [
     {

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -333,7 +333,7 @@ const OptimizationsPage: React.FunctionComponent = () => {
       {isEmpty ? (
         isOptimizationStudioEnabled && canUseOptimizationStudio ? (
           <OptimizationsEmptyState
-            onOptimizeClick={handleNewOptimizationClick}
+            onOptimizeViaSdkClick={handleNewOptimizationClick}
           />
         ) : (
           <PageEmptyState


### PR DESCRIPTION
## Details
Reworks the **Optimization runs** empty state to match the Figma design (OPIK-6761). The previous state had two action cards; the design has three, with refreshed copy, icons, and layout. Frontend-only — no backend, migrations, or `v1` changes; the rich empty state remains gated behind the `OPTIMIZATION_STUDIO_ENABLED` flag + `canUseOptimizationStudio` permission, with the `PageEmptyState` fallback untouched.

Each card maps to an existing entry point:
- **Run a demo example** → Optimization Studio wizard pre-filled with the `opik-chatbot` template (`/optimizations/new?template=opik-chatbot`).
- **Use the Optimization Studio** → blank Studio wizard (`/optimizations/new`).
- **Optimize via SDK** (new) → opens the existing `AddOptimizationDialog` (SDK starter code: `pip install opik-optimizer` + a credential-injected snippet + Colab link).

Also: consolidated studio navigation into a single `navigateToStudio()` helper mirroring `StudioTemplates`, aligned card layout/typography/icon colors to the design tokens (`comet-*`, `text-chart-blue|purple|burgundy`), and renamed the prop `onOptimizeClick` → `onOptimizeViaSdkClick` for clarity.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6761

## AI-WATERMARK

AI-WATERMARK: yes

  - Tools: Claude-Code
  - Model: Opus-4.8
  - Scope: All files
  - Human verification: Yes — verified 1:1 against the Figma and exercised all three cards in the running app (local, Chrome).

## Testing
Commands (from `apps/opik-frontend`):
- `npx eslint` on both changed files — 0 problems
- `npx tsc --noEmit` (project-wide) — no errors in the changed files

Manual UI (local process mode, Chrome, on an empty project) — temporarily forced the flagged branch to render `OptimizationsEmptyState`, then:
- Compared the rendered empty state side-by-side with the Figma node (`642-30557`) — cards, order, copy, icon colors (blue/purple/burgundy), icon+title-row / description-below layout, "View docs" button, and right-side illustration all match.
- **Run a demo example** → navigates to `/optimizations/new?template=opik-chatbot`; Studio form pre-filled (Name "Opik chatbot optimization", "Demo - Opik Chatbot" dataset, G-Eval metric).
- **Use the Optimization Studio** → navigates to `/optimizations/new`; blank Studio wizard.
- **Optimize via SDK** → opens the "Start optimization run" dialog with `pip install opik-optimizer` + live SDK snippet + Colab link.
- Reverted the temporary flag override before committing (not part of the diff).

Not run: automated component tests — this is a presentational empty state with no existing test coverage for the component; behavior was verified manually end-to-end.

Notes for reviewers:
- Title kept as "No optimization run**s** yet" (plural) to match the page heading and product wording; the Figma reads singular ("run"), which looks like a design typo — happy to flip if intended.
- Title uses `comet-title-s` (18px), consistent with other empty states (`PageEmptyState`); the Figma token is 16px but the codebase has no 16px title utility.

## Documentation
N/A — no user-facing docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)