### PR TITLE
[issue-1620] [FE] fix: pin experiment name in compare table

### DIFF
--- a/apps/opik-frontend/src/lib/compare-experiments-export.ts
+++ b/apps/opik-frontend/src/lib/compare-experiments-export.ts
@@ -1,0 +1,34 @@
+import { Experiment } from "@/types/datasets";
+
+export const getExperimentExportIds = (
+  comparisonExperimentIds: string[],
+  localExperiments: Experiment[],
+  rowExperimentIds: string[],
+) =>
+  Array.from(
+    new Set([
+      ...comparisonExperimentIds,
+      ...localExperiments.map((experiment) => experiment.id),
+      ...rowExperimentIds,
+    ]),
+  );
+
+export const getExperimentExportPrefix = (
+  experimentId: string,
+  nameMap: Record<string, string>,
+) => {
+  const experimentName = nameMap[experimentId];
+
+  if (experimentName) return `${experimentName}.`;
+
+  const usedNames = new Set(Object.values(nameMap));
+  let fallbackName = `unknown(${experimentId})`;
+  let suffix = 2;
+
+  while (usedNames.has(fallbackName)) {
+    fallbackName = `unknown(${experimentId}) ${suffix}`;
+    suffix += 1;
+  }
+
+  return `${fallbackName}.`;
+};

