### PR TITLE
[DND-827] [BE] perf: fix sandbox-executor per-request latency regression (recompiling stdlib)

### DIFF
--- a/apps/opik-sandbox-executor-python/Dockerfile
+++ b/apps/opik-sandbox-executor-python/Dockerfile
@@ -57,6 +57,15 @@ COPY --from=builder /build/scoring_runner.pyc ./scoring_runner.pyc
 COPY --from=builder /prewarm.pyc /tmp/prewarm.pyc
 COPY --from=builder /usr/local/bin/selftest.sh /usr/local/bin/selftest.sh
 
+# Bake stdlib bytecode at build time. The slimming above only touched
+# site-packages; the stdlib under /usr/local/lib/python3.12 keeps its source
+# with no __pycache__. The runtime CMD runs as user 1001 with
+# PYTHONDONTWRITEBYTECODE=1, so without this the cold per-request process
+# recompiles inspect/typing/ast/re/... from source on EVERY invocation and
+# cannot cache the result (root-owned dir + DONTWRITEBYTECODE). Compile at
+# opt-level 0 so the cached .pyc matches the runtime optimization level.
+RUN python -m compileall -q /usr/local/lib/python3.12 || true
+
 # Prewarm imports, then fail the build if the runner can't score in this stage.
 RUN python /tmp/prewarm.pyc \
     && sh /usr/local/bin/selftest.sh ./scoring_runner.pyc


### PR DESCRIPTION
## Details

The `scoring_executor_latency` metric ("Container Request Execution Latency") rose ~60ms uniformly across p50/p90/p95 after the sandbox-executor Dockerfile optimization (#7010). The metric measures `python scoring_runner.pyc <code> <data>` run via `exec_run` inside a **warm pooled container** — but the Python **process is cold on every request**, so its import cost is paid per-request.

**Root cause:** the optimization compiled & stripped **`site-packages`** to bytecode, but the **standard library** under `/usr/local/lib/python3.12/` kept its `.py` source with **no `__pycache__`**. Combined with `PYTHONDONTWRITEBYTECODE=1` and running as `USER 1001` (read-only on the root-owned stdlib dir), every request's cold process **recompiles `inspect`/`typing`/`ast`/`re`/`traceback`/… from source and throws the bytecode away** — every single time.

**Fix:** bake stdlib bytecode at build time, before dropping privileges:

```dockerfile
RUN python -m compileall -q /usr/local/lib/python3.12 || true
```

Plain `compileall` (no `-o 2`) so the cached `.pyc` matches the runtime's opt-level 0 — otherwise Python ignores opt-2 bytecode at opt-0 and recompiles anyway.

## Change checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update

## Issues

DND-827

## Testing

Built the pre-#7010, current, and patched images locally and benchmarked the exact runtime path (`exec_run python scoring_runner.pyc` against a warm pooled container, 23 runs after warmup):

| Image | p50 | p90 | p95 | p99 | stdlib import self-time |
|---|---|---|---|---|---|
| Pre-#7010 | 105ms | 116ms | 117ms | 117ms | 31ms |
| Current (regressed) | 171ms | 176ms | 190ms | 213ms | 109ms |
| **This PR** | **109ms** | **119ms** | **120ms** | **124ms** | — |

Restores pre-regression latency. `selftest.sh` still passes in both build stages.

## Documentation

No documentation changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
