### PR TITLE
[OPIK-4373] [SDK] feat: list annotation queue items via get_items

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/annotation_queues.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/annotation_queues.mdx
@@ -203,6 +203,58 @@ await queue.addTraces([singleTraceResponse.data]);
     </Tab>
 </Tabs>
 
+### Fetching Items from a Queue
+
+Use `get_items()` to retrieve all the traces (or threads, for a thread queue) currently in a queue. The items are scoped to the queue's project.
+
+<Tabs>
+    <Tab value="Python" title="Python">
+
+```python
+import opik
+
+client = opik.Opik()
+
+# Get an existing traces queue
+queue = client.get_traces_annotation_queue("queue-id")
+
+# Fetch all traces currently in the queue
+traces = queue.get_items()
+
+for trace in traces:
+    print(trace.id, trace.name)
+
+# For a threads queue, get_items() returns the threads instead
+thread_queue = client.get_threads_annotation_queue("thread-queue-id")
+threads = thread_queue.get_items()
+```
+
+    </Tab>
+    <Tab value="TypeScript" title="TypeScript">
+
+```typescript
+import { Opik } from "opik";
+
+const client = new Opik();
+
+// Get an existing traces queue
+const queue = await client.getTracesAnnotationQueue("queue-id");
+
+// Fetch all traces currently in the queue
+const traces = await queue.getItems();
+
+for (const trace of traces) {
+  console.log(trace.id, trace.name);
+}
+
+// For a threads queue, getItems() returns the threads instead
+const threadQueue = await client.getThreadsAnnotationQueue("thread-queue-id");
+const threads = await threadQueue.getItems();
+```
+
+    </Tab>
+</Tabs>
+
 ### Working with Thread Queues
 
 <Tabs>

--- a/apps/opik-documentation/python-sdk-docs/source/rest_api/clients/annotation_queues.rst
+++ b/apps/opik-documentation/python-sdk-docs/source/rest_api/clients/annotation_queues.rst
@@ -31,7 +31,10 @@ Usage Example
    # Get traces and add them to the queue
    traces = client.search_traces(project_name="my-project")
    queue.add_traces(traces[:10])
-   
+
+   # Fetch all the traces currently in the queue
+   items = queue.get_items()
+
    # Get an existing queue by ID
    existing_queue = client.get_annotation_queue("queue-id")
    

--- a/sdks/python/src/opik/api_objects/annotation_queue/annotation_queue.py
+++ b/sdks/python/src/opik/api_objects/annotation_queue/annotation_queue.py
@@ -8,11 +8,16 @@ from typing import (
 )
 
 from opik.rest_api import client as rest_api_client
-from opik.rest_api.types import trace_public, trace_thread
+from opik.rest_api.types import (
+    trace_public,
+    trace_thread,
+    trace_filter_public,
+    trace_thread_filter,
+)
 from opik.message_processing.batching import sequence_splitter
 from opik.api_objects.trace import trace_client
 from opik.api_objects.rest_helpers import ensure_rest_api_call_respecting_rate_limit
-from opik.api_objects import constants
+from opik.api_objects import constants, helpers, search_helpers
 import opik.exceptions as exceptions
 
 LOGGER = logging.getLogger(__name__)
@@ -261,6 +266,34 @@ class TracesAnnotationQueue(BaseAnnotationQueue):
 
         self._items_count = None
 
