### PR TITLE
[OPIK-6917] [QA] fix: update E2E create-flow POMs + specs for OPIK-6818 redesign

### DIFF
--- a/tests_end_to_end/e2e/pom/datasets.page.ts
+++ b/tests_end_to_end/e2e/pom/datasets.page.ts
@@ -45,8 +45,20 @@ export class DatasetsPage {
     return new DatasetItemsPage(this.page, this.projectId, datasetId);
   }
 
+  /**
+   * Opens the create sidebar in SDK mode. The empty state shows "Upload a file"
+   * and "Use SDK" cards directly; once the list has rows the header button is a
+   * dropdown trigger with the same two options. Handle both so the method works
+   * regardless of list state.
+   */
   async clickCreateDataset(): Promise<void> {
-    await this.page.getByRole('button', { name: 'Create dataset' }).click();
+    const emptyStateUseSdk = this.page.getByRole('button', { name: 'Use SDK' });
+    if (await emptyStateUseSdk.count()) {
+      await emptyStateUseSdk.first().click();
+    } else {
+      await this.page.getByRole('button', { name: 'Create dataset' }).click();
+      await this.page.getByRole('menuitem', { name: 'Use SDK' }).click();
+    }
     await this.createDialog.waitFor({ state: 'visible' });
     await this.waitForCreateDialogTransform('translateX(0');
   }
@@ -54,21 +66,15 @@ export class DatasetsPage {
   async fillCreateDialog(args: { name: string; description?: string }): Promise<void> {
     await this.createDialog.getByRole('textbox', { name: 'Name' }).fill(args.name);
     if (args.description !== undefined) {
-      await this.createDialog.getByRole('textbox', { name: 'Description' }).fill(args.description);
+      await this.createDialog
+        .getByRole('textbox', { name: 'Description (optional)' })
+        .fill(args.description);
     }
   }
 
-  /** Three-step dialog: name+description → CSV/SDK chooser → success. Success step doesn't auto-close. */
+  /** SDK-mode create: footer "Create dataset" submits, then the sidebar closes (no success step). */
   async submitCreateDialog(): Promise<void> {
-    await this.createDialog.getByRole('button', { name: 'Next' }).click();
-    await this.createDialog
-      .getByRole('heading', { name: 'Add data', level: 3 })
-      .waitFor({ state: 'visible' });
-    await this.createDialog.getByRole('button', { name: 'Create' }).click();
-    await this.createDialog
-      .getByRole('heading', { name: 'Dataset created!', level: 3 })
-      .waitFor({ state: 'visible' });
-    await this.createDialog.getByRole('button', { name: 'Close' }).click();
+    await this.createDialog.getByRole('button', { name: 'Create dataset' }).click();
     await this.waitForCreateDialogTransform('translateX(100%)');
   }
 

--- a/tests_end_to_end/e2e/pom/test-suites.page.ts
+++ b/tests_end_to_end/e2e/pom/test-suites.page.ts
@@ -12,6 +12,15 @@ export interface CreateTestSuiteDialogFields {
 
 export class TestSuitesPage {
   private projectId: string | null = null;
+  /**
+   * Assertions/policy stashed by fillCreateDialog. The SDK create flow only takes
+   * name + description; assertions and pass criteria are applied after creation
+   * via the in-suite Test settings dialog (see submitCreateDialog).
+   */
+  private pendingCriteria: Pick<
+    CreateTestSuiteDialogFields,
+    'assertions' | 'runsPerItem' | 'passThreshold'
+  > = {};
 
   constructor(private readonly page: Page) {}
 
@@ -51,74 +60,97 @@ export class TestSuitesPage {
     return new TestSuiteItemsPage(this.page, projectId, suiteId);
   }
 
+  /**
+   * Opens the create sidebar in SDK mode. The empty state shows "Upload a file"
+   * and "Use SDK" cards directly; once the list has rows the header button is a
+   * dropdown trigger with the same two options. Handle both so the method works
+   * regardless of list state.
+   */
   async clickCreateTestSuite(): Promise<void> {
-    await this.page.getByRole('button', { name: 'Create test suite' }).click();
+    const emptyStateUseSdk = this.page.getByRole('button', { name: 'Use SDK' });
+    if (await emptyStateUseSdk.count()) {
+      await emptyStateUseSdk.first().click();
+    } else {
+      await this.page.getByRole('button', { name: 'Create test suite' }).click();
+      await this.page.getByRole('menuitem', { name: 'Use SDK' }).click();
+    }
     await this.createDialog.waitFor({ state: 'visible' });
     await this.waitForCreateDialogTransform('translateX(0');
   }
 
+  /**
+   * SDK-mode create takes only name + description. Assertions and pass criteria
+   * have no input in this flow — they're stashed and applied after creation via
+   * the in-suite Test settings dialog (see submitCreateDialog).
+   */
   async fillCreateDialog(fields: CreateTestSuiteDialogFields): Promise<void> {
     await this.createDialog.getByRole('textbox', { name: 'Name' }).fill(fields.name);
     if (fields.description !== undefined) {
-      await this.createDialog.getByRole('textbox', { name: 'Description' }).fill(fields.description);
+      await this.createDialog
+        .getByRole('textbox', { name: 'Description (optional)' })
+        .fill(fields.description);
     }
-    await this.createDialog.getByRole('button', { name: 'Next' }).click();
-    await this.createDialog
-      .getByRole('heading', { name: 'Add test data', level: 3 })
-      .waitFor({ state: 'visible' });
-
-    const hasAdvanced =
-      fields.assertions?.length || fields.runsPerItem !== undefined || fields.passThreshold !== undefined;
-    if (hasAdvanced) {
-      await this.createDialog.getByRole('heading', { name: 'Advanced settings', level: 3 }).click();
-      if (fields.runsPerItem !== undefined) {
-        await this.createDialog
-          .getByRole('spinbutton', { name: 'Default runs per item' })
-          .fill(String(fields.runsPerItem));
-      }
-      if (fields.passThreshold !== undefined) {
-        await this.createDialog
-          .getByRole('spinbutton', { name: 'Default pass threshold' })
-          .fill(String(fields.passThreshold));
-      }
-      for (const assertion of fields.assertions ?? []) {
-        // Trigger button is "No assertions added yet" before any are added; becomes
-        // "Assertion" (with a plus icon) once at least one exists.
-        const addAssertionTrigger = this.createDialog
-          .getByRole('button', { name: 'No assertions added yet' })
-          .or(this.createDialog.getByRole('button', { name: 'Assertion', exact: true }));
-        await addAssertionTrigger.first().click();
-        const inputs = this.createDialog.getByRole('textbox', {
-          name: /Response should be factually accurate/,
-        });
-        await inputs.last().fill(assertion);
-      }
-    }
+    this.pendingCriteria = {
+      assertions: fields.assertions,
+      runsPerItem: fields.runsPerItem,
+      passThreshold: fields.passThreshold,
+    };
   }
 
   /**
-   * Submits the dialog (already on step 2). Returns the new suite's items page.
-   *
-   * The dialog has a 3-step flow ending on a "Test suite created!" success screen
-   * with "Go to test suite" + "Create another" buttons (mirrors the dataset
-   * create flow). We click "Go to test suite" to land on the items page.
+   * Creates the (empty) suite via the SDK-mode footer button, lands on the items
+   * page, then applies any assertions/pass criteria stashed by fillCreateDialog
+   * through the Test settings dialog. Returns the new suite's items page.
    */
   async submitCreateDialog(name: string): Promise<TestSuiteItemsPage> {
     const projectId = this.resolveProjectId();
-    await this.createDialog.getByRole('button', { name: 'Create', exact: true }).click();
-    // Wait for the success screen.
-    await this.createDialog
-      .getByRole('heading', { name: 'Test suite created!' })
-      .waitFor({ state: 'visible', timeout: 15_000 });
-    await this.createDialog.getByRole('button', { name: 'Go to test suite' }).click();
+    await this.createDialog.getByRole('button', { name: 'Create test suite' }).click();
+    await this.waitForCreateDialogTransform('translateX(100%)');
 
-    // After "Go to test suite", the URL navigates to the items page.
-    await this.page.waitForURL(/\/test-suites\/[0-9a-f-]+\/items/, { timeout: 15_000 });
+    await this.openTestSuiteByName(name);
     const match = this.page.url().match(/\/test-suites\/([0-9a-f-]+)/);
     if (!match) {
       throw new Error('TestSuitesPage.submitCreateDialog: could not derive suiteId from URL');
     }
-    return new TestSuiteItemsPage(this.page, projectId, match[1]);
+    const items = new TestSuiteItemsPage(this.page, projectId, match[1]);
+
+    await this.applyTestSettings();
+    return items;
+  }
+
+  /** Apply the criteria stashed by fillCreateDialog via the in-suite Test settings dialog. */
+  private async applyTestSettings(): Promise<void> {
+    const { assertions, runsPerItem, passThreshold } = this.pendingCriteria;
+    this.pendingCriteria = {};
+    if (!assertions?.length && runsPerItem === undefined && passThreshold === undefined) {
+      return;
+    }
+
+    await this.page.getByRole('button', { name: 'Test settings' }).click();
+    const dialog = this.page.getByRole('dialog', { name: 'Test settings' });
+    await dialog.waitFor({ state: 'visible' });
+
+    if (runsPerItem !== undefined) {
+      await dialog.getByRole('spinbutton', { name: 'Default runs per item' }).fill(String(runsPerItem));
+    }
+    if (passThreshold !== undefined) {
+      await dialog.getByRole('spinbutton', { name: 'Default pass threshold' }).fill(String(passThreshold));
+    }
+    for (const assertion of assertions ?? []) {
+      // Trigger button is "Add assertion" before any are added; becomes
+      // "Assertion" (with a plus icon) once at least one exists.
+      const addAssertionTrigger = dialog
+        .getByRole('button', { name: 'Add assertion' })
+        .or(dialog.getByRole('button', { name: 'Assertion', exact: true }));
+      await addAssertionTrigger.first().click();
+      const inputs = dialog.getByRole('textbox', {
+        name: /Response should be factually accurate/,
+      });
+      await inputs.last().fill(assertion);
+    }
+
+    await dialog.getByRole('button', { name: 'Save' }).click();
+    await dialog.waitFor({ state: 'hidden' });
   }
 
   /** Read projectId from the instance (set by goto) or fall back to the current URL. */

--- a/tests_end_to_end/e2e/tests/test-suites/test-suites-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/test-suites/test-suites-smoke.spec.ts
@@ -41,7 +41,22 @@ test.describe('Test Suites — smoke', { tag: ['@t1-smoke', '@test-suites'] }, (
   }) => {
     test.setTimeout(120_000);
 
+    // The LLM judge runs inside the SDK bridge via LiteLLM, which reads the
+    // provider key from the bridge process env (not the backend-stored key).
+    // Without a key every judge call raises AuthenticationError and the run
+    // reports 0 passing items. CI injects these secrets; locally they may be
+    // absent — skip rather than fail, mirroring Test B's ensureModelAvailable.
+    test.skip(
+      !process.env.ANTHROPIC_API_KEY && !process.env.OPENAI_API_KEY,
+      'Neither ANTHROPIC_API_KEY nor OPENAI_API_KEY is set',
+    );
+
     const experimentName = `${testSuite.name}-sdk-run`;
+    // Match the judge model to whichever provider key the bridge has (Anthropic
+    // preferred, OpenAI fallback) so the LiteLLM judge can authenticate.
+    const judgeModel = process.env.ANTHROPIC_API_KEY
+      ? 'anthropic/claude-haiku-4-5'
+      : 'openai/gpt-4o-mini';
 
     await test.step('SDK-trigger a run against the seeded suite', async () => {
       const result = await sdkClient.python.runTestSuite({
@@ -49,7 +64,7 @@ test.describe('Test Suites — smoke', { tag: ['@t1-smoke', '@test-suites'] }, (
         project_name: testSuite.projectName,
         task_output: 'PASS',
         experiment_name: experimentName,
-        judge_model: 'anthropic/claude-haiku-4-5',
+        judge_model: judgeModel,
       });
       expect(result.items_total).toBe(3);
       // Assertions are tautological ("contains literal text PASS" + "non-empty"),
@@ -137,8 +152,9 @@ test.describe('Test Suites — smoke', { tag: ['@t1-smoke', '@test-suites'] }, (
       // committed item AND a latestVersion that the FE has picked up. Item-add
       // via UI stages a draft which the SDK can't see until version-committed.
       // Use the idempotent insert-items bridge route which calls
-      // get_or_create_test_suite under the hood and lands the item in a new
-      // version (v2 here).
+      // get_or_create_test_suite under the hood and commits the item as a
+      // version. The UI-created suite is born empty (SDK create flow), so this
+      // first insert lands as v1.
       await sdkClient.python.insertTestSuiteItems({
         suite_name: name,
         project_name: project.name,
@@ -147,12 +163,12 @@ test.describe('Test Suites — smoke', { tag: ['@t1-smoke', '@test-suites'] }, (
       // Reload the items page so the FE refetches the latest version.
       await items.goto();
       await items.waitForReady();
-      // Wait for the version label to be at v2 — only then has the FE picked
-      // up the new committed version and `latestVersion.id` will be populated
+      // Wait for the version label to be at v1 — only then has the FE picked
+      // up the committed version and `latestVersion.id` will be populated
       // (UseDatasetDropdown needs this to call loadPlayground successfully).
       await expect
         .poll(async () => items.readVersionLabel(), { timeout: 15_000 })
-        .toBe('v2');
+        .toBe('v1');
       await expect
         .poll(async () => items.countItems(), { timeout: 15_000 })
         .toBeGreaterThanOrEqual(1);


### PR DESCRIPTION
## Details

The dataset & test-suite creation flow redesign ([OPIK-6818](https://comet-ml.atlassian.net/browse/OPIK-6818), #7014) changed the v2 create UX and broke the create-path Page Object Models in the E2E smoke suite (`tests_end_to_end/e2e/`). This updates the POMs and one spec to match the new flow.

- **POMs** (`datasets.page.ts`, `test-suites.page.ts`): the `clickCreate*` / `fillCreateDialog` / `submitCreateDialog` methods now drive the new **"Use SDK"** sidebar (empty-state card, or header dropdown when the list is non-empty) instead of the removed 3-step dialog + success screen. Name + "Description (optional)" are filled, then the footer "Create …" button submits and the sidebar closes. The test-suite POM applies assertions/pass-criteria **after** creation via the in-suite "Test settings" dialog, since SDK-create no longer accepts them.
- **`test-suites-smoke.spec.ts`**: the UI-created suite is now born **empty**, so the first SDK item-insert commits as **v1** (was v2) — assertion updated. Added a `test.skip` guard when no `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` is set and made the judge model honor the available provider key (the SDK-bridge LLM judge authenticates via LiteLLM using the bridge process env, not the backend-stored key; CI injects the secret, local runs may not).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-6917
- Related to OPIK-6818

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation (diagnosis + POM/spec fixes)
- Human verification: live UI verification on locally-built main + local test runs, reviewed by author

## Testing

- Built latest `main` locally (frontend on `:5173`) and reproduced both the create-flow regression and the redesigned flow in the browser.
- Ran from `tests_end_to_end/e2e/`:
  - `npx tsc --noEmit` — passes.
  - `OPIK_DEPLOYMENT=oss OPIK_BASE_URL=http://localhost:5173 npx playwright test tests/datasets/dataset-crud-smoke.spec.ts tests/test-suites/test-suites-smoke.spec.ts --workers=1`
- Results: dataset smoke **2/2 pass**; test-suite smoke **skips cleanly** locally without a judge key (runs + passes in CI where `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` is injected). The test-suite `v1` step + Playground run were verified green locally with a key env var present.
- Confirmed the v1 behavior at the API level: empty suite `/versions` total `0` → after SDK insert total `1`, `version_name "v1"`.
- Observed (and did **not** fix here) a pre-existing flake in the unchanged dataset `commitDraft()` path where a toast/overlay intermittently intercepts the commit-button click; tracked as a separate follow-up.

## Documentation

N/A — test-suite-internal change; no user-facing docs affected.


[OPIK-6818]: https://comet-ml.atlassian.net/browse/OPIK-6818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