### PR TITLE
[NA] [QA] fix: surface bridge client timeouts as descriptive errors

### DIFF
--- a/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
+++ b/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
@@ -112,12 +112,25 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
       // is picked up after the bridge has already spawned.
       const apiKey = process.env.OPIK_API_KEY;
       if (apiKey) headers['X-Opik-Api-Key'] = apiKey;
-      const res = await fetch(`${bridgeUrl}${path}`, {
-        method,
-        headers: Object.keys(headers).length > 0 ? headers : undefined,
-        body: body !== undefined ? JSON.stringify(body) : undefined,
-        signal: ctrl.signal,
-      });
+      let res: Response;
+      try {
+        res = await fetch(`${bridgeUrl}${path}`, {
+          method,
+          headers: Object.keys(headers).length > 0 ? headers : undefined,
+          body: body !== undefined ? JSON.stringify(body) : undefined,
+          signal: ctrl.signal,
+        });
+      } catch (err) {
+        if (ctrl.signal.aborted) {
+          throw new PythonSdkBridgeError({
+            status: 0,
+            endpoint,
+            detail: 'client-timeout',
+            message: `opik-sdk-driver ${endpoint} aborted after ${REQUEST_TIMEOUT_MS}ms (client-side timeout — the bridge or backend did not respond in time)`,
+          });
+        }
+        throw err;
+      }
       if (res.ok) {
         return (await res.json()) as TResponse;
       }


### PR DESCRIPTION
## Details

The E2E suite's `opik-sdk-driver` HTTP client aborts each request after a 30s `AbortController` timeout. When that timer fired, the failure surfaced as a context-free `AbortError: This operation was aborted`, which made production E2E launch failures hard to triage — you couldn't tell which bridge endpoint stalled or that it was a client-side timeout at all. This rethrows our own timeout as a `PythonSdkBridgeError` that names the endpoint and states it was a client-side timeout after the configured budget, while leaving genuine network errors and the timeout budget itself unchanged.

- Discriminates on `ctrl.signal.aborted` (definitively our own timer) rather than matching `err.name`, so real network errors still propagate untouched.
- The catch is scoped to just the `fetch` call; the existing non-OK HTTP handling and the `clearTimeout` in `finally` are unchanged.
- No change to `REQUEST_TIMEOUT_MS` or any poll budgets — those are intentionally kept as-is so they continue to surface backend latency.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: full implementation of this fix
- Human verification: investigated the failing E2E launches that motivated it, reviewed the diff, ran pre-commit on the changed file

## Testing

- `pre-commit run --files tests_end_to_end/e2e/core/sdk/python-sdk-client.ts` — passes (no applicable lint hook flags the file).
- Single-file TypeScript transpile of `python-sdk-client.ts` — clean; the only diagnostics are two pre-existing `process.env` references that exist on `main` and are unrelated to this change.
- Change is logically isolated to the abort path of one helper; the request budget and the non-OK response handling are unchanged, so existing passing behavior is unaffected. A full Playwright run was not executed locally (this worktree has no installed `node_modules`); the new branch only adds error context on a path that previously threw anyway.

## Documentation

N/A
