### PR TITLE
[OPIK-6425] [FE] feat: add Explain bridge contract + AssistantStore

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.bridge.test.ts
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.bridge.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createHostListeners,
+  emitHostEvent,
+} from "@/plugins/comet/AssistantSidebar";
+import { ExplainTarget } from "@/types/assistant-sidebar";
+
+const target: ExplainTarget = {
+  kind: "trace.error",
+  entityId: "t1",
+  projectId: "p1",
+  payload: {},
+};
+
+// VER-4 runtime smoke-test. The compile-time contract assertion
+// (assistant-sidebar.contract.ts) guards that the event KEYS exist in both
+// maps; this confirms the host actually DISPATCHES the three new host->shell
+// events to subscribed listeners at runtime — i.e. createHostListeners()
+// allocates the Sets and emitHostEvent() iterates the right one.
+describe("bridge host-event dispatch (VER-4 runtime smoke)", () => {
+  it("delivers explain:run / explain:cancel / chat:continue to subscribers", () => {
+    const listenersRef = { current: createHostListeners() };
+
+    const onRun = vi.fn();
+    const onCancel = vi.fn();
+    const onContinue = vi.fn();
+    listenersRef.current["explain:run"].add(onRun);
+    listenersRef.current["explain:cancel"].add(onCancel);
+    listenersRef.current["chat:continue"].add(onContinue);
+
+    emitHostEvent(listenersRef, "explain:run", { explainId: "e1", target });
+    emitHostEvent(listenersRef, "explain:cancel", { explainId: "e1" });
+    emitHostEvent(listenersRef, "chat:continue", {
+      question: "q",
+      answer: "a",
+      target,
+    });
+
+    expect(onRun).toHaveBeenCalledWith({ explainId: "e1", target });
+    expect(onCancel).toHaveBeenCalledWith({ explainId: "e1" });
+    expect(onContinue).toHaveBeenCalledWith({
+      question: "q",
+      answer: "a",
+      target,
+    });
+  });
+
+  it("does not cross-deliver between event channels", () => {
+    const listenersRef = { current: createHostListeners() };
+    const onCancel = vi.fn();
+    listenersRef.current["explain:cancel"].add(onCancel);
+
+    emitHostEvent(listenersRef, "explain:run", { explainId: "e2", target });
+
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
+++ b/apps/opik-frontend/src/plugins/comet/AssistantSidebar.tsx
@@ -34,8 +34,15 @@ import {
   isAssistantSidebarOpen,
   setAssistantSidebarOpen,
 } from "@/constants/assistantSidebar";
+import useAssistantStore, {
+  AssistantConsoleStatus,
+  ConsoleEmit,
+} from "@/store/AssistantStore";
 
-const BRIDGE_PROTOCOL_VERSION = 1;
+// 2 = explain/chat events added (`explain:run`/`explain:cancel`/`chat:continue`
+// + `console:ready`/`explain:chunk`/`explain:done`/`explain:error`). MUST move
+// in lockstep with `ollie-console/src/bridge.ts`; VER-4 asserts the contract.
+const BRIDGE_PROTOCOL_VERSION = 2;
 
 interface AssistantSidebarLoaderProps {
   error: string | null;
@@ -112,12 +119,16 @@ type HostListeners = {
   [K in keyof HostEventMap]: Set<(data: HostEventMap[K]) => void>;
 };
 
-function createHostListeners(): HostListeners {
+// Exported for the VER-4 runtime smoke-test (bridge dispatch), not for app use.
+export function createHostListeners(): HostListeners {
   return {
     "context:changed": new Set(),
     "visibility:changed": new Set(),
     "runner:state-changed": new Set(),
     "conversation:start": new Set(),
+    "explain:run": new Set(),
+    "explain:cancel": new Set(),
+    "chat:continue": new Set(),
   };
 }
 
@@ -185,6 +196,28 @@ const createBridge = (refs: BridgeRefs): AssistantSidebarBridge => ({
           data as SidebarEventMap["runner:request-pair"],
         );
         break;
+      // Explain relay (shell → host). Routed straight into AssistantStore — the
+      // global singleton owns capabilities + per-explainId stream state.
+      case "console:ready":
+        useAssistantStore
+          .getState()
+          .applyConsoleReady(data as SidebarEventMap["console:ready"]);
+        break;
+      case "explain:chunk":
+        useAssistantStore
+          .getState()
+          .applyExplainChunk(data as SidebarEventMap["explain:chunk"]);
+        break;
+      case "explain:done":
+        useAssistantStore
+          .getState()
+          .applyExplainDone(data as SidebarEventMap["explain:done"]);
+        break;
+      case "explain:error":
+        useAssistantStore
+          .getState()
+          .applyExplainError(data as SidebarEventMap["explain:error"]);
+        break;
       default:
         if (IS_ASSISTANT_DEV) {
           console.warn(
@@ -200,7 +233,7 @@ const createBridge = (refs: BridgeRefs): AssistantSidebarBridge => ({
 });
 
 /** Emit a host event to all subscribed sidebar listeners. */
-function emitHostEvent<E extends keyof HostEventMap>(
+export function emitHostEvent<E extends keyof HostEventMap>(
   listenersRef: React.MutableRefObject<HostListeners>,
   event: E,
   data: HostEventMap[E],
@@ -393,6 +426,34 @@ const AssistantSidebar: React.FC<AssistantSidebarProps> = ({
       }
     };
   }, [meta]);
+
+  // Claim the AssistantStore's host→shell emit channel. Ownership-guarded the
+  // same way as window.opikBridge: a stale unmount whose emitter no longer
+  // matches the current owner is a no-op (the sidebar↔OlliePage instance
+  // switch), so it can't tear down a freshly mounted instance.
+  useEffect(() => {
+    const emit: ConsoleEmit = (event, data) =>
+      emitHostEvent(listenersRef, event, data);
+    useAssistantStore.getState().registerConsoleEmit(emit);
+    return () => {
+      useAssistantStore.getState().unregisterConsoleEmit(emit);
+    };
+  }, []);
+
+  // Mirror the backend pod phase into the store's console lifecycle status.
+  // Backend-ready is still "waking" — only the iframe console's `console:ready`
+  // handshake promotes it to "ready" (which gates Explain buttons).
+  useEffect(() => {
+    let status: AssistantConsoleStatus;
+    if (phase === "disabled") {
+      status = "unavailable";
+    } else if (phase === "error") {
+      status = "error";
+    } else {
+      status = "waking";
+    }
+    useAssistantStore.getState().setStatus(status);
+  }, [phase]);
 
   // Emit context changes to sidebar listeners
   useEffect(() => {

--- a/apps/opik-frontend/src/store/AssistantStore.test.ts
+++ b/apps/opik-frontend/src/store/AssistantStore.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import useAssistantStore, { MAX_CONCURRENT_EXPLAINS } from "./AssistantStore";
+import { ExplainTarget } from "@/types/assistant-sidebar";
+
+const target: ExplainTarget = {
+  kind: "trace.error",
+  entityId: "trace-1",
+  projectId: "proj-1",
+  payload: { exception_type: "ValueError" },
+};
+
+const READY = { bridgeVersion: 2, capabilities: ["explain"] };
+
+/** Reset the singleton's mutable slices (partial merge keeps the actions). */
+function resetStore() {
+  useAssistantStore.setState({
+    status: "unavailable",
+    capabilities: [],
+    consoleEmit: null,
+    emitQueue: [],
+    explains: {},
+  });
+}
+
+/** Register an emitter and complete the console handshake so emits go out
+ * immediately. Returns the emit spy. */
+function makeReady() {
+  const emit = vi.fn();
+  useAssistantStore.getState().registerConsoleEmit(emit);
+  useAssistantStore.getState().applyConsoleReady({ ...READY });
+  return emit;
+}
+
+describe("AssistantStore", () => {
+  beforeEach(resetStore);
+
+  describe("console handshake", () => {
+    it("applyConsoleReady promotes status to ready and stores capabilities", () => {
+      expect(useAssistantStore.getState().status).toBe("unavailable");
+      useAssistantStore
+        .getState()
+        .applyConsoleReady({ bridgeVersion: 2, capabilities: ["explain"] });
+      expect(useAssistantStore.getState().status).toBe("ready");
+      expect(useAssistantStore.getState().capabilities).toEqual(["explain"]);
+    });
+  });
+
+  describe("emitToConsole queue + flush", () => {
+    it("buffers emits until ready, then flushes them in order", () => {
+      const emit = vi.fn();
+      useAssistantStore.getState().registerConsoleEmit(emit);
+
+      // Not ready yet -> queued, not emitted.
+      useAssistantStore
+        .getState()
+        .emitToConsole("chat:continue", { question: "q", answer: "a", target });
+      useAssistantStore
+        .getState()
+        .emitToConsole("explain:cancel", { explainId: "x" });
+      expect(emit).not.toHaveBeenCalled();
+
+      useAssistantStore.getState().applyConsoleReady({ ...READY });
+
+      expect(emit).toHaveBeenCalledTimes(2);
+      expect(emit).toHaveBeenNthCalledWith(1, "chat:continue", {
+        question: "q",
+        answer: "a",
+        target,
+      });
+      expect(emit).toHaveBeenNthCalledWith(2, "explain:cancel", {
+        explainId: "x",
+      });
+      expect(useAssistantStore.getState().emitQueue).toHaveLength(0);
+    });
+
+    it("emits immediately once ready", () => {
+      const emit = makeReady();
+      useAssistantStore
+        .getState()
+        .emitToConsole("explain:cancel", { explainId: "y" });
+      expect(emit).toHaveBeenCalledWith("explain:cancel", { explainId: "y" });
+    });
+  });
+
+  describe("ownership guard", () => {
+    it("unregister by a non-owner is a no-op", () => {
+      const owner = vi.fn();
+      const stale = vi.fn();
+      useAssistantStore.getState().registerConsoleEmit(owner);
+      useAssistantStore.getState().unregisterConsoleEmit(stale);
+      expect(useAssistantStore.getState().consoleEmit).toBe(owner);
+    });
+
+    it("unregister by the owner tears down the channel and resets status", () => {
+      const owner = makeReady();
+      useAssistantStore.getState().unregisterConsoleEmit(owner);
+      const state = useAssistantStore.getState();
+      expect(state.consoleEmit).toBeNull();
+      expect(state.status).toBe("unavailable");
+      expect(state.capabilities).toEqual([]);
+    });
+
+    it("unregister by the owner drops in-flight explains so cap slots free up", () => {
+      const owner = makeReady();
+      const id = useAssistantStore.getState().runExplain(target)!;
+      expect(useAssistantStore.getState().explains[id]).toBeDefined();
+      useAssistantStore.getState().unregisterConsoleEmit(owner);
+      expect(useAssistantStore.getState().explains).toEqual({});
+    });
+  });
+
+  describe("runExplain + concurrency cap", () => {
+    beforeEach(makeReady);
+
+    it("mints an id, starts in thinking, and emits explain:run", () => {
+      const emit = vi.fn();
+      useAssistantStore.getState().registerConsoleEmit(emit);
+      const id = useAssistantStore.getState().runExplain(target);
+      expect(id).toBeTruthy();
+      expect(useAssistantStore.getState().explains[id!].phase).toBe("thinking");
+      expect(emit).toHaveBeenCalledWith("explain:run", {
+        explainId: id,
+        target,
+      });
+    });
+
+    it("returns null once MAX_CONCURRENT_EXPLAINS are in flight", () => {
+      const ids = Array.from({ length: MAX_CONCURRENT_EXPLAINS }, () =>
+        useAssistantStore.getState().runExplain(target),
+      );
+      expect(ids.every(Boolean)).toBe(true);
+      expect(useAssistantStore.getState().runExplain(target)).toBeNull();
+    });
+
+    it("frees a cap slot when an explain finishes", () => {
+      const ids = Array.from(
+        { length: MAX_CONCURRENT_EXPLAINS },
+        () => useAssistantStore.getState().runExplain(target)!,
+      );
+      useAssistantStore.getState().applyExplainDone({ explainId: ids[0] });
+      expect(useAssistantStore.getState().runExplain(target)).toBeTruthy();
+    });
+
+    it("frees a cap slot when an explain is cancelled", () => {
+      const ids = Array.from(
+        { length: MAX_CONCURRENT_EXPLAINS },
+        () => useAssistantStore.getState().runExplain(target)!,
+      );
+      expect(useAssistantStore.getState().runExplain(target)).toBeNull();
+      useAssistantStore.getState().cancelExplain(ids[0]);
+      expect(useAssistantStore.getState().runExplain(target)).toBeTruthy();
+    });
+  });
+
+  describe("explain stream transitions", () => {
+    let id: string;
+    beforeEach(() => {
+      makeReady();
+      id = useAssistantStore.getState().runExplain(target)!;
+    });
+
+    it("chunks accumulate text and move to streaming", () => {
+      useAssistantStore
+        .getState()
+        .applyExplainChunk({ explainId: id, delta: "Hello " });
+      useAssistantStore
+        .getState()
+        .applyExplainChunk({ explainId: id, delta: "world" });
+      const explain = useAssistantStore.getState().explains[id];
+      expect(explain.phase).toBe("streaming");
+      expect(explain.text).toBe("Hello world");
+    });
+
+    it("done moves to done; an empty body stays done with empty text", () => {
+      useAssistantStore.getState().applyExplainDone({ explainId: id });
+      const explain = useAssistantStore.getState().explains[id];
+      expect(explain.phase).toBe("done");
+      expect(explain.text).toBe("");
+    });
+
+    it("error sets the error phase and message", () => {
+      useAssistantStore
+        .getState()
+        .applyExplainError({ explainId: id, message: "boom" });
+      const explain = useAssistantStore.getState().explains[id];
+      expect(explain.phase).toBe("error");
+      expect(explain.error).toBe("boom");
+    });
+
+    it("ignores deltas for an unknown / already-cleared id (cancel race)", () => {
+      useAssistantStore.getState().clearExplain(id);
+      useAssistantStore
+        .getState()
+        .applyExplainChunk({ explainId: id, delta: "late" });
+      expect(useAssistantStore.getState().explains[id]).toBeUndefined();
+    });
+
+    it("applyExplainDone ignores an unknown / already-cleared id", () => {
+      useAssistantStore.getState().clearExplain(id);
+      useAssistantStore.getState().applyExplainDone({ explainId: id });
+      expect(useAssistantStore.getState().explains[id]).toBeUndefined();
+    });
+
+    it("applyExplainError ignores an unknown / already-cleared id", () => {
+      useAssistantStore.getState().clearExplain(id);
+      useAssistantStore
+        .getState()
+        .applyExplainError({ explainId: id, message: "late" });
+      expect(useAssistantStore.getState().explains[id]).toBeUndefined();
+    });
+
+    it("cancelExplain emits explain:cancel and drops the entry", () => {
+      const emit = vi.fn();
+      useAssistantStore.getState().registerConsoleEmit(emit);
+      useAssistantStore.getState().cancelExplain(id);
+      expect(emit).toHaveBeenCalledWith("explain:cancel", { explainId: id });
+      expect(useAssistantStore.getState().explains[id]).toBeUndefined();
+    });
+
+    it("clearExplain removes a finished entry and is idempotent", () => {
+      useAssistantStore.getState().applyExplainDone({ explainId: id });
+      useAssistantStore.getState().clearExplain(id);
+      useAssistantStore.getState().clearExplain(id);
+      expect(useAssistantStore.getState().explains[id]).toBeUndefined();
+    });
+  });
+});
+
+// FE-1a regression guard: the open/width slice MUST seed from the same
+// localStorage keys the iframe console writes, or width/open is lost across
+// remounts and refreshes (VER-9).
+function createLocalStorageMock(): Storage {
+  let data: Record<string, string> = {};
+  return {
+    getItem: (key) => (key in data ? data[key] : null),
+    setItem: (key, value) => {
+      data[key] = String(value);
+    },
+    removeItem: (key) => {
+      delete data[key];
+    },
+    clear: () => {
+      data = {};
+    },
+    key: (index) => Object.keys(data)[index] ?? null,
+    get length() {
+      return Object.keys(data).length;
+    },
+  } as Storage;
+}
+
+describe("AssistantStore sidebar seed (FE-1a)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal("localStorage", createLocalStorageMock());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults to the open default width when nothing is stored", async () => {
+    const { default: store } = await import("./AssistantStore");
+    const { ASSISTANT_SIDEBAR_DEFAULT_WIDTH } = await import(
+      "@/constants/assistantSidebar"
+    );
+    expect(store.getState().sidebarWidth).toBe(ASSISTANT_SIDEBAR_DEFAULT_WIDTH);
+  });
+
+  it("seeds the stored width when the sidebar was left open", async () => {
+    localStorage.setItem("assistant-sidebar-open", "true");
+    localStorage.setItem("assistant-sidebar-width", "512");
+    const { default: store } = await import("./AssistantStore");
+    expect(store.getState().sidebarWidth).toBe(512);
+  });
+
+  it("seeds the collapsed width when the sidebar was left closed", async () => {
+    localStorage.setItem("assistant-sidebar-open", "false");
+    localStorage.setItem("assistant-sidebar-width", "512");
+    const { default: store } = await import("./AssistantStore");
+    const { ASSISTANT_SIDEBAR_COLLAPSED_WIDTH } = await import(
+      "@/constants/assistantSidebar"
+    );
+    expect(store.getState().sidebarWidth).toBe(
+      ASSISTANT_SIDEBAR_COLLAPSED_WIDTH,
+    );
+  });
+});

--- a/apps/opik-frontend/src/store/AssistantStore.ts
+++ b/apps/opik-frontend/src/store/AssistantStore.ts
@@ -1,0 +1,292 @@
+import { create } from "zustand";
+import { v4 as uuidv4 } from "uuid";
+import {
+  ASSISTANT_SIDEBAR_COLLAPSED_WIDTH,
+  getStoredAssistantSidebarWidth,
+  isAssistantSidebarOpen,
+  setAssistantSidebarOpen,
+} from "@/constants/assistantSidebar";
+import {
+  ExplainTarget,
+  HostEventMap,
+  SidebarEventMap,
+} from "@/types/assistant-sidebar";
+
+/**
+ * Console lifecycle from the host's point of view. This is NOT the backend pod
+ * phase (`useAssistantBackend`) — it reflects whether the iframe console has
+ * completed its `console:ready` handshake, which is what gates Explain
+ * buttons. Mapping pod phase → this status is the owning comet
+ * `AssistantSidebar`'s job (`setStatus`); `console:ready` is the only thing
+ * that promotes to `"ready"`.
+ *
+ * - `unavailable`: OSS / no comet sidebar mounted / Ollie disabled. Default —
+ *   nobody writes the store, so Explain buttons never render (the OSS boundary).
+ * - `waking`: pod provisioning or cold-starting, or the iframe console has not
+ *   yet emitted `console:ready`. Drives the §5 bounded "waking up" popover
+ *   state, distinct from the in-flight thinking pulse.
+ * - `ready`: console handshake done; `capabilities` are known.
+ * - `error`: backend or console error.
+ */
+export type AssistantConsoleStatus =
+  | "unavailable"
+  | "waking"
+  | "ready"
+  | "error";
+
+/** Lifecycle of a single explain request, keyed by `explainId`. */
+export type ExplainPhase = "thinking" | "streaming" | "done" | "error";
+
+export interface ExplainState {
+  explainId: string;
+  target: ExplainTarget;
+  phase: ExplainPhase;
+  /** Streamed `explain:chunk` deltas, concatenated. */
+  text: string;
+  /** Set only when `phase === "error"`. */
+  error: string | null;
+}
+
+/**
+ * Host → shell emitter, registered by the owning comet `AssistantSidebar`.
+ * Generic over `HostEventMap` so `emitToConsole` is type-checked against the
+ * bridge contract.
+ */
+export type ConsoleEmit = <E extends keyof HostEventMap>(
+  event: E,
+  data: HostEventMap[E],
+) => void;
+
+/**
+ * Hard cap on concurrent in-flight explains — a client-side rate-limit / cost
+ * guard. `runExplain` returns `null` once this many are `thinking`/`streaming`
+ * (the §5 "at-cap" state).
+ */
+export const MAX_CONCURRENT_EXPLAINS = 3;
+
+interface QueuedEmit {
+  event: keyof HostEventMap;
+  data: HostEventMap[keyof HostEventMap];
+}
+
+type AssistantStore = {
+  // ── sidebar open/width (FE-1a) ──────────────────────────────────────────
+  // Seeded from localStorage on init. The store does NOT write these keys
+  // itself: the iframe console writes `assistant-sidebar-width` directly and
+  // the `setAssistantSidebarOpen()` helper (via `openSidebar`) owns the
+  // `assistant-sidebar-open` key. The seed is what survives iframe remounts
+  // and page refreshes (VER-9).
+  sidebarWidth: number;
+  setSidebarWidth: (width: number) => void;
+  openSidebar: () => void;
+
+  // ── console lifecycle + capabilities (FE-1b) ────────────────────────────
+  status: AssistantConsoleStatus;
+  capabilities: string[];
+  setStatus: (status: AssistantConsoleStatus) => void;
+
+  // ── ownership-guarded host → shell emit (FE-1b) ─────────────────────────
+  consoleEmit: ConsoleEmit | null;
+  emitQueue: QueuedEmit[];
+  /** Claim ownership of the host→shell channel (called on sidebar mount). */
+  registerConsoleEmit: (emit: ConsoleEmit) => void;
+  /**
+   * Release ownership (called on sidebar unmount). Ownership-guarded: a stale
+   * unmount whose `emit` no longer matches the current owner is a no-op, so it
+   * cannot clobber a freshly mounted instance (the sidebar↔OlliePage switch).
+   */
+  unregisterConsoleEmit: (emit: ConsoleEmit) => void;
+  /** Emit a host event now if ready, else queue it until `console:ready`. */
+  emitToConsole: ConsoleEmit;
+
+  // ── explain state, keyed by explainId (FE-1b) ───────────────────────────
+  explains: Record<string, ExplainState>;
+  /** Mint an explainId, enforce the concurrency cap, emit `explain:run`.
+   * Returns the id, or `null` when at cap. */
+  runExplain: (target: ExplainTarget) => string | null;
+  /** Emit `explain:cancel` and drop the entry (terminal — frees a cap slot). */
+  cancelExplain: (explainId: string) => void;
+  /** Drop a finished entry so the explains map doesn't grow unbounded
+   * (called on popover unmount). Idempotent. */
+  clearExplain: (explainId: string) => void;
+
+  // ── bridge → store routing (FE-2; called from AssistantSidebar.emit) ─────
+  applyConsoleReady: (data: SidebarEventMap["console:ready"]) => void;
+  applyExplainChunk: (data: SidebarEventMap["explain:chunk"]) => void;
+  applyExplainDone: (data: SidebarEventMap["explain:done"]) => void;
+  applyExplainError: (data: SidebarEventMap["explain:error"]) => void;
+};
+
+const countActiveExplains = (explains: Record<string, ExplainState>): number =>
+  Object.values(explains).filter(
+    (e) => e.phase === "thinking" || e.phase === "streaming",
+  ).length;
+
+const useAssistantStore = create<AssistantStore>((set, get) => ({
+  // ── sidebar open/width ──────────────────────────────────────────────────
+  sidebarWidth: isAssistantSidebarOpen()
+    ? getStoredAssistantSidebarWidth()
+    : ASSISTANT_SIDEBAR_COLLAPSED_WIDTH,
+  setSidebarWidth: (width) => set({ sidebarWidth: width }),
+  openSidebar: () => {
+    setAssistantSidebarOpen(true);
+    set({ sidebarWidth: getStoredAssistantSidebarWidth() });
+  },
+
+  // ── console lifecycle + capabilities ────────────────────────────────────
+  status: "unavailable",
+  capabilities: [],
+  setStatus: (status) => set({ status }),
+
+  // ── ownership-guarded host → shell emit ─────────────────────────────────
+  consoleEmit: null,
+  emitQueue: [],
+  registerConsoleEmit: (emit) => set({ consoleEmit: emit }),
+  unregisterConsoleEmit: (emit) => {
+    // Guard: only the current owner may tear down (sidebar↔OlliePage switch).
+    if (get().consoleEmit !== emit) return;
+    // Drop in-flight explains too: the next console has no knowledge of these
+    // explainIds, so it will never emit their chunk/done/error — leaving them
+    // stuck in `thinking`/`streaming` and permanently consuming cap slots.
+    set({
+      consoleEmit: null,
+      emitQueue: [],
+      status: "unavailable",
+      capabilities: [],
+      explains: {},
+    });
+  },
+  emitToConsole: (event, data) => {
+    const { status, consoleEmit } = get();
+    if (status === "ready" && consoleEmit) {
+      consoleEmit(event, data);
+    } else {
+      // Buffer until the console handshake completes so e.g. a `chat:continue`
+      // fired mid-load isn't dropped.
+      set((s) => ({ emitQueue: [...s.emitQueue, { event, data }] }));
+    }
+  },
+
+  // ── explain state ───────────────────────────────────────────────────────
+  explains: {},
+  runExplain: (target) => {
+    if (countActiveExplains(get().explains) >= MAX_CONCURRENT_EXPLAINS) {
+      return null;
+    }
+    const explainId = uuidv4();
+    set((s) => ({
+      explains: {
+        ...s.explains,
+        [explainId]: {
+          explainId,
+          target,
+          phase: "thinking",
+          text: "",
+          error: null,
+        },
+      },
+    }));
+    get().emitToConsole("explain:run", { explainId, target });
+    return explainId;
+  },
+  cancelExplain: (explainId) => {
+    get().emitToConsole("explain:cancel", { explainId });
+    set((s) => {
+      if (!s.explains[explainId]) return s;
+      const next = { ...s.explains };
+      delete next[explainId];
+      return { explains: next };
+    });
+  },
+  clearExplain: (explainId) => {
+    set((s) => {
+      if (!s.explains[explainId]) return s;
+      const next = { ...s.explains };
+      delete next[explainId];
+      return { explains: next };
+    });
+  },
+
+  // ── bridge → store routing ──────────────────────────────────────────────
+  applyConsoleReady: ({ capabilities }) => {
+    const { consoleEmit, emitQueue } = get();
+    set({ status: "ready", capabilities, emitQueue: [] });
+    // Flush anything buffered while the console was still loading.
+    if (consoleEmit) {
+      for (const queued of emitQueue) {
+        consoleEmit(queued.event, queued.data);
+      }
+    }
+  },
+  applyExplainChunk: ({ explainId, delta }) => {
+    set((s) => {
+      const current = s.explains[explainId];
+      // Ignore deltas for an unknown / already-cleared explain (cancel race).
+      if (!current) return s;
+      return {
+        explains: {
+          ...s.explains,
+          [explainId]: {
+            ...current,
+            phase: "streaming",
+            text: current.text + delta,
+          },
+        },
+      };
+    });
+  },
+  applyExplainDone: ({ explainId }) => {
+    set((s) => {
+      const current = s.explains[explainId];
+      if (!current) return s;
+      // Empty body stays `done` with empty text — the popover renders the §5
+      // "No explanation available" fallback, not a separate store phase.
+      return {
+        explains: {
+          ...s.explains,
+          [explainId]: { ...current, phase: "done" },
+        },
+      };
+    });
+  },
+  applyExplainError: ({ explainId, message }) => {
+    set((s) => {
+      const current = s.explains[explainId];
+      if (!current) return s;
+      return {
+        explains: {
+          ...s.explains,
+          [explainId]: { ...current, phase: "error", error: message },
+        },
+      };
+    });
+  },
+}));
+
+// ── selector hooks (AppStore convention) ──────────────────────────────────
+export const useAssistantSidebarWidth = () =>
+  useAssistantStore((state) => state.sidebarWidth);
+
+export const useIsAssistantSidebarOpen = () =>
+  useAssistantStore(
+    (state) => state.sidebarWidth > ASSISTANT_SIDEBAR_COLLAPSED_WIDTH,
+  );
+
+export const useSetAssistantSidebarWidth = () =>
+  useAssistantStore((state) => state.setSidebarWidth);
+
+export const useOpenAssistantSidebar = () =>
+  useAssistantStore((state) => state.openSidebar);
+
+export const useAssistantStatus = () =>
+  useAssistantStore((state) => state.status);
+
+export const useAssistantCapabilities = () =>
+  useAssistantStore((state) => state.capabilities);
+
+export const useExplainState = (explainId: string | null) =>
+  useAssistantStore((state) =>
+    explainId ? state.explains[explainId] : undefined,
+  );
+
+export default useAssistantStore;

--- a/apps/opik-frontend/src/types/assistant-sidebar.contract.ts
+++ b/apps/opik-frontend/src/types/assistant-sidebar.contract.ts
@@ -1,0 +1,62 @@
+/**
+ * VER-4 — compile-time bridge-contract assertions (ships with G1b).
+ *
+ * `npm run typecheck` (`tsc --noEmit`) FAILS if any of the 7 explain/chat/
+ * console events is missing from `HostEventMap` / `SidebarEventMap`. This is
+ * the guard against the two repos' bridge type maps silently skewing — the
+ * exact failure mode that produced the pre-existing `runner:*` divergence and
+ * would otherwise surface only as a permanent thinking-pulse bug at INT.
+ *
+ * No runtime footprint: this module is never imported, exports only types, and
+ * is excluded from the bundle. It exists purely so tsc evaluates the
+ * assertions below.
+ *
+ * SCOPE: the explain set only (per G1b). The pre-existing `runner:*` skew
+ * between `opik-frontend` (`runner:state-changed`) and `ollie-console`
+ * (`runner:paired` / `runner:pair-failed` / `runner:connected`) is deliberately
+ * OUT of scope here — reconciling it is tracked as a separate follow-up ticket
+ * (owner: whoever owns both repos). The `BRIDGE_PROTOCOL_VERSION` bump to 2
+ * means "explain events added", NOT "full map coherence".
+ *
+ * Keep `ollie-console/src/bridge.ts` byte-identical and mirror an equivalent
+ * assertion there (`ollie-console/src/__tests__/bridge.test.ts`).
+ */
+import { HostEventMap, SidebarEventMap } from "@/types/assistant-sidebar";
+
+/**
+ * `T` must contain every key of `U`. If it does not, `T` violates the
+ * `Record<keyof U, unknown>` constraint and tsc errors where the alias is
+ * instantiated below — even though the result is never used at runtime.
+ *
+ * (The plan's equivalent value-level form is
+ * `const _c: AssertAllKeys<HostEventMap, Expected> = {} as HostEventMap`; the
+ * type-only form here enforces the identical constraint with no runtime binding,
+ * so it stays clear of unused-var / object-literal-cast lint.)
+ */
+type AssertAllKeys<T extends Record<keyof U, unknown>, U> = T;
+
+/** The explain/chat events the host emits to the shell. */
+interface ExpectedHostExplainEvents {
+  "explain:run": unknown;
+  "explain:cancel": unknown;
+  "chat:continue": unknown;
+}
+
+/** The handshake/explain events the shell emits back to the host. */
+interface ExpectedSidebarExplainEvents {
+  "console:ready": unknown;
+  "explain:chunk": unknown;
+  "explain:done": unknown;
+  "explain:error": unknown;
+}
+
+// The assertions. tsc fails to compile if HostEventMap / SidebarEventMap is
+// missing any expected explain event key.
+export type HostExplainEventsContract = AssertAllKeys<
+  HostEventMap,
+  ExpectedHostExplainEvents
+>;
+export type SidebarExplainEventsContract = AssertAllKeys<
+  SidebarEventMap,
+  ExpectedSidebarExplainEvents
+>;

--- a/apps/opik-frontend/src/types/assistant-sidebar.ts
+++ b/apps/opik-frontend/src/types/assistant-sidebar.ts
@@ -31,12 +31,41 @@ export interface RunnerBridgeState {
   runnerId: string | null;
 }
 
+/** The cell kinds the Explain feature understands. Only `trace.error` ships
+ * at launch (D-D); `trace.cost`/`trace.duration` are registry-reserved. */
+export type ExplainKind = "trace.error" | "trace.cost" | "trace.duration";
+
+/**
+ * The cell data the host already has on the row, handed verbatim to the
+ * console's ExplainRunner (no extra fetch). `payload` is kind-specific and
+ * shaped by the FE kind registry; the bridge stays transport-neutral and does
+ * not validate it.
+ *
+ * ⚠️ This type and the 7 explain/chat/console events below MUST stay
+ * byte-identical with `ollie-console/src/bridge.ts`. The runtime bridge is
+ * untyped, so a name/shape skew silently no-ops (a permanent thinking-pulse
+ * bug). VER-4's compile-time assertions guard the event keys; keep this shape
+ * in sync by hand until a shared `@comet/ollie-bridge-types` package exists.
+ */
+export interface ExplainTarget {
+  kind: ExplainKind;
+  entityId: string;
+  projectId: string;
+  payload: Record<string, unknown>;
+}
+
 /** Host → Sidebar events */
 export interface HostEventMap {
   "context:changed": BridgeContext;
   "visibility:changed": { isOpen: boolean };
   "runner:state-changed": RunnerBridgeState;
   "conversation:start": { message: string };
+  // Explain (host → shell). `explainId` correlates concurrent explains over
+  // the single bridge. `chat:continue` carries the verbatim Q&A already shown
+  // in the popover so the console seeds one consistent session.
+  "explain:run": { explainId: string; target: ExplainTarget };
+  "explain:cancel": { explainId: string };
+  "chat:continue": { question: string; answer: string; target: ExplainTarget };
 }
 
 /** Sidebar → Host events */
@@ -51,6 +80,14 @@ export interface SidebarEventMap {
   "sidebar:request-close": Record<string, never>;
   "sidebar:request-open": Record<string, never>;
   "runner:request-pair": { projectId: string };
+  // Explain (shell → host). `console:ready` is the mount handshake whose
+  // `capabilities` gate the Explain buttons (old console builds without
+  // "explain" degrade to no-buttons). `explain:done` carries no sessionId —
+  // there is no session; Continue seeds one later from the streamed text.
+  "console:ready": { bridgeVersion: number; capabilities: string[] };
+  "explain:chunk": { explainId: string; delta: string };
+  "explain:done": { explainId: string };
+  "explain:error": { explainId: string; message: string };
 }
 
 export interface AssistantSidebarBridge {

--- a/apps/opik-frontend/src/v2/layout/PageLayout/PageLayout.tsx
+++ b/apps/opik-frontend/src/v2/layout/PageLayout/PageLayout.tsx
@@ -13,12 +13,12 @@ import { PortalContainerProvider } from "@/lib/portal-container";
 import SilentErrorBoundary from "@/shared/SilentErrorBoundary/SilentErrorBoundary";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useIsPhone } from "@/hooks/useIsPhone";
+import { ASSISTANT_SIDEBAR_COLLAPSED_WIDTH } from "@/constants/assistantSidebar";
 import {
-  ASSISTANT_SIDEBAR_COLLAPSED_WIDTH,
-  getStoredAssistantSidebarWidth,
-  isAssistantSidebarOpen,
-  setAssistantSidebarOpen,
-} from "@/constants/assistantSidebar";
+  useAssistantSidebarWidth,
+  useOpenAssistantSidebar,
+  useSetAssistantSidebarWidth,
+} from "@/store/AssistantStore";
 import DemoProjectBanner from "@/v2/layout/DemoProjectBanner/DemoProjectBanner";
 
 const PageLayout = () => {
@@ -32,11 +32,12 @@ const PageLayout = () => {
   const [demoBannerHeight, setDemoBannerHeight] = useState(0);
   const bannerHeight = retentionBannerHeight + demoBannerHeight;
   const [showWelcomeWizard, setShowWelcomeWizard] = useState(false);
-  const [assistantSidebarWidth, setAssistantSidebarWidth] = useState(() =>
-    isAssistantSidebarOpen()
-      ? getStoredAssistantSidebarWidth()
-      : ASSISTANT_SIDEBAR_COLLAPSED_WIDTH,
-  );
+  // Sidebar open/width now lives in AssistantStore (seeded from the same
+  // localStorage keys the iframe console writes), so a remount/refresh keeps
+  // the width and the store stays the single source of truth.
+  const assistantSidebarWidth = useAssistantSidebarWidth();
+  const setAssistantSidebarWidth = useSetAssistantSidebarWidth();
+  const handleOpenAssistant = useOpenAssistantSidebar();
 
   const welcomeWizardEnabled = useIsFeatureEnabled(
     FeatureToggleKeys.WELCOME_WIZARD_ENABLED,
@@ -69,11 +70,6 @@ const PageLayout = () => {
   // `.comet-content-inset`'s calc resolves correctly.
   const layoutAssistantWidth =
     showAssistantSidebar && !isPhone ? `${assistantSidebarWidth}px` : "0px";
-
-  const handleOpenAssistant = useCallback(() => {
-    setAssistantSidebarOpen(true);
-    setAssistantSidebarWidth(getStoredAssistantSidebarWidth());
-  }, []);
 
   const expanded = isPhone
     ? false


### PR DESCRIPTION
## Details
Implements the **opik-frontend "Explain" bridge** slice of OPIK-6425 (G1, G1b, FE-1a, FE-1b, FE-2). This lands the host-side foundation the Explain popover/cells build on; there is **no user-facing UI yet** (FE-3/FE-4/FE-5 follow). Frontend-only — no backend, migrations, or `v1` changes.

- **Bridge contract (G1):** adds the 7 explain/chat/console events (`explain:run`/`cancel`, `chat:continue`, `console:ready`, `explain:chunk`/`done`/`error`) + `ExplainTarget` to `assistant-sidebar.ts`, bumps `BRIDGE_PROTOCOL_VERSION` 1→2, and wires `createHostListeners()` + the `console:ready`/`explain:*` handlers in the comet `AssistantSidebar`. Must stay byte-identical with `ollie-console/src/bridge.ts` (separate repo; the mirror lands in lockstep).
- **AssistantStore (FE-1b):** console lifecycle status (incl. a named `waking`), `capabilities` from `console:ready`, a queued `emitToConsole` that flushes on ready, per-`explainId` stream state, `runExplain`/`cancelExplain`/`clearExplain` with a hard concurrency cap of 3, and ownership-guarded emit registration (mirrors the `window.opikBridge` guard for the sidebar↔OlliePage instance switch).
- **Sidebar state migration (FE-1a):** moves sidebar open/width out of `PageLayout` `useState` into the store, seeded from the same `assistant-sidebar-open`/`-width` localStorage keys the console writes (survives refresh/remount). Nav-sidebar key (`sidebar-expanded`) untouched.
- **VER-4 (G1b):** a compile-time contract assertion (`tsc --noEmit` fails if any event key is missing from either map) + a runtime `emitHostEvent` dispatch smoke test.

Out of scope (follow-ups): FE-3 ExplainButton/Popover, FE-4 Error-cell wiring, FE-5 BI events, the G3 `EXPLAIN_ENABLED` flag, and the `ollie-console`/`ollie-assist` repo changes.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6425

## AI-WATERMARK

AI-WATERMARK: yes

  - Tools: Claude-Code
  - Model: Opus-4.8
  - Scope: All files in this PR
  - Human verification: Yes — implementation went through a multi-agent adversarial review pass; one real bug (orphaned explains leaking concurrency-cap slots on unregister) was fixed and re-verified.

## Testing
Commands (from `apps/opik-frontend`):
- `npm run typecheck` — clean
- `npx vitest run src/store/AssistantStore.test.ts src/plugins/comet/AssistantSidebar.bridge.test.ts` — 23 passing
- `npx eslint` on all changed files — 0 problems

Scenarios validated (unit, happy-dom):
- Console handshake: `console:ready` promotes status to `ready` and stores capabilities.
- `emitToConsole` buffers before ready and flushes in order once `console:ready` arrives.
- Ownership guard: a non-owner `unregister` is a no-op; the owner's `unregister` tears down the channel/status and drops in-flight explains (cap-slot leak fix).
- Concurrency cap: `runExplain` returns `null` at cap; a finished or cancelled explain frees a slot.
- Stream transitions: chunk→streaming (text accumulates), done, error; an unknown/cleared `explainId` is ignored on chunk/done/error (cancel race).
- VER-4: verified `tsc` fails when an event key is removed (then restored); `emitHostEvent` dispatches each new host event to subscribers with no cross-delivery.
- FE-1a seed: the store seeds default / stored / collapsed width from localStorage.

Regression check: a full `npx vitest run` shows only 2 pre-existing failing files (`src/lib/ls-migrations/*`, a `localStorage.clear` env quirk) that fail identically on `main`. This change adds 23 passing tests and introduces no regressions.

Not run: Playwright E2E (VER-9) and cross-repo INT-1 — they depend on the `ollie-console` mirror + UI (FE-3+), which are out of this PR's scope.

## Documentation
N/A — no user-facing docs change (internal host bridge + zustand store only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
