### PR TITLE
feat: add bulk annotation of traces and spans from the selection bar

### DIFF
--- a/apps/opik-frontend/src/api/traces/useSpanFeedbackScoreBatchSetMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useSpanFeedbackScoreBatchSetMutation.ts
@@ -1,0 +1,58 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+
+import api, { SPANS_KEY, SPANS_REST_ENDPOINT } from "@/api/api";
+import { FEEDBACK_SCORE_TYPE } from "@/types/traces";
+import { useToast } from "@/ui/use-toast";
+import { extractErrorMessage } from "@/lib/errors";
+
+type FeedbackScoreEntry = {
+  id: string;
+  name: string;
+  value: number;
+  categoryName?: string;
+  reason?: string;
+};
+
+type UseSpanFeedbackScoreBatchSetMutationParams = {
+  projectId: string;
+  scores: FeedbackScoreEntry[];
+};
+
+const useSpanFeedbackScoreBatchSetMutation = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async ({
+      scores,
+    }: UseSpanFeedbackScoreBatchSetMutationParams) => {
+      const { data } = await api.put(`${SPANS_REST_ENDPOINT}feedback-scores`, {
+        scores: scores.map((score) => ({
+          id: score.id,
+          name: score.name,
+          value: score.value,
+          source: FEEDBACK_SCORE_TYPE.ui,
+          category_name: score.categoryName,
+          reason: score.reason,
+        })),
+      });
+
+      return data;
+    },
+    onError: (error: AxiosError) => {
+      toast({
+        title: "Error",
+        description: extractErrorMessage(error),
+        variant: "destructive",
+      });
+    },
+    onSettled: (data, error, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [SPANS_KEY, { projectId: variables.projectId }],
+      });
+    },
+  });
+};
+
+export default useSpanFeedbackScoreBatchSetMutation;

--- a/apps/opik-frontend/src/api/traces/useSpanFeedbackScoreBatchSetMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useSpanFeedbackScoreBatchSetMutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 
-import api, { SPANS_KEY, SPANS_REST_ENDPOINT } from "@/api/api";
+import api, { SPANS_KEY, TRACE_KEY, SPANS_REST_ENDPOINT } from "@/api/api";
 import { FEEDBACK_SCORE_TYPE } from "@/types/traces";
 import { useToast } from "@/ui/use-toast";
 import { extractErrorMessage } from "@/lib/errors";
@@ -47,10 +47,15 @@ const useSpanFeedbackScoreBatchSetMutation = () => {
         variant: "destructive",
       });
     },
-    onSettled: (data, error, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: [SPANS_KEY, { projectId: variables.projectId }],
-      });
+    onSettled: async () => {
+      // Mirror useTraceFeedbackScoreSetMutation's span branch: refresh the spans
+      // list, its columns/statistics, and the trace details panel (which shows
+      // aggregated span_feedback_scores). The batch only carries span ids, so the
+      // per-trace cache is invalidated broadly rather than by traceId.
+      await queryClient.invalidateQueries({ queryKey: [SPANS_KEY] });
+      await queryClient.invalidateQueries({ queryKey: ["spans-columns"] });
+      await queryClient.invalidateQueries({ queryKey: ["spans-statistic"] });
+      await queryClient.invalidateQueries({ queryKey: [TRACE_KEY] });
     },
   });
 };

--- a/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreBatchSetMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreBatchSetMutation.ts
@@ -1,0 +1,58 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+
+import api, { TRACES_KEY, TRACES_REST_ENDPOINT } from "@/api/api";
+import { FEEDBACK_SCORE_TYPE } from "@/types/traces";
+import { useToast } from "@/ui/use-toast";
+import { extractErrorMessage } from "@/lib/errors";
+
+type FeedbackScoreEntry = {
+  id: string;
+  name: string;
+  value: number;
+  categoryName?: string;
+  reason?: string;
+};
+
+type UseTraceFeedbackScoreBatchSetMutationParams = {
+  projectId: string;
+  scores: FeedbackScoreEntry[];
+};
+
+const useTraceFeedbackScoreBatchSetMutation = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async ({
+      scores,
+    }: UseTraceFeedbackScoreBatchSetMutationParams) => {
+      const { data } = await api.put(`${TRACES_REST_ENDPOINT}feedback-scores`, {
+        scores: scores.map((score) => ({
+          id: score.id,
+          name: score.name,
+          value: score.value,
+          source: FEEDBACK_SCORE_TYPE.ui,
+          category_name: score.categoryName,
+          reason: score.reason,
+        })),
+      });
+
+      return data;
+    },
+    onError: (error: AxiosError) => {
+      toast({
+        title: "Error",
+        description: extractErrorMessage(error),
+        variant: "destructive",
+      });
+    },
+    onSettled: (data, error, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [TRACES_KEY, { projectId: variables.projectId }],
+      });
+    },
+  });
+};
+
+export default useTraceFeedbackScoreBatchSetMutation;

