### PR TITLE
[NA] [Deployment] fix: port PR #3756 ClickHouse hardening to docker-compose

### DIFF
--- a/deployment/docker-compose/clickhouse_config/memory.xml
+++ b/deployment/docker-compose/clickhouse_config/memory.xml
@@ -1,0 +1,12 @@
+<!--
+  Cap ClickHouse's total memory usage to 85% of the container's cgroup
+  memory limit, leaving headroom for the OS, merges, and TTL mutations
+  on large tables. Without this, ClickHouse will use the default ratio
+  (~90% of detected RAM) and OOM during merge-heavy workloads.
+
+  Mirrors the Helm chart block at deployment/helm_chart/opik/values.yaml
+  (under `clickhouse.configuration.files."conf.d/memory.xml"`).
+-->
+<clickhouse>
+    <max_server_memory_usage_to_ram_ratio>0.85</max_server_memory_usage_to_ram_ratio>
+</clickhouse>

--- a/deployment/docker-compose/clickhouse_config/profiles.xml
+++ b/deployment/docker-compose/clickhouse_config/profiles.xml
@@ -1,0 +1,16 @@
+<!--
+  Allow sort and group-by operations to spill to disk when their working
+  memory exceeds 20% of the server memory budget, rather than OOMing the
+  whole server. This is a safety net for ad-hoc queries on large tables.
+
+  Mirrors the Helm chart block at deployment/helm_chart/opik/values.yaml
+  (under `clickhouse.configuration.files."conf.d/profiles.xml"`).
+-->
+<clickhouse>
+    <profiles>
+        <default>
+            <max_bytes_ratio_before_external_sort>0.2</max_bytes_ratio_before_external_sort>
+            <max_bytes_ratio_before_external_group_by>0.2</max_bytes_ratio_before_external_group_by>
+        </default>
+    </profiles>
+</clickhouse>

--- a/deployment/docker-compose/clickhouse_config/system_tables.xml
+++ b/deployment/docker-compose/clickhouse_config/system_tables.xml
@@ -1,0 +1,68 @@
+<!--
+  Disable ClickHouse internal observability tables that Opik does not use,
+  and cap retention on the ones we keep. Without this config, a long-running
+  ClickHouse instance accumulates tens of GiB in `system.trace_log` (memory
+  profiler stack traces, 4 MiB step, no TTL) until the Docker data volume
+  fills and Redis enters `stop-writes-on-bgsave-error` read-only mode,
+  which takes down Opik span ingestion.
+
+  This mirrors the hardening applied to the Helm chart in PR #3756
+  (merged 2025-10-28), ported here to close the docker-compose gap.
+  See also: https://github.com/comet-ml/opik/issues/6224
+-->
+<clickhouse>
+    <opentelemetry_span_log remove="1"/>
+    <asynchronous_metric_log remove="1"/>
+    <processors_profile_log remove="1"/>
+    <text_log remove="1"/>
+    <trace_log remove="1"/>
+    <blob_storage_log remove="1"/>
+
+    <error_log>
+        <engine>
+            ENGINE = MergeTree
+            PARTITION BY toYYYYMM(event_date)
+            ORDER BY (event_date, event_time)
+            TTL event_date + toIntervalDay(30)
+            SETTINGS index_granularity = 8192
+        </engine>
+        <database>system</database>
+        <table>error_log</table>
+    </error_log>
+
+    <latency_log>
+        <engine>
+            ENGINE = MergeTree
+            PARTITION BY toYYYYMM(event_date)
+            ORDER BY (event_date, event_time)
+            TTL event_date + toIntervalDay(30)
+            SETTINGS index_granularity = 8192
+        </engine>
+        <database>system</database>
+        <table>latency_log</table>
+    </latency_log>
+
+    <metric_log>
+        <engine>
+            ENGINE = MergeTree
+            PARTITION BY toYYYYMM(event_date)
+            ORDER BY (event_date, event_time)
+            TTL event_date + toIntervalDay(30)
+            SETTINGS index_granularity = 8192
+        </engine>
+        <database>system</database>
+        <table>metric_log</table>
+    </metric_log>
+
+    <query_metric_log>
+        <engine>
+            ENGINE = MergeTree
+            PARTITION BY toYYYYMM(event_date)
+            ORDER BY (event_date, event_time)
+            TTL event_date + toIntervalDay(30)
+            SETTINGS index_granularity = 8192
+        </engine>
+        <database>system</database>
+        <table>query_metric_log</table>
+    </query_metric_log>
+</clickhouse>


### PR DESCRIPTION
> ♻️ Re-opened on behalf of @lupuletic. All commits are authored by @lupuletic. Apologies for the inconvenience. Original PR for reference: #6225.

---

## Summary

Ports the ClickHouse hardening from PR #3756 (Helm, merged 2025-10-28) to the docker-compose deployment. Adds three files under `deployment/docker-compose/clickhouse_config/`:

