### PR TITLE
[OPIK-6968] [BE] perf: bulk thread resolve/create + scope open/close locks to non-idempotent ops

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
@@ -786,19 +786,14 @@ public class TracesResource {
 
         String workspaceId = requestContext.get().getWorkspaceId();
 
-        // Validate project identifier and get projectId
-        UUID projectId = projectService.validateProjectIdentifier(identifier.projectId(), identifier.projectName(),
-                workspaceId);
+        log.info("Open trace thread_id: '{}' for project_id: '{}', project_name: '{}' on workspace_id: '{}'",
+                identifier.threadId(), identifier.projectId(), identifier.projectName(), workspaceId);
 
-        log.info("Open trace thread_id: '{}' and project_id: '{}' on workspace_id: '{}'", identifier.threadId(),
-                projectId, workspaceId);
-
-        traceThreadService.openThread(projectId, identifier.threadId())
+        traceThreadService.openThread(identifier.projectId(), identifier.projectName(), identifier.threadId())
                 .contextWrite(ctx -> setRequestContext(ctx, requestContext))
                 .block();
 
-        log.info("Opened trace thread_id: '{}' and project_id: '{}' on workspace_id: '{}'", identifier.threadId(),
-                projectId, workspaceId);
+        log.info("Opened trace thread_id: '{}' on workspace_id: '{}'", identifier.threadId(), workspaceId);
 
         return Response.noContent().build();
     }
