### PR TITLE
[issue-4772] [BE/FE] feat: show attachment icon on spans and traces in tree view

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Span.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Span.java
@@ -80,6 +80,8 @@ public record Span(
         String totalEstimatedCostVersion,
         @JsonView({
                 Span.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Duration in milliseconds as a decimal number to support sub-millisecond precision") Double duration,
+        @JsonView({
+                Span.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Integer attachmentCount,
         @JsonView({Span.View.Public.class, Span.View.Write.class,
                 ExperimentItemBulkUpload.View.ExperimentItemBulkWriteView.class}) @Schema(description = "Time to first token in milliseconds") @PositiveOrZero Double ttft,
         @JsonView({Span.View.Public.class, Span.View.Write.class,
@@ -121,6 +123,7 @@ public record Span(
         TOTAL_ESTIMATED_COST("total_estimated_cost"),
         TOTAL_ESTIMATED_COST_VERSION("total_estimated_cost_version"),
         DURATION("duration"),
+        ATTACHMENT_COUNT("attachment_count"),
         TTFT("ttft"),
         SOURCE("source");
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Trace.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Trace.java
@@ -77,6 +77,8 @@ public record Trace(
         @JsonView({
                 Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "List of unique provider names from all spans in this trace, sorted alphabetically") List<String> providers,
         @JsonView({
+                Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Integer attachmentCount,
+        @JsonView({
                 Trace.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Experiment associated with this trace") ExperimentItemReference experiment,
         @JsonView({Trace.View.Public.class, Trace.View.Write.class}) Source source){
 
@@ -122,6 +124,7 @@ public record Trace(
         THREAD_ID("thread_id"),
         VISIBILITY_MODE("visibility_mode"),
         PROVIDERS("providers"),
+        ATTACHMENT_COUNT("attachment_count"),
         EXPERIMENT("experiment"),
         SOURCE("source"),
         ;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -591,7 +591,16 @@ public class SpanDAO {
             """;
 
     private static final String SELECT_BY_IDS = """
-            WITH feedback_scores_deduped AS (
+            WITH attachment_counts AS (
+                SELECT
+                    entity_id,
+                    COUNT(*) AS attachment_count
+                FROM attachments
+                WHERE workspace_id = :workspace_id
+                AND entity_id IN :ids
+                AND entity_type = 'span'
+                GROUP BY entity_id
+            ), feedback_scores_deduped AS (
                 SELECT workspace_id,
                        project_id,
                        entity_id,
@@ -679,7 +688,8 @@ public class SpanDAO {
                 s.*,
                 s.project_id as project_id,
                 groupArray(tuple(c.*)) AS comments,
-                any(fs.feedback_scores) as feedback_scores_list
+                any(fs.feedback_scores) as feedback_scores_list,
+                coalesce(a.attachment_count, 0) as attachment_count
             FROM (
                 SELECT
                     *,
@@ -727,8 +737,9 @@ public class SpanDAO {
                 FROM feedback_scores_final
                 GROUP BY workspace_id, project_id, entity_id
             ) AS fs ON s.id = fs.entity_id
+            LEFT JOIN attachment_counts a ON s.id = a.entity_id
             GROUP BY
-                s.*
+                s.*, a.attachment_count
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
@@ -780,7 +791,18 @@ public class SpanDAO {
             """;
 
     private static final String SELECT_BY_PROJECT_ID = """
-            WITH <if(span_id_prefilter)>span_id_prefilter AS (
+            WITH attachment_counts AS (
+                SELECT
+                    entity_id,
+                    COUNT(*) AS attachment_count
+                FROM attachments
+                WHERE workspace_id = :workspace_id
+                AND project_id = :project_id
+                <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
+                <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                AND entity_type = 'span'
+                GROUP BY entity_id
+            ), <if(span_id_prefilter)>span_id_prefilter AS (
                 SELECT DISTINCT id FROM spans
                 WHERE project_id = :project_id
                 AND workspace_id = :workspace_id
@@ -1006,9 +1028,11 @@ public class SpanDAO {
                 , fsa.feedback_scores as feedback_scores
                 <endif>
                 <if(!exclude_comments)>, c.comments AS comments <endif>
+                , coalesce(a.attachment_count, 0) as attachment_count
             FROM spans_final s
             LEFT JOIN comments_final c ON s.id = c.entity_id
             <if(!exclude_feedback_scores)>LEFT JOIN feedback_scores_agg fsa ON fsa.entity_id = s.id<endif>
+            LEFT JOIN attachment_counts a ON s.id = a.entity_id
             <if(stream)>
             ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
             <else>
@@ -2123,6 +2147,8 @@ public class SpanDAO {
                 .lastUpdatedBy(
                         getValue(exclude, SpanField.LAST_UPDATED_BY, row, "last_updated_by", String.class))
                 .duration(getValue(exclude, SpanField.DURATION, row, "duration", Double.class))
+                .attachmentCount(
+                        getValue(exclude, SpanField.ATTACHMENT_COUNT, row, "attachment_count", Integer.class))
                 .ttft(getValue(exclude, SpanField.TTFT, row, "ttft", Double.class))
                 .source(Optional.ofNullable(
                         getValue(exclude, SpanField.SOURCE, row, "source", String.class))

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -436,7 +436,30 @@ class TraceDAOImpl implements TraceDAO {
     // Format: if span_id exists, use 'author_spanId', otherwise use 'author'.
     // The tuple contains: (value, reason, category_name, source, last_updated_at, span_type, span_id)
     private static final String SELECT_BY_IDS = """
-            WITH target_spans AS (
+            WITH attachment_counts AS (
+                SELECT
+                    entity_id,
+                    entity_type,
+                    COUNT(*) AS attachment_count
+                FROM attachments
+                WHERE workspace_id = :workspace_id
+                AND (
+                    (entity_id IN :ids AND entity_type = 'trace')
+                    OR (entity_type = 'span' AND entity_id IN (
+                        SELECT id FROM spans FINAL
+                        WHERE workspace_id = :workspace_id AND trace_id IN :ids
+                    ))
+                )
+                GROUP BY entity_id, entity_type
+            ), trace_attachment_counts AS (
+                SELECT
+                    multiIf(entity_type = 'trace', entity_id,
+                        (SELECT trace_id FROM spans FINAL
+                         WHERE id = entity_id AND workspace_id = :workspace_id LIMIT 1)) AS trace_id,
+                    SUM(attachment_count) AS total_attachment_count
+                FROM attachment_counts
+                GROUP BY trace_id
+            ), target_spans AS (
                 SELECT id, trace_id, type
                 FROM spans FINAL
                 WHERE workspace_id = :workspace_id
@@ -681,6 +704,7 @@ class TraceDAOImpl implements TraceDAO {
                 fs.feedback_scores_list as feedback_scores_list,
                 sfs.span_feedback_scores_list as span_feedback_scores_list,
                 gr.guardrails as guardrails_validations,
+                coalesce(a.total_attachment_count, 0) as attachment_count,
                 eaag.experiment_id as experiment_id,
                 eaag.experiment_name as experiment_name,
                 eaag.experiment_dataset_id as experiment_dataset_id,
@@ -788,6 +812,7 @@ class TraceDAOImpl implements TraceDAO {
                 )
                 GROUP BY workspace_id, project_id, entity_type, entity_id
             ) AS gr ON t.id = gr.entity_id
+            LEFT JOIN trace_attachment_counts a ON t.id = a.trace_id
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
@@ -803,7 +828,26 @@ class TraceDAOImpl implements TraceDAO {
             """;
 
     private static final String SELECT_BY_PROJECT_ID = """
-            WITH <if(trace_id_prefilter)>trace_id_prefilter AS (
+            WITH attachment_counts AS (
+                SELECT
+                    entity_id,
+                    entity_type,
+                    COUNT(*) AS attachment_count
+                FROM attachments
+                WHERE workspace_id = :workspace_id
+                AND project_id = :project_id
+                <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
+                <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                GROUP BY entity_id, entity_type
+            ), trace_attachment_counts AS (
+                SELECT
+                    multiIf(entity_type = 'trace', entity_id,
+                        (SELECT trace_id FROM spans FINAL
+                         WHERE id = entity_id AND workspace_id = :workspace_id LIMIT 1)) AS trace_id,
+                    SUM(attachment_count) AS total_attachment_count
+                FROM attachment_counts
+                GROUP BY trace_id
+            ), <if(trace_id_prefilter)>trace_id_prefilter AS (
                 SELECT DISTINCT id
                 FROM traces
                 WHERE workspace_id = :workspace_id
@@ -1325,6 +1369,7 @@ class TraceDAOImpl implements TraceDAO {
                   <if(!exclude_llm_span_count)>, s.llm_span_count AS llm_span_count<endif>
                   <if(!exclude_has_tool_spans)>, s.has_tool_spans AS has_tool_spans<endif>
                   , s.providers AS providers
+                  , coalesce(a.total_attachment_count, 0) as attachment_count
                   <if(!exclude_experiment)>, eaag.experiment_id, eaag.experiment_name, eaag.experiment_dataset_id, eaag.experiment_dataset_item_id<endif>
              FROM traces_final t
              <if(!exclude_feedback_scores)>
@@ -1335,6 +1380,7 @@ class TraceDAOImpl implements TraceDAO {
              LEFT JOIN comments_agg c ON t.id = c.entity_id
              LEFT JOIN guardrails_agg gagg ON gagg.entity_id = t.id
              <if(sort_has_experiment || !exclude_experiment)>LEFT JOIN experiments_agg eaag ON eaag.trace_id = t.id<endif>
+             LEFT JOIN trace_attachment_counts a ON t.id = a.trace_id
              ORDER BY <if(sort_fields)> <sort_fields>, <endif>(workspace_id, project_id, id) DESC, last_updated_at DESC
             SETTINGS log_comment = '<log_comment>'
             ;
@@ -2925,6 +2971,8 @@ class TraceDAOImpl implements TraceDAO {
                         getValue(exclude, Trace.TraceField.SOURCE, row, "source", String.class))
                         .flatMap(Source::fromString)
                         .orElse(null))
+                .attachmentCount(
+                        getValue(exclude, Trace.TraceField.ATTACHMENT_COUNT, row, "attachment_count", Integer.class))
                 .experiment(mapExperiment(exclude, row))
                 .build();
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/spans/SpanAssertions.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/spans/SpanAssertions.java
@@ -49,13 +49,15 @@ public class SpanAssertions {
         EXCLUDE_FUNCTIONS.put(Span.SpanField.TOTAL_ESTIMATED_COST_VERSION,
                 it -> it.toBuilder().totalEstimatedCostVersion(null).build());
         EXCLUDE_FUNCTIONS.put(Span.SpanField.DURATION, it -> it.toBuilder().duration(null).build());
+        EXCLUDE_FUNCTIONS.put(Span.SpanField.ATTACHMENT_COUNT,
+                it -> it.toBuilder().attachmentCount(null).build());
         EXCLUDE_FUNCTIONS.put(Span.SpanField.TTFT, it -> it.toBuilder().ttft(null).build());
         EXCLUDE_FUNCTIONS.put(Span.SpanField.SOURCE, it -> it.toBuilder().source(null).build());
     }
 
     public static final String[] IGNORED_FIELDS = {"projectId", "projectName", "createdAt",
             "lastUpdatedAt", "feedbackScores", "createdBy", "lastUpdatedBy", "totalEstimatedCost", "duration",
-            "totalEstimatedCostVersion", "comments"};
+            "totalEstimatedCostVersion", "comments", "attachmentCount"};
 
     public static final String[] IGNORED_FIELDS_SCORES = {"createdAt", "lastUpdatedAt", "createdBy", "lastUpdatedBy",
             "valueByAuthor"};

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/traces/TraceAssertions.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/traces/TraceAssertions.java
@@ -27,7 +27,7 @@ public class TraceAssertions {
     public static final String[] IGNORED_FIELDS_TRACES = {"projectId", "projectName", "createdAt",
             "lastUpdatedAt", "feedbackScores", "spanFeedbackScores", "createdBy", "lastUpdatedBy", "totalEstimatedCost",
             "spanCount", "llmSpanCount", "hasToolSpans", "duration", "comments", "threadId", "guardrailsValidations",
-            "providers", "experiment"};
+            "providers", "attachmentCount", "experiment"};
 
     public static final String[] IGNORED_FIELDS_SCORES = {"createdAt", "lastUpdatedAt", "createdBy", "lastUpdatedBy",
             "valueByAuthor"};
@@ -99,6 +99,8 @@ public class TraceAssertions {
         EXCLUDE_FUNCTIONS.put(Trace.TraceField.DURATION, it -> it.toBuilder().duration(null).build());
         EXCLUDE_FUNCTIONS.put(Trace.TraceField.VISIBILITY_MODE, it -> it.toBuilder().visibilityMode(null).build());
         EXCLUDE_FUNCTIONS.put(Trace.TraceField.PROVIDERS, it -> it.toBuilder().providers(null).build());
+        EXCLUDE_FUNCTIONS.put(Trace.TraceField.ATTACHMENT_COUNT,
+                it -> it.toBuilder().attachmentCount(null).build());
         EXCLUDE_FUNCTIONS.put(Trace.TraceField.EXPERIMENT, it -> it.toBuilder().experiment(null).build());
         EXCLUDE_FUNCTIONS.put(Trace.TraceField.TTFT, it -> it.toBuilder().ttft(null).build());
         EXCLUDE_FUNCTIONS.put(Trace.TraceField.SOURCE, it -> it.toBuilder().source(null).build());

--- a/apps/opik-frontend/src/types/traces.ts
+++ b/apps/opik-frontend/src/types/traces.ts
@@ -75,6 +75,7 @@ export interface BaseTraceData {
   total_estimated_cost?: number;
   error_info?: BaseTraceDataErrorInfo;
   guardrails_validations?: GuardrailValidation[];
+  attachment_count?: number;
 }
 
 export interface ExperimentItemReference {

--- a/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceTreeViewer/VirtualizedTreeViewer.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceTreeViewer/VirtualizedTreeViewer.tsx
@@ -9,6 +9,7 @@ import {
   Coins,
   Hash,
   MessageSquareMore,
+  Paperclip,
   PenLine,
   Tag,
   TriangleAlert,
@@ -416,6 +417,15 @@ const VirtualizedTreeViewer: React.FC<VirtualizedTreeViewerProps> = ({
                         {name}
                       </span>
                     </TooltipWrapper>
+                    {Boolean(node.data.attachment_count) && (
+                      <TooltipWrapper
+                        content={`${node.data.attachment_count} attachment${node.data.attachment_count! > 1 ? "s" : ""}`}
+                      >
+                        <div className="flex size-5 items-center justify-center">
+                          <Paperclip className="size-3 text-muted-slate" />
+                        </div>
+                      </TooltipWrapper>
+                    )}
                     {node.data.hasError && (
                       <>
                         <div className="flex-auto" />

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceTreeViewer/VirtualizedTreeViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceTreeViewer/VirtualizedTreeViewer.tsx
@@ -9,6 +9,7 @@ import {
   Coins,
   Hash,
   MessageSquareMore,
+  Paperclip,
   PenLine,
   Tag,
 } from "lucide-react";
@@ -477,6 +478,15 @@ const VirtualizedTreeViewer: React.FC<VirtualizedTreeViewerProps> = ({
                     {name}
                   </span>
                 </TooltipWrapper>
+                {Boolean(node.data.attachment_count) && (
+                  <TooltipWrapper
+                    content={`${node.data.attachment_count} attachment${node.data.attachment_count! > 1 ? "s" : ""}`}
+                  >
+                    <div className="ml-1 flex size-4 shrink-0 items-center justify-center">
+                      <Paperclip className="size-3 text-muted-slate" />
+                    </div>
+                  </TooltipWrapper>
+                )}
                 <div className="flex-auto" />
                 {node.data.hasError && (
                   <TooltipWrapper


### PR DESCRIPTION
> ♻️ Re-opened on behalf of @nowhere168. All commits are authored by @nowhere168. Apologies for the inconvenience. Original PR for reference: #6489.

---

## Details

Add a paperclip icon indicator to spans and traces in the trace tree viewer when they contain attachments. Previously, users had no way to know whether a span had attachments without clicking into it individually. This change makes attachments discoverable at a glance.

- Backend: adds `attachment_count` field to `Span` and `Trace` API models, populated via a LEFT JOIN CTE against the `attachments` table in `SpanDAO` and `TraceDAO`
- Frontend: adds a `Paperclip` icon with tooltip (e.g. "2 attachments") next to the span/trace name in both v1 and v2 `VirtualizedTreeViewer` components

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #4772

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: Full implementation (backend SQL, Java model fields, TypeScript types, React components, test assertion helpers)
- Human verification: Code reviewed for correctness; SQL CTEs verified against existing DAO patterns

## Testing

Manual verification not run (no local Docker environment). Changes follow the exact same patterns as existing fields (`duration`, `providers`, `hasToolSpans`) in both DAO query templates and `mapRowToSpan`/`mapRowToTrace` mapper methods.

Tests not run: backend integration tests require a running ClickHouse + MySQL environment. The test assertion helpers (`SpanAssertions`, `TraceAssertions`) have been updated to ignore `attachmentCount` in field comparisons, consistent with how `duration` and other computed read-only fields are handled.

## Documentation

No documentation changes required — `attachment_count` is a read-only computed field exposed in the existing API response, consistent with similar fields.