### PR TITLE
[OPIK-6921] [DOCS] clarify project_name is optional when derivable in experiment_items_bulk

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/log_experiments_with_rest_api.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/log_experiments_with_rest_api.mdx
@@ -263,12 +263,11 @@ print(f"Prepared {len(evaluation_items)} evaluation items")
 Use the bulk endpoint to efficiently log multiple evaluation results at once.
 
 <Note>
-  Pass `project_name` on the bulk request so the experiment, its dataset (when it
-  doesn't exist yet), and any traces auto-created from `evaluate_task_result` are
-  placed in that project. If you omit it, those traces fall back to the
-  `Default Project` — this fallback is deprecated and the response includes an
-  `X-Opik-Deprecation` header. The value should match the `project_name` you used
-  when creating the experiment.
+  `project_name` sets the project for the experiment, dataset, and auto-created traces.
+  When provided, it is used — and the request fails (409) if it conflicts with the existing
+  experiment's or dataset's project. When omitted, the project is derived from the existing
+  experiment or dataset; if neither applies, it falls back to the deprecated `Default Project`
+  (the response includes an `X-Opik-Deprecation` header).
 </Note>
 
 <CodeBlocks>

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/log_experiments_with_rest_api.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/log_experiments_with_rest_api.mdx
@@ -265,12 +265,11 @@ print(f"Prepared {len(evaluation_items)} evaluation items")
 Use the bulk endpoint to efficiently log multiple evaluation results at once.
 
 <Note>
-  Pass `project_name` on the bulk request so the experiment, its dataset (when it
-  doesn't exist yet), and any traces auto-created from `evaluate_task_result` are
-  placed in that project. If you omit it, those traces fall back to the
-  `Default Project` — this fallback is deprecated and the response includes an
-  `X-Opik-Deprecation` header. The value should match the `project_name` you used
-  when creating the experiment.
+  `project_name` sets the project for the experiment, dataset, and auto-created traces.
+  When provided, it is used — and the request fails (409) if it conflicts with the existing
+  experiment's or dataset's project. When omitted, the project is derived from the existing
+  experiment or dataset; if neither applies, it falls back to the deprecated `Default Project`
+  (the response includes an `X-Opik-Deprecation` header).
 </Note>
 
 <CodeBlocks>


### PR DESCRIPTION
## Details

Follow-up to the merged docs PR #7045, reflecting OPIK-6921 (#7049). Updates the note on the "Log experiments with the REST API" guide so it states that `project_name` is optional when the referenced experiment or dataset already has a project.

The note now summarizes the resolution: when `project_name` is provided it is used (409 on conflict with the existing experiment's/dataset's project); when omitted the project is derived from the existing experiment or dataset; otherwise it falls back to the deprecated `Default Project` (with an `X-Opik-Deprecation` header). Applied to both the latest and v1 versions of the page.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-6921

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: documentation update

## Testing

Docs-only change (`.mdx`).

## Documentation

This PR is the documentation update.