### PR TITLE
[OPIK-6843] [FE] fix: correct copy in dataset expansion success/error toasts and buttons

### DIFF
--- a/apps/opik-frontend/src/api/datasets/useDatasetExpansionMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useDatasetExpansionMutation.ts
@@ -10,6 +10,7 @@ import { useToast } from "@/ui/use-toast";
 
 type UseDatasetExpansionMutationParams = {
   datasetId: string;
+  entityName?: string;
 } & DatasetExpansionRequest;
 
 const useDatasetExpansionMutation = () => {
@@ -21,20 +22,22 @@ const useDatasetExpansionMutation = () => {
     AxiosError,
     UseDatasetExpansionMutationParams
   >({
-    mutationFn: async ({ datasetId, ...data }) => {
+    mutationFn: async ({ datasetId, entityName: _, ...data }) => {
+      void _;
       const { data: response } = await api.post(
         `${DATASETS_REST_ENDPOINT}${datasetId}/expansions`,
         data,
       );
       return response;
     },
-    onSuccess: () => {
+    onSuccess: (_, { entityName = "dataset" }) => {
+      const label = entityName.charAt(0).toUpperCase() + entityName.slice(1);
       toast({
-        title: "Test suite expansion successful",
+        title: `${label} expansion successful`,
         description: "Synthetic samples have been generated successfully",
       });
     },
-    onError: (error) => {
+    onError: (error, { entityName = "dataset" }) => {
       const errorData = error?.response?.data as {
         message?: string;
         detail?: string;
@@ -43,7 +46,7 @@ const useDatasetExpansionMutation = () => {
       let message =
         errorData?.message ||
         errorData?.detail ||
-        "Failed to expand test suite";
+        `Failed to expand ${entityName}`;
 
       // Handle specific model not supported error
       if (message.includes("model not supported")) {
@@ -52,8 +55,9 @@ const useDatasetExpansionMutation = () => {
         message = `The ${modelName} is not supported by the backend. Please select a different model from the dropdown.`;
       }
 
+      const label = entityName.charAt(0).toUpperCase() + entityName.slice(1);
       toast({
-        title: "Test suite expansion failed",
+        title: `${label} expansion failed`,
         description: message,
         variant: "destructive",
       });

--- a/apps/opik-frontend/src/api/datasets/useDatasetExpansionMutation.ts
+++ b/apps/opik-frontend/src/api/datasets/useDatasetExpansionMutation.ts
@@ -22,11 +22,11 @@ const useDatasetExpansionMutation = () => {
     AxiosError,
     UseDatasetExpansionMutationParams
   >({
-    mutationFn: async ({ datasetId, entityName: _, ...data }) => {
-      void _;
+    mutationFn: async ({ datasetId, entityName, ...reqData }) => {
+      void entityName;
       const { data: response } = await api.post(
         `${DATASETS_REST_ENDPOINT}${datasetId}/expansions`,
-        data,
+        reqData,
       );
       return response;
     },

--- a/apps/opik-frontend/src/v1/pages-shared/datasets/DatasetExpansionDialog.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/datasets/DatasetExpansionDialog.tsx
@@ -664,7 +664,7 @@ const DatasetExpansionDialog: React.FunctionComponent<
                 </div>
               </div>
             ) : (
-              "Generate Samples"
+              "Generate samples"
             )}
           </Button>
         </DialogFooter>

--- a/apps/opik-frontend/src/v1/pages-shared/datasets/GeneratedSamplesDialog.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/datasets/GeneratedSamplesDialog.tsx
@@ -422,8 +422,8 @@ const GeneratedSamplesDialog: React.FunctionComponent<
             <Button variant="outline">Cancel</Button>
           </DialogClose>
           <Button onClick={handleAddToDataset} disabled={noneSelected}>
-            Add {selectedSamples.size} Sample
-            {selectedSamples.size !== 1 ? "s" : ""} to Dataset
+            Add {selectedSamples.size} sample
+            {selectedSamples.size !== 1 ? "s" : ""} to dataset
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetExpansionDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetExpansionDialog.tsx
@@ -293,7 +293,7 @@ const DatasetExpansionDialog: React.FunctionComponent<
     };
 
     mutate(
-      { datasetId: initialDatasetId, ...requestData },
+      { datasetId: initialDatasetId, entityName, ...requestData },
       {
         onSuccess: (response) => {
           complete();
@@ -308,6 +308,7 @@ const DatasetExpansionDialog: React.FunctionComponent<
     );
   }, [
     initialDatasetId,
+    entityName,
     model,
     validateForm,
     sampleCount,
@@ -670,7 +671,7 @@ const DatasetExpansionDialog: React.FunctionComponent<
                 </div>
               </div>
             ) : (
-              "Generate Samples"
+              "Generate samples"
             )}
           </Button>
         </DialogFooter>

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsActionsPanel.tsx
@@ -185,6 +185,7 @@ const DatasetItemsActionsPanel: React.FunctionComponent<
         open={generatedSamplesDialogOpen}
         setOpen={setGeneratedSamplesDialogOpen}
         onAddItems={handleAddGeneratedItems}
+        entityName={entityName}
       />
 
       <AddTagDialog

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/GeneratedSamplesDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/GeneratedSamplesDialog.tsx
@@ -96,11 +96,12 @@ type GeneratedSamplesDialogProps = {
   open: boolean;
   setOpen: (open: boolean) => void;
   onAddItems?: (items: DatasetItem[]) => void;
+  entityName?: string;
 };
 
 const GeneratedSamplesDialog: React.FunctionComponent<
   GeneratedSamplesDialogProps
-> = ({ samples, open, setOpen, onAddItems }) => {
+> = ({ samples, open, setOpen, onAddItems, entityName = "dataset" }) => {
   const [selectedSamples, setSelectedSamples] = useState<Set<string>>(
     new Set(samples.map((sample) => sample.id)),
   );
@@ -422,8 +423,8 @@ const GeneratedSamplesDialog: React.FunctionComponent<
             <Button variant="outline">Cancel</Button>
           </DialogClose>
           <Button onClick={handleAddToDataset} disabled={noneSelected}>
-            Add {selectedSamples.size} Sample
-            {selectedSamples.size !== 1 ? "s" : ""} to Dataset
+            Add {selectedSamples.size} sample
+            {selectedSamples.size !== 1 ? "s" : ""} to {entityName}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Details

Fixed incorrect copy in the dataset expansion (Expand with AI) feature:

- Toast messages were hardcoded to say "Test suite" even when expanding a dataset. They now correctly say "Dataset expansion successful/failed" or "Test suite expansion successful/failed" based on the entity type.
- Primary button on the Expand with AI modal changed from "Generate Samples" to "Generate samples" (sentence case) in both v1 and v2.
- Primary button on the Generated Samples modal changed from "Add N Sample(s) to Dataset" to "Add N sample(s) to dataset/test suite" (sentence case + correct entity name) in v2; sentence case only in v1 (no test suites in v1).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6843

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: full implementation
- Human verification: manual testing in local dev environment

## Testing

- `npm run lint && npm run typecheck` — passed
- Manually tested dataset expansion flow in local dev environment
- Verified toast shows "Dataset expansion successful" for datasets
- Verified button reads "Generate samples" (sentence case)
- Verified button reads "Add N sample(s) to dataset" (sentence case)

## Documentation

N/A