### PR TITLE
[issue-6721] [DOCS] [SDK] Add Qianfan integration docs and provider regression test

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/overview.mdx
@@ -96,6 +96,7 @@ Opik helps you easily log, visualize, and evaluate everything from raw LLM calls
   <Card title="Ollama" href="/integrations/ollama" />
   <Card title="OpenAI" href="/integrations/openai" />
   <Card title="Predibase" href="/integrations/predibase" />
+  <Card title="Qianfan" href="/integrations/qianfan" />
   <Card title="Together AI" href="/integrations/together-ai" />
   <Card title="WatsonX" href="/integrations/watsonx" />
   <Card title="xAI Grok" href="/integrations/xai-grok" />

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/qianfan.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/qianfan.mdx
@@ -1,0 +1,125 @@
+---
+description: Start here to integrate Opik into your Qianfan-based genai application
+  for end-to-end LLM observability, unit testing, and optimization.
+headline: Qianfan | Opik Documentation
+og:description: Learn to integrate Opik with Baidu Qianfan using the OpenAI SDK
+  compatibility layer and track_openai for end-to-end tracing.
+og:site_name: Opik Documentation
+og:title: Integrate Opik with Baidu Qianfan
+title: Observability for Qianfan with Opik
+---
+
+[Baidu Qianfan](https://cloud.baidu.com/product/wenxinworkshop) is Baidu AI Cloud's model platform for building and deploying generative AI applications. Qianfan provides an OpenAI-compatible API in its V2 inference service, which lets you instrument Qianfan calls with Opik by using the standard OpenAI Python SDK.
+
+This guide explains how to integrate Opik with Qianfan using the OpenAI SDK and `track_openai()`. This is the fastest path if you already call Qianfan through its OpenAI-compatible endpoint.
+
+## Getting started
+
+First, ensure you have both `opik` and `openai` packages installed:
+
+```bash
+pip install opik openai
+```
+
+You also need:
+
+- An Opik project configured locally
+- A Qianfan API key for the OpenAI-compatible V2 inference service
+- A Qianfan application with a model enabled for inference
+
+<Note>
+  Qianfan's OpenAI-compatible flow uses an API key tied to your application identity.
+  If your request is authenticated correctly but the application or model is not enabled,
+  Qianfan may reject the call even when the `base_url` is correct.
+</Note>
+
+## Configure Opik
+
+Configure the Opik Python SDK for your deployment type. See the [Python SDK Configuration guide](/tracing/advanced/sdk_configuration) for all available options.
+
+```bash
+opik configure
+```
+
+## Track Qianfan API calls
+
+```python
+from openai import OpenAI
+from opik.integrations.openai import track_openai
+
+client = OpenAI(
+    api_key="YOUR_QIANFAN_API_KEY",
+    base_url="https://qianfan.baidubce.com/v2",
+)
+client = track_openai(client)
+
+response = client.chat.completions.create(
+    model="YOUR_QIANFAN_MODEL",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Explain what Opik traces capture."},
+    ],
+    temperature=0.7,
+)
+
+print(response.choices[0].message.content)
+```
+
+Opik will automatically capture the request inputs, response content, model name, token usage, and timing information for each Qianfan call.
+
+## Advanced usage
+
+### Combine Qianfan tracing with `@track`
+
+If you want Opik to show both your application steps and the underlying Qianfan request, wrap your business logic with `@track` and keep the tracked OpenAI client inside that flow:
+
+```python
+from opik import track
+from openai import OpenAI
+from opik.integrations.openai import track_openai
+
+client = OpenAI(
+    api_key="YOUR_QIANFAN_API_KEY",
+    base_url="https://qianfan.baidubce.com/v2",
+)
+client = track_openai(client)
+
+@track
+def summarize_customer_feedback(feedback: str) -> str:
+    response = client.chat.completions.create(
+        model="YOUR_QIANFAN_MODEL",
+        messages=[
+            {
+                "role": "user",
+                "content": f"Summarize the main themes in this feedback: {feedback}",
+            }
+        ],
+    )
+    return response.choices[0].message.content
+
+summary = summarize_customer_feedback("Users want faster search and clearer pricing.")
+```
+
+This gives you a parent application span plus a child LLM span for the Qianfan request.
+
+## Troubleshooting
+
+### Common issues
+
+1. **Authentication errors**: Ensure you are using a Qianfan API key for the V2 inference service and that the target application is configured correctly.
+2. **Model not found**: Verify the model name is enabled in your Qianfan application and matches the currently supported model list.
+3. **Base URL issues**: Use `https://qianfan.baidubce.com/v2` for the OpenAI-compatible V2 endpoint.
+4. **Gateway mismatch**: If you call Qianfan through another proxy or gateway, use that gateway's base URL and review the [custom AI provider settings](/administration/workspace-settings/ai_providers) if you also want Opik UI-side provider configuration.
+
+### Getting help
+
+- Review the [Qianfan V2 inference API documentation](https://cloud.baidu.com/doc/qianfan/s/qmh4sv5vi)
+- Review the [Qianfan OpenAI SDK compatibility guide](https://cloud.baidu.com/doc/qianfan/s/Hmh4suq26)
+- Review the [Opik OpenAI integration guide](/integrations/openai)
+
+## Next steps
+
+- [Evaluate your LLM applications](/evaluation/overview) using Opik's evaluation framework
+- [Create datasets](/evaluation/advanced/manage_datasets) to test and improve your prompts
+- [Set up feedback collection](/tracing/advanced/annotate_traces) to gather human evaluation
+- [Monitor performance](/tracing/concepts) across Qianfan models and prompt versions

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/overview.mdx
@@ -96,6 +96,7 @@ Opik helps you easily log, visualize, and evaluate everything from raw LLM calls
   <Card title="Ollama" href="/v1/integrations/ollama" />
   <Card title="OpenAI" href="/v1/integrations/openai" />
   <Card title="Predibase" href="/v1/integrations/predibase" />
+  <Card title="Qianfan" href="/v1/integrations/qianfan" />
   <Card title="Together AI" href="/v1/integrations/together-ai" />
   <Card title="WatsonX" href="/v1/integrations/watsonx" />
   <Card title="xAI Grok" href="/v1/integrations/xai-grok" />

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/qianfan.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/qianfan.mdx
@@ -1,0 +1,125 @@
+---
+description: Start here to integrate Opik into your Qianfan-based genai application
+  for end-to-end LLM observability, unit testing, and optimization.
+headline: Qianfan | Opik Documentation
+og:description: Learn to integrate Opik with Baidu Qianfan using the OpenAI SDK
+  compatibility layer and track_openai for end-to-end tracing.
+og:site_name: Opik Documentation
+og:title: Integrate Opik with Baidu Qianfan
+title: Observability for Qianfan with Opik
+---
+
+[Baidu Qianfan](https://cloud.baidu.com/product/wenxinworkshop) is Baidu AI Cloud's model platform for building and deploying generative AI applications. Qianfan provides an OpenAI-compatible API in its V2 inference service, which lets you instrument Qianfan calls with Opik by using the standard OpenAI Python SDK.
+
+This guide explains how to integrate Opik with Qianfan using the OpenAI SDK and `track_openai()`. This is the fastest path if you already call Qianfan through its OpenAI-compatible endpoint.
+
+## Getting started
+
+First, ensure you have both `opik` and `openai` packages installed:
+
+```bash
+pip install opik openai
+```
+
+You also need:
+
+- An Opik project configured locally
+- A Qianfan API key for the OpenAI-compatible V2 inference service
+- A Qianfan application with a model enabled for inference
+
+<Note>
+  Qianfan's OpenAI-compatible flow uses an API key tied to your application identity.
+  If your request is authenticated correctly but the application or model is not enabled,
+  Qianfan may reject the call even when the `base_url` is correct.
+</Note>
+
+## Configure Opik
+
+Configure the Opik Python SDK for your deployment type. See the [Python SDK Configuration guide](/v1/tracing/sdk_configuration) for all available options.
+
+```bash
+opik configure
+```
+
+## Track Qianfan API calls
+
+```python
+from openai import OpenAI
+from opik.integrations.openai import track_openai
+
+client = OpenAI(
+    api_key="YOUR_QIANFAN_API_KEY",
+    base_url="https://qianfan.baidubce.com/v2",
+)
+client = track_openai(client)
+
+response = client.chat.completions.create(
+    model="YOUR_QIANFAN_MODEL",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Explain what Opik traces capture."},
+    ],
+    temperature=0.7,
+)
+
+print(response.choices[0].message.content)
+```
+
+Opik will automatically capture the request inputs, response content, model name, token usage, and timing information for each Qianfan call.
+
+## Advanced usage
+
+### Combine Qianfan tracing with `@track`
+
+If you want Opik to show both your application steps and the underlying Qianfan request, wrap your business logic with `@track` and keep the tracked OpenAI client inside that flow:
+
+```python
+from opik import track
+from openai import OpenAI
+from opik.integrations.openai import track_openai
+
+client = OpenAI(
+    api_key="YOUR_QIANFAN_API_KEY",
+    base_url="https://qianfan.baidubce.com/v2",
+)
+client = track_openai(client)
+
+@track
+def summarize_customer_feedback(feedback: str) -> str:
+    response = client.chat.completions.create(
+        model="YOUR_QIANFAN_MODEL",
+        messages=[
+            {
+                "role": "user",
+                "content": f"Summarize the main themes in this feedback: {feedback}",
+            }
+        ],
+    )
+    return response.choices[0].message.content
+
+summary = summarize_customer_feedback("Users want faster search and clearer pricing.")
+```
+
+This gives you a parent application span plus a child LLM span for the Qianfan request.
+
+## Troubleshooting
+
+### Common issues
+
+1. **Authentication errors**: Ensure you are using a Qianfan API key for the V2 inference service and that the target application is configured correctly.
+2. **Model not found**: Verify the model name is enabled in your Qianfan application and matches the currently supported model list.
+3. **Base URL issues**: Use `https://qianfan.baidubce.com/v2` for the OpenAI-compatible V2 endpoint.
+4. **Gateway mismatch**: If you call Qianfan through another proxy or gateway, use that gateway's base URL and review the [custom AI provider settings](/v1/administration/workspace-settings/ai_providers) if you also want Opik UI-side provider configuration.
+
+### Getting help
+
+- Review the [Qianfan V2 inference API documentation](https://cloud.baidu.com/doc/qianfan/s/qmh4sv5vi)
+- Review the [Qianfan OpenAI SDK compatibility guide](https://cloud.baidu.com/doc/qianfan/s/Hmh4suq26)
+- Review the [Opik OpenAI integration guide](/v1/integrations/openai)
+
+## Next steps
+
+- [Evaluate your LLM applications](/v1/evaluation/overview) using Opik's evaluation framework
+- [Create datasets](/v1/evaluation/manage_datasets) to test and improve your prompts
+- [Set up feedback collection](/v1/tracing/annotate_traces) to gather human evaluation
+- [Monitor performance](/v1/tracing/concepts) across Qianfan models and prompt versions

--- a/apps/opik-documentation/documentation/fern/versions/latest.yml
+++ b/apps/opik-documentation/documentation/fern/versions/latest.yml
@@ -719,6 +719,9 @@ navigation:
               - page: Predibase
                 path: ../docs-v2/integrations/predibase.mdx
                 slug: predibase
+              - page: Qianfan
+                path: ../docs-v2/integrations/qianfan.mdx
+                slug: qianfan
               - page: Together AI
                 path: ../docs-v2/integrations/together-ai.mdx
                 slug: together-ai

--- a/apps/opik-documentation/documentation/fern/versions/v1.yml
+++ b/apps/opik-documentation/documentation/fern/versions/v1.yml
@@ -549,6 +549,9 @@ navigation:
               - page: Predibase
                 path: ../docs/tracing/integrations/predibase.mdx
                 slug: predibase
+              - page: Qianfan
+                path: ../docs/tracing/integrations/qianfan.mdx
+                slug: qianfan
               - page: Together AI
                 path: ../docs/tracing/integrations/together-ai.mdx
                 slug: together-ai

--- a/sdks/python/tests/unit/integrations/test_openai_tracker.py
+++ b/sdks/python/tests/unit/integrations/test_openai_tracker.py
@@ -1,0 +1,37 @@
+from unittest import mock
+
+import openai
+
+from opik.integrations.openai import track_openai
+
+
+QIANFAN_BASE_URL = "https://qianfan.baidubce.com/v2"
+QIANFAN_PROVIDER = "qianfan.baidubce.com"
+
+
+def test_track_openai__non_openai_base_url__provider_is_forwarded_to_chat_and_responses_decorators():
+    client = openai.OpenAI(
+        api_key="test-api-key",
+        base_url=QIANFAN_BASE_URL,
+    )
+
+    chat_decorator_factory = mock.Mock()
+    chat_decorator_factory.track.side_effect = lambda **kwargs: (
+        lambda original: original
+    )
+    responses_decorator_factory = mock.Mock()
+    responses_decorator_factory.track.side_effect = lambda **kwargs: (
+        lambda original: original
+    )
+
+    with mock.patch(
+        "opik.integrations.openai.openai_chat_completions_decorator.OpenaiChatCompletionsTrackDecorator",
+        return_value=chat_decorator_factory,
+    ), mock.patch(
+        "opik.integrations.openai.openai_responses_decorator.OpenaiResponsesTrackDecorator",
+        return_value=responses_decorator_factory,
+    ):
+        track_openai(client)
+
+    assert chat_decorator_factory.provider == QIANFAN_PROVIDER
+    assert responses_decorator_factory.provider == QIANFAN_PROVIDER

--- a/sdks/python/tests/unit/integrations/test_openai_tracker.py
+++ b/sdks/python/tests/unit/integrations/test_openai_tracker.py
@@ -24,12 +24,15 @@ def test_track_openai__non_openai_base_url__provider_is_forwarded_to_chat_and_re
         lambda original: original
     )
 
-    with mock.patch(
-        "opik.integrations.openai.openai_chat_completions_decorator.OpenaiChatCompletionsTrackDecorator",
-        return_value=chat_decorator_factory,
-    ), mock.patch(
-        "opik.integrations.openai.openai_responses_decorator.OpenaiResponsesTrackDecorator",
-        return_value=responses_decorator_factory,
+    with (
+        mock.patch(
+            "opik.integrations.openai.openai_chat_completions_decorator.OpenaiChatCompletionsTrackDecorator",
+            return_value=chat_decorator_factory,
+        ),
+        mock.patch(
+            "opik.integrations.openai.openai_responses_decorator.OpenaiResponsesTrackDecorator",
+            return_value=responses_decorator_factory,
+        ),
     ):
         track_openai(client)
 


### PR DESCRIPTION
> ♻️ Re-opened on behalf of @jimmyzhuu. All commits are authored by @jimmyzhuu. Apologies for the inconvenience. Original PR for reference: #6722.

---

## Details
Add dedicated Qianfan integration docs for both the latest and v1 documentation surfaces, wire the new page into the integrations overview and version navigation, and add a focused regression test covering non-OpenAI base URL provider forwarding in `track_openai()`.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- Resolves #6721

## AI-WATERMARK
AI-WATERMARK: yes

Tools: Codex CLI, GitHub CLI, ripgrep, pytest
Model(s): GPT-5.4 (xhigh)
Scope: implementation, validation, and PR preparation
Human verification: reviewed file diffs, validated targeted test output, verified external doc URLs

## Testing
- Ran `cd /Users/zimingzhu/githubProject/opik/sdks/python && .venv/bin/python -m pytest tests/unit/integrations/test_openai_tracker.py`
- Validated the new regression test for non-OpenAI base URLs forwarded provider information to the OpenAI tracking decorators
- Verified the referenced Qianfan documentation URLs return `200 OK`
- Did not run the full documentation site build because `apps/opik-documentation/documentation/node_modules` is not installed in the local environment

## Documentation
- Added dedicated Qianfan integration pages for both docs surfaces
- Added Qianfan entries to the integrations overview pages and version navigation