### PR TITLE
[OPIK-6813] [BE] feat: add distributed lock (semaphore) metrics

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/lock/LockService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/lock/LockService.java
@@ -5,6 +5,7 @@ import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 public interface LockService {
 
@@ -12,12 +13,26 @@ public interface LockService {
 
         private static final String KEY_FORMAT = "%s-%s";
 
+        // UUID ids in the key are the high-cardinality part (projectId, datasetId, …); collapse them so the
+        // metric label is the stable lock type, e.g. "{projectId}-Trace" -> "*-Trace".
+        private static final Pattern UUID_PATTERN = Pattern.compile(
+                "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+
         public Lock(UUID id, String name) {
             this(KEY_FORMAT.formatted(id, name));
         }
 
         public Lock(String id, String name) {
             this(KEY_FORMAT.formatted(id, name));
+        }
+
+        /**
+         * Low-cardinality label for metrics: the key with embedded UUIDs collapsed to {@code *}. Bounds
+         * lock-metric cardinality by lock type rather than by entity. Lives on the lock so observability
+         * doesn't depend on callers — see {@code LockMetrics}.
+         */
+        public String metricName() {
+            return UUID_PATTERN.matcher(key).replaceAll("*");
         }
 
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/LockMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/LockMetrics.java
@@ -3,61 +3,39 @@ package com.comet.opik.infrastructure.redis;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.DoubleGauge;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.LongUpDownCounter;
 import io.opentelemetry.api.metrics.Meter;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.regex.Pattern;
 
 /**
  * Observability for the distributed {@link RedissonLockService}. The signal that matters for OPIK-6813
  * is {@code lock_waiting}: callers blocked on a permit are {@code CompletableFuture}s held in the pod
  * heap (each pinning its payload), so a runaway acquire-queue is invisible in Redis and surfaces only
- * as heap growth. These gauges/counters expose it directly, tagged by a low-cardinality lock name so a
- * per-project hotspot (e.g. {@code *-trace-threads-process}) is visible in Grafana without per-entity
- * cardinality. Best-effort: a telemetry failure must never break locking.
+ * as heap growth. These instruments expose it directly, tagged by the lock's stable {@code name} (see
+ * {@link com.comet.opik.infrastructure.lock.LockService.Lock}) so cardinality is bounded by the set of
+ * declared lock names, not by how many entities exist. Stateless: {@code lock_waiting}/{@code lock_held}
+ * are {@link LongUpDownCounter}s, so OpenTelemetry keeps the running per-name total — we don't. Best-effort:
+ * a telemetry failure must never break locking.
  */
 @Slf4j
 class LockMetrics {
 
-    // UUID ids in the key are the high-cardinality part (projectId, datasetId, …); collapse them so the
-    // label is the stable lock type, e.g. "{projectId}-trace-threads-process" -> "*-trace-threads-process".
-    private static final Pattern UUID = Pattern.compile(
-            "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
     private static final AttributeKey<String> LOCK = AttributeKey.stringKey("lock");
 
-    // Safety bound on distinct lock labels we will record. Keys are UUID-collapsed before reaching here
-    // (see RedissonLockService), so the labeled set equals the fixed number of lock templates in the code
-    // (~25 today). The cap is a guard: if a future caller interpolates a non-UUID dynamic segment (a name,
-    // an email, …) into a lock key, the "lock" attribute would otherwise grow without bound and blow up
-    // metric cardinality. Past the cap we skip the new label and log once, instead of leaking series.
-    static final int MAX_DISTINCT_LOCKS = 256;
-
-    private final DoubleGauge waiting;
-    private final DoubleGauge held;
+    private final LongUpDownCounter waiting;
+    private final LongUpDownCounter held;
     private final LongHistogram acquireWait;
     private final LongCounter acquired;
     private final LongCounter acquireFailed;
 
-    private final ConcurrentHashMap<String, AtomicLong> waitingByLock = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, AtomicLong> heldByLock = new ConcurrentHashMap<>();
-
-    // Distinct lock labels admitted so far — bounds both the gauge maps and the "lock" attribute cardinality.
-    private final Set<String> admittedLocks = ConcurrentHashMap.newKeySet();
-    private final AtomicBoolean cardinalityCapLogged = new AtomicBoolean();
-
     LockMetrics() {
         Meter meter = GlobalOpenTelemetry.getMeter("opik.lock");
-        this.waiting = meter.gaugeBuilder("lock_waiting")
+        this.waiting = meter.upDownCounterBuilder("lock_waiting")
                 .setDescription("Acquire attempts currently waiting for a permit (queued in the pod heap)")
                 .build();
-        this.held = meter.gaugeBuilder("lock_held")
+        this.held = meter.upDownCounterBuilder("lock_held")
                 .setDescription("Permits currently held (action running under the lock)")
                 .build();
         this.acquireWait = meter.histogramBuilder("lock_acquire_wait_milliseconds")
@@ -73,79 +51,42 @@ class LockMetrics {
                 .build();
     }
 
-    static String label(String key) {
-        return key == null ? "unknown" : UUID.matcher(key).replaceAll("*");
-    }
-
     void waitStart(String lock) {
-        record(lock, () -> adjust(waiting, waitingByLock, lock, 1));
+        record(() -> waiting.add(1, attrs(lock)));
     }
 
     void waitEnd(String lock) {
-        record(lock, () -> adjust(waiting, waitingByLock, lock, -1));
+        record(() -> waiting.add(-1, attrs(lock)));
     }
 
     void heldStart(String lock) {
-        record(lock, () -> adjust(held, heldByLock, lock, 1));
+        record(() -> held.add(1, attrs(lock)));
     }
 
     void heldEnd(String lock) {
-        record(lock, () -> adjust(held, heldByLock, lock, -1));
+        record(() -> held.add(-1, attrs(lock)));
     }
 
     void acquired(String lock, long waitMillis) {
-        record(lock, () -> {
+        record(() -> {
             acquireWait.record(Math.max(0, waitMillis), attrs(lock));
             acquired.add(1, attrs(lock));
         });
     }
 
     void acquireFailed(String lock) {
-        record(lock, () -> acquireFailed.add(1, attrs(lock)));
-    }
-
-    private void adjust(DoubleGauge gauge, ConcurrentHashMap<String, AtomicLong> state, String lock, long delta) {
-        gauge.set(state.computeIfAbsent(lock, k -> new AtomicLong()).addAndGet(delta), attrs(lock));
+        record(() -> acquireFailed.add(1, attrs(lock)));
     }
 
     private static Attributes attrs(String lock) {
         return Attributes.of(LOCK, lock);
     }
 
-    /**
-     * Records the metric only for an admitted lock label, swallowing any telemetry failure — metrics are
-     * best-effort and must never break locking. A label beyond {@link #MAX_DISTINCT_LOCKS} is skipped and
-     * logged, so a caller that interpolates a non-UUID dynamic segment into a lock key can't explode the
-     * metric's cardinality. {@code admit} runs inside the guard, so even an unexpected null label is logged
-     * and skipped rather than propagated.
-     */
-    private void record(String lock, Runnable action) {
+    private void record(Runnable action) {
         try {
-            if (admit(lock)) {
-                action.run();
-            }
+            action.run();
         } catch (RuntimeException exception) {
             log.debug("Failed to record lock metric", exception);
         }
-    }
-
-    private boolean admit(String lock) {
-        if (admittedLocks.contains(lock)) {
-            return true;
-        }
-        if (admittedLocks.size() >= MAX_DISTINCT_LOCKS) {
-            if (cardinalityCapLogged.compareAndSet(false, true)) {
-                log.error("Lock metric cardinality cap '{}' reached; skipping new lock labels."
-                        + " A lock key likely contains a non-UUID dynamic segment.", MAX_DISTINCT_LOCKS);
-            }
-            return false;
-        }
-        admittedLocks.add(lock);
-        return true;
-    }
-
-    // Distinct lock labels currently tracked; package-private for tests / cardinality observability.
-    int trackedLocks() {
-        return admittedLocks.size();
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/LockMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/LockMetrics.java
@@ -9,7 +9,9 @@ import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.Meter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 
@@ -30,6 +32,13 @@ class LockMetrics {
             "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
     private static final AttributeKey<String> LOCK = AttributeKey.stringKey("lock");
 
+    // Safety bound on distinct lock labels we will record. Keys are UUID-collapsed before reaching here
+    // (see RedissonLockService), so the labeled set equals the fixed number of lock templates in the code
+    // (~25 today). The cap is a guard: if a future caller interpolates a non-UUID dynamic segment (a name,
+    // an email, …) into a lock key, the "lock" attribute would otherwise grow without bound and blow up
+    // metric cardinality. Past the cap we skip the new label and log once, instead of leaking series.
+    static final int MAX_DISTINCT_LOCKS = 256;
+
     private final DoubleGauge waiting;
     private final DoubleGauge held;
     private final LongHistogram acquireWait;
@@ -38,6 +47,10 @@ class LockMetrics {
 
     private final ConcurrentHashMap<String, AtomicLong> waitingByLock = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, AtomicLong> heldByLock = new ConcurrentHashMap<>();
+
+    // Distinct lock labels admitted so far — bounds both the gauge maps and the "lock" attribute cardinality.
+    private final Set<String> admittedLocks = ConcurrentHashMap.newKeySet();
+    private final AtomicBoolean cardinalityCapLogged = new AtomicBoolean();
 
     LockMetrics() {
         Meter meter = GlobalOpenTelemetry.getMeter("opik.lock");
@@ -65,45 +78,74 @@ class LockMetrics {
     }
 
     void waitStart(String lock) {
-        adjust(waiting, waitingByLock, lock, 1);
+        record(lock, () -> adjust(waiting, waitingByLock, lock, 1));
     }
 
     void waitEnd(String lock) {
-        adjust(waiting, waitingByLock, lock, -1);
+        record(lock, () -> adjust(waiting, waitingByLock, lock, -1));
     }
 
     void heldStart(String lock) {
-        adjust(held, heldByLock, lock, 1);
+        record(lock, () -> adjust(held, heldByLock, lock, 1));
     }
 
     void heldEnd(String lock) {
-        adjust(held, heldByLock, lock, -1);
+        record(lock, () -> adjust(held, heldByLock, lock, -1));
     }
 
     void acquired(String lock, long waitMillis) {
-        record(() -> {
+        record(lock, () -> {
             acquireWait.record(Math.max(0, waitMillis), attrs(lock));
             acquired.add(1, attrs(lock));
         });
     }
 
     void acquireFailed(String lock) {
-        record(() -> acquireFailed.add(1, attrs(lock)));
+        record(lock, () -> acquireFailed.add(1, attrs(lock)));
     }
 
     private void adjust(DoubleGauge gauge, ConcurrentHashMap<String, AtomicLong> state, String lock, long delta) {
-        record(() -> gauge.set(state.computeIfAbsent(lock, k -> new AtomicLong()).addAndGet(delta), attrs(lock)));
+        gauge.set(state.computeIfAbsent(lock, k -> new AtomicLong()).addAndGet(delta), attrs(lock));
     }
 
     private static Attributes attrs(String lock) {
         return Attributes.of(LOCK, lock);
     }
 
-    private void record(Runnable action) {
+    /**
+     * Records the metric only for an admitted lock label, swallowing any telemetry failure — metrics are
+     * best-effort and must never break locking. A label beyond {@link #MAX_DISTINCT_LOCKS} is skipped and
+     * logged, so a caller that interpolates a non-UUID dynamic segment into a lock key can't explode the
+     * metric's cardinality. {@code admit} runs inside the guard, so even an unexpected null label is logged
+     * and skipped rather than propagated.
+     */
+    private void record(String lock, Runnable action) {
         try {
-            action.run();
+            if (admit(lock)) {
+                action.run();
+            }
         } catch (RuntimeException exception) {
             log.debug("Failed to record lock metric", exception);
         }
+    }
+
+    private boolean admit(String lock) {
+        if (admittedLocks.contains(lock)) {
+            return true;
+        }
+        if (admittedLocks.size() >= MAX_DISTINCT_LOCKS) {
+            if (cardinalityCapLogged.compareAndSet(false, true)) {
+                log.error("Lock metric cardinality cap '{}' reached; skipping new lock labels."
+                        + " A lock key likely contains a non-UUID dynamic segment.", MAX_DISTINCT_LOCKS);
+            }
+            return false;
+        }
+        admittedLocks.add(lock);
+        return true;
+    }
+
+    // Distinct lock labels currently tracked; package-private for tests / cardinality observability.
+    int trackedLocks() {
+        return admittedLocks.size();
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/LockMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/LockMetrics.java
@@ -3,7 +3,6 @@ package com.comet.opik.infrastructure.redis;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.LongUpDownCounter;
 import io.opentelemetry.api.metrics.Meter;
@@ -13,22 +12,27 @@ import lombok.extern.slf4j.Slf4j;
  * Observability for the distributed {@link RedissonLockService}. The signal that matters for OPIK-6813
  * is {@code lock_waiting}: callers blocked on a permit are {@code CompletableFuture}s held in the pod
  * heap (each pinning its payload), so a runaway acquire-queue is invisible in Redis and surfaces only
- * as heap growth. These instruments expose it directly, tagged by the lock's stable {@code name} (see
- * {@link com.comet.opik.infrastructure.lock.LockService.Lock}) so cardinality is bounded by the set of
- * declared lock names, not by how many entities exist. Stateless: {@code lock_waiting}/{@code lock_held}
- * are {@link LongUpDownCounter}s, so OpenTelemetry keeps the running per-name total — we don't. Best-effort:
- * a telemetry failure must never break locking.
+ * as heap growth. Tagged by the lock's stable {@code metricName} (see
+ * {@link com.comet.opik.infrastructure.lock.LockService.Lock}) so cardinality is bounded by lock type,
+ * not by entity.
+ *
+ * <p>Stateless: {@code lock_waiting}/{@code lock_held} are {@link LongUpDownCounter}s (OpenTelemetry keeps
+ * the running per-name total). Acquire outcomes are a single multidimensional histogram,
+ * {@code lock_acquire_wait_milliseconds}, tagged by {@code outcome=success|failure} — its {@code _count}
+ * already gives the acquire/failure totals, so no separate counters are needed. Best-effort: a telemetry
+ * failure must never break locking.
  */
 @Slf4j
 class LockMetrics {
 
     private static final AttributeKey<String> LOCK = AttributeKey.stringKey("lock");
+    private static final AttributeKey<String> OUTCOME = AttributeKey.stringKey("outcome");
+    private static final String SUCCESS = "success";
+    private static final String FAILURE = "failure";
 
     private final LongUpDownCounter waiting;
     private final LongUpDownCounter held;
     private final LongHistogram acquireWait;
-    private final LongCounter acquired;
-    private final LongCounter acquireFailed;
 
     LockMetrics() {
         Meter meter = GlobalOpenTelemetry.getMeter("opik.lock");
@@ -39,47 +43,42 @@ class LockMetrics {
                 .setDescription("Permits currently held (action running under the lock)")
                 .build();
         this.acquireWait = meter.histogramBuilder("lock_acquire_wait_milliseconds")
-                .setDescription("Time spent waiting to acquire a permit")
+                .setDescription("Time spent trying to acquire a permit; _count by outcome gives acquire/failure totals")
                 .setUnit("ms")
                 .ofLongs()
-                .build();
-        this.acquired = meter.counterBuilder("lock_acquired_total")
-                .setDescription("Permits successfully acquired")
-                .build();
-        this.acquireFailed = meter.counterBuilder("lock_acquire_failed_total")
-                .setDescription("Acquire attempts that errored or failed to obtain a permit")
                 .build();
     }
 
     void waitStart(String lock) {
-        record(() -> waiting.add(1, attrs(lock)));
+        record(() -> waiting.add(1, lockAttrs(lock)));
     }
 
     void waitEnd(String lock) {
-        record(() -> waiting.add(-1, attrs(lock)));
+        record(() -> waiting.add(-1, lockAttrs(lock)));
     }
 
     void heldStart(String lock) {
-        record(() -> held.add(1, attrs(lock)));
+        record(() -> held.add(1, lockAttrs(lock)));
     }
 
     void heldEnd(String lock) {
-        record(() -> held.add(-1, attrs(lock)));
+        record(() -> held.add(-1, lockAttrs(lock)));
     }
 
     void acquired(String lock, long waitMillis) {
-        record(() -> {
-            acquireWait.record(Math.max(0, waitMillis), attrs(lock));
-            acquired.add(1, attrs(lock));
-        });
+        record(() -> acquireWait.record(Math.max(0, waitMillis), outcomeAttrs(lock, SUCCESS)));
     }
 
-    void acquireFailed(String lock) {
-        record(() -> acquireFailed.add(1, attrs(lock)));
+    void acquireFailed(String lock, long waitMillis) {
+        record(() -> acquireWait.record(Math.max(0, waitMillis), outcomeAttrs(lock, FAILURE)));
     }
 
-    private static Attributes attrs(String lock) {
+    private static Attributes lockAttrs(String lock) {
         return Attributes.of(LOCK, lock);
+    }
+
+    private static Attributes outcomeAttrs(String lock, String outcome) {
+        return Attributes.of(LOCK, lock, OUTCOME, outcome);
     }
 
     private void record(Runnable action) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/LockMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/LockMetrics.java
@@ -1,0 +1,109 @@
+package com.comet.opik.infrastructure.redis;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleGauge;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.Meter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
+
+/**
+ * Observability for the distributed {@link RedissonLockService}. The signal that matters for OPIK-6813
+ * is {@code lock_waiting}: callers blocked on a permit are {@code CompletableFuture}s held in the pod
+ * heap (each pinning its payload), so a runaway acquire-queue is invisible in Redis and surfaces only
+ * as heap growth. These gauges/counters expose it directly, tagged by a low-cardinality lock name so a
+ * per-project hotspot (e.g. {@code *-trace-threads-process}) is visible in Grafana without per-entity
+ * cardinality. Best-effort: a telemetry failure must never break locking.
+ */
+@Slf4j
+class LockMetrics {
+
+    // UUID ids in the key are the high-cardinality part (projectId, datasetId, …); collapse them so the
+    // label is the stable lock type, e.g. "{projectId}-trace-threads-process" -> "*-trace-threads-process".
+    private static final Pattern UUID = Pattern.compile(
+            "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+    private static final AttributeKey<String> LOCK = AttributeKey.stringKey("lock");
+
+    private final DoubleGauge waiting;
+    private final DoubleGauge held;
+    private final LongHistogram acquireWait;
+    private final LongCounter acquired;
+    private final LongCounter acquireFailed;
+
+    private final ConcurrentHashMap<String, AtomicLong> waitingByLock = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, AtomicLong> heldByLock = new ConcurrentHashMap<>();
+
+    LockMetrics() {
+        Meter meter = GlobalOpenTelemetry.getMeter("opik.lock");
+        this.waiting = meter.gaugeBuilder("lock_waiting")
+                .setDescription("Acquire attempts currently waiting for a permit (queued in the pod heap)")
+                .build();
+        this.held = meter.gaugeBuilder("lock_held")
+                .setDescription("Permits currently held (action running under the lock)")
+                .build();
+        this.acquireWait = meter.histogramBuilder("lock_acquire_wait_milliseconds")
+                .setDescription("Time spent waiting to acquire a permit")
+                .setUnit("ms")
+                .ofLongs()
+                .build();
+        this.acquired = meter.counterBuilder("lock_acquired_total")
+                .setDescription("Permits successfully acquired")
+                .build();
+        this.acquireFailed = meter.counterBuilder("lock_acquire_failed_total")
+                .setDescription("Acquire attempts that errored or failed to obtain a permit")
+                .build();
+    }
+
+    static String label(String key) {
+        return key == null ? "unknown" : UUID.matcher(key).replaceAll("*");
+    }
+
+    void waitStart(String lock) {
+        adjust(waiting, waitingByLock, lock, 1);
+    }
+
+    void waitEnd(String lock) {
+        adjust(waiting, waitingByLock, lock, -1);
+    }
+
+    void heldStart(String lock) {
+        adjust(held, heldByLock, lock, 1);
+    }
+
+    void heldEnd(String lock) {
+        adjust(held, heldByLock, lock, -1);
+    }
+
+    void acquired(String lock, long waitMillis) {
+        record(() -> {
+            acquireWait.record(Math.max(0, waitMillis), attrs(lock));
+            acquired.add(1, attrs(lock));
+        });
+    }
+
+    void acquireFailed(String lock) {
+        record(() -> acquireFailed.add(1, attrs(lock)));
+    }
+
+    private void adjust(DoubleGauge gauge, ConcurrentHashMap<String, AtomicLong> state, String lock, long delta) {
+        record(() -> gauge.set(state.computeIfAbsent(lock, k -> new AtomicLong()).addAndGet(delta), attrs(lock)));
+    }
+
+    private static Attributes attrs(String lock) {
+        return Attributes.of(LOCK, lock);
+    }
+
+    private void record(Runnable action) {
+        try {
+            action.run();
+        } catch (RuntimeException exception) {
+            log.debug("Failed to record lock metric", exception);
+        }
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedisModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedisModule.java
@@ -52,9 +52,15 @@ public class RedisModule extends DropwizardAwareModule<OpikConfiguration> {
 
     @Provides
     @Singleton
+    public LockMetrics lockMetrics() {
+        return new LockMetrics();
+    }
+
+    @Provides
+    @Singleton
     public LockService lockService(RedissonReactiveClient redisClient,
-            @Config("distributedLock") DistributedLockConfig distributedLockConfig) {
-        return new RedissonLockService(redisClient, distributedLockConfig);
+            @Config("distributedLock") DistributedLockConfig distributedLockConfig, LockMetrics lockMetrics) {
+        return new RedissonLockService(redisClient, distributedLockConfig, lockMetrics);
     }
 
     @Provides

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedissonLockService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedissonLockService.java
@@ -28,6 +28,7 @@ class RedissonLockService implements LockService {
 
     private final @NonNull RedissonReactiveClient redisClient;
     private final @NonNull DistributedLockConfig distributedLockConfig;
+    private final LockMetrics lockMetrics = new LockMetrics();
 
     private record LockInstance(RPermitExpirableSemaphoreReactive semaphore, String permitId) {
 
@@ -65,17 +66,42 @@ class RedissonLockService implements LockService {
     public <T> Mono<T> executeWithLockCustomExpire(
             @NonNull Lock lock, @NonNull Mono<T> action, @NonNull Duration duration) {
         var semaphore = getSemaphore(lock);
+        var metricLock = LockMetrics.label(lock.key());
         log.debug(TRYING_TO_LOCK_WITH, lock);
-        return acquireLock(semaphore, duration)
-                .flatMap(lockInstance -> runAction(lock, action, lockInstance));
+        return instrumentedAcquire(metricLock, acquireLock(semaphore, duration))
+                .flatMap(lockInstance -> runAction(lock, action, lockInstance)
+                        .doFinally(signalType -> lockMetrics.heldEnd(metricLock)));
     }
 
     @Override
     public <T> Flux<T> executeWithLock(@NonNull Lock lock, @NonNull Flux<T> stream) {
         var semaphore = getSemaphore(lock);
+        var metricLock = LockMetrics.label(lock.key());
         log.debug(TRYING_TO_LOCK_WITH, lock);
-        return acquireLock(semaphore, Duration.ofMillis(distributedLockConfig.getLockTimeoutMS()))
-                .flatMapMany(lockInstance -> runStream(lock, stream, lockInstance));
+        return instrumentedAcquire(metricLock,
+                acquireLock(semaphore, Duration.ofMillis(distributedLockConfig.getLockTimeoutMS())))
+                .flatMapMany(lockInstance -> runStream(lock, stream, lockInstance)
+                        .doFinally(signalType -> lockMetrics.heldEnd(metricLock)));
+    }
+
+    /**
+     * Wrap a permit-acquire with waiting/held gauges + acquire-time/outcome metrics. {@code lock_waiting}
+     * is incremented on subscribe and decremented on any terminal signal (success, error, cancel), so a
+     * waiter that times out, errors, or is cancelled never leaks the gauge. {@code lock_held} is bumped
+     * once the permit is obtained; the caller decrements it when the held action terminates.
+     */
+    private Mono<LockInstance> instrumentedAcquire(String metricLock, Mono<LockInstance> acquire) {
+        return Mono.defer(() -> {
+            long start = System.currentTimeMillis();
+            lockMetrics.waitStart(metricLock);
+            return acquire
+                    .doOnNext(lockInstance -> {
+                        lockMetrics.acquired(metricLock, System.currentTimeMillis() - start);
+                        lockMetrics.heldStart(metricLock);
+                    })
+                    .doOnError(throwable -> lockMetrics.acquireFailed(metricLock))
+                    .doFinally(signalType -> lockMetrics.waitEnd(metricLock));
+        });
     }
 
     private RPermitExpirableSemaphoreReactive getSemaphore(Lock lock) {
@@ -154,26 +180,44 @@ class RedissonLockService implements LockService {
     public <T> Mono<T> bestEffortLock(Lock lock, Mono<T> action, Mono<Void> failToAcquireLockAction,
             Duration actionTimeout, Duration lockWaitTime, boolean holdUntilExpiry) {
         var semaphore = getSemaphore(lock);
+        var metricLock = LockMetrics.label(lock.key());
         log.debug(TRYING_TO_LOCK_WITH, lock);
-        return Mono.defer(() -> semaphore.trySetPermits(1)
-                //Try to acquire the lock until the lockWaitTime expires if the lock is not available it will return Mono.empty()
-                .then(Mono.defer(() -> semaphore.tryAcquire(
-                        lockWaitTime.toMillis(), actionTimeout.toMillis(), TimeUnit.MILLISECONDS))
-                        // If the lock is not acquired, run the fallback and return empty so the main action does not execute.
-                        .switchIfEmpty(failToAcquireLockAction.then(Mono.empty()))
-                        .flatMap(permitId -> {
-                            var lockInstance = new LockInstance(semaphore, permitId);
-                            // If the lock is acquired, it sets the expiration time using the actionTimeout
-                            return expire(lockInstance, actionTimeout)
-                                    .then(Mono.defer(() -> runAction(lock, action)))
-                                    .doFinally(signal -> {
-                                        if (!holdUntilExpiry) {
-                                            lockInstance.release();
-                                        }
-                                    });
-                        })))
+        return Mono.defer(() -> {
+            long start = System.currentTimeMillis();
+            lockMetrics.waitStart(metricLock);
+            return semaphore.trySetPermits(1)
+                    //Try to acquire the lock until the lockWaitTime expires if the lock is not available it will return Mono.empty()
+                    .then(Mono.defer(() -> semaphore.tryAcquire(
+                            lockWaitTime.toMillis(), actionTimeout.toMillis(), TimeUnit.MILLISECONDS))
+                            // An empty completion means the wait elapsed without obtaining a permit.
+                            .doOnSuccess(permitId -> {
+                                if (permitId == null) {
+                                    lockMetrics.acquireFailed(metricLock);
+                                }
+                            })
+                            // If the lock is not acquired, run the fallback and return empty so the main action does not execute.
+                            .switchIfEmpty(failToAcquireLockAction.then(Mono.empty()))
+                            .flatMap(permitId -> {
+                                lockMetrics.acquired(metricLock, System.currentTimeMillis() - start);
+                                lockMetrics.heldStart(metricLock);
+                                var lockInstance = new LockInstance(semaphore, permitId);
+                                // If the lock is acquired, it sets the expiration time using the actionTimeout
+                                return expire(lockInstance, actionTimeout)
+                                        .then(Mono.defer(() -> runAction(lock, action)))
+                                        .doFinally(signal -> {
+                                            lockMetrics.heldEnd(metricLock);
+                                            if (!holdUntilExpiry) {
+                                                lockInstance.release();
+                                            }
+                                        });
+                            }))
+                    .doFinally(signal -> lockMetrics.waitEnd(metricLock));
+        })
                 .onErrorResume(RedisException.class,
-                        redisException -> handleError(failToAcquireLockAction, redisException).then(Mono.empty()));
+                        redisException -> {
+                            lockMetrics.acquireFailed(metricLock);
+                            return handleError(failToAcquireLockAction, redisException).then(Mono.empty());
+                        });
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedissonLockService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedissonLockService.java
@@ -66,7 +66,7 @@ class RedissonLockService implements LockService {
     public <T> Mono<T> executeWithLockCustomExpire(
             @NonNull Lock lock, @NonNull Mono<T> action, @NonNull Duration duration) {
         var semaphore = getSemaphore(lock);
-        var metricLock = LockMetrics.label(lock.key());
+        var metricLock = lock.metricName();
         log.debug(TRYING_TO_LOCK_WITH, lock);
         return instrumentedAcquire(metricLock, acquireLock(semaphore, duration))
                 .flatMap(lockInstance -> runAction(lock, action, lockInstance)
@@ -76,7 +76,7 @@ class RedissonLockService implements LockService {
     @Override
     public <T> Flux<T> executeWithLock(@NonNull Lock lock, @NonNull Flux<T> stream) {
         var semaphore = getSemaphore(lock);
-        var metricLock = LockMetrics.label(lock.key());
+        var metricLock = lock.metricName();
         log.debug(TRYING_TO_LOCK_WITH, lock);
         return instrumentedAcquire(metricLock,
                 acquireLock(semaphore, Duration.ofMillis(distributedLockConfig.getLockTimeoutMS())))
@@ -180,7 +180,7 @@ class RedissonLockService implements LockService {
     public <T> Mono<T> bestEffortLock(Lock lock, Mono<T> action, Mono<Void> failToAcquireLockAction,
             Duration actionTimeout, Duration lockWaitTime, boolean holdUntilExpiry) {
         var semaphore = getSemaphore(lock);
-        var metricLock = LockMetrics.label(lock.key());
+        var metricLock = lock.metricName();
         log.debug(TRYING_TO_LOCK_WITH, lock);
         return Mono.defer(() -> {
             long start = System.currentTimeMillis();

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedissonLockService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedissonLockService.java
@@ -28,7 +28,7 @@ class RedissonLockService implements LockService {
 
     private final @NonNull RedissonReactiveClient redisClient;
     private final @NonNull DistributedLockConfig distributedLockConfig;
-    private final LockMetrics lockMetrics = new LockMetrics();
+    private final @NonNull LockMetrics lockMetrics;
 
     private record LockInstance(RPermitExpirableSemaphoreReactive semaphore, String permitId) {
 
@@ -69,8 +69,7 @@ class RedissonLockService implements LockService {
         var metricLock = lock.metricName();
         log.debug(TRYING_TO_LOCK_WITH, lock);
         return instrumentedAcquire(metricLock, acquireLock(semaphore, duration))
-                .flatMap(lockInstance -> runAction(lock, action, lockInstance)
-                        .doFinally(signalType -> lockMetrics.heldEnd(metricLock)));
+                .flatMap(lockInstance -> instrumentHeld(metricLock, runAction(lock, action, lockInstance)));
     }
 
     @Override
@@ -80,28 +79,49 @@ class RedissonLockService implements LockService {
         log.debug(TRYING_TO_LOCK_WITH, lock);
         return instrumentedAcquire(metricLock,
                 acquireLock(semaphore, Duration.ofMillis(distributedLockConfig.getLockTimeoutMS())))
-                .flatMapMany(lockInstance -> runStream(lock, stream, lockInstance)
-                        .doFinally(signalType -> lockMetrics.heldEnd(metricLock)));
+                .flatMapMany(lockInstance -> instrumentHeld(metricLock, runStream(lock, stream, lockInstance)));
     }
 
     /**
-     * Wrap a permit-acquire with waiting/held gauges + acquire-time/outcome metrics. {@code lock_waiting}
-     * is incremented on subscribe and decremented on any terminal signal (success, error, cancel), so a
-     * waiter that times out, errors, or is cancelled never leaks the gauge. {@code lock_held} is bumped
-     * once the permit is obtained; the caller decrements it when the held action terminates.
+     * Wraps a permit-acquire with the {@code lock_waiting} gauge and the acquire-outcome histogram.
+     * {@code lock_waiting} is incremented on subscribe and decremented on any terminal signal (success,
+     * error, cancel), so a waiter that times out, errors, or is cancelled never leaks the gauge.
+     * <p>Outcome is emitted precisely: {@code doOnSuccess} fires both for an emitted {@link LockInstance}
+     * (acquired) and for an empty completion (the wait elapsed without a permit), so a timed-out acquire
+     * is recorded as a failure — not silently dropped as it would be with {@code doOnNext} alone. The
+     * {@code lock_held} side is paired in {@link #instrumentHeld} so it brackets the held action.
      */
     private Mono<LockInstance> instrumentedAcquire(String metricLock, Mono<LockInstance> acquire) {
         return Mono.defer(() -> {
             long start = System.currentTimeMillis();
             lockMetrics.waitStart(metricLock);
             return acquire
-                    .doOnNext(lockInstance -> {
-                        lockMetrics.acquired(metricLock, System.currentTimeMillis() - start);
-                        lockMetrics.heldStart(metricLock);
+                    .doOnSuccess(lockInstance -> {
+                        long waitMillis = System.currentTimeMillis() - start;
+                        if (lockInstance != null) {
+                            lockMetrics.acquired(metricLock, waitMillis);
+                        } else {
+                            lockMetrics.acquireFailed(metricLock, waitMillis);
+                        }
                     })
-                    .doOnError(throwable -> lockMetrics.acquireFailed(metricLock))
+                    .doOnError(throwable -> lockMetrics.acquireFailed(metricLock, System.currentTimeMillis() - start))
                     .doFinally(signalType -> lockMetrics.waitEnd(metricLock));
         });
+    }
+
+    /** Brackets a held action with the {@code lock_held} gauge: {@code +1} on subscribe, {@code -1} on any
+     * terminal signal (success, error, cancel), so held start and end stay paired in one place. */
+    private <T> Mono<T> instrumentHeld(String metricLock, Mono<T> heldAction) {
+        return heldAction
+                .doOnSubscribe(subscription -> lockMetrics.heldStart(metricLock))
+                .doFinally(signalType -> lockMetrics.heldEnd(metricLock));
+    }
+
+    /** {@link Flux} variant of {@link #instrumentHeld(String, Mono)}. */
+    private <T> Flux<T> instrumentHeld(String metricLock, Flux<T> heldStream) {
+        return heldStream
+                .doOnSubscribe(subscription -> lockMetrics.heldStart(metricLock))
+                .doFinally(signalType -> lockMetrics.heldEnd(metricLock));
     }
 
     private RPermitExpirableSemaphoreReactive getSemaphore(Lock lock) {
@@ -192,7 +212,7 @@ class RedissonLockService implements LockService {
                             // An empty completion means the wait elapsed without obtaining a permit.
                             .doOnSuccess(permitId -> {
                                 if (permitId == null) {
-                                    lockMetrics.acquireFailed(metricLock);
+                                    lockMetrics.acquireFailed(metricLock, System.currentTimeMillis() - start);
                                 }
                             })
                             // If the lock is not acquired, run the fallback and return empty so the main action does not execute.
@@ -211,13 +231,13 @@ class RedissonLockService implements LockService {
                                             }
                                         });
                             }))
-                    .doFinally(signal -> lockMetrics.waitEnd(metricLock));
-        })
-                .onErrorResume(RedisException.class,
-                        redisException -> {
-                            lockMetrics.acquireFailed(metricLock);
-                            return handleError(failToAcquireLockAction, redisException).then(Mono.empty());
-                        });
+                    .doFinally(signal -> lockMetrics.waitEnd(metricLock))
+                    .onErrorResume(RedisException.class,
+                            redisException -> {
+                                lockMetrics.acquireFailed(metricLock, System.currentTimeMillis() - start);
+                                return handleError(failToAcquireLockAction, redisException).then(Mono.empty());
+                            });
+        });
     }
 
     @Override

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/lock/LockTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/lock/LockTest.java
@@ -1,0 +1,49 @@
+package com.comet.opik.infrastructure.lock;
+
+import com.comet.opik.infrastructure.lock.LockService.Lock;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link Lock#metricName()} — the low-cardinality label exposed on the lock for metrics.
+ * It collapses embedded UUIDs to {@code *} so cardinality is bounded by lock type, not by entity. The
+ * Redis {@code key} itself is left untouched (high-cardinality, the lock's real identity).
+ */
+class LockTest {
+
+    static Stream<Arguments> metricNameCollapsesUuids() {
+        return Stream.of(
+                // Static key, no UUID — unchanged.
+                Arguments.of(new Lock("alert_job:scan_lock"), "alert_job:scan_lock"),
+                // UUID-scoped lock: id collapses, stable name kept.
+                Arguments.of(new Lock(UUID.fromString("0190babc-62a0-71d2-832a-0feffa4676eb"), "Trace"), "*-Trace"),
+                // Pre-formatted dynamic key: embedded UUID collapses, surrounding template kept.
+                Arguments.of(new Lock("prompt_version:0190babc-62a0-71d2-832a-0feffa4676eb:c12d"),
+                        "prompt_version:*:c12d"),
+                // Multiple UUIDs all collapse.
+                Arguments.of(new Lock("0190babc-62a0-71d2-832a-0feffa4676eb-0190babc-62a0-71d2-832a-0feffa4676ec"),
+                        "*-*"));
+    }
+
+    @ParameterizedTest(name = "metricName -> ''{1}''")
+    @MethodSource
+    void metricNameCollapsesUuids(Lock lock, String expected) {
+        assertThat(lock.metricName()).isEqualTo(expected);
+    }
+
+    @Test
+    void metricNameLeavesTheRedisKeyUntouched() {
+        var lock = new Lock(UUID.fromString("0190babc-62a0-71d2-832a-0feffa4676eb"), "Trace");
+
+        // The Redis identity keeps the full UUID; only the metric label collapses it.
+        assertThat(lock.key()).isEqualTo("0190babc-62a0-71d2-832a-0feffa4676eb-Trace");
+        assertThat(lock.metricName()).isEqualTo("*-Trace");
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/LockMetricsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/LockMetricsTest.java
@@ -2,81 +2,34 @@ package com.comet.opik.infrastructure.redis;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
- * Unit tests for {@link LockMetrics}. Covers the pure label-normalization logic (UUID
- * collapsing, null handling) directly, and asserts the best-effort recording contract:
- * a telemetry failure must never propagate to the caller. The recording methods run
- * against the no-op {@code GlobalOpenTelemetry} meter (no SDK registered in unit tests),
- * which is enough to exercise the {@code adjust()} delta state, the negative-wait clamp,
- * and the {@code record()} swallow-and-log guard without standing up an OTel pipeline.
+ * Unit tests for {@link LockMetrics}. The class is stateless — {@code lock_waiting}/{@code lock_held} are
+ * OpenTelemetry UpDownCounters, so there's nothing to assert about internal counters here. These tests pin
+ * the best-effort contract: recording runs against the no-op {@code GlobalOpenTelemetry} meter (no SDK in
+ * unit tests) and must never throw, including the negative-wait clamp and a balanced increment/decrement
+ * lifecycle. The low-cardinality label itself lives on {@code LockService.Lock} (see {@code LockTest}).
  */
 class LockMetricsTest {
 
-    static Stream<Arguments> labelCollapsesUuids() {
-        return Stream.of(
-                // No UUID present — returned unchanged.
-                Arguments.of("trace-threads-process", "trace-threads-process"),
-                // Empty key — no UUID to collapse, returned as-is.
-                Arguments.of("", ""),
-                // Single leading UUID — the high-cardinality part is collapsed to '*'.
-                Arguments.of("123e4567-e89b-12d3-a456-426614174000-trace-threads-process",
-                        "*-trace-threads-process"),
-                // Uppercase hex is still a valid UUID per the pattern.
-                Arguments.of("123E4567-E89B-12D3-A456-426614174000-trace-threads-process",
-                        "*-trace-threads-process"),
-                // Multiple UUIDs — every occurrence is collapsed.
-                Arguments.of("123e4567-e89b-12d3-a456-426614174000-x-223e4567-e89b-12d3-a456-426614174001",
-                        "*-x-*"));
-    }
-
-    @ParameterizedTest(name = "label(''{0}'') -> ''{1}''")
-    @MethodSource
-    void labelCollapsesUuids(String key, String expected) {
-        assertThat(LockMetrics.label(key)).isEqualTo(expected);
-    }
-
-    @Test
-    void labelWhenKeyIsNullReturnsUnknown() {
-        assertThat(LockMetrics.label(null)).isEqualTo("unknown");
-    }
+    private static final String LOCK = "trace-threads-process";
 
     @Test
     void recordingMetricsNeverThrows() {
         var metrics = new LockMetrics();
-        var lock = "123e4567-e89b-12d3-a456-426614174000-trace-threads-process";
 
-        // A full waiting -> held -> released lifecycle plus the terminal counters must
+        // A full waiting -> acquired -> held -> released lifecycle plus the failure counter must
         // complete silently — telemetry is best-effort and must not break locking.
         assertThatCode(() -> {
-            metrics.waitStart(lock);
-            metrics.acquired(lock, 42);
-            metrics.waitEnd(lock);
-            metrics.heldStart(lock);
-            metrics.heldEnd(lock);
-            metrics.acquireFailed(lock);
-        }).doesNotThrowAnyException();
-    }
-
-    @Test
-    void adjustReturningToZeroNeverThrows() {
-        var metrics = new LockMetrics();
-        var lock = "123e4567-e89b-12d3-a456-426614174000-trace-threads-process";
-
-        // Balanced increments/decrements drive the per-lock AtomicLong delta back to zero.
-        assertThatCode(() -> {
-            metrics.heldStart(lock);
-            metrics.heldStart(lock);
-            metrics.heldEnd(lock);
-            metrics.heldEnd(lock);
+            metrics.waitStart(LOCK);
+            metrics.acquired(LOCK, 42);
+            metrics.waitEnd(LOCK);
+            metrics.heldStart(LOCK);
+            metrics.heldEnd(LOCK);
+            metrics.acquireFailed(LOCK);
         }).doesNotThrowAnyException();
     }
 
@@ -84,24 +37,8 @@ class LockMetricsTest {
     @ValueSource(longs = {-100L, 0L, 100L})
     void acquiredClampsNegativeWaitWithoutThrowing(long waitMillis) {
         var metrics = new LockMetrics();
-        var lock = "123e4567-e89b-12d3-a456-426614174000-trace-threads-process";
 
         // Negative waits (clock skew) are clamped via Math.max(0, ...) before recording.
-        assertThatCode(() -> metrics.acquired(lock, waitMillis)).doesNotThrowAnyException();
-    }
-
-    @Test
-    void nonUuidLockLabelsAreCappedToBoundCardinality() {
-        var metrics = new LockMetrics();
-
-        // A caller that interpolates a non-UUID dynamic segment (a name, an email, ...) produces
-        // labels that label() can't collapse. The cap bounds the distinct labels we record so the
-        // gauge maps and the "lock" attribute cardinality can't grow without bound.
-        assertThatCode(() -> {
-            for (int i = 0; i < LockMetrics.MAX_DISTINCT_LOCKS + 50; i++) {
-                metrics.waitStart("export-for-workspace-" + i);
-            }
-        }).doesNotThrowAnyException();
-        assertThat(metrics.trackedLocks()).isEqualTo(LockMetrics.MAX_DISTINCT_LOCKS);
+        assertThatCode(() -> metrics.acquired(LOCK, waitMillis)).doesNotThrowAnyException();
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/LockMetricsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/LockMetricsTest.java
@@ -29,7 +29,7 @@ class LockMetricsTest {
             metrics.waitEnd(LOCK);
             metrics.heldStart(LOCK);
             metrics.heldEnd(LOCK);
-            metrics.acquireFailed(LOCK);
+            metrics.acquireFailed(LOCK, 7);
         }).doesNotThrowAnyException();
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/LockMetricsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/LockMetricsTest.java
@@ -89,4 +89,19 @@ class LockMetricsTest {
         // Negative waits (clock skew) are clamped via Math.max(0, ...) before recording.
         assertThatCode(() -> metrics.acquired(lock, waitMillis)).doesNotThrowAnyException();
     }
+
+    @Test
+    void nonUuidLockLabelsAreCappedToBoundCardinality() {
+        var metrics = new LockMetrics();
+
+        // A caller that interpolates a non-UUID dynamic segment (a name, an email, ...) produces
+        // labels that label() can't collapse. The cap bounds the distinct labels we record so the
+        // gauge maps and the "lock" attribute cardinality can't grow without bound.
+        assertThatCode(() -> {
+            for (int i = 0; i < LockMetrics.MAX_DISTINCT_LOCKS + 50; i++) {
+                metrics.waitStart("export-for-workspace-" + i);
+            }
+        }).doesNotThrowAnyException();
+        assertThat(metrics.trackedLocks()).isEqualTo(LockMetrics.MAX_DISTINCT_LOCKS);
+    }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/LockMetricsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/LockMetricsTest.java
@@ -1,0 +1,92 @@
+package com.comet.opik.infrastructure.redis;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Unit tests for {@link LockMetrics}. Covers the pure label-normalization logic (UUID
+ * collapsing, null handling) directly, and asserts the best-effort recording contract:
+ * a telemetry failure must never propagate to the caller. The recording methods run
+ * against the no-op {@code GlobalOpenTelemetry} meter (no SDK registered in unit tests),
+ * which is enough to exercise the {@code adjust()} delta state, the negative-wait clamp,
+ * and the {@code record()} swallow-and-log guard without standing up an OTel pipeline.
+ */
+class LockMetricsTest {
+
+    static Stream<Arguments> labelCollapsesUuids() {
+        return Stream.of(
+                // No UUID present — returned unchanged.
+                Arguments.of("trace-threads-process", "trace-threads-process"),
+                // Empty key — no UUID to collapse, returned as-is.
+                Arguments.of("", ""),
+                // Single leading UUID — the high-cardinality part is collapsed to '*'.
+                Arguments.of("123e4567-e89b-12d3-a456-426614174000-trace-threads-process",
+                        "*-trace-threads-process"),
+                // Uppercase hex is still a valid UUID per the pattern.
+                Arguments.of("123E4567-E89B-12D3-A456-426614174000-trace-threads-process",
+                        "*-trace-threads-process"),
+                // Multiple UUIDs — every occurrence is collapsed.
+                Arguments.of("123e4567-e89b-12d3-a456-426614174000-x-223e4567-e89b-12d3-a456-426614174001",
+                        "*-x-*"));
+    }
+
+    @ParameterizedTest(name = "label(''{0}'') -> ''{1}''")
+    @MethodSource
+    void labelCollapsesUuids(String key, String expected) {
+        assertThat(LockMetrics.label(key)).isEqualTo(expected);
+    }
+
+    @Test
+    void labelWhenKeyIsNullReturnsUnknown() {
+        assertThat(LockMetrics.label(null)).isEqualTo("unknown");
+    }
+
+    @Test
+    void recordingMetricsNeverThrows() {
+        var metrics = new LockMetrics();
+        var lock = "123e4567-e89b-12d3-a456-426614174000-trace-threads-process";
+
+        // A full waiting -> held -> released lifecycle plus the terminal counters must
+        // complete silently — telemetry is best-effort and must not break locking.
+        assertThatCode(() -> {
+            metrics.waitStart(lock);
+            metrics.acquired(lock, 42);
+            metrics.waitEnd(lock);
+            metrics.heldStart(lock);
+            metrics.heldEnd(lock);
+            metrics.acquireFailed(lock);
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void adjustReturningToZeroNeverThrows() {
+        var metrics = new LockMetrics();
+        var lock = "123e4567-e89b-12d3-a456-426614174000-trace-threads-process";
+
+        // Balanced increments/decrements drive the per-lock AtomicLong delta back to zero.
+        assertThatCode(() -> {
+            metrics.heldStart(lock);
+            metrics.heldStart(lock);
+            metrics.heldEnd(lock);
+            metrics.heldEnd(lock);
+        }).doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest(name = "acquired(waitMillis={0}) is clamped and never throws")
+    @ValueSource(longs = {-100L, 0L, 100L})
+    void acquiredClampsNegativeWaitWithoutThrowing(long waitMillis) {
+        var metrics = new LockMetrics();
+        var lock = "123e4567-e89b-12d3-a456-426614174000-trace-threads-process";
+
+        // Negative waits (clock skew) are clamped via Math.max(0, ...) before recording.
+        assertThatCode(() -> metrics.acquired(lock, waitMillis)).doesNotThrowAnyException();
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/RedissonLockServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/RedissonLockServiceTest.java
@@ -77,7 +77,7 @@ class RedissonLockServiceTest {
                 .ttlInSeconds(TTL_IN_SECONDS)
                 .build();
         when(redisClient.getPermitExpirableSemaphore(any(CommonOptions.class))).thenReturn(semaphore);
-        lockService = new RedissonLockService(redisClient, config);
+        lockService = new RedissonLockService(redisClient, config, new LockMetrics());
     }
 
     @Test


### PR DESCRIPTION
## Details

Adds OpenTelemetry observability for the distributed `RedissonLockService` (semaphore-based locks). The headline signal for OPIK-6813 is `lock_waiting`: callers blocked on a permit are `CompletableFuture`s held in the pod heap, each pinning its payload, so a runaway acquire-queue is invisible in Redis and only surfaces as heap growth. These metrics expose it directly, tagged by a low-cardinality lock name (UUIDs collapsed to `*`) so a per-project hotspot is visible without per-entity cardinality.

- `LockMetrics.java` (new): `lock_waiting` / `lock_held` gauges, `lock_acquire_wait_milliseconds` histogram, `lock_acquired_total` / `lock_acquire_failed_total` counters. Best-effort — a telemetry failure is swallowed-and-logged, never breaks locking.
- `RedissonLockService.java`: instruments the acquire / held / release paths; release rides the existing `doFinally` so it fires on complete, error, and cancel.
- `LockMetricsTest.java` (new): covers `label()` normalization and the best-effort recording contract.
- Purely additive — metrics are emitted unconditionally, no behavior change to locking.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6813

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: authored `LockMetricsTest.java` and the PR description; reviewed the branch against the team's mined PR-review rules.
- Human verification: author ran `mvn test -Dtest=LockMetricsTest` (11/11 passing) and `mvn spotless:check` (clean) locally, and reviewed all changes.

## Testing

- `mvn test -Dtest="LockMetricsTest"` — 11 tests, all passing (local process mode, macOS).
  - Scenarios: `label()` null → `unknown`, single / multiple / uppercase UUID collapsing, no-UUID passthrough; best-effort recording (negative-wait clamp, balanced increment/decrement, no-throw on the no-op meter).
- `mvn spotless:check` — clean.
- `RedissonLockService` happy/contention/lease paths are covered by the existing `RedissonLockServiceIntegrationTest` against real Redis (run in CI).

## Documentation

No documentation changes — internal observability metrics, no user-facing or SDK surface.