--- a/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreBatchSetMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreBatchSetMutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 
-import api, { TRACES_KEY, TRACES_REST_ENDPOINT } from "@/api/api";
+import api, { TRACE_KEY, TRACES_KEY, TRACES_REST_ENDPOINT } from "@/api/api";
 import { FEEDBACK_SCORE_TYPE } from "@/types/traces";
 import { useToast } from "@/ui/use-toast";
 import { extractErrorMessage } from "@/lib/errors";
@@ -47,10 +47,22 @@ const useTraceFeedbackScoreBatchSetMutation = () => {
         variant: "destructive",
       });
     },
-    onSettled: (data, error, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: [TRACES_KEY, { projectId: variables.projectId }],
-      });
+    onSettled: async (data, error, variables) => {
+      // Mirror useTraceFeedbackScoreSetMutation: the scores feed the traces list,
+      // its columns/statistics, and the per-trace details panel — invalidate them
+      // all so the selection-bar dialog doesn't leave stale values behind.
+      await queryClient.invalidateQueries({ queryKey: [TRACES_KEY] });
+      await queryClient.invalidateQueries({ queryKey: ["traces-columns"] });
+      await queryClient.invalidateQueries({ queryKey: ["traces-statistic"] });
+
+      const traceIds = [...new Set(variables.scores.map((score) => score.id))];
+      await Promise.all(
+        traceIds.map((traceId) =>
+          queryClient.invalidateQueries({
+            queryKey: [TRACE_KEY, { traceId }],
+          }),
+        ),
+      );
     },
   });
 };

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddAnnotationDialog/AddAnnotationDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddAnnotationDialog/AddAnnotationDialog.tsx
@@ -1,0 +1,166 @@
+import React, { useCallback, useState } from "react";
+import {
+  FEEDBACK_SCORE_TYPE,
+  Span,
+  Trace,
+  TraceFeedbackScore,
+} from "@/types/traces";
+import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/ui/dialog";
+import { Button } from "@/ui/button";
+import { useToast } from "@/ui/use-toast";
+import FeedbackScoresEditor from "@/v2/pages-shared/traces/FeedbackScoresEditor/FeedbackScoresEditor";
+import { UpdateFeedbackScoreData } from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/types";
+import useTraceFeedbackScoreBatchSetMutation from "@/api/traces/useTraceFeedbackScoreBatchSetMutation";
+import useSpanFeedbackScoreBatchSetMutation from "@/api/traces/useSpanFeedbackScoreBatchSetMutation";
+
+type AddAnnotationDialogProps = {
+  rows: Array<Trace | Span>;
+  open: boolean | number;
+  setOpen: (open: boolean | number) => void;
+  projectId: string;
+  type: TRACE_DATA_TYPE;
+};
+
+const AddAnnotationDialog: React.FunctionComponent<
+  AddAnnotationDialogProps
+> = ({ rows, open, setOpen, projectId, type }) => {
+  const { toast } = useToast();
+  const [pendingScores, setPendingScores] = useState<
+    Record<string, TraceFeedbackScore>
+  >({});
+
+  const { mutateAsync: batchSetTraceScores } =
+    useTraceFeedbackScoreBatchSetMutation();
+  const { mutateAsync: batchSetSpanScores } =
+    useSpanFeedbackScoreBatchSetMutation();
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+    setPendingScores({});
+  }, [setOpen]);
+
+  const onUpdateFeedbackScore = useCallback(
+    (update: UpdateFeedbackScoreData) => {
+      setPendingScores((prev) => ({
+        ...prev,
+        [update.name]: {
+          name: update.name,
+          value: update.value,
+          source: FEEDBACK_SCORE_TYPE.ui,
+          category_name: update.categoryName,
+          reason: update.reason,
+        },
+      }));
+    },
+    [],
+  );
+
+  const onDeleteFeedbackScore = useCallback((name: string) => {
+    setPendingScores((prev) => {
+      const next = { ...prev };
+      delete next[name];
+      return next;
+    });
+  }, []);
+
+  const feedbackScores: TraceFeedbackScore[] = Object.values(pendingScores);
+
+  const handleApply = async () => {
+    if (feedbackScores.length === 0) {
+      handleClose();
+      return;
+    }
+
+    const scoreEntries = feedbackScores.map((score) => ({
+      name: score.name,
+      value: score.value,
+      categoryName: score.category_name,
+      reason: score.reason,
+    }));
+
+    const allScores = rows.flatMap((row) =>
+      scoreEntries.map((entry) => ({
+        id: row.id,
+        ...entry,
+      })),
+    );
+
+    try {
+      if (type === TRACE_DATA_TYPE.traces) {
+        await batchSetTraceScores({ projectId, scores: allScores });
+      } else {
+        await batchSetSpanScores({ projectId, scores: allScores });
+      }
+
+      toast({
+        title: "Feedback scores applied",
+        description: `Applied ${feedbackScores.length} score${
+          feedbackScores.length === 1 ? "" : "s"
+        } to ${rows.length} ${
+          rows.length === 1
+            ? type === TRACE_DATA_TYPE.traces
+              ? "trace"
+              : "span"
+            : type === TRACE_DATA_TYPE.traces
+              ? "traces"
+              : "spans"
+        }`,
+      });
+      handleClose();
+    } catch {
+      // Error handling is done by the mutation hook
+    }
+  };
+
+  const itemCount = rows.length;
+  const entityLabel =
+    itemCount === 1
+      ? type === TRACE_DATA_TYPE.traces
+        ? "trace"
+        : "span"
+      : type === TRACE_DATA_TYPE.traces
+        ? "traces"
+        : "spans";
+
+  return (
+    <Dialog open={Boolean(open)} onOpenChange={handleClose}>
+      <DialogContent className="outline-none sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle>
+            Annotate {itemCount} {entityLabel}
+          </DialogTitle>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Set feedback scores to apply to all selected {entityLabel}.
+          </p>
+        </DialogHeader>
+
+        <div className="max-h-96 overflow-y-auto py-2">
+          <FeedbackScoresEditor
+            feedbackScores={feedbackScores}
+            onUpdateFeedbackScore={onUpdateFeedbackScore}
+            onDeleteFeedbackScore={onDeleteFeedbackScore}
+            header={<FeedbackScoresEditor.Header title="Feedback scores" />}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleApply} disabled={feedbackScores.length === 0}>
+            Apply to {itemCount} {entityLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AddAnnotationDialog;

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useCallback } from "react";
-import { Tag, Trash } from "lucide-react";
+import { PenLine, Tag, Trash } from "lucide-react";
 import slugify from "slugify";
 import { cn } from "@/lib/utils";
 import { Button, ButtonProps } from "@/ui/button";
