### PR TITLE
[issue-7083] [SDK] fix: correct health-check URL path

### DIFF
--- a/sdks/python/src/opik/url_helpers.py
+++ b/sdks/python/src/opik/url_helpers.py
@@ -98,7 +98,7 @@ def get_workspace_list_url(base_url: str) -> str:
 
 
 def get_is_alive_ping_url(base_url: str) -> str:
-    return urllib.parse.urljoin(base_url, HEALTH_CHECK_URL_POSTFIX)
+    return urllib.parse.urljoin(ensure_ending_slash(base_url), HEALTH_CHECK_URL_POSTFIX)
 
 
 def is_aws_presigned_url(url: str) -> bool:

--- a/sdks/python/src/opik/url_helpers.py
+++ b/sdks/python/src/opik/url_helpers.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 URL_ACCOUNT_DETAILS_POSTFIX: Final[str] = "api/rest/v2/account-details"
 URL_WORKSPACE_GET_LIST_POSTFIX: Final[str] = "api/rest/v2/workspaces"
-HEALTH_CHECK_URL_POSTFIX: Final[str] = "/is-alive/ping"
+HEALTH_CHECK_URL_POSTFIX: Final[str] = "is-alive/ping"
 ALLOWED_URL_CHARACTERS: Final[str] = ":/&?="
 
 

--- a/sdks/python/tests/unit/test_url_helpers.py
+++ b/sdks/python/tests/unit/test_url_helpers.py
@@ -6,6 +6,10 @@ from opik import url_helpers
     ("base_url", "expected_ping_url"),
     [
         (
+            "http://localhost:5173/api",
+            "http://localhost:5173/api/is-alive/ping",
+        ),
+        (
             "http://localhost:5173/api/",
             "http://localhost:5173/api/is-alive/ping",
         ),
@@ -14,10 +18,16 @@ from opik import url_helpers
             "http://localhost:5173/api/is-alive/ping",
         ),
         (
+            "https://www.comet.com/opik/api",
+            "https://www.comet.com/opik/api/is-alive/ping",
+        ),
+        (
             "https://www.comet.com/opik/api/",
             "https://www.comet.com/opik/api/is-alive/ping",
         ),
     ],
 )
-def test_get_is_alive_ping_url(base_url: str, expected_ping_url: str) -> None:
+def test_get_is_alive_ping_url__base_url__returns_expected_ping_url(
+    base_url: str, expected_ping_url: str
+) -> None:
     assert url_helpers.get_is_alive_ping_url(base_url) == expected_ping_url

--- a/sdks/python/tests/unit/test_url_helpers.py
+++ b/sdks/python/tests/unit/test_url_helpers.py
@@ -1,0 +1,23 @@
+import pytest
+from opik import url_helpers
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected_ping_url"),
+    [
+        (
+            "http://localhost:5173/api/",
+            "http://localhost:5173/api/is-alive/ping",
+        ),
+        (
+            "http://localhost:5173/api//",
+            "http://localhost:5173/api/is-alive/ping",
+        ),
+        (
+            "https://www.comet.com/opik/api/",
+            "https://www.comet.com/opik/api/is-alive/ping",
+        ),
+    ],
+)
+def test_get_is_alive_ping_url(base_url: str, expected_ping_url: str) -> None:
+    assert url_helpers.get_is_alive_ping_url(base_url) == expected_ping_url


### PR DESCRIPTION
Change HEALTH_CHECK_URL_POSTFIX from '/is-alive/ping' to 'is-alive/ping'

so urllib.parse.urljoin preserves the /api/ base path, matching the

frontend nginx proxy route used by the UI and backend API traffic.

## Details
- **`sdks/python/src/opik/url_helpers.py`**
  - Changed `HEALTH_CHECK_URL_POSTFIX` from `"/is-alive/ping"` to `"is-alive/ping"` 

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #7083 

## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools: Codex
  - Model(s): GPT-5
  - Scope: Generate test command, help reading the project
  - Human verification: all modifications and experiments are done manually

## Testing
Unit tests in `sdks/python/tests/unit/test_url_helpers.py` covering URL resolution for local and cloud deployments.

Run:

```bash
cd sdks/python
python -m pytest tests/unit/test_url_helpers.py -v
```

Also ran the existing `ConnectionProbe` tests to ensure no regression:

```bash
cd sdks/python
python -m pytest tests/unit/healthcheck/test_connection_probe.py -v
```


## After modification
1. the right health probe path
<img width="1716" height="234" alt="image" src="https://github.com/user-attachments/assets/99d2de37-561f-4369-a529-34f017657c75" />

2. stop the backend, send a trace, there's message in db files
<img width="2854" height="432" alt="image" src="https://github.com/user-attachments/assets/902a1910-38e4-491e-afda-d52218b20c90" />

3. restart the backend, the message successfully restored
<img width="2174" height="900" alt="image" src="https://github.com/user-attachments/assets/8e655b70-1de6-426f-a6c5-28f8fee5f08b" />



