### PR TITLE
[OPIK-6918] [FE] test: add E2E tests for Prompt Library and Playground

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/LLMPromptMessages/LLMPromptMessageActions.tsx
@@ -395,6 +395,7 @@ const LLMPromptMessageActions: React.FC<LLMPromptLibraryActionsProps> = ({
               <Button
                 variant="minimal"
                 size="icon-2xs"
+                data-testid="save-text-prompt-button"
                 onClick={() => {
                   resetKeyRef.current = resetKeyRef.current + 1;
                   setOpen("save");

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
@@ -95,6 +95,7 @@ const PromptLibraryMenu: React.FC<PromptLibraryMenuProps> = ({
       <PopoverContent
         align="end"
         className="w-[320px] p-0"
+        data-testid="prompt-library-menu"
         onCloseAutoFocus={(e) => e.preventDefault()}
         onInteractOutside={(e) => {
           const target = e.target as HTMLElement | null;

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
@@ -201,6 +201,7 @@ const PromptRow: React.FC<PromptRowProps> = ({
         sideOffset={8}
         className="w-[220px] p-1"
         data-prompt-versions-submenu=""
+        data-testid="prompt-versions-submenu"
       >
         <PromptVersionsList
           promptId={prompt.id}

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
@@ -184,7 +184,12 @@ const PromptsSelectBox: React.FC<PromptsSelectBoxProps> = ({
         trigger={
           <div>
             <TooltipWrapper content="Load prompt">
-              <Button variant="minimal" size="icon-sm" disabled={disabled} data-testid="load-text-prompt-button">
+              <Button
+                variant="minimal"
+                size="icon-sm"
+                disabled={disabled}
+                data-testid="load-text-prompt-button"
+              >
                 <FileTerminal />
               </Button>
             </TooltipWrapper>

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
@@ -184,7 +184,7 @@ const PromptsSelectBox: React.FC<PromptsSelectBoxProps> = ({
         trigger={
           <div>
             <TooltipWrapper content="Load prompt">
-              <Button variant="minimal" size="icon-sm" disabled={disabled}>
+              <Button variant="minimal" size="icon-sm" disabled={disabled} data-testid="load-text-prompt-button">
                 <FileTerminal />
               </Button>
             </TooltipWrapper>

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebarButton.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebarButton.tsx
@@ -61,7 +61,12 @@ const TraceLogsSidebarButton: React.FunctionComponent<
   const trigger =
     variant === "icon" ? (
       <TooltipWrapper content="Go to logs">
-        <Button variant="outline" size="icon-2xs" onClick={handleOpen}>
+        <Button
+          data-testid="playground-logs-sidebar-button"
+          variant="outline"
+          size="icon-2xs"
+          onClick={handleOpen}
+        >
           <ListTree />
         </Button>
       </TooltipWrapper>

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -406,7 +406,11 @@ const PlaygroundPrompt = ({
               trigger={
                 <div>
                   <TooltipWrapper content="Load prompt">
-                    <Button variant="minimal" size="icon-sm" data-testid="load-prompt-button">
+                    <Button
+                      variant="minimal"
+                      size="icon-sm"
+                      data-testid="load-prompt-button"
+                    >
                       <FileTerminal />
                     </Button>
                   </TooltipWrapper>

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -406,7 +406,7 @@ const PlaygroundPrompt = ({
               trigger={
                 <div>
                   <TooltipWrapper content="Load prompt">
-                    <Button variant="minimal" size="icon-sm">
+                    <Button variant="minimal" size="icon-sm" data-testid="load-prompt-button">
                       <FileTerminal />
                     </Button>
                   </TooltipWrapper>

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundPrompts/PlaygroundPrompt.tsx
@@ -429,6 +429,7 @@ const PlaygroundPrompt = ({
                   size="icon-sm"
                   onClick={handleSaveChatPrompt}
                   disabled={!canCreatePrompts && !selectedChatPromptId}
+                  data-testid="playground-save-prompt-button"
                 >
                   <Save />
                 </Button>

--- a/tests_end_to_end/e2e/pom/playground-logs-sidebar.page.ts
+++ b/tests_end_to_end/e2e/pom/playground-logs-sidebar.page.ts
@@ -1,0 +1,60 @@
+import type { Page, Locator } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+/**
+ * Page object for the Playground logs sidebar (TraceLogsSidebar).
+ *
+ * The sidebar opens as a Sheet/dialog when the user clicks the "Go to logs"
+ * icon button in the Playground header. The URL gains `tls_open=1`.
+ * Clicking a trace row adds `tls_trace=<id>` and renders the trace detail
+ * panel (`data-testid="traces"`) inside the same dialog.
+ */
+export class PlaygroundLogsSidebarPage {
+  constructor(private readonly page: Page) {}
+
+  /** The Sheet dialog element that hosts the sidebar. */
+  get dialog(): Locator {
+    return this.page.getByRole('dialog', { name: 'Playground logs' });
+  }
+
+  /** Wait for the sidebar sheet to be visible. */
+  async waitForOpen(): Promise<void> {
+    await this.dialog.waitFor({ state: 'visible' });
+  }
+
+  /** All trace rows in the sidebar table. */
+  traceRows(): Locator {
+    return this.dialog.locator('tr[data-row-id]');
+  }
+
+  firstTraceRow(): Locator {
+    return this.traceRows().first();
+  }
+
+  /** Poll until at least one trace row appears (traces are async after a run). */
+  async waitForTraceRow(timeoutMs = 30_000): Promise<void> {
+    await expect
+      .poll(
+        async () => (await this.traceRows().count()) > 0,
+        { timeout: timeoutMs, intervals: [500, 1000, 2000] },
+      )
+      .toBe(true);
+  }
+
+  /** Click the first trace row and wait for the trace detail panel to open. */
+  async openFirstTrace(): Promise<void> {
+    await this.firstTraceRow().click();
+    await this.page.waitForURL((url) => !!url.searchParams.get('tls_trace'));
+    await this.traceDetailPanel().waitFor({ state: 'visible' });
+  }
+
+  /** The trace detail panel rendered inside the sidebar. */
+  traceDetailPanel(): Locator {
+    return this.dialog.getByTestId('traces');
+  }
+
+  /** Click the "Prompts" tab in the trace detail panel. */
+  async clickPromptsTab(): Promise<void> {
+    await this.traceDetailPanel().getByRole('tab', { name: 'Prompts' }).click();
+  }
+}

--- a/tests_end_to_end/e2e/pom/playground-logs-sidebar.page.ts
+++ b/tests_end_to_end/e2e/pom/playground-logs-sidebar.page.ts
@@ -1,5 +1,5 @@
+import { test, expect } from '@playwright/test';
 import type { Page, Locator } from '@playwright/test';
-import { expect } from '@playwright/test';
 
 /**
  * Page object for the Playground logs sidebar (TraceLogsSidebar).
@@ -19,7 +19,9 @@ export class PlaygroundLogsSidebarPage {
 
   /** Wait for the sidebar sheet to be visible. */
   async waitForOpen(): Promise<void> {
-    await this.dialog.waitFor({ state: 'visible' });
+    return test.step('wait for logs sidebar to open', async () => {
+      await this.dialog.waitFor({ state: 'visible' });
+    });
   }
 
   /** All trace rows in the sidebar table. */
@@ -33,19 +35,23 @@ export class PlaygroundLogsSidebarPage {
 
   /** Poll until at least one trace row appears (traces are async after a run). */
   async waitForTraceRow(timeoutMs = 30_000): Promise<void> {
-    await expect
-      .poll(
-        async () => (await this.traceRows().count()) > 0,
-        { timeout: timeoutMs, intervals: [500, 1000, 2000] },
-      )
-      .toBe(true);
+    return test.step('wait for trace row to appear', async () => {
+      await expect
+        .poll(
+          async () => (await this.traceRows().count()) > 0,
+          { timeout: timeoutMs, intervals: [500, 1000, 2000] },
+        )
+        .toBe(true);
+    });
   }
 
   /** Click the first trace row and wait for the trace detail panel to open. */
   async openFirstTrace(): Promise<void> {
-    await this.firstTraceRow().click();
-    await this.page.waitForURL((url) => !!url.searchParams.get('tls_trace'));
-    await this.traceDetailPanel().waitFor({ state: 'visible' });
+    return test.step('open first trace', async () => {
+      await this.firstTraceRow().click();
+      await this.page.waitForURL((url) => !!url.searchParams.get('tls_trace'));
+      await this.traceDetailPanel().waitFor({ state: 'visible' });
+    });
   }
 
   /** The trace detail panel rendered inside the sidebar. */
@@ -55,6 +61,8 @@ export class PlaygroundLogsSidebarPage {
 
   /** Click the "Prompts" tab in the trace detail panel. */
   async clickPromptsTab(): Promise<void> {
-    await this.traceDetailPanel().getByRole('tab', { name: 'Prompts' }).click();
+    return test.step('click Prompts tab', async () => {
+      await this.traceDetailPanel().getByRole('tab', { name: 'Prompts' }).click();
+    });
   }
 }

--- a/tests_end_to_end/e2e/pom/playground.page.ts
+++ b/tests_end_to_end/e2e/pom/playground.page.ts
@@ -273,29 +273,33 @@ export class PlaygroundPage {
    * Open the prompt library menu in the first variant card, hover the named prompt
    * to reveal the version submenu, and click the specified version label (e.g. "v1").
    */
+  private async navigateLibraryMenuToVersion(promptName: string, versionLabel: string): Promise<void> {
+    const menu = this.page.getByTestId('prompt-library-menu');
+    await menu.waitFor({ state: 'visible' });
+
+    await menu.getByPlaceholder('Search').fill(promptName);
+
+    const promptRow = menu.getByRole('button').filter({ hasText: promptName }).first();
+    await promptRow.waitFor({ state: 'visible' });
+    await promptRow.hover();
+
+    const versionSubmenu = this.page.getByTestId('prompt-versions-submenu');
+    await versionSubmenu.waitFor({ state: 'visible' });
+
+    await versionSubmenu
+      .getByRole('button')
+      .filter({ has: this.page.getByText(versionLabel, { exact: true }) })
+      .first()
+      .click();
+  }
+
   async loadPromptVersionFromLibrary(promptName: string, versionLabel: string): Promise<void> {
     return test.step(`load prompt "${promptName}" version "${versionLabel}" from library`, async () => {
       // The button is in a div that only expands on group-hover; hover the card first.
       await this.variantCard(0).hover();
       await this.variantCard(0).getByTestId('load-prompt-button').click();
 
-      const menu = this.page.getByTestId('prompt-library-menu');
-      await menu.waitFor({ state: 'visible' });
-
-      await menu.getByPlaceholder('Search').fill(promptName);
-
-      const promptRow = menu.getByRole('button').filter({ hasText: promptName }).first();
-      await promptRow.waitFor({ state: 'visible' });
-      await promptRow.hover();
-
-      const versionSubmenu = this.page.locator('[data-prompt-versions-submenu]');
-      await versionSubmenu.waitFor({ state: 'visible' });
-
-      await versionSubmenu
-        .getByRole('button')
-        .filter({ has: this.page.getByText(versionLabel, { exact: true }) })
-        .first()
-        .click();
+      await this.navigateLibraryMenuToVersion(promptName, versionLabel);
     });
   }
 
@@ -311,23 +315,7 @@ export class PlaygroundPage {
       await messageRow.hover();
       await messageRow.getByTestId('load-text-prompt-button').click();
 
-      const menu = this.page.getByTestId('prompt-library-menu');
-      await menu.waitFor({ state: 'visible' });
-
-      await menu.getByPlaceholder('Search').fill(promptName);
-
-      const promptRow = menu.getByRole('button').filter({ hasText: promptName }).first();
-      await promptRow.waitFor({ state: 'visible' });
-      await promptRow.hover();
-
-      const versionSubmenu = this.page.locator('[data-prompt-versions-submenu]');
-      await versionSubmenu.waitFor({ state: 'visible' });
-
-      await versionSubmenu
-        .getByRole('button')
-        .filter({ has: this.page.getByText(versionLabel, { exact: true }) })
-        .first()
-        .click();
+      await this.navigateLibraryMenuToVersion(promptName, versionLabel);
     });
   }
 
@@ -353,6 +341,16 @@ export class PlaygroundPage {
     });
   }
 
+  private async submitSaveDialog(promptName?: string): Promise<void> {
+    const dialog = this.page.getByRole('dialog', { name: 'Save to prompt library' });
+    await dialog.waitFor({ state: 'visible' });
+    if (promptName) {
+      await dialog.getByLabel('Name').fill(promptName);
+    }
+    await dialog.getByRole('button', { name: 'Save to library' }).click();
+    await dialog.waitFor({ state: 'hidden' });
+  }
+
   /**
    * Click the Save button (disk icon) in the first message row of variant 0 and submit the
    * "Save to prompt library" dialog in "Update existing" mode (text prompts).
@@ -363,10 +361,7 @@ export class PlaygroundPage {
       const messageRow = this.variantMessages(0).first();
       await messageRow.hover();
       await messageRow.getByTestId('save-text-prompt-button').click();
-      const dialog = this.page.getByRole('dialog', { name: 'Save to prompt library' });
-      await dialog.waitFor({ state: 'visible' });
-      await dialog.getByRole('button', { name: 'Save to library' }).click();
-      await dialog.waitFor({ state: 'hidden' });
+      await this.submitSaveDialog();
     });
   }
 
@@ -380,11 +375,7 @@ export class PlaygroundPage {
       const messageRow = this.variantMessages(0).first();
       await messageRow.hover();
       await messageRow.getByTestId('save-text-prompt-button').click();
-      const dialog = this.page.getByRole('dialog', { name: 'Save to prompt library' });
-      await dialog.waitFor({ state: 'visible' });
-      await dialog.getByLabel('Name').fill(promptName);
-      await dialog.getByRole('button', { name: 'Save to library' }).click();
-      await dialog.waitFor({ state: 'hidden' });
+      await this.submitSaveDialog(promptName);
     });
   }
 
@@ -397,11 +388,7 @@ export class PlaygroundPage {
     return test.step(`save new chat prompt "${promptName}" to library from Playground`, async () => {
       await this.variantCard(0).hover();
       await this.page.getByTestId('playground-save-prompt-button').click();
-      const dialog = this.page.getByRole('dialog', { name: 'Save to prompt library' });
-      await dialog.waitFor({ state: 'visible' });
-      await dialog.getByLabel('Name').fill(promptName);
-      await dialog.getByRole('button', { name: 'Save to library' }).click();
-      await dialog.waitFor({ state: 'hidden' });
+      await this.submitSaveDialog(promptName);
     });
   }
 
@@ -414,10 +401,7 @@ export class PlaygroundPage {
     return test.step('save prompt to library from Playground', async () => {
       await this.variantCard(0).hover();
       await this.page.getByTestId('playground-save-prompt-button').click();
-      const dialog = this.page.getByRole('dialog', { name: 'Save to prompt library' });
-      await dialog.waitFor({ state: 'visible' });
-      await dialog.getByRole('button', { name: 'Save to library' }).click();
-      await dialog.waitFor({ state: 'hidden' });
+      await this.submitSaveDialog();
     });
   }
 

--- a/tests_end_to_end/e2e/pom/playground.page.ts
+++ b/tests_end_to_end/e2e/pom/playground.page.ts
@@ -344,6 +344,48 @@ export class PlaygroundPage {
     });
   }
 
+  /** Edit the content of the first message in variant 0 directly in the Playground editor. */
+  async editFirstMessage(newContent: string): Promise<void> {
+    return test.step('edit first message in Playground', async () => {
+      const editor = this.variantMessages(0).first().locator('.cm-content').first();
+      await editor.click();
+      await editor.fill(newContent);
+    });
+  }
+
+  /**
+   * Click the Save button (disk icon) in the first message row of variant 0 and submit the
+   * "Save to prompt library" dialog in "Update existing" mode (text prompts).
+   * Assumes a text prompt is already loaded so the dialog defaults to update mode.
+   */
+  async saveTextPromptToLibrary(): Promise<void> {
+    return test.step('save text prompt to library from Playground', async () => {
+      const messageRow = this.variantMessages(0).first();
+      await messageRow.hover();
+      await messageRow.getByTestId('save-text-prompt-button').click();
+      const dialog = this.page.getByRole('dialog', { name: 'Save to prompt library' });
+      await dialog.waitFor({ state: 'visible' });
+      await dialog.getByRole('button', { name: 'Save to library' }).click();
+      await dialog.waitFor({ state: 'hidden' });
+    });
+  }
+
+  /**
+   * Click the Save button (disk icon) in variant 0 and submit the
+   * "Save to prompt library" dialog in "Update existing" mode.
+   * Assumes a chat prompt is already loaded so the dialog defaults to update mode.
+   */
+  async savePromptToLibrary(): Promise<void> {
+    return test.step('save prompt to library from Playground', async () => {
+      await this.variantCard(0).hover();
+      await this.page.getByTestId('playground-save-prompt-button').click();
+      const dialog = this.page.getByRole('dialog', { name: 'Save to prompt library' });
+      await dialog.waitFor({ state: 'visible' });
+      await dialog.getByRole('button', { name: 'Save to library' }).click();
+      await dialog.waitFor({ state: 'hidden' });
+    });
+  }
+
   /** Click the "Go to logs" icon button to open the Playground logs sidebar. */
   async openLogsPanel(): Promise<void> {
     return test.step('open Playground logs panel', async () => {

--- a/tests_end_to_end/e2e/pom/playground.page.ts
+++ b/tests_end_to_end/e2e/pom/playground.page.ts
@@ -1,5 +1,5 @@
+import { test, expect } from '@playwright/test';
 import type { Page, Locator } from '@playwright/test';
-import { expect } from '@playwright/test';
 import { loadEnvConfig } from '../config/env.config';
 
 export type RunExperimentSourceMode = 'dataset' | 'test_suite';
@@ -39,18 +39,22 @@ export class PlaygroundPage {
   ) {}
 
   async goto(): Promise<void> {
-    const env = loadEnvConfig();
-    await this.page.goto(
-      `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/playground`,
-    );
+    return test.step('navigate to Playground', async () => {
+      const env = loadEnvConfig();
+      await this.page.goto(
+        `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/playground`,
+      );
+    });
   }
 
   async waitForReady(): Promise<void> {
-    await this.page
-      .getByRole('heading', { name: 'Playground', level: 1 })
-      .waitFor({ state: 'visible' });
-    // Variant card "A" should be mounted with its model picker.
-    await this.modelPicker(0).waitFor({ state: 'visible' });
+    return test.step('wait for Playground to be ready', async () => {
+      await this.page
+        .getByRole('heading', { name: 'Playground', level: 1 })
+        .waitFor({ state: 'visible' });
+      // Variant card "A" should be mounted with its model picker.
+      await this.modelPicker(0).waitFor({ state: 'visible' });
+    });
   }
 
   /**
@@ -60,33 +64,37 @@ export class PlaygroundPage {
    * - Otherwise, the first message row (already User by default) is filled directly.
    */
   async configureVariant(index: number, cfg: PlaygroundVariantConfig): Promise<void> {
-    if (cfg.modelDisplayName) {
-      await this.setModelForVariant(index, cfg.modelDisplayName);
-    }
+    return test.step(`configure variant ${index}`, async () => {
+      if (cfg.modelDisplayName) {
+        await this.setModelForVariant(index, cfg.modelDisplayName);
+      }
 
-    const messages = this.variantMessages(index);
+      const messages = this.variantMessages(index);
 
-    if (cfg.systemPrompt !== undefined) {
-      // Flip first message role to System and fill it.
-      const firstMessage = messages.first();
-      await firstMessage.getByRole('button', { name: 'User' }).click();
-      await this.page.getByRole('menuitemcheckbox', { name: 'System' }).click();
-      await this.fillMessageBody(firstMessage, cfg.systemPrompt);
+      if (cfg.systemPrompt !== undefined) {
+        // Flip first message role to System and fill it.
+        const firstMessage = messages.first();
+        await firstMessage.getByRole('button', { name: 'User' }).click();
+        await this.page.getByRole('menuitemcheckbox', { name: 'System' }).click();
+        await this.fillMessageBody(firstMessage, cfg.systemPrompt);
 
-      // Add a new message; defaults to User.
-      await this.variantCard(index).getByRole('button', { name: 'Message' }).click();
-      const userMessage = messages.nth(1);
-      await this.fillMessageBody(userMessage, cfg.userPrompt);
-    } else {
-      const firstMessage = messages.first();
-      await this.fillMessageBody(firstMessage, cfg.userPrompt);
-    }
+        // Add a new message; defaults to User.
+        await this.variantCard(index).getByRole('button', { name: 'Message' }).click();
+        const userMessage = messages.nth(1);
+        await this.fillMessageBody(userMessage, cfg.userPrompt);
+      } else {
+        const firstMessage = messages.first();
+        await this.fillMessageBody(firstMessage, cfg.userPrompt);
+      }
+    });
   }
 
   /** Open the "Run experiment" dialog (when no suite/dataset is loaded). */
   async clickRunExperiment(): Promise<void> {
-    await this.runExperimentTriggerButton().click();
-    await this.runExperimentDialog().waitFor({ state: 'visible' });
+    return test.step('click Run experiment', async () => {
+      await this.runExperimentTriggerButton().click();
+      await this.runExperimentDialog().waitFor({ state: 'visible' });
+    });
   }
 
   /**
@@ -98,28 +106,32 @@ export class PlaygroundPage {
     mode: RunExperimentSourceMode;
     entityName: string;
   }): Promise<void> {
-    const dialog = this.runExperimentDialog();
-    const testid =
-      args.mode === 'test_suite'
-        ? 'run-experiment-dialog-source-suite'
-        : 'run-experiment-dialog-source-dataset';
-    await dialog.getByTestId(testid).click();
+    return test.step(`submit Run experiment dialog with ${args.mode} "${args.entityName}"`, async () => {
+      const dialog = this.runExperimentDialog();
+      const testid =
+        args.mode === 'test_suite'
+          ? 'run-experiment-dialog-source-suite'
+          : 'run-experiment-dialog-source-dataset';
+      await dialog.getByTestId(testid).click();
 
-    // Open the source selector combobox and pick the entity by name.
-    await dialog.getByRole('combobox').click();
-    const listbox = this.page.getByRole('listbox');
-    await listbox.waitFor({ state: 'visible' });
-    await listbox.getByPlaceholder(/^Search (dataset|test suite)/).fill(args.entityName);
-    await listbox.getByText(args.entityName, { exact: true }).first().click();
+      // Open the source selector combobox and pick the entity by name.
+      await dialog.getByRole('combobox').click();
+      const listbox = this.page.getByRole('listbox');
+      await listbox.waitFor({ state: 'visible' });
+      await listbox.getByPlaceholder(/^Search (dataset|test suite)/).fill(args.entityName);
+      await listbox.getByText(args.entityName, { exact: true }).first().click();
 
-    const submitLabel = args.mode === 'test_suite' ? 'Use test suite' : 'Use dataset';
-    await dialog.getByRole('button', { name: submitLabel, exact: true }).click();
-    await dialog.waitFor({ state: 'hidden' });
+      const submitLabel = args.mode === 'test_suite' ? 'Use test suite' : 'Use dataset';
+      await dialog.getByRole('button', { name: submitLabel, exact: true }).click();
+      await dialog.waitFor({ state: 'hidden' });
+    });
   }
 
   /** Click Re-run when a suite/dataset is already loaded. */
   async clickReRun(): Promise<void> {
-    await this.runButton().click();
+    return test.step('click Re-run', async () => {
+      await this.runButton().click();
+    });
   }
 
   /**
@@ -135,18 +147,20 @@ export class PlaygroundPage {
    * loading (`No runs yet` is unmounted while rows are still being painted).
    */
   async waitForRunsComplete(opts: { expectedRows: number; timeoutMs?: number }): Promise<void> {
-    const table = this.resultsTable();
-    await expect
-      .poll(
-        async () => {
-          const noRunsYet = await table.getByText('No runs yet').count();
-          if (noRunsYet !== 0) return false;
-          const rowCount = await this.countOutputRows();
-          return rowCount >= opts.expectedRows;
-        },
-        { timeout: opts.timeoutMs ?? 120_000, intervals: [1000, 2000, 3000] },
-      )
-      .toBe(true);
+    return test.step(`wait for ${opts.expectedRows} run(s) to complete`, async () => {
+      const table = this.resultsTable();
+      await expect
+        .poll(
+          async () => {
+            const noRunsYet = await table.getByText('No runs yet').count();
+            if (noRunsYet !== 0) return false;
+            const rowCount = await this.countOutputRows();
+            return rowCount >= opts.expectedRows;
+          },
+          { timeout: opts.timeoutMs ?? 120_000, intervals: [1000, 2000, 3000] },
+        )
+        .toBe(true);
+    });
   }
 
   /**
@@ -191,43 +205,47 @@ export class PlaygroundPage {
    * mode writes results to the right side of each variant card.
    */
   async runSimplePromptAndAwaitResponse(args: RunSimplePromptArgs): Promise<RunSimplePromptResult> {
-    await this.setModelForVariant(0, args.modelDisplayName);
-    const messages = this.variantMessages(0);
-    await this.fillMessageBody(messages.first(), args.prompt);
+    return test.step('run simple prompt and await response', async () => {
+      await this.setModelForVariant(0, args.modelDisplayName);
+      const messages = this.variantMessages(0);
+      await this.fillMessageBody(messages.first(), args.prompt);
 
-    // Use the top-right Run button (playground-run-button testid) for inline runs.
-    await this.runButton().click();
+      // Use the top-right Run button (playground-run-button testid) for inline runs.
+      await this.runButton().click();
 
-    const timeoutMs = args.timeoutMs ?? 60_000;
-    // After clicking Run, the variant card shows the model's response inline.
-    // Wait for any non-empty text that wasn't there before, scoped to the
-    // variant card's bottom half (output area).
-    const errorIndicator = this.variantCard(0).getByText(/error|failed/i);
-    await expect
-      .poll(
-        async () => {
-          // Detect completion via the "No runs yet" empty state disappearing OR
-          // the page rendering an error.
-          const noRunsYet = await this.page.getByText('No runs yet').count();
-          const errored = (await errorIndicator.count()) > 0;
-          return noRunsYet === 0 || errored;
-        },
-        { timeout: timeoutMs, intervals: [500, 1000, 2000] },
-      )
-      .toBeTruthy();
+      const timeoutMs = args.timeoutMs ?? 60_000;
+      // After clicking Run, the variant card shows the model's response inline.
+      // Wait for any non-empty text that wasn't there before, scoped to the
+      // variant card's bottom half (output area).
+      const errorIndicator = this.variantCard(0).getByText(/error|failed/i);
+      await expect
+        .poll(
+          async () => {
+            // Detect completion via the "No runs yet" empty state disappearing OR
+            // the page rendering an error.
+            const noRunsYet = await this.page.getByText('No runs yet').count();
+            const errored = (await errorIndicator.count()) > 0;
+            return noRunsYet === 0 || errored;
+          },
+          { timeout: timeoutMs, intervals: [500, 1000, 2000] },
+        )
+        .toBeTruthy();
 
-    // Grab the rendered response text. The Playground emits output to a region
-    // that follows the variant card. We use the variant card root and trim its
-    // textContent — this includes the model picker label etc., but a non-empty
-    // result string is enough for sanity assertion.
-    const cardText = ((await this.variantCard(0).textContent()) ?? '').trim();
-    const isError = (await errorIndicator.count()) > 0;
-    return { outputText: cardText, isError };
+      // Grab the rendered response text. The Playground emits output to a region
+      // that follows the variant card. We use the variant card root and trim its
+      // textContent — this includes the model picker label etc., but a non-empty
+      // result string is enough for sanity assertion.
+      const cardText = ((await this.variantCard(0).textContent()) ?? '').trim();
+      const isError = (await errorIndicator.count()) > 0;
+      return { outputText: cardText, isError };
+    });
   }
 
   /** Set the model for a variant — public wrapper for setModelForVariant. */
   async selectModel(index: number, modelDisplayName: string): Promise<void> {
-    await this.setModelForVariant(index, modelDisplayName);
+    return test.step(`select model "${modelDisplayName}" for variant ${index}`, async () => {
+      await this.setModelForVariant(index, modelDisplayName);
+    });
   }
 
   /**
@@ -235,41 +253,122 @@ export class PlaygroundPage {
    * The prompt content must already be loaded — this does NOT fill a message body.
    */
   async runFreeMode(timeoutMs = 120_000): Promise<void> {
-    await this.runButton().click();
-    const errorText = this.page.getByText(/error|failed/i);
-    await expect
-      .poll(
-        async () => {
-          const noRunsYet = await this.page.getByText('No runs yet').count();
-          const errored = (await errorText.count()) > 0;
-          return noRunsYet === 0 || errored;
-        },
-        { timeout: timeoutMs, intervals: [500, 1000, 2000] },
-      )
-      .toBeTruthy();
+    return test.step('run prompt (free mode)', async () => {
+      await this.runButton().click();
+      const errorText = this.page.getByText(/error|failed/i);
+      await expect
+        .poll(
+          async () => {
+            const noRunsYet = await this.page.getByText('No runs yet').count();
+            const errored = (await errorText.count()) > 0;
+            return noRunsYet === 0 || errored;
+          },
+          { timeout: timeoutMs, intervals: [500, 1000, 2000] },
+        )
+        .toBeTruthy();
+    });
+  }
+
+  /**
+   * Open the prompt library menu in the first variant card, hover the named prompt
+   * to reveal the version submenu, and click the specified version label (e.g. "v1").
+   */
+  async loadPromptVersionFromLibrary(promptName: string, versionLabel: string): Promise<void> {
+    return test.step(`load prompt "${promptName}" version "${versionLabel}" from library`, async () => {
+      // The button is in a div that only expands on group-hover; hover the card first.
+      await this.variantCard(0).hover();
+      await this.variantCard(0).getByTestId('load-prompt-button').click();
+
+      const menu = this.page.getByTestId('prompt-library-menu');
+      await menu.waitFor({ state: 'visible' });
+
+      await menu.getByPlaceholder('Search').fill(promptName);
+
+      const promptRow = menu.getByRole('button').filter({ hasText: promptName }).first();
+      await promptRow.waitFor({ state: 'visible' });
+      await promptRow.hover();
+
+      const versionSubmenu = this.page.locator('[data-prompt-versions-submenu]');
+      await versionSubmenu.waitFor({ state: 'visible' });
+
+      await versionSubmenu
+        .getByRole('button')
+        .filter({ has: this.page.getByText(versionLabel, { exact: true }) })
+        .first()
+        .click();
+    });
+  }
+
+  /**
+   * Open the text-prompt library menu in the first message row of variant 0,
+   * hover the named prompt to reveal the version submenu, and click the specified
+   * version label (e.g. "v1"). The button lives inside the message-row actions
+   * area which is hidden until the row is hovered.
+   */
+  async loadTextPromptVersionFromLibrary(promptName: string, versionLabel: string): Promise<void> {
+    return test.step(`load text prompt "${promptName}" version "${versionLabel}" from message-row library`, async () => {
+      const messageRow = this.variantMessages(0).first();
+      await messageRow.hover();
+      await messageRow.getByTestId('load-text-prompt-button').click();
+
+      const menu = this.page.getByTestId('prompt-library-menu');
+      await menu.waitFor({ state: 'visible' });
+
+      await menu.getByPlaceholder('Search').fill(promptName);
+
+      const promptRow = menu.getByRole('button').filter({ hasText: promptName }).first();
+      await promptRow.waitFor({ state: 'visible' });
+      await promptRow.hover();
+
+      const versionSubmenu = this.page.locator('[data-prompt-versions-submenu]');
+      await versionSubmenu.waitFor({ state: 'visible' });
+
+      await versionSubmenu
+        .getByRole('button')
+        .filter({ has: this.page.getByText(versionLabel, { exact: true }) })
+        .first()
+        .click();
+    });
+  }
+
+  /** Assert the LoadedPromptDisplay in variant 0 shows the given prompt name and version label. */
+  async waitForLoadedPromptVersion(promptName: string, versionLabel: string): Promise<void> {
+    return test.step(`wait for prompt "${promptName}" at version "${versionLabel}" to be loaded`, async () => {
+      const card = this.variantCard(0);
+      // For text prompts the loaded-prompt chip is inside the message-row actions
+      // area which is only visible on hover (invisible group-hover:visible).
+      // Hovering the first message row reveals it without affecting chat-prompt cards.
+      await this.variantMessages(0).first().hover();
+      await expect(card.getByText(promptName)).toBeVisible();
+      await expect(card.getByText(versionLabel, { exact: true })).toBeVisible();
+    });
   }
 
   /** Click the "Go to logs" icon button to open the Playground logs sidebar. */
   async openLogsPanel(): Promise<void> {
-    await this.page.getByTestId('playground-logs-sidebar-button').click();
+    return test.step('open Playground logs panel', async () => {
+      await this.page.getByTestId('playground-logs-sidebar-button').click();
+    });
   }
 
   /** Set a single model-config option (e.g., temperature, max_tokens) on a variant. */
   async setVariantOption(index: number, optionName: string, value: number | string): Promise<void> {
-    // The options pane is collapsed by default; expand it first. Implementation
-    // is exploratory — Phase 4 will refine if discovery reveals a different shape.
-    const card = this.variantCard(index);
-    // Try to open the options pane via the gear/settings affordance.
-    const settingsButton = card.getByRole('button', { name: /settings|options/i });
-    if ((await settingsButton.count()) > 0) {
-      await settingsButton.first().click();
-    }
-    // Fill the named input. Provider-sanity tests use a small whitelist of
-    // option names that map to spinbutton inputs.
-    const input = card.getByRole('spinbutton', { name: new RegExp(`^${optionName}$`, 'i') });
-    if ((await input.count()) > 0) {
-      await input.first().fill(String(value));
-    }
+    return test.step(`set variant ${index} option "${optionName}" to ${value}`, async () => {
+      // The options pane is collapsed by default; expand it first. Implementation
+      // is exploratory — Phase 4 will refine if discovery reveals a different shape.
+      const card = this.variantCard(index);
+      // Try to open the options pane via the gear/settings affordance.
+      const settingsButton = card.getByRole('button', { name: /settings|options/i });
+      if ((await settingsButton.count()) > 0) {
+        await settingsButton.first().click();
+      }
+      // Fill the named input. Provider-sanity tests use a small whitelist of
+      // option names that map to spinbutton inputs.
+      const input = card.getByRole('spinbutton', { name: new RegExp(`^${optionName}$`, 'i') });
+      if ((await input.count()) > 0) {
+        await input.first().fill(String(value));
+      }
+    });
   }
 
   // ── private helpers ─────────────────────────────────────────────────────

--- a/tests_end_to_end/e2e/pom/playground.page.ts
+++ b/tests_end_to_end/e2e/pom/playground.page.ts
@@ -225,6 +225,35 @@ export class PlaygroundPage {
     return { outputText: cardText, isError };
   }
 
+  /** Set the model for a variant — public wrapper for setModelForVariant. */
+  async selectModel(index: number, modelDisplayName: string): Promise<void> {
+    await this.setModelForVariant(index, modelDisplayName);
+  }
+
+  /**
+   * Click Run (free mode) and wait for the "No runs yet" placeholder to disappear.
+   * The prompt content must already be loaded — this does NOT fill a message body.
+   */
+  async runFreeMode(timeoutMs = 120_000): Promise<void> {
+    await this.runButton().click();
+    const errorText = this.page.getByText(/error|failed/i);
+    await expect
+      .poll(
+        async () => {
+          const noRunsYet = await this.page.getByText('No runs yet').count();
+          const errored = (await errorText.count()) > 0;
+          return noRunsYet === 0 || errored;
+        },
+        { timeout: timeoutMs, intervals: [500, 1000, 2000] },
+      )
+      .toBeTruthy();
+  }
+
+  /** Click the "Go to logs" icon button to open the Playground logs sidebar. */
+  async openLogsPanel(): Promise<void> {
+    await this.page.getByTestId('playground-logs-sidebar-button').click();
+  }
+
   /** Set a single model-config option (e.g., temperature, max_tokens) on a variant. */
   async setVariantOption(index: number, optionName: string, value: number | string): Promise<void> {
     // The options pane is collapsed by default; expand it first. Implementation

--- a/tests_end_to_end/e2e/pom/playground.page.ts
+++ b/tests_end_to_end/e2e/pom/playground.page.ts
@@ -371,6 +371,41 @@ export class PlaygroundPage {
   }
 
   /**
+   * Click the Save button in the first message row of variant 0 and submit the
+   * "Save to prompt library" dialog as a new text prompt.
+   * Fills the given name and clicks "Save to library".
+   */
+  async saveNewTextPromptToLibrary(promptName: string): Promise<void> {
+    return test.step(`save new text prompt "${promptName}" to library from Playground`, async () => {
+      const messageRow = this.variantMessages(0).first();
+      await messageRow.hover();
+      await messageRow.getByTestId('save-text-prompt-button').click();
+      const dialog = this.page.getByRole('dialog', { name: 'Save to prompt library' });
+      await dialog.waitFor({ state: 'visible' });
+      await dialog.getByLabel('Name').fill(promptName);
+      await dialog.getByRole('button', { name: 'Save to library' }).click();
+      await dialog.waitFor({ state: 'hidden' });
+    });
+  }
+
+  /**
+   * Click the Save button in variant 0 and submit the "Save to prompt library"
+   * dialog in "Save as new" mode — for prompts NOT imported from the library.
+   * Fills the given name and clicks "Save to library".
+   */
+  async saveNewChatPromptToLibrary(promptName: string): Promise<void> {
+    return test.step(`save new chat prompt "${promptName}" to library from Playground`, async () => {
+      await this.variantCard(0).hover();
+      await this.page.getByTestId('playground-save-prompt-button').click();
+      const dialog = this.page.getByRole('dialog', { name: 'Save to prompt library' });
+      await dialog.waitFor({ state: 'visible' });
+      await dialog.getByLabel('Name').fill(promptName);
+      await dialog.getByRole('button', { name: 'Save to library' }).click();
+      await dialog.waitFor({ state: 'hidden' });
+    });
+  }
+
+  /**
    * Click the Save button (disk icon) in variant 0 and submit the
    * "Save to prompt library" dialog in "Update existing" mode.
    * Assumes a chat prompt is already loaded so the dialog defaults to update mode.

--- a/tests_end_to_end/e2e/pom/prompt-detail.page.ts
+++ b/tests_end_to_end/e2e/pom/prompt-detail.page.ts
@@ -66,4 +66,25 @@ export class PromptDetailPage {
       await expect(this.activeVersionLabel()).toHaveText(label);
     });
   }
+
+  /** Open the "Use" dropdown and click "Load in Prompt playground", then wait for the Playground URL.
+   * A confirmation dialog may appear if the playground is not empty — handle it if present. */
+  async loadInPlayground(): Promise<void> {
+    return test.step('load prompt into Playground', async () => {
+      await this.page.getByRole('button', { name: 'Use' }).click();
+      await this.page.getByRole('menuitem', { name: 'Load in Prompt playground' }).click();
+      // A confirmation dialog appears only when the playground already has content.
+      // If it shows up within a short window, click through it; otherwise proceed.
+      const dialog = this.page.getByRole('dialog', { name: 'Load prompt' });
+      const confirmBtn = dialog.getByRole('button', { name: 'Load prompt' });
+      const appeared = await confirmBtn.isVisible().catch(() => false);
+      if (!appeared) {
+        await confirmBtn.waitFor({ state: 'visible', timeout: 3000 }).catch(() => {});
+      }
+      if (await confirmBtn.isVisible().catch(() => false)) {
+        await confirmBtn.click();
+      }
+      await this.page.waitForURL((url) => url.pathname.includes('/playground'));
+    });
+  }
 }

--- a/tests_end_to_end/e2e/tests/prompts/prompt-library-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/prompts/prompt-library-smoke.spec.ts
@@ -1,5 +1,35 @@
 import { test, expect } from '../../fixtures/prompt.fixture';
 import { PromptsPage } from '@e2e/pom/prompts.page';
+import type { PromptDetailPage } from '@e2e/pom/prompt-detail.page';
+import type { Locator } from '@playwright/test';
+
+type VersioningOpts = {
+  contentLocator: (d: PromptDetailPage) => Locator;
+  initialContent: string;
+  updatedContent: string;
+  edit: (d: PromptDetailPage, content: string) => Promise<void>;
+};
+
+async function runVersioningSteps(detail: PromptDetailPage, opts: VersioningOpts): Promise<void> {
+  await test.step('Initial version is v1', async () => {
+    await expect(detail.activeVersionLabel()).toHaveText('v1');
+  });
+
+  await test.step('Edit the prompt and save as new version', async () => {
+    await opts.edit(detail, opts.updatedContent);
+  });
+
+  await test.step('v2 is active and shows the updated content', async () => {
+    await expect(detail.activeVersionLabel()).toHaveText('v2');
+    await expect(opts.contentLocator(detail)).toContainText(opts.updatedContent);
+  });
+
+  await test.step('Select v1 from version history and verify original content is restored', async () => {
+    await detail.selectVersion('v1');
+    await expect(detail.activeVersionLabel()).toHaveText('v1');
+    await expect(opts.contentLocator(detail)).toContainText(opts.initialContent);
+  });
+}
 
 test.describe('Prompt Library — smoke', { tag: ['@t1-smoke', '@prompts'] }, () => {
   test.use({ viewport: { width: 1600, height: 900 } });
@@ -10,7 +40,6 @@ test.describe('Prompt Library — smoke', { tag: ['@t1-smoke', '@prompts'] }, ()
     page,
   }) => {
     const prompts = new PromptsPage(page);
-    const updatedTemplate = 'You are an expert assistant. Respond concisely to: {{question}}';
 
     await test.step('Navigate to Prompts Library', async () => {
       await prompts.goto(project.id);
@@ -29,23 +58,11 @@ test.describe('Prompt Library — smoke', { tag: ['@t1-smoke', '@prompts'] }, ()
       await expect(detail.textContent()).toContainText('You are a helpful assistant');
     });
 
-    await test.step('Initial version is v1', async () => {
-      await expect(detail.activeVersionLabel()).toHaveText('v1');
-    });
-
-    await test.step('Edit the prompt and save as new version', async () => {
-      await detail.editTextPrompt(updatedTemplate);
-    });
-
-    await test.step('v2 is active and shows the updated content', async () => {
-      await expect(detail.activeVersionLabel()).toHaveText('v2');
-      await expect(detail.textContent()).toContainText('You are an expert assistant');
-    });
-
-    await test.step('Select v1 from version history and verify original content is restored', async () => {
-      await detail.selectVersion('v1');
-      await expect(detail.activeVersionLabel()).toHaveText('v1');
-      await expect(detail.textContent()).toContainText('You are a helpful assistant');
+    await runVersioningSteps(detail, {
+      contentLocator: (d) => d.textContent(),
+      initialContent: 'You are a helpful assistant',
+      updatedContent: 'You are an expert assistant. Respond concisely to: {{question}}',
+      edit: (d, content) => d.editTextPrompt(content),
     });
   });
 
@@ -55,7 +72,6 @@ test.describe('Prompt Library — smoke', { tag: ['@t1-smoke', '@prompts'] }, ()
     page,
   }) => {
     const prompts = new PromptsPage(page);
-    const updatedMessage = 'Provide a concise expert answer to: {{question}}';
 
     await test.step('Navigate to Prompts Library', async () => {
       await prompts.goto(project.id);
@@ -75,120 +91,82 @@ test.describe('Prompt Library — smoke', { tag: ['@t1-smoke', '@prompts'] }, ()
       await expect(detail.chatMessages()).toContainText('You are a helpful assistant.');
     });
 
-    await test.step('Initial version is v1', async () => {
-      await expect(detail.activeVersionLabel()).toHaveText('v1');
-    });
-
-    await test.step('Edit the first chat message and save as new version', async () => {
-      await detail.editChatFirstMessage(updatedMessage);
-    });
-
-    await test.step('v2 is active and shows the updated message content', async () => {
-      await expect(detail.activeVersionLabel()).toHaveText('v2');
-      await expect(detail.chatMessages()).toContainText('Provide a concise expert answer');
-    });
-
-    await test.step('Select v1 from version history and verify original messages are restored', async () => {
-      await detail.selectVersion('v1');
-      await expect(detail.activeVersionLabel()).toHaveText('v1');
-      await expect(detail.chatMessages()).toContainText('You are a helpful assistant.');
+    await runVersioningSteps(detail, {
+      contentLocator: (d) => d.chatMessages(),
+      initialContent: 'You are a helpful assistant.',
+      updatedContent: 'Provide a concise expert answer to: {{question}}',
+      edit: (d, content) => d.editChatFirstMessage(content),
     });
   });
 
-  test('UI-created text prompt shows content, edit creates new version, old version is preserved', async ({
-    project,
-    page,
-    registerPromptCleanup,
-    testNamespace,
-  }) => {
-    const promptName = `${testNamespace}-ui-text`;
-    const template = 'You are a helpful assistant. Answer: {{question}}';
-    const updatedTemplate = 'You are an expert assistant. Respond concisely to: {{question}}';
-    const prompts = new PromptsPage(page);
+  type UiVariant = {
+    label: string;
+    nameSuffix: string;
+    template: string;
+    updatedContent: string;
+    create: (prompts: PromptsPage, name: string, content: string) => Promise<PromptDetailPage>;
+    versioning: VersioningOpts;
+  };
 
-    await test.step('Navigate to empty Prompts Library', async () => {
-      await prompts.goto(project.id);
-      await prompts.waitForReady();
+  const UI_VARIANTS: UiVariant[] = [
+    {
+      label: 'text',
+      nameSuffix: 'ui-text',
+      template: 'You are a helpful assistant. Answer: {{question}}',
+      updatedContent: 'You are an expert assistant. Respond concisely to: {{question}}',
+      create: (prompts, name, content) => prompts.createTextPromptViaUI(name, content),
+      versioning: {
+        contentLocator: (d) => d.textContent(),
+        initialContent: 'You are a helpful assistant',
+        updatedContent: 'You are an expert assistant. Respond concisely to: {{question}}',
+        edit: (d, content) => d.editTextPrompt(content),
+      },
+    },
+    {
+      label: 'chat',
+      nameSuffix: 'ui-chat',
+      template: 'Answer the following: {{question}}',
+      updatedContent: 'Provide a concise expert answer to: {{question}}',
+      create: (prompts, name, content) => prompts.createChatPromptViaUI(name, content),
+      versioning: {
+        contentLocator: (d) => d.chatMessages(),
+        initialContent: 'Answer the following',
+        updatedContent: 'Provide a concise expert answer to: {{question}}',
+        edit: (d, content) => d.editChatFirstMessage(content),
+      },
+    },
+  ];
+
+  for (const variant of UI_VARIANTS) {
+    test(`UI-created ${variant.label} prompt shows content, edit creates new version, old version is preserved`, async ({
+      project,
+      page,
+      registerPromptCleanup,
+      testNamespace,
+    }) => {
+      const promptName = `${testNamespace}-${variant.nameSuffix}`;
+      const prompts = new PromptsPage(page);
+
+      await test.step('Navigate to empty Prompts Library', async () => {
+        await prompts.goto(project.id);
+        await prompts.waitForReady();
+      });
+
+      const detail = await variant.create(prompts, promptName, variant.template);
+
+      const urlParts = new URL(page.url()).pathname.split('/').filter(Boolean);
+      const promptsIdx = urlParts.lastIndexOf('prompts');
+      const promptId = promptsIdx >= 0 ? (urlParts[promptsIdx + 1] ?? '') : '';
+      expect(promptId, 'Expected to extract promptId from URL after prompt creation').toBeTruthy();
+      registerPromptCleanup(promptId, promptName);
+
+      await test.step('Verify detail page shows correct content', async () => {
+        await detail.waitForReady();
+        await expect(detail.promptNameHeading()).toHaveText(promptName);
+        await expect(variant.versioning.contentLocator(detail)).toContainText(variant.versioning.initialContent);
+      });
+
+      await runVersioningSteps(detail, variant.versioning);
     });
-
-    const detail = await prompts.createTextPromptViaUI(promptName, template);
-    const urlParts = new URL(page.url()).pathname.split('/').filter(Boolean);
-    const promptsIdx = urlParts.lastIndexOf('prompts');
-    const promptId = promptsIdx >= 0 ? (urlParts[promptsIdx + 1] ?? '') : '';
-    if (promptId) registerPromptCleanup(promptId, promptName);
-
-    await test.step('Verify detail page shows correct content', async () => {
-      await detail.waitForReady();
-      await expect(detail.promptNameHeading()).toHaveText(promptName);
-      await expect(detail.textContent()).toContainText('You are a helpful assistant');
-    });
-
-    await test.step('Initial version is v1', async () => {
-      await expect(detail.activeVersionLabel()).toHaveText('v1');
-    });
-
-    await test.step('Edit the prompt and save as new version', async () => {
-      await detail.editTextPrompt(updatedTemplate);
-    });
-
-    await test.step('v2 is active and shows the updated content', async () => {
-      await expect(detail.activeVersionLabel()).toHaveText('v2');
-      await expect(detail.textContent()).toContainText('You are an expert assistant');
-    });
-
-    await test.step('Select v1 from version history and verify original content is restored', async () => {
-      await detail.selectVersion('v1');
-      await expect(detail.activeVersionLabel()).toHaveText('v1');
-      await expect(detail.textContent()).toContainText('You are a helpful assistant');
-    });
-  });
-
-  test('UI-created chat prompt shows messages, edit creates new version, old version is preserved', async ({
-    project,
-    page,
-    registerPromptCleanup,
-    testNamespace,
-  }) => {
-    const promptName = `${testNamespace}-ui-chat`;
-    const messageContent = 'Answer the following: {{question}}';
-    const updatedMessage = 'Provide a concise expert answer to: {{question}}';
-    const prompts = new PromptsPage(page);
-
-    await test.step('Navigate to empty Prompts Library', async () => {
-      await prompts.goto(project.id);
-      await prompts.waitForReady();
-    });
-
-    const detail = await prompts.createChatPromptViaUI(promptName, messageContent);
-    const urlParts = new URL(page.url()).pathname.split('/').filter(Boolean);
-    const promptsIdx = urlParts.lastIndexOf('prompts');
-    const promptId = promptsIdx >= 0 ? (urlParts[promptsIdx + 1] ?? '') : '';
-    if (promptId) registerPromptCleanup(promptId, promptName);
-
-    await test.step('Verify detail page shows chat messages', async () => {
-      await detail.waitForReady();
-      await expect(detail.promptNameHeading()).toHaveText(promptName);
-      await expect(detail.chatMessages()).toBeVisible();
-      await expect(detail.chatMessages()).toContainText('Answer the following');
-    });
-
-    await test.step('Initial version is v1', async () => {
-      await expect(detail.activeVersionLabel()).toHaveText('v1');
-    });
-
-    await test.step('Edit the first chat message and save as new version', async () => {
-      await detail.editChatFirstMessage(updatedMessage);
-    });
-
-    await test.step('v2 is active and shows the updated message content', async () => {
-      await expect(detail.activeVersionLabel()).toHaveText('v2');
-      await expect(detail.chatMessages()).toContainText('Provide a concise expert answer');
-    });
-
-    await test.step('Select v1 from version history and verify original messages are restored', async () => {
-      await detail.selectVersion('v1');
-      await expect(detail.activeVersionLabel()).toHaveText('v1');
-      await expect(detail.chatMessages()).toContainText('Answer the following');
-    });
-  });
+  }
 });

--- a/tests_end_to_end/e2e/tests/prompts/prompt-library-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/prompts/prompt-library-smoke.spec.ts
@@ -15,9 +15,7 @@ async function runVersioningSteps(detail: PromptDetailPage, opts: VersioningOpts
     await expect(detail.activeVersionLabel()).toHaveText('v1');
   });
 
-  await test.step('Edit the prompt and save as new version', async () => {
-    await opts.edit(detail, opts.updatedContent);
-  });
+  await opts.edit(detail, opts.updatedContent);
 
   await test.step('v2 is active and shows the updated content', async () => {
     await expect(detail.activeVersionLabel()).toHaveText('v2');

--- a/tests_end_to_end/e2e/tests/prompts/prompt-playground-new-prompt.spec.ts
+++ b/tests_end_to_end/e2e/tests/prompts/prompt-playground-new-prompt.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '../../fixtures/prompt.fixture';
+import { PlaygroundPage } from '@e2e/pom/playground.page';
+import { PromptsPage } from '@e2e/pom/prompts.page';
+
+const PROMPT_VARIANTS = [
+  {
+    promptType: 'chat' as const,
+    title: 'type text in Playground and save creates new prompt in library with correct content',
+    nameSuffix: 'playground-new-prompt',
+    promptText: 'Describe the water cycle in one sentence.',
+  },
+  {
+    promptType: 'text' as const,
+    title: 'type text in Playground message row and save creates new text prompt in library with correct content',
+    nameSuffix: 'playground-new-text-prompt',
+    promptText: 'Explain the concept of recursion in simple terms.',
+  },
+];
+
+test.describe(
+  'Playground → save new prompt to library',
+  { tag: ['@t1-smoke', '@prompts', '@playground'] },
+  () => {
+    test.use({ viewport: { width: 1600, height: 900 } });
+
+    for (const { promptType, title, nameSuffix, promptText } of PROMPT_VARIANTS) {
+      test(title, async ({ project, page, registerPromptCleanup, testNamespace }) => {
+        test.setTimeout(60_000);
+
+        const promptName = `${testNamespace}-${nameSuffix}`;
+        const playground = new PlaygroundPage(page, project.id);
+
+        await test.step('Navigate to Playground', async () => {
+          await playground.goto();
+          await playground.waitForReady();
+        });
+
+        await test.step('Enter text in the message area', async () => {
+          await playground.editFirstMessage(promptText);
+        });
+
+        await test.step('Save prompt to library as a new prompt', async () => {
+          if (promptType === 'chat') {
+            await playground.saveNewChatPromptToLibrary(promptName);
+          } else {
+            await playground.saveNewTextPromptToLibrary(promptName);
+          }
+        });
+
+        const prompts = new PromptsPage(page);
+
+        await test.step('Navigate to Prompt Library', async () => {
+          await prompts.goto(project.id);
+          await prompts.waitForReady();
+        });
+
+        await test.step('New prompt row is visible in the library', async () => {
+          await expect(prompts.promptRow(promptName)).toBeVisible();
+        });
+
+        const promptId = await prompts.promptRow(promptName).getAttribute('data-row-id');
+        if (promptId) registerPromptCleanup(promptId, promptName);
+
+        const detail = await prompts.openPromptByName(promptName);
+
+        await test.step('Prompt detail shows the saved text content', async () => {
+          await detail.waitForReady();
+          await expect(detail.promptNameHeading()).toHaveText(promptName);
+          if (promptType === 'chat') {
+            await expect(detail.chatMessages()).toContainText(promptText);
+          } else {
+            await expect(detail.textContent()).toContainText(promptText);
+          }
+        });
+      });
+    }
+  },
+);

--- a/tests_end_to_end/e2e/tests/prompts/prompt-playground-save.spec.ts
+++ b/tests_end_to_end/e2e/tests/prompts/prompt-playground-save.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '../../fixtures/prompt.fixture';
+import { PlaygroundPage } from '@e2e/pom/playground.page';
+import { PromptsPage } from '@e2e/pom/prompts.page';
+
+const PROMPT_VARIANTS = [
+  {
+    promptType: 'text' as const,
+    title: 'edit text prompt v1 in Playground and save creates new version in prompt library',
+    promptNameSuffix: 'playground-save-text',
+    editedContent: 'Describe the water cycle in one sentence.',
+  },
+  {
+    promptType: 'chat' as const,
+    title: 'edit chat prompt v1 in Playground and save creates new version in prompt library',
+    promptNameSuffix: 'playground-save',
+    editedContent: 'Explain quantum computing in simple terms.',
+  },
+];
+
+test.describe(
+  'Playground → save prompt to library',
+  { tag: ['@t2-cuj', '@prompts', '@playground'] },
+  () => {
+    test.use({ viewport: { width: 1600, height: 900 } });
+
+    for (const { promptType, title, promptNameSuffix, editedContent } of PROMPT_VARIANTS) {
+      test(
+        title,
+        async ({ project, page, sdkClient, registerPromptCleanup, testNamespace }) => {
+          test.setTimeout(90_000);
+
+          const promptName = `${testNamespace}-${promptNameSuffix}`;
+          const v1Content = 'Say hello in exactly one word.';
+          const v2Content = 'Say goodbye in exactly one word.';
+          const v3Content = 'What is the capital of France?';
+
+          await test.step(`Create 3 versions of the ${promptType} prompt via SDK`, async () => {
+            for (const [i, content] of [v1Content, v2Content, v3Content].entries()) {
+              const result =
+                promptType === 'chat'
+                  ? await sdkClient.python.createChatPrompt({
+                      name: promptName,
+                      messages: [{ role: 'user', content }],
+                      project_name: project.name,
+                    })
+                  : await sdkClient.python.createTextPrompt({
+                      name: promptName,
+                      prompt: content,
+                      project_name: project.name,
+                    });
+              if (i === 0) registerPromptCleanup(result.id, promptName);
+            }
+          });
+
+          const playground = new PlaygroundPage(page, project.id);
+
+          await test.step('Pre-initialize Playground (set lastActiveProjectId)', async () => {
+            await playground.goto();
+            await playground.waitForReady();
+          });
+
+          if (promptType === 'chat') {
+            await playground.loadPromptVersionFromLibrary(promptName, 'v1');
+          } else {
+            await playground.loadTextPromptVersionFromLibrary(promptName, 'v1');
+          }
+
+          await test.step(`Verify Playground shows ${promptType} prompt at v1`, async () => {
+            await playground.waitForReady();
+            await playground.waitForLoadedPromptVersion(promptName, 'v1');
+          });
+
+          await test.step('Edit the first message in the Playground', async () => {
+            await playground.editFirstMessage(editedContent);
+          });
+
+          await test.step('Save the prompt back to the library (update existing)', async () => {
+            if (promptType === 'chat') {
+              await playground.savePromptToLibrary();
+            } else {
+              await playground.saveTextPromptToLibrary();
+            }
+          });
+
+          const prompts = new PromptsPage(page);
+
+          await test.step('Navigate to Prompts Library', async () => {
+            await prompts.goto(project.id);
+            await prompts.waitForReady();
+          });
+
+          const detail = await prompts.openPromptByName(promptName);
+
+          await test.step('Verify new version (v4) is active and contains edited content', async () => {
+            await detail.waitForReady();
+            await expect(detail.activeVersionLabel()).toHaveText('v4');
+            if (promptType === 'chat') {
+              await expect(detail.chatMessages()).toContainText(editedContent);
+            } else {
+              await expect(detail.textContent()).toContainText(editedContent);
+            }
+          });
+        },
+      );
+    }
+  },
+);

--- a/tests_end_to_end/e2e/tests/prompts/prompt-playground-traces.spec.ts
+++ b/tests_end_to_end/e2e/tests/prompts/prompt-playground-traces.spec.ts
@@ -97,13 +97,9 @@ test.describe('Prompt → Playground → Traces', { tag: ['@t2-cuj', '@prompts',
         await expect(variant.detailLocator(detail)).toContainText(messageContent);
       });
 
-      await test.step('Load prompt into Playground', async () => {
-        await detail.loadInPlayground();
-      });
+      await detail.loadInPlayground();
 
-      await test.step('Verify Playground loaded with the prompt', async () => {
-        await playground.waitForReady();
-      });
+      await playground.waitForReady();
 
       await test.step('Select model and run prompt', async () => {
         await playground.selectModel(0, modelDisplayName);
@@ -129,9 +125,7 @@ test.describe('Prompt → Playground → Traces', { tag: ['@t2-cuj', '@prompts',
         await expect(sidebar.firstTraceRow()).toBeVisible();
       });
 
-      await test.step('Open trace details', async () => {
-        await sidebar.openFirstTrace();
-      });
+      await sidebar.openFirstTrace();
 
       await test.step('Verify trace detail panel shows the prompt message', async () => {
         await expect(sidebar.traceDetailPanel().getByText(messageContent).first()).toBeVisible();

--- a/tests_end_to_end/e2e/tests/prompts/prompt-playground-traces.spec.ts
+++ b/tests_end_to_end/e2e/tests/prompts/prompt-playground-traces.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from '../../fixtures/prompt.fixture';
+import { PromptsPage } from '@e2e/pom/prompts.page';
+import { PlaygroundPage } from '@e2e/pom/playground.page';
+import { PlaygroundLogsSidebarPage } from '@e2e/pom/playground-logs-sidebar.page';
+import { ConfigurationPage } from '@e2e/pom/configuration.page';
+import type { PromptDetailPage } from '@e2e/pom/prompt-detail.page';
+import type { Locator } from '@playwright/test';
+
+async function ensureModelAvailable(page: import('@playwright/test').Page): Promise<string> {
+  const anthropic = process.env.ANTHROPIC_API_KEY;
+  const openai = process.env.OPENAI_API_KEY;
+  if (!anthropic && !openai) {
+    test.skip(true, 'Neither ANTHROPIC_API_KEY nor OPENAI_API_KEY is set');
+    return '';
+  }
+  const cfg = new ConfigurationPage(page);
+  await cfg.gotoAiProviders();
+  if (anthropic) {
+    await cfg.ensureProviderConfigured('Anthropic', anthropic);
+    return 'Claude Haiku 4.5';
+  }
+  await cfg.ensureProviderConfigured('OpenAI', openai!);
+  return 'GPT 4o Mini';
+}
+
+type PromptVariant = {
+  label: string;
+  nameSuffix: string;
+  create: (prompts: PromptsPage, name: string, content: string) => Promise<PromptDetailPage>;
+  detailLocator: (detail: PromptDetailPage) => Locator;
+};
+
+const PROMPT_VARIANTS: PromptVariant[] = [
+  {
+    label: 'chat',
+    nameSuffix: 'chat-playground',
+    create: (prompts, name, content) => prompts.createChatPromptViaUI(name, content),
+    detailLocator: (detail) => detail.chatMessages(),
+  },
+  {
+    label: 'text',
+    nameSuffix: 'text-playground',
+    create: (prompts, name, content) => prompts.createTextPromptViaUI(name, content),
+    detailLocator: (detail) => detail.textContent(),
+  },
+];
+
+test.describe('Prompt → Playground → Traces', { tag: ['@t2-cuj', '@prompts', '@playground'] }, () => {
+  test.use({ viewport: { width: 1600, height: 900 } });
+
+  for (const variant of PROMPT_VARIANTS) {
+    test(`create ${variant.label} prompt, load in Playground, run, verify trace and Prompts tab`, async ({
+      project,
+      page,
+      registerPromptCleanup,
+      testNamespace,
+    }) => {
+      test.setTimeout(90_000);
+
+      const promptName = `${testNamespace}-${variant.nameSuffix}`;
+      const messageContent = 'Say hello in exactly one word.';
+
+      const modelDisplayName = await test.step('Ensure a model is available', async () => {
+        return ensureModelAvailable(page);
+      });
+
+      const playground = new PlaygroundPage(page, project.id);
+
+      // Visit the playground once so `lastActiveProjectId` is initialised in the
+      // Zustand PlaygroundStore. Without this, the store's resetPlayground()
+      // effect fires on first mount (null !== projectId) and clears the prompt
+      // map that `useLoadPlayground` set just before navigating here.
+      await test.step('Initialize Playground lastActiveProjectId', async () => {
+        await playground.goto();
+        await playground.waitForReady();
+      });
+
+      const prompts = new PromptsPage(page);
+
+      await test.step('Navigate to Prompts Library', async () => {
+        await prompts.goto(project.id);
+        await prompts.waitForReady();
+      });
+
+      const detail = await variant.create(prompts, promptName, messageContent);
+
+      // Register cleanup before any navigation so teardown still runs on failure
+      const urlParts = new URL(page.url()).pathname.split('/').filter(Boolean);
+      const promptsIdx = urlParts.lastIndexOf('prompts');
+      const promptId = promptsIdx >= 0 ? (urlParts[promptsIdx + 1] ?? '') : '';
+      expect(promptId, 'Expected to extract promptId from URL after prompt creation').toBeTruthy();
+      registerPromptCleanup(promptId, promptName);
+
+      await test.step('Verify prompt detail page', async () => {
+        await detail.waitForReady();
+        await expect(detail.promptNameHeading()).toHaveText(promptName);
+        await expect(variant.detailLocator(detail)).toContainText(messageContent);
+      });
+
+      await test.step('Load prompt into Playground', async () => {
+        await detail.loadInPlayground();
+      });
+
+      await test.step('Verify Playground loaded with the prompt', async () => {
+        await playground.waitForReady();
+      });
+
+      await test.step('Select model and run prompt', async () => {
+        await playground.selectModel(0, modelDisplayName);
+        // Set up listener BEFORE clicking Run so we don't miss the batch response.
+        const traceLogged = page.waitForResponse(
+          (r) => r.url().includes('/traces/batch') && r.ok(),
+          { timeout: 60_000 },
+        );
+        await playground.runFreeMode(60_000);
+        // Wait for the trace batch POST to return — trace is now committed to the backend.
+        await traceLogged;
+      });
+
+      const sidebar = new PlaygroundLogsSidebarPage(page);
+
+      await test.step('Open Playground logs sidebar', async () => {
+        await playground.openLogsPanel();
+        await sidebar.waitForOpen();
+      });
+
+      await test.step('Verify trace row appears in the sidebar', async () => {
+        await sidebar.waitForTraceRow(15_000);
+        await expect(sidebar.firstTraceRow()).toBeVisible();
+      });
+
+      await test.step('Open trace details', async () => {
+        await sidebar.openFirstTrace();
+      });
+
+      await test.step('Verify trace detail panel shows the prompt message', async () => {
+        await expect(sidebar.traceDetailPanel().getByText(messageContent).first()).toBeVisible();
+      });
+
+      await test.step('Open Prompts tab and verify prompt is linked', async () => {
+        await sidebar.clickPromptsTab();
+        await expect(sidebar.traceDetailPanel().getByText(promptName).first()).toBeVisible();
+        await expect(sidebar.traceDetailPanel().getByText(messageContent).first()).toBeVisible();
+      });
+    });
+  }
+});

--- a/tests_end_to_end/e2e/tests/prompts/prompt-version-playground.spec.ts
+++ b/tests_end_to_end/e2e/tests/prompts/prompt-version-playground.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '../../fixtures/prompt.fixture';
+import { PlaygroundPage } from '@e2e/pom/playground.page';
+import { PlaygroundLogsSidebarPage } from '@e2e/pom/playground-logs-sidebar.page';
+import { ConfigurationPage } from '@e2e/pom/configuration.page';
+
+async function ensureModelAvailable(page: import('@playwright/test').Page): Promise<string> {
+  const anthropic = process.env.ANTHROPIC_API_KEY;
+  const openai = process.env.OPENAI_API_KEY;
+  if (!anthropic && !openai) {
+    test.skip(true, 'Neither ANTHROPIC_API_KEY nor OPENAI_API_KEY is set');
+    return '';
+  }
+  const cfg = new ConfigurationPage(page);
+  await cfg.gotoAiProviders();
+  if (anthropic) {
+    await cfg.ensureProviderConfigured('Anthropic', anthropic);
+    return 'Claude Haiku 4.5';
+  }
+  await cfg.ensureProviderConfigured('OpenAI', openai!);
+  return 'GPT 4o Mini';
+}
+
+const PROMPT_VARIANTS = [
+  {
+    promptType: 'chat' as const,
+    title: 'create 3 chat prompt versions, load v1 in Playground, verify trace shows v1',
+  },
+  {
+    promptType: 'text' as const,
+    title: 'create 3 text prompt versions, load v1 via Playground dropdown, verify trace shows v1',
+  },
+];
+
+test.describe(
+  'Prompt versioning → Playground → Trace verification',
+  { tag: ['@t2-cuj', '@prompts', '@playground'] },
+  () => {
+    test.use({ viewport: { width: 1600, height: 900 } });
+
+    for (const { promptType, title } of PROMPT_VARIANTS) {
+      test(title, async ({ project, page, sdkClient, registerPromptCleanup, testNamespace }) => {
+        test.setTimeout(120_000);
+
+        const promptName = `${testNamespace}-versioned-${promptType}`;
+        const v1Content = 'Say hello in exactly one word.';
+        const v2Content = 'Say goodbye in exactly one word.';
+        const v3Content = 'What is the capital of France?';
+
+        const modelDisplayName = await test.step('Ensure a model is available', () =>
+          ensureModelAvailable(page),
+        );
+
+        await test.step(`Create 3 versions of the ${promptType} prompt via SDK`, async () => {
+          const contents = [v1Content, v2Content, v3Content];
+          for (const [i, content] of contents.entries()) {
+            const result =
+              promptType === 'chat'
+                ? await sdkClient.python.createChatPrompt({
+                    name: promptName,
+                    messages: [{ role: 'user', content }],
+                    project_name: project.name,
+                  })
+                : await sdkClient.python.createTextPrompt({
+                    name: promptName,
+                    prompt: content,
+                    project_name: project.name,
+                  });
+            if (i === 0) registerPromptCleanup(result.id, promptName);
+          }
+        });
+
+        const playground = new PlaygroundPage(page, project.id);
+
+        await test.step('Pre-initialize Playground (set lastActiveProjectId)', async () => {
+          await playground.goto();
+          await playground.waitForReady();
+        });
+
+        if (promptType === 'chat') {
+          await playground.loadPromptVersionFromLibrary(promptName, 'v1');
+        } else {
+          await playground.loadTextPromptVersionFromLibrary(promptName, 'v1');
+        }
+
+        await test.step('Verify Playground shows the prompt loaded at v1', async () => {
+          await playground.waitForReady();
+          await playground.waitForLoadedPromptVersion(promptName, 'v1');
+        });
+
+        await test.step('Select model and run the prompt', async () => {
+          await playground.selectModel(0, modelDisplayName);
+          const traceLogged = page.waitForResponse(
+            (r) => r.url().includes('/traces/batch') && r.ok(),
+            { timeout: 60_000 },
+          );
+          await playground.runFreeMode(60_000);
+          await traceLogged;
+        });
+
+        const sidebar = new PlaygroundLogsSidebarPage(page);
+
+        await test.step('Open Playground logs sidebar', async () => {
+          await playground.openLogsPanel();
+          await sidebar.waitForOpen();
+        });
+
+        await test.step('Verify trace row appears in the sidebar', async () => {
+          await sidebar.waitForTraceRow(15_000);
+          await expect(sidebar.firstTraceRow()).toBeVisible();
+        });
+
+        await sidebar.openFirstTrace();
+
+        await test.step('Open Prompts tab and verify v1 is linked', async () => {
+          await sidebar.clickPromptsTab();
+          const panel = sidebar.traceDetailPanel();
+          await expect(panel.getByText(promptName).first()).toBeVisible();
+          await expect(panel.getByText(v1Content).first()).toBeVisible();
+          await expect(panel.getByText('v1').first()).toBeVisible();
+        });
+      });
+    }
+  },
+);


### PR DESCRIPTION
## Details
Adds comprehensive E2E test coverage for the Prompt Library and Playground features, covering prompt creation, saving, prompt version loading, and trace logging workflows.

- Added 4 new test specs: creating prompts from playground, saving prompts, loading prompt versions, and viewing trace logs in the playground sidebar
- Refactored `playground.page.ts` POM by wrapping all actions in `test.step()` for better test reports and added methods for prompt library interaction
- Added `playground-logs-sidebar.page.ts` POM for the trace logs sidebar Sheet in the playground
- Extended `prompt-detail.page.ts` with a `loadInPlayground()` method to load prompt versions into the playground
- Added minimal `data-testid` attributes to 5 FE components to enable stable locators in tests (`load-prompt-button`, `playground-save-prompt-button`, `prompt-library-menu`, `load-text-prompt-button`, `playground-logs-sidebar-button`, `save-text-prompt-button`)

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6918

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: assisted — test design, POM implementation, debugging timing/hover quirks
- Human verification: manual test run + code review

## Testing

Run from `tests_end_to_end/e2e/`:

```bash
OPIK_BASE_URL=http://localhost:5173 OPIK_API_KEY= npx playwright test tests/prompts/ --project=chromium
```

Scenarios validated:
- Creating a new prompt from the playground save dialog
- Saving an existing prompt (updating a version) from the playground
- Loading prompt versions into the playground via the Prompt Library menu
- Opening the trace logs sidebar after a playground run and verifying trace data

Environment: Docker OSS local

## Documentation

N/A