### PR TITLE
[OPIK-6028] [CI] perf: build Docker images once via GHCR, parallelize E2E tests

### DIFF
--- a/.github/workflows/build_e2e_docker.yaml
+++ b/.github/workflows/build_e2e_docker.yaml
@@ -35,7 +35,7 @@ jobs:
           else
             TAG="ci-e2e-${{ github.sha }}${{ inputs.include_guardrails == true && '-guardrails' || '' }}"
           fi
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@v6
@@ -55,6 +55,7 @@ jobs:
           if [ "${{ inputs.include_guardrails }}" = "true" ]; then
             SERVICES="$SERVICES guardrails-backend"
           fi
+          # shellcheck disable=SC2086
           docker compose -f deployment/docker-compose/docker-compose.yaml \
             build $SERVICES
 

--- a/.github/workflows/build_e2e_docker.yaml
+++ b/.github/workflows/build_e2e_docker.yaml
@@ -30,10 +30,13 @@ jobs:
       - name: Set image tag
         id: tag
         run: |
+          SHA="${{ github.sha }}"
+          SHORT_SHA="${SHA:0:7}"
+          SUFFIX="${{ inputs.include_guardrails == true && '-guardrails' || '' }}"
           if [ -n "${{ github.event.pull_request.number }}" ]; then
-            TAG="ci-e2e-${{ github.event.pull_request.number }}${{ inputs.include_guardrails == true && '-guardrails' || '' }}"
+            TAG="ci-e2e-pr${{ github.event.pull_request.number }}-${SHORT_SHA}${SUFFIX}"
           else
-            TAG="ci-e2e-${{ github.sha }}${{ inputs.include_guardrails == true && '-guardrails' || '' }}"
+            TAG="ci-e2e-${SHORT_SHA}${SUFFIX}"
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build_e2e_docker.yaml
+++ b/.github/workflows/build_e2e_docker.yaml
@@ -62,14 +62,27 @@ jobs:
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
 
-          for IMAGE in opik-backend opik-python-backend; do
-            docker tag ${{ env.DOCKER_REGISTRY }}/$IMAGE:latest \
-              ${{ env.DOCKER_REGISTRY }}/$IMAGE:$TAG
-            docker push ${{ env.DOCKER_REGISTRY }}/$IMAGE:$TAG
+          IMAGES="opik-backend opik-python-backend"
+          if [ "${{ inputs.include_guardrails }}" = "true" ]; then
+            IMAGES="${IMAGES} opik-guardrails-backend"
+          fi
+
+          # Tag all images first (cheap, sequential)
+          for IMAGE in ${IMAGES}; do
+            docker tag "${{ env.DOCKER_REGISTRY }}/${IMAGE}:latest" \
+              "${{ env.DOCKER_REGISTRY }}/${IMAGE}:${TAG}"
           done
 
-          if [ "${{ inputs.include_guardrails }}" = "true" ]; then
-            docker tag ${{ env.DOCKER_REGISTRY }}/opik-guardrails-backend:latest \
-              ${{ env.DOCKER_REGISTRY }}/opik-guardrails-backend:$TAG
-            docker push ${{ env.DOCKER_REGISTRY }}/opik-guardrails-backend:$TAG
-          fi
+          # Push all images in parallel
+          PIDS=()
+          for IMAGE in ${IMAGES}; do
+            docker push "${{ env.DOCKER_REGISTRY }}/${IMAGE}:${TAG}" &
+            PIDS+=($!)
+          done
+
+          # Wait for all pushes, fail if any fails
+          FAILED=0
+          for PID in "${PIDS[@]}"; do
+            wait "${PID}" || FAILED=1
+          done
+          exit "${FAILED}"

--- a/.github/workflows/build_e2e_docker.yaml
+++ b/.github/workflows/build_e2e_docker.yaml
@@ -1,0 +1,75 @@
+name: Build E2E Docker Images
+
+on:
+  workflow_call:
+    inputs:
+      include_guardrails:
+        description: "Build and include guardrails-backend image"
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      image_tag:
+        description: "The GHCR image tag used for this build"
+        value: ${{ jobs.build.outputs.image_tag }}
+
+env:
+  DOCKER_REGISTRY: ghcr.io/comet-ml/opik
+
+jobs:
+  build:
+    name: Build E2E Docker Images
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Set image tag
+        id: tag
+        run: |
+          if [ -n "${{ github.event.pull_request.number }}" ]; then
+            TAG="ci-e2e-${{ github.event.pull_request.number }}${{ inputs.include_guardrails == true && '-guardrails' || '' }}"
+          else
+            TAG="ci-e2e-${{ github.sha }}${{ inputs.include_guardrails == true && '-guardrails' || '' }}"
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build E2E Docker images
+        env:
+          COMPOSE_BAKE: false
+        run: |
+          SERVICES="backend python-backend"
+          if [ "${{ inputs.include_guardrails }}" = "true" ]; then
+            SERVICES="$SERVICES guardrails-backend"
+          fi
+          docker compose -f deployment/docker-compose/docker-compose.yaml \
+            build $SERVICES
+
+      - name: Push images to GHCR
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+
+          for IMAGE in opik-backend opik-python-backend; do
+            docker tag ${{ env.DOCKER_REGISTRY }}/$IMAGE:latest \
+              ${{ env.DOCKER_REGISTRY }}/$IMAGE:$TAG
+            docker push ${{ env.DOCKER_REGISTRY }}/$IMAGE:$TAG
+          done
+
+          if [ "${{ inputs.include_guardrails }}" = "true" ]; then
+            docker tag ${{ env.DOCKER_REGISTRY }}/opik-guardrails-backend:latest \
+              ${{ env.DOCKER_REGISTRY }}/opik-guardrails-backend:$TAG
+            docker push ${{ env.DOCKER_REGISTRY }}/opik-guardrails-backend:$TAG
+          fi

--- a/.github/workflows/cleanup_e2e_docker.yaml
+++ b/.github/workflows/cleanup_e2e_docker.yaml
@@ -6,6 +6,12 @@ on:
   schedule:
     - cron: "0 3 * * 6"  # Every Saturday at 03:00 UTC
   workflow_dispatch:
+    inputs:
+      max_age_days:
+        description: "Delete SHA-based tags older than this many days (0 = delete all)"
+        required: false
+        default: "7"
+        type: string
 
 permissions:
   contents: read
@@ -58,7 +64,7 @@ jobs:
       - name: Delete ci-e2e-* images for closed PRs and old SHA tags
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_TO_ACCESS_GITHUB_API || secrets.GITHUB_TOKEN }}
-          MAX_AGE_DAYS: 7
+          MAX_AGE_DAYS: ${{ github.event.inputs.max_age_days || '7' }}
         run: |
           DELETED=0
           SKIPPED=0

--- a/.github/workflows/cleanup_e2e_docker.yaml
+++ b/.github/workflows/cleanup_e2e_docker.yaml
@@ -24,39 +24,78 @@ env:
     opik-guardrails-backend
 
 jobs:
-  cleanup-pr:
-    name: Cleanup closed PR images
-    if: github.event_name == 'pull_request'
+  cleanup:
+    name: Cleanup CI images
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Delete CI images for PR ${{ github.event.pull_request.number }}
+      - name: Delete CI images
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MAX_AGE_DAYS: ${{ github.event.inputs.max_age_days || '7' }}
         run: |
-          PR="${{ github.event.pull_request.number }}"
           DELETED=0
+          SKIPPED=0
           FAILED=0
 
+          # Build the jq filter and age cutoff based on trigger type
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "Mode: PR close — deleting all ci-e2e-pr${PR_NUMBER}-* images"
+            JQ_FILTER=".[] | select(.metadata.container.tags | any(startswith(\"ci-e2e-pr${PR_NUMBER}-\"))) | {id: .id, tags: .metadata.container.tags, created_at: .created_at}"
+            CUTOFF=""
+          else
+            echo "Mode: stale sweep — deleting ci-e2e-* images older than ${MAX_AGE_DAYS} days"
+            JQ_FILTER='.[] | select(.metadata.container.tags | any(startswith("ci-e2e-"))) | {id: .id, tags: .metadata.container.tags, created_at: .created_at}'
+            CUTOFF=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s 2>/dev/null \
+              || date -u -v-"${MAX_AGE_DAYS}"d +%s)
+          fi
+
           for IMAGE in ${{ env.IMAGES }}; do
-            echo "=== Scanning ${IMAGE} for PR #${PR} images ==="
+            echo "=== Scanning ${IMAGE} ==="
 
             if ! VERSIONS=$(gh api \
               "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions" \
               --paginate \
-              --jq ".[] | select(.metadata.container.tags | any(startswith(\"ci-e2e-pr${PR}-\"))) | .id" 2>&1); then
+              --jq "$JQ_FILTER" 2>&1); then
               echo "  Failed to list versions: ${VERSIONS}"
               continue
             fi
 
             if [ -z "$VERSIONS" ]; then
-              echo "  No ci-e2e-pr${PR}-* versions found"
+              echo "  No matching versions found"
               continue
             fi
 
-            while read -r VERSION_ID; do
-              [ -z "$VERSION_ID" ] && continue
-              echo "  Deleting version ${VERSION_ID}"
+            COUNT=$(echo "$VERSIONS" | wc -l | tr -d ' ')
+            echo "  Found ${COUNT} matching versions"
+
+            while read -r VERSION; do
+              [ -z "$VERSION" ] && continue
+              VERSION_ID=$(echo "$VERSION" | jq -r '.id')
+              CI_TAG=$(echo "$VERSION" | jq -r '.tags[] | select(startswith("ci-e2e-"))' | head -1)
+
+              # For stale sweep, check age; for PR close, delete unconditionally
+              if [ -n "$CUTOFF" ]; then
+                CREATED_AT=$(echo "$VERSION" | jq -r '.created_at')
+                CREATED_TS=$(date -u -d "$CREATED_AT" +%s 2>/dev/null \
+                  || date -u -j -f "%Y-%m-%dT%H:%M:%S" "${CREATED_AT%%.*}" +%s 2>/dev/null \
+                  || echo "")
+                if [ -z "$CREATED_TS" ]; then
+                  echo "  Skipping ${IMAGE}:${CI_TAG} (could not parse created_at: ${CREATED_AT})"
+                  SKIPPED=$((SKIPPED + 1))
+                  continue
+                fi
+                if [ "$CREATED_TS" -ge "$CUTOFF" ]; then
+                  SKIPPED=$((SKIPPED + 1))
+                  continue
+                fi
+                echo "  Deleting ${IMAGE}:${CI_TAG} (older than ${MAX_AGE_DAYS} days)"
+              else
+                echo "  Deleting ${IMAGE}:${CI_TAG}"
+              fi
+
               if gh api --method DELETE \
                 "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}"; then
                 DELETED=$((DELETED + 1))
