### PR TITLE
[OPIK-6970] [FE] feat: swap user menu entry to Opik within Cost Intelligence

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "@tanstack/react-router";
 import copy from "clipboard-copy";
 import {
   ArrowUpRight,
@@ -90,7 +91,11 @@ const UserMenu = () => {
   );
 
   const { canInviteMembers } = useUserPermission();
-  const { hasAccess: hasAiSpendAccess, goToCostIntelligence } = useAiSpend();
+  const {
+    hasAccess: hasAiSpendAccess,
+    isSpendWorkspaceActive,
+    goToCostIntelligence,
+  } = useAiSpend();
   const hasAiSpendPlugin = usePluginsStore((state) =>
     state.hasPlugin("ai-spend"),
   );
@@ -98,7 +103,11 @@ const UserMenu = () => {
     FeatureToggleKeys.COST_INTELLIGENCE_ENABLED,
   );
   const showCostIntelligence =
-    hasAiSpendPlugin && hasAiSpendAccess && costIntelligenceFeatureEnabled;
+    hasAiSpendPlugin &&
+    hasAiSpendAccess &&
+    costIntelligenceFeatureEnabled &&
+    !isSpendWorkspaceActive;
+  const showOpikReturn = hasAiSpendPlugin && Boolean(isSpendWorkspaceActive);
   const opikWorkspaceName = useOpikWorkspaceName();
   const [inviteSearchQuery, setInviteSearchQuery] = useState("");
   const [isInviteSubmenuOpen, setIsInviteSubmenuOpen] = useState(false);
@@ -301,9 +310,25 @@ const UserMenu = () => {
               </DropdownMenuItem>
             )}
           </DropdownMenuGroup>
