### PR TITLE
fix(sdk): add max retry limit to rate-limited API calls

### DIFF
--- a/sdks/python/src/opik/api_objects/rest_helpers.py
+++ b/sdks/python/src/opik/api_objects/rest_helpers.py
@@ -8,6 +8,8 @@ from ..rate_limit import rate_limit
 
 LOGGER = logging.getLogger(__name__)
 
+MAX_RATE_LIMIT_RETRIES = 10
+
 
 def ensure_rest_api_call_respecting_rate_limit(
     rest_callable: Callable[[], Any],
@@ -26,27 +28,39 @@ def ensure_rest_api_call_respecting_rate_limit(
         The result of the successful REST API call.
 
     Raises:
-        ApiError: If the error is not a 429 rate limit error.
+        ApiError: If the error is not a 429 rate limit error, or if the maximum
+            number of retries is exceeded.
     """
-    while True:
+    for attempt in range(MAX_RATE_LIMIT_RETRIES):
         try:
             result = rest_callable()
             return result
         except ApiError as exception:
             if exception.status_code == 429:
+                if attempt >= MAX_RATE_LIMIT_RETRIES - 1:
+                    LOGGER.error(
+                        "Rate limit retries exhausted after %d attempts",
+                        MAX_RATE_LIMIT_RETRIES,
+                    )
+                    raise
+
                 if exception.headers is not None:
                     rate_limiter = rate_limit.parse_rate_limit(exception.headers)
                     if rate_limiter is not None:
                         retry_after = rate_limiter.retry_after()
                         LOGGER.info(
-                            "Rate limited (HTTP 429), retrying in %s seconds",
+                            "Rate limited (HTTP 429), retrying in %s seconds (attempt %d/%d)",
                             retry_after,
+                            attempt + 1,
+                            MAX_RATE_LIMIT_RETRIES,
                         )
                         time.sleep(retry_after)
                         continue
 
                 LOGGER.info(
-                    "Rate limited (HTTP 429) with no retry-after header, retrying in 1 second"
+                    "Rate limited (HTTP 429) with no retry-after header, retrying in 1 second (attempt %d/%d)",
+                    attempt + 1,
+                    MAX_RATE_LIMIT_RETRIES,
                 )
                 time.sleep(1)
                 continue


### PR DESCRIPTION
> ♻️ Re-opened on behalf of @zhoufengen. All commits are authored by @zhoufengen. Apologies for the inconvenience. Original PR for reference: #6542.

---

## Summary

The `ensure_rest_api_call_respecting_rate_limit` function in the Python SDK retries indefinitely on persistent HTTP 429 responses, which can cause callers to hang forever when account quota is exhausted or rate limits are misconfigured.

## Changes

- Replace `while True` loop with a bounded `for` loop capped at `MAX_RATE_LIMIT_RETRIES = 10` attempts
- Re-raise the `ApiError` after exhausting all retries
- Add attempt count to log messages for better observability

## Testing

- The change is backward-compatible: normal rate-limited calls that succeed within 10 retries behave identically
- The retry decorator (`retry_decorator.py`) already caps at 3 attempts for other errors; this brings rate limit handling in line with that pattern
- Edge case: after 10 consecutive 429 responses, the original `ApiError` is raised to the caller

## Related Issues

None (discovered during code review)

---

> This PR was authored with AI assistance. All changes have been reviewed for correctness.