### PR TITLE
[OPIK-6386] fix: propagate cache tokens in Bedrock Claude streaming aggregator

### DIFF
--- a/sdks/python/src/opik/integrations/bedrock/invoke_model/chunks_aggregator/claude.py
+++ b/sdks/python/src/opik/integrations/bedrock/invoke_model/chunks_aggregator/claude.py
@@ -36,6 +36,8 @@ class ClaudeAggregator(ChunkAggregator):
         stop_reason = None
         input_tokens = 0
         output_tokens = 0
+        cache_creation_input_tokens = 0
+        cache_read_input_tokens = 0
 
         for item in items:
             if "chunk" not in item:
@@ -51,6 +53,10 @@ class ClaudeAggregator(ChunkAggregator):
                     usage = message.get("usage", {})
                     input_tokens = usage.get("input_tokens", 0)
                     output_tokens = usage.get("output_tokens", 0)
+                    cache_creation_input_tokens = usage.get(
+                        "cache_creation_input_tokens", 0
+                    )
+                    cache_read_input_tokens = usage.get("cache_read_input_tokens", 0)
                     LOGGER.debug(
                         "Claude message_start: input_tokens=%d, output_tokens=%d",
                         input_tokens,
@@ -109,7 +115,12 @@ class ClaudeAggregator(ChunkAggregator):
 
         # Convert to Bedrock usage format using shared converter
         bedrock_usage = usage_converters.anthropic_to_bedrock_usage(
-            {"input_tokens": input_tokens, "output_tokens": output_tokens}
+            {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_creation_input_tokens": cache_creation_input_tokens,
+                "cache_read_input_tokens": cache_read_input_tokens,
+            }
         )
 
         # Return Claude's native format with Bedrock usage

--- a/sdks/python/tests/unit/integrations/bedrock/test_claude_aggregator.py
+++ b/sdks/python/tests/unit/integrations/bedrock/test_claude_aggregator.py
@@ -1,0 +1,125 @@
+import json
+
+from opik.integrations.bedrock.invoke_model.chunks_aggregator.claude import (
+    ClaudeAggregator,
+)
+
+
+def _make_chunk(data: dict) -> dict:
+    """Create a chunk matching the Bedrock streaming format."""
+    return {"chunk": {"bytes": json.dumps(data).encode()}}
+
+
+def test_claude_aggregator__cache_tokens_in_message_start__included_in_usage():
+    """Cache tokens from message_start are propagated to the final usage dict."""
+    aggregator = ClaudeAggregator()
+
+    chunks = [
+        _make_chunk(
+            {
+                "type": "message_start",
+                "message": {
+                    "role": "assistant",
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 0,
+                        "cache_creation_input_tokens": 50,
+                        "cache_read_input_tokens": 200,
+                    },
+                },
+            }
+        ),
+        _make_chunk(
+            {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "Hello"},
+            }
+        ),
+        _make_chunk({"type": "content_block_stop"}),
+        _make_chunk(
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                "usage": {"output_tokens": 5},
+            }
+        ),
+        _make_chunk({"type": "message_stop", "amazon-bedrock-invocationMetrics": {}}),
+    ]
+
+    result = aggregator.aggregate(chunks)
+
+    assert result["usage"]["cacheWriteInputTokens"] == 50
+    assert result["usage"]["cacheReadInputTokens"] == 200
+    assert result["usage"]["inputTokens"] == 100
+    assert result["usage"]["outputTokens"] == 5
+
+
+def test_claude_aggregator__no_cache_tokens__defaults_to_zero():
+    """When message_start has no cache tokens, they default to zero."""
+    aggregator = ClaudeAggregator()
+
+    chunks = [
+        _make_chunk(
+            {
+                "type": "message_start",
+                "message": {
+                    "role": "assistant",
+                    "usage": {
+                        "input_tokens": 10,
+                        "output_tokens": 0,
+                    },
+                },
+            }
+        ),
+        _make_chunk({"type": "content_block_stop"}),
+        _make_chunk(
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                "usage": {"output_tokens": 3},
+            }
+        ),
+        _make_chunk({"type": "message_stop", "amazon-bedrock-invocationMetrics": {}}),
+    ]
+
+    result = aggregator.aggregate(chunks)
+
+    assert result["usage"]["cacheWriteInputTokens"] == 0
+    assert result["usage"]["cacheReadInputTokens"] == 0
+    assert result["usage"]["inputTokens"] == 10
+    assert result["usage"]["outputTokens"] == 3
+
+
+def test_claude_aggregator__only_cache_write__partial_cache():
+    """Only cache_creation_input_tokens present, cache_read is absent."""
+    aggregator = ClaudeAggregator()
+
+    chunks = [
+        _make_chunk(
+            {
+                "type": "message_start",
+                "message": {
+                    "role": "assistant",
+                    "usage": {
+                        "input_tokens": 50,
+                        "output_tokens": 0,
+                        "cache_creation_input_tokens": 100,
+                    },
+                },
+            }
+        ),
+        _make_chunk({"type": "content_block_stop"}),
+        _make_chunk(
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                "usage": {"output_tokens": 10},
+            }
+        ),
+        _make_chunk({"type": "message_stop", "amazon-bedrock-invocationMetrics": {}}),
+    ]
+
+    result = aggregator.aggregate(chunks)
+
+    assert result["usage"]["cacheWriteInputTokens"] == 100
+    assert result["usage"]["cacheReadInputTokens"] == 0


### PR DESCRIPTION
> ♻️ Re-opened on behalf of @zhoufengen. All commits are authored by @zhoufengen. Apologies for the inconvenience. Original PR for reference: #6784.

---

## Summary

The Bedrock Claude streaming path was silently dropping cache tokens (`cache_creation_input_tokens` and `cache_read_input_tokens`) from the `message_start` chunk, causing `cacheWriteInputTokens` and `cacheReadInputTokens` to always be zero in the Opik UI.

The `anthropic_to_bedrock_usage` converter already supported these fields — the aggregator simply wasn't extracting or passing them through.

## Changes

- Extract `cache_creation_input_tokens` and `cache_read_input_tokens` from the `message_start` chunk in `ClaudeAggregator.aggregate()`
- Pass both values through to `anthropic_to_bedrock_usage()` when building the final usage dict

## Testing

Added 3 unit tests in `tests/unit/integrations/bedrock/test_claude_aggregator.py`:
- Cache tokens from `message_start` are propagated to the final usage dict
- When no cache tokens are present in the response, defaults to zero
- Partial cache (only `cache_creation_input_tokens`, no `cache_read_input_tokens`)

All 3 tests pass. The tests are self-contained and don't require AWS credentials or Bedrock access.

## Related Issues

Fixes #6019