### PR TITLE
[OPIK-6786] [DOCS] docs: document the Opik MCP install step in opik configure

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/mcp-server.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/mcp-server.mdx
@@ -29,7 +29,35 @@ PyPI release lands, replace `uvx opik-mcp` in any snippet on this page with
 `uvx --from git+https://github.com/comet-ml/opik-mcp.git opik-mcp`.
 </Tip>
 
-## Setting up the MCP server
+## Quick setup with the Opik CLI
+
+The easiest way to connect the MCP server is the Opik CLI. It detects your AI
+host (Claude Code, Cursor, VS Code Copilot) and sets it up for you.
+
+When you run [`opik configure`](/tracing/advanced/sdk_configuration), it offers
+to set up the MCP server at the end:
+
+> Set up the Opik MCP server for an AI assistant (Claude Code, Cursor, VS Code)? (y/N)
+
+Already configured Opik? Run the wizard on its own at any time:
+
+```bash
+opik mcp configure
+```
+
+That's it — restart your AI host and ask **"list my Opik projects"** to confirm
+it works.
+
+<Note>
+You need [`uv`](https://docs.astral.sh/uv/) installed (`brew install uv` or
+`curl -LsSf https://astral.sh/uv/install.sh | sh`). If your host isn't detected,
+use [Manual setup](#manual-setup) below.
+</Note>
+
+## Manual setup
+
+Prefer to wire it up yourself, or your host wasn't detected? Configure any host
+by hand below.
 
 <Tip>
 `OPIK_WORKSPACE` is **optional** — you can omit the `OPIK_WORKSPACE` line/key


### PR DESCRIPTION
## Details

Documents the automated MCP setup flow added in OPIK-6767 on the MCP server docs page. Previously the page only covered manual per-host configuration. Adds a "Quick setup with the Opik CLI" section describing the opt-in MCP step at the end of `opik configure` and the standalone `opik mcp configure` wizard, kept intentionally user-focused (minimal internals), and links out to the SDK configuration page. The existing manual instructions are retained under a "Manual setup" heading.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-6786

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8 (1M context)
  - Scope: full implementation (docs authoring)
  - Human verification: code review

## Testing

Documentation-only change (single MDX file). Verified MDX components are balanced and the in-page (`#manual-setup`) and cross-page (`/tracing/advanced/sdk_configuration`) links resolve. No code paths changed, so no automated tests apply.

## Documentation

Updates `apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/mcp-server.mdx` (MCP server page). No routing change needed — the page is already registered in `versions/latest.yml`.