### PR TITLE
Fix installing the opik sdist from source (setup.py reads ../../README.md, which escapes the sdist)

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -14,6 +14,13 @@ if version is None:
     else:
         version = "0.0.1"
 
+readme_file = os.path.join(HERE, "..", "..", "README.md")
+if os.path.exists(readme_file):
+    with open(readme_file, encoding="utf-8") as fp:
+        long_description = fp.read()
+else:
+    long_description = "Comet tool for logging and evaluating LLM traces"
+
 setup(
     author="Comet ML Inc.",
     author_email="mail@comet.com",
@@ -32,9 +39,7 @@ setup(
         "Programming Language :: Python :: 3.14",
     ],
     description="Comet tool for logging and evaluating LLM traces",
-    long_description=open(
-        os.path.join(HERE, "..", "..", "README.md"), encoding="utf-8"
-    ).read(),
+    long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=[
         "boto3-stubs[bedrock-runtime]>=1.34.110",


### PR DESCRIPTION
> ♻️ Re-opened on behalf of @sethc555. All commits are authored by @sethc555. Apologies for the inconvenience. Original PR for reference: #7036.

---

Installing opik from source currently fails:

```
$ docker run --rm python:3.12 pip install --no-binary :all: opik
...
FileNotFoundError: [Errno 2] No such file or directory: '../../README.md'
```

sdks/python/setup.py reads the monorepo root README via a relative path that no sdist can contain. This change uses it when present (repo builds unchanged) and falls back to the static description otherwise.

Verified: with this change, `python -m build` (sdist → wheel built from that sdist) succeeds in a clean python:3.12 container; without it, it fails. Found while build-checking popular PyPI packages for source-install breakage ([wheelproof](https://github.com/sethc555/wheelproof)).