### PR TITLE
[OPIK-6863] [FE] fix: keep Experiments charts fixed during horizontal table scroll

### DIFF
--- a/apps/opik-frontend/src/v2/pages/ExperimentsPage/ExperimentsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/ExperimentsPage/ExperimentsPage.tsx
@@ -48,7 +48,7 @@ const ExperimentsPage: React.FC = () => {
 
   return (
     <PageBodyScrollContainer>
-      <div className="flex min-h-full flex-col pt-4">
+      <div className="flex min-h-full w-fit min-w-full flex-col pt-4">
         <PageBodyStickyContainer
           className="flex items-center justify-between pb-1"
           direction="horizontal"


### PR DESCRIPTION
## Details

<img width="1920" height="1884" alt="image" src="https://github.com/user-attachments/assets/d604815d-e7a5-4242-a607-c0531d9c4558" />

The Experiments page body scroll container holds both the feedback-score charts (in a horizontal sticky container) and the experiments table. When the table was wide enough to require horizontal scrolling, the charts and toolbar scrolled away with the table instead of staying pinned to the top.

The sticky top section could not offset during horizontal scroll because its flex-column parent's box width stayed at the viewport width even as the wide table pushed the scroll content wider — leaving the `sticky; left: 0` element no room to slide within its containing block. Adding `w-fit min-w-full` to that wrapper lets the column grow to its content width while still filling the viewport when content is narrow, so the top section stays fixed (matching the Optimization runs page).

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6863

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: full implementation (root-cause analysis, fix, browser verification)
  - Human verification: code review + manual testing

## Testing

Reproduced and verified against a local Docker stack with a seeded project (4 experiments, 3 feedback-score metrics so charts render and the table is wide enough to scroll):

- **Before fix:** scrolling the experiments table right by 300px moved the charts container by -300px (charts scrolled away with the table).
- **After fix:** the same scroll moves the charts by 0px — charts, title, and toolbar stay pinned while the table scrolls underneath. Confirmed on a real Vite dev build (not just injected styles) by measuring `getBoundingClientRect` and by screenshot.
- `npm run lint` and `npm run typecheck` pass via the pre-commit hook.

## Documentation

N/A — no documentation changes.
