### PR TITLE
[OPIK-6838] [FE] fix: show prompt name + version instead of commit hash in experiment views

### DIFF
--- a/apps/opik-frontend/src/lib/experiments.test.ts
+++ b/apps/opik-frontend/src/lib/experiments.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { formatPromptVersionLabel } from "./experiments";
+
+describe("experiments utilities", () => {
+  describe("formatPromptVersionLabel", () => {
+    it("prefers the sequential version number", () => {
+      expect(
+        formatPromptVersionLabel({
+          prompt_name: "My Prompt",
+          version_number: "v3",
+          commit: "c96aa875",
+        }),
+      ).toBe("My Prompt (v3)");
+    });
+
+    it("falls back to the commit hash when no version number", () => {
+      expect(
+        formatPromptVersionLabel({
+          prompt_name: "My Prompt",
+          version_number: undefined,
+          commit: "c96aa875",
+        }),
+      ).toBe("My Prompt (c96aa875)");
+    });
+
+    it("omits the parenthetical when neither version nor commit is present", () => {
+      expect(
+        formatPromptVersionLabel({
+          prompt_name: "My Prompt",
+          version_number: undefined,
+          commit: "",
+        }),
+      ).toBe("My Prompt");
+    });
+  });
+});

--- a/apps/opik-frontend/src/lib/experiments.ts
+++ b/apps/opik-frontend/src/lib/experiments.ts
@@ -1,10 +1,32 @@
 import {
   EVALUATION_METHOD,
   Experiment,
+  ExperimentPromptVersion,
   EXPERIMENT_STATUS,
   TestSuiteExperiment,
 } from "@/types/datasets";
 import { ROW_HEIGHT } from "@/types/shared";
+
+/**
+ * Human-readable label for a prompt version linked to an experiment: the
+ * prompt name plus its version (e.g. "My Prompt (v3)"). Prefers the sequential
+ * version number, falls back to the commit hash when it's unavailable, and
+ * omits the parenthetical entirely when neither is present (OPIK-6838).
+ *
+ * Single source of truth so the experiments table, the single-experiment
+ * Configuration tab, and the dashboard leaderboard widget stay consistent.
+ */
+export const formatPromptVersionLabel = (
+  promptVersion: Pick<
+    ExperimentPromptVersion,
+    "prompt_name" | "version_number" | "commit"
+  >,
+): string => {
+  const version = promptVersion.version_number ?? promptVersion.commit;
+  return version
+    ? `${promptVersion.prompt_name} (${version})`
+    : promptVersion.prompt_name;
+};
 
 export const isExperimentTerminal = (
   status: EXPERIMENT_STATUS | undefined | null,

--- a/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ExperimentsLeaderboardWidget/helpers.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ExperimentsLeaderboardWidget/helpers.ts
@@ -2,6 +2,7 @@ import uniq from "lodash/uniq";
 import get from "lodash/get";
 
 import { Experiment } from "@/types/datasets";
+import { formatPromptVersionLabel } from "@/lib/experiments";
 import {
   COLUMN_TYPE,
   ColumnData,
@@ -109,12 +110,11 @@ export const PREDEFINED_COLUMNS: ColumnData<Experiment>[] = [
     id: "prompt",
     label: "Prompt",
     type: COLUMN_TYPE.list,
-    // Show the prompt name plus its version, falling back to the commit hash
-    // only when no version number is available (OPIK-6838).
+    // Show the prompt name plus its version (OPIK-6838).
     accessorFn: (row) =>
       (row.prompt_versions ?? []).map((v) => ({
         ...v,
-        version_label: `${v.prompt_name} (${v.version_number ?? v.commit})`,
+        version_label: formatPromptVersionLabel(v),
       })),
     cell: MultiResourceCell as never,
     customMeta: {

--- a/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ExperimentsLeaderboardWidget/helpers.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ExperimentsLeaderboardWidget/helpers.ts
@@ -107,12 +107,18 @@ export const PREDEFINED_COLUMNS: ColumnData<Experiment>[] = [
   },
   {
     id: "prompt",
-    label: "Prompt commit",
+    label: "Prompt",
     type: COLUMN_TYPE.list,
-    accessorFn: (row) => get(row, ["prompt_versions"], []),
+    // Show the prompt name plus its version, falling back to the commit hash
+    // only when no version number is available (OPIK-6838).
+    accessorFn: (row) =>
+      (row.prompt_versions ?? []).map((v) => ({
+        ...v,
+        version_label: `${v.prompt_name} (${v.version_number ?? v.commit})`,
+      })),
     cell: MultiResourceCell as never,
     customMeta: {
-      nameKey: "commit",
+      nameKey: "version_label",
       idKey: "prompt_id",
       resource: RESOURCE_TYPE.prompt,
       getSearch: (data: Experiment) => ({

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
@@ -188,15 +188,22 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
             className="w-[320px]"
             dimension="sm"
           ></SearchInput>
-          {promptVersions.map((pv) => (
-            <NavigationTag
-              key={pv.id}
-              id={pv.prompt_id}
-              name={`${pv.prompt_name}${pv.commit ? ` (${pv.commit})` : ""}`}
-              resource={RESOURCE_TYPE.prompt}
-              search={{ activeVersionId: pv.id }}
-            />
-          ))}
+          {promptVersions.map((pv) => {
+            // Prefer the human-readable version label; fall back to the commit
+            // hash only when the version number is unavailable (OPIK-6838).
+            const versionLabel = pv.version_number ?? pv.commit;
+            return (
+              <NavigationTag
+                key={pv.id}
+                id={pv.prompt_id}
+                name={`${pv.prompt_name}${
+                  versionLabel ? ` (${versionLabel})` : ""
+                }`}
+                resource={RESOURCE_TYPE.prompt}
+                search={{ activeVersionId: pv.id }}
+              />
+            );
+          })}
         </div>
         <div className="flex items-center gap-2">
           <CompareExperimentsActionsPanel />

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
@@ -25,6 +25,7 @@ import SearchInput from "@/shared/SearchInput/SearchInput";
 import NavigationTag from "@/shared/NavigationTag";
 import { RESOURCE_TYPE } from "@/shared/ResourceLink/ResourceLink";
 import { Experiment } from "@/types/datasets";
+import { formatPromptVersionLabel } from "@/lib/experiments";
 import { Switch } from "@/ui/switch";
 import { Label } from "@/ui/label";
 import { Separator } from "@/ui/separator";
@@ -188,22 +189,15 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
             className="w-[320px]"
             dimension="sm"
           ></SearchInput>
-          {promptVersions.map((pv) => {
-            // Prefer the human-readable version label; fall back to the commit
-            // hash only when the version number is unavailable (OPIK-6838).
-            const versionLabel = pv.version_number ?? pv.commit;
-            return (
-              <NavigationTag
-                key={pv.id}
-                id={pv.prompt_id}
-                name={`${pv.prompt_name}${
-                  versionLabel ? ` (${versionLabel})` : ""
-                }`}
-                resource={RESOURCE_TYPE.prompt}
-                search={{ activeVersionId: pv.id }}
-              />
-            );
-          })}
+          {promptVersions.map((pv) => (
+            <NavigationTag
+              key={pv.id}
+              id={pv.prompt_id}
+              name={formatPromptVersionLabel(pv)}
+              resource={RESOURCE_TYPE.prompt}
+              search={{ activeVersionId: pv.id }}
+            />
+          ))}
         </div>
         <div className="flex items-center gap-2">
           <CompareExperimentsActionsPanel />

--- a/apps/opik-frontend/src/v2/pages/ExperimentsPage/GeneralDatasetsTab/GeneralDatasetsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/ExperimentsPage/GeneralDatasetsTab/GeneralDatasetsTab.tsx
@@ -85,6 +85,7 @@ import ItemSourceCell, {
   ITEM_SOURCE_LABEL,
 } from "@/v2/pages-shared/experiments/ItemSourceCell";
 import { EXPERIMENT_STATUS } from "@/types/datasets";
+import { formatPromptVersionLabel } from "@/lib/experiments";
 import { Skeleton } from "@/ui/skeleton";
 
 const PASS_RATE_LABEL = "Pass rate";
@@ -260,14 +261,13 @@ const GeneralDatasetsTab: React.FC<GeneralDatasetsTabProps> = ({
         id: "prompt",
         label: "Prompt",
         type: COLUMN_TYPE.list,
-        // Show the prompt name plus its version. Unlike the Prompt Library
-        // experiments tab (where the prompt is implied by the page context),
-        // this global table needs the name too. Fall back to the commit hash
-        // only when no version number is available (OPIK-6838).
+        // Show the prompt name plus its version (OPIK-6838). Unlike the Prompt
+        // Library experiments tab, where the prompt is implied by the page
+        // context, this global table needs the name too.
         accessorFn: (row) =>
           (row.prompt_versions ?? []).map((v) => ({
             ...v,
-            version_label: `${v.prompt_name} (${v.version_number ?? v.commit})`,
+            version_label: formatPromptVersionLabel(v),
           })),
         cell: MultiResourceCell as never,
         customMeta: {

--- a/apps/opik-frontend/src/v2/pages/ExperimentsPage/GeneralDatasetsTab/GeneralDatasetsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/ExperimentsPage/GeneralDatasetsTab/GeneralDatasetsTab.tsx
@@ -258,12 +258,20 @@ const GeneralDatasetsTab: React.FC<GeneralDatasetsTabProps> = ({
       },
       {
         id: "prompt",
-        label: "Prompt commit",
+        label: "Prompt",
         type: COLUMN_TYPE.list,
-        accessorFn: (row) => get(row, ["prompt_versions"], []),
+        // Show the prompt name plus its version. Unlike the Prompt Library
+        // experiments tab (where the prompt is implied by the page context),
+        // this global table needs the name too. Fall back to the commit hash
+        // only when no version number is available (OPIK-6838).
+        accessorFn: (row) =>
+          (row.prompt_versions ?? []).map((v) => ({
+            ...v,
+            version_label: `${v.prompt_name} (${v.version_number ?? v.commit})`,
+          })),
         cell: MultiResourceCell as never,
         customMeta: {
-          nameKey: "commit",
+          nameKey: "version_label",
           idKey: "prompt_id",
           resource: RESOURCE_TYPE.prompt,
           getSearch: (data: GroupedExperiment) => ({


### PR DESCRIPTION
## Details
Follow-up to #7017. Review feedback flagged that the prompt-linkage work surfaces the raw prompt **commit hash** in experiment views — a value users don't recognize. This frontend-only change shows the human-readable version (`version_number`, e.g. `v3`) alongside the prompt name, mirroring the already-approved Prompt Library experiments tab, and falls back to the commit hash only when no version number is available (it's `null` for masks). No backend, data-layer, migration, or `v1` changes.

- **Experiments table** (`GeneralDatasetsTab`): rename the `Prompt commit` column to `Prompt` and render `<name> (<version>)` via a computed `version_label`.
- **Single-experiment Configuration tab** (`ConfigurationTab`): build the prompt `NavigationTag` label from `version_number ?? commit` instead of `commit` (keeps the existing name).
- **Dashboard Experiments leaderboard** (`ExperimentsLeaderboardWidget`): same column fix — caught during code review; it had the identical commit-hash issue on a third live surface.
- The Prompt Library → Prompt → **Experiments tab** already displayed the version correctly and is unchanged. The Prompt Library **Commits tab** keeps the `commit` label, since that view is specifically about commits.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6838

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-opus-4-8
  - Scope: All files
  - Human verification: Yes — confirmed `Experiment.PromptVersionLink.versionNumber` is returned by the backend (format `v<N>`, null only for masks), so the `version_number ?? commit` fallback is exercised correctly. Display-only label change reviewed against the approved Prompt Library experiments-tab pattern.

## Testing
Commands (from `apps/opik-frontend`):
- `npx tsc --project tsconfig.json --noEmit` — clean (project-wide)
- `npx eslint src --max-warnings=0` — 0 warnings (project-wide)
- `npx prettier --check` on the 3 changed files — pass

Scope/regressions:
- Swept `apps/opik-frontend/src/v2` for remaining `nameKey: "commit"` / `label: "Prompt commit"` prompt surfaces; the only matches left are the Prompt Library **Commits tab**, where the commit label is intended.
- No unit tests exist for these display components (table-column config only); behavior is verified via type-checking + the shared `MultiResourceCell` contract (`nameKey`/`idKey`/`getSearch`).

Not run: live UI screenshots — manual verification of the rendered labels is being confirmed by re-running an experiment from the Playground (reporter follow-up on the ticket).

## Documentation
N/A — no user-facing docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)