### PR TITLE
fix(examples): guard against IndexError on empty LLM choices list

### DIFF
--- a/apps/opik-documentation/documentation/scripts/generate_seo_metadata.py
+++ b/apps/opik-documentation/documentation/scripts/generate_seo_metadata.py
@@ -186,6 +186,7 @@ Return ONLY the JSON object, no explanation."""
         )
         
         if not getattr(response, "choices", None) or response.choices[0].message is None:
+            print("  Warning: LLM returned no choices or null message; skipping")
             return None
         result_text = response.choices[0].message.content.strip()
         

--- a/apps/opik-documentation/documentation/scripts/generate_seo_metadata.py
+++ b/apps/opik-documentation/documentation/scripts/generate_seo_metadata.py
@@ -185,7 +185,7 @@ Return ONLY the JSON object, no explanation."""
             max_tokens=200
         )
         
-        if not response.choices:
+        if not getattr(response, "choices", None):
             return None
         result_text = response.choices[0].message.content.strip()
         

--- a/apps/opik-documentation/documentation/scripts/generate_seo_metadata.py
+++ b/apps/opik-documentation/documentation/scripts/generate_seo_metadata.py
@@ -185,7 +185,7 @@ Return ONLY the JSON object, no explanation."""
             max_tokens=200
         )
         
-        if not getattr(response, "choices", None):
+        if not getattr(response, "choices", None) or response.choices[0].message is None:
             return None
         result_text = response.choices[0].message.content.strip()
         

--- a/apps/opik-documentation/documentation/scripts/generate_seo_metadata.py
+++ b/apps/opik-documentation/documentation/scripts/generate_seo_metadata.py
@@ -185,6 +185,8 @@ Return ONLY the JSON object, no explanation."""
             max_tokens=200
         )
         
+        if not response.choices:
+            return None
         result_text = response.choices[0].message.content.strip()
         
         # Clean up response - remove markdown code blocks if present
@@ -332,4 +334,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/apps/opik-frontend/src/integrations/integration-scripts/DeepSeek.py
+++ b/apps/opik-frontend/src/integrations/integration-scripts/DeepSeek.py
@@ -23,4 +23,5 @@ response = client.chat.completions.create(
     stream=False,
 )
 
-print(response.choices[0].message.content)
+if response.choices:
+    print(response.choices[0].message.content)

--- a/apps/opik-frontend/src/integrations/integration-scripts/DeepSeek.py
+++ b/apps/opik-frontend/src/integrations/integration-scripts/DeepSeek.py
@@ -23,5 +23,5 @@ response = client.chat.completions.create(
     stream=False,
 )
 
-if response.choices:
+if getattr(response, "choices", None):
     print(response.choices[0].message.content)

--- a/apps/opik-frontend/src/integrations/integration-scripts/DeepSeek.py
+++ b/apps/opik-frontend/src/integrations/integration-scripts/DeepSeek.py
@@ -23,5 +23,5 @@ response = client.chat.completions.create(
     stream=False,
 )
 
-if getattr(response, "choices", None):
+if getattr(response, "choices", None) and response.choices[0].message is not None:
     print(response.choices[0].message.content)

--- a/apps/opik-frontend/src/integrations/integration-scripts/FunctionDecorators.py
+++ b/apps/opik-frontend/src/integrations/integration-scripts/FunctionDecorators.py
@@ -25,7 +25,7 @@ def generate_response(input_text, context):
     response = client.chat.completions.create(
         model="gpt-3.5-turbo", messages=[{"role": "user", "content": full_prompt}]
     )
-    if not getattr(response, "choices", None):
+    if not getattr(response, "choices", None) or response.choices[0].message is None:
         return None
     return response.choices[0].message.content
 

--- a/apps/opik-frontend/src/integrations/integration-scripts/FunctionDecorators.py
+++ b/apps/opik-frontend/src/integrations/integration-scripts/FunctionDecorators.py
@@ -25,6 +25,8 @@ def generate_response(input_text, context):
     response = client.chat.completions.create(
         model="gpt-3.5-turbo", messages=[{"role": "user", "content": full_prompt}]
     )
+    if not response.choices:
+        return None
     return response.choices[0].message.content
 
 

--- a/apps/opik-frontend/src/integrations/integration-scripts/FunctionDecorators.py
+++ b/apps/opik-frontend/src/integrations/integration-scripts/FunctionDecorators.py
@@ -25,7 +25,7 @@ def generate_response(input_text, context):
     response = client.chat.completions.create(
         model="gpt-3.5-turbo", messages=[{"role": "user", "content": full_prompt}]
     )
-    if not response.choices:
+    if not getattr(response, "choices", None):
         return None
     return response.choices[0].message.content
 

--- a/apps/opik-frontend/src/integrations/integration-scripts/Groq.py
+++ b/apps/opik-frontend/src/integrations/integration-scripts/Groq.py
@@ -13,4 +13,5 @@ response = litellm.completion(
     model="groq/llama3-8b-8192",
     messages=[{"role": "user", "content": "Write a haiku about AI engineering."}],
 )
-print(response.choices[0].message.content)
+if getattr(response, "choices", None) and response.choices[0].message is not None:
+    print(response.choices[0].message.content)

