### PR TITLE
[OPIK-6985] [BE][FE] feat: gate Cost Intelligence on org entitlement

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1093,9 +1093,6 @@ serviceToggles:
   # Default: false
   # Description: Whether or not Optimization Studio feature is enabled
   optimizationStudioEnabled: ${TOGGLE_OPTIMIZATION_STUDIO_ENABLED:-"false"}
-  # Default: false
-  # Description: Whether or not the Cost Intelligence (AI Spend) feature is enabled
-  costIntelligenceEnabled: ${TOGGLE_COST_INTELLIGENCE_ENABLED:-"false"}
   # Default: true
   # Description: Whether or not OpenAI provider is enabled
   openaiProviderEnabled: ${TOGGLE_OPENAI_PROVIDER_ENABLED:-"true"}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
@@ -39,8 +39,6 @@ public class ServiceTogglesConfig {
     @JsonProperty
     @NotNull boolean optimizationStudioEnabled;
     @JsonProperty
-    @NotNull boolean costIntelligenceEnabled;
-    @JsonProperty
     @NotNull boolean datasetVersioningEnabled;
     @JsonProperty
     @NotNull boolean datasetExportEnabled;

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -650,9 +650,6 @@ serviceToggles:
   # Default: false
   # Description: Whether or not Optimization Studio feature is enabled
   optimizationStudioEnabled: "false"
-  # Default: false
-  # Description: Whether or not the Cost Intelligence (AI Spend) feature is enabled
-  costIntelligenceEnabled: "false"
   # Default: true
   # Description: Whether or not OpenAI provider is enabled
   openaiProviderEnabled: "true"

--- a/apps/opik-frontend/src/contexts/feature-toggles-provider.tsx
+++ b/apps/opik-frontend/src/contexts/feature-toggles-provider.tsx
@@ -28,7 +28,6 @@ const DEFAULT_STATE: FeatureToggles = {
   [FeatureToggleKeys.OLLIE_ENABLED]: false,
   [FeatureToggleKeys.PROJECT_HOMEPAGE_ENABLED]: false,
   [FeatureToggleKeys.OPTIMIZATION_STUDIO_ENABLED]: false,
-  [FeatureToggleKeys.COST_INTELLIGENCE_ENABLED]: false,
   [FeatureToggleKeys.SPAN_LLM_AS_JUDGE_ENABLED]: false,
   [FeatureToggleKeys.SPAN_USER_DEFINED_METRIC_PYTHON_ENABLED]: false,
   [FeatureToggleKeys.AGENTIC_TOOLS_ENABLED]: false,

--- a/apps/opik-frontend/src/plugins/comet/UserMenuAppLinks.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenuAppLinks.tsx
@@ -5,8 +5,6 @@ import { cn } from "@/lib/utils";
 import { useOpikWorkspaceName } from "@/store/AppStore";
 import { useAiSpend } from "@/contexts/AiSpendContext";
 import usePluginsStore from "@/store/PluginsStore";
-import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
-import { FeatureToggleKeys } from "@/types/feature-toggles";
 import { buildUrl } from "./utils";
 
 type AppLinkItemProps = {
@@ -68,16 +66,9 @@ const UserMenuAppLinks = ({ isLLMOnlyOrganization }: UserMenuAppLinksProps) => {
   const hasAiSpendPlugin = usePluginsStore((state) =>
     state.hasPlugin("ai-spend"),
   );
-  const costIntelligenceFeatureEnabled = useIsFeatureEnabled(
-    FeatureToggleKeys.COST_INTELLIGENCE_ENABLED,
-  );
-
   const showOpikReturn = Boolean(isSpendWorkspaceActive);
   const showCostIntelligence =
-    hasAiSpendPlugin &&
-    hasAiSpendAccess &&
-    costIntelligenceFeatureEnabled &&
-    !isSpendWorkspaceActive;
+    hasAiSpendPlugin && hasAiSpendAccess && !isSpendWorkspaceActive;
   const showExperimentManagement = !isLLMOnlyOrganization;
 
   if (!showOpikReturn && !showCostIntelligence && !showExperimentManagement) {

--- a/apps/opik-frontend/src/plugins/comet/types.ts
+++ b/apps/opik-frontend/src/plugins/comet/types.ts
@@ -55,6 +55,7 @@ export interface Organization {
   role: ORGANIZATION_ROLE_TYPE;
   onlyAdminsInviteByEmail: boolean;
   workspaceRolesEnabled: boolean;
+  costIntelligenceEnabled: boolean;
 }
 
 export enum ManagementPermissionsNames {

--- a/apps/opik-frontend/src/plugins/comet/useAiSpendManager.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAiSpendManager.ts
@@ -45,7 +45,7 @@ const useAiSpendManager = () => {
     isOrganizationAdmin,
     hasAccess:
       Boolean(spendWorkspace) &&
-      isEnterprise &&
+      Boolean(organization?.costIntelligenceEnabled) &&
       isOrganizationAdmin &&
       workspaceVersion === "v2",
   };

--- a/apps/opik-frontend/src/types/feature-toggles.ts
+++ b/apps/opik-frontend/src/types/feature-toggles.ts
@@ -15,7 +15,6 @@ export enum FeatureToggleKeys {
   SPAN_LLM_AS_JUDGE_ENABLED = "span_llm_as_judge_enabled",
   SPAN_USER_DEFINED_METRIC_PYTHON_ENABLED = "span_user_defined_metric_python_enabled",
   OPTIMIZATION_STUDIO_ENABLED = "optimization_studio_enabled",
-  COST_INTELLIGENCE_ENABLED = "cost_intelligence_enabled",
   // Gates the spans-in-LLM-judge feature: agentic-tools loop AND the {{spans}}
   // template substitution in trace-scope rules. When off, FE editors stop
   // auto-filling `spans → "spans"` and keep the row visible/editable so the user


### PR DESCRIPTION
## Details

Replaces the deployment-wide `cost_intelligence_enabled` service toggle with a per-organization entitlement. The Cost Intelligence menu/access now gates on `organization.costIntelligenceEnabled` (returned by comet's `/organizations`), giving sales a reversible, per-customer on/off switch instead of an all-or-nothing deployment flag.

- `useAiSpendManager.hasAccess` now reads `organization.costIntelligenceEnabled` (kept org-admin + v2 guards); `UserMenuAppLinks` no longer checks the feature toggle.
- Removes the `costIntelligenceEnabled` service toggle from `ServiceTogglesConfig`, `config.yml`/`config-test.yml`, and the FE feature-toggle definitions.
- Depends on the comet-backend PR that adds the `costIntelligenceEnabled` org field, and on the standard OpenAPI/Fern + SDK regeneration (generated specs intentionally left untouched here — regenerate via `scripts/generate_openapi.sh`).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6985

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.x
  - Scope: full implementation
  - Human verification: code review + manual testing

## Testing

- `scripts/dev-runner.sh --lint-fe` (eslint + tsc typecheck + dependency-cruiser) — all pass.
- Backend: field removal compiles; no remaining references to the toggle (`AiSpendResource` never gated on it).
- Not run locally: full `mvn test`; generated OpenAPI/Fern + SDKs require regeneration (follow-up / CI).

## Documentation

N/A