### PR TITLE
[OPIK-6952] [FE] Fix sidebar extra padding when home group is empty

### DIFF
--- a/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
+++ b/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
@@ -217,7 +217,7 @@ const getMenuItems = ({
         },
       ],
     },
-  ];
+  ].filter((group) => group.items.length > 0);
 };
 
 export const getWorkspaceMenuItems = (): MenuItemGroup[] => {


### PR DESCRIPTION
## Details

Filter empty menu groups in `getMenuItems` so the sidebar doesn't render an empty `<li>` with bottom padding when both Home and Ollie items are hidden (both feature toggles off).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-6952

## Testing
- With both `PROJECT_HOMEPAGE_ENABLED` and `OLLIE_ENABLED` off: verify no extra padding at the top of the sidebar
- With either or both on: verify sidebar renders normally

## Documentation
N/A