### PR TITLE
fix: preserve dotted column IDs in DataTable to enable sorting (#5170)

### DIFF
--- a/apps/opik-frontend/src/lib/table.ts
+++ b/apps/opik-frontend/src/lib/table.ts
@@ -122,8 +122,10 @@ export const mapColumnDataFields = <TColumnData, TData>(
   columnData: ColumnData<TColumnData>,
 ): ColumnDef<TData> => {
   return {
-    ...(columnData.accessorFn && { accessorFn: columnData.accessorFn }),
-    accessorKey: columnData.id,
+    id: columnData.id,
+    ...(columnData.accessorFn
+      ? { accessorFn: columnData.accessorFn }
+      : { accessorKey: columnData.id }),
     header: (columnData.header ?? TypeHeader) as never,
     meta: {
       type: columnData.type,


### PR DESCRIPTION
> ♻️ Re-opened on behalf of @awesome-pro. All commits are authored by @awesome-pro. Apologies for the inconvenience. Original PR for reference: #6692.

---

## Summary

- Fixes a bug in `mapColumnDataFields` (`src/lib/table.ts`) where TanStack React Table v8 was silently sanitizing dotted column IDs (e.g. `"usage.total_tokens"`) to underscores (`"usage_total_tokens"`) when deriving the column ID from `accessorKey`
- This caused `isColumnSortable` to fail its wildcard check against `"usage.*"` (dot-split length was 1 for underscore ID), making token usage columns appear unsortable in the Spans tab
- Added an explicit `id: columnData.id` to every column definition so TanStack uses the original ID without sanitization
- When `accessorFn` is provided, `accessorKey` is now omitted to avoid conflict (setting both can confuse TanStack's ID derivation)

## Root Cause

TanStack React Table v8 derives a column's internal ID from `accessorKey` using:
```
accessorKey.replace(/[^a-zA-Z0-9_]/g, '_')
```

So `accessorKey: "usage.total_tokens"` → column ID `"usage_total_tokens"`.

`isColumnSortable` checks for wildcard sortable fields (`"usage.*"`) by splitting the ID on `.` — which produces a single-element array for underscore IDs, so the wildcard branch is never reached.

## Fix

```ts
// Before
...(columnData.accessorFn && { accessorFn: columnData.accessorFn }),
accessorKey: columnData.id,

// After  
id: columnData.id,
...(columnData.accessorFn
  ? { accessorFn: columnData.accessorFn }
  : { accessorKey: columnData.id }),
```

## Test plan

- [x] All 1599 existing unit tests pass (`npx vitest run`)
- [x] TypeScript compilation succeeds (`npx tsc --noEmit`)
- [ ] Manually verify in Spans tab: sort by "Total tokens", "Prompt tokens", "Completion tokens" columns works correctly
- [ ] Verify column header statistics (avg/sum) still display correctly
- [ ] Verify no regressions on Traces tab sorting

Fixes #5170

🤖 Generated with [Claude Code](https://claude.ai/code)