### PR TITLE
[OPIK-6791] [BE][FE] Add source_queue_id to scores/comments and scope feedback by queue

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/Comment.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/Comment.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 public record Comment(
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) UUID id,
         @NotBlank String text,
+        UUID sourceQueueId,
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant createdAt,
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/DeleteFeedbackScore.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/DeleteFeedbackScore.java
@@ -6,8 +6,10 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
+import java.util.UUID;
+
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record DeleteFeedbackScore(@NotBlank String name, String author) {
+public record DeleteFeedbackScore(@NotBlank String name, String author, UUID sourceQueueId) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/DeleteThreadFeedbackScores.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/DeleteThreadFeedbackScores.java
@@ -9,10 +9,11 @@ import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 import java.util.Set;
+import java.util.UUID;
 
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record DeleteThreadFeedbackScores(@NotBlank String projectName, @NotBlank String threadId,
-        @NotNull @Size(min = 1, max = 1000) Set<@NotBlank String> names, String author) {
+        @NotNull @Size(min = 1, max = 1000) Set<@NotBlank String> names, String author, UUID sourceQueueId) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/FeedbackScore.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/FeedbackScore.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Map;
+import java.util.UUID;
 
 import static com.comet.opik.utils.ValidationUtils.MAX_FEEDBACK_SCORE_VALUE;
 import static com.comet.opik.utils.ValidationUtils.MIN_FEEDBACK_SCORE_VALUE;
@@ -26,6 +27,7 @@ public record FeedbackScore(
         @NotNull @DecimalMax(MAX_FEEDBACK_SCORE_VALUE) @DecimalMin(MIN_FEEDBACK_SCORE_VALUE) BigDecimal value,
         String reason,
         @NotNull ScoreSource source,
+        UUID sourceQueueId,
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant createdAt,
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/FeedbackScoreItem.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/FeedbackScoreItem.java
@@ -51,6 +51,8 @@ public abstract sealed class FeedbackScoreItem {
 
     private final String author;
 
+    private final UUID sourceQueueId;
+
     public abstract UUID id();
 
     public abstract String threadId();
@@ -75,10 +77,10 @@ public abstract sealed class FeedbackScoreItem {
         @NotNull private UUID id;
 
         @ConstructorProperties({"projectName", "projectId", "name", "categoryName", "value", "reason", "source",
-                "author", "id"})
+                "author", "sourceQueueId", "id"})
         public FeedbackScoreBatchItem(String projectName, UUID projectId, String name, String categoryName,
-                BigDecimal value, String reason, ScoreSource source, String author, UUID id) {
-            super(projectName, projectId, name, value, categoryName, reason, source, author);
+                BigDecimal value, String reason, ScoreSource source, String author, UUID sourceQueueId, UUID id) {
+            super(projectName, projectId, name, value, categoryName, reason, source, author, sourceQueueId);
             this.id = id;
         }
 
@@ -104,10 +106,11 @@ public abstract sealed class FeedbackScoreItem {
         private UUID id;
 
         @ConstructorProperties({"projectName", "projectId", "name", "categoryName", "value", "reason",
-                "source", "author", "threadId"})
+                "source", "author", "sourceQueueId", "threadId"})
         public FeedbackScoreBatchItemThread(String projectName, UUID projectId, String name, String categoryName,
-                BigDecimal value, String reason, ScoreSource source, String author, String threadId) {
-            super(projectName, projectId, name, value, categoryName, reason, source, author);
+                BigDecimal value, String reason, ScoreSource source, String author, UUID sourceQueueId,
+                String threadId) {
+            super(projectName, projectId, name, value, categoryName, reason, source, author, sourceQueueId);
             this.threadId = threadId;
         }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
@@ -140,7 +140,8 @@ public class TracesResource {
             @QueryParam("exclude") String exclude,
             @QueryParam("search") @Schema(description = "Full-text search across trace fields") String search,
             @QueryParam("from_time") @Schema(description = "Filter traces created from this time (ISO-8601 format).") Instant startTime,
-            @QueryParam("to_time") @Schema(description = "Filter traces created up to this time (ISO-8601 format). If not provided, defaults to current time. Must be after 'from_time'.") Instant endTime) {
+            @QueryParam("to_time") @Schema(description = "Filter traces created up to this time (ISO-8601 format). If not provided, defaults to current time. Must be after 'from_time'.") Instant endTime,
+            @QueryParam("annotation_queue_id") @Schema(description = "Filter traces belonging to this annotation queue and scope feedback scores/comments to it") UUID annotationQueueId) {
 
         validateProjectNameAndProjectId(projectName, projectId);
         validateTimeRangeParameters(startTime, endTime);
@@ -170,6 +171,7 @@ public class TracesResource {
                 .exclude(ParamsValidator.get(exclude, Trace.TraceField.class, "exclude"))
                 .sortingFields(sortingFields)
                 .searchText(StringUtils.trimToNull(search))
+                .annotationQueueId(annotationQueueId)
                 .build();
 
         log.info("Get traces by '{}' on workspaceId '{}'", searchCriteria, workspaceId);
@@ -635,7 +637,8 @@ public class TracesResource {
             @QueryParam("sorting") String sorting,
             @QueryParam("search") @Schema(description = "Full-text search across thread fields") String search,
             @QueryParam("from_time") @Schema(description = "Filter trace threads created from this time (ISO-8601 format).") Instant startTime,
-            @QueryParam("to_time") @Schema(description = "Filter trace threads created up to this time (ISO-8601 format). If not provided, defaults to current time. Must be after 'from_time'.") Instant endTime) {
+            @QueryParam("to_time") @Schema(description = "Filter trace threads created up to this time (ISO-8601 format). If not provided, defaults to current time. Must be after 'from_time'.") Instant endTime,
+            @QueryParam("annotation_queue_id") @Schema(description = "Filter threads belonging to this annotation queue and scope feedback scores/comments to it") UUID annotationQueueId) {
 
         validateProjectNameAndProjectId(projectName, projectId);
         validateTimeRangeParameters(startTime, endTime);
@@ -664,6 +667,7 @@ public class TracesResource {
                 .searchText(StringUtils.trimToNull(search))
                 .uuidFromTime(instantToUUIDMapper.toLowerBound(startTime))
                 .uuidToTime(instantToUUIDMapper.toUpperBound(endTime))
+                .annotationQueueId(annotationQueueId)
                 .build();
 
         log.info("Get trace threads by '{}' on workspaceId '{}'", searchCriteria, workspaceId);

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
@@ -965,7 +965,8 @@ public class TracesResource {
                 scores.threadId(),
                 projectName, scores.author(), workspaceId);
 
-        feedbackScoreService.deleteThreadScores(projectName, scores.threadId(), scores.names(), scores.author())
+        feedbackScoreService.deleteThreadScores(projectName, scores.threadId(), scores.names(), scores.author(),
+                scores.sourceQueueId())
                 .contextWrite(ctx -> setRequestContext(ctx, requestContext))
                 .block();
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueDAO.java
@@ -64,6 +64,7 @@ public interface AnnotationQueueDAO {
     Mono<Long> removeItems(UUID queueId, Set<UUID> itemIds, UUID projectId);
 
     Mono<Integer> getDistinctAnnotatorCount(UUID itemId, UUID projectId, String entityType,
+            UUID queueId,
             List<String> feedbackDefinitionNames);
 }
 
@@ -198,19 +199,12 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
             WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
                 AND entity_id = :item_id
+                AND source_queue_id = :queue_id
             """;
 
     private static final String COUNT_DISTINCT_ANNOTATORS = """
             SELECT uniqExact(author) AS cnt
             FROM (
-                SELECT last_updated_by AS author
-                FROM feedback_scores FINAL
-                WHERE workspace_id = :workspace_id
-                    AND project_id = :project_id
-                    AND entity_type = :entity_type
-                    AND entity_id = :item_id
-                    AND name IN :feedback_names
-                UNION ALL
                 SELECT author
                 FROM authored_feedback_scores
                 WHERE workspace_id = :workspace_id
@@ -218,12 +212,14 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                     AND entity_type = :entity_type
                     AND entity_id = :item_id
                     AND name IN :feedback_names
+                    AND source_queue_id = :queue_id
                 UNION ALL
                 SELECT created_by AS author
                 FROM comments
                 WHERE workspace_id = :workspace_id
                     AND project_id = :project_id
                     AND entity_id = :item_id
+                    AND source_queue_id = :queue_id
             )
             """;
 
@@ -285,7 +281,8 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                        value,
                        created_by,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM (
                     SELECT workspace_id,
                            project_id,
@@ -294,7 +291,8 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                            value,
                            created_by,
                            last_updated_at,
-                           last_updated_by AS author
+                           last_updated_by AS author,
+                           CAST(NULL AS Nullable(FixedString(36))) AS source_queue_id
                     FROM feedback_scores
                     WHERE workspace_id = :workspace_id
                         AND project_id IN (SELECT project_id FROM queues_final)
@@ -308,7 +306,8 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                         value,
                         created_by,
                         last_updated_at,
-                        author
+                        author,
+                        source_queue_id
                     FROM authored_feedback_scores
                     WHERE workspace_id = :workspace_id
                        AND project_id IN (SELECT project_id FROM queues_final)
@@ -320,21 +319,17 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                 SELECT entity_id,
                        name,
                        value,
-                       created_by
+                       created_by,
+                       source_queue_id
                 FROM feedback_scores_deduped
-            ), feedback_scores_grouped AS (
+            ), feedback_scores_per_item AS (
                 SELECT
                     entity_id,
                     name,
-                    groupArray(value) AS values
+                    source_queue_id,
+                    toDecimal64(avg(value), 9) AS value
                 FROM feedback_scores_combined
-                GROUP BY entity_id, name
-            ), feedback_scores_final AS (
-                SELECT
-                    entity_id,
-                    name,
-                    IF(length(values) = 1, arrayElement(values, 1), toDecimal64(arrayAvg(values), 9)) AS value
-                FROM feedback_scores_grouped
+                GROUP BY entity_id, name, source_queue_id
             ), feedback_scores_agg AS (
                 SELECT
                     fs_avg.queue_id,
@@ -348,17 +343,19 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                         fs.name,
                         avg(fs.value) AS avg_value
                     FROM queue_items_final AS qi
-                    INNER JOIN feedback_scores_final AS fs
+                    INNER JOIN feedback_scores_per_item AS fs
                       ON fs.entity_id = qi.item_id
                     WHERE length(fs.name) > 0
                       AND has(qi.feedback_definitions, fs.name)  -- only names defined for this queue
+                      AND fs.source_queue_id = qi.queue_id
                     GROUP BY qi.queue_id, fs.name
                 ) as fs_avg
                 GROUP BY queue_id
             ), comments_combined AS (
                 SELECT DISTINCT
                     entity_id,
-                    created_by
+                    created_by,
+                    source_queue_id
                 FROM comments FINAL
                 WHERE workspace_id = :workspace_id
                     AND project_id IN (SELECT project_id FROM queues_final)
@@ -372,7 +369,8 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                 INNER JOIN feedback_scores_combined AS fsc
                  ON fsc.entity_id = qi.item_id
                 WHERE length(qi.feedback_definitions) > 0
-                  AND has(qi.feedback_definitions, fsc.name)  -- only names defined for this queue
+                  AND has(qi.feedback_definitions, fsc.name) -- only names defined for this queue
+                  AND fsc.source_queue_id = qi.queue_id
             ), queue_items_with_comment_reviewers AS (
                 SELECT DISTINCT
                     qi.queue_id,
@@ -382,6 +380,7 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                 INNER JOIN comments_combined AS c
                  ON c.entity_id = qi.item_id
                 WHERE length(c.created_by) > 0
+                  AND c.source_queue_id = qi.queue_id
             ), queue_items_with_reviewers AS (
                 SELECT queue_id, item_id, username
                 FROM queue_items_with_feedback_reviewers
@@ -784,7 +783,8 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
 
     @Override
     public Mono<Integer> getDistinctAnnotatorCount(@NonNull UUID itemId, @NonNull UUID projectId,
-            @NonNull String entityType, List<String> feedbackDefinitionNames) {
+            @NonNull String entityType, @NonNull UUID queueId,
+            List<String> feedbackDefinitionNames) {
         var query = CollectionUtils.isEmpty(feedbackDefinitionNames)
                 ? COUNT_DISTINCT_COMMENT_AUTHORS
                 : COUNT_DISTINCT_ANNOTATORS;
@@ -793,7 +793,8 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                 .flatMapMany(connection -> {
                     var statement = connection.createStatement(query)
                             .bind("item_id", itemId)
-                            .bind("project_id", projectId);
+                            .bind("project_id", projectId)
+                            .bind("queue_id", queueId.toString());
 
                     if (!CollectionUtils.isEmpty(feedbackDefinitionNames)) {
                         statement.bind("entity_type", entityType);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueDAO.java
@@ -292,7 +292,7 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                            created_by,
                            last_updated_at,
                            last_updated_by AS author,
-                           CAST(NULL AS Nullable(FixedString(36))) AS source_queue_id
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE workspace_id = :workspace_id
                         AND project_id IN (SELECT project_id FROM queues_final)
@@ -314,7 +314,7 @@ class AnnotationQueueDAOImpl implements AnnotationQueueDAO {
                        AND entity_id IN (SELECT item_id FROM queue_items_final)
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_combined AS (
                 SELECT entity_id,
                        name,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueService.java
@@ -187,6 +187,7 @@ class AnnotationQueueServiceImpl implements AnnotationQueueService {
                     .flatMap(queue -> annotationQueueDAO.getDistinctAnnotatorCount(
                             itemId, queue.projectId(),
                             queue.scope().getValue(),
+                            queueId,
                             queue.feedbackDefinitionNames())
                             .map(scoredCount -> Map.entry(queue, scoredCount)))
                     .flatMap(entry -> lockService.tryLock(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CommentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CommentDAO.java
@@ -66,6 +66,7 @@ class CommentDAOImpl implements CommentDAO {
                 project_id,
                 workspace_id,
                 text,
+                source_queue_id,
                 created_by,
                 last_updated_by
             )
@@ -77,6 +78,7 @@ class CommentDAOImpl implements CommentDAO {
                  :project_id,
                  :workspace_id,
                  :text,
+                 :source_queue_id,
                  :user_name,
                  :user_name
             )
@@ -97,7 +99,7 @@ class CommentDAOImpl implements CommentDAO {
 
     private static final String UPDATE = """
             INSERT INTO comments (
-            	id, entity_id, entity_type, project_id, workspace_id, text, created_at, created_by, last_updated_by
+            	id, entity_id, entity_type, project_id, workspace_id, text, source_queue_id, created_at, created_by, last_updated_by
             )
             SELECT
             	id,
@@ -106,6 +108,7 @@ class CommentDAOImpl implements CommentDAO {
             	project_id,
             	workspace_id,
             	:text as text,
+            	source_queue_id,
             	created_at,
             	created_by,
                 :user_name as last_updated_by
@@ -263,5 +266,11 @@ class CommentDAOImpl implements CommentDAO {
                 .bind("entity_type", entityType.getType())
                 .bind("project_id", projectId)
                 .bind("text", comment.text());
+
+        if (comment.sourceQueueId() != null) {
+            statement.bind("source_queue_id", comment.sourceQueueId().toString());
+        } else {
+            statement.bindNull("source_queue_id", String.class);
+        }
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CommentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CommentDAO.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -267,10 +268,7 @@ class CommentDAOImpl implements CommentDAO {
                 .bind("project_id", projectId)
                 .bind("text", comment.text());
 
-        if (comment.sourceQueueId() != null) {
-            statement.bind("source_queue_id", comment.sourceQueueId().toString());
-        } else {
-            statement.bindNull("source_queue_id", String.class);
-        }
+        statement.bind("source_queue_id",
+                Optional.ofNullable(comment.sourceQueueId()).map(UUID::toString).orElse(""));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
@@ -371,11 +371,8 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
 
             if (author != null) {
                 statement.bind("author" + i, getValueOrDefault(author));
-                if (feedbackScoreBatchItem.sourceQueueId() != null) {
-                    statement.bind("source_queue_id" + i, feedbackScoreBatchItem.sourceQueueId().toString());
-                } else {
-                    statement.bindNull("source_queue_id" + i, String.class);
-                }
+                statement.bind("source_queue_id" + i,
+                        Optional.ofNullable(feedbackScoreBatchItem.sourceQueueId()).map(UUID::toString).orElse(""));
             }
         }
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
@@ -88,6 +88,7 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
                 reason,
                 source,
                 <if(author)>author,<endif>
+                <if(author)>source_queue_id,<endif>
                 created_by,
                 last_updated_by
             )
@@ -105,6 +106,7 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
                          :reason<item.index>,
                          :source<item.index>,
                          <if(author)>:author<item.index>,<endif>
+                         <if(author)>:source_queue_id<item.index>,<endif>
                          :user_name,
                          :user_name
                      )
@@ -369,6 +371,11 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
 
             if (author != null) {
                 statement.bind("author" + i, getValueOrDefault(author));
+                if (feedbackScoreBatchItem.sourceQueueId() != null) {
+                    statement.bind("source_queue_id" + i, feedbackScoreBatchItem.sourceQueueId().toString());
+                } else {
+                    statement.bindNull("source_queue_id" + i, String.class);
+                }
             }
         }
     }
@@ -379,46 +386,36 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
 
         return asyncTemplate.nonTransaction(connection -> makeMonoContextAware((userName, workspaceId) -> {
 
-            // Delete from feedback_scores table
+            // Delete from feedback_scores table — scope by current user via last_updated_by
             var deleteFeedbackScore = getSTWithLogComment(DELETE_FEEDBACK_SCORE, "delete_feedback_score", workspaceId,
                     userName, "")
-                    .add("table_name", "feedback_scores");
-
-            if (StringUtils.isNotBlank(score.author())) {
-                deleteFeedbackScore.add("author", "last_updated_by");
-            }
+                    .add("table_name", "feedback_scores")
+                    .add("author", "last_updated_by");
 
             var statement1 = connection.createStatement(deleteFeedbackScore.render());
             statement1
                     .bind("entity_id", id)
                     .bind("entity_type", entityType.getType())
                     .bind("name", score.name())
-                    .bind("workspace_id", workspaceId);
-
-            if (StringUtils.isNotBlank(score.author())) {
-                statement1.bind("author", score.author());
-            }
+                    .bind("workspace_id", workspaceId)
+                    .bind("author", userName);
 
             var deleteNonAuthoredOperation = Mono.from(statement1.execute())
                     .flatMap(result -> Mono.from(result.getRowsUpdated()));
 
-            // Delete from authored_feedback_scores table
+            // Delete from authored_feedback_scores table — always scope by current user
             var deleteAuthoredFeedbackScore = getSTWithLogComment(DELETE_FEEDBACK_SCORE,
                     "delete_authored_feedback_score", workspaceId, userName, "")
-                    .add("table_name", "authored_feedback_scores");
-            Optional.ofNullable(score.author())
-                    .filter(StringUtils::isNotBlank)
-                    .ifPresent(author -> deleteAuthoredFeedbackScore.add("author", "author"));
+                    .add("table_name", "authored_feedback_scores")
+                    .add("author", "author");
 
             var statement2 = connection.createStatement(deleteAuthoredFeedbackScore.render());
             statement2
                     .bind("entity_id", id)
                     .bind("entity_type", entityType.getType())
                     .bind("name", score.name())
-                    .bind("workspace_id", workspaceId);
-            Optional.ofNullable(score.author())
-                    .filter(StringUtils::isNotBlank)
-                    .ifPresent(author -> statement2.bind("author", author));
+                    .bind("workspace_id", workspaceId)
+                    .bind("author", userName);
 
             return deleteNonAuthoredOperation
                     .then(Mono.from(statement2.execute()))
@@ -449,46 +446,36 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
 
         return asyncTemplate.nonTransaction(connection -> makeMonoContextAware((userName, workspaceId) -> {
 
-            // Delete from feedback_scores table
+            // Delete from feedback_scores table — scope by current user via last_updated_by
             var template1 = getSTWithLogComment(DELETE_FEEDBACK_SCORE_BY_ENTITY_IDS,
                     "delete_feedback_scores_by_entity_ids", workspaceId, userName, names.size());
             template1.add("names", names);
             template1.add("table_name", "feedback_scores");
-
-            if (StringUtils.isNotBlank(author)) {
-                template1.add("author", "last_updated_by");
-            }
+            template1.add("author", "last_updated_by");
 
             var statement1 = connection.createStatement(template1.render())
                     .bind("entity_ids", Set.of(entityId))
                     .bind("entity_type", entityType.getType())
                     .bind("names", names)
-                    .bind("workspace_id", workspaceId);
-
-            if (StringUtils.isNotBlank(author)) {
-                statement1.bind("author", author);
-            }
+                    .bind("workspace_id", workspaceId)
+                    .bind("author", userName);
 
             var deleteNonAuthoredOperation = Mono.from(statement1.execute())
                     .flatMap(result -> Mono.from(result.getRowsUpdated()));
 
-            // Delete from authored_feedback_scores table
+            // Delete from authored_feedback_scores table — always scope by current user
             var template2 = getSTWithLogComment(DELETE_FEEDBACK_SCORE_BY_ENTITY_IDS,
                     "delete_authored_feedback_scores_by_entity_ids", workspaceId, userName, names.size());
             template2.add("names", names);
             template2.add("table_name", "authored_feedback_scores");
-            Optional.ofNullable(author)
-                    .filter(StringUtils::isNotBlank)
-                    .ifPresent(a -> template2.add("author", "author"));
+            template2.add("author", "author");
 
             var statement2 = connection.createStatement(template2.render())
                     .bind("entity_ids", Set.of(entityId))
                     .bind("entity_type", entityType.getType())
                     .bind("names", names)
-                    .bind("workspace_id", workspaceId);
-            Optional.ofNullable(author)
-                    .filter(StringUtils::isNotBlank)
-                    .ifPresent(a -> statement2.bind("author", a));
+                    .bind("workspace_id", workspaceId)
+                    .bind("author", userName);
 
             return deleteNonAuthoredOperation
                     .then(Mono.from(statement2.execute()))

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
@@ -46,7 +46,8 @@ public interface FeedbackScoreDAO {
 
     Mono<Void> deleteByEntityIds(EntityType entityType, Set<UUID> entityIds, UUID projectId);
 
-    Mono<Long> deleteByEntityIdAndNames(EntityType entityType, UUID entityId, Set<String> names, String author);
+    Mono<Long> deleteByEntityIdAndNames(EntityType entityType, UUID entityId, Set<String> names, String author,
+            UUID sourceQueueId);
 
     Mono<Long> scoreBatchOf(EntityType entityType, List<? extends FeedbackScoreItem> scores, @Nullable String author);
 
@@ -124,6 +125,7 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
             AND name = :name
             AND workspace_id = :workspace_id
             <if(author)>AND <author> = :author<endif>
+            <if(source_queue_id)>AND source_queue_id = :source_queue_id<endif>
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
@@ -153,6 +155,7 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
             <if(names)>AND name IN :names <endif>
             <if(project_id)>AND project_id = :project_id<endif>
             <if(sources)>AND source IN :sources<endif>
+            <if(source_queue_id)>AND source_queue_id = :source_queue_id<endif>
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
@@ -400,11 +403,14 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
             var deleteNonAuthoredOperation = Mono.from(statement1.execute())
                     .flatMap(result -> Mono.from(result.getRowsUpdated()));
 
-            // Delete from authored_feedback_scores table — always scope by current user
             var deleteAuthoredFeedbackScore = getSTWithLogComment(DELETE_FEEDBACK_SCORE,
                     "delete_authored_feedback_score", workspaceId, userName, "")
                     .add("table_name", "authored_feedback_scores")
                     .add("author", "author");
+
+            if (score.sourceQueueId() != null) {
+                deleteAuthoredFeedbackScore.add("source_queue_id", "source_queue_id");
+            }
 
             var statement2 = connection.createStatement(deleteAuthoredFeedbackScore.render());
             statement2
@@ -413,6 +419,10 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
                     .bind("name", score.name())
                     .bind("workspace_id", workspaceId)
                     .bind("author", userName);
+
+            if (score.sourceQueueId() != null) {
+                statement2.bind("source_queue_id", score.sourceQueueId().toString());
+            }
 
             return deleteNonAuthoredOperation
                     .then(Mono.from(statement2.execute()))
@@ -435,7 +445,7 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
 
     @Override
     public Mono<Long> deleteByEntityIdAndNames(@NonNull EntityType entityType, @NonNull UUID entityId,
-            @NonNull Set<String> names, String author) {
+            @NonNull Set<String> names, String author, UUID sourceQueueId) {
 
         if (names.isEmpty()) {
             return Mono.just(0L);
@@ -466,6 +476,9 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
             template2.add("names", names);
             template2.add("table_name", "authored_feedback_scores");
             template2.add("author", "author");
+            if (sourceQueueId != null) {
+                template2.add("source_queue_id", "source_queue_id");
+            }
 
             var statement2 = connection.createStatement(template2.render())
                     .bind("entity_ids", Set.of(entityId))
@@ -473,6 +486,9 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
                     .bind("names", names)
                     .bind("workspace_id", workspaceId)
                     .bind("author", userName);
+            if (sourceQueueId != null) {
+                statement2.bind("source_queue_id", sourceQueueId.toString());
+            }
 
             return deleteNonAuthoredOperation
                     .then(Mono.from(statement2.execute()))

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
@@ -386,27 +386,34 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
 
         return asyncTemplate.nonTransaction(connection -> makeMonoContextAware((userName, workspaceId) -> {
 
-            // Delete from feedback_scores table — scope by current user via last_updated_by
             var deleteFeedbackScore = getSTWithLogComment(DELETE_FEEDBACK_SCORE, "delete_feedback_score", workspaceId,
                     userName, "")
-                    .add("table_name", "feedback_scores")
-                    .add("author", "last_updated_by");
+                    .add("table_name", "feedback_scores");
+
+            if (StringUtils.isNotBlank(score.author())) {
+                deleteFeedbackScore.add("author", "last_updated_by");
+            }
 
             var statement1 = connection.createStatement(deleteFeedbackScore.render());
             statement1
                     .bind("entity_id", id)
                     .bind("entity_type", entityType.getType())
                     .bind("name", score.name())
-                    .bind("workspace_id", workspaceId)
-                    .bind("author", userName);
+                    .bind("workspace_id", workspaceId);
+
+            if (StringUtils.isNotBlank(score.author())) {
+                statement1.bind("author", score.author());
+            }
 
             var deleteNonAuthoredOperation = Mono.from(statement1.execute())
                     .flatMap(result -> Mono.from(result.getRowsUpdated()));
 
             var deleteAuthoredFeedbackScore = getSTWithLogComment(DELETE_FEEDBACK_SCORE,
                     "delete_authored_feedback_score", workspaceId, userName, "")
-                    .add("table_name", "authored_feedback_scores")
-                    .add("author", "author");
+                    .add("table_name", "authored_feedback_scores");
+            Optional.ofNullable(score.author())
+                    .filter(StringUtils::isNotBlank)
+                    .ifPresent(author -> deleteAuthoredFeedbackScore.add("author", "author"));
 
             if (score.sourceQueueId() != null) {
                 deleteAuthoredFeedbackScore.add("source_queue_id", "source_queue_id");
@@ -417,8 +424,10 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
                     .bind("entity_id", id)
                     .bind("entity_type", entityType.getType())
                     .bind("name", score.name())
-                    .bind("workspace_id", workspaceId)
-                    .bind("author", userName);
+                    .bind("workspace_id", workspaceId);
+            Optional.ofNullable(score.author())
+                    .filter(StringUtils::isNotBlank)
+                    .ifPresent(author -> statement2.bind("author", author));
 
             if (score.sourceQueueId() != null) {
                 statement2.bind("source_queue_id", score.sourceQueueId().toString());
@@ -453,29 +462,35 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
 
         return asyncTemplate.nonTransaction(connection -> makeMonoContextAware((userName, workspaceId) -> {
 
-            // Delete from feedback_scores table — scope by current user via last_updated_by
             var template1 = getSTWithLogComment(DELETE_FEEDBACK_SCORE_BY_ENTITY_IDS,
                     "delete_feedback_scores_by_entity_ids", workspaceId, userName, names.size());
             template1.add("names", names);
             template1.add("table_name", "feedback_scores");
-            template1.add("author", "last_updated_by");
+
+            if (StringUtils.isNotBlank(author)) {
+                template1.add("author", "last_updated_by");
+            }
 
             var statement1 = connection.createStatement(template1.render())
                     .bind("entity_ids", Set.of(entityId))
                     .bind("entity_type", entityType.getType())
                     .bind("names", names)
-                    .bind("workspace_id", workspaceId)
-                    .bind("author", userName);
+                    .bind("workspace_id", workspaceId);
+
+            if (StringUtils.isNotBlank(author)) {
+                statement1.bind("author", author);
+            }
 
             var deleteNonAuthoredOperation = Mono.from(statement1.execute())
                     .flatMap(result -> Mono.from(result.getRowsUpdated()));
 
-            // Delete from authored_feedback_scores table — always scope by current user
             var template2 = getSTWithLogComment(DELETE_FEEDBACK_SCORE_BY_ENTITY_IDS,
                     "delete_authored_feedback_scores_by_entity_ids", workspaceId, userName, names.size());
             template2.add("names", names);
             template2.add("table_name", "authored_feedback_scores");
-            template2.add("author", "author");
+            Optional.ofNullable(author)
+                    .filter(StringUtils::isNotBlank)
+                    .ifPresent(a -> template2.add("author", "author"));
             if (sourceQueueId != null) {
                 template2.add("source_queue_id", "source_queue_id");
             }
@@ -484,8 +499,10 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
                     .bind("entity_ids", Set.of(entityId))
                     .bind("entity_type", entityType.getType())
                     .bind("names", names)
-                    .bind("workspace_id", workspaceId)
-                    .bind("author", userName);
+                    .bind("workspace_id", workspaceId);
+            Optional.ofNullable(author)
+                    .filter(StringUtils::isNotBlank)
+                    .ifPresent(a -> statement2.bind("author", a));
             if (sourceQueueId != null) {
                 statement2.bind("source_queue_id", sourceQueueId.toString());
             }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
@@ -66,7 +66,8 @@ public interface FeedbackScoreService {
 
     Mono<Void> scoreBatchOfThreads(List<FeedbackScoreBatchItemThread> scores);
 
-    Mono<Void> deleteThreadScores(String projectName, String threadId, Set<String> names, String author);
+    Mono<Void> deleteThreadScores(String projectName, String threadId, Set<String> names, String author,
+            UUID sourceQueueId);
 
     Mono<FeedbackScoreNames> getTraceThreadsFeedbackScoreNames(UUID projectId);
 
@@ -322,7 +323,7 @@ class FeedbackScoreServiceImpl implements FeedbackScoreService {
 
     @Override
     public Mono<Void> deleteThreadScores(@NonNull String projectName, @NonNull String threadId,
-            @NonNull Set<String> names, String author) {
+            @NonNull Set<String> names, String author, UUID sourceQueueId) {
         Preconditions.checkArgument(!StringUtils.isBlank(projectName), "Project name cannot be blank");
         Preconditions.checkArgument(!StringUtils.isBlank(threadId), "Thread ID cannot be blank");
 
@@ -335,7 +336,7 @@ class FeedbackScoreServiceImpl implements FeedbackScoreService {
         return getProject(projectName)
                 .flatMap(projectId -> traceThreadService.getThreadModelId(projectId, threadId)
                         .flatMap(threadModelId -> dao.deleteByEntityIdAndNames(EntityType.THREAD, threadModelId, names,
-                                author))
+                                author, sourceQueueId))
                         .switchIfEmpty(Mono.defer(() -> {
                             log.info("ThreadId '{}' not found in project '{}'. No scores deleted.", threadId,
                                     projectId);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
@@ -60,6 +60,7 @@ public interface ThreadDAO {
 @Slf4j
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
+// TODO: after v1 drop, remove annotation_queue_filters conditions and keep only annotation_queue_id
 class ThreadDAOImpl implements ThreadDAO {
 
     private static final String THREAD_SEARCH_CLAUSE = """
@@ -229,6 +230,7 @@ class ThreadDAOImpl implements ThreadDAO {
                        AND workspace_id = :workspace_id
                        AND project_id IN :project_id
                        AND entity_id IN (SELECT thread_model_id FROM trace_threads_final)
+                       <if(annotation_queue_id)>AND source_queue_id = :annotation_queue_id<endif>
                 )
                 ORDER BY last_updated_at DESC
                 LIMIT 1 BY workspace_id, project_id, entity_id, name, author
@@ -300,6 +302,7 @@ class ThreadDAOImpl implements ThreadDAO {
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
                 AND entity_id IN (SELECT thread_model_id FROM trace_threads_final)
+                <if(annotation_queue_id)>AND source_queue_id = :annotation_queue_id<endif>
                 ORDER BY (workspace_id, project_id, entity_id, id) DESC, last_updated_at DESC
                 LIMIT 1 BY id
               )
@@ -393,7 +396,7 @@ class ThreadDAOImpl implements ThreadDAO {
                 AND t.id = tt.thread_id
             LEFT JOIN feedback_scores_agg fsagg ON fsagg.entity_id = tt.thread_model_id
             LEFT JOIN comments_final c ON c.entity_id = tt.thread_model_id
-            <if(annotation_queue_filters)>
+            <if(annotation_queue_filters || annotation_queue_id)>
             LEFT JOIN thread_annotation_queue_ids as ttaqi ON ttaqi.thread_id = tt.thread_model_id
             <endif>
             WHERE workspace_id = :workspace_id
@@ -420,6 +423,7 @@ class ThreadDAOImpl implements ThreadDAO {
             <endif>
             <if(trace_thread_filters)>AND<trace_thread_filters><endif>
             <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>
+            <if(annotation_queue_id)> AND has(ttaqi.annotation_queue_ids, :annotation_queue_id) <endif>
             <if(last_retrieved_id)> AND thread_model_id > :last_retrieved_id<endif>
             <if(stream)>
             ORDER BY workspace_id, project_id, thread_model_id DESC
@@ -552,6 +556,7 @@ class ThreadDAOImpl implements ThreadDAO {
                        AND workspace_id = :workspace_id
                        AND project_id = :project_id
                        AND entity_id IN (SELECT thread_model_id FROM trace_threads_final)
+                       <if(annotation_queue_id)>AND source_queue_id = :annotation_queue_id<endif>
                 )
                 ORDER BY last_updated_at DESC
                 LIMIT 1 BY workspace_id, project_id, entity_id, name, author
@@ -686,6 +691,7 @@ class ThreadDAOImpl implements ThreadDAO {
                 <endif>
                 <if(trace_thread_filters)>AND<trace_thread_filters><endif>
                 <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>
+            <if(annotation_queue_id)> AND has(ttaqi.annotation_queue_ids, :annotation_queue_id) <endif>
             ) AS t
             SETTINGS log_comment = '<log_comment>'
             """;
@@ -1120,6 +1126,7 @@ class ThreadDAOImpl implements ThreadDAO {
                            AND workspace_id = :workspace_id
                            AND project_id IN :project_id
                            AND entity_id IN (SELECT thread_model_id FROM trace_threads_final)
+                           <if(annotation_queue_id)>AND source_queue_id = :annotation_queue_id<endif>
                     )
                     ORDER BY last_updated_at DESC
                     LIMIT 1 BY workspace_id, project_id, entity_id, name, author
@@ -1263,6 +1270,7 @@ class ThreadDAOImpl implements ThreadDAO {
                 <endif>
                 <if(trace_thread_filters)>AND<trace_thread_filters><endif>
                 <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>
+                <if(annotation_queue_id)> AND has(ttaqi.annotation_queue_ids, :annotation_queue_id) <endif>
             ) AS threads
             GROUP BY threads.workspace_id, threads.project_id
             SETTINGS log_comment = '<log_comment>'

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -180,6 +180,7 @@ public interface TraceDAO {
 @Slf4j
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
+// TODO: after v1 drop, remove annotation_queue_filters conditions and keep only annotation_queue_id
 class TraceDAOImpl implements TraceDAO {
 
     private static final String TRACE_SEARCH_CLAUSE = """
@@ -894,6 +895,7 @@ class TraceDAOImpl implements TraceDAO {
                     WHERE entity_type = 'trace'
                       AND workspace_id = :workspace_id
                       AND project_id = :project_id
+                      <if(annotation_queue_id)>AND source_queue_id = :annotation_queue_id<endif>
                       <if(trace_id_prefilter)> AND entity_id IN (SELECT id FROM trace_id_prefilter)
                       <else>
                       <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
@@ -1153,6 +1155,7 @@ class TraceDAOImpl implements TraceDAO {
                     FROM comments
                     WHERE workspace_id = :workspace_id
                     AND project_id = :project_id
+                    <if(annotation_queue_id)>AND source_queue_id = :annotation_queue_id<endif>
                     <if(trace_id_prefilter)> AND entity_id IN (SELECT id FROM trace_id_prefilter)
                     <else>
                     <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
@@ -1251,7 +1254,7 @@ class TraceDAOImpl implements TraceDAO {
                 <if(span_feedback_scores_empty_filters)>
                 LEFT JOIN sfsc ON sfsc.trace_id = t.id
                 <endif>
-                <if(annotation_queue_filters)>
+                <if(annotation_queue_filters || annotation_queue_id)>
                 LEFT JOIN trace_annotation_queue_ids as taqi ON taqi.trace_id = t.id
                 <endif>
                 WHERE workspace_id = :workspace_id
@@ -1262,6 +1265,7 @@ class TraceDAOImpl implements TraceDAO {
                 <if(filters)> AND <filters> <endif>
                 <if(search_text)> AND <search_text> <endif>
                 <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>
+                <if(annotation_queue_id)> AND has(taqi.annotation_queue_ids, :annotation_queue_id) <endif>
                 <if(feedback_scores_filters)>
                  AND id IN (
                     SELECT entity_id
@@ -1440,6 +1444,7 @@ class TraceDAOImpl implements TraceDAO {
                      WHERE entity_type = 'trace'
                        AND workspace_id = :workspace_id
                        AND project_id = :project_id
+                       <if(annotation_queue_id)>AND source_queue_id = :annotation_queue_id<endif>
                        <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
                        <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
                 )
@@ -1647,7 +1652,7 @@ class TraceDAOImpl implements TraceDAO {
                     <if(span_feedback_scores_empty_filters)>
                     LEFT JOIN sfsc ON sfsc.trace_id = traces.id
                     <endif>
-                    <if(annotation_queue_filters)>
+                    <if(annotation_queue_filters || annotation_queue_id)>
                     LEFT JOIN trace_annotation_queue_ids as taqi ON taqi.trace_id = traces.id
                     <endif>
                     WHERE project_id = :project_id
@@ -1657,6 +1662,7 @@ class TraceDAOImpl implements TraceDAO {
                     <if(filters)> AND <filters> <endif>
                     <if(search_text)> AND <search_text> <endif>
                     <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>
+                    <if(annotation_queue_id)> AND has(taqi.annotation_queue_ids, :annotation_queue_id) <endif>
                     <if(feedback_scores_filters)>
                     AND id IN (
                         SELECT entity_id
@@ -2053,6 +2059,7 @@ class TraceDAOImpl implements TraceDAO {
                     WHERE entity_type = 'trace'
                        AND workspace_id = :workspace_id
                        AND project_id IN :project_ids
+                       <if(annotation_queue_id)>AND source_queue_id = :annotation_queue_id<endif>
                        <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
                        <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
                 )
@@ -2299,7 +2306,7 @@ class TraceDAOImpl implements TraceDAO {
                 <if(span_feedback_scores_empty_filters)>
                 LEFT JOIN sfsc ON sfsc.trace_id = traces.id
                 <endif>
-                <if(annotation_queue_filters)>
+                <if(annotation_queue_filters || annotation_queue_id)>
                 LEFT JOIN trace_annotation_queue_ids as taqi ON taqi.trace_id = traces.id
                 <endif>
                 WHERE workspace_id = :workspace_id
@@ -2309,6 +2316,7 @@ class TraceDAOImpl implements TraceDAO {
                 <if(filters)> AND <filters> <endif>
                 <if(search_text)> AND <search_text> <endif>
                 <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>
+                <if(annotation_queue_id)> AND has(taqi.annotation_queue_ids, :annotation_queue_id) <endif>
                 <if(feedback_scores_filters)>
                 AND id IN (
                     SELECT entity_id
@@ -2480,6 +2488,7 @@ class TraceDAOImpl implements TraceDAO {
                     WHERE entity_type = 'trace'
                        AND workspace_id = :workspace_id
                        AND project_id IN :project_ids
+                       <if(annotation_queue_id)>AND source_queue_id = :annotation_queue_id<endif>
                        <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
                        <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
                 )
@@ -2640,7 +2649,7 @@ class TraceDAOImpl implements TraceDAO {
                 <if(span_feedback_scores_empty_filters)>
                 LEFT JOIN sfsc ON sfsc.trace_id = traces.id
                 <endif>
-                <if(annotation_queue_filters)>
+                <if(annotation_queue_filters || annotation_queue_id)>
                 LEFT JOIN trace_annotation_queue_ids as taqi ON taqi.trace_id = traces.id
                 <endif>
                 WHERE workspace_id = :workspace_id
@@ -2650,6 +2659,7 @@ class TraceDAOImpl implements TraceDAO {
                 <if(filters)> AND <filters> <endif>
                 <if(search_text)> AND <search_text> <endif>
                 <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>
+                <if(annotation_queue_id)> AND has(taqi.annotation_queue_ids, :annotation_queue_id) <endif>
                 <if(feedback_scores_filters)>
                 AND id IN (
                     SELECT entity_id
@@ -3939,6 +3949,7 @@ class TraceDAOImpl implements TraceDAO {
         return template.getAttribute("filters") != null
                 || template.getAttribute("search_text") != null
                 || template.getAttribute("annotation_queue_filters") != null
+                || template.getAttribute("annotation_queue_id") != null
                 || template.getAttribute("feedback_scores_filters") != null
                 || template.getAttribute("span_feedback_scores_filters") != null
                 || template.getAttribute("trace_aggregation_filters") != null

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceSearchCriteria.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceSearchCriteria.java
@@ -21,5 +21,6 @@ public record TraceSearchCriteria(
         Set<Trace.TraceField> exclude,
         UUID uuidFromTime,
         UUID uuidToTime,
-        String searchText) {
+        String searchText,
+        UUID annotationQueueId) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/FilterUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/FilterUtils.java
@@ -161,7 +161,10 @@ public class FilterUtils {
 
                     findTraceThreadIdPushdownFilter(filters)
                             .ifPresent(idFilter -> template.add("traces_pushdown_filter", true));
+
                 });
+        Optional.ofNullable(traceSearchCriteria.annotationQueueId())
+                .ifPresent(queueId -> template.add("annotation_queue_id", queueId.toString()));
         Optional.ofNullable(traceSearchCriteria.lastReceivedId())
                 .ifPresent(lastReceivedTraceId -> template.add("last_received_id", lastReceivedTraceId));
 
@@ -192,8 +195,10 @@ public class FilterUtils {
 
                     findTraceThreadIdPushdownFilter(filters)
                             .ifPresent(idFilter -> statement.bind("thread_id_pushdown", idFilter.value()));
-                });
 
+                });
+        Optional.ofNullable(traceSearchCriteria.annotationQueueId())
+                .ifPresent(queueId -> statement.bind("annotation_queue_id", queueId.toString()));
         Optional.ofNullable(traceSearchCriteria.lastReceivedId())
                 .ifPresent(lastReceivedTraceId -> statement.bind("last_received_id", lastReceivedTraceId));
         // Bind UUID BETWEEN bounds for time-based filtering

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000090_add_source_queue_id_to_scores_and_comments.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000090_add_source_queue_id_to_scores_and_comments.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+--changeset miguelg:000090_add_source_queue_id_to_scores_and_comments
+--comment: Add source_queue_id to authored_feedback_scores and comments for annotation queue provenance tracking (OPIK-6791)
+
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.authored_feedback_scores ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS source_queue_id Nullable(FixedString(36)) DEFAULT NULL;
+
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.comments ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS source_queue_id Nullable(FixedString(36)) DEFAULT NULL;
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.authored_feedback_scores ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS source_queue_id;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.comments ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS source_queue_id;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000090_add_source_queue_id_to_scores_and_comments.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000090_add_source_queue_id_to_scores_and_comments.sql
@@ -3,10 +3,12 @@
 --comment: Add source_queue_id to authored_feedback_scores and comments for annotation queue provenance tracking (OPIK-6791)
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.authored_feedback_scores ON CLUSTER '{cluster}'
-    ADD COLUMN IF NOT EXISTS source_queue_id Nullable(FixedString(36)) DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS source_queue_id FixedString(36),
+    MODIFY ORDER BY (workspace_id, project_id, entity_type, entity_id, author, name, source_queue_id);
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.comments ON CLUSTER '{cluster}'
-    ADD COLUMN IF NOT EXISTS source_queue_id Nullable(FixedString(36)) DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS source_queue_id FixedString(36);
 
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.authored_feedback_scores ON CLUSTER '{cluster}' MODIFY ORDER BY (workspace_id, project_id, entity_type, entity_id, author, name);
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.authored_feedback_scores ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS source_queue_id;
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.comments ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS source_queue_id;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/ScoreDestinationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/ScoreDestinationTest.java
@@ -37,7 +37,7 @@ class ScoreDestinationTest {
     void feedbackScoreBatchItemDefaultsToFeedbackScores() {
         var item = new FeedbackScoreItem.FeedbackScoreBatchItem(
                 "project", UUID.randomUUID(), "score-name", null,
-                BigDecimal.ONE, null, ScoreSource.ONLINE_SCORING, null, UUID.randomUUID());
+                BigDecimal.ONE, null, ScoreSource.ONLINE_SCORING, null, null, UUID.randomUUID());
 
         assertThat(item.scoreDestination()).isEqualTo(ScoreDestination.FEEDBACK_SCORES);
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/CommentAssertionUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/CommentAssertionUtils.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @UtilityClass
 public class CommentAssertionUtils {
     public static final String[] IGNORED_FIELDS_COMMENTS = {"id", "createdAt", "lastUpdatedAt", "createdBy",
-            "lastUpdatedBy"};
+            "lastUpdatedBy", "sourceQueueId"};
 
     public static void assertComment(Comment expected, Comment actual) {
         assertThat(actual)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/FeedbackScoreAssertionUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/FeedbackScoreAssertionUtils.java
@@ -40,6 +40,7 @@ public class FeedbackScoreAssertionUtils {
                                 .createdAt(null)
                                 .lastUpdatedAt(null)
                                 .valueByAuthor(null)
+                                .sourceQueueId(null)
                                 .build())
                         .toList())
                 .build();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/BaseCommentResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/BaseCommentResourceClient.java
@@ -28,7 +28,15 @@ public abstract class BaseCommentResourceClient {
     protected final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
 
     public Comment generateAndCreateComment(UUID entityId, String apiKey, String workspaceName, int expectedStatus) {
-        Comment comment = Comment.builder().text(podamFactory.manufacturePojo(String.class)).build();
+        return generateAndCreateComment(entityId, null, apiKey, workspaceName, expectedStatus);
+    }
+
+    public Comment generateAndCreateComment(UUID entityId, UUID sourceQueueId, String apiKey, String workspaceName,
+            int expectedStatus) {
+        Comment comment = Comment.builder()
+                .text(podamFactory.manufacturePojo(String.class))
+                .sourceQueueId(sourceQueueId)
+                .build();
         var commentId = createComment(comment, entityId, apiKey, workspaceName, expectedStatus);
 
         return comment.toBuilder().id(commentId).build();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ExperimentTestAssertions.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ExperimentTestAssertions.java
@@ -18,7 +18,7 @@ public class ExperimentTestAssertions {
 
     public static final String[] EXPERIMENT_ITEMS_IGNORED_FIELDS = {"createdAt", "lastUpdatedAt",
             "feedbackScores.createdAt", "feedbackScores.lastUpdatedAt", "comments.createdAt", "comments.lastUpdatedAt",
-            "feedbackScores.valueByAuthor", "projectName"
+            "feedbackScores.valueByAuthor", "feedbackScores.sourceQueueId", "comments.sourceQueueId", "projectName"
     };
 
     // Experiment items returned by the bulk endpoint get server-generated ids/traceId/experimentId, so those

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
@@ -324,8 +324,18 @@ public class TraceResourceClient extends BaseCommentResourceClient {
             String author,
             String apiKey,
             String workspaceName) {
+        deleteThreadFeedbackScores(projectName, threadId, scoreNames, author, null, apiKey, workspaceName);
+    }
+
+    public void deleteThreadFeedbackScores(String projectName,
+            String threadId,
+            Set<String> scoreNames,
+            String author,
+            UUID sourceQueueId,
+            String apiKey,
+            String workspaceName) {
         try (var response = callDeleteThreadFeedbackScores(
-                projectName, threadId, scoreNames, author, apiKey, workspaceName)) {
+                projectName, threadId, scoreNames, author, sourceQueueId, apiKey, workspaceName)) {
             assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
         }
     }
@@ -334,6 +344,16 @@ public class TraceResourceClient extends BaseCommentResourceClient {
             String threadId,
             Set<String> scoreNames,
             String author,
+            String apiKey,
+            String workspaceName) {
+        return callDeleteThreadFeedbackScores(projectName, threadId, scoreNames, author, null, apiKey, workspaceName);
+    }
+
+    public Response callDeleteThreadFeedbackScores(String projectName,
+            String threadId,
+            Set<String> scoreNames,
+            String author,
+            UUID sourceQueueId,
             String apiKey,
             String workspaceName) {
         return client.target(RESOURCE_PATH.formatted(baseURI))
@@ -348,6 +368,7 @@ public class TraceResourceClient extends BaseCommentResourceClient {
                         .threadId(threadId)
                         .names(scoreNames)
                         .author(author)
+                        .sourceQueueId(sourceQueueId)
                         .build()));
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/spans/SpanAssertions.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/spans/SpanAssertions.java
@@ -59,7 +59,7 @@ public class SpanAssertions {
             "totalEstimatedCostVersion", "comments"};
 
     public static final String[] IGNORED_FIELDS_SCORES = {"createdAt", "lastUpdatedAt", "createdBy", "lastUpdatedBy",
-            "valueByAuthor"};
+            "valueByAuthor", "sourceQueueId"};
 
     /**
      * Prepares a span for assertion by injecting provider into metadata if provider is set.

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/traces/TraceAssertions.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/traces/TraceAssertions.java
@@ -30,11 +30,11 @@ public class TraceAssertions {
             "providers", "experiment"};
 
     public static final String[] IGNORED_FIELDS_SCORES = {"createdAt", "lastUpdatedAt", "createdBy", "lastUpdatedBy",
-            "valueByAuthor"};
+            "valueByAuthor", "sourceQueueId"};
 
     private static final String[] IGNORED_FIELDS_THREADS = {"createdAt", "lastUpdatedAt", "createdBy", "lastUpdatedBy",
             "threadModelId", "feedbackScores.createdAt", "feedbackScores.lastUpdatedAt",
-            "feedbackScores.valueByAuthor"};
+            "feedbackScores.valueByAuthor", "feedbackScores.sourceQueueId"};
 
     /**
      * Prepares a trace for assertion by injecting providers into metadata if providers are set.

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResourceTest.java
@@ -696,11 +696,11 @@ class AnnotationQueuesResourceTest {
             annotationQueuesResourceClient.addItemsToAnnotationQueue(
                     annotationQueue.id(), itemIds, API_KEY, TEST_WORKSPACE, HttpStatus.SC_NO_CONTENT);
 
-            // Create feedback scores - some for traces in the queue, some for traces not in the queue
-            createFeedbackScoreForTrace(trace1, "quality", 0.8, project.name());
-            createFeedbackScoreForTrace(trace1, "relevance", 0.9, project.name());
-            createFeedbackScoreForTrace(trace2, "quality", 0.7, project.name());
-            createFeedbackScoreForTrace(trace2, "relevance", 0.85, project.name());
+            // Create feedback scores for traces in the queue, tagged with this queue's source_queue_id
+            createFeedbackScoreForTrace(trace1, "quality", 0.8, project.name(), annotationQueue.id());
+            createFeedbackScoreForTrace(trace1, "relevance", 0.9, project.name(), annotationQueue.id());
+            createFeedbackScoreForTrace(trace2, "quality", 0.7, project.name(), annotationQueue.id());
+            createFeedbackScoreForTrace(trace2, "relevance", 0.85, project.name(), annotationQueue.id());
 
             // Feedback scores for trace3 (NOT in the queue) - should not be aggregated
             createFeedbackScoreForTrace(trace3, "quality", 0.5, project.name());
@@ -738,6 +738,77 @@ class AnnotationQueuesResourceTest {
 
             // Verify reviewers match the original annotation queue
             verifyReviewers(retrievedQueue, 2L);
+        }
+
+        @Test
+        @DisplayName("should scope feedback scores and comments by source_queue_id when two queues share the same items")
+        void getAnnotationQueueScopedBySourceQueueId() {
+            var project = factory.manufacturePojo(Project.class);
+            var projectId = projectResourceClient.createProject(project, API_KEY, TEST_WORKSPACE);
+
+            var queueA = newAnnotationQueue()
+                    .toBuilder()
+                    .projectId(projectId)
+                    .projectName(project.name())
+                    .scope(AnnotationQueue.AnnotationScope.TRACE)
+                    .feedbackDefinitionNames(List.of("quality", "relevance"))
+                    .commentsEnabled(true)
+                    .build();
+
+            var queueB = newAnnotationQueue()
+                    .toBuilder()
+                    .projectId(projectId)
+                    .projectName(project.name())
+                    .scope(AnnotationQueue.AnnotationScope.TRACE)
+                    .feedbackDefinitionNames(List.of("quality", "relevance"))
+                    .commentsEnabled(true)
+                    .build();
+
+            annotationQueuesResourceClient.createAnnotationQueueBatch(
+                    new LinkedHashSet<>(List.of(queueA, queueB)), API_KEY, TEST_WORKSPACE, HttpStatus.SC_NO_CONTENT);
+
+            var trace1 = createTrace(project.name());
+            var trace2 = createTrace(project.name());
+            var itemIds = Set.of(trace1, trace2);
+
+            annotationQueuesResourceClient.addItemsToAnnotationQueue(
+                    queueA.id(), itemIds, API_KEY, TEST_WORKSPACE, HttpStatus.SC_NO_CONTENT);
+            annotationQueuesResourceClient.addItemsToAnnotationQueue(
+                    queueB.id(), itemIds, API_KEY, TEST_WORKSPACE, HttpStatus.SC_NO_CONTENT);
+
+            // Scores: queue A gets 3 scores across 2 traces, queue B gets 1 score on trace1
+            createFeedbackScoreForTrace(trace1, "quality", 0.9, project.name(), queueA.id());
+            createFeedbackScoreForTrace(trace2, "quality", 0.7, project.name(), queueA.id());
+            createFeedbackScoreForTrace(trace1, "relevance", 0.8, project.name(), queueA.id());
+            createFeedbackScoreForTrace(trace1, "quality", 0.3, project.name(), queueB.id());
+
+            // Comments: queue A gets comments on both traces, queue B gets none
+            traceResourceClient.generateAndCreateComment(trace1, queueA.id(), API_KEY, TEST_WORKSPACE,
+                    HttpStatus.SC_CREATED);
+            traceResourceClient.generateAndCreateComment(trace2, queueA.id(), API_KEY, TEST_WORKSPACE,
+                    HttpStatus.SC_CREATED);
+
+            // Queue A: avg quality = (0.9+0.7)/2 = 0.8, avg relevance = 0.8, reviewer scored 2 items + commented 2
+            var retrievedA = annotationQueuesResourceClient.getAnnotationQueueById(
+                    queueA.id(), API_KEY, TEST_WORKSPACE, HttpStatus.SC_OK);
+
+            assertThat(retrievedA.feedbackScores()).hasSize(2);
+            var scoresA = retrievedA.feedbackScores().stream()
+                    .collect(toMap(FeedbackScoreAverage::name, FeedbackScoreAverage::value));
+            assertThat(scoresA.get("quality")).isEqualByComparingTo(new BigDecimal("0.8"));
+            assertThat(scoresA.get("relevance")).isEqualByComparingTo(new BigDecimal("0.8"));
+            verifyReviewers(retrievedA, 2L);
+
+            // Queue B: avg quality = 0.3, no relevance, no comments — reviewer scored 1 item only
+            var retrievedB = annotationQueuesResourceClient.getAnnotationQueueById(
+                    queueB.id(), API_KEY, TEST_WORKSPACE, HttpStatus.SC_OK);
+
+            assertThat(retrievedB.feedbackScores()).hasSize(1);
+            var scoresB = retrievedB.feedbackScores().stream()
+                    .collect(toMap(FeedbackScoreAverage::name, FeedbackScoreAverage::value));
+            assertThat(scoresB.get("quality")).isEqualByComparingTo(new BigDecimal("0.3"));
+            assertThat(scoresB).doesNotContainKey("relevance");
+            verifyReviewers(retrievedB, 1L);
         }
 
         @Test
@@ -787,11 +858,11 @@ class AnnotationQueuesResourceTest {
             annotationQueuesResourceClient.addItemsToAnnotationQueue(
                     annotationQueue.id(), itemIds, API_KEY, TEST_WORKSPACE, HttpStatus.SC_NO_CONTENT);
 
-            // Create thread feedback scores - some for threads in the queue, some for threads not in the queue
-            createFeedbackScoreForThread(threadId1, "coherence", 0.9, project.name());
-            createFeedbackScoreForThread(threadId1, "completeness", 0.8, project.name());
-            createFeedbackScoreForThread(threadId2, "coherence", 0.85, project.name());
-            createFeedbackScoreForThread(threadId2, "completeness", 0.75, project.name());
+            // Create thread feedback scores for threads in the queue, tagged with this queue's source_queue_id
+            createFeedbackScoreForThread(threadId1, "coherence", 0.9, project.name(), annotationQueue.id());
+            createFeedbackScoreForThread(threadId1, "completeness", 0.8, project.name(), annotationQueue.id());
+            createFeedbackScoreForThread(threadId2, "coherence", 0.85, project.name(), annotationQueue.id());
+            createFeedbackScoreForThread(threadId2, "completeness", 0.75, project.name(), annotationQueue.id());
 
             // Feedback scores for threadId3 (NOT in the queue) - should not be aggregated
             createFeedbackScoreForThread(threadId3, "coherence", 0.4, project.name());
@@ -912,8 +983,10 @@ class AnnotationQueuesResourceTest {
                     annotationQueue.id(), itemIds, API_KEY, TEST_WORKSPACE, HttpStatus.SC_NO_CONTENT);
 
             // Add comments to traces (without any feedback scores)
-            traceResourceClient.generateAndCreateComment(trace1, API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
-            traceResourceClient.generateAndCreateComment(trace2, API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+            traceResourceClient.generateAndCreateComment(trace1, annotationQueue.id(), API_KEY, TEST_WORKSPACE,
+                    HttpStatus.SC_CREATED);
+            traceResourceClient.generateAndCreateComment(trace2, annotationQueue.id(), API_KEY, TEST_WORKSPACE,
+                    HttpStatus.SC_CREATED);
 
             // When
             var retrievedQueue = annotationQueuesResourceClient.getAnnotationQueueById(
@@ -962,14 +1035,16 @@ class AnnotationQueuesResourceTest {
                     annotationQueue.id(), itemIds, API_KEY, TEST_WORKSPACE, HttpStatus.SC_NO_CONTENT);
 
             // Add feedback score to trace1
-            createFeedbackScoreForTrace(trace1, "quality", 0.8, project.name());
+            createFeedbackScoreForTrace(trace1, "quality", 0.8, project.name(), annotationQueue.id());
 
             // Add comment to trace2 (no feedback)
-            traceResourceClient.generateAndCreateComment(trace2, API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+            traceResourceClient.generateAndCreateComment(trace2, annotationQueue.id(), API_KEY, TEST_WORKSPACE,
+                    HttpStatus.SC_CREATED);
 
             // Add both feedback and comment to trace3
-            createFeedbackScoreForTrace(trace3, "quality", 0.9, project.name());
-            traceResourceClient.generateAndCreateComment(trace3, API_KEY, TEST_WORKSPACE, HttpStatus.SC_CREATED);
+            createFeedbackScoreForTrace(trace3, "quality", 0.9, project.name(), annotationQueue.id());
+            traceResourceClient.generateAndCreateComment(trace3, annotationQueue.id(), API_KEY, TEST_WORKSPACE,
+                    HttpStatus.SC_CREATED);
 
             // When
             var retrievedQueue = annotationQueuesResourceClient.getAnnotationQueueById(
@@ -1473,11 +1548,15 @@ class AnnotationQueuesResourceTest {
                         annotationQueuesResourceClient.addItemsToAnnotationQueue(
                                 annotationQueue.id(), itemIds, apiKey, workspaceName, HttpStatus.SC_NO_CONTENT);
 
-                        // Create feedback scores - some for traces in the queue, some for traces not in the queue
-                        createFeedbackScoreForTrace(trace1, "quality", 0.8, project.name(), apiKey, workspaceName);
-                        createFeedbackScoreForTrace(trace1, "relevance", 0.9, project.name(), apiKey, workspaceName);
-                        createFeedbackScoreForTrace(trace2, "quality", 0.7, project.name(), apiKey, workspaceName);
-                        createFeedbackScoreForTrace(trace2, "relevance", 0.85, project.name(), apiKey, workspaceName);
+                        // Create feedback scores for traces in the queue, tagged with this queue's source_queue_id
+                        createFeedbackScoreForTrace(trace1, "quality", 0.8, project.name(), annotationQueue.id(),
+                                apiKey, workspaceName);
+                        createFeedbackScoreForTrace(trace1, "relevance", 0.9, project.name(), annotationQueue.id(),
+                                apiKey, workspaceName);
+                        createFeedbackScoreForTrace(trace2, "quality", 0.7, project.name(), annotationQueue.id(),
+                                apiKey, workspaceName);
+                        createFeedbackScoreForTrace(trace2, "relevance", 0.85, project.name(), annotationQueue.id(),
+                                apiKey, workspaceName);
 
                         // Feedback scores for trace3 (NOT in the queue) - should not be aggregated
                         createFeedbackScoreForTrace(trace3, "quality", 0.5, project.name(), apiKey, workspaceName);
@@ -1895,27 +1974,45 @@ class AnnotationQueuesResourceTest {
 
     private void createFeedbackScoreForTrace(UUID traceId, String scoreName, double scoreValue,
             String projectName) {
-        createFeedbackScoreForTrace(traceId, scoreName, scoreValue, projectName, API_KEY, TEST_WORKSPACE);
+        createFeedbackScoreForTrace(traceId, scoreName, scoreValue, projectName, null, API_KEY, TEST_WORKSPACE);
+    }
+
+    private void createFeedbackScoreForTrace(UUID traceId, String scoreName, double scoreValue,
+            String projectName, UUID sourceQueueId) {
+        createFeedbackScoreForTrace(traceId, scoreName, scoreValue, projectName, sourceQueueId, API_KEY,
+                TEST_WORKSPACE);
     }
 
     private void createFeedbackScoreForTrace(UUID traceId, String scoreName, double scoreValue,
             String projectName, String apiKey, String workspaceName) {
+        createFeedbackScoreForTrace(traceId, scoreName, scoreValue, projectName, null, apiKey, workspaceName);
+    }
+
+    private void createFeedbackScoreForTrace(UUID traceId, String scoreName, double scoreValue,
+            String projectName, UUID sourceQueueId, String apiKey, String workspaceName) {
         var feedbackScore = factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
                 .id(traceId)
                 .name(scoreName)
                 .value(BigDecimal.valueOf(scoreValue))
                 .projectName(projectName)
+                .sourceQueueId(sourceQueueId)
                 .build();
         traceResourceClient.feedbackScores(List.of(feedbackScore), apiKey, workspaceName);
     }
 
     private void createFeedbackScoreForThread(UUID threadId, String scoreName, double scoreValue,
             String projectName) {
+        createFeedbackScoreForThread(threadId, scoreName, scoreValue, projectName, null);
+    }
+
+    private void createFeedbackScoreForThread(UUID threadId, String scoreName, double scoreValue,
+            String projectName, UUID sourceQueueId) {
         var feedbackScore = factory.manufacturePojo(FeedbackScoreBatchItemThread.class).toBuilder()
                 .threadId(threadId.toString())
                 .name(scoreName)
                 .value(BigDecimal.valueOf(scoreValue))
                 .projectName(projectName)
+                .sourceQueueId(sourceQueueId)
                 .build();
         traceResourceClient.threadFeedbackScores(List.of(feedbackScore), API_KEY, TEST_WORKSPACE);
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AnnotationQueuesResourceTest.java
@@ -792,22 +792,24 @@ class AnnotationQueuesResourceTest {
             var retrievedA = annotationQueuesResourceClient.getAnnotationQueueById(
                     queueA.id(), API_KEY, TEST_WORKSPACE, HttpStatus.SC_OK);
 
-            assertThat(retrievedA.feedbackScores()).hasSize(2);
-            var scoresA = retrievedA.feedbackScores().stream()
-                    .collect(toMap(FeedbackScoreAverage::name, FeedbackScoreAverage::value));
-            assertThat(scoresA.get("quality")).isEqualByComparingTo(new BigDecimal("0.8"));
-            assertThat(scoresA.get("relevance")).isEqualByComparingTo(new BigDecimal("0.8"));
+            assertThat(retrievedA.feedbackScores())
+                    .usingRecursiveComparison()
+                    .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
+                    .ignoringCollectionOrder()
+                    .isEqualTo(List.of(
+                            FeedbackScoreAverage.builder().name("quality").value(new BigDecimal("0.8")).build(),
+                            FeedbackScoreAverage.builder().name("relevance").value(new BigDecimal("0.8")).build()));
             verifyReviewers(retrievedA, 2L);
 
             // Queue B: avg quality = 0.3, no relevance, no comments — reviewer scored 1 item only
             var retrievedB = annotationQueuesResourceClient.getAnnotationQueueById(
                     queueB.id(), API_KEY, TEST_WORKSPACE, HttpStatus.SC_OK);
 
-            assertThat(retrievedB.feedbackScores()).hasSize(1);
-            var scoresB = retrievedB.feedbackScores().stream()
-                    .collect(toMap(FeedbackScoreAverage::name, FeedbackScoreAverage::value));
-            assertThat(scoresB.get("quality")).isEqualByComparingTo(new BigDecimal("0.3"));
-            assertThat(scoresB).doesNotContainKey("relevance");
+            assertThat(retrievedB.feedbackScores())
+                    .usingRecursiveComparison()
+                    .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
+                    .isEqualTo(List.of(
+                            FeedbackScoreAverage.builder().name("quality").value(new BigDecimal("0.3")).build()));
             verifyReviewers(retrievedB, 1L);
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceCreateFromSpansTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceCreateFromSpansTest.java
@@ -208,6 +208,7 @@ class DatasetsResourceCreateFromSpansTest {
                 null,
                 null,
                 null,
+                null,
                 null);
 
         spanResourceClient.createComment(comment, span1.id(), apiKey, workspaceName, 201);
@@ -324,6 +325,7 @@ class DatasetsResourceCreateFromSpansTest {
         var comment = new Comment(
                 null,
                 "Test comment",
+                null,
                 null,
                 null,
                 null,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceCreateFromTracesTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceCreateFromTracesTest.java
@@ -192,6 +192,7 @@ class DatasetsResourceCreateFromTracesTest {
                 null,
                 null,
                 null,
+                null,
                 null);
 
         traceResourceClient.createComment(comment, trace1.id(), apiKey, workspaceName, 201);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
@@ -277,6 +277,58 @@ class MultiValueFeedbackScoresE2ETest {
     }
 
     @Test
+    @DisplayName("delete trace score scoped by source_queue_id: wrong queue is a no-op, correct queue deletes")
+    void deleteTraceFeedbackScoreScopedBySourceQueueId() {
+        var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                .id(null)
+                .projectName(DEFAULT_PROJECT)
+                .usage(null)
+                .feedbackScores(null)
+                .startTime(Instant.now().truncatedTo(ChronoUnit.HOURS))
+                .build();
+        var traceId = traceResourceClient.createTrace(trace, API_KEY1, TEST_WORKSPACE);
+
+        var queueIdA = randomUUID();
+        var queueIdB = randomUUID();
+
+        // Score from queue A
+        var score = factory.manufacturePojo(FeedbackScore.class).toBuilder()
+                .sourceQueueId(queueIdA)
+                .build();
+        traceResourceClient.feedbackScore(traceId, score, TEST_WORKSPACE, API_KEY1);
+
+        // Verify score is present
+        var actualTrace = traceResourceClient.getById(traceId, TEST_WORKSPACE, API_KEY1);
+        assertThat(actualTrace.feedbackScores()).hasSize(1);
+
+        // Delete scoped to wrong queue B — should be a no-op
+        traceResourceClient.deleteTraceFeedbackScore(
+                DeleteFeedbackScore.builder().name(score.name()).sourceQueueId(queueIdB).build(),
+                traceId, API_KEY1, TEST_WORKSPACE);
+
+        // Score should still be present and match the original
+        actualTrace = traceResourceClient.getById(traceId, TEST_WORKSPACE, API_KEY1);
+        assertThat(actualTrace.feedbackScores()).singleElement().satisfies(actual -> {
+            assertThat(actual)
+                    .usingRecursiveComparison()
+                    .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
+                    .ignoringFields("createdAt", "lastUpdatedAt", "createdBy", "lastUpdatedBy",
+                            "sourceQueueId", "valueByAuthor")
+                    .isEqualTo(score);
+            assertThat(actual.valueByAuthor().keySet()).containsExactly(USER1);
+        });
+
+        // Delete scoped to correct queue A — should remove the score
+        traceResourceClient.deleteTraceFeedbackScore(
+                DeleteFeedbackScore.builder().name(score.name()).sourceQueueId(queueIdA).build(),
+                traceId, API_KEY1, TEST_WORKSPACE);
+
+        // Score should be gone
+        actualTrace = traceResourceClient.getById(traceId, TEST_WORKSPACE, API_KEY1);
+        assertThat(actualTrace.feedbackScores()).isNullOrEmpty();
+    }
+
+    @Test
     @DisplayName("test score span by multiple authors")
     void testScoreSpanByMultipleAuthors() {
         // create spans
@@ -460,6 +512,84 @@ class MultiValueFeedbackScoresE2ETest {
         assertThat(actualThread.feedbackScores()).hasSize(1);
         assertThat(actualThread.feedbackScores().getFirst().valueByAuthor()).hasSize(1);
         assertThat(actualThread.feedbackScores().getFirst().valueByAuthor().keySet()).containsExactly(USER1);
+    }
+
+    @Test
+    @DisplayName("delete thread score scoped by source_queue_id: wrong queue is a no-op, correct queue deletes")
+    void deleteThreadFeedbackScoreScopedBySourceQueueId() {
+        var threadId = randomUUID().toString();
+        var projectName = RandomStringUtils.secure().nextAlphanumeric(10);
+        UUID projectId = projectResourceClient.createProject(projectName, API_KEY1, TEST_WORKSPACE);
+
+        traceResourceClient.openTraceThread(threadId, null, projectName, API_KEY1, TEST_WORKSPACE);
+
+        var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                .id(null)
+                .threadId(threadId)
+                .projectName(projectName)
+                .usage(null)
+                .feedbackScores(null)
+                .startTime(Instant.now().truncatedTo(ChronoUnit.HOURS))
+                .build();
+        traceResourceClient.batchCreateTraces(List.of(trace), API_KEY1, TEST_WORKSPACE);
+        traceResourceClient.closeTraceThread(threadId, null, projectName, API_KEY1, TEST_WORKSPACE);
+
+        Awaitility.await().pollInterval(100, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+            TraceThread thread = traceResourceClient.getTraceThread(threadId, projectId, API_KEY1, TEST_WORKSPACE);
+            assertThat(thread.threadModelId()).isNotNull();
+        });
+
+        var queueIdA = randomUUID();
+        var queueIdB = randomUUID();
+        var score = factory.manufacturePojo(FeedbackScore.class);
+
+        // Score from queue A
+        traceResourceClient.threadFeedbackScores(
+                List.of(FeedbackScoreBatchItemThread.builder()
+                        .threadId(threadId)
+                        .projectName(projectName)
+                        .name(score.name())
+                        .categoryName(score.categoryName())
+                        .value(score.value())
+                        .reason(score.reason())
+                        .source(score.source())
+                        .sourceQueueId(queueIdA)
+                        .build()),
+                API_KEY1, TEST_WORKSPACE);
+
+        // Verify score is present
+        var actualThreads = traceResourceClient.getTraceThreads(projectId, projectName, API_KEY1,
+                TEST_WORKSPACE, null, null, Map.of());
+        assertThat(actualThreads.content()).hasSize(1);
+        assertThat(actualThreads.content().getFirst().feedbackScores()).hasSize(1);
+
+        // Delete scoped to wrong queue B — should be a no-op
+        traceResourceClient.deleteThreadFeedbackScores(projectName, threadId, Set.of(score.name()), USER1,
+                queueIdB, API_KEY1, TEST_WORKSPACE);
+
+        // Score should still be present and match the original
+        actualThreads = traceResourceClient.getTraceThreads(projectId, projectName, API_KEY1,
+                TEST_WORKSPACE, null, null, Map.of());
+        assertThat(actualThreads.content()).hasSize(1);
+        assertThat(actualThreads.content().getFirst().feedbackScores()).singleElement().satisfies(actual -> {
+            assertThat(actual)
+                    .usingRecursiveComparison()
+                    .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
+                    .ignoringFields("createdAt", "lastUpdatedAt", "createdBy", "lastUpdatedBy",
+                            "sourceQueueId", "valueByAuthor")
+                    .isEqualTo(score);
+            assertThat(actual.valueByAuthor().keySet()).containsExactly(USER1);
+        });
+
+        // Delete scoped to correct queue A — should remove the score
+        traceResourceClient.deleteThreadFeedbackScores(projectName, threadId, Set.of(score.name()), USER1,
+                queueIdA, API_KEY1, TEST_WORKSPACE);
+
+        // Score should be gone
+        actualThreads = traceResourceClient.getTraceThreads(projectId, projectName, API_KEY1,
+                TEST_WORKSPACE, null, null, Map.of());
+        assertThat(actualThreads.content()).hasSize(1);
+        assertThat(actualThreads.content().getFirst().feedbackScores()).isNullOrEmpty();
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
@@ -264,9 +264,9 @@ class MultiValueFeedbackScoresE2ETest {
         assertThat(actualTrace.feedbackScores()).hasSize(1);
         assertThat(actualTrace.feedbackScores().getFirst().valueByAuthor()).hasSize(2);
 
-        // Delete user 2 feedback score (must be authenticated as user 2)
+        // Delete user 2 feedback score
         traceResourceClient.deleteTraceFeedbackScore(
-                DeleteFeedbackScore.builder().name(user1Score.name()).build(), traceId, API_KEY2,
+                DeleteFeedbackScore.builder().name(user1Score.name()).author(USER2).build(), traceId, API_KEY1,
                 TEST_WORKSPACE);
 
         // verify only user 1 score is present
@@ -303,7 +303,7 @@ class MultiValueFeedbackScoresE2ETest {
 
         // Delete scoped to wrong queue B — should be a no-op
         traceResourceClient.deleteTraceFeedbackScore(
-                DeleteFeedbackScore.builder().name(score.name()).sourceQueueId(queueIdB).build(),
+                DeleteFeedbackScore.builder().name(score.name()).author(USER1).sourceQueueId(queueIdB).build(),
                 traceId, API_KEY1, TEST_WORKSPACE);
 
         // Score should still be present and match the original
@@ -320,7 +320,7 @@ class MultiValueFeedbackScoresE2ETest {
 
         // Delete scoped to correct queue A — should remove the score
         traceResourceClient.deleteTraceFeedbackScore(
-                DeleteFeedbackScore.builder().name(score.name()).sourceQueueId(queueIdA).build(),
+                DeleteFeedbackScore.builder().name(score.name()).author(USER1).sourceQueueId(queueIdA).build(),
                 traceId, API_KEY1, TEST_WORKSPACE);
 
         // Score should be gone
@@ -433,9 +433,9 @@ class MultiValueFeedbackScoresE2ETest {
         assertThat(actualSpan.feedbackScores()).hasSize(1);
         assertThat(actualSpan.feedbackScores().getFirst().valueByAuthor()).hasSize(2);
 
-        // Delete user 2 feedback score (must be authenticated as user 2)
+        // Delete user 2 feedback score
         spanResourceClient.deleteSpanFeedbackScore(
-                DeleteFeedbackScore.builder().name(user1Score.name()).build(), spanId, API_KEY2,
+                DeleteFeedbackScore.builder().name(user1Score.name()).author(USER2).build(), spanId, API_KEY1,
                 TEST_WORKSPACE);
 
         // verify only user 1 score is present
@@ -499,9 +499,9 @@ class MultiValueFeedbackScoresE2ETest {
         assertThat(actualThread.feedbackScores()).hasSize(1);
         assertThat(actualThread.feedbackScores().getFirst().valueByAuthor()).hasSize(2);
 
-        // Delete user 2 feedback score (must be authenticated as user 2)
+        // Delete user 2 feedback score
         traceResourceClient.deleteThreadFeedbackScores(projectName, threadId, Set.of(user1Score.name()), USER2,
-                API_KEY2,
+                API_KEY1,
                 TEST_WORKSPACE);
 
         // verify only user 1 score is present

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
@@ -264,9 +264,9 @@ class MultiValueFeedbackScoresE2ETest {
         assertThat(actualTrace.feedbackScores()).hasSize(1);
         assertThat(actualTrace.feedbackScores().getFirst().valueByAuthor()).hasSize(2);
 
-        // Delete user 2 feedback score
+        // Delete user 2 feedback score (must be authenticated as user 2)
         traceResourceClient.deleteTraceFeedbackScore(
-                DeleteFeedbackScore.builder().name(user1Score.name()).author(USER2).build(), traceId, API_KEY1,
+                DeleteFeedbackScore.builder().name(user1Score.name()).build(), traceId, API_KEY2,
                 TEST_WORKSPACE);
 
         // verify only user 1 score is present
@@ -381,9 +381,9 @@ class MultiValueFeedbackScoresE2ETest {
         assertThat(actualSpan.feedbackScores()).hasSize(1);
         assertThat(actualSpan.feedbackScores().getFirst().valueByAuthor()).hasSize(2);
 
-        // Delete user 2 feedback score
+        // Delete user 2 feedback score (must be authenticated as user 2)
         spanResourceClient.deleteSpanFeedbackScore(
-                DeleteFeedbackScore.builder().name(user1Score.name()).author(USER2).build(), spanId, API_KEY1,
+                DeleteFeedbackScore.builder().name(user1Score.name()).build(), spanId, API_KEY2,
                 TEST_WORKSPACE);
 
         // verify only user 1 score is present
@@ -447,9 +447,9 @@ class MultiValueFeedbackScoresE2ETest {
         assertThat(actualThread.feedbackScores()).hasSize(1);
         assertThat(actualThread.feedbackScores().getFirst().valueByAuthor()).hasSize(2);
 
-        // Delete user 2 feedback score
+        // Delete user 2 feedback score (must be authenticated as user 2)
         traceResourceClient.deleteThreadFeedbackScores(projectName, threadId, Set.of(user1Score.name()), USER2,
-                API_KEY1,
+                API_KEY2,
                 TEST_WORKSPACE);
 
         // verify only user 1 score is present

--- a/apps/opik-frontend/src/api/traces/useCreateThreadCommentMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useCreateThreadCommentMutation.ts
@@ -9,6 +9,7 @@ type UseCreateThreadCommentMutationParams = {
   threadId: string;
   projectId: string;
   text: string;
+  sourceQueueId?: string;
 };
 
 const useCreateThreadCommentMutation = () => {
@@ -19,10 +20,11 @@ const useCreateThreadCommentMutation = () => {
     mutationFn: async ({
       text,
       threadId,
+      sourceQueueId,
     }: UseCreateThreadCommentMutationParams) => {
       const { data } = await api.post(
         `${TRACES_REST_ENDPOINT}threads/${threadId}/comments`,
-        { text },
+        { text, source_queue_id: sourceQueueId },
       );
 
       return data;

--- a/apps/opik-frontend/src/api/traces/useCreateTraceCommentMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useCreateTraceCommentMutation.ts
@@ -13,6 +13,7 @@ import { useToast } from "@/ui/use-toast";
 type UseCreateTraceCommentMutationParams = {
   traceId: string;
   text: string;
+  sourceQueueId?: string;
 };
 
 const useCreateTraceCommentMutation = () => {
@@ -23,10 +24,11 @@ const useCreateTraceCommentMutation = () => {
     mutationFn: async ({
       text,
       traceId,
+      sourceQueueId,
     }: UseCreateTraceCommentMutationParams) => {
       const { data } = await api.post(
         `${TRACES_REST_ENDPOINT}${traceId}/comments`,
-        { text },
+        { text, source_queue_id: sourceQueueId },
       );
 
       return data;

--- a/apps/opik-frontend/src/api/traces/useThreadFeedbackScoreDeleteMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useThreadFeedbackScoreDeleteMutation.ts
@@ -11,6 +11,7 @@ type UseThreadFeedbackScoreDeleteMutationParams = {
   projectId: string;
   projectName: string;
   author?: string;
+  sourceQueueId?: string;
 };
 
 const useThreadFeedbackScoreDeleteMutation = () => {
@@ -24,6 +25,7 @@ const useThreadFeedbackScoreDeleteMutation = () => {
       threadId,
       projectName,
       author,
+      sourceQueueId,
     }: UseThreadFeedbackScoreDeleteMutationParams) => {
       const endpoint = `${TRACES_REST_ENDPOINT}threads/feedback-scores/delete`;
 
@@ -32,6 +34,7 @@ const useThreadFeedbackScoreDeleteMutation = () => {
         thread_id: threadId,
         project_name: projectName,
         author: author ?? currentUserName,
+        source_queue_id: sourceQueueId,
       });
 
       return data;

--- a/apps/opik-frontend/src/api/traces/useThreadFeedbackScoreSetMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useThreadFeedbackScoreSetMutation.ts
@@ -17,6 +17,7 @@ type UseThreadFeedbackScoreSetMutationParams = {
   projectName: string;
   projectId: string;
   scores: UseThreadFeedbackScoreSetMutationScore[];
+  sourceQueueId?: string;
 };
 
 const useThreadFeedbackScoreSetMutation = () => {
@@ -28,6 +29,7 @@ const useThreadFeedbackScoreSetMutation = () => {
       threadId,
       projectName,
       scores,
+      sourceQueueId,
     }: UseThreadFeedbackScoreSetMutationParams) => {
       const { data } = await api.put(
         `${TRACES_REST_ENDPOINT}threads/feedback-scores`,
@@ -40,6 +42,7 @@ const useThreadFeedbackScoreSetMutation = () => {
             source: FEEDBACK_SCORE_TYPE.ui,
             value,
             reason,
+            source_queue_id: sourceQueueId,
           })),
         },
       );

--- a/apps/opik-frontend/src/api/traces/useThreadsList.ts
+++ b/apps/opik-frontend/src/api/traces/useThreadsList.ts
@@ -18,6 +18,7 @@ type UseThreadListParams = {
   fromTime?: string;
   toTime?: string;
   logsSource?: LOGS_SOURCE;
+  annotationQueueId?: string;
 };
 
 export type UseThreadListResponse = {
@@ -39,6 +40,7 @@ const getThreadList = async (
     fromTime,
     toTime,
     logsSource,
+    annotationQueueId,
   }: UseThreadListParams,
 ) => {
   const { data } = await api.get<UseThreadListResponse>(
@@ -58,6 +60,9 @@ const getThreadList = async (
         truncate,
         ...(fromTime && { from_time: fromTime }),
         ...(toTime && { to_time: toTime }),
+        ...(annotationQueueId && {
+          annotation_queue_id: annotationQueueId,
+        }),
       },
     },
   );

--- a/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreDeleteMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreDeleteMutation.ts
@@ -25,6 +25,7 @@ type UseTraceFeedbackScoreDeleteMutationParams = {
   spanId?: string;
   traceId: string;
   author?: string;
+  sourceQueueId?: string;
 };
 
 const useTraceFeedbackScoreDeleteMutation = () => {
@@ -38,6 +39,7 @@ const useTraceFeedbackScoreDeleteMutation = () => {
       spanId,
       traceId,
       author,
+      sourceQueueId,
     }: UseTraceFeedbackScoreDeleteMutationParams) => {
       const endpoint = spanId
         ? `${SPANS_REST_ENDPOINT}${spanId}/feedback-scores/delete`
@@ -46,6 +48,7 @@ const useTraceFeedbackScoreDeleteMutation = () => {
       const { data } = await api.post(endpoint, {
         name,
         author: author ?? currentUserName,
+        source_queue_id: sourceQueueId,
       });
 
       return data;

--- a/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreSetMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreSetMutation.ts
@@ -27,6 +27,7 @@ type UseTraceFeedbackScoreSetMutationParams = {
   traceId: string;
   value: number;
   reason?: string;
+  sourceQueueId?: string;
 };
 
 const useTraceFeedbackScoreSetMutation = () => {
@@ -42,6 +43,7 @@ const useTraceFeedbackScoreSetMutation = () => {
       traceId,
       value,
       reason,
+      sourceQueueId,
     }: UseTraceFeedbackScoreSetMutationParams) => {
       const endpoint = spanId
         ? `${SPANS_REST_ENDPOINT}${spanId}/feedback-scores`
@@ -53,6 +55,7 @@ const useTraceFeedbackScoreSetMutation = () => {
         source: FEEDBACK_SCORE_TYPE.ui,
         value,
         reason,
+        source_queue_id: sourceQueueId,
       });
 
       return data;

--- a/apps/opik-frontend/src/api/traces/useTracesList.ts
+++ b/apps/opik-frontend/src/api/traces/useTracesList.ts
@@ -24,6 +24,7 @@ type UseTracesListParams = {
   toTime?: string;
   exclude?: string[];
   logsSource?: LOGS_SOURCE;
+  annotationQueueId?: string;
 };
 
 export type UseTracesListResponse = {
@@ -47,6 +48,7 @@ const getTracesList = async (
     toTime,
     exclude,
     logsSource,
+    annotationQueueId,
   }: UseTracesListParams,
 ) => {
   const additionalFilters = [
@@ -71,6 +73,9 @@ const getTracesList = async (
       ...(toTime && { to_time: toTime }),
       ...(exclude &&
         exclude.length > 0 && { exclude: JSON.stringify(exclude) }),
+      ...(annotationQueueId && {
+        annotation_queue_id: annotationQueueId,
+      }),
     },
   });
 

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/ActionsCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/ActionsCell.tsx
@@ -4,7 +4,6 @@ import CellWrapper from "@/shared/DataTableCells/CellWrapper";
 import { ExpandingFeedbackScoreRow } from "../types";
 import { X } from "lucide-react";
 import { getIsParentFeedbackScoreRow } from "../utils";
-import { FEEDBACK_SCORE_TYPE } from "@/types/traces";
 import { useLoggedInUserName } from "@/store/AppStore";
 
 type CustomMeta = {
@@ -23,10 +22,8 @@ const ActionsCell: React.FunctionComponent<
   );
 
   const isUserOwner = context.row.original.created_by === currentUserName;
-  const isOnlineEvaluationScore =
-    context.row.original.source === FEEDBACK_SCORE_TYPE.online_scoring;
 
-  if (isParentFeedbackScoreRow || (isOnlineEvaluationScore && !isUserOwner)) {
+  if (isParentFeedbackScoreRow || !isUserOwner) {
     return null;
   }
 

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/ActionsCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/ActionsCell.tsx
@@ -21,7 +21,8 @@ const ActionsCell: React.FunctionComponent<
     context.row.original,
   );
 
-  const isUserOwner = context.row.original.created_by === currentUserName;
+  const row = context.row.original;
+  const isUserOwner = (row.author ?? row.created_by) === currentUserName;
 
   if (isParentFeedbackScoreRow || !isUserOwner) {
     return null;

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/ActionsCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/ActionsCell.tsx
@@ -4,7 +4,7 @@ import CellWrapper from "@/shared/DataTableCells/CellWrapper";
 import { ExpandingFeedbackScoreRow } from "../types";
 import { X } from "lucide-react";
 import { getIsParentFeedbackScoreRow } from "../utils";
-import { useLoggedInUserName } from "@/store/AppStore";
+import { useLoggedInUserNameOrOpenSourceDefaultUser } from "@/store/AppStore";
 
 type CustomMeta = {
   onDelete: (row: ExpandingFeedbackScoreRow) => void;
@@ -15,7 +15,7 @@ const ActionsCell: React.FunctionComponent<
 > = (context) => {
   const { custom } = context.column.columnDef.meta ?? {};
   const { onDelete } = (custom ?? {}) as CustomMeta;
-  const currentUserName = useLoggedInUserName();
+  const currentUserName = useLoggedInUserNameOrOpenSourceDefaultUser();
 
   const isParentFeedbackScoreRow = getIsParentFeedbackScoreRow(
     context.row.original,

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
@@ -310,6 +310,7 @@ const ThreadQueueItemsTab: React.FunctionComponent<
       size: size as number,
       search: search as string,
       truncate: truncationEnabled,
+      annotationQueueId: annotationQueue.id,
     },
     {
       placeholderData: keepPreviousData,

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
@@ -384,6 +384,7 @@ const TraceQueueItemsTab: React.FC<TraceQueueItemsTabProps> = ({
       search: search as string,
       truncate: truncationEnabled,
       stripAttachments: true,
+      annotationQueueId: annotationQueue.id,
     },
     {
       placeholderData: keepPreviousData,

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/SMEFlowContext.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/SMEFlowContext.tsx
@@ -15,7 +15,6 @@ import useAnnotationQueueLocks from "@/api/annotation-queues/useAnnotationQueueL
 import { useAnnotationQueueItemLockMutation } from "@/api/annotation-queues/useAnnotationQueueItemLockMutation";
 import useTracesList from "@/api/traces/useTracesList";
 import useThreadsList from "@/api/traces/useThreadsList";
-import { generateAnnotationQueueIdFilter } from "@/lib/filters";
 import {
   AnnotationQueue,
   ANNOTATION_QUEUE_SCOPE,
@@ -130,11 +129,6 @@ export const SMEFlowProvider: React.FunctionComponent<{
     { enabled: !!queueId },
   );
 
-  const annotationQueueFilter = useMemo(
-    () => generateAnnotationQueueIdFilter(annotationQueue?.id),
-    [annotationQueue?.id],
-  );
-
   const ascendingSort = [{ id: "created_at", desc: false }];
 
   const {
@@ -147,10 +141,10 @@ export const SMEFlowProvider: React.FunctionComponent<{
       page: 1,
       size: MAX_QUEUE_ITEMS,
       sorting: ascendingSort,
-      filters: annotationQueueFilter,
       search: "",
       truncate: true,
       stripAttachments: true,
+      annotationQueueId: annotationQueue?.id,
     },
     {
       enabled:
@@ -172,9 +166,9 @@ export const SMEFlowProvider: React.FunctionComponent<{
       page: 1,
       size: MAX_QUEUE_ITEMS,
       sorting: ascendingSort,
-      filters: annotationQueueFilter,
       search: "",
       truncate: true,
+      annotationQueueId: annotationQueue?.id,
     },
     {
       enabled:

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/useAnnotationPersistence.test.ts
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/useAnnotationPersistence.test.ts
@@ -291,6 +291,7 @@ describe("useAnnotationPersistence", () => {
       expect(mockDeleteTraceFeedbackScore).toHaveBeenCalledWith({
         traceId: "trace-1",
         name: "accuracy",
+        sourceQueueId: "queue-1",
       });
     });
 

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/useAnnotationPersistence.test.ts
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/useAnnotationPersistence.test.ts
@@ -110,7 +110,7 @@ describe("useAnnotationPersistence", () => {
       act(() => result.current.flushPendingChanges());
 
       expect(mockCreateTraceComment).toHaveBeenCalledWith(
-        { traceId: "trace-1", text: "hello" },
+        { traceId: "trace-1", text: "hello", sourceQueueId: "queue-1" },
         expect.objectContaining({ onSuccess: expect.any(Function) }),
       );
     });
@@ -226,7 +226,7 @@ describe("useAnnotationPersistence", () => {
       act(() => result.current.flushPendingChanges());
 
       expect(mockCreateTraceComment).toHaveBeenCalledWith(
-        { traceId: "trace-1", text: "new text" },
+        { traceId: "trace-1", text: "new text", sourceQueueId: "queue-1" },
         expect.any(Object),
       );
     });
@@ -255,7 +255,7 @@ describe("useAnnotationPersistence", () => {
 
       expect(mockCreateTraceComment).toHaveBeenCalledTimes(2);
       expect(mockCreateTraceComment).toHaveBeenLastCalledWith(
-        { traceId: "trace-2", text: "item2 comment" },
+        { traceId: "trace-2", text: "item2 comment", sourceQueueId: "queue-1" },
         expect.any(Object),
       );
       expect(mockUpdateTraceComment).not.toHaveBeenCalled();
@@ -275,6 +275,7 @@ describe("useAnnotationPersistence", () => {
           traceId: "trace-1",
           name: "accuracy",
           value: 0.8,
+          sourceQueueId: "queue-1",
         }),
       );
     });
@@ -383,7 +384,7 @@ describe("useAnnotationPersistence", () => {
 
       expect(mockCreateTraceComment).toHaveBeenCalledTimes(2);
       expect(mockCreateTraceComment).toHaveBeenLastCalledWith(
-        { traceId: "trace-2", text: "new" },
+        { traceId: "trace-2", text: "new", sourceQueueId: "queue-1" },
         expect.any(Object),
       );
     });

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/useAnnotationPersistence.ts
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/useAnnotationPersistence.ts
@@ -177,6 +177,7 @@ export function useAnnotationPersistence({
             projectId: thread.project_id,
             projectName: annotationQueue.project_name,
             names: deletedScores.map((s) => s.name),
+            sourceQueueId: annotationQueue.id,
           });
         }
         if (changedScores.length) {
@@ -195,7 +196,11 @@ export function useAnnotationPersistence({
         }
       } else {
         deletedScores.forEach((score) => {
-          deleteTraceFeedbackScore({ traceId: item.id, name: score.name });
+          deleteTraceFeedbackScore({
+            traceId: item.id,
+            name: score.name,
+            sourceQueueId: annotationQueue?.id,
+          });
         });
         changedScores.forEach((score) => {
           setTraceFeedbackScore({

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/useAnnotationPersistence.ts
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/useAnnotationPersistence.ts
@@ -106,12 +106,17 @@ export function useAnnotationPersistence({
               threadId: getAnnotationQueueItemId(thread),
               projectId: thread.project_id,
               text: currentText,
+              sourceQueueId: annotationQueue?.id,
             },
             { onSuccess: onCommentCreated, onError: onCommentCreateError },
           );
         } else {
           createTraceComment(
-            { traceId: item.id, text: currentText },
+            {
+              traceId: item.id,
+              text: currentText,
+              sourceQueueId: annotationQueue?.id,
+            },
             { onSuccess: onCommentCreated, onError: onCommentCreateError },
           );
         }
@@ -179,6 +184,7 @@ export function useAnnotationPersistence({
             threadId: thread.id,
             projectId: thread.project_id,
             projectName: annotationQueue.project_name,
+            sourceQueueId: annotationQueue.id,
             scores: changedScores.map((s) => ({
               name: s.name,
               categoryName: s.category_name,
@@ -198,6 +204,7 @@ export function useAnnotationPersistence({
             categoryName: score.category_name,
             value: score.value,
             reason: score.reason,
+            sourceQueueId: annotationQueue?.id,
           });
         });
       }


### PR DESCRIPTION
## Details

Adds `source_queue_id` to feedback scores and comments so that annotation queue metrics (avg scores, reviewer counts) are scoped to the queue that produced them. Previously, a score submitted through Queue A would also count toward Queue B's annotator count if the same trace appeared in both queues.

**Backend:**
- Add `source_queue_id FixedString(36)` column to `authored_feedback_scores` (included in ORDER BY for ReplacingMergeTree deduplication) and `comments` ClickHouse tables
- Filter feedback scores, comments, and reviewer counts by `source_queue_id` in annotation queue FIND queries
- Pass `annotation_queue_id` as a query parameter on traces/threads list endpoints so the FE can scope displayed scores
- Scope feedback score deletion by `source_queue_id` in SME flow — deleting a score from one annotation queue no longer removes it from other queues that share the same item
- Preserve main's conditional author behavior on delete: when `author` is provided in the request, deletion is scoped to that author; when omitted, deletion is unscoped (backwards-compatible with existing SDK/API callers)

**Frontend:**
- Pass `annotationQueueId` from SME flow context through to score/comment creation and deletion mutations and list hooks
- Fix v2 ActionsCell ownership check for multi-author expanded rows: use `row.author ?? row.created_by` instead of `created_by` (which was inherited from parent spread, not the per-user child row)
- Fix v2 feedback score delete button in open-source mode (use `useLoggedInUserNameOrOpenSourceDefaultUser` so username resolves to `"admin"` instead of `undefined`)

**Design decisions:**
- `source_queue_id` is non-nullable `FixedString(36)` (not `Nullable`) because ClickHouse forbids nullable columns in ORDER BY keys. Empty string (`\0`-padded) represents "no queue".
- `source_queue_id` is added to the `authored_feedback_scores` ORDER BY key so ReplacingMergeTree deduplicates per-queue — the same user can score the same entity/name from different annotation queues without one overwriting the other.
- Annotation queue scoring always goes through `authored_feedback_scores` (never the legacy `feedback_scores` table), because the `author` is always set from request context for any authenticated user action. Legacy `feedback_scores` rows get `source_queue_id = ''` in the UNION, which never matches a real queue UUID, so they are correctly excluded from per-queue metrics.
- Queue-scoped deletion is only applied to the `authored_feedback_scores` delete (never legacy `feedback_scores`), since SME flow always writes to the authored table. The `source_queue_id` filter is conditional — when `null` (non-SME callers), deletion behaves as before.
- Ownership restriction on delete is handled by the FE (hide delete button for scores not by current user), not enforced server-side, to preserve SDK backwards compatibility where callers can delete any author's score by specifying the target author.

## Limitations and follow-up

**OPIK-6983** tracks the remaining work to propagate `source_queue_id` end-to-end:
- Currently `source_queue_id` is only written and filtered in the annotation queue FIND query (AnnotationQueueDAO). The 24+ DAO queries in TraceDAO, SpanDAO, ThreadDAO, and ExperimentItemDAO that read/aggregate feedback scores do not yet filter by `source_queue_id`.
- The FE passes `annotationQueueId` to score/comment creation, but the trace/span detail panels outside the SME flow do not yet display per-queue scores separately.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6791

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.6
  - Scope: Implementation assistance, test writing, code review
  - Human verification: All changes reviewed and tested by developer

## Testing

- `mvn spotless:apply` — formatting passes
- `mvn compile -pl apps/opik-backend -DskipTests` — compilation clean
- 2489 unit tests pass
- New integration tests:
  - `getAnnotationQueueScopedBySourceQueueId` — two queues sharing items get independent avg scores and reviewer counts
  - `deleteTraceFeedbackScoreScopedBySourceQueueId` — wrong queue delete is a no-op, correct queue delete removes the score
  - `deleteThreadFeedbackScoreScopedBySourceQueueId` — same as above for threads
- Updated 4 existing `AnnotationQueuesResourceTest` tests to pass `sourceQueueId`
- Updated 3 `MultiValueFeedbackScoresE2ETest` delete tests to match main's pattern (specify target author explicitly with any API key, not requiring the target user's API key)
- Fixed constructor calls in `ScoreDestinationTest`, `DatasetsResourceCreateFromSpansTest`, `DatasetsResourceCreateFromTracesTest` for new `sourceQueueId` field

## Documentation

N/A — internal behavior change, no new user-facing configuration or API surface changes required in docs.