### PR TITLE
[OPIK-6947] [BE] feat: add cost_intelligence_enabled service toggle

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1087,6 +1087,9 @@ serviceToggles:
   # Default: false
   # Description: Whether or not Optimization Studio feature is enabled
   optimizationStudioEnabled: ${TOGGLE_OPTIMIZATION_STUDIO_ENABLED:-"false"}
+  # Default: false
+  # Description: Whether or not the Cost Intelligence (AI Spend) feature is enabled
+  costIntelligenceEnabled: ${TOGGLE_COST_INTELLIGENCE_ENABLED:-"false"}
   # Default: true
   # Description: Whether or not OpenAI provider is enabled
   openaiProviderEnabled: ${TOGGLE_OPENAI_PROVIDER_ENABLED:-"true"}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
@@ -39,6 +39,8 @@ public class ServiceTogglesConfig {
     @JsonProperty
     @NotNull boolean optimizationStudioEnabled;
     @JsonProperty
+    @NotNull boolean costIntelligenceEnabled;
+    @JsonProperty
     @NotNull boolean datasetVersioningEnabled;
     @JsonProperty
     @NotNull boolean datasetExportEnabled;

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -626,6 +626,9 @@ serviceToggles:
   # Default: false
   # Description: Whether or not Optimization Studio feature is enabled
   optimizationStudioEnabled: "false"
+  # Default: false
+  # Description: Whether or not the Cost Intelligence (AI Spend) feature is enabled
+  costIntelligenceEnabled: "false"
   # Default: true
   # Description: Whether or not OpenAI provider is enabled
   openaiProviderEnabled: "true"


### PR DESCRIPTION
## Details
The Cost Intelligence (AI Spend) feature toggle was added only on the frontend, so it could not be enabled/disabled **per environment from the backend**. This adds `costIntelligenceEnabled` to the backend `ServiceTogglesConfig` (served via `/v1/private/toggles/` as `cost_intelligence_enabled`), with config defaults (off by default, overridable via `TOGGLE_COST_INTELLIGENCE_ENABLED`).

The frontend already declares this key and merges the backend value over its default, so no FE change is needed — comet.com can now enable the Cost Intelligence menu via config without an FE deploy.

- `ServiceTogglesConfig.java`: new `costIntelligenceEnabled` field
- `config.yml`: `costIntelligenceEnabled: ${TOGGLE_COST_INTELLIGENCE_ENABLED:-"false"}`
- `config-test.yml`: `costIntelligenceEnabled: "false"`

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6947

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: code review + CI

## Testing
Mirrors the existing toggle pattern (e.g. `ollieEnabled`). `@NotNull` field backed by defaults in both `config.yml` and `config-test.yml` so config validation passes. Backend compiles/tests in CI (JDK 25). No dedicated toggles-resource test asserts the toggle set.

## Documentation
N/A