@@ -815,24 +810,19 @@ public class TracesResource {
 
         String workspaceId = requestContext.get().getWorkspaceId();
 
-        // Validate project identifier and get projectId
-        UUID projectId = projectService.validateProjectIdentifier(identifier.projectId(), identifier.projectName(),
-                workspaceId);
-
         // Handle both single and batch operations
         Set<String> threadIds = CollectionUtils.isNotEmpty(identifier.threadIds())
                 ? Set.copyOf(identifier.threadIds())
                 : Set.of(identifier.threadId());
 
-        log.info("Close trace thread_ids: '{}' and project_id: '{}' on workspace_id: '{}'", threadIds,
-                projectId, workspaceId);
+        log.info("Close trace thread_ids: '{}' for project_id: '{}', project_name: '{}' on workspace_id: '{}'",
+                threadIds, identifier.projectId(), identifier.projectName(), workspaceId);
 
-        traceThreadService.closeThreads(projectId, threadIds)
+        traceThreadService.closeThreads(identifier.projectId(), identifier.projectName(), threadIds)
                 .contextWrite(ctx -> setRequestContext(ctx, requestContext))
                 .block();
 
-        log.info("Closed trace thread_ids: '{}' and project_id: '{}' on workspace_id: '{}'", threadIds,
-                projectId, workspaceId);
+        log.info("Closed trace thread_ids: '{}' on workspace_id: '{}'", threadIds, workspaceId);
 
         return Response.noContent().build();
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadIdDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadIdDAO.java
@@ -8,7 +8,6 @@ import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.BindMethods;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
-import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
 import java.util.List;
 import java.util.UUID;
@@ -17,23 +16,15 @@ import java.util.UUID;
 @RegisterConstructorMapper(TraceThreadIdModel.class)
 interface TraceThreadIdDAO {
 
-    @SqlUpdate("""
-                INSERT INTO project_trace_threads(id, project_id, thread_id, created_by, created_at)
-                VALUES (:thread.id, :thread.projectId, :thread.threadId, :thread.createdBy, :thread.createdAt)
-            """)
-    void save(@BindMethods("thread") TraceThreadIdModel rule);
-
     @SqlBatch("""
                 INSERT INTO project_trace_threads(id, project_id, thread_id, created_by, created_at)
                 VALUES (:thread.id, :thread.projectId, :thread.threadId, :thread.createdBy, :thread.createdAt)
             """)
     void save(@BindMethods("thread") List<TraceThreadIdModel> threads);
 
-    @SqlQuery("""
-                SELECT * FROM project_trace_threads
-                WHERE project_id = :projectId AND thread_id = :threadId
-            """)
-    TraceThreadIdModel findByProjectIdAndThreadId(@Bind("projectId") UUID projectId, @Bind("threadId") String threadId);
+    default void save(TraceThreadIdModel thread) {
+        save(List.of(thread));
+    }
 
     @SqlQuery("""
                 SELECT * FROM project_trace_threads
@@ -41,6 +32,10 @@ interface TraceThreadIdDAO {
             """)
     List<TraceThreadIdModel> findByProjectIdAndThreadIds(@Bind("projectId") UUID projectId,
             @BindList("threadIds") List<String> threadIds);
+
+    default TraceThreadIdModel findByProjectIdAndThreadId(UUID projectId, String threadId) {
+        return findByProjectIdAndThreadIds(projectId, List.of(threadId)).stream().findFirst().orElse(null);
+    }
 
     @SqlQuery("""
                 SELECT * FROM project_trace_threads

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadIdDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadIdDAO.java
@@ -10,6 +10,7 @@ import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @RegisterArgumentFactory(UUIDArgumentFactory.class)
@@ -33,8 +34,8 @@ interface TraceThreadIdDAO {
     List<TraceThreadIdModel> findByProjectIdAndThreadIds(@Bind("projectId") UUID projectId,
             @BindList("threadIds") List<String> threadIds);
 
-    default TraceThreadIdModel findByProjectIdAndThreadId(UUID projectId, String threadId) {
-        return findByProjectIdAndThreadIds(projectId, List.of(threadId)).stream().findFirst().orElse(null);
+    default Optional<TraceThreadIdModel> findByProjectIdAndThreadId(UUID projectId, String threadId) {
+        return findByProjectIdAndThreadIds(projectId, List.of(threadId)).stream().findFirst();
     }
 
     @SqlQuery("""

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadIdDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadIdDAO.java
@@ -6,6 +6,7 @@ import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.BindMethods;
+import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
@@ -22,11 +23,24 @@ interface TraceThreadIdDAO {
             """)
     void save(@BindMethods("thread") TraceThreadIdModel rule);
 
+    @SqlBatch("""
+                INSERT INTO project_trace_threads(id, project_id, thread_id, created_by, created_at)
+                VALUES (:thread.id, :thread.projectId, :thread.threadId, :thread.createdBy, :thread.createdAt)
+            """)
+    void save(@BindMethods("thread") List<TraceThreadIdModel> threads);
+
     @SqlQuery("""
                 SELECT * FROM project_trace_threads
                 WHERE project_id = :projectId AND thread_id = :threadId
             """)
     TraceThreadIdModel findByProjectIdAndThreadId(@Bind("projectId") UUID projectId, @Bind("threadId") String threadId);
+
+    @SqlQuery("""
+                SELECT * FROM project_trace_threads
+                WHERE project_id = :projectId AND thread_id IN (<threadIds>)
+            """)
+    List<TraceThreadIdModel> findByProjectIdAndThreadIds(@Bind("projectId") UUID projectId,
+            @BindList("threadIds") List<String> threadIds);
 
     @SqlQuery("""
                 SELECT * FROM project_trace_threads

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadIdService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadIdService.java
@@ -1,5 +1,6 @@
 package com.comet.opik.domain.threads;
 
+import com.comet.opik.api.error.EntityAlreadyExistsException;
 import com.comet.opik.domain.EntityConstraintHandler;
 import com.comet.opik.domain.IdGenerator;
 import com.comet.opik.domain.ProjectService;
@@ -9,6 +10,7 @@ import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.google.common.base.Preconditions;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Singleton;
+import io.dropwizard.jersey.errors.ErrorMessage;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 import lombok.NonNull;
@@ -20,8 +22,10 @@ import reactor.core.scheduler.Schedulers;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -30,6 +34,9 @@ interface TraceThreadIdService {
 
     Mono<TraceThreadIdModel> getOrCreateTraceThreadId(String workspaceId, UUID projectId, String threadId,
             Instant timestamp);
+
+    Mono<List<TraceThreadIdModel>> getOrCreateTraceThreadIds(String workspaceId, UUID projectId,
+            Map<String, Instant> threadIdToTimestamp);
 
     Mono<UUID> getThreadModelId(String workspaceId, UUID projectId, String threadId);
 
@@ -62,6 +69,64 @@ class TraceThreadIdServiceImpl implements TraceThreadIdService {
                         .switchIfEmpty(createThread(threadId, projectId, timestamp)))
                 .subscribeOn(Schedulers.boundedElastic())
                 .switchIfEmpty(Mono.error(new NotFoundException("Project not found: " + projectId)));
+    }
+
+    @Override
+    public Mono<List<TraceThreadIdModel>> getOrCreateTraceThreadIds(@NonNull String workspaceId,
+            @NonNull UUID projectId, @NonNull Map<String, Instant> threadIdToTimestamp) {
+        Preconditions.checkArgument(!StringUtils.isBlank(workspaceId), "Workspace ID cannot be blank");
+
+        if (threadIdToTimestamp.isEmpty()) {
+            return Mono.just(List.of());
+        }
+
+        return Mono.deferContextual(context -> Mono.fromCallable(() -> {
+            List<String> threadIds = List.copyOf(threadIdToTimestamp.keySet());
+            String userName = context.get(RequestContext.USER_NAME);
+
+            // Each attempt runs in its own transaction: a constraint-violation retry must re-read a
+            // fresh snapshot, and under REPEATABLE READ re-reading within the same transaction would
+            // reuse the original snapshot and never converge.
+            return EntityConstraintHandler.<List<TraceThreadIdModel>>handle(
+                    () -> transactionTemplate.inTransaction(TransactionTemplateAsync.WRITE, handle -> {
+                        var dao = handle.attach(TraceThreadIdDAO.class);
+
+                        List<TraceThreadIdModel> existing = dao.findByProjectIdAndThreadIds(projectId, threadIds);
+                        Set<String> existingThreadIds = existing.stream()
+                                .map(TraceThreadIdModel::threadId)
+                                .collect(Collectors.toSet());
+
+                        List<String> missingThreadIds = threadIds.stream()
+                                .filter(threadId -> !existingThreadIds.contains(threadId))
+                                .toList();
+
+                        if (missingThreadIds.isEmpty()) {
+                            // Common case: every thread already has an id — no write needed.
+                            return existing;
+                        }
+
+                        // We already know exactly which threads are missing, so we own their ids.
+                        List<TraceThreadIdModel> created = missingThreadIds.stream()
+                                .map(threadId -> TraceThreadIdModel.builder()
+                                        .id(generateThreadModelId(threadIdToTimestamp.get(threadId)))
+                                        .projectId(projectId)
+                                        .threadId(threadId)
+                                        .createdBy(userName)
+                                        .createdAt(Instant.now())
+                                        .build())
+                                .toList();
+
+                        // Plain INSERT: a concurrent create trips the (project_id, thread_id) constraint
+                        // and triggers a retry, which re-reads the now-smaller missing set.
+                        dao.save(created);
+
+                        List<TraceThreadIdModel> result = new ArrayList<>(existing);
+                        result.addAll(created);
+                        return result;
+                    }))
+                    .withRetry(3, () -> new EntityAlreadyExistsException(
+                            new ErrorMessage("Failed to resolve trace thread ids for project: " + projectId)));
+        }).subscribeOn(Schedulers.boundedElastic()));
     }
 
     @Cacheable(name = "GET_TRACE_THREAD_ID", key = "$workspaceId +'-'+ $projectId +'-'+ $threadId", returnType = UUID.class)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadIdService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadIdService.java
@@ -16,6 +16,7 @@ import jakarta.ws.rs.NotFoundException;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -71,12 +72,23 @@ class TraceThreadIdServiceImpl implements TraceThreadIdService {
                 .switchIfEmpty(Mono.error(new NotFoundException("Project not found: " + projectId)));
     }
 
+    /**
+     * Bulk get-or-create of trace-thread-model ids for a project.
+     * <p>
+     * Reads the existing {@code (project_id, thread_id)} rows, then inserts only the missing ones. A
+     * conflict can arise when a concurrent caller creates the same {@code (project_id, thread_id)}
+     * between our read and our insert — the unique constraint then rejects our insert. In that case
+     * {@code withRetry} re-runs the whole read-then-insert in a fresh transaction (so a fresh snapshot
+     * under REPEATABLE READ): the retry sees the now-existing row, drops it from the missing set, and
+     * converges. The unique key guarantees a single canonical id per thread; the retry only covers the
+     * read→write race.
+     */
     @Override
-    public Mono<List<TraceThreadIdModel>> getOrCreateTraceThreadIds(@NonNull String workspaceId,
-            @NonNull UUID projectId, @NonNull Map<String, Instant> threadIdToTimestamp) {
+    public Mono<List<TraceThreadIdModel>> getOrCreateTraceThreadIds(String workspaceId,
+            @NonNull UUID projectId, Map<String, Instant> threadIdToTimestamp) {
         Preconditions.checkArgument(!StringUtils.isBlank(workspaceId), "Workspace ID cannot be blank");
 
-        if (threadIdToTimestamp.isEmpty()) {
+        if (MapUtils.isEmpty(threadIdToTimestamp)) {
             return Mono.just(List.of());
         }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadIdService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadIdService.java
@@ -62,8 +62,8 @@ class TraceThreadIdServiceImpl implements TraceThreadIdService {
     @Cacheable(name = "GET_OR_CREATE_TRACE_THREAD_ID", key = "$workspaceId +'-'+ $projectId +'-'+ $threadId", returnType = TraceThreadIdModel.class)
     public Mono<TraceThreadIdModel> getOrCreateTraceThreadId(@NonNull String workspaceId, @NonNull UUID projectId,
             @NonNull String threadId, Instant timestamp) {
-        Preconditions.checkArgument(!StringUtils.isBlank(workspaceId), "Workspace ID cannot be blank");
-        Preconditions.checkArgument(!StringUtils.isBlank(threadId), "Thread ID cannot be blank");
+        Preconditions.checkArgument(StringUtils.isNotBlank(workspaceId), "Workspace ID cannot be blank");
+        Preconditions.checkArgument(StringUtils.isNotBlank(threadId), "Thread ID cannot be blank");
 
         return Mono.fromCallable(() -> projectService.get(projectId, workspaceId))
                 .flatMap(project -> getTraceThreadId(threadId, project.id())
@@ -86,7 +86,7 @@ class TraceThreadIdServiceImpl implements TraceThreadIdService {
     @Override
     public Mono<List<TraceThreadIdModel>> getOrCreateTraceThreadIds(String workspaceId,
             @NonNull UUID projectId, Map<String, Instant> threadIdToTimestamp) {
-        Preconditions.checkArgument(!StringUtils.isBlank(workspaceId), "Workspace ID cannot be blank");
+        Preconditions.checkArgument(StringUtils.isNotBlank(workspaceId), "Workspace ID cannot be blank");
 
         if (MapUtils.isEmpty(threadIdToTimestamp)) {
             return Mono.just(List.of());
@@ -136,16 +136,17 @@ class TraceThreadIdServiceImpl implements TraceThreadIdService {
                         result.addAll(created);
                         return result;
                     }))
-                    .withRetry(3, () -> new EntityAlreadyExistsException(
-                            new ErrorMessage("Failed to resolve trace thread ids for project: " + projectId)));
+                    .withRetry(3, () -> new EntityAlreadyExistsException(new ErrorMessage(
+                            "Failed to resolve trace thread ids for project: '%s', workspace: '%s'"
+                                    .formatted(projectId, workspaceId))));
         }).subscribeOn(Schedulers.boundedElastic()));
     }
 
     @Cacheable(name = "GET_TRACE_THREAD_ID", key = "$workspaceId +'-'+ $projectId +'-'+ $threadId", returnType = UUID.class)
     public Mono<UUID> getThreadModelId(@NonNull String workspaceId, @NonNull UUID projectId,
             @NonNull String threadId) {
-        Preconditions.checkArgument(!StringUtils.isBlank(workspaceId), "Workspace ID cannot be blank");
-        Preconditions.checkArgument(!StringUtils.isBlank(threadId), "Thread ID cannot be blank");
+        Preconditions.checkArgument(StringUtils.isNotBlank(workspaceId), "Workspace ID cannot be blank");
+        Preconditions.checkArgument(StringUtils.isNotBlank(threadId), "Thread ID cannot be blank");
 
         return Mono.fromCallable(() -> projectService.get(projectId, workspaceId))
                 .flatMap(project -> getTraceThreadId(threadId, project.id())
@@ -203,7 +204,8 @@ class TraceThreadIdServiceImpl implements TraceThreadIdService {
 
     private Mono<TraceThreadIdModel> getTraceThreadId(String threadId, UUID projectId) {
         return Mono.fromCallable(() -> transactionTemplate.inTransaction(TransactionTemplateAsync.READ_ONLY,
-                handle -> handle.attach(TraceThreadIdDAO.class).findByProjectIdAndThreadId(projectId, threadId)));
+                handle -> handle.attach(TraceThreadIdDAO.class).findByProjectIdAndThreadId(projectId, threadId)
+                        .orElse(null)));
     }
 
     private Mono<TraceThreadIdModel> createThread(String threadId, UUID projectId, Instant timestamp) {
@@ -228,7 +230,7 @@ class TraceThreadIdServiceImpl implements TraceThreadIdService {
                             log.error(
                                     "Failed to create thread trying to retrieve it with project id '{}' and thread id '{}'",
                                     projectId, threadModel.threadId());
-                            return traceThreadDAO.findByProjectIdAndThreadId(projectId, threadId);
+                            return traceThreadDAO.findByProjectIdAndThreadId(projectId, threadId).orElse(null);
                         });
             });
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
@@ -356,14 +356,13 @@ class TraceThreadServiceImpl implements TraceThreadService {
 
     @Override
     public Mono<Void> openThread(@NonNull UUID projectId, @NonNull String threadId) {
-        return Mono.deferContextual(_ -> lockService.executeWithLockCustomExpire(
-                new LockService.Lock(projectId, TraceThreadService.THREADS_LOCK),
-                Mono.defer(() -> traceThreadDAO.openThread(projectId, threadId))
-                        .then(Mono.defer(() -> getOrCreateThreadId(projectId, threadId)))
-                        .doOnSuccess(_ -> log.info("Opened thread for threadId '{}' and projectId: '{}'",
-                                threadId, projectId))
-                        .then(),
-                LOCK_DURATION));
+        return getOrCreateThreadId(projectId, threadId)
+                .then(Mono.defer(() -> lockService.executeWithLockCustomExpire(
+                        new LockService.Lock(projectId, TraceThreadService.THREADS_LOCK),
+                        Mono.defer(() -> traceThreadDAO.openThread(projectId, threadId)),
+                        LOCK_DURATION)))
+                .doOnSuccess(_ -> log.info("Opened thread for threadId '{}' and projectId: '{}'", threadId, projectId))
+                .then();
     }
 
     @Override
@@ -373,19 +372,21 @@ class TraceThreadServiceImpl implements TraceThreadService {
         }
 
         return verifyAndCreateThreadsIfNeeded(projectId, threadIds)
+                // Lock only the non-idempotent op: the closure write itself.
                 .then(Mono.defer(() -> lockService.executeWithLockCustomExpire(
                         new LockService.Lock(projectId, TraceThreadService.THREADS_LOCK),
                         Mono.defer(() -> traceThreadDAO.closeThread(projectId, threadIds))
                                 .doOnSuccess(count -> log.info(
                                         "Closed count '{}' for threadIds '{}' and projectId: '{}'",
-                                        count, threadIds, projectId))
-                                .then(Mono.defer(() -> traceThreadDAO.findThreadsByProject(1, threadIds.size(),
-                                        TraceThreadCriteria.builder()
-                                                .projectId(projectId)
-                                                .threadIds(threadIds)
-                                                .build())))
-                                .flatMap(threadModels -> checkAndTriggerOnlineScoring(projectId, threadModels)),
-                        LOCK_DURATION)));
+                                        count, threadIds, projectId)),
+                        LOCK_DURATION)))
+                // The post-close read (idempotent) and online-scoring publish run outside the lock.
+                .then(Mono.defer(() -> traceThreadDAO.findThreadsByProject(1, threadIds.size(),
+                        TraceThreadCriteria.builder()
+                                .projectId(projectId)
+                                .threadIds(threadIds)
+                                .build())))
+                .flatMap(threadModels -> checkAndTriggerOnlineScoring(projectId, threadModels));
     }
 
     private Mono<Void> verifyAndCreateThreadsIfNeeded(UUID projectId, Set<String> threadIds) {
@@ -397,27 +398,80 @@ class TraceThreadServiceImpl implements TraceThreadService {
     }
 
     private Mono<Void> verifyAndCreateThreadIfNeed(UUID projectId, Set<String> threadIds) {
-        return traceService.getMinimalThreadInfoByIds(projectId, threadIds)
-                .flatMap(existingThreads -> validateIfAllThreadsExist(threadIds, existingThreads))
-                .flatMapMany(Flux::fromIterable)
-                // If the trace thread exists on the trace table, let's check if it has a trace thread model id
-                .flatMap(traceThread -> {
-                    if (traceThread.threadModelId() != null) {
-                        return Mono.just(traceThread);
+        return Mono.deferContextual(ctx -> {
+            String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
+            String userName = ctx.get(RequestContext.USER_NAME);
+
+            return traceService.getMinimalThreadInfoByIds(projectId, threadIds)
+                    .flatMap(existingThreads -> validateIfAllThreadsExist(threadIds, existingThreads))
+                    .flatMap(existingThreads -> resolveThreadModelIds(projectId, workspaceId, existingThreads))
+                    .flatMap(threadsWithIds -> createMissingThreads(projectId, workspaceId, userName, threadsWithIds))
+                    .then();
+        });
+    }
+
+    // Bulk-resolve a trace-thread-model id for every thread, allocating ids only for those missing one.
+    private Mono<List<TraceThread>> resolveThreadModelIds(UUID projectId, String workspaceId,
+            List<TraceThread> threads) {
+        Map<String, Instant> needIds = threads.stream()
+                .filter(thread -> thread.threadModelId() == null)
+                .collect(Collectors.toMap(TraceThread::id, TraceThread::createdAt, (a, b) -> a));
+
+        if (needIds.isEmpty()) {
+            return Mono.just(threads);
+        }
+
+        return traceThreadIdService.getOrCreateTraceThreadIds(workspaceId, projectId, needIds)
+                .map(models -> {
+                    Map<String, UUID> idByThreadId = models.stream()
+                            .collect(Collectors.toMap(TraceThreadIdModel::threadId, TraceThreadIdModel::id));
+                    return threads.stream()
+                            .map(thread -> thread.threadModelId() != null
+                                    ? thread
+                                    : thread.toBuilder().threadModelId(idByThreadId.get(thread.id())).build())
+                            .toList();
+                });
+    }
+
+    // Bulk-check which threads already exist in trace_threads and create the missing ones in a single write + event.
+    private Mono<Void> createMissingThreads(UUID projectId, String workspaceId, String userName,
+            List<TraceThread> threads) {
+        List<UUID> modelIds = threads.stream().map(TraceThread::threadModelId).toList();
+        var criteria = TraceThreadCriteria.builder().projectId(projectId).ids(modelIds).build();
+
+        return traceThreadDAO.findThreadsByProject(1, modelIds.size(), criteria)
+                .flatMap(existing -> {
+                    Set<UUID> existingIds = existing.stream()
+                            .map(TraceThreadModel::id)
+                            .collect(Collectors.toSet());
+
+                    List<TraceThreadModel> toCreate = threads.stream()
+                            .filter(thread -> !existingIds.contains(thread.threadModelId()))
+                            .map(thread -> TraceThreadModel.builder()
+                                    .projectId(projectId)
+                                    .threadId(thread.id())
+                                    .id(thread.threadModelId())
+                                    .status(TraceThreadStatus.ACTIVE)
+                                    .createdBy(thread.createdBy())
+                                    .lastUpdatedBy(userName)
+                                    .createdAt(thread.createdAt())
+                                    .lastUpdatedAt(Instant.now())
+                                    .environment(thread.environment())
+                                    .build())
+                            .toList();
+
+                    if (toCreate.isEmpty()) {
+                        return Mono.empty();
                     }
-                    // If it does not have a trace thread model id, create a new one using the minimum trace timestamp
-                    return getOrCreateThreadId(projectId, traceThread.id(), traceThread.createdAt())
-                            .map(id -> traceThread.toBuilder().threadModelId(id).build());
-                })
-                // If it has a trace thread model id, check if the trace thread entity exists in the database
-                .flatMap(traceThread -> traceThreadDAO.findByThreadModelId(traceThread.threadModelId(), projectId)
-                        .map(TraceThreadModel::id)
-                        //If it does not exist, create a new one
-                        .switchIfEmpty(Mono.deferContextual(ctx -> {
-                            String userName = ctx.get(RequestContext.USER_NAME);
-                            return createTraceThread(projectId, traceThread.id(), traceThread, userName);
-                        })))
-                .then();
+
+                    return traceThreadDAO.save(toCreate)
+                            .doOnSuccess(__ -> {
+                                eventBus.post(new TraceThreadsCreated(toCreate, projectId, workspaceId, userName));
+                                log.info("Created '{}' new trace threads for projectId: '{}'", toCreate.size(),
+                                        projectId);
+                            })
+                            .then();
+                });
     }
 
     private Mono<List<TraceThread>> validateIfAllThreadsExist(Set<String> threadIds,
@@ -437,33 +491,5 @@ class TraceThreadServiceImpl implements TraceThreadService {
 
         // If all threadIds exist, return any of them to continue the flow
         return Mono.just(existingThreads);
-    }
-
-    private Mono<UUID> createTraceThread(UUID projectId, String threadId, TraceThread traceThread, String userName) {
-        log.warn("Creating a new thread with id '{}' for threadId '{}' and projectId: '{}'",
-                traceThread.threadModelId(), threadId, projectId);
-
-        List<TraceThreadModel> traceThreads = List.of(TraceThreadModel.builder()
-                .projectId(projectId)
-                .threadId(threadId)
-                .id(traceThread.threadModelId())
-                .status(TraceThreadStatus.ACTIVE)
-                .createdBy(traceThread.createdBy())
-                .lastUpdatedBy(userName)
-                .createdAt(traceThread.createdAt())
-                .lastUpdatedAt(Instant.now())
-                .environment(traceThread.environment())
-                .build());
-
-        return traceThreadDAO
-                .save(traceThreads)
-                .thenReturn(traceThread.threadModelId())
-                .doOnSuccess(
-                        id -> {
-                            eventBus.post(new TraceThreadsCreated(traceThreads, projectId, traceThread.workspaceId(),
-                                    userName));
-                            log.info("Created new trace thread with id '{}' for threadId '{}' and projectId: '{}'",
-                                    id, threadId, projectId);
-                        });
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
@@ -11,6 +11,7 @@ import com.comet.opik.api.events.ProjectWithPendingClosureTraceThreads;
 import com.comet.opik.api.events.TraceThreadsCreated;
 import com.comet.opik.api.resources.v1.events.TraceThreadBufferConfig;
 import com.comet.opik.domain.IdGenerator;
+import com.comet.opik.domain.ProjectService;
 import com.comet.opik.domain.TagOperations;
 import com.comet.opik.domain.TraceService;
 import com.comet.opik.domain.WorkspaceConfigurationService;
@@ -58,9 +59,9 @@ public interface TraceThreadService {
 
     Mono<Boolean> addToPendingQueue(UUID projectId);
 
-    Mono<Void> openThread(UUID projectId, String threadId);
+    Mono<Void> openThread(UUID projectId, String projectName, String threadId);
 
-    Mono<Void> closeThreads(UUID projectId, Set<String> threadIds);
+    Mono<Void> closeThreads(UUID projectId, String projectName, Set<String> threadIds);
 
     Mono<UUID> getOrCreateThreadId(UUID projectId, String threadId);
 
@@ -85,6 +86,7 @@ class TraceThreadServiceImpl implements TraceThreadService {
     private final @NonNull TraceThreadDAO traceThreadDAO;
     private final @NonNull TraceThreadIdService traceThreadIdService;
     private final @NonNull TraceService traceService;
+    private final @NonNull ProjectService projectService;
     private final @NonNull LockService lockService;
     private final @NonNull EventBus eventBus;
     private final @NonNull TraceThreadOnlineScorerPublisher onlineScorePublisher;
@@ -355,38 +357,40 @@ class TraceThreadServiceImpl implements TraceThreadService {
     }
 
     @Override
-    public Mono<Void> openThread(@NonNull UUID projectId, @NonNull String threadId) {
-        return getOrCreateThreadId(projectId, threadId)
-                .then(Mono.defer(() -> lockService.executeWithLockCustomExpire(
-                        new LockService.Lock(projectId, TraceThreadService.THREADS_LOCK),
-                        Mono.defer(() -> traceThreadDAO.openThread(projectId, threadId)),
-                        LOCK_DURATION)))
-                .doOnSuccess(_ -> log.info("Opened thread for threadId '{}' and projectId: '{}'", threadId, projectId))
-                .then();
+    public Mono<Void> openThread(UUID projectId, String projectName, @NonNull String threadId) {
+        return projectService.resolveProjectIdAndVerifyVisibility(projectId, projectName)
+                .flatMap(id -> getOrCreateThreadId(id, threadId)
+                        .then(Mono.defer(() -> lockService.executeWithLockCustomExpire(
+                                new LockService.Lock(id, TraceThreadService.THREADS_LOCK),
+                                Mono.defer(() -> traceThreadDAO.openThread(id, threadId)),
+                                LOCK_DURATION)))
+                        .doOnSuccess(_ -> log.info("Opened thread for threadId '{}' and projectId: '{}'", threadId, id))
+                        .then());
     }
 
     @Override
-    public Mono<Void> closeThreads(@NonNull UUID projectId, @NonNull Set<String> threadIds) {
+    public Mono<Void> closeThreads(UUID projectId, String projectName, @NonNull Set<String> threadIds) {
         if (CollectionUtils.isEmpty(threadIds)) {
             return Mono.empty();
         }
 
-        return verifyAndCreateThreadsIfNeeded(projectId, threadIds)
-                // Lock only the non-idempotent op: the closure write itself.
-                .then(Mono.defer(() -> lockService.executeWithLockCustomExpire(
-                        new LockService.Lock(projectId, TraceThreadService.THREADS_LOCK),
-                        Mono.defer(() -> traceThreadDAO.closeThread(projectId, threadIds))
-                                .doOnSuccess(count -> log.info(
-                                        "Closed count '{}' for threadIds '{}' and projectId: '{}'",
-                                        count, threadIds, projectId)),
-                        LOCK_DURATION)))
-                // The post-close read (idempotent) and online-scoring publish run outside the lock.
-                .then(Mono.defer(() -> traceThreadDAO.findThreadsByProject(1, threadIds.size(),
-                        TraceThreadCriteria.builder()
-                                .projectId(projectId)
-                                .threadIds(threadIds)
-                                .build())))
-                .flatMap(threadModels -> checkAndTriggerOnlineScoring(projectId, threadModels));
+        return projectService.resolveProjectIdAndVerifyVisibility(projectId, projectName)
+                .flatMap(id -> verifyAndCreateThreadsIfNeeded(id, threadIds)
+                        // Lock only the non-idempotent op: the closure write itself.
+                        .then(Mono.defer(() -> lockService.executeWithLockCustomExpire(
+                                new LockService.Lock(id, TraceThreadService.THREADS_LOCK),
+                                Mono.defer(() -> traceThreadDAO.closeThread(id, threadIds))
+                                        .doOnSuccess(count -> log.info(
+                                                "Closed count '{}' for threadIds '{}' and projectId: '{}'",
+                                                count, threadIds, id)),
+                                LOCK_DURATION)))
+                        // The post-close read (idempotent) and online-scoring publish run outside the lock.
+                        .then(Mono.defer(() -> traceThreadDAO.findThreadsByProject(1, threadIds.size(),
+                                TraceThreadCriteria.builder()
+                                        .projectId(id)
+                                        .threadIds(threadIds)
+                                        .build())))
+                        .flatMap(threadModels -> checkAndTriggerOnlineScoring(id, threadModels)));
     }
 
     private Mono<Void> verifyAndCreateThreadsIfNeeded(UUID projectId, Set<String> threadIds) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
@@ -420,7 +420,10 @@ class TraceThreadServiceImpl implements TraceThreadService {
             List<TraceThread> threads) {
         Map<String, Instant> needIds = threads.stream()
                 .filter(thread -> thread.threadModelId() == null)
-                .collect(Collectors.toMap(TraceThread::id, TraceThread::createdAt, (a, b) -> a));
+                // On a duplicate threadId, keep the earliest createdAt — the thread-model id is derived
+                // from the first trace's timestamp.
+                .collect(Collectors.toMap(TraceThread::id, TraceThread::createdAt,
+                        (a, b) -> a.isBefore(b) ? a : b));
 
         if (needIds.isEmpty()) {
             return Mono.just(threads);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
@@ -359,12 +359,13 @@ class TraceThreadServiceImpl implements TraceThreadService {
     @Override
     public Mono<Void> openThread(UUID projectId, String projectName, @NonNull String threadId) {
         return projectService.resolveProjectIdAndVerifyVisibility(projectId, projectName)
-                .flatMap(id -> getOrCreateThreadId(id, threadId)
+                .flatMap(verifiedProjectId -> getOrCreateThreadId(verifiedProjectId, threadId)
                         .then(Mono.defer(() -> lockService.executeWithLockCustomExpire(
-                                new LockService.Lock(id, TraceThreadService.THREADS_LOCK),
-                                Mono.defer(() -> traceThreadDAO.openThread(id, threadId)),
+                                new LockService.Lock(verifiedProjectId, TraceThreadService.THREADS_LOCK),
+                                Mono.defer(() -> traceThreadDAO.openThread(verifiedProjectId, threadId)),
                                 LOCK_DURATION)))
-                        .doOnSuccess(_ -> log.info("Opened thread for threadId '{}' and projectId: '{}'", threadId, id))
+                        .doOnSuccess(_ -> log.info("Opened thread for threadId '{}' and projectId: '{}'", threadId,
+                                verifiedProjectId))
                         .then());
     }
 
@@ -375,22 +376,22 @@ class TraceThreadServiceImpl implements TraceThreadService {
         }
 
         return projectService.resolveProjectIdAndVerifyVisibility(projectId, projectName)
-                .flatMap(id -> verifyAndCreateThreadsIfNeeded(id, threadIds)
+                .flatMap(verifiedProjectId -> verifyAndCreateThreadsIfNeeded(verifiedProjectId, threadIds)
                         // Lock only the non-idempotent op: the closure write itself.
                         .then(Mono.defer(() -> lockService.executeWithLockCustomExpire(
-                                new LockService.Lock(id, TraceThreadService.THREADS_LOCK),
-                                Mono.defer(() -> traceThreadDAO.closeThread(id, threadIds))
+                                new LockService.Lock(verifiedProjectId, TraceThreadService.THREADS_LOCK),
+                                Mono.defer(() -> traceThreadDAO.closeThread(verifiedProjectId, threadIds))
                                         .doOnSuccess(count -> log.info(
                                                 "Closed count '{}' for threadIds '{}' and projectId: '{}'",
-                                                count, threadIds, id)),
+                                                count, threadIds, verifiedProjectId)),
                                 LOCK_DURATION)))
                         // The post-close read (idempotent) and online-scoring publish run outside the lock.
                         .then(Mono.defer(() -> traceThreadDAO.findThreadsByProject(1, threadIds.size(),
                                 TraceThreadCriteria.builder()
-                                        .projectId(id)
+                                        .projectId(verifiedProjectId)
                                         .threadIds(threadIds)
                                         .build())))
-                        .flatMap(threadModels -> checkAndTriggerOnlineScoring(id, threadModels)));
+                        .flatMap(threadModels -> checkAndTriggerOnlineScoring(verifiedProjectId, threadModels)));
     }
 
     private Mono<Void> verifyAndCreateThreadsIfNeeded(UUID projectId, Set<String> threadIds) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
@@ -585,6 +585,11 @@ public class TraceResourceClient extends BaseCommentResourceClient {
 
     public void openTraceThread(String threadId, UUID projectId, String projectName, String apiKey,
             String workspaceName) {
+        openTraceThread(threadId, projectId, projectName, apiKey, workspaceName, HttpStatus.SC_NO_CONTENT);
+    }
+
+    public void openTraceThread(String threadId, UUID projectId, String projectName, String apiKey,
+            String workspaceName, int expectedStatus) {
         try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
                 .path("threads")
                 .path("open")
@@ -594,7 +599,7 @@ public class TraceResourceClient extends BaseCommentResourceClient {
                 .put(Entity.json(TraceThreadIdentifier.builder().projectId(projectId).projectName(projectName)
                         .threadId(threadId).build()))) {
 
-            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+            assertThat(response.getStatus()).isEqualTo(expectedStatus);
         }
     }
 
@@ -615,6 +620,11 @@ public class TraceResourceClient extends BaseCommentResourceClient {
 
     public void closeTraceThreads(Set<String> threadIds, UUID projectId, String projectName, String apiKey,
             String workspaceName) {
+        closeTraceThreads(threadIds, projectId, projectName, apiKey, workspaceName, HttpStatus.SC_NO_CONTENT);
+    }
+
+    public void closeTraceThreads(Set<String> threadIds, UUID projectId, String projectName, String apiKey,
+            String workspaceName, int expectedStatus) {
         try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
                 .path("threads")
                 .path("close")
@@ -624,7 +634,7 @@ public class TraceResourceClient extends BaseCommentResourceClient {
                 .put(Entity.json(TraceThreadBatchIdentifier.builder().projectId(projectId).projectName(projectName)
                         .threadIds(threadIds).build()))) {
 
-            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+            assertThat(response.getStatus()).isEqualTo(expectedStatus);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -6474,6 +6474,39 @@ class TracesResourceTest {
             traceResourceClient.closeTraceThreads(Set.of(randomUUID().toString()), projectId, projectName, apiKeyB,
                     workspaceNameB, HttpStatus.SC_NOT_FOUND);
         }
+
+        @Test
+        @DisplayName("close threads: when thread belongs to a different project in the same workspace, then return not found")
+        void closeTraceThreads__whenThreadBelongsToAnotherProject__thenReturnNotFound() {
+            var workspaceName = RandomStringUtils.secure().nextAlphanumeric(10);
+            var apiKey = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, UUID.randomUUID().toString());
+
+            // Project A owns the thread
+            var projectNameA = RandomStringUtils.secure().nextAlphanumeric(10);
+            UUID projectIdA = projectResourceClient.createProject(projectNameA, apiKey, workspaceName);
+            var threadId = randomUUID().toString();
+
+            Trace trace = createTrace().toBuilder()
+                    .threadId(threadId)
+                    .projectId(projectIdA)
+                    .projectName(projectNameA)
+                    .build();
+            traceResourceClient.batchCreateTraces(List.of(trace), apiKey, workspaceName);
+
+            Awaitility.await().pollInterval(500, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+                var page = traceResourceClient.getTraceThreads(projectIdA, projectNameA, apiKey, workspaceName,
+                        List.of(), List.of(), Map.of());
+                assertThat(page.content()).hasSize(1);
+            });
+
+            // Project B (same workspace) does not contain the thread
+            var projectNameB = RandomStringUtils.secure().nextAlphanumeric(10);
+            UUID projectIdB = projectResourceClient.createProject(projectNameB, apiKey, workspaceName);
+
+            traceResourceClient.closeTraceThreads(Set.of(threadId), projectIdB, projectNameB, apiKey, workspaceName,
+                    HttpStatus.SC_NOT_FOUND);
+        }
     }
 
     @Nested

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -6434,6 +6434,46 @@ class TracesResourceTest {
 
             TraceAssertions.assertThreads(expectedClosedThreads, closedThreadPage.content());
         }
+
+        @Test
+        @DisplayName("open thread: when projectId belongs to another workspace, then return not found")
+        void openTraceThread__whenProjectBelongsToAnotherWorkspace__thenReturnNotFound() {
+            // Workspace A owns the project
+            var workspaceNameA = RandomStringUtils.secure().nextAlphanumeric(10);
+            var apiKeyA = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKeyA, workspaceNameA, UUID.randomUUID().toString());
+
+            var projectName = RandomStringUtils.secure().nextAlphanumeric(10);
+            UUID projectId = projectResourceClient.createProject(projectName, apiKeyA, workspaceNameA);
+
+            // Workspace B does not own it
+            var workspaceNameB = RandomStringUtils.secure().nextAlphanumeric(10);
+            var apiKeyB = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKeyB, workspaceNameB, UUID.randomUUID().toString());
+
+            traceResourceClient.openTraceThread(randomUUID().toString(), projectId, projectName, apiKeyB,
+                    workspaceNameB, HttpStatus.SC_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("close threads: when projectId belongs to another workspace, then return not found")
+        void closeTraceThreads__whenProjectBelongsToAnotherWorkspace__thenReturnNotFound() {
+            // Workspace A owns the project
+            var workspaceNameA = RandomStringUtils.secure().nextAlphanumeric(10);
+            var apiKeyA = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKeyA, workspaceNameA, UUID.randomUUID().toString());
+
+            var projectName = RandomStringUtils.secure().nextAlphanumeric(10);
+            UUID projectId = projectResourceClient.createProject(projectName, apiKeyA, workspaceNameA);
+
+            // Workspace B does not own it
+            var workspaceNameB = RandomStringUtils.secure().nextAlphanumeric(10);
+            var apiKeyB = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKeyB, workspaceNameB, UUID.randomUUID().toString());
+
+            traceResourceClient.closeTraceThreads(Set.of(randomUUID().toString()), projectId, projectName, apiKeyB,
+                    workspaceNameB, HttpStatus.SC_NOT_FOUND);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Details

Follow-up to #7121 and #7131 (both merged). Tightens the remaining trace-thread lock usage and removes per-thread DB round-trips on the open/close paths.

Why keep the project-based lock instead of going per-thread: #7121 and #7131 already removed the lock from the two most expensive acquirers — trace ingestion (`processTraceThreads`) and the online-scoring writes (`setScoredAt` / sampling) — which were the real contention against ingestion and online scoring. What remains (`openThread` / `closeThreads`) is low-frequency, and going per-thread there would be a net loss (a batch of N threads → N locks + N DB round-trips vs one bulk op under one lock). So we keep the project lock and shrink what runs under it to the genuinely non-idempotent work.

- `openThread`: resolve the thread-model id (`getOrCreateThreadId`, idempotent) outside the lock; the lock wraps only the status flip.
- `closeThreads`: lock only the non-idempotent closure write; the post-close read (idempotent) and the online-scoring publish (a Redis-stream write) run outside the lock.
- `verifyAndCreateThreadIfNeed`: fully bulk — one bulk get-or-create of thread-model ids (`getOrCreateTraceThreadIds`: bulk read + batch `INSERT`, with a constraint-violation retry in a fresh transaction so it converges under REPEATABLE READ), one bulk existence check, one batch `save` + a single `TraceThreadsCreated` event. For N threads this goes from ~3N sequential round-trips + N events to ~3 queries + 1 event.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6968

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8 (1M context)
  - Scope: Scoped open/close locks to non-idempotent ops; bulked the thread resolve/create path (new bulk DAO + service methods); audited that every read-modify-write still reads the latest version.
  - Human verification: pending review

## Testing

- `mvn test-compile` (JDK 25) — BUILD SUCCESS (main + test).
- `mvn spotless:check` — passed.
- Not run locally: full `mvn test` (DB-backed integration suites, incl. JDBI batch + constraint-retry behavior) — relying on CI.

## Documentation

N/A — internal performance refactor; no API or user-facing documentation changes.