@@ -12,6 +12,7 @@ import useTracesBatchDeleteMutation from "@/api/traces/useTraceBatchDeleteMutati
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import ExportToButton from "@/shared/ExportToButton/ExportToButton";
 import AddTagDialog from "@/v2/pages-shared/traces/AddTagDialog/AddTagDialog";
+import AddAnnotationDialog from "@/v2/pages-shared/traces/AddAnnotationDialog/AddAnnotationDialog";
 import EvaluateButton from "@/v2/pages-shared/automations/EvaluateButton/EvaluateButton";
 import RunEvaluationDialog from "@/v2/pages-shared/automations/RunEvaluationDialog/RunEvaluationDialog";
 import useFilteredRulesList from "@/api/automations/useFilteredRulesList";
@@ -70,7 +71,11 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
   const isExportEnabled = useIsFeatureEnabled(FeatureToggleKeys.EXPORT_ENABLED);
 
   const {
-    permissions: { canDeleteTraces, canLogTraceSpanThread },
+    permissions: {
+      canAnnotateTraceSpanThread,
+      canDeleteTraces,
+      canLogTraceSpanThread,
+    },
   } = usePermissions();
 
   const showEvaluate =
@@ -143,6 +148,16 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
           isLoading={isRulesLoading}
         />
       )}
+      {canAnnotateTraceSpanThread && (
+        <AddAnnotationDialog
+          key={`annotate-${resetKeyRef.current}`}
+          rows={selectedRows}
+          open={open === 5}
+          setOpen={setOpen}
+          projectId={projectId}
+          type={type}
+        />
+      )}
       <AddToDropdown
         getDataForExport={getDataForExport}
         selectedRows={selectedRows}
@@ -164,6 +179,22 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
           >
             <Tag className={leadIconClassName} />
             <span>Manage tags</span>
+          </Button>
+        </TooltipWrapper>
+      )}
+      {canAnnotateTraceSpanThread && (
+        <TooltipWrapper content="Annotate">
+          <Button
+            variant={buttonVariant}
+            size={buttonSize}
+            onClick={() => {
+              setOpen(5);
+              resetKeyRef.current = resetKeyRef.current + 1;
+            }}
+            disabled={disabled}
+          >
+            <PenLine className={leadIconClassName} />
+            <span>Annotate</span>
           </Button>
         </TooltipWrapper>
       )}


### PR DESCRIPTION
> ♻️ Re-opened on behalf of @bisgeario. All commits are authored by @bisgeario. Apologies for the inconvenience. Original PR for reference: #6945.

---

## Details
Adds an **Annotate** bulk action to the `TracesActionsPanel` (the action bar shown when multiple traces or spans are selected). Clicking the button opens a dialog that renders the existing `FeedbackScoresEditor`, letting users set one or more feedback scores and apply them to all selected items in a single batch API call.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #1010
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude
  - Model(s): claude-opus-4-5
  - Scope: Full implementation of the feature (new API hooks, dialog component, TracesActionsPanel wiring)
  - Human verification: TypeScript and ESLint pass; logic verified against existing batch tag and delete patterns

## Testing

- `npx tsc --project tsconfig.json --noEmit` — clean
- `npx eslint` on all four changed/new files — clean
- Manual review: follows same pattern as `AddTagDialog` / `ManageTagsDialog`; reuses `FeedbackScoresEditor` without modification; permission gated by `canAnnotateTraceSpanThread`

## Documentation

No documentation changes needed — this is an incremental addition to an existing UI pattern.

Closes #1010
/claim #1010