### PR TITLE
[OPIK-6950] [FE] test: add initial Ollie E2E coverage

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -460,6 +460,7 @@ const AssistantSidebar: React.FC<AssistantSidebarProps> = ({
   return (
     <iframe
       ref={setIframeRef}
+      data-testid="ollie-assistant-iframe"
       src={meta.shellUrl}
       className="size-full border-none"
       // Radix's DismissableLayer sets pointer-events:none on the body when a

--- a/tests_end_to_end/e2e/pom/ollie.page.ts
+++ b/tests_end_to_end/e2e/pom/ollie.page.ts
@@ -1,0 +1,121 @@
+import type { Page, FrameLocator, Locator } from '@playwright/test';
+import { test, expect } from '@playwright/test';
+import { loadEnvConfig } from '../config/env.config';
+
+// The chat UI lives inside a separately-deployed iframe we don't control, so
+// every locator goes through frameLocator() and matches on accessible role/name
+// or the iframe's own data hooks — no host-side data-testids are reachable.
+export class OlliePage {
+  constructor(
+    private readonly page: Page,
+    private readonly projectId: string,
+  ) {}
+
+  async goto(): Promise<void> {
+    return test.step('open the Ollie page', async () => {
+      const env = loadEnvConfig();
+      await this.page.goto(
+        `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/ollie`,
+      );
+    });
+  }
+
+  /**
+   * Wait until Ollie is fully loaded and ready to take a prompt.
+   *
+   * On a cold project the assistant pod is provisioned on demand: the host polls
+   * `/health/ready` for up to ~2 minutes while showing the "Ollie is waking up…"
+   * loader before the iframe mounts. So this waits on a generous budget for the
+   * in-iframe greeting and input, not just the iframe element.
+   */
+  async waitForReady(timeoutMs = 150_000): Promise<void> {
+    return test.step('wait for Ollie to be ready', async () => {
+      await this.iframeElement().waitFor({ state: 'visible', timeout: timeoutMs });
+      // The usable input is the surface-agnostic readiness signal: it's present
+      // once Ollie has fully loaded, regardless of whether the project is empty
+      // (onboarding greeting) or already has traces (chat greeting).
+      await expect(this.inputTextbox()).toBeVisible({ timeout: timeoutMs });
+      await expect(this.greeting()).toBeVisible({ timeout: timeoutMs });
+    });
+  }
+
+  /** Send a prompt and wait for a non-empty assistant reply to render. */
+  async sendMessageAndAwaitReply(prompt: string, timeoutMs = 90_000): Promise<string> {
+    return test.step(`ask Ollie "${prompt}"`, async () => {
+      const before = await this.messages().count();
+      await this.inputTextbox().fill(prompt);
+      await this.sendButton().click();
+
+      // The user echo and the assistant reply each mount as a [data-message-id]
+      // node. Wait for both to land (count grows by 2), then for the reply's
+      // text to be non-empty (it streams in after the bubble appears).
+      await expect
+        .poll(async () => this.messages().count(), {
+          timeout: timeoutMs,
+          intervals: [500, 1000, 2000],
+        })
+        .toBeGreaterThanOrEqual(before + 2);
+
+      const reply = this.messages().last();
+      await expect
+        .poll(async () => ((await reply.textContent()) ?? '').trim().length, {
+          timeout: timeoutMs,
+          intervals: [500, 1000, 2000],
+        })
+        .toBeGreaterThan(0);
+
+      return ((await reply.textContent()) ?? '').trim();
+    });
+  }
+
+  /** Reset to a fresh conversation (clears history back to the greeting). */
+  async startNewChat(): Promise<void> {
+    return test.step('start a new Ollie chat', async () => {
+      await this.frame().getByRole('button', { name: 'New chat' }).click();
+      await expect(this.greeting()).toBeVisible();
+    });
+  }
+
+  greeting(): Locator {
+    // "Hi there!" opens both greetings — the empty-project onboarding state
+    // ("I'm Ollie, your AI coding assistant…") and the chat state on a project
+    // that already has traces ("How can I help you today?").
+    return this.frame().getByText('Hi there!');
+  }
+
+  inputTextbox(): Locator {
+    // Ollie's own `data-chat-input-textarea` hook — stable across the page vs
+    // sidebar surfaces (whose placeholder copy differs: "Ask Ollie about your
+    // agent..." vs "Send a message..."). This attribute lives inside the
+    // ollie-assist iframe, which is a separate deploy we can't add testids to;
+    // it's the most durable selector available there.
+    return this.frame().locator('[data-chat-input-textarea]');
+  }
+
+  /** All chat message bubbles (user echoes + assistant replies), in order. */
+  messages(): Locator {
+    return this.frame().locator('[data-message-id]');
+  }
+
+  // ── private helpers ─────────────────────────────────────────────────────
+
+  // Anchor on the testid added to the host iframe in AssistantSidebar.tsx, OR
+  // on the `title="Assistant"` attribute already present on deployed builds.
+  // The `,` selector keeps the POM working against a cloud env running an older
+  // FE bundle that predates the testid, while preferring the testid once the FE
+  // change ships. Both resolve to the same single iframe.
+  private static readonly IFRAME_SELECTOR =
+    '[data-testid="ollie-assistant-iframe"], iframe[title="Assistant"]';
+
+  private iframeElement(): Locator {
+    return this.page.locator(OlliePage.IFRAME_SELECTOR);
+  }
+
+  private frame(): FrameLocator {
+    return this.page.frameLocator(OlliePage.IFRAME_SELECTOR);
+  }
+
+  private sendButton(): Locator {
+    return this.frame().getByRole('button', { name: 'Send message' });
+  }
+}

--- a/tests_end_to_end/e2e/tests/ollie/ollie-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/ollie/ollie-smoke.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@e2e/fixtures';
+import { OlliePage } from '@e2e/pom/ollie.page';
+
+function skipIfOllieDisabled(envConfig: { features: { ollie: boolean } }): void {
+  test.skip(!envConfig.features.ollie, 'Ollie is cloud/client-only (OLLIE_ENABLED off)');
+}
+
+test.describe('Ollie — smoke', { tag: ['@t1-smoke', '@ollie'] }, () => {
+  test.beforeEach(({ envConfig }) => skipIfOllieDisabled(envConfig));
+
+  test('Ollie surface mounts and reaches a ready state', async ({ project, page }) => {
+    test.setTimeout(180_000);
+    const ollie = new OlliePage(page, project.id);
+
+    await test.step('Open Ollie and wait for it to be ready', async () => {
+      await ollie.goto();
+      await ollie.waitForReady();
+    });
+
+    await test.step('Ready state shows the greeting and a usable input', async () => {
+      await expect(ollie.greeting()).toBeVisible();
+      await expect(ollie.inputTextbox()).toBeEnabled();
+    });
+  });
+});
+
+test.describe('Ollie — completion', { tag: ['@t2-cuj', '@ollie'] }, () => {
+  test.beforeEach(({ envConfig }) => skipIfOllieDisabled(envConfig));
+
+  test('Ollie returns a completion for a basic prompt', async ({ project, page }) => {
+    test.setTimeout(240_000);
+    const ollie = new OlliePage(page, project.id);
+
+    await test.step('Open Ollie and start a fresh chat', async () => {
+      await ollie.goto();
+      await ollie.waitForReady();
+      await ollie.startNewChat();
+    });
+
+    await test.step('Send a prompt and verify a non-empty reply renders', async () => {
+      // Keep the prompt inside Ollie's domain — it is tuned to answer
+      // Opik-related questions and may decline off-topic asks (e.g. arithmetic),
+      // which would make an off-topic prompt a flaky completion signal.
+      const reply = await ollie.sendMessageAndAwaitReply(
+        'In one sentence, what is a trace in Opik?',
+      );
+      expect(reply.length).toBeGreaterThan(0);
+      // At least the user echo and the assistant reply are now in the log.
+      expect(await ollie.messages().count()).toBeGreaterThanOrEqual(2);
+    });
+  });
+});


### PR DESCRIPTION
## Details

Adds the first automated E2E coverage for the Ollie assistant in the Opik 2.0 suite (`tests_end_to_end/e2e/`), so a broken Ollie deployment is caught automatically. Ollie is cloud/client-only, so the tests gate on `envConfig.features.ollie` and skip cleanly on OSS/local.

- New Page Object `pom/ollie.page.ts` and spec `tests/ollie/ollie-smoke.spec.ts` with two tests: a `@t1-smoke` ready-state check (surface mounts, input usable) and a `@t2-cuj` basic-completion check (asks an Opik-domain question, asserts a non-empty reply).
- Ollie's chat UI lives inside a separately-deployed iframe, so it's reached via `frameLocator` with role/accessible-name and Ollie's own data hooks (`data-chat-input-textarea`, `data-message-id`); the host iframe gets a `data-testid="ollie-assistant-iframe"` as the one stable anchor this repo owns.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6950

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: full implementation (live UI exploration, POM + specs, FE testid)
  - Human verification: code review + manual test runs against Cloud staging

## Testing

Both tests run green against Cloud staging (3 consecutive runs):

```
OPIK_DEPLOYMENT=cloud OPIK_BASE_URL=https://staging.dev.comet.com/opik \
  OPIK_WORKSPACE=<ws> OPIK_API_KEY=<key> WORKERS=1 \
  npx playwright test tests/ollie/ollie-smoke.spec.ts --reporter=list
# ✓ Ollie surface mounts and reaches a ready state @t1-smoke @ollie
# ✓ Ollie returns a completion for a basic prompt @t2-cuj @ollie
# 2 passed
```

- Scenarios validated: surface mount + ready state on a fresh (empty) project; basic completion round-trip with an Opik-domain prompt. Each test seeds and tears down its own project.
- Both tests skip cleanly when `envConfig.features.ollie` is false (OSS/local), verified via `--grep` tier listing.
- FE change verified with `npm run typecheck` and `eslint` on the changed file.

## Documentation

N/A — internal test coverage; no user-facing docs change.