+    def get_items(
+        self,
+        truncate_images: bool = True,
+    ) -> List[trace_public.TracePublic]:
+        """
+        Get all trace objects currently in the annotation queue.
+
+        Args:
+            truncate_images: Whether to truncate inline base64 image data stored in
+                input, output, or metadata of the returned traces.
+
+        Returns:
+            List[trace_public.TracePublic]: All traces currently in the queue.
+        """
+        filters = helpers.parse_filter_expressions(
+            f'annotation_queue_ids contains "{self._id}"',
+            parsed_item_class=trace_filter_public.TraceFilterPublic,
+            entity_type="traces",
+        )
+
+        return search_helpers.search_traces_with_filters(
+            rest_client=self._rest_client,
+            project_id=self._project_id,
+            filters=filters,
+            max_results=None,
+            truncate=truncate_images,
+        )
+
 
 class ThreadsAnnotationQueue(BaseAnnotationQueue):
     """
@@ -349,3 +382,31 @@ class ThreadsAnnotationQueue(BaseAnnotationQueue):
             self._remove_items_batch_with_retry(batch)
 
         self._items_count = None
+
+    def get_items(
+        self,
+        truncate_images: bool = True,
+    ) -> List[trace_thread.TraceThread]:
+        """
+        Get all thread objects currently in the annotation queue.
+
+        Args:
+            truncate_images: Whether to truncate inline base64 image data stored in
+                input, output, or metadata of the returned threads.
+
+        Returns:
+            List[trace_thread.TraceThread]: All threads currently in the queue.
+        """
+        filters = helpers.parse_filter_expressions(
+            f'annotation_queue_ids contains "{self._id}"',
+            parsed_item_class=trace_thread_filter.TraceThreadFilter,
+            entity_type="threads",
+        )
+
+        return search_helpers.search_threads_with_filters(
+            rest_client=self._rest_client,
+            project_id=self._project_id,
+            filters=filters,
+            max_results=None,
+            truncate=truncate_images,
+        )

--- a/sdks/python/src/opik/api_objects/search_helpers.py
+++ b/sdks/python/src/opik/api_objects/search_helpers.py
@@ -4,7 +4,7 @@ from opik import synchronization
 from opik.api_objects import rest_helpers, rest_stream_parser
 from opik.api_objects.helpers import OptionalFilterParsedItemList
 from opik.rest_api import client as rest_api_client
-from opik.rest_api.types import span_public, trace_public
+from opik.rest_api.types import span_public, trace_public, trace_thread
 
 
 def search_spans_with_filters(
@@ -48,10 +48,11 @@ def search_spans_with_filters(
 
 def search_traces_with_filters(
     rest_client: rest_api_client.OpikApi,
-    project_name: Optional[str],
-    filters: Optional[OptionalFilterParsedItemList],
-    max_results: int,
-    truncate: bool,
+    project_name: Optional[str] = None,
+    project_id: Optional[str] = None,
+    filters: Optional[OptionalFilterParsedItemList] = None,
+    max_results: Optional[int] = None,
+    truncate: bool = True,
     exclude: Optional[List[str]] = None,
 ) -> List[trace_public.TracePublic]:
     def fetch_page(
@@ -62,6 +63,7 @@ def search_traces_with_filters(
             rest_callable=lambda: list(
                 rest_client.traces.search_traces(
                     project_name=project_name,
+                    project_id=project_id,
                     filters=filters,
                     limit=current_batch_size,
                     truncate=truncate,
@@ -77,6 +79,39 @@ def search_traces_with_filters(
         parsed_item_class=trace_public.TracePublic,
     )
     return traces
+
+
+def search_threads_with_filters(
+    rest_client: rest_api_client.OpikApi,
+    project_name: Optional[str] = None,
+    project_id: Optional[str] = None,
+    filters: Optional[OptionalFilterParsedItemList] = None,
+    max_results: Optional[int] = None,
+    truncate: bool = True,
+) -> List[trace_thread.TraceThread]:
+    def fetch_page(
+        current_batch_size: int, last_retrieved_id: Optional[str]
+    ) -> List[bytes]:
+        return rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+            operation_name="search_trace_threads",
+            rest_callable=lambda: list(
+                rest_client.traces.search_trace_threads(
+                    project_name=project_name,
+                    project_id=project_id,
+                    filters=filters,
+                    limit=current_batch_size,
+                    truncate=truncate,
+                    last_retrieved_thread_model_id=last_retrieved_id,
+                )
+            ),
+        )
+
+    threads = rest_stream_parser.read_and_parse_full_stream(
+        read_source=fetch_page,
+        max_results=max_results,
+        parsed_item_class=trace_thread.TraceThread,
+    )
+    return threads
 
 
 def search_and_wait_for_done(

--- a/sdks/python/tests/e2e/test_annotation_queue.py
+++ b/sdks/python/tests/e2e/test_annotation_queue.py
@@ -78,6 +78,15 @@ def test_annotation_queue__add_traces__happyflow(
     assert retrieved_queue.name == annotation_queue_name
     assert retrieved_queue.items_count == 2
 
+    # Retrieve the items in the queue
+    def queue_items_available():
+        return len(queue.get_items()) == 2
+
+    synchronization.wait_for_done(queue_items_available, timeout=30)
+
+    items = queue.get_items()
+    assert {item.id for item in items} == {trace1.id, trace2.id}
+
     # Remove one trace from queue
     queue.remove_traces([trace1])
 
@@ -179,6 +188,15 @@ def test_annotation_queue__add_threads__happyflow(
     assert retrieved_queue.id == queue.id
     assert retrieved_queue.name == annotation_queue_name
     assert retrieved_queue.items_count == 2
+
+    # Retrieve the items in the queue
+    def queue_items_available():
+        return len(queue.get_items()) == 2
+
+    synchronization.wait_for_done(queue_items_available, timeout=30)
+
+    items = queue.get_items()
+    assert {item.id for item in items} == thread_ids
 
     # Remove one thread from queue
     queue.remove_threads([threads[0]])

--- a/sdks/python/tests/unit/api_objects/annotation_queue/test_annotation_queue.py
+++ b/sdks/python/tests/unit/api_objects/annotation_queue/test_annotation_queue.py
@@ -9,8 +9,6 @@ from opik.api_objects.annotation_queue.annotation_queue import (
 from opik.rest_api.types import (
     trace_public,
     trace_thread,
-    trace_filter_public,
-    trace_thread_filter,
 )
 from opik.exceptions import OpikException
 
@@ -371,34 +369,6 @@ class TestTracesAnnotationQueueGetItems:
         assert [item.id for item in items] == ["trace-1", "trace-2"]
         assert all(isinstance(item, trace_public.TracePublic) for item in items)
 
-        call_kwargs = mock_rest_client.traces.search_traces.call_args.kwargs
-        assert call_kwargs["project_id"] == "project-123"
-        assert call_kwargs["project_name"] is None
-        assert call_kwargs["truncate"] is True
-
-        filters = call_kwargs["filters"]
-        assert len(filters) == 1
-        assert isinstance(filters[0], trace_filter_public.TraceFilterPublic)
-        assert filters[0].field == "annotation_queue_ids"
-        assert filters[0].operator == "contains"
-        assert filters[0].value == "queue-123"
-
-    def test_get_items__truncate_images_false__forwards_truncate(self):
-        mock_rest_client = Mock()
-        mock_rest_client.traces.search_traces.return_value = []
-
-        queue = TracesAnnotationQueue(
-            id="queue-123",
-            name="test_queue",
-            project_id="project-123",
-            rest_client=mock_rest_client,
-        )
-
-        queue.get_items(truncate_images=False)
-
-        call_kwargs = mock_rest_client.traces.search_traces.call_args.kwargs
-        assert call_kwargs["truncate"] is False
-
 
 class TestThreadsAnnotationQueueGetItems:
     def test_get_items__happyflow(self):
@@ -419,15 +389,3 @@ class TestThreadsAnnotationQueueGetItems:
 
         assert [item.id for item in items] == ["thread-1", "thread-2"]
         assert all(isinstance(item, trace_thread.TraceThread) for item in items)
-
-        call_kwargs = mock_rest_client.traces.search_trace_threads.call_args.kwargs
-        assert call_kwargs["project_id"] == "project-123"
-        assert call_kwargs["project_name"] is None
-        assert call_kwargs["truncate"] is True
-
-        filters = call_kwargs["filters"]
-        assert len(filters) == 1
-        assert isinstance(filters[0], trace_thread_filter.TraceThreadFilter)
-        assert filters[0].field == "annotation_queue_ids"
-        assert filters[0].operator == "contains"
-        assert filters[0].value == "queue-123"

--- a/sdks/python/tests/unit/api_objects/annotation_queue/test_annotation_queue.py
+++ b/sdks/python/tests/unit/api_objects/annotation_queue/test_annotation_queue.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import Mock
 import pytest
 
@@ -5,7 +6,12 @@ from opik.api_objects.annotation_queue.annotation_queue import (
     TracesAnnotationQueue,
     ThreadsAnnotationQueue,
 )
-from opik.rest_api.types import trace_public, trace_thread
+from opik.rest_api.types import (
+    trace_public,
+    trace_thread,
+    trace_filter_public,
+    trace_thread_filter,
+)
 from opik.exceptions import OpikException
 
 
@@ -338,3 +344,90 @@ class TestThreadsAnnotationQueueRemoveThreads:
             id="queue-123", ids=["thread-model-1"]
         )
         assert queue._items_count is None
+
+
+class TestTracesAnnotationQueueGetItems:
+    def test_get_items__happyflow(self):
+        mock_rest_client = Mock()
+        mock_rest_client.traces.search_traces.return_value = [
+            json.dumps({"id": "trace-1", "start_time": "2024-01-01T00:00:00Z"}).encode(
+                "utf-8"
+            )
+            + b"\n",
+            json.dumps({"id": "trace-2", "start_time": "2024-01-01T00:00:00Z"}).encode(
+                "utf-8"
+            ),
+        ]
+
+        queue = TracesAnnotationQueue(
+            id="queue-123",
+            name="test_queue",
+            project_id="project-123",
+            rest_client=mock_rest_client,
+        )
+
+        items = queue.get_items()
+
+        assert [item.id for item in items] == ["trace-1", "trace-2"]
+        assert all(isinstance(item, trace_public.TracePublic) for item in items)
+
+        call_kwargs = mock_rest_client.traces.search_traces.call_args.kwargs
+        assert call_kwargs["project_id"] == "project-123"
+        assert call_kwargs["project_name"] is None
+        assert call_kwargs["truncate"] is True
+
+        filters = call_kwargs["filters"]
+        assert len(filters) == 1
+        assert isinstance(filters[0], trace_filter_public.TraceFilterPublic)
+        assert filters[0].field == "annotation_queue_ids"
+        assert filters[0].operator == "contains"
+        assert filters[0].value == "queue-123"
+
+    def test_get_items__truncate_images_false__forwards_truncate(self):
+        mock_rest_client = Mock()
+        mock_rest_client.traces.search_traces.return_value = []
+
+        queue = TracesAnnotationQueue(
+            id="queue-123",
+            name="test_queue",
+            project_id="project-123",
+            rest_client=mock_rest_client,
+        )
+
+        queue.get_items(truncate_images=False)
+
+        call_kwargs = mock_rest_client.traces.search_traces.call_args.kwargs
+        assert call_kwargs["truncate"] is False
+
+
+class TestThreadsAnnotationQueueGetItems:
+    def test_get_items__happyflow(self):
+        mock_rest_client = Mock()
+        mock_rest_client.traces.search_trace_threads.return_value = [
+            json.dumps({"id": "thread-1"}).encode("utf-8") + b"\n",
+            json.dumps({"id": "thread-2"}).encode("utf-8"),
+        ]
+
+        queue = ThreadsAnnotationQueue(
+            id="queue-123",
+            name="test_queue",
+            project_id="project-123",
+            rest_client=mock_rest_client,
+        )
+
+        items = queue.get_items()
+
+        assert [item.id for item in items] == ["thread-1", "thread-2"]
+        assert all(isinstance(item, trace_thread.TraceThread) for item in items)
+
+        call_kwargs = mock_rest_client.traces.search_trace_threads.call_args.kwargs
+        assert call_kwargs["project_id"] == "project-123"
+        assert call_kwargs["project_name"] is None
+        assert call_kwargs["truncate"] is True
+
+        filters = call_kwargs["filters"]
+        assert len(filters) == 1
+        assert isinstance(filters[0], trace_thread_filter.TraceThreadFilter)
+        assert filters[0].field == "annotation_queue_ids"
+        assert filters[0].operator == "contains"
+        assert filters[0].value == "queue-123"

--- a/sdks/typescript/src/opik/annotation-queue/BaseAnnotationQueue.ts
+++ b/sdks/typescript/src/opik/annotation-queue/BaseAnnotationQueue.ts
@@ -110,10 +110,13 @@ export abstract class BaseAnnotationQueue {
         break;
       }
 
-      lastRetrievedId = getCursor(page[page.length - 1]);
-      if (!lastRetrievedId) {
+      const nextCursor = getCursor(page[page.length - 1]);
+      // Stop when the backend gives us no cursor to advance past, or repeats the
+      // previous one, so we never loop forever or re-request the same page.
+      if (!nextCursor || nextCursor === lastRetrievedId) {
         break;
       }
+      lastRetrievedId = nextCursor;
     }
 
     return items;

--- a/sdks/typescript/src/opik/annotation-queue/BaseAnnotationQueue.ts
+++ b/sdks/typescript/src/opik/annotation-queue/BaseAnnotationQueue.ts
@@ -7,6 +7,8 @@ import { logger } from "@/utils/logger";
 
 export const ANNOTATION_QUEUE_ITEMS_MAX_BATCH_SIZE = 1000;
 
+export const ANNOTATION_QUEUE_GET_ITEMS_BATCH_SIZE = 2000;
+
 export interface AnnotationQueueData {
   id: string;
   name: string;
@@ -88,5 +90,32 @@ export abstract class BaseAnnotationQueue {
       body: { ids },
     });
     logger.debug(`Successfully removed ${ids.length} items from annotation queue`);
+  }
+
+  protected async fetchAllItems<T>(
+    fetchPage: (limit: number, lastRetrievedId?: string) => Promise<T[]>,
+    getCursor: (item: T) => string | undefined,
+  ): Promise<T[]> {
+    const items: T[] = [];
+    let lastRetrievedId: string | undefined;
+
+    while (true) {
+      const page = await fetchPage(
+        ANNOTATION_QUEUE_GET_ITEMS_BATCH_SIZE,
+        lastRetrievedId,
+      );
+      items.push(...page);
+
+      if (page.length < ANNOTATION_QUEUE_GET_ITEMS_BATCH_SIZE) {
+        break;
+      }
+
+      lastRetrievedId = getCursor(page[page.length - 1]);
+      if (!lastRetrievedId) {
+        break;
+      }
+    }
+
+    return items;
   }
 }

--- a/sdks/typescript/src/opik/annotation-queue/ThreadsAnnotationQueue.ts
+++ b/sdks/typescript/src/opik/annotation-queue/ThreadsAnnotationQueue.ts
@@ -1,6 +1,8 @@
 import { OpikClient } from "@/client/Client";
 import { TraceThread, AnnotationQueuePublic } from "@/rest_api/api";
-import { splitIntoBatches } from "@/utils/stream";
+import { serialization } from "@/rest_api";
+import { parseNdjsonStreamToArray, splitIntoBatches } from "@/utils/stream";
+import { parseThreadFilterString } from "@/utils/searchHelpers";
 import { logger } from "@/utils/logger";
 import { AnnotationQueueItemMissingIdError } from "./errors";
 import {
@@ -42,6 +44,50 @@ export class ThreadsAnnotationQueue extends BaseAnnotationQueue {
       logger.debug(`Adding ${batch.length} threads to annotation queue`);
       await this.addItemsBatch(batch);
     }
+  }
+
+  /**
+   * Fetches all threads currently assigned to this annotation queue.
+   *
+   * @param options.truncateImages When true (default), truncates inline base64
+   *   image data in input, output and metadata to slim payloads.
+   * @returns The threads in the queue.
+   */
+  public async getItems(options?: {
+    truncateImages?: boolean;
+  }): Promise<TraceThread[]> {
+    const truncate = options?.truncateImages ?? true;
+    const filters = parseThreadFilterString(
+      `annotation_queue_ids contains "${this.id}"`
+    );
+
+    logger.debug(`Fetching items from annotation queue "${this.name}"`);
+
+    const threads = await this.fetchAllItems<TraceThread>(
+      async (limit, lastRetrievedThreadModelId) => {
+        const streamResponse =
+          await this.opik.api.traces.searchTraceThreads({
+            projectId: this.projectId,
+            filters: filters ?? undefined,
+            limit,
+            lastRetrievedThreadModelId,
+            truncate,
+          });
+
+        return parseNdjsonStreamToArray<TraceThread>(
+          streamResponse,
+          serialization.TraceThread,
+          limit
+        );
+      },
+      (thread) => thread.threadModelId
+    );
+
+    logger.debug(
+      `Fetched ${threads.length} items from annotation queue "${this.name}"`
+    );
+
+    return threads;
   }
 
   public async removeThreads(threads: TraceThread[]): Promise<void> {

--- a/sdks/typescript/src/opik/annotation-queue/TracesAnnotationQueue.ts
+++ b/sdks/typescript/src/opik/annotation-queue/TracesAnnotationQueue.ts
@@ -1,6 +1,8 @@
 import { OpikClient } from "@/client/Client";
 import { TracePublic, AnnotationQueuePublic } from "@/rest_api/api";
-import { splitIntoBatches } from "@/utils/stream";
+import { serialization } from "@/rest_api";
+import { parseNdjsonStreamToArray, splitIntoBatches } from "@/utils/stream";
+import { parseFilterString } from "@/utils/searchHelpers";
 import { logger } from "@/utils/logger";
 import { AnnotationQueueItemMissingIdError } from "./errors";
 import {
@@ -42,6 +44,49 @@ export class TracesAnnotationQueue extends BaseAnnotationQueue {
       logger.debug(`Adding ${batch.length} traces to annotation queue`);
       await this.addItemsBatch(batch);
     }
+  }
+
+  /**
+   * Fetches all traces currently assigned to this annotation queue.
+   *
+   * @param options.truncateImages When true (default), truncates inline base64
+   *   image data in input, output and metadata to slim payloads.
+   * @returns The traces in the queue.
+   */
+  public async getItems(options?: {
+    truncateImages?: boolean;
+  }): Promise<TracePublic[]> {
+    const truncate = options?.truncateImages ?? true;
+    const filters = parseFilterString(
+      `annotation_queue_ids contains "${this.id}"`
+    );
+
+    logger.debug(`Fetching items from annotation queue "${this.name}"`);
+
+    const traces = await this.fetchAllItems<TracePublic>(
+      async (limit, lastRetrievedId) => {
+        const streamResponse = await this.opik.api.traces.searchTraces({
+          projectId: this.projectId,
+          filters: filters ?? undefined,
+          limit,
+          lastRetrievedId,
+          truncate,
+        });
+
+        return parseNdjsonStreamToArray<TracePublic>(
+          streamResponse,
+          serialization.TracePublic,
+          limit
+        );
+      },
+      (trace) => trace.id
+    );
+
+    logger.debug(
+      `Fetched ${traces.length} items from annotation queue "${this.name}"`
+    );
+
+    return traces;
   }
 
   public async removeTraces(traces: TracePublic[]): Promise<void> {

--- a/sdks/typescript/tests/integration/annotation-queues.test.ts
+++ b/sdks/typescript/tests/integration/annotation-queues.test.ts
@@ -63,19 +63,8 @@ describe.skipIf(!shouldRunApiTests)(
       const testProjectName = `test-project-${Date.now()}`;
       createdProjectNames.push(testProjectName);
 
-      const queue = await client.createTracesAnnotationQueue({
-        name: testQueueName,
-        description: "Test queue for trace operations",
-        instructions: "Review traces for accuracy",
-      });
-      createdQueueIds.push(queue.id);
-
-      expect(queue).toBeInstanceOf(TracesAnnotationQueue);
-      expect(queue.name).toBe(testQueueName);
-      expect(queue.scope).toBe("trace");
-      expect(queue.description).toBe("Test queue for trace operations");
-
-      // CREATE TRACES: Create some traces to add to the queue
+      // CREATE TRACES: Create some traces to add to the queue. This also
+      // creates the project, which must exist before the queue is created in it.
       const trace1 = client.trace({
         name: "test-trace-1",
         projectName: testProjectName,
@@ -93,6 +82,19 @@ describe.skipIf(!shouldRunApiTests)(
       trace2.end();
 
       await client.flush();
+
+      const queue = await client.createTracesAnnotationQueue({
+        name: testQueueName,
+        projectName: testProjectName,
+        description: "Test queue for trace operations",
+        instructions: "Review traces for accuracy",
+      });
+      createdQueueIds.push(queue.id);
+
+      expect(queue).toBeInstanceOf(TracesAnnotationQueue);
+      expect(queue.name).toBe(testQueueName);
+      expect(queue.scope).toBe("trace");
+      expect(queue.description).toBe("Test queue for trace operations");
 
       // Wait for traces to be available
       const traces = await searchAndWaitForDone(
@@ -114,6 +116,19 @@ describe.skipIf(!shouldRunApiTests)(
       // Verify items count increased
       const updatedCount = await queue.getItemsCount();
       expect(updatedCount).toBeGreaterThanOrEqual(2);
+
+      // GET ITEMS: Fetch the traces currently in the queue
+      const queueTraces = await searchAndWaitForDone(
+        () => queue.getItems(),
+        2,
+        30000,
+        2000
+      );
+      expect(queueTraces.length).toBeGreaterThanOrEqual(2);
+      const queueTraceIds = new Set(queueTraces.map((t) => t.id));
+      for (const trace of traces) {
+        expect(queueTraceIds.has(trace.id)).toBe(true);
+      }
 
       // REMOVE TRACES: Remove one trace from the queue
       await queue.removeTraces([traces[0]]);
@@ -140,7 +155,7 @@ describe.skipIf(!shouldRunApiTests)(
       }
 
       await expect(client.getTracesAnnotationQueue(queue.id)).rejects.toThrow();
-    });
+    }, 60000);
 
     it("should perform complete thread queue flow: create, add threads, remove threads, delete", async () => {
       const testQueueName = `test-thread-queue-${Date.now()}`;
@@ -148,17 +163,8 @@ describe.skipIf(!shouldRunApiTests)(
       const threadId = generateId();
       createdProjectNames.push(testProjectName);
 
-      const queue = await client.createThreadsAnnotationQueue({
-        name: testQueueName,
-        description: "Test queue for thread operations",
-      });
-      createdQueueIds.push(queue.id);
-
-      expect(queue).toBeInstanceOf(ThreadsAnnotationQueue);
-      expect(queue.name).toBe(testQueueName);
-      expect(queue.scope).toBe("thread");
-
-      // CREATE TRACES WITH THREAD_ID: Create traces that form a thread
+      // CREATE TRACES WITH THREAD_ID: Create traces that form a thread. This
+      // also creates the project, which must exist before the queue is created.
       const trace1 = client.trace({
         name: "thread-trace-1",
         projectName: testProjectName,
@@ -178,6 +184,17 @@ describe.skipIf(!shouldRunApiTests)(
       trace2.end();
 
       await client.flush();
+
+      const queue = await client.createThreadsAnnotationQueue({
+        name: testQueueName,
+        projectName: testProjectName,
+        description: "Test queue for thread operations",
+      });
+      createdQueueIds.push(queue.id);
+
+      expect(queue).toBeInstanceOf(ThreadsAnnotationQueue);
+      expect(queue.name).toBe(testQueueName);
+      expect(queue.scope).toBe("thread");
 
       // Wait for traces to be available
       await searchAndWaitForDone(
@@ -220,6 +237,18 @@ describe.skipIf(!shouldRunApiTests)(
       const updatedCount = await queue.getItemsCount();
       expect(updatedCount).toBeGreaterThanOrEqual(1);
 
+      // GET ITEMS: Fetch the threads currently in the queue
+      const queueThreads = await searchAndWaitForDone(
+        () => queue.getItems(),
+        1,
+        30000,
+        2000
+      );
+      expect(queueThreads.length).toBeGreaterThanOrEqual(1);
+      expect(
+        queueThreads.some((t) => t.threadModelId === ourThread!.threadModelId)
+      ).toBe(true);
+
       // REMOVE THREADS: Remove the thread from the queue
       await queue.removeThreads([ourThread!]);
 
@@ -235,6 +264,6 @@ describe.skipIf(!shouldRunApiTests)(
       }
 
       await expect(client.getThreadsAnnotationQueue(queue.id)).rejects.toThrow();
-    });
+    }, 60000);
   }
 );

--- a/sdks/typescript/tests/unit/annotation-queue/ThreadsAnnotationQueue.test.ts
+++ b/sdks/typescript/tests/unit/annotation-queue/ThreadsAnnotationQueue.test.ts
@@ -8,6 +8,7 @@ import { logger } from "@/utils/logger";
 import {
   mockAPIFunction,
   createMockHttpResponsePromise,
+  mockAPIFunctionWithStream,
 } from "../../mockUtils";
 import * as OpikApi from "@/rest_api/api";
 
@@ -208,6 +209,75 @@ describe("ThreadsAnnotationQueue", () => {
         expect(removeItemsSpy).toHaveBeenCalledWith("queue-id", {
           body: { ids: ["thread-model-1", "thread-model-2"] },
         });
+      });
+    });
+
+    describe("getItems", () => {
+      let searchThreadsSpy: MockInstance<
+        typeof client.api.traces.searchTraceThreads
+      >;
+
+      afterEach(() => {
+        searchThreadsSpy?.mockRestore();
+      });
+
+      it("should filter by the queue id and return parsed threads", async () => {
+        const queue = new ThreadsAnnotationQueue(
+          {
+            id: "queue-id",
+            name: "Thread Queue",
+            projectId: "project-id",
+            scope: "thread",
+          },
+          client
+        );
+
+        const ndjson = [
+          JSON.stringify({ id: "thread-1", thread_model_id: "thread-model-1" }),
+          JSON.stringify({ id: "thread-2", thread_model_id: "thread-model-2" }),
+        ].join("\n");
+
+        searchThreadsSpy = vi
+          .spyOn(client.api.traces, "searchTraceThreads")
+          .mockImplementation(() => mockAPIFunctionWithStream(ndjson));
+
+        const items = await queue.getItems();
+
+        expect(items.map((t) => t.threadModelId)).toEqual([
+          "thread-model-1",
+          "thread-model-2",
+        ]);
+
+        const request = searchThreadsSpy.mock.calls[0][0]!;
+        expect(request.projectId).toBe("project-id");
+        expect(request.truncate).toBe(true);
+        expect(request.filters).toEqual([
+          {
+            field: "annotation_queue_ids",
+            operator: "contains",
+            value: "queue-id",
+          },
+        ]);
+      });
+
+      it("should pass truncate=false when truncateImages is false", async () => {
+        const queue = new ThreadsAnnotationQueue(
+          {
+            id: "queue-id",
+            name: "Thread Queue",
+            projectId: "project-id",
+            scope: "thread",
+          },
+          client
+        );
+
+        searchThreadsSpy = vi
+          .spyOn(client.api.traces, "searchTraceThreads")
+          .mockImplementation(() => mockAPIFunctionWithStream(""));
+
+        await queue.getItems({ truncateImages: false });
+
+        expect(searchThreadsSpy.mock.calls[0][0]!.truncate).toBe(false);
       });
     });
   });

--- a/sdks/typescript/tests/unit/annotation-queue/TracesAnnotationQueue.test.ts
+++ b/sdks/typescript/tests/unit/annotation-queue/TracesAnnotationQueue.test.ts
@@ -8,6 +8,7 @@ import { logger } from "@/utils/logger";
 import {
   mockAPIFunction,
   createMockHttpResponsePromise,
+  mockAPIFunctionWithStream,
 } from "../../mockUtils";
 import * as OpikApi from "@/rest_api/api";
 
@@ -227,6 +228,72 @@ describe("TracesAnnotationQueue", () => {
         await queue.removeTraces([]);
 
         expect(removeItemsSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("getItems", () => {
+      let searchTracesSpy: MockInstance<
+        typeof client.api.traces.searchTraces
+      >;
+
+      afterEach(() => {
+        searchTracesSpy?.mockRestore();
+      });
+
+      it("should filter by the queue id and return parsed traces", async () => {
+        const queue = new TracesAnnotationQueue(
+          {
+            id: "queue-id",
+            name: "Test Queue",
+            projectId: "project-id",
+            scope: "trace",
+          },
+          client
+        );
+
+        const ndjson = [
+          JSON.stringify({ id: "trace-1", start_time: new Date().toISOString() }),
+          JSON.stringify({ id: "trace-2", start_time: new Date().toISOString() }),
+        ].join("\n");
+
+        searchTracesSpy = vi
+          .spyOn(client.api.traces, "searchTraces")
+          .mockImplementation(() => mockAPIFunctionWithStream(ndjson));
+
+        const items = await queue.getItems();
+
+        expect(items.map((t) => t.id)).toEqual(["trace-1", "trace-2"]);
+
+        const request = searchTracesSpy.mock.calls[0][0]!;
+        expect(request.projectId).toBe("project-id");
+        expect(request.truncate).toBe(true);
+        expect(request.filters).toEqual([
+          {
+            field: "annotation_queue_ids",
+            operator: "contains",
+            value: "queue-id",
+          },
+        ]);
+      });
+
+      it("should pass truncate=false when truncateImages is false", async () => {
+        const queue = new TracesAnnotationQueue(
+          {
+            id: "queue-id",
+            name: "Test Queue",
+            projectId: "project-id",
+            scope: "trace",
+          },
+          client
+        );
+
+        searchTracesSpy = vi
+          .spyOn(client.api.traces, "searchTraces")
+          .mockImplementation(() => mockAPIFunctionWithStream(""));
+
+        await queue.getItems({ truncateImages: false });
+
+        expect(searchTracesSpy.mock.calls[0][0]!.truncate).toBe(false);
       });
     });
   });


### PR DESCRIPTION
## Details

Adds `get_items()` (Python) / `getItems()` (TypeScript) to the traces and threads annotation queue classes so users can programmatically fetch the items currently in a queue. Reuses the existing search-with-filter mechanism (traces/threads filtered by `annotation_queue_ids`, scoped to the queue's project) — no new backend endpoint is required.
- All items are returned (paged internally); a `truncate_images` / `truncateImages` flag (default `true`) controls truncation of inline base64 image data in input/output/metadata.

## Usage

Python:
```python
import opik

client = opik.Opik()

# Traces queue -> returns the traces in the queue
queue = client.get_traces_annotation_queue("queue-id")
traces = queue.get_items()

# Threads queue -> returns the threads in the queue
thread_queue = client.get_threads_annotation_queue("thread-queue-id")
threads = thread_queue.get_items()
```

TypeScript:
```typescript
import { Opik } from "opik";

const client = new Opik();

// Traces queue -> returns the traces in the queue
const queue = await client.getTracesAnnotationQueue("queue-id");
const traces = await queue.getItems();

// Threads queue -> returns the threads in the queue
const threadQueue = await client.getThreadsAnnotationQueue("thread-queue-id");
const threads = await threadQueue.getItems();
```

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-4373

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8, Claude Sonnet 4.6
- Scope: full implementation (Python + TypeScript SDK methods and tests)
- Human verification: code review + tests run against a local backend

## Testing

Run against a local Opik backend (`http://localhost:8080`):
- Python e2e: `pytest tests/e2e/test_annotation_queue.py` → 2 passed (`get_items` for trace + thread queues)
- Python unit: `pytest tests/unit/api_objects/annotation_queue/ tests/unit/api_objects/test_search_helpers.py` → passed
- Python pre-commit (ruff, ruff-format, mypy) on changed files → passed
- TS unit: `npx vitest run tests/unit/annotation-queue` → 17 passed
- TS integration: `npx vitest run tests/integration/annotation-queues.test.ts` → 2 passed
- TS `npm run typecheck` + `eslint` → clean

Scenarios validated: happy path for both trace and thread queues (add items → `getItems` returns exactly those items), project-scoped filtering. No new backend code paths to test.

## Documentation

Added a "Fetching Items from a Queue" example (Python + TypeScript) to the annotation queues docs:
- `apps/opik-documentation/documentation/fern/docs/evaluation/annotation_queues.mdx`
- `apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/annotation_queues.mdx`
- `apps/opik-documentation/python-sdk-docs/source/rest_api/clients/annotation_queues.rst`

Method docstrings/JSDoc added inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
