### PR TITLE
[OPIK-6858] Collapsible JSON/YAML code blocks in trace/span view

### DIFF
--- a/apps/opik-frontend/src/shared/SyntaxHighlighter/foldingExtension.ts
+++ b/apps/opik-frontend/src/shared/SyntaxHighlighter/foldingExtension.ts
@@ -1,0 +1,181 @@
+import {
+  codeFolding,
+  foldable,
+  foldedRanges,
+  foldEffect,
+  foldKeymap,
+  unfoldEffect,
+} from "@codemirror/language";
+import {
+  Decoration,
+  DecorationSet,
+  EditorView,
+  keymap,
+  ViewPlugin,
+  ViewUpdate,
+  WidgetType,
+} from "@codemirror/view";
+import { Extension, RangeSetBuilder } from "@codemirror/state";
+
+// Chevron icons mirror lucide's ChevronDown / ChevronRight used elsewhere in
+// the trace view so the fold affordance feels native to the design system.
+const CHEVRON_DOWN =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>';
+const CHEVRON_RIGHT =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>';
+
+// Clickable chevron rendered inline at the end of an expanded foldable line.
+// Clicking it collapses the JSON object / array or YAML block it heads.
+class FoldChevronWidget extends WidgetType {
+  constructor(
+    readonly from: number,
+    readonly to: number,
+  ) {
+    super();
+  }
+
+  eq(other: FoldChevronWidget) {
+    return other.from === this.from && other.to === this.to;
+  }
+
+  toDOM(view: EditorView) {
+    const button = document.createElement("span");
+    button.className = "cm-inline-fold-marker";
+    button.setAttribute("role", "button");
+    button.setAttribute("aria-label", "Collapse");
+    button.innerHTML = CHEVRON_DOWN;
+    button.onmousedown = (event) => {
+      // Prevent the read-only editor from moving the caret / selection.
+      event.preventDefault();
+      event.stopPropagation();
+      view.dispatch({
+        effects: foldEffect.of({ from: this.from, to: this.to }),
+      });
+    };
+    return button;
+  }
+
+  ignoreEvent() {
+    return false;
+  }
+}
+
+const isRangeFolded = (
+  state: EditorView["state"],
+  range: { from: number; to: number },
+) => {
+  let folded = false;
+  foldedRanges(state).between(range.from, range.to, (from, to) => {
+    if (from === range.from && to === range.to) folded = true;
+  });
+  return folded;
+};
+
+const buildFoldMarkers = (view: EditorView): DecorationSet => {
+  const builder = new RangeSetBuilder<Decoration>();
+  const { state } = view;
+
+  for (const { from, to } of view.visibleRanges) {
+    let pos = from;
+    while (pos <= to) {
+      const line = state.doc.lineAt(pos);
+      const range = foldable(state, line.from, line.to);
+      // Only decorate expanded lines — collapsed ones surface the placeholder.
+      if (range && !isRangeFolded(state, range)) {
+        builder.add(
+          line.to,
+          line.to,
+          Decoration.widget({
+            widget: new FoldChevronWidget(range.from, range.to),
+            side: 1,
+          }),
+        );
+      }
+      pos = line.to + 1;
+    }
+  }
+
+  return builder.finish();
+};
+
+const foldToggledBy = (update: ViewUpdate) =>
+  update.transactions.some((tr) =>
+    tr.effects.some((e) => e.is(foldEffect) || e.is(unfoldEffect)),
+  );
+
+const foldMarkers = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = buildFoldMarkers(view);
+    }
+
+    update(update: ViewUpdate) {
+      if (
+        update.docChanged ||
+        update.viewportChanged ||
+        foldToggledBy(update)
+      ) {
+        this.decorations = buildFoldMarkers(update.view);
+      }
+    }
+  },
+  { decorations: (v) => v.decorations },
+);
+
+const foldingTheme = EditorView.baseTheme({
+  ".cm-inline-fold-marker": {
+    display: "inline-flex",
+    alignItems: "center",
+    verticalAlign: "middle",
+    marginLeft: "4px",
+    color: "var(--codemirror-gutter)",
+    cursor: "pointer",
+    opacity: "0.5",
+    transition: "opacity 0.1s ease-in-out, color 0.1s ease-in-out",
+  },
+  ".cm-inline-fold-marker:hover": {
+    opacity: "1",
+    color: "hsl(var(--text-primary))",
+  },
+  ".cm-inline-fold-placeholder": {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "1px",
+    background: "hsl(var(--muted))",
+    borderRadius: "4px",
+    color: "hsl(var(--text-secondary))",
+    margin: "0 4px",
+    padding: "0 4px",
+    verticalAlign: "middle",
+    cursor: "pointer",
+  },
+});
+
+// Inline placeholder shown in place of a collapsed block; clicking expands it.
+const createFoldPlaceholder = (
+  _view: EditorView,
+  onclick: (event: Event) => void,
+) => {
+  const el = document.createElement("span");
+  el.className = "cm-inline-fold-placeholder";
+  el.setAttribute("role", "button");
+  el.setAttribute("aria-label", "Expand");
+  el.innerHTML = `${CHEVRON_RIGHT}<span>…</span>`;
+  el.onclick = onclick;
+  return el;
+};
+
+/**
+ * Enables collapse / expand of JSON objects, arrays and YAML blocks inside the
+ * read-only CodeMirror viewers used in the trace / span detail view. Instead of
+ * a left fold gutter, the chevron sits inline at the end of each foldable line;
+ * collapsed blocks render a clickable placeholder that expands them again.
+ */
+export const createFoldingExtension = (): Extension => [
+  codeFolding({ placeholderDOM: createFoldPlaceholder }),
+  foldMarkers,
+  foldingTheme,
+  keymap.of(foldKeymap),
+];

