### PR TITLE
[OPIK-6820] [FE] feat: add total tokens KPI card to AI Spend home

### DIFF
--- a/apps/opik-frontend/src/api/ai-spend/claudePricing.ts
+++ b/apps/opik-frontend/src/api/ai-spend/claudePricing.ts
@@ -194,6 +194,13 @@ const tierTotal = (tiers: ModelTiers): number =>
   (tiers.cache_creation_tokens ?? 0) +
   (tiers.output_tokens ?? 0);
 
+// Total tokens across a per-model tier breakdown, summed via tierTotal. Null
+// when there's no per-model data so the UI shows N/A instead of 0.
+export const tiersTokens = (byModel?: ModelTiers[] | null): number | null =>
+  byModel && byModel.length > 0
+    ? byModel.reduce((sum, tiers) => sum + tierTotal(tiers), 0)
+    : null;
+
 // The model carrying the most tokens, for a single-chip label. Null when the
 // breakdown is empty.
 export const dominantModel = (byModel?: ModelTiers[] | null): string | null => {

--- a/apps/opik-frontend/src/v2/pages/AiSpendHomePage/HomeSummaryCards.tsx
+++ b/apps/opik-frontend/src/v2/pages/AiSpendHomePage/HomeSummaryCards.tsx
@@ -4,7 +4,7 @@ import {
   ArrowRightToLine,
   CircleDollarSign,
   MessagesSquare,
-  PiggyBank,
+  Sigma,
   User,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -12,7 +12,7 @@ import PercentageTrend, {
   PercentageTrendType,
 } from "@/shared/PercentageTrend/PercentageTrend";
 import useAiSpendSummary from "@/api/ai-spend/useAiSpendSummary";
-import { tiersCost } from "@/api/ai-spend/claudePricing";
+import { tiersCost, tiersTokens } from "@/api/ai-spend/claudePricing";
 import { useAiSpend } from "@/contexts/AiSpendContext";
 import KpiCard from "./KpiCard";
 import {
@@ -76,6 +76,11 @@ const HomeSummaryCards: React.FC<HomeSummaryCardsProps> = ({
   const activeUsers = get("active_users");
   const totalUsers = get("total_users");
 
+  const totalTokens: SpendMetric = {
+    current: tiersTokens(data?.spend_current),
+    previous: tiersTokens(data?.spend_previous),
+  };
+
   const renderTrend = (
     metric: SpendMetric,
     trend: PercentageTrendType = "inverted",
@@ -110,9 +115,10 @@ const HomeSummaryCards: React.FC<HomeSummaryCardsProps> = ({
         loading={isPending}
       />
       <KpiCard
-        icon={PiggyBank}
-        label="Budget remaining"
-        value={NO_DATA}
+        icon={Sigma}
+        label="Total tokens"
+        value={showData ? formatSpendCount(totalTokens.current) : NO_DATA}
+        trend={renderTrend(totalTokens)}
         loading={isPending}
       />
       <KpiCard


### PR DESCRIPTION
## Details

<img width="1656" height="929" alt="image" src="https://github.com/user-attachments/assets/d47f8aa5-e8b5-4402-b46c-96b512c7b9ee" />

Replace the placeholder "Budget remaining" card on the AI Spend home dashboard with a **Total tokens** KPI (with period-over-period trend). FE-only — built on the `cc.billing` token-native schema (#7037): the summary endpoint already returns per-model cache-tier sums in `spend_current` / `spend_previous`, so the card sums those tiers (input + cache read + cache creation + output) across models, mirroring how the existing "Total spend" card prices the same tiers via `tiersCost`.

- No backend change — reuses the tier data the summary already returns.
- `Total tokens` value + trend computed inline in `HomeSummaryCards`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6820

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: full implementation
  - Human verification: code review + manual testing on dev

## Testing

- `bash scripts/dev-runner.sh --lint-fe` (ESLint + Stylelint + `tsc --noEmit` + dependency-cruiser) — green.
- Manual: verified the Total tokens card renders real numbers (not N/A) with data and updates across the 7d/30d/90d period toggles on dev.

## Documentation

N/A