### PR TITLE
[OPIK-6820] [FE] feat: add onboarding empty state to AI Spend home page

### DIFF
--- a/apps/opik-frontend/src/v2/pages/AiSpendHomePage/AiSpendEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AiSpendHomePage/AiSpendEmptyState.tsx
@@ -1,0 +1,75 @@
+import React, { useMemo } from "react";
+import { ChartNoAxesColumn } from "lucide-react";
+import CodeHighlighter, {
+  SUPPORTED_LANGUAGE,
+} from "@/shared/CodeHighlighter/CodeHighlighter";
+import { BASE_API_URL } from "@/api/api";
+import { useAiSpend } from "@/contexts/AiSpendContext";
+
+const AiSpendEmptyState: React.FC = () => {
+  const { projectName, spendWorkspaceName } = useAiSpend();
+
+  const settingsSnippet = useMemo(
+    () =>
+      JSON.stringify(
+        {
+          extraKnownMarketplaces: {
+            opik: {
+              source: {
+                source: "github",
+                repo: "comet-ml/opik-claude-code-plugin",
+              },
+              autoUpdate: true,
+            },
+          },
+          enabledPlugins: { "opik@opik": true },
+          env: {
+            OPIK_CC_TRACING_ENABLED: "true",
+            OPIK_BASE_URL: new URL(
+              BASE_API_URL,
+              window.location.origin,
+            ).toString(),
+            OPIK_CC_WORKSPACE: spendWorkspaceName || "your-org-cc-workspace",
+            OPIK_API_KEY: "<workspace-scoped API key>",
+            OPIK_CC_PROJECT: projectName,
+          },
+          forceRemoteSettingsRefresh: true,
+        },
+        null,
+        2,
+      ),
+    [projectName, spendWorkspaceName],
+  );
+
+  return (
+    <div className="flex flex-col items-center gap-6 py-16">
+      <div className="flex size-12 items-center justify-center rounded-full bg-primary-foreground">
+        <ChartNoAxesColumn className="size-6 text-muted-slate" />
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <h2 className="comet-title-s text-foreground">No AI usage data yet</h2>
+        <p className="comet-body-s max-w-[570px] text-center text-muted-slate">
+          Cost Intelligence builds these dashboards from Claude Code sessions
+          traced by the Opik plugin. Roll the plugin out to your team to start
+          collecting data.
+        </p>
+      </div>
+      <div className="flex w-full max-w-[640px] flex-col gap-2">
+        <span className="comet-body-s text-foreground">
+          Add this to your organization&apos;s managed settings or each
+          developer&apos;s .claude/settings.json:
+        </span>
+        <CodeHighlighter
+          data={settingsSnippet}
+          language={SUPPORTED_LANGUAGE.json}
+        />
+        <span className="comet-body-xs text-muted-slate">
+          Replace OPIK_API_KEY with a workspace-scoped API key. Data appears
+          here shortly after the first traced session.
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default AiSpendEmptyState;

--- a/apps/opik-frontend/src/v2/pages/AiSpendHomePage/AiSpendEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/AiSpendHomePage/AiSpendEmptyState.tsx
@@ -54,7 +54,7 @@ const AiSpendEmptyState: React.FC = () => {
           collecting data.
         </p>
       </div>
-      <div className="flex w-full max-w-[640px] flex-col gap-2">
+      <div className="flex w-full max-w-screen-sm flex-col gap-2">
         <span className="comet-body-s text-foreground">
           Add this to your organization&apos;s managed settings or each
           developer&apos;s .claude/settings.json:

--- a/apps/opik-frontend/src/v2/pages/AiSpendHomePage/AiSpendHomePage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AiSpendHomePage/AiSpendHomePage.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from "react";
+import { AxiosError } from "axios";
 import HomeSummaryCards from "./HomeSummaryCards";
 import AiSpendEmptyState from "./AiSpendEmptyState";
 import SpendPeriodSelect from "@/v2/pages-shared/SpendPeriodSelect/SpendPeriodSelect";
@@ -22,13 +23,21 @@ const AiSpendHomePage: React.FC = () => {
     [windowDays],
   );
 
-  const { data: project, isPending: isProbePending } = useProjectByName(
+  const {
+    data: project,
+    isPending: isProbePending,
+    isError,
+    error,
+  } = useProjectByName(
     { projectName },
     { refetchOnMount: false, retry: false },
   );
 
-  const hasAnyData = Boolean(project?.last_updated_trace_at);
-  const showEmptyState = !isProbePending && !hasAnyData;
+  const isProjectMissing =
+    isError && error instanceof AxiosError && error.response?.status === 404;
+  const isRealError = isError && !isProjectMissing;
+  const showEmptyState =
+    !isProbePending && !isRealError && !project?.last_updated_trace_at;
 
   return (
     <div className="py-6">

--- a/apps/opik-frontend/src/v2/pages/AiSpendHomePage/AiSpendHomePage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AiSpendHomePage/AiSpendHomePage.tsx
@@ -1,16 +1,16 @@
 import React, { useMemo, useState } from "react";
 import HomeSummaryCards from "./HomeSummaryCards";
+import AiSpendEmptyState from "./AiSpendEmptyState";
 import SpendPeriodSelect from "@/v2/pages-shared/SpendPeriodSelect/SpendPeriodSelect";
 import AiUsageBreakdown from "@/v2/pages-shared/AiUsageBreakdown/AiUsageBreakdown";
 import AiUsageRecommendations from "@/v2/pages-shared/AiUsageRecommendations/AiUsageRecommendations";
 import AiUsageLaneDetailsPanel from "@/v2/pages-shared/AiUsageLaneDetails/AiUsageLaneDetailsPanel";
-import {
-  AI_SPEND_PROJECT_NAME,
-  getSpendInterval,
-  SpendWindow,
-} from "@/lib/aiSpend";
+import useProjectByName from "@/api/projects/useProjectByName";
+import { useAiSpend } from "@/contexts/AiSpendContext";
+import { getSpendInterval, SpendWindow } from "@/lib/aiSpend";
 
 const AiSpendHomePage: React.FC = () => {
+  const { projectName } = useAiSpend();
   const [windowDays, setWindowDays] = useState<SpendWindow>(30);
   const [detailsLaneKey, setDetailsLaneKey] = useState<string | null>(null);
   const [highlightedLaneKey, setHighlightedLaneKey] = useState<string | null>(
@@ -22,46 +22,62 @@ const AiSpendHomePage: React.FC = () => {
     [windowDays],
   );
 
+  const { data: project, isPending: isProbePending } = useProjectByName(
+    { projectName },
+    { refetchOnMount: false, retry: false },
+  );
+
+  const hasAnyData = Boolean(project?.last_updated_trace_at);
+  const showEmptyState = !isProbePending && !hasAnyData;
+
   return (
     <div className="py-6">
       <div className="mb-4 flex items-center justify-between gap-3">
         <h1 className="comet-title-l truncate break-words text-foreground">
           Home
         </h1>
-        <SpendPeriodSelect value={windowDays} onChange={setWindowDays} />
+        {!showEmptyState && (
+          <SpendPeriodSelect value={windowDays} onChange={setWindowDays} />
+        )}
       </div>
 
-      <HomeSummaryCards
-        intervalStart={intervalStart}
-        intervalEnd={intervalEnd}
-      />
+      {showEmptyState ? (
+        <AiSpendEmptyState />
+      ) : (
+        <>
+          <HomeSummaryCards
+            intervalStart={intervalStart}
+            intervalEnd={intervalEnd}
+          />
 
-      <h2 className="comet-body-accented mb-2 mt-6 text-foreground">
-        AI usage breakdown
-      </h2>
-      <AiUsageBreakdown
-        projectName={AI_SPEND_PROJECT_NAME}
-        intervalStart={intervalStart}
-        intervalEnd={intervalEnd}
-        onLaneClick={setDetailsLaneKey}
-        activeLaneKey={detailsLaneKey}
-        highlightedLaneKey={highlightedLaneKey}
-      />
+          <h2 className="comet-body-accented mb-2 mt-6 text-foreground">
+            AI usage breakdown
+          </h2>
+          <AiUsageBreakdown
+            projectName={projectName}
+            intervalStart={intervalStart}
+            intervalEnd={intervalEnd}
+            onLaneClick={setDetailsLaneKey}
+            activeLaneKey={detailsLaneKey}
+            highlightedLaneKey={highlightedLaneKey}
+          />
 
-      <AiUsageRecommendations
-        projectName={AI_SPEND_PROJECT_NAME}
-        intervalStart={intervalStart}
-        intervalEnd={intervalEnd}
-        onHoverRecommendation={setHighlightedLaneKey}
-        className="mt-6"
-      />
+          <AiUsageRecommendations
+            projectName={projectName}
+            intervalStart={intervalStart}
+            intervalEnd={intervalEnd}
+            onHoverRecommendation={setHighlightedLaneKey}
+            className="mt-6"
+          />
 
-      <AiUsageLaneDetailsPanel
-        laneKey={detailsLaneKey}
-        projectName={AI_SPEND_PROJECT_NAME}
-        defaultWindow={windowDays}
-        onClose={() => setDetailsLaneKey(null)}
-      />
+          <AiUsageLaneDetailsPanel
+            laneKey={detailsLaneKey}
+            projectName={projectName}
+            defaultWindow={windowDays}
+            onClose={() => setDetailsLaneKey(null)}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/apps/opik-frontend/src/v2/pages/LogsPage/AiSpendSessionsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/AiSpendSessionsPage.tsx
@@ -1,5 +1,5 @@
 import useProjectByName from "@/api/projects/useProjectByName";
-import { AI_SPEND_PROJECT_NAME } from "@/lib/aiSpend";
+import { useAiSpend } from "@/contexts/AiSpendContext";
 import PageBodyScrollContainer from "@/v2/layout/PageBodyScrollContainer/PageBodyScrollContainer";
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
 import LogsTab from "@/v2/pages/LogsPage/LogsTab";
@@ -8,17 +8,17 @@ import Loader from "@/shared/Loader/Loader";
 import NoData from "@/shared/NoData/NoData";
 
 const AiSpendSessionsPage = () => {
+  const { projectName } = useAiSpend();
   const {
     data: project,
     isPending,
     isError,
   } = useProjectByName(
-    { projectName: AI_SPEND_PROJECT_NAME },
+    { projectName },
     { refetchOnMount: false, retry: false },
   );
 
   const projectId = project?.id ?? "";
-  const projectName = project?.name || AI_SPEND_PROJECT_NAME;
 
   const { logsType, needsDefaultResolution, setLogsType } = useLogsType({
     projectId,


### PR DESCRIPTION
## Details

<img width="1506" height="926" alt="image" src="https://github.com/user-attachments/assets/6241d0bc-bfaa-4c1b-aeff-37c677b178b2" />


Adds an onboarding empty state to the AI Spend Home page shown when the spend project has never received a trace. The state explains how to roll out the Opik Claude Code plugin and renders a ready-to-copy managed-settings JSON snippet, dynamically populated with the deployment URL, spend workspace, and project name.

- Detect "no data yet" via the project's `last_updated_trace_at` (time-unbounded, single cheap call) instead of a windowed composition query
- New `AiSpendEmptyState` component with a code-highlighted settings snippet (`OPIK_BASE_URL` from deployment origin, `OPIK_CC_WORKSPACE` from the spend workspace, `OPIK_CC_PROJECT` from context)
- All AI Spend pages now read `projectName` from `useAiSpend()` context instead of importing the constant; hide the period selector while the empty state is shown

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6820

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: code review + manual testing on dev

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean
- Manual: empty state renders when the spend project has no `last_updated_trace_at`; dashboard renders normally once data exists; period selector hidden in empty state; snippet values reflect the active deployment/workspace

## Documentation

N/A