@@ -67,77 +106,7 @@ jobs:
           done
 
           echo ""
-          echo "=== PR #${PR} Cleanup Summary ==="
-          echo "Deleted: ${DELETED}"
-          echo "Failed: ${FAILED}"
-
-  cleanup-stale:
-    name: Cleanup old CI images
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Delete old ci-e2e-* images
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAX_AGE_DAYS: ${{ github.event.inputs.max_age_days || '7' }}
-        run: |
-          DELETED=0
-          SKIPPED=0
-          FAILED=0
-          CUTOFF=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s 2>/dev/null \
-            || date -u -v-"${MAX_AGE_DAYS}"d +%s)
-
-          for IMAGE in ${{ env.IMAGES }}; do
-            echo "=== Scanning ${IMAGE} ==="
-
-            if ! CI_VERSIONS=$(gh api \
-              "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions" \
-              --paginate \
-              --jq '.[] | select(.metadata.container.tags | any(startswith("ci-e2e-"))) | {id: .id, tags: .metadata.container.tags, created_at: .created_at}' 2>&1); then
-              echo "  Failed to list versions: ${CI_VERSIONS}"
-              continue
-            fi
-
-            if [ -z "$CI_VERSIONS" ]; then
-              echo "  No ci-e2e-* versions found"
-              continue
-            fi
-
-            COUNT=$(echo "$CI_VERSIONS" | wc -l | tr -d ' ')
-            echo "  Found ${COUNT} ci-e2e-* versions"
-
-            while read -r VERSION; do
-              [ -z "$VERSION" ] && continue
-              VERSION_ID=$(echo "$VERSION" | jq -r '.id')
-              CREATED_AT=$(echo "$VERSION" | jq -r '.created_at')
-              CI_TAG=$(echo "$VERSION" | jq -r '.tags[] | select(startswith("ci-e2e-"))' | head -1)
-
-              CREATED_TS=$(date -u -d "$CREATED_AT" +%s 2>/dev/null \
-                || date -u -j -f "%Y-%m-%dT%H:%M:%S" "${CREATED_AT%%.*}" +%s 2>/dev/null \
-                || echo "")
-              if [ -z "$CREATED_TS" ]; then
-                echo "  Skipping ${IMAGE}:${CI_TAG} (could not parse created_at: ${CREATED_AT})"
-                SKIPPED=$((SKIPPED + 1))
-                continue
-              fi
-
-              if [ "$CREATED_TS" -lt "$CUTOFF" ]; then
-                echo "  Deleting ${IMAGE}:${CI_TAG} (older than ${MAX_AGE_DAYS} days)"
-                if gh api --method DELETE \
-                  "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}"; then
-                  DELETED=$((DELETED + 1))
-                else
-                  FAILED=$((FAILED + 1))
-                fi
-              else
-                SKIPPED=$((SKIPPED + 1))
-              fi
-            done <<< "$CI_VERSIONS"
-          done
-
-          echo ""
           echo "=== Summary ==="
           echo "Deleted: ${DELETED}"
-          echo "Skipped (recent): ${SKIPPED}"
+          echo "Skipped: ${SKIPPED}"
           echo "Failed: ${FAILED}"

--- a/.github/workflows/cleanup_e2e_docker.yaml
+++ b/.github/workflows/cleanup_e2e_docker.yaml
@@ -55,13 +55,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Delete ci-e2e-* images for closed PRs
+      - name: Delete ci-e2e-* images for closed PRs and old SHA tags
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_TO_ACCESS_GITHUB_API || secrets.GITHUB_TOKEN }}
+          MAX_AGE_DAYS: 7
         run: |
           DELETED=0
           SKIPPED=0
           FAILED=0
+          CUTOFF=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s 2>/dev/null \
+            || date -u -v-${MAX_AGE_DAYS}d +%s)
 
           for IMAGE in ${{ env.IMAGES }}; do
             echo "=== Scanning ${IMAGE} ==="
@@ -70,8 +73,9 @@ jobs:
               "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions" \
               --paginate --jq '.[]' 2>/dev/null) || continue
 
-            echo "$VERSIONS" | jq -c '{id: .id, tags: .metadata.container.tags}' | while read -r VERSION; do
+            echo "$VERSIONS" | jq -c '{id: .id, tags: .metadata.container.tags, created_at: .created_at}' | while read -r VERSION; do
               VERSION_ID=$(echo "$VERSION" | jq -r '.id')
+              CREATED_AT=$(echo "$VERSION" | jq -r '.created_at')
               TAGS=$(echo "$VERSION" | jq -r '.tags[]' 2>/dev/null)
 
               for TAG in $TAGS; do
@@ -82,8 +86,20 @@ jobs:
                 PR_NUM=$(echo "$TAG" | sed -n 's/^ci-e2e-\([0-9]*\)\(-guardrails\)\{0,1\}$/\1/p')
 
                 if [ -z "$PR_NUM" ]; then
-                  # SHA-based tag (workflow_dispatch/schedule/main) — delete if older than 7 days
-                  # These are handled by age below
+                  # SHA-based tag (workflow_dispatch/schedule/main) — delete if older than MAX_AGE_DAYS
+                  CREATED_TS=$(date -u -d "$CREATED_AT" +%s 2>/dev/null \
+                    || date -u -j -f "%Y-%m-%dT%H:%M:%S" "${CREATED_AT%%.*}" +%s 2>/dev/null \
+                    || echo "0")
+                  if [ "$CREATED_TS" -lt "$CUTOFF" ]; then
+                    echo "Deleting ${IMAGE}:${TAG} (SHA tag older than ${MAX_AGE_DAYS} days)"
+                    if gh api --method DELETE \
+                      "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}" 2>/dev/null; then
+                      DELETED=$((DELETED + 1))
+                    else
+                      FAILED=$((FAILED + 1))
+                    fi
+                    break
+                  fi
                   continue
                 fi
 
@@ -97,7 +113,7 @@ jobs:
                   else
                     FAILED=$((FAILED + 1))
                   fi
-                  break  # version deleted, no need to check other tags
+                  break
                 else
                   SKIPPED=$((SKIPPED + 1))
                 fi

--- a/.github/workflows/cleanup_e2e_docker.yaml
+++ b/.github/workflows/cleanup_e2e_docker.yaml
@@ -1,11 +1,112 @@
 name: Cleanup E2E Docker Images
 
 on:
+  pull_request:
+    types: [closed]
+  schedule:
+    - cron: "0 3 * * 6"  # Every Saturday at 03:00 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGES: >-
+    opik-backend
+    opik-python-backend
+    opik-guardrails-backend
+
 jobs:
-  dummy:
-    runs-on: ubuntu-22.04
+  cleanup-pr:
+    name: Cleanup merged PR images
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - name: echo
-        run: echo
+      - name: Delete CI images for PR ${{ github.event.pull_request.number }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_TO_ACCESS_GITHUB_API || secrets.GITHUB_TOKEN }}
+        run: |
+          PR="${{ github.event.pull_request.number }}"
+          TAGS=("ci-e2e-${PR}" "ci-e2e-${PR}-guardrails")
+
+          for IMAGE in ${{ env.IMAGES }}; do
+            VERSIONS=$(gh api \
+              "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions" \
+              --paginate --jq '.[]' 2>/dev/null) || continue
+
+            for TAG in "${TAGS[@]}"; do
+              VERSION_ID=$(echo "$VERSIONS" | jq -r \
+                "select(.metadata.container.tags | index(\"${TAG}\")) | .id" 2>/dev/null)
+
+              if [ -n "$VERSION_ID" ] && [ "$VERSION_ID" != "null" ]; then
+                echo "Deleting ${IMAGE}:${TAG} (version ${VERSION_ID})"
+                gh api --method DELETE \
+                  "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}" \
+                  2>/dev/null && echo "  Deleted" || echo "  Failed (may need admin token)"
+              fi
+            done
+          done
+
+  cleanup-stale:
+    name: Cleanup stale CI images
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Delete ci-e2e-* images for closed PRs
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_TO_ACCESS_GITHUB_API || secrets.GITHUB_TOKEN }}
+        run: |
+          DELETED=0
+          SKIPPED=0
+          FAILED=0
+
+          for IMAGE in ${{ env.IMAGES }}; do
+            echo "=== Scanning ${IMAGE} ==="
+
+            VERSIONS=$(gh api \
+              "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions" \
+              --paginate --jq '.[]' 2>/dev/null) || continue
+
+            echo "$VERSIONS" | jq -c '{id: .id, tags: .metadata.container.tags}' | while read -r VERSION; do
+              VERSION_ID=$(echo "$VERSION" | jq -r '.id')
+              TAGS=$(echo "$VERSION" | jq -r '.tags[]' 2>/dev/null)
+
+              for TAG in $TAGS; do
+                if [[ ! "$TAG" =~ ^ci-e2e- ]]; then
+                  continue
+                fi
+
+                PR_NUM=$(echo "$TAG" | sed -n 's/^ci-e2e-\([0-9]*\)\(-guardrails\)\{0,1\}$/\1/p')
+
+                if [ -z "$PR_NUM" ]; then
+                  # SHA-based tag (workflow_dispatch/schedule/main) — delete if older than 7 days
+                  # These are handled by age below
+                  continue
+                fi
+
+                PR_STATE=$(gh api "/repos/comet-ml/opik/pulls/${PR_NUM}" --jq '.state' 2>/dev/null || echo "unknown")
+
+                if [ "$PR_STATE" = "closed" ]; then
+                  echo "Deleting ${IMAGE}:${TAG} (PR #${PR_NUM} is closed)"
+                  if gh api --method DELETE \
+                    "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}" 2>/dev/null; then
+                    DELETED=$((DELETED + 1))
+                  else
+                    FAILED=$((FAILED + 1))
+                  fi
+                  break  # version deleted, no need to check other tags
+                else
+                  SKIPPED=$((SKIPPED + 1))
+                fi
+              done
+            done
+          done
+
+          echo ""
+          echo "=== Summary ==="
+          echo "Deleted: ${DELETED}"
+          echo "Skipped (open PRs): ${SKIPPED}"
+          echo "Failed: ${FAILED}"

