### PR TITLE
[NA] [BE][FE] chore: sync provider model definitions

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterModelName.java
@@ -527,6 +527,7 @@ public enum OpenRouterModelName implements StructuredOutputSupported {
     Z_AI_GLM_5("z-ai/glm-5"),
     Z_AI_GLM_5_TURBO("z-ai/glm-5-turbo"),
     Z_AI_GLM_5_1("z-ai/glm-5.1"),
+    Z_AI_GLM_5_2("z-ai/glm-5.2"),
     Z_AI_GLM_5V_TURBO("z-ai/glm-5v-turbo"),
     ANTHROPIC_CLAUDE_FABLE_LATEST("~anthropic/claude-fable-latest"),
     ANTHROPIC_CLAUDE_HAIKU_LATEST("~anthropic/claude-haiku-latest"),

--- a/apps/opik-backend/src/main/resources/llm-models-default.yaml
+++ b/apps/opik-backend/src/main/resources/llm-models-default.yaml
@@ -158,9 +158,7 @@ anthropic:
     structuredOutput: true
   - id: "claude-3-7-sonnet-20250219"
   - id: "claude-opus-4-20250514"
-    structuredOutput: true
   - id: "claude-sonnet-4-20250514"
-    structuredOutput: true
   - id: "claude-sonnet-4-5-20250929"
     structuredOutput: true
 gemini:
@@ -1386,6 +1384,8 @@ openrouter:
     label: "z-ai/glm-5-turbo"
   - id: "z-ai/glm-5.1"
     label: "z-ai/glm-5.1"
+  - id: "z-ai/glm-5.2"
+    label: "z-ai/glm-5.2"
   - id: "z-ai/glm-5v-turbo"
     label: "z-ai/glm-5v-turbo"
   - id: "~anthropic/claude-fable-latest"

--- a/apps/opik-frontend/src/constants/providerModels.ts
+++ b/apps/opik-frontend/src/constants/providerModels.ts
@@ -2180,6 +2180,10 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       label: "z-ai/glm-5.1",
     },
     {
+      value: PROVIDER_MODEL_TYPE.Z_AI_GLM_5_2,
+      label: "z-ai/glm-5.2",
+    },
+    {
       value: PROVIDER_MODEL_TYPE.Z_AI_GLM_5V_TURBO,
       label: "z-ai/glm-5v-turbo",
     },

