### PR TITLE
[OPIK-6308] [BE] feat: fast-fail with HTTP 503 when Python BE pool is saturated

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/executor.py
+++ b/apps/opik-python-backend/src/opik_backend/executor.py
@@ -25,9 +25,10 @@ DEFAULT_CPU_LIMIT = None
 SATURATED_ERROR = "Code executor is saturated, please retry"
 SHUTDOWN_ERROR = "Service is shutting down"
 
+# Body returned with HTTP 504 when a single execution exceeds exec_timeout.
+EXEC_TIMEOUT_ERROR = "Server processing exceeded timeout limit."
+
 # Tunable acquire wait for the in-memory pool before responding HTTP 503.
-# Centralized so the env-var name and its fallback live next to the rest
-# of the executor's runtime configuration.
 POOL_ACQUIRE_TIMEOUT_ENV_VAR = "PYTHON_CODE_EXECUTOR_POOL_ACQUIRE_TIMEOUT_IN_SECS"
 POOL_ACQUIRE_TIMEOUT_DEFAULT = 0.0
 
@@ -70,7 +71,7 @@ class CodeExecutorBase(ABC):
         if not math.isfinite(value) or value < 0:
             # Reject nan/inf alongside negatives: an infinite timeout would
             # re-introduce the unbounded blocking acquire this knob exists
-            # to bound (see OPIK-6308).
+            # to bound.
             logger.warning(
                 f"{POOL_ACQUIRE_TIMEOUT_ENV_VAR} must be a finite non-negative "
                 f"number, got '{raw}'; falling back to {POOL_ACQUIRE_TIMEOUT_DEFAULT}"

--- a/apps/opik-python-backend/src/opik_backend/executor.py
+++ b/apps/opik-python-backend/src/opik_backend/executor.py
@@ -25,6 +25,12 @@ DEFAULT_CPU_LIMIT = None
 SATURATED_ERROR = "Code executor is saturated, please retry"
 SHUTDOWN_ERROR = "Service is shutting down"
 
+# Tunable acquire wait for the in-memory pool before responding HTTP 503.
+# Centralized so the env-var name and its fallback live next to the rest
+# of the executor's runtime configuration.
+POOL_ACQUIRE_TIMEOUT_ENV_VAR = "PYTHON_CODE_EXECUTOR_POOL_ACQUIRE_TIMEOUT_IN_SECS"
+POOL_ACQUIRE_TIMEOUT_DEFAULT = 0.0
+
 @dataclass
 class ExecutionResult:
     """Result of code execution."""
@@ -49,27 +55,27 @@ class CodeExecutorBase(ABC):
 
     @staticmethod
     def _parse_pool_acquire_timeout():
-        """Parse PYTHON_CODE_EXECUTOR_POOL_ACQUIRE_TIMEOUT_IN_SECS as a non-negative float."""
-        raw = os.getenv("PYTHON_CODE_EXECUTOR_POOL_ACQUIRE_TIMEOUT_IN_SECS")
+        """Parse the pool-acquire timeout env var as a non-negative float."""
+        raw = os.getenv(POOL_ACQUIRE_TIMEOUT_ENV_VAR)
         if raw is None:
-            return 0.0
+            return POOL_ACQUIRE_TIMEOUT_DEFAULT
         try:
             value = float(raw)
         except (TypeError, ValueError):
             logger.warning(
-                f"PYTHON_CODE_EXECUTOR_POOL_ACQUIRE_TIMEOUT_IN_SECS must be a number, "
-                f"got '{raw}'; falling back to 0"
+                f"{POOL_ACQUIRE_TIMEOUT_ENV_VAR} must be a number, "
+                f"got '{raw}'; falling back to {POOL_ACQUIRE_TIMEOUT_DEFAULT}"
             )
-            return 0.0
+            return POOL_ACQUIRE_TIMEOUT_DEFAULT
         if not math.isfinite(value) or value < 0:
             # Reject nan/inf alongside negatives: an infinite timeout would
             # re-introduce the unbounded blocking acquire this knob exists
             # to bound (see OPIK-6308).
             logger.warning(
-                f"PYTHON_CODE_EXECUTOR_POOL_ACQUIRE_TIMEOUT_IN_SECS must be a finite "
-                f"non-negative number, got '{raw}'; falling back to 0"
+                f"{POOL_ACQUIRE_TIMEOUT_ENV_VAR} must be a finite non-negative "
+                f"number, got '{raw}'; falling back to {POOL_ACQUIRE_TIMEOUT_DEFAULT}"
             )
-            return 0.0
+            return POOL_ACQUIRE_TIMEOUT_DEFAULT
         return value
 
     def parse_execution_result(self, result: ExecutionResult) -> dict:

--- a/apps/opik-python-backend/src/opik_backend/executor.py
+++ b/apps/opik-python-backend/src/opik_backend/executor.py
@@ -1,6 +1,7 @@
 """Base class for code execution strategies."""
 import json
 import logging
+import math
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -19,6 +20,11 @@ DEFAULT_MEM_LIMIT = "256m"
 # None means no hard limit (only cpu_shares soft priority applies)
 DEFAULT_CPU_LIMIT = None
 
+# Human-readable bodies returned with HTTP 503. Callers should branch on
+# the HTTP status code, not on these strings.
+SATURATED_ERROR = "Code executor is saturated, please retry"
+SHUTDOWN_ERROR = "Service is shutting down"
+
 @dataclass
 class ExecutionResult:
     """Result of code execution."""
@@ -32,6 +38,39 @@ class CodeExecutorBase(ABC):
         # Shared configuration
         self.max_parallel = int(os.getenv("PYTHON_CODE_EXECUTOR_PARALLEL_NUM", 5))
         self.exec_timeout = int(os.getenv("PYTHON_CODE_EXECUTOR_EXEC_TIMEOUT_IN_SECS", 3))
+        # Maximum wait for a free executor before responding with HTTP 503.
+        # Defaults to 0 (fail fast): once the pool is empty, the next slot
+        # only opens after a fresh container/worker is created — too long to
+        # absorb on the server side without re-pinning request threads, which
+        # is the failure mode this knob exists to prevent. The HTTP layer's
+        # retry-with-backoff is the right place to soak up bursts. Operators
+        # can raise this if their traffic shape benefits from a short wait.
+        self.pool_acquire_timeout = self._parse_pool_acquire_timeout()
+
+    @staticmethod
+    def _parse_pool_acquire_timeout():
+        """Parse PYTHON_CODE_EXECUTOR_POOL_ACQUIRE_TIMEOUT_IN_SECS as a non-negative float."""
+        raw = os.getenv("PYTHON_CODE_EXECUTOR_POOL_ACQUIRE_TIMEOUT_IN_SECS")
+        if raw is None:
+            return 0.0
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                f"PYTHON_CODE_EXECUTOR_POOL_ACQUIRE_TIMEOUT_IN_SECS must be a number, "
+                f"got '{raw}'; falling back to 0"
+            )
+            return 0.0
+        if not math.isfinite(value) or value < 0:
+            # Reject nan/inf alongside negatives: an infinite timeout would
+            # re-introduce the unbounded blocking acquire this knob exists
+            # to bound (see OPIK-6308).
+            logger.warning(
+                f"PYTHON_CODE_EXECUTOR_POOL_ACQUIRE_TIMEOUT_IN_SECS must be a finite "
+                f"non-negative number, got '{raw}'; falling back to 0"
+            )
+            return 0.0
+        return value
 
     def parse_execution_result(self, result: ExecutionResult) -> dict:
         """Parse execution result into API response format."""
@@ -46,7 +85,7 @@ class CodeExecutorBase(ABC):
             except Exception as e:
                 logger.info(f"Exception parsing execution logs: {e}")
                 return {"code": 400, "error": "Execution failed: Python code contains an invalid metric"}
-    
+
     @abstractmethod
     def run_scoring(self, code: str, data: dict, payload_type: Optional[str] = None) -> dict:
         """Execute code with data and return results."""

--- a/apps/opik-python-backend/src/opik_backend/executor_docker.py
+++ b/apps/opik-python-backend/src/opik_backend/executor_docker.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 import time
-from queue import Queue
+from queue import Queue, Empty
 from threading import Lock, Event
 from typing import Optional
 from uuid6 import uuid7
@@ -15,7 +15,15 @@ from opentelemetry import metrics
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 
-from opik_backend.executor import CodeExecutorBase, ExecutionResult, DEFAULT_CPU_SHARES, DEFAULT_MEM_LIMIT, DEFAULT_CPU_LIMIT
+from opik_backend.executor import (
+    CodeExecutorBase,
+    ExecutionResult,
+    DEFAULT_CPU_SHARES,
+    DEFAULT_MEM_LIMIT,
+    DEFAULT_CPU_LIMIT,
+    SATURATED_ERROR,
+    SHUTDOWN_ERROR,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -293,7 +301,7 @@ class DockerExecutor(CodeExecutorBase):
         # Record the start time for detailed container creation metrics
         start_time = time.time()
         with self.tracer.start_as_current_span("docker.create_container"):
-            
+
             run_kwargs = dict(
                 image=f"{self.docker_registry}/{self.docker_image}:{self.docker_tag}",
                 command=["tail", "-f", "/dev/null"], # a never ending process so Docker won't kill the container
@@ -311,6 +319,7 @@ class DockerExecutor(CodeExecutorBase):
 
             # Add the container to the pool
             self.container_pool.put(new_container)
+            self._update_container_pool_size_metric()
 
             # Calculate and record the latency for the direct container creation
             latency = self._calculate_latency_ms(start_time)
@@ -365,18 +374,29 @@ class DockerExecutor(CodeExecutorBase):
                 logger.error(f"Failed to stop container {container.id}: {e}")
 
     def get_container(self):
+        """Acquire a container from the pool.
+
+        Blocks up to ``pool_acquire_timeout`` seconds and raises
+        :class:`TimeoutError` if no container becomes available, or if the
+        executor is shutting down. ``run_scoring`` translates this into HTTP
+        503 so callers can retry with backoff.
+        """
         with self.tracer.start_as_current_span("get_container"):
             if self.stop_event.is_set():
-                raise RuntimeError("Executor is shutting down, no containers available")
+                raise TimeoutError("Executor is shutting down, no containers available")
 
-            while not self.stop_event.is_set():
-                try:
-                    return self.container_pool.get(timeout=self.exec_timeout)
-                except Exception as e:
-                    if self.stop_event.is_set():
-                        raise RuntimeError("Executor is shutting down, no containers available")
-
-                    logger.warning(f"Couldn't get a container to execute after waiting for {self.exec_timeout}s. Will retry: {e}")
+            self._update_container_pool_size_metric()
+            try:
+                container = self.container_pool.get(timeout=self.pool_acquire_timeout)
+            except Empty as e:
+                message = f"Container pool exhausted: no container available within {self.pool_acquire_timeout:.3f}s"
+                logger.warning(message)
+                # Refresh the gauge so the saturation event reports the
+                # zero-available state, not the pre-call value.
+                self._update_container_pool_size_metric()
+                raise TimeoutError(message) from e
+            self._update_container_pool_size_metric()
+            return container
 
     def _record_execution_outcome(self, status: str, payload_type: Optional[str] = None):
         """Record execution outcome for monitoring failure rates."""
@@ -387,12 +407,12 @@ class DockerExecutor(CodeExecutorBase):
 
     def run_scoring(self, code: str, data: dict, payload_type: Optional[str] = None) -> dict:
         if self.stop_event.is_set():
-            return {"code": 503, "error": "Service is shutting down"}
-        
+            return {"code": 503, "error": SHUTDOWN_ERROR}
+
         # Record code payload size early (string encoding is safe)
         code_size = len(code.encode('utf-8')) if code else 0
         payload_code_size_histogram.record(code_size, attributes={"payload_type": payload_type or "unknown"})
-        
+
         # Serialize data payload - can fail if data contains non-serializable objects
         try:
             data_json = json.dumps(data)
@@ -402,9 +422,13 @@ class DockerExecutor(CodeExecutorBase):
             self._record_execution_outcome("serialization_error", payload_type)
             logger.error(f"Failed to serialize data payload: {e}")
             return {"code": 400, "error": f"Data serialization failed: {e}"}
-        
+
         start_time = time.time()
-        container = self.get_container()
+        try:
+            container = self.get_container()
+        except TimeoutError:
+            self._record_execution_outcome("saturated", payload_type)
+            return {"code": 503, "error": SATURATED_ERROR}
         get_container_latency = self._calculate_latency_ms(start_time)
         logger.debug(f"Get container latency: {get_container_latency:.3f} milliseconds")
         get_container_histogram.record(get_container_latency, attributes={"method": "get_container"})
@@ -412,7 +436,7 @@ class DockerExecutor(CodeExecutorBase):
         with self.tracer.start_as_current_span("docker.run_scoring") as span:
             try:
                 cmd = ["python", "/opt/opik-sandbox-executor-python/scoring_runner.pyc", code, data_json, payload_type or ""]
-                
+
                 future = self.scoring_executor.submit(
                     container.exec_run,
                     cmd=cmd,
@@ -422,19 +446,19 @@ class DockerExecutor(CodeExecutorBase):
                 )
 
                 result = future.result(timeout=self.exec_timeout)
-                
+
                 exec_result = ExecutionResult(
                     exit_code=result.exit_code,
                     output=result.output
                 )
-                
+
                 # Access ThreadPoolExecutor's internal work queue (private attribute)
                 queue_size = self.scoring_executor._work_queue.qsize()
                 scoring_executor_queue_size_gauge.set(queue_size)
-                
+
                 # Parse result and track outcome
                 parsed_result = self.parse_execution_result(exec_result)
-                
+
                 # Determine outcome status based on result
                 if exec_result.exit_code == 0:
                     outcome_status = "success"
@@ -443,7 +467,7 @@ class DockerExecutor(CodeExecutorBase):
                     span.set_status(Status(StatusCode.ERROR, f"Execution failed with exit_code={exec_result.exit_code}"))
                     span.set_attribute("error.type", "invalid_code")
                     span.set_attribute("error.exit_code", exec_result.exit_code)
-                
+
                 self._record_execution_outcome(outcome_status, payload_type)
                 return parsed_result
             except concurrent.futures.TimeoutError as e:
@@ -468,10 +492,10 @@ class DockerExecutor(CodeExecutorBase):
                 span.set_attribute("code_size_bytes", code_size)
                 span.set_attribute("data_size_bytes", data_size)
                 logger.debug(f"Scoring executor latency: {total_latency:.3f} ms (code_size: {code_size} bytes, data_size: {data_size} bytes)")
-                
+
                 # Stop and remove the container, then create a new one asynchronously
                 self.release_container(container)
-            
+
     def cleanup(self):
         """Clean up all containers managed by this executor."""
         logger.debug("Shutting down Docker executor")

--- a/apps/opik-python-backend/src/opik_backend/executor_docker.py
+++ b/apps/opik-python-backend/src/opik_backend/executor_docker.py
@@ -388,18 +388,24 @@ class DockerExecutor(CodeExecutorBase):
         """
         with self.tracer.start_as_current_span("get_container"):
             if self.stop_event.is_set():
-                raise TimeoutError("Executor is shutting down, no containers available")
+                raise TimeoutError(SHUTDOWN_ERROR)
 
             self._update_container_pool_size_metric()
             try:
                 container = self.container_pool.get(timeout=self.pool_acquire_timeout)
             except Empty as e:
-                message = f"Container pool exhausted: no container available within {self.pool_acquire_timeout:.3f}s"
-                logger.warning(message)
+                # Detailed diagnostic stays in the log; the exception
+                # carries the wire-facing constant so internal config
+                # (pool_acquire_timeout) can't leak to a downstream
+                # `str(exc)`.
+                logger.warning(
+                    f"Container pool exhausted: no container available within "
+                    f"{self.pool_acquire_timeout:.3f}s"
+                )
                 # Refresh the gauge so the saturation event reports the
                 # zero-available state, not the pre-call value.
                 self._update_container_pool_size_metric()
-                raise TimeoutError(message) from e
+                raise TimeoutError(SATURATED_ERROR) from e
             self._update_container_pool_size_metric()
             return container
 

--- a/apps/opik-python-backend/src/opik_backend/executor_docker.py
+++ b/apps/opik-python-backend/src/opik_backend/executor_docker.py
@@ -432,6 +432,12 @@ class DockerExecutor(CodeExecutorBase):
         try:
             container = self.get_container()
         except TimeoutError:
+            # Re-check stop_event: shutdown can fire between get_container's
+            # pre-check and the bounded Queue.get, in which case the failure
+            # is really shutdown, not pool saturation. Report it as the
+            # former so monitoring doesn't false-positive on saturation.
+            if self.stop_event.is_set():
+                return {"code": 503, "error": SHUTDOWN_ERROR}
             self._record_execution_outcome("saturated", payload_type)
             return {"code": 503, "error": SATURATED_ERROR}
         get_container_latency = self._calculate_latency_ms(start_time)

--- a/apps/opik-python-backend/src/opik_backend/executor_docker.py
+++ b/apps/opik-python-backend/src/opik_backend/executor_docker.py
@@ -122,6 +122,13 @@ class DockerExecutor(CodeExecutorBase):
 
         self.stop_event = Event()
 
+        # Initialize the tracer before pre-warm and the pool monitor — both
+        # paths call create_container, which opens a span on self.tracer.
+        # Setting it later left pre-warm raising AttributeError silently
+        # (futures swallowed the exception), so the pool started empty and
+        # only refilled on the next scheduler tick.
+        self.tracer = trace.get_tracer(__name__)
+
         # Log container configuration for debugging
         logger.debug(f"Docker executor configuration: cpu_shares={self.cpu_shares}, mem_limit={self.mem_limit}, "
                     f"nano_cpus={self.nano_cpus}, exec_timeout={self.exec_timeout}s, "
@@ -132,8 +139,6 @@ class DockerExecutor(CodeExecutorBase):
 
         # Start the pool monitor
         self._start_pool_monitor()
-
-        self.tracer = trace.get_tracer(__name__)
 
         atexit.register(self.cleanup)
 

--- a/apps/opik-python-backend/src/opik_backend/executor_docker.py
+++ b/apps/opik-python-backend/src/opik_backend/executor_docker.py
@@ -21,6 +21,7 @@ from opik_backend.executor import (
     DEFAULT_CPU_SHARES,
     DEFAULT_MEM_LIMIT,
     DEFAULT_CPU_LIMIT,
+    EXEC_TIMEOUT_ERROR,
     SATURATED_ERROR,
     SHUTDOWN_ERROR,
 )
@@ -122,11 +123,9 @@ class DockerExecutor(CodeExecutorBase):
 
         self.stop_event = Event()
 
-        # Initialize the tracer before pre-warm and the pool monitor — both
-        # paths call create_container, which opens a span on self.tracer.
-        # Setting it later left pre-warm raising AttributeError silently
-        # (futures swallowed the exception), so the pool started empty and
-        # only refilled on the next scheduler tick.
+        # Initialize the tracer before pre-warm and the pool monitor —
+        # create_container opens a span on self.tracer, so it must exist
+        # before any code path that creates containers runs.
         self.tracer = trace.get_tracer(__name__)
 
         # Log container configuration for debugging
@@ -394,10 +393,9 @@ class DockerExecutor(CodeExecutorBase):
             try:
                 container = self.container_pool.get(timeout=self.pool_acquire_timeout)
             except Empty as e:
-                # Detailed diagnostic stays in the log; the exception
-                # carries the wire-facing constant so internal config
-                # (pool_acquire_timeout) can't leak to a downstream
-                # `str(exc)`.
+                # Detailed diagnostic stays in the log; the exception uses
+                # the wire-facing constant so internal config doesn't leak
+                # to downstream `str(exc)` consumers.
                 logger.warning(
                     f"Container pool exhausted: no container available within "
                     f"{self.pool_acquire_timeout:.3f}s"
@@ -493,7 +491,7 @@ class DockerExecutor(CodeExecutorBase):
                 span.set_status(Status(StatusCode.ERROR, "Execution timed out"))
                 span.set_attribute("error.type", "timeout")
                 span.set_attribute("error.timeout_seconds", self.exec_timeout)
-                return {"code": 504, "error": "Server processing exceeded timeout limit."}
+                return {"code": 504, "error": EXEC_TIMEOUT_ERROR}
             except Exception as e:
                 self._record_execution_outcome("error", payload_type)
                 span.record_exception(e)

--- a/apps/opik-python-backend/src/opik_backend/executor_process.py
+++ b/apps/opik-python-backend/src/opik_backend/executor_process.py
@@ -16,6 +16,7 @@ from opentelemetry import metrics
 
 from opik_backend.executor import (
     CodeExecutorBase,
+    EXEC_TIMEOUT_ERROR,
     SATURATED_ERROR,
     SHUTDOWN_ERROR,
 )
@@ -255,12 +256,10 @@ class ProcessExecutor(CodeExecutorBase):
 
         Single-pass: one queue read and one liveness check. Raises
         :class:`TimeoutError` on saturation, executor shutdown, or when the
-        retrieved worker is dead. Holding the request thread on the
-        SIGTERM/SIGKILL handshake of a stale worker was the latent thread-
-        pinning hazard OPIK-6308 set out to remove, so dead-worker cleanup
-        is dispatched asynchronously and the caller is asked to retry via
-        the same 503 path as saturation. ``run_scoring`` translates this
-        into HTTP 503.
+        retrieved worker is dead. Dead-worker cleanup is dispatched
+        asynchronously so the request thread isn't held on the
+        SIGTERM/SIGKILL handshake; the caller retries via the same 503
+        path as saturation. ``run_scoring`` translates this into HTTP 503.
         """
         if self.stop_event.is_set():
             raise TimeoutError(SHUTDOWN_ERROR)
@@ -268,9 +267,9 @@ class ProcessExecutor(CodeExecutorBase):
         try:
             worker = self.process_pool.get(timeout=self.pool_acquire_timeout)
         except Empty as e:
-            # Detailed diagnostic stays in the log; the exception carries
-            # the wire-facing constant so internal config (timeout,
-            # max_parallel) can't leak to a downstream `str(exc)`.
+            # Detailed diagnostic stays in the log; the exception uses
+            # the wire-facing constant so internal config doesn't leak
+            # to downstream `str(exc)` consumers.
             logger.warning(
                 f"Process pool exhausted: no worker available within "
                 f"{self.pool_acquire_timeout:.3f}s (max_parallel={self.max_parallel})"
@@ -329,9 +328,12 @@ class ProcessExecutor(CodeExecutorBase):
                 result = connection.recv()
             else:
                 logger.error(f"Timeout waiting for result from worker {worker_id}")
-                # Terminate the worker as it's unresponsive
-                terminate_worker(worker)
-                return {"code": 500, "error": "Execution timed out"}
+                # Dispatch termination off the request thread so the
+                # SIGTERM/SIGKILL handshake doesn't block the caller.
+                self._async_terminate(worker)
+                # 504 (not 500) so Java BE's retry policy treats per-execution
+                # timeouts uniformly with the Docker executor.
+                return {"code": 504, "error": EXEC_TIMEOUT_ERROR}
 
             latency = _calculate_latency_ms(start_exec_time)
             process_execution_histogram.record(latency)
@@ -341,5 +343,7 @@ class ProcessExecutor(CodeExecutorBase):
             return result
         except Exception as e:
             logger.error(f"Error in run_scoring with worker {worker.get('id', 'unknown')}: {e}")
-            terminate_worker(worker)
+            # Dispatch termination off the request thread so the
+            # SIGTERM/SIGKILL handshake doesn't block the caller.
+            self._async_terminate(worker)
             return {"code": 500, "error": f"Failed to execute code: {e}"}

--- a/apps/opik-python-backend/src/opik_backend/executor_process.py
+++ b/apps/opik-python-backend/src/opik_backend/executor_process.py
@@ -253,34 +253,53 @@ class ProcessExecutor(CodeExecutorBase):
     def get_worker(self):
         """Acquire a worker from the pool.
 
-        Blocks up to ``pool_acquire_timeout`` seconds and raises
-        :class:`TimeoutError` if no worker becomes available, or if the
-        executor is shutting down. ``run_scoring`` translates this into HTTP
-        503 so callers can retry with backoff.
+        Single-pass: one queue read and one liveness check. Raises
+        :class:`TimeoutError` on saturation, executor shutdown, or when the
+        retrieved worker is dead. Holding the request thread on the
+        SIGTERM/SIGKILL handshake of a stale worker was the latent thread-
+        pinning hazard OPIK-6308 set out to remove, so dead-worker cleanup
+        is dispatched asynchronously and the caller is asked to retry via
+        the same 503 path as saturation. ``run_scoring`` translates this
+        into HTTP 503.
         """
         if self.stop_event.is_set():
-            raise TimeoutError("Executor is shutting down, no workers available")
+            raise TimeoutError(SHUTDOWN_ERROR)
         self._update_pool_size_metric()
         try:
             worker = self.process_pool.get(timeout=self.pool_acquire_timeout)
         except Empty as e:
-            message = (
+            # Detailed diagnostic stays in the log; the exception carries
+            # the wire-facing constant so internal config (timeout,
+            # max_parallel) can't leak to a downstream `str(exc)`.
+            logger.warning(
                 f"Process pool exhausted: no worker available within "
                 f"{self.pool_acquire_timeout:.3f}s (max_parallel={self.max_parallel})"
             )
-            logger.warning(message)
             # Refresh the gauge so the saturation event reports the
             # zero-available state, not the pre-call value.
             self._update_pool_size_metric()
-            raise TimeoutError(message) from e
+            raise TimeoutError(SATURATED_ERROR) from e
         self._update_pool_size_metric()
         if not worker['process'].is_alive():
-            logger.warning(f"Got a dead worker {worker['id']} from pool. Terminating and retrying.")
-            terminate_worker(worker)
-            # Bounded recursion: each retry drops one dead worker from the pool.
-            # A non-zero pool_acquire_timeout will compound across retries.
-            return self.get_worker()
+            logger.warning(
+                f"Dead worker {worker['id']} retrieved from pool; "
+                f"terminating asynchronously and surfacing as saturation"
+            )
+            self._async_terminate(worker)
+            raise TimeoutError(SATURATED_ERROR)
         return worker
+
+    def _async_terminate(self, worker):
+        """Schedule worker termination off the request thread.
+
+        Falls back to inline termination when the releaser pool isn't up —
+        ``start_services`` hasn't run, e.g. in test fixtures or pre-init —
+        where the request thread isn't on the line and inline is fine.
+        """
+        if self.releaser_executor is not None:
+            self.releaser_executor.submit(terminate_worker, worker)
+        else:
+            terminate_worker(worker)
 
     def run_scoring(self, code: str, data: dict, payload_type: Optional[str] = None) -> dict:
         if self.stop_event.is_set():

--- a/apps/opik-python-backend/src/opik_backend/executor_process.py
+++ b/apps/opik-python-backend/src/opik_backend/executor_process.py
@@ -288,6 +288,13 @@ class ProcessExecutor(CodeExecutorBase):
         try:
             worker = self.get_worker()
         except TimeoutError:
+            # Re-check stop_event: a SIGTERM/SIGINT during the bounded
+            # Queue.get races into the TimeoutError branch, in which case
+            # the failure is really shutdown, not pool saturation. Report
+            # it as the former so monitoring doesn't false-positive on
+            # saturation.
+            if self.stop_event.is_set():
+                return {"code": 503, "error": SHUTDOWN_ERROR}
             return {"code": 503, "error": SATURATED_ERROR}
         try:
             worker_id = worker.get('id', 'unknown')

--- a/apps/opik-python-backend/src/opik_backend/executor_process.py
+++ b/apps/opik-python-backend/src/opik_backend/executor_process.py
@@ -14,7 +14,11 @@ from typing import Optional
 
 from opentelemetry import metrics
 
-from opik_backend.executor import CodeExecutorBase
+from opik_backend.executor import (
+    CodeExecutorBase,
+    SATURATED_ERROR,
+    SHUTDOWN_ERROR,
+)
 from opik_backend import process_worker
 
 logger = logging.getLogger(__name__)
@@ -228,6 +232,7 @@ class ProcessExecutor(CodeExecutorBase):
 
             worker = {'id': worker_id, 'process': process, 'connection': parent_conn}
             self.process_pool.put(worker)
+            self._update_pool_size_metric()
             latency = _calculate_latency_ms(start_time)
             process_creation_histogram.record(latency)
             logger.info(f"Created worker {worker_id} (PID: {process.pid}) in {latency:.3f}ms.")
@@ -242,26 +247,49 @@ class ProcessExecutor(CodeExecutorBase):
             if child_conn:
                 child_conn.close()
 
+    def _update_pool_size_metric(self):
+        process_pool_size_gauge.set(self.process_pool.qsize())
+
     def get_worker(self):
+        """Acquire a worker from the pool.
+
+        Blocks up to ``pool_acquire_timeout`` seconds and raises
+        :class:`TimeoutError` if no worker becomes available, or if the
+        executor is shutting down. ``run_scoring`` translates this into HTTP
+        503 so callers can retry with backoff.
+        """
         if self.stop_event.is_set():
-            raise RuntimeError("Executor is shutting down")
+            raise TimeoutError("Executor is shutting down, no workers available")
+        self._update_pool_size_metric()
         try:
-            worker = self.process_pool.get(timeout=self.exec_timeout)
-            if not worker['process'].is_alive():
-                logger.warning(f"Got a dead worker {worker['id']} from pool. Terminating and retrying.")
-                terminate_worker(worker)
-                return self.get_worker()  # Retry
-            return worker
-        except Empty:
-            logger.error("Timeout getting a worker from the pool.")
-            raise RuntimeError("No available workers in the pool.")
+            worker = self.process_pool.get(timeout=self.pool_acquire_timeout)
+        except Empty as e:
+            message = (
+                f"Process pool exhausted: no worker available within "
+                f"{self.pool_acquire_timeout:.3f}s (max_parallel={self.max_parallel})"
+            )
+            logger.warning(message)
+            # Refresh the gauge so the saturation event reports the
+            # zero-available state, not the pre-call value.
+            self._update_pool_size_metric()
+            raise TimeoutError(message) from e
+        self._update_pool_size_metric()
+        if not worker['process'].is_alive():
+            logger.warning(f"Got a dead worker {worker['id']} from pool. Terminating and retrying.")
+            terminate_worker(worker)
+            # Bounded recursion: each retry drops one dead worker from the pool.
+            # A non-zero pool_acquire_timeout will compound across retries.
+            return self.get_worker()
+        return worker
 
     def run_scoring(self, code: str, data: dict, payload_type: Optional[str] = None) -> dict:
         if self.stop_event.is_set():
-            return {"code": 503, "error": "Service is shutting down"}
-        worker = None
+            return {"code": 503, "error": SHUTDOWN_ERROR}
         try:
             worker = self.get_worker()
+        except TimeoutError:
+            return {"code": 503, "error": SATURATED_ERROR}
+        try:
             worker_id = worker.get('id', 'unknown')
             connection = worker.get('connection')
             if not connection:
@@ -283,9 +311,9 @@ class ProcessExecutor(CodeExecutorBase):
             process_execution_histogram.record(latency)
 
             self.process_pool.put(worker)  # Return worker to pool
+            self._update_pool_size_metric()
             return result
         except Exception as e:
-            logger.error(f"Error in run_scoring with worker {worker.get('id') if worker else 'N/A'}: {e}")
-            if worker:
-                terminate_worker(worker)  # Terminate failed worker
+            logger.error(f"Error in run_scoring with worker {worker.get('id', 'unknown')}: {e}")
+            terminate_worker(worker)
             return {"code": 500, "error": f"Failed to execute code: {e}"}

--- a/apps/opik-python-backend/tests/test_executor_docker_saturation.py
+++ b/apps/opik-python-backend/tests/test_executor_docker_saturation.py
@@ -98,6 +98,23 @@ def test_run_scoring_returns_shutdown_body_when_stopping(empty_pool_executor):
     assert response["error"] != SATURATED_ERROR
 
 
+def test_run_scoring_returns_shutdown_body_when_stop_event_wins_race(empty_pool_executor):
+    """If stop_event fires between get_container's pre-check and the bounded
+    Queue.get, the resulting TimeoutError should surface as shutdown, not as
+    pool saturation — and must not tick the saturated outcome counter."""
+
+    def stop_then_raise():
+        empty_pool_executor.stop_event.set()
+        raise TimeoutError("Container pool exhausted: simulated race")
+
+    with patch.object(empty_pool_executor, "get_container", side_effect=stop_then_raise):
+        with patch.object(empty_pool_executor, "_record_execution_outcome") as record:
+            response = empty_pool_executor.run_scoring(code="<unused>", data=DATA)
+
+    assert response == {"code": 503, "error": SHUTDOWN_ERROR}
+    assert all(call.args[0] != "saturated" for call in record.call_args_list)
+
+
 @pytest.mark.parametrize("payload_type", [None, "trace", "trace_thread"])
 def test_run_scoring_records_saturated_outcome(empty_pool_executor, payload_type):
     with patch.object(empty_pool_executor, "_record_execution_outcome") as record:

--- a/apps/opik-python-backend/tests/test_executor_docker_saturation.py
+++ b/apps/opik-python-backend/tests/test_executor_docker_saturation.py
@@ -13,6 +13,7 @@ monitor scheduler is stubbed, and ``_pre_warm_container_pool`` is patched
 out so no real containers are created.
 """
 import logging
+from queue import Empty
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -46,8 +47,8 @@ def empty_pool_executor():
 def test_tracer_is_initialized_before_pre_warm():
     """Pre-warm reads ``self.tracer`` to open a span on ``create_container``;
     if the tracer is initialized after pre-warm the pool silently starts
-    empty (CI regression caught in 12155a833). Lock the ordering directly
-    so the regression surfaces locally instead of only in real-Docker CI."""
+    empty. Lock the ordering directly so the regression surfaces without
+    needing a real Docker daemon."""
     tracer_visible_in_pre_warm = []
 
     def capture(self):
@@ -77,6 +78,16 @@ def test_get_container_raises_timeout_error(empty_pool_executor, set_stop_event,
         empty_pool_executor.get_container()
 
     assert str(excinfo.value) == expected_message
+
+
+def test_get_container_preserves_empty_cause_on_saturation(empty_pool_executor):
+    """``raise TimeoutError(...) from e`` keeps the underlying
+    :class:`queue.Empty` as ``__cause__`` so tracebacks still link the
+    saturation TimeoutError to its originating queue event for debugging."""
+    with pytest.raises(TimeoutError) as excinfo:
+        empty_pool_executor.get_container()
+
+    assert isinstance(excinfo.value.__cause__, Empty)
 
 
 def test_get_container_logs_warning_on_saturation(empty_pool_executor, caplog):

--- a/apps/opik-python-backend/tests/test_executor_docker_saturation.py
+++ b/apps/opik-python-backend/tests/test_executor_docker_saturation.py
@@ -43,16 +43,40 @@ def empty_pool_executor():
         executor.stop_event.set()
 
 
-@pytest.mark.parametrize("set_stop_event, expected_match", [
-    pytest.param(False, "pool exhausted", id="empty_pool"),
-    pytest.param(True,  "shutting down",  id="shutdown"),
+def test_tracer_is_initialized_before_pre_warm():
+    """Pre-warm reads ``self.tracer`` to open a span on ``create_container``;
+    if the tracer is initialized after pre-warm the pool silently starts
+    empty (CI regression caught in 12155a833). Lock the ordering directly
+    so the regression surfaces locally instead of only in real-Docker CI."""
+    tracer_visible_in_pre_warm = []
+
+    def capture(self):
+        tracer_visible_in_pre_warm.append(hasattr(self, "tracer"))
+
+    with (
+        patch("opik_backend.executor_docker.docker.from_env", return_value=MagicMock()),
+        patch.object(DockerExecutor, "_pre_warm_container_pool", capture),
+        patch.object(DockerExecutor, "_start_pool_monitor"),
+    ):
+        DockerExecutor()
+
+    assert tracer_visible_in_pre_warm == [True]
+
+
+@pytest.mark.parametrize("set_stop_event, expected_message", [
+    pytest.param(False, SATURATED_ERROR, id="empty_pool"),
+    pytest.param(True,  SHUTDOWN_ERROR,  id="shutdown"),
 ])
-def test_get_container_raises_timeout_error(empty_pool_executor, set_stop_event, expected_match):
+def test_get_container_raises_timeout_error(empty_pool_executor, set_stop_event, expected_message):
+    """The exception text is one of the two wire-facing constants; internal
+    config (pool_acquire_timeout) stays in the log only."""
     if set_stop_event:
         empty_pool_executor.stop_event.set()
 
-    with pytest.raises(TimeoutError, match=expected_match):
+    with pytest.raises(TimeoutError) as excinfo:
         empty_pool_executor.get_container()
+
+    assert str(excinfo.value) == expected_message
 
 
 def test_get_container_logs_warning_on_saturation(empty_pool_executor, caplog):

--- a/apps/opik-python-backend/tests/test_executor_docker_saturation.py
+++ b/apps/opik-python-backend/tests/test_executor_docker_saturation.py
@@ -1,0 +1,120 @@
+"""Saturation/backpressure behavior of DockerExecutor.
+
+Covers the public contract:
+- pool acquisition fails fast and surfaces as HTTP 503 with the shared
+  ``SATURATED_ERROR`` body
+- ``get_container`` raises stdlib :class:`TimeoutError` on saturation and on
+  executor shutdown
+- the saturation outcome is recorded via the existing
+  ``execution_outcome_counter`` metric
+
+The Docker daemon is not required: ``docker.from_env`` is mocked, the pool
+monitor scheduler is stubbed, and ``_pre_warm_container_pool`` is patched
+out so no real containers are created.
+"""
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from opik_backend import create_app
+from opik_backend.executor import SATURATED_ERROR, SHUTDOWN_ERROR
+from opik_backend.executor_docker import DockerExecutor
+
+EVALUATORS_URL = "/v1/private/evaluators/python"
+DATA = {"output": "x", "reference": "x"}
+
+
+@pytest.fixture
+def empty_pool_executor():
+    """DockerExecutor whose container_pool is empty, with the Docker daemon mocked.
+
+    Only the saturation surface (``get_container`` + ``run_scoring``) is exercised,
+    so the Docker client, pool pre-warming, and pool-monitor scheduler are stubbed.
+    The in-memory ``container_pool`` queue is left empty to simulate saturation.
+    """
+    with (
+        patch("opik_backend.executor_docker.docker.from_env", return_value=MagicMock()),
+        patch("opik_backend.executor_docker.DockerExecutor._pre_warm_container_pool"),
+        patch("opik_backend.executor_docker.DockerExecutor._start_pool_monitor"),
+    ):
+        executor = DockerExecutor()
+        yield executor
+        executor.stop_event.set()
+
+
+@pytest.mark.parametrize("set_stop_event, expected_match", [
+    pytest.param(False, "pool exhausted", id="empty_pool"),
+    pytest.param(True,  "shutting down",  id="shutdown"),
+])
+def test_get_container_raises_timeout_error(empty_pool_executor, set_stop_event, expected_match):
+    if set_stop_event:
+        empty_pool_executor.stop_event.set()
+
+    with pytest.raises(TimeoutError, match=expected_match):
+        empty_pool_executor.get_container()
+
+
+def test_get_container_logs_warning_on_saturation(empty_pool_executor, caplog):
+    """Saturation is the third leg of the observability triangle (gauge,
+    counter, log). Without the WARNING, ops loses the real-time signal."""
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(TimeoutError):
+            empty_pool_executor.get_container()
+
+    assert any(
+        "pool exhausted" in r.message
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    )
+
+
+def test_get_container_refreshes_gauge_on_saturation(empty_pool_executor):
+    """The Empty branch refreshes the pool-size gauge so the saturation event
+    reports the zero-available state instead of the pre-call snapshot."""
+    with patch.object(empty_pool_executor, "_update_container_pool_size_metric") as update:
+        with pytest.raises(TimeoutError):
+            empty_pool_executor.get_container()
+
+    # Pre-call update + Empty-branch update; dropping the latter regresses
+    # to a single call and would silently leave the gauge stale on saturation.
+    assert update.call_count == 2
+
+
+def test_run_scoring_returns_503_with_pool_saturated_message(empty_pool_executor):
+    response = empty_pool_executor.run_scoring(code="<unused>", data=DATA)
+
+    assert response == {"code": 503, "error": SATURATED_ERROR}
+
+
+def test_run_scoring_returns_shutdown_body_when_stopping(empty_pool_executor):
+    """503 on shutdown uses a distinct body from the saturation body so the
+    two paths remain diagnosable in monitoring."""
+    empty_pool_executor.stop_event.set()
+
+    response = empty_pool_executor.run_scoring(code="<unused>", data=DATA)
+
+    assert response == {"code": 503, "error": SHUTDOWN_ERROR}
+    assert response["error"] != SATURATED_ERROR
+
+
+@pytest.mark.parametrize("payload_type", [None, "trace", "trace_thread"])
+def test_run_scoring_records_saturated_outcome(empty_pool_executor, payload_type):
+    with patch.object(empty_pool_executor, "_record_execution_outcome") as record:
+        empty_pool_executor.run_scoring(code="<unused>", data=DATA, payload_type=payload_type)
+
+    record.assert_any_call("saturated", payload_type)
+
+
+def test_route_returns_503_when_pool_saturated(empty_pool_executor):
+    app = create_app(should_init_executor=False)
+    app.executor = empty_pool_executor
+    client = app.test_client()
+
+    response = client.post(
+        EVALUATORS_URL,
+        json={"code": "<unused>", "data": DATA},
+    )
+
+    assert response.status_code == 503
+    assert SATURATED_ERROR in response.json["error"]

--- a/apps/opik-python-backend/tests/test_executor_process_saturation.py
+++ b/apps/opik-python-backend/tests/test_executor_process_saturation.py
@@ -90,6 +90,21 @@ def test_run_scoring_returns_shutdown_body_when_stopping(empty_pool_executor):
     assert response["error"] != SATURATED_ERROR
 
 
+def test_run_scoring_returns_shutdown_body_when_stop_event_wins_race(empty_pool_executor):
+    """If a SIGTERM/SIGINT fires during the bounded Queue.get inside
+    get_worker, the resulting TimeoutError should surface as shutdown, not
+    as pool saturation."""
+
+    def stop_then_raise():
+        empty_pool_executor.stop_event.set()
+        raise TimeoutError("Process pool exhausted: simulated race")
+
+    with patch.object(empty_pool_executor, "get_worker", side_effect=stop_then_raise):
+        response = empty_pool_executor.run_scoring(code="<unused>", data=DATA)
+
+    assert response == {"code": 503, "error": SHUTDOWN_ERROR}
+
+
 @pytest.mark.parametrize("raw, expected", [
     ("0",    0.0),
     ("0.25", 0.25),

--- a/apps/opik-python-backend/tests/test_executor_process_saturation.py
+++ b/apps/opik-python-backend/tests/test_executor_process_saturation.py
@@ -10,6 +10,7 @@ Covers the public contract:
 - the Flask route translates saturation to HTTP 503
 """
 import logging
+from queue import Empty
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,6 +18,7 @@ import pytest
 from opik_backend import create_app
 from opik_backend.executor import (
     CodeExecutorBase,
+    EXEC_TIMEOUT_ERROR,
     POOL_ACQUIRE_TIMEOUT_ENV_VAR,
     SATURATED_ERROR,
     SHUTDOWN_ERROR,
@@ -54,6 +56,16 @@ def test_get_worker_raises_timeout_error(empty_pool_executor, set_stop_event, ex
         empty_pool_executor.get_worker()
 
     assert str(excinfo.value) == expected_message
+
+
+def test_get_worker_preserves_empty_cause_on_saturation(empty_pool_executor):
+    """``raise TimeoutError(...) from e`` keeps the underlying
+    :class:`queue.Empty` as ``__cause__`` so tracebacks still link the
+    saturation TimeoutError to its originating queue event for debugging."""
+    with pytest.raises(TimeoutError) as excinfo:
+        empty_pool_executor.get_worker()
+
+    assert isinstance(excinfo.value.__cause__, Empty)
 
 
 def test_get_worker_logs_warning_on_saturation(empty_pool_executor, caplog):
@@ -113,7 +125,7 @@ def test_run_scoring_returns_503_when_pool_yields_dead_worker(empty_pool_executo
     """End-to-end: a dead worker collapses to the same 503 + SATURATED_ERROR
     body as real pool saturation. Body intentionally re-used — the wire
     contract is the HTTP status, the dead-worker case is distinguishable
-    via logs (and outcome counter, once M1 lands on the process side)."""
+    via logs."""
     dead_process = MagicMock()
     dead_process.is_alive.return_value = False
     dead_worker = {"id": "dead", "process": dead_process, "connection": MagicMock()}
@@ -123,6 +135,42 @@ def test_run_scoring_returns_503_when_pool_yields_dead_worker(empty_pool_executo
             response = empty_pool_executor.run_scoring(code="<unused>", data=DATA)
 
     assert response == {"code": 503, "error": SATURATED_ERROR}
+
+
+def test_run_scoring_async_terminates_on_exec_timeout(empty_pool_executor):
+    """The exec-timeout branch must terminate the unresponsive worker off
+    the request thread, and return 504 with the shared exec-timeout body
+    so Java BE's retry policy treats this uniformly with the Docker
+    executor (504 is retryable; 500 is not)."""
+    process = MagicMock()
+    process.is_alive.return_value = True
+    connection = MagicMock()
+    connection.poll.return_value = False  # exec_timeout elapses with no result
+    worker = {"id": "w-timeout", "process": process, "connection": connection}
+
+    with patch.object(empty_pool_executor, "get_worker", return_value=worker):
+        with patch.object(empty_pool_executor, "_async_terminate") as async_term:
+            response = empty_pool_executor.run_scoring(code="<unused>", data=DATA)
+
+    async_term.assert_called_once_with(worker)
+    assert response == {"code": 504, "error": EXEC_TIMEOUT_ERROR}
+
+
+def test_run_scoring_async_terminates_on_exception(empty_pool_executor):
+    """The generic exception branch must also terminate the failed worker
+    off the request thread, symmetric to the exec-timeout branch."""
+    process = MagicMock()
+    process.is_alive.return_value = True
+    # connection=None makes the inner ``if not connection: raise`` fire,
+    # which is the simplest way to land us in the generic except branch.
+    worker = {"id": "w-error", "process": process, "connection": None}
+
+    with patch.object(empty_pool_executor, "get_worker", return_value=worker):
+        with patch.object(empty_pool_executor, "_async_terminate") as async_term:
+            response = empty_pool_executor.run_scoring(code="<unused>", data=DATA)
+
+    async_term.assert_called_once_with(worker)
+    assert response["code"] == 500
 
 
 def test_async_terminate_dispatches_via_releaser_executor_when_available(empty_pool_executor):

--- a/apps/opik-python-backend/tests/test_executor_process_saturation.py
+++ b/apps/opik-python-backend/tests/test_executor_process_saturation.py
@@ -10,16 +10,21 @@ Covers the public contract:
 - the Flask route translates saturation to HTTP 503
 """
 import logging
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from opik_backend import create_app
-from opik_backend.executor import SATURATED_ERROR, SHUTDOWN_ERROR, CodeExecutorBase
+from opik_backend.executor import (
+    CodeExecutorBase,
+    POOL_ACQUIRE_TIMEOUT_ENV_VAR,
+    SATURATED_ERROR,
+    SHUTDOWN_ERROR,
+)
 from opik_backend.executor_process import ProcessExecutor
 
 EVALUATORS_URL = "/v1/private/evaluators/python"
-ENV_VAR = "PYTHON_CODE_EXECUTOR_POOL_ACQUIRE_TIMEOUT_IN_SECS"
+ENV_VAR = POOL_ACQUIRE_TIMEOUT_ENV_VAR
 DATA = {"output": "x", "reference": "x"}
 
 
@@ -35,16 +40,20 @@ def empty_pool_executor():
     yield executor
 
 
-@pytest.mark.parametrize("set_stop_event, expected_match", [
-    pytest.param(False, "pool exhausted", id="empty_pool"),
-    pytest.param(True,  "shutting down",  id="shutdown"),
+@pytest.mark.parametrize("set_stop_event, expected_message", [
+    pytest.param(False, SATURATED_ERROR, id="empty_pool"),
+    pytest.param(True,  SHUTDOWN_ERROR,  id="shutdown"),
 ])
-def test_get_worker_raises_timeout_error(empty_pool_executor, set_stop_event, expected_match):
+def test_get_worker_raises_timeout_error(empty_pool_executor, set_stop_event, expected_message):
+    """The exception text is one of the two wire-facing constants; internal
+    config (pool_acquire_timeout, max_parallel) stays in the log only."""
     if set_stop_event:
         empty_pool_executor.stop_event.set()
 
-    with pytest.raises(TimeoutError, match=expected_match):
+    with pytest.raises(TimeoutError) as excinfo:
         empty_pool_executor.get_worker()
+
+    assert str(excinfo.value) == expected_message
 
 
 def test_get_worker_logs_warning_on_saturation(empty_pool_executor, caplog):
@@ -59,6 +68,86 @@ def test_get_worker_logs_warning_on_saturation(empty_pool_executor, caplog):
         for r in caplog.records
         if r.levelno == logging.WARNING
     )
+
+
+def test_get_worker_logs_warning_on_dead_worker(empty_pool_executor, caplog):
+    """The dead-worker WARNING is the operator-facing signal that
+    distinguishes 'workers dying' from 'all workers busy' — both surface
+    as 503 + SATURATED_ERROR, only the log tells the difference."""
+    dead_process = MagicMock()
+    dead_process.is_alive.return_value = False
+    dead_worker = {"id": "dead-x", "process": dead_process, "connection": MagicMock()}
+
+    with caplog.at_level(logging.WARNING):
+        with patch.object(empty_pool_executor.process_pool, "get", return_value=dead_worker):
+            with patch.object(empty_pool_executor, "_async_terminate"):
+                with pytest.raises(TimeoutError):
+                    empty_pool_executor.get_worker()
+
+    assert any(
+        "Dead worker" in r.message and "dead-x" in r.message
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    )
+
+
+def test_get_worker_treats_dead_worker_as_saturation(empty_pool_executor):
+    """A dead worker retrieved from the pool is async-terminated and
+    surfaces as TimeoutError with the wire-facing saturation constant —
+    internal worker state stays in the log, not in anything a downstream
+    ``str(exc)`` could observe."""
+    dead_process = MagicMock()
+    dead_process.is_alive.return_value = False
+    dead_worker = {"id": "dead", "process": dead_process, "connection": MagicMock()}
+
+    with patch.object(empty_pool_executor.process_pool, "get", return_value=dead_worker):
+        with patch.object(empty_pool_executor, "_async_terminate") as async_term:
+            with pytest.raises(TimeoutError) as excinfo:
+                empty_pool_executor.get_worker()
+
+    async_term.assert_called_once_with(dead_worker)
+    assert str(excinfo.value) == SATURATED_ERROR
+
+
+def test_run_scoring_returns_503_when_pool_yields_dead_worker(empty_pool_executor):
+    """End-to-end: a dead worker collapses to the same 503 + SATURATED_ERROR
+    body as real pool saturation. Body intentionally re-used — the wire
+    contract is the HTTP status, the dead-worker case is distinguishable
+    via logs (and outcome counter, once M1 lands on the process side)."""
+    dead_process = MagicMock()
+    dead_process.is_alive.return_value = False
+    dead_worker = {"id": "dead", "process": dead_process, "connection": MagicMock()}
+
+    with patch.object(empty_pool_executor.process_pool, "get", return_value=dead_worker):
+        with patch.object(empty_pool_executor, "_async_terminate"):
+            response = empty_pool_executor.run_scoring(code="<unused>", data=DATA)
+
+    assert response == {"code": 503, "error": SATURATED_ERROR}
+
+
+def test_async_terminate_dispatches_via_releaser_executor_when_available(empty_pool_executor):
+    """When start_services has wired up the releaser pool, termination must
+    happen off the request thread."""
+    worker = {"id": "any", "process": MagicMock(), "connection": MagicMock()}
+    fake_releaser = MagicMock()
+    empty_pool_executor.releaser_executor = fake_releaser
+
+    from opik_backend.executor_process import terminate_worker
+    empty_pool_executor._async_terminate(worker)
+
+    fake_releaser.submit.assert_called_once_with(terminate_worker, worker)
+
+
+def test_async_terminate_falls_back_to_inline_when_releaser_unavailable(empty_pool_executor):
+    """Without a releaser pool (pre-start_services / tests), termination
+    runs inline — acceptable since no request thread is on the line."""
+    worker = {"id": "any", "process": MagicMock(), "connection": MagicMock()}
+    assert empty_pool_executor.releaser_executor is None
+
+    with patch("opik_backend.executor_process.terminate_worker") as terminate:
+        empty_pool_executor._async_terminate(worker)
+
+    terminate.assert_called_once_with(worker)
 
 
 def test_get_worker_refreshes_gauge_on_saturation(empty_pool_executor):

--- a/apps/opik-python-backend/tests/test_executor_process_saturation.py
+++ b/apps/opik-python-backend/tests/test_executor_process_saturation.py
@@ -1,0 +1,142 @@
+"""Saturation/backpressure behavior of ProcessExecutor.
+
+Covers the public contract:
+- pool acquisition fails fast and surfaces as HTTP 503 with the shared
+  ``SATURATED_ERROR`` body
+- ``get_worker`` raises stdlib :class:`TimeoutError` on saturation and on
+  executor shutdown
+- the acquire timeout is configurable via env var and falls back to 0
+  for any invalid input
+- the Flask route translates saturation to HTTP 503
+"""
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from opik_backend import create_app
+from opik_backend.executor import SATURATED_ERROR, SHUTDOWN_ERROR, CodeExecutorBase
+from opik_backend.executor_process import ProcessExecutor
+
+EVALUATORS_URL = "/v1/private/evaluators/python"
+ENV_VAR = "PYTHON_CODE_EXECUTOR_POOL_ACQUIRE_TIMEOUT_IN_SECS"
+DATA = {"output": "x", "reference": "x"}
+
+
+@pytest.fixture
+def empty_pool_executor():
+    """ProcessExecutor with an empty process_pool and no started services.
+
+    ``start_services()`` is intentionally not called: the saturation path lives
+    entirely in the in-memory pool, so we exercise it without spinning up real
+    subprocesses.
+    """
+    executor = ProcessExecutor()
+    yield executor
+
+
+@pytest.mark.parametrize("set_stop_event, expected_match", [
+    pytest.param(False, "pool exhausted", id="empty_pool"),
+    pytest.param(True,  "shutting down",  id="shutdown"),
+])
+def test_get_worker_raises_timeout_error(empty_pool_executor, set_stop_event, expected_match):
+    if set_stop_event:
+        empty_pool_executor.stop_event.set()
+
+    with pytest.raises(TimeoutError, match=expected_match):
+        empty_pool_executor.get_worker()
+
+
+def test_get_worker_logs_warning_on_saturation(empty_pool_executor, caplog):
+    """Saturation is the third leg of the observability triangle (gauge,
+    counter, log). Without the WARNING, ops loses the real-time signal."""
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(TimeoutError):
+            empty_pool_executor.get_worker()
+
+    assert any(
+        "pool exhausted" in r.message
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    )
+
+
+def test_get_worker_refreshes_gauge_on_saturation(empty_pool_executor):
+    """The Empty branch refreshes the pool-size gauge so the saturation event
+    reports the zero-available state instead of the pre-call snapshot."""
+    with patch.object(empty_pool_executor, "_update_pool_size_metric") as update:
+        with pytest.raises(TimeoutError):
+            empty_pool_executor.get_worker()
+
+    # Pre-call update + Empty-branch update; dropping the latter regresses
+    # to a single call and would silently leave the gauge stale on saturation.
+    assert update.call_count == 2
+
+
+def test_run_scoring_returns_503_with_pool_saturated_message(empty_pool_executor):
+    response = empty_pool_executor.run_scoring(code="<unused>", data=DATA)
+
+    assert response == {"code": 503, "error": SATURATED_ERROR}
+
+
+def test_run_scoring_returns_shutdown_body_when_stopping(empty_pool_executor):
+    """503 on shutdown uses a distinct body from the saturation body so the
+    two paths remain diagnosable in monitoring."""
+    empty_pool_executor.stop_event.set()
+
+    response = empty_pool_executor.run_scoring(code="<unused>", data=DATA)
+
+    assert response == {"code": 503, "error": SHUTDOWN_ERROR}
+    assert response["error"] != SATURATED_ERROR
+
+
+@pytest.mark.parametrize("raw, expected", [
+    ("0",    0.0),
+    ("0.25", 0.25),
+    ("1",    1.0),
+    ("5",    5.0),
+])
+def test_parse_pool_acquire_timeout_accepts_finite_non_negative(monkeypatch, raw, expected):
+    monkeypatch.setenv(ENV_VAR, raw)
+
+    assert CodeExecutorBase._parse_pool_acquire_timeout() == expected
+
+
+@pytest.mark.parametrize("raw", [
+    "not-a-number", "",        # non-numeric
+    "-1", "-0.5",              # negative
+    "inf", "-inf", "nan",      # non-finite — would re-arm the unbounded wait
+])
+def test_parse_pool_acquire_timeout_falls_back_to_zero_on_invalid(monkeypatch, raw):
+    monkeypatch.setenv(ENV_VAR, raw)
+
+    assert CodeExecutorBase._parse_pool_acquire_timeout() == 0.0
+
+
+def test_parse_pool_acquire_timeout_defaults_to_zero(monkeypatch):
+    monkeypatch.delenv(ENV_VAR, raising=False)
+
+    assert CodeExecutorBase._parse_pool_acquire_timeout() == 0.0
+
+
+def test_executor_applies_parsed_pool_acquire_timeout(monkeypatch):
+    """__init__ wires the parsed timeout onto the instance field."""
+    monkeypatch.setenv(ENV_VAR, "0.5")
+
+    executor = ProcessExecutor()
+
+    assert executor.pool_acquire_timeout == 0.5
+
+
+def test_route_returns_503_when_pool_saturated(empty_pool_executor):
+    app = create_app(should_init_executor=False)
+    app.executor = empty_pool_executor
+    client = app.test_client()
+
+    response = client.post(
+        EVALUATORS_URL,
+        json={"code": "<unused>", "data": DATA},
+    )
+
+    assert response.status_code == 503
+    assert SATURATED_ERROR in response.json["error"]


### PR DESCRIPTION
## Details

Python BE was silently absorbing pool saturation:

- `DockerExecutor.get_container` looped on `Queue.get(timeout=exec_timeout)` while the executor was running, so a burst-saturated pool kept callers parked on the socket.
- `ProcessExecutor.get_worker` blocked for `exec_timeout` (3s) and returned HTTP 500 on `Empty`. Java BE only retries on retryable 5xx codes (503/504), so 500 silently rolled up and pinned upstream threads.

Both behaviors contributed to the JVM thread starvation reported in OPIK-6308 when Online Evaluation traffic spiked. This change introduces an explicit, bounded-wait saturation contract:

- `get_container` and `get_worker` raise stdlib `TimeoutError` after at most `pool_acquire_timeout` seconds (default `0` = fail fast). `run_scoring` translates the exception to `{"code": 503, "error": SATURATED_ERROR}` so the Java BE retry-with-backoff layer drives recovery instead of threads parking on the Python BE call.
- `pool_acquire_timeout` is configurable via `PYTHON_CODE_EXECUTOR_POOL_ACQUIRE_TIMEOUT_IN_SECS`. A defensive parser falls back to `0.0` on missing / non-numeric / negative / non-finite input (including `inf`, which would silently re-arm the unbounded wait).
- The pool-size gauge is refreshed on the `Empty` branch so the saturation event reports the zero-available state instead of the pre-call snapshot. Docker additionally ticks `execution_outcome_counter` with `status="saturated"` on every saturation event.
- The shutdown 503 body is centralized behind `SHUTDOWN_ERROR` alongside `SATURATED_ERROR`, keeping the two 503 paths diagnosable in monitoring.

## Change checklist

- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6308
- Recovery PR of: https://github.com/comet-ml/opik/pull/7046
  - See old PR above to back track previous comments.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.7 (1M context)
- Scope: full implementation
- Human verification: multi-round code and test review; CI-driven verification

## Testing

New test files cover the full saturation surface on both executors:

- `apps/opik-python-backend/tests/test_executor_docker_saturation.py`
- `apps/opik-python-backend/tests/test_executor_process_saturation.py`

Coverage (parametrized where applicable):

- `get_container` / `get_worker` raise `TimeoutError` with the right diagnostic message on empty-pool and shutdown
- WARNING log is emitted on saturation (caplog assertion)
- Pool-size gauge is refreshed on the `Empty` branch
- `run_scoring` returns `{"code": 503, "error": SATURATED_ERROR}` on saturation
- `run_scoring` returns `{"code": 503, "error": SHUTDOWN_ERROR}` on shutdown, distinct from the saturation body
- `_record_execution_outcome("saturated", payload_type)` ticks on Docker for `payload_type` in `{None, "trace", "trace_thread"}`
- `_parse_pool_acquire_timeout` accepts finite non-negative values, falls back to `0.0` on invalid / negative / non-finite inputs, defaults to `0.0` when env unset
- `__init__` wires the parsed value onto the instance field
- Flask route translates saturation into an HTTP 503 with the saturation body

Local run command:

- `cd apps/opik-python-backend && pytest tests/test_executor_docker_saturation.py tests/test_executor_process_saturation.py -v`

CI will run the full Python BE test suite.

## Documentation

N/A — operational fix, no user-facing or doc-site changes. The new env var `PYTHON_CODE_EXECUTOR_POOL_ACQUIRE_TIMEOUT_IN_SECS` is documented inline in `CodeExecutorBase.__init__` (intent + trade-off) and via the runtime WARNING fallback log.