### PR TITLE
[NA] [SDK] test: update Anthropic integration tests to use newer models

### DIFF
--- a/sdks/python/tests/library_integration/anthropic/test_anthropic.py
+++ b/sdks/python/tests/library_integration/anthropic/test_anthropic.py
@@ -46,7 +46,7 @@ EXPECTED_ANTHROPIC_USAGE_DICT = {
     "original_usage.cache_creation.ephemeral_1h_input_tokens": ANY_BUT_NONE,
 }
 
-MODEL_FOR_TESTS_FULL = "claude-sonnet-4-0"
+MODEL_FOR_TESTS_FULL = "claude-sonnet-4-6"
 MODEL_FOR_TESTS_SHORT = "claude-sonnet-4"
 
 pytestmark = pytest.mark.usefixtures("ensure_anthropic_configured")

--- a/sdks/python/tests/library_integration/anthropic/test_anthropic.py
+++ b/sdks/python/tests/library_integration/anthropic/test_anthropic.py
@@ -16,6 +16,12 @@ from ...testlib import (
     ANY,
     assert_equal,
 )
+from ...llm_constants import (
+    ANTHROPIC_CLAUDE_SONNET,
+    ANTHROPIC_CLAUDE_SONNET_SHORT,
+    ANTHROPIC_CLAUDE_HAIKU,
+    ANTHROPIC_CLAUDE_HAIKU_SHORT,
+)
 
 import anthropic
 import tenacity
@@ -46,9 +52,6 @@ EXPECTED_ANTHROPIC_USAGE_DICT = {
     "original_usage.cache_creation.ephemeral_1h_input_tokens": ANY_BUT_NONE,
 }
 
-MODEL_FOR_TESTS_FULL = "claude-sonnet-4-6"
-MODEL_FOR_TESTS_SHORT = "claude-sonnet-4"
-
 pytestmark = pytest.mark.usefixtures("ensure_anthropic_configured")
 
 