--- a/.github/workflows/cleanup_e2e_docker.yaml
+++ b/.github/workflows/cleanup_e2e_docker.yaml
@@ -70,16 +70,23 @@ jobs:
           SKIPPED=0
           FAILED=0
           CUTOFF=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s 2>/dev/null \
-            || date -u -v-${MAX_AGE_DAYS}d +%s)
+            || date -u -v-"${MAX_AGE_DAYS}"d +%s)
 
           for IMAGE in ${{ env.IMAGES }}; do
             echo "=== Scanning ${IMAGE} ==="
 
-            VERSIONS=$(gh api \
+            if ! VERSIONS=$(gh api \
               "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions" \
-              --paginate --jq '.[]' 2>/dev/null) || continue
+              --paginate 2>&1); then
+              echo "  Failed to list versions: ${VERSIONS}"
+              continue
+            fi
 
-            echo "$VERSIONS" | jq -c '{id: .id, tags: .metadata.container.tags, created_at: .created_at}' | while read -r VERSION; do
+            COUNT=$(echo "$VERSIONS" | jq 'length')
+            echo "  Found ${COUNT} versions"
+
+            while read -r VERSION; do
+              [ -z "$VERSION" ] && continue
               VERSION_ID=$(echo "$VERSION" | jq -r '.id')
               CREATED_AT=$(echo "$VERSION" | jq -r '.created_at')
               TAGS=$(echo "$VERSION" | jq -r '.tags[]' 2>/dev/null)
@@ -92,12 +99,11 @@ jobs:
                 PR_NUM=$(echo "$TAG" | sed -n 's/^ci-e2e-\([0-9]*\)\(-guardrails\)\{0,1\}$/\1/p')
 
                 if [ -z "$PR_NUM" ]; then
-                  # SHA-based tag (workflow_dispatch/schedule/main) — delete if older than MAX_AGE_DAYS
                   CREATED_TS=$(date -u -d "$CREATED_AT" +%s 2>/dev/null \
                     || date -u -j -f "%Y-%m-%dT%H:%M:%S" "${CREATED_AT%%.*}" +%s 2>/dev/null \
                     || echo "0")
                   if [ "$CREATED_TS" -lt "$CUTOFF" ]; then
-                    echo "Deleting ${IMAGE}:${TAG} (SHA tag older than ${MAX_AGE_DAYS} days)"
+                    echo "  Deleting ${IMAGE}:${TAG} (SHA tag older than ${MAX_AGE_DAYS} days)"
                     if gh api --method DELETE \
                       "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}" 2>/dev/null; then
                       DELETED=$((DELETED + 1))
@@ -112,7 +118,7 @@ jobs:
                 PR_STATE=$(gh api "/repos/comet-ml/opik/pulls/${PR_NUM}" --jq '.state' 2>/dev/null || echo "unknown")
 
                 if [ "$PR_STATE" = "closed" ]; then
-                  echo "Deleting ${IMAGE}:${TAG} (PR #${PR_NUM} is closed)"
+                  echo "  Deleting ${IMAGE}:${TAG} (PR #${PR_NUM} is closed)"
                   if gh api --method DELETE \
                     "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}" 2>/dev/null; then
                     DELETED=$((DELETED + 1))
@@ -121,10 +127,11 @@ jobs:
                   fi
                   break
                 else
+                  echo "  Skipping ${IMAGE}:${TAG} (PR #${PR_NUM} is ${PR_STATE})"
                   SKIPPED=$((SKIPPED + 1))
                 fi
               done
-            done
+            done < <(echo "$VERSIONS" | jq -c '.[] | {id: .id, tags: .metadata.container.tags, created_at: .created_at}')
           done
 
           echo ""

--- a/.github/workflows/cleanup_e2e_docker.yaml
+++ b/.github/workflows/cleanup_e2e_docker.yaml
@@ -8,10 +8,10 @@ on:
   workflow_dispatch:
     inputs:
       max_age_days:
-        description: "Delete SHA-based tags older than this many days (0 = delete all)"
+        description: "Delete CI tags older than this many days (0 = delete all)"
         required: false
-        default: "7"
-        type: string
+        default: 7
+        type: number
 
 permissions:
   contents: read

--- a/.github/workflows/cleanup_e2e_docker.yaml
+++ b/.github/workflows/cleanup_e2e_docker.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Delete CI images for PR ${{ github.event.pull_request.number }}
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_TO_ACCESS_GITHUB_API || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR="${{ github.event.pull_request.number }}"
           TAGS=("ci-e2e-${PR}" "ci-e2e-${PR}-guardrails")
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: Delete ci-e2e-* images for closed PRs and old SHA tags
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_TO_ACCESS_GITHUB_API || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAX_AGE_DAYS: ${{ github.event.inputs.max_age_days || '7' }}
         run: |
           DELETED=0

--- a/.github/workflows/cleanup_e2e_docker.yaml
+++ b/.github/workflows/cleanup_e2e_docker.yaml
@@ -28,7 +28,7 @@ jobs:
     name: Cleanup closed PR images
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - name: Delete CI images for PR ${{ github.event.pull_request.number }}
         env:

--- a/.github/workflows/cleanup_e2e_docker.yaml
+++ b/.github/workflows/cleanup_e2e_docker.yaml
@@ -139,7 +139,66 @@ jobs:
           done
 
           echo ""
-          echo "=== Summary ==="
+          echo "=== Tagged Summary ==="
           echo "Deleted: ${DELETED}"
           echo "Skipped (open PRs): ${SKIPPED}"
+          echo "Failed: ${FAILED}"
+
+      - name: Delete untagged CI versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAX_AGE_DAYS: ${{ github.event.inputs.max_age_days || '7' }}
+        run: |
+          DELETED=0
+          FAILED=0
+          CUTOFF=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s 2>/dev/null \
+            || date -u -v-"${MAX_AGE_DAYS}"d +%s)
+
+          for IMAGE in ${{ env.IMAGES }}; do
+            echo "=== Scanning ${IMAGE} for untagged versions ==="
+
+            if ! UNTAGGED=$(gh api \
+              "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions" \
+              --paginate \
+              --jq '.[] | select(.metadata.container.tags | length == 0) | {id: .id, created_at: .created_at}' 2>&1); then
+              echo "  Failed to list versions: ${UNTAGGED}"
+              continue
+            fi
+
+            if [ -z "$UNTAGGED" ]; then
+              echo "  No untagged versions found"
+              continue
+            fi
+
+            COUNT=$(echo "$UNTAGGED" | wc -l | tr -d ' ')
+            echo "  Found ${COUNT} untagged versions"
+
+            while read -r VERSION; do
+              [ -z "$VERSION" ] && continue
+              VERSION_ID=$(echo "$VERSION" | jq -r '.id')
+              CREATED_AT=$(echo "$VERSION" | jq -r '.created_at')
+
+              CREATED_TS=$(date -u -d "$CREATED_AT" +%s 2>/dev/null \
+                || date -u -j -f "%Y-%m-%dT%H:%M:%S" "${CREATED_AT%%.*}" +%s 2>/dev/null \
+                || echo "")
+              if [ -z "$CREATED_TS" ]; then
+                echo "  Skipping untagged version ${VERSION_ID} (could not parse created_at: ${CREATED_AT})"
+                continue
+              fi
+
+              if [ "$CREATED_TS" -lt "$CUTOFF" ]; then
+                echo "  Deleting untagged version ${VERSION_ID} (older than ${MAX_AGE_DAYS} days)"
+                if gh api --method DELETE \
+                  "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}"; then
+                  DELETED=$((DELETED + 1))
+                else
+                  FAILED=$((FAILED + 1))
+                fi
+              fi
+            done <<< "$UNTAGGED"
+          done
+
+          echo ""
+          echo "=== Untagged Summary ==="
+          echo "Deleted: ${DELETED}"
           echo "Failed: ${FAILED}"

--- a/.github/workflows/cleanup_e2e_docker.yaml
+++ b/.github/workflows/cleanup_e2e_docker.yaml
@@ -35,25 +35,41 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR="${{ github.event.pull_request.number }}"
-          TAGS=("ci-e2e-${PR}" "ci-e2e-${PR}-guardrails")
+          DELETED=0
+          FAILED=0
 
           for IMAGE in ${{ env.IMAGES }}; do
-            for TAG in "${TAGS[@]}"; do
-              VERSION_ID=$(gh api \
-                "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions" \
-                --paginate --jq ".[] | select(.metadata.container.tags | index(\"${TAG}\")) | .id" 2>/dev/null | head -1)
+            echo "=== Scanning ${IMAGE} for PR #${PR} images ==="
 
-              if [ -n "$VERSION_ID" ] && [ "$VERSION_ID" != "null" ]; then
-                echo "Deleting ${IMAGE}:${TAG} (version ${VERSION_ID})"
-                if gh api --method DELETE \
-                  "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}"; then
-                  echo "  Deleted"
-                else
-                  echo "  Failed to delete ${IMAGE}:${TAG}"
-                fi
+            if ! VERSIONS=$(gh api \
+              "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions" \
+              --paginate \
+              --jq ".[] | select(.metadata.container.tags | any(startswith(\"ci-e2e-pr${PR}-\"))) | .id" 2>&1); then
+              echo "  Failed to list versions: ${VERSIONS}"
+              continue
+            fi
+
+            if [ -z "$VERSIONS" ]; then
+              echo "  No ci-e2e-pr${PR}-* versions found"
+              continue
+            fi
+
+            while read -r VERSION_ID; do
+              [ -z "$VERSION_ID" ] && continue
+              echo "  Deleting version ${VERSION_ID}"
+              if gh api --method DELETE \
+                "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}"; then
+                DELETED=$((DELETED + 1))
+              else
+                FAILED=$((FAILED + 1))
               fi
