### PR TITLE
fix(sdk): add cyclic reference and max depth protection to flatten_dict

### DIFF
--- a/sdks/python/src/opik/dict_utils.py
+++ b/sdks/python/src/opik/dict_utils.py
@@ -1,27 +1,55 @@
 import copy
 import logging
-from typing import Any, Dict, Optional, List, Tuple, TypeVar, Type
+from typing import Any, Dict, Optional, List, Set, Tuple, TypeVar, Type
 
 from . import logging_messages
 
 LOGGER = logging.getLogger(__name__)
 
+_MAX_FLATTEN_DEPTH = 20
+
 
 def flatten_dict(
-    d: Dict[str, Any], parent_key: str, delim: str = "."
+    d: Dict[str, Any],
+    parent_key: str,
+    delim: str = ".",
+    _depth: int = 0,
+    _seen: Optional[Set[int]] = None,
 ) -> Dict[str, Any]:
-    """
-    The current implementation does not have max depth restrictions or cyclic references handling!
-    """
+    if _seen is None:
+        _seen = set()
+
+    dict_id = id(d)
+    if dict_id in _seen:
+        LOGGER.warning("Cyclic reference detected in flatten_dict, skipping")
+        return {}
+
+    if _depth >= _MAX_FLATTEN_DEPTH:
+        LOGGER.warning(
+            "Max depth (%d) reached in flatten_dict, returning remaining value as-is",
+            _MAX_FLATTEN_DEPTH,
+        )
+        return {parent_key: d} if parent_key else {}
+
+    _seen.add(dict_id)
     items = []  # type: ignore
 
     for key, value in d.items():
         new_key = f"{parent_key}{delim}{key}" if parent_key else key
         if isinstance(value, dict):
-            items.extend(flatten_dict(value, parent_key=new_key, delim=delim).items())
+            items.extend(
+                flatten_dict(
+                    value,
+                    parent_key=new_key,
+                    delim=delim,
+                    _depth=_depth + 1,
+                    _seen=_seen,
+                ).items()
+            )
         else:
             items.append((new_key, value))
 
+    _seen.discard(dict_id)
     return dict(items)
 
 


### PR DESCRIPTION
> ♻️ Re-opened on behalf of @zhoufengen. All commits are authored by @zhoufengen. Apologies for the inconvenience. Original PR for reference: #6545.

---

## Summary

`flatten_dict` in `dict_utils.py` recursed without any guard against cyclic references or deeply nested structures. The function's own docstring acknowledged this limitation: *"The current implementation does not have max depth restrictions or cyclic references handling!"*. This could cause `RecursionError` crashes when processing user-provided metadata containing circular references.

## Changes

- Add a `_seen` set parameter to detect cyclic references (logs a warning and returns empty dict for the cyclic branch)
- Add a `_depth` counter with `_MAX_FLATTEN_DEPTH = 20` limit (logs a warning and returns the remaining value as-is)
- Both parameters are internal (prefixed with `_`) and default to safe values, so the public API is unchanged
- Pattern is consistent with the cycle detection already used in `jsonable_encoder.py`

## Testing

- The public API signature is unchanged: `flatten_dict(d, parent_key, delim)` works identically
- Normal nested dicts (depth < 20) produce the same output as before
- Cyclic references now log a warning instead of crashing with `RecursionError`
- Deeply nested dicts (depth >= 20) now log a warning and stop flattening instead of hitting Python's recursion limit

## Related Issues

None (discovered during code review; the docstring itself documented the limitation)

---

> This PR was authored with AI assistance. All changes have been reviewed for correctness.