--- a/apps/opik-frontend/src/types/providers.ts
+++ b/apps/opik-frontend/src/types/providers.ts
@@ -619,6 +619,7 @@ export enum PROVIDER_MODEL_TYPE {
   Z_AI_GLM_5 = "z-ai/glm-5",
   Z_AI_GLM_5_TURBO = "z-ai/glm-5-turbo",
   Z_AI_GLM_5_1 = "z-ai/glm-5.1",
+  Z_AI_GLM_5_2 = "z-ai/glm-5.2",
   Z_AI_GLM_5V_TURBO = "z-ai/glm-5v-turbo",
   ANTHROPIC_CLAUDE_FABLE_LATEST = "~anthropic/claude-fable-latest",
   ANTHROPIC_CLAUDE_HAIKU_LATEST = "~anthropic/claude-haiku-latest",


### PR DESCRIPTION
## Details

Automated sync of LLM provider model definitions from source APIs and prices JSON.

**Sync summary:**
```
## Provider Model Sync

### Openrouter
- Added 1 model(s):
  + z-ai/glm-5.2
- Stale 183 model(s) (not in source, manual review needed):
  ? ai21/jamba-mini-1.7
  ? alfredpros/codellama-7b-instruct-solidity
  ? alibaba/tongyi-deepresearch-30b-a3b
  ? alibaba/tongyi-deepresearch-30b-a3b:free
  ? allenai/molmo-2-8b
  ? allenai/olmo-2-0325-32b-instruct
  ? allenai/olmo-3-7b-instruct
  ? allenai/olmo-3-7b-think
  ? allenai/olmo-3.1-32b-instruct
  ? allenai/olmo-3.1-32b-think
  ? alpindale/goliath-120b
  ? anthropic/claude-3.5-sonnet
  ? anthropic/claude-3.7-sonnet
  ? anthropic/claude-3.7-sonnet:thinking
  ? arcee-ai/afm-4.5b
  ? arcee-ai/maestro-reasoning
  ? arcee-ai/spotlight
  ? arcee-ai/trinity-large-preview
  ? arcee-ai/trinity-large-preview:free
  ? arcee-ai/trinity-large-thinking:free
  ? arcee-ai/trinity-mini:free
  ? arliai/qwq-32b-arliai-rpr-v1
  ? arliai/qwq-32b-arliai-rpr-v1:free
  ? baidu/cobuddy:free
  ? baidu/ernie-4.5-21b-a3b
  ? baidu/ernie-4.5-21b-a3b-thinking
  ? baidu/ernie-4.5-300b-a47b
  ? baidu/ernie-4.5-vl-28b-a3b
  ? baidu/qianfan-ocr-fast
  ? baidu/qianfan-ocr-fast:free
  ? deepcogito/cogito-v2-preview-deepseek-671b
  ? deepcogito/cogito-v2-preview-llama-109b-moe
  ? deepcogito/cogito-v2-preview-llama-405b
  ? deepcogito/cogito-v2-preview-llama-70b
  ? deepseek/deepseek-chat-v3-0324:free
  ? deepseek/deepseek-prover-v2
  ? deepseek/deepseek-r1-0528-qwen3-8b
  ? deepseek/deepseek-r1-0528-qwen3-8b:free
  ? deepseek/deepseek-r1-0528:free
  ? deepseek/deepseek-r1-distill-llama-70b:free
  ? deepseek/deepseek-r1-distill-qwen-14b
  ? deepseek/deepseek-r1-distill-qwen-32b
  ? deepseek/deepseek-r1:free
  ? deepseek/deepseek-v3.1-terminus:exacto
  ? deepseek/deepseek-v3.2-speciale
  ? deepseek/deepseek-v4-flash:free
  ? eleutherai/llemma_7b
  ? google/gemini-2.0-flash-001
  ? google/gemini-2.0-flash-exp:free
  ? google/gemini-2.0-flash-lite-001
  ? google/gemini-2.5-flash-image-preview
  ? google/gemini-2.5-flash-preview-09-2025
  ? google/gemini-3-pro-preview
  ? google/gemma-2-9b-it
  ? google/gemma-3-12b-it:free
  ? google/gemma-3-27b-it:free
  ? google/gemma-3-4b-it:free
  ? google/gemma-3n-e2b-it:free
  ? google/gemma-3n-e4b-it:free
  ? inception/mercury
  ? inception/mercury-coder
  ? inclusionai/ling-2.6-1t:free
  ? inclusionai/ling-2.6-flash:free
  ? inclusionai/ring-2.6-1t:free
  ? kwaipilot/kat-coder-pro
  ? kwaipilot/kat-coder-pro:free
  ? liquid/lfm-2.2-6b
  ? liquid/lfm2-8b-a1b
  ? meituan/longcat-flash-chat
  ? meituan/longcat-flash-chat:free
  ? meta-llama/llama-3.1-405b
  ? meta-llama/llama-3.1-405b-instruct
  ? meta-llama/llama-3.2-90b-vision-instruct
  ? meta-llama/llama-guard-2-8b
  ? meta-llama/llama-guard-3-8b
  ? meta-llama/llama-guard-4-12b:free
  ? microsoft/mai-ds-r1
  ? microsoft/mai-ds-r1:free
  ? microsoft/phi-3-medium-128k-instruct
  ? microsoft/phi-3-mini-128k-instruct
  ? microsoft/phi-3.5-mini-128k-instruct
  ? microsoft/phi-4-multimodal-instruct
  ? microsoft/phi-4-reasoning-plus
  ? minimax/minimax-m2.5:free
  ? mistralai/codestral-2501
  ? mistralai/devstral-medium
  ? mistralai/devstral-small
  ? mistralai/devstral-small-2505
  ? mistralai/magistral-medium-2506
  ? mistralai/magistral-medium-2506:thinking
  ? mistralai/magistral-small-2506
  ? mistralai/ministral-3b
  ? mistralai/ministral-8b
  ? mistralai/mistral-7b-instruct
  ? mistralai/mistral-7b-instruct-v0.1
  ? mistralai/mistral-7b-instruct-v0.2
  ? mistralai/mistral-7b-instruct-v0.3
  ? mistralai/mistral-7b-instruct:free
  ? mistralai/mistral-large-2411
  ? mistralai/mistral-nemo:free
  ? mistralai/mistral-small
  ? mistralai/mistral-small-24b-instruct-2501:free
  ? mistralai/mistral-small-3.1-24b-instruct:free
  ? mistralai/mistral-small-3.2-24b-instruct:free
  ? mistralai/mistral-small-creative
  ? mistralai/mistral-tiny
  ? mistralai/mixtral-8x7b-instruct
  ? mistralai/pixtral-12b
  ? mistralai/pixtral-large-2411
  ? moonshotai/kimi-dev-72b
  ? moonshotai/kimi-k2-0905:exacto
  ? moonshotai/kimi-k2.6:free
  ? moonshotai/kimi-k2:free
  ? moonshotai/kimi-linear-48b-a3b-instruct
  ? neversleep/llama-3.1-lumimaid-8b
  ? neversleep/noromaid-20b
  ? nex-agi/deepseek-v3.1-nex-n1
  ? nousresearch/deephermes-3-mistral-24b-preview
  ? nousresearch/hermes-2-pro-llama-3-8b
  ? nvidia/llama-3.1-nemotron-70b-instruct
  ? nvidia/llama-3.1-nemotron-ultra-253b-v1
  ? nvidia/nemotron-nano-12b-v2-vl
  ? nvidia/nemotron-nano-9b-v2
  ? openai/chatgpt-4o-latest
  ? openai/codex-mini
  ? openai/gpt-4-0314
  ? openai/gpt-4-1106-preview
  ? openai/gpt-4o-audio-preview
  ? openai/gpt-4o:extended
  ? openai/gpt-5.2-chat-latest
  ? openai/gpt-oss-120b:exacto
  ? opengvlab/internvl3-78b
  ? openrouter/elephant-alpha
  ? openrouter/healer-alpha
  ? openrouter/hunter-alpha
  ? perplexity/sonar-reasoning
  ? qwen/qwen-2.5-72b-instruct:free
  ? qwen/qwen-2.5-coder-32b-instruct:free
  ? qwen/qwen-2.5-vl-7b-instruct
  ? qwen/qwen-max
  ? qwen/qwen-turbo
  ? qwen/qwen-vl-max
  ? qwen/qwen-vl-plus
  ? qwen/qwen2.5-coder-7b-instruct
  ? qwen/qwen2.5-vl-32b-instruct
  ? qwen/qwen2.5-vl-32b-instruct:free
  ? qwen/qwen3-14b:free
  ? qwen/qwen3-235b-a22b:free
  ? qwen/qwen3-30b-a3b:free
  ? qwen/qwen3-4b:free
  ? qwen/qwen3-coder:exacto
  ? qwen/qwen3.6-plus-preview:free
  ? qwen/qwen3.6-plus:free
  ? qwen/qwq-32b
  ? raifle/sorcererlm-8x22b
  ? reka/reka-edge
  ? sao10k/l3-euryale-70b
  ? stepfun-ai/step3
  ? stepfun/step-3.5-flash:free
  ? tencent/hy3-preview:free
  ? thedrummer/anubis-70b-v1.1
  ? thudm/glm-4.1v-9b-thinking
  ? tngtech/deepseek-r1t-chimera
  ? tngtech/deepseek-r1t-chimera:free
  ? tngtech/deepseek-r1t2-chimera
  ? tngtech/deepseek-r1t2-chimera:free
  ? x-ai/grok-3
  ? x-ai/grok-3-beta
  ? x-ai/grok-3-mini
  ? x-ai/grok-3-mini-beta
  ? x-ai/grok-4
  ? x-ai/grok-4-fast
  ? x-ai/grok-4.1-fast
  ? x-ai/grok-4.1-fast:free
  ? x-ai/grok-4.20-beta
  ? x-ai/grok-4.20-multi-agent-beta
  ? x-ai/grok-code-fast-1
  ? xiaomi/mimo-v2-omni
  ? xiaomi/mimo-v2-pro
  ? z-ai/glm-4-32b
  ? z-ai/glm-4.5-air:free
  ? z-ai/glm-4.6:exacto
  ? z-ai/glm-5v-turbo
- Deprecated 1 model(s) (past deprecation_date, excluded from dropdown):
  ✗ google/gemini-2.0-flash-001
- Total models: 520 (dropdown: 519)

### Openai
- Stale 15 model(s) (not in source, manual review needed):
  ? chatgpt-4o-latest
  ? gpt-4-0125-preview
  ? gpt-4-0314
  ? gpt-4-1106-preview
  ? gpt-4-turbo-2024-04-09
  ? gpt-4-turbo-preview
  ? gpt-4o-2024-05-13
  ? gpt-4o-2024-08-06
  ? gpt-4o-2024-11-20
  ? gpt-4o-mini-2024-07-18
  ? o1-2024-12-17
  ? o1-mini
  ? o1-mini-2024-09-12
  ? o1-preview
  ? o1-preview-2024-09-12
- Deprecated 4 model(s) (past deprecation_date, excluded from dropdown):
  ✗ gpt-4-0125-preview
  ✗ gpt-4-0314
  ✗ gpt-4-0613
  ✗ gpt-4-1106-preview
- Total models: 65 (dropdown: 20)

### Anthropic
- Stale 4 model(s) (not in source, manual review needed):
  ? claude-3-7-sonnet-20250219
  ? claude-opus-4-20250514
  ? claude-sonnet-4-20250514
  ? claude-sonnet-4-5
- Deprecated 3 model(s) (past deprecation_date, excluded from dropdown):
  ✗ claude-3-7-sonnet-20250219
  ✗ claude-opus-4-20250514
  ✗ claude-sonnet-4-20250514
- Total models: 13 (dropdown: 9)

### Gemini
- Stale 6 model(s) (not in source, manual review needed):
  ? aqa
  ? gemini-1.0-pro
  ? gemini-1.5-flash-latest
  ? gemini-1.5-pro-latest
  ? gemini-pro-vision
  ? text-embedding-004
- Deprecated 4 model(s) (past deprecation_date, excluded from dropdown):
  ✗ gemini-2.0-flash
  ✗ gemini-2.0-flash-lite
  ✗ gemini-3-pro-preview
  ✗ text-embedding-004
- Total models: 28 (dropdown: 12)

### Vertexai
- Stale 9 model(s) (not in source, manual review needed):
  ? vertex_ai/gemini-2.0-flash-001
  ? vertex_ai/gemini-2.0-flash-lite-001
  ? vertex_ai/gemini-2.5-flash
  ? vertex_ai/gemini-2.5-flash-lite-preview-06-17
  ? vertex_ai/gemini-2.5-flash-preview-04-17
  ? vertex_ai/gemini-2.5-pro
  ? vertex_ai/gemini-2.5-pro-exp-03-25
  ? vertex_ai/gemini-2.5-pro-preview-03-25
  ? vertex_ai/gemini-2.5-pro-preview-05-06
- Total models: 13 (dropdown: 8)

```

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: GitHub Actions (`sync_provider_models.yml`)
  - Model(s): N/A (scripted automation)
  - Scope: Automated model list sync
  - Human verification: Requires manual review before merge

## Testing

- Script dry-run passed in CI
- Changes are add-only; stale/deprecated models flagged for manual review

## Documentation

N/A