### PR TITLE
[OPIK-6954] [BE] [SDK] fix: reinject extracted attachments as data URIs so the UI can render them

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/attachment/AttachmentReinjectorService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/attachment/AttachmentReinjectorService.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.function.Tuple2;
@@ -183,8 +184,16 @@ public class AttachmentReinjectorService {
                             .flatMap(this::readAllBytesAsync)
                             .map(data -> {
                                 String base64 = Base64.getEncoder().encodeToString(data);
+                                // Restore the data URI form so consumers (e.g. the UI inline
+                                // image renderer) can recognize and render the payload. Raw
+                                // base64 is neither folded nor rendered, leaving a giant blob
+                                // in the input (OPIK-6954).
+                                String mimeType = attachInfo.mimeType();
+                                String value = StringUtils.isNotBlank(mimeType)
+                                        ? "data:%s;base64,%s".formatted(mimeType, base64)
+                                        : base64;
                                 String wrappedRef = AttachmentUtils.wrapReference(filename);
-                                return Tuples.of(wrappedRef, base64);
+                                return Tuples.of(wrappedRef, value);
                             })
                             .onErrorResume(e -> {
                                 log.error("Failed to download attachment: {}", filename, e);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/attachment/AttachmentReinjectorService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/attachment/AttachmentReinjectorService.java
@@ -188,8 +188,13 @@ public class AttachmentReinjectorService {
                                 // image renderer) can recognize and render the payload. Raw
                                 // base64 is neither folded nor rendered, leaving a giant blob
                                 // in the input (OPIK-6954).
-                                String mimeType = attachInfo.mimeType();
-                                String value = StringUtils.isNotBlank(mimeType)
+                                // Canonicalize the stored mime type before interpolating it:
+                                // drop any parameters (e.g. "; charset=utf-8") and accept only a
+                                // strict type/subtype, otherwise an invalid data URI would itself
+                                // break inline rendering. Fall back to raw base64 when unusable.
+                                String mimeType = StringUtils
+                                        .trimToEmpty(StringUtils.substringBefore(attachInfo.mimeType(), ";"));
+                                String value = mimeType.matches("[\\w.+-]+/[\\w.+-]+")
                                         ? "data:%s;base64,%s".formatted(mimeType, base64)
                                         : base64;
                                 String wrappedRef = AttachmentUtils.wrapReference(filename);

--- a/sdks/python/tests/e2e/test_attachments_extraction.py
+++ b/sdks/python/tests/e2e/test_attachments_extraction.py
@@ -483,16 +483,16 @@ def test_extraction__backend_reinjects_extracted_attachments(
     # Verify trace and span returned by backend has extracted attachments injected back into
     #
 
-    # The SDK consumes the `data:<mime>;base64,` prefix as part of the
-    # extraction match (OPIK-6608), so the placeholder replaces the whole data
-    # URI. On reinjection the backend only knows the raw base64 payload —
-    # round-trip strips the data URI prefix by design.
+    # On reinjection the backend restores the `data:<mime>;base64,` data URI
+    # using the stored attachment mime type, so the round-tripped value is a
+    # renderable data URI rather than a raw base64 blob the UI cannot render
+    # (OPIK-6954).
     expected_trace_input = {
-        "image1": constants.PNG_BASE64,
+        "image1": _create_base64_url("image/png", constants.PNG_BASE64),
         "text": "regular text field",
     }
     expected_span_input = {
-        "image": constants.PNG_BASE64,
+        "image": _create_base64_url("image/png", constants.PNG_BASE64),
     }
 
     # Verify trace


### PR DESCRIPTION
## Details

On non-truncated reads (`truncate=false`, the default for `GET /traces/{id}` and `GET /spans/{id}`), the backend re-injected previously stripped attachments as **raw base64 with no `data:<mime>;base64,` prefix**. The frontend only folds/renders base64 that is a data URI, so the image did not render and the long base64 string reappeared in the trace/span input — the reported symptom. The SDK and storage were already correct (ClickHouse stores a clean placeholder); the regression lived purely in reinjection, and was introduced when attachment extraction started stripping the data-URI prefix on the SDK side while reinjection still emitted raw base64.

- `AttachmentReinjectorService` now reinjects `data:<mimeType>;base64,<data>` using the stored attachment mime type, restoring the prefix the SDK strips on extraction and keeping the strip/reinject round-trip symmetric.
- This makes the reinjected payload renderable (and foldable) by the UI; the stored value remains a clean placeholder, so the earlier dangling-prefix issue cannot return.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6954
- Follow-up to OPIK-6387

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: assisted (root-cause investigation, fix, and test)
  - Human verification: code review + manual reproduction + e2e tests

## Testing

- Updated the attachment-extraction e2e test `test_extraction__backend_reinjects_extracted_attachments` to assert the renderable data-URI round-trip. Verified it **fails** against the prior behavior (expects `data:image/png;base64,…`, got raw base64) and **passes** with the fix.
- Full suite: `pytest sdks/python/tests/e2e/test_attachments_extraction.py` → 12 passed, against a locally built backend image carrying the fix.
- Backend: `mvn spotless:apply compile -DskipTests` clean; `ruff check`/`ruff format --check` clean on the changed test.
- Manual: reproduced the original Google ADK image flow against a local stack — trace and LLM-span `input` now round-trip to `data:image/png;base64,…` (renderable), with no raw base64 blob remaining.

## Documentation

N/A
