### PR TITLE
[OPIK-6687] [FE] feat: surface integration logo in IntegrationDetailsDialog title

### DIFF
--- a/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/components/IntegrationDetailsDialog.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/components/IntegrationDetailsDialog.tsx
@@ -83,7 +83,7 @@ const IntegrationDetailsDialog: React.FunctionComponent<
     <Dialog open={!!selectedIntegration} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-[920px] gap-2">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-3">
+          <DialogTitle className="flex items-center gap-1.5">
             <img
               alt={selectedIntegration.title}
               src={iconSrc}

--- a/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/components/IntegrationDetailsDialog.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/components/IntegrationDetailsDialog.tsx
@@ -23,8 +23,6 @@ import { IntegrationStep } from "./IntegrationStep";
 import { useFeatureFlagVariantKey } from "posthog-js/react";
 import { CODE_EXECUTOR_SERVICE_URL } from "@/api/api";
 import CodeExecutor from "@/v1/pages-shared/onboarding/CodeExecutor/CodeExecutor";
-import { useTheme } from "@/contexts/theme-provider";
-import { THEME_MODE } from "@/constants/theme";
 
 type IntegrationDetailsDialogProps = {
   selectedIntegration?: Integration;
@@ -37,16 +35,10 @@ const IntegrationDetailsDialog: React.FunctionComponent<
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const apiKey = useUserApiKey();
   const variant = useFeatureFlagVariantKey("run-button-activation-test");
-  const { themeMode } = useTheme();
 
   if (!selectedIntegration) {
     return null;
   }
-
-  const iconSrc =
-    themeMode === THEME_MODE.DARK && selectedIntegration.whiteIcon
-      ? selectedIntegration.whiteIcon
-      : selectedIntegration.icon;
 
   const { code: codeWithConfig, lines } = putConfigInCode({
     code: selectedIntegration.code,
@@ -83,12 +75,7 @@ const IntegrationDetailsDialog: React.FunctionComponent<
     <Dialog open={!!selectedIntegration} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-[920px] gap-2">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-1.5">
-            <img
-              alt={selectedIntegration.title}
-              src={iconSrc}
-              className="size-7 shrink-0"
-            />
+          <DialogTitle className="flex items-center gap-3">
             {selectedIntegration.title} Integration
           </DialogTitle>
         </DialogHeader>

--- a/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/components/IntegrationDetailsDialog.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/onboarding/IntegrationExplorer/components/IntegrationDetailsDialog.tsx
@@ -23,6 +23,8 @@ import { IntegrationStep } from "./IntegrationStep";
 import { useFeatureFlagVariantKey } from "posthog-js/react";
 import { CODE_EXECUTOR_SERVICE_URL } from "@/api/api";
 import CodeExecutor from "@/v1/pages-shared/onboarding/CodeExecutor/CodeExecutor";
+import { useTheme } from "@/contexts/theme-provider";
+import { THEME_MODE } from "@/constants/theme";
 
 type IntegrationDetailsDialogProps = {
   selectedIntegration?: Integration;
@@ -35,10 +37,16 @@ const IntegrationDetailsDialog: React.FunctionComponent<
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const apiKey = useUserApiKey();
   const variant = useFeatureFlagVariantKey("run-button-activation-test");
+  const { themeMode } = useTheme();
 
   if (!selectedIntegration) {
     return null;
   }
+
+  const iconSrc =
+    themeMode === THEME_MODE.DARK && selectedIntegration.whiteIcon
+      ? selectedIntegration.whiteIcon
+      : selectedIntegration.icon;
 
   const { code: codeWithConfig, lines } = putConfigInCode({
     code: selectedIntegration.code,
@@ -76,6 +84,11 @@ const IntegrationDetailsDialog: React.FunctionComponent<
       <DialogContent className="max-w-[920px] gap-2">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-3">
+            <img
+              alt={selectedIntegration.title}
+              src={iconSrc}
+              className="size-7 shrink-0"
+            />
             {selectedIntegration.title} Integration
           </DialogTitle>
         </DialogHeader>

--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationExplorer/components/IntegrationDetailsDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationExplorer/components/IntegrationDetailsDialog.tsx
@@ -82,7 +82,7 @@ const IntegrationDetailsDialog: React.FunctionComponent<
     <Dialog open={!!selectedIntegration} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-[920px] gap-2">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-3">
+          <DialogTitle className="flex items-center gap-1.5">
             <img
               alt={selectedIntegration.title}
               src={iconSrc}

--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationExplorer/components/IntegrationDetailsDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/IntegrationExplorer/components/IntegrationDetailsDialog.tsx
@@ -21,6 +21,8 @@ import { IntegrationStep } from "./IntegrationStep";
 import { useFeatureFlagVariantKey } from "posthog-js/react";
 import { CODE_EXECUTOR_SERVICE_URL } from "@/api/api";
 import CodeExecutor from "@/v2/pages-shared/onboarding/CodeExecutor/CodeExecutor";
+import { useTheme } from "@/contexts/theme-provider";
+import { THEME_MODE } from "@/constants/theme";
 
 type IntegrationDetailsDialogProps = {
   selectedIntegration?: Integration;
@@ -34,10 +36,16 @@ const IntegrationDetailsDialog: React.FunctionComponent<
   const apiKey = useUserApiKey();
   const variant = useFeatureFlagVariantKey("run-button-activation-test");
   const projectName = useActiveProjectName();
+  const { themeMode } = useTheme();
 
   if (!selectedIntegration) {
     return null;
   }
+
+  const iconSrc =
+    themeMode === THEME_MODE.DARK && selectedIntegration.whiteIcon
+      ? selectedIntegration.whiteIcon
+      : selectedIntegration.icon;
 
   const { code: codeWithConfig, lines } = putConfigInCode({
     code: selectedIntegration.code,
@@ -75,6 +83,11 @@ const IntegrationDetailsDialog: React.FunctionComponent<
       <DialogContent className="max-w-[920px] gap-2">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-3">
+            <img
+              alt={selectedIntegration.title}
+              src={iconSrc}
+              className="size-7 shrink-0"
+            />
             {selectedIntegration.title} Integration
           </DialogTitle>
         </DialogHeader>

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ManualIntegrationDetail.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ManualIntegrationDetail.tsx
@@ -49,7 +49,7 @@ const ManualIntegrationDetail: React.FC<ManualIntegrationDetailProps> = ({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-1.5">
-        <h3 className="comet-title-xs flex items-center gap-3">
+        <h3 className="comet-title-xs flex items-center gap-1.5">
           <img
             alt={integration.title}
             src={iconSrc}

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ManualIntegrationDetail.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/AgentOnboarding/ManualIntegrationDetail.tsx
@@ -9,6 +9,8 @@ import { INSTALL_OPIK_SECTION_TITLE } from "@/constants/shared";
 import { useAgentOnboarding } from "./AgentOnboardingContext";
 import AgentCopyButtons from "@/v2/pages-shared/onboarding/AgentCopyButtons";
 import { Separator } from "@/ui/separator";
+import { useTheme } from "@/contexts/theme-provider";
+import { THEME_MODE } from "@/constants/theme";
 
 type ManualIntegrationDetailProps = {
   integration: Integration;
@@ -20,6 +22,12 @@ const ManualIntegrationDetail: React.FC<ManualIntegrationDetailProps> = ({
   const { agentName } = useAgentOnboarding();
   const workspaceName = useActiveWorkspaceName();
   const apiKey = useUserApiKey();
+  const { themeMode } = useTheme();
+
+  const iconSrc =
+    themeMode === THEME_MODE.DARK && integration.whiteIcon
+      ? integration.whiteIcon
+      : integration.icon;
 
   const { code: codeWithConfig, lines } = putConfigInCode({
     code: integration.code,
@@ -41,7 +49,12 @@ const ManualIntegrationDetail: React.FC<ManualIntegrationDetailProps> = ({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-1.5">
-        <h3 className="comet-title-xs">
+        <h3 className="comet-title-xs flex items-center gap-3">
+          <img
+            alt={integration.title}
+            src={iconSrc}
+            className="size-7 shrink-0"
+          />
           Integrate Opik with {integration.title}
         </h3>
         <p className="comet-body-s text-muted-slate">


### PR DESCRIPTION
## Details

<img width="1220" height="870" alt="image" src="https://github.com/user-attachments/assets/9528287d-d3aa-49e7-b014-31d2dfc6059c" />

When a user clicks an integration card on the Get Started page, the resulting integration detail view shows a text-only title with no visual anchor to the logo-first integration grid the user just came from. This PR fills the existing leading-icon slot on `DialogTitle` and adds the same treatment to the `<h3>` in the AgentOnboarding manual-integration detail, so the detail view stays visually anchored to its card.

- v2 `IntegrationDetailsDialog`: render a `size-7` `<img>` of `selectedIntegration.icon` to the left of the title, with the existing dark-mode `whiteIcon` swap via `useTheme()` — mirrors the pattern already used by `IntegrationGrid`/`IntegrationCard`. Gap on `DialogTitle` tightened from `gap-3` to `gap-1.5` so the logo reads as a leading icon rather than a separate column.
- v2 `ManualIntegrationDetail`: same treatment on the `<h3>` (added `flex items-center gap-1.5` since the heading wasn't a flex container).
- v1 `IntegrationDetailsDialog` is intentionally not changed. The ticket originally listed v1 too, but per `.claude/rules/agents.md` ("v1 changes only on special request") and PR review feedback, this stays v2-only. v1 parity is a one-file follow-up if ever wanted.

> Recreated from #6858 (closed without merging). Branch rebased onto the latest `main`.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6687

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.7
  - Scope: full implementation
  - Human verification: code review pending; visual QA via test-environment deploy

## Testing

- `pre-commit run --files <changed .tsx files>` — clean (no findings)
- Repo pre-commit hook on commit ran `npm run lint:fix`, `npm run typecheck`, and `depcruise` against the FE — all green
- Visual QA: `test-environment` label applied; verified IntegrationDetailsDialog logo placement and tightened gap on https://pr-7116.dev.comet.com. `ManualIntegrationDetail` h3 requires a signed-in environment (Agent Onboarding flow), so not visually verifiable in the public test env — covered by lint/typecheck + code review.

## Documentation

N/A