### PR TITLE
[OPIK-6968] [BE] perf: drop per-project trace-threads lock from ingestion, closing and sampling

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
@@ -95,11 +95,8 @@ class TraceThreadServiceImpl implements TraceThreadService {
 
         return processThreadAsync(threadInfo, projectId)
                 .collectList()
-                .flatMap(traceThreads -> lockService.executeWithLockCustomExpire(
-                        new LockService.Lock(projectId, TraceThreadService.THREADS_LOCK),
-                        Mono.defer(() -> this.saveTraceThreads(projectId, traceThreads)
-                                .then()),
-                        LOCK_DURATION));
+                .flatMap(traceThreads -> this.saveTraceThreads(projectId, traceThreads))
+                .then();
     }
 
     private Flux<TraceThreadModel> processThreadAsync(Map<String, ThreadTimestamps> threadInfo, UUID projectId) {
@@ -147,10 +144,7 @@ class TraceThreadServiceImpl implements TraceThreadService {
             return Mono.empty();
         }
 
-        return lockService.executeWithLockCustomExpire(
-                new LockService.Lock(projectId, TraceThreadService.THREADS_LOCK),
-                Mono.defer(() -> processUpdateThreadSampledValue(projectId, threadSamplingPerRules)),
-                LOCK_DURATION);
+        return processUpdateThreadSampledValue(projectId, threadSamplingPerRules);
     }
 
     private Mono<Void> processUpdateThreadSampledValue(UUID projectId,
@@ -295,12 +289,10 @@ class TraceThreadServiceImpl implements TraceThreadService {
     @Override
     public Mono<Void> processProjectWithTraceThreadsPendingClosure(@NonNull UUID projectId,
             @NonNull Instant now, @NonNull Duration defaultTimeoutToMarkThreadAsInactive) {
-        return lockService.executeWithLockCustomExpire(
-                new LockService.Lock(projectId, TraceThreadService.THREADS_LOCK),
-                Mono.deferContextual(
-                        contextView -> closeThreadWith(projectId, now, defaultTimeoutToMarkThreadAsInactive,
-                                contextView)),
-                LOCK_DURATION).then();
+        return Mono.deferContextual(
+                contextView -> closeThreadWith(projectId, now, defaultTimeoutToMarkThreadAsInactive,
+                        contextView))
+                .then();
     }
 
     private Mono<Long> closeThreadWith(UUID projectId, Instant now, Duration defaultTimeoutToMarkThreadAsInactive,


### PR DESCRIPTION
## Details

Follow-up to #7121. Removes the per-project `{projectId}-trace-threads-process` lock from two flows where it is no longer needed, reducing contention on the single per-project permit:

- **`processTraceThreads` (ingestion save)** — `processThreadAsync` resolves thread IDs idempotently (get-or-create on the thread-id table), and `saveTraceThreads` writes to a `ReplacingMergeTree` keyed by `last_updated_at`, so concurrent ingestion saves converge instead of racing.
- **`processProjectWithTraceThreadsPendingClosure` (closing scan)** — a project's closing is already serialized across pods by the per-project **buffer token** (`addToPendingQueue` / `unlockUsingToken`, retained), so the trace-threads lock was redundant. Closing-vs-ingestion is resolved by `ReplacingMergeTree` version ordering: a thread that received new traces (newer `last_updated_at`, `active`) wins over a concurrent close (`inactive`, older version).
- **`updateThreadSampledValue`** - Similar to the points before, it leverages `last_updated_at` and only updates sampling info while copying the rest. 
 
## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6968

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: Removed the per-project lock from the two flows above; verified the remaining lock sites and the buffer-token serialization are untouched.
- Human verification: pending review

## Testing

- `mvn test-compile` (JDK 25) — BUILD SUCCESS (main + test).
- `mvn spotless:check` — passed.
- Not run locally: full `mvn test` (DB-backed integration suites) — relying on CI.

## Documentation
NA