-            done
+            done <<< "$VERSIONS"
           done
+
+          echo ""
+          echo "=== PR #${PR} Cleanup Summary ==="
+          echo "Deleted: ${DELETED}"
+          echo "Failed: ${FAILED}"
 
   cleanup-stale:
     name: Cleanup old CI images
@@ -61,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Delete ci-e2e-* images for closed PRs and old SHA tags
+      - name: Delete old ci-e2e-* images
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAX_AGE_DAYS: ${{ github.event.inputs.max_age_days || '7' }}
@@ -75,7 +91,6 @@ jobs:
           for IMAGE in ${{ env.IMAGES }}; do
             echo "=== Scanning ${IMAGE} ==="
 
-            # Fetch only versions that have ci-e2e-* tags (server-side jq filter)
             if ! CI_VERSIONS=$(gh api \
               "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions" \
               --paginate \
@@ -98,33 +113,17 @@ jobs:
               CREATED_AT=$(echo "$VERSION" | jq -r '.created_at')
               CI_TAG=$(echo "$VERSION" | jq -r '.tags[] | select(startswith("ci-e2e-"))' | head -1)
 
-              PR_NUM=$(echo "$CI_TAG" | sed -n 's/^ci-e2e-\([0-9]*\)\(-guardrails\)\{0,1\}$/\1/p')
-
-              if [ -z "$PR_NUM" ]; then
-                CREATED_TS=$(date -u -d "$CREATED_AT" +%s 2>/dev/null \
-                  || date -u -j -f "%Y-%m-%dT%H:%M:%S" "${CREATED_AT%%.*}" +%s 2>/dev/null \
-                  || echo "")
-                if [ -z "$CREATED_TS" ]; then
-                  echo "  Skipping ${IMAGE}:${CI_TAG} (could not parse created_at: ${CREATED_AT})"
-                  SKIPPED=$((SKIPPED + 1))
-                  continue
-                fi
-                if [ "$CREATED_TS" -lt "$CUTOFF" ]; then
-                  echo "  Deleting ${IMAGE}:${CI_TAG} (SHA tag older than ${MAX_AGE_DAYS} days)"
-                  if gh api --method DELETE \
-                    "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}"; then
-                    DELETED=$((DELETED + 1))
-                  else
-                    FAILED=$((FAILED + 1))
-                  fi
-                fi
+              CREATED_TS=$(date -u -d "$CREATED_AT" +%s 2>/dev/null \
+                || date -u -j -f "%Y-%m-%dT%H:%M:%S" "${CREATED_AT%%.*}" +%s 2>/dev/null \
+                || echo "")
+              if [ -z "$CREATED_TS" ]; then
+                echo "  Skipping ${IMAGE}:${CI_TAG} (could not parse created_at: ${CREATED_AT})"
+                SKIPPED=$((SKIPPED + 1))
                 continue
               fi
 
-              PR_STATE=$(gh api "/repos/comet-ml/opik/pulls/${PR_NUM}" --jq '.state' 2>/dev/null || echo "unknown")
-
-              if [ "$PR_STATE" = "closed" ]; then
-                echo "  Deleting ${IMAGE}:${CI_TAG} (PR #${PR_NUM} is closed)"
+              if [ "$CREATED_TS" -lt "$CUTOFF" ]; then
+                echo "  Deleting ${IMAGE}:${CI_TAG} (older than ${MAX_AGE_DAYS} days)"
                 if gh api --method DELETE \
                   "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}"; then
                   DELETED=$((DELETED + 1))
@@ -132,73 +131,13 @@ jobs:
                   FAILED=$((FAILED + 1))
                 fi
               else
-                echo "  Skipping ${IMAGE}:${CI_TAG} (PR #${PR_NUM} is ${PR_STATE})"
                 SKIPPED=$((SKIPPED + 1))
               fi
             done <<< "$CI_VERSIONS"
           done
 
           echo ""
-          echo "=== Tagged Summary ==="
+          echo "=== Summary ==="
           echo "Deleted: ${DELETED}"
-          echo "Skipped (open PRs): ${SKIPPED}"
-          echo "Failed: ${FAILED}"
-
-      - name: Delete untagged CI versions
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAX_AGE_DAYS: ${{ github.event.inputs.max_age_days || '7' }}
-        run: |
-          DELETED=0
-          FAILED=0
-          CUTOFF=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s 2>/dev/null \
-            || date -u -v-"${MAX_AGE_DAYS}"d +%s)
-
-          for IMAGE in ${{ env.IMAGES }}; do
-            echo "=== Scanning ${IMAGE} for untagged versions ==="
-
-            if ! UNTAGGED=$(gh api \
-              "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions" \
-              --paginate \
-              --jq '.[] | select(.metadata.container.tags | length == 0) | {id: .id, created_at: .created_at}' 2>&1); then
-              echo "  Failed to list versions: ${UNTAGGED}"
-              continue
-            fi
-
-            if [ -z "$UNTAGGED" ]; then
-              echo "  No untagged versions found"
-              continue
-            fi
-
-            COUNT=$(echo "$UNTAGGED" | wc -l | tr -d ' ')
-            echo "  Found ${COUNT} untagged versions"
-
-            while read -r VERSION; do
-              [ -z "$VERSION" ] && continue
-              VERSION_ID=$(echo "$VERSION" | jq -r '.id')
-              CREATED_AT=$(echo "$VERSION" | jq -r '.created_at')
-
-              CREATED_TS=$(date -u -d "$CREATED_AT" +%s 2>/dev/null \
-                || date -u -j -f "%Y-%m-%dT%H:%M:%S" "${CREATED_AT%%.*}" +%s 2>/dev/null \
-                || echo "")
-              if [ -z "$CREATED_TS" ]; then
-                echo "  Skipping untagged version ${VERSION_ID} (could not parse created_at: ${CREATED_AT})"
-                continue
-              fi
-
-              if [ "$CREATED_TS" -lt "$CUTOFF" ]; then
-                echo "  Deleting untagged version ${VERSION_ID} (older than ${MAX_AGE_DAYS} days)"
-                if gh api --method DELETE \
-                  "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}"; then
-                  DELETED=$((DELETED + 1))
-                else
-                  FAILED=$((FAILED + 1))
-                fi
-              fi
-            done <<< "$UNTAGGED"
-          done
-
-          echo ""
-          echo "=== Untagged Summary ==="
-          echo "Deleted: ${DELETED}"
+          echo "Skipped (recent): ${SKIPPED}"
           echo "Failed: ${FAILED}"

--- a/.github/workflows/cleanup_e2e_docker.yaml
+++ b/.github/workflows/cleanup_e2e_docker.yaml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   cleanup-pr:
-    name: Cleanup merged PR images
+    name: Cleanup closed PR images
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -45,15 +45,18 @@ jobs:
 
               if [ -n "$VERSION_ID" ] && [ "$VERSION_ID" != "null" ]; then
                 echo "Deleting ${IMAGE}:${TAG} (version ${VERSION_ID})"
-                gh api --method DELETE \
-                  "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}" \
-                  2>/dev/null && echo "  Deleted" || echo "  Failed (may need admin token)"
+                if gh api --method DELETE \
+                  "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}"; then
+                  echo "  Deleted"
+                else
+                  echo "  Failed to delete ${IMAGE}:${TAG}"
+                fi
               fi
             done
           done
 
   cleanup-stale:
-    name: Cleanup stale CI images
+    name: Cleanup old CI images
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -100,11 +103,16 @@ jobs:
               if [ -z "$PR_NUM" ]; then
                 CREATED_TS=$(date -u -d "$CREATED_AT" +%s 2>/dev/null \
                   || date -u -j -f "%Y-%m-%dT%H:%M:%S" "${CREATED_AT%%.*}" +%s 2>/dev/null \
-                  || echo "0")
+                  || echo "")
+                if [ -z "$CREATED_TS" ]; then
+                  echo "  Skipping ${IMAGE}:${CI_TAG} (could not parse created_at: ${CREATED_AT})"
+                  SKIPPED=$((SKIPPED + 1))
+                  continue
+                fi
                 if [ "$CREATED_TS" -lt "$CUTOFF" ]; then
                   echo "  Deleting ${IMAGE}:${CI_TAG} (SHA tag older than ${MAX_AGE_DAYS} days)"
                   if gh api --method DELETE \
-                    "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}" 2>/dev/null; then
+                    "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}"; then
                     DELETED=$((DELETED + 1))
                   else
                     FAILED=$((FAILED + 1))
@@ -118,7 +126,7 @@ jobs:
               if [ "$PR_STATE" = "closed" ]; then
                 echo "  Deleting ${IMAGE}:${CI_TAG} (PR #${PR_NUM} is closed)"
                 if gh api --method DELETE \
-                  "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}" 2>/dev/null; then
+                  "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}"; then
                   DELETED=$((DELETED + 1))
                 else
                   FAILED=$((FAILED + 1))

--- a/.github/workflows/cleanup_e2e_docker.yaml
+++ b/.github/workflows/cleanup_e2e_docker.yaml
@@ -38,13 +38,10 @@ jobs:
           TAGS=("ci-e2e-${PR}" "ci-e2e-${PR}-guardrails")
 
           for IMAGE in ${{ env.IMAGES }}; do
-            VERSIONS=$(gh api \
-              "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions" \
-              --paginate --jq '.[]' 2>/dev/null) || continue
-
             for TAG in "${TAGS[@]}"; do
-              VERSION_ID=$(echo "$VERSIONS" | jq -r \
-                "select(.metadata.container.tags | index(\"${TAG}\")) | .id" 2>/dev/null)
+              VERSION_ID=$(gh api \
+                "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions" \
+                --paginate --jq ".[] | select(.metadata.container.tags | index(\"${TAG}\")) | .id" 2>/dev/null | head -1)
 
               if [ -n "$VERSION_ID" ] && [ "$VERSION_ID" != "null" ]; then
                 echo "Deleting ${IMAGE}:${TAG} (version ${VERSION_ID})"
@@ -75,63 +72,62 @@ jobs:
           for IMAGE in ${{ env.IMAGES }}; do
             echo "=== Scanning ${IMAGE} ==="
 