-          {(showCostIntelligence || !isLLMOnlyOrganization) && (
+          {(showCostIntelligence ||
+            showOpikReturn ||
+            !isLLMOnlyOrganization) && (
             <>
               <DropdownMenuSeparator />
+              {showOpikReturn && (
+                <Link
+                  to="/$workspaceName/home"
+                  params={{ workspaceName: opikWorkspaceName }}
+                >
+                  <DropdownMenuItem className="cursor-pointer">
+                    <span className="mr-2 flex size-5 shrink-0 items-center justify-center rounded bg-chart-green text-[10px] font-medium text-white">
+                      O
+                    </span>
+                    <span className="truncate">Opik</span>
+                    <ArrowUpRight className="ml-auto size-4 shrink-0 text-light-slate" />
+                  </DropdownMenuItem>
+                </Link>
+              )}
               {showCostIntelligence && (
                 <DropdownMenuItem
                   className="cursor-pointer"

--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
-import { Link } from "@tanstack/react-router";
 import copy from "clipboard-copy";
 import {
-  ArrowUpRight,
   Check,
   Copy,
   KeyRound,
@@ -54,10 +52,7 @@ import { buildUrl } from "./utils";
 import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
 import InviteUsersPopover from "@/plugins/comet/InviteUsersPopover";
 import useUserPermission from "@/plugins/comet/useUserPermission";
-import { useAiSpend } from "@/contexts/AiSpendContext";
-import usePluginsStore from "@/store/PluginsStore";
-import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
-import { FeatureToggleKeys } from "@/types/feature-toggles";
+import UserMenuAppLinks from "@/plugins/comet/UserMenuAppLinks";
 
 const UserMenu = () => {
   const { toast } = useToast();
@@ -91,23 +86,6 @@ const UserMenu = () => {
   );
 
   const { canInviteMembers } = useUserPermission();
-  const {
-    hasAccess: hasAiSpendAccess,
-    isSpendWorkspaceActive,
-    goToCostIntelligence,
-  } = useAiSpend();
-  const hasAiSpendPlugin = usePluginsStore((state) =>
-    state.hasPlugin("ai-spend"),
-  );
-  const costIntelligenceFeatureEnabled = useIsFeatureEnabled(
-    FeatureToggleKeys.COST_INTELLIGENCE_ENABLED,
-  );
-  const showCostIntelligence =
-    hasAiSpendPlugin &&
-    hasAiSpendAccess &&
-    costIntelligenceFeatureEnabled &&
-    !isSpendWorkspaceActive;
-  const showOpikReturn = hasAiSpendPlugin && Boolean(isSpendWorkspaceActive);
   const opikWorkspaceName = useOpikWorkspaceName();
   const [inviteSearchQuery, setInviteSearchQuery] = useState("");
   const [isInviteSubmenuOpen, setIsInviteSubmenuOpen] = useState(false);
@@ -127,14 +105,6 @@ const UserMenu = () => {
   ) {
     return null;
   }
-
-  const handleSwitchToEM = () => {
-    window.location.href = buildUrl(
-      opikWorkspaceName,
-      opikWorkspaceName,
-      "&changeApplication=em",
-    );
-  };
 
   const organization = organizations.find((org) => {
     return org.id === workspace?.organizationId;
@@ -310,51 +280,7 @@ const UserMenu = () => {
               </DropdownMenuItem>
             )}
           </DropdownMenuGroup>
-          {(showCostIntelligence ||
-            showOpikReturn ||
-            !isLLMOnlyOrganization) && (
-            <>
-              <DropdownMenuSeparator />
-              {showOpikReturn && (
-                <Link
-                  to="/$workspaceName/home"
-                  params={{ workspaceName: opikWorkspaceName }}
-                >
-                  <DropdownMenuItem className="cursor-pointer">
-                    <span className="mr-2 flex size-5 shrink-0 items-center justify-center rounded bg-chart-green text-[10px] font-medium text-white">
-                      O
-                    </span>
-                    <span className="truncate">Opik</span>
-                    <ArrowUpRight className="ml-auto size-4 shrink-0 text-light-slate" />
-                  </DropdownMenuItem>
-                </Link>
-              )}
-              {showCostIntelligence && (
-                <DropdownMenuItem
-                  className="cursor-pointer"
-                  onClick={goToCostIntelligence}
-                >
-                  <span className="mr-2 flex size-5 shrink-0 items-center justify-center rounded bg-chart-green text-[10px] font-medium text-white">
-                    CI
-                  </span>
-                  <span className="truncate">Cost Intelligence</span>
-                  <ArrowUpRight className="ml-auto size-4 shrink-0 text-light-slate" />
-                </DropdownMenuItem>
-              )}
-              {!isLLMOnlyOrganization && (
-                <DropdownMenuItem
-                  className="cursor-pointer"
-                  onClick={handleSwitchToEM}
-                >
-                  <span className="mr-2 flex size-5 shrink-0 items-center justify-center rounded bg-[var(--feature-experiment-management)] text-[10px] font-medium text-white">
-                    EM
-                  </span>
-                  <span className="truncate">Experiment Management</span>
-                  <ArrowUpRight className="ml-auto size-4 shrink-0 text-light-slate" />
-                </DropdownMenuItem>
-              )}
-            </>
-          )}
+          <UserMenuAppLinks isLLMOnlyOrganization={isLLMOnlyOrganization} />
           <DropdownMenuItem
             className="cursor-pointer"
             onClick={async () => {

--- a/apps/opik-frontend/src/plugins/comet/UserMenuAppLinks.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenuAppLinks.tsx
@@ -1,0 +1,126 @@
+import { ArrowUpRight } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { DropdownMenuItem, DropdownMenuSeparator } from "@/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { useOpikWorkspaceName } from "@/store/AppStore";
+import { useAiSpend } from "@/contexts/AiSpendContext";
+import usePluginsStore from "@/store/PluginsStore";
+import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
+import { FeatureToggleKeys } from "@/types/feature-toggles";
+import { buildUrl } from "./utils";
+
+type AppLinkItemProps = {
+  badge: string;
+  badgeClassName: string;
+  label: string;
+  to?: string;
+  params?: { workspaceName: string };
+  onClick?: () => void;
+};
+
+const AppLinkItem = ({
+  badge,
+  badgeClassName,
+  label,
+  to,
+  params,
+  onClick,
+}: AppLinkItemProps) => {
+  const content = (
+    <>
+      <span
+        className={cn(
+          "mr-2 flex size-5 shrink-0 items-center justify-center rounded text-[10px] font-medium text-white",
+          badgeClassName,
+        )}
+      >
+        {badge}
+      </span>
+      <span className="truncate">{label}</span>
+      <ArrowUpRight className="ml-auto size-4 shrink-0 text-light-slate" />
+    </>
+  );
+
+  return to ? (
+    <DropdownMenuItem asChild className="cursor-pointer">
+      <Link to={to} params={params}>
+        {content}
+      </Link>
+    </DropdownMenuItem>
+  ) : (
+    <DropdownMenuItem className="cursor-pointer" onClick={onClick}>
+      {content}
+    </DropdownMenuItem>
+  );
+};
+
+type UserMenuAppLinksProps = {
+  isLLMOnlyOrganization: boolean;
+};
+
+const UserMenuAppLinks = ({ isLLMOnlyOrganization }: UserMenuAppLinksProps) => {
+  const opikWorkspaceName = useOpikWorkspaceName();
+  const {
+    hasAccess: hasAiSpendAccess,
+    isSpendWorkspaceActive,
+    goToCostIntelligence,
+  } = useAiSpend();
+  const hasAiSpendPlugin = usePluginsStore((state) =>
+    state.hasPlugin("ai-spend"),
+  );
+  const costIntelligenceFeatureEnabled = useIsFeatureEnabled(
+    FeatureToggleKeys.COST_INTELLIGENCE_ENABLED,
+  );
+
+  const showOpikReturn = Boolean(isSpendWorkspaceActive);
+  const showCostIntelligence =
+    hasAiSpendPlugin &&
+    hasAiSpendAccess &&
+    costIntelligenceFeatureEnabled &&
+    !isSpendWorkspaceActive;
+  const showExperimentManagement = !isLLMOnlyOrganization;
+
+  if (!showOpikReturn && !showCostIntelligence && !showExperimentManagement) {
+    return null;
+  }
+
+  const switchToEM = () =>
+    (window.location.href = buildUrl(
+      opikWorkspaceName,
+      opikWorkspaceName,
+      "&changeApplication=em",
+    ));
+
+  return (
+    <>
+      <DropdownMenuSeparator />
+      {showOpikReturn && (
+        <AppLinkItem
+          badge="O"
+          badgeClassName="bg-chart-green"
+          label="Opik"
+          to="/$workspaceName/home"
+          params={{ workspaceName: opikWorkspaceName }}
+        />
+      )}
+      {showCostIntelligence && (
+        <AppLinkItem
+          badge="CI"
+          badgeClassName="bg-chart-green"
+          label="Cost Intelligence"
+          onClick={goToCostIntelligence}
+        />
+      )}
+      {showExperimentManagement && (
+        <AppLinkItem
+          badge="EM"
+          badgeClassName="bg-[var(--feature-experiment-management)]"
+          label="Experiment Management"
+          onClick={switchToEM}
+        />
+      )}
+    </>
+  );
+};
+
+export default UserMenuAppLinks;


### PR DESCRIPTION
## Details

<img width="1508" height="928" alt="image" src="https://github.com/user-attachments/assets/d7638d20-e53c-4f13-bd4c-2359e5d54445" />
<img width="1508" height="927" alt="image" src="https://github.com/user-attachments/assets/d2af2f64-e031-4b8e-9bec-761b5f1e7655" />



Within the Cost Intelligence experience (spend workspace active), the user menu now shows an **"Opik"** return link (green "O" badge, links to the origin workspace home) instead of the **"Cost Intelligence"** entry. Matches the Figma design (node 47-43811). The return link is a `<Link>` and is gated on `isSpendWorkspaceActive`, so a path back to Opik always exists even if the feature flag is off.

The companion private-plugin PR (`comet-ml/opik-plugin-ai-spend`) removes the now-redundant "Back to Opik" button from the Cost Intelligence sidebar.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6970

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: full implementation
  - Human verification: code review + manual testing

## Testing
- `npm run lint` and `npm run typecheck` in `apps/opik-frontend` — both pass.
- Manual: inside the spend workspace the menu shows "Opik" (green O) linking to the origin workspace home; outside it shows "Cost Intelligence". Verified the section still renders Experiment Management + Logout.

## Documentation
N/A