--- a/apps/opik-frontend/src/integrations/integration-scripts/LiteLLM.py
+++ b/apps/opik-frontend/src/integrations/integration-scripts/LiteLLM.py
@@ -9,4 +9,5 @@ response = litellm.completion(
     model="gpt-3.5-turbo",
     messages=[{"role": "user", "content": "Write a haiku about AI engineering."}],
 )
-print(response.choices[0].message.content)
+if getattr(response, "choices", None) and response.choices[0].message is not None:
+    print(response.choices[0].message.content)

--- a/apps/opik-frontend/src/integrations/integration-scripts/OpenAI.py
+++ b/apps/opik-frontend/src/integrations/integration-scripts/OpenAI.py
@@ -14,5 +14,5 @@ response = openai_client.chat.completions.create(
     model="gpt-3.5-turbo",
     messages=[{"role": "user", "content": prompt}],
 )
-if response.choices:
+if getattr(response, "choices", None):
     print(response.choices[0].message.content)

--- a/apps/opik-frontend/src/integrations/integration-scripts/OpenAI.py
+++ b/apps/opik-frontend/src/integrations/integration-scripts/OpenAI.py
@@ -14,4 +14,5 @@ response = openai_client.chat.completions.create(
     model="gpt-3.5-turbo",
     messages=[{"role": "user", "content": prompt}],
 )
-print(response.choices[0].message.content)
+if response.choices:
+    print(response.choices[0].message.content)

--- a/apps/opik-frontend/src/integrations/integration-scripts/OpenAI.py
+++ b/apps/opik-frontend/src/integrations/integration-scripts/OpenAI.py
@@ -14,5 +14,5 @@ response = openai_client.chat.completions.create(
     model="gpt-3.5-turbo",
     messages=[{"role": "user", "content": prompt}],
 )
-if getattr(response, "choices", None):
+if getattr(response, "choices", None) and response.choices[0].message is not None:
     print(response.choices[0].message.content)

--- a/apps/opik-frontend/src/integrations/integration-scripts/OpenRouter.py
+++ b/apps/opik-frontend/src/integrations/integration-scripts/OpenRouter.py
@@ -28,5 +28,5 @@ response = client.chat.completions.create(
     max_tokens=100,
 )
 
-if response.choices:
+if getattr(response, "choices", None):
     print(response.choices[0].message.content)

--- a/apps/opik-frontend/src/integrations/integration-scripts/OpenRouter.py
+++ b/apps/opik-frontend/src/integrations/integration-scripts/OpenRouter.py
@@ -28,4 +28,5 @@ response = client.chat.completions.create(
     max_tokens=100,
 )
 
-print(response.choices[0].message.content)
+if response.choices:
+    print(response.choices[0].message.content)

--- a/apps/opik-frontend/src/integrations/integration-scripts/OpenRouter.py
+++ b/apps/opik-frontend/src/integrations/integration-scripts/OpenRouter.py
@@ -28,5 +28,5 @@ response = client.chat.completions.create(
     max_tokens=100,
 )
 
-if getattr(response, "choices", None):
+if getattr(response, "choices", None) and response.choices[0].message is not None:
     print(response.choices[0].message.content)

--- a/apps/opik-frontend/src/integrations/integration-scripts/WatsonX.py
+++ b/apps/opik-frontend/src/integrations/integration-scripts/WatsonX.py
@@ -1,7 +1,10 @@
+import logging
 import os
 
 import litellm
 import opik  # HIGHLIGHTED_LINE
+
+logger = logging.getLogger(__name__)
 from litellm.integrations.opik.opik import OpikLogger  # HIGHLIGHTED_LINE
 from opik import track  # HIGHLIGHTED_LINE
 from opik.opik_context import get_current_span_data  # HIGHLIGHTED_LINE
@@ -42,6 +45,7 @@ def generate_story(prompt):
         },
     )
     if not getattr(response, "choices", None) or response.choices[0].message is None:
+        logger.warning("LLM returned no choices or null message; skipping response")
         return None
     return response.choices[0].message.content
 

--- a/apps/opik-frontend/src/integrations/integration-scripts/WatsonX.py
+++ b/apps/opik-frontend/src/integrations/integration-scripts/WatsonX.py
@@ -41,6 +41,8 @@ def generate_story(prompt):
             },
         },
     )
+    if not getattr(response, "choices", None) or response.choices[0].message is None:
+        return None
     return response.choices[0].message.content
 
 


### PR DESCRIPTION
> ♻️ Re-opened on behalf of @qizwiz. All commits are authored by @qizwiz. Apologies for the inconvenience. Original PR for reference: #6700.

---

## Summary

Five example scripts call `response.choices[0].message.content` without checking whether the API returned any choices. This raises a bare `IndexError` when the LLM:

- applies a content-policy filter and returns an empty choices list
- returns a truncated streaming response before the first choice arrives
- hits a rate-limit and returns a non-standard reply

### Changes

Inline guard at each of the five call sites:

| File | Fix |
|------|-----|
| `generate_seo_metadata.py` | `if not response.choices: return None` before accessing `choices[0]` |
| `FunctionDecorators.py` | `if not response.choices: return None` before accessing `choices[0]` |
| `DeepSeek.py` | `if response.choices: print(...)` wraps the print |
| `OpenAI.py` | `if response.choices: print(...)` wraps the print |
| `OpenRouter.py` | `if response.choices: print(...)` wraps the print |

No new files, no monkey-patching — just minimal defensive checks at each site.