--- a/apps/opik-frontend/src/shared/SyntaxHighlighter/foldingExtension.ts
+++ b/apps/opik-frontend/src/shared/SyntaxHighlighter/foldingExtension.ts
@@ -16,13 +16,19 @@ import {
   WidgetType,
 } from "@codemirror/view";
 import { Extension, RangeSetBuilder } from "@codemirror/state";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ChevronDown, ChevronRight } from "lucide-react";
 
-// Chevron icons mirror lucide's ChevronDown / ChevronRight used elsewhere in
-// the trace view so the fold affordance feels native to the design system.
-const CHEVRON_DOWN =
-  '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>';
-const CHEVRON_RIGHT =
-  '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>';
+// CodeMirror widgets are imperative DOM, so we render the lucide icons used
+// elsewhere in the trace view to static markup once at module load and reuse
+// the resulting SVG strings. This keeps the fold chevrons in sync with lucide
+// without paying a render cost per widget.
+const renderChevron = (Icon: typeof ChevronDown) =>
+  renderToStaticMarkup(createElement(Icon, { size: 14, strokeWidth: 2.25 }));
+
+const CHEVRON_DOWN = renderChevron(ChevronDown);
+const CHEVRON_RIGHT = renderChevron(ChevronRight);
 
 // Clickable chevron rendered inline at the end of an expanded foldable line.
 // Clicking it collapses the JSON object / array or YAML block it heads.

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/CodeBlock/CodeBlockBody.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/CodeBlock/CodeBlockBody.tsx
@@ -14,6 +14,7 @@ import { useSearchPanelTheme } from "@/shared/SyntaxHighlighter/hooks/useSearchP
 import { useCodeMirrorSearch } from "@/shared/SyntaxHighlighter/hooks/useCodeMirrorSearch";
 import { useMarkdownSearch } from "@/shared/SyntaxHighlighter/hooks/useMarkdownSearch";
 import { createBase64ExpandExtension } from "@/shared/SyntaxHighlighter/base64Extension";
+import { createFoldingExtension } from "@/shared/SyntaxHighlighter/foldingExtension";
 import { EXTENSION_MAP, MODE_TYPE } from "@/shared/SyntaxHighlighter/constants";
 import { CodeOutput } from "@/shared/SyntaxHighlighter/types";
 import { cn, isStringMarkdown } from "@/lib/utils";
@@ -86,6 +87,7 @@ const CodeMirrorBody: React.FC<CodeBlockBodyProps> = ({
   });
 
   const base64Extension = useMemo(() => createBase64ExpandExtension(), []);
+  const foldingExtension = useMemo(() => createFoldingExtension(), []);
 
   const handleCreateEditor = (view: EditorView) => {
     viewRef.current = view;
@@ -111,6 +113,7 @@ const CodeMirrorBody: React.FC<CodeBlockBodyProps> = ({
           searchExtension,
           hyperLink,
           base64Extension,
+          foldingExtension,
           EXTENSION_MAP[code.mode] as LRLanguage,
         ]}
         maxHeight="700px"

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -280,7 +280,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
             >
               Feedback scores
               <ExplainerIcon
-                className="ml-1"
+                className="ml-1 size-3"
                 {...EXPLAINERS_MAP[EXPLAINER_ID.what_are_feedback_scores]}
               />
             </TabsTrigger>


### PR DESCRIPTION
## Details
<img width="539" height="299" alt="image" src="https://github.com/user-attachments/assets/619a5ace-7a30-4b75-8b58-eb8daf5af4bc" />
<img width="821" height="178" alt="image" src="https://github.com/user-attachments/assets/b15a7aaf-53e2-4cf2-94b8-aec4f59c4ac9" />
<img width="1007" height="456" alt="image" src="https://github.com/user-attachments/assets/8491cba0-f156-4332-8caf-3a1ecec7acba" />

JSON and YAML content in the trace/span detail view is now collapsible: users can fold/unfold JSON objects, arrays and YAML blocks in the read-only CodeMirror viewers. The fold affordance is an inline chevron at the end of each foldable line, and a collapsed block renders as a clickable gray placeholder that expands it again.

- New shared `createFoldingExtension` (CodeMirror `codeFolding` + an inline end-of-line chevron widget + a clickable `…` placeholder, styled with design-system tokens), wired into the v2 trace/span `CodeBlockBody`.
- Collapsed-section placeholder background uses `hsl(var(--muted))` so it adapts to light/dark mode.
- Shrinks the "Feedback scores" tab info icon (`size-3.5` → `size-3`) to better match the label.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6858

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Implementation of the folding extension and the icon size tweak, plus this PR description.
- Human verification: Author reviewed the diff; lint and typecheck pass. Visual confirmation of collapse/expand pending local run.

## Testing

- `npx eslint` and `npx tsc --noEmit` pass for the changed files.
- Verified `@codemirror/lang-json` and `@codemirror/lang-yaml` produce fold ranges for nested objects/arrays/mappings/sequences, and that the folding APIs used (`foldable`, `foldedRanges`, `foldEffect`, `unfoldEffect`, `placeholderDOM`) exist in the installed `@codemirror/language`.
- Not yet run: full visual pass of collapse/expand in the running app (inline fold widget layout / placeholder positioning).

## Documentation