--- a/apps/opik-frontend/src/shared/DataTable/DataTable.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/DataTable.tsx
@@ -406,9 +406,11 @@ const DataTable = <TData, TValue>({
         <DataTableTooltipContext>
           <Table
             ref={tableRef}
-            className="comet-cell-borders"
+            className={cn("comet-cell-borders", autoWidth && "w-auto")}
             style={{
-              ...(!autoWidth && { minWidth: table.getTotalSize() }),
+              ...(autoWidth
+                ? { width: table.getTotalSize() }
+                : { minWidth: table.getTotalSize() }),
               ...(tableHeight && { "--data-table-height": `${tableHeight}px` }),
             }}
           >

--- a/apps/opik-frontend/src/shared/DataTable/DataTable.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/DataTable.tsx
@@ -235,23 +235,17 @@ const DataTable = <TData, TValue>({
   const { lastLeftPinnedColumnId, lastRightPinnedColumnId } =
     computePinnedColumnIds(table);
   const columnSizing = table.getState().columnSizing;
-  const headers = table.getFlatHeaders();
+  const headerGroups = table.getHeaderGroups();
+  const leafHeaders = headerGroups[headerGroups.length - 1]?.headers ?? [];
 
   const cols = useMemo(() => {
-    const retVal: { id: string; size: number }[] = [];
-    headers.forEach((header) => {
-      const index = header.column.getIndex();
-      if (index !== -1) {
-        retVal[index] = {
-          id: header.column.id,
-          size: header.column.getSize(),
-        };
-      }
-    });
-    return retVal;
+    return leafHeaders.map((header) => ({
+      id: header.column.id,
+      size: header.column.getSize(),
+    }));
     // we need columnSizing here to rebuild the cols array
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [headers, columnSizing]);
+  }, [leafHeaders, columnSizing]);
 
   const [tableHeight, setTableHeight] = useState(0);
   const [hasHorizontalScroll, setHasHorizontalScroll] = useState(false);
@@ -429,7 +423,7 @@ const DataTable = <TData, TValue>({
                 ...{ [STICKY_ATTRIBUTE_VERTICAL]: STICKY_DIRECTION.vertical },
               })}
             >
-              {table.getHeaderGroups().map((headerGroup, index, groups) => {
+              {headerGroups.map((headerGroup, index, groups) => {
                 const isLastRow = index === groups.length - 1;
 
                 return (

--- a/apps/opik-frontend/src/types/shared.ts
+++ b/apps/opik-frontend/src/types/shared.ts
@@ -37,6 +37,7 @@ export const COLUMN_CREATED_AT_ID = "created_at";
 export const COLUMN_DATASET_ID = "dataset_id";
 export const COLUMN_PROJECT_ID = "project_id";
 export const COLUMN_DURATION_ID = "duration";
+export const COLUMN_PASSED_ID = "passed";
 export const COLUMN_CUSTOM_ID = "custom";
 export const COLUMN_EXPERIMENT_ID = "experiment_id";
 export const COLUMN_ENVIRONMENT_ID = "environment";

--- a/apps/opik-frontend/src/v1/pages-shared/experiments/CompareExperimentsNameCell/CompareExperimentsNameCell.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/experiments/CompareExperimentsNameCell/CompareExperimentsNameCell.tsx
@@ -23,7 +23,7 @@ const CompareExperimentsNameCell: React.FC<
     const experiment = experiments.find((e) => e.id === experimentId);
 
     return (
-      <div className="-mt-2 h-8">
+      <div className="flex h-full items-center">
         <ResourceLink
           id={experiment?.dataset_id || ""}
           name={experiment?.name}

--- a/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
@@ -25,16 +25,69 @@ import {
   EXPERIMENT_ITEM_DATASET_PREFIX,
 } from "@/constants/experiments";
 import { Separator } from "@/ui/separator";
+import { RunStatus } from "@/types/test-suites";
 
 const EVALUATION_EXPORT_COLUMNS = [
   EXPERIMENT_ITEM_OUTPUT_PREFIX,
   COLUMN_COMMENTS_ID,
   COLUMN_DURATION_ID,
 ];
+const COLUMN_PASSED_ID = "passed";
 const FLAT_COLUMNS = [COLUMN_CREATED_AT_ID, COLUMN_ID_ID];
 
 const extractFieldName = (column: string, prefix: string): string =>
   column.replace(`${prefix}.`, "");
+
+const resolvePassedStatus = (
+  row: ExperimentsCompare,
+  items: ExperimentItem[],
+  experimentId?: string,
+) => {
+  if (experimentId) {
+    return (
+      row.run_summaries_by_experiment?.[experimentId]?.status ??
+      items[0]?.status
+    );
+  }
+
+  const summaries = Object.values(row.run_summaries_by_experiment ?? {});
+
+  if (summaries.length > 0) {
+    if (summaries.every((s) => s.status === RunStatus.PASSED)) {
+      return RunStatus.PASSED;
+    }
+    if (summaries.every((s) => s.status === RunStatus.SKIPPED)) {
+      return RunStatus.SKIPPED;
+    }
+    return RunStatus.FAILED;
+  }
+
+  return items[0]?.status;
+};
+
+const processPassedExportColumn = (
+  row: ExperimentsCompare,
+  items: ExperimentItem[],
+  accumulator: Record<string, unknown>,
+  prefix: string = "",
+  experimentId?: string,
+) => {
+  const status = resolvePassedStatus(row, items, experimentId);
+  accumulator[`${prefix}status`] = status ?? "-";
+
+  items
+    .flatMap((item) => item.assertion_results ?? [])
+    .forEach((ar, index) => {
+      const idx = index + 1;
+      accumulator[`${prefix}assertion_${idx}.name`] = ar.value;
+      accumulator[`${prefix}assertion_${idx}.result`] = ar.passed
+        ? "passed"
+        : "failed";
+      if (ar.reason) {
+        accumulator[`${prefix}assertion_${idx}.reason`] = ar.reason;
+      }
+    });
+};
 
 const processNestedExportColumn = (
   item: ExperimentItem,
@@ -122,7 +175,8 @@ const CompareExperimentsActionsPanel: React.FC<
           const prefix = first(column.split(".")) as string;
           const isDatasetColumn = !(
             EVALUATION_EXPORT_COLUMNS.includes(prefix) ||
-            prefix === COLUMN_FEEDBACK_SCORES_ID
+            prefix === COLUMN_FEEDBACK_SCORES_ID ||
+            prefix === COLUMN_PASSED_ID
           );
 
           if (isDatasetColumn) {
@@ -132,6 +186,32 @@ const CompareExperimentsActionsPanel: React.FC<
                 ? column.replace(`${EXPERIMENT_ITEM_DATASET_PREFIX}.`, "")
                 : column;
             accumulator[`dataset.${fieldName}`] = get(row.data, fieldName, "-");
+
+            return accumulator;
+          }
+
+          if (column === COLUMN_PASSED_ID) {
+            if (isCompare) {
+              localExperiments.forEach((experiment) => {
+                const items = (row.experiment_items ?? []).filter(
+                  (item) => item.experiment_id === experiment.id,
+                );
+                const prefix = `${nameMap[experiment.id] ?? "unknown"}.`;
+                processPassedExportColumn(
+                  row,
+                  items,
+                  accumulator,
+                  prefix,
+                  experiment.id,
+                );
+              });
+            } else {
+              processPassedExportColumn(
+                row,
+                row.experiment_items ?? [],
+                accumulator,
+              );
+            }
 
             return accumulator;
           }

--- a/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
@@ -3,6 +3,7 @@ import get from "lodash/get";
 import slugify from "slugify";
 import uniq from "lodash/uniq";
 import first from "lodash/first";
+import groupBy from "lodash/groupBy";
 
 import CompareExperimentsButton from "@/v1/pages/CompareExperimentsPage/CompareExperimentsButton/CompareExperimentsButton";
 import ExportToButton from "@/shared/ExportToButton/ExportToButton";
@@ -19,6 +20,7 @@ import {
   COLUMN_ID_ID,
   COLUMN_FEEDBACK_SCORES_ID,
   COLUMN_DURATION_ID,
+  COLUMN_PASSED_ID,
 } from "@/types/shared";
 import {
   EXPERIMENT_ITEM_OUTPUT_PREFIX,
@@ -32,7 +34,6 @@ const EVALUATION_EXPORT_COLUMNS = [
   COLUMN_COMMENTS_ID,
   COLUMN_DURATION_ID,
 ];
-const COLUMN_PASSED_ID = "passed";
 const FLAT_COLUMNS = [COLUMN_CREATED_AT_ID, COLUMN_ID_ID];
 
 const extractFieldName = (column: string, prefix: string): string =>
@@ -111,8 +112,14 @@ const CompareExperimentsActionsPanel: React.FC<
     );
 
     const isCompare = localExperiments?.length > 1;
+    const shouldGroupItemsByExperiment =
+      isCompare && columnsToExport.includes(COLUMN_PASSED_ID);
 
     return rows.map((row) => {
+      const itemsByExperiment = shouldGroupItemsByExperiment
+        ? groupBy(row.experiment_items ?? [], (item) => item.experiment_id)
+        : {};
+
       return columnsToExport.reduce<Record<string, unknown>>(
         (accumulator, column) => {
           if (FLAT_COLUMNS.includes(column)) {
@@ -121,17 +128,17 @@ const CompareExperimentsActionsPanel: React.FC<
             return accumulator;
           }
 
-          const prefix = first(column.split(".")) as string;
+          const columnPrefix = first(column.split(".")) as string;
           const isDatasetColumn = !(
-            EVALUATION_EXPORT_COLUMNS.includes(prefix) ||
-            prefix === COLUMN_FEEDBACK_SCORES_ID ||
-            prefix === COLUMN_PASSED_ID
+            EVALUATION_EXPORT_COLUMNS.includes(columnPrefix) ||
+            columnPrefix === COLUMN_FEEDBACK_SCORES_ID ||
+            columnPrefix === COLUMN_PASSED_ID
           );
 
           if (isDatasetColumn) {
             // Handle dataset columns with "data." prefix
             const fieldName =
-              prefix === EXPERIMENT_ITEM_DATASET_PREFIX
+              columnPrefix === EXPERIMENT_ITEM_DATASET_PREFIX
                 ? column.replace(`${EXPERIMENT_ITEM_DATASET_PREFIX}.`, "")
                 : column;
             accumulator[`dataset.${fieldName}`] = get(row.data, fieldName, "-");
@@ -142,15 +149,15 @@ const CompareExperimentsActionsPanel: React.FC<
           if (column === COLUMN_PASSED_ID) {
             if (isCompare) {
               localExperiments.forEach((experiment) => {
-                const items = (row.experiment_items ?? []).filter(
-                  (item) => item.experiment_id === experiment.id,
-                );
-                const prefix = `${nameMap[experiment.id] ?? "unknown"}.`;
+                const items = itemsByExperiment[experiment.id] ?? [];
+                const experimentPrefix = `${
+                  nameMap[experiment.id] ?? "unknown"
+                }.`;
                 processPassedExportColumn(
                   row,
                   items,
                   accumulator,
-                  prefix,
+                  experimentPrefix,
                   experiment.id,
                 );
               });
@@ -167,13 +174,15 @@ const CompareExperimentsActionsPanel: React.FC<
 
           if (isCompare) {
             (row.experiment_items ?? []).forEach((item) => {
-              const prefix = `${nameMap[item.experiment_id] ?? "unknown"}.`;
+              const experimentPrefix = `${
+                nameMap[item.experiment_id] ?? "unknown"
+              }.`;
               processNestedExportColumn(
                 item,
                 column,
                 accumulator,
                 row.data,
-                prefix,
+                experimentPrefix,
               );
             });
           } else {

--- a/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
@@ -25,7 +25,7 @@ import {
   EXPERIMENT_ITEM_DATASET_PREFIX,
 } from "@/constants/experiments";
 import { Separator } from "@/ui/separator";
-import { RunStatus } from "@/types/test-suites";
+import { processPassedExportColumn } from "./compareExperimentsExportUtils";
 
 const EVALUATION_EXPORT_COLUMNS = [
   EXPERIMENT_ITEM_OUTPUT_PREFIX,
@@ -37,57 +37,6 @@ const FLAT_COLUMNS = [COLUMN_CREATED_AT_ID, COLUMN_ID_ID];
 
 const extractFieldName = (column: string, prefix: string): string =>
   column.replace(`${prefix}.`, "");
-
-const resolvePassedStatus = (
-  row: ExperimentsCompare,
-  items: ExperimentItem[],
-  experimentId?: string,
-) => {
-  if (experimentId) {
-    return (
-      row.run_summaries_by_experiment?.[experimentId]?.status ??
-      items[0]?.status
-    );
-  }
-
-  const summaries = Object.values(row.run_summaries_by_experiment ?? {});
-
-  if (summaries.length > 0) {
-    if (summaries.every((s) => s.status === RunStatus.PASSED)) {
-      return RunStatus.PASSED;
-    }
-    if (summaries.every((s) => s.status === RunStatus.SKIPPED)) {
-      return RunStatus.SKIPPED;
-    }
-    return RunStatus.FAILED;
-  }
-
-  return items[0]?.status;
-};
-
-const processPassedExportColumn = (
-  row: ExperimentsCompare,
-  items: ExperimentItem[],
-  accumulator: Record<string, unknown>,
-  prefix: string = "",
-  experimentId?: string,
-) => {
-  const status = resolvePassedStatus(row, items, experimentId);
-  accumulator[`${prefix}status`] = status ?? "-";
-
-  items
-    .flatMap((item) => item.assertion_results ?? [])
-    .forEach((ar, index) => {
-      const idx = index + 1;
-      accumulator[`${prefix}assertion_${idx}.name`] = ar.value;
-      accumulator[`${prefix}assertion_${idx}.result`] = ar.passed
-        ? "passed"
-        : "failed";
-      if (ar.reason) {
-        accumulator[`${prefix}assertion_${idx}.reason`] = ar.reason;
-      }
-    });
-};
 
 const processNestedExportColumn = (
   item: ExperimentItem,

--- a/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
@@ -27,6 +27,10 @@ import {
   EXPERIMENT_ITEM_DATASET_PREFIX,
 } from "@/constants/experiments";
 import { Separator } from "@/ui/separator";
+import {
+  getExperimentExportIds,
+  getExperimentExportPrefix,
+} from "@/lib/compare-experiments-export";
 import { processPassedExportColumn } from "./compareExperimentsExportUtils";
 
 const EVALUATION_EXPORT_COLUMNS = [
@@ -40,7 +44,7 @@ const extractFieldName = (column: string, prefix: string): string =>
   column.replace(`${prefix}.`, "");
 
 const processNestedExportColumn = (
-  item: ExperimentItem,
+  item: ExperimentItem | undefined,
   column: string,
   accumulator: Record<string, unknown>,
   rowData: object,
@@ -51,7 +55,9 @@ const processNestedExportColumn = (
 
   if (prefixColumnKey === COLUMN_FEEDBACK_SCORES_ID) {
     const scoreName = extractFieldName(column, prefixColumnKey);
-    const scoreObject = item.feedback_scores?.find((f) => f.name === scoreName);
+    const scoreObject = item?.feedback_scores?.find(
+      (f) => f.name === scoreName,
+    );
     accumulator[`${prefix}${column}`] = get(scoreObject, "value", "-");
 
     if (scoreObject?.reason) {
@@ -86,11 +92,18 @@ type CompareExperimentsActionsPanelProps = {
   selectedRows?: ExperimentsCompare[];
   columnsToExport?: string[];
   experiments?: Experiment[];
+  experimentsIds?: string[];
 };
 
 const CompareExperimentsActionsPanel: React.FC<
   CompareExperimentsActionsPanelProps
-> = ({ getDataForExport, selectedRows = [], columnsToExport, experiments }) => {
+> = ({
+  getDataForExport,
+  selectedRows = [],
+  columnsToExport,
+  experiments,
+  experimentsIds = [],
+}) => {
   const disabled = !selectedRows?.length;
   const isExportEnabled = useIsFeatureEnabled(FeatureToggleKeys.EXPORT_ENABLED);
 
@@ -111,14 +124,20 @@ const CompareExperimentsActionsPanel: React.FC<
       {},
     );
 
-    const isCompare = localExperiments?.length > 1;
-    const shouldGroupItemsByExperiment =
-      isCompare && columnsToExport.includes(COLUMN_PASSED_ID);
+    const isCompare = experimentsIds.length > 1 || localExperiments.length > 1;
 
     return rows.map((row) => {
-      const itemsByExperiment = shouldGroupItemsByExperiment
-        ? groupBy(row.experiment_items ?? [], (item) => item.experiment_id)
-        : {};
+      const itemsByExperiment = groupBy(
+        row.experiment_items ?? [],
+        (item) => item.experiment_id,
+      );
+      const rowExperimentIds = Object.keys(itemsByExperiment);
+      const exportExperimentIds = getExperimentExportIds(
+        experimentsIds,
+        localExperiments,
+        rowExperimentIds,
+      );
+      const shouldExportByExperiment = exportExperimentIds.length > 1;
 
       return columnsToExport.reduce<Record<string, unknown>>(
         (accumulator, column) => {
@@ -147,18 +166,19 @@ const CompareExperimentsActionsPanel: React.FC<
           }
 
           if (column === COLUMN_PASSED_ID) {
-            if (isCompare) {
-              localExperiments.forEach((experiment) => {
-                const items = itemsByExperiment[experiment.id] ?? [];
-                const experimentPrefix = `${
-                  nameMap[experiment.id] ?? "unknown"
-                }.`;
+            if (shouldExportByExperiment) {
+              exportExperimentIds.forEach((experimentId) => {
+                const items = itemsByExperiment[experimentId] ?? [];
+                const experimentPrefix = getExperimentExportPrefix(
+                  experimentId,
+                  nameMap,
+                );
                 processPassedExportColumn(
                   row,
                   items,
                   accumulator,
                   experimentPrefix,
-                  experiment.id,
+                  experimentId,
                 );
               });
             } else {
@@ -173,17 +193,32 @@ const CompareExperimentsActionsPanel: React.FC<
           }
 
           if (isCompare) {
-            (row.experiment_items ?? []).forEach((item) => {
-              const experimentPrefix = `${
-                nameMap[item.experiment_id] ?? "unknown"
-              }.`;
-              processNestedExportColumn(
-                item,
-                column,
-                accumulator,
-                row.data,
-                experimentPrefix,
+            exportExperimentIds.forEach((experimentId) => {
+              const experimentPrefix = getExperimentExportPrefix(
+                experimentId,
+                nameMap,
               );
+              const items = itemsByExperiment[experimentId] ?? [];
+
+              if (items.length === 0) {
+                processNestedExportColumn(
+                  undefined,
+                  column,
+                  accumulator,
+                  row.data,
+                  experimentPrefix,
+                );
+              }
+
+              items.forEach((item) => {
+                processNestedExportColumn(
+                  item,
+                  column,
+                  accumulator,
+                  row.data,
+                  experimentPrefix,
+                );
+              });
             });
           } else {
             const item = row.experiment_items?.[0];
@@ -195,19 +230,21 @@ const CompareExperimentsActionsPanel: React.FC<
         {},
       );
     });
-  }, [getDataForExport, columnsToExport, experiments]);
+  }, [getDataForExport, columnsToExport, experiments, experimentsIds]);
 
   const generateFileName = useCallback(
     (extension = "csv") => {
+      const experimentsCount =
+        experimentsIds.length || experiments?.length || 0;
       const fileName =
-        experiments?.length === 1
+        experimentsCount === 1 && experiments?.[0]?.name
           ? experiments[0].name
-          : `compare ${experiments?.length}`;
+          : `compare ${experimentsCount}`;
       return `${slugify(fileName, {
         lower: true,
       })}.${extension}`;
     },
-    [experiments],
+    [experiments, experimentsIds],
   );
 
   return (

--- a/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -533,7 +533,9 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
         }
 
         return (
-          selectedColumns.includes(c) || (columnPinning.left || []).includes(c)
+          selectedColumns.includes(c) ||
+          (columnPinning.left || []).includes(c) ||
+          (columnPinning.right || []).includes(c)
         );
       });
   }, [columns, selectedColumns, columnPinning]);

--- a/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -14,6 +14,7 @@ import {
   COLUMN_DURATION_ID,
   COLUMN_FEEDBACK_SCORES_ID,
   COLUMN_ID_ID,
+  COLUMN_PASSED_ID,
   COLUMN_SELECT_ID,
   COLUMN_TYPE,
   COLUMN_USAGE_ID,
@@ -82,7 +83,6 @@ const calculateVerticalAlignment = (count: number) =>
 const columnHelper = createColumnHelper<ExperimentsCompare>();
 
 const COLUMN_EXPERIMENT_NAME_ID = "experiment_name";
-const COLUMN_PASSED_ID = "passed";
 const STORAGE_PREFIX = "compare-experiments";
 const DYNAMIC_COLUMNS_KEY = "compare-experiments-dynamic-columns";
 

--- a/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -682,6 +682,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
             selectedRows={selectedRows}
             columnsToExport={columnsToExport}
             experiments={experiments}
+            experimentsIds={experimentsIds}
           />
           <Separator orientation="vertical" className="mx-2 h-4" />
           <DataTableRowHeightSelector

--- a/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -118,11 +118,6 @@ function getFilterColumns(
   ];
 }
 
-const DEFAULT_COLUMN_PINNING: ColumnPinningState = {
-  left: [COLUMN_SELECT_ID],
-  right: [],
-};
-
 export const DEFAULT_SELECTED_COLUMNS: string[] = [
   COLUMN_DURATION_ID,
   `${COLUMN_USAGE_ID}.total_tokens`,
@@ -223,10 +218,13 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
 
   const columnPinning = useMemo<ColumnPinningState>(
     () => ({
-      left: [COLUMN_SELECT_ID],
+      left:
+        experimentsCount > 1
+          ? [COLUMN_SELECT_ID, COLUMN_EXPERIMENT_NAME_ID]
+          : [COLUMN_SELECT_ID],
       right: isTestSuite ? [COLUMN_PASSED_ID] : [],
     }),
-    [isTestSuite],
+    [experimentsCount, isTestSuite],
   );
 
   const filtersConfig = useMemo(
@@ -529,13 +527,16 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
         return acc.concat(subColumns ? subColumns : [c]);
       }, [])
       .map((c) => get(c, "accessorKey", ""))
-      .filter((c) =>
-        c === COLUMN_SELECT_ID
-          ? false
-          : selectedColumns.includes(c) ||
-            (DEFAULT_COLUMN_PINNING.left || []).includes(c),
-      );
-  }, [columns, selectedColumns]);
+      .filter((c) => {
+        if (c === COLUMN_SELECT_ID || c === COLUMN_EXPERIMENT_NAME_ID) {
+          return false;
+        }
+
+        return (
+          selectedColumns.includes(c) || (columnPinning.left || []).includes(c)
+        );
+      });
+  }, [columns, selectedColumns, columnPinning]);
 
   const filterColumns = useMemo(() => {
     return [
@@ -713,7 +714,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
         getRowId={getRowId}
         rowHeight={height as ROW_HEIGHT}
         getRowHeightStyle={getRowHeightStyle}
-        columnPinning={columnPinning}
+        columnPinningState={columnPinning}
         noData={<DataTableNoData title={noDataText} />}
         TableWrapper={PageBodyStickyTableWrapper}
         TableBody={DataTableVirtualBody}

--- a/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -720,6 +720,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
         noData={<DataTableNoData title={noDataText} />}
         TableWrapper={PageBodyStickyTableWrapper}
         TableBody={DataTableVirtualBody}
+        autoWidth
         stickyHeader
         meta={meta}
         showLoadingOverlay={isPlaceholderData && isFetching}

--- a/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/compareExperimentsExportUtils.ts
+++ b/apps/opik-frontend/src/v1/pages/CompareExperimentsPage/compareExperimentsExportUtils.ts
@@ -1,0 +1,61 @@
+import { ExperimentItem, ExperimentsCompare } from "@/types/datasets";
+import { RunStatus } from "@/types/test-suites";
+
+const shouldSuppressSkippedStatus = (
+  row: ExperimentsCompare,
+  status: RunStatus | undefined,
+) => status === RunStatus.SKIPPED && (row.evaluators?.length ?? 0) > 0;
+
+export const resolvePassedStatus = (
+  row: ExperimentsCompare,
+  items: ExperimentItem[],
+  experimentId?: string,
+) => {
+  if (experimentId) {
+    const status =
+      row.run_summaries_by_experiment?.[experimentId]?.status ??
+      items[0]?.status;
+    return shouldSuppressSkippedStatus(row, status) ? undefined : status;
+  }
+
+  const summaries = Object.values(row.run_summaries_by_experiment ?? {});
+  let status: RunStatus | undefined;
+
+  if (summaries.length > 0) {
+    if (summaries.every((s) => s.status === RunStatus.PASSED)) {
+      status = RunStatus.PASSED;
+    } else if (summaries.every((s) => s.status === RunStatus.SKIPPED)) {
+      status = RunStatus.SKIPPED;
+    } else {
+      status = RunStatus.FAILED;
+    }
+  } else {
+    status = items[0]?.status;
+  }
+
+  return shouldSuppressSkippedStatus(row, status) ? undefined : status;
+};
+
+export const processPassedExportColumn = (
+  row: ExperimentsCompare,
+  items: ExperimentItem[],
+  accumulator: Record<string, unknown>,
+  prefix: string = "",
+  experimentId?: string,
+) => {
+  const status = resolvePassedStatus(row, items, experimentId);
+  accumulator[`${prefix}status`] = status ?? "-";
+
+  items
+    .flatMap((item) => item.assertion_results ?? [])
+    .forEach((ar, index) => {
+      const idx = index + 1;
+      accumulator[`${prefix}assertion_${idx}.name`] = ar.value;
+      accumulator[`${prefix}assertion_${idx}.result`] = ar.passed
+        ? "passed"
+        : "failed";
+      if (ar.reason) {
+        accumulator[`${prefix}assertion_${idx}.reason`] = ar.reason;
+      }
+    });
+};

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/CompareExperimentsNameCell/CompareExperimentsNameCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/CompareExperimentsNameCell/CompareExperimentsNameCell.tsx
@@ -23,7 +23,7 @@ const CompareExperimentsNameCell: React.FC<
     const experiment = experiments.find((e) => e.id === experimentId);
 
     return (
-      <div className="-mt-2 h-8">
+      <div className="flex h-full items-center">
         <ResourceLink
           id={experiment?.dataset_id || ""}
           name={experiment?.name}

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
@@ -3,6 +3,7 @@ import get from "lodash/get";
 import slugify from "slugify";
 import uniq from "lodash/uniq";
 import first from "lodash/first";
+import groupBy from "lodash/groupBy";
 
 import CompareExperimentsButton from "@/v2/pages/CompareExperimentsPage/CompareExperimentsButton/CompareExperimentsButton";
 import ExportToButton from "@/shared/ExportToButton/ExportToButton";
@@ -27,6 +28,10 @@ import {
   EXPERIMENT_ITEM_DATASET_PREFIX,
 } from "@/constants/experiments";
 import { Separator } from "@/ui/separator";
+import {
+  getExperimentExportIds,
+  getExperimentExportPrefix,
+} from "@/lib/compare-experiments-export";
 
 const COLUMN_TOTAL_ESTIMATED_COST_ID = "total_estimated_cost";
 
@@ -40,7 +45,7 @@ const EXPERIMENT_ITEM_COLUMNS = [
 const FLAT_COLUMNS = [COLUMN_CREATED_AT_ID, COLUMN_ID_ID];
 
 const processNestedExportColumn = (
-  item: ExperimentItem,
+  item: ExperimentItem | undefined,
   column: string,
   accumulator: Record<string, unknown>,
   rowData: object,
@@ -51,7 +56,9 @@ const processNestedExportColumn = (
 
   if (prefixColumnKey === COLUMN_FEEDBACK_SCORES_ID) {
     const scoreName = keys.slice(1).join(".");
-    const scoreObject = item.feedback_scores?.find((f) => f.name === scoreName);
+    const scoreObject = item?.feedback_scores?.find(
+      (f) => f.name === scoreName,
+    );
     accumulator[`${prefix}${column}`] = get(scoreObject, "value", "-");
 
     if (scoreObject?.reason) {
@@ -98,11 +105,18 @@ type CompareExperimentsActionsPanelProps = {
   selectedRows?: ExperimentsCompare[];
   columnsToExport?: string[];
   experiments?: Experiment[];
+  experimentsIds?: string[];
 };
 
 const CompareExperimentsActionsPanel: React.FC<
   CompareExperimentsActionsPanelProps
-> = ({ getDataForExport, selectedRows = [], columnsToExport, experiments }) => {
+> = ({
+  getDataForExport,
+  selectedRows = [],
+  columnsToExport,
+  experiments,
+  experimentsIds = [],
+}) => {
   const disabled = !selectedRows?.length;
   const isExportEnabled = useIsFeatureEnabled(FeatureToggleKeys.EXPORT_ENABLED);
 
@@ -123,9 +137,20 @@ const CompareExperimentsActionsPanel: React.FC<
       {},
     );
 
-    const isCompare = localExperiments?.length > 1;
+    const isCompare = experimentsIds.length > 1 || localExperiments.length > 1;
 
     return rows.map((row) => {
+      const itemsByExperiment = groupBy(
+        row.experiment_items ?? [],
+        (item) => item.experiment_id,
+      );
+      const rowExperimentIds = Object.keys(itemsByExperiment);
+      const exportExperimentIds = getExperimentExportIds(
+        experimentsIds,
+        localExperiments,
+        rowExperimentIds,
+      );
+
       return columnsToExport.reduce<Record<string, unknown>>(
         (accumulator, column) => {
           if (FLAT_COLUMNS.includes(column)) {
@@ -153,17 +178,32 @@ const CompareExperimentsActionsPanel: React.FC<
           }
 
           if (isCompare) {
-            (row.experiment_items ?? []).forEach((item) => {
-              const experimentPrefix = `${
-                nameMap[item.experiment_id] ?? "unknown"
-              }.`;
-              processNestedExportColumn(
-                item,
-                column,
-                accumulator,
-                row.data,
-                experimentPrefix,
+            exportExperimentIds.forEach((experimentId) => {
+              const experimentPrefix = getExperimentExportPrefix(
+                experimentId,
+                nameMap,
               );
+              const items = itemsByExperiment[experimentId] ?? [];
+
+              if (items.length === 0) {
+                processNestedExportColumn(
+                  undefined,
+                  column,
+                  accumulator,
+                  row.data,
+                  experimentPrefix,
+                );
+              }
+
+              items.forEach((item) => {
+                processNestedExportColumn(
+                  item,
+                  column,
+                  accumulator,
+                  row.data,
+                  experimentPrefix,
+                );
+              });
             });
           } else {
             const item = row.experiment_items?.[0];
@@ -175,19 +215,21 @@ const CompareExperimentsActionsPanel: React.FC<
         {},
       );
     });
-  }, [getDataForExport, columnsToExport, experiments]);
+  }, [getDataForExport, columnsToExport, experiments, experimentsIds]);
 
   const generateFileName = useCallback(
     (extension = "csv") => {
+      const experimentsCount =
+        experimentsIds.length || experiments?.length || 0;
       const fileName =
-        experiments?.length === 1
+        experimentsCount === 1 && experiments?.[0]?.name
           ? experiments[0].name
-          : `compare ${experiments?.length}`;
+          : `compare ${experimentsCount}`;
       return `${slugify(fileName, {
         lower: true,
       })}.${extension}`;
     },
-    [experiments],
+    [experiments, experimentsIds],
   );
 
   return (

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
@@ -19,6 +19,7 @@ import {
   COLUMN_ID_ID,
   COLUMN_FEEDBACK_SCORES_ID,
   COLUMN_DURATION_ID,
+  COLUMN_PASSED_ID,
   COLUMN_USAGE_ID,
 } from "@/types/shared";
 import {
@@ -27,7 +28,6 @@ import {
 } from "@/constants/experiments";
 import { Separator } from "@/ui/separator";
 
-const COLUMN_PASSED_ID = "passed";
 const COLUMN_TOTAL_ESTIMATED_COST_ID = "total_estimated_cost";
 
 const EXPERIMENT_ITEM_COLUMNS = [
@@ -134,17 +134,17 @@ const CompareExperimentsActionsPanel: React.FC<
             return accumulator;
           }
 
-          const prefix = first(column.split(".")) as string;
+          const columnPrefix = first(column.split(".")) as string;
           const isDatasetColumn = !(
-            EXPERIMENT_ITEM_COLUMNS.includes(prefix) ||
-            prefix === COLUMN_FEEDBACK_SCORES_ID ||
-            prefix === COLUMN_PASSED_ID
+            EXPERIMENT_ITEM_COLUMNS.includes(columnPrefix) ||
+            columnPrefix === COLUMN_FEEDBACK_SCORES_ID ||
+            columnPrefix === COLUMN_PASSED_ID
           );
 
           if (isDatasetColumn) {
             // Handle dataset columns with "data." prefix
             const fieldName =
-              prefix === EXPERIMENT_ITEM_DATASET_PREFIX
+              columnPrefix === EXPERIMENT_ITEM_DATASET_PREFIX
                 ? column.replace(`${EXPERIMENT_ITEM_DATASET_PREFIX}.`, "")
                 : column;
             accumulator[`dataset.${fieldName}`] = get(row.data, fieldName, "-");
@@ -154,13 +154,15 @@ const CompareExperimentsActionsPanel: React.FC<
 
           if (isCompare) {
             (row.experiment_items ?? []).forEach((item) => {
-              const prefix = `${nameMap[item.experiment_id] ?? "unknown"}.`;
+              const experimentPrefix = `${
+                nameMap[item.experiment_id] ?? "unknown"
+              }.`;
               processNestedExportColumn(
                 item,
                 column,
                 accumulator,
                 row.data,
-                prefix,
+                experimentPrefix,
               );
             });
           } else {

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -729,6 +729,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
         noData={<DataTableNoData title={noDataText} />}
         TableWrapper={PageBodyStickyTableWrapper}
         TableBody={DataTableVirtualBody}
+        autoWidth
         stickyHeader
         meta={meta}
         showSkeleton={isTableLoading}

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -14,6 +14,7 @@ import {
   COLUMN_DURATION_ID,
   COLUMN_FEEDBACK_SCORES_ID,
   COLUMN_ID_ID,
+  COLUMN_PASSED_ID,
   COLUMN_SELECT_ID,
   COLUMN_TYPE,
   COLUMN_USAGE_ID,
@@ -82,7 +83,6 @@ const calculateVerticalAlignment = (count: number) =>
 const columnHelper = createColumnHelper<ExperimentsCompare>();
 
 const COLUMN_EXPERIMENT_NAME_ID = "experiment_name";
-const COLUMN_PASSED_ID = "passed";
 const STORAGE_PREFIX = "compare-experiments";
 const DYNAMIC_COLUMNS_KEY = "compare-experiments-dynamic-columns";
 const EVAL_SUITE_ECHOED_OUTPUT_KEY = "input";

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -117,11 +117,6 @@ function getFilterColumns(): ColumnData<ExperimentsCompare>[] {
   ];
 }
 
-const DEFAULT_COLUMN_PINNING: ColumnPinningState = {
-  left: [COLUMN_SELECT_ID],
-  right: [],
-};
-
 export const DEFAULT_SELECTED_COLUMNS: string[] = [
   COLUMN_DURATION_ID,
   `${COLUMN_USAGE_ID}.total_tokens`,
@@ -222,10 +217,13 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
 
   const columnPinning = useMemo<ColumnPinningState>(
     () => ({
-      left: [COLUMN_SELECT_ID],
+      left:
+        experimentsCount > 1
+          ? [COLUMN_SELECT_ID, COLUMN_EXPERIMENT_NAME_ID]
+          : [COLUMN_SELECT_ID],
       right: isTestSuite ? [COLUMN_PASSED_ID] : [],
     }),
-    [isTestSuite],
+    [experimentsCount, isTestSuite],
   );
 
   const filtersConfig = useMemo(
@@ -540,13 +538,17 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
         return acc.concat(subColumns ? subColumns : [c]);
       }, [])
       .map((c) => get(c, "accessorKey", ""))
-      .filter((c) =>
-        c === COLUMN_SELECT_ID
-          ? false
-          : selectedColumns.includes(c) ||
-            (DEFAULT_COLUMN_PINNING.left || []).includes(c) ||
-            (columnPinning.right || []).includes(c),
-      );
+      .filter((c) => {
+        if (c === COLUMN_SELECT_ID || c === COLUMN_EXPERIMENT_NAME_ID) {
+          return false;
+        }
+
+        return (
+          selectedColumns.includes(c) ||
+          (columnPinning.left || []).includes(c) ||
+          (columnPinning.right || []).includes(c)
+        );
+      });
   }, [columns, selectedColumns, columnPinning]);
 
   const filterColumns = useMemo(() => {
@@ -723,7 +725,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
         getRowId={getRowId}
         rowHeight={height as ROW_HEIGHT}
         getRowHeightStyle={getRowHeightStyle}
-        columnPinning={columnPinning}
+        columnPinningState={columnPinning}
         noData={<DataTableNoData title={noDataText} />}
         TableWrapper={PageBodyStickyTableWrapper}
         TableBody={DataTableVirtualBody}

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -691,6 +691,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
             selectedRows={selectedRows}
             columnsToExport={columnsToExport}
             experiments={experiments}
+            experimentsIds={experimentsIds}
           />
           <Separator orientation="vertical" className="mx-2 h-4" />
           <DataTableRowHeightSelector

--- a/apps/opik-frontend/tests/v1/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.test.ts
+++ b/apps/opik-frontend/tests/v1/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  getExperimentExportIds,
+  getExperimentExportPrefix,
+} from "@/lib/compare-experiments-export";
+import {
   processPassedExportColumn,
   resolvePassedStatus,
 } from "@/v1/pages/CompareExperimentsPage/compareExperimentsExportUtils";
 import {
   DATASET_ITEM_SOURCE,
   type Evaluator,
+  type Experiment,
   type ExperimentItem,
   type ExperimentsCompare,
 } from "@/types/datasets";
@@ -46,6 +51,49 @@ const evaluators: Evaluator[] = [
 ];
 
 describe("CompareExperimentsActionsPanel export helpers", () => {
+  describe("getExperimentExportIds", () => {
+    it("should keep selected experiment order and append unresolved row experiments", () => {
+      // Arrange
+      const localExperiments = [
+        { id: "experiment-2", name: "Experiment 2" } as Experiment,
+      ];
+
+      // Act
+      const experimentIds = getExperimentExportIds(
+        ["experiment-1", "experiment-2"],
+        localExperiments,
+        ["experiment-3", "experiment-1"],
+      );
+
+      // Assert
+      expect(experimentIds).toEqual([
+        "experiment-1",
+        "experiment-2",
+        "experiment-3",
+      ]);
+    });
+  });
+
+  describe("getExperimentExportPrefix", () => {
+    it("should use a unique unknown prefix when experiment metadata is missing", () => {
+      // Act
+      const prefix = getExperimentExportPrefix("experiment-1", {});
+
+      // Assert
+      expect(prefix).toBe("unknown(experiment-1).");
+    });
+
+    it("should avoid colliding with loaded experiment names", () => {
+      // Act
+      const prefix = getExperimentExportPrefix("experiment-1", {
+        "experiment-2": "unknown(experiment-1)",
+      });
+
+      // Assert
+      expect(prefix).toBe("unknown(experiment-1) 2.");
+    });
+  });
+
   describe("resolvePassedStatus", () => {
     it("should fall back to the first item status when summaries are missing", () => {
       // Arrange

--- a/apps/opik-frontend/tests/v1/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.test.ts
+++ b/apps/opik-frontend/tests/v1/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  processPassedExportColumn,
+  resolvePassedStatus,
+} from "@/v1/pages/CompareExperimentsPage/compareExperimentsExportUtils";
+import {
+  DATASET_ITEM_SOURCE,
+  type Evaluator,
+  type ExperimentItem,
+  type ExperimentsCompare,
+} from "@/types/datasets";
+import { RunStatus } from "@/types/test-suites";
+
+const createExperimentItem = (
+  overrides: Partial<ExperimentItem> = {},
+): ExperimentItem => ({
+  id: "item-1",
+  experiment_id: "experiment-1",
+  dataset_item_id: "dataset-item-1",
+  input: {},
+  output: {},
+  created_at: "2026-05-22T00:00:00.000Z",
+  last_updated_at: "2026-05-22T00:00:00.000Z",
+  ...overrides,
+});
+
+const createCompareRow = (
+  overrides: Partial<ExperimentsCompare> = {},
+): ExperimentsCompare => ({
+  id: "dataset-item-1",
+  data: {},
+  source: DATASET_ITEM_SOURCE.manual,
+  created_at: "2026-05-22T00:00:00.000Z",
+  last_updated_at: "2026-05-22T00:00:00.000Z",
+  experiment_items: [],
+  ...overrides,
+});
+
+const evaluators: Evaluator[] = [
+  {
+    name: "judge",
+    type: "llm_judge",
+    config: {},
+  },
+];
+
+describe("CompareExperimentsActionsPanel export helpers", () => {
+  describe("resolvePassedStatus", () => {
+    it("should fall back to the first item status when summaries are missing", () => {
+      // Arrange
+      const items = [createExperimentItem({ status: RunStatus.PASSED })];
+      const row = createCompareRow({ experiment_items: items });
+
+      // Act
+      const status = resolvePassedStatus(row, items);
+
+      // Assert
+      expect(status).toBe(RunStatus.PASSED);
+    });
+
+    it("should resolve failed when summaries are mixed", () => {
+      // Arrange
+      const row = createCompareRow({
+        run_summaries_by_experiment: {
+          "experiment-1": {
+            passed_runs: 1,
+            total_runs: 1,
+            status: RunStatus.PASSED,
+          },
+          "experiment-2": {
+            passed_runs: 0,
+            total_runs: 1,
+            status: RunStatus.FAILED,
+          },
+        },
+      });
+
+      // Act
+      const status = resolvePassedStatus(row, []);
+
+      // Assert
+      expect(status).toBe(RunStatus.FAILED);
+    });
+
+    it("should resolve passed when all summaries are passed", () => {
+      // Arrange
+      const row = createCompareRow({
+        run_summaries_by_experiment: {
+          "experiment-1": {
+            passed_runs: 1,
+            total_runs: 1,
+            status: RunStatus.PASSED,
+          },
+          "experiment-2": {
+            passed_runs: 1,
+            total_runs: 1,
+            status: RunStatus.PASSED,
+          },
+        },
+      });
+
+      // Act
+      const status = resolvePassedStatus(row, []);
+
+      // Assert
+      expect(status).toBe(RunStatus.PASSED);
+    });
+
+    it("should resolve skipped when all summaries are skipped without evaluators", () => {
+      // Arrange
+      const row = createCompareRow({
+        run_summaries_by_experiment: {
+          "experiment-1": {
+            passed_runs: 0,
+            total_runs: 0,
+            status: RunStatus.SKIPPED,
+          },
+          "experiment-2": {
+            passed_runs: 0,
+            total_runs: 0,
+            status: RunStatus.SKIPPED,
+          },
+        },
+      });
+
+      // Act
+      const status = resolvePassedStatus(row, []);
+
+      // Assert
+      expect(status).toBe(RunStatus.SKIPPED);
+    });
+
+    it("should use an experiment summary before falling back to item status", () => {
+      // Arrange
+      const items = [createExperimentItem({ status: RunStatus.FAILED })];
+      const row = createCompareRow({
+        experiment_items: items,
+        run_summaries_by_experiment: {
+          "experiment-1": {
+            passed_runs: 1,
+            total_runs: 1,
+            status: RunStatus.PASSED,
+          },
+        },
+      });
+
+      // Act
+      const status = resolvePassedStatus(row, items, "experiment-1");
+
+      // Assert
+      expect(status).toBe(RunStatus.PASSED);
+    });
+
+    it("should suppress skipped summaries when the row has evaluators", () => {
+      // Arrange
+      const row = createCompareRow({
+        evaluators,
+        run_summaries_by_experiment: {
+          "experiment-1": {
+            passed_runs: 0,
+            total_runs: 0,
+            status: RunStatus.SKIPPED,
+          },
+        },
+      });
+
+      // Act
+      const status = resolvePassedStatus(row, [], "experiment-1");
+
+      // Assert
+      expect(status).toBeUndefined();
+    });
+  });
+
+  describe("processPassedExportColumn", () => {
+    it("should write status without assertion columns when assertion_results is empty", () => {
+      // Arrange
+      const items = [
+        createExperimentItem({
+          status: RunStatus.PASSED,
+          assertion_results: [],
+        }),
+      ];
+      const row = createCompareRow({ experiment_items: items });
+      const accumulator: Record<string, unknown> = {};
+
+      // Act
+      processPassedExportColumn(row, items, accumulator);
+
+      // Assert
+      expect(accumulator).toEqual({
+        status: RunStatus.PASSED,
+      });
+    });
+
+    it("should write prefixed status and assertion result fields", () => {
+      // Arrange
+      const items = [
+        createExperimentItem({
+          status: RunStatus.FAILED,
+          assertion_results: [
+            {
+              value: "is_correct",
+              passed: false,
+              reason: "Expected a different answer",
+            },
+          ],
+        }),
+      ];
+      const row = createCompareRow({ experiment_items: items });
+      const accumulator: Record<string, unknown> = {};
+
+      // Act
+      processPassedExportColumn(row, items, accumulator, "Experiment A.");
+
+      // Assert
+      expect(accumulator).toEqual({
+        "Experiment A.status": RunStatus.FAILED,
+        "Experiment A.assertion_1.name": "is_correct",
+        "Experiment A.assertion_1.result": "failed",
+        "Experiment A.assertion_1.reason": "Expected a different answer",
+      });
+    });
+
+    it("should write dash when skipped status is suppressed", () => {
+      // Arrange
+      const items = [
+        createExperimentItem({
+          status: RunStatus.SKIPPED,
+        }),
+      ];
+      const row = createCompareRow({
+        evaluators,
+        experiment_items: items,
+      });
+      const accumulator: Record<string, unknown> = {};
+
+      // Act
+      processPassedExportColumn(row, items, accumulator);
+
+      // Assert
+      expect(accumulator).toEqual({
+        status: "-",
+      });
+    });
+  });
+});


### PR DESCRIPTION
> ♻️ Re-opened on behalf of @pragnyanramtha. All commits are authored by @pragnyanramtha. Apologies for the inconvenience. Original PR for reference: #6837.

---

## Details
Pins the experiment name column in the compare experiments item table when comparing multiple experiments, so horizontal scrolling keeps the experiment identity visible. The table now uses controlled column pinning so the pinned state updates when the compare selection changes without a remount.

The export column list continues to avoid synthetic pinned columns like selection and experiment name, and keeps the existing v1/v2 export behavior intact.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #1620
- OPIK-NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: neoforge agent
- Model(s): GPT-5.5-xhigh
- Scope: Implemented small frontend table pinning change and review/fix loop for issue #1620.

## Testing
- `cd apps/opik-frontend && ./node_modules/.bin/eslint src/v1/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx --max-warnings=0`
- `git diff --check`

Validated by review:
- Experiment name is left-pinned only when comparing more than one experiment.
- Controlled `columnPinningState` is used so pinning updates when experiment count changes.
- `experiment_name` is excluded from export columns.
- v1 test-suite export does not accidentally include right-pinned `passed`.

Not run:
- Browser QA/horizontal scroll screenshot verification.

## Documentation
No documentation update. This is a UI behavior fix for an existing table.