-            if ! VERSIONS=$(gh api \
+            # Fetch only versions that have ci-e2e-* tags (server-side jq filter)
+            if ! CI_VERSIONS=$(gh api \
               "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions" \
-              --paginate 2>&1); then
-              echo "  Failed to list versions: ${VERSIONS}"
+              --paginate \
+              --jq '.[] | select(.metadata.container.tags | any(startswith("ci-e2e-"))) | {id: .id, tags: .metadata.container.tags, created_at: .created_at}' 2>&1); then
+              echo "  Failed to list versions: ${CI_VERSIONS}"
               continue
             fi
 
-            COUNT=$(echo "$VERSIONS" | jq 'length')
-            echo "  Found ${COUNT} versions"
+            if [ -z "$CI_VERSIONS" ]; then
+              echo "  No ci-e2e-* versions found"
+              continue
+            fi
+
+            COUNT=$(echo "$CI_VERSIONS" | wc -l | tr -d ' ')
+            echo "  Found ${COUNT} ci-e2e-* versions"
 
             while read -r VERSION; do
               [ -z "$VERSION" ] && continue
               VERSION_ID=$(echo "$VERSION" | jq -r '.id')
               CREATED_AT=$(echo "$VERSION" | jq -r '.created_at')
-              TAGS=$(echo "$VERSION" | jq -r '.tags[]' 2>/dev/null)
+              CI_TAG=$(echo "$VERSION" | jq -r '.tags[] | select(startswith("ci-e2e-"))' | head -1)
 
-              for TAG in $TAGS; do
-                if [[ ! "$TAG" =~ ^ci-e2e- ]]; then
-                  continue
-                fi
+              PR_NUM=$(echo "$CI_TAG" | sed -n 's/^ci-e2e-\([0-9]*\)\(-guardrails\)\{0,1\}$/\1/p')
 
-                PR_NUM=$(echo "$TAG" | sed -n 's/^ci-e2e-\([0-9]*\)\(-guardrails\)\{0,1\}$/\1/p')
-
-                if [ -z "$PR_NUM" ]; then
-                  CREATED_TS=$(date -u -d "$CREATED_AT" +%s 2>/dev/null \
-                    || date -u -j -f "%Y-%m-%dT%H:%M:%S" "${CREATED_AT%%.*}" +%s 2>/dev/null \
-                    || echo "0")
-                  if [ "$CREATED_TS" -lt "$CUTOFF" ]; then
-                    echo "  Deleting ${IMAGE}:${TAG} (SHA tag older than ${MAX_AGE_DAYS} days)"
-                    if gh api --method DELETE \
-                      "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}" 2>/dev/null; then
-                      DELETED=$((DELETED + 1))
-                    else
-                      FAILED=$((FAILED + 1))
-                    fi
-                    break
-                  fi
-                  continue
-                fi
-
-                PR_STATE=$(gh api "/repos/comet-ml/opik/pulls/${PR_NUM}" --jq '.state' 2>/dev/null || echo "unknown")
-
-                if [ "$PR_STATE" = "closed" ]; then
-                  echo "  Deleting ${IMAGE}:${TAG} (PR #${PR_NUM} is closed)"
+              if [ -z "$PR_NUM" ]; then
+                CREATED_TS=$(date -u -d "$CREATED_AT" +%s 2>/dev/null \
+                  || date -u -j -f "%Y-%m-%dT%H:%M:%S" "${CREATED_AT%%.*}" +%s 2>/dev/null \
+                  || echo "0")
+                if [ "$CREATED_TS" -lt "$CUTOFF" ]; then
+                  echo "  Deleting ${IMAGE}:${CI_TAG} (SHA tag older than ${MAX_AGE_DAYS} days)"
                   if gh api --method DELETE \
                     "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}" 2>/dev/null; then
                     DELETED=$((DELETED + 1))
                   else
                     FAILED=$((FAILED + 1))
                   fi
-                  break
-                else
-                  echo "  Skipping ${IMAGE}:${TAG} (PR #${PR_NUM} is ${PR_STATE})"
-                  SKIPPED=$((SKIPPED + 1))
                 fi
-              done
-            done < <(echo "$VERSIONS" | jq -c '.[] | {id: .id, tags: .metadata.container.tags, created_at: .created_at}')
+                continue
+              fi
+
+              PR_STATE=$(gh api "/repos/comet-ml/opik/pulls/${PR_NUM}" --jq '.state' 2>/dev/null || echo "unknown")
+
+              if [ "$PR_STATE" = "closed" ]; then
+                echo "  Deleting ${IMAGE}:${CI_TAG} (PR #${PR_NUM} is closed)"
+                if gh api --method DELETE \
+                  "/orgs/comet-ml/packages/container/opik%2F${IMAGE}/versions/${VERSION_ID}" 2>/dev/null; then
+                  DELETED=$((DELETED + 1))
+                else
+                  FAILED=$((FAILED + 1))
+                fi
+              else
+                echo "  Skipping ${IMAGE}:${CI_TAG} (PR #${PR_NUM} is ${PR_STATE})"
+                SKIPPED=$((SKIPPED + 1))
+              fi
+            done <<< "$CI_VERSIONS"
           done
 
           echo ""

--- a/.github/workflows/opik-optimizer-e2e-tests.yaml
+++ b/.github/workflows/opik-optimizer-e2e-tests.yaml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 env:
   OPIK_ENABLE_LITELLM_MODELS_MONITORING: False
@@ -30,8 +31,14 @@ env:
   OPENAI_ORG_ID: ${{ secrets.OPENAI_ORG_ID }}
 
 jobs:
+    build-opik:
+        uses: ./.github/workflows/build_e2e_docker.yaml
+        with:
+          include_guardrails: true
+
     run-e2e-tests:
         name: Opik Optimizer E2E Tests Python ${{matrix.python_version}}
+        needs: build-opik
         runs-on: ubuntu-latest
         timeout-minutes: 40
 
@@ -48,6 +55,24 @@ jobs:
         - name: Check out code
           uses: actions/checkout@v6
 
+        - name: Login to GHCR
+          uses: docker/login-action@v3
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: Pull Docker images from GHCR
+          env:
+            TAG: ${{ needs.build-opik.outputs.image_tag }}
+          run: |
+            docker pull ghcr.io/comet-ml/opik/opik-backend:$TAG
+            docker pull ghcr.io/comet-ml/opik/opik-python-backend:$TAG
+            docker pull ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG
+            docker tag ghcr.io/comet-ml/opik/opik-backend:$TAG ghcr.io/comet-ml/opik/opik-backend:latest
+            docker tag ghcr.io/comet-ml/opik/opik-python-backend:$TAG ghcr.io/comet-ml/opik/opik-python-backend:latest
+            docker tag ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG ghcr.io/comet-ml/opik/opik-guardrails-backend:latest
+
         - name: Setup Python ${{matrix.python_version}}
           uses: actions/setup-python@v5
           with:
@@ -61,12 +86,14 @@ jobs:
         - name: Run latest Opik server
           env:
             OPIK_USAGE_REPORT_ENABLED: false
-            # Avoid Buildx Bake concurrent image export collisions in CI.
             COMPOSE_BAKE: false
             TOGGLE_RUNNERS_ENABLED: "true"
+            OPIK_BACKEND_PULL_POLICY: never
+            PYTHON_BACKEND_PULL_POLICY: never
+            OPIK_GUARDRAILS_BACKEND_PULL_POLICY: never
           run: |
             cd ${{ github.workspace }}
-            ./opik.sh --backend --port-mapping --build
+            ./opik.sh --backend --port-mapping --guardrails
 
         - name: Check Opik server availability
           shell: bash
@@ -119,7 +146,7 @@ jobs:
           if: always()
           run: |
             cd ${{ github.workspace }}
-            ./opik.sh --stop
+            ./opik.sh --stop --guardrails
 
     dataset-source-check:
         name: Opik Optimizer Integration Smoke Tests

--- a/.github/workflows/opik-optimizer-e2e-tests.yaml
+++ b/.github/workflows/opik-optimizer-e2e-tests.yaml
@@ -66,12 +66,12 @@ jobs:
           env:
             TAG: ${{ needs.build-opik.outputs.image_tag }}
           run: |
-            docker pull ghcr.io/comet-ml/opik/opik-backend:$TAG
-            docker pull ghcr.io/comet-ml/opik/opik-python-backend:$TAG
-            docker pull ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG
-            docker tag ghcr.io/comet-ml/opik/opik-backend:$TAG ghcr.io/comet-ml/opik/opik-backend:latest
-            docker tag ghcr.io/comet-ml/opik/opik-python-backend:$TAG ghcr.io/comet-ml/opik/opik-python-backend:latest
-            docker tag ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG ghcr.io/comet-ml/opik/opik-guardrails-backend:latest
+            docker pull "ghcr.io/comet-ml/opik/opik-backend:$TAG"
+            docker pull "ghcr.io/comet-ml/opik/opik-python-backend:$TAG"
+            docker pull "ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG"
+            docker tag "ghcr.io/comet-ml/opik/opik-backend:$TAG" ghcr.io/comet-ml/opik/opik-backend:latest
+            docker tag "ghcr.io/comet-ml/opik/opik-python-backend:$TAG" ghcr.io/comet-ml/opik/opik-python-backend:latest
+            docker tag "ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG" ghcr.io/comet-ml/opik/opik-guardrails-backend:latest
 
         - name: Setup Python ${{matrix.python_version}}
           uses: actions/setup-python@v5

--- a/.github/workflows/opik-optimizer-e2e-tests.yaml
+++ b/.github/workflows/opik-optimizer-e2e-tests.yaml
@@ -86,6 +86,7 @@ jobs:
         - name: Run latest Opik server
           env:
             OPIK_USAGE_REPORT_ENABLED: false
+            # Avoid Buildx Bake concurrent image export collisions in CI.
             COMPOSE_BAKE: false
             TOGGLE_RUNNERS_ENABLED: "true"
             OPIK_BACKEND_PULL_POLICY: never

--- a/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
@@ -79,12 +79,12 @@ jobs:
           env:
             TAG: ${{ needs.build-opik.outputs.image_tag }}
           run: |