@@ -71,7 +74,7 @@ def test_anthropic_messages_create__happyflow(
     messages = [{"role": "user", "content": "Tell a short fact"}]
 
     response = wrapped_client.messages.create(
-        model=MODEL_FOR_TESTS_FULL,
+        model=ANTHROPIC_CLAUDE_SONNET,
         messages=messages,
         max_tokens=10,
         system="You are a helpful assistant",
@@ -106,7 +109,7 @@ def test_anthropic_messages_create__happyflow(
                 project_name=expected_project_name,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",
@@ -209,7 +212,7 @@ def test_anthropic_messages_create__create_call_made_in_another_tracked_function
         ]
 
         _ = wrapped_client.messages.create(
-            model=MODEL_FOR_TESTS_FULL,
+            model=ANTHROPIC_CLAUDE_SONNET,
             messages=messages,
             max_tokens=10,
             system="You are a helpful assistant",
@@ -253,7 +256,7 @@ def test_anthropic_messages_create__create_call_made_in_another_tracked_function
                         project_name="anthropic-integration-test",
                         type="llm",
                         usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                        model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                        model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                         provider="anthropic",
                         spans=[],
                         source="sdk",
@@ -283,7 +286,7 @@ def test_async_anthropic_messages_create_call_made_in_another_tracked_async_func
         client = anthropic.AsyncAnthropic()
         wrapped_client = track_anthropic(client)
         _ = await wrapped_client.messages.create(
-            model=MODEL_FOR_TESTS_FULL,
+            model=ANTHROPIC_CLAUDE_SONNET,
             messages=messages,
             max_tokens=10,
             system="You are a helpful assistant",
@@ -327,7 +330,7 @@ def test_async_anthropic_messages_create_call_made_in_another_tracked_async_func
                         project_name=ANY_BUT_NONE,
                         type="llm",
                         usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                        model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                        model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                         provider="anthropic",
                         spans=[],
                         source="sdk",
@@ -358,7 +361,7 @@ def test_anthropic_messages_stream__generator_tracked_correctly(
     ]
 
     message_stream_manager = wrapped_client.messages.stream(
-        model=MODEL_FOR_TESTS_FULL,
+        model=ANTHROPIC_CLAUDE_SONNET,
         messages=messages,
         max_tokens=10,
         system="You are a helpful assistant",
@@ -394,7 +397,7 @@ def test_anthropic_messages_stream__generator_tracked_correctly(
                 end_time=ANY_BUT_NONE,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",
@@ -414,7 +417,7 @@ def test_anthropic_messages_stream__stream_called_2_times__generator_tracked_cor
 ):
     def run_stream(client, messages):
         message_stream_manager = wrapped_client.messages.stream(
-            model=MODEL_FOR_TESTS_FULL,
+            model=ANTHROPIC_CLAUDE_SONNET,
             messages=messages,
             max_tokens=10,
             system="You are a helpful assistant",
@@ -471,7 +474,7 @@ def test_anthropic_messages_stream__stream_called_2_times__generator_tracked_cor
                 end_time=ANY_BUT_NONE,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",
@@ -504,7 +507,7 @@ def test_anthropic_messages_stream__stream_called_2_times__generator_tracked_cor
                 end_time=ANY_BUT_NONE,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",
@@ -533,7 +536,7 @@ def test_anthropic_messages_stream__get_final_message_called__generator_tracked_
     ]
 
     message_stream_manager = wrapped_client.messages.stream(
-        model=MODEL_FOR_TESTS_FULL,
+        model=ANTHROPIC_CLAUDE_SONNET,
         messages=messages,
         max_tokens=10,
         system="You are a helpful assistant",
@@ -568,7 +571,7 @@ def test_anthropic_messages_stream__get_final_message_called__generator_tracked_
                 end_time=ANY_BUT_NONE,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",
@@ -596,7 +599,7 @@ def test_anthropic_messages_stream__get_final_message_called_after_stream_iterat
     ]
 
     message_stream_manager = wrapped_client.messages.stream(
-        model=MODEL_FOR_TESTS_FULL,
+        model=ANTHROPIC_CLAUDE_SONNET,
         messages=messages,
         max_tokens=10,
         system="You are a helpful assistant",
@@ -633,7 +636,7 @@ def test_anthropic_messages_stream__get_final_message_called_after_stream_iterat
                 end_time=ANY_BUT_NONE,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",
@@ -662,7 +665,7 @@ def test_async_anthropic_messages_stream__data_tracked_correctly(
 
     async def async_f():
         message_stream_manager = wrapped_client.messages.stream(
-            model=MODEL_FOR_TESTS_FULL,
+            model=ANTHROPIC_CLAUDE_SONNET,
             messages=messages,
             max_tokens=10,
             system="You are a helpful assistant",
@@ -700,7 +703,7 @@ def test_async_anthropic_messages_stream__data_tracked_correctly(
                 end_time=ANY_BUT_NONE,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",
@@ -729,7 +732,7 @@ def test_async_anthropic_messages_stream__get_final_message_called_twice__data_t
 
     async def async_f():
         message_stream_manager = wrapped_client.messages.stream(
-            model=MODEL_FOR_TESTS_FULL,
+            model=ANTHROPIC_CLAUDE_SONNET,
             messages=messages,
             max_tokens=10,
             system="You are a helpful assistant",
@@ -767,7 +770,7 @@ def test_async_anthropic_messages_stream__get_final_message_called_twice__data_t
                 end_time=ANY_BUT_NONE,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",
@@ -795,7 +798,7 @@ def test_anthropic_messages_create__stream_argument_is_True__Stream_object_retur
     ]
 
     stream = wrapped_client.messages.create(
-        model=MODEL_FOR_TESTS_FULL,
+        model=ANTHROPIC_CLAUDE_SONNET,
         messages=messages,
         max_tokens=10,
         system="You are a helpful assistant",
@@ -831,7 +834,7 @@ def test_anthropic_messages_create__stream_argument_is_True__Stream_object_retur
                 end_time=ANY_BUT_NONE,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",
@@ -860,7 +863,7 @@ def test_async_anthropic_messages_create__stream_argument_is_True__AsyncStream_o
         ]
 
         stream = await wrapped_client.messages.create(
-            model=MODEL_FOR_TESTS_FULL,
+            model=ANTHROPIC_CLAUDE_SONNET,
             messages=messages,
             max_tokens=10,
             system="You are a helpful assistant",
@@ -910,7 +913,7 @@ def test_async_anthropic_messages_create__stream_argument_is_True__AsyncStream_o
                 end_time=ANY_BUT_NONE,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",
@@ -952,7 +955,7 @@ def test_anthropic_messages_create__opik_args__happyflow(
     }
 
     response = wrapped_client.messages.create(
-        model=MODEL_FOR_TESTS_FULL,
+        model=ANTHROPIC_CLAUDE_SONNET,
         messages=messages,
         max_tokens=10,
         system="You are a helpful assistant",
@@ -989,7 +992,7 @@ def test_anthropic_messages_create__opik_args__happyflow(
                 project_name=expected_project_name,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",
@@ -1001,10 +1004,6 @@ def test_anthropic_messages_create__opik_args__happyflow(
     assert len(fake_backend.trace_trees) == 1
 
     assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
-
-
-PARSE_MODEL = "claude-haiku-4-5-20251001"
-PARSE_MODEL_PREFIX = "claude-haiku-4"
 
 
 class _FactResponse(pydantic.BaseModel):
@@ -1019,7 +1018,7 @@ def test_anthropic_messages_parse__happyflow(fake_backend):
     messages = [{"role": "user", "content": "Tell a short fact about Paris"}]
 
     response = wrapped_client.messages.parse(
-        model=PARSE_MODEL,
+        model=ANTHROPIC_CLAUDE_HAIKU,
         messages=messages,
         max_tokens=200,
         output_format=_FactResponse,
@@ -1051,7 +1050,7 @@ def test_anthropic_messages_parse__happyflow(fake_backend):
                 project_name=ANY_BUT_NONE,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(PARSE_MODEL_PREFIX),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_HAIKU_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",
@@ -1072,7 +1071,7 @@ def test_async_anthropic_messages_parse__happyflow(fake_backend):
         messages = [{"role": "user", "content": "Tell a short fact about Paris"}]
 
         response = await wrapped_client.messages.parse(
-            model=PARSE_MODEL,
+            model=ANTHROPIC_CLAUDE_HAIKU,
             messages=messages,
             max_tokens=200,
             output_format=_FactResponse,
@@ -1107,7 +1106,7 @@ def test_async_anthropic_messages_parse__happyflow(fake_backend):
                 project_name=ANY_BUT_NONE,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(PARSE_MODEL_PREFIX),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_HAIKU_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",
@@ -1127,7 +1126,7 @@ def test_anthropic_beta_messages_create__happyflow(fake_backend):
     messages = [{"role": "user", "content": "Tell a short fact"}]
 
     response = wrapped_client.beta.messages.create(
-        model=MODEL_FOR_TESTS_FULL,
+        model=ANTHROPIC_CLAUDE_SONNET,
         messages=messages,
         max_tokens=10,
         system="You are a helpful assistant",
@@ -1159,7 +1158,7 @@ def test_anthropic_beta_messages_create__happyflow(fake_backend):
                 project_name=ANY_BUT_NONE,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",
@@ -1179,7 +1178,7 @@ def test_anthropic_beta_messages_parse__happyflow(fake_backend):
     messages = [{"role": "user", "content": "Tell a short fact about Paris"}]
 
     response = wrapped_client.beta.messages.parse(
-        model=PARSE_MODEL,
+        model=ANTHROPIC_CLAUDE_HAIKU,
         messages=messages,
         max_tokens=200,
         output_format=_FactResponse,
@@ -1211,7 +1210,7 @@ def test_anthropic_beta_messages_parse__happyflow(fake_backend):
                 project_name=ANY_BUT_NONE,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(PARSE_MODEL_PREFIX),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_HAIKU_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",
@@ -1231,7 +1230,7 @@ def test_anthropic_beta_messages_stream__generator_tracked_correctly(fake_backen
     messages = [{"role": "user", "content": "Tell a short fact"}]
 
     with wrapped_client.beta.messages.stream(
-        model=MODEL_FOR_TESTS_FULL,
+        model=ANTHROPIC_CLAUDE_SONNET,
         messages=messages,
         max_tokens=10,
         system="You are a helpful assistant",
@@ -1265,7 +1264,7 @@ def test_anthropic_beta_messages_stream__generator_tracked_correctly(fake_backen
                 project_name=ANY_BUT_NONE,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",
@@ -1286,7 +1285,7 @@ def test_async_anthropic_beta_messages_stream__data_tracked_correctly(fake_backe
 
     async def async_f():
         async with wrapped_client.beta.messages.stream(
-            model=MODEL_FOR_TESTS_FULL,
+            model=ANTHROPIC_CLAUDE_SONNET,
             messages=messages,
             max_tokens=10,
             system="You are a helpful assistant",
@@ -1322,7 +1321,7 @@ def test_async_anthropic_beta_messages_stream__data_tracked_correctly(fake_backe
                 project_name=ANY_BUT_NONE,
                 type="llm",
                 usage=EXPECTED_ANTHROPIC_USAGE_DICT,
-                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                 provider="anthropic",
                 spans=[],
                 source="sdk",

--- a/sdks/python/tests/library_integration/langchain/test_langchain_anthropic.py
+++ b/sdks/python/tests/library_integration/langchain/test_langchain_anthropic.py
@@ -30,7 +30,7 @@ EXPECTED_USAGE_ANTHROPIC = ANY_DICT.containing(
 )
 
 
-MODEL_FOR_TESTS_FULL = "claude-sonnet-4-0"
+MODEL_FOR_TESTS_FULL = "claude-sonnet-4-6"
 MODEL_FOR_TESTS_SHORT = "claude-sonnet-4"
 
 

--- a/sdks/python/tests/library_integration/langchain/test_langchain_anthropic.py
+++ b/sdks/python/tests/library_integration/langchain/test_langchain_anthropic.py
@@ -12,6 +12,10 @@ from ...testlib import (
     TraceModel,
     assert_equal,
 )
+from ...llm_constants import (
+    ANTHROPIC_CLAUDE_SONNET,
+    ANTHROPIC_CLAUDE_SONNET_SHORT,
+)
 
 
 pytestmark = pytest.mark.usefixtures("ensure_anthropic_configured")
@@ -30,17 +34,13 @@ EXPECTED_USAGE_ANTHROPIC = ANY_DICT.containing(
 )
 
 
-MODEL_FOR_TESTS_FULL = "claude-sonnet-4-6"
-MODEL_FOR_TESTS_SHORT = "claude-sonnet-4"
-
-
 def test_langchain__anthropic_chat_is_used__token_usage_and_provider_is_logged__happyflow(
     fake_backend,
 ):
     # langchain_anthropic.Anthropic/AnthropicLLM is not tested because it is considered a legacy API which does not support the newest models
     llm = langchain_anthropic.ChatAnthropic(
         max_tokens=100,
-        model_name=MODEL_FOR_TESTS_FULL,
+        model_name=ANTHROPIC_CLAUDE_SONNET,
         name="custom-anthropic-llm-name",
     )
 
@@ -109,7 +109,7 @@ def test_langchain__anthropic_chat_is_used__token_usage_and_provider_is_logged__
                 end_time=ANY_BUT_NONE,
                 usage=EXPECTED_USAGE_ANTHROPIC,
                 provider="anthropic",
-                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                 source="sdk",
             ),
         ],
@@ -128,7 +128,7 @@ def test_langchain__anthropic_chat_is_used__streaming_mode__token_usage_and_prov
     # langchain_anthropic.Anthropic/AnthropicLLM is not tested because it is considered a legacy API which does not support the newest models
     llm = langchain_anthropic.ChatAnthropic(
         max_tokens=100,
-        model_name=MODEL_FOR_TESTS_FULL,
+        model_name=ANTHROPIC_CLAUDE_SONNET,
         name="custom-anthropic-llm-name",
         streaming=True,
         stream_usage=True,
@@ -203,7 +203,7 @@ def test_langchain__anthropic_chat_is_used__streaming_mode__token_usage_and_prov
                 end_time=ANY_BUT_NONE,
                 usage=EXPECTED_USAGE_ANTHROPIC,
                 provider="anthropic",
-                model=ANY_STRING.starting_with(MODEL_FOR_TESTS_SHORT),
+                model=ANY_STRING.starting_with(ANTHROPIC_CLAUDE_SONNET_SHORT),
                 source="sdk",
             ),
         ],

--- a/sdks/python/tests/llm_constants.py
+++ b/sdks/python/tests/llm_constants.py
@@ -55,6 +55,10 @@ OPENAI_REASONING_EFFORT = "minimal"
 ANTHROPIC_CLAUDE_SONNET = "claude-sonnet-4-6"
 ANTHROPIC_CLAUDE_HAIKU = "claude-haiku-4-5-20251001"
 
+# Short prefixes for version checking in tests (e.g. ANY_STRING.starting_with(...))
+ANTHROPIC_CLAUDE_SONNET_SHORT = "claude-sonnet-4"
+ANTHROPIC_CLAUDE_HAIKU_SHORT = "claude-haiku-4"
+
 LITELLM_ANTHROPIC_CLAUDE_SONNET = f"anthropic/{ANTHROPIC_CLAUDE_SONNET}"
 LITELLM_ANTHROPIC_CLAUDE_HAIKU = f"anthropic/{ANTHROPIC_CLAUDE_HAIKU}"
 


### PR DESCRIPTION
## Details

Updates Anthropic integration tests to use the latest Claude model versions (claude-sonnet-4-6). This fixes test failures for outdated models 4-0.

Example failure https://github.com/comet-ml/opik/actions/runs/27571143741/job/81507705580?pr=7115

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves NA
- OPIK-NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Haiku 4.5
  - Scope: Test model version updates
  - Human verification: Manual review of test file changes

## Testing

Tests were validated locally:
- Ran `make precommit-sdks` to verify linting and formatting passes
- Pre-commit hooks for Python SDK passed successfully
- Changes are isolated to test constant definitions

Tests not run:
- Full test suite not executed as this is just a model version update (tests use existing test infrastructure)

## Documentation

N/A - test-only changes