### PR TITLE
[NA] [DOCKER] update Docker base images

### DIFF
--- a/apps/opik-frontend/Dockerfile
+++ b/apps/opik-frontend/Dockerfile
@@ -26,7 +26,7 @@ RUN printf '{"version": "%s"}\n' "$VITE_APP_VERSION" > dist/version.json
 
 # Production stage
 # Using nginx alpine image with OpenTelemetry support
-FROM nginx:1.30.1-alpine-otel AS nginx
+FROM nginx:1.30.2-alpine-otel AS nginx
 
 # Add label for later inspection
 ARG BUILD_MODE=production

--- a/apps/opik-python-backend/Dockerfile
+++ b/apps/opik-python-backend/Dockerfile
@@ -2,7 +2,7 @@
 #######################################################################
 # Multi-stage build: Build stage
 #######################################################################
-FROM docker:29.5.1 AS builder
+FROM docker:29.5.3 AS builder
 
 # Toolchain only for compiling native wheels (rust/cargo for pydantic-core).
 RUN apk add --no-cache python3 py3-pip build-base python3-dev musl-dev gcc libffi-dev rust cargo
@@ -35,7 +35,7 @@ RUN set -eux; \
 #######################################################################
 # Multi-stage build: Runtime stage
 #######################################################################
-FROM docker:29.5.1
+FROM docker:29.5.3
 
 # Upgrade libexpat to the latest available version to mitigate CVEs.
 RUN apk add --no-cache --upgrade libexpat


### PR DESCRIPTION
## Docker Base Image Updates

Automated update of Docker base images to latest patch versions to resolve known vulnerabilities.

### Changes Summary

| Dockerfile | Stage | Image | Current | Updated | Base Image Scan |
|---|---|---|---|---|---|
| `apps/opik-frontend/Dockerfile` | final | `nginx` | `1.30.1-alpine-otel` | `1.30.2-alpine-otel` | 3 HIGH/CRIT |
| `apps/opik-python-backend/Dockerfile` | build (synced) | `docker` | `29.5.1` | `29.5.3` | 17 HIGH/CRIT |
| `apps/opik-python-backend/Dockerfile` | final | `docker` | `29.5.1` | `29.5.3` | 17 HIGH/CRIT |

### Dockerfiles with no updates available

- `apps/opik-backend/Dockerfile` -- `amazoncorretto:25.0.3-al2023` is already latest
- `apps/opik-guardrails-backend/Dockerfile` -- `nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04` is already latest
- `apps/opik-sandbox-executor-python/Dockerfile` -- `python:3.12.13-slim` is already latest

### Notes
- Trivy scans above are on the **base images only**, not the final built application images.
- The target repo's CI will build and test the full Docker images on this branch.
- Only patch versions were bumped (same major.minor line) to minimize breaking changes.

### Vulnerability Details

<details><summary>opik-python-backend: 17 vulnerabilities</summary>

```
HIGH     CVE-2026-29181       go.opentelemetry.io/otel v1.38.0 -> 1.41.0
HIGH     CVE-2026-24051       go.opentelemetry.io/otel/sdk v1.38.0 -> 1.40.0
HIGH     CVE-2026-39883       go.opentelemetry.io/otel/sdk v1.38.0 -> 1.43.0
CRITICAL CVE-2026-33186       google.golang.org/grpc v1.78.0 -> 1.79.3
CRITICAL CVE-2026-33186       google.golang.org/grpc v1.78.0 -> 1.79.3
HIGH     CVE-2026-29181       go.opentelemetry.io/otel v1.38.0 -> 1.41.0
CRITICAL CVE-2026-33186       google.golang.org/grpc v1.78.0 -> 1.79.3
HIGH     CVE-2026-46680       github.com/containerd/containerd/v2 v2.2.3 -> 2.0.9, 2.2.4, 2.3.1
HIGH     CVE-2026-34040       github.com/docker/docker v28.5.2+incompatible -> 29.3.1
HIGH     CVE-2026-41567       github.com/docker/docker v28.5.2+incompatible -> no fix
HIGH     CVE-2026-42306       github.com/docker/docker v28.5.2+incompatible -> no fix
HIGH     CVE-2026-42504       stdlib v1.26.3 -> 1.25.11, 1.26.4
HIGH     CVE-2026-46680       github.com/containerd/containerd/v2 v2.2.3 -> 2.0.9, 2.2.4, 2.3.1
HIGH     CVE-2026-34040       github.com/docker/docker v28.5.2+incompatible -> 29.3.1
HIGH     CVE-2026-41567       github.com/docker/docker v28.5.2+incompatible -> no fix
HIGH     CVE-2026-42306       github.com/docker/docker v28.5.2+incompatible -> no fix
HIGH     CVE-2026-42504       stdlib v1.26.3 -> 1.25.11, 1.26.4
```
</details>

<details><summary>opik-frontend: 3 vulnerabilities</summary>

```
HIGH     CVE-2026-45447       libcrypto3 3.5.6-r0 -> 3.5.7-r0
HIGH     CVE-2026-45447       libssl3 3.5.6-r0 -> 3.5.7-r0
HIGH     CVE-2026-6732        libxml2 2.13.9-r0 -> 2.13.9-r1
```
</details>
