### PR TITLE
[OPIK-6944] [BE] fix(security): drop perl to clear CVE-2026-9538 in opik-backend

### DIFF
--- a/apps/opik-backend/Dockerfile
+++ b/apps/opik-backend/Dockerfile
@@ -29,8 +29,11 @@ LABEL org.opencontainers.image.vendor="Comet ML"
 ARG RDS_CERT_SHA256=e5bb2084ccf45087bda1c9bffdea0eb15ee67f0b91646106e466714f9de3c7e3
 ARG STORE_PASSWORD=changeit
 COPY install_rds_cert.sh /tmp/install_rds_cert.sh
+# perl is intentionally not installed: it pulls in perl-Archive-Tar, which is
+# affected by CVE-2026-9538 (ALAS2023-2026-1805) and has no patched AL2023 RPM.
+# install_rds_cert.sh uses sed/openssl instead of perl to extract the cert CN.
 RUN yum update -y && \
-    yum install -y --allowerasing shadow ca-certificates openssl perl dos2unix curl && \
+    yum install -y --allowerasing shadow ca-certificates openssl dos2unix curl && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     mkdir -p /tmp/certs && \

--- a/apps/opik-backend/install_rds_cert.sh
+++ b/apps/opik-backend/install_rds_cert.sh
@@ -7,7 +7,7 @@ storepassword=$2
 awk 'split_after == 1 {n++;split_after=0} /-----END CERTIFICATE-----/ {split_after=1}{print > "rds-ca-" n ".pem"}' < $path_to_cert
 
 for CERT in rds-ca-*; do
-  alias=$(openssl x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print')
+  alias=$(openssl x509 -noout -subject -in $CERT | sed -n 's/.*CN *= *\([^,]*\).*/\1/p')
   echo "Importing $alias"
   keytool -import -file ${CERT} -alias "${alias}" -storepass ${storepassword} -keystore ${truststore} -noprompt
   rm $CERT


### PR DESCRIPTION
## Details

<img width="1920" height="1938" alt="image" src="https://github.com/user-attachments/assets/2786d97d-aaeb-4816-947e-86ca998f7c22" />

Removes the `perl` package from the `opik-backend` runtime image to eliminate **CVE-2026-9538** (ALAS2023-2026-1805) — a critical memory-exhaustion vulnerability in `Archive::Tar` < 3.10, flagged by a customer security scan of `opik-backend:2.0.61`.

- `perl` was installed solely to extract a certificate CN in `install_rds_cert.sh`; it transitively pulls in the vulnerable `perl-Archive-Tar`.
- Amazon Linux 2023 has not yet published a patched RPM, so a version bump / `yum update` cannot remediate it — the package had to be removed.
- The cert CN is now extracted with `openssl -subject | sed` instead of `perl`, dropping `perl` (and `perl-Archive-Tar`) from the image entirely.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6944

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: code review + local Docker build verification

## Testing

Verified by building throwaway images from the exact base (`amazoncorretto:25.0.3-al2023`) and running the same install steps:

- Confirmed `perl` and `perl-Archive-Tar` are both **absent** from the resulting image (`rpm -q`), structurally eliminating CVE-2026-9538 with no dangling rpm dependency.
- Confirmed the new `openssl -subject | sed` CN extraction is correct against the **real 108-cert AWS RDS global bundle**: all 108 certs yield a non-empty CN with no trailing fields (the previous logic left a trailing `, L=Seattle` on aliases).
- Confirmed `openssl`, `keytool`, `dos2unix`, `curl` remain present.

The `test-environment` label is added to spin up a deployment and validate the image builds and boots end-to-end (full RDS cert-import path) with `perl` removed.

## Documentation

N/A
