### PR TITLE
[OPIK-6218] [BE] fix: compare endpoint missing version-level evaluators

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItem.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/DatasetItem.java
@@ -1,6 +1,7 @@
 package com.comet.opik.api;
 
 import com.comet.opik.api.validation.SourceValidation;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -62,7 +63,8 @@ public record DatasetItem(
                 DatasetItem.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
         @JsonView({DatasetItem.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,
         @JsonView({
-                DatasetItem.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String lastUpdatedBy){
+                DatasetItem.View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String lastUpdatedBy,
+        @JsonIgnore UUID datasetVersionId){
 
     @Builder(toBuilder = true)
     public record DatasetItemPage(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
@@ -225,7 +225,8 @@ public class DatasetItemResultMapper {
             return null;
         }
         return Optional.ofNullable(row.get("dataset_version_id", String.class))
-                .filter(s -> !s.isBlank())
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
                 .map(UUID::fromString)
                 .orElse(null);
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
@@ -199,6 +199,7 @@ public class DatasetItemResultMapper {
                 .createdAt(nullIfEpoch(row.get("created_at", Instant.class)))
                 .createdBy(row.get("created_by", String.class))
                 .lastUpdatedBy(row.get("last_updated_by", String.class))
+                .datasetVersionId(getDatasetVersionId(row, rowMetadata))
                 .build();
     }
 
@@ -216,6 +217,16 @@ public class DatasetItemResultMapper {
         return Optional.ofNullable(row.get("evaluators", String.class))
                 .filter(s -> !s.isBlank() && !EvaluatorItem.EMPTY_LIST_JSON.equals(s))
                 .map(s -> JsonUtils.readValue(s, EVALUATOR_LIST_TYPE))
+                .orElse(null);
+    }
+
+    static UUID getDatasetVersionId(Row row, RowMetadata rowMetadata) {
+        if (!rowMetadata.contains("dataset_version_id")) {
+            return null;
+        }
+        return Optional.ofNullable(row.get("dataset_version_id", String.class))
+                .filter(s -> !s.isBlank())
+                .map(UUID::fromString)
                 .orElse(null);
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -50,6 +50,7 @@ import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1331,42 +1332,62 @@ class DatasetItemServiceImpl implements DatasetItemService {
                 "Fetching items with experiment items for dataset '{}', legacy fallback version '{}'",
                 criteria.datasetId(), legacyFallbackVersionId);
 
-        // Fetch version-level evaluators from the actual version the experiments ran against,
-        // not from the latest version (which may have different evaluators).
-        UUID anyExperimentId = criteria.experimentIds().iterator().next();
-        Mono<List<EvaluatorItem>> versionEvaluatorsMono = experimentDAO.getById(anyExperimentId)
-                .flatMap(experiment -> {
-                    if (experiment.datasetVersionId() == null) {
-                        return Mono.just(List.<EvaluatorItem>of());
-                    }
-                    return Mono.fromCallable(() -> {
-                        DatasetVersion version = versionService.getVersionById(workspaceId,
-                                criteria.datasetId(), experiment.datasetVersionId());
-                        return CollectionUtils.isNotEmpty(version.evaluators())
-                                ? version.evaluators()
-                                : List.<EvaluatorItem>of();
-                    })
-                            .subscribeOn(Schedulers.boundedElastic())
-                            .onErrorResume(NotFoundException.class, e -> {
-                                log.warn("Version '{}' not found for experiment '{}', dataset '{}'",
-                                        experiment.datasetVersionId(), anyExperimentId, criteria.datasetId());
-                                return Mono.just(List.<EvaluatorItem>of());
-                            });
-                })
-                .defaultIfEmpty(List.of());
+        // Build a per-version evaluator map so each item gets its own version's evaluators.
+        Mono<Map<UUID, List<EvaluatorItem>>> evaluatorsByVersionMono = experimentDAO.getByIds(criteria.experimentIds())
+                .collectList()
+                .flatMap(experiments -> {
+                    var versionIds = experiments.stream()
+                            .map(exp -> exp.datasetVersionId())
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toSet());
 
-        return versionEvaluatorsMono.flatMap(versionEvaluators -> versionDao
-                .getItemsWithExperimentItems(criteria, page, size, legacyFallbackVersionId)
-                .map(itemPage -> {
-                    if (versionEvaluators.isEmpty()) {
-                        return itemPage;
+                    if (versionIds.isEmpty()) {
+                        return Mono.just(Map.<UUID, List<EvaluatorItem>>of());
                     }
-                    List<DatasetItem> items = itemPage.content().stream()
-                            .map(item -> applyVersionEvaluators(item, versionEvaluators))
-                            .toList();
-                    return itemPage.toBuilder().content(items).build();
+
+                    return Mono.fromCallable(() -> {
+                        var map = new HashMap<UUID, List<EvaluatorItem>>();
+                        for (UUID versionId : versionIds) {
+                            try {
+                                DatasetVersion version = versionService.getVersionById(workspaceId,
+                                        criteria.datasetId(), versionId);
+                                if (CollectionUtils.isNotEmpty(version.evaluators())) {
+                                    map.put(versionId, version.evaluators());
+                                }
+                            } catch (NotFoundException e) {
+                                log.warn("Version '{}' not found for dataset '{}'",
+                                        versionId, criteria.datasetId());
+                            }
+                        }
+                        return Map.copyOf(map);
+                    }).subscribeOn(Schedulers.boundedElastic());
                 })
+                .defaultIfEmpty(Map.of());
+
+        return evaluatorsByVersionMono.flatMap(evaluatorsByVersion -> versionDao
+                .getItemsWithExperimentItems(criteria, page, size, legacyFallbackVersionId)
+                .map(itemPage -> applyVersionEvaluatorsToPage(itemPage, evaluatorsByVersion))
                 .defaultIfEmpty(DatasetItemPage.empty(page, sortingFactory.getSortableFields())));
+    }
+
+    DatasetItemPage applyVersionEvaluatorsToPage(DatasetItemPage itemPage,
+            Map<UUID, List<EvaluatorItem>> evaluatorsByVersion) {
+        if (evaluatorsByVersion.isEmpty()) {
+            return itemPage;
+        }
+        List<DatasetItem> items = itemPage.content().stream()
+                .map(item -> {
+                    if (item.datasetVersionId() == null) {
+                        return item;
+                    }
+                    var versionEvals = evaluatorsByVersion.getOrDefault(
+                            item.datasetVersionId(), List.of());
+                    return versionEvals.isEmpty()
+                            ? item
+                            : applyVersionEvaluators(item, versionEvals);
+                })
+                .toList();
+        return itemPage.toBuilder().content(items).build();
     }
 
     DatasetItem applyVersionEvaluators(DatasetItem item, List<EvaluatorItem> versionEvaluators) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -151,6 +151,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
     private final @NonNull DatasetItemVersionDAO versionDao;
     private final @NonNull DatasetService datasetService;
     private final @NonNull DatasetVersionService versionService;
+    private final @NonNull ExperimentDAO experimentDAO;
     private final @NonNull TraceService traceService;
     private final @NonNull SpanService spanService;
     private final @NonNull TraceEnrichmentService traceEnrichmentService;
@@ -1319,13 +1320,13 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
     private Mono<DatasetItemPage> getItemsWithExperimentItems(DatasetItemSearchCriteria criteria,
             int page, int size, String workspaceId) {
-        Optional<UUID> fallbackVersionId = getFallbackVersionId(criteria.datasetId(), workspaceId);
+        Optional<DatasetVersion> latestDatasetVersion = versionService.getLatestVersion(criteria.datasetId(),
+                workspaceId);
 
-        // When the dataset no longer exists (e.g. test suite deleted), version records are gone from MySQL.
-        // Use an empty string as a harmless placeholder: test suite experiments always carry their own explicit
-        // dataset_version_id in ClickHouse, so the empty fallback is never used for matching, and assertion_results
-        // are still returned correctly via the versioned query.
-        String resolvedFallbackVersionId = fallbackVersionId.map(UUID::toString).orElseGet(() -> {
+        // Each experiment in ClickHouse carries its own dataset_version_id. This fallback is only used
+        // for legacy experiments that predate versioning and have an empty dataset_version_id.
+        // The DAO SQL resolves it via: COALESCE(nullIf(dataset_version_id, ''), :versionId)
+        String legacyFallbackVersionId = latestDatasetVersion.map(v -> v.id().toString()).orElseGet(() -> {
             log.info(
                     "No versions found for dataset '{}', using empty string as fallback version to query experiment items",
                     criteria.datasetId());
@@ -1333,11 +1334,54 @@ class DatasetItemServiceImpl implements DatasetItemService {
         });
 
         log.info(
-                "Fetching items with experiment items for dataset '{}', using version '{}' as fallback for experiments without explicit version",
-                criteria.datasetId(), resolvedFallbackVersionId);
+                "Fetching items with experiment items for dataset '{}', legacy fallback version '{}'",
+                criteria.datasetId(), legacyFallbackVersionId);
 
-        return versionDao.getItemsWithExperimentItems(criteria, page, size, resolvedFallbackVersionId)
-                .defaultIfEmpty(DatasetItemPage.empty(page, sortingFactory.getSortableFields()));
+        // Fetch version-level evaluators from the actual version the experiments ran against,
+        // not from the latest version (which may have different evaluators).
+        UUID anyExperimentId = criteria.experimentIds().iterator().next();
+        Mono<List<EvaluatorItem>> versionEvaluatorsMono = experimentDAO.getById(anyExperimentId)
+                .flatMap(experiment -> {
+                    if (experiment.datasetVersionId() == null) {
+                        return Mono.just(List.<EvaluatorItem>of());
+                    }
+                    return Mono.fromCallable(() -> {
+                        DatasetVersion version = versionService.getVersionById(workspaceId,
+                                criteria.datasetId(), experiment.datasetVersionId());
+                        return CollectionUtils.isNotEmpty(version.evaluators())
+                                ? version.evaluators()
+                                : List.<EvaluatorItem>of();
+                    })
+                            .subscribeOn(Schedulers.boundedElastic())
+                            .onErrorResume(NotFoundException.class, e -> {
+                                log.warn("Version '{}' not found for experiment '{}', dataset '{}'",
+                                        experiment.datasetVersionId(), anyExperimentId, criteria.datasetId());
+                                return Mono.just(List.<EvaluatorItem>of());
+                            });
+                })
+                .defaultIfEmpty(List.of());
+
+        return versionEvaluatorsMono.flatMap(versionEvaluators -> versionDao
+                .getItemsWithExperimentItems(criteria, page, size, legacyFallbackVersionId)
+                .map(itemPage -> {
+                    if (versionEvaluators.isEmpty()) {
+                        return itemPage;
+                    }
+                    List<DatasetItem> items = itemPage.content().stream()
+                            .map(item -> applyVersionEvaluators(item, versionEvaluators))
+                            .toList();
+                    return itemPage.toBuilder().content(items).build();
+                })
+                .defaultIfEmpty(DatasetItemPage.empty(page, sortingFactory.getSortableFields())));
+    }
+
+    DatasetItem applyVersionEvaluators(DatasetItem item, List<EvaluatorItem> versionEvaluators) {
+        if (CollectionUtils.isEmpty(item.evaluators())) {
+            return item.toBuilder().evaluators(versionEvaluators).build();
+        }
+        var merged = new ArrayList<>(versionEvaluators);
+        merged.addAll(item.evaluators());
+        return item.toBuilder().evaluators(merged).build();
     }
 
     public Mono<ProjectStats> getExperimentItemsStats(@NonNull UUID datasetId,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1320,18 +1320,12 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
     private Mono<DatasetItemPage> getItemsWithExperimentItems(DatasetItemSearchCriteria criteria,
             int page, int size, String workspaceId) {
-        Optional<DatasetVersion> latestDatasetVersion = versionService.getLatestVersion(criteria.datasetId(),
-                workspaceId);
-
         // Each experiment in ClickHouse carries its own dataset_version_id. This fallback is only used
         // for legacy experiments that predate versioning and have an empty dataset_version_id.
         // The DAO SQL resolves it via: COALESCE(nullIf(dataset_version_id, ''), :versionId)
-        String legacyFallbackVersionId = latestDatasetVersion.map(v -> v.id().toString()).orElseGet(() -> {
-            log.info(
-                    "No versions found for dataset '{}', using empty string as fallback version to query experiment items",
-                    criteria.datasetId());
-            return "";
-        });
+        String legacyFallbackVersionId = getFallbackVersionId(criteria.datasetId(), workspaceId)
+                .map(UUID::toString)
+                .orElse("");
 
         log.info(
                 "Fetching items with experiment items for dataset '{}', legacy fallback version '{}'",

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -1043,6 +1043,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     di.tags AS tags,
                     di.evaluators AS evaluators,
                     di.execution_policy AS execution_policy,
+                    di.dataset_version_id AS dataset_version_id,
                     di.item_created_at AS created_at,
                     di.item_last_updated_at AS last_updated_at,
                     di.item_created_by AS created_by,
@@ -1128,6 +1129,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     di.tags,
                     di.evaluators,
                     di.execution_policy,
+                    di.dataset_version_id,
                     di.item_created_at,
                     di.item_last_updated_at,
                     di.item_created_by,
@@ -1161,6 +1163,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     di.tags AS tags,
                     di.evaluators AS evaluators,
                     di.execution_policy AS execution_policy,
+                    di.dataset_version_id AS dataset_version_id,
                     di.item_created_at AS created_at,
                     di.item_last_updated_at AS last_updated_at,
                     di.item_created_by AS created_by,
@@ -1344,6 +1347,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     di.tags,
                     di.evaluators,
                     di.execution_policy,
+                    di.dataset_version_id,
                     di.item_created_at,
                     di.item_last_updated_at,
                     di.item_created_by,
@@ -2363,7 +2367,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
     @Override
     public Mono<DatasetItemPage> getItemsWithExperimentItems(@NonNull DatasetItemSearchCriteria criteria, int page,
             int size, @NonNull String legacyFallbackVersionId) {
-        log.info(
+        log.debug(
                 "Getting versioned dataset items with experiment items for dataset '{}', legacy fallback version '{}', experiments '{}'",
                 criteria.datasetId(), legacyFallbackVersionId, criteria.experimentIds());
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -70,11 +70,12 @@ public interface DatasetItemVersionDAO {
      * @param searchCriteria the search criteria including experiment IDs
      * @param page the page number
      * @param size the page size
-     * @param versionId the dataset version ID
+     * @param legacyFallbackVersionId fallback version ID for legacy experiments that predate versioning;
+     *                                 modern experiments carry their own dataset_version_id in ClickHouse
      * @return a Mono containing the page of dataset items with experiment items
      */
     Mono<DatasetItemPage> getItemsWithExperimentItems(DatasetItemSearchCriteria searchCriteria, int page, int size,
-            String versionId);
+            String legacyFallbackVersionId);
 
     Mono<List<Column>> getExperimentItemsOutputColumns(UUID datasetId, Set<UUID> experimentIds);
 
@@ -2361,10 +2362,10 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
 
     @Override
     public Mono<DatasetItemPage> getItemsWithExperimentItems(@NonNull DatasetItemSearchCriteria criteria, int page,
-            int size, @NonNull String versionId) {
+            int size, @NonNull String legacyFallbackVersionId) {
         log.info(
-                "Getting versioned dataset items with experiment items for dataset '{}', version '{}', experiments '{}'",
-                criteria.datasetId(), versionId, criteria.experimentIds());
+                "Getting versioned dataset items with experiment items for dataset '{}', legacy fallback version '{}', experiments '{}'",
+                criteria.datasetId(), legacyFallbackVersionId, criteria.experimentIds());
 
         return Mono.deferContextual(ctx -> {
             String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
@@ -2447,7 +2448,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                             var statement = connection.createStatement(query)
                                     .bind("workspace_id", workspaceId)
                                     .bind("datasetId", criteria.datasetId())
-                                    .bind("versionId", versionId)
+                                    .bind("versionId", legacyFallbackVersionId)
                                     .bind("limit", size);
 
                             if (pushTopLimit) {
@@ -2488,9 +2489,9 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                                     .flatMap(DatasetItemResultMapper::mapItem)
                                     .collectList()
                                     .onErrorResume(e -> handleSqlError(e, List.of()))
-                                    .zipWith(getCountWithExperimentFilters(criteria, versionId,
+                                    .zipWith(getCountWithExperimentFilters(criteria, legacyFallbackVersionId,
                                             targetProjectIds, hasAggregated, hasRaw))
-                                    .zipWith(getColumns(criteria.datasetId(), versionId))
+                                    .zipWith(getColumns(criteria.datasetId(), legacyFallbackVersionId))
 
                                     .map(tuple -> {
                                         var itemsAndCount = tuple.getT1();

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemServiceApplyVersionEvaluatorsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemServiceApplyVersionEvaluatorsTest.java
@@ -1,0 +1,124 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.DatasetItem;
+import com.comet.opik.api.DatasetItemSource;
+import com.comet.opik.api.EvaluatorItem;
+import com.comet.opik.api.EvaluatorType;
+import com.comet.opik.api.sorting.SortingFactoryDatasets;
+import com.comet.opik.infrastructure.FeatureFlags;
+import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.utils.JsonUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("DatasetItemService applyVersionEvaluators:")
+class DatasetItemServiceApplyVersionEvaluatorsTest {
+
+    private final DatasetItemServiceImpl service = new DatasetItemServiceImpl(
+            mock(DatasetItemDAO.class),
+            mock(DatasetItemVersionDAO.class),
+            mock(DatasetService.class),
+            mock(DatasetVersionService.class),
+            mock(ExperimentDAO.class),
+            mock(TraceService.class),
+            mock(SpanService.class),
+            mock(TraceEnrichmentService.class),
+            mock(SpanEnrichmentService.class),
+            mock(IdGenerator.class),
+            mock(SortingFactoryDatasets.class),
+            mock(TransactionTemplate.class),
+            mock(FeatureFlags.class),
+            mock(DatasetVersioningMigrationService.class),
+            mock(ProjectService.class),
+            mock(OpikConfiguration.class));
+
+    private static final EvaluatorItem VERSION_EVALUATOR = EvaluatorItem.builder()
+            .name("Should be in English")
+            .type(EvaluatorType.LLM_JUDGE)
+            .config(JsonUtils.getJsonNodeFromString("{\"schema\":[{\"name\":\"english\",\"type\":\"boolean\"}]}"))
+            .build();
+
+    private static final EvaluatorItem ITEM_EVALUATOR = EvaluatorItem.builder()
+            .name("Is factual")
+            .type(EvaluatorType.LLM_JUDGE)
+            .config(JsonUtils.getJsonNodeFromString("{\"schema\":[{\"name\":\"factual\",\"type\":\"boolean\"}]}"))
+            .build();
+
+    @Test
+    @DisplayName("item with no evaluators gets version evaluators")
+    void applyVersionEvaluatorsWhenItemHasNoEvaluators() {
+        var item = DatasetItem.builder().build();
+
+        var result = service.applyVersionEvaluators(item, List.of(VERSION_EVALUATOR));
+
+        assertThat(result.evaluators()).containsExactly(VERSION_EVALUATOR);
+    }
+
+    @Test
+    @DisplayName("item with null evaluators gets version evaluators")
+    void applyVersionEvaluatorsWhenItemHasNullEvaluators() {
+        var item = DatasetItem.builder().evaluators(null).build();
+
+        var result = service.applyVersionEvaluators(item, List.of(VERSION_EVALUATOR));
+
+        assertThat(result.evaluators()).containsExactly(VERSION_EVALUATOR);
+    }
+
+    @Test
+    @DisplayName("item with its own evaluators gets both merged (version first, then item)")
+    void applyVersionEvaluatorsWhenItemHasOwnEvaluators() {
+        var item = DatasetItem.builder().evaluators(List.of(ITEM_EVALUATOR)).build();
+
+        var result = service.applyVersionEvaluators(item, List.of(VERSION_EVALUATOR));
+
+        assertThat(result.evaluators()).containsExactly(VERSION_EVALUATOR, ITEM_EVALUATOR);
+    }
+
+    @Test
+    @DisplayName("item with empty evaluators list gets version evaluators")
+    void applyVersionEvaluatorsWhenItemHasEmptyEvaluatorsList() {
+        var item = DatasetItem.builder().evaluators(List.of()).build();
+
+        var result = service.applyVersionEvaluators(item, List.of(VERSION_EVALUATOR));
+
+        assertThat(result.evaluators()).containsExactly(VERSION_EVALUATOR);
+    }
+
+    @Test
+    @DisplayName("multiple version evaluators are all included")
+    void applyVersionEvaluatorsWithMultipleVersionEvaluators() {
+        var secondVersionEval = EvaluatorItem.builder()
+                .name("Is concise")
+                .type(EvaluatorType.LLM_JUDGE)
+                .config(JsonUtils.getJsonNodeFromString("{\"schema\":[]}"))
+                .build();
+        var item = DatasetItem.builder().evaluators(List.of(ITEM_EVALUATOR)).build();
+
+        var result = service.applyVersionEvaluators(item, List.of(VERSION_EVALUATOR, secondVersionEval));
+
+        assertThat(result.evaluators()).containsExactly(VERSION_EVALUATOR, secondVersionEval, ITEM_EVALUATOR);
+    }
+
+    @Test
+    @DisplayName("non-evaluator fields are preserved")
+    void applyVersionEvaluatorsPreservesOtherFields() {
+        var data = Map.of("input", JsonUtils.getJsonNodeFromString("{\"q\":\"hello\"}"));
+        var item = DatasetItem.builder()
+                .data(data)
+                .source(DatasetItemSource.MANUAL)
+                .build();
+
+        var result = service.applyVersionEvaluators(item, List.of(VERSION_EVALUATOR));
+
+        assertThat(result.evaluators()).containsExactly(VERSION_EVALUATOR);
+        assertThat(result.data()).isEqualTo(data);
+        assertThat(result.source()).isEqualTo(DatasetItemSource.MANUAL);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemServiceApplyVersionEvaluatorsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemServiceApplyVersionEvaluatorsTest.java
@@ -1,6 +1,7 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.DatasetItem;
+import com.comet.opik.api.DatasetItem.DatasetItemPage;
 import com.comet.opik.api.DatasetItemSource;
 import com.comet.opik.api.EvaluatorItem;
 import com.comet.opik.api.EvaluatorType;
@@ -10,10 +11,15 @@ import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.utils.JsonUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -51,21 +57,16 @@ class DatasetItemServiceApplyVersionEvaluatorsTest {
             .config(JsonUtils.getJsonNodeFromString("{\"schema\":[{\"name\":\"factual\",\"type\":\"boolean\"}]}"))
             .build();
 
-    @Test
-    @DisplayName("item with no evaluators gets version evaluators")
-    void applyVersionEvaluatorsWhenItemHasNoEvaluators() {
-        var item = DatasetItem.builder().build();
-
-        var result = service.applyVersionEvaluators(item, List.of(VERSION_EVALUATOR));
-
-        assertThat(result.evaluators()).containsExactly(VERSION_EVALUATOR);
+    static Stream<Arguments> emptyEvaluatorVariants() {
+        return Stream.of(
+                Arguments.of("no evaluators set", DatasetItem.builder().build()),
+                Arguments.of("null evaluators", DatasetItem.builder().evaluators(null).build()),
+                Arguments.of("empty evaluators list", DatasetItem.builder().evaluators(List.of()).build()));
     }
 
-    @Test
-    @DisplayName("item with null evaluators gets version evaluators")
-    void applyVersionEvaluatorsWhenItemHasNullEvaluators() {
-        var item = DatasetItem.builder().evaluators(null).build();
-
+    @ParameterizedTest(name = "item with {0} gets version evaluators")
+    @MethodSource("emptyEvaluatorVariants")
+    void applyVersionEvaluatorsWhenItemHasNoEvaluators(String description, DatasetItem item) {
         var result = service.applyVersionEvaluators(item, List.of(VERSION_EVALUATOR));
 
         assertThat(result.evaluators()).containsExactly(VERSION_EVALUATOR);
@@ -79,16 +80,6 @@ class DatasetItemServiceApplyVersionEvaluatorsTest {
         var result = service.applyVersionEvaluators(item, List.of(VERSION_EVALUATOR));
 
         assertThat(result.evaluators()).containsExactly(VERSION_EVALUATOR, ITEM_EVALUATOR);
-    }
-
-    @Test
-    @DisplayName("item with empty evaluators list gets version evaluators")
-    void applyVersionEvaluatorsWhenItemHasEmptyEvaluatorsList() {
-        var item = DatasetItem.builder().evaluators(List.of()).build();
-
-        var result = service.applyVersionEvaluators(item, List.of(VERSION_EVALUATOR));
-
-        assertThat(result.evaluators()).containsExactly(VERSION_EVALUATOR);
     }
 
     @Test
@@ -120,5 +111,99 @@ class DatasetItemServiceApplyVersionEvaluatorsTest {
         assertThat(result.evaluators()).containsExactly(VERSION_EVALUATOR);
         assertThat(result.data()).isEqualTo(data);
         assertThat(result.source()).isEqualTo(DatasetItemSource.MANUAL);
+    }
+
+    // --- per-version routing tests (applyVersionEvaluatorsToPage) ---
+
+    private static final EvaluatorItem V2_EVALUATOR = EvaluatorItem.builder()
+            .name("Is concise")
+            .type(EvaluatorType.LLM_JUDGE)
+            .config(JsonUtils.getJsonNodeFromString("{\"schema\":[{\"name\":\"concise\",\"type\":\"boolean\"}]}"))
+            .build();
+
+    @Test
+    @DisplayName("items from different versions get their own version's evaluators")
+    void applyVersionEvaluatorsToPageRoutesPerVersion() {
+        var v1Id = UUID.randomUUID();
+        var v2Id = UUID.randomUUID();
+
+        var itemFromV1 = DatasetItem.builder().datasetVersionId(v1Id).build();
+        var itemFromV2 = DatasetItem.builder().datasetVersionId(v2Id).build();
+
+        var page = DatasetItemPage.builder()
+                .content(List.of(itemFromV1, itemFromV2))
+                .page(1).size(10).total(2).sortableBy(List.of())
+                .build();
+
+        var evaluatorsByVersion = Map.of(
+                v1Id, List.of(VERSION_EVALUATOR),
+                v2Id, List.of(V2_EVALUATOR));
+
+        var result = service.applyVersionEvaluatorsToPage(page, evaluatorsByVersion);
+
+        assertThat(result.content().get(0).evaluators()).containsExactly(VERSION_EVALUATOR);
+        assertThat(result.content().get(1).evaluators()).containsExactly(V2_EVALUATOR);
+    }
+
+    @Test
+    @DisplayName("item with unknown version gets no version evaluators")
+    void applyVersionEvaluatorsToPageSkipsUnknownVersion() {
+        var knownVersionId = UUID.randomUUID();
+        var unknownVersionId = UUID.randomUUID();
+
+        var itemKnown = DatasetItem.builder().datasetVersionId(knownVersionId).build();
+        var itemUnknown = DatasetItem.builder().datasetVersionId(unknownVersionId)
+                .evaluators(List.of(ITEM_EVALUATOR)).build();
+
+        var page = DatasetItemPage.builder()
+                .content(List.of(itemKnown, itemUnknown))
+                .page(1).size(10).total(2).sortableBy(List.of())
+                .build();
+
+        var evaluatorsByVersion = Map.of(knownVersionId, List.of(VERSION_EVALUATOR));
+
+        var result = service.applyVersionEvaluatorsToPage(page, evaluatorsByVersion);
+
+        assertThat(result.content().get(0).evaluators()).containsExactly(VERSION_EVALUATOR);
+        assertThat(result.content().get(1).evaluators()).containsExactly(ITEM_EVALUATOR);
+    }
+
+    @Test
+    @DisplayName("item with null versionId gets no version evaluators")
+    void applyVersionEvaluatorsToPageSkipsNullVersion() {
+        var versionId = UUID.randomUUID();
+
+        var itemWithVersion = DatasetItem.builder().datasetVersionId(versionId).build();
+        var itemWithoutVersion = DatasetItem.builder().build();
+
+        var page = DatasetItemPage.builder()
+                .content(List.of(itemWithVersion, itemWithoutVersion))
+                .page(1).size(10).total(2).sortableBy(List.of())
+                .build();
+
+        var evaluatorsByVersion = Map.of(versionId, List.of(VERSION_EVALUATOR));
+
+        var result = service.applyVersionEvaluatorsToPage(page, evaluatorsByVersion);
+
+        assertThat(result.content().get(0).evaluators()).containsExactly(VERSION_EVALUATOR);
+        assertThat(result.content().get(1).evaluators()).isNull();
+    }
+
+    @Test
+    @DisplayName("empty evaluator map returns page unchanged")
+    void applyVersionEvaluatorsToPageEmptyMapReturnsUnchanged() {
+        var item = DatasetItem.builder()
+                .datasetVersionId(UUID.randomUUID())
+                .evaluators(List.of(ITEM_EVALUATOR))
+                .build();
+
+        var page = DatasetItemPage.builder()
+                .content(List.of(item))
+                .page(1).size(10).total(1).sortableBy(List.of())
+                .build();
+
+        var result = service.applyVersionEvaluatorsToPage(page, Map.of());
+
+        assertThat(result).isSameAs(page);
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemServiceFilterDataTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemServiceFilterDataTest.java
@@ -26,6 +26,7 @@ class DatasetItemServiceFilterDataTest {
             mock(DatasetItemVersionDAO.class),
             mock(DatasetService.class),
             mock(DatasetVersionService.class),
+            mock(ExperimentDAO.class),
             mock(TraceService.class),
             mock(SpanService.class),
             mock(TraceEnrichmentService.class),


### PR DESCRIPTION
> ♻️ Re-opened on behalf of @itamargolan. All commits are authored by @itamargolan. Apologies for the inconvenience. Original PR for reference: #6487.

---

## Details

The compare endpoint (`GET /api/v1/datasets/{id}/items/experiments/items`) only returned item-level evaluators from ClickHouse `dataset_item_versions`, never version-level evaluators from MySQL. This caused dataset items with no item-level assertions to show "Skipped - No assertions defined" in the UI, even when the dataset version had version-level assertions that applied to all items.

The fix builds a per-version evaluator map by looking up each experiment's `dataset_version_id`, fetching the corresponding version evaluators from MySQL, and merging them into each item — version-level first, then item-level — matching `TestSuiteAssertionSampler` behavior. Items from different dataset versions each get their own version's evaluators.

- Added `ExperimentDAO` dependency to `DatasetItemServiceImpl` to resolve experiment → dataset version mapping
- Flowed `dataset_version_id` through ClickHouse query, result mapper, and `DatasetItem` DTO (as `@JsonIgnore`) so each item knows which version it belongs to
- Renamed `versionId` → `legacyFallbackVersionId` in the DAO interface to clarify its purpose (only used for pre-versioning experiments)
- Demoted DAO-level log from INFO to DEBUG (service already logs at INFO)
- Wrapped blocking MySQL call in `Mono.fromCallable` + `subscribeOn(Schedulers.boundedElastic())`

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6218

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (CLI)
- Model(s): Claude Opus 4.6
- Scope: implementation, tests
- Human verification: code reviewed, tests verified, UI tested locally

## Testing

- `mvn test -Dtest="DatasetItemServiceApplyVersionEvaluatorsTest"` — unit tests covering both `applyVersionEvaluators` (parameterized empty/null/empty-list variants, merge ordering, multiple version evaluators, field preservation) and `applyVersionEvaluatorsToPage` (per-version routing, unknown version skipping, null version skipping, empty map passthrough)
- `mvn test -Dtest="DatasetItemServiceFilterDataTest"` — 8 existing tests pass with updated constructor
- `mvn spotless:check` — formatting clean
- Local UI testing via `scripts/dev-runner.sh --restart`:
  - Playground: run experiment on test suite v3 with version-level assertions → all items show evaluator results
  - Compare experiments page: items display correct evaluators

## Documentation

No documentation changes needed — this is a backend bug fix with no API contract changes.