### PR TITLE
[OPIK-6584] [CI] feat: lint workflows at info+ severity; diff-scoped on CI mirroring pre-commit

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -2,6 +2,9 @@ name: '🐙 Lint Workflows'
 
 on:
   pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
 
 permissions:
   contents: read

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -2,9 +2,6 @@ name: '🐙 Lint Workflows'
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/**'
-      - '.github/actions/**'
 
 permissions:
   contents: read
@@ -14,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Install actionlint
         # Download the latest actionlint release directly from the upstream repo and
@@ -38,41 +33,4 @@ jobs:
           actionlint --version
 
       - name: Run actionlint
-        env:
-          BASE_REF: ${{ github.base_ref }}
-          # Suppress info-level shellcheck noise (SC2086 backlog tracked in OPIK-6323).
-          # Real issues at warning+ severity still gate.
-          SHELLCHECK_OPTS: --severity=warning
-        run: |
-          mapfile -t CHANGED_WORKFLOWS < <(git diff --name-only --diff-filter=d "origin/${BASE_REF}...HEAD" -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
-          mapfile -t CHANGED_ACTIONS < <(git diff --name-only --diff-filter=d "origin/${BASE_REF}...HEAD" -- '.github/actions/**')
-
-          if [ ${#CHANGED_WORKFLOWS[@]} -eq 0 ] && [ ${#CHANGED_ACTIONS[@]} -eq 0 ]; then
-            echo "No workflow or composite-action files changed."
-            exit 0
-          fi
-
-          # actionlint cannot lint composite action.yml files directly — they're
-          # validated transitively when a workflow that uses them is linted.
-          # For each changed composite action, find workflows that reference it
-          # via `uses: ./.github/actions/<name>` and add them to the lint set.
-          declare -A TO_LINT_SET=()
-          for f in "${CHANGED_WORKFLOWS[@]}"; do TO_LINT_SET["$f"]=1; done
-          for action_file in "${CHANGED_ACTIONS[@]}"; do
-            action_dir=$(dirname "$action_file")
-            while IFS= read -r caller; do
-              [ -n "$caller" ] && TO_LINT_SET["$caller"]=1
-            done < <(grep -lE "uses:\s*\.?/?${action_dir}/?(\s|$)" .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null || true)
-          done
-
-          if [ ${#TO_LINT_SET[@]} -eq 0 ]; then
-            echo "Composite action(s) changed but no workflow references them. Nothing to lint."
-            printf '  %s\n' "${CHANGED_ACTIONS[@]}"
-            exit 0
-          fi
-
-          mapfile -t TO_LINT < <(printf '%s\n' "${!TO_LINT_SET[@]}" | sort)
-          echo "Linting:"
-          printf '  %s\n' "${TO_LINT[@]}"
-          echo
-          actionlint -- "${TO_LINT[@]}"
+        run: actionlint

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install actionlint
         # Download the latest actionlint release directly from the upstream repo and
@@ -36,4 +38,38 @@ jobs:
           actionlint --version
 
       - name: Run actionlint
-        run: actionlint
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          mapfile -t CHANGED_WORKFLOWS < <(git diff --name-only --diff-filter=d "origin/${BASE_REF}...HEAD" -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
+          mapfile -t CHANGED_ACTIONS < <(git diff --name-only --diff-filter=d "origin/${BASE_REF}...HEAD" -- '.github/actions/**')
+
+          if [ ${#CHANGED_WORKFLOWS[@]} -eq 0 ] && [ ${#CHANGED_ACTIONS[@]} -eq 0 ]; then
+            echo "No workflow or composite-action files changed."
+            exit 0
+          fi
+
+          # actionlint cannot lint composite action.yml files directly — they're
+          # validated transitively when a workflow that uses them is linted.
+          # For each changed composite action, find workflows that reference it
+          # via `uses: ./.github/actions/<name>` and add them to the lint set.
+          declare -A TO_LINT_SET=()
+          for f in "${CHANGED_WORKFLOWS[@]}"; do TO_LINT_SET["$f"]=1; done
+          for action_file in "${CHANGED_ACTIONS[@]}"; do
+            action_dir=$(dirname "$action_file")
+            while IFS= read -r caller; do
+              [ -n "$caller" ] && TO_LINT_SET["$caller"]=1
+            done < <(grep -lE "uses:\s*\.?/?${action_dir}/?(\s|$)" .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null || true)
+          done
+
+          if [ ${#TO_LINT_SET[@]} -eq 0 ]; then
+            echo "Composite action(s) changed but no workflow references them. Nothing to lint."
+            printf '  %s\n' "${CHANGED_ACTIONS[@]}"
+            exit 0
+          fi
+
+          mapfile -t TO_LINT < <(printf '%s\n' "${!TO_LINT_SET[@]}" | sort)
+          echo "Linting:"
+          printf '  %s\n' "${TO_LINT[@]}"
+          echo
+          actionlint -- "${TO_LINT[@]}"

--- a/.github/workflows/publish_helm_chart.yaml
+++ b/.github/workflows/publish_helm_chart.yaml
@@ -95,7 +95,7 @@ jobs:
             # 1. Set timestamp for the newly packaged chart from source repo tag
             NEW_CHART_FILE="opik-${VERSION}.tgz"
             if [ -f "$NEW_CHART_FILE" ]; then
-              NEW_CHART_TIME=$(cd ../src && git log -1 --format="%cI" "$VERSION" || true)
+              NEW_CHART_TIME=$(cd ../src && git log -1 --format="%cI" "$VERSION") || NEW_CHART_TIME=""
               if [ -n "$NEW_CHART_TIME" ]; then
                 touch -d "$NEW_CHART_TIME" "$NEW_CHART_FILE"
                 echo "Set $NEW_CHART_FILE mtime to $NEW_CHART_TIME (from source tag)"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -167,7 +167,7 @@ jobs:
           sed -i "s/^version:.*/version: ${{ needs.set-version.outputs.version }}/" Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: ${{ needs.set-version.outputs.version }}/" Chart.yaml
           echo "Updated Chart.yaml version and appVersion to: ${{ needs.set-version.outputs.version }}"