- **`system_tables.xml`** — removes unused ClickHouse self-observability tables (`trace_log`, `text_log`, `asynchronous_metric_log`, `processors_profile_log`, `opentelemetry_span_log`, `blob_storage_log`) via `remove="1"`, and applies 30-day TTL to the ones worth keeping (`error_log`, `latency_log`, `metric_log`, `query_metric_log`).
- **`memory.xml`** — caps `max_server_memory_usage_to_ram_ratio=0.85`.
- **`profiles.xml`** — allows sort/group-by to spill to disk at 20% of the memory budget.

No `docker-compose.yaml` changes are needed because the existing `clickhouse-init` sidecar already `cp -r`s the entire `clickhouse_config/` directory into the `clickhouse-config` volume on startup.

## Why

Without this config, any long-running docker-compose Opik deployment eventually fills its Docker data volume with ClickHouse's own memory profiler stack traces in `system.trace_log` (no TTL, 4 MiB allocation threshold, every background merge triggers thousands of rows). Once the volume hits 100%, Redis — sharing the same volume — enters `MISCONF ... stop-writes-on-bgsave-error` read-only mode, Opik's backend starts returning HTTP 500 on span ingestion via the Redis-stream fan-out, and telemetry silently disappears.

We just hit this on a production deployment:

```
system  trace_log              66.42 GiB  3053322612 rows
system  text_log               12.66 GiB  275962581 rows
opik    spans                   1.73 GiB     184513 rows  (← actual Opik data, dwarfed by CH internals)
```

Full root-cause writeup + reproduction in #6224.

## On duplication with the Helm chart

The XML content in these three files is duplicated from the inline block under `clickhouse.configuration.files` in `deployment/helm_chart/opik/values.yaml`. This is a conscious scope decision, not an oversight — automated reviewers (e.g. `baz-reviewer`) have rightly flagged it. Here's the reasoning:

- **Helm embeds XML inline as template strings** which Helm renders into a ConfigMap at install time; docker-compose uses a `clickhouse-init` sidecar that `cp -r`s files into a shared volume. Neither path has a native include mechanism, so a true single-source-of-truth would need a pre-build script that emits both formats from one canonical input, plus a CI check to keep them in sync. That's a real refactor touching both deployment modes — strictly larger than this PR's goal of closing the docker-compose gap.
- **This PR's scope is narrow on purpose**: port what the Helm chart already has, nothing more. Keeps the diff reviewable (+96 lines, three new files, zero changes to existing files) and the revert path trivial.
- **Drift risk is low in practice**: the blocks are small, encode stable ClickHouse tuning knobs, and the TTL value is the only thing likely to ever change (a single `30` repeated across four table definitions).

I'd be happy to open a follow-up PR with either of:

1. A lightweight `scripts/check-clickhouse-config-parity.sh` CI gate that fails if the Helm and docker-compose XML diverge (smallest change, zero runtime impact — my preference for cost/benefit).
2. A full generator-based single-source-of-truth refactor (larger change, touches Helm templates too).

Maintainer call on which direction to go. For *this* PR I'd like to keep the current shape and merge the port as-is.

## One upstream typo worth fixing

The Helm block at `deployment/helm_chart/opik/values.yaml:660` has a one-character typo I corrected in the port:

```xml
<error_log>
    <engine>
        ENGINE MergeTree  ← missing `=`
        ...
```

Every other table in the same block (`latency_log`, `metric_log`, `query_metric_log`) correctly says `ENGINE = MergeTree`. If this config were ever applied to a fresh ClickHouse instance, `error_log` creation would fail with a SQL parse error. Because ClickHouse only applies this config at *create* time, existing Helm deployments with a pre-existing `error_log` never notice — the bug is invisible to everyone who's already running Opik. Worth fixing the Helm side too in a follow-up. Happy to open that separate one-line PR if you'd like.

## Verification

Applied the same fix to our production docker-compose deployment earlier today and confirmed:

1. Disk usage dropped from 100% → 7% after `TRUNCATE`-ing the offending tables and restarting ClickHouse with the new config.
2. `system_tables.xml` is picked up on restart (`Merging configuration file '/etc/clickhouse-server/config.d/system_tables.xml'` in the CH startup log).
3. The `remove="1"` directive only takes effect for fresh bootstraps — on an upgrade path, operators will additionally need to `DROP TABLE system.trace_log SYNC` (etc.) once after applying the config, because ClickHouse skips table creation on startup if the metadata already exists on disk. Not a blocker for this PR (new installs get the clean path for free), but worth documenting. I can add a note to the docker-compose README in a follow-up commit if you'd like.
4. Span ingestion resumed immediately after restart and has been healthy since.

## Files changed

```
 deployment/docker-compose/clickhouse_config/memory.xml        | 12 +++
 deployment/docker-compose/clickhouse_config/profiles.xml      | 16 ++++
 deployment/docker-compose/clickhouse_config/system_tables.xml | 68 ++++++++++++++
 3 files changed, 96 insertions(+)
```

Closes #6224.

## Test plan

- [x] XML syntax-validates via `python3 -c "import xml.etree.ElementTree as ET; ET.parse(...)"` for all three files
- [x] Applied to a running production docker-compose Opik instance; confirmed CH picks up the config on restart and span ingestion is healthy
- [ ] CI validates the docker-compose stack still comes up cleanly (happy to iterate if the existing CI has a docker-compose smoke test — let me know if there's a specific workflow that should be green before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)