### PR TITLE
[OPIK-6921] [BE] derive bulk project from the experiment or dataset

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
@@ -80,7 +80,6 @@ import jakarta.ws.rs.core.UriInfo;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.glassfish.jersey.server.ChunkedOutput;
 
 import java.util.Collections;
@@ -520,9 +519,6 @@ public class ExperimentsResource {
     public Response experimentItemsBulk(
             @RequestBody(content = @Content(schema = @Schema(implementation = ExperimentItemBulkUpload.class))) @NotNull @Valid @JsonView(ExperimentItemBulkUpload.View.ExperimentItemBulkWriteView.class) ExperimentItemBulkUpload request) {
 
-        String workspaceId = requestContext.get().getWorkspaceId();
-        String userName = requestContext.get().getUserName();
-
         log.info("Recording experiment items in bulk, count '{}', experimentId '{}'", request.items().size(),
                 request.experimentId());
 
@@ -542,27 +538,33 @@ public class ExperimentsResource {
                 .projectName(request.projectName())
                 .build();
 
-        experimentItemBulkIngestionService.ingest(experiment, request.projectName(), items)
-                .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, userName)
-                        .put(RequestContext.WORKSPACE_ID, workspaceId))
+        // The service resolves the project (explicit project_name, else derived from the existing experiment
+        // or dataset, else the default project) and returns whether the deprecated default-project fallback
+        // was used for any item.
+        boolean usedDefaultProjectFallback = Boolean.TRUE.equals(experimentItemBulkIngestionService
+                .ingest(experiment, request.projectName(), items)
+                .contextWrite(ctx -> setRequestContext(ctx, requestContext))
                 .retryWhen(RetryUtils.handleConnectionError())
-                .block();
+                .block());
 
         log.info("Recorded experiment items in bulk, count '{}', experimentId '{}'", request.items().size(),
                 request.experimentId());
 
         Response.ResponseBuilder responseBuilder = Response.noContent();
-        // Warn only when a fallback to the default project actually happened: no request-level project_name AND
-        // at least one item without its own project (no trace, or a trace with a blank project_name).
-        boolean usedDefaultProjectFallback = StringUtils.isBlank(request.projectName())
-                && items.stream().anyMatch(
-                        item -> item.trace() == null || StringUtils.isBlank(item.trace().projectName()));
+
+        // Two deprecation fallbacks can surface on this endpoint, both via the X-Opik-Deprecation header:
+        // 1) the project fallback — traces without a project were placed in the default project;
         if (usedDefaultProjectFallback) {
-            // Nudge clients to set project_name so experiments stay in their intended project.
             responseBuilder.header(RequestContext.WORKSPACE_FALLBACK_HEADER,
-                    ("project_name was not provided; traces without a project were placed in the default project "
-                            + "'%s'. This fallback is deprecated, please provide project_name.")
+                    ("project_name could not be resolved; traces without a project were placed in the default "
+                            + "project '%s'. This fallback is deprecated, please provide project_name.")
                             .formatted(ProjectService.DEFAULT_PROJECT));
+        }
+        // 2) the workspace fallback — an entity (e.g. the dataset) was resolved via workspace-wide search,
+        //    set on the request context during resolution (same mechanism used by other resources).
+        String workspaceFallbackMessage = requestContext.get().getWorkspaceFallbackMessage();
+        if (workspaceFallbackMessage != null) {
+            responseBuilder.header(RequestContext.WORKSPACE_FALLBACK_HEADER, workspaceFallbackMessage);
         }
 
         return responseBuilder.build();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ExperimentsResource.java
@@ -539,32 +539,33 @@ public class ExperimentsResource {
                 .build();
 
         // The service resolves the project (explicit project_name, else derived from the existing experiment
-        // or dataset, else the default project) and returns whether the deprecated default-project fallback
-        // was used for any item.
-        boolean usedDefaultProjectFallback = Boolean.TRUE.equals(experimentItemBulkIngestionService
+        // or dataset, else the default project) and reports which deprecated fallback (if any) it used.
+        ExperimentItemBulkIngestionService.ProjectFallback fallback = experimentItemBulkIngestionService
                 .ingest(experiment, request.projectName(), items)
                 .contextWrite(ctx -> setRequestContext(ctx, requestContext))
                 .retryWhen(RetryUtils.handleConnectionError())
-                .block());
+                .block();
 
         log.info("Recorded experiment items in bulk, count '{}', experimentId '{}'", request.items().size(),
                 request.experimentId());
 
         Response.ResponseBuilder responseBuilder = Response.noContent();
 
-        // Two deprecation fallbacks can surface on this endpoint, both via the X-Opik-Deprecation header:
-        // 1) the project fallback — traces without a project were placed in the default project;
-        if (usedDefaultProjectFallback) {
-            responseBuilder.header(RequestContext.WORKSPACE_FALLBACK_HEADER,
+        // Surface the deprecated implicit-fallback as the X-Opik-Deprecation header (on the request thread, so
+        // the request-scoped fallback message can be set/read safely — same mechanism as other resources).
+        switch (fallback) {
+            case DATASET -> {
+                requestContext.get().setWorkspaceFallbackFor("Dataset", request.datasetName());
+                responseBuilder.header(RequestContext.WORKSPACE_FALLBACK_HEADER,
+                        requestContext.get().getWorkspaceFallbackMessage());
+            }
+            case DEFAULT -> responseBuilder.header(RequestContext.WORKSPACE_FALLBACK_HEADER,
                     ("project_name could not be resolved; traces without a project were placed in the default "
                             + "project '%s'. This fallback is deprecated, please provide project_name.")
                             .formatted(ProjectService.DEFAULT_PROJECT));
-        }
-        // 2) the workspace fallback — an entity (e.g. the dataset) was resolved via workspace-wide search,
-        //    set on the request context during resolution (same mechanism used by other resources).
-        String workspaceFallbackMessage = requestContext.get().getWorkspaceFallbackMessage();
-        if (workspaceFallbackMessage != null) {
-            responseBuilder.header(RequestContext.WORKSPACE_FALLBACK_HEADER, workspaceFallbackMessage);
+            case NONE -> {
+                // no deprecation
+            }
         }
 
         return responseBuilder.build();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
@@ -1,5 +1,6 @@
 package com.comet.opik.domain;
 
+import com.comet.opik.api.DatasetIdentifier;
 import com.comet.opik.api.Experiment;
 import com.comet.opik.api.ExperimentItem;
 import com.comet.opik.api.ExperimentItemBulkRecord;
@@ -48,12 +49,13 @@ public interface ExperimentItemBulkIngestionService {
      * Ingests a batch of experiment items.
      *
      * @param experiment the experiment to add items to
-     * @param projectName the project for traces auto-created from items that provide evaluate_task_result
-     *                    (i.e. without an explicit trace); when blank, the default project is used
+     * @param projectName the explicit project for traces that don't carry their own project. When blank, the
+     *                    project is derived from the existing experiment or dataset; if neither resolves, the
+     *                    default project is used.
      * @param items the list of experiment items to ingest
-     * @return a list of feedback score batch items
+     * @return {@code true} when traces fell back to the default project (deprecated), {@code false} otherwise
      */
-    Mono<Void> ingest(Experiment experiment, String projectName, List<ExperimentItemBulkRecord> items);
+    Mono<Boolean> ingest(Experiment experiment, String projectName, List<ExperimentItemBulkRecord> items);
 }
 
 @Singleton
@@ -67,7 +69,11 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
     private final @NonNull ExperimentItemService experimentItemService;
     private final @NonNull FeedbackScoreService feedbackScoreService;
     private final @NonNull ProjectService projectService;
+    private final @NonNull DatasetService datasetService;
     private final @NonNull IdGenerator idGenerator;
+
+    private record ResolvedProject(String name, boolean fallback) {
+    }
 
     /**
      * Ingests a batch of experiment items.
@@ -77,115 +83,183 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
      * @return a list of feedback score batch items
      */
     @Override
-    public Mono<Void> ingest(Experiment experiment, String projectName, List<ExperimentItemBulkRecord> items) {
+    public Mono<Boolean> ingest(Experiment experiment, String projectName, List<ExperimentItemBulkRecord> items) {
 
         return Mono.deferContextual(ctx -> {
 
             String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
 
-            // Project applied to traces that don't carry their own project: traces auto-created from
-            // evaluate_task_result items, and explicit traces with a blank project_name. When the request
-            // does not specify one, fall back to the default project (deprecated behavior).
-            String bulkProjectName = StringUtils.isNotBlank(projectName)
-                    ? projectName
-                    : ProjectService.DEFAULT_PROJECT;
+            return loadExistingExperiment(experiment)
+                    .flatMap(existingExperiment -> validateExperimentConsistency(experiment, projectName,
+                            existingExperiment)
+                            .then(resolveBulkProject(experiment, projectName, existingExperiment))
+                            .flatMap(resolvedProject -> {
+                                // Project applied to traces that don't carry their own project (auto-created
+                                // from evaluate_task_result, or explicit traces with a blank project_name).
+                                String bulkProjectName = resolvedProject.name();
 
-            return validateExperimentConsistency(experiment)
-                    .then(experimentService.create(experiment))
-                    .retryWhen(RetryUtils.handleConnectionError())
-                    .flatMap(experimentId -> {
-                        log.info(
-                                "Using experiment with id '{}', name '{}', datasetName '{}', projectName '{}', workspaceId '{}'",
-                                experimentId, experiment.name(), experiment.datasetName(), experiment.projectName(),
-                                workspaceId);
+                                // Flag the deprecated default-project fallback only when it actually applies to
+                                // at least one item without its own project.
+                                boolean usedDefaultProjectFallback = resolvedProject.fallback()
+                                        && items.stream().anyMatch(item -> item.trace() == null
+                                                || StringUtils.isBlank(item.trace().projectName()));
 
-                        // Collect unique project names: the bulk project (for auto-created traces and
-                        // traces without a project), plus any project specified on item-level traces.
-                        List<String> projectNames = Stream.concat(
-                                Stream.of(bulkProjectName),
-                                items.stream()
-                                        .map(ExperimentItemBulkRecord::trace)
-                                        .filter(Objects::nonNull)
-                                        .map(Trace::projectName)
-                                        .filter(StringUtils::isNotBlank))
-                                .distinct()
-                                .toList();
+                                // When the project was explicitly provided or derived, create the experiment
+                                // (and its dataset) in it too so everything stays in one project.
+                                Experiment experimentToCreate = resolvedProject.fallback()
+                                        ? experiment
+                                        : experiment.toBuilder().projectName(bulkProjectName).build();
 
-                        // Resolve project names to project IDs upfront
-                        return Flux.fromIterable(projectNames)
-                                .flatMap(projectService::getOrCreate)
-                                .collectMap(Project::name, Project::id,
-                                        () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER))
-                                .flatMap(projectNameToIdMap -> {
-                                    Set<ExperimentItem> experimentItems = new HashSet<>();
-                                    List<Trace> traces = new ArrayList<>();
-                                    List<Span> spans = new ArrayList<>();
-                                    List<FeedbackScoreBatchItem> feedbackScores = new ArrayList<>();
+                                return experimentService.create(experimentToCreate)
+                                        .retryWhen(RetryUtils.handleConnectionError())
+                                        .flatMap(experimentId -> {
+                                            log.info(
+                                                    "Using experiment with id '{}', name '{}', datasetName '{}', projectName '{}', workspaceId '{}'",
+                                                    experimentId, experimentToCreate.name(),
+                                                    experimentToCreate.datasetName(), bulkProjectName, workspaceId);
 
-                                    this.splitBatches(
-                                            items,
-                                            traces,
-                                            experimentId,
-                                            experimentItems,
-                                            spans,
-                                            feedbackScores,
-                                            projectNameToIdMap,
-                                            bulkProjectName);
+                                            // Collect unique project names: the bulk project (for auto-created
+                                            // traces and traces without a project), plus any project specified
+                                            // on item-level traces.
+                                            List<String> projectNames = Stream.concat(
+                                                    Stream.of(bulkProjectName),
+                                                    items.stream()
+                                                            .map(ExperimentItemBulkRecord::trace)
+                                                            .filter(Objects::nonNull)
+                                                            .map(Trace::projectName)
+                                                            .filter(StringUtils::isNotBlank))
+                                                    .distinct()
+                                                    .toList();
 
-                                    return experimentItemService.create(experimentItems)
-                                            .then(saveAll(traces, spans, feedbackScores))
-                                            .flatMap(tuple -> {
+                                            // Resolve project names to project IDs upfront
+                                            return Flux.fromIterable(projectNames)
+                                                    .flatMap(projectService::getOrCreate)
+                                                    .collectMap(Project::name, Project::id,
+                                                            () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER))
+                                                    .flatMap(projectNameToIdMap -> {
+                                                        Set<ExperimentItem> experimentItems = new HashSet<>();
+                                                        List<Trace> traces = new ArrayList<>();
+                                                        List<Span> spans = new ArrayList<>();
+                                                        List<FeedbackScoreBatchItem> feedbackScores = new ArrayList<>();
 
-                                                log.info(
-                                                        "Recorded experiment items in bulk, experiment items count '{}', traces count '{}', spans count '{}' and feedback scores count '{}'",
-                                                        experimentItems.size(), traces.size(), spans.size(),
-                                                        feedbackScores.size());
+                                                        this.splitBatches(
+                                                                items,
+                                                                traces,
+                                                                experimentId,
+                                                                experimentItems,
+                                                                spans,
+                                                                feedbackScores,
+                                                                projectNameToIdMap,
+                                                                bulkProjectName);
 
-                                                return Mono.just(tuple);
-                                            })
-                                            .then();
-                                });
-                    });
+                                                        return experimentItemService.create(experimentItems)
+                                                                .then(saveAll(traces, spans, feedbackScores))
+                                                                .doOnSuccess(tuple -> log.info(
+                                                                        "Recorded experiment items in bulk, experiment items count '{}', traces count '{}', spans count '{}' and feedback scores count '{}'",
+                                                                        experimentItems.size(), traces.size(),
+                                                                        spans.size(), feedbackScores.size()))
+                                                                .thenReturn(usedDefaultProjectFallback);
+                                                    });
+                                        });
+                            }));
         });
     }
 
-    private Mono<Void> validateExperimentConsistency(Experiment experiment) {
+    private Mono<Optional<Experiment>> loadExistingExperiment(Experiment experiment) {
         if (experiment.id() == null) {
-            return Mono.empty(); // New experiment, no validation needed
+            return Mono.just(Optional.empty());
         }
 
         return experimentService.getById(experiment.id())
-                .flatMap(existingExperiment -> {
-                    // Validate dataset consistency
-                    if (!experiment.datasetName().equals(existingExperiment.datasetName())) {
-                        String errorMessage = "Experiment '%s' belongs to dataset '%s', but request specifies dataset '%s'"
-                                .formatted(experiment.id(), existingExperiment.datasetName(), experiment.datasetName());
-                        return Mono.error(new ClientErrorException(errorMessage, Response.Status.CONFLICT));
+                .map(Optional::of)
+                .onErrorResume(NotFoundException.class, ex -> Mono.just(Optional.empty()));
+    }
+
+    /**
+     * Resolves the project for traces that don't carry their own project:
+     * <ol>
+     * <li>the explicit request {@code project_name}, when provided;</li>
+     * <li>otherwise the existing experiment's project, when it already exists and has one;</li>
+     * <li>otherwise the existing dataset's project, when it already exists and has one;</li>
+     * <li>otherwise the default project (deprecated fallback).</li>
+     * </ol>
+     * Derivation only reads existing entities; it never creates an experiment or dataset to obtain a project.
+     */
+    private Mono<ResolvedProject> resolveBulkProject(Experiment experiment, String projectName,
+            Optional<Experiment> existingExperiment) {
+
+        if (StringUtils.isNotBlank(projectName)) {
+            return Mono.just(new ResolvedProject(projectName, false));
+        }
+
+        if (existingExperiment.isPresent() && StringUtils.isNotBlank(existingExperiment.get().projectName())) {
+            return Mono.just(new ResolvedProject(existingExperiment.get().projectName(), false));
+        }
+
+        return resolveDatasetProjectName(experiment.datasetName())
+                .map(datasetProjectName -> new ResolvedProject(datasetProjectName, false))
+                .defaultIfEmpty(new ResolvedProject(ProjectService.DEFAULT_PROJECT, true));
+    }
+
+    private Mono<String> resolveDatasetProjectName(String datasetName) {
+        return datasetService
+                .resolveDatasetByNameAsync(DatasetIdentifier.builder().datasetName(datasetName).build())
+                .flatMap(dataset -> dataset.projectId() == null
+                        ? Mono.<String>empty()
+                        : projectService.getOrFail(dataset.projectId())
+                                .map(Project::name)
+                                .onErrorResume(NotFoundException.class, ex -> Mono.empty()))
+                .onErrorResume(NotFoundException.class, ex -> Mono.empty());
+    }
+
+    private Mono<Void> validateExperimentConsistency(Experiment experiment, String projectName,
+            Optional<Experiment> existingExperiment) {
+
+        // Validate dataset-name consistency against an existing experiment.
+        if (existingExperiment.isPresent()
+                && !experiment.datasetName().equals(existingExperiment.get().datasetName())) {
+            String errorMessage = "Experiment '%s' belongs to dataset '%s', but request specifies dataset '%s'"
+                    .formatted(experiment.id(), existingExperiment.get().datasetName(), experiment.datasetName());
+            return Mono.error(new ClientErrorException(errorMessage, Response.Status.CONFLICT));
+        }
+
+        // Mismatches are only validated when an explicit project_name is provided (backward compatible). When
+        // it is omitted, the project is derived best-effort (experiment, else dataset, else default), so a
+        // mismatch is only possible in that case and is tolerated.
+        if (StringUtils.isBlank(projectName)) {
+            return Mono.empty();
+        }
+
+        return projectService.resolveProjectId(projectName)
+                .flatMap(requestProjectId -> {
+                    if (existingExperiment.isPresent()
+                            && !Optional.ofNullable(existingExperiment.get().projectId()).equals(requestProjectId)) {
+                        String errorMessage = "Experiment '%s' belongs to project '%s', but request specifies project_name '%s'"
+                                .formatted(experiment.id(), existingExperiment.get().projectName(), projectName);
+                        return Mono.<Void>error(new ClientErrorException(errorMessage, Response.Status.CONFLICT));
                     }
 
-                    // Validate project consistency: a request-level project_name must match the existing
-                    // experiment's project, otherwise items would be split across projects.
-                    if (StringUtils.isNotBlank(experiment.projectName())) {
-                        return projectService.resolveProjectId(experiment.projectName())
-                                .flatMap(resolvedProjectId -> {
-                                    if (!Optional.ofNullable(existingExperiment.projectId())
-                                            .equals(resolvedProjectId)) {
-                                        String errorMessage = "Experiment '%s' belongs to project '%s', but request specifies project_name '%s'"
-                                                .formatted(experiment.id(), existingExperiment.projectName(),
-                                                        experiment.projectName());
-                                        return Mono.<Void>error(
-                                                new ClientErrorException(errorMessage, Response.Status.CONFLICT));
-                                    }
-                                    return Mono.<Void>empty();
-                                });
-                    }
-
-                    return Mono.<Void>empty();
-                })
-                .onErrorResume(NotFoundException.class, ex -> {
-                    // Experiment doesn't exist yet, validation passes
-                    return Mono.empty();
+                    return resolveDatasetProjectId(experiment.datasetName(), projectName)
+                            .flatMap(datasetProjectId -> {
+                                if (datasetProjectId.isPresent() && !datasetProjectId.equals(requestProjectId)) {
+                                    String errorMessage = "Dataset '%s' belongs to a different project than the request project_name '%s'"
+                                            .formatted(experiment.datasetName(), projectName);
+                                    return Mono.<Void>error(
+                                            new ClientErrorException(errorMessage, Response.Status.CONFLICT));
+                                }
+                                return Mono.<Void>empty();
+                            });
                 });
+    }
+
+    private Mono<Optional<UUID>> resolveDatasetProjectId(String datasetName, String projectName) {
+        // Resolve the dataset scoped to the request project so the lookup is project-aware.
+        return datasetService
+                .resolveDatasetByNameAsync(
+                        DatasetIdentifier.builder().datasetName(datasetName).projectName(projectName).build())
+                .map(dataset -> Optional.ofNullable(dataset.projectId()))
+                .defaultIfEmpty(Optional.empty())
+                .onErrorResume(NotFoundException.class, ex -> Mono.just(Optional.empty()));
     }
 
     private Mono<? extends Tuple3<Long, ? extends Number, Integer>> saveAll(List<Trace> traces,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemBulkIngestionService.java
@@ -46,6 +46,17 @@ import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
 public interface ExperimentItemBulkIngestionService {
 
     /**
+     * Which deprecated implicit fallback (if any) was used to resolve the project for traces that don't carry
+     * their own project. Returned so the caller can surface the {@code X-Opik-Deprecation} header on the
+     * request thread (the service must not mutate the request-scoped context from the reactive chain).
+     */
+    enum ProjectFallback {
+        NONE,
+        DATASET,
+        DEFAULT
+    }
+
+    /**
      * Ingests a batch of experiment items.
      *
      * @param experiment the experiment to add items to
@@ -53,9 +64,9 @@ public interface ExperimentItemBulkIngestionService {
      *                    project is derived from the existing experiment or dataset; if neither resolves, the
      *                    default project is used.
      * @param items the list of experiment items to ingest
-     * @return {@code true} when traces fell back to the default project (deprecated), {@code false} otherwise
+     * @return the deprecated fallback used (if any) to resolve the bulk project
      */
-    Mono<Boolean> ingest(Experiment experiment, String projectName, List<ExperimentItemBulkRecord> items);
+    Mono<ProjectFallback> ingest(Experiment experiment, String projectName, List<ExperimentItemBulkRecord> items);
 }
 
 @Singleton
@@ -72,7 +83,7 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
     private final @NonNull DatasetService datasetService;
     private final @NonNull IdGenerator idGenerator;
 
-    private record ResolvedProject(String name, boolean fallback) {
+    private record ResolvedProject(String name, ProjectFallback fallback) {
     }
 
     /**
@@ -80,10 +91,11 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
      *
      * @param experiment the experiment to add items to
      * @param items the list of experiment items to ingest
-     * @return a list of feedback score batch items
+     * @return the deprecated fallback used (if any) to resolve the bulk project
      */
     @Override
-    public Mono<Boolean> ingest(Experiment experiment, String projectName, List<ExperimentItemBulkRecord> items) {
+    public Mono<ProjectFallback> ingest(Experiment experiment, String projectName,
+            List<ExperimentItemBulkRecord> items) {
 
         return Mono.deferContextual(ctx -> {
 
@@ -98,15 +110,20 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
                                 // from evaluate_task_result, or explicit traces with a blank project_name).
                                 String bulkProjectName = resolvedProject.name();
 
-                                // Flag the deprecated default-project fallback only when it actually applies to
-                                // at least one item without its own project.
-                                boolean usedDefaultProjectFallback = resolvedProject.fallback()
-                                        && items.stream().anyMatch(item -> item.trace() == null
-                                                || StringUtils.isBlank(item.trace().projectName()));
+                                // A deprecated fallback is only reported when it actually applies to at least
+                                // one item without its own project. Returned to the caller (request thread) to
+                                // emit the X-Opik-Deprecation header — the request-scoped context must not be
+                                // mutated from this reactive chain.
+                                boolean usesBulkProject = items.stream().anyMatch(item -> item.trace() == null
+                                        || StringUtils.isBlank(item.trace().projectName()));
+                                ProjectFallback fallback = usesBulkProject
+                                        ? resolvedProject.fallback()
+                                        : ProjectFallback.NONE;
 
                                 // When the project was explicitly provided or derived, create the experiment
-                                // (and its dataset) in it too so everything stays in one project.
-                                Experiment experimentToCreate = resolvedProject.fallback()
+                                // (and its dataset) in it too so everything stays in one project; on the default
+                                // fallback leave the experiment as-is.
+                                Experiment experimentToCreate = resolvedProject.fallback() == ProjectFallback.DEFAULT
                                         ? experiment
                                         : experiment.toBuilder().projectName(bulkProjectName).build();
 
@@ -158,7 +175,7 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
                                                                         "Recorded experiment items in bulk, experiment items count '{}', traces count '{}', spans count '{}' and feedback scores count '{}'",
                                                                         experimentItems.size(), traces.size(),
                                                                         spans.size(), feedbackScores.size()))
-                                                                .thenReturn(usedDefaultProjectFallback);
+                                                                .thenReturn(fallback);
                                                     });
                                         });
                             }));
@@ -189,16 +206,16 @@ class ExperimentItemBulkIngestionServiceImpl implements ExperimentItemBulkIngest
             Optional<Experiment> existingExperiment) {
 
         if (StringUtils.isNotBlank(projectName)) {
-            return Mono.just(new ResolvedProject(projectName, false));
+            return Mono.just(new ResolvedProject(projectName, ProjectFallback.NONE));
         }
 
         if (existingExperiment.isPresent() && StringUtils.isNotBlank(existingExperiment.get().projectName())) {
-            return Mono.just(new ResolvedProject(existingExperiment.get().projectName(), false));
+            return Mono.just(new ResolvedProject(existingExperiment.get().projectName(), ProjectFallback.NONE));
         }
 
         return resolveDatasetProjectName(experiment.datasetName())
-                .map(datasetProjectName -> new ResolvedProject(datasetProjectName, false))
-                .defaultIfEmpty(new ResolvedProject(ProjectService.DEFAULT_PROJECT, true));
+                .map(datasetProjectName -> new ResolvedProject(datasetProjectName, ProjectFallback.DATASET))
+                .defaultIfEmpty(new ResolvedProject(ProjectService.DEFAULT_PROJECT, ProjectFallback.DEFAULT));
     }
 
     private Mono<String> resolveDatasetProjectName(String datasetName) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -7079,9 +7079,9 @@ class ExperimentsResourceTest {
             // when
             try (var response = experimentResourceClient.callExperimentItemBulkUpload(bulkUploadRequest, API_KEY,
                     TEST_WORKSPACE)) {
-                // then — derived from the dataset, no fallback
+                // then — derived from the dataset (workspace-wide), which is a deprecated implicit fallback
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
-                assertThat(response.getHeaderString(RequestContext.WORKSPACE_FALLBACK_HEADER)).isNull();
+                assertThat(response.getHeaderString(RequestContext.WORKSPACE_FALLBACK_HEADER)).isNotNull();
             }
 
             List<ExperimentItem> actualExperimentItems = experimentResourceClient.getExperimentItems(experimentName,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -6955,7 +6955,7 @@ class ExperimentsResourceTest {
                             .build(),
                     API_KEY, TEST_WORKSPACE);
 
-            // when — upload again to the same experiment but with a different project
+            // when — upload again to the same experiment but with a different project_name
             var mismatched = ExperimentItemBulkUpload.builder()
                     .experimentId(experimentId)
                     .experimentName(experimentName)
@@ -6972,6 +6972,131 @@ class ExperimentsResourceTest {
                 // then
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
             }
+        }
+
+        @Test
+        @DisplayName("when project_name is provided but the dataset already belongs to a different project, then return conflict")
+        void experimentItemsBulk__whenProjectNameMismatchesDatasetProject__thenReturnConflict() {
+            // given — a dataset that already belongs to one project
+            var datasetProjectName = newProjectName();
+            projectResourceClient.createProject(datasetProjectName, API_KEY, TEST_WORKSPACE);
+            var dataset = buildDataset().toBuilder().projectName(datasetProjectName).build();
+            datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
+
+            // the request asks for a different project
+            var requestProjectName = newProjectName();
+            projectResourceClient.createProject(requestProjectName, API_KEY, TEST_WORKSPACE);
+
+            var bulkUploadRequest = ExperimentItemBulkUpload.builder()
+                    .experimentName(newExperimentName())
+                    .datasetName(dataset.name())
+                    .projectName(requestProjectName)
+                    .items(List.of(ExperimentItemBulkRecord.builder()
+                            .datasetItemId(podamFactory.manufacturePojo(UUID.class))
+                            .evaluateTaskResult(JsonUtils.readTree("{\"answer\": \"42\"}"))
+                            .build()))
+                    .build();
+
+            // when / then
+            try (var response = experimentResourceClient.callExperimentItemBulkUpload(bulkUploadRequest, API_KEY,
+                    TEST_WORKSPACE)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
+            }
+        }
+
+        @Test
+        @DisplayName("when no project_name and experiment_id points to an existing experiment with a project, then traces use the experiment's project")
+        void experimentItemsBulk__whenNoProjectNameAndExistingExperimentHasProject__thenUseExperimentProject() {
+            // given
+            var datasetWithItem = createDatasetWithItem();
+            var projectName = newProjectName();
+            UUID projectId = projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
+
+            var experimentId = podamFactory.manufacturePojo(UUID.class);
+            var experimentName = newExperimentName();
+
+            // create the experiment in the project via a first bulk upload (with project_name)
+            experimentResourceClient.bulkUploadExperimentItem(
+                    ExperimentItemBulkUpload.builder()
+                            .experimentId(experimentId)
+                            .experimentName(experimentName)
+                            .datasetName(datasetWithItem.datasetName())
+                            .projectName(projectName)
+                            .items(List.of(ExperimentItemBulkRecord.builder()
+                                    .datasetItemId(datasetWithItem.item().id())
+                                    .evaluateTaskResult(JsonUtils.readTree("{\"answer\": \"42\"}"))
+                                    .build()))
+                            .build(),
+                    API_KEY, TEST_WORKSPACE);
+
+            // when — second upload to the same experiment WITHOUT project_name (derive from the experiment)
+            var bulkUploadRequest = ExperimentItemBulkUpload.builder()
+                    .experimentId(experimentId)
+                    .experimentName(experimentName)
+                    .datasetName(datasetWithItem.datasetName())
+                    .items(List.of(ExperimentItemBulkRecord.builder()
+                            .datasetItemId(datasetWithItem.item().id())
+                            .evaluateTaskResult(JsonUtils.readTree("{\"answer\": \"43\"}"))
+                            .build()))
+                    .build();
+
+            try (var response = experimentResourceClient.callExperimentItemBulkUpload(bulkUploadRequest, API_KEY,
+                    TEST_WORKSPACE)) {
+                // then — derived from the experiment, no fallback
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+                assertThat(response.getHeaderString(RequestContext.WORKSPACE_FALLBACK_HEADER)).isNull();
+            }
+
+            List<ExperimentItem> actualExperimentItems = experimentResourceClient.getExperimentItems(experimentName,
+                    API_KEY, TEST_WORKSPACE);
+            // every auto-created trace lands in the experiment's project
+            for (ExperimentItem item : actualExperimentItems) {
+                Trace trace = traceResourceClient.getById(item.traceId(), TEST_WORKSPACE, API_KEY);
+                assertThat(trace.projectId()).isEqualTo(projectId);
+            }
+        }
+
+        @Test
+        @DisplayName("when no project_name and no existing experiment but the dataset already has a project, then traces use the dataset's project")
+        void experimentItemsBulk__whenNoProjectNameAndDatasetHasProject__thenUseDatasetProject() {
+            // given — a dataset that already belongs to a project
+            var projectName = newProjectName();
+            UUID projectId = projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
+
+            var dataset = buildDataset().toBuilder().projectName(projectName).build();
+            datasetResourceClient.createDataset(dataset, API_KEY, TEST_WORKSPACE);
+
+            var experimentName = newExperimentName();
+            var bulkUploadRequest = ExperimentItemBulkUpload.builder()
+                    .experimentName(experimentName)
+                    .datasetName(dataset.name())
+                    .items(List.of(ExperimentItemBulkRecord.builder()
+                            .datasetItemId(podamFactory.manufacturePojo(UUID.class))
+                            .evaluateTaskResult(JsonUtils.readTree("{\"answer\": \"42\"}"))
+                            .build()))
+                    .build();
+
+            // when
+            try (var response = experimentResourceClient.callExperimentItemBulkUpload(bulkUploadRequest, API_KEY,
+                    TEST_WORKSPACE)) {
+                // then — derived from the dataset, no fallback
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+                assertThat(response.getHeaderString(RequestContext.WORKSPACE_FALLBACK_HEADER)).isNull();
+            }
+
+            List<ExperimentItem> actualExperimentItems = experimentResourceClient.getExperimentItems(experimentName,
+                    API_KEY, TEST_WORKSPACE);
+            assertThat(actualExperimentItems).hasSize(1);
+
+            // the experiment was created in the dataset's project
+            Experiment experiment = experimentResourceClient.getExperiment(
+                    actualExperimentItems.getFirst().experimentId(), API_KEY, TEST_WORKSPACE);
+            assertThat(experiment.projectId()).isEqualTo(projectId);
+
+            // the auto-created trace landed in the dataset's project
+            Trace trace = traceResourceClient.getById(actualExperimentItems.getFirst().traceId(), TEST_WORKSPACE,
+                    API_KEY);
+            assertThat(trace.projectId()).isEqualTo(projectId);
         }
 
         @Test

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/log_experiments_with_rest_api.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/log_experiments_with_rest_api.mdx
@@ -263,12 +263,11 @@ print(f"Prepared {len(evaluation_items)} evaluation items")
 Use the bulk endpoint to efficiently log multiple evaluation results at once.
 
 <Note>
-  Pass `project_name` on the bulk request so the experiment, its dataset (when it
-  doesn't exist yet), and any traces auto-created from `evaluate_task_result` are
-  placed in that project. If you omit it, those traces fall back to the
-  `Default Project` — this fallback is deprecated and the response includes an
-  `X-Opik-Deprecation` header. The value should match the `project_name` you used
-  when creating the experiment.
+  `project_name` sets the project for the experiment, dataset, and auto-created traces.
+  When provided, it is used — and the request fails (409) if it conflicts with the existing
+  experiment's or dataset's project. When omitted, the project is derived from the existing
+  experiment or dataset; if neither applies, it falls back to the deprecated `Default Project`
+  (the response includes an `X-Opik-Deprecation` header).
 </Note>
 
 <CodeBlocks>

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/log_experiments_with_rest_api.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/log_experiments_with_rest_api.mdx
@@ -265,12 +265,11 @@ print(f"Prepared {len(evaluation_items)} evaluation items")
 Use the bulk endpoint to efficiently log multiple evaluation results at once.
 
 <Note>
-  Pass `project_name` on the bulk request so the experiment, its dataset (when it
-  doesn't exist yet), and any traces auto-created from `evaluate_task_result` are
-  placed in that project. If you omit it, those traces fall back to the
-  `Default Project` — this fallback is deprecated and the response includes an
-  `X-Opik-Deprecation` header. The value should match the `project_name` you used
-  when creating the experiment.
+  `project_name` sets the project for the experiment, dataset, and auto-created traces.
+  When provided, it is used — and the request fails (409) if it conflicts with the existing
+  experiment's or dataset's project. When omitted, the project is derived from the existing
+  experiment or dataset; if neither applies, it falls back to the deprecated `Default Project`
+  (the response includes an `X-Opik-Deprecation` header).
 </Note>
 
 <CodeBlocks>


### PR DESCRIPTION
## Details

Follow-up to OPIK-6810 (#7021). `experiment_items_bulk` no longer requires `project_name` to be repeated when it can be derived. The project for traces that don't carry their own project is resolved as:

1. the request `project_name` (when provided);
2. else the existing **experiment's** project (when it exists and has one);
3. else the existing **dataset's** project (when it exists and has one);
4. else the **default project** (deprecated; `X-Opik-Deprecation` header).

Derivation only **reads** existing entities — it never creates an experiment or dataset just to obtain a project. The experiment (and dataset, when created) are created in the resolved project so the experiment, dataset, traces and spans all stay in one project.

Backward compatible:
- When `project_name` **is** provided it is validated against the existing experiment's and dataset's projects — **409** on mismatch (as in #7021).
- When `project_name` is **omitted**, the project is derived best-effort, so a project mismatch is only possible (and tolerated) in that case.

The resource emits `X-Opik-Deprecation` for both fallbacks: the default-project fallback and the workspace-wide resolution fallback (the existing `RequestContext` mechanism).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6921

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: backend implementation, tests, PR description
- Human verification: tests run locally (see Testing)

## Testing

`mvn test -Dtest='ExperimentsResourceTest$BulkUpload'` — 24/24 green (Testcontainers: ClickHouse/MySQL/Redis, local). `mvn spotless:check` clean; `mvn compile` / `test-compile` green.

Scenarios covered (new/updated):
- no `project_name` + existing experiment with a project → traces use the experiment's project; no deprecation header.
- no `project_name` + no existing experiment + dataset has a project → experiment created and traces land in the dataset's project; no header.
- `project_name` provided + experiment/dataset don't exist → both created in the request project.
- `project_name` provided but conflicts with the existing experiment's project → 409.
- `project_name` provided but conflicts with the existing dataset's project → 409.
- fallbacks (no `project_name`, nothing derivable) → default project + `X-Opik-Deprecation` header — preserved.

## Documentation

The REST API guide already documents `project_name`; a follow-up note can clarify it's optional when the experiment/dataset already has a project (tracked in OPIK-6921).