### PR TITLE
[NA] [SDK] fix: stop leaked Opik background threads after each unit test

### DIFF
--- a/sdks/python/tests/unit/conftest.py
+++ b/sdks/python/tests/unit/conftest.py
@@ -1,7 +1,40 @@
 import os
+import threading
 
 import pytest
 import logging
+
+from opik.api_objects import opik_client
+from opik.message_processing.replay import replay_manager
+
+
+@pytest.fixture(autouse=True)
+def shutdown_opik_background_threads():
+    """Stop Opik background threads after every unit test.
+
+    Constructing a real Opik client starts daemon threads — the streamer's queue
+    consumers and batch preprocessor, plus a ReplayManager that periodically probes the
+    server through a ConnectionMonitor. Unit tests rarely tear their clients down, so
+    across the suite these threads accumulate into hundreds of live threads, the
+    ReplayManager probe loops in particular generating ongoing scheduling/IO pressure.
+    That contention can push an unrelated test past pytest's per-test --timeout, and with
+    --timeout-method=thread the whole run is hard-killed (no report, exit 1).
+
+    Ending the cached global client closes its streamer (idempotent, fire-and-forget — no
+    network wait); we then close any ReplayManager left behind by directly-constructed
+    clients. close() only signals a stop event, so this never blocks on the network.
+    """
+    yield
+
+    client = opik_client.get_current_client_raw()
+    if client is not None:
+        client.end(flush=False)
+    opik_client.reset_global_client(end_client=False)
+
+    for thread in threading.enumerate():
+        if isinstance(thread, replay_manager.ReplayManager) and thread.is_alive():
+            thread.close()
+            thread.join(timeout=5)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Details

Real Opik clients constructed in unit tests start daemon threads — the streamer's queue consumers and batch preprocessor, plus a `ReplayManager` that periodically probes the server through a `ConnectionMonitor`. Unit tests rarely tear their clients down, so across the suite these threads accumulate into hundreds of live threads (a recent failing run showed **136 live `ReplayManager` threads**), with the probe loops generating ongoing scheduling/IO pressure.

That contention can push an unrelated test past pytest's per-test `--timeout=120`, and because the job runs with `--timeout-method=thread`, hitting the timeout **hard-kills the whole pytest process** — no `test_results.xml`, exit code 1 — surfacing as a random, hard-to-reproduce unit-test failure (e.g. `test_export_project_rate_limiting.py` blocked in `TemporaryDirectory.cleanup()`).

This adds an autouse teardown to `tests/unit/conftest.py` that, after every test:
- ends the cached global client (`client.end(flush=False)` — idempotent and fire-and-forget, so no network wait), which closes its streamer/replay/consumer threads, then clears the singleton;
- closes any `ReplayManager` left behind by directly-constructed clients (`close()` only signals a stop event).

Verified locally: a 3-client scenario goes from 3 live `ReplayManager` threads to 0 after the teardown runs.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA — CI hardening (no ticket)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: unit-test teardown fixture in `sdks/python/tests/unit/conftest.py`
- Human verification: ran the affected unit modules locally and a thread-count before/after check

## Testing

- `pytest tests/unit/message_processing/ tests/unit/cli/test_export_project_rate_limiting.py` → 409 passed (covers the ReplayManager/streamer/replay tests and the previously-flaky export test).
- `pytest tests/unit/decorator/ tests/unit/llm_usage/` → 202 passed (heavy global-client users).
- Standalone check: created global + directly-constructed clients, ran the teardown logic, confirmed live `ReplayManager` threads dropped 3 → 0.
- `ruff check` + `ruff format` clean on the changed file.

## Documentation

No documentation changes — internal test-harness hardening only.