-            docker pull ghcr.io/comet-ml/opik/opik-backend:$TAG
-            docker pull ghcr.io/comet-ml/opik/opik-python-backend:$TAG
-            docker pull ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG
-            docker tag ghcr.io/comet-ml/opik/opik-backend:$TAG ghcr.io/comet-ml/opik/opik-backend:latest
-            docker tag ghcr.io/comet-ml/opik/opik-python-backend:$TAG ghcr.io/comet-ml/opik/opik-python-backend:latest
-            docker tag ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG ghcr.io/comet-ml/opik/opik-guardrails-backend:latest
+            docker pull "ghcr.io/comet-ml/opik/opik-backend:$TAG"
+            docker pull "ghcr.io/comet-ml/opik/opik-python-backend:$TAG"
+            docker pull "ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG"
+            docker tag "ghcr.io/comet-ml/opik/opik-backend:$TAG" ghcr.io/comet-ml/opik/opik-backend:latest
+            docker tag "ghcr.io/comet-ml/opik/opik-python-backend:$TAG" ghcr.io/comet-ml/opik/opik-python-backend:latest
+            docker tag "ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG" ghcr.io/comet-ml/opik/opik-guardrails-backend:latest
 
         - name: Setup Python ${{matrix.python_version}}
           uses: actions/setup-python@v5

--- a/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   checks: write
   pull-requests: write
+  packages: write
 on:
     workflow_dispatch:
     pull_request:
@@ -48,8 +49,13 @@ jobs:
                   match-regex: '^sdks/python/|^\.github/workflows/python_sdk_compatibility_v1_e2e_tests\.yml$'
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
+    build-opik:
+        uses: ./.github/workflows/build_e2e_docker.yaml
+        with:
+          include_guardrails: true
+
     run-compatibility-v1-e2e:
-        needs: select-matrix
+        needs: [select-matrix, build-opik]
         name: Python SDK Compatibility V1.x E2E Tests ${{matrix.python_version}}
         runs-on: ubuntu-latest
         timeout-minutes: 30
@@ -60,7 +66,25 @@ jobs:
 
         steps:
         - name: Checkout
-          uses: actions/checkout@v4.1.1
+          uses: actions/checkout@v6
+
+        - name: Login to GHCR
+          uses: docker/login-action@v3
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: Pull Docker images from GHCR
+          env:
+            TAG: ${{ needs.build-opik.outputs.image_tag }}
+          run: |
+            docker pull ghcr.io/comet-ml/opik/opik-backend:$TAG
+            docker pull ghcr.io/comet-ml/opik/opik-python-backend:$TAG
+            docker pull ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG
+            docker tag ghcr.io/comet-ml/opik/opik-backend:$TAG ghcr.io/comet-ml/opik/opik-backend:latest
+            docker tag ghcr.io/comet-ml/opik/opik-python-backend:$TAG ghcr.io/comet-ml/opik/opik-python-backend:latest
+            docker tag ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG ghcr.io/comet-ml/opik/opik-guardrails-backend:latest
 
         - name: Setup Python ${{matrix.python_version}}
           uses: actions/setup-python@v5
@@ -70,13 +94,15 @@ jobs:
         - name: Run latest Opik server
           env:
             OPIK_USAGE_REPORT_ENABLED: false
-            # Avoid Buildx Bake concurrent image export collisions in CI.
             COMPOSE_BAKE: false
             TOGGLE_RUNNERS_ENABLED: "true"
             TOGGLE_AGENT_CONFIGURATION_ENABLED: "true"
+            OPIK_BACKEND_PULL_POLICY: never
+            PYTHON_BACKEND_PULL_POLICY: never
+            OPIK_GUARDRAILS_BACKEND_PULL_POLICY: never
           run: |
             cd ${{ github.workspace }}
-            ./opik.sh --backend --port-mapping --build
+            ./opik.sh --backend --port-mapping --guardrails
 
         - name: Check Opik server availability
           shell: bash
@@ -120,7 +146,7 @@ jobs:
 
         - name: Attach BE log
           if: failure()
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v7
           with:
               name: opik-backend-log-compat-v1-p${{matrix.python_version}}
               path: ${{ github.workspace }}/opik-backend_compat_v1_p${{matrix.python_version}}.log
@@ -129,4 +155,4 @@ jobs:
           if: always()
           run: |
             cd ${{ github.workspace }}
-            ./opik.sh --stop
+            ./opik.sh --stop --guardrails

--- a/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
@@ -94,6 +94,7 @@ jobs:
         - name: Run latest Opik server
           env:
             OPIK_USAGE_REPORT_ENABLED: false
+            # Avoid Buildx Bake concurrent image export collisions in CI.
             COMPOSE_BAKE: false
             TOGGLE_RUNNERS_ENABLED: "true"
             TOGGLE_AGENT_CONFIGURATION_ENABLED: "true"

--- a/.github/workflows/python_sdk_e2e_tests.yml
+++ b/.github/workflows/python_sdk_e2e_tests.yml
@@ -79,12 +79,12 @@ jobs:
           env:
             TAG: ${{ needs.build-opik.outputs.image_tag }}
           run: |
-            docker pull ghcr.io/comet-ml/opik/opik-backend:$TAG
-            docker pull ghcr.io/comet-ml/opik/opik-python-backend:$TAG
-            docker pull ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG
-            docker tag ghcr.io/comet-ml/opik/opik-backend:$TAG ghcr.io/comet-ml/opik/opik-backend:latest
-            docker tag ghcr.io/comet-ml/opik/opik-python-backend:$TAG ghcr.io/comet-ml/opik/opik-python-backend:latest
-            docker tag ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG ghcr.io/comet-ml/opik/opik-guardrails-backend:latest
+            docker pull "ghcr.io/comet-ml/opik/opik-backend:$TAG"
+            docker pull "ghcr.io/comet-ml/opik/opik-python-backend:$TAG"
+            docker pull "ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG"
+            docker tag "ghcr.io/comet-ml/opik/opik-backend:$TAG" ghcr.io/comet-ml/opik/opik-backend:latest
+            docker tag "ghcr.io/comet-ml/opik/opik-python-backend:$TAG" ghcr.io/comet-ml/opik/opik-python-backend:latest
+            docker tag "ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG" ghcr.io/comet-ml/opik/opik-guardrails-backend:latest
 
         - name: Setup Python ${{matrix.python_version}}
           uses: actions/setup-python@v5

--- a/.github/workflows/python_sdk_e2e_tests.yml
+++ b/.github/workflows/python_sdk_e2e_tests.yml
@@ -94,6 +94,7 @@ jobs:
         - name: Run latest Opik server
           env:
             OPIK_USAGE_REPORT_ENABLED: false
+            # Avoid Buildx Bake concurrent image export collisions in CI.
             COMPOSE_BAKE: false
             TOGGLE_RUNNERS_ENABLED: "true"
             OPIK_BACKEND_PULL_POLICY: never
@@ -130,6 +131,15 @@ jobs:
             pip list
 
         - name: Run tests
+          # -n 3 + --dist=loadfile distributes whole test files across three
+          # worker processes (one file per worker). Past ~3 the gains
+          # flatten — we become tail-bound on the slowest single file and
+          # the docker-compose backend on the same runner starts to thrash.
+          # E2E isolation hinges on --dist=loadfile: the per-module project
+          # name (generate_project_name("e2e", __name__)) is only collision-
+          # free if a single file is not split across workers.
+          # -p no:benchmark silences pytest-benchmark's auto-disable warning
+          # under xdist.
           run: |
             cd ${{ github.workspace }}/sdks/python
             pytest tests/e2e --ignore=tests/e2e/test_guardrails.py --ignore=tests/e2e/compatibility_v1 -vv -n 3 --dist=loadfile -p no:benchmark --durations=20 --junitxml=${{ github.workspace }}/test_results_${{matrix.python_version}}.xml

--- a/.github/workflows/python_sdk_e2e_tests.yml
+++ b/.github/workflows/python_sdk_e2e_tests.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   checks: write
   pull-requests: write
+  packages: write
 on:
     workflow_dispatch:
     pull_request:
@@ -48,8 +49,13 @@ jobs:
                   match-regex: '^sdks/python/|^\.github/workflows/python_sdk_e2e_tests\.yml$'
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
+    build-opik:
+        uses: ./.github/workflows/build_e2e_docker.yaml
+        with:
+          include_guardrails: true
+
     run-e2e:
-        needs: select-matrix
+        needs: [select-matrix, build-opik]
         name: Python SDK E2E Tests ${{matrix.python_version}}
         runs-on: ubuntu-latest
         timeout-minutes: 30
@@ -62,6 +68,24 @@ jobs:
         - name: Checkout
           uses: actions/checkout@v6
 
+        - name: Login to GHCR
+          uses: docker/login-action@v3
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: Pull Docker images from GHCR
+          env:
+            TAG: ${{ needs.build-opik.outputs.image_tag }}
+          run: |
+            docker pull ghcr.io/comet-ml/opik/opik-backend:$TAG
+            docker pull ghcr.io/comet-ml/opik/opik-python-backend:$TAG
+            docker pull ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG
+            docker tag ghcr.io/comet-ml/opik/opik-backend:$TAG ghcr.io/comet-ml/opik/opik-backend:latest
+            docker tag ghcr.io/comet-ml/opik/opik-python-backend:$TAG ghcr.io/comet-ml/opik/opik-python-backend:latest
+            docker tag ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG ghcr.io/comet-ml/opik/opik-guardrails-backend:latest
+
         - name: Setup Python ${{matrix.python_version}}
           uses: actions/setup-python@v5
           with:
@@ -70,12 +94,14 @@ jobs:
         - name: Run latest Opik server
           env:
             OPIK_USAGE_REPORT_ENABLED: false
-            # Avoid Buildx Bake concurrent image export collisions in CI.
             COMPOSE_BAKE: false
             TOGGLE_RUNNERS_ENABLED: "true"
+            OPIK_BACKEND_PULL_POLICY: never
+            PYTHON_BACKEND_PULL_POLICY: never
+            OPIK_GUARDRAILS_BACKEND_PULL_POLICY: never
           run: |
             cd ${{ github.workspace }}
-            ./opik.sh --backend --port-mapping --build
+            ./opik.sh --backend --port-mapping --guardrails
 
         - name: Check Opik server availability
           shell: bash
@@ -104,15 +130,6 @@ jobs:
             pip list
 
         - name: Run tests
