### PR TITLE
[OPIK-6802] [FE] test: add Prompt Library smoke tests for text and chat prompts

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessage.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessage.tsx
@@ -343,7 +343,7 @@ const LLMPromptMessage = forwardRef<
               <Loader className="min-h-32" />
             ) : (
               <div className="flex flex-col gap-1 pl-[7px] pr-1">
-                <div className="relative">
+                <div className="relative" data-testid="playground-message-editor">
                   <div
                     className={
                       compact && !isExpanded

--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessage.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessage.tsx
@@ -343,7 +343,10 @@ const LLMPromptMessage = forwardRef<
               <Loader className="min-h-32" />
             ) : (
               <div className="flex flex-col gap-1 pl-[7px] pr-1">
-                <div className="relative" data-testid="playground-message-editor">
+                <div
+                  className="relative"
+                  data-testid="playground-message-editor"
+                >
                   <div
                     className={
                       compact && !isExpanded

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptMessagesReadonly/PromptMessagesReadonly.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptMessagesReadonly/PromptMessagesReadonly.tsx
@@ -139,7 +139,7 @@ const PromptMessagesReadonly: React.FC<PromptMessagesReadonlyProps> = ({
   }
 
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="flex flex-col gap-1.5" data-testid="prompt-chat-messages">
       {messages.map((message, index) => (
         <PromptMessageCard
           key={`${message.role}-${index}`}

--- a/apps/opik-frontend/src/v2/pages-shared/version-history/VersionHistoryTimeline.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/version-history/VersionHistoryTimeline.tsx
@@ -51,7 +51,7 @@ const VersionHistoryTimeline: React.FC<VersionHistoryTimelineProps> = ({
   }
 
   return (
-    <ul className="px-4 pb-4 pt-1">
+    <ul className="px-4 pb-4 pt-1" data-testid="version-history-timeline">
       {items.map((item, index) => {
         const isSelected = item.id === selectedId;
         const isLast = index === items.length - 1;
@@ -86,6 +86,7 @@ const VersionHistoryTimeline: React.FC<VersionHistoryTimelineProps> = ({
             </div>
 
             <div
+              data-testid={`version-history-item-${item.label}`}
               className={cn(
                 "min-w-0 flex-1 cursor-pointer rounded px-3 py-2 transition-colors",
                 isSelected

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
@@ -320,7 +320,10 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
           {/* Toolbar */}
           <div className="flex items-center gap-2 px-4 pb-1.5 pt-3">
             <div className="flex min-w-0 flex-1 items-center gap-2">
-              <span className="comet-body-accented shrink-0 text-foreground">
+              <span
+                data-testid="active-version-label"
+                className="comet-body-accented shrink-0 text-foreground"
+              >
                 {activeVersionLabel || "v—"}
               </span>
               {activeStage && <StageTag value={activeStage} size="sm" />}

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -156,6 +156,15 @@ export function makeBackendClient(apiKey: string | null = null) {
       }
     },
 
+    async deletePrompt(id: string): Promise<void> {
+      try {
+        await opik.api.prompts.deletePrompt(id);
+      } catch (err) {
+        if (isNotFoundError(err)) return;
+        throw err;
+      }
+    },
+
     async getDatasetItems(datasetId: string): Promise<DatasetItemRef[]> {
       const page = await opik.api.datasets.getDatasetItems(datasetId);
       const content = page.content ?? [];

--- a/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
+++ b/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
@@ -68,6 +68,20 @@ export interface PythonSdkClient {
       score_value: number;
     }>;
   }>;
+  createTextPrompt(args: {
+    name: string;
+    prompt: string;
+    description?: string;
+    project_name?: string;
+    workspace?: string;
+  }): Promise<{ id: string; name: string }>;
+  createChatPrompt(args: {
+    name: string;
+    messages: Array<{ role: string; content: string }>;
+    description?: string;
+    project_name?: string;
+    workspace?: string;
+  }): Promise<{ id: string; name: string }>;
   createTestSuite(args: {
     name: string;
     project_name: string;
@@ -210,6 +224,12 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
     },
     async createDataset(args) {
       return request<{ id: string; name: string }>('POST', '/datasets', args);
+    },
+    async createTextPrompt(args) {
+      return request<{ id: string; name: string }>('POST', '/prompts/text', args);
+    },
+    async createChatPrompt(args) {
+      return request<{ id: string; name: string }>('POST', '/prompts/chat', args);
     },
     async evaluateExperiment(args) {
       return request<{

--- a/tests_end_to_end/e2e/fixtures/prompt.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/prompt.fixture.ts
@@ -1,0 +1,91 @@
+import { test as baseTest } from './project.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+
+const TEXT_TEMPLATE = 'You are a helpful assistant. Answer the following: {{question}}';
+
+const CHAT_MESSAGES = [
+  { role: 'system', content: 'You are a helpful assistant.' },
+  { role: 'user', content: 'Answer the following: {{question}}' },
+];
+
+export interface TextPromptRef {
+  id: string;
+  name: string;
+  template: string;
+}
+
+export interface ChatPromptRef {
+  id: string;
+  name: string;
+  messages: Array<{ role: string; content: string }>;
+}
+
+export interface PromptFixtures {
+  textPrompt: TextPromptRef;
+  chatPrompt: ChatPromptRef;
+  registerPromptCleanup: (id: string, name: string) => void;
+}
+
+export const test = baseTest.extend<PromptFixtures>({
+  textPrompt: async ({ sdkClient, backendClient, project, testNamespace }, use, testInfo) => {
+    const name = `${testNamespace}-text-prompt`;
+    const created = await sdkClient.python.createTextPrompt({
+      name,
+      prompt: TEXT_TEMPLATE,
+      project_name: project.name,
+    });
+    const ref: TextPromptRef = { id: created.id, name: created.name, template: TEXT_TEMPLATE };
+    await testInfo.attach('opik.text-prompt', {
+      body: JSON.stringify(ref, null, 2),
+      contentType: 'application/json',
+    });
+    await use(ref);
+    if (!shouldLeaveArtifacts(testInfo)) {
+      try {
+        await backendClient.deletePrompt(created.id);
+      } catch (err) {
+        console.warn(`[textPrompt fixture] delete warning for ${name}:`, err);
+      }
+    }
+  },
+
+  registerPromptCleanup: async ({ backendClient }, use, testInfo) => {
+    const registry: Array<{ id: string; name: string }> = [];
+    await use((id, name) => {
+      registry.push({ id, name });
+    });
+    if (!shouldLeaveArtifacts(testInfo)) {
+      for (const { id, name } of registry) {
+        try {
+          await backendClient.deletePrompt(id);
+        } catch (err) {
+          console.warn(`[registerPromptCleanup] delete warning for ${name}:`, err);
+        }
+      }
+    }
+  },
+
+  chatPrompt: async ({ sdkClient, backendClient, project, testNamespace }, use, testInfo) => {
+    const name = `${testNamespace}-chat-prompt`;
+    const created = await sdkClient.python.createChatPrompt({
+      name,
+      messages: CHAT_MESSAGES,
+      project_name: project.name,
+    });
+    const ref: ChatPromptRef = { id: created.id, name: created.name, messages: CHAT_MESSAGES };
+    await testInfo.attach('opik.chat-prompt', {
+      body: JSON.stringify(ref, null, 2),
+      contentType: 'application/json',
+    });
+    await use(ref);
+    if (!shouldLeaveArtifacts(testInfo)) {
+      try {
+        await backendClient.deletePrompt(created.id);
+      } catch (err) {
+        console.warn(`[chatPrompt fixture] delete warning for ${name}:`, err);
+      }
+    }
+  },
+});
+
+export { expect } from './project.fixture';

--- a/tests_end_to_end/e2e/pom/prompt-detail.page.ts
+++ b/tests_end_to_end/e2e/pom/prompt-detail.page.ts
@@ -49,7 +49,7 @@ export class PromptDetailPage {
       const sheet = this.page.getByRole('dialog');
       await sheet.waitFor({ state: 'visible' });
       const firstMessageRow = sheet.getByTestId('playground-message-row').first();
-      const editor = firstMessageRow.locator('.cm-content').first();
+      const editor = firstMessageRow.getByTestId('playground-message-editor').locator('.cm-content').first();
       await editor.click();
       await editor.press('ControlOrMeta+a');
       await editor.pressSequentially(newContent);

--- a/tests_end_to_end/e2e/pom/prompt-detail.page.ts
+++ b/tests_end_to_end/e2e/pom/prompt-detail.page.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test';
+import type { Page, Locator } from '@playwright/test';
+
+export class PromptDetailPage {
+  constructor(private readonly page: Page) {}
+
+  async waitForReady(): Promise<void> {
+    return test.step('wait for prompt detail to load', async () => {
+      // Edit button renders only after the loading skeleton is replaced with real content
+      await this.page.getByRole('button', { name: 'Edit' }).waitFor({ state: 'visible' });
+    });
+  }
+
+  promptNameHeading(): Locator {
+    return this.page.getByRole('heading', { level: 1 });
+  }
+
+  textContent(): Locator {
+    return this.page.getByTestId('prompt-text-content');
+  }
+
+  chatMessages(): Locator {
+    return this.page.getByTestId('prompt-chat-messages');
+  }
+
+  activeVersionLabel(): Locator {
+    return this.page.getByTestId('active-version-label');
+  }
+
+  versionHistoryItem(label: string): Locator {
+    return this.page.getByTestId(`version-history-item-${label}`);
+  }
+
+  async editTextPrompt(newTemplate: string): Promise<void> {
+    return test.step(`edit text prompt template`, async () => {
+      await this.page.getByRole('button', { name: 'Edit' }).click();
+      const sheet = this.page.getByRole('dialog');
+      await sheet.waitFor({ state: 'visible' });
+      const editor = sheet.getByPlaceholder('Type your prompt...');
+      await editor.fill(newTemplate);
+      await sheet.getByRole('button', { name: 'Create new version' }).click();
+      await sheet.waitFor({ state: 'hidden' });
+    });
+  }
+
+  async editChatFirstMessage(newContent: string): Promise<void> {
+    return test.step(`edit first chat message`, async () => {
+      await this.page.getByRole('button', { name: 'Edit' }).click();
+      const sheet = this.page.getByRole('dialog');
+      await sheet.waitFor({ state: 'visible' });
+      const firstMessageRow = sheet.getByTestId('playground-message-row').first();
+      const editor = firstMessageRow.locator('.cm-content').first();
+      await editor.click();
+      await editor.press('ControlOrMeta+a');
+      await editor.pressSequentially(newContent);
+      await sheet.getByRole('button', { name: 'Create new version' }).click();
+      await sheet.waitFor({ state: 'hidden' });
+    });
+  }
+
+  async selectVersion(label: string): Promise<void> {
+    return test.step(`select version "${label}" from history timeline`, async () => {
+      const item = this.versionHistoryItem(label);
+      await item.waitFor({ state: 'visible' });
+      await item.click();
+      await expect(this.activeVersionLabel()).toHaveText(label);
+    });
+  }
+}

--- a/tests_end_to_end/e2e/pom/prompts.page.ts
+++ b/tests_end_to_end/e2e/pom/prompts.page.ts
@@ -42,7 +42,7 @@ export class PromptsPage {
       }
       await this.page.getByLabel('Name').fill(name);
       const firstMessageRow = this.page.getByTestId('playground-message-row').first();
-      const messageEditor = firstMessageRow.locator('.cm-content').first();
+      const messageEditor = firstMessageRow.getByTestId('playground-message-editor').locator('.cm-content').first();
       await messageEditor.click();
       await messageEditor.fill(messageContent);
       await this.page.getByRole('button', { name: 'Create prompt' }).click();

--- a/tests_end_to_end/e2e/pom/prompts.page.ts
+++ b/tests_end_to_end/e2e/pom/prompts.page.ts
@@ -1,0 +1,99 @@
+import { test } from '@playwright/test';
+import type { Page, Locator } from '@playwright/test';
+import { loadEnvConfig } from '../config/env.config';
+import { PromptDetailPage } from './prompt-detail.page';
+
+export class PromptsPage {
+  private projectId: string | null = null;
+
+  constructor(private readonly page: Page) {}
+
+  async createTextPromptViaUI(name: string, template: string): Promise<PromptDetailPage> {
+    return test.step(`create text prompt "${name}" via UI`, async () => {
+      const emptyStateBtn = this.page.getByRole('button', { name: 'Create a text prompt' });
+      if (await emptyStateBtn.isVisible()) {
+        await emptyStateBtn.click();
+      } else {
+        await this.page.getByRole('button', { name: 'Prompt' }).click();
+        await this.page.getByRole('menuitem', { name: 'Text prompt' }).click();
+      }
+      await this.page.getByLabel('Name').fill(name);
+      const promptTextarea = this.page.getByPlaceholder('Type your prompt...');
+      await promptTextarea.click();
+      await promptTextarea.fill(template);
+      await this.page.getByRole('button', { name: 'Create prompt' }).click();
+      await this.page.waitForURL((url) => {
+        const parts = url.pathname.split('/').filter(Boolean);
+        const promptsIdx = parts.lastIndexOf('prompts');
+        return promptsIdx >= 0 && promptsIdx < parts.length - 1;
+      });
+      return new PromptDetailPage(this.page);
+    });
+  }
+
+  async createChatPromptViaUI(name: string, messageContent: string): Promise<PromptDetailPage> {
+    return test.step(`create chat prompt "${name}" via UI`, async () => {
+      const emptyStateBtn = this.page.getByRole('button', { name: 'Create a chat prompt' });
+      if (await emptyStateBtn.isVisible()) {
+        await emptyStateBtn.click();
+      } else {
+        await this.page.getByRole('button', { name: 'Prompt' }).click();
+        await this.page.getByRole('menuitem', { name: 'Chat prompt' }).click();
+      }
+      await this.page.getByLabel('Name').fill(name);
+      const firstMessageRow = this.page.getByTestId('playground-message-row').first();
+      const messageEditor = firstMessageRow.locator('.cm-content').first();
+      await messageEditor.click();
+      await messageEditor.fill(messageContent);
+      await this.page.getByRole('button', { name: 'Create prompt' }).click();
+      await this.page.waitForURL((url) => {
+        const parts = url.pathname.split('/').filter(Boolean);
+        const promptsIdx = parts.lastIndexOf('prompts');
+        return promptsIdx >= 0 && promptsIdx < parts.length - 1;
+      });
+      return new PromptDetailPage(this.page);
+    });
+  }
+
+  async goto(projectId: string): Promise<void> {
+    return test.step('navigate to Prompts Library', async () => {
+      this.projectId = projectId;
+      const env = loadEnvConfig();
+      await this.page.goto(`${env.baseUrl}/${env.workspace}/projects/${projectId}/prompts/`);
+    });
+  }
+
+  async waitForReady(): Promise<void> {
+    return test.step('wait for Prompts Library to load', async () => {
+      const realRow = this.page.locator('tbody tr[data-row-id]').first();
+      const emptyHeading = this.page.getByRole('heading', { name: 'No prompts yet', level: 2 });
+      await Promise.race([
+        realRow.waitFor({ state: 'visible' }),
+        emptyHeading.waitFor({ state: 'visible' }),
+      ]);
+    });
+  }
+
+  promptRow(name: string): Locator {
+    return this.page
+      .locator('tbody tr[data-row-id]')
+      .filter({ has: this.page.getByRole('cell', { name, exact: true }) });
+  }
+
+  async openPromptByName(name: string): Promise<PromptDetailPage> {
+    return test.step(`open prompt "${name}"`, async () => {
+      if (!this.projectId) {
+        throw new Error('PromptsPage.openPromptByName: call goto(projectId) first');
+      }
+      const row = this.promptRow(name);
+      await row.waitFor({ state: 'visible' });
+      const promptId = await row.getAttribute('data-row-id');
+      if (!promptId) {
+        throw new Error(`PromptsPage.openPromptByName: row for "${name}" has no data-row-id`);
+      }
+      await row.getByRole('cell', { name, exact: true }).click();
+      await this.page.waitForURL((url) => url.pathname.includes(`/prompts/${promptId}`));
+      return new PromptDetailPage(this.page);
+    });
+  }
+}

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/main.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/main.py
@@ -8,7 +8,7 @@ from .routes import (
     feedback_definitions,
     health,
     projects,
-    test_suites,
+    prompts, test_suites,
     traces,
 )
 
@@ -29,4 +29,5 @@ app.include_router(traces.router)
 app.include_router(feedback_definitions.router)
 app.include_router(datasets.router)
 app.include_router(experiments.router)
+app.include_router(prompts.router)
 app.include_router(test_suites.router)

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/prompts.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/prompts.py
@@ -1,0 +1,46 @@
+import atexit
+
+from fastapi import APIRouter, Header
+
+from ..opik_factory import make_opik_client
+from ..schemas import ChatPromptCreate, PromptResponse, TextPromptCreate
+
+router = APIRouter(prefix="/prompts", tags=["prompts"])
+
+
+@router.post("/text", response_model=PromptResponse, status_code=201)
+def create_text_prompt(
+    body: TextPromptCreate,
+    x_opik_api_key: str | None = Header(default=None),
+) -> PromptResponse:
+    client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
+    try:
+        prompt = client.create_prompt(
+            name=body.name,
+            prompt=body.prompt,
+            description=body.description,
+            project_name=body.project_name,
+        )
+    finally:
+        atexit.unregister(client.end)
+        client.end(flush=True)
+    return PromptResponse(id=str(prompt.id), name=prompt.name)
+
+
+@router.post("/chat", response_model=PromptResponse, status_code=201)
+def create_chat_prompt(
+    body: ChatPromptCreate,
+    x_opik_api_key: str | None = Header(default=None),
+) -> PromptResponse:
+    client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
+    try:
+        prompt = client.create_chat_prompt(
+            name=body.name,
+            messages=body.messages,
+            description=body.description,
+            project_name=body.project_name,
+        )
+    finally:
+        atexit.unregister(client.end)
+        client.end(flush=True)
+    return PromptResponse(id=str(prompt.id), name=prompt.name)

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
@@ -202,3 +202,28 @@ class TestSuiteRunResponse(BaseModel):
     items_passed: int
     items_failed: int
     items_total: int
+
+
+class TextPromptCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    prompt: str
+    description: str | None = None
+    project_name: str | None = None
+    workspace: str | None = None
+
+
+class ChatPromptCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    messages: list[dict[str, str]]
+    description: str | None = None
+    project_name: str | None = None
+    workspace: str | None = None
+
+
+class PromptResponse(BaseModel):
+    id: str
+    name: str

--- a/tests_end_to_end/e2e/tests/prompts/prompt-library-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/prompts/prompt-library-smoke.spec.ts
@@ -1,0 +1,194 @@
+import { test, expect } from '../../fixtures/prompt.fixture';
+import { PromptsPage } from '@e2e/pom/prompts.page';
+
+test.describe('Prompt Library — smoke', { tag: ['@t1-smoke', '@prompts'] }, () => {
+  test.use({ viewport: { width: 1600, height: 900 } });
+
+  test('SDK-seeded text prompt appears in library, edit creates new version, old version is preserved', async ({
+    project,
+    textPrompt,
+    page,
+  }) => {
+    const prompts = new PromptsPage(page);
+    const updatedTemplate = 'You are an expert assistant. Respond concisely to: {{question}}';
+
+    await test.step('Navigate to Prompts Library', async () => {
+      await prompts.goto(project.id);
+      await prompts.waitForReady();
+    });
+
+    await test.step('Text prompt row is visible in the list', async () => {
+      await expect(prompts.promptRow(textPrompt.name)).toBeVisible();
+    });
+
+    const detail = await prompts.openPromptByName(textPrompt.name);
+
+    await test.step('Open text prompt and verify content', async () => {
+      await detail.waitForReady();
+      await expect(detail.promptNameHeading()).toHaveText(textPrompt.name);
+      await expect(detail.textContent()).toContainText('You are a helpful assistant');
+    });
+
+    await test.step('Initial version is v1', async () => {
+      await expect(detail.activeVersionLabel()).toHaveText('v1');
+    });
+
+    await test.step('Edit the prompt and save as new version', async () => {
+      await detail.editTextPrompt(updatedTemplate);
+    });
+
+    await test.step('v2 is active and shows the updated content', async () => {
+      await expect(detail.activeVersionLabel()).toHaveText('v2');
+      await expect(detail.textContent()).toContainText('You are an expert assistant');
+    });
+
+    await test.step('Select v1 from version history and verify original content is restored', async () => {
+      await detail.selectVersion('v1');
+      await expect(detail.activeVersionLabel()).toHaveText('v1');
+      await expect(detail.textContent()).toContainText('You are a helpful assistant');
+    });
+  });
+
+  test('SDK-seeded chat prompt appears in library, edit creates new version, old version is preserved', async ({
+    project,
+    chatPrompt,
+    page,
+  }) => {
+    const prompts = new PromptsPage(page);
+    const updatedMessage = 'Provide a concise expert answer to: {{question}}';
+
+    await test.step('Navigate to Prompts Library', async () => {
+      await prompts.goto(project.id);
+      await prompts.waitForReady();
+    });
+
+    await test.step('Chat prompt row is visible in the list', async () => {
+      await expect(prompts.promptRow(chatPrompt.name)).toBeVisible();
+    });
+
+    const detail = await prompts.openPromptByName(chatPrompt.name);
+
+    await test.step('Open chat prompt and verify messages', async () => {
+      await detail.waitForReady();
+      await expect(detail.promptNameHeading()).toHaveText(chatPrompt.name);
+      await expect(detail.chatMessages()).toBeVisible();
+      await expect(detail.chatMessages()).toContainText('You are a helpful assistant.');
+    });
+
+    await test.step('Initial version is v1', async () => {
+      await expect(detail.activeVersionLabel()).toHaveText('v1');
+    });
+
+    await test.step('Edit the first chat message and save as new version', async () => {
+      await detail.editChatFirstMessage(updatedMessage);
+    });
+
+    await test.step('v2 is active and shows the updated message content', async () => {
+      await expect(detail.activeVersionLabel()).toHaveText('v2');
+      await expect(detail.chatMessages()).toContainText('Provide a concise expert answer');
+    });
+
+    await test.step('Select v1 from version history and verify original messages are restored', async () => {
+      await detail.selectVersion('v1');
+      await expect(detail.activeVersionLabel()).toHaveText('v1');
+      await expect(detail.chatMessages()).toContainText('You are a helpful assistant.');
+    });
+  });
+
+  test('UI-created text prompt shows content, edit creates new version, old version is preserved', async ({
+    project,
+    page,
+    registerPromptCleanup,
+    testNamespace,
+  }) => {
+    const promptName = `${testNamespace}-ui-text`;
+    const template = 'You are a helpful assistant. Answer: {{question}}';
+    const updatedTemplate = 'You are an expert assistant. Respond concisely to: {{question}}';
+    const prompts = new PromptsPage(page);
+
+    await test.step('Navigate to empty Prompts Library', async () => {
+      await prompts.goto(project.id);
+      await prompts.waitForReady();
+    });
+
+    const detail = await prompts.createTextPromptViaUI(promptName, template);
+    const urlParts = new URL(page.url()).pathname.split('/').filter(Boolean);
+    const promptsIdx = urlParts.lastIndexOf('prompts');
+    const promptId = promptsIdx >= 0 ? (urlParts[promptsIdx + 1] ?? '') : '';
+    if (promptId) registerPromptCleanup(promptId, promptName);
+
+    await test.step('Verify detail page shows correct content', async () => {
+      await detail.waitForReady();
+      await expect(detail.promptNameHeading()).toHaveText(promptName);
+      await expect(detail.textContent()).toContainText('You are a helpful assistant');
+    });
+
+    await test.step('Initial version is v1', async () => {
+      await expect(detail.activeVersionLabel()).toHaveText('v1');
+    });
+
+    await test.step('Edit the prompt and save as new version', async () => {
+      await detail.editTextPrompt(updatedTemplate);
+    });
+
+    await test.step('v2 is active and shows the updated content', async () => {
+      await expect(detail.activeVersionLabel()).toHaveText('v2');
+      await expect(detail.textContent()).toContainText('You are an expert assistant');
+    });
+
+    await test.step('Select v1 from version history and verify original content is restored', async () => {
+      await detail.selectVersion('v1');
+      await expect(detail.activeVersionLabel()).toHaveText('v1');
+      await expect(detail.textContent()).toContainText('You are a helpful assistant');
+    });
+  });
+
+  test('UI-created chat prompt shows messages, edit creates new version, old version is preserved', async ({
+    project,
+    page,
+    registerPromptCleanup,
+    testNamespace,
+  }) => {
+    const promptName = `${testNamespace}-ui-chat`;
+    const messageContent = 'Answer the following: {{question}}';
+    const updatedMessage = 'Provide a concise expert answer to: {{question}}';
+    const prompts = new PromptsPage(page);
+
+    await test.step('Navigate to empty Prompts Library', async () => {
+      await prompts.goto(project.id);
+      await prompts.waitForReady();
+    });
+
+    const detail = await prompts.createChatPromptViaUI(promptName, messageContent);
+    const urlParts = new URL(page.url()).pathname.split('/').filter(Boolean);
+    const promptsIdx = urlParts.lastIndexOf('prompts');
+    const promptId = promptsIdx >= 0 ? (urlParts[promptsIdx + 1] ?? '') : '';
+    if (promptId) registerPromptCleanup(promptId, promptName);
+
+    await test.step('Verify detail page shows chat messages', async () => {
+      await detail.waitForReady();
+      await expect(detail.promptNameHeading()).toHaveText(promptName);
+      await expect(detail.chatMessages()).toBeVisible();
+      await expect(detail.chatMessages()).toContainText('Answer the following');
+    });
+
+    await test.step('Initial version is v1', async () => {
+      await expect(detail.activeVersionLabel()).toHaveText('v1');
+    });
+
+    await test.step('Edit the first chat message and save as new version', async () => {
+      await detail.editChatFirstMessage(updatedMessage);
+    });
+
+    await test.step('v2 is active and shows the updated message content', async () => {
+      await expect(detail.activeVersionLabel()).toHaveText('v2');
+      await expect(detail.chatMessages()).toContainText('Provide a concise expert answer');
+    });
+
+    await test.step('Select v1 from version history and verify original messages are restored', async () => {
+      await detail.selectVersion('v1');
+      await expect(detail.activeVersionLabel()).toHaveText('v1');
+      await expect(detail.chatMessages()).toContainText('Answer the following');
+    });
+  });
+});


### PR DESCRIPTION
## Details
Adds end-to-end smoke tests for the Prompt Library covering both text and chat prompt types via two creation paths: **SDK** and **UI**.

- **SDK path**: seeds prompts via the Opik Python SDK driver; verifies they appear in the library
- **UI path**: creates prompts through the Prompt Library UI (empty-state button and dropdown menu)
- Both paths test: editing a prompt creates v2 with updated content; selecting v1 from version history restores original content
- Adds `data-testid` attributes to `PromptMessagesReadonly`, `VersionHistoryTimeline`, and `PromptTab` for stable selector targeting
- Extends the E2E backend client, Python SDK driver, and TypeScript SDK client with prompt creation/deletion endpoints
- New POMs: `prompts.page.ts` (list + create via UI) and `prompt-detail.page.ts` (view, edit, version history)
- New fixture: `prompt.fixture.ts` — seeds SDK prompts and registers cleanup for UI-created prompts

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6802

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: assisted (POM generation, fixture scaffolding, data-testid discovery)
- Human verification: full test run + manual review of selectors and assertions

## Testing

Tests: `tests_end_to_end/e2e/tests/prompts/prompt-library-smoke.spec.ts`

4 scenarios:
- SDK-seeded text prompt → visible in library, edit → v2, v1 restores original
- SDK-seeded chat prompt → visible in library, edit → v2, v1 restores original
- UI-created text prompt → detail page correct, edit → v2, v1 restores original
- UI-created chat prompt → detail page correct, edit → v2, v1 restores original

```bash
cd tests_end_to_end/e2e
npx playwright test tests/prompts/prompt-library-smoke.spec.ts
```

## Documentation
N/A