### PR TITLE
[OPIK-6951] [QA] test: Ollie deeper E2E coverage (sidebar, context, /analyze, /instrument, /improve)

### DIFF
--- a/tests_end_to_end/e2e/agents/README.md
+++ b/tests_end_to_end/e2e/agents/README.md
@@ -1,0 +1,39 @@
+# Golden agents
+
+Small, dependency-free, offline agents used as known fixtures for the Ollie
+Local-Runner flows (OPIK-6125, consumed by OPIK-6951). Each is a self-contained
+`agent.py` with a typed `run(...)` entrypoint so `opik connect` can discover its
+schema.
+
+They are deterministic and make no real LLM call — the point is the *shape*
+(call tree, instrumentation state, pass-rate direction), not model output, so
+they behave identically wherever the E2E suite runs.
+
+## `uninstrumented/`
+
+A plain multi-step agent with **no** Opik instrumentation (no `@opik.track`, no
+`opik` import). Target for the Ollie `/instrument` flow: a `run` entrypoint that
+fans out to a `retrieve` (tool-shaped) step and a `generate` (llm-shaped) step.
+After Ollie instruments it, the test asserts the agent source gained an `opik`
+import and `@track` decorators (`/instrument` edits the code but doesn't
+necessarily run it, so the source is the reliable signal).
+
+## `known-failing/`
+
+An instrumented agent whose answer format is governed by an externalized
+`SYSTEM_PROMPT`, plus a fixed evaluation suite (`suite.json`). The baseline
+prompt omits units, so it fails the unit-bearing suite cases — baseline pass
+rate ≈ 33%. The Ollie `/improve` flow tunes the prompt (e.g. "always include
+units"), which lifts the pass rate (→ 100% with the obvious fix). The /improve
+test asserts the **direction** of the pass rate (after > before), never an exact
+value, because Ollie may propose different fixes on different runs.
+
+`agent.py` is self-contained (its own question→value and question→unit data) so
+it reads like a real agent Ollie can instrument. `suite.json` holds the test's
+**independent** expected answers — the oracle the eval checks against, kept
+separate from the agent's data on purpose.
+
+`harness.ts` (beside the agent) holds the test helpers specific to this agent:
+`evaluatePassRate` and `seedFailingTraces`, which run `agent.py` through the
+bridge venv and read `suite.json`. Generic `opik connect` plumbing lives in
+`core/local-runner/connect.ts`, not here.

--- a/tests_end_to_end/e2e/agents/known-failing/agent.py
+++ b/tests_end_to_end/e2e/agents/known-failing/agent.py
@@ -1,0 +1,83 @@
+"""Known-failing golden agent (for the Ollie /improve loop).
+
+An instrumented agent whose answer format is governed by an externalized system
+prompt (`SYSTEM_PROMPT`) — the knob the Ollie /improve flow tunes by editing the
+source. The baseline prompt under-specifies the output (it never asks for
+units), so the agent fails the unit-checked half of a fixed evaluation suite.
+A more explicit prompt (the kind /improve proposes — "always include units")
+raises the pass rate.
+
+The "LLM" here is a deterministic stand-in that honours the prompt's
+instructions rather than a real model call — this keeps the agent offline and
+the /improve pass-rate change reproducible in CI. The assertion that matters is
+the *direction* of the pass rate, not any model's wording.
+
+Entrypoint + type hints are present for Local Runner (`opik connect`) schema
+discovery.
+"""
+
+import opik
+
+# Externalized, tunable system prompt — the knob the Ollie /improve flow turns.
+# Baseline: it does not ask for units, so the unit-checked suite cases fail.
+SYSTEM_PROMPT = "Answer the question."
+
+
+@opik.track(type="tool", name="lookup")
+def lookup(question: str) -> str:
+    table = {
+        "distance earth to moon": "384400",
+        "boiling point of water": "100",
+        "speed of light": "299792458",
+        "freezing point of water": "0",
+        "number of continents": "7",
+        "days in a week": "7",
+    }
+    return table.get(question.strip().lower(), "unknown")
+
+
+# Signals in the system prompt that should make the agent append units. Kept
+# broad on purpose: the Ollie /improve flow may word its fix many ways
+# ("include units", "give a complete answer", "be precise with measurements"),
+# and the directional pass-rate test must hold for any reasonable improvement,
+# not just the literal word "unit".
+_UNIT_SIGNALS = ("unit", "complete", "precise", "full", "measurement", "exact")
+
+
+@opik.track(type="llm", name="format-answer")
+def format_answer(system_prompt: str, value: str, units: str) -> str:
+    # Deterministic prompt-follower: appends units when the prompt asks for a
+    # more complete/precise answer. The baseline prompt does not, so the
+    # unit-required cases fail until /improve clarifies the prompt.
+    sp = system_prompt.lower()
+    if units and any(sig in sp for sig in _UNIT_SIGNALS):
+        return f"{value} {units}"
+    return value
+
+
+# The agent's own data: the unit for each question (empty = no unit). Some
+# questions carry a unit (these fail on the baseline prompt, which omits units),
+# some don't (they pass regardless) — so the baseline lands at a partial pass
+# rate that /improve can lift, rather than an all-or-nothing 0%. This is the
+# standalone agent's data; suite.json holds the test's independent expected
+# answers and is the oracle the eval checks against.
+SUITE_UNITS = {
+    "distance earth to moon": "km",
+    "boiling point of water": "C",
+    "speed of light": "m/s",
+    "freezing point of water": "C",
+    "number of continents": "",
+    "days in a week": "",
+}
+
+
+@opik.track(entrypoint=True, name="known-failing-agent")
+def run(question: str) -> str:
+    value = lookup(question)
+    units = SUITE_UNITS.get(question.strip().lower(), "")
+    return format_answer(SYSTEM_PROMPT, value, units)
+
+
+if __name__ == "__main__":
+    print(run("boiling point of water"))
+    opik.flush_tracker()

--- a/tests_end_to_end/e2e/agents/known-failing/harness.ts
+++ b/tests_end_to_end/e2e/agents/known-failing/harness.ts
@@ -1,0 +1,73 @@
+import * as path from 'node:path';
+import { runBridgePython } from '@e2e/core/local-runner/connect';
+
+/**
+ * Test helpers specific to the known-failing golden agent (agents/known-failing).
+ * They run the agent's `run()` through the bridge venv (its `@opik.track`
+ * decorators need opik importable) and read its `suite.json` as the single
+ * source of truth for the eval items. Kept beside the agent, not in the generic
+ * Local-Runner helper, because they encode this agent's suite shape.
+ */
+
+export interface SuitePassRate {
+  passed: number;
+  total: number;
+  rate: number;
+}
+
+/** Build the Python preamble that imports the agent module from `agentDir`. */
+function importAgent(agentDir: string): string {
+  return [
+    'import importlib.util, json, os',
+    `d = ${JSON.stringify(agentDir)}`,
+    'spec = importlib.util.spec_from_file_location("kf", os.path.join(d, "agent.py"))',
+    'kf = importlib.util.module_from_spec(spec); spec.loader.exec_module(kf)',
+    'suite = json.load(open(os.path.join(d, "suite.json")))',
+  ].join('\n');
+}
+
+/**
+ * Evaluate the agent in `agentDir` against its `suite.json`: run each item's
+ * question through `run(...)` and count exact-match passes. Used to measure the
+ * pass rate before and after the Ollie /improve flow edits the agent — the test
+ * asserts the *direction*, not a value, since /improve may land different fixes.
+ * A fresh import each call reflects any /improve edit to the agent source.
+ */
+export async function evaluatePassRate(agentDir: string): Promise<SuitePassRate> {
+  const code = `${importAgent(agentDir)}
+passed = sum(kf.run(i["data"]["question"]) == i["expected"] for i in suite["items"])
+print(json.dumps({"passed": passed, "total": len(suite["items"])}))`;
+  const stdout = await runBridgePython(code, {}, agentDir);
+  const line = stdout.trim().split('\n').pop() ?? '{}';
+  const { passed, total } = JSON.parse(line) as { passed: number; total: number };
+  return { passed, total, rate: total ? passed / total : 0 };
+}
+
+/**
+ * Run the agent over its suite with tracing enabled, logging a trace per item
+ * to `projectName`. Ollie's /improve flow only surfaces once the project has
+ * traces to improve from, so this seeds the failing runs it works on.
+ */
+export async function seedFailingTraces(
+  agentDir: string,
+  opts: { projectName: string; workspace: string; apiKey: string; apiUrl: string },
+): Promise<void> {
+  const code = `import opik
+${importAgent(agentDir)}
+for i in suite["items"]:
+    kf.run(i["data"]["question"])
+opik.flush_tracker()`;
+  await runBridgePython(
+    code,
+    {
+      OPIK_API_KEY: opts.apiKey,
+      OPIK_WORKSPACE: opts.workspace,
+      OPIK_URL_OVERRIDE: opts.apiUrl,
+      OPIK_PROJECT_NAME: opts.projectName,
+    },
+    agentDir,
+  );
+}
+
+/** Absolute path to the known-failing golden agent directory. */
+export const KNOWN_FAILING_DIR = path.resolve(__dirname);

--- a/tests_end_to_end/e2e/agents/known-failing/suite.json
+++ b/tests_end_to_end/e2e/agents/known-failing/suite.json
@@ -1,0 +1,13 @@
+{
+  "name": "known-failing-suite",
+  "description": "Fixed evaluation suite for the Ollie /improve loop. The expected answers carry units where applicable; the baseline agent prompt omits units, so those cases fail until /improve makes the prompt require them. The unit-free cases pass regardless, so the baseline lands at a partial pass rate that /improve should raise. Assert the direction of the pass rate, never an exact value.",
+  "items": [
+    { "data": { "question": "distance earth to moon" }, "expected": "384400 km" },
+    { "data": { "question": "boiling point of water" }, "expected": "100 C" },
+    { "data": { "question": "speed of light" }, "expected": "299792458 m/s" },
+    { "data": { "question": "freezing point of water" }, "expected": "0 C" },
+    { "data": { "question": "number of continents" }, "expected": "7" },
+    { "data": { "question": "days in a week" }, "expected": "7" }
+  ],
+  "assertion": "The response must equal the expected value exactly, including any unit suffix."
+}

--- a/tests_end_to_end/e2e/agents/uninstrumented/agent.py
+++ b/tests_end_to_end/e2e/agents/uninstrumented/agent.py
@@ -1,0 +1,33 @@
+"""Uninstrumented golden agent.
+
+A small, deterministic multi-step agent with NO Opik instrumentation — no
+`@opik.track`, no imports from opik. It exists so the Ollie `/instrument` flow
+has a known-shaped target to add tracing to: an entrypoint that fans out to a
+retrieval "tool" step and a generation "llm" step, two levels deep.
+
+Deliberately dependency-free and offline (no real LLM call) so it runs anywhere
+the E2E suite runs. The point is the call structure Ollie should discover and
+wrap, not the model output.
+"""
+
+
+def retrieve(query: str) -> list[str]:
+    facts = {
+        "capital of france": ["Paris is the capital of France."],
+        "tallest mountain": ["Mount Everest is the tallest mountain."],
+    }
+    return facts.get(query.strip().lower(), ["No relevant facts found."])
+
+
+def generate(query: str, context: list[str]) -> str:
+    joined = " ".join(context)
+    return f"Answer to '{query}': {joined}"
+
+
+def run(query: str) -> str:
+    context = retrieve(query)
+    return generate(query, context)
+
+
+if __name__ == "__main__":
+    print(run("capital of france"))

--- a/tests_end_to_end/e2e/core/local-runner/connect.ts
+++ b/tests_end_to_end/e2e/core/local-runner/connect.ts
@@ -1,0 +1,117 @@
+import { spawn, type ChildProcess, execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as path from 'node:path';
+
+const execFileAsync = promisify(execFile);
+
+const E2E_DIR = path.resolve(__dirname, '../..');
+/** The opik-sdk-driver bridge project — `uv run` resolves its pinned venv from here. */
+export const BRIDGE_DIR = path.join(E2E_DIR, 'services/opik-sdk-driver');
+
+// The connect daemon renders the pairing URL as a Rich OSC-8 terminal
+// hyperlink — `ESC]8;;<URL>ESC\<label>…`. The full URL (with its activation
+// fragment) lives inside the OSC payload, so match a URL token bounded by
+// whitespace/BEL/ESC. Matching the visible plain-text echo instead truncates at
+// the terminal wrap width and corrupts the fragment.
+// eslint-disable-next-line no-control-regex
+const PAIR_URL_RE = /https?:\/\/[^\s\x07\x1b]*pair\/v1[^\s\x07\x1b]*/;
+
+export interface ConnectRunner {
+  /** The scraped `…/opik/pair/v1?…#<fragment>` URL to open in the browser. */
+  pairUrl: string;
+  /** Accumulated daemon stdout/stderr (ANSI included), for diagnostics. */
+  output(): string;
+  /** Stop the daemon. */
+  stop(): void;
+}
+
+export interface StartConnectOpts {
+  /** Project the runner attaches to (must already exist). */
+  projectName: string;
+  workspace: string;
+  apiKey: string;
+  /** Agent working directory the daemon watches (Ollie reads/edits code here). */
+  cwd: string;
+  /** How long to wait for the pairing URL to appear. */
+  scrapeTimeoutMs?: number;
+}
+
+/**
+ * Start an `opik connect` daemon (Local Runner) against the bridge venv and
+ * return once its pairing URL has been scraped from stdout. `connect`'s `_run`
+ * takes only options — no trailing command — and watches `cwd` so Ollie can see
+ * and instrument the agent source there. Pair by opening `pairUrl` in an
+ * authenticated browser (see `OlliePage.pairConnectRunner`).
+ */
+export async function startConnectRunner(opts: StartConnectOpts): Promise<ConnectRunner> {
+  const scrapeTimeoutMs = opts.scrapeTimeoutMs ?? 40_000;
+  let out = '';
+
+  const proc: ChildProcess = spawn(
+    'uv',
+    [
+      'run',
+      'opik',
+      '--api-key',
+      opts.apiKey,
+      'connect',
+      '--project',
+      opts.projectName,
+      '--workspace',
+      opts.workspace,
+      '--non-interactive',
+    ],
+    {
+      cwd: opts.cwd,
+      env: {
+        ...process.env,
+        OPIK_API_KEY: opts.apiKey,
+        OPIK_WORKSPACE: opts.workspace,
+        // `uv run` resolves the bridge venv from this project dir, so the
+        // command uses the same pinned opik the suite seeds with.
+        UV_PROJECT: BRIDGE_DIR,
+      },
+    },
+  );
+  proc.stdout?.on('data', (d) => (out += d.toString()));
+  proc.stderr?.on('data', (d) => (out += d.toString()));
+
+  const stop = () => {
+    try {
+      proc.kill();
+    } catch {
+      /* already gone */
+    }
+  };
+
+  const deadline = Date.now() + scrapeTimeoutMs;
+  while (Date.now() < deadline) {
+    const m = out.match(PAIR_URL_RE);
+    if (m) {
+      return { pairUrl: m[0], output: () => out, stop };
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  stop();
+  throw new Error(
+    `startConnectRunner: no pairing URL scraped within ${scrapeTimeoutMs}ms. Daemon output:\n${out.slice(0, 2000)}`,
+  );
+}
+
+/**
+ * Run an inline Python snippet under `uv run` in the bridge project, so it uses
+ * the same pinned opik the suite seeds with (agents decorated with
+ * `@opik.track` need opik importable). Returns stdout. Generic plumbing —
+ * agent-specific harnesses build their shim and parse the output.
+ */
+export async function runBridgePython(
+  code: string,
+  env: NodeJS.ProcessEnv = {},
+  cwd?: string,
+): Promise<string> {
+  const { stdout } = await execFileAsync('uv', ['run', 'python', '-c', code], {
+    cwd,
+    env: { ...process.env, UV_PROJECT: BRIDGE_DIR, ...env },
+  });
+  return stdout;
+}

--- a/tests_end_to_end/e2e/pom/ollie.page.ts
+++ b/tests_end_to_end/e2e/pom/ollie.page.ts
@@ -50,9 +50,13 @@ export class OlliePage {
       await this.iframeElement().waitFor({ state: 'visible', timeout: timeoutMs });
       // The usable input is the surface-agnostic readiness signal: it's present
       // once Ollie has fully loaded, regardless of whether the project is empty
-      // (onboarding greeting) or already has traces (chat greeting).
+      // (onboarding greeting) or already has traces (chat greeting). Key
+      // readiness on it, not on a specific greeting line — the greeting copy
+      // varies (onboarding vs chat vs "Ollie connected") and can render split
+      // across nodes, which makes an exact-text wait flake when the pod is slow
+      // to provision.
       await expect(this.inputTextbox()).toBeVisible({ timeout: timeoutMs });
-      await expect(this.greeting()).toBeVisible({ timeout: timeoutMs });
+      await expect(this.inputTextbox()).toBeEnabled({ timeout: timeoutMs });
     });
   }
 
@@ -96,6 +100,7 @@ export class OlliePage {
     return test.step('wait for the Ollie sidebar to be ready', async () => {
       await this.iframeElement().waitFor({ state: 'visible', timeout: timeoutMs });
       await expect(this.inputTextbox()).toBeVisible({ timeout: timeoutMs });
+      await expect(this.inputTextbox()).toBeEnabled({ timeout: timeoutMs });
     });
   }
 
@@ -151,9 +156,104 @@ export class OlliePage {
     });
   }
 
+  /**
+   * Open the pairing URL emitted by a running `opik connect` daemon and wait
+   * for the pairing page to confirm the connection. The page lands on one of
+   * three states: connected ("…connected to your codebase"), an invalid-link
+   * error, or an unreachable error — this asserts the success heading and fails
+   * fast on the error ones.
+   *
+   * `pairUrl` is the `…/opik/pair/v1?…#<fragment>` URL scraped from the connect
+   * daemon's stdout. The fragment carries the activation key, so it must be the
+   * full, un-truncated URL (Rich wraps it in an OSC-8 hyperlink — see the
+   * connect helper that scrapes it).
+   */
+  async pairConnectRunner(pairUrl: string, timeoutMs = 30_000): Promise<void> {
+    return test.step('open the pairing link and confirm the runner connects', async () => {
+      await this.page.goto(pairUrl);
+      await expect(
+        this.page.getByRole('heading', { name: /invalid|couldn't reach/i }),
+      ).toHaveCount(0, { timeout: timeoutMs });
+      await expect(
+        this.page.getByRole('heading', { name: /connected to your codebase/i }),
+      ).toBeVisible({ timeout: timeoutMs });
+    });
+  }
+
+  /** Click `/instrument` to kick off the instrumentation flow on a connected runner. */
+  async startInstrument(): Promise<void> {
+    return test.step('run /instrument', async () => {
+      await this.instrumentButton().click();
+    });
+  }
+
+  /** Click `/improve` to kick off the improvement flow on a connected runner. */
+  async startImprove(): Promise<void> {
+    return test.step('run /improve', async () => {
+      await this.improveButton().click();
+    });
+  }
+
+  /**
+   * Drive Ollie's agentic loop to completion by approving each tool action as it
+   * comes up. Ollie gates tool calls (`connect_bash`, edits, runs) behind an
+   * approval row — it re-prompts for new distinct actions even after "Always
+   * allow", so this polls and clicks until no approval has appeared for
+   * `quietMs`, or the overall budget expires.
+   */
+  async approveUntilSettled(opts: { budgetMs?: number; quietMs?: number } = {}): Promise<void> {
+    const budgetMs = opts.budgetMs ?? 300_000;
+    const quietMs = opts.quietMs ?? 30_000;
+    return test.step('approve tool actions until the agent settles', async () => {
+      const deadline = Date.now() + budgetMs;
+      let lastApproval = Date.now();
+      while (Date.now() < deadline) {
+        const approve = this.approveButton();
+        if (await approve.count()) {
+          await approve.first().click();
+          lastApproval = Date.now();
+        } else if (Date.now() - lastApproval > quietMs) {
+          return; // no approval prompt for a while — the agent has settled
+        }
+        await this.page.waitForTimeout(2000);
+      }
+    });
+  }
+
+  /**
+   * The `/improve` flow ends its proposal with a chat prompt — "Reply `apply` to
+   * apply this fix" — rather than an accept button. This waits for that prompt
+   * (the agent has finished analysing and proposed an edit), then sends "apply"
+   * to authorise it. Returns once the apply message is in the log; the caller
+   * should then `approveUntilSettled()` again to drive the edit/run tools.
+   */
+  async applyProposal(timeoutMs = 240_000): Promise<void> {
+    return test.step('approve the proposed fix by replying "apply"', async () => {
+      await expect(this.frame().getByText(/reply\s+.?apply/i).first()).toBeVisible({
+        timeout: timeoutMs,
+      });
+      await this.inputTextbox().fill('apply');
+      await this.sendButton().click();
+    });
+  }
+
   /** The greeting-block action button that kicks off the `/analyze` flow. */
   analyzeButton(): Locator {
     return this.frame().getByRole('button', { name: /Run \/analyze/ });
+  }
+
+  /**
+   * The `/instrument` action button. On a connected runner its name is the bare
+   * `/instrument`; before connecting it reads "…— run /connect first", so match
+   * on the `/instrument` token either way.
+   */
+  instrumentButton(): Locator {
+    return this.frame().getByRole('button', { name: /\/instrument/ });
+  }
+
+  /** A pending tool-approval action ("Always allow" / "Allow once"). */
+  approveButton(): Locator {
+    return this.frame().getByRole('button', { name: /Always allow|Allow once/ });
   }
 
   /** The greeting-block action button that kicks off the `/improve` flow. */

--- a/tests_end_to_end/e2e/pom/ollie.page.ts
+++ b/tests_end_to_end/e2e/pom/ollie.page.ts
@@ -21,6 +21,23 @@ export class OlliePage {
   }
 
   /**
+   * Open a project page that hosts the Ollie *sidebar* surface, rather than the
+   * dedicated `/ollie` page route. The sidebar is rendered by the Opik host on
+   * every project page EXCEPT `/ollie` (see `PageLayout` / `isOlliePage`), so any
+   * other project sub-route works; the default is `logs`. The same iframe and
+   * Ollie deploy back both surfaces — only the surrounding chrome and the input
+   * placeholder differ.
+   */
+  async gotoSidebarSurface(subRoute = 'logs'): Promise<void> {
+    return test.step(`open the ${subRoute} page (Ollie sidebar surface)`, async () => {
+      const env = loadEnvConfig();
+      await this.page.goto(
+        `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/${subRoute}`,
+      );
+    });
+  }
+
+  /**
    * Wait until Ollie is fully loaded and ready to take a prompt.
    *
    * On a cold project the assistant pod is provisioned on demand: the host polls
@@ -66,6 +83,94 @@ export class OlliePage {
 
       return ((await reply.textContent()) ?? '').trim();
     });
+  }
+
+  /**
+   * Wait until the Ollie sidebar surface has mounted and is ready to take a
+   * prompt. The sidebar provisions on demand exactly like the page route, so
+   * this keys on the same surface-agnostic signal: the iframe is visible and the
+   * input is present. Greeting copy is intentionally not asserted here — see
+   * `waitForReady`.
+   */
+  async waitForSidebarReady(timeoutMs = 150_000): Promise<void> {
+    return test.step('wait for the Ollie sidebar to be ready', async () => {
+      await this.iframeElement().waitFor({ state: 'visible', timeout: timeoutMs });
+      await expect(this.inputTextbox()).toBeVisible({ timeout: timeoutMs });
+    });
+  }
+
+  /** True if the Ollie iframe is mounted on the current host page. */
+  async isMounted(): Promise<boolean> {
+    return test.step('check the Ollie iframe is mounted', async () => {
+      return (await this.iframeElement().count()) > 0;
+    });
+  }
+
+  /**
+   * The number Ollie reports for the active project's trace context, read from
+   * the "Traces: N" badge in the greeting block. Ollie derives this from the
+   * project it's scoped to, so it should track the seeded trace count. Returns
+   * null if the badge isn't present (e.g. the conversation has moved past the
+   * greeting).
+   */
+  async contextTraceCount(timeoutMs = 60_000): Promise<number | null> {
+    return test.step('read the Ollie "Traces: N" context badge', async () => {
+      const badge = this.traceCountBadge();
+      await expect(badge).toBeVisible({ timeout: timeoutMs });
+      const text = (await badge.textContent()) ?? '';
+      const match = text.match(/Traces:\s*(\d+)/);
+      return match ? Number(match[1]) : null;
+    });
+  }
+
+  /**
+   * Run the `/analyze` flow from the greeting action button and wait for a
+   * non-empty assistant response to render. Ollie is a non-deterministic agent,
+   * so callers should assert structurally (a reply landed, no error state), not
+   * on exact wording.
+   */
+  async runAnalyze(timeoutMs = 120_000): Promise<string> {
+    return test.step('run /analyze and await a response', async () => {
+      const before = await this.messages().count();
+      await this.analyzeButton().click();
+      await expect
+        .poll(async () => this.messages().count(), {
+          timeout: timeoutMs,
+          intervals: [1000, 2000, 5000],
+        })
+        .toBeGreaterThan(before);
+
+      const reply = this.messages().last();
+      await expect
+        .poll(async () => ((await reply.textContent()) ?? '').trim().length, {
+          timeout: timeoutMs,
+          intervals: [1000, 2000, 5000],
+        })
+        .toBeGreaterThan(0);
+      return ((await reply.textContent()) ?? '').trim();
+    });
+  }
+
+  /** The greeting-block action button that kicks off the `/analyze` flow. */
+  analyzeButton(): Locator {
+    return this.frame().getByRole('button', { name: /Run \/analyze/ });
+  }
+
+  /** The greeting-block action button that kicks off the `/improve` flow. */
+  improveButton(): Locator {
+    return this.frame().getByRole('button', { name: /Run \/improve/ });
+  }
+
+  /** The "Connect Ollie locally" entry point for the Local Runner (`opik connect`) flow. */
+  connectButton(): Locator {
+    return this.frame().getByRole('button', { name: 'Connect Ollie locally' });
+  }
+
+  /** The "Traces: N" context badge in the greeting block. */
+  traceCountBadge(): Locator {
+    // Bare <span> with no testid/class inside the ollie-assist iframe; text is
+    // the only stable hook. Scope to the badge text rather than a structural path.
+    return this.frame().getByText(/Traces:\s*\d+/);
   }
 
   /** Reset to a fresh conversation (clears history back to the greeting). */

--- a/tests_end_to_end/e2e/tests/ollie/ollie-agentic.spec.ts
+++ b/tests_end_to_end/e2e/tests/ollie/ollie-agentic.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '@e2e/fixtures';
+import { OlliePage } from '@e2e/pom/ollie.page';
+
+/**
+ * Ollie — deeper agentic coverage (OPIK-6951), building on the initial smoke
+ * coverage (OPIK-6950). Three flows beyond surface-mount + basic completion:
+ *
+ *   1. Sidebar surface  — the Ollie sidebar iframe mounts on a project page and
+ *                          persists across navigation. Deterministic. @t1-smoke.
+ *   2. Context awareness — the "Traces: N" badge reflects the seeded trace count
+ *                          for the active project. @t2-cuj.
+ *   3. /analyze flow     — running /analyze on a project with traces renders a
+ *                          structured, non-empty response (directional). @t3-nightly.
+ *
+ * All cloud-only — Ollie does not exist on OSS/local. Ollie is a non-deterministic
+ * LLM agent, so assertions are structural/directional, never on exact wording.
+ */
+function skipIfOllieDisabled(envConfig: { features: { ollie: boolean } }): void {
+  test.skip(!envConfig.features.ollie, 'Ollie is cloud/client-only (OLLIE_ENABLED off)');
+}
+
+test.describe('Ollie — sidebar surface', { tag: ['@t1-smoke', '@ollie'] }, () => {
+  test.beforeEach(({ envConfig }) => skipIfOllieDisabled(envConfig));
+
+  test('Ollie sidebar mounts on a project page and persists across navigation', async ({
+    project,
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const ollie = new OlliePage(page, project.id);
+
+    await test.step('Open the Logs page and confirm the Ollie sidebar mounts', async () => {
+      await ollie.gotoSidebarSurface('logs');
+      await ollie.waitForSidebarReady();
+      expect(await ollie.isMounted()).toBe(true);
+    });
+
+    await test.step('Navigate to Experiments and confirm the sidebar persists', async () => {
+      await ollie.gotoSidebarSurface('experiments');
+      // The host re-renders the page content but keeps the sidebar mounted; key
+      // on the iframe being present + usable rather than a full cold re-provision.
+      await ollie.waitForSidebarReady();
+      expect(await ollie.isMounted()).toBe(true);
+    });
+  });
+});
+
+test.describe('Ollie — context awareness', { tag: ['@t2-cuj', '@ollie'] }, () => {
+  test.beforeEach(({ envConfig }) => skipIfOllieDisabled(envConfig));
+
+  const SEEDED_TRACES = 3;
+
+  test('Ollie reflects the seeded trace count in its context badge', async ({
+    project,
+    sdkClient,
+    page,
+  }) => {
+    test.setTimeout(240_000);
+    const ollie = new OlliePage(page, project.id);
+
+    await test.step(`Seed ${SEEDED_TRACES} traces via the Python SDK`, async () => {
+      for (let i = 0; i < SEEDED_TRACES; i++) {
+        await sdkClient.python.createTrace({
+          project_name: project.name,
+          name: `ctx-trace-${i}`,
+          input: `question ${i}`,
+          output: `answer ${i}`,
+        });
+      }
+    });
+
+    await test.step('Open Ollie and verify the "Traces: N" badge matches the seed', async () => {
+      await ollie.goto();
+      await ollie.waitForReady();
+      // Trace ingestion is eventually consistent; contextTraceCount polls the
+      // badge into visibility. Assert it reports the count we seeded.
+      expect(await ollie.contextTraceCount()).toBe(SEEDED_TRACES);
+    });
+  });
+});
+
+test.describe('Ollie — /analyze flow', { tag: ['@t3-nightly', '@ollie'] }, () => {
+  test.beforeEach(({ envConfig }) => skipIfOllieDisabled(envConfig));
+
+  test('Ollie returns a structured response for /analyze on a project with traces', async ({
+    project,
+    sdkClient,
+    page,
+  }) => {
+    test.setTimeout(300_000);
+    const ollie = new OlliePage(page, project.id);
+
+    await test.step('Seed a trace so /analyze has data to work with', async () => {
+      await sdkClient.python.createTrace({
+        project_name: project.name,
+        name: 'analyze-trace',
+        input: 'why did this fail?',
+        output: 'timeout in the search tool',
+      });
+    });
+
+    await test.step('Open Ollie and confirm the /analyze action is offered', async () => {
+      await ollie.goto();
+      await ollie.waitForReady();
+      await expect(ollie.analyzeButton()).toBeVisible();
+    });
+
+    await test.step('Run /analyze and verify a non-empty response renders', async () => {
+      const reply = await ollie.runAnalyze();
+      expect(reply.length).toBeGreaterThan(0);
+      // User-initiated /analyze plus Ollie's response are now in the log.
+      expect(await ollie.messages().count()).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/tests_end_to_end/e2e/tests/ollie/ollie-connect.spec.ts
+++ b/tests_end_to_end/e2e/tests/ollie/ollie-connect.spec.ts
@@ -1,0 +1,178 @@
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import { test, expect } from '@e2e/fixtures';
+import { OlliePage } from '@e2e/pom/ollie.page';
+import { startConnectRunner, type ConnectRunner } from '@e2e/core/local-runner/connect';
+import {
+  evaluatePassRate,
+  seedFailingTraces,
+  KNOWN_FAILING_DIR,
+} from '@e2e/agents/known-failing/harness';
+
+/**
+ * Ollie — Local Runner flows (OPIK-6951 #4/#5; supersedes the abandoned
+ * OPIK-6118/6119/6131/6132 sketches). These drive the heavy, fixture-dependent
+ * agentic loops that depend on a paired `opik connect` runner:
+ *
+ *   - /instrument: connect an UNinstrumented golden agent, run /instrument,
+ *     then assert the agent source gained opik imports + @track decorators.
+ *   - /improve pass-rate loop: connect the known-failing golden agent, run
+ *     /improve, and assert the eval-suite pass rate moves in the right direction.
+ *
+ * Cloud-only and slow (minutes): pairing + an approval-gated LLM agent loop.
+ * Tagged @t3-nightly so they never gate the faster tiers. Ollie is
+ * non-deterministic — assertions are structural (trace shape) and directional
+ * (pass rate up), never on wording or exact values.
+ *
+ * Each test runs `opik connect` as a child process that watches a *scratch
+ * clone* of the golden agent, so Ollie's edits never touch the committed
+ * fixture. The connect daemon is always stopped in a finally block.
+ */
+function skipIfOllieDisabled(envConfig: { features: { ollie: boolean }; apiKey: string | null }): void {
+  test.skip(!envConfig.features.ollie, 'Ollie is cloud/client-only (OLLIE_ENABLED off)');
+  test.skip(!envConfig.apiKey, 'Local Runner pairing needs an OPIK_API_KEY');
+}
+
+const AGENTS_DIR = path.resolve(__dirname, '../../agents');
+
+test.describe('Ollie — Local Runner', { tag: ['@t3-nightly', '@ollie'] }, () => {
+  test.beforeEach(({ envConfig }) => skipIfOllieDisabled(envConfig));
+
+  test('/instrument adds Opik tracing to a connected uninstrumented agent', async ({
+    project,
+    scratchDir,
+    envConfig,
+    page,
+  }) => {
+    test.setTimeout(600_000);
+    const ollie = new OlliePage(page, project.id);
+    let runner: ConnectRunner | null = null;
+
+    try {
+      await test.step('Clone the uninstrumented golden agent into a scratch dir', async () => {
+        await scratchDir.clone(path.join(AGENTS_DIR, 'uninstrumented'));
+      });
+
+      runner = await test.step('Start opik connect against the scratch agent', async () =>
+        startConnectRunner({
+          projectName: project.name,
+          workspace: envConfig.workspace,
+          apiKey: envConfig.apiKey!,
+          cwd: scratchDir.path,
+        }));
+
+      await test.step('Pair the connected runner', async () => {
+        await ollie.pairConnectRunner(runner!.pairUrl);
+      });
+
+      await test.step('Open Ollie, run /instrument, and drive the approval loop', async () => {
+        await ollie.goto();
+        await ollie.waitForReady();
+        await ollie.startInstrument();
+        await ollie.approveUntilSettled();
+      });
+
+      await test.step('Assert the agent source was instrumented with Opik tracing', async () => {
+        // /instrument edits the agent code in the connected dir but does not
+        // necessarily *run* it, so the deterministic, directly-checkable outcome
+        // is the instrumentation itself: the previously-bare agent now imports
+        // opik and carries at least one @opik.track decorator. Asserting on a
+        // logged trace would couple to Ollie also executing the agent and to the
+        // project name it picks — neither is guaranteed by /instrument. The
+        // exact number of decorated functions varies run to run (Ollie is
+        // non-deterministic), so assert presence (>=1), not a count.
+        const agentSrc = await fs.readFile(path.join(scratchDir.path, 'agent.py'), 'utf8');
+        expect(agentSrc, 'agent.py should import opik after /instrument').toMatch(/import opik|from opik/);
+        const trackCount = (agentSrc.match(/@(opik\.)?track/g) ?? []).length;
+        expect(trackCount, 'agent.py should gain at least one @track decorator').toBeGreaterThanOrEqual(1);
+      });
+    } finally {
+      runner?.stop();
+    }
+  });
+
+  // Note: /improve consumes Ollie tokens, so a workspace that exhausts its
+  // credit will stall the loop on a "Manage credits" banner — keep an eye on
+  // that if this flakes. The accept step is a chat reply ("apply"), not a
+  // button (see OlliePage.applyProposal).
+  test('/improve raises the eval-suite pass rate on a known-failing agent', async ({
+    project,
+    scratchDir,
+    envConfig,
+    page,
+  }) => {
+    test.setTimeout(600_000);
+    const ollie = new OlliePage(page, project.id);
+    let runner: ConnectRunner | null = null;
+
+    try {
+      const agentFile = path.join(scratchDir.path, 'agent.py');
+      let agentSrcBefore = '';
+
+      await test.step('Clone the known-failing golden agent into a scratch dir', async () => {
+        await scratchDir.clone(KNOWN_FAILING_DIR);
+        agentSrcBefore = await fs.readFile(agentFile, 'utf8');
+      });
+
+      const before = await test.step('Measure the baseline suite pass rate', async () =>
+        evaluatePassRate(scratchDir.path));
+      // The baseline prompt omits units, so the unit-checked half fails.
+      expect(before.rate, 'baseline should be a partial (failing) pass rate').toBeLessThan(1);
+
+      await test.step('Seed failing traces so Ollie has runs to improve from', async () => {
+        // /improve only surfaces once the project has traces/evaluations — it
+        // improves *from* observed failures. Log a trace per suite item first.
+        await seedFailingTraces(scratchDir.path, {
+          projectName: project.name,
+          workspace: envConfig.workspace,
+          apiKey: envConfig.apiKey!,
+          apiUrl: envConfig.apiBaseUrl,
+        });
+      });
+
+      runner = await test.step('Start opik connect against the scratch agent', async () =>
+        startConnectRunner({
+          projectName: project.name,
+          workspace: envConfig.workspace,
+          apiKey: envConfig.apiKey!,
+          cwd: scratchDir.path,
+        }));
+
+      await test.step('Pair the connected runner', async () => {
+        await ollie.pairConnectRunner(runner!.pairUrl);
+      });
+
+      await test.step('Open Ollie and run /improve to completion', async () => {
+        await ollie.goto();
+        await ollie.waitForReady();
+        // The seeded traces are eventually consistent; wait for /improve to be
+        // offered before clicking it.
+        await expect(ollie.improveButton()).toBeVisible({ timeout: 60_000 });
+        await ollie.startImprove();
+        // Analyse phase: approve tool calls while Ollie reads the traces + code.
+        await ollie.approveUntilSettled();
+        // Ollie proposes a fix and waits for a chat "apply" to authorise it.
+        await ollie.applyProposal();
+        // Apply phase: approve the edit/run tools that land the change.
+        await ollie.approveUntilSettled();
+      });
+
+      await test.step('Assert Ollie edited the agent and the pass rate improved', async () => {
+        // First confirm /improve actually changed the agent source. This makes a
+        // failure self-diagnosing: "Ollie made no edit" (proposed-but-not-applied,
+        // out of credit, etc.) reads differently from "edited but the suite still
+        // fails". Don't assert *what* changed — Ollie may word its fix any way.
+        const agentSrcAfter = await fs.readFile(agentFile, 'utf8');
+        expect(agentSrcAfter, '/improve should have edited agent.py').not.toBe(agentSrcBefore);
+
+        const after = await evaluatePassRate(scratchDir.path);
+        expect(
+          after.rate,
+          `pass rate should rise after /improve (before=${before.passed}/${before.total}, after=${after.passed}/${after.total})`,
+        ).toBeGreaterThan(before.rate);
+      });
+    } finally {
+      runner?.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Details

Adds deeper Ollie E2E coverage (follow-up to the initial smoke tests in OPIK-6950), covering its agentic flows. Five new tests under `tests_end_to_end/e2e/tests/ollie/`, all cloud-gated and verified green on staging. Ollie is a non-deterministic LLM, so assertions are structural (DOM/file shape) or directional (pass rate up), never exact wording.

- **`ollie-agentic.spec.ts`** — sidebar surface mounts + persists across navigation (`@t1-smoke`); the "Traces: N" context badge matches the SDK-seeded count (`@t2-cuj`); `/analyze` renders a structured response (`@t3-nightly`).
- **`ollie-connect.spec.ts`** (`@t3-nightly`) — the Local Runner flows: `/instrument` adds tracing to a connected uninstrumented agent (asserts the source gains `opik` imports + `@track`); `/improve` runs the optimize loop on a known-failing agent and asserts the eval-suite pass rate rises (2/6 → 6/6).
- **Golden agents** (`agents/`, OPIK-6125): one uninstrumented + one known-failing (with a fixed eval suite). Offline/deterministic — no real LLM call.
- **`core/local-runner/connect.ts`** — reusable helper to spawn `opik connect`, pair it, and seed/evaluate the agent.

### How the `opik connect` tests work (for adding more coverage)

The two `@t3-nightly` tests drive Ollie's Local Runner end to end. The reusable pieces make it straightforward to cover other connect-dependent flows (e.g. **prompt-library ↔ agent sync**: connect an agent, then assert the UI reflects its prompts):

1. `startConnectRunner({ projectName, workspace, apiKey, cwd })` — spawns `opik connect` as a child process pointed at `cwd` (a scratch copy of an agent), and returns the scraped pairing URL. Always call `runner.stop()` in a `finally`.
2. `ollie.pairConnectRunner(pairUrl)` — opens the pairing link in the authed browser; Ollie is now connected and can see the agent's code.
3. Drive Ollie from the POM: `startInstrument()` / `startImprove()`, `approveUntilSettled()` to clear the per-action approval prompts, and `applyProposal()` when Ollie asks you to reply "apply" to accept a change.
4. Assert your outcome (a UI state, a trace via the SDK, a file edit, etc.).

Notes for authors: connect runs consume Ollie tokens (an out-of-credit workspace stalls on a "Manage credits" banner), and these flows take ~1–2 min — hence `@t3-nightly`. Point the runner at a *scratch copy* so Ollie's edits never touch the committed fixture.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6951
- OPIK-6125 (golden agent fixtures)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation (live UI discovery, POM + specs, golden agents, connect harness)
- Human verification: code review + live staging runs (full Ollie suite green)

## Testing

Run against Cloud staging (Ollie is cloud-only and skips on OSS):

```
cd tests_end_to_end/e2e
OPIK_DEPLOYMENT=cloud OPIK_BASE_URL=https://<staging>/opik \
OPIK_WORKSPACE=<ws> OPIK_API_KEY=<key> WORKERS=1 \
npx playwright test tests/ollie/ --reporter=list
```

- All 7 Ollie tests (2 existing smoke + 5 new) pass end-to-end (~3.6 min full suite).
- `/instrument` and `/improve` verified repeatedly via the live `opik connect` flow; `/improve` confirmed lifting pass rate 2/6 → 6/6.
- `npx tsc --noEmit` clean.
- Not run: OSS/local (tests skip there by design — Ollie doesn't exist).

## Documentation

N/A — test-only change. The connect harness usage is documented in this PR's Details and in `agents/README.md`.
