### PR TITLE
[OPIK-6820] [FE] Route shared navigation via workspace override

### DIFF
--- a/apps/opik-frontend/src/api/ai-spend/useAiSpendComposition.ts
+++ b/apps/opik-frontend/src/api/ai-spend/useAiSpendComposition.ts
@@ -1,6 +1,5 @@
 import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import api, { AI_SPEND_REST_ENDPOINT, QueryConfig } from "@/api/api";
-import { useAiSpend } from "@/contexts/AiSpendContext";
 
 export interface AiSpendLaneApi {
   key: string;
@@ -31,7 +30,6 @@ type UseAiSpendCompositionParams = {
   intervalStart: string;
   intervalEnd: string;
   userUuid?: string;
-  workspaceName?: string;
 };
 
 const buildBody = ({
@@ -53,27 +51,19 @@ const getAiSpendComposition = async (
   const { data } = await api.post<AiSpendCompositionResponse>(
     `${AI_SPEND_REST_ENDPOINT}composition`,
     buildBody(params),
-    {
-      signal,
-      ...(params.workspaceName && {
-        headers: { "Comet-Workspace": params.workspaceName },
-      }),
-    },
+    { signal },
   );
 
   return data;
 };
 
 export default function useAiSpendComposition(
-  params: Omit<UseAiSpendCompositionParams, "workspaceName">,
+  params: UseAiSpendCompositionParams,
   options?: QueryConfig<AiSpendCompositionResponse>,
 ) {
-  const { spendWorkspaceName } = useAiSpend();
-  const queryParams = { ...params, workspaceName: spendWorkspaceName };
-
   return useQuery({
-    queryKey: ["ai-spend-composition", queryParams],
-    queryFn: (context) => getAiSpendComposition(context, queryParams),
+    queryKey: ["ai-spend-composition", params],
+    queryFn: (context) => getAiSpendComposition(context, params),
     ...options,
   });
 }

--- a/apps/opik-frontend/src/api/ai-spend/useAiSpendLaneBreakdown.ts
+++ b/apps/opik-frontend/src/api/ai-spend/useAiSpendLaneBreakdown.ts
@@ -1,6 +1,5 @@
 import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import api, { AI_SPEND_REST_ENDPOINT, QueryConfig } from "@/api/api";
-import { useAiSpend } from "@/contexts/AiSpendContext";
 
 export interface AiSpendBreakdownItemApi {
   label: string;
@@ -22,7 +21,6 @@ type UseAiSpendLaneBreakdownParams = {
   intervalStart: string;
   intervalEnd: string;
   userUuid?: string;
-  workspaceName?: string;
 };
 
 const getAiSpendLaneBreakdown = async (
@@ -33,7 +31,6 @@ const getAiSpendLaneBreakdown = async (
     intervalStart,
     intervalEnd,
     userUuid,
-    workspaceName,
   }: UseAiSpendLaneBreakdownParams,
 ) => {
   const { data } = await api.post<AiSpendBreakdownResponse>(
@@ -44,27 +41,19 @@ const getAiSpendLaneBreakdown = async (
       interval_end: intervalEnd,
       ...(userUuid && { user_id: userUuid }),
     },
-    {
-      signal,
-      ...(workspaceName && {
-        headers: { "Comet-Workspace": workspaceName },
-      }),
-    },
+    { signal },
   );
 
   return data;
 };
 
 export default function useAiSpendLaneBreakdown(
-  params: Omit<UseAiSpendLaneBreakdownParams, "workspaceName">,
+  params: UseAiSpendLaneBreakdownParams,
   options?: QueryConfig<AiSpendBreakdownResponse>,
 ) {
-  const { spendWorkspaceName } = useAiSpend();
-  const queryParams = { ...params, workspaceName: spendWorkspaceName };
-
   return useQuery({
-    queryKey: ["ai-spend-lane-breakdown", queryParams],
-    queryFn: (context) => getAiSpendLaneBreakdown(context, queryParams),
+    queryKey: ["ai-spend-lane-breakdown", params],
+    queryFn: (context) => getAiSpendLaneBreakdown(context, params),
     enabled: Boolean(params.laneKey),
     ...options,
   });

--- a/apps/opik-frontend/src/api/ai-spend/useAiSpendRecommendations.ts
+++ b/apps/opik-frontend/src/api/ai-spend/useAiSpendRecommendations.ts
@@ -1,6 +1,5 @@
 import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import api, { AI_SPEND_REST_ENDPOINT, QueryConfig } from "@/api/api";
-import { useAiSpend } from "@/contexts/AiSpendContext";
 
 export interface SpendRecommendation {
   id: string;
@@ -22,7 +21,6 @@ type UseAiSpendRecommendationsParams = {
   intervalStart: string;
   intervalEnd: string;
   userUuid?: string;
-  workspaceName?: string;
 };
 
 const getAiSpendRecommendations = async (
@@ -32,7 +30,6 @@ const getAiSpendRecommendations = async (
     intervalStart,
     intervalEnd,
     userUuid,
-    workspaceName,
   }: UseAiSpendRecommendationsParams,
 ) => {
   const { data } = await api.post<SpendRecommendationsResponse>(
@@ -43,27 +40,19 @@ const getAiSpendRecommendations = async (
       interval_end: intervalEnd,
       ...(userUuid && { user_id: userUuid }),
     },
-    {
-      signal,
-      ...(workspaceName && {
-        headers: { "Comet-Workspace": workspaceName },
-      }),
-    },
+    { signal },
   );
 
   return data;
 };
 
 export default function useAiSpendRecommendations(
-  params: Omit<UseAiSpendRecommendationsParams, "workspaceName">,
+  params: UseAiSpendRecommendationsParams,
   options?: QueryConfig<SpendRecommendationsResponse>,
 ) {
-  const { spendWorkspaceName } = useAiSpend();
-  const queryParams = { ...params, workspaceName: spendWorkspaceName };
-
   return useQuery({
-    queryKey: ["ai-spend-recommendations", queryParams],
-    queryFn: (context) => getAiSpendRecommendations(context, queryParams),
+    queryKey: ["ai-spend-recommendations", params],
+    queryFn: (context) => getAiSpendRecommendations(context, params),
     ...options,
   });
 }

--- a/apps/opik-frontend/src/api/ai-spend/useAiSpendSummary.ts
+++ b/apps/opik-frontend/src/api/ai-spend/useAiSpendSummary.ts
@@ -1,6 +1,5 @@
 import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import api, { AI_SPEND_REST_ENDPOINT, QueryConfig } from "@/api/api";
-import { useAiSpend } from "@/contexts/AiSpendContext";
 
 export interface SpendSummaryResult {
   name: string;
@@ -16,17 +15,11 @@ type UseAiSpendSummaryParams = {
   projectName: string;
   intervalStart: string;
   intervalEnd: string;
-  workspaceName?: string;
 };
 
 const getAiSpendSummary = async (
   { signal }: QueryFunctionContext,
-  {
-    projectName,
-    intervalStart,
-    intervalEnd,
-    workspaceName,
-  }: UseAiSpendSummaryParams,
+  { projectName, intervalStart, intervalEnd }: UseAiSpendSummaryParams,
 ) => {
   const { data } = await api.post<SpendSummaryResponse>(
     `${AI_SPEND_REST_ENDPOINT}summary`,
@@ -35,27 +28,19 @@ const getAiSpendSummary = async (
       interval_start: intervalStart,
       interval_end: intervalEnd,
     },
-    {
-      signal,
-      ...(workspaceName && {
-        headers: { "Comet-Workspace": workspaceName },
-      }),
-    },
+    { signal },
   );
 
   return data;
 };
 
 export default function useAiSpendSummary(
-  params: Omit<UseAiSpendSummaryParams, "workspaceName">,
+  params: UseAiSpendSummaryParams,
   options?: QueryConfig<SpendSummaryResponse>,
 ) {
-  const { spendWorkspaceName } = useAiSpend();
-  const queryParams = { ...params, workspaceName: spendWorkspaceName };
-
   return useQuery({
-    queryKey: ["ai-spend-summary", queryParams],
-    queryFn: (context) => getAiSpendSummary(context, queryParams),
+    queryKey: ["ai-spend-summary", params],
+    queryFn: (context) => getAiSpendSummary(context, params),
     ...options,
   });
 }

--- a/apps/opik-frontend/src/api/ai-spend/useAiSpendUsers.ts
+++ b/apps/opik-frontend/src/api/ai-spend/useAiSpendUsers.ts
@@ -2,7 +2,6 @@ import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import { ColumnSort } from "@tanstack/react-table";
 import api, { AI_SPEND_REST_ENDPOINT, QueryConfig } from "@/api/api";
 import { processSorting } from "@/lib/sorting";
-import { useAiSpend } from "@/contexts/AiSpendContext";
 
 export interface SpendUserRow {
   user_uuid: string;
@@ -34,7 +33,6 @@ type UseAiSpendUsersParams = {
   size: number;
   name?: string;
   sorting?: ColumnSort[];
-  workspaceName?: string;
 };
 
 const getAiSpendUsers = async (
@@ -47,7 +45,6 @@ const getAiSpendUsers = async (
     size,
     name,
     sorting,
-    workspaceName,
   }: UseAiSpendUsersParams,
 ) => {
   const { data } = await api.post<SpendUserPage>(
@@ -60,9 +57,6 @@ const getAiSpendUsers = async (
     {
       signal,
       params: { page, size, ...(name && { name }), ...processSorting(sorting) },
-      ...(workspaceName && {
-        headers: { "Comet-Workspace": workspaceName },
-      }),
     },
   );
 
@@ -70,15 +64,12 @@ const getAiSpendUsers = async (
 };
 
 export default function useAiSpendUsers(
-  params: Omit<UseAiSpendUsersParams, "workspaceName">,
+  params: UseAiSpendUsersParams,
   options?: QueryConfig<SpendUserPage>,
 ) {
-  const { spendWorkspaceName } = useAiSpend();
-  const queryParams = { ...params, workspaceName: spendWorkspaceName };
-
   return useQuery({
-    queryKey: ["ai-spend-users", queryParams],
-    queryFn: (context) => getAiSpendUsers(context, queryParams),
+    queryKey: ["ai-spend-users", params],
+    queryFn: (context) => getAiSpendUsers(context, params),
     ...options,
   });
 }

--- a/apps/opik-frontend/src/contexts/AiSpendContext.tsx
+++ b/apps/opik-frontend/src/contexts/AiSpendContext.tsx
@@ -4,14 +4,17 @@ export type AiSpendContextValue = {
   isPending: boolean;
   hasAccess: boolean;
   spendWorkspaceName?: string;
+  isSpendWorkspaceActive?: boolean;
   organizationName?: string;
   projectName: string;
+  goToCostIntelligence: () => void;
 };
 
 const DEFAULT_VALUE: AiSpendContextValue = {
   isPending: false,
   hasAccess: false,
   projectName: "",
+  goToCostIntelligence: () => {},
 };
 
 const AiSpendContext = createContext<AiSpendContextValue>(DEFAULT_VALUE);

--- a/apps/opik-frontend/src/lib/utils.ts
+++ b/apps/opik-frontend/src/lib/utils.ts
@@ -248,6 +248,7 @@ export const truncateMiddle = (text: string, maxLength: number): string => {
 
 export const formatNumberInK = (value: number, precision = 1): string => {
   const ranges = [
+    { threshold: 1000000000000, suffix: "T", divider: 1000000000000 },
     { threshold: 1000000000, suffix: "B", divider: 1000000000 },
     { threshold: 1000000, suffix: "M", divider: 1000000 },
     { threshold: 1000, suffix: "K", divider: 1000 },

--- a/apps/opik-frontend/src/plugins/comet/AiSpendProvider.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AiSpendProvider.tsx
@@ -1,21 +1,78 @@
-import React, { ReactNode, useMemo } from "react";
+import React, { ReactNode, useCallback, useMemo } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import { AiSpendProvider as BaseAiSpendProvider } from "@/contexts/AiSpendContext";
+import useAppStore, {
+  useActiveWorkspaceName,
+  useSetPreviousWorkspaceName,
+  usePreviousWorkspaceName,
+} from "@/store/AppStore";
 import { AI_SPEND_PROJECT_NAME } from "@/lib/aiSpend";
 import useAiSpendManager from "./useAiSpendManager";
+import useUser from "./useUser";
 
 const AiSpendProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const { isPending, hasAccess, spendWorkspaceName, organization } =
-    useAiSpendManager();
+  const {
+    isPending,
+    hasAccess,
+    spendWorkspaceName,
+    isSpendWorkspaceActive,
+    organization,
+  } = useAiSpendManager();
+  const previousWorkspaceName = usePreviousWorkspaceName();
+  const { data: user } = useUser();
+
+  const navigate = useNavigate();
+  const activeWorkspaceName = useActiveWorkspaceName();
+  const setPreviousWorkspaceName = useSetPreviousWorkspaceName();
+
+  // Resolve the shared-navigation target synchronously during render (not in an
+  // effect) so it is correct in the same commit the sidebar/header read it.
+  // Otherwise there is a one-frame window right after entering the spend
+  // workspace where the override is still null and `useOpikWorkspaceName()`
+  // falls back to the active (hidden spend) workspace — chrome links built in
+  // that frame point at `/$spendWs/home`, which renders "private project".
+  const opikWorkspaceOverride = isSpendWorkspaceActive
+    ? previousWorkspaceName ?? user?.defaultWorkspace ?? null
+    : null;
+  if (useAppStore.getState().opikWorkspaceOverride !== opikWorkspaceOverride) {
+    useAppStore.getState().setOpikWorkspaceOverride(opikWorkspaceOverride);
+  }
+
+  const goToCostIntelligence = useCallback(() => {
+    if (!spendWorkspaceName) return;
+    if (!isSpendWorkspaceActive) {
+      setPreviousWorkspaceName(activeWorkspaceName);
+    }
+    navigate({
+      to: "/$workspaceName/ai-spend/home",
+      params: { workspaceName: spendWorkspaceName },
+    });
+  }, [
+    spendWorkspaceName,
+    isSpendWorkspaceActive,
+    activeWorkspaceName,
+    setPreviousWorkspaceName,
+    navigate,
+  ]);
 
   const value = useMemo(
     () => ({
       isPending,
       hasAccess,
       spendWorkspaceName,
+      isSpendWorkspaceActive,
       organizationName: organization?.name,
       projectName: AI_SPEND_PROJECT_NAME,
+      goToCostIntelligence,
     }),
-    [isPending, hasAccess, spendWorkspaceName, organization?.name],
+    [
+      isPending,
+      hasAccess,
+      spendWorkspaceName,
+      isSpendWorkspaceActive,
+      organization?.name,
+      goToCostIntelligence,
+    ],
   );
 
   return <BaseAiSpendProvider value={value}>{children}</BaseAiSpendProvider>;

--- a/apps/opik-frontend/src/plugins/comet/InviteUsersForm.tsx
+++ b/apps/opik-frontend/src/plugins/comet/InviteUsersForm.tsx
@@ -13,7 +13,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/ui/form";
-import useAppStore from "@/store/AppStore";
+import { useOpikWorkspaceName } from "@/store/AppStore";
 import useUser from "@/plugins/comet/useUser";
 import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
 import { useInviteUsersMutation } from "@/plugins/comet/api/useInviteMembersMutation";
@@ -59,7 +59,7 @@ export const inviteUsersSchema = z.object({
 type InviteUsersFormData = z.infer<typeof inviteUsersSchema>;
 
 const InviteUsersForm = () => {
-  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const workspaceName = useOpikWorkspaceName();
   const { data: user } = useUser();
   const { data: allWorkspaces } = useAllWorkspaces({
     enabled: !!user?.loggedIn,

--- a/apps/opik-frontend/src/plugins/comet/InviteUsersPopover.tsx
+++ b/apps/opik-frontend/src/plugins/comet/InviteUsersPopover.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Mail } from "lucide-react";
 import useCurrentOrganization from "@/plugins/comet/useCurrentOrganization";
 import useWorkspace from "@/plugins/comet/useWorkspace";
+import { useOpikWorkspaceName } from "@/store/AppStore";
 import useUsernameAutocomplete from "@/plugins/comet/api/useUsernameAutocomplete";
 import { useInviteUsersMutation } from "@/plugins/comet/api/useInviteMembersMutation";
 import { useWorkspaceUserRolesMap } from "@/plugins/comet/hooks/useWorkspaceUserRolesMap";
@@ -30,7 +31,8 @@ const InviteUsersPopover: React.FC<InviteUsersPopoverProps> = ({
   side = "bottom",
   asSubContent = false,
 }) => {
-  const workspace = useWorkspace();
+  const opikWorkspaceName = useOpikWorkspaceName();
+  const workspace = useWorkspace(opikWorkspaceName);
   const workspaceId = workspace?.workspaceId;
   const workspaceName = workspace?.workspaceName;
 

--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -55,6 +55,10 @@ import InviteUsersPopover from "@/plugins/comet/InviteUsersPopover";
 import useUserPermission from "@/plugins/comet/useUserPermission";
 import { useAiSpend } from "@/contexts/AiSpendContext";
 
+// Hidden per product for now. Direct URL access to the spend workspace
+// (/$__ai_spend_<orgId>__/ai-spend/home) keeps working regardless.
+const SHOW_COST_INTELLIGENCE: boolean = false;
+
 const UserMenu = () => {
   const { toast } = useToast();
   const { theme, themeOptions, CurrentIcon, handleThemeSelect } =
@@ -290,10 +294,11 @@ const UserMenu = () => {
               </DropdownMenuItem>
             )}
           </DropdownMenuGroup>
-          {(hasAiSpendAccess || !isLLMOnlyOrganization) && (
+          {((SHOW_COST_INTELLIGENCE && hasAiSpendAccess) ||
+            !isLLMOnlyOrganization) && (
             <>
               <DropdownMenuSeparator />
-              {hasAiSpendAccess && (
+              {SHOW_COST_INTELLIGENCE && hasAiSpendAccess && (
                 <DropdownMenuItem
                   className="cursor-pointer"
                   onClick={goToCostIntelligence}

--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -12,8 +12,6 @@ import {
   Sparkles,
   UserPlus,
 } from "lucide-react";
-import { useNavigate } from "@tanstack/react-router";
-
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import SupportHubSubMenu from "@/shared/SupportHub/SupportHubSubMenu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/ui/avatar";
@@ -35,7 +33,10 @@ import { useThemeOptions } from "@/hooks/useThemeOptions";
 import { APP_VERSION } from "@/constants/app";
 import { ADMIN_DASHBOARD_LABEL } from "@/constants/labels";
 import { cn, maskAPIKey } from "@/lib/utils";
-import useAppStore, { useDetectedWorkspaceVersion } from "@/store/AppStore";
+import useAppStore, {
+  useDetectedWorkspaceVersion,
+  useOpikWorkspaceName,
+} from "@/store/AppStore";
 import {
   getNewExperienceOptIn,
   getVersionOverride,
@@ -86,8 +87,8 @@ const UserMenu = () => {
   );
 
   const { canInviteMembers } = useUserPermission();
-  const navigate = useNavigate();
-  const { hasAccess: hasAiSpendAccess } = useAiSpend();
+  const { hasAccess: hasAiSpendAccess, goToCostIntelligence } = useAiSpend();
+  const opikWorkspaceName = useOpikWorkspaceName();
   const [inviteSearchQuery, setInviteSearchQuery] = useState("");
   const [isInviteSubmenuOpen, setIsInviteSubmenuOpen] = useState(false);
 
@@ -109,8 +110,8 @@ const UserMenu = () => {
 
   const handleSwitchToEM = () => {
     window.location.href = buildUrl(
-      workspaceName,
-      workspaceName,
+      opikWorkspaceName,
+      opikWorkspaceName,
       "&changeApplication=em",
     );
   };
@@ -180,7 +181,7 @@ const UserMenu = () => {
           </div>
           <DropdownMenuSeparator />
           <DropdownMenuGroup>
-            <a href={buildUrl("account-settings", workspaceName)}>
+            <a href={buildUrl("account-settings", opikWorkspaceName)}>
               <DropdownMenuItem className="cursor-pointer">
                 <Settings className="mr-2 size-4" />
                 <span>Account settings</span>
@@ -190,7 +191,7 @@ const UserMenu = () => {
               <a
                 href={buildUrl(
                   `organizations/${workspace?.organizationId}`,
-                  workspaceName,
+                  opikWorkspaceName,
                 )}
               >
                 <DropdownMenuItem className="cursor-pointer">
@@ -228,7 +229,7 @@ const UserMenu = () => {
                           className="cursor-pointer rounded p-0.5 hover:text-foreground"
                           href={buildUrl(
                             "account-settings/apiKeys",
-                            workspaceName,
+                            opikWorkspaceName,
                           )}
                         >
                           <Settings2 className="size-3.5" />
@@ -276,7 +277,7 @@ const UserMenu = () => {
                 onSelect={(e) => {
                   e.preventDefault();
                   setNewExperienceOptIn(!hasOptedIn);
-                  navigateToWorkspaceRoot(workspaceName);
+                  navigateToWorkspaceRoot(opikWorkspaceName);
                 }}
               >
                 <Sparkles className="mr-2 size-4" />
@@ -295,12 +296,7 @@ const UserMenu = () => {
               {hasAiSpendAccess && (
                 <DropdownMenuItem
                   className="cursor-pointer"
-                  onClick={() =>
-                    navigate({
-                      to: "/$workspaceName/ai-spend/home",
-                      params: { workspaceName },
-                    })
-                  }
+                  onClick={goToCostIntelligence}
                 >
                   <span className="mr-2 flex size-5 shrink-0 items-center justify-center rounded bg-chart-green text-[10px] font-medium text-white">
                     CI

--- a/apps/opik-frontend/src/plugins/comet/lib/aiSpend.ts
+++ b/apps/opik-frontend/src/plugins/comet/lib/aiSpend.ts
@@ -1,7 +1,7 @@
 import { isAiSpendRoute } from "@/lib/aiSpend";
 import { Workspace } from "../types";
 
-const AI_SPEND_WORKSPACE_PATTERN = /^__cc_.+__$/;
+const AI_SPEND_WORKSPACE_PATTERN = /^__(?:ai_spend|cc)_.+__$/;
 
 export const isAiSpendWorkspace = (workspace?: Workspace | null): boolean =>
   AI_SPEND_WORKSPACE_PATTERN.test(workspace?.workspaceName ?? "");

--- a/apps/opik-frontend/src/plugins/comet/useAiSpendManager.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAiSpendManager.ts
@@ -34,10 +34,13 @@ const useAiSpendManager = () => {
     organization?.role === ORGANIZATION_ROLE_TYPE.admin;
 
   return {
-    isPending: isEnabled && (isOrganizationsPending || isWorkspacesPending),
+    isPending:
+      isEnabled &&
+      (isOrganizationsPending || isWorkspacesPending || !workspaceVersion),
     organization,
     spendWorkspace,
     spendWorkspaceName: spendWorkspace?.workspaceName,
+    isSpendWorkspaceActive: isAiSpendWorkspace(currentWorkspace),
     isEnterprise,
     isOrganizationAdmin,
     hasAccess:

--- a/apps/opik-frontend/src/plugins/comet/useInviteMembersURL.ts
+++ b/apps/opik-frontend/src/plugins/comet/useInviteMembersURL.ts
@@ -1,4 +1,4 @@
-import useAppStore from "@/store/AppStore";
+import { useOpikWorkspaceName } from "@/store/AppStore";
 import useUser from "@/plugins/comet/useUser";
 import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
 import { buildUrl } from "@/plugins/comet/utils";
@@ -7,7 +7,7 @@ import useOrganizations from "@/plugins/comet/useOrganizations";
 import useUserPermissions from "@/plugins/comet/useUserPermissions";
 
 const useInviteMembersURL = () => {
-  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const workspaceName = useOpikWorkspaceName();
 
   const { data: user } = useUser();
   const { data: allWorkspaces } = useAllWorkspaces({

--- a/apps/opik-frontend/src/plugins/comet/useWorkspace.ts
+++ b/apps/opik-frontend/src/plugins/comet/useWorkspace.ts
@@ -1,14 +1,13 @@
 import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
 import useAppStore from "@/store/AppStore";
 
-const useWorkspace = () => {
-  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+const useWorkspace = (workspaceName?: string) => {
+  const activeWorkspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const name = workspaceName ?? activeWorkspaceName;
 
   const { data: allWorkspaces } = useAllWorkspaces();
 
-  const workspace = allWorkspaces?.find(
-    (w) => w.workspaceName === workspaceName,
-  );
+  const workspace = allWorkspaces?.find((w) => w.workspaceName === name);
 
   return workspace;
 };

--- a/apps/opik-frontend/src/store/AppStore.ts
+++ b/apps/opik-frontend/src/store/AppStore.ts
@@ -21,6 +21,10 @@ type AppStore = {
   setWorkspaceVersion: (version: WorkspaceVersion) => void;
   detectedWorkspaceVersion: WorkspaceVersion | null;
   setDetectedWorkspaceVersion: (version: WorkspaceVersion | null) => void;
+  previousWorkspaceName: string | null;
+  setPreviousWorkspaceName: (workspaceName: string | null) => void;
+  opikWorkspaceOverride: string | null;
+  setOpikWorkspaceOverride: (workspaceName: string | null) => void;
 };
 
 const useAppStore = create<AppStore>((set) => ({
@@ -48,6 +52,12 @@ const useAppStore = create<AppStore>((set) => ({
   detectedWorkspaceVersion: null,
   setDetectedWorkspaceVersion: (version: WorkspaceVersion | null) =>
     set({ detectedWorkspaceVersion: version }),
+  previousWorkspaceName: null,
+  setPreviousWorkspaceName: (workspaceName: string | null) =>
+    set({ previousWorkspaceName: workspaceName }),
+  opikWorkspaceOverride: null,
+  setOpikWorkspaceOverride: (workspaceName: string | null) =>
+    set({ opikWorkspaceOverride: workspaceName }),
 }));
 
 export const useActiveWorkspaceName = () =>
@@ -64,6 +74,29 @@ export const useWorkspaceVersion = () =>
 
 export const useDetectedWorkspaceVersion = () =>
   useAppStore((state) => state.detectedWorkspaceVersion);
+
+export const usePreviousWorkspaceName = () =>
+  useAppStore((state) => state.previousWorkspaceName);
+
+export const useSetPreviousWorkspaceName = () =>
+  useAppStore((state) => state.setPreviousWorkspaceName);
+
+// The workspace that shared navigation (logo, breadcrumbs, account settings,
+// invites, "Back to Opik") should target. Normally this is the active
+// workspace, but special sections can run inside a workspace the user should
+// not be sent "home" into — today the hidden AI-Spend workspace
+// (`__ai_spend_<orgId>__`), where the active workspace is the spend workspace
+// but those links must point back at the user's real workspace. That feature
+// sets `opikWorkspaceOverride` to the real workspace while active and clears it
+// on exit; generic components read `useOpikWorkspaceName()` and stay unaware of
+// the feature. When no override is set it falls back to the active workspace.
+export const useSetOpikWorkspaceOverride = () =>
+  useAppStore((state) => state.setOpikWorkspaceOverride);
+
+export const useOpikWorkspaceName = () =>
+  useAppStore(
+    (state) => state.opikWorkspaceOverride ?? state.activeWorkspaceName,
+  );
 
 const getResolvedUserName = (userName: string, defaultUserName?: string) => {
   return isDefaultUser(userName) ? defaultUserName : userName;

--- a/apps/opik-frontend/src/v2/layout/SideBar/AiSpendSidebarContent.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/AiSpendSidebarContent.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { LayoutDashboard, Trophy, Undo2, Zap } from "lucide-react";
+import { LayoutDashboard, ScrollText, Trophy, Undo2, Zap } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useActiveWorkspaceName } from "@/store/AppStore";
+import { useOpikWorkspaceName } from "@/store/AppStore";
 import { useAiSpend } from "@/contexts/AiSpendContext";
 import { Separator } from "@/ui/separator";
 import { Button } from "@/ui/button";
@@ -28,6 +28,13 @@ const OVERVIEW_ITEMS: MenuItem[] = [
     icon: Trophy,
     label: "User leaderboard",
   },
+  {
+    id: "ai_spend_sessions",
+    path: "/$workspaceName/ai-spend/sessions",
+    type: MENU_ITEM_TYPE.router,
+    icon: ScrollText,
+    label: "Sessions",
+  },
 ];
 
 const groupLabelClasses =
@@ -40,12 +47,15 @@ interface AiSpendSidebarContentProps {
 const AiSpendSidebarContent: React.FC<AiSpendSidebarContentProps> = ({
   expanded,
 }) => {
-  const workspaceName = useActiveWorkspaceName();
   const navigate = useNavigate();
   const { organizationName } = useAiSpend();
+  const opikWorkspaceName = useOpikWorkspaceName();
 
   const goBackToOpik = () =>
-    navigate({ to: "/$workspaceName/home", params: { workspaceName } });
+    navigate({
+      to: "/$workspaceName/home",
+      params: { workspaceName: opikWorkspaceName },
+    });
 
   const header = expanded ? (
     <div className="flex items-center gap-2 px-1 py-0.5">

--- a/apps/opik-frontend/src/v2/layout/SideBar/SideBar.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/SideBar.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link, useRouterState } from "@tanstack/react-router";
 import { PanelLeft } from "lucide-react";
-import { useActiveWorkspaceName } from "@/store/AppStore";
+import { useOpikWorkspaceName } from "@/store/AppStore";
 import { Button } from "@/ui/button";
 import Logo from "@/shared/Logo/Logo";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
@@ -25,7 +25,6 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
   onToggle,
 }) => {
   useActiveProjectInitializer();
-  const workspaceName = useActiveWorkspaceName();
 
   const isProjectRoute = useRouterState({
     select: (state) =>
@@ -36,6 +35,8 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
     select: (state) => isAiSpendRoute(state.location.pathname),
   });
 
+  const opikWorkspaceName = useOpikWorkspaceName();
+
   const logo = <Logo expanded={expanded} />;
 
   return (
@@ -44,7 +45,7 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
         <Link
           to={HOME_PATH}
           className="absolute left-[15px] top-1/2 block -translate-y-1/2"
-          params={{ workspaceName }}
+          params={{ workspaceName: opikWorkspaceName }}
         >
           {logo}
           {canToggle && !expanded && (

--- a/apps/opik-frontend/src/v2/pages/AiSpend/AiSpend.tsx
+++ b/apps/opik-frontend/src/v2/pages/AiSpend/AiSpend.tsx
@@ -1,19 +1,24 @@
 import React from "react";
 import { Navigate, Outlet } from "@tanstack/react-router";
 import Loader from "@/shared/Loader/Loader";
-import { useActiveWorkspaceName } from "@/store/AppStore";
+import { useOpikWorkspaceName } from "@/store/AppStore";
 import { useAiSpend } from "@/contexts/AiSpendContext";
 
 const AiSpend: React.FC = () => {
-  const workspaceName = useActiveWorkspaceName();
-  const { isPending, hasAccess } = useAiSpend();
+  const opikWorkspaceName = useOpikWorkspaceName();
+  const { isPending, hasAccess, isSpendWorkspaceActive } = useAiSpend();
 
   if (isPending) {
     return <Loader />;
   }
 
-  if (!hasAccess) {
-    return <Navigate to="/$workspaceName/home" params={{ workspaceName }} />;
+  if (!hasAccess || !isSpendWorkspaceActive) {
+    return (
+      <Navigate
+        to="/$workspaceName/home"
+        params={{ workspaceName: opikWorkspaceName }}
+      />
+    );
   }
 
   return <Outlet />;

--- a/apps/opik-frontend/src/v2/pages/LogsPage/AiSpendSessionsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/AiSpendSessionsPage.tsx
@@ -1,0 +1,62 @@
+import useProjectByName from "@/api/projects/useProjectByName";
+import { AI_SPEND_PROJECT_NAME } from "@/lib/aiSpend";
+import PageBodyScrollContainer from "@/v2/layout/PageBodyScrollContainer/PageBodyScrollContainer";
+import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
+import LogsTab from "@/v2/pages/LogsPage/LogsTab";
+import useLogsType from "@/v2/pages/LogsPage/useLogsType";
+import Loader from "@/shared/Loader/Loader";
+import NoData from "@/shared/NoData/NoData";
+
+const AiSpendSessionsPage = () => {
+  const {
+    data: project,
+    isPending,
+    isError,
+  } = useProjectByName(
+    { projectName: AI_SPEND_PROJECT_NAME },
+    { refetchOnMount: false, retry: false },
+  );
+
+  const projectId = project?.id ?? "";
+  const projectName = project?.name || AI_SPEND_PROJECT_NAME;
+
+  const { logsType, needsDefaultResolution, setLogsType } = useLogsType({
+    projectId,
+  });
+
+  if (isPending) {
+    return <Loader />;
+  }
+
+  if (isError || !project) {
+    return (
+      <NoData
+        title="No sessions yet"
+        message="No Claude Code activity has been logged for this organization yet."
+      />
+    );
+  }
+
+  return (
+    <PageBodyScrollContainer>
+      <PageBodyStickyContainer
+        className="mb-3 mt-6 flex items-center justify-between"
+        direction="horizontal"
+      >
+        <h1 className="comet-body-accented truncate break-words">Sessions</h1>
+      </PageBodyStickyContainer>
+      {needsDefaultResolution ? (
+        <Loader />
+      ) : (
+        <LogsTab
+          projectId={projectId}
+          projectName={projectName}
+          logsType={logsType}
+          onLogsTypeChange={setLogsType}
+        />
+      )}
+    </PageBodyScrollContainer>
+  );
+};
+
+export default AiSpendSessionsPage;

--- a/apps/opik-frontend/src/v2/router.tsx
+++ b/apps/opik-frontend/src/v2/router.tsx
@@ -67,6 +67,7 @@ import ProjectDashboardsPage from "@/v2/pages/ProjectDashboardsPage/ProjectDashb
 import AiSpend from "@/v2/pages/AiSpend/AiSpend";
 import AiSpendHomePage from "@/v2/pages/AiSpendHomePage/AiSpendHomePage";
 import AiSpendLeaderboardPage from "@/v2/pages/AiSpendLeaderboardPage/AiSpendLeaderboardPage";
+import AiSpendSessionsPage from "@/v2/pages/LogsPage/AiSpendSessionsPage";
 
 const TanStackRouterDevtools =
   process.env.NODE_ENV === "production"
@@ -646,6 +647,15 @@ const aiSpendLeaderboardRoute = createRoute({
   },
 });
 
+const aiSpendSessionsRoute = createRoute({
+  path: "/sessions",
+  getParentRoute: () => aiSpendRoute,
+  component: AiSpendSessionsPage,
+  staticData: {
+    title: "Sessions",
+  },
+});
+
 // ----------- Automation logs
 const automationLogsRoute = createRoute({
   path: "/$workspaceName/automation-logs",
@@ -679,6 +689,7 @@ const routeTree = rootRoute.addChildren([
       aiSpendIndexRoute,
       aiSpendHomeRoute,
       aiSpendLeaderboardRoute,
+      aiSpendSessionsRoute,
     ]),
     workspaceRoute.addChildren([
       workspaceIndexRoute,


### PR DESCRIPTION
Routes shared navigation (logo, back link, invites) through a neutral workspace-name override resolved synchronously, and adds a trillions bucket to formatNumberInK.