### PR TITLE
[NA] [BE] Bump clickhouse-java 0.9.0 -> 0.9.8

### DIFF
--- a/apps/opik-backend/pom.xml
+++ b/apps/opik-backend/pom.xml
@@ -24,7 +24,7 @@
         <stringtemplate.version>3.53.0</stringtemplate.version>
         <jakarta.annotation.version>3.0.0</jakarta.annotation.version>
         <liquibase-clickhouse.version>0.7.2</liquibase-clickhouse.version>
-        <clickhouse-java.version>0.9.0</clickhouse-java.version>
+        <clickhouse-java.version>0.9.8</clickhouse-java.version>
         <google-protobuf.version>4.35.0</google-protobuf.version>
         <org.mapstruct.version>1.6.3</org.mapstruct.version>
         <testcontainers.version>2.0.2</testcontainers.version>
@@ -432,7 +432,7 @@
         <dependency>
             <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
-            <version>0.9.0</version>
+            <version>${clickhouse-java.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Details

Bump the `clickhouse-java` driver stack (`clickhouse-r2dbc`, `clickhouse-http-client`, `clickhouse-jdbc`) from **0.9.0** to **0.9.8** (latest on Maven Central) to pick up upstream maintenance fixes.

- Bumps the shared `clickhouse-java.version` property `0.9.0` → `0.9.8`.
- Points the test-scoped `clickhouse-jdbc` dependency at `${clickhouse-java.version}` — it was hardcoded at `0.9.0` and would otherwise drift out of sync with the other driver artifacts.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: dependency version bump in `apps/opik-backend/pom.xml` (2 lines)
- Human verification: pending reviewer; rely on CI build + tests

## Testing

Local build/tests were **not** run for this change. The bump is a same-minor (0.9.x) maintenance update and is covered by the existing CI pipeline (`mvn` build + backend integration tests against the Testcontainers ClickHouse). Please verify CI is green before merge.

## Documentation

N/A — internal dependency bump, no user-facing or API changes.