-          # -n 3 + --dist=loadfile distributes whole test files across three
-          # worker processes (one file per worker). Past ~3 the gains
-          # flatten — we become tail-bound on the slowest single file and
-          # the docker-compose backend on the same runner starts to thrash.
-          # E2E isolation hinges on --dist=loadfile: the per-module project
-          # name (generate_project_name("e2e", __name__)) is only collision-
-          # free if a single file is not split across workers.
-          # -p no:benchmark silences pytest-benchmark's auto-disable warning
-          # under xdist.
           run: |
             cd ${{ github.workspace }}/sdks/python
             pytest tests/e2e --ignore=tests/e2e/test_guardrails.py --ignore=tests/e2e/compatibility_v1 -vv -n 3 --dist=loadfile -p no:benchmark --durations=20 --junitxml=${{ github.workspace }}/test_results_${{matrix.python_version}}.xml
@@ -142,5 +159,4 @@ jobs:
           if: always()
           run: |
             cd ${{ github.workspace }}
-            ./opik.sh --stop
-
+            ./opik.sh --stop --guardrails

--- a/.github/workflows/sdk-e2e-library-tests.yaml
+++ b/.github/workflows/sdk-e2e-library-tests.yaml
@@ -3,6 +3,7 @@
 name: SDK E2E Libraries Integration Tests
 permissions:
   contents: read
+  packages: write
 run-name: "SDK E2E Libraries Integration Tests ${{ github.ref_name }} by @${{ github.actor }}"
 on:
     workflow_dispatch:
@@ -62,9 +63,14 @@ jobs:
         run: |
           echo "::warning::SDK E2E Libraries Integration Tests workflow is disabled because OPENAI_API_KEY is not set"
 
+  build-opik:
+    needs: [has_needed_secrets]
+    if: ${{ needs.has_needed_secrets.outputs.has_secrets == 'true' }}
+    uses: ./.github/workflows/build_e2e_docker.yaml
+
   run_e2e_lib_integration:
     name: E2E Lib Integration Python ${{matrix.python_version}}
-    needs: [has_needed_secrets]
+    needs: [has_needed_secrets, build-opik]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: ${{ needs.has_needed_secrets.outputs.has_secrets == 'true' }}
@@ -76,6 +82,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull Docker images from GHCR
+        env:
+          TAG: ${{ needs.build-opik.outputs.image_tag }}
+        run: |
+          docker pull ghcr.io/comet-ml/opik/opik-backend:$TAG
+          docker pull ghcr.io/comet-ml/opik/opik-python-backend:$TAG
+          docker tag ghcr.io/comet-ml/opik/opik-backend:$TAG ghcr.io/comet-ml/opik/opik-backend:latest
+          docker tag ghcr.io/comet-ml/opik/opik-python-backend:$TAG ghcr.io/comet-ml/opik/opik-python-backend:latest
 
       - name: Install uv and set the Python version ${{ matrix.python_version }}
         uses: astral-sh/setup-uv@v5
@@ -90,12 +112,13 @@ jobs:
       - name: Run latest Opik server
         env:
           OPIK_USAGE_REPORT_ENABLED: false
-          # Avoid Buildx Bake concurrent image export collisions in CI.
           COMPOSE_BAKE: false
+          OPIK_BACKEND_PULL_POLICY: never
+          PYTHON_BACKEND_PULL_POLICY: never
         shell: bash
         run: |
           cd ${{ github.workspace }}
-          ./opik.sh --backend --port-mapping --build
+          ./opik.sh --backend --port-mapping
 
       - name: Check Opik server availability
         shell: bash

--- a/.github/workflows/sdk-e2e-library-tests.yaml
+++ b/.github/workflows/sdk-e2e-library-tests.yaml
@@ -112,6 +112,7 @@ jobs:
       - name: Run latest Opik server
         env:
           OPIK_USAGE_REPORT_ENABLED: false
+          # Avoid Buildx Bake concurrent image export collisions in CI.
           COMPOSE_BAKE: false
           OPIK_BACKEND_PULL_POLICY: never
           PYTHON_BACKEND_PULL_POLICY: never

--- a/.github/workflows/sdk-e2e-library-tests.yaml
+++ b/.github/workflows/sdk-e2e-library-tests.yaml
@@ -94,10 +94,10 @@ jobs:
         env:
           TAG: ${{ needs.build-opik.outputs.image_tag }}
         run: |
-          docker pull ghcr.io/comet-ml/opik/opik-backend:$TAG
-          docker pull ghcr.io/comet-ml/opik/opik-python-backend:$TAG
-          docker tag ghcr.io/comet-ml/opik/opik-backend:$TAG ghcr.io/comet-ml/opik/opik-backend:latest
-          docker tag ghcr.io/comet-ml/opik/opik-python-backend:$TAG ghcr.io/comet-ml/opik/opik-python-backend:latest
+          docker pull "ghcr.io/comet-ml/opik/opik-backend:$TAG"
+          docker pull "ghcr.io/comet-ml/opik/opik-python-backend:$TAG"
+          docker tag "ghcr.io/comet-ml/opik/opik-backend:$TAG" ghcr.io/comet-ml/opik/opik-backend:latest
+          docker tag "ghcr.io/comet-ml/opik/opik-python-backend:$TAG" ghcr.io/comet-ml/opik/opik-python-backend:latest
 
       - name: Install uv and set the Python version ${{ matrix.python_version }}
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
@@ -75,10 +75,10 @@ jobs:
         env:
           TAG: ${{ needs.build-opik.outputs.image_tag }}
         run: |
-          docker pull ghcr.io/comet-ml/opik/opik-backend:$TAG
-          docker pull ghcr.io/comet-ml/opik/opik-python-backend:$TAG
-          docker tag ghcr.io/comet-ml/opik/opik-backend:$TAG ghcr.io/comet-ml/opik/opik-backend:latest
-          docker tag ghcr.io/comet-ml/opik/opik-python-backend:$TAG ghcr.io/comet-ml/opik/opik-python-backend:latest
+          docker pull "ghcr.io/comet-ml/opik/opik-backend:$TAG"
+          docker pull "ghcr.io/comet-ml/opik/opik-python-backend:$TAG"
+          docker tag "ghcr.io/comet-ml/opik/opik-backend:$TAG" ghcr.io/comet-ml/opik/opik-backend:latest
+          docker tag "ghcr.io/comet-ml/opik/opik-python-backend:$TAG" ghcr.io/comet-ml/opik/opik-python-backend:latest
 
       - name: Set up Node.js ${{matrix.node_version}}
         uses: actions/setup-node@v4.2.0

--- a/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   checks: write
   pull-requests: write
+  packages: write
 on:
   workflow_dispatch:
   pull_request:
@@ -46,8 +47,11 @@ jobs:
           match-regex: '^sdks/typescript/|^\.github/workflows/typescript_sdk_compatibility_v1_e2e_tests\.yml$'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  build-opik:
+    uses: ./.github/workflows/build_e2e_docker.yaml
+
   run-compatibility-v1-e2e:
-    needs: select-matrix
+    needs: [select-matrix, build-opik]
     name: TypeScript SDK Compatibility V1.x E2E Tests Node ${{matrix.node_version}}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -58,7 +62,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull Docker images from GHCR
+        env:
+          TAG: ${{ needs.build-opik.outputs.image_tag }}
+        run: |
+          docker pull ghcr.io/comet-ml/opik/opik-backend:$TAG
+          docker pull ghcr.io/comet-ml/opik/opik-python-backend:$TAG
+          docker tag ghcr.io/comet-ml/opik/opik-backend:$TAG ghcr.io/comet-ml/opik/opik-backend:latest
+          docker tag ghcr.io/comet-ml/opik/opik-python-backend:$TAG ghcr.io/comet-ml/opik/opik-python-backend:latest
 
       - name: Set up Node.js ${{matrix.node_version}}
         uses: actions/setup-node@v4.2.0
@@ -69,9 +89,11 @@ jobs:
         env:
           OPIK_USAGE_REPORT_ENABLED: false
           COMPOSE_BAKE: false
+          OPIK_BACKEND_PULL_POLICY: never
+          PYTHON_BACKEND_PULL_POLICY: never
         run: |
           cd ${{ github.workspace }}
-          ./opik.sh --backend --port-mapping --build
+          ./opik.sh --backend --port-mapping
 
       - name: Check Opik server availability
         shell: bash
@@ -114,7 +136,7 @@ jobs:
 
       - name: Attach BE log
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: opik-backend-compat-v1-log-node${{matrix.node_version}}
           path: ${{ github.workspace }}/opik-backend_compat_v1_node${{matrix.node_version}}.log

--- a/.github/workflows/typescript_sdk_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_e2e_tests.yml
@@ -86,10 +86,10 @@ jobs:
         env:
           TAG: ${{ needs.build-opik.outputs.image_tag }}
         run: |
-          docker pull ghcr.io/comet-ml/opik/opik-backend:$TAG
-          docker pull ghcr.io/comet-ml/opik/opik-python-backend:$TAG
-          docker tag ghcr.io/comet-ml/opik/opik-backend:$TAG ghcr.io/comet-ml/opik/opik-backend:latest
-          docker tag ghcr.io/comet-ml/opik/opik-python-backend:$TAG ghcr.io/comet-ml/opik/opik-python-backend:latest
+          docker pull "ghcr.io/comet-ml/opik/opik-backend:$TAG"
+          docker pull "ghcr.io/comet-ml/opik/opik-python-backend:$TAG"
+          docker tag "ghcr.io/comet-ml/opik/opik-backend:$TAG" ghcr.io/comet-ml/opik/opik-backend:latest
+          docker tag "ghcr.io/comet-ml/opik/opik-python-backend:$TAG" ghcr.io/comet-ml/opik/opik-python-backend:latest
 
       - name: Set up Node.js ${{matrix.node_version}}
         uses: actions/setup-node@v4.2.0

--- a/.github/workflows/typescript_sdk_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_e2e_tests.yml
@@ -1,5 +1,10 @@
 name: TypeScript SDK E2E Tests
 run-name: "TypeScript SDK E2E Tests ${{ github.ref_name }} by @${{ github.actor }}"
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+  packages: write
 on:
   workflow_dispatch:
   pull_request:
@@ -48,13 +53,17 @@ jobs:
           match-regex: '^sdks/typescript/|^\.github/workflows/typescript_sdk_e2e_tests\.yml$'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  build-opik:
+    uses: ./.github/workflows/build_e2e_docker.yaml
+
   run-e2e:
-    needs: select-matrix
+    needs: [select-matrix, build-opik]
     name: TypeScript SDK E2E Tests Node ${{matrix.node_version}}
     permissions:
       contents: read
       checks: write
       pull-requests: write
+      packages: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -66,6 +75,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull Docker images from GHCR
+        env:
+          TAG: ${{ needs.build-opik.outputs.image_tag }}
+        run: |
+          docker pull ghcr.io/comet-ml/opik/opik-backend:$TAG
+          docker pull ghcr.io/comet-ml/opik/opik-python-backend:$TAG
+          docker tag ghcr.io/comet-ml/opik/opik-backend:$TAG ghcr.io/comet-ml/opik/opik-backend:latest
+          docker tag ghcr.io/comet-ml/opik/opik-python-backend:$TAG ghcr.io/comet-ml/opik/opik-python-backend:latest
+
       - name: Set up Node.js ${{matrix.node_version}}
         uses: actions/setup-node@v4.2.0
         with:
@@ -76,9 +101,11 @@ jobs:
           OPIK_USAGE_REPORT_ENABLED: false
           COMPOSE_BAKE: false
           TOGGLE_RUNNERS_ENABLED: "true"
+          OPIK_BACKEND_PULL_POLICY: never
+          PYTHON_BACKEND_PULL_POLICY: never
         run: |
           cd ${{ github.workspace }}
-          ./opik.sh --backend --port-mapping --build
+          ./opik.sh --backend --port-mapping
 
       - name: Check Opik server availability
         shell: bash

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -136,7 +136,7 @@ services:
 
   backend:
     image: ghcr.io/comet-ml/opik/opik-backend:${OPIK_VERSION:-latest}
-    pull_policy: always
+    pull_policy: ${OPIK_BACKEND_PULL_POLICY:-always}
     profiles:
       - backend
       - opik
@@ -276,7 +276,7 @@ services:
 
   guardrails-backend:
     image: ghcr.io/comet-ml/opik/opik-guardrails-backend:${OPIK_VERSION:-latest}
-    pull_policy: always
+    pull_policy: ${OPIK_GUARDRAILS_BACKEND_PULL_POLICY:-always}
     profiles:
       - guardrails
     build:


### PR DESCRIPTION
## Details

<img width="1920" height="3636" alt="image" src="https://github.com/user-attachments/assets/9487bef7-d7b4-4bc9-a894-903f6700ea2d" />

All 6 E2E test workflows (Python SDK, Python SDK Compat V1, TypeScript SDK, TypeScript SDK Compat V1, SDK Libraries, Opik Optimizer) previously built Docker images independently in every matrix entry. This meant up to 26 redundant Docker builds per PR.

This PR introduces a reusable `build_e2e_docker.yaml` workflow that builds once per workflow, pushes to GHCR with immutable SHA-based tags, and test runners pull pre-built images. A cleanup workflow (`cleanup_e2e_docker.yaml`) deletes stale images on PR close and via weekly Saturday sweep.

**Key changes:**

- **New reusable workflow** (`build_e2e_docker.yaml`): builds backend + python-backend (+ guardrails-backend when needed), pushes to `ghcr.io/comet-ml/opik/` with immutable `ci-e2e-pr<N>-<sha7>` tags
- **6 consumer workflows updated**: replaced inline `--build` with `docker pull` from GHCR + retag to `:latest`
- **docker-compose.yaml**: made `backend` and `guardrails-backend` `pull_policy` configurable via env vars (defaults to `always`, set to `never` in CI)
- **New cleanup workflow** (`cleanup_e2e_docker.yaml`): deletes all `ci-e2e-pr<N>-*` tags on PR close (immediate) + weekly Saturday sweep at 03:00 UTC (safety net, age-based with configurable `max_age_days`)

**Tag scheme** (immutable, unique per push):
- PR trigger: `ci-e2e-pr<N>-<sha7>` (e.g., `ci-e2e-pr777-abc123d`)
- PR trigger with guardrails: `ci-e2e-pr<N>-<sha7>-guardrails`
- Non-PR trigger (workflow_dispatch/schedule/main): `ci-e2e-<sha7>`

Each push creates a new unique tag — no overwrites, no orphaned untagged manifests, no race conditions. This is the industry standard for container CI.

| Metric | Before | After | Future (OPIK-6039) |
|---|---|---|---|
| Docker builds per PR | ~26 (per matrix runner) | ~6 (per workflow) | 2 (orchestrator) |
| Runner setup time | ~4m (build from scratch) | ~0.5–2.5m (pull + startup) | same |
| Flaky test re-run | ~10–12m (rebuild) | ~3–9m (pull only) | same |
| Image cleanup | N/A | On PR close + weekly Saturday | same |

**Concurrent workflow race**: When multiple workflows trigger on the same PR push, each builds independently with the same immutable tag (same SHA = same content = same tag). Docker registry pushes are atomic and idempotent — concurrent pushes of identical content are safe. But still wasteful (up to 6 identical builds instead of 2). Follow-up OPIK-6039 introduces a shared orchestrator to eliminate this.

**Measured CI times** (from PR #6764's run vs main baselines):
- TS SDK E2E runner setup: 4m20s → 1m23s (pull 27s + startup 56s)
- Python SDK E2E runner setup: 4m06s → 3m27s (pull 2m26s + startup 1m01s, 3 images w/ guardrails)
- Flaky re-run: skips build job entirely — images already in GHCR

**Cleanup workflow**:
- **PR close**: deletes all `ci-e2e-pr<N>-*` versions for that PR (catches all historical pushes)
- **Weekly Saturday sweep**: deletes all `ci-e2e-*` versions older than `max_age_days` (default 7, configurable via `workflow_dispatch` with `type: number` validation)
- No untagged cleanup needed — immutable tags don't produce orphaned untagged manifests
- Uses `GITHUB_TOKEN` with `packages: write` (no PAT needed)

> Re-creation of PR #6764 which was closed for cleanup workflow testing. Same commits, clean branch from main.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6028

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: full implementation
- Human verification: code review + CI validation + manual workflow dispatch testing

## Testing

### CI end-to-end validation — all 6 E2E workflows green

All 6 E2E workflows ran on this PR (commit `7ad8de5`). The workflows themselves are the test:
1. `build_e2e_docker.yaml` builds and pushes images to GHCR with immutable `ci-e2e-pr7117-<sha7>` tags
2. Each matrix runner pulls images from GHCR, retags to `:latest`, starts Opik server with `pull_policy: never`
3. Existing test suites run against the pre-built images

**CI run links (all green):**

| Workflow | Run | Status |
|---|---|---|
| Python SDK E2E (5 Python versions) | [27693149735](https://github.com/comet-ml/opik/actions/runs/27693149735) | ✅ passed |
| Python SDK Compat V1.x (5 Python versions) | [27693147220](https://github.com/comet-ml/opik/actions/runs/27693147220) | ✅ passed |
| TypeScript SDK E2E (3 Node versions) | [27693149683](https://github.com/comet-ml/opik/actions/runs/27693149683) | ✅ passed |
| TypeScript SDK Compat V1.x (5 Node versions) | [27693149650](https://github.com/comet-ml/opik/actions/runs/27693149650) | ✅ passed |
| SDK E2E Libraries Integration | [27693149808](https://github.com/comet-ml/opik/actions/runs/27693149808) | ✅ passed |
| Opik Optimizer E2E (5 Python versions + Smoke) | [27693149727](https://github.com/comet-ml/opik/actions/runs/27693149727) | ✅ passed |

**Results summary:**
- **6 build jobs** (one per workflow): all passed — GHCR push with immutable SHA tags confirmed working
- **22+ GHCR pull runners** across all workflows: all passed — pull + retag + `pull_policy: never` working
- **TS SDK E2E**: passed on re-run (first run hit external LLM API timeouts — flaky, unrelated)
- **Python SDK E2E**: 4/5 passed first try; Python 3.11 had a flaky timing assertion, passed on re-run

### Cleanup workflow validation — both trigger paths tested

Both cleanup trigger paths have been tested across PR #6764 (original, closed for testing) and PR #7117 (this PR):

| Test | Trigger | Run | Result |
|---|---|---|---|
| PR #6764 close | `pull_request: [closed]` | [26108094902](https://github.com/comet-ml/opik/actions/runs/26108094902) | ✅ Triggered on close, deleted 3/6 images before being externally cancelled |
| PR #6764 stale sweep | `workflow_dispatch` (`max_age_days=0`) | [26099058327](https://github.com/comet-ml/opik/actions/runs/26099058327) | ✅ Deleted 5 images for closed PR #6764, 0 failures |
| PR #7117 stale sweep | `workflow_dispatch` (`max_age_days=0`) | [27694643974](https://github.com/comet-ml/opik/actions/runs/27694643974) | ✅ Deleted 30 images across 3 repos, 0 failures |

**PR-close trigger (run 26108094902)**: When PR #6764 was closed, the `pull_request: [closed]` event fired and the `cleanup-pr` job correctly extracted PR number 6764 and began deleting `ci-e2e-6764*` versions. It successfully deleted `opik-backend:ci-e2e-6764`, `opik-backend:ci-e2e-6764-guardrails`, and `opik-python-backend:ci-e2e-6764` before being cancelled (the remaining images were cleaned up by subsequent `workflow_dispatch` runs).

**Weekly sweep / `workflow_dispatch` (run 27694643974)**: Triggered manually on this PR's branch with `max_age_days=0`. Scanned all 3 image repos (opik-backend, opik-python-backend, opik-guardrails-backend), found and deleted 12 + 12 + 6 = 30 ci-e2e-* versions. `cleanup-pr` job correctly skipped (not a PR close event). Confirms age-based deletion logic, pagination across ~31K package versions, and `GITHUB_TOKEN` with `packages: write`.

### What can only be tested after merge

- `schedule` cron trigger (Saturday 03:00 UTC) — requires the workflow definition to exist on `main`

## Documentation

N/A