-          cat Chart.yaml | grep -E "^version:|^appVersion:"
+          grep -E "^version:|^appVersion:" Chart.yaml
           cd -
 
       - name: Bump version.txt for next release

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -93,38 +93,17 @@ else
 fi
 
 # Workflows / composite actions: validate with actionlint when available.
-# Composite actions (`.github/actions/*/action.yml`) cannot be linted directly —
-# they're validated transitively when a workflow that uses them is linted. For
-# each staged composite action, find workflows that reference it and lint those.
-staged_workflows=$(staged_files | grep -E '^\.github/workflows/.+\.(yml|yaml)$' || true)
-staged_actions=$(staged_files | grep -E '^\.github/actions/.+\.(yml|yaml)$' || true)
+staged_workflows=$(staged_files | grep -E '^\.github/(workflows|actions)/.+\.(yml|yaml)$' || true)
 
-if [ -z "$staged_workflows" ] && [ -z "$staged_actions" ]; then
+if [ -z "$staged_workflows" ]; then
   echo "No workflow or composite-action files changed. Skipping actionlint."
 elif ! command -v actionlint >/dev/null 2>&1; then
   echo "Workflow/composite-action files changed but actionlint is not installed. Skipping local validation."
   echo "Install: brew install actionlint  (or see https://github.com/rhysd/actionlint#installation)"
 else
-  files_to_lint="$staged_workflows"
-  if [ -n "$staged_actions" ]; then
-    callers=""
-    for action_file in $staged_actions; do
-      action_dir=$(dirname "$action_file")
-      found=$(grep -lE "uses:\s*\.?/?${action_dir}/?(\s|$)" .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null || true)
-      callers="${callers}${found}
-"
-    done
-    files_to_lint=$(printf '%s\n%s\n' "$files_to_lint" "$callers" | sed '/^$/d' | sort -u)
-  fi
-
-  if [ -z "$files_to_lint" ]; then
-    echo "Composite action(s) staged but no workflow references them. Skipping actionlint."
-  else
-    echo "Workflow/composite-action files have been changed. Running actionlint..."
-    # Match CI: suppress info-level shellcheck noise (SC2086 backlog tracked in OPIK-6323).
-    if ! printf '%s\n' "$files_to_lint" | SHELLCHECK_OPTS="--severity=warning" xargs actionlint --; then
-      echo "actionlint found issues. Please fix them before committing."
-      exit 1
-    fi
+  echo "Workflow/composite-action files have been changed. Running actionlint against all workflows..."
+  if ! actionlint; then
+    echo "actionlint found issues. Please fix them before committing."
+    exit 1
   fi
 fi

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -96,8 +96,6 @@ fi
 # Composite actions (`.github/actions/*/action.yml`) cannot be linted directly —
 # they're validated transitively when a workflow that uses them is linted. For
 # each staged composite action, find workflows that reference it and lint those.
-# CI lints the full tree at default severity on every PR; this hook just
-# fast-checks the files the developer is touching.
 staged_workflows=$(staged_files | grep -E '^\.github/workflows/.+\.(yml|yaml)$' || true)
 staged_actions=$(staged_files | grep -E '^\.github/actions/.+\.(yml|yaml)$' || true)
 

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -93,17 +93,39 @@ else
 fi
 
 # Workflows / composite actions: validate with actionlint when available.
-staged_workflows=$(staged_files | grep -E '^\.github/(workflows|actions)/.+\.(yml|yaml)$' || true)
+# Composite actions (`.github/actions/*/action.yml`) cannot be linted directly —
+# they're validated transitively when a workflow that uses them is linted. For
+# each staged composite action, find workflows that reference it and lint those.
+# CI lints the full tree at default severity on every PR; this hook just
+# fast-checks the files the developer is touching.
+staged_workflows=$(staged_files | grep -E '^\.github/workflows/.+\.(yml|yaml)$' || true)
+staged_actions=$(staged_files | grep -E '^\.github/actions/.+\.(yml|yaml)$' || true)
 
-if [ -z "$staged_workflows" ]; then
+if [ -z "$staged_workflows" ] && [ -z "$staged_actions" ]; then
   echo "No workflow or composite-action files changed. Skipping actionlint."
 elif ! command -v actionlint >/dev/null 2>&1; then
   echo "Workflow/composite-action files changed but actionlint is not installed. Skipping local validation."
   echo "Install: brew install actionlint  (or see https://github.com/rhysd/actionlint#installation)"
 else
-  echo "Workflow/composite-action files have been changed. Running actionlint against all workflows..."
-  if ! actionlint; then
-    echo "actionlint found issues. Please fix them before committing."
-    exit 1
+  files_to_lint="$staged_workflows"
+  if [ -n "$staged_actions" ]; then
+    callers=""
+    for action_file in $staged_actions; do
+      action_dir=$(dirname "$action_file")
+      found=$(grep -lE "uses:\s*\.?/?${action_dir}/?(\s|$)" .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null || true)
+      callers="${callers}${found}
+"
+    done
+    files_to_lint=$(printf '%s\n%s\n' "$files_to_lint" "$callers" | sed '/^$/d' | sort -u)
+  fi
+
+  if [ -z "$files_to_lint" ]; then
+    echo "Composite action(s) staged but no workflow references them. Skipping actionlint."
+  else
+    echo "Workflow/composite-action files have been changed. Running actionlint..."
+    if ! printf '%s\n' "$files_to_lint" | xargs actionlint --; then
+      echo "actionlint found issues. Please fix them before committing."
+      exit 1
+    fi
   fi
 fi


### PR DESCRIPTION
## Details

<img width="1920" height="2364" alt="image" src="https://github.com/user-attachments/assets/b6f6eab0-b46c-44b6-9312-dff88f60a464" />

Final subtask of [OPIK-6323](https://comet-ml.atlassian.net/browse/OPIK-6323). Locks in the clean baseline produced by subtasks [OPIK-6580](https://comet-ml.atlassian.net/browse/OPIK-6580)–[OPIK-6583](https://comet-ml.atlassian.net/browse/OPIK-6583).

**Note:** This supersedes the closed predecessor [#6850](https://github.com/comet-ml/opik/pull/6850), which experimented with full-tree CI scanning. After reviewer pushback, this iteration narrows scope: CI keeps its existing diff-scoped behavior (changed workflows + caller workflows for changed composite actions). Only the severity floor (`info+` default) changes.

### Two surfaces, single axis tightened

| Surface | Trigger | File scope | Rule scope |
|---|---|---|---|
| **CI** (`actionlint.yml`) | only PRs touching `.github/workflows/**` or `.github/actions/**` (unchanged) | diff-scoped: changed workflows + caller workflows for changed composite actions (unchanged) | default `info+` &mdash; was `warning+` |
| **pre-commit** (`.hooks/pre-commit`) | when workflow/composite-action files are staged (unchanged) | staged files + caller workflows for staged composite actions (unchanged) | default `info+` &mdash; was `warning+` |

Trigger and file scope are identical to `main`. The only behavior change is the rule-scope severity floor on both surfaces.

### What changes vs. main

- `.github/workflows/actionlint.yml` &mdash; **3-line removal** of `SHELLCHECK_OPTS=--severity=warning` (plus its 2 comment lines). All other behavior (paths trigger, fetch-depth, diff scaffolding, composite-action caller resolution) preserved.
- `.hooks/pre-commit` &mdash; removes the `SHELLCHECK_OPTS=--severity=warning` env-wrapper on the `xargs actionlint --` invocation. Same scoping logic as before.
- `.github/workflows/publish_helm_chart.yaml` &mdash; fixes a latent SC2015 (`A && B || C` is not if-then-else) surfaced when the severity floor dropped. `$(cmd && cmd2 || true)` &rarr; `$(cmd && cmd2) || NEW_CHART_TIME=""`. Existing `[ -n "$NEW_CHART_TIME" ]` guard already handled the empty case &mdash; functional behavior unchanged.
- `.github/workflows/release.yaml` &mdash; fixes a latent SC2002 (useless `cat`). `cat X | grep ...` &rarr; `grep ... X`. Functional behavior unchanged.

### Sequencing

- Lands AFTER subtasks 6580&ndash;6583 (all merged).
- `github-actions` dependabot piece originally scoped here was split out to [OPIK-6669](https://comet-ml.atlassian.net/browse/OPIK-6669), blocked by [OPIK-6366](https://comet-ml.atlassian.net/browse/OPIK-6366) (zizmor SHA-pinning).

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6584

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-7[1m]
- Scope: full implementation (workflow + hook edits, latent-finding fixes, ticket scope-narrowing, follow-up ticket creation and linking)
- Human verification: PR opened after rebase + CI verification round (full-tree probe → 0 findings → diff-scoped restoration)

## Testing

CI's `🐙 Lint Workflows` job is the source of truth (per OPIK-6584 memory entry on local-vs-CI shellcheck divergence).

Verification path executed on this branch:
1. ✅ Rebased on latest `main` (190 commits of churn since the predecessor PR).
2. ✅ Pushed a probe commit (`4b02fb533b`) with **full-tree** actionlint to surface any latent findings introduced into the tree since the last verification. CI [Run #27541744904](https://github.com/comet-ml/opik/actions/runs/27541744904) **passed in 19s** — 0 findings across 79 workflow files at default `info+` severity.
3. ✅ Switched CI back to its existing diff-scoped behavior (`9be3b99344`).
4. ✅ CI on the final commit [Run #27542019167](https://github.com/comet-ml/opik/actions/runs/27542019167) **passed**.

Net result: repo's workflow tree is verified clean at the new `info+` floor; the steady-state CI lint stays diff-scoped (no new per-PR friction).

The pre-commit hook was exercised by commits on this branch and ran the staged-files actionlint check successfully.

## Documentation

N/A — internal CI plumbing only; no user-facing or developer-facing docs surfaces affected.

[OPIK-6323]: https://comet-ml.atlassian.net/browse/OPIK-6323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPIK-6580]: https://comet-ml.atlassian.net/browse/OPIK-6580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPIK-6583]: https://comet-ml.atlassian.net/browse/OPIK-6583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPIK-6669]: https://comet-ml.atlassian.net/browse/OPIK-6669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