### PR TITLE
[OPIK-6964] [SDK] [DOCS] feat: scope opik export/import to a project (v2)

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/export_data.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/export_data.mdx
@@ -143,6 +143,8 @@ Select the traces or spans you want to export in the Opik dashboard and click **
 
 The `opik export` and `opik import` commands let you export traces, spans, datasets, prompts, and experiments for a project to local JSON or CSV files, and import them back — useful for migrations, backups, and cross-environment syncs. Every command is scoped to a single project, named right after the workspace.
 
+On disk, folders and files are keyed by **ID**: data lands under `<path>/<workspace>/projects/<project_id>/`, with a `project.json` (`{"id", "name"}`) and id-named item files (`dataset_<id>.json`, `prompt_<id>.json`, `experiment_<id>.json`, `trace_<id>.json`). Human names are stored as data inside the files — this keeps paths free of `/`, `:`, and spaces. You still pass project and item **names** on the command line; the CLI resolves names ↔ IDs for you.
+
 ### Export
 
 ```bash
@@ -184,7 +186,12 @@ opik import my-workspace my-project traces
 
 # Preview what would be imported
 opik import my-workspace my-project all --dry-run
+
+# Import into a different (renamed or scratch) destination project
+opik import my-workspace my-project all --to-project my-restore
 ```
+
+The project name is matched against the `name` recorded in each exported `project.json`, so point `--path` at the workspace directory produced by export (`<export --path>/<workspace>`). Use `--to-project <NAME>` to import into a different destination project (default: the source project's name).
 
 Imports are automatically resumable — if interrupted, re-run the same command and it picks up where it left off using a local `migration_manifest.db`.
 
@@ -192,12 +199,14 @@ Imports are automatically resumable — if interrupted, re-run the same command 
 
 ```bash
 # Step 1: Export from source (use source credentials)
+# Writes to ./migration_data/my-workspace/projects/<project_id>/
 OPIK_API_KEY=<source_key> OPIK_URL_OVERRIDE=https://source.opik.example.com \
   opik export my-workspace my-project all --path ./migration_data
 
 # Step 2: Import to destination (use destination credentials)
+# Point --path at the workspace dir produced by export.
 OPIK_API_KEY=<dest_key> OPIK_URL_OVERRIDE=https://dest.opik.example.com \
-  opik import my-workspace my-project all --path ./migration_data
+  opik import my-workspace my-project all --path ./migration_data/my-workspace
 ```
 
 See the CLI help (`opik export --help` / `opik import --help`) for all options and troubleshooting.

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/export_data.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/export_data.mdx
@@ -148,10 +148,10 @@ On disk, folders and files are keyed by **ID**: data lands under `<path>/<worksp
 ### Export
 
 ```bash
-opik export WORKSPACE PROJECT TYPE [NAME] [OPTIONS]
+opik export WORKSPACE PROJECT ITEM [NAME] [OPTIONS]
 ```
 
-`TYPE` is one of: `all`, `dataset`, `traces`, `experiment`, `prompt`
+`ITEM` is one of: `all`, `dataset`, `traces`, `experiment`, `prompt`
 
 ```bash
 # Export everything in a project
@@ -174,7 +174,7 @@ opik export my-workspace my-project traces --format csv --path ./csv_data
 ### Import
 
 ```bash
-opik import WORKSPACE PROJECT TYPE [NAME] [OPTIONS]
+opik import WORKSPACE PROJECT ITEM [NAME] [OPTIONS]
 ```
 
 ```bash

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/export_data.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/export_data.mdx
@@ -141,49 +141,49 @@ Select the traces or spans you want to export in the Opik dashboard and click **
 
 ## Command-line tools
 
-The `opik export` and `opik import` commands let you export traces, spans, datasets, prompts, and experiments to local JSON or CSV files, and import them back — useful for migrations, backups, and cross-environment syncs.
+The `opik export` and `opik import` commands let you export traces, spans, datasets, prompts, and experiments for a project to local JSON or CSV files, and import them back — useful for migrations, backups, and cross-environment syncs. Every command is scoped to a single project, named right after the workspace.
 
 ### Export
 
 ```bash
-opik export WORKSPACE TYPE NAME [OPTIONS]
+opik export WORKSPACE PROJECT TYPE [NAME] [OPTIONS]
 ```
 
-`TYPE` is one of: `all`, `dataset`, `project`, `experiment`, `prompt`
+`TYPE` is one of: `all`, `dataset`, `traces`, `experiment`, `prompt`
 
 ```bash
-# Export everything in a workspace
-opik export my-workspace all
+# Export everything in a project
+opik export my-workspace my-project all
 
-# Export a specific project
-opik export my-workspace project "my-project"
+# Export the project's traces
+opik export my-workspace my-project traces
 
 # Export a specific dataset
-opik export my-workspace dataset "my-test-dataset"
+opik export my-workspace my-project dataset "my-test-dataset"
 
 # Export with a date filter
-opik export my-workspace project "my-project" \
+opik export my-workspace my-project traces \
   --filter 'created_at >= "2024-01-01T00:00:00Z"'
 
 # Export as CSV for analysis
-opik export my-workspace project "my-project" --format csv --path ./csv_data
+opik export my-workspace my-project traces --format csv --path ./csv_data
 ```
 
 ### Import
 
 ```bash
-opik import WORKSPACE TYPE NAME [OPTIONS]
+opik import WORKSPACE PROJECT TYPE [NAME] [OPTIONS]
 ```
 
 ```bash
 # Import a dataset
-opik import my-workspace dataset "my-dataset"
+opik import my-workspace my-project dataset "my-dataset"
 
-# Import a project
-opik import my-workspace project "my-project"
+# Import the project's traces
+opik import my-workspace my-project traces
 
 # Preview what would be imported
-opik import my-workspace project "my-project" --dry-run
+opik import my-workspace my-project all --dry-run
 ```
 
 Imports are automatically resumable — if interrupted, re-run the same command and it picks up where it left off using a local `migration_manifest.db`.
@@ -193,11 +193,11 @@ Imports are automatically resumable — if interrupted, re-run the same command 
 ```bash
 # Step 1: Export from source (use source credentials)
 OPIK_API_KEY=<source_key> OPIK_URL_OVERRIDE=https://source.opik.example.com \
-  opik export my-workspace project "my-project" --path ./migration_data
+  opik export my-workspace my-project all --path ./migration_data
 
 # Step 2: Import to destination (use destination credentials)
 OPIK_API_KEY=<dest_key> OPIK_URL_OVERRIDE=https://dest.opik.example.com \
-  opik import my-workspace project "my-project" --path ./migration_data
+  opik import my-workspace my-project all --path ./migration_data
 ```
 
 See the CLI help (`opik export --help` / `opik import --help`) for all options and troubleshooting.

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/export_data.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/export_data.mdx
@@ -191,7 +191,7 @@ opik import my-workspace my-project all --dry-run
 opik import my-workspace my-project all --to-project my-restore
 ```
 
-The project name is matched against the `name` recorded in each exported `project.json`, so point `--path` at the workspace directory produced by export (`<export --path>/<workspace>`). Use `--to-project <NAME>` to import into a different destination project (default: the source project's name).
+The project name is matched against the `name` recorded in each exported `project.json`. Import uses the same `--path` as export (both resolve `<path>/<workspace>/projects/<id>/`), so no path juggling is needed. Use `--to-project <NAME>` to import into a different destination project (default: the source project's name).
 
 Imports are automatically resumable — if interrupted, re-run the same command and it picks up where it left off using a local `migration_manifest.db`.
 
@@ -204,9 +204,9 @@ OPIK_API_KEY=<source_key> OPIK_URL_OVERRIDE=https://source.opik.example.com \
   opik export my-workspace my-project all --path ./migration_data
 
 # Step 2: Import to destination (use destination credentials)
-# Point --path at the workspace dir produced by export.
+# Same --path as export — import resolves <path>/my-workspace/projects/<id>/.
 OPIK_API_KEY=<dest_key> OPIK_URL_OVERRIDE=https://dest.opik.example.com \
-  opik import my-workspace my-project all --path ./migration_data/my-workspace
+  opik import my-workspace my-project all --path ./migration_data
 ```
 
 See the CLI help (`opik export --help` / `opik import --help`) for all options and troubleshooting.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
@@ -148,9 +148,9 @@ Imports specific data types from local files into the specified project.
 **Note:** Experiment imports automatically recreate experiments where possible. No additional flags are needed.
 
 **Note:** `PROJECT` is matched by name against the `name` recorded in each
-exported `project.json` (folders on disk are named by project ID). Point
-`--path` at the directory that contains `projects/` — i.e. the workspace
-directory produced by export (`<export --path>/<workspace>`).
+exported `project.json` (folders on disk are named by project ID). Import uses
+the same `--path` as export — both resolve `<path>/<workspace>/projects/<id>/` —
+so the same `--path` round-trips with no path juggling.
 
 ### Resumable imports
 
@@ -455,9 +455,9 @@ your destination credentials. The `migration_manifest.db` created during
 import travels with the exported data and makes the import safe to interrupt
 and resume.
 
-Export writes to `<--path>/<workspace>/projects/<project_id>/`, so on import
-point `--path` at the workspace directory (one level below the export `--path`).
-Add `--to-project <NAME>` to import into a different destination project.
+Export writes to `<--path>/<workspace>/projects/<project_id>/`, and import reads
+the same layout, so use the same `--path` on both sides. Add `--to-project <NAME>`
+to import into a different destination project.
 
 ```bash
 # Step 1: Export from source (run with source API key / Opik URL)
@@ -466,10 +466,9 @@ OPIK_API_KEY=<source_key> OPIK_URL_OVERRIDE=https://source.opik.example.com \
   opik export my-workspace my-project traces --path ./migration_data
 
 # Step 2: Import to destination (run with destination API key / Opik URL)
-# Point --path at the workspace dir produced by export.
-# If this is interrupted, just re-run the same command — it resumes automatically.
+# Same --path as export. If interrupted, just re-run — it resumes automatically.
 OPIK_API_KEY=<dest_key> OPIK_URL_OVERRIDE=https://dest.opik.example.com \
-  opik import my-workspace my-project traces --path ./migration_data/my-workspace
+  opik import my-workspace my-project traces --path ./migration_data
 ```
 
 To migrate all data types at once:
@@ -481,12 +480,11 @@ OPIK_API_KEY=<source_key> opik export my-workspace my-project prompt "my-prompt"
 OPIK_API_KEY=<source_key> opik export my-workspace my-project traces --path ./migration_data
 OPIK_API_KEY=<source_key> opik export my-workspace my-project experiment "my-experiment" --path ./migration_data
 
-# Import everything (destination credentials).
-# Point --path at the workspace dir produced by export.
-OPIK_API_KEY=<dest_key> opik import my-workspace my-project dataset "my-dataset" --path ./migration_data/my-workspace
-OPIK_API_KEY=<dest_key> opik import my-workspace my-project prompt "my-prompt" --path ./migration_data/my-workspace
-OPIK_API_KEY=<dest_key> opik import my-workspace my-project traces --path ./migration_data/my-workspace
-OPIK_API_KEY=<dest_key> opik import my-workspace my-project experiment "my-experiment" --path ./migration_data/my-workspace
+# Import everything (destination credentials) — same --path as export.
+OPIK_API_KEY=<dest_key> opik import my-workspace my-project dataset "my-dataset" --path ./migration_data
+OPIK_API_KEY=<dest_key> opik import my-workspace my-project prompt "my-prompt" --path ./migration_data
+OPIK_API_KEY=<dest_key> opik import my-workspace my-project traces --path ./migration_data
+OPIK_API_KEY=<dest_key> opik import my-workspace my-project experiment "my-experiment" --path ./migration_data
 ```
 
 ### 2. Data Backup
@@ -669,17 +667,17 @@ cat ./temp_data/my-workspace/projects/*/project.json   # maps the ID folder to t
 ls ./temp_data/my-workspace/projects/*/datasets/
 cat ./temp_data/my-workspace/projects/*/trace_*.json | head -20
 
-# 3. Dry run import to see what would be imported (point --path at the workspace dir)
-opik import my-workspace my-project dataset "my-dataset" --path ./temp_data/my-workspace --dry-run
-opik import my-workspace my-project traces --path ./temp_data/my-workspace --dry-run
-opik import my-workspace my-project experiment "my-experiment" --path ./temp_data/my-workspace --dry-run
-opik import my-workspace my-project prompt "my-template" --path ./temp_data/my-workspace --dry-run
+# 3. Dry run import to see what would be imported (same --path as export)
+opik import my-workspace my-project dataset "my-dataset" --path ./temp_data --dry-run
+opik import my-workspace my-project traces --path ./temp_data --dry-run
+opik import my-workspace my-project experiment "my-experiment" --path ./temp_data --dry-run
+opik import my-workspace my-project prompt "my-template" --path ./temp_data --dry-run
 
 # 4. Import all data — if interrupted, just re-run the same commands to resume
-opik import my-workspace my-project dataset "my-dataset" --path ./temp_data/my-workspace
-opik import my-workspace my-project traces --path ./temp_data/my-workspace
-opik import my-workspace my-project experiment "my-experiment" --path ./temp_data/my-workspace
-opik import my-workspace my-project prompt "my-template" --path ./temp_data/my-workspace
+opik import my-workspace my-project dataset "my-dataset" --path ./temp_data
+opik import my-workspace my-project traces --path ./temp_data
+opik import my-workspace my-project experiment "my-experiment" --path ./temp_data
+opik import my-workspace my-project prompt "my-template" --path ./temp_data
 
 # 5. Clean up temporary data
 rm -rf ./temp_data

--- a/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
@@ -16,14 +16,14 @@ The export/import command-line functions enable you to:
 - **Migrate**: Move data between projects or environments, including experiments and prompts
 - **Backup**: Create local backups of specific project data
 
-## `opik export WORKSPACE PROJECT TYPE [NAME]`
+## `opik export WORKSPACE PROJECT ITEM [NAME]`
 
 Exports specific data types from the specified project to local files.
 
 **Arguments:**
 - `WORKSPACE`: The workspace name to export from
 - `PROJECT`: The project to export from (every dataset, prompt, and experiment belongs to it)
-- `TYPE`: The type of data to export (`all`, `dataset`, `traces`, `experiment`, or `prompt`)
+- `ITEM`: The kind of data to export (`all`, `dataset`, `traces`, `experiment`, or `prompt`)
 - `NAME`: Exact name of the item to export (not used with `all` or `traces`)
 
 **Options:**
@@ -127,14 +127,14 @@ opik export my-workspace my-project dataset "my-dataset" --debug --force
 opik export my-workspace my-project traces --page-size 100
 ```
 
-## `opik import WORKSPACE PROJECT TYPE [NAME]`
+## `opik import WORKSPACE PROJECT ITEM [NAME]`
 
 Imports specific data types from local files into the specified project.
 
 **Arguments:**
 - `WORKSPACE`: The workspace name to import to
 - `PROJECT`: The project to import into (every dataset, prompt, and experiment belongs to it)
-- `TYPE`: The type of data to import (`all`, `dataset`, `traces`, `experiment`, or `prompt`)
+- `ITEM`: The kind of data to import (`all`, `dataset`, `traces`, `experiment`, or `prompt`)
 - `NAME`: Name pattern to match items (case-insensitive substring matching; not used with `all` or `traces`)
 
 **Options:**

--- a/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
@@ -16,27 +16,28 @@ The export/import command-line functions enable you to:
 - **Migrate**: Move data between projects or environments, including experiments and prompts
 - **Backup**: Create local backups of specific project data
 
-## `opik export WORKSPACE TYPE NAME`
+## `opik export WORKSPACE PROJECT TYPE [NAME]`
 
-Exports specific data types from the specified workspace to local files.
+Exports specific data types from the specified project to local files.
 
 **Arguments:**
 - `WORKSPACE`: The workspace name to export from
-- `TYPE`: The type of data to export (`all`, `dataset`, `project`, `experiment`, or `prompt`)
-- `NAME`: Exact name of the item to export (not used with `all`)
+- `PROJECT`: The project to export from (every dataset, prompt, and experiment belongs to it)
+- `TYPE`: The type of data to export (`all`, `dataset`, `traces`, `experiment`, or `prompt`)
+- `NAME`: Exact name of the item to export (not used with `all` or `traces`)
 
 **Options:**
 - `--path, -p`: Directory to save exported data (default: `opik_exports`)
 - `--max-results`: Maximum number of items to export per data type (default: 1000)
-- `--filter`: OQL filter string applied to traces — works with `project`, `experiment`, and `all`
+- `--filter`: OQL filter string applied to traces — works with `traces`, `experiment`, and `all`
 - `--force`: Re-download items even if they already exist locally
 - `--format`: Format for exporting data (`json` or `csv`, default: `json`)
 - `--debug`: Enable debug output to show detailed information about the export process
 - `--no-attachments`: Skip downloading attachment files.
-- `--page-size INTEGER`: Number of traces to fetch per API request when exporting projects (1–1000, default: `500`). Applies to `project` and `all`. Increase for fewer round-trips; decrease if you hit persistent rate-limit errors.
+- `--page-size INTEGER`: Number of traces to fetch per API request when exporting traces (1–1000, default: `500`). Applies to `traces` and `all`. Increase for fewer round-trips; decrease if you hit persistent rate-limit errors.
 
 **`all`-specific options:**
-- `--include`: Comma-separated list of data types to include (`datasets`, `prompts`, `projects`, `experiments`). Defaults to all four.
+- `--include`: Comma-separated list of data types to include (`datasets`, `prompts`, `traces`, `experiments`). Defaults to all four.
 
 **`experiment`-specific options:**
 - `--dataset NAME`: Filter experiments by dataset name (only experiments using this dataset will be exported)
@@ -48,92 +49,93 @@ Exports specific data types from the specified workspace to local files.
     all flags and defaults is `sdks/python/src/opik/cli/`. Re-verify against
     `opik export --help` whenever CLI options change. */}
 
-Use `all` when you want to export every data type in one shot — useful for full workspace backups or bulk migrations:
+Use `all` when you want to export every data type in one shot — useful for full project backups or bulk migrations:
 ```bash
-# Export every data type (datasets, prompts, projects, experiments)
-opik export my-workspace all
+# Export every data type (datasets, prompts, traces, experiments)
+opik export my-workspace my-project all
 
-# Export only datasets and prompts — skip projects and experiments
-opik export my-workspace all --include datasets,prompts
+# Export only datasets and prompts — skip traces and experiments
+opik export my-workspace my-project all --include datasets,prompts
 
-# Export all traces logged after a given date across every project
-opik export my-workspace all --filter 'created_at >= "2024-01-01T00:00:00Z"'
+# Export all traces logged after a given date
+opik export my-workspace my-project all --filter 'created_at >= "2024-01-01T00:00:00Z"'
 ```
 
-Use `dataset`, `project`, `experiment`, or `prompt` when you need to export a single named item:
+Use `dataset`, `traces`, `experiment`, or `prompt` when you need to export a specific data type:
 ```bash
 # Export specific dataset by exact name
-opik export my-workspace dataset "my-test-dataset"
+opik export my-workspace my-project dataset "my-test-dataset"
 
-# Export specific project by exact name
-opik export my-workspace project "my-project"
+# Export the project's traces
+opik export my-workspace my-project traces
 
 # Export specific experiment by exact name (--force re-downloads even if local files exist)
-opik export my-workspace experiment "my-experiment" --force
+opik export my-workspace my-project experiment "my-experiment" --force
 
 # Export specific prompt by exact name
-opik export my-workspace prompt "my-template"
+opik export my-workspace my-project prompt "my-template"
 ```
 
 Use `--filter` to narrow exports to a time window or any OQL predicate — avoids downloading data you don't need:
 ```bash
 # Export project traces logged after a given date
-opik export my-workspace project "my-project" --filter 'created_at >= "2024-01-01T00:00:00Z"'
+opik export my-workspace my-project traces --filter 'created_at >= "2024-01-01T00:00:00Z"'
 
 # Export project traces in a date range
-opik export my-workspace project "my-project" --filter 'created_at >= "2024-01-01T00:00:00Z" AND created_at < "2024-02-01T00:00:00Z"'
+opik export my-workspace my-project traces --filter 'created_at >= "2024-01-01T00:00:00Z" AND created_at < "2024-02-01T00:00:00Z"'
 
 # Export experiment traces logged after a given date
-opik export my-workspace experiment "my-experiment" --filter 'created_at >= "2024-06-01T00:00:00Z"'
+opik export my-workspace my-project experiment "my-experiment" --filter 'created_at >= "2024-06-01T00:00:00Z"'
 ```
 
 Use experiment-specific options to scope large experiment exports:
 ```bash
 # Export only traces from experiments that used a specific dataset
-opik export my-workspace experiment "my-experiment" --dataset "my-dataset"
+opik export my-workspace my-project experiment "my-experiment" --dataset "my-dataset"
 
 # Cap total traces downloaded (useful for very large experiments)
-opik export my-workspace experiment "my-experiment" --max-traces 100
+opik export my-workspace my-project experiment "my-experiment" --max-traces 100
 ```
 
 Use `--format csv` when the target is a spreadsheet or analysis tool rather than a re-import:
 ```bash
 # Export project traces as CSV for analysis in Excel, Google Sheets, or pandas
-opik export my-workspace project "my-project" --format csv --path ./csv_data
+opik export my-workspace my-project traces --format csv --path ./csv_data
 ```
 
 Use `--no-attachments` to skip downloading attachment files (faster exports when you only need trace/span data):
 ```bash
-# Export project without downloading attachments
-opik export my-workspace project "my-project" --no-attachments
+# Export project traces without downloading attachments
+opik export my-workspace my-project traces --no-attachments
 
 # Export all data without attachments
-opik export my-workspace all --no-attachments
+opik export my-workspace my-project all --no-attachments
 ```
 
 Miscellaneous options:
 ```bash
 # Save to a custom directory
-opik export my-workspace dataset "my-dataset" --path ./backup_data
+opik export my-workspace my-project dataset "my-dataset" --path ./backup_data
 
 # Combine filter, result cap, and custom path
-opik export my-workspace project "my-project" --filter 'start_time >= "2024-01-01T00:00:00Z"' --max-results 100
+opik export my-workspace my-project traces --filter 'start_time >= "2024-01-01T00:00:00Z"' --max-results 100
 
 # Show detailed API call and file I/O information during export
-opik export my-workspace dataset "my-dataset" --debug --force
+opik export my-workspace my-project dataset "my-dataset" --debug --force
 
 # Reduce page size if you are hitting persistent rate-limit errors on large projects
-opik export my-workspace project "my-project" --page-size 100
+opik export my-workspace my-project traces --page-size 100
 ```
 
-## `opik import WORKSPACE TYPE NAME`
+## `opik import WORKSPACE PROJECT TYPE [NAME]`
 
-Imports specific data types from local files to the specified workspace.
+Imports specific data types from local files into the specified project.
 
 **Arguments:**
 - `WORKSPACE`: The workspace name to import to
-- `TYPE`: The type of data to import (`dataset`, `project`, `experiment`, or `prompt`)
-- `NAME`: Name pattern to match items (case-insensitive substring matching)
+- `PROJECT`: The project to import into (every dataset, prompt, and experiment belongs to it)
+- `TYPE`: The type of data to import (`all`, `dataset`, `traces`, `experiment`, or `prompt`)
+- `NAME`: Name pattern to match items (case-insensitive substring matching; not used with `all` or `traces`)
 
 **Options:**
 - `--path, -p`: Directory containing exported data (default: `opik_exports`)
@@ -147,8 +149,9 @@ Imports specific data types from local files to the specified workspace.
 ### Resumable imports
 
 Every import automatically maintains a `migration_manifest.db` SQLite database
-in the `--path` directory. It tracks which files have been imported and the ID
-mappings needed to link experiments back to their traces.
+under the project directory (`projects/PROJECT_NAME/migration_manifest.db`). It
+tracks which files have been imported and the ID mappings needed to link
+experiments back to their traces.
 
 If an import is interrupted (e.g. network error, Ctrl-C), simply re-run the
 same command — it will resume from where it left off without creating
@@ -175,55 +178,55 @@ Use `--force` to discard the manifest and start fresh.
 Basic imports — reads from the default `opik_exports` directory created by `opik export`:
 ```bash
 # Import a dataset by exact name
-opik import my-workspace dataset "my-dataset"
+opik import my-workspace my-project dataset "my-dataset"
 
-# Import a project by exact name
-opik import my-workspace project "my-project"
+# Import the project's traces
+opik import my-workspace my-project traces
 
 # Import an experiment (automatically recreates the experiment record)
-opik import my-workspace experiment "my-experiment"
+opik import my-workspace my-project experiment "my-experiment"
 
 # Import a prompt by exact name
-opik import my-workspace prompt "my-prompt"
+opik import my-workspace my-project prompt "my-prompt"
 ```
 
 Use a name pattern when you want to import multiple items whose names share a substring:
 ```bash
 # Import every dataset whose name contains "test"
-opik import my-workspace dataset "test"
+opik import my-workspace my-project dataset "test"
 ```
 
 Use `--path` when your exported data is not in the default `opik_exports` directory:
 ```bash
-opik import my-workspace dataset "my-dataset" --path ./custom-exports
+opik import my-workspace my-project dataset "my-dataset" --path ./custom-exports
 ```
 
 Use `--dry-run` to preview what would be imported before committing — helpful to verify names and counts:
 ```bash
-opik import my-workspace project "my-project" --dry-run
+opik import my-workspace my-project traces --dry-run
 ```
 
-Resuming and forcing — the manifest in `--path` handles resumption automatically; use `--force` only to start over:
+Resuming and forcing — the manifest under the project directory handles resumption automatically; use `--force` only to start over:
 ```bash
 # Interrupted import: just re-run the same command — progress is resumed from the manifest
-opik import my-workspace project "my-project" --path ./migration_data
+opik import my-workspace my-project traces --path ./migration_data
 
 # Discard the manifest and re-import everything from scratch
-opik import my-workspace project "my-project" --path ./migration_data --force
+opik import my-workspace my-project traces --path ./migration_data --force
 ```
 
 Use `--no-attachments` to skip uploading attachment files (faster imports when you only need trace/span data):
 ```bash
-# Import project without uploading attachments
-opik import my-workspace project "my-project" --no-attachments
+# Import project traces without uploading attachments
+opik import my-workspace my-project traces --no-attachments
 
 # Import all data without attachments
-opik import my-workspace all --no-attachments
+opik import my-workspace my-project all --no-attachments
 ```
 
 Use `--debug` to see per-file status and API call details:
 ```bash
-opik import my-workspace experiment "my-experiment" --debug
+opik import my-workspace my-project experiment "my-experiment" --debug
 ```
 
 ## File Format
@@ -234,28 +237,24 @@ The exported data is stored in JSON files with the following structure:
 
 ```
 OUTPUT_DIR/
-├── migration_manifest.db          # Created automatically during import to track progress
 └── WORKSPACE/
-    ├── datasets/
-    │   ├── dataset_DATASET_NAME_1.json
-    │   └── dataset_DATASET_NAME_2.json
-    ├── projects/
-    │   └── PROJECT_NAME/
-    │       ├── trace_TRACE_ID_1.json
-    │       ├── trace_TRACE_ID_2.json
-    │       └── attachments/
-    │           ├── trace/
-    │           │   └── TRACE_ID/
-    │           │       └── image.png
-    │           └── span/
-    │               └── SPAN_ID/
-    │                   └── document.pdf
-    ├── experiments/
-    │   ├── experiment_EXPERIMENT_NAME_1.json
-    │   └── experiment_EXPERIMENT_NAME_2.json
-    └── prompts/
-        ├── prompt_PROMPT_NAME_1.json
-        └── prompt_PROMPT_NAME_2.json
+    └── projects/
+        └── PROJECT_NAME/
+            ├── migration_manifest.db      # created automatically during import
+            ├── datasets/
+            │   ├── dataset_DATASET_NAME_1.json
+            │   └── dataset_DATASET_NAME_2.json
+            ├── prompts/
+            │   ├── prompt_PROMPT_NAME_1.json
+            │   └── prompt_PROMPT_NAME_2.json
+            ├── experiments/
+            │   ├── experiment_EXPERIMENT_NAME_1.json
+            │   └── experiment_EXPERIMENT_NAME_2.json
+            ├── trace_TRACE_ID_1.json
+            ├── trace_TRACE_ID_2.json
+            └── attachments/
+                ├── trace/<TRACE_ID>/image.png
+                └── span/<SPAN_ID>/document.pdf
 ```
 
 Each trace file contains:
@@ -391,15 +390,15 @@ When using `--format csv`, data is exported as CSV files with flattened data str
 ```
 OUTPUT_DIR/
 └── WORKSPACE/
-    ├── datasets/
-    │   └── datasets_DATASET_NAME.csv      # Dataset data in CSV format
-    ├── projects/
-    │   └── PROJECT_NAME/
-    │       └── traces_PROJECT_NAME.csv    # All traces in a single CSV file
-    ├── experiments/
-    │   └── experiments_EXPERIMENT_NAME.csv # Experiment data in CSV format
-    └── prompts/
-        └── prompts_PROMPT_NAME.csv        # Prompt data in CSV format
+    └── projects/
+        └── PROJECT_NAME/
+            ├── datasets/
+            │   └── datasets_DATASET_NAME.csv      # Dataset data in CSV format
+            ├── prompts/
+            │   └── prompts_PROMPT_NAME.csv         # Prompt data in CSV format
+            ├── experiments/
+            │   └── experiments_EXPERIMENT_NAME.csv # Experiment data in CSV format
+            └── traces_PROJECT_NAME.csv             # All traces in a single CSV file
 ```
 
 **CSV Format Benefits:**
@@ -407,7 +406,7 @@ OUTPUT_DIR/
 - **Flattened Structure**: Nested JSON data is flattened with dot notation
 - **Column Headers**: Clear column names for easy analysis
 - **Compatible**: Works with Excel, Google Sheets, pandas, etc.
-- **Universal Format**: All data types (datasets, projects, experiments, prompts) support CSV export
+- **Universal Format**: All data types (datasets, traces, experiments, prompts) support CSV export
 
 **Example CSV Structure:**
 ```csv
@@ -428,80 +427,80 @@ and resume.
 ```bash
 # Step 1: Export from source (run with source API key / Opik URL)
 OPIK_API_KEY=<source_key> OPIK_URL_OVERRIDE=https://source.opik.example.com \
-  opik export my-workspace project "my-project" --path ./migration_data
+  opik export my-workspace my-project traces --path ./migration_data
 
 # Step 2: Import to destination (run with destination API key / Opik URL)
 # If this is interrupted, just re-run the same command — it resumes automatically.
 OPIK_API_KEY=<dest_key> OPIK_URL_OVERRIDE=https://dest.opik.example.com \
-  opik import my-workspace project "my-project" --path ./migration_data
+  opik import my-workspace my-project traces --path ./migration_data
 ```
 
 To migrate all data types at once:
 
 ```bash
 # Export everything (source credentials)
-OPIK_API_KEY=<source_key> opik export my-workspace dataset "my-dataset" --path ./migration_data
-OPIK_API_KEY=<source_key> opik export my-workspace prompt "my-prompt" --path ./migration_data
-OPIK_API_KEY=<source_key> opik export my-workspace project "my-project" --path ./migration_data
-OPIK_API_KEY=<source_key> opik export my-workspace experiment "my-experiment" --path ./migration_data
+OPIK_API_KEY=<source_key> opik export my-workspace my-project dataset "my-dataset" --path ./migration_data
+OPIK_API_KEY=<source_key> opik export my-workspace my-project prompt "my-prompt" --path ./migration_data
+OPIK_API_KEY=<source_key> opik export my-workspace my-project traces --path ./migration_data
+OPIK_API_KEY=<source_key> opik export my-workspace my-project experiment "my-experiment" --path ./migration_data
 
 # Import everything (destination credentials)
-OPIK_API_KEY=<dest_key> opik import my-workspace dataset "my-dataset" --path ./migration_data
-OPIK_API_KEY=<dest_key> opik import my-workspace prompt "my-prompt" --path ./migration_data
-OPIK_API_KEY=<dest_key> opik import my-workspace project "my-project" --path ./migration_data
-OPIK_API_KEY=<dest_key> opik import my-workspace experiment "my-experiment" --path ./migration_data
+OPIK_API_KEY=<dest_key> opik import my-workspace my-project dataset "my-dataset" --path ./migration_data
+OPIK_API_KEY=<dest_key> opik import my-workspace my-project prompt "my-prompt" --path ./migration_data
+OPIK_API_KEY=<dest_key> opik import my-workspace my-project traces --path ./migration_data
+OPIK_API_KEY=<dest_key> opik import my-workspace my-project experiment "my-experiment" --path ./migration_data
 ```
 
 ### 2. Data Backup
 ```bash
 # Create backup of specific data (requires knowing exact names)
-opik export my-workspace dataset "my-dataset" --path ./backup_$(date +%Y%m%d)
-opik export my-workspace project "my-project" --path ./backup_$(date +%Y%m%d)
-opik export my-workspace experiment "my-experiment" --path ./backup_$(date +%Y%m%d)
+opik export my-workspace my-project dataset "my-dataset" --path ./backup_$(date +%Y%m%d)
+opik export my-workspace my-project traces --path ./backup_$(date +%Y%m%d)
+opik export my-workspace my-project experiment "my-experiment" --path ./backup_$(date +%Y%m%d)
 ```
 
 ### 3. Environment Sync
 ```bash
 # Sync from staging to production
-opik export my-workspace project "staging-project" --filter 'tags contains "ready-for-prod"'
-opik import my-workspace project "staging-project"
+opik export my-workspace staging-project traces --filter 'tags contains "ready-for-prod"'
+opik import my-workspace staging-project traces
 ```
 
 ### 4. Data Analysis
 ```bash
 # Export traces for a specific time window
-opik export my-workspace project "my-project" \
+opik export my-workspace my-project traces \
   --filter 'created_at >= "2024-01-01T00:00:00Z" AND created_at < "2024-04-01T00:00:00Z"'
 
-# Export all traces logged before a cutoff date across every project
-opik export my-workspace all --filter 'created_at < "2024-01-01T00:00:00Z"'
+# Export all traces logged before a cutoff date
+opik export my-workspace my-project all --filter 'created_at < "2024-01-01T00:00:00Z"'
 
 # Export recent experiment traces only
-opik export my-workspace experiment "my-experiment" --filter 'created_at >= "2024-06-01T00:00:00Z"'
+opik export my-workspace my-project experiment "my-experiment" --filter 'created_at >= "2024-06-01T00:00:00Z"'
 ```
 
 ### 5. Dataset Management
 ```bash
-# Export specific dataset from a workspace
-opik export my-workspace dataset "my-dataset"
+# Export specific dataset from a project
+opik export my-workspace my-project dataset "my-dataset"
 
-# Import datasets to another workspace (uses default opik_exports directory)
-opik import my-workspace dataset "my-dataset"
+# Import datasets to another project (uses default opik_exports directory)
+opik import my-workspace my-project dataset "my-dataset"
 ```
 
 ### 6. Data Analysis with CSV
 ```bash
 # Export traces in CSV format for analysis
-opik export my-workspace project "my-project" --format csv --path ./analysis_data
+opik export my-workspace my-project traces --format csv --path ./analysis_data
 
 # Export datasets in CSV format for analysis
-opik export my-workspace dataset "my-dataset" --format csv --path ./analysis_data
+opik export my-workspace my-project dataset "my-dataset" --format csv --path ./analysis_data
 
 # Export experiments in CSV format for analysis
-opik export my-workspace experiment "my-experiment" --format csv --path ./analysis_data
+opik export my-workspace my-project experiment "my-experiment" --format csv --path ./analysis_data
 
 # Export prompts in CSV format for analysis
-opik export my-workspace prompt "my-template" --format csv --path ./analysis_data
+opik export my-workspace my-project prompt "my-template" --format csv --path ./analysis_data
 
 # Open in Excel or Google Sheets for analysis
 # Or use with pandas in Python:
@@ -511,38 +510,38 @@ opik export my-workspace prompt "my-template" --format csv --path ./analysis_dat
 
 ### 7. Prompt Management
 ```bash
-# Export specific prompt from a workspace
-opik export my-workspace prompt "my-template" --path ./prompt_backup
+# Export specific prompt from a project
+opik export my-workspace my-project prompt "my-template" --path ./prompt_backup
 
 # Export another prompt template
-opik export my-workspace prompt "system-prompt" --path ./templates
+opik export my-workspace my-project prompt "system-prompt" --path ./templates
 
-# Import prompts to another workspace
-opik import my-workspace prompt "my-template" --path ./prompt_backup
+# Import prompts to another project
+opik import my-workspace my-project prompt "my-template" --path ./prompt_backup
 
 # Import with name pattern matching
-opik import my-workspace prompt "production" --path ./prompt_backup
+opik import my-workspace my-project prompt "production" --path ./prompt_backup
 ```
 
 ### 8. Experiment Migration
 ```bash
-# Export specific experiment from source workspace
-opik export my-workspace experiment "my-experiment" --path ./experiment_data
+# Export specific experiment from source project
+opik export my-workspace my-project experiment "my-experiment" --path ./experiment_data
 
 # Export experiment with dataset filtering
-opik export my-workspace experiment "evaluation-exp" --dataset "test-dataset"
+opik export my-workspace my-project experiment "evaluation-exp" --dataset "test-dataset"
 
 # Export only traces logged after a given date
-opik export my-workspace experiment "large-experiment" --filter 'created_at >= "2024-06-01T00:00:00Z"'
+opik export my-workspace my-project experiment "large-experiment" --filter 'created_at >= "2024-06-01T00:00:00Z"'
 
 # Export experiment with trace limit (useful for large experiments)
-opik export my-workspace experiment "large-experiment" --max-traces 50
+opik export my-workspace my-project experiment "large-experiment" --max-traces 50
 
 # Import experiments (automatically recreates experiments)
-opik import my-workspace experiment "my-experiment" --path ./experiment_data
+opik import my-workspace my-project experiment "my-experiment" --path ./experiment_data
 
 # Import experiments matching name pattern
-opik import my-workspace experiment "evaluation" --path ./experiment_data
+opik import my-workspace my-project experiment "evaluation" --path ./experiment_data
 ```
 
 ## Troubleshooting
@@ -550,8 +549,8 @@ opik import my-workspace experiment "evaluation" --path ./experiment_data
 ### Common Issues
 
 1. **Import was interrupted and re-running creates duplicates**
-   - This should not happen — the import automatically detects and resumes from the `migration_manifest.db` in your `--path` directory
-   - If you do not see the "Resuming interrupted import" message, check that you are pointing to the same `--path` as the original run
+   - This should not happen — the import automatically detects and resumes from the `migration_manifest.db` under the project directory (`projects/PROJECT_NAME/migration_manifest.db`)
+   - If you do not see the "Resuming interrupted import" message, check that you are pointing to the same `--path` and project as the original run
    - If the manifest database is unreadable, delete `migration_manifest.db` and use `--force` to start fresh (this will re-import everything)
 
 2. **"Import already completed. Use --force to re-import."**
@@ -617,33 +616,33 @@ Here's a complete example of exporting and importing trace data:
 
 ### JSON Format Workflow
 ```bash
-# 1. Export specific data from source workspace (JSON format)
-opik export my-workspace dataset "my-dataset" --path ./temp_data
-opik export my-workspace project "my-project" --path ./temp_data
-opik export my-workspace experiment "my-experiment" --path ./temp_data
-opik export my-workspace prompt "my-template" --path ./temp_data
+# 1. Export specific data from source project (JSON format)
+opik export my-workspace my-project dataset "my-dataset" --path ./temp_data
+opik export my-workspace my-project traces --path ./temp_data
+opik export my-workspace my-project experiment "my-experiment" --path ./temp_data
+opik export my-workspace my-project prompt "my-template" --path ./temp_data
 
 # Alternative: Export experiment with specific dataset filtering
-opik export my-workspace experiment "evaluation-exp" --dataset "test-dataset" --max-traces 100 --path ./temp_data
+opik export my-workspace my-project experiment "evaluation-exp" --dataset "test-dataset" --max-traces 100 --path ./temp_data
 
 # 2. Inspect the exported data
-ls ./temp_data/my-workspace/datasets/
-ls ./temp_data/my-workspace/projects/
-ls ./temp_data/my-workspace/experiments/
-ls ./temp_data/my-workspace/prompts/
+ls ./temp_data/my-workspace/projects/my-project/datasets/
+ls ./temp_data/my-workspace/projects/my-project/
+ls ./temp_data/my-workspace/projects/my-project/experiments/
+ls ./temp_data/my-workspace/projects/my-project/prompts/
 cat ./temp_data/my-workspace/projects/my-project/trace_*.json | head -20
 
 # 3. Dry run import to see what would be imported
-opik import my-workspace dataset "my-dataset" --path ./temp_data --dry-run
-opik import my-workspace project "my-project" --path ./temp_data --dry-run
-opik import my-workspace experiment "my-experiment" --path ./temp_data --dry-run
-opik import my-workspace prompt "my-template" --path ./temp_data --dry-run
+opik import my-workspace my-project dataset "my-dataset" --path ./temp_data --dry-run
+opik import my-workspace my-project traces --path ./temp_data --dry-run
+opik import my-workspace my-project experiment "my-experiment" --path ./temp_data --dry-run
+opik import my-workspace my-project prompt "my-template" --path ./temp_data --dry-run
 
 # 4. Import all data — if interrupted, just re-run the same commands to resume
-opik import my-workspace dataset "my-dataset" --path ./temp_data
-opik import my-workspace project "my-project" --path ./temp_data
-opik import my-workspace experiment "my-experiment" --path ./temp_data
-opik import my-workspace prompt "my-template" --path ./temp_data
+opik import my-workspace my-project dataset "my-dataset" --path ./temp_data
+opik import my-workspace my-project traces --path ./temp_data
+opik import my-workspace my-project experiment "my-experiment" --path ./temp_data
+opik import my-workspace my-project prompt "my-template" --path ./temp_data
 
 # 5. Clean up temporary data
 rm -rf ./temp_data
@@ -652,20 +651,20 @@ rm -rf ./temp_data
 ### CSV Format Workflow
 ```bash
 # 1. Export data in CSV format for analysis
-opik export my-workspace project "my-source-project" --format csv --path ./csv_data
-opik export my-workspace dataset "my-dataset" --format csv --path ./csv_data
-opik export my-workspace experiment "my-experiment" --format csv --path ./csv_data
-opik export my-workspace prompt "my-template" --format csv --path ./csv_data
+opik export my-workspace my-source-project traces --format csv --path ./csv_data
+opik export my-workspace my-source-project dataset "my-dataset" --format csv --path ./csv_data
+opik export my-workspace my-source-project experiment "my-experiment" --format csv --path ./csv_data
+opik export my-workspace my-source-project prompt "my-template" --format csv --path ./csv_data
 
 # 2. Inspect the CSV files
 ls ./csv_data/my-workspace/projects/my-source-project/
-ls ./csv_data/my-workspace/datasets/
-ls ./csv_data/my-workspace/experiments/
-ls ./csv_data/my-workspace/prompts/
+ls ./csv_data/my-workspace/projects/my-source-project/datasets/
+ls ./csv_data/my-workspace/projects/my-source-project/experiments/
+ls ./csv_data/my-workspace/projects/my-source-project/prompts/
 
 # Each trace is exported to its own CSV file
 head -5 ./csv_data/my-workspace/projects/my-source-project/trace_*.csv | head -20
-head -5 ./csv_data/my-workspace/datasets/datasets_test-dataset.csv
+head -5 ./csv_data/my-workspace/projects/my-source-project/datasets/datasets_test-dataset.csv
 
 # 3. Analyze with pandas (optional)
 python -c "
@@ -675,7 +674,7 @@ import glob
 # Read all trace CSV files and combine them
 trace_files = glob.glob('./csv_data/my-workspace/projects/my-source-project/trace_*.csv')
 df_traces = pd.concat([pd.read_csv(f) for f in trace_files], ignore_index=True) if trace_files else pd.DataFrame()
-df_datasets = pd.read_csv('./csv_data/my-workspace/datasets/datasets_test-dataset.csv')
+df_datasets = pd.read_csv('./csv_data/my-workspace/projects/my-source-project/datasets/datasets_test-dataset.csv')
 print(f'Exported {len(df_traces)} trace records from {len(trace_files)} files')
 print(f'Exported {len(df_datasets)} dataset records')
 print('Trace columns:', df_traces.columns.tolist() if not df_traces.empty else 'No traces')
@@ -686,4 +685,4 @@ print('Dataset columns:', df_datasets.columns.tolist())
 # (CSV format is primarily for analysis, not import)
 ```
 
-This workflow ensures you can safely migrate all data including experiments and prompts between workspaces while maintaining data integrity and providing visibility into the process. The CSV format is particularly useful for data analysis and reporting, while the JSON format preserves the complete structure needed for experiment and prompt recreation. The new command structure provides better organization with separate commands for datasets, projects, experiments, and prompts, making it easier to manage specific data types.
+This workflow ensures you can safely migrate all data including experiments and prompts between workspaces while maintaining data integrity and providing visibility into the process. The CSV format is particularly useful for data analysis and reporting, while the JSON format preserves the complete structure needed for experiment and prompt recreation. The new command structure provides better organization with separate commands for datasets, traces, experiments, and prompts, all scoped to a project, making it easier to manage specific data types.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
@@ -656,6 +656,11 @@ opik healthcheck
 
 Here's a complete example of exporting and importing trace data:
 
+{/* These examples (including the pandas snippet below) are maintained by hand.
+    The canonical source of truth for all flags and defaults is
+    `sdks/python/src/opik/cli/`. Re-verify against `opik export --help` /
+    `opik import --help` whenever CLI options change. */}
+
 ### JSON Format Workflow
 ```bash
 # 1. Export specific data from source project (JSON format)

--- a/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
@@ -155,9 +155,12 @@ so the same `--path` round-trips with no path juggling.
 ### Resumable imports
 
 Every import automatically maintains a `migration_manifest.db` SQLite database
-under the project directory (`projects/PROJECT_ID/migration_manifest.db`). It
-tracks which files have been imported and the ID mappings needed to link
-experiments back to their traces.
+under the project directory, in a per-destination subdirectory
+(`projects/PROJECT_ID/import_manifests/<destination-key>/migration_manifest.db`).
+It tracks which files have been imported and the ID mappings needed to link
+experiments back to their traces. Keying the manifest by destination means
+importing the same export into different `--to-project` targets keeps independent
+resume/completion state.
 
 If an import is interrupted (e.g. network error, Ctrl-C), simply re-run the
 same command — it will resume from where it left off without creating
@@ -253,7 +256,8 @@ OUTPUT_DIR/
         └── PROJECT_ID/
             ├── project.json               # {"id": "PROJECT_ID", "name": "project name"}
             ├── export_manifest.db          # created during export to track progress
-            ├── migration_manifest.db       # created during import to track progress
+            ├── import_manifests/           # per-destination import resume state
+            │   └── <destination-key>/migration_manifest.db
             ├── datasets/
             │   ├── dataset_DATASET_ID_1.json
             │   └── dataset_DATASET_ID_2.json
@@ -591,9 +595,9 @@ opik import my-workspace my-project experiment "evaluation" --path ./experiment_
 ### Common Issues
 
 1. **Import was interrupted and re-running creates duplicates**
-   - This should not happen — the import automatically detects and resumes from the `migration_manifest.db` under the project directory (`projects/PROJECT_ID/migration_manifest.db`)
-   - If you do not see the "Resuming interrupted import" message, check that you are pointing to the same `--path` and project as the original run
-   - If the manifest database is unreadable, delete `migration_manifest.db` and use `--force` to start fresh (this will re-import everything)
+   - This should not happen — the import automatically detects and resumes from the per-destination `migration_manifest.db` under `projects/PROJECT_ID/import_manifests/<destination-key>/`
+   - If you do not see the "Resuming interrupted import" message, check that you are pointing to the same `--path`, project, and `--to-project` as the original run
+   - If the manifest database is unreadable, delete the `import_manifests/` directory and use `--force` to start fresh (this will re-import everything)
 
 2. **"Import already completed. Use --force to re-import."**
    - The manifest records that a previous run finished successfully

--- a/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
@@ -459,6 +459,12 @@ Export writes to `<--path>/<workspace>/projects/<project_id>/`, and import reads
 the same layout, so use the same `--path` on both sides. Add `--to-project <NAME>`
 to import into a different destination project.
 
+To import into a **different workspace** than the data was exported from, point
+`--path` at the exported workspace directory (the export `--path` plus the source
+workspace), e.g. `opik export ws-a my-project all --path ./data` writes to
+`./data/ws-a/...`, then `opik import ws-b my-project all --path ./data/ws-a`
+imports it into `ws-b`.
+
 ```bash
 # Step 1: Export from source (run with source API key / Opik URL)
 # Writes to ./migration_data/my-workspace/projects/<project_id>/

--- a/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
@@ -139,6 +139,7 @@ Imports specific data types from local files into the specified project.
 
 **Options:**
 - `--path, -p`: Directory containing exported data (default: `opik_exports`)
+- `--to-project NAME`: Destination project to import into. Defaults to the source project's name (the `name` recorded in `project.json`). Use this to restore into a renamed or scratch project. Available on `all`, `traces`, `dataset`, `experiment`, and `prompt`.
 - `--dry-run`: Show what would be imported without actually importing
 - `--force`: Discard the migration manifest and re-import everything from scratch
 - `--no-attachments`: Skip uploading attachment files.
@@ -146,10 +147,15 @@ Imports specific data types from local files into the specified project.
 
 **Note:** Experiment imports automatically recreate experiments where possible. No additional flags are needed.
 
+**Note:** `PROJECT` is matched by name against the `name` recorded in each
+exported `project.json` (folders on disk are named by project ID). Point
+`--path` at the directory that contains `projects/` — i.e. the workspace
+directory produced by export (`<export --path>/<workspace>`).
+
 ### Resumable imports
 
 Every import automatically maintains a `migration_manifest.db` SQLite database
-under the project directory (`projects/PROJECT_NAME/migration_manifest.db`). It
+under the project directory (`projects/PROJECT_ID/migration_manifest.db`). It
 tracks which files have been imported and the ID mappings needed to link
 experiments back to their traces.
 
@@ -196,6 +202,11 @@ Use a name pattern when you want to import multiple items whose names share a su
 opik import my-workspace my-project dataset "test"
 ```
 
+Use `--to-project` to import into a different (e.g. renamed or scratch) destination project. The source folder is still located by the `my-project` name; the data is created in `my-restore`:
+```bash
+opik import my-workspace my-project all --to-project my-restore
+```
+
 Use `--path` when your exported data is not in the default `opik_exports` directory:
 ```bash
 opik import my-workspace my-project dataset "my-dataset" --path ./custom-exports
@@ -239,23 +250,37 @@ The exported data is stored in JSON files with the following structure:
 OUTPUT_DIR/
 └── WORKSPACE/
     └── projects/
-        └── PROJECT_NAME/
-            ├── migration_manifest.db      # created automatically during import
+        └── PROJECT_ID/
+            ├── project.json               # {"id": "PROJECT_ID", "name": "project name"}
+            ├── export_manifest.db          # created during export to track progress
+            ├── migration_manifest.db       # created during import to track progress
             ├── datasets/
-            │   ├── dataset_DATASET_NAME_1.json
-            │   └── dataset_DATASET_NAME_2.json
+            │   ├── dataset_DATASET_ID_1.json
+            │   └── dataset_DATASET_ID_2.json
             ├── prompts/
-            │   ├── prompt_PROMPT_NAME_1.json
-            │   └── prompt_PROMPT_NAME_2.json
+            │   ├── prompt_PROMPT_ID_1.json
+            │   └── prompt_PROMPT_ID_2.json
             ├── experiments/
-            │   ├── experiment_EXPERIMENT_NAME_1.json
-            │   └── experiment_EXPERIMENT_NAME_2.json
+            │   ├── experiment_EXPERIMENT_ID_1.json
+            │   └── experiment_EXPERIMENT_ID_2.json
             ├── trace_TRACE_ID_1.json
             ├── trace_TRACE_ID_2.json
             └── attachments/
                 ├── trace/<TRACE_ID>/image.png
                 └── span/<SPAN_ID>/document.pdf
 ```
+
+<Note>
+Folders and files are keyed by **ID**, not by human name. The project folder is
+the project's UUID, and each item file is named by its own ID
+(`dataset_<dataset_id>.json`, `prompt_<prompt_id>.json`,
+`experiment_<experiment_id>.json`, `trace_<trace_id>.json`). The human-readable
+names live as data — inside `project.json` and inside each file. This keeps
+paths free of characters like `/`, `:`, or spaces that commonly appear in names.
+You still pass project and item **names** on the command line; the CLI resolves
+names ↔ IDs for you (on import it matches the name you type against the `name`
+recorded in `project.json`).
+</Note>
 
 Each trace file contains:
 ```json
@@ -356,9 +381,10 @@ Each experiment file contains:
 }
 ```
 
-Each prompt file contains:
+Each prompt file contains (the file is named `prompt_<id>.json`; the `id` and `name` are stored inside):
 ```json
 {
+  "id": "prompt-uuid",
   "name": "prompt-name",
   "current_version": {
     "prompt": "Your prompt template here...",
@@ -391,15 +417,20 @@ When using `--format csv`, data is exported as CSV files with flattened data str
 OUTPUT_DIR/
 └── WORKSPACE/
     └── projects/
-        └── PROJECT_NAME/
+        └── PROJECT_ID/
+            ├── project.json                       # {"id": "PROJECT_ID", "name": "project name"}
             ├── datasets/
-            │   └── datasets_DATASET_NAME.csv      # Dataset data in CSV format
+            │   └── dataset_DATASET_ID.csv          # Dataset data in CSV format
             ├── prompts/
-            │   └── prompts_PROMPT_NAME.csv         # Prompt data in CSV format
+            │   └── prompt_PROMPT_ID.csv            # Prompt data in CSV format
             ├── experiments/
-            │   └── experiments_EXPERIMENT_NAME.csv # Experiment data in CSV format
-            └── traces_PROJECT_NAME.csv             # All traces in a single CSV file
+            │   └── experiment_EXPERIMENT_ID.csv    # Experiment data in CSV format
+            ├── trace_TRACE_ID_1.csv                # One CSV per trace, under the project folder
+            └── trace_TRACE_ID_2.csv
 ```
+
+As with JSON, CSV files are named by **ID**; the human names are stored in the
+file contents and in `project.json`.
 
 **CSV Format Benefits:**
 - **Single File**: All data combined into one CSV file per data type
@@ -424,15 +455,21 @@ your destination credentials. The `migration_manifest.db` created during
 import travels with the exported data and makes the import safe to interrupt
 and resume.
 
+Export writes to `<--path>/<workspace>/projects/<project_id>/`, so on import
+point `--path` at the workspace directory (one level below the export `--path`).
+Add `--to-project <NAME>` to import into a different destination project.
+
 ```bash
 # Step 1: Export from source (run with source API key / Opik URL)
+# Writes to ./migration_data/my-workspace/projects/<project_id>/
 OPIK_API_KEY=<source_key> OPIK_URL_OVERRIDE=https://source.opik.example.com \
   opik export my-workspace my-project traces --path ./migration_data
 
 # Step 2: Import to destination (run with destination API key / Opik URL)
+# Point --path at the workspace dir produced by export.
 # If this is interrupted, just re-run the same command — it resumes automatically.
 OPIK_API_KEY=<dest_key> OPIK_URL_OVERRIDE=https://dest.opik.example.com \
-  opik import my-workspace my-project traces --path ./migration_data
+  opik import my-workspace my-project traces --path ./migration_data/my-workspace
 ```
 
 To migrate all data types at once:
@@ -444,11 +481,12 @@ OPIK_API_KEY=<source_key> opik export my-workspace my-project prompt "my-prompt"
 OPIK_API_KEY=<source_key> opik export my-workspace my-project traces --path ./migration_data
 OPIK_API_KEY=<source_key> opik export my-workspace my-project experiment "my-experiment" --path ./migration_data
 
-# Import everything (destination credentials)
-OPIK_API_KEY=<dest_key> opik import my-workspace my-project dataset "my-dataset" --path ./migration_data
-OPIK_API_KEY=<dest_key> opik import my-workspace my-project prompt "my-prompt" --path ./migration_data
-OPIK_API_KEY=<dest_key> opik import my-workspace my-project traces --path ./migration_data
-OPIK_API_KEY=<dest_key> opik import my-workspace my-project experiment "my-experiment" --path ./migration_data
+# Import everything (destination credentials).
+# Point --path at the workspace dir produced by export.
+OPIK_API_KEY=<dest_key> opik import my-workspace my-project dataset "my-dataset" --path ./migration_data/my-workspace
+OPIK_API_KEY=<dest_key> opik import my-workspace my-project prompt "my-prompt" --path ./migration_data/my-workspace
+OPIK_API_KEY=<dest_key> opik import my-workspace my-project traces --path ./migration_data/my-workspace
+OPIK_API_KEY=<dest_key> opik import my-workspace my-project experiment "my-experiment" --path ./migration_data/my-workspace
 ```
 
 ### 2. Data Backup
@@ -503,9 +541,9 @@ opik export my-workspace my-project experiment "my-experiment" --format csv --pa
 opik export my-workspace my-project prompt "my-template" --format csv --path ./analysis_data
 
 # Open in Excel or Google Sheets for analysis
-# Or use with pandas in Python:
-# import pandas as pd
-# df = pd.read_csv('./analysis_data/my-workspace/projects/my-project/traces_my-project.csv')
+# Or use with pandas in Python (the project folder is the project ID — use a glob):
+# import pandas as pd, glob
+# df = pd.concat([pd.read_csv(f) for f in glob.glob('./analysis_data/my-workspace/projects/*/trace_*.csv')])
 ```
 
 ### 7. Prompt Management
@@ -549,7 +587,7 @@ opik import my-workspace my-project experiment "evaluation" --path ./experiment_
 ### Common Issues
 
 1. **Import was interrupted and re-running creates duplicates**
-   - This should not happen — the import automatically detects and resumes from the `migration_manifest.db` under the project directory (`projects/PROJECT_NAME/migration_manifest.db`)
+   - This should not happen — the import automatically detects and resumes from the `migration_manifest.db` under the project directory (`projects/PROJECT_ID/migration_manifest.db`)
    - If you do not see the "Resuming interrupted import" message, check that you are pointing to the same `--path` and project as the original run
    - If the manifest database is unreadable, delete `migration_manifest.db` and use `--force` to start fresh (this will re-import everything)
 
@@ -625,24 +663,23 @@ opik export my-workspace my-project prompt "my-template" --path ./temp_data
 # Alternative: Export experiment with specific dataset filtering
 opik export my-workspace my-project experiment "evaluation-exp" --dataset "test-dataset" --max-traces 100 --path ./temp_data
 
-# 2. Inspect the exported data
-ls ./temp_data/my-workspace/projects/my-project/datasets/
-ls ./temp_data/my-workspace/projects/my-project/
-ls ./temp_data/my-workspace/projects/my-project/experiments/
-ls ./temp_data/my-workspace/projects/my-project/prompts/
-cat ./temp_data/my-workspace/projects/my-project/trace_*.json | head -20
+# 2. Inspect the exported data (the project folder is the project ID; use a glob)
+ls ./temp_data/my-workspace/projects/*/        # project.json + datasets/ prompts/ experiments/ + trace files
+cat ./temp_data/my-workspace/projects/*/project.json   # maps the ID folder to the project name
+ls ./temp_data/my-workspace/projects/*/datasets/
+cat ./temp_data/my-workspace/projects/*/trace_*.json | head -20
 
-# 3. Dry run import to see what would be imported
-opik import my-workspace my-project dataset "my-dataset" --path ./temp_data --dry-run
-opik import my-workspace my-project traces --path ./temp_data --dry-run
-opik import my-workspace my-project experiment "my-experiment" --path ./temp_data --dry-run
-opik import my-workspace my-project prompt "my-template" --path ./temp_data --dry-run
+# 3. Dry run import to see what would be imported (point --path at the workspace dir)
+opik import my-workspace my-project dataset "my-dataset" --path ./temp_data/my-workspace --dry-run
+opik import my-workspace my-project traces --path ./temp_data/my-workspace --dry-run
+opik import my-workspace my-project experiment "my-experiment" --path ./temp_data/my-workspace --dry-run
+opik import my-workspace my-project prompt "my-template" --path ./temp_data/my-workspace --dry-run
 
 # 4. Import all data — if interrupted, just re-run the same commands to resume
-opik import my-workspace my-project dataset "my-dataset" --path ./temp_data
-opik import my-workspace my-project traces --path ./temp_data
-opik import my-workspace my-project experiment "my-experiment" --path ./temp_data
-opik import my-workspace my-project prompt "my-template" --path ./temp_data
+opik import my-workspace my-project dataset "my-dataset" --path ./temp_data/my-workspace
+opik import my-workspace my-project traces --path ./temp_data/my-workspace
+opik import my-workspace my-project experiment "my-experiment" --path ./temp_data/my-workspace
+opik import my-workspace my-project prompt "my-template" --path ./temp_data/my-workspace
 
 # 5. Clean up temporary data
 rm -rf ./temp_data
@@ -656,29 +693,30 @@ opik export my-workspace my-source-project dataset "my-dataset" --format csv --p
 opik export my-workspace my-source-project experiment "my-experiment" --format csv --path ./csv_data
 opik export my-workspace my-source-project prompt "my-template" --format csv --path ./csv_data
 
-# 2. Inspect the CSV files
-ls ./csv_data/my-workspace/projects/my-source-project/
-ls ./csv_data/my-workspace/projects/my-source-project/datasets/
-ls ./csv_data/my-workspace/projects/my-source-project/experiments/
-ls ./csv_data/my-workspace/projects/my-source-project/prompts/
+# 2. Inspect the CSV files (the project folder is the project ID; use a glob)
+ls ./csv_data/my-workspace/projects/*/
+ls ./csv_data/my-workspace/projects/*/datasets/
+ls ./csv_data/my-workspace/projects/*/experiments/
+ls ./csv_data/my-workspace/projects/*/prompts/
 
 # Each trace is exported to its own CSV file
-head -5 ./csv_data/my-workspace/projects/my-source-project/trace_*.csv | head -20
-head -5 ./csv_data/my-workspace/projects/my-source-project/datasets/datasets_test-dataset.csv
+head -5 ./csv_data/my-workspace/projects/*/trace_*.csv | head -20
+head -5 ./csv_data/my-workspace/projects/*/datasets/dataset_*.csv
 
 # 3. Analyze with pandas (optional)
 python -c "
 import pandas as pd
 import glob
 
-# Read all trace CSV files and combine them
-trace_files = glob.glob('./csv_data/my-workspace/projects/my-source-project/trace_*.csv')
+# Read all trace CSV files and combine them (folder is the project ID — use a glob)
+trace_files = glob.glob('./csv_data/my-workspace/projects/*/trace_*.csv')
 df_traces = pd.concat([pd.read_csv(f) for f in trace_files], ignore_index=True) if trace_files else pd.DataFrame()
-df_datasets = pd.read_csv('./csv_data/my-workspace/projects/my-source-project/datasets/datasets_test-dataset.csv')
+dataset_files = glob.glob('./csv_data/my-workspace/projects/*/datasets/dataset_*.csv')
+df_datasets = pd.concat([pd.read_csv(f) for f in dataset_files], ignore_index=True) if dataset_files else pd.DataFrame()
 print(f'Exported {len(df_traces)} trace records from {len(trace_files)} files')
 print(f'Exported {len(df_datasets)} dataset records')
 print('Trace columns:', df_traces.columns.tolist() if not df_traces.empty else 'No traces')
-print('Dataset columns:', df_datasets.columns.tolist())
+print('Dataset columns:', df_datasets.columns.tolist() if not df_datasets.empty else 'No datasets')
 "
 
 # 4. For import, you would need to convert back to JSON format

--- a/sdks/python/src/opik/cli/exports/__init__.py
+++ b/sdks/python/src/opik/cli/exports/__init__.py
@@ -10,7 +10,7 @@ from .all import export_all_command
 from .dataset import export_dataset_command
 from .experiment import export_experiment_command
 from .prompt import export_prompt_command
-from .project import export_project_command
+from .project import export_traces_command
 
 EXPORT_CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
@@ -19,27 +19,31 @@ EXPORT_CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
     name="export", context_settings=EXPORT_CONTEXT_SETTINGS, invoke_without_command=True
 )
 @click.argument("workspace", type=str)
+@click.argument("project", type=str)
 @click.option(
     "--api-key",
     type=str,
     help="Opik API key. If not provided, will use OPIK_API_KEY environment variable or configuration.",
 )
 @click.pass_context
-def export_group(ctx: click.Context, workspace: str, api_key: Optional[str]) -> None:
-    """Export data from Opik workspace.
+def export_group(
+    ctx: click.Context, workspace: str, project: str, api_key: Optional[str]
+) -> None:
+    """Export data from an Opik project.
 
-    This command allows you to export specific data from an Opik workspace to local files.
-    Supported data types include datasets, projects, experiments, and prompts.
+    In Opik v2 every dataset, prompt, and experiment belongs to a project, so
+    exports are always scoped to a single project named on the command line.
+    Exported data is written under ``PATH/WORKSPACE/projects/PROJECT/``.
 
     \b
     General Usage:
-        opik export WORKSPACE ITEM NAME [OPTIONS]
+        opik export WORKSPACE PROJECT ITEM [NAME] [OPTIONS]
 
     \b
     Data Types (ITEM):
-        all          Export everything: datasets, prompts, projects, and experiments
+        all          Export everything in the project: datasets, prompts, experiments, and traces
         dataset      Export a dataset by exact name (exports dataset definition and items)
-        project      Export a project by name or ID (exports project traces and metadata)
+        traces       Export the project's traces and their spans
         experiment   Export an experiment by name or ID (exports experiment configuration and results)
         prompt       Export a prompt by exact name (exports prompt templates and versions)
 
@@ -53,27 +57,28 @@ def export_group(ctx: click.Context, workspace: str, api_key: Optional[str]) -> 
 
     \b
     Examples:
-        # Export everything in the workspace
-        opik export my-workspace all
+        # Export everything in the project
+        opik export my-workspace my-project all
 
         # Export only datasets and prompts
-        opik export my-workspace all --include datasets,prompts
+        opik export my-workspace my-project all --include datasets,prompts
 
         # Export a specific dataset
-        opik export my-workspace dataset "my-dataset"
+        opik export my-workspace my-project dataset "my-dataset"
 
-        # Export a project with OQL filter
-        opik export my-workspace project "my-project" --filter "status:completed"
+        # Export the project's traces with an OQL filter
+        opik export my-workspace my-project traces --filter "status:completed"
 
         # Export an experiment with dataset filter (by name or ID)
-        opik export my-workspace experiment "my-experiment" --dataset "my-dataset"
-        opik export my-workspace experiment "01234567-89ab-cdef-0123-456789abcdef" --dataset "my-dataset"
+        opik export my-workspace my-project experiment "my-experiment" --dataset "my-dataset"
+        opik export my-workspace my-project experiment "01234567-89ab-cdef-0123-456789abcdef" --dataset "my-dataset"
 
         # Export in CSV format to a specific directory
-        opik export my-workspace prompt "my-template" --format csv --path ./custom-exports
+        opik export my-workspace my-project prompt "my-template" --format csv --path ./custom-exports
     """
     ctx.ensure_object(dict)
     ctx.obj["workspace"] = workspace
+    ctx.obj["project_name"] = project
     # Use API key from this command or from parent context
     ctx.obj["api_key"] = api_key or (
         ctx.parent.obj.get("api_key") if ctx.parent and ctx.parent.obj else None
@@ -124,19 +129,19 @@ def export_group(ctx: click.Context, workspace: str, api_key: Optional[str]) -> 
     # If no subcommand was invoked, show helpful error
     if ctx.invoked_subcommand is None:
         available_items = ", ".join(
-            sorted(["all", "dataset", "experiment", "prompt", "project"])
+            sorted(["all", "dataset", "experiment", "prompt", "traces"])
         )
         click.echo(
             f"Error: Missing ITEM.\n\n"
             f"Available items: {available_items}\n\n"
-            f"Usage: opik export {workspace} ITEM NAME [OPTIONS]\n\n"
+            f"Usage: opik export {workspace} {project} ITEM [NAME] [OPTIONS]\n\n"
             f"Examples:\n"
-            f"  opik export {workspace} all\n"
-            f'  opik export {workspace} dataset "my-dataset"\n'
-            f'  opik export {workspace} project "my-project"\n'
-            f'  opik export {workspace} experiment "my-experiment"\n'
-            f'  opik export {workspace} prompt "my-template"\n\n'
-            f"Run 'opik export {workspace} --help' for more information.",
+            f"  opik export {workspace} {project} all\n"
+            f'  opik export {workspace} {project} dataset "my-dataset"\n'
+            f"  opik export {workspace} {project} traces\n"
+            f'  opik export {workspace} {project} experiment "my-experiment"\n'
+            f'  opik export {workspace} {project} prompt "my-template"\n\n'
+            f"Run 'opik export {workspace} {project} --help' for more information.",
             err=True,
         )
         ctx.exit(2)
@@ -182,4 +187,4 @@ export_group.add_command(export_all_command)
 export_group.add_command(export_dataset_command)
 export_group.add_command(export_experiment_command)
 export_group.add_command(export_prompt_command)
-export_group.add_command(export_project_command)
+export_group.add_command(export_traces_command)

--- a/sdks/python/src/opik/cli/exports/all.py
+++ b/sdks/python/src/opik/cli/exports/all.py
@@ -19,6 +19,7 @@ from rich.progress import (
 )
 
 import opik
+from opik.api_objects import rest_helpers
 from opik.api_objects.prompt import Prompt, ChatPrompt
 from .dataset import export_single_dataset
 from .experiment import (
@@ -50,7 +51,9 @@ def _paginate(list_fn: Any, **kwargs: Any) -> Iterator:
         page += 1
 
 
-def _fetch_experiments_page_raw(client: opik.Opik, page: int) -> tuple[list, int]:
+def _fetch_experiments_page_raw(
+    client: opik.Opik, page: int, project_id: Optional[str]
+) -> tuple[list, int]:
     """Fetch one page of experiments via raw HTTP, tolerating missing fields.
 
     Used as a fallback when the typed client fails pydantic validation because
@@ -60,11 +63,14 @@ def _fetch_experiments_page_raw(client: opik.Opik, page: int) -> tuple[list, int
     httpx_client = (
         client.rest_client.experiments._raw_client._client_wrapper.httpx_client
     )
+    params: dict = {"page": page, "size": PAGE_SIZE}
+    if project_id is not None:
+        params["project_id"] = project_id
     try:
         response = httpx_client.request(
             "v1/private/experiments",
             method="GET",
-            params={"page": page, "size": PAGE_SIZE},
+            params=params,
         )
         response.raise_for_status()
         data = response.json()
@@ -89,13 +95,13 @@ def _fetch_experiments_page_raw(client: opik.Opik, page: int) -> tuple[list, int
     return items, total
 
 
-def _paginate_experiments(client: opik.Opik) -> Iterator:
+def _paginate_experiments(client: opik.Opik, project_id: Optional[str]) -> Iterator:
     """Paginate experiments, falling back to raw HTTP on pydantic validation errors."""
     page = 1
     while True:
         try:
             resp = client.rest_client.experiments.find_experiments(
-                page=page, size=PAGE_SIZE
+                page=page, size=PAGE_SIZE, project_id=project_id
             )
             items = resp.content or []
             total = resp.total or 0
@@ -104,7 +110,7 @@ def _paginate_experiments(client: opik.Opik) -> Iterator:
                 f"[yellow]Warning: page {page} of experiments failed validation "
                 f"(some experiments may be missing fields). Falling back to raw fetch.[/yellow]"
             )
-            items, total = _fetch_experiments_page_raw(client, page)
+            items, total = _fetch_experiments_page_raw(client, page, project_id)
 
         if not items:
             break
@@ -117,17 +123,21 @@ def _paginate_experiments(client: opik.Opik) -> Iterator:
 def _export_all_datasets(
     client: opik.Opik,
     datasets_dir: Path,
+    project_name: str,
+    project_id: Optional[str],
     max_results: Optional[int],
     force: bool,
     debug: bool,
     format: str,
 ) -> tuple[int, int]:
-    """Export all datasets in the workspace. Returns (exported, skipped)."""
+    """Export all datasets in the project. Returns (exported, skipped)."""
     exported = 0
     skipped = 0
 
     try:
-        all_datasets = list(_paginate(client.rest_client.datasets.find_datasets))
+        all_datasets = list(
+            _paginate(client.rest_client.datasets.find_datasets, project_id=project_id)
+        )
     except Exception as e:
         console.print(f"[red]Error listing datasets: {e}[/red]")
         return 0, 0
@@ -150,7 +160,9 @@ def _export_all_datasets(
         for ds_public in all_datasets:
             progress.update(task, description=f"Dataset: {ds_public.name}")
             try:
-                dataset_obj = client.get_dataset(ds_public.name)
+                dataset_obj = client.get_dataset(
+                    ds_public.name, project_name=project_name
+                )
                 result = export_single_dataset(
                     dataset_obj, datasets_dir, max_results, force, debug, format
                 )
@@ -171,17 +183,21 @@ def _export_all_datasets(
 def _export_all_prompts(
     client: opik.Opik,
     prompts_dir: Path,
+    project_name: str,
+    project_id: Optional[str],
     max_results: Optional[int],
     force: bool,
     debug: bool,
     format: str,
 ) -> tuple[int, int]:
-    """Export all prompts in the workspace. Returns (exported, skipped)."""
+    """Export all prompts in the project. Returns (exported, skipped)."""
     exported = 0
     skipped = 0
 
     try:
-        all_prompts = list(_paginate(client.rest_client.prompts.get_prompts))
+        all_prompts = list(
+            _paginate(client.rest_client.prompts.get_prompts, project_id=project_id)
+        )
     except Exception as e:
         console.print(f"[red]Error listing prompts: {e}[/red]")
         return 0, 0
@@ -208,12 +224,16 @@ def _export_all_prompts(
                 prompt_obj: Optional[Union[Prompt, ChatPrompt]] = None
                 if prompt_public.template_structure == "chat":
                     try:
-                        prompt_obj = client.get_chat_prompt(prompt_public.name)
+                        prompt_obj = client.get_chat_prompt(
+                            prompt_public.name, project_name=project_name
+                        )
                     except Exception:
                         pass
                 if prompt_obj is None:
                     try:
-                        prompt_obj = client.get_prompt(prompt_public.name)
+                        prompt_obj = client.get_prompt(
+                            prompt_public.name, project_name=project_name
+                        )
                     except Exception:
                         pass
 
@@ -227,6 +247,7 @@ def _export_all_prompts(
                         client,
                         prompt_obj,
                         prompts_dir,
+                        project_name,
                         max_results,
                         force,
                         debug,
@@ -246,95 +267,41 @@ def _export_all_prompts(
     return exported, skipped
 
 
-def _export_all_projects(
+def _export_project_traces(
     client: opik.Opik,
-    projects_dir: Path,
+    project_name: str,
+    project_dir: Path,
     max_results: Optional[int],
     force: bool,
     debug: bool,
     format: str,
-    max_workers: int = 5,
     filter_string: Optional[str] = None,
     include_attachments: bool = True,
     page_size: int = 500,
 ) -> tuple[int, int, int, bool]:
-    """Export all projects in the workspace.
+    """Export the named project's traces.
 
     Returns (projects_exported, traces_exported, traces_skipped, had_errors).
     """
-    projects_exported = 0
-    traces_exported = 0
-    traces_skipped = 0
-    had_errors = False
-
-    try:
-        all_projects = list(_paginate(client.rest_client.projects.find_projects))
-    except Exception as e:
-        console.print(f"[red]Error listing projects: {e}[/red]")
-        return 0, 0, 0, True
-
-    if not all_projects:
-        console.print("[yellow]No projects found.[/yellow]")
-        return 0, 0, 0, False
-
-    console.print(f"[blue]Found {len(all_projects)} project(s)[/blue]")
-
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        BarColumn(),
-        TaskProgressColumn(),
-        console=console,
-    ) as progress:
-        task = progress.add_task("Exporting projects...", total=len(all_projects))
-
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            future_to_project = {
-                executor.submit(
-                    export_single_project,
-                    client=client,
-                    project=project,
-                    output_dir=projects_dir,
-                    filter_string=filter_string,
-                    max_results=max_results,
-                    force=force,
-                    debug=debug,
-                    format=format,
-                    show_progress=False,  # outer bar tracks progress
-                    include_attachments=include_attachments,
-                    page_size=page_size,
-                ): project
-                for project in all_projects
-            }
-            for future in as_completed(future_to_project):
-                project = future_to_project[future]
-                try:
-                    proj_count, t_exported, t_skipped, proj_had_errors = future.result()
-                    projects_exported += proj_count
-                    traces_exported += t_exported
-                    traces_skipped += t_skipped
-                    if proj_had_errors:
-                        had_errors = True
-                        console.print(
-                            f"[yellow]Project '{project.name}' exported with errors — "
-                            "some traces may be missing. Run the export again to fill gaps.[/yellow]"
-                        )
-                except Exception as e:
-                    console.print(
-                        f"[red]Error exporting project '{project.name}': {e}[/red]"
-                    )
-                    had_errors = True
-                finally:
-                    progress.update(
-                        task, advance=1, description=f"Project: {project.name}"
-                    )
-
-    return projects_exported, traces_exported, traces_skipped, had_errors
+    return export_single_project(
+        client=client,
+        project_name=project_name,
+        project_dir=project_dir,
+        filter_string=filter_string,
+        max_results=max_results,
+        force=force,
+        debug=debug,
+        format=format,
+        include_attachments=include_attachments,
+        page_size=page_size,
+    )
 
 
 def _export_all_experiments(
     client: opik.Opik,
-    workspace_root: Path,
+    project_dir: Path,
+    project_name: str,
+    project_id: Optional[str],
     experiments_dir: Path,
     max_results: Optional[int],
     force: bool,
@@ -343,7 +310,7 @@ def _export_all_experiments(
     filter_string: Optional[str] = None,
     max_workers: int = 10,
 ) -> tuple[int, int, int, int, bool]:
-    """Export all experiments.
+    """Export all experiments in the project.
 
     Returns (exported, skipped, traces_exported, traces_skipped, had_errors).
     """
@@ -353,7 +320,7 @@ def _export_all_experiments(
     all_trace_ids: set[str] = set()
 
     try:
-        all_experiments = list(_paginate_experiments(client))
+        all_experiments = list(_paginate_experiments(client, project_id))
     except Exception as e:
         console.print(f"[red]Error listing experiments: {e}[/red]")
         return 0, 0, 0, 0, True
@@ -383,6 +350,7 @@ def _export_all_experiments(
                     export_experiment_by_id,
                     client,
                     experiments_dir,
+                    project_name,
                     exp.id,
                     max_results,
                     force,
@@ -425,7 +393,8 @@ def _export_all_experiments(
     # Batch-export all traces collected from experiments
     traces_exported, traces_skipped = export_collected_trace_ids(
         client,
-        workspace_root,
+        project_dir,
+        project_name,
         all_trace_ids,
         max_results,
         format,
@@ -439,6 +408,7 @@ def _export_all_experiments(
 
 def export_all(
     workspace: str,
+    project_name: str,
     output_path: str,
     include: list[str],
     max_results: Optional[int],
@@ -450,15 +420,20 @@ def export_all(
     include_attachments: bool = True,
     page_size: int = 500,
 ) -> None:
-    """Export all data from the workspace."""
+    """Export all data from a single project."""
     try:
         if api_key:
             client = opik.Opik(api_key=api_key, workspace=workspace)
         else:
             client = opik.Opik(workspace=workspace)
 
-        workspace_root = Path(output_path) / workspace
-        workspace_root.mkdir(parents=True, exist_ok=True)
+        project_root = Path(output_path) / workspace / "projects" / project_name
+        project_root.mkdir(parents=True, exist_ok=True)
+
+        # Resolve the project id once so per-entity listings can be scoped to it.
+        project_id = rest_helpers.resolve_project_id_by_name_optional(
+            client.rest_client, project_name=project_name
+        )
 
         total_stats: dict = {}
         any_errors = False
@@ -466,10 +441,17 @@ def export_all(
         # Phase 1: Datasets
         if "datasets" in include:
             console.print("\n[bold blue]--- Exporting Datasets ---[/bold blue]")
-            datasets_dir = workspace_root / "datasets"
+            datasets_dir = project_root / "datasets"
             datasets_dir.mkdir(parents=True, exist_ok=True)
             ds_exp, ds_skip = _export_all_datasets(
-                client, datasets_dir, max_results, force, debug, format
+                client,
+                datasets_dir,
+                project_name,
+                project_id,
+                max_results,
+                force,
+                debug,
+                format,
             )
             total_stats["datasets"] = ds_exp
             total_stats["datasets_skipped"] = ds_skip
@@ -477,22 +459,28 @@ def export_all(
         # Phase 2: Prompts
         if "prompts" in include:
             console.print("\n[bold blue]--- Exporting Prompts ---[/bold blue]")
-            prompts_dir = workspace_root / "prompts"
+            prompts_dir = project_root / "prompts"
             prompts_dir.mkdir(parents=True, exist_ok=True)
             pr_exp, pr_skip = _export_all_prompts(
-                client, prompts_dir, max_results, force, debug, format
+                client,
+                prompts_dir,
+                project_name,
+                project_id,
+                max_results,
+                force,
+                debug,
+                format,
             )
             total_stats["prompts"] = pr_exp
             total_stats["prompts_skipped"] = pr_skip
 
-        # Phase 3: Projects (traces)
-        if "projects" in include:
-            console.print("\n[bold blue]--- Exporting Projects ---[/bold blue]")
-            projects_dir = workspace_root / "projects"
-            projects_dir.mkdir(parents=True, exist_ok=True)
-            proj_exp, tr_exp, tr_skip, proj_errors = _export_all_projects(
+        # Phase 3: Traces
+        if "traces" in include:
+            console.print("\n[bold blue]--- Exporting Traces ---[/bold blue]")
+            proj_exp, tr_exp, tr_skip, proj_errors = _export_project_traces(
                 client,
-                projects_dir,
+                project_name,
+                project_root,
                 max_results,
                 force,
                 debug,
@@ -511,12 +499,14 @@ def export_all(
         # Phase 4: Experiments (related datasets/prompts skipped via file-existence check)
         if "experiments" in include:
             console.print("\n[bold blue]--- Exporting Experiments ---[/bold blue]")
-            experiments_dir = workspace_root / "experiments"
+            experiments_dir = project_root / "experiments"
             experiments_dir.mkdir(parents=True, exist_ok=True)
             exp_exp, exp_skip, exp_tr_exp, exp_tr_skip, exp_errors = (
                 _export_all_experiments(
                     client,
-                    workspace_root,
+                    project_root,
+                    project_name,
+                    project_id,
                     experiments_dir,
                     max_results,
                     force,
@@ -538,12 +528,12 @@ def export_all(
         if any_errors:
             console.print(
                 "\n[bold yellow]Export completed with errors — "
-                "some projects or experiments could not be exported.[/bold yellow]"
+                "some traces or experiments could not be exported.[/bold yellow]"
             )
         else:
             console.print("\n[bold green]Export complete.[/bold green]")
         print_export_summary(total_stats, format)
-        console.print(f"[green]All data saved to: {workspace_root}[/green]")
+        console.print(f"[green]All data saved to: {project_root}[/green]")
         if any_errors:
             sys.exit(1)
 
@@ -556,8 +546,8 @@ def export_all(
         sys.exit(1)
 
 
-_VALID_INCLUDES = {"datasets", "prompts", "projects", "experiments"}
-_DEFAULT_INCLUDE = "datasets,prompts,projects,experiments"
+_VALID_INCLUDES = {"datasets", "prompts", "traces", "experiments"}
+_DEFAULT_INCLUDE = "datasets,prompts,traces,experiments"
 
 
 def _validate_include(
@@ -632,27 +622,29 @@ def export_all_command(
     no_attachments: bool,
     page_size: int,
 ) -> None:
-    """Export all datasets, prompts, projects, and experiments from the workspace.
+    """Export all datasets, prompts, experiments, and traces from the project.
 
-    Downloads everything in the workspace in dependency order:
-    datasets and prompts first, then projects (traces), then experiments.
+    Downloads everything in the project in dependency order:
+    datasets and prompts first, then traces, then experiments.
     Items already downloaded are skipped unless --force is set.
 
     \b
     Examples:
         # Export everything
-        opik export my-workspace all
+        opik export my-workspace my-project all
 
         # Export only datasets and prompts
-        opik export my-workspace all --include datasets,prompts
+        opik export my-workspace my-project all --include datasets,prompts
 
         # Re-download everything to a custom path
-        opik export my-workspace all --force --path ./backup
+        opik export my-workspace my-project all --force --path ./backup
     """
     workspace = ctx.obj["workspace"]
+    project_name = ctx.obj["project_name"]
     api_key = ctx.obj.get("api_key") if ctx.obj else None
     export_all(
         workspace,
+        project_name,
         path,
         include,
         max_results,

--- a/sdks/python/src/opik/cli/exports/all.py
+++ b/sdks/python/src/opik/cli/exports/all.py
@@ -19,7 +19,6 @@ from rich.progress import (
 )
 
 import opik
-from opik.api_objects import rest_helpers
 from opik.api_objects.prompt import Prompt, ChatPrompt
 from .dataset import export_single_dataset
 from .experiment import (
@@ -28,7 +27,13 @@ from .experiment import (
 )
 from .project import export_single_project
 from .prompt import export_single_prompt
-from .utils import console, debug_print, no_attachments_option, print_export_summary
+from .utils import (
+    console,
+    debug_print,
+    no_attachments_option,
+    prepare_project_export_dir,
+    print_export_summary,
+)
 from ..include_validation import validate_include
 
 PAGE_SIZE = 500
@@ -427,13 +432,15 @@ def export_all(
         else:
             client = opik.Opik(workspace=workspace)
 
-        project_root = Path(output_path) / workspace / "projects" / project_name
-        project_root.mkdir(parents=True, exist_ok=True)
-
-        # Resolve the project id once so per-entity listings can be scoped to it.
-        project_id = rest_helpers.resolve_project_id_by_name_optional(
-            client.rest_client, project_name=project_name
-        )
+        # Resolve the project to its ID, create projects/<id>/ and write
+        # project.json. The id also scopes per-entity listings below.
+        try:
+            project_id, project_root = prepare_project_export_dir(
+                client, output_path, workspace, project_name
+            )
+        except ValueError:
+            console.print(f"[red]Project '{project_name}' not found[/red]")
+            sys.exit(1)
 
         total_stats: dict = {}
         any_errors = False

--- a/sdks/python/src/opik/cli/exports/dataset.py
+++ b/sdks/python/src/opik/cli/exports/dataset.py
@@ -12,6 +12,7 @@ from .utils import (
     console,
     debug_print,
     dataset_to_csv_rows,
+    prepare_project_export_dir,
     should_skip_file,
     write_csv_data,
     write_json_data,
@@ -27,13 +28,13 @@ def export_single_dataset(
     debug: bool,
     format: str,
 ) -> int:
-    """Export a single dataset."""
+    """Export a single dataset. The file is named by dataset ID; the human
+    name is stored inside the file."""
     try:
-        # Check if already exists and force is not set
-        if format.lower() == "csv":
-            dataset_file = output_dir / f"dataset_{dataset.name}.csv"
-        else:
-            dataset_file = output_dir / f"dataset_{dataset.name}.json"
+        # File is keyed by dataset ID (the name lives inside the file).
+        dataset_id = dataset.id
+        ext = "csv" if format.lower() == "csv" else "json"
+        dataset_file = output_dir / f"dataset_{dataset_id}.{ext}"
 
         if should_skip_file(dataset_file, force):
             if debug:
@@ -56,6 +57,7 @@ def export_single_dataset(
 
         # Create dataset data structure
         dataset_data = {
+            "id": dataset_id,
             "name": dataset.name,
             "description": dataset.description,
             "items": formatted_items,
@@ -99,10 +101,11 @@ def export_dataset_by_name(
         else:
             client = opik.Opik(workspace=workspace)
 
-        # Create output directory (project-nested layout)
-        output_dir = (
-            Path(output_path) / workspace / "projects" / project_name / "datasets"
+        # Resolve the project to its ID and create projects/<id>/datasets.
+        _project_id, project_dir = prepare_project_export_dir(
+            client, output_path, workspace, project_name
         )
+        output_dir = project_dir / "datasets"
         output_dir.mkdir(parents=True, exist_ok=True)
 
         if debug:
@@ -173,12 +176,18 @@ def export_experiment_datasets(
 
     for dataset_name in datasets_to_export:
         try:
-            # Use format parameter to determine file extension
-            if format.lower() == "csv":
-                dataset_file = datasets_dir / f"dataset_{dataset_name}.csv"
-            else:
-                dataset_file = datasets_dir / f"dataset_{dataset_name}.json"
             datasets_dir.mkdir(parents=True, exist_ok=True)
+
+            dataset_obj = opik.Dataset(
+                name=dataset_name,
+                description=None,  # Description not available from experiment
+                project_name=project_name,
+                rest_client=client.rest_client,
+            )
+            # File is keyed by dataset ID (the name lives inside the file).
+            dataset_id = dataset_obj.id
+            ext = "csv" if format.lower() == "csv" else "json"
+            dataset_file = datasets_dir / f"dataset_{dataset_id}.{ext}"
 
             # Check if file already exists and should be skipped
             if should_skip_file(dataset_file, force):
@@ -193,18 +202,12 @@ def export_experiment_datasets(
                 skipped_count += 1
                 continue
 
-            dataset_obj = opik.Dataset(
-                name=dataset_name,
-                description=None,  # Description not available from experiment
-                project_name=project_name,
-                rest_client=client.rest_client,
-            )
             dataset_items = dataset_obj.get_items()
 
             dataset_data = {
                 "dataset": {
                     "name": dataset_name,
-                    "id": getattr(dataset_obj, "id", None),
+                    "id": dataset_id,
                 },
                 # Use all fields from each item, excluding 'id' (internal field)
                 "items": [

--- a/sdks/python/src/opik/cli/exports/dataset.py
+++ b/sdks/python/src/opik/cli/exports/dataset.py
@@ -80,6 +80,7 @@ def export_single_dataset(
 def export_dataset_by_name(
     name: str,
     workspace: str,
+    project_name: str,
     output_path: str,
     max_results: Optional[int],
     force: bool,
@@ -87,7 +88,7 @@ def export_dataset_by_name(
     format: str,
     api_key: Optional[str] = None,
 ) -> None:
-    """Export a dataset by exact name."""
+    """Export a dataset by exact name from the given project."""
     try:
         if debug:
             debug_print(f"Exporting dataset: {name}", debug)
@@ -98,16 +99,18 @@ def export_dataset_by_name(
         else:
             client = opik.Opik(workspace=workspace)
 
-        # Create output directory
-        output_dir = Path(output_path) / workspace / "datasets"
+        # Create output directory (project-nested layout)
+        output_dir = (
+            Path(output_path) / workspace / "projects" / project_name / "datasets"
+        )
         output_dir.mkdir(parents=True, exist_ok=True)
 
         if debug:
             debug_print(f"Target directory: {output_dir}", debug)
 
-        # Try to get dataset by exact name
+        # Try to get dataset by exact name within the project
         try:
-            dataset = client.get_dataset(name)
+            dataset = client.get_dataset(name, project_name=project_name)
             if debug:
                 debug_print(f"Found dataset by direct lookup: {dataset.name}", debug)
         except Exception as e:
@@ -146,6 +149,7 @@ def export_experiment_datasets(
     client: opik.Opik,
     datasets_to_export: set[str],
     datasets_dir: Path,
+    project_name: str,
     format: str,
     debug: bool,
     force: bool,
@@ -156,6 +160,7 @@ def export_experiment_datasets(
         client: Opik client instance
         datasets_to_export: Set of dataset names to export
         datasets_dir: Directory to save datasets
+        project_name: Project the experiment (and its datasets) belong to
         format: Export format ('json' or 'csv')
         debug: Enable debug output
         force: Re-download datasets even if they already exist locally
@@ -191,7 +196,7 @@ def export_experiment_datasets(
             dataset_obj = opik.Dataset(
                 name=dataset_name,
                 description=None,  # Description not available from experiment
-                project_name=None,
+                project_name=project_name,
                 rest_client=client.rest_client,
             )
             dataset_items = dataset_obj.get_items()
@@ -268,10 +273,11 @@ def export_dataset_command(
     debug: bool,
     format: str,
 ) -> None:
-    """Export a dataset by exact name to workspace/datasets."""
-    # Get workspace and API key from context
+    """Export a dataset by exact name to projects/<project>/datasets."""
+    # Get workspace, project, and API key from context
     workspace = ctx.obj["workspace"]
+    project_name = ctx.obj["project_name"]
     api_key = ctx.obj.get("api_key") if ctx.obj else None
     export_dataset_by_name(
-        name, workspace, path, max_results, force, debug, format, api_key
+        name, workspace, project_name, path, max_results, force, debug, format, api_key
     )

--- a/sdks/python/src/opik/cli/exports/experiment.py
+++ b/sdks/python/src/opik/cli/exports/experiment.py
@@ -24,6 +24,7 @@ from .utils import (
     create_experiment_data_structure,
     debug_print,
     extract_trace_id_from_filename,
+    prepare_project_export_dir,
     write_json_data,
     write_csv_data,
     print_export_summary,
@@ -423,9 +424,7 @@ def export_experiment_by_id(
         # e.g. a previous run that fetched items but crashed before finishing traces.
         if not force:
             stored_ids = manifest.get_all_trace_ids()
-            experiment_files = list(
-                output_dir.glob(f"experiment_*_{experiment_id}.json")
-            )
+            experiment_files = list(output_dir.glob(f"experiment_{experiment_id}.json"))
             if stored_ids is not None and experiment_files:
                 if trace_ids_collector is not None:
                     trace_ids_collector.update(stored_ids)
@@ -525,9 +524,7 @@ def export_experiment_by_id(
 
         # Save experiment data
         # Include experiment ID in filename to handle multiple experiments with same name
-        experiment_file = (
-            output_dir / f"experiment_{experiment.name}_{experiment.id}.json"
-        )
+        experiment_file = output_dir / f"experiment_{experiment.id}.json"
         file_already_exists = experiment_file.exists()
         experiment_file_written = False
 
@@ -608,8 +605,10 @@ def export_experiment_by_name(
         else:
             client = opik.Opik(workspace=workspace)
 
-        # Create output directory (project-nested layout)
-        project_root = Path(output_path) / workspace / "projects" / project_name
+        # Resolve the project to its ID and create projects/<id>/.
+        _project_id, project_root = prepare_project_export_dir(
+            client, output_path, workspace, project_name
+        )
         output_dir = project_root / "experiments"
         output_dir.mkdir(parents=True, exist_ok=True)
         datasets_dir = project_root / "datasets"
@@ -840,8 +839,10 @@ def export_experiment_by_name_or_id(
         else:
             client = opik.Opik(workspace=workspace)
 
-        # Create output directory (project-nested layout)
-        project_root = Path(output_path) / workspace / "projects" / project_name
+        # Resolve the project to its ID and create projects/<id>/.
+        _project_id, project_root = prepare_project_export_dir(
+            client, output_path, workspace, project_name
+        )
         output_dir = project_root / "experiments"
         output_dir.mkdir(parents=True, exist_ok=True)
         datasets_dir = project_root / "datasets"

--- a/sdks/python/src/opik/cli/exports/experiment.py
+++ b/sdks/python/src/opik/cli/exports/experiment.py
@@ -2,7 +2,6 @@
 
 import json
 import sys
-import threading
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
@@ -47,42 +46,20 @@ MAX_WORKERS = 20
 def _fetch_trace_data(
     client: opik.Opik,
     trace_id: str,
-    project_name_cache: dict[str, str],
-    cache_lock: threading.Lock,
+    project_name: str,
     debug: bool,
-) -> Optional[Tuple[str, dict, str]]:
+) -> Optional[Tuple[str, dict]]:
     """Fetch trace and span data for a single trace ID.
 
+    The export is scoped to ``project_name``, so the trace is recorded under
+    that project without a per-trace project lookup.
+
     Returns:
-        Tuple of (trace_id, trace_data_dict, project_name) or None if failed.
+        Tuple of (trace_id, trace_data_dict) or None if failed.
     """
     try:
         # Get trace by ID
         trace = client.get_trace_content(trace_id)
-
-        # Get project name for this trace
-        if not trace.project_id:
-            return None
-
-        # Get project name (use cache if available).
-        # Fast path: check without the lock first (already-cached entries).
-        # If missing, fetch without holding the lock (slow API call), then
-        # use setdefault so that the first writer wins in case two threads
-        # raced on the same project_id.
-        if trace.project_id not in project_name_cache:
-            try:
-                project = client.get_project(trace.project_id)
-                with cache_lock:
-                    project_name_cache.setdefault(trace.project_id, project.name)
-            except Exception as e:
-                if debug:
-                    debug_print(
-                        f"Warning: Could not get project for trace {trace_id}: {e}",
-                        debug,
-                    )
-                return None
-
-        project_name = project_name_cache[trace.project_id]
 
         # Get spans for this trace
         spans = client.search_spans(
@@ -99,7 +76,7 @@ def _fetch_trace_data(
             "project_name": project_name,
         }
 
-        return (trace_id, trace_data, project_name)
+        return (trace_id, trace_data)
     except Exception as e:
         if debug:
             import traceback
@@ -113,16 +90,14 @@ def _fetch_trace_data(
 def _write_trace_file(
     trace_id: str,
     trace_data: dict,
-    project_name: str,
-    workspace_root: Path,
+    project_dir: Path,
     format: str,
     force: bool,
     debug: bool,
 ) -> bool:
     """Write a single trace to file. Returns True if exported, False if skipped."""
     try:
-        # Save trace in projects/PROJECT_NAME/ directory
-        project_dir = workspace_root / "projects" / project_name
+        # Save trace directly in the project directory
         project_dir.mkdir(parents=True, exist_ok=True)
 
         # Determine file path based on format
@@ -157,18 +132,17 @@ def _write_trace_file(
         return False
 
 
-def _scan_downloaded_trace_ids(workspace_root: Path, format: str) -> Set[str]:
-    """Scan projects/ dirs for already-downloaded trace files and return their IDs.
+def _scan_downloaded_trace_ids(project_dir: Path, format: str) -> Set[str]:
+    """Scan the project dir for already-downloaded trace files and return their IDs.
 
     This is a fast, zero-network way to pre-filter traces before making any API
-    calls.  A single glob over the output directory is all it takes.
+    calls.  A single glob over the project directory is all it takes.
     """
     ext = "csv" if format.lower() == "csv" else "json"
     downloaded: Set[str] = set()
-    projects_dir = workspace_root / "projects"
-    if not projects_dir.is_dir():
+    if not project_dir.is_dir():
         return downloaded
-    for trace_file in projects_dir.glob(f"*/trace_*.{ext}"):
+    for trace_file in project_dir.glob(f"trace_*.{ext}"):
         trace_id = extract_trace_id_from_filename(trace_file)
         if trace_id:
             downloaded.add(trace_id)
@@ -177,7 +151,8 @@ def _scan_downloaded_trace_ids(workspace_root: Path, format: str) -> Set[str]:
 
 def export_collected_trace_ids(
     client: opik.Opik,
-    workspace_root: Path,
+    project_dir: Path,
+    project_name: str,
     all_trace_ids: set,
     max_limit: Optional[int],
     format: str,
@@ -204,7 +179,8 @@ def export_collected_trace_ids(
     return export_traces_by_ids(
         client,
         trace_ids_list,
-        workspace_root,
+        project_dir,
+        project_name,
         None,
         format,
         debug,
@@ -217,7 +193,8 @@ def export_collected_trace_ids(
 def export_traces_by_ids(
     client: opik.Opik,
     trace_ids: List[str],
-    workspace_root: Path,
+    project_dir: Path,
+    project_name: str,
     max_traces: Optional[int],
     format: str,
     debug: bool,
@@ -227,12 +204,12 @@ def export_traces_by_ids(
 ) -> tuple[int, int]:
     """Export traces by their IDs using parallel batch processing.
 
-    Traces are saved in projects/PROJECT_NAME/ directory based on each trace's project.
+    Traces are saved directly in the project directory (``project_dir``).
     Uses parallel execution to fetch traces/spans and write files concurrently.
 
     Already-downloaded traces are skipped before any API call is made:
     - When *manifest* is provided its downloaded-ID set is used for the check.
-    - Otherwise the projects/ directory is scanned for existing trace files.
+    - Otherwise the project directory is scanned for existing trace files.
     """
     exported_count = 0
     skipped_count = 0
@@ -258,9 +235,9 @@ def export_traces_by_ids(
             # exist on disk from an earlier run.  Fall back to a filesystem scan so
             # pre-existing traces are detected and skipped before any API call.
             if not already_downloaded:
-                already_downloaded = _scan_downloaded_trace_ids(workspace_root, format)
+                already_downloaded = _scan_downloaded_trace_ids(project_dir, format)
         else:
-            already_downloaded = _scan_downloaded_trace_ids(workspace_root, format)
+            already_downloaded = _scan_downloaded_trace_ids(project_dir, format)
         pending_ids = [tid for tid in trace_ids if tid not in already_downloaded]
         skipped_count = len(trace_ids) - len(pending_ids)
     else:
@@ -274,10 +251,6 @@ def export_traces_by_ids(
         )
 
     if pending_ids:
-        # Cache project names to avoid repeated API calls (shared across threads).
-        project_name_cache: dict[str, str] = {}
-        cache_lock = threading.Lock()
-
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
@@ -300,20 +273,17 @@ def export_traces_by_ids(
                     )
 
                 # Fetch trace data in parallel
-                fetched_traces: dict[str, Tuple[dict, str]] = {}
+                fetched_traces: dict[str, dict] = {}
 
                 with ThreadPoolExecutor(max_workers=MAX_WORKERS) as fetch_executor:
-                    fetch_futures: Dict[
-                        Future[Optional[Tuple[str, dict, str]]], str
-                    ] = {}
+                    fetch_futures: Dict[Future[Optional[Tuple[str, dict]]], str] = {}
                     for trace_id in batch_trace_ids:
-                        fetch_future: Future[Optional[Tuple[str, dict, str]]] = (
+                        fetch_future: Future[Optional[Tuple[str, dict]]] = (
                             fetch_executor.submit(
                                 _fetch_trace_data,
                                 client,
                                 trace_id,
-                                project_name_cache,
-                                cache_lock,
+                                project_name,
                                 debug,
                             )
                         )
@@ -326,22 +296,19 @@ def export_traces_by_ids(
                         try:
                             result = fetch_future.result()
                             if result is not None:
-                                fetched_trace_id, trace_data, project_name = result
+                                fetched_trace_id, trace_data = result
                                 if filter_string and not matches_trace_filter(
                                     trace_data.get("trace", {}), filter_string
                                 ):
                                     skipped_count += 1
                                     batch_filter_skipped += 1
                                     continue
-                                fetched_traces[fetched_trace_id] = (
-                                    trace_data,
-                                    project_name,
-                                )
+                                fetched_traces[fetched_trace_id] = trace_data
                             else:
-                                # _fetch_trace_data returns None for unresolvable
-                                # traces (e.g. missing project_id).  Treat as skipped
-                                # rather than failed so manifest.complete() isn't
-                                # permanently blocked by permanently-unresolvable IDs.
+                                # _fetch_trace_data returns None for traces that could
+                                # not be fetched.  Treat as skipped rather than failed
+                                # so manifest.complete() isn't permanently blocked by
+                                # permanently-unresolvable IDs.
                                 skipped_count += 1
                                 batch_none_count += 1
                         except Exception as e:
@@ -362,13 +329,12 @@ def export_traces_by_ids(
                 # Write files in parallel
                 with ThreadPoolExecutor(max_workers=MAX_WORKERS) as write_executor:
                     write_futures: Dict[Future[bool], str] = {}
-                    for trace_id, (trace_data, project_name) in fetched_traces.items():
+                    for trace_id, trace_data in fetched_traces.items():
                         write_future: Future[bool] = write_executor.submit(
                             _write_trace_file,
                             trace_id,
                             trace_data,
-                            project_name,
-                            workspace_root,
+                            project_dir,
                             format,
                             force,
                             debug,
@@ -413,6 +379,7 @@ def export_traces_by_ids(
 def export_experiment_by_id(
     client: opik.Opik,
     output_dir: Path,
+    project_name: str,
     experiment_id: str,
     max_traces: Optional[int],
     force: bool,
@@ -587,7 +554,7 @@ def export_experiment_by_id(
             "traces_skipped": 0,
         }
         stats["prompts"] = export_related_prompts_by_name(
-            client, experiment, output_dir, force, debug, format
+            client, experiment, output_dir, project_name, force, debug, format
         )
 
         # Collect trace IDs from experiment items (for batch export later).
@@ -620,6 +587,7 @@ def export_experiment_by_id(
 def export_experiment_by_name(
     name: str,
     workspace: str,
+    project_name: str,
     output_path: str,
     dataset: Optional[str],
     max_traces: Optional[int],
@@ -629,7 +597,7 @@ def export_experiment_by_name(
     api_key: Optional[str] = None,
     filter_string: Optional[str] = None,
 ) -> None:
-    """Export an experiment by exact name."""
+    """Export an experiment by exact name from the given project."""
     try:
         if debug:
             debug_print(f"Exporting experiment: {name}", debug)
@@ -640,18 +608,21 @@ def export_experiment_by_name(
         else:
             client = opik.Opik(workspace=workspace)
 
-        # Create output directory
-        output_dir = Path(output_path) / workspace / "experiments"
+        # Create output directory (project-nested layout)
+        project_root = Path(output_path) / workspace / "projects" / project_name
+        output_dir = project_root / "experiments"
         output_dir.mkdir(parents=True, exist_ok=True)
-        datasets_dir = Path(output_path) / workspace / "datasets"
+        datasets_dir = project_root / "datasets"
         datasets_dir.mkdir(parents=True, exist_ok=True)
 
         if debug:
             debug_print(f"Target directory: {output_dir}", debug)
 
-        # Try to get experiments by exact name
+        # Try to get experiments by exact name within the project
         try:
-            experiments = client.get_experiments_by_name(name)
+            experiments = client.get_experiments_by_name(
+                name, project_name=project_name
+            )
             if not experiments:
                 console.print(f"[red]Experiment '{name}' not found[/red]")
                 return
@@ -707,7 +678,13 @@ def export_experiment_by_name(
                     f"[blue]Exporting {len(unique_datasets)} unique dataset(s) used by these experiments...[/blue]"
                 )
             datasets_exported, datasets_skipped = export_experiment_datasets(
-                client, unique_datasets, datasets_dir, format, debug, force
+                client,
+                unique_datasets,
+                datasets_dir,
+                project_name,
+                format,
+                debug,
+                force,
             )
 
         # Export all unique prompts once before processing experiments
@@ -721,7 +698,13 @@ def export_experiment_by_name(
                     f"[blue]Exporting {len(unique_prompt_ids)} unique prompt(s) used by these experiments...[/blue]"
                 )
             prompts_exported, prompts_skipped = export_prompts_by_ids(
-                client, unique_prompt_ids, prompts_dir, format, debug, force
+                client,
+                unique_prompt_ids,
+                prompts_dir,
+                project_name,
+                format,
+                debug,
+                force,
             )
 
         # Collect all unique trace IDs from all experiments as we process them
@@ -752,6 +735,7 @@ def export_experiment_by_name(
             result = export_experiment_by_id(
                 client,
                 output_dir,
+                project_name,
                 experiment.id,
                 max_traces,
                 force,
@@ -777,7 +761,6 @@ def export_experiment_by_name(
         # For a single experiment we pass its manifest so Phase 2 can skip traces
         # that are already in the downloaded set without touching the filesystem.
         # For multiple experiments we pass None and rely on Phase 1 (filesystem scan).
-        workspace_root = output_dir.parent
         trace_manifest: Optional[ExportManifest] = (
             experiment_manifests.get(experiments[0].id)
             if len(experiments) == 1
@@ -785,7 +768,8 @@ def export_experiment_by_name(
         )
         traces_exported, traces_skipped = export_collected_trace_ids(
             client,
-            workspace_root,
+            project_root,
+            project_name,
             all_trace_ids,
             max_traces,
             format,
@@ -832,6 +816,7 @@ def export_experiment_by_name(
 def export_experiment_by_name_or_id(
     name_or_id: str,
     workspace: str,
+    project_name: str,
     output_path: str,
     dataset: Optional[str],
     max_traces: Optional[int],
@@ -841,7 +826,7 @@ def export_experiment_by_name_or_id(
     api_key: Optional[str] = None,
     filter_string: Optional[str] = None,
 ) -> None:
-    """Export an experiment by name or ID.
+    """Export an experiment by name or ID from the given project.
 
     First tries to get the experiment by ID. If not found, tries by name.
     """
@@ -855,10 +840,11 @@ def export_experiment_by_name_or_id(
         else:
             client = opik.Opik(workspace=workspace)
 
-        # Create output directory
-        output_dir = Path(output_path) / workspace / "experiments"
+        # Create output directory (project-nested layout)
+        project_root = Path(output_path) / workspace / "projects" / project_name
+        output_dir = project_root / "experiments"
         output_dir.mkdir(parents=True, exist_ok=True)
-        datasets_dir = Path(output_path) / workspace / "datasets"
+        datasets_dir = project_root / "datasets"
         datasets_dir.mkdir(parents=True, exist_ok=True)
 
         # Try to get experiment by ID first
@@ -881,6 +867,7 @@ def export_experiment_by_name_or_id(
             result = export_experiment_by_id(
                 client,
                 output_dir,
+                project_name,
                 name_or_id,
                 max_traces,
                 force,
@@ -900,12 +887,17 @@ def export_experiment_by_name_or_id(
             datasets_skipped = 0
             if unique_datasets:
                 datasets_exported, datasets_skipped = export_experiment_datasets(
-                    client, unique_datasets, datasets_dir, format, debug, force
+                    client,
+                    unique_datasets,
+                    datasets_dir,
+                    project_name,
+                    format,
+                    debug,
+                    force,
                 )
 
             # Export traces collected from experiment items, passing the manifest
             # so already-downloaded traces are skipped before any API call.
-            workspace_root = output_dir.parent
             traces_exported = 0
             traces_skipped = 0
             if trace_ids_collector:
@@ -916,7 +908,8 @@ def export_experiment_by_name_or_id(
                     traces_exported, traces_skipped = export_traces_by_ids(
                         client,
                         trace_ids_list,
-                        workspace_root,
+                        project_root,
+                        project_name,
                         None,
                         format,
                         debug,
@@ -963,6 +956,7 @@ def export_experiment_by_name_or_id(
         export_experiment_by_name(
             name_or_id,
             workspace,
+            project_name,
             output_path,
             dataset,
             max_traces,
@@ -1030,16 +1024,18 @@ def export_experiment_command(
     debug: bool,
     format: str,
 ) -> None:
-    """Export an experiment by exact name to workspace/experiments.
+    """Export an experiment by exact name to projects/<project>/experiments.
 
     The command will first try to find the experiment by ID. If not found, it will try by name.
     """
-    # Get workspace and API key from context
+    # Get workspace, project, and API key from context
     workspace = ctx.obj["workspace"]
+    project_name = ctx.obj["project_name"]
     api_key = ctx.obj.get("api_key") if ctx.obj else None
     export_experiment_by_name_or_id(
         name_or_id,
         workspace,
+        project_name,
         path,
         dataset,
         max_traces,

--- a/sdks/python/src/opik/cli/exports/project.py
+++ b/sdks/python/src/opik/cli/exports/project.py
@@ -18,12 +18,12 @@ import tenacity
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 import opik
+from opik.api_objects import rest_helpers
 from opik.api_objects.attachment import client as attachment_client
 from opik import exceptions as opik_exceptions
 from opik.rate_limit import rate_limit
 from opik.rest_api.core.api_error import ApiError
 from opik.rest_api.core.http_client import _parse_retry_after
-from opik.rest_api.types.project_public import ProjectPublic
 from opik.rest_client_configurator import retry_decorator
 from .._attachment_path import safe_attachment_path
 from ..export_manifest import ExportManifest
@@ -783,8 +783,8 @@ def export_traces(
     return exported_count, skipped_count, had_errors
 
 
-def export_project_by_name(
-    name: str,
+def export_project_traces(
+    project_name: str,
     workspace: str,
     output_path: str,
     filter_string: Optional[str],
@@ -796,10 +796,10 @@ def export_project_by_name(
     include_attachments: bool = True,
     page_size: int = 500,
 ) -> None:
-    """Export a project by exact name."""
+    """Export the named project's traces into projects/<project>/."""
     try:
         if debug:
-            debug_print(f"Exporting project: {name}", debug)
+            debug_print(f"Exporting traces for project: {project_name}", debug)
 
         # Validate filter syntax before doing anything else
         if filter_string and filter_string.strip():
@@ -811,76 +811,27 @@ def export_project_by_name(
         else:
             client = opik.Opik(workspace=workspace)
 
-        # Create output directory
-        output_dir = Path(output_path) / workspace / "projects"
-        output_dir.mkdir(parents=True, exist_ok=True)
+        # Create the project's output directory (project-nested layout)
+        project_dir = Path(output_path) / workspace / "projects" / project_name
+        project_dir.mkdir(parents=True, exist_ok=True)
 
         if debug:
-            debug_print(f"Target directory: {output_dir}", debug)
+            debug_print(f"Target directory: {project_dir}", debug)
 
-        # Get projects and find exact match
-        # Use name filter to narrow down results (backend does partial match, case-insensitive)
-        # Then verify exact match on client side
-        projects_response = client.rest_client.projects.find_projects(name=name)
-        projects = projects_response.content or []
-        matching_project = None
-
-        for project in projects:
-            if project.name == name:
-                matching_project = project
-                break
-
-        # If not found with name filter, try paginating through all projects as fallback
-        # This handles edge cases where the name filter might not work as expected
-        if not matching_project:
-            if debug:
-                debug_print(
-                    f"Project '{name}' not found in filtered results, searching all projects...",
-                    debug,
-                )
-            # Paginate through all projects
-            page = 1
-            page_size = 100
-            while True:
-                projects_response = client.rest_client.projects.find_projects(
-                    page=page, size=page_size
-                )
-                projects = projects_response.content or []
-                if not projects:
-                    break
-
-                for project in projects:
-                    if project.name == name:
-                        matching_project = project
-                        break
-
-                if matching_project:
-                    break
-
-                # Check if there are more pages
-                if projects_response.total is not None:
-                    total_pages = (projects_response.total + page_size - 1) // page_size
-                    if page >= total_pages:
-                        break
-                elif len(projects) < page_size:
-                    # No more pages if we got fewer results than page size
-                    break
-
-                page += 1
-
-        if not matching_project:
-            console.print(f"[red]Project '{name}' not found[/red]")
+        # Validate the project exists so we can give a clear error message.
+        project_id = rest_helpers.resolve_project_id_by_name_optional(
+            client.rest_client, project_name=project_name
+        )
+        if project_id is None:
+            console.print(f"[red]Project '{project_name}' not found[/red]")
             sys.exit(1)
 
-        if debug:
-            debug_print(f"Found project by exact match: {matching_project.name}", debug)
-
-        # Export the project
+        # Export the project's traces
         exported_count, traces_exported, traces_skipped, had_errors = (
             export_single_project(
                 client=client,
-                project=matching_project,
-                output_dir=output_dir,
+                project_name=project_name,
+                project_dir=project_dir,
                 filter_string=filter_string,
                 max_results=max_results,
                 force=force,
@@ -902,24 +853,26 @@ def export_project_by_name(
         # Show export summary
         print_export_summary(stats, format)
 
-        _print_project_export_status(name, output_dir, exported_count, had_errors)
+        _print_project_export_status(
+            project_name, project_dir, exported_count, had_errors
+        )
 
     except ValueError as e:
         # Filter validation errors are already formatted, just exit
         if "Invalid filter syntax" in str(e):
             sys.exit(1)
         # Other ValueErrors should be shown
-        console.print(f"[red]Error exporting project: {e}[/red]")
+        console.print(f"[red]Error exporting traces: {e}[/red]")
         sys.exit(1)
     except Exception as e:
-        console.print(f"[red]Error exporting project: {e}[/red]")
+        console.print(f"[red]Error exporting traces: {e}[/red]")
         sys.exit(1)
 
 
 def export_single_project(
     client: opik.Opik,
-    project: ProjectPublic,
-    output_dir: Path,
+    project_name: str,
+    project_dir: Path,
     filter_string: Optional[str],
     max_results: Optional[int],
     force: bool,
@@ -929,7 +882,7 @@ def export_single_project(
     include_attachments: bool = True,
     page_size: int = 500,
 ) -> tuple[int, int, int, bool]:
-    """Export a single project.
+    """Export a single project's traces into ``project_dir``.
 
     Returns:
         A 4-tuple ``(project_exported, traces_exported, traces_skipped, traces_had_errors)``:
@@ -942,8 +895,8 @@ def export_single_project(
           the manifest is left incomplete so the next run resumes from where it left off.
     """
     try:
-        # Create project-specific directory for traces
-        project_traces_dir = output_dir / project.name
+        # Trace files are written directly into the project directory.
+        project_traces_dir = project_dir
         project_traces_dir.mkdir(parents=True, exist_ok=True)
 
         # Record the export start time BEFORE the first API call so that any
@@ -1048,7 +1001,7 @@ def export_single_project(
         # Export related traces for this project
         traces_exported, traces_skipped, traces_had_errors = export_traces(
             client=client,
-            project_name=project.name,
+            project_name=project_name,
             project_dir=project_traces_dir,
             max_results=max_results,  # None means no limit — fetch all pages
             filter_string=effective_filter,
@@ -1073,142 +1026,29 @@ def export_single_project(
         if traces_exported > 0:
             if debug:
                 debug_print(
-                    f"Exported project: {project.name} with {traces_exported} traces",
+                    f"Exported project: {project_name} with {traces_exported} traces",
                     debug,
                 )
         elif traces_skipped > 0:
             if debug:
                 debug_print(
-                    f"Project {project.name} already has {traces_skipped} trace files",
+                    f"Project {project_name} already has {traces_skipped} trace files",
                     debug,
                 )
         else:
             if debug:
                 debug_print(
-                    f"No traces found in project: {project.name}",
+                    f"No traces found in project: {project_name}",
                     debug,
                 )
         return (project_exported, traces_exported, traces_skipped, traces_had_errors)
 
     except Exception as e:
-        console.print(f"[red]Error exporting project {project.name}: {e}[/red]")
+        console.print(f"[red]Error exporting project {project_name}: {e}[/red]")
         return (0, 0, 0, True)
 
 
-def export_project_by_name_or_id(
-    name_or_id: str,
-    workspace: str,
-    output_path: str,
-    filter_string: Optional[str],
-    max_results: Optional[int],
-    force: bool,
-    debug: bool,
-    format: str,
-    api_key: Optional[str] = None,
-    include_attachments: bool = True,
-    page_size: int = 500,
-) -> None:
-    """Export a project by name or ID.
-
-    First tries to get the project by ID. If not found, tries by name.
-    """
-    try:
-        if debug:
-            debug_print(f"Attempting to export project: {name_or_id}", debug)
-
-        # Initialize client
-        if api_key:
-            client = opik.Opik(api_key=api_key, workspace=workspace)
-        else:
-            client = opik.Opik(workspace=workspace)
-
-        # Create output directory
-        output_dir = Path(output_path) / workspace / "projects"
-        output_dir.mkdir(parents=True, exist_ok=True)
-
-        if debug:
-            debug_print(f"Target directory: {output_dir}", debug)
-
-        # Try to get project by ID first
-        try:
-            if debug:
-                debug_print(f"Trying to get project by ID: {name_or_id}", debug)
-            project = client.get_project(name_or_id)
-
-            # Successfully found by ID, export it
-            if debug:
-                debug_print(
-                    f"Found project by ID: {project.name} (ID: {project.id})", debug
-                )
-
-            # Export the project
-            exported_count, traces_exported, traces_skipped, had_errors = (
-                export_single_project(
-                    client=client,
-                    project=project,
-                    output_dir=output_dir,
-                    filter_string=filter_string,
-                    max_results=max_results,
-                    force=force,
-                    debug=debug,
-                    format=format,
-                    include_attachments=include_attachments,
-                    page_size=page_size,
-                )
-            )
-
-            # Show export summary
-            stats = {
-                "projects": exported_count,
-                "traces": traces_exported,
-                "traces_skipped": traces_skipped,
-            }
-            print_export_summary(stats, format)
-
-            _print_project_export_status(
-                f"{project.name} (ID: {project.id})",
-                output_dir,
-                exported_count,
-                had_errors,
-            )
-            return
-
-        except ApiError as e:
-            # Check if it's a 404 (not found) error
-            if e.status_code == 404:
-                # Not found by ID, try by name
-                if debug:
-                    debug_print(
-                        f"Project not found by ID, trying by name: {name_or_id}", debug
-                    )
-                # Fall through to name-based export
-                pass
-            else:
-                # Some other API error, re-raise it
-                raise
-
-        # Try by name (either because ID lookup failed or we're explicitly trying name)
-        export_project_by_name(
-            name=name_or_id,
-            workspace=workspace,
-            output_path=output_path,
-            filter_string=filter_string,
-            max_results=max_results,
-            force=force,
-            debug=debug,
-            format=format,
-            api_key=api_key,
-            include_attachments=include_attachments,
-            page_size=page_size,
-        )
-
-    except Exception as e:
-        console.print(f"[red]Error exporting project: {e}[/red]")
-        sys.exit(1)
-
-
-@click.command(name="project")
-@click.argument("name_or_id", type=str)
+@click.command(name="traces")
 @click.option(
     "--filter",
     type=str,
@@ -1251,9 +1091,8 @@ def export_project_by_name_or_id(
     help="Number of traces to fetch per API request. Larger values reduce round-trips but increase memory usage.",
 )
 @click.pass_context
-def export_project_command(
+def export_traces_command(
     ctx: click.Context,
-    name_or_id: str,
     filter: Optional[str],
     max_results: Optional[int],
     path: str,
@@ -1263,15 +1102,13 @@ def export_project_command(
     no_attachments: bool,
     page_size: int,
 ) -> None:
-    """Export a project by name or ID to workspace/projects.
-
-    The command will first try to find the project by ID. If not found, it will try by name.
-    """
-    # Get workspace and API key from context
+    """Export the project's traces to projects/<project>/."""
+    # Get workspace, project, and API key from context
     workspace = ctx.obj["workspace"]
+    project_name = ctx.obj["project_name"]
     api_key = ctx.obj.get("api_key") if ctx.obj else None
-    export_project_by_name_or_id(
-        name_or_id=name_or_id,
+    export_project_traces(
+        project_name=project_name,
         workspace=workspace,
         output_path=path,
         filter_string=filter,

--- a/sdks/python/src/opik/cli/exports/project.py
+++ b/sdks/python/src/opik/cli/exports/project.py
@@ -18,7 +18,6 @@ import tenacity
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 import opik
-from opik.api_objects import rest_helpers
 from opik.api_objects.attachment import client as attachment_client
 from opik import exceptions as opik_exceptions
 from opik.rate_limit import rate_limit
@@ -33,6 +32,7 @@ from .utils import (
     extract_trace_id_from_filename,
     matches_name_pattern,
     no_attachments_option,
+    prepare_project_export_dir,
     print_export_summary,
     trace_to_csv_rows,
     write_csv_data,
@@ -811,20 +811,18 @@ def export_project_traces(
         else:
             client = opik.Opik(workspace=workspace)
 
-        # Create the project's output directory (project-nested layout)
-        project_dir = Path(output_path) / workspace / "projects" / project_name
-        project_dir.mkdir(parents=True, exist_ok=True)
+        # Resolve the project to its ID and create projects/<id>/ (writes
+        # project.json). Raises ValueError if the project does not exist.
+        try:
+            _project_id, project_dir = prepare_project_export_dir(
+                client, output_path, workspace, project_name
+            )
+        except ValueError:
+            console.print(f"[red]Project '{project_name}' not found[/red]")
+            sys.exit(1)
 
         if debug:
             debug_print(f"Target directory: {project_dir}", debug)
-
-        # Validate the project exists so we can give a clear error message.
-        project_id = rest_helpers.resolve_project_id_by_name_optional(
-            client.rest_client, project_name=project_name
-        )
-        if project_id is None:
-            console.print(f"[red]Project '{project_name}' not found[/red]")
-            sys.exit(1)
 
         # Export the project's traces
         exported_count, traces_exported, traces_skipped, had_errors = (

--- a/sdks/python/src/opik/cli/exports/prompt.py
+++ b/sdks/python/src/opik/cli/exports/prompt.py
@@ -13,6 +13,7 @@ from opik.api_objects.prompt import Prompt, ChatPrompt
 from .utils import (
     console,
     debug_print,
+    prepare_project_export_dir,
     prompt_to_csv_rows,
     should_skip_file,
     write_csv_data,
@@ -88,13 +89,13 @@ def export_single_prompt(
     debug: bool,
     format: str,
 ) -> int:
-    """Export a single prompt."""
+    """Export a single prompt. The file is named by prompt ID; the human name
+    is stored inside the file."""
     try:
-        # Check if already exists and force is not set
-        if format.lower() == "csv":
-            prompt_file = output_dir / f"prompts_{prompt.name.replace('/', '_')}.csv"
-        else:
-            prompt_file = output_dir / f"prompt_{prompt.name.replace('/', '_')}.json"
+        # File is keyed by prompt ID (the name lives inside the file).
+        prompt_id = prompt.id
+        ext = "csv" if format.lower() == "csv" else "json"
+        prompt_file = output_dir / f"prompt_{prompt_id}.{ext}"
 
         if should_skip_file(prompt_file, force):
             if debug:
@@ -125,6 +126,7 @@ def export_single_prompt(
 
         # Create prompt data structure
         prompt_data = {
+            "id": prompt_id,
             "name": prompt.name,
             "current_version": {
                 "prompt": _get_prompt_content(prompt),
@@ -183,10 +185,11 @@ def export_prompt_by_name(
         else:
             client = opik.Opik(workspace=workspace)
 
-        # Create output directory (project-nested layout)
-        output_dir = (
-            Path(output_path) / workspace / "projects" / project_name / "prompts"
+        # Resolve the project to its ID and create projects/<id>/prompts.
+        _project_id, project_dir = prepare_project_export_dir(
+            client, output_path, workspace, project_name
         )
+        output_dir = project_dir / "prompts"
         output_dir.mkdir(parents=True, exist_ok=True)
 
         if debug:
@@ -287,17 +290,10 @@ def export_prompts_by_ids(
                     )
                 continue
 
-            # Determine file path
-            if format.lower() == "csv":
-                prompt_file = (
-                    prompts_dir
-                    / f"prompts_{prompt.name or getattr(prompt, 'id', 'unknown')}.csv"
-                )
-            else:
-                prompt_file = (
-                    prompts_dir
-                    / f"prompt_{prompt.name or getattr(prompt, 'id', 'unknown')}.json"
-                )
+            # File is keyed by prompt ID (the name lives inside the file).
+            resolved_prompt_id = prompt.id or prompt_id
+            ext = "csv" if format.lower() == "csv" else "json"
+            prompt_file = prompts_dir / f"prompt_{resolved_prompt_id}.{ext}"
 
             # Check if file already exists and should be skipped
             if should_skip_file(prompt_file, force):
@@ -528,13 +524,9 @@ def export_related_prompts_by_name(
                     "related_to_experiment": experiment.name or experiment.id,
                 }
 
-                # Save prompt data using the appropriate format
-                # Sanitize prompt name for filename (replace / with _)
-                sanitized_name = prompt.name.replace("/", "_")
-                if format.lower() == "csv":
-                    prompt_file = prompts_dir / f"prompts_{sanitized_name}.csv"
-                else:
-                    prompt_file = prompts_dir / f"prompt_{sanitized_name}.json"
+                # File is keyed by prompt ID (the name lives inside the file).
+                ext = "csv" if format.lower() == "csv" else "json"
+                prompt_file = prompts_dir / f"prompt_{prompt.id}.{ext}"
 
                 # Check if file should be skipped using the standard utility
                 if should_skip_file(prompt_file, force):

--- a/sdks/python/src/opik/cli/exports/prompt.py
+++ b/sdks/python/src/opik/cli/exports/prompt.py
@@ -82,6 +82,7 @@ def export_single_prompt(
     client: opik.Opik,
     prompt: Union[Prompt, ChatPrompt],
     output_dir: Path,
+    project_name: str,
     max_results: Optional[int],
     force: bool,
     debug: bool,
@@ -100,16 +101,20 @@ def export_single_prompt(
                 debug_print(f"Skipping {prompt.name} (already exists)", debug)
             return 0
 
-        # Get prompt history - use appropriate method based on prompt type
+        # Get prompt history (scoped to the prompt's project)
         prompt_history: List[Union[Prompt, ChatPrompt]]
         try:
             if isinstance(prompt, ChatPrompt):
-                prompt_history = list(client.get_chat_prompt_history(prompt.name))
+                prompt_history = list(
+                    client.get_chat_prompt_history(
+                        prompt.name, project_name=project_name
+                    )
+                )
             else:
-                prompt_history = list(client.get_prompt_history(prompt.name))
+                prompt_history = list(
+                    client.get_prompt_history(prompt.name, project_name=project_name)
+                )
         except (ValueError, Exception):
-            # History lookup may fail if the prompt is not associated with the
-            # default project (get_prompt_history filters by project_id internally).
             # Fall back to empty history so the current version is still exported.
             if debug:
                 debug_print(
@@ -159,6 +164,7 @@ def export_single_prompt(
 def export_prompt_by_name(
     name: str,
     workspace: str,
+    project_name: str,
     output_path: str,
     max_results: Optional[int],
     force: bool,
@@ -166,7 +172,7 @@ def export_prompt_by_name(
     format: str,
     api_key: Optional[str] = None,
 ) -> None:
-    """Export a prompt by exact name."""
+    """Export a prompt by exact name from the given project."""
     try:
         if debug:
             debug_print(f"Exporting prompt: {name}", debug)
@@ -177,24 +183,26 @@ def export_prompt_by_name(
         else:
             client = opik.Opik(workspace=workspace)
 
-        # Create output directory
-        output_dir = Path(output_path) / workspace / "prompts"
+        # Create output directory (project-nested layout)
+        output_dir = (
+            Path(output_path) / workspace / "projects" / project_name / "prompts"
+        )
         output_dir.mkdir(parents=True, exist_ok=True)
 
         if debug:
             debug_print(f"Target directory: {output_dir}", debug)
 
-        # Try to get prompt by exact name
+        # Try to get prompt by exact name within the project
         # Try ChatPrompt first, then regular Prompt
         prompt: Optional[Union[Prompt, ChatPrompt]] = None
         try:
-            prompt = client.get_chat_prompt(name)
+            prompt = client.get_chat_prompt(name, project_name=project_name)
             if debug and prompt:
                 debug_print(f"Found ChatPrompt by direct lookup: {prompt.name}", debug)
         except Exception:
             # Not a ChatPrompt, try regular Prompt
             try:
-                prompt = client.get_prompt(name)
+                prompt = client.get_prompt(name, project_name=project_name)
                 if not prompt:
                     console.print(f"[red]Prompt '{name}' not found[/red]")
                     return
@@ -210,7 +218,7 @@ def export_prompt_by_name(
 
         # Export the prompt
         exported_count = export_single_prompt(
-            client, prompt, output_dir, max_results, force, debug, format
+            client, prompt, output_dir, project_name, max_results, force, debug, format
         )
 
         # Collect statistics for summary
@@ -240,6 +248,7 @@ def export_prompts_by_ids(
     client: opik.Opik,
     prompt_ids: set[str],
     prompts_dir: Path,
+    project_name: str,
     format: str,
     debug: bool,
     force: bool,
@@ -250,6 +259,7 @@ def export_prompts_by_ids(
         client: Opik client instance
         prompt_ids: Set of prompt IDs to export
         prompts_dir: Directory to save prompts
+        project_name: Project the prompts belong to
         format: Export format ('json' or 'csv')
         debug: Enable debug output
         force: Re-download prompts even if they already exist locally
@@ -265,10 +275,10 @@ def export_prompts_by_ids(
             # Get the prompt - try ChatPrompt first, then regular Prompt
             prompt: Optional[Union[Prompt, ChatPrompt]] = None
             try:
-                prompt = client.get_chat_prompt(prompt_id)
+                prompt = client.get_chat_prompt(prompt_id, project_name=project_name)
             except Exception:
                 # Not a ChatPrompt, try regular Prompt
-                prompt = client.get_prompt(prompt_id)
+                prompt = client.get_prompt(prompt_id, project_name=project_name)
 
             if not prompt:
                 if debug:
@@ -306,9 +316,15 @@ def export_prompts_by_ids(
             # Get prompt history - use appropriate method based on prompt type
             prompt_history: List[Union[Prompt, ChatPrompt]]
             if isinstance(prompt, ChatPrompt):
-                prompt_history = list(client.get_chat_prompt_history(prompt.name))
+                prompt_history = list(
+                    client.get_chat_prompt_history(
+                        prompt.name, project_name=project_name
+                    )
+                )
             else:
-                prompt_history = list(client.get_prompt_history(prompt_id))
+                prompt_history = list(
+                    client.get_prompt_history(prompt_id, project_name=project_name)
+                )
 
             # Create prompt data structure
             prompt_data = {
@@ -372,6 +388,7 @@ def export_related_prompts_by_name(
     client: opik.Opik,
     experiment: Any,
     output_dir: Path,
+    project_name: str,
     force: bool,
     debug: bool,
     format: str = "json",
@@ -440,11 +457,15 @@ def export_related_prompts_by_name(
                 # Try to get the prompt - try ChatPrompt first, then regular Prompt
                 prompt: Optional[Union[Prompt, ChatPrompt]] = None
                 try:
-                    prompt = client.get_chat_prompt(prompt_name)
+                    prompt = client.get_chat_prompt(
+                        prompt_name, project_name=project_name
+                    )
                 except Exception:
                     # Not a ChatPrompt, try regular Prompt
                     try:
-                        prompt = client.get_prompt(prompt_name)
+                        prompt = client.get_prompt(
+                            prompt_name, project_name=project_name
+                        )
                     except Exception as e:
                         if debug:
                             console.print(
@@ -464,10 +485,16 @@ def export_related_prompts_by_name(
                 try:
                     if isinstance(prompt, ChatPrompt):
                         prompt_history = list(
-                            client.get_chat_prompt_history(prompt.name)
+                            client.get_chat_prompt_history(
+                                prompt.name, project_name=project_name
+                            )
                         )
                     else:
-                        prompt_history = list(client.get_prompt_history(prompt.name))
+                        prompt_history = list(
+                            client.get_prompt_history(
+                                prompt.name, project_name=project_name
+                            )
+                        )
                 except (ValueError, Exception):
                     prompt_history = []
 
@@ -583,10 +610,11 @@ def export_prompt_command(
     debug: bool,
     format: str,
 ) -> None:
-    """Export a prompt by exact name to workspace/prompts."""
-    # Get workspace and API key from context
+    """Export a prompt by exact name to projects/<project>/prompts."""
+    # Get workspace, project, and API key from context
     workspace = ctx.obj["workspace"]
+    project_name = ctx.obj["project_name"]
     api_key = ctx.obj.get("api_key") if ctx.obj else None
     export_prompt_by_name(
-        name, workspace, path, max_results, force, debug, format, api_key
+        name, workspace, project_name, path, max_results, force, debug, format, api_key
     )

--- a/sdks/python/src/opik/cli/exports/utils.py
+++ b/sdks/python/src/opik/cli/exports/utils.py
@@ -11,8 +11,12 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+import opik
 import opik.dict_utils as dict_utils
+from opik.api_objects import rest_helpers
 from opik.api_objects.experiment.experiment_item import ExperimentItemContent
+
+PROJECT_METADATA_FILENAME = "project.json"
 
 
 def no_attachments_option() -> Callable:
@@ -25,6 +29,42 @@ def no_attachments_option() -> Callable:
 
 
 console = Console()
+
+
+def write_project_metadata(
+    project_dir: Path, project_id: str, project_name: str
+) -> None:
+    """Write ``project.json`` so the id-named folder is self-describing.
+
+    The on-disk layout is keyed by project ID (UUIDs avoid the ``/``, ``:`` and
+    whitespace problems of human names); the human name lives here as data so
+    ``opik import`` can locate the folder by name.
+    """
+    write_json_data(
+        {"id": project_id, "name": project_name},
+        project_dir / PROJECT_METADATA_FILENAME,
+    )
+
+
+def prepare_project_export_dir(
+    client: "opik.Opik", output_path: str, workspace: str, project_name: str
+) -> tuple[str, Path]:
+    """Resolve ``project_name`` to its ID and prepare ``projects/<id>/``.
+
+    Creates the project directory, writes ``project.json``, and returns
+    ``(project_id, project_dir)``. Raises ``ValueError`` if the project does not
+    exist in the workspace.
+    """
+    project_id = rest_helpers.resolve_project_id_by_name_optional(
+        client.rest_client, project_name=project_name
+    )
+    if project_id is None:
+        raise ValueError(f"Project '{project_name}' not found")
+    project_dir = Path(output_path) / workspace / "projects" / project_id
+    project_dir.mkdir(parents=True, exist_ok=True)
+    write_project_metadata(project_dir, project_id, project_name)
+    return project_id, project_dir
+
 
 _TRACE_FILE_PREFIX = "trace_"
 

--- a/sdks/python/src/opik/cli/imports/__init__.py
+++ b/sdks/python/src/opik/cli/imports/__init__.py
@@ -16,6 +16,7 @@ from .project import import_traces_from_directory
 from .prompt import import_prompts_from_directory
 from .utils import (
     debug_print,
+    destination_manifest_dir,
     finalize_import,
     no_attachments_option,
     print_import_summary,
@@ -82,14 +83,17 @@ def _import_by_type(
         # ------------------------------------------------------------------
         # Manifest lifecycle management
         # MigrationManifest is only constructed for real (non-dry-run) imports
-        # so that --dry-run never creates the manifest DB on disk.
+        # so that --dry-run never creates the manifest DB on disk. The manifest
+        # is keyed by the destination project so importing the same source into
+        # different --to-project targets keeps independent resume state.
         # ------------------------------------------------------------------
         manifest: Optional[MigrationManifest] = None
+        manifest_dir = destination_manifest_dir(project_root, target_project_name)
 
         if not dry_run:
-            manifest = MigrationManifest(project_root)
+            manifest = MigrationManifest(manifest_dir)
             if force:
-                if MigrationManifest.exists(project_root):
+                if MigrationManifest.exists(manifest_dir):
                     manifest.reset()
                     console.print(
                         "[yellow]--force: discarding existing manifest, starting fresh[/yellow]"

--- a/sdks/python/src/opik/cli/imports/__init__.py
+++ b/sdks/python/src/opik/cli/imports/__init__.py
@@ -15,7 +15,14 @@ from .dataset import import_datasets_from_directory
 from .experiment import import_experiments_from_directory
 from .project import import_traces_from_directory
 from .prompt import import_prompts_from_directory
-from .utils import debug_print, no_attachments_option, print_import_summary
+from .utils import (
+    available_project_names,
+    debug_print,
+    find_project_export_dir,
+    no_attachments_option,
+    print_import_summary,
+    to_project_option,
+)
 
 console = Console()
 
@@ -34,6 +41,7 @@ def _import_by_type(
     api_key: Optional[str] = None,
     force: bool = False,
     include_attachments: bool = True,
+    to_project: Optional[str] = None,
 ) -> None:
     """
     Import data by type (dataset, traces, experiment, prompt) into a project.
@@ -42,13 +50,16 @@ def _import_by_type(
         import_type: Type of data to import ("dataset", "traces", "experiment", "prompt")
         path: Base directory containing the exported data
         workspace: Target workspace name
-        project_name: Target project name. Every imported dataset, prompt,
-            experiment, and trace is created in this project.
+        project_name: Source project name. Used to locate the exported project
+            folder (matched against the name recorded in project.json). Also the
+            default destination project when ``to_project`` is not given.
         dry_run: Whether to show what would be imported without importing
         name_pattern: Optional string pattern to filter items by name
         debug: Enable debug output
         recreate_experiments: Whether to recreate experiments after importing
         force: Discard any existing manifest and restart from scratch
+        to_project: Optional destination project name. When provided the data is
+            created in this project instead of ``project_name``.
     """
     try:
         debug_print(f"DEBUG: Starting {import_type} import from {path}", debug)
@@ -59,8 +70,25 @@ def _import_by_type(
         else:
             client = opik.Opik(workspace=workspace)
 
-        # Everything for one project lives under projects/<project>/.
-        project_root = Path(path) / "projects" / project_name
+        # Locate the exported project folder by its recorded name (folders are
+        # keyed by id on disk; project.json holds the human name).
+        base_path = Path(path)
+        project_root = find_project_export_dir(base_path, project_name)
+        if project_root is None:
+            available = available_project_names(base_path)
+            hint = (
+                f" Available: {', '.join(available)}"
+                if available
+                else " No exported projects were found."
+            )
+            console.print(
+                f"[red]No exported project named '{project_name}' under "
+                f"{base_path / 'projects'}.{hint}[/red]"
+            )
+            sys.exit(1)
+
+        # Data is created in --to-project when given, else the source name.
+        target_project_name = to_project or project_name
 
         # ------------------------------------------------------------------
         # Manifest lifecycle management
@@ -117,7 +145,7 @@ def _import_by_type(
             stats = import_datasets_from_directory(
                 client,
                 source_dir,
-                project_name,
+                target_project_name,
                 dry_run,
                 name_pattern,
                 debug,
@@ -127,7 +155,7 @@ def _import_by_type(
             stats = import_traces_from_directory(
                 client,
                 source_dir,
-                project_name,
+                target_project_name,
                 dry_run,
                 name_pattern,
                 debug,
@@ -139,7 +167,7 @@ def _import_by_type(
             stats = import_experiments_from_directory(
                 client,
                 source_dir,
-                project_name,
+                target_project_name,
                 dry_run,
                 name_pattern,
                 debug,
@@ -149,7 +177,7 @@ def _import_by_type(
             stats = import_prompts_from_directory(
                 client,
                 source_dir,
-                project_name,
+                target_project_name,
                 dry_run,
                 name_pattern,
                 debug,
@@ -366,6 +394,7 @@ import_group.add_command(import_all_command)
     is_flag=True,
     help="Enable debug output to show detailed information about the import process.",
 )
+@to_project_option()
 @click.pass_context
 def import_dataset(
     ctx: click.Context,
@@ -374,23 +403,25 @@ def import_dataset(
     dry_run: bool,
     force: bool,
     debug: bool,
+    to_project: Optional[str],
 ) -> None:
-    """Import datasets from workspace/datasets directory.
+    """Import datasets from projects/PROJECT/datasets.
 
-    This command imports datasets matching the specified name from the path/datasets/ directory.
-    The name is matched using case-insensitive substring matching.
+    This command imports datasets matching the specified name from the source
+    project's datasets directory. The name is matched using case-insensitive
+    substring matching.
 
     \b
     Examples:
     \b
         # Preview a dataset that would be imported
-        opik import my-workspace dataset "my-dataset" --dry-run
+        opik import my-workspace my-project dataset "my-dataset" --dry-run
     \b
         # Import a specific dataset
-        opik import my-workspace dataset "my-dataset"
+        opik import my-workspace my-project dataset "my-dataset"
     \b
-        # Import datasets containing "training" in the name
-        opik import my-workspace dataset "training"
+        # Import into a different destination project
+        opik import my-workspace my-project dataset "my-dataset" --to-project other-project
     \b
         # Import from a custom path
         opik import my-workspace my-project dataset "my-dataset" --path ./custom-exports/
@@ -408,6 +439,7 @@ def import_dataset(
         debug,
         api_key=api_key,
         force=force,
+        to_project=to_project,
     )
 
 
@@ -435,6 +467,7 @@ def import_dataset(
     help="Enable debug output to show detailed information about the import process.",
 )
 @no_attachments_option()
+@to_project_option()
 @click.pass_context
 def import_traces(
     ctx: click.Context,
@@ -443,11 +476,12 @@ def import_traces(
     force: bool,
     debug: bool,
     no_attachments: bool,
+    to_project: Optional[str],
 ) -> None:
     """Import the project's traces from projects/PROJECT/.
 
-    Reads the trace files exported under projects/PROJECT/ and recreates the
-    traces and their spans in the named project.
+    Reads the trace files exported under the source project's folder and
+    recreates the traces and their spans in the destination project.
 
     If a previous import was interrupted, re-running the same command automatically
     resumes from where it left off. Use --force to start over from scratch.
@@ -461,8 +495,8 @@ def import_traces(
         # Import the project's traces
         opik import my-workspace my-project traces
     \b
-        # Import traces with debug output
-        opik import my-workspace my-project traces --debug
+        # Import into a different destination project
+        opik import my-workspace my-project traces --to-project other-project
     \b
         # Import from a custom path
         opik import my-workspace my-project traces --path ./custom-exports/
@@ -485,6 +519,7 @@ def import_traces(
         api_key=api_key,
         force=force,
         include_attachments=not no_attachments,
+        to_project=to_project,
     )
 
 
@@ -512,6 +547,7 @@ def import_traces(
     is_flag=True,
     help="Enable debug output to show detailed information about the import process.",
 )
+@to_project_option()
 @click.pass_context
 def import_experiment(
     ctx: click.Context,
@@ -520,11 +556,13 @@ def import_experiment(
     dry_run: bool,
     force: bool,
     debug: bool,
+    to_project: Optional[str],
 ) -> None:
-    """Import experiments from workspace/experiments directory.
+    """Import experiments from projects/PROJECT/experiments.
 
-    This command imports experiments matching the specified name from the path/experiments/ directory.
-    The name is matched using case-insensitive substring matching.
+    This command imports experiments matching the specified name from the source
+    project's experiments directory. The name is matched using case-insensitive
+    substring matching.
 
     If a previous import was interrupted, re-running the same command automatically
     resumes from where it left off. Use --force to start over from scratch.
@@ -533,10 +571,13 @@ def import_experiment(
     Examples:
     \b
         # Preview an experiment that would be imported
-        opik import my-workspace experiment "my-experiment" --dry-run
+        opik import my-workspace my-project experiment "my-experiment" --dry-run
     \b
         # Import a specific experiment
-        opik import my-workspace experiment "my-experiment"
+        opik import my-workspace my-project experiment "my-experiment"
+    \b
+        # Import into a different destination project
+        opik import my-workspace my-project experiment "my-experiment" --to-project other-project
     \b
         # Import from a custom path
         opik import my-workspace my-project experiment "my-experiment" --path ./custom-exports/
@@ -555,6 +596,7 @@ def import_experiment(
         True,
         api_key=api_key,
         force=force,
+        to_project=to_project,
     )
 
 
@@ -582,6 +624,7 @@ def import_experiment(
     is_flag=True,
     help="Enable debug output to show detailed information about the import process.",
 )
+@to_project_option()
 @click.pass_context
 def import_prompt(
     ctx: click.Context,
@@ -590,20 +633,25 @@ def import_prompt(
     dry_run: bool,
     force: bool,
     debug: bool,
+    to_project: Optional[str],
 ) -> None:
-    """Import prompts from workspace/prompts directory.
+    """Import prompts from projects/PROJECT/prompts.
 
-    This command imports prompts matching the specified name from the path/prompts/ directory.
-    The name is matched using case-insensitive substring matching.
+    This command imports prompts matching the specified name from the source
+    project's prompts directory. The name is matched using case-insensitive
+    substring matching.
 
     \b
     Examples:
     \b
         # Preview a prompt that would be imported
-        opik import my-workspace prompt "my-prompt" --dry-run
+        opik import my-workspace my-project prompt "my-prompt" --dry-run
     \b
         # Import a specific prompt
-        opik import my-workspace prompt "my-prompt"
+        opik import my-workspace my-project prompt "my-prompt"
+    \b
+        # Import into a different destination project
+        opik import my-workspace my-project prompt "my-prompt" --to-project other-project
     \b
         # Import from a custom path
         opik import my-workspace my-project prompt "my-prompt" --path ./custom-exports/
@@ -621,4 +669,5 @@ def import_prompt(
         debug,
         api_key=api_key,
         force=force,
+        to_project=to_project,
     )

--- a/sdks/python/src/opik/cli/imports/__init__.py
+++ b/sdks/python/src/opik/cli/imports/__init__.py
@@ -71,8 +71,10 @@ def _import_by_type(
             client = opik.Opik(workspace=workspace)
 
         # Locate the exported project folder by its recorded name (folders are
-        # keyed by id on disk; project.json holds the human name).
-        base_path = Path(path)
+        # keyed by id on disk; project.json holds the human name). The workspace
+        # segment mirrors the export layout (PATH/WORKSPACE/projects/<id>/) so
+        # the same --path round-trips between export and import.
+        base_path = Path(path) / workspace
         project_root = find_project_export_dir(base_path, project_name)
         if project_root is None:
             available = available_project_names(base_path)
@@ -272,9 +274,9 @@ def import_group(
 
     In Opik v2 every dataset, prompt, and experiment belongs to a project, so
     imports are always scoped to a single project named on the command line.
-    Data is read from the project-nested layout produced by ``opik export``:
-    ``PATH/projects/PROJECT/{datasets,prompts,experiments}`` and the project's
-    trace files directly under ``PATH/projects/PROJECT/``.
+    Data is read from the same layout ``opik export`` writes — folders are keyed
+    by project id on disk and the project name is matched against each project's
+    project.json, so the same ``--path`` round-trips between export and import.
 
     A migration_manifest.db file is automatically maintained under the project
     directory. If an import is interrupted, re-running the same command resumes

--- a/sdks/python/src/opik/cli/imports/__init__.py
+++ b/sdks/python/src/opik/cli/imports/__init__.py
@@ -8,7 +8,6 @@ from rich.console import Console
 
 import opik
 
-from ..migration_manifest import MigrationManifest
 from .all import import_all_command
 from .dataset import import_datasets_from_directory
 from .experiment import import_experiments_from_directory
@@ -16,11 +15,11 @@ from .project import import_traces_from_directory
 from .prompt import import_prompts_from_directory
 from .utils import (
     debug_print,
-    destination_manifest_dir,
     finalize_import,
     no_attachments_option,
     print_import_summary,
     resolve_import_project_root,
+    setup_import_manifest,
     to_project_option,
 )
 
@@ -80,36 +79,14 @@ def _import_by_type(
             path, workspace, project_name, to_project
         )
 
-        # ------------------------------------------------------------------
-        # Manifest lifecycle management
-        # MigrationManifest is only constructed for real (non-dry-run) imports
-        # so that --dry-run never creates the manifest DB on disk. The manifest
-        # is keyed by the destination project so importing the same source into
-        # different --to-project targets keeps independent resume state.
-        # ------------------------------------------------------------------
-        manifest: Optional[MigrationManifest] = None
-        manifest_dir = destination_manifest_dir(project_root, target_project_name)
-
-        if not dry_run:
-            manifest = MigrationManifest(manifest_dir)
-            if force:
-                if MigrationManifest.exists(manifest_dir):
-                    manifest.reset()
-                    console.print(
-                        "[yellow]--force: discarding existing manifest, starting fresh[/yellow]"
-                    )
-            else:
-                if manifest.is_completed:
-                    console.print(
-                        "[green]Import already completed. Use --force to re-import.[/green]"
-                    )
-                    return
-                elif manifest.is_in_progress:
-                    console.print(
-                        f"[blue]Resuming interrupted import: "
-                        f"{manifest.completed_count()} file(s) already completed[/blue]"
-                    )
-            manifest.start()
+        # Construct + initialize the per-destination manifest (keyed by the
+        # destination project so different --to-project targets keep independent
+        # resume state). Skipped for --dry-run.
+        manifest, already_completed = setup_import_manifest(
+            project_root, target_project_name, dry_run, force
+        )
+        if already_completed:
+            return
 
         # ------------------------------------------------------------------
         # Determine source directory (project-nested layout)

--- a/sdks/python/src/opik/cli/imports/__init__.py
+++ b/sdks/python/src/opik/cli/imports/__init__.py
@@ -235,23 +235,32 @@ def _import_by_type(
         stats_key = type_key_map.get(import_type, import_type + "s")
         label = label_map.get(import_type, import_type + "s")
         imported_count = stats.get(stats_key, 0)
-        errors = stats.get(stats_key + "_errors", 0)
+        # Sum every "*_errors" counter, not just this item's: importers that
+        # cascade (e.g. experiments pull in datasets/prompts/traces) and the
+        # whole-directory failure path report under other keys, and those
+        # failures must not be masked.
+        total_errors = sum(
+            value for key, value in stats.items() if key.endswith("_errors")
+        )
 
         if dry_run:
             console.print(
                 f"[blue]Dry run complete: Would import {imported_count} {label}[/blue]"
             )
+        elif total_errors > 0:
+            # Individual errors were already printed in red by the importer;
+            # exit non-zero so the failure is not masked by a 0 exit code.
+            console.print(
+                f"[red]Import completed with {total_errors} error(s) while importing {label} "
+                "(see messages above). Re-run the import to retry.[/red]"
+            )
+            sys.exit(1)
+        elif imported_count == 0:
+            console.print(f"[yellow]No {label} were imported[/yellow]")
         else:
-            if errors > 0:
-                console.print(
-                    f"[yellow]Import completed with {errors} error(s) while importing {label}[/yellow]"
-                )
-            elif imported_count == 0:
-                console.print(f"[yellow]No {label} were imported[/yellow]")
-            else:
-                console.print(
-                    f"[green]Successfully imported {imported_count} {label}[/green]"
-                )
+            console.print(
+                f"[green]Successfully imported {imported_count} {label}[/green]"
+            )
 
     except Exception as e:
         console.print(f"[red]Error importing {import_type}: {e}[/red]")

--- a/sdks/python/src/opik/cli/imports/__init__.py
+++ b/sdks/python/src/opik/cli/imports/__init__.py
@@ -172,6 +172,16 @@ def _import_by_type(
                 manifest=manifest,
             )
 
+        # Sum every "*_errors" counter, not just this item's: importers that
+        # cascade (e.g. experiments pull in datasets/prompts/traces, and the
+        # traces importer recreates experiments) and the whole-directory failure
+        # path report under other keys, and those failures must not be masked.
+        # Computed before manifest.complete() so a partial failure never marks
+        # the manifest completed.
+        total_errors = sum(
+            value for key, value in stats.items() if key.endswith("_errors")
+        )
+
         # Flush the async ingestion queue before returning so that all
         # enqueued traces/spans are persisted on the server.  Without this,
         # the process can exit while the background worker is still sending
@@ -197,10 +207,13 @@ def _import_by_type(
                 sys.exit(1)
 
             # ------------------------------------------------------------------
-            # Mark manifest complete (only on full success, not dry-run)
+            # Mark manifest complete only on a fully clean run. On any error we
+            # leave it in_progress so the next (non---force) run resumes/retries
+            # instead of short-circuiting on manifest.is_completed.
             # ------------------------------------------------------------------
             assert manifest is not None  # guaranteed: manifest is set when not dry_run
-            manifest.complete()
+            if total_errors == 0:
+                manifest.complete()
 
         # Display summary
         print_import_summary(stats)
@@ -221,13 +234,6 @@ def _import_by_type(
         stats_key = type_key_map.get(import_type, import_type + "s")
         label = label_map.get(import_type, import_type + "s")
         imported_count = stats.get(stats_key, 0)
-        # Sum every "*_errors" counter, not just this item's: importers that
-        # cascade (e.g. experiments pull in datasets/prompts/traces) and the
-        # whole-directory failure path report under other keys, and those
-        # failures must not be masked.
-        total_errors = sum(
-            value for key, value in stats.items() if key.endswith("_errors")
-        )
 
         if dry_run:
             console.print(

--- a/sdks/python/src/opik/cli/imports/__init__.py
+++ b/sdks/python/src/opik/cli/imports/__init__.py
@@ -13,7 +13,7 @@ from ..migration_manifest import MigrationManifest
 from .all import import_all_command
 from .dataset import import_datasets_from_directory
 from .experiment import import_experiments_from_directory
-from .project import import_projects_from_directory
+from .project import import_traces_from_directory
 from .prompt import import_prompts_from_directory
 from .utils import debug_print, no_attachments_option, print_import_summary
 
@@ -26,6 +26,7 @@ def _import_by_type(
     import_type: str,
     path: str,
     workspace: str,
+    project_name: str,
     dry_run: bool,
     name_pattern: Optional[str],
     debug: bool,
@@ -35,12 +36,14 @@ def _import_by_type(
     include_attachments: bool = True,
 ) -> None:
     """
-    Import data by type (dataset, project, experiment) with pattern matching.
+    Import data by type (dataset, traces, experiment, prompt) into a project.
 
     Args:
-        import_type: Type of data to import ("dataset", "project", "experiment")
+        import_type: Type of data to import ("dataset", "traces", "experiment", "prompt")
         path: Base directory containing the exported data
         workspace: Target workspace name
+        project_name: Target project name. Every imported dataset, prompt,
+            experiment, and trace is created in this project.
         dry_run: Whether to show what would be imported without importing
         name_pattern: Optional string pattern to filter items by name
         debug: Enable debug output
@@ -56,7 +59,8 @@ def _import_by_type(
         else:
             client = opik.Opik(workspace=workspace)
 
-        base_path = Path(path)
+        # Everything for one project lives under projects/<project>/.
+        project_root = Path(path) / "projects" / project_name
 
         # ------------------------------------------------------------------
         # Manifest lifecycle management
@@ -66,9 +70,9 @@ def _import_by_type(
         manifest: Optional[MigrationManifest] = None
 
         if not dry_run:
-            manifest = MigrationManifest(base_path)
+            manifest = MigrationManifest(project_root)
             if force:
-                if MigrationManifest.exists(base_path):
+                if MigrationManifest.exists(project_root):
                     manifest.reset()
                     console.print(
                         "[yellow]--force: discarding existing manifest, starting fresh[/yellow]"
@@ -87,16 +91,16 @@ def _import_by_type(
             manifest.start()
 
         # ------------------------------------------------------------------
-        # Determine source directory
+        # Determine source directory (project-nested layout)
         # ------------------------------------------------------------------
         if import_type == "dataset":
-            source_dir = base_path / "datasets"
-        elif import_type == "project":
-            source_dir = base_path / "projects"
+            source_dir = project_root / "datasets"
+        elif import_type == "traces":
+            source_dir = project_root
         elif import_type == "experiment":
-            source_dir = base_path / "experiments"
+            source_dir = project_root / "experiments"
         elif import_type == "prompt":
-            source_dir = base_path / "prompts"
+            source_dir = project_root / "prompts"
         else:
             console.print(f"[red]Unknown import type: {import_type}[/red]")
             return
@@ -111,12 +115,19 @@ def _import_by_type(
 
         if import_type == "dataset":
             stats = import_datasets_from_directory(
-                client, source_dir, dry_run, name_pattern, debug, manifest=manifest
-            )
-        elif import_type == "project":
-            stats = import_projects_from_directory(
                 client,
                 source_dir,
+                project_name,
+                dry_run,
+                name_pattern,
+                debug,
+                manifest=manifest,
+            )
+        elif import_type == "traces":
+            stats = import_traces_from_directory(
+                client,
+                source_dir,
+                project_name,
                 dry_run,
                 name_pattern,
                 debug,
@@ -126,11 +137,23 @@ def _import_by_type(
             )
         elif import_type == "experiment":
             stats = import_experiments_from_directory(
-                client, source_dir, dry_run, name_pattern, debug, manifest=manifest
+                client,
+                source_dir,
+                project_name,
+                dry_run,
+                name_pattern,
+                debug,
+                manifest=manifest,
             )
         elif import_type == "prompt":
             stats = import_prompts_from_directory(
-                client, source_dir, dry_run, name_pattern, debug, manifest=manifest
+                client,
+                source_dir,
+                project_name,
+                dry_run,
+                name_pattern,
+                debug,
+                manifest=manifest,
             )
 
         # Flush the async ingestion queue before returning so that all
@@ -166,67 +189,81 @@ def _import_by_type(
         # Display summary
         print_import_summary(stats)
 
-        # Map import_type to the key used in stats dictionary
+        # Map import_type to the stats dictionary key and a human-readable label.
         type_key_map = {
             "dataset": "datasets",
             "prompt": "prompts",
-            "project": "projects",
+            "traces": "traces",
+            "experiment": "experiments",
+        }
+        label_map = {
+            "dataset": "datasets",
+            "prompt": "prompts",
+            "traces": "traces",
             "experiment": "experiments",
         }
         stats_key = type_key_map.get(import_type, import_type + "s")
+        label = label_map.get(import_type, import_type + "s")
         imported_count = stats.get(stats_key, 0)
         errors = stats.get(stats_key + "_errors", 0)
 
         if dry_run:
             console.print(
-                f"[blue]Dry run complete: Would import {imported_count} {import_type}s[/blue]"
+                f"[blue]Dry run complete: Would import {imported_count} {label}[/blue]"
             )
         else:
             if errors > 0:
                 console.print(
-                    f"[yellow]Import completed with {errors} error(s) while importing {import_type}s[/yellow]"
+                    f"[yellow]Import completed with {errors} error(s) while importing {label}[/yellow]"
                 )
             elif imported_count == 0:
-                console.print(f"[yellow]No {import_type}s were imported[/yellow]")
+                console.print(f"[yellow]No {label} were imported[/yellow]")
             else:
                 console.print(
-                    f"[green]Successfully imported {imported_count} {import_type}s[/green]"
+                    f"[green]Successfully imported {imported_count} {label}[/green]"
                 )
 
     except Exception as e:
-        console.print(f"[red]Error importing {import_type}s: {e}[/red]")
+        console.print(f"[red]Error importing {import_type}: {e}[/red]")
         sys.exit(1)
 
 
 @click.group(name="import", context_settings=IMPORT_CONTEXT_SETTINGS)
 @click.argument("workspace", type=str)
+@click.argument("project", type=str)
 @click.option(
     "--api-key",
     type=str,
     help="Opik API key. If not provided, will use OPIK_API_KEY environment variable or configuration.",
 )
 @click.pass_context
-def import_group(ctx: click.Context, workspace: str, api_key: Optional[str]) -> None:
-    """Import data to Opik workspace.
+def import_group(
+    ctx: click.Context, workspace: str, project: str, api_key: Optional[str]
+) -> None:
+    """Import data into an Opik project.
 
-    This command allows you to import previously exported data back into an Opik workspace.
-    Supported data types include projects, datasets, experiments, and prompts.
+    In Opik v2 every dataset, prompt, and experiment belongs to a project, so
+    imports are always scoped to a single project named on the command line.
+    Data is read from the project-nested layout produced by ``opik export``:
+    ``PATH/projects/PROJECT/{datasets,prompts,experiments}`` and the project's
+    trace files directly under ``PATH/projects/PROJECT/``.
 
-    A migration_manifest.db file is automatically maintained in the import directory.
-    If an import is interrupted, re-running the same command will resume from where it
-    left off without creating duplicates. Use --force to discard the manifest and restart.
+    A migration_manifest.db file is automatically maintained under the project
+    directory. If an import is interrupted, re-running the same command resumes
+    from where it left off without creating duplicates. Use --force to discard
+    the manifest and restart.
 
     \b
     General Usage:
-        opik import WORKSPACE TYPE NAME [OPTIONS]
+        opik import WORKSPACE PROJECT ITEM [NAME] [OPTIONS]
 
     \b
-    Data Types:
-        all         Import everything: datasets, prompts, projects, and experiments
-        project     Import projects from path/projects/ (default: opik_exports)
-        dataset     Import datasets from path/datasets/ (default: opik_exports)
-        experiment  Import experiments from path/experiments/ (default: opik_exports)
-        prompt      Import prompts from path/prompts/ (default: opik_exports)
+    Data Types (ITEM):
+        all         Import everything: datasets, prompts, traces, and experiments
+        traces      Import the project's traces (and their spans)
+        dataset     Import datasets from projects/PROJECT/datasets/
+        experiment  Import experiments from projects/PROJECT/experiments/
+        prompt      Import prompts from projects/PROJECT/prompts/
 
     \b
     Common Options:
@@ -237,32 +274,30 @@ def import_group(ctx: click.Context, workspace: str, api_key: Optional[str]) -> 
 
     \b
     Examples:
-        # Import everything in the workspace
-        opik import my-workspace all
+        # Import everything into the project
+        opik import my-workspace my-project all
 
         # Preview what would be imported
-        opik import my-workspace all --dry-run
+        opik import my-workspace my-project all --dry-run
 
-        # Preview an experiment that would be imported
-        opik import my-workspace experiment "my-experiment" --dry-run
-
-        # Import a specific project
-        opik import my-workspace project "my-project"
+        # Import the project's traces
+        opik import my-workspace my-project traces
 
         # Import a specific dataset
-        opik import my-workspace dataset "my-dataset"
+        opik import my-workspace my-project dataset "my-dataset"
 
         # Import from a custom path
-        opik import my-workspace project "my-project" --path ./custom-exports/
+        opik import my-workspace my-project all --path ./custom-exports/
 
         # Resume an interrupted import (automatic — just re-run the same command)
-        opik import my-workspace project "my-project"
+        opik import my-workspace my-project all
 
         # Discard progress and restart from scratch
-        opik import my-workspace project "my-project" --force
+        opik import my-workspace my-project all --force
     """
     ctx.ensure_object(dict)
     ctx.obj["workspace"] = workspace
+    ctx.obj["project_name"] = project
     # Use API key from this command or from parent context
     ctx.obj["api_key"] = api_key or (
         ctx.parent.obj.get("api_key") if ctx.parent and ctx.parent.obj else None
@@ -358,17 +393,25 @@ def import_dataset(
         opik import my-workspace dataset "training"
     \b
         # Import from a custom path
-        opik import my-workspace dataset "my-dataset" --path ./custom-exports/
+        opik import my-workspace my-project dataset "my-dataset" --path ./custom-exports/
     """
     workspace = ctx.obj["workspace"]
+    project_name = ctx.obj["project_name"]
     api_key = ctx.obj.get("api_key") if ctx.obj else None
     _import_by_type(
-        "dataset", path, workspace, dry_run, name, debug, api_key=api_key, force=force
+        "dataset",
+        path,
+        workspace,
+        project_name,
+        dry_run,
+        name,
+        debug,
+        api_key=api_key,
+        force=force,
     )
 
 
-@import_group.command(name="project")
-@click.argument("name", type=str)
+@import_group.command(name="traces")
 @click.option(
     "--path",
     "-p",
@@ -393,19 +436,18 @@ def import_dataset(
 )
 @no_attachments_option()
 @click.pass_context
-def import_project(
+def import_traces(
     ctx: click.Context,
-    name: str,
     path: str,
     dry_run: bool,
     force: bool,
     debug: bool,
     no_attachments: bool,
 ) -> None:
-    """Import projects from workspace/projects directory.
+    """Import the project's traces from projects/PROJECT/.
 
-    This command imports projects matching the specified name from the path/projects/ directory.
-    The name is matched using case-insensitive substring matching.
+    Reads the trace files exported under projects/PROJECT/ and recreates the
+    traces and their spans in the named project.
 
     If a previous import was interrupted, re-running the same command automatically
     resumes from where it left off. Use --force to start over from scratch.
@@ -413,34 +455,33 @@ def import_project(
     \b
     Examples:
     \b
-        # Preview a project that would be imported
-        opik import my-workspace project "my-project" --dry-run
+        # Preview the traces that would be imported
+        opik import my-workspace my-project traces --dry-run
     \b
-        # Import a specific project
-        opik import my-workspace project "my-project"
+        # Import the project's traces
+        opik import my-workspace my-project traces
     \b
-        # Import projects containing "test" in the name
-        opik import my-workspace project "test"
-    \b
-        # Import projects with debug output
-        opik import my-workspace project "my-project" --debug
+        # Import traces with debug output
+        opik import my-workspace my-project traces --debug
     \b
         # Import from a custom path
-        opik import my-workspace project "my-project" --path ./custom-exports/
+        opik import my-workspace my-project traces --path ./custom-exports/
     \b
         # Discard progress and restart
-        opik import my-workspace project "my-project" --force
+        opik import my-workspace my-project traces --force
     """
     workspace = ctx.obj["workspace"]
+    project_name = ctx.obj["project_name"]
     api_key = ctx.obj.get("api_key") if ctx.obj else None
     _import_by_type(
-        "project",
+        "traces",
         path,
         workspace,
+        project_name,
         dry_run,
-        name,
+        None,
         debug,
-        True,  # Always recreate experiments when importing projects
+        True,  # Always recreate experiments when importing traces
         api_key=api_key,
         force=force,
         include_attachments=not no_attachments,
@@ -498,14 +539,16 @@ def import_experiment(
         opik import my-workspace experiment "my-experiment"
     \b
         # Import from a custom path
-        opik import my-workspace experiment "my-experiment" --path ./custom-exports/
+        opik import my-workspace my-project experiment "my-experiment" --path ./custom-exports/
     """
     workspace = ctx.obj["workspace"]
+    project_name = ctx.obj["project_name"]
     api_key = ctx.obj.get("api_key") if ctx.obj else None
     _import_by_type(
         "experiment",
         path,
         workspace,
+        project_name,
         dry_run,
         name,
         debug,
@@ -563,10 +606,19 @@ def import_prompt(
         opik import my-workspace prompt "my-prompt"
     \b
         # Import from a custom path
-        opik import my-workspace prompt "my-prompt" --path ./custom-exports/
+        opik import my-workspace my-project prompt "my-prompt" --path ./custom-exports/
     """
     workspace = ctx.obj["workspace"]
+    project_name = ctx.obj["project_name"]
     api_key = ctx.obj.get("api_key") if ctx.obj else None
     _import_by_type(
-        "prompt", path, workspace, dry_run, name, debug, api_key=api_key, force=force
+        "prompt",
+        path,
+        workspace,
+        project_name,
+        dry_run,
+        name,
+        debug,
+        api_key=api_key,
+        force=force,
     )

--- a/sdks/python/src/opik/cli/imports/__init__.py
+++ b/sdks/python/src/opik/cli/imports/__init__.py
@@ -15,12 +15,10 @@ from .experiment import import_experiments_from_directory
 from .project import import_traces_from_directory
 from .prompt import import_prompts_from_directory
 from .utils import (
-    available_project_names,
     debug_print,
-    find_project_export_dir,
     no_attachments_option,
     print_import_summary,
-    resolve_import_base_path,
+    resolve_import_project_root,
     to_project_option,
 )
 
@@ -70,27 +68,15 @@ def _import_by_type(
         else:
             client = opik.Opik(workspace=workspace)
 
-        # Locate the exported project folder by its recorded name (folders are
-        # keyed by id on disk; project.json holds the human name). Prefers
-        # PATH/WORKSPACE/projects/ (symmetric with export) and falls back to
-        # PATH/projects/ for cross-workspace imports.
-        base_path = resolve_import_base_path(path, workspace)
-        project_root = find_project_export_dir(base_path, project_name)
-        if project_root is None:
-            available = available_project_names(base_path)
-            hint = (
-                f" Available: {', '.join(available)}"
-                if available
-                else " No exported projects were found."
-            )
-            console.print(
-                f"[red]No exported project named '{project_name}' under "
-                f"{base_path / 'projects'}.{hint}[/red]"
-            )
-            sys.exit(1)
-
-        # Data is created in --to-project when given, else the source name.
-        target_project_name = to_project or project_name
+        # Locate the exported project folder by its recorded name and resolve
+        # the destination project. Folders are keyed by id on disk; project.json
+        # holds the human name. The source folder is found under
+        # PATH/WORKSPACE/projects/ (symmetric with export), falling back to
+        # PATH/projects/ for cross-workspace imports. Data is created in
+        # --to-project when given, else the source name.
+        project_root, target_project_name = resolve_import_project_root(
+            path, workspace, project_name, to_project
+        )
 
         # ------------------------------------------------------------------
         # Manifest lifecycle management

--- a/sdks/python/src/opik/cli/imports/__init__.py
+++ b/sdks/python/src/opik/cli/imports/__init__.py
@@ -16,6 +16,7 @@ from .project import import_traces_from_directory
 from .prompt import import_prompts_from_directory
 from .utils import (
     debug_print,
+    finalize_import,
     no_attachments_option,
     print_import_summary,
     resolve_import_project_root,
@@ -182,38 +183,9 @@ def _import_by_type(
             value for key, value in stats.items() if key.endswith("_errors")
         )
 
-        # Flush the async ingestion queue before returning so that all
-        # enqueued traces/spans are persisted on the server.  Without this,
-        # the process can exit while the background worker is still sending
-        # data, silently dropping items (especially under rate-limiting).
-        if not dry_run:
-            flushed = client.flush()
-            if not flushed:
-                console.print(
-                    "[yellow]Warning: flush timed out — some traces/spans may not have been ingested. "
-                    "Re-run the import to retry.[/yellow]"
-                )
-                sys.exit(1)
-
-            # FileUploadManager.flush() returns True even when individual
-            # uploads fail (only False on timeout), so check failed_uploads
-            # separately to catch silent upload failures.
-            failed = client.__internal_api__failed_uploads__(timeout=None)
-            if failed > 0:
-                console.print(
-                    f"[yellow]Warning: {failed} file upload(s) failed during import. "
-                    "Re-run the import to retry.[/yellow]"
-                )
-                sys.exit(1)
-
-            # ------------------------------------------------------------------
-            # Mark manifest complete only on a fully clean run. On any error we
-            # leave it in_progress so the next run (without --force) resumes/retries
-            # instead of short-circuiting on manifest.is_completed.
-            # ------------------------------------------------------------------
-            assert manifest is not None  # guaranteed: manifest is set when not dry_run
-            if total_errors == 0:
-                manifest.complete()
+        # Flush ingestion, surface upload failures, and complete the manifest
+        # (only on a clean run). Shared with import_all.
+        finalize_import(manifest, client, total_errors, dry_run)
 
         # Display summary
         print_import_summary(stats)

--- a/sdks/python/src/opik/cli/imports/__init__.py
+++ b/sdks/python/src/opik/cli/imports/__init__.py
@@ -1,7 +1,6 @@
 """Import command for Opik CLI."""
 
 import sys
-from pathlib import Path
 from typing import Dict, Optional
 
 import click
@@ -21,6 +20,7 @@ from .utils import (
     find_project_export_dir,
     no_attachments_option,
     print_import_summary,
+    resolve_import_base_path,
     to_project_option,
 )
 
@@ -71,10 +71,10 @@ def _import_by_type(
             client = opik.Opik(workspace=workspace)
 
         # Locate the exported project folder by its recorded name (folders are
-        # keyed by id on disk; project.json holds the human name). The workspace
-        # segment mirrors the export layout (PATH/WORKSPACE/projects/<id>/) so
-        # the same --path round-trips between export and import.
-        base_path = Path(path) / workspace
+        # keyed by id on disk; project.json holds the human name). Prefers
+        # PATH/WORKSPACE/projects/ (symmetric with export) and falls back to
+        # PATH/projects/ for cross-workspace imports.
+        base_path = resolve_import_base_path(path, workspace)
         project_root = find_project_export_dir(base_path, project_name)
         if project_root is None:
             available = available_project_names(base_path)

--- a/sdks/python/src/opik/cli/imports/__init__.py
+++ b/sdks/python/src/opik/cli/imports/__init__.py
@@ -208,7 +208,7 @@ def _import_by_type(
 
             # ------------------------------------------------------------------
             # Mark manifest complete only on a fully clean run. On any error we
-            # leave it in_progress so the next (non---force) run resumes/retries
+            # leave it in_progress so the next run (without --force) resumes/retries
             # instead of short-circuiting on manifest.is_completed.
             # ------------------------------------------------------------------
             assert manifest is not None  # guaranteed: manifest is set when not dry_run

--- a/sdks/python/src/opik/cli/imports/all.py
+++ b/sdks/python/src/opik/cli/imports/all.py
@@ -62,8 +62,10 @@ def import_all(
             client = opik.Opik(workspace=workspace)
 
         # Locate the exported project folder by its recorded name (folders are
-        # keyed by id on disk; project.json holds the human name).
-        base_path = Path(path)
+        # keyed by id on disk; project.json holds the human name). The workspace
+        # segment mirrors the export layout (PATH/WORKSPACE/projects/<id>/) so
+        # the same --path round-trips between export and import.
+        base_path = Path(path) / workspace
         project_root = find_project_export_dir(base_path, project_name)
         if project_root is None:
             available = available_project_names(base_path)

--- a/sdks/python/src/opik/cli/imports/all.py
+++ b/sdks/python/src/opik/cli/imports/all.py
@@ -8,18 +8,17 @@ from rich.console import Console
 
 import opik
 
-from ..migration_manifest import MigrationManifest
 from .dataset import import_datasets_from_directory
 from .experiment import import_experiments_from_directory
 from .project import import_traces_from_directory
 from .prompt import import_prompts_from_directory
 from .utils import (
     debug_print,
-    destination_manifest_dir,
     finalize_import,
     no_attachments_option,
     print_import_summary,
     resolve_import_project_root,
+    setup_import_manifest,
     to_project_option,
 )
 from ..include_validation import validate_include
@@ -69,34 +68,14 @@ def import_all(
             path, workspace, project_name, to_project
         )
 
-        # ------------------------------------------------------------------
-        # Manifest lifecycle (skipped for --dry-run). Keyed by the destination
-        # project so importing the same source into different --to-project
-        # targets keeps independent resume state.
-        # ------------------------------------------------------------------
-        manifest: Optional[MigrationManifest] = None
-        manifest_dir = destination_manifest_dir(project_root, project_name)
-
-        if not dry_run:
-            manifest = MigrationManifest(manifest_dir)
-            if force:
-                if MigrationManifest.exists(manifest_dir):
-                    manifest.reset()
-                    console.print(
-                        "[yellow]--force: discarding existing manifest, starting fresh[/yellow]"
-                    )
-            else:
-                if manifest.is_completed:
-                    console.print(
-                        "[green]Import already completed. Use --force to re-import.[/green]"
-                    )
-                    return
-                elif manifest.is_in_progress:
-                    console.print(
-                        f"[blue]Resuming interrupted import: "
-                        f"{manifest.completed_count()} file(s) already completed[/blue]"
-                    )
-            manifest.start()
+        # Construct + initialize the per-destination manifest (shared with
+        # _import_by_type; keyed by the destination project). Skipped for
+        # --dry-run.
+        manifest, already_completed = setup_import_manifest(
+            project_root, project_name, dry_run, force
+        )
+        if already_completed:
+            return
 
         total_stats: Dict[str, int] = {}
 

--- a/sdks/python/src/opik/cli/imports/all.py
+++ b/sdks/python/src/opik/cli/imports/all.py
@@ -14,7 +14,14 @@ from .dataset import import_datasets_from_directory
 from .experiment import import_experiments_from_directory
 from .project import import_traces_from_directory
 from .prompt import import_prompts_from_directory
-from .utils import debug_print, no_attachments_option, print_import_summary
+from .utils import (
+    available_project_names,
+    debug_print,
+    find_project_export_dir,
+    no_attachments_option,
+    print_import_summary,
+    to_project_option,
+)
 from ..include_validation import validate_include
 
 console = Console()
@@ -45,6 +52,7 @@ def import_all(
     debug: bool,
     api_key: Optional[str] = None,
     include_attachments: bool = True,
+    to_project: Optional[str] = None,
 ) -> None:
     """Import all data types from the project export directory."""
     try:
@@ -53,8 +61,25 @@ def import_all(
         else:
             client = opik.Opik(workspace=workspace)
 
-        # Everything for one project lives under projects/<project>/.
-        project_root = Path(path) / "projects" / project_name
+        # Locate the exported project folder by its recorded name (folders are
+        # keyed by id on disk; project.json holds the human name).
+        base_path = Path(path)
+        project_root = find_project_export_dir(base_path, project_name)
+        if project_root is None:
+            available = available_project_names(base_path)
+            hint = (
+                f" Available: {', '.join(available)}"
+                if available
+                else " No exported projects were found."
+            )
+            console.print(
+                f"[red]No exported project named '{project_name}' under "
+                f"{base_path / 'projects'}.{hint}[/red]"
+            )
+            sys.exit(1)
+
+        # Data is created in --to-project when given, else the source name.
+        project_name = to_project or project_name
 
         # ------------------------------------------------------------------
         # Manifest lifecycle (skipped for --dry-run)
@@ -247,6 +272,7 @@ def import_all(
     ),
 )
 @no_attachments_option()
+@to_project_option()
 @click.pass_context
 def import_all_command(
     ctx: click.Context,
@@ -256,6 +282,7 @@ def import_all_command(
     debug: bool,
     include: List[str],
     no_attachments: bool,
+    to_project: Optional[str],
 ) -> None:
     """Import all datasets, prompts, traces, and experiments into the project.
 
@@ -297,4 +324,5 @@ def import_all_command(
         debug,
         api_key,
         include_attachments=not no_attachments,
+        to_project=to_project,
     )

--- a/sdks/python/src/opik/cli/imports/all.py
+++ b/sdks/python/src/opik/cli/imports/all.py
@@ -14,12 +14,10 @@ from .experiment import import_experiments_from_directory
 from .project import import_traces_from_directory
 from .prompt import import_prompts_from_directory
 from .utils import (
-    available_project_names,
     debug_print,
-    find_project_export_dir,
     no_attachments_option,
     print_import_summary,
-    resolve_import_base_path,
+    resolve_import_project_root,
     to_project_option,
 )
 from ..include_validation import validate_include
@@ -61,27 +59,13 @@ def import_all(
         else:
             client = opik.Opik(workspace=workspace)
 
-        # Locate the exported project folder by its recorded name (folders are
-        # keyed by id on disk; project.json holds the human name). Prefers
-        # PATH/WORKSPACE/projects/ (symmetric with export) and falls back to
-        # PATH/projects/ for cross-workspace imports.
-        base_path = resolve_import_base_path(path, workspace)
-        project_root = find_project_export_dir(base_path, project_name)
-        if project_root is None:
-            available = available_project_names(base_path)
-            hint = (
-                f" Available: {', '.join(available)}"
-                if available
-                else " No exported projects were found."
-            )
-            console.print(
-                f"[red]No exported project named '{project_name}' under "
-                f"{base_path / 'projects'}.{hint}[/red]"
-            )
-            sys.exit(1)
-
-        # Data is created in --to-project when given, else the source name.
-        project_name = to_project or project_name
+        # Locate the exported project folder by its recorded name and resolve
+        # the destination project (shared with _import_by_type). Folders are
+        # keyed by id on disk; project.json holds the human name. project_name
+        # becomes the destination — --to-project when given, else the source.
+        project_root, project_name = resolve_import_project_root(
+            path, workspace, project_name, to_project
+        )
 
         # ------------------------------------------------------------------
         # Manifest lifecycle (skipped for --dry-run)

--- a/sdks/python/src/opik/cli/imports/all.py
+++ b/sdks/python/src/opik/cli/imports/all.py
@@ -12,15 +12,15 @@ import opik
 from ..migration_manifest import MigrationManifest
 from .dataset import import_datasets_from_directory
 from .experiment import import_experiments_from_directory
-from .project import import_projects_from_directory
+from .project import import_traces_from_directory
 from .prompt import import_prompts_from_directory
 from .utils import debug_print, no_attachments_option, print_import_summary
 from ..include_validation import validate_include
 
 console = Console()
 
-_VALID_INCLUDES = {"datasets", "prompts", "projects", "experiments"}
-_DEFAULT_INCLUDE = "datasets,prompts,projects,experiments"
+_VALID_INCLUDES = {"datasets", "prompts", "traces", "experiments"}
+_DEFAULT_INCLUDE = "datasets,prompts,traces,experiments"
 
 
 def _validate_include(
@@ -37,6 +37,7 @@ def _merge_stats(total: Dict[str, int], phase: Dict[str, int]) -> None:
 
 def import_all(
     workspace: str,
+    project_name: str,
     path: str,
     include: List[str],
     dry_run: bool,
@@ -45,14 +46,15 @@ def import_all(
     api_key: Optional[str] = None,
     include_attachments: bool = True,
 ) -> None:
-    """Import all data types from the workspace export directory."""
+    """Import all data types from the project export directory."""
     try:
         if api_key:
             client = opik.Opik(api_key=api_key, workspace=workspace)
         else:
             client = opik.Opik(workspace=workspace)
 
-        base_path = Path(path)
+        # Everything for one project lives under projects/<project>/.
+        project_root = Path(path) / "projects" / project_name
 
         # ------------------------------------------------------------------
         # Manifest lifecycle (skipped for --dry-run)
@@ -60,9 +62,9 @@ def import_all(
         manifest: Optional[MigrationManifest] = None
 
         if not dry_run:
-            manifest = MigrationManifest(base_path)
+            manifest = MigrationManifest(project_root)
             if force:
-                if MigrationManifest.exists(base_path):
+                if MigrationManifest.exists(project_root):
                     manifest.reset()
                     console.print(
                         "[yellow]--force: discarding existing manifest, starting fresh[/yellow]"
@@ -86,11 +88,17 @@ def import_all(
         # Phase 1 — Datasets
         # ------------------------------------------------------------------
         if "datasets" in include:
-            datasets_dir = base_path / "datasets"
+            datasets_dir = project_root / "datasets"
             if datasets_dir.exists():
                 console.print("\n[bold blue]--- Importing Datasets ---[/bold blue]")
                 stats = import_datasets_from_directory(
-                    client, datasets_dir, dry_run, None, debug, manifest=manifest
+                    client,
+                    datasets_dir,
+                    project_name,
+                    dry_run,
+                    None,
+                    debug,
+                    manifest=manifest,
                 )
                 _merge_stats(total_stats, stats)
             else:
@@ -100,11 +108,17 @@ def import_all(
         # Phase 2 — Prompts
         # ------------------------------------------------------------------
         if "prompts" in include:
-            prompts_dir = base_path / "prompts"
+            prompts_dir = project_root / "prompts"
             if prompts_dir.exists():
                 console.print("\n[bold blue]--- Importing Prompts ---[/bold blue]")
                 stats = import_prompts_from_directory(
-                    client, prompts_dir, dry_run, None, debug, manifest=manifest
+                    client,
+                    prompts_dir,
+                    project_name,
+                    dry_run,
+                    None,
+                    debug,
+                    manifest=manifest,
                 )
                 _merge_stats(total_stats, stats)
                 # Flush so prompts are available before experiments reference them
@@ -114,26 +128,23 @@ def import_all(
                 debug_print(f"No prompts directory at {prompts_dir}, skipping", debug)
 
         # ------------------------------------------------------------------
-        # Phase 3 — Projects (traces)
+        # Phase 3 — Traces
         # Populates trace ID mappings in the manifest for experiments to use.
         # ------------------------------------------------------------------
-        if "projects" in include:
-            projects_dir = base_path / "projects"
-            if projects_dir.exists():
-                console.print("\n[bold blue]--- Importing Projects ---[/bold blue]")
-                stats = import_projects_from_directory(
-                    client,
-                    projects_dir,
-                    dry_run,
-                    None,
-                    debug,
-                    recreate_experiments_flag=False,
-                    manifest=manifest,
-                    include_attachments=include_attachments,
-                )
-                _merge_stats(total_stats, stats)
-            else:
-                debug_print(f"No projects directory at {projects_dir}, skipping", debug)
+        if "traces" in include:
+            console.print("\n[bold blue]--- Importing Traces ---[/bold blue]")
+            stats = import_traces_from_directory(
+                client,
+                project_root,
+                project_name,
+                dry_run,
+                None,
+                debug,
+                recreate_experiments_flag=False,
+                manifest=manifest,
+                include_attachments=include_attachments,
+            )
+            _merge_stats(total_stats, stats)
 
         # ------------------------------------------------------------------
         # Phase 4 — Experiments
@@ -143,11 +154,17 @@ def import_all(
         # phase 3 directly from the manifest DB.
         # ------------------------------------------------------------------
         if "experiments" in include:
-            experiments_dir = base_path / "experiments"
+            experiments_dir = project_root / "experiments"
             if experiments_dir.exists():
                 console.print("\n[bold blue]--- Importing Experiments ---[/bold blue]")
                 stats = import_experiments_from_directory(
-                    client, experiments_dir, dry_run, None, debug, manifest=manifest
+                    client,
+                    experiments_dir,
+                    project_name,
+                    dry_run,
+                    None,
+                    debug,
+                    manifest=manifest,
                 )
                 _merge_stats(total_stats, stats)
             else:
@@ -240,37 +257,39 @@ def import_all_command(
     include: List[str],
     no_attachments: bool,
 ) -> None:
-    """Import all datasets, prompts, projects, and experiments into the workspace.
+    """Import all datasets, prompts, traces, and experiments into the project.
 
-    Reads from the directory structure produced by 'opik export WORKSPACE all'.
+    Reads from the directory structure produced by 'opik export WORKSPACE PROJECT all'.
     A single migration manifest tracks progress across all data types, so an
     interrupted import can be resumed by re-running the same command.
 
-    Import order: datasets → prompts → projects → experiments.
-    Experiments depend on datasets, prompts, and project traces being present,
+    Import order: datasets → prompts → traces → experiments.
+    Experiments depend on datasets, prompts, and traces being present,
     so earlier phases are always run first when included.
 
     \b
     Examples:
         # Import everything
-        opik import my-workspace all
+        opik import my-workspace my-project all
 
         # Preview what would be imported
-        opik import my-workspace all --dry-run
+        opik import my-workspace my-project all --dry-run
 
         # Import only datasets and prompts
-        opik import my-workspace all --include datasets,prompts
+        opik import my-workspace my-project all --include datasets,prompts
 
         # Restart from scratch, discarding previous progress
-        opik import my-workspace all --force
+        opik import my-workspace my-project all --force
 
         # Import from a custom path
-        opik import my-workspace all --path ./backup
+        opik import my-workspace my-project all --path ./backup
     """
     workspace = ctx.obj["workspace"]
+    project_name = ctx.obj["project_name"]
     api_key = ctx.obj.get("api_key") if ctx.obj else None
     import_all(
         workspace,
+        project_name,
         path,
         include,
         dry_run,

--- a/sdks/python/src/opik/cli/imports/all.py
+++ b/sdks/python/src/opik/cli/imports/all.py
@@ -186,6 +186,12 @@ def import_all(
         # ------------------------------------------------------------------
         # Flush ingestion queue and check for upload failures
         # ------------------------------------------------------------------
+        # Total error count across all phases — computed before manifest.complete()
+        # so a partial failure never marks the manifest completed.
+        total_errors = sum(
+            value for key, value in total_stats.items() if key.endswith("_errors")
+        )
+
         if not dry_run:
             flushed = client.flush()
             if not flushed:
@@ -203,15 +209,16 @@ def import_all(
                 )
                 sys.exit(1)
 
+            # Mark complete only on a fully clean run, so a partial failure leaves
+            # the manifest in_progress and the next run resumes/retries instead of
+            # short-circuiting on manifest.is_completed.
             assert manifest is not None
-            manifest.complete()
+            if total_errors == 0:
+                manifest.complete()
 
         # ------------------------------------------------------------------
         # Summary
         # ------------------------------------------------------------------
-        total_errors = sum(
-            value for key, value in total_stats.items() if key.endswith("_errors")
-        )
         if total_errors > 0 and not dry_run:
             print_import_summary(total_stats)
             # Per-item errors were already printed in red by the importers; exit

--- a/sdks/python/src/opik/cli/imports/all.py
+++ b/sdks/python/src/opik/cli/imports/all.py
@@ -15,6 +15,7 @@ from .project import import_traces_from_directory
 from .prompt import import_prompts_from_directory
 from .utils import (
     debug_print,
+    destination_manifest_dir,
     finalize_import,
     no_attachments_option,
     print_import_summary,
@@ -69,14 +70,17 @@ def import_all(
         )
 
         # ------------------------------------------------------------------
-        # Manifest lifecycle (skipped for --dry-run)
+        # Manifest lifecycle (skipped for --dry-run). Keyed by the destination
+        # project so importing the same source into different --to-project
+        # targets keeps independent resume state.
         # ------------------------------------------------------------------
         manifest: Optional[MigrationManifest] = None
+        manifest_dir = destination_manifest_dir(project_root, project_name)
 
         if not dry_run:
-            manifest = MigrationManifest(project_root)
+            manifest = MigrationManifest(manifest_dir)
             if force:
-                if MigrationManifest.exists(project_root):
+                if MigrationManifest.exists(manifest_dir):
                     manifest.reset()
                     console.print(
                         "[yellow]--force: discarding existing manifest, starting fresh[/yellow]"

--- a/sdks/python/src/opik/cli/imports/all.py
+++ b/sdks/python/src/opik/cli/imports/all.py
@@ -15,6 +15,7 @@ from .project import import_traces_from_directory
 from .prompt import import_prompts_from_directory
 from .utils import (
     debug_print,
+    finalize_import,
     no_attachments_option,
     print_import_summary,
     resolve_import_project_root,
@@ -192,29 +193,9 @@ def import_all(
             value for key, value in total_stats.items() if key.endswith("_errors")
         )
 
-        if not dry_run:
-            flushed = client.flush()
-            if not flushed:
-                console.print(
-                    "[yellow]Warning: flush timed out — some traces/spans may not have been "
-                    "ingested. Re-run the import to retry.[/yellow]"
-                )
-                sys.exit(1)
-
-            failed = client.__internal_api__failed_uploads__(timeout=None)
-            if failed > 0:
-                console.print(
-                    f"[yellow]Warning: {failed} file upload(s) failed during import. "
-                    "Re-run the import to retry.[/yellow]"
-                )
-                sys.exit(1)
-
-            # Mark complete only on a fully clean run, so a partial failure leaves
-            # the manifest in_progress and the next run resumes/retries instead of
-            # short-circuiting on manifest.is_completed.
-            assert manifest is not None
-            if total_errors == 0:
-                manifest.complete()
+        # Flush ingestion, surface upload failures, and complete the manifest
+        # (only on a clean run). Shared with _import_by_type.
+        finalize_import(manifest, client, total_errors, dry_run)
 
         # ------------------------------------------------------------------
         # Summary

--- a/sdks/python/src/opik/cli/imports/all.py
+++ b/sdks/python/src/opik/cli/imports/all.py
@@ -225,6 +225,19 @@ def import_all(
         # ------------------------------------------------------------------
         # Summary
         # ------------------------------------------------------------------
+        total_errors = sum(
+            value for key, value in total_stats.items() if key.endswith("_errors")
+        )
+        if total_errors > 0 and not dry_run:
+            print_import_summary(total_stats)
+            # Per-item errors were already printed in red by the importers; exit
+            # non-zero so the failure is not masked by a 0 exit code.
+            console.print(
+                f"\n[bold red]Import completed with {total_errors} error(s) "
+                "(see messages above). Re-run the import to retry.[/bold red]"
+            )
+            sys.exit(1)
+
         console.print("\n[bold green]Import complete.[/bold green]")
         print_import_summary(total_stats)
 

--- a/sdks/python/src/opik/cli/imports/all.py
+++ b/sdks/python/src/opik/cli/imports/all.py
@@ -1,7 +1,6 @@
 """Import all workspace data."""
 
 import sys
-from pathlib import Path
 from typing import Dict, List, Optional
 
 import click
@@ -20,6 +19,7 @@ from .utils import (
     find_project_export_dir,
     no_attachments_option,
     print_import_summary,
+    resolve_import_base_path,
     to_project_option,
 )
 from ..include_validation import validate_include
@@ -62,10 +62,10 @@ def import_all(
             client = opik.Opik(workspace=workspace)
 
         # Locate the exported project folder by its recorded name (folders are
-        # keyed by id on disk; project.json holds the human name). The workspace
-        # segment mirrors the export layout (PATH/WORKSPACE/projects/<id>/) so
-        # the same --path round-trips between export and import.
-        base_path = Path(path) / workspace
+        # keyed by id on disk; project.json holds the human name). Prefers
+        # PATH/WORKSPACE/projects/ (symmetric with export) and falls back to
+        # PATH/projects/ for cross-workspace imports.
+        base_path = resolve_import_base_path(path, workspace)
         project_root = find_project_export_dir(base_path, project_name)
         if project_root is None:
             available = available_project_names(base_path)

--- a/sdks/python/src/opik/cli/imports/dataset.py
+++ b/sdks/python/src/opik/cli/imports/dataset.py
@@ -16,12 +16,13 @@ console = Console()
 def import_datasets_from_directory(
     client: opik.Opik,
     source_dir: Path,
+    project_name: str,
     dry_run: bool,
     name_pattern: Optional[str],
     debug: bool,
     manifest: Optional[MigrationManifest] = None,
 ) -> Dict[str, int]:
-    """Import datasets from a directory.
+    """Import datasets from a directory into the given project.
 
     Returns:
         Dictionary with keys: 'datasets', 'datasets_skipped', 'datasets_errors'
@@ -97,14 +98,18 @@ def import_datasets_from_directory(
 
                 # Get or create dataset (handles case where dataset already exists)
                 try:
-                    dataset = client.get_dataset(dataset_name)
+                    dataset = client.get_dataset(
+                        dataset_name, project_name=project_name
+                    )
                     if debug:
                         console.print(
                             f"[blue]Dataset '{dataset_name}' already exists, using existing dataset[/blue]"
                         )
                 except Exception:
                     # Dataset doesn't exist, create it
-                    dataset = client.create_dataset(name=dataset_name)
+                    dataset = client.create_dataset(
+                        name=dataset_name, project_name=project_name
+                    )
                     if debug:
                         console.print(
                             f"[blue]Created new dataset: {dataset_name}[/blue]"

--- a/sdks/python/src/opik/cli/imports/experiment.py
+++ b/sdks/python/src/opik/cli/imports/experiment.py
@@ -137,10 +137,6 @@ def _build_dataset_item_id_map(
                 original_dataset_item_id = item_data.get("dataset_item_id")
                 dataset_item_data = item_data.get("dataset_item_data")
 
-                # Fallback to input for older exports
-                if not dataset_item_data:
-                    dataset_item_data = item_data.get("input")
-
                 if not original_dataset_item_id or not dataset_item_data:
                     continue
 

--- a/sdks/python/src/opik/cli/imports/experiment.py
+++ b/sdks/python/src/opik/cli/imports/experiment.py
@@ -26,7 +26,6 @@ from opik.rest_api.types.experiment_item import ExperimentItem
 from rich.console import Console
 
 from ..migration_manifest import MigrationManifest
-from ..exports.utils import extract_trace_id_from_filename
 from .utils import (
     handle_trace_reference,
     translate_trace_id,
@@ -90,6 +89,7 @@ def _build_dataset_item_id_map(
     client: opik.Opik,
     experiment_files: List[Path],
     datasets_dir: Path,
+    project_name: str,
     dry_run: bool,
     debug: bool,
     manifest: Optional[MigrationManifest] = None,
@@ -207,7 +207,7 @@ def _build_dataset_item_id_map(
 
     # Import datasets (this will create dataset items with new IDs)
     dataset_import_stats = import_datasets_from_directory(
-        client, datasets_dir, dry_run, None, debug, manifest=manifest
+        client, datasets_dir, project_name, dry_run, None, debug, manifest=manifest
     )
 
     # Update dataset_stats with import results
@@ -268,7 +268,7 @@ def _build_dataset_item_id_map(
 
             # Get the imported dataset
             try:
-                dataset = client.get_dataset(dataset_name)
+                dataset = client.get_dataset(dataset_name, project_name=project_name)
             except Exception:
                 debug_print(
                     f"Warning: Could not get dataset '{dataset_name}' after import",
@@ -402,15 +402,17 @@ def recreate_experiment(
     Args:
         client: Opik client instance
         experiment_data: Experiment data structure from export
-        project_name: Name of the project to create the experiment in
+        project_name: Name of the project to create the experiment (and its dataset) in.
+            The experiment always lands in this project on both the import-from-disk and
+            migrate paths.
         trace_id_map: Mapping from original trace IDs to new trace IDs (required, can be empty dict)
         dataset_item_id_map: Mapping from original dataset_item_id to new dataset_item_id (optional)
         dry_run: If True, only simulate the import without making changes
         debug: If True, print debug messages
-        target_project_name: When set, the experiment is created in this project at the
-            destination (used by ``opik migrate dataset``). When ``None`` (default,
-            import-from-disk path), the experiment lands in the client's default project
-            and ``project_name`` is recorded in metadata only.
+        target_project_name: Migrate-path marker (used by ``opik migrate dataset``). When
+            set it equals ``project_name`` and additionally enables migrate-only fidelity
+            forwarding (evaluation_method/tags/dataset_version_id/optimization_id) and
+            prompt-version stripping. ``None`` selects the plain import-from-disk path.
         target_dataset_name: When set, override the dataset name on the destination
             experiment (used by migrate when the dataset was renamed at the target).
             Defaults to the source experiment's ``dataset_name``.
@@ -446,14 +448,14 @@ def recreate_experiment(
         return True
 
     try:
-        # Get or create the dataset.
+        # Get or create the dataset in the experiment's project.
         # In the migrate path the dataset already exists at the destination (created
         # by Slice 1/2); this call is a no-op fetch and ensures the experiment binds
-        # to the destination-project copy rather than the client's default.
+        # to the destination-project copy.
         _ = client.get_or_create_dataset(
             name=destination_dataset_name,
             description=f"Recreated dataset for experiment {experiment_name}",
-            project_name=target_project_name,
+            project_name=project_name,
         )
 
         debug_print(
@@ -499,11 +501,16 @@ def recreate_experiment(
         # the destination id before this function sees it, so by the
         # time we get here ``experiment_info["optimization_id"]`` is
         # already a destination-valid pointer.
+        # The experiment is always created in its project. ``project_name`` equals
+        # ``target_project_name`` on the migrate path, so this is unchanged for
+        # migrate; on the import-from-disk path it now lands the experiment in the
+        # named project instead of the client's default.
         create_kwargs: Dict[str, Any] = {
             "dataset_name": destination_dataset_name,
             "name": experiment_name,
             "experiment_config": experiment_metadata,
             "type": experiment_info.get("type", "regular"),
+            "project_name": project_name,
         }
         if is_migrate_path:
             create_kwargs["evaluation_method"] = experiment_info.get(
@@ -511,7 +518,6 @@ def recreate_experiment(
             )
             create_kwargs["tags"] = experiment_info.get("tags")
             create_kwargs["dataset_version_id"] = target_dataset_version_id
-            create_kwargs["project_name"] = target_project_name
             optimization_id = experiment_info.get("optimization_id")
             if optimization_id:
                 create_kwargs["optimization_id"] = optimization_id
@@ -844,14 +850,18 @@ def recreate_experiments(
     return successful
 
 
-def _import_traces_from_projects_directory(
+def _import_traces_for_project(
     client: opik.Opik,
-    workspace_root: Path,
+    project_dir: Path,
+    project_name: str,
     dry_run: bool,
     debug: bool,
     manifest: Optional[MigrationManifest] = None,
 ) -> tuple[Dict[str, str], Dict[str, int]]:
-    """Import traces from projects directory and return trace_id_map and statistics.
+    """Import the project's traces and return trace_id_map and statistics.
+
+    Trace files live directly under ``project_dir`` (``trace_*.json``) and are
+    created in ``project_name``.
 
     Returns:
         Tuple of (trace_id_map, stats_dict) where:
@@ -862,192 +872,166 @@ def _import_traces_from_projects_directory(
     trace_id_map: Dict[str, str] = manifest.get_trace_id_map() if manifest else {}
     traces_imported = 0
     traces_errors = 0
-    projects_dir = workspace_root / "projects"
 
-    if not projects_dir.exists():
-        debug_print(
-            f"No projects directory found at {projects_dir}, skipping trace import",
-            debug,
-        )
-        return trace_id_map, {"traces": 0, "traces_errors": 0}
+    trace_files = list(project_dir.glob("trace_*.json"))
 
-    project_dirs = [d for d in projects_dir.iterdir() if d.is_dir()]
-
-    if not project_dirs:
-        debug_print("No project directories found, skipping trace import", debug)
+    if not trace_files:
+        debug_print(f"No trace files found in {project_dir}", debug)
         return trace_id_map, {"traces": 0, "traces_errors": 0}
 
     debug_print(
-        f"Importing traces from {len(project_dirs)} project(s) to build trace ID mapping...",
+        f"Importing {len(trace_files)} trace(s) into project '{project_name}'...",
         debug,
     )
 
-    for project_dir in project_dirs:
-        project_name = project_dir.name
-        trace_files = list(project_dir.glob("trace_*.json"))
+    for trace_file in trace_files:
+        try:
+            # Skip trace files already imported in a previous run.
+            # Their ID mappings are already in trace_id_map (seeded from manifest).
+            if manifest and not dry_run and manifest.is_file_completed(trace_file):
+                debug_print(
+                    f"Skipping {trace_file.name} (already imported in a previous run)",
+                    debug,
+                )
+                traces_imported += 1
+                continue
 
-        if not trace_files:
-            debug_print(f"No trace files found in project '{project_name}'", debug)
-            continue
+            with open(trace_file, "r", encoding="utf-8") as f:
+                trace_data = json.load(f)
 
-        debug_print(
-            f"Importing {len(trace_files)} trace(s) from project '{project_name}'...",
-            debug,
-        )
+            trace_info = trace_data.get("trace", {})
+            spans_info = trace_data.get("spans", [])
+            original_trace_id = trace_info.get("id")
 
-        for trace_file in trace_files:
-            try:
-                # Skip trace files already imported in a previous run.
-                # Their ID mappings are already in trace_id_map (seeded from manifest).
-                if manifest and not dry_run and manifest.is_file_completed(trace_file):
-                    debug_print(
-                        f"Skipping {trace_file.name} (already imported in a previous run)",
-                        debug,
+            if not original_trace_id:
+                debug_print(
+                    f"Warning: Trace file {trace_file.name} has no trace ID, skipping",
+                    debug,
+                )
+                traces_errors += 1
+                continue
+
+            if dry_run:
+                debug_print(
+                    f"Would import trace {original_trace_id} into project '{project_name}'",
+                    debug,
+                )
+                continue
+
+            # Create trace with full data
+            # Clean feedback scores to remove read-only fields
+            feedback_scores = clean_feedback_scores(trace_info.get("feedback_scores"))
+
+            trace = client.trace(
+                name=trace_info.get("name", "imported_trace"),
+                start_time=(
+                    datetime.fromisoformat(
+                        trace_info["start_time"].replace("Z", "+00:00")
                     )
-                    traces_imported += 1
-                    continue
-
-                with open(trace_file, "r", encoding="utf-8") as f:
-                    trace_data = json.load(f)
-
-                trace_info = trace_data.get("trace", {})
-                spans_info = trace_data.get("spans", [])
-                original_trace_id = trace_info.get("id")
-
-                if not original_trace_id:
-                    debug_print(
-                        f"Warning: Trace file {trace_file.name} has no trace ID, skipping",
-                        debug,
+                    if trace_info.get("start_time")
+                    else None
+                ),
+                end_time=(
+                    datetime.fromisoformat(
+                        trace_info["end_time"].replace("Z", "+00:00")
                     )
-                    traces_errors += 1
-                    continue
+                    if trace_info.get("end_time")
+                    else None
+                ),
+                input=trace_info.get("input", {}),
+                output=trace_info.get("output", {}),
+                metadata=trace_info.get("metadata"),
+                tags=trace_info.get("tags"),
+                feedback_scores=feedback_scores,
+                error_info=trace_info.get("error_info"),
+                thread_id=trace_info.get("thread_id"),
+                project_name=project_name,
+            )
 
-                if dry_run:
-                    debug_print(
-                        f"Would import trace {original_trace_id} from project '{project_name}'",
-                        debug,
-                    )
-                    continue
+            # Map original trace ID to new trace ID
+            trace_id_map[original_trace_id] = trace.id
+            if manifest:
+                manifest.add_trace_mapping(original_trace_id, trace.id)
+            traces_imported += 1
+            debug_print(
+                f"Mapped trace {original_trace_id} -> {trace.id} (project: {project_name})",
+                debug,
+            )
 
-                # Create trace with full data
+            # Create spans with full data, preserving parent-child relationships
+            # Build span_id_map to translate parent_span_id references
+            span_id_map: Dict[str, str] = {}  # Maps original span ID to new span ID
+
+            # Sort spans topologically to ensure parents are processed before children
+            # This handles multi-level hierarchies correctly
+            sorted_spans = sort_spans_topologically(spans_info)
+
+            for span_info in sorted_spans:
                 # Clean feedback scores to remove read-only fields
-                feedback_scores = clean_feedback_scores(
-                    trace_info.get("feedback_scores")
+                span_feedback_scores = clean_feedback_scores(
+                    span_info.get("feedback_scores")
                 )
 
-                trace = client.trace(
-                    name=trace_info.get("name", "imported_trace"),
+                original_span_id = span_info.get("id")
+                original_parent_span_id = span_info.get("parent_span_id")
+
+                # Translate parent_span_id if it exists
+                new_parent_span_id = None
+                if original_parent_span_id and original_parent_span_id in span_id_map:
+                    new_parent_span_id = span_id_map[original_parent_span_id]
+
+                # Create span with parent_span_id if available
+                # Clean usage data to avoid double-prefixing of original_usage keys
+                usage_data = clean_usage_for_import(span_info.get("usage"))
+
+                span = client.span(
+                    name=span_info.get("name", "imported_span"),
+                    type=span_info.get("type", "general"),
                     start_time=(
                         datetime.fromisoformat(
-                            trace_info["start_time"].replace("Z", "+00:00")
+                            span_info["start_time"].replace("Z", "+00:00")
                         )
-                        if trace_info.get("start_time")
+                        if span_info.get("start_time")
                         else None
                     ),
                     end_time=(
                         datetime.fromisoformat(
-                            trace_info["end_time"].replace("Z", "+00:00")
+                            span_info["end_time"].replace("Z", "+00:00")
                         )
-                        if trace_info.get("end_time")
+                        if span_info.get("end_time")
                         else None
                     ),
-                    input=trace_info.get("input", {}),
-                    output=trace_info.get("output", {}),
-                    metadata=trace_info.get("metadata"),
-                    tags=trace_info.get("tags"),
-                    feedback_scores=feedback_scores,
-                    error_info=trace_info.get("error_info"),
-                    thread_id=trace_info.get("thread_id"),
+                    input=span_info.get("input", {}),
+                    output=span_info.get("output", {}),
+                    metadata=span_info.get("metadata"),
+                    tags=span_info.get("tags"),
+                    usage=usage_data,
+                    feedback_scores=span_feedback_scores,
+                    model=span_info.get("model"),
+                    provider=span_info.get("provider"),
+                    error_info=span_info.get("error_info"),
+                    total_cost=span_info.get("total_cost"),
+                    trace_id=trace.id,
+                    parent_span_id=new_parent_span_id,
                     project_name=project_name,
                 )
 
-                # Map original trace ID to new trace ID
-                trace_id_map[original_trace_id] = trace.id
-                if manifest:
-                    manifest.add_trace_mapping(original_trace_id, trace.id)
-                traces_imported += 1
-                debug_print(
-                    f"Mapped trace {original_trace_id} -> {trace.id} (project: {project_name})",
-                    debug,
-                )
+                # Map original span ID to new span ID for parent relationship mapping
+                if original_span_id and span.id:
+                    span_id_map[original_span_id] = span.id
 
-                # Create spans with full data, preserving parent-child relationships
-                # Build span_id_map to translate parent_span_id references
-                span_id_map: Dict[str, str] = {}  # Maps original span ID to new span ID
+            # Mark trace file completed and persist trace mapping to disk
+            if manifest:
+                manifest.mark_file_completed(trace_file)
 
-                # Sort spans topologically to ensure parents are processed before children
-                # This handles multi-level hierarchies correctly
-                sorted_spans = sort_spans_topologically(spans_info)
-
-                for span_info in sorted_spans:
-                    # Clean feedback scores to remove read-only fields
-                    span_feedback_scores = clean_feedback_scores(
-                        span_info.get("feedback_scores")
-                    )
-
-                    original_span_id = span_info.get("id")
-                    original_parent_span_id = span_info.get("parent_span_id")
-
-                    # Translate parent_span_id if it exists
-                    new_parent_span_id = None
-                    if (
-                        original_parent_span_id
-                        and original_parent_span_id in span_id_map
-                    ):
-                        new_parent_span_id = span_id_map[original_parent_span_id]
-
-                    # Create span with parent_span_id if available
-                    # Clean usage data to avoid double-prefixing of original_usage keys
-                    usage_data = clean_usage_for_import(span_info.get("usage"))
-
-                    span = client.span(
-                        name=span_info.get("name", "imported_span"),
-                        type=span_info.get("type", "general"),
-                        start_time=(
-                            datetime.fromisoformat(
-                                span_info["start_time"].replace("Z", "+00:00")
-                            )
-                            if span_info.get("start_time")
-                            else None
-                        ),
-                        end_time=(
-                            datetime.fromisoformat(
-                                span_info["end_time"].replace("Z", "+00:00")
-                            )
-                            if span_info.get("end_time")
-                            else None
-                        ),
-                        input=span_info.get("input", {}),
-                        output=span_info.get("output", {}),
-                        metadata=span_info.get("metadata"),
-                        tags=span_info.get("tags"),
-                        usage=usage_data,
-                        feedback_scores=span_feedback_scores,
-                        model=span_info.get("model"),
-                        provider=span_info.get("provider"),
-                        error_info=span_info.get("error_info"),
-                        total_cost=span_info.get("total_cost"),
-                        trace_id=trace.id,
-                        parent_span_id=new_parent_span_id,
-                        project_name=project_name,
-                    )
-
-                    # Map original span ID to new span ID for parent relationship mapping
-                    if original_span_id and span.id:
-                        span_id_map[original_span_id] = span.id
-
-                # Mark trace file completed and persist trace mapping to disk
-                if manifest:
-                    manifest.mark_file_completed(trace_file)
-
-            except Exception as e:
-                console.print(
-                    f"[yellow]Warning: Failed to import trace from {trace_file}: {e}[/yellow]"
-                )
-                if manifest:
-                    manifest.mark_file_failed(trace_file, str(e))
-                traces_errors += 1
-                continue
+        except Exception as e:
+            console.print(
+                f"[yellow]Warning: Failed to import trace from {trace_file}: {e}[/yellow]"
+            )
+            if manifest:
+                manifest.mark_file_failed(trace_file, str(e))
+            traces_errors += 1
+            continue
 
     if not dry_run and trace_id_map:
         # Flush client to ensure traces are persisted before recreating experiments
@@ -1063,10 +1047,6 @@ def _import_traces_from_projects_directory(
         console.print(
             "[yellow]Warning: No traces were imported. Trace ID map is empty.[/yellow]"
         )
-        if traces_imported == 0 and traces_errors == 0:
-            console.print(
-                f"[yellow]No trace files were found in {projects_dir}[/yellow]"
-            )
 
     return trace_id_map, {"traces": traces_imported, "traces_errors": traces_errors}
 
@@ -1074,12 +1054,13 @@ def _import_traces_from_projects_directory(
 def import_experiments_from_directory(
     client: opik.Opik,
     source_dir: Path,
+    project_name: str,
     dry_run: bool,
     name_pattern: Optional[str],
     debug: bool,
     manifest: Optional[MigrationManifest] = None,
 ) -> Dict[str, int]:
-    """Import experiments from a directory.
+    """Import experiments from a directory into the given project.
 
     This function will first import prompts and traces from their respective directories
     (if they exist) to build a trace_id_map, then use that map when recreating experiments.
@@ -1107,16 +1088,23 @@ def import_experiments_from_directory(
                 "traces_errors": 0,
             }
 
-        # source_dir is typically workspace/experiments, so parent is workspace root
-        workspace_root = source_dir.parent
+        # source_dir is projects/<project>/experiments, so its parent is the
+        # project root that holds datasets/, prompts/, and the trace files.
+        project_root = source_dir.parent
 
         # Import prompts first (they may be referenced by experiments)
         prompts_stats = {"prompts": 0, "prompts_skipped": 0, "prompts_errors": 0}
-        prompts_dir = workspace_root / "prompts"
+        prompts_dir = project_root / "prompts"
         if prompts_dir.exists():
             debug_print("Importing prompts from prompts directory...", debug)
             prompts_stats = import_prompts_from_directory(
-                client, prompts_dir, dry_run, name_pattern, debug, manifest=manifest
+                client,
+                prompts_dir,
+                project_name,
+                dry_run,
+                name_pattern,
+                debug,
+                manifest=manifest,
             )
             if prompts_stats.get("prompts", 0) > 0 and not dry_run:
                 # Flush client to ensure prompts are persisted
@@ -1129,7 +1117,7 @@ def import_experiments_from_directory(
             debug_print("No prompts directory found, skipping prompt import", debug)
 
         # Import datasets first to build dataset_item_id_map
-        datasets_dir = workspace_root / "datasets"
+        datasets_dir = project_root / "datasets"
         dataset_item_id_map: Dict[str, str] = {}
         datasets_stats: Dict[str, int] = {
             "datasets": 0,
@@ -1145,6 +1133,7 @@ def import_experiments_from_directory(
                 client,
                 experiment_files,
                 datasets_dir,
+                project_name,
                 dry_run,
                 debug,
                 manifest=manifest,
@@ -1155,34 +1144,15 @@ def import_experiments_from_directory(
                 debug,
             )
 
-        # Import traces first to build trace_id_map
-        trace_id_map, traces_stats = _import_traces_from_projects_directory(
-            client, workspace_root, dry_run, debug, manifest=manifest
+        # Import the project's traces first to build trace_id_map
+        trace_id_map, traces_stats = _import_traces_for_project(
+            client, project_root, project_name, dry_run, debug, manifest=manifest
         )
 
         if not trace_id_map and not dry_run:
             console.print(
                 "[yellow]Warning: No traces were imported. Experiment items may be skipped if they reference traces.[/yellow]"
             )
-            # Try to diagnose why traces weren't imported
-            projects_dir = workspace_root / "projects"
-            if projects_dir.exists():
-                project_dirs = [d for d in projects_dir.iterdir() if d.is_dir()]
-                debug_print(
-                    f"Found {len(project_dirs)} project directory(ies): {[d.name for d in project_dirs]}",
-                    debug,
-                )
-                for project_dir in project_dirs:
-                    trace_files = list(project_dir.glob("trace_*.json"))
-                    debug_print(
-                        f"Project '{project_dir.name}' has {len(trace_files)} trace file(s)",
-                        debug,
-                    )
-            else:
-                debug_print(
-                    f"Projects directory not found at {projects_dir}",
-                    debug,
-                )
         elif trace_id_map:
             debug_print(
                 f"Built trace ID mapping with {len(trace_id_map)} trace(s)",
@@ -1193,21 +1163,6 @@ def import_experiments_from_directory(
             debug_print(
                 f"Sample original trace IDs in map: {sample_original_ids}", debug
             )
-
-        # Build a map of trace_id -> project_name from trace filenames for project inference.
-        # The original trace ID is encoded in the filename (trace_{id}.json), so there is
-        # no need to open the files.
-        trace_to_project_map: Dict[str, str] = {}
-        projects_dir = workspace_root / "projects"
-        if projects_dir.exists():
-            for project_dir in projects_dir.iterdir():
-                if not project_dir.is_dir():
-                    continue
-                project_name = project_dir.name
-                for trace_file in project_dir.glob("trace_*.json"):
-                    original_trace_id = extract_trace_id_from_filename(trace_file)
-                    if original_trace_id:
-                        trace_to_project_map[original_trace_id] = project_name
 
         imported_count = 0
         skipped_count = 0
@@ -1281,39 +1236,13 @@ def import_experiments_from_directory(
 
                 debug_print(f"Importing experiment: {experiment_name}", debug)
 
-                # Determine project name: try metadata first, then infer from trace files
-                project_for_logs = (experiment_info.get("metadata") or {}).get(
-                    "project_name"
-                )
-
-                # If no project in metadata, try to infer from trace files
-                if not project_for_logs and trace_to_project_map:
-                    items_data = experiment_data.items
-                    # Find the first trace_id in items and use its project
-                    for item_data in items_data:
-                        trace_id = handle_trace_reference(item_data)
-                        if trace_id and trace_id in trace_to_project_map:
-                            project_for_logs = trace_to_project_map[trace_id]
-                            debug_print(
-                                f"Inferred project name '{project_for_logs}' from trace files",
-                                debug,
-                            )
-                            break
-
-                # Default to "default" if still not found
-                if not project_for_logs:
-                    project_for_logs = "default"
-                    debug_print(
-                        "Using default project name (no project found in metadata or trace files)",
-                        debug,
-                    )
-
+                # The experiment is created in the project named on the command line.
                 # Use trace_id_map and dataset_item_id_map to translate IDs (empty dicts if None)
                 # Note: dataset_item_id_map is already a dict (not None) from _build_dataset_item_id_map
                 success = recreate_experiment(
                     client,
                     experiment_data,
-                    project_for_logs,
+                    project_name,
                     trace_id_map or {},
                     dataset_item_id_map,
                     dry_run,

--- a/sdks/python/src/opik/cli/imports/experiment.py
+++ b/sdks/python/src/opik/cli/imports/experiment.py
@@ -760,7 +760,7 @@ def recreate_experiments(
     dataset_item_id_map: Optional[Dict[str, str]] = None,
     debug: bool = False,
     manifest: Optional[MigrationManifest] = None,
-) -> int:
+) -> tuple[int, int]:
     """Recreate experiments from JSON files.
 
     Args:
@@ -769,12 +769,15 @@ def recreate_experiments(
         dataset_item_id_map: Mapping from original dataset_item_id to new dataset_item_id.
                             If None, will be treated as empty dict (all items will be skipped).
         manifest: Optional migration manifest for resumable imports.
+
+    Returns:
+        Tuple of ``(successful, failed)`` experiment counts.
     """
     experiment_files = find_experiment_files(project_dir)
 
     if not experiment_files:
         console.print(f"[yellow]No experiment files found in {project_dir}[/yellow]")
-        return 0
+        return 0, 0
 
     console.print(f"[green]Found {len(experiment_files)} experiment files[/green]")
 
@@ -799,7 +802,7 @@ def recreate_experiments(
             console.print(
                 f"[yellow]No experiments found matching pattern '{name_pattern}'[/yellow]"
             )
-            return 0
+            return 0, 0
 
     successful = 0
     failed = 0
@@ -843,7 +846,7 @@ def recreate_experiments(
             failed += 1
             continue
 
-    return successful
+    return successful, failed
 
 
 def _import_traces_for_project(

--- a/sdks/python/src/opik/cli/imports/project.py
+++ b/sdks/python/src/opik/cli/imports/project.py
@@ -14,7 +14,6 @@ from .._attachment_path import safe_attachment_path
 from ..migration_manifest import MigrationManifest
 from .experiment import recreate_experiments
 from .utils import (
-    matches_name_pattern,
     clean_feedback_scores,
     clean_usage_for_import,
     sort_spans_topologically,
@@ -102,9 +101,10 @@ def _upload_attachments_for_trace(
         )
 
 
-def import_projects_from_directory(
+def import_traces_from_directory(
     client: opik.Opik,
-    source_dir: Path,
+    project_dir: Path,
+    project_name: str,
     dry_run: bool,
     name_pattern: Optional[str],
     debug: bool,
@@ -112,285 +112,254 @@ def import_projects_from_directory(
     manifest: Optional[MigrationManifest] = None,
     include_attachments: bool = True,
 ) -> Dict[str, int]:
-    """Import projects from a directory.
+    """Import the project's traces (and optionally experiments) from ``project_dir``.
+
+    Trace files live directly in ``project_dir`` (``trace_*.json``); experiment
+    files, when recreated, live in ``project_dir/experiments``. Everything is
+    created in ``project_name``.
 
     Returns:
         Dictionary with keys: 'projects', 'projects_skipped', 'projects_errors', 'traces', 'traces_errors'
     """
     try:
-        project_dirs = [d for d in source_dir.iterdir() if d.is_dir()]
+        trace_files = list(project_dir.glob("trace_*.json"))
 
-        if not project_dirs:
-            console.print("[yellow]No project directories found[/yellow]")
+        if not trace_files and not dry_run:
+            console.print(f"[yellow]No trace files found in {project_dir}[/yellow]")
+
+        traces_imported = 0
+        traces_errors = 0
+
+        if dry_run:
+            console.print(
+                f"[blue]Would import {len(trace_files)} trace(s) into project "
+                f"'{project_name}'[/blue]"
+            )
             return {
-                "projects": 0,
+                "projects": 1 if trace_files else 0,
                 "projects_skipped": 0,
                 "projects_errors": 0,
-                "traces": 0,
+                "traces": len(trace_files),
                 "traces_errors": 0,
             }
 
-        imported_count = 0
-        skipped_count = 0
-        error_count = 0
-        total_traces_imported = 0
-        total_traces_errors = 0
+        debug_print(f"Importing traces into project: {project_name}", debug)
 
         # Seed trace_id_map from the manifest so experiments can cross-reference
         # traces that were imported in a previous (interrupted) run.
         trace_id_map: Dict[str, str] = manifest.get_trace_id_map() if manifest else {}
 
-        for project_dir in project_dirs:
-            try:
-                project_name = project_dir.name
+        # Per-project span ID map (only needed during this import session,
+        # not persisted — span IDs are not referenced across files).
+        span_id_map: Dict[str, str] = {}
 
-                # Filter by name pattern if specified
-                if name_pattern and not matches_name_pattern(
-                    project_name, name_pattern
-                ):
+        for trace_file in trace_files:
+            try:
+                # Skip trace files already imported in a previous run
+                if manifest and manifest.is_file_completed(trace_file):
                     debug_print(
-                        f"Skipping project {project_name} (doesn't match pattern)",
+                        f"Skipping {trace_file.name} (already imported in a previous run)",
                         debug,
                     )
-                    skipped_count += 1
+                    traces_imported += 1
                     continue
 
-                if dry_run:
-                    console.print(f"[blue]Would import project: {project_name}[/blue]")
-                    imported_count += 1
-                    continue
+                with open(trace_file, "r", encoding="utf-8") as f:
+                    trace_data = json.load(f)
 
-                debug_print(f"Importing project: {project_name}", debug)
+                # Import trace and spans
+                trace_info = trace_data.get("trace", {})
+                spans_info = trace_data.get("spans", [])
+                original_trace_id = trace_info.get("id")
 
-                # Per-project span ID map (only needed during this import session,
-                # not persisted — span IDs are not referenced across files).
-                span_id_map: Dict[str, str] = {}
+                # Clean feedback scores to remove read-only fields
+                feedback_scores = clean_feedback_scores(
+                    trace_info.get("feedback_scores")
+                )
 
-                trace_files = list(project_dir.glob("trace_*.json"))
-                traces_imported = 0
-                traces_errors = 0
+                original_start_time = (
+                    datetime.fromisoformat(
+                        trace_info["start_time"].replace("Z", "+00:00")
+                    )
+                    if trace_info.get("start_time")
+                    else None
+                )
 
-                for trace_file in trace_files:
-                    try:
-                        # Skip trace files already imported in a previous run
-                        if manifest and manifest.is_file_completed(trace_file):
-                            debug_print(
-                                f"Skipping {trace_file.name} (already imported in a previous run)",
-                                debug,
-                            )
-                            traces_imported += 1
-                            continue
-
-                        with open(trace_file, "r", encoding="utf-8") as f:
-                            trace_data = json.load(f)
-
-                        # Import trace and spans
-                        trace_info = trace_data.get("trace", {})
-                        spans_info = trace_data.get("spans", [])
-                        original_trace_id = trace_info.get("id")
-
-                        # Clean feedback scores to remove read-only fields
-                        feedback_scores = clean_feedback_scores(
-                            trace_info.get("feedback_scores")
+                trace = client.trace(
+                    id=id_helpers.generate_id(timestamp=original_start_time),
+                    name=trace_info.get("name", "imported_trace"),
+                    start_time=original_start_time,
+                    end_time=(
+                        datetime.fromisoformat(
+                            trace_info["end_time"].replace("Z", "+00:00")
                         )
+                        if trace_info.get("end_time")
+                        else None
+                    ),
+                    input=trace_info.get("input", {}),
+                    output=trace_info.get("output", {}),
+                    metadata=build_import_metadata(
+                        trace_info,
+                        _TRACE_IMPORT_FIELDS,
+                        trace_info.get("metadata"),
+                    ),
+                    tags=trace_info.get("tags"),
+                    feedback_scores=feedback_scores,
+                    error_info=trace_info.get("error_info"),
+                    thread_id=trace_info.get("thread_id"),
+                    project_name=project_name,
+                )
 
-                        original_start_time = (
+                if original_trace_id:
+                    trace_id_map[original_trace_id] = trace.id
+                    # Persist the mapping so it survives if we are interrupted
+                    # before completing all files.
+                    if manifest:
+                        manifest.add_trace_mapping(original_trace_id, trace.id)
+
+                # Create spans with full data, preserving parent-child relationships.
+                # Sort spans topologically to ensure parents are processed before children
+                # so that multi-level hierarchies are handled correctly.
+                sorted_spans = sort_spans_topologically(spans_info)
+
+                for span_info in sorted_spans:
+                    # Clean feedback scores to remove read-only fields
+                    span_feedback_scores = clean_feedback_scores(
+                        span_info.get("feedback_scores")
+                    )
+
+                    original_span_id = span_info.get("id")
+                    # Translate parent_span_id to the new ID if it was already created
+                    original_parent_span_id = span_info.get("parent_span_id")
+
+                    new_parent_span_id = None
+                    if (
+                        original_parent_span_id
+                        and original_parent_span_id in span_id_map
+                    ):
+                        new_parent_span_id = span_id_map[original_parent_span_id]
+
+                    # Create span with parent_span_id if available
+                    # Clean usage data to avoid double-prefixing of original_usage keys
+                    usage_data = clean_usage_for_import(span_info.get("usage"))
+
+                    span = client.span(
+                        name=span_info.get("name", "imported_span"),
+                        type=span_info.get("type", "general"),
+                        start_time=(
                             datetime.fromisoformat(
-                                trace_info["start_time"].replace("Z", "+00:00")
+                                span_info["start_time"].replace("Z", "+00:00")
                             )
-                            if trace_info.get("start_time")
+                            if span_info.get("start_time")
                             else None
-                        )
+                        ),
+                        end_time=(
+                            datetime.fromisoformat(
+                                span_info["end_time"].replace("Z", "+00:00")
+                            )
+                            if span_info.get("end_time")
+                            else None
+                        ),
+                        input=span_info.get("input", {}),
+                        output=span_info.get("output", {}),
+                        metadata=build_import_metadata(
+                            span_info,
+                            _SPAN_IMPORT_FIELDS,
+                            span_info.get("metadata"),
+                        ),
+                        tags=span_info.get("tags"),
+                        usage=usage_data,
+                        feedback_scores=span_feedback_scores,
+                        model=span_info.get("model"),
+                        provider=span_info.get("provider"),
+                        error_info=span_info.get("error_info"),
+                        total_cost=span_info.get("total_cost"),
+                        trace_id=trace.id,
+                        parent_span_id=new_parent_span_id,
+                        project_name=project_name,
+                    )
 
-                        trace = client.trace(
-                            id=id_helpers.generate_id(timestamp=original_start_time),
-                            name=trace_info.get("name", "imported_trace"),
-                            start_time=original_start_time,
-                            end_time=(
-                                datetime.fromisoformat(
-                                    trace_info["end_time"].replace("Z", "+00:00")
-                                )
-                                if trace_info.get("end_time")
-                                else None
-                            ),
-                            input=trace_info.get("input", {}),
-                            output=trace_info.get("output", {}),
-                            metadata=build_import_metadata(
-                                trace_info,
-                                _TRACE_IMPORT_FIELDS,
-                                trace_info.get("metadata"),
-                            ),
-                            tags=trace_info.get("tags"),
-                            feedback_scores=feedback_scores,
-                            error_info=trace_info.get("error_info"),
-                            thread_id=trace_info.get("thread_id"),
+                    # Map original span ID to new span ID for parent relationship mapping
+                    if original_span_id and span.id:
+                        span_id_map[original_span_id] = span.id
+
+                # Queue attachment uploads while span_id_map is still
+                # populated. Uploads run in the background via the
+                # streamer (retries + parallelism); flush() is called
+                # after all traces for this project are processed.
+                if include_attachments and not dry_run:
+                    attachments = trace_data.get("attachments", [])
+                    if attachments:
+                        _upload_attachments_for_trace(
+                            client=client,
+                            project_dir=project_dir,
+                            attachments=attachments,
+                            new_trace_id=trace.id,
+                            span_id_map=span_id_map,
                             project_name=project_name,
                         )
 
-                        if original_trace_id:
-                            trace_id_map[original_trace_id] = trace.id
-                            # Persist the mapping so it survives if we are interrupted
-                            # before completing all files.
-                            if manifest:
-                                manifest.add_trace_mapping(original_trace_id, trace.id)
+                traces_imported += 1
 
-                        # Create spans with full data, preserving parent-child relationships.
-                        # Sort spans topologically to ensure parents are processed before children
-                        # so that multi-level hierarchies are handled correctly.
-                        sorted_spans = sort_spans_topologically(spans_info)
-
-                        for span_info in sorted_spans:
-                            # Clean feedback scores to remove read-only fields
-                            span_feedback_scores = clean_feedback_scores(
-                                span_info.get("feedback_scores")
-                            )
-
-                            original_span_id = span_info.get("id")
-                            # Translate parent_span_id to the new ID if it was already created
-                            original_parent_span_id = span_info.get("parent_span_id")
-
-                            new_parent_span_id = None
-                            if (
-                                original_parent_span_id
-                                and original_parent_span_id in span_id_map
-                            ):
-                                new_parent_span_id = span_id_map[
-                                    original_parent_span_id
-                                ]
-
-                            # Create span with parent_span_id if available
-                            # Clean usage data to avoid double-prefixing of original_usage keys
-                            usage_data = clean_usage_for_import(span_info.get("usage"))
-
-                            span = client.span(
-                                name=span_info.get("name", "imported_span"),
-                                type=span_info.get("type", "general"),
-                                start_time=(
-                                    datetime.fromisoformat(
-                                        span_info["start_time"].replace("Z", "+00:00")
-                                    )
-                                    if span_info.get("start_time")
-                                    else None
-                                ),
-                                end_time=(
-                                    datetime.fromisoformat(
-                                        span_info["end_time"].replace("Z", "+00:00")
-                                    )
-                                    if span_info.get("end_time")
-                                    else None
-                                ),
-                                input=span_info.get("input", {}),
-                                output=span_info.get("output", {}),
-                                metadata=build_import_metadata(
-                                    span_info,
-                                    _SPAN_IMPORT_FIELDS,
-                                    span_info.get("metadata"),
-                                ),
-                                tags=span_info.get("tags"),
-                                usage=usage_data,
-                                feedback_scores=span_feedback_scores,
-                                model=span_info.get("model"),
-                                provider=span_info.get("provider"),
-                                error_info=span_info.get("error_info"),
-                                total_cost=span_info.get("total_cost"),
-                                trace_id=trace.id,
-                                parent_span_id=new_parent_span_id,
-                                project_name=project_name,
-                            )
-
-                            # Map original span ID to new span ID for parent relationship mapping
-                            if original_span_id and span.id:
-                                span_id_map[original_span_id] = span.id
-
-                        # Queue attachment uploads while span_id_map is still
-                        # populated. Uploads run in the background via the
-                        # streamer (retries + parallelism); flush() is called
-                        # after all traces for this project are processed.
-                        if include_attachments and not dry_run:
-                            attachments = trace_data.get("attachments", [])
-                            if attachments:
-                                _upload_attachments_for_trace(
-                                    client=client,
-                                    project_dir=project_dir,
-                                    attachments=attachments,
-                                    new_trace_id=trace.id,
-                                    span_id_map=span_id_map,
-                                    project_name=project_name,
-                                )
-
-                        traces_imported += 1
-
-                        # Mark file as completed and flush trace mapping to disk
-                        if manifest:
-                            manifest.mark_file_completed(trace_file)
-
-                    except Exception as e:
-                        console.print(
-                            f"[red]Error importing trace from {trace_file}: {e}[/red]"
-                        )
-                        if manifest:
-                            manifest.mark_file_failed(trace_file, str(e))
-                        traces_errors += 1
-                        continue
-
-                # Flush queued attachment uploads (and any other streamed messages)
-                # before proceeding so all data is persisted before we move on.
-                client.flush()
-
-                # Handle experiment recreation if requested
-                if recreate_experiments_flag:
-                    experiment_files = list(project_dir.glob("experiment_*.json"))
-                    if experiment_files:
-                        debug_print(
-                            f"Found {len(experiment_files)} experiment files in project {project_name}",
-                            debug,
-                        )
-
-                        experiments_recreated = recreate_experiments(
-                            client,
-                            project_dir,
-                            project_name,
-                            dry_run,
-                            name_pattern,
-                            trace_id_map,
-                            None,  # dataset_item_id_map - not available in project import context
-                            debug,
-                            manifest=manifest,
-                        )
-
-                        if experiments_recreated > 0:
-                            debug_print(
-                                f"Recreated {experiments_recreated} experiments for project {project_name}",
-                                debug,
-                            )
-
-                total_traces_imported += traces_imported
-                total_traces_errors += traces_errors
-
-                if traces_imported > 0:
-                    imported_count += 1
-                    debug_print(
-                        f"Imported project: {project_name} with {traces_imported} traces",
-                        debug,
-                    )
+                # Mark file as completed and flush trace mapping to disk
+                if manifest:
+                    manifest.mark_file_completed(trace_file)
 
             except Exception as e:
                 console.print(
-                    f"[red]Error importing project {project_dir.name}: {e}[/red]"
+                    f"[red]Error importing trace from {trace_file}: {e}[/red]"
                 )
-                error_count += 1
+                if manifest:
+                    manifest.mark_file_failed(trace_file, str(e))
+                traces_errors += 1
                 continue
 
+        # Flush queued attachment uploads (and any other streamed messages)
+        # before proceeding so all data is persisted before we move on.
+        client.flush()
+
+        # Handle experiment recreation if requested
+        if recreate_experiments_flag:
+            experiments_dir = project_dir / "experiments"
+            experiment_files = (
+                list(experiments_dir.glob("experiment_*.json"))
+                if experiments_dir.exists()
+                else []
+            )
+            if experiment_files:
+                debug_print(
+                    f"Found {len(experiment_files)} experiment files in project {project_name}",
+                    debug,
+                )
+
+                experiments_recreated = recreate_experiments(
+                    client,
+                    experiments_dir,
+                    project_name,
+                    dry_run,
+                    name_pattern,
+                    trace_id_map,
+                    None,  # dataset_item_id_map - not available in traces import context
+                    debug,
+                    manifest=manifest,
+                )
+
+                if experiments_recreated > 0:
+                    debug_print(
+                        f"Recreated {experiments_recreated} experiments for project {project_name}",
+                        debug,
+                    )
+
         return {
-            "projects": imported_count,
-            "projects_skipped": skipped_count,
-            "projects_errors": error_count,
-            "traces": total_traces_imported,
-            "traces_errors": total_traces_errors,
+            "projects": 1 if traces_imported > 0 else 0,
+            "projects_skipped": 0,
+            "projects_errors": 0,
+            "traces": traces_imported,
+            "traces_errors": traces_errors,
         }
 
     except Exception as e:
-        console.print(f"[red]Error importing projects: {e}[/red]")
+        console.print(f"[red]Error importing traces: {e}[/red]")
         return {
             "projects": 0,
             "projects_skipped": 0,

--- a/sdks/python/src/opik/cli/imports/project.py
+++ b/sdks/python/src/opik/cli/imports/project.py
@@ -319,6 +319,8 @@ def import_traces_from_directory(
         client.flush()
 
         # Handle experiment recreation if requested
+        experiments_recreated = 0
+        experiments_failed = 0
         if recreate_experiments_flag:
             experiments_dir = project_dir / "experiments"
             experiment_files = (
@@ -332,7 +334,7 @@ def import_traces_from_directory(
                     debug,
                 )
 
-                experiments_recreated = recreate_experiments(
+                experiments_recreated, experiments_failed = recreate_experiments(
                     client,
                     experiments_dir,
                     project_name,
@@ -356,6 +358,10 @@ def import_traces_from_directory(
             "projects_errors": 0,
             "traces": traces_imported,
             "traces_errors": traces_errors,
+            # Surface recreated-experiment failures so callers (and the CLI exit
+            # code) don't treat a partial traces import as a clean success.
+            "experiments": experiments_recreated,
+            "experiments_errors": experiments_failed,
         }
 
     except Exception as e:

--- a/sdks/python/src/opik/cli/imports/prompt.py
+++ b/sdks/python/src/opik/cli/imports/prompt.py
@@ -18,12 +18,13 @@ console = Console()
 def import_prompts_from_directory(
     client: opik.Opik,
     source_dir: Path,
+    project_name: str,
     dry_run: bool,
     name_pattern: Optional[str],
     debug: bool,
     manifest: Optional[MigrationManifest] = None,
 ) -> Dict[str, int]:
-    """Import prompts from a directory.
+    """Import prompts from a directory into the given project.
 
     Returns:
         Dictionary with keys: 'prompts', 'prompts_skipped', 'prompts_errors'
@@ -140,6 +141,7 @@ def import_prompts_from_directory(
                             messages=prompt_content,
                             metadata=metadata,
                             type=prompt_type_enum,
+                            project_name=project_name,
                         )
                         if debug:
                             console.print(
@@ -160,6 +162,7 @@ def import_prompts_from_directory(
                             prompt=prompt_content,
                             metadata=metadata,
                             type=prompt_type_enum,
+                            project_name=project_name,
                         )
                         if debug:
                             console.print(

--- a/sdks/python/src/opik/cli/imports/prompt.py
+++ b/sdks/python/src/opik/cli/imports/prompt.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import opik
-from opik.api_objects.prompt import Prompt, ChatPrompt
 from opik.api_objects.prompt.types import PromptType
 from rich.console import Console
 
@@ -135,8 +134,10 @@ def import_prompts_from_directory(
                             skipped_count += 1
                             continue
 
-                        # Create ChatPrompt
-                        ChatPrompt(
+                        # Use the client factory (the opik.ChatPrompt()
+                        # constructor is deprecated) so the prompt lands in the
+                        # target project without a per-prompt deprecation warning.
+                        client.create_chat_prompt(
                             name=prompt_name,
                             messages=prompt_content,
                             metadata=metadata,
@@ -156,8 +157,9 @@ def import_prompts_from_directory(
                             skipped_count += 1
                             continue
 
-                        # Create Prompt
-                        Prompt(
+                        # Use the client factory (the opik.Prompt() constructor
+                        # is deprecated).
+                        client.create_prompt(
                             name=prompt_name,
                             prompt=prompt_content,
                             metadata=metadata,

--- a/sdks/python/src/opik/cli/imports/utils.py
+++ b/sdks/python/src/opik/cli/imports/utils.py
@@ -4,13 +4,16 @@ import json
 import sys
 from collections import deque
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 import click
 import opik
 from opik.types import FeedbackScoreDict
 from rich.console import Console
 from rich.table import Table
+
+if TYPE_CHECKING:
+    from ..migration_manifest import MigrationManifest
 
 PROJECT_METADATA_FILENAME = "project.json"
 
@@ -133,6 +136,52 @@ def resolve_import_project_root(
         )
         sys.exit(1)
     return project_root, (to_project or project_name)
+
+
+def finalize_import(
+    manifest: Optional["MigrationManifest"],
+    client: opik.Opik,
+    total_errors: int,
+    dry_run: bool,
+) -> None:
+    """Flush ingestion, surface upload failures, and complete the manifest.
+
+    Shared tail of ``import_all`` and ``_import_by_type`` so resume/manifest
+    tweaks stay in one place. No-op on dry runs. Exits with code 1 if the flush
+    times out or any file upload failed. Marks the manifest complete only when
+    ``total_errors == 0``, so a partial failure leaves it ``in_progress`` for a
+    resumable rerun.
+    """
+    if dry_run:
+        return
+
+    # Flush the async ingestion queue so all enqueued traces/spans are persisted
+    # before we return; otherwise the process can exit while the background
+    # worker is still sending data (especially under rate-limiting).
+    flushed = client.flush()
+    if not flushed:
+        console.print(
+            "[yellow]Warning: flush timed out — some traces/spans may not have been "
+            "ingested. Re-run the import to retry.[/yellow]"
+        )
+        sys.exit(1)
+
+    # FileUploadManager.flush() returns True even when individual uploads fail
+    # (only False on timeout), so check failed_uploads separately.
+    failed = client.__internal_api__failed_uploads__(timeout=None)
+    if failed > 0:
+        console.print(
+            f"[yellow]Warning: {failed} file upload(s) failed during import. "
+            "Re-run the import to retry.[/yellow]"
+        )
+        sys.exit(1)
+
+    # Mark complete only on a fully clean run. On any error, leave it in_progress
+    # so the next run (without --force) resumes/retries instead of
+    # short-circuiting on manifest.is_completed.
+    assert manifest is not None  # guaranteed: manifest is set whenever not dry_run
+    if total_errors == 0:
+        manifest.complete()
 
 
 def debug_print(message: str, debug: bool) -> None:

--- a/sdks/python/src/opik/cli/imports/utils.py
+++ b/sdks/python/src/opik/cli/imports/utils.py
@@ -1,6 +1,8 @@
 """Common utilities for import functionality."""
 
+import json
 from collections import deque
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 import click
@@ -8,6 +10,8 @@ import opik
 from opik.types import FeedbackScoreDict
 from rich.console import Console
 from rich.table import Table
+
+PROJECT_METADATA_FILENAME = "project.json"
 
 
 def no_attachments_option() -> Callable:
@@ -19,7 +23,63 @@ def no_attachments_option() -> Callable:
     )
 
 
+def to_project_option() -> Callable:
+    """Shared Click decorator for the ``--to-project`` flag.
+
+    Overrides the destination project. When omitted, data is imported into a
+    project named after the source (the name recorded in ``project.json``).
+    """
+    return click.option(
+        "--to-project",
+        "to_project",
+        type=str,
+        default=None,
+        help="Create the imported data in this project instead of the source project's name.",
+    )
+
+
 console = Console()
+
+
+def _read_project_metadata_name(project_dir: Path) -> Optional[str]:
+    """Return the recorded project name from ``<project_dir>/project.json``."""
+    meta = project_dir / PROJECT_METADATA_FILENAME
+    if not meta.exists():
+        return None
+    try:
+        return json.loads(meta.read_text(encoding="utf-8")).get("name")
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def find_project_export_dir(base_path: Path, project_name: str) -> Optional[Path]:
+    """Locate the exported project folder whose ``project.json`` name matches.
+
+    The on-disk layout keys folders by project ID; the human name lives in
+    ``project.json``. This resolves a user-supplied project *name* back to its
+    id-named directory under ``base_path/projects/``. Returns ``None`` if no
+    folder records that name.
+    """
+    projects_dir = base_path / "projects"
+    if not projects_dir.is_dir():
+        return None
+    for child in sorted(projects_dir.iterdir()):
+        if child.is_dir() and _read_project_metadata_name(child) == project_name:
+            return child
+    return None
+
+
+def available_project_names(base_path: Path) -> List[str]:
+    """List the project names recorded under ``base_path/projects/*/project.json``."""
+    projects_dir = base_path / "projects"
+    if not projects_dir.is_dir():
+        return []
+    names = [
+        name
+        for child in sorted(projects_dir.iterdir())
+        if child.is_dir() and (name := _read_project_metadata_name(child)) is not None
+    ]
+    return names
 
 
 def debug_print(message: str, debug: bool) -> None:

--- a/sdks/python/src/opik/cli/imports/utils.py
+++ b/sdks/python/src/opik/cli/imports/utils.py
@@ -41,6 +41,22 @@ def to_project_option() -> Callable:
 console = Console()
 
 
+def resolve_import_base_path(path: str, workspace: str) -> Path:
+    """Resolve the directory that contains ``projects/`` for import.
+
+    Prefers ``<path>/<workspace>/`` — symmetric with the export layout
+    (``<path>/<workspace>/projects/<id>/``), so the same ``--path`` round-trips
+    within a workspace. Falls back to ``<path>/`` when the workspace segment is
+    absent, which is the cross-workspace case: when importing into a different
+    workspace than the data was exported from, point ``--path`` at the exported
+    workspace directory and the project folders are found directly under it.
+    """
+    workspace_scoped = Path(path) / workspace
+    if (workspace_scoped / "projects").is_dir():
+        return workspace_scoped
+    return Path(path)
+
+
 def _read_project_metadata_name(project_dir: Path) -> Optional[str]:
     """Return the recorded project name from ``<project_dir>/project.json``."""
     meta = project_dir / PROJECT_METADATA_FILENAME

--- a/sdks/python/src/opik/cli/imports/utils.py
+++ b/sdks/python/src/opik/cli/imports/utils.py
@@ -1,5 +1,6 @@
 """Common utilities for import functionality."""
 
+import hashlib
 import json
 import sys
 from collections import deque
@@ -92,10 +93,22 @@ def find_project_export_dir(base_path: Path, project_name: str) -> Optional[Path
     projects_dir = base_path / "projects"
     if not projects_dir.is_dir():
         return None
-    for child in sorted(projects_dir.iterdir()):
-        if child.is_dir() and _read_project_metadata_name(child) == project_name:
-            return child
-    return None
+    matches = [
+        child
+        for child in sorted(projects_dir.iterdir())
+        if child.is_dir() and _read_project_metadata_name(child) == project_name
+    ]
+    if not matches:
+        return None
+    if len(matches) > 1:
+        # Ambiguous: e.g. a project renamed and re-exported, or the name reused
+        # across folders. Surface it rather than silently picking by sort order.
+        console.print(
+            f"[yellow]Warning: {len(matches)} exported folders record project "
+            f"name '{project_name}' ({', '.join(m.name for m in matches)}); "
+            f"using '{matches[0].name}'.[/yellow]"
+        )
+    return matches[0]
 
 
 def available_project_names(base_path: Path) -> List[str]:
@@ -136,6 +149,24 @@ def resolve_import_project_root(
         )
         sys.exit(1)
     return project_root, (to_project or project_name)
+
+
+def destination_manifest_dir(project_root: Path, destination_project_name: str) -> Path:
+    """Return the per-destination import-manifest directory under the source folder.
+
+    The resume/completion manifest must be keyed by the *destination* project, not
+    just the source folder: importing the same exported project into different
+    ``--to-project`` targets must keep independent state (each destination gets its
+    own newly-created trace ids and completion status). Without this, a clean
+    import into A would make a later import into B short-circuit on
+    ``manifest.is_completed`` (and a partially-failed import into A would resume
+    into B, splitting one project's data across two destinations).
+
+    Destination names may contain ``/``, ``:`` or whitespace, so the directory is
+    keyed by a short hash of the name rather than the name itself.
+    """
+    dest_key = hashlib.sha256(destination_project_name.encode("utf-8")).hexdigest()[:16]
+    return project_root / "import_manifests" / dest_key
 
 
 def finalize_import(

--- a/sdks/python/src/opik/cli/imports/utils.py
+++ b/sdks/python/src/opik/cli/imports/utils.py
@@ -5,7 +5,7 @@ import json
 import sys
 from collections import deque
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import click
 import opik
@@ -13,8 +13,7 @@ from opik.types import FeedbackScoreDict
 from rich.console import Console
 from rich.table import Table
 
-if TYPE_CHECKING:
-    from ..migration_manifest import MigrationManifest
+from ..migration_manifest import MANIFEST_FILENAME, MigrationManifest
 
 PROJECT_METADATA_FILENAME = "project.json"
 
@@ -169,8 +168,54 @@ def destination_manifest_dir(project_root: Path, destination_project_name: str) 
     return project_root / "import_manifests" / dest_key
 
 
+def setup_import_manifest(
+    project_root: Path,
+    destination_project_name: str,
+    dry_run: bool,
+    force: bool,
+) -> Tuple[Optional[MigrationManifest], bool]:
+    """Construct and initialize the per-destination import manifest.
+
+    Shared by ``import_all`` and ``_import_by_type`` so the start/resume/force
+    lifecycle stays in one place. The manifest's ``base_path`` is ``project_root``
+    (so file keys under ``project_root/datasets`` etc. resolve), while the SQLite
+    file lives in the per-destination subdir from :func:`destination_manifest_dir`.
+
+    Returns ``(manifest, already_completed)``. ``manifest`` is ``None`` for dry
+    runs. When ``already_completed`` is ``True`` (a prior run finished and
+    ``--force`` was not given), the caller should return without re-importing.
+    """
+    if dry_run:
+        return None, False
+
+    manifest_file = (
+        destination_manifest_dir(project_root, destination_project_name)
+        / MANIFEST_FILENAME
+    )
+    manifest = MigrationManifest(project_root, manifest_path=manifest_file)
+    if force:
+        if MigrationManifest.exists(project_root, manifest_path=manifest_file):
+            manifest.reset()
+            console.print(
+                "[yellow]--force: discarding existing manifest, starting fresh[/yellow]"
+            )
+    else:
+        if manifest.is_completed:
+            console.print(
+                "[green]Import already completed. Use --force to re-import.[/green]"
+            )
+            return manifest, True
+        elif manifest.is_in_progress:
+            console.print(
+                f"[blue]Resuming interrupted import: "
+                f"{manifest.completed_count()} file(s) already completed[/blue]"
+            )
+    manifest.start()
+    return manifest, False
+
+
 def finalize_import(
-    manifest: Optional["MigrationManifest"],
+    manifest: Optional[MigrationManifest],
     client: opik.Opik,
     total_errors: int,
     dry_run: bool,

--- a/sdks/python/src/opik/cli/imports/utils.py
+++ b/sdks/python/src/opik/cli/imports/utils.py
@@ -1,9 +1,10 @@
 """Common utilities for import functionality."""
 
 import json
+import sys
 from collections import deque
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import click
 import opik
@@ -58,14 +59,23 @@ def resolve_import_base_path(path: str, workspace: str) -> Path:
 
 
 def _read_project_metadata_name(project_dir: Path) -> Optional[str]:
-    """Return the recorded project name from ``<project_dir>/project.json``."""
+    """Return the recorded project name from ``<project_dir>/project.json``.
+
+    Returns ``None`` for a missing/unreadable/malformed file, a non-object JSON
+    body, or a non-string ``name`` — so a corrupt ``project.json`` can never
+    crash ``find_project_export_dir`` / ``available_project_names``.
+    """
     meta = project_dir / PROJECT_METADATA_FILENAME
     if not meta.exists():
         return None
     try:
-        return json.loads(meta.read_text(encoding="utf-8")).get("name")
+        data = json.loads(meta.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
+    if not isinstance(data, dict):
+        return None
+    name = data.get("name")
+    return name if isinstance(name, str) else None
 
 
 def find_project_export_dir(base_path: Path, project_name: str) -> Optional[Path]:
@@ -96,6 +106,33 @@ def available_project_names(base_path: Path) -> List[str]:
         if child.is_dir() and (name := _read_project_metadata_name(child)) is not None
     ]
     return names
+
+
+def resolve_import_project_root(
+    path: str, workspace: str, project_name: str, to_project: Optional[str] = None
+) -> Tuple[Path, str]:
+    """Locate the exported project folder and resolve the destination project.
+
+    Shared by ``import_all`` and ``_import_by_type`` so the source lookup and the
+    not-found messaging stay in sync. Returns ``(project_root, target_project_name)``
+    where ``target_project_name`` is ``to_project`` when given, else ``project_name``.
+    Prints an error and exits with code 1 when no exported project records the name.
+    """
+    base_path = resolve_import_base_path(path, workspace)
+    project_root = find_project_export_dir(base_path, project_name)
+    if project_root is None:
+        available = available_project_names(base_path)
+        hint = (
+            f" Available: {', '.join(available)}"
+            if available
+            else " No exported projects were found."
+        )
+        console.print(
+            f"[red]No exported project named '{project_name}' under "
+            f"{base_path / 'projects'}.{hint}[/red]"
+        )
+        sys.exit(1)
+    return project_root, (to_project or project_name)
 
 
 def debug_print(message: str, debug: bool) -> None:

--- a/sdks/python/src/opik/cli/imports/utils.py
+++ b/sdks/python/src/opik/cli/imports/utils.py
@@ -192,9 +192,16 @@ def setup_import_manifest(
         destination_manifest_dir(project_root, destination_project_name)
         / MANIFEST_FILENAME
     )
+    # Capture existence BEFORE constructing — the constructor creates the SQLite
+    # file, which would otherwise make the --force "existing manifest" check
+    # tautologically true (and reset/warn against a manifest that never existed)
+    # on a first run.
+    manifest_existed = MigrationManifest.exists(
+        project_root, manifest_path=manifest_file
+    )
     manifest = MigrationManifest(project_root, manifest_path=manifest_file)
     if force:
-        if MigrationManifest.exists(project_root, manifest_path=manifest_file):
+        if manifest_existed:
             manifest.reset()
             console.print(
                 "[yellow]--force: discarding existing manifest, starting fresh[/yellow]"

--- a/sdks/python/src/opik/cli/migration_manifest.py
+++ b/sdks/python/src/opik/cli/migration_manifest.py
@@ -43,7 +43,7 @@ import os
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Set
+from typing import Dict, Optional, Set
 
 LOGGER = logging.getLogger(__name__)
 
@@ -110,9 +110,22 @@ class MigrationManifest:
         Defaults to ``DEFAULT_BATCH_SIZE`` (50).
     """
 
-    def __init__(self, base_path: Path, batch_size: int = DEFAULT_BATCH_SIZE) -> None:
+    def __init__(
+        self,
+        base_path: Path,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        manifest_path: Optional[Path] = None,
+    ) -> None:
+        # base_path is the root that file keys are stored relative to (e.g. the
+        # exported project dir). manifest_path lets the SQLite file live
+        # elsewhere — e.g. a per-destination subdir — without changing how files
+        # are keyed; defaults to ``base_path/migration_manifest.db``.
         self.base_path = base_path
-        self.manifest_file = base_path / MANIFEST_FILENAME
+        self.manifest_file = (
+            manifest_path
+            if manifest_path is not None
+            else base_path / MANIFEST_FILENAME
+        )
         self._batch_size = batch_size
 
         # In-memory write buffers — flushed in one transaction per batch.
@@ -128,7 +141,7 @@ class MigrationManifest:
     # ------------------------------------------------------------------
 
     def _open(self) -> sqlite3.Connection:
-        self.base_path.mkdir(parents=True, exist_ok=True)
+        self.manifest_file.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(
             str(self.manifest_file),
             # autocommit mode — we manage every transaction explicitly with
@@ -146,8 +159,12 @@ class MigrationManifest:
         return conn
 
     @classmethod
-    def exists(cls, base_path: Path) -> bool:
-        return (base_path / MANIFEST_FILENAME).exists()
+    def exists(cls, base_path: Path, manifest_path: Optional[Path] = None) -> bool:
+        return (
+            manifest_path
+            if manifest_path is not None
+            else base_path / MANIFEST_FILENAME
+        ).exists()
 
     # ------------------------------------------------------------------
     # Status

--- a/sdks/python/tests/e2e/test_cli_import_export.py
+++ b/sdks/python/tests/e2e/test_cli_import_export.py
@@ -22,6 +22,27 @@ from ..conftest import random_chars
 from . import verifiers
 
 
+def _find_project_dir(base_dir: Path, project_name: str) -> Path:
+    """Locate the id-named export folder for a project by its recorded name.
+
+    Export folders are keyed by project id on disk; the human name lives in
+    ``project.json``. This resolves a project name back to its directory under
+    ``base_dir/default/projects/``.
+    """
+    projects = base_dir / "default" / "projects"
+    for child in sorted(projects.iterdir()):
+        meta = child / "project.json"
+        if (
+            child.is_dir()
+            and meta.exists()
+            and json.loads(meta.read_text()).get("name") == project_name
+        ):
+            return child
+    raise AssertionError(
+        f"No exported project dir for {project_name!r} under {projects}"
+    )
+
+
 class TestCLIImportExport:
     """Test CLI import/export functionality end-to-end."""
 
@@ -227,7 +248,7 @@ class TestCLIImportExport:
 
         # Check if the directory was created
         # New CLI structure: default/projects/{project_name}/ for traces
-        project_dir = test_data_dir / "default" / "projects" / source_project_name
+        project_dir = _find_project_dir(test_data_dir, source_project_name)
         assert project_dir.exists(), f"Export directory not found: {project_dir}"
 
         print(f"Export directory created: {project_dir}")
@@ -248,7 +269,7 @@ class TestCLIImportExport:
         assert trace_data["project_name"] == source_project_name
 
         # Step 3: Import traces using direct function call
-        project_dir = test_data_dir / "default" / "projects" / source_project_name
+        project_dir = _find_project_dir(test_data_dir, source_project_name)
         stats = import_traces_from_directory(
             client=opik_client,
             project_dir=project_dir,
@@ -294,7 +315,7 @@ class TestCLIImportExport:
         # Verify export files were created
         # New CLI structure: default/datasets/ for datasets
         datasets_dir = (
-            test_data_dir / "default" / "projects" / source_project_name / "datasets"
+            _find_project_dir(test_data_dir, source_project_name) / "datasets"
         )
         assert datasets_dir.exists(), f"Export directory not found: {datasets_dir}"
 
@@ -312,9 +333,7 @@ class TestCLIImportExport:
         assert "downloaded_at" in dataset_data
 
         # Step 3: Import datasets using direct function call
-        source_dir = (
-            test_data_dir / "default" / "projects" / source_project_name / "datasets"
-        )
+        source_dir = _find_project_dir(test_data_dir, source_project_name) / "datasets"
         stats = import_datasets_from_directory(
             client=opik_client,
             source_dir=source_dir,
@@ -361,9 +380,7 @@ class TestCLIImportExport:
 
         # Verify export files were created
         # New CLI structure: default/prompts/ for prompts
-        prompts_dir = (
-            test_data_dir / "default" / "projects" / source_project_name / "prompts"
-        )
+        prompts_dir = _find_project_dir(test_data_dir, source_project_name) / "prompts"
         assert prompts_dir.exists(), f"Export directory not found: {prompts_dir}"
 
         prompt_files = list(prompts_dir.glob("prompt_*.json"))
@@ -381,9 +398,7 @@ class TestCLIImportExport:
         assert "downloaded_at" in prompt_data
 
         # Step 3: Import prompts using direct function call
-        source_dir = (
-            test_data_dir / "default" / "projects" / source_project_name / "prompts"
-        )
+        source_dir = _find_project_dir(test_data_dir, source_project_name) / "prompts"
         stats = import_prompts_from_directory(
             client=opik_client,
             source_dir=source_dir,
@@ -463,13 +478,11 @@ class TestCLIImportExport:
         )
 
         # Verify export files were created
-        project_dir = test_data_dir / "default" / "projects" / source_project_name
+        project_dir = _find_project_dir(test_data_dir, source_project_name)
         datasets_dir = (
-            test_data_dir / "default" / "projects" / source_project_name / "datasets"
+            _find_project_dir(test_data_dir, source_project_name) / "datasets"
         )
-        prompts_dir = (
-            test_data_dir / "default" / "projects" / source_project_name / "prompts"
-        )
+        prompts_dir = _find_project_dir(test_data_dir, source_project_name) / "prompts"
 
         assert project_dir.exists(), f"Export directory not found: {project_dir}"
         assert datasets_dir.exists(), f"Export directory not found: {datasets_dir}"
@@ -488,7 +501,7 @@ class TestCLIImportExport:
         # Import projects (traces)
         projects_stats = import_traces_from_directory(
             client=opik_client,
-            project_dir=test_data_dir / "default" / "projects" / source_project_name,
+            project_dir=_find_project_dir(test_data_dir, source_project_name),
             project_name=source_project_name,
             dry_run=False,
             name_pattern=None,
@@ -502,10 +515,7 @@ class TestCLIImportExport:
         # Import datasets
         datasets_stats = import_datasets_from_directory(
             client=opik_client,
-            source_dir=test_data_dir
-            / "default"
-            / "projects"
-            / source_project_name
+            source_dir=_find_project_dir(test_data_dir, source_project_name)
             / "datasets",
             project_name=source_project_name,
             dry_run=False,
@@ -519,10 +529,7 @@ class TestCLIImportExport:
         # Import prompts
         prompts_stats = import_prompts_from_directory(
             client=opik_client,
-            source_dir=test_data_dir
-            / "default"
-            / "projects"
-            / source_project_name
+            source_dir=_find_project_dir(test_data_dir, source_project_name)
             / "prompts",
             project_name=source_project_name,
             dry_run=False,
@@ -553,7 +560,7 @@ class TestCLIImportExport:
         )
 
         # Verify filtered export
-        project_dir = test_data_dir / "default" / "projects" / source_project_name
+        project_dir = _find_project_dir(test_data_dir, source_project_name)
         if project_dir.exists():
             trace_files = list(project_dir.glob("trace_*.json"))
             # The exact number depends on the filter, but we should have some files
@@ -582,7 +589,7 @@ class TestCLIImportExport:
         )
 
         # Test dry run import using direct function call
-        project_dir = test_data_dir / "default" / "projects" / source_project_name
+        project_dir = _find_project_dir(test_data_dir, source_project_name)
 
         # Count traces before dry run
         traces_before = opik_client.search_traces(project_name=source_project_name)
@@ -634,7 +641,7 @@ class TestCLIImportExport:
         assert result.returncode == 0, f"CLI export failed: {result.stderr}"
 
         # Verify export worked
-        project_dir = test_data_dir / "default" / "projects" / source_project_name
+        project_dir = _find_project_dir(test_data_dir, source_project_name)
         assert project_dir.exists(), "CLI export did not create directory"
         trace_files = list(project_dir.glob("trace_*.json"))
         assert len(trace_files) >= 1, "CLI export did not create trace files"
@@ -805,27 +812,35 @@ class TestCLIImportExport:
             api_key=None,
         )
 
-        # Step 4: Verify only experiment1 was exported
+        # Step 4: Verify only experiment1 was exported. Files are named by
+        # experiment id now, so match on the name recorded inside each file.
         experiments_dir = (
-            test_data_dir / "default" / "projects" / source_project_name / "experiments"
+            _find_project_dir(test_data_dir, source_project_name) / "experiments"
         )
         assert experiments_dir.exists(), (
             f"Export directory not found: {experiments_dir}"
         )
 
-        experiment_files = list(experiments_dir.glob(f"experiment_{exp1_name}_*.json"))
-        assert len(experiment_files) == 1, (
-            f"Expected exactly 1 experiment file for {exp1_name}, found: {len(experiment_files)}"
-        )
+        exp1_files = []
+        exp2_files = []
+        for ef in experiments_dir.glob("experiment_*.json"):
+            with open(ef, "r") as f:
+                name = json.load(f).get("experiment", {}).get("name")
+            if name == exp1_name:
+                exp1_files.append(ef)
+            elif name == exp2_name:
+                exp2_files.append(ef)
 
+        assert len(exp1_files) == 1, (
+            f"Expected exactly 1 experiment file for {exp1_name}, found: {len(exp1_files)}"
+        )
         # Verify exp2 was NOT exported
-        exp2_files = list(experiments_dir.glob(f"experiment_{exp2_name}_*.json"))
         assert len(exp2_files) == 0, (
             f"Expected 0 experiment files for {exp2_name}, found: {len(exp2_files)}"
         )
 
         # Step 5: Verify the exported experiment has the correct dataset
-        with open(experiment_files[0], "r") as f:
+        with open(exp1_files[0], "r") as f:
             exp_data = json.load(f)
 
         assert exp_data["experiment"]["dataset_name"] == dataset1_name, (
@@ -863,9 +878,7 @@ class TestCLIImportExport:
         )
 
         # Verify export files were created
-        prompts_dir = (
-            test_data_dir / "default" / "projects" / source_project_name / "prompts"
-        )
+        prompts_dir = _find_project_dir(test_data_dir, source_project_name) / "prompts"
         assert prompts_dir.exists(), f"Export directory not found: {prompts_dir}"
 
         prompt_files = list(prompts_dir.glob("prompt_*.json"))
@@ -889,9 +902,7 @@ class TestCLIImportExport:
         assert current_version["template_structure"] == "chat"
 
         # Step 3: Import chat prompt using direct function call
-        source_dir = (
-            test_data_dir / "default" / "projects" / source_project_name / "prompts"
-        )
+        source_dir = _find_project_dir(test_data_dir, source_project_name) / "prompts"
         stats = import_prompts_from_directory(
             client=opik_client,
             source_dir=source_dir,
@@ -944,11 +955,11 @@ class TestCLIImportExport:
         )
 
         # Verify export files were created
-        project_dir = test_data_dir / "default" / "projects" / source_project_name
+        project_dir = _find_project_dir(test_data_dir, source_project_name)
         assert project_dir.exists(), f"Export directory not found: {project_dir}"
 
         # Step 3: Test import (experiments are automatically recreated) using direct function call
-        project_dir = test_data_dir / "default" / "projects" / source_project_name
+        project_dir = _find_project_dir(test_data_dir, source_project_name)
         stats = import_traces_from_directory(
             client=opik_client,
             project_dir=project_dir,
@@ -1066,7 +1077,7 @@ class TestCLIImportExport:
         )
 
         # Verify export was created
-        project_dir = test_data_dir / "default" / "projects" / project_name
+        project_dir = _find_project_dir(test_data_dir, project_name)
         assert project_dir.exists(), f"Export directory not found: {project_dir}"
 
         trace_files = list(project_dir.glob("trace_*.json"))

--- a/sdks/python/tests/e2e/test_cli_import_export.py
+++ b/sdks/python/tests/e2e/test_cli_import_export.py
@@ -13,9 +13,9 @@ from opik import synchronization
 from opik.api_objects.experiment.experiment_item import ExperimentItemReferences
 from opik.cli.exports.dataset import export_dataset_by_name
 from opik.cli.exports.experiment import export_experiment_by_name
-from opik.cli.exports.project import export_project_by_name
+from opik.cli.exports.project import export_project_traces
 from opik.cli.exports.prompt import export_prompt_by_name
-from opik.cli.imports.project import import_projects_from_directory
+from opik.cli.imports.project import import_traces_from_directory
 from opik.cli.imports.dataset import import_datasets_from_directory
 from opik.cli.imports.prompt import import_prompts_from_directory
 from ..conftest import random_chars
@@ -68,11 +68,11 @@ class TestCLIImportExport:
 
         return trace_ids
 
-    def _create_test_dataset(self, opik_client: opik.Opik) -> str:
-        """Create a test dataset."""
+    def _create_test_dataset(self, opik_client: opik.Opik, project_name: str) -> str:
+        """Create a test dataset in the given project."""
         dataset_name = f"cli-test-dataset-{random_chars()}"
         dataset = opik_client.create_dataset(
-            dataset_name, description="CLI test dataset"
+            dataset_name, description="CLI test dataset", project_name=project_name
         )
 
         # Insert test data
@@ -91,17 +91,20 @@ class TestCLIImportExport:
 
         return dataset_name
 
-    def _create_test_prompt(self, opik_client: opik.Opik) -> str:
-        """Create a test prompt."""
+    def _create_test_prompt(self, opik_client: opik.Opik, project_name: str) -> str:
+        """Create a test prompt in the given project."""
         prompt_name = f"cli-test-prompt-{random_chars()}"
         opik_client.create_prompt(
             name=prompt_name,
             prompt="You are a helpful assistant. Answer the following question: {question}",
+            project_name=project_name,
         )
         return prompt_name
 
-    def _create_test_chat_prompt(self, opik_client: opik.Opik) -> str:
-        """Create a test chat prompt."""
+    def _create_test_chat_prompt(
+        self, opik_client: opik.Opik, project_name: str
+    ) -> str:
+        """Create a test chat prompt in the given project."""
         prompt_name = f"cli-test-chat-prompt-{random_chars()}"
         messages = [
             {"role": "system", "content": "You are a helpful assistant."},
@@ -114,6 +117,7 @@ class TestCLIImportExport:
             name=prompt_name,
             messages=messages,
             metadata={"version": "1.0", "test": "chat_import_export"},
+            project_name=project_name,
         )
         return prompt_name
 
@@ -130,6 +134,7 @@ class TestCLIImportExport:
             dataset_name=dataset_name,
             name=experiment_name,
             experiment_config={"model": "test-model", "version": "1.0"},
+            project_name=project_name,
         )
 
         print(f"Created experiment with ID: {experiment.id}")
@@ -140,7 +145,7 @@ class TestCLIImportExport:
 
         if traces:
             # Get dataset items
-            dataset = opik_client.get_dataset(dataset_name)
+            dataset = opik_client.get_dataset(dataset_name, project_name=project_name)
             dataset_items = dataset.get_items()
             print(f"Found {len(dataset_items)} dataset items")
 
@@ -208,8 +213,8 @@ class TestCLIImportExport:
         assert len(traces) >= 1, "Expected at least 1 trace to be created"
 
         # Step 2: Export traces using direct function call
-        export_project_by_name(
-            name=source_project_name,
+        export_project_traces(
+            project_name=source_project_name,
             workspace="default",
             output_path=str(test_data_dir),
             max_results=None,
@@ -243,10 +248,11 @@ class TestCLIImportExport:
         assert trace_data["project_name"] == source_project_name
 
         # Step 3: Import traces using direct function call
-        source_dir = test_data_dir / "default" / "projects"
-        stats = import_projects_from_directory(
+        project_dir = test_data_dir / "default" / "projects" / source_project_name
+        stats = import_traces_from_directory(
             client=opik_client,
-            source_dir=source_dir,
+            project_dir=project_dir,
+            project_name=source_project_name,
             dry_run=False,
             name_pattern=None,
             debug=False,
@@ -266,7 +272,7 @@ class TestCLIImportExport:
     ) -> None:
         """Test the complete export/import flow for datasets."""
         # Step 1: Prepare test data
-        dataset_name = self._create_test_dataset(opik_client)
+        dataset_name = self._create_test_dataset(opik_client, source_project_name)
 
         # Verify dataset was created
         datasets = opik_client.get_datasets(max_results=100)
@@ -276,6 +282,7 @@ class TestCLIImportExport:
         export_dataset_by_name(
             name=dataset_name,
             workspace="default",
+            project_name=source_project_name,
             output_path=str(test_data_dir),
             max_results=None,
             force=False,
@@ -286,7 +293,9 @@ class TestCLIImportExport:
 
         # Verify export files were created
         # New CLI structure: default/datasets/ for datasets
-        datasets_dir = test_data_dir / "default" / "datasets"
+        datasets_dir = (
+            test_data_dir / "default" / "projects" / source_project_name / "datasets"
+        )
         assert datasets_dir.exists(), f"Export directory not found: {datasets_dir}"
 
         dataset_files = list(datasets_dir.glob("dataset_*.json"))
@@ -303,10 +312,13 @@ class TestCLIImportExport:
         assert "downloaded_at" in dataset_data
 
         # Step 3: Import datasets using direct function call
-        source_dir = test_data_dir / "default" / "datasets"
+        source_dir = (
+            test_data_dir / "default" / "projects" / source_project_name / "datasets"
+        )
         stats = import_datasets_from_directory(
             client=opik_client,
             source_dir=source_dir,
+            project_name=source_project_name,
             dry_run=False,
             name_pattern=None,
             debug=False,
@@ -325,7 +337,7 @@ class TestCLIImportExport:
     ) -> None:
         """Test the complete export/import flow for prompts."""
         # Step 1: Prepare test data
-        prompt_name = self._create_test_prompt(opik_client)
+        prompt_name = self._create_test_prompt(opik_client, source_project_name)
 
         # Verify prompt was created
         prompts = opik_client.search_prompts()
@@ -338,6 +350,7 @@ class TestCLIImportExport:
         export_prompt_by_name(
             name=prompt_name,
             workspace="default",
+            project_name=source_project_name,
             output_path=str(test_data_dir),
             max_results=None,
             force=False,
@@ -348,7 +361,9 @@ class TestCLIImportExport:
 
         # Verify export files were created
         # New CLI structure: default/prompts/ for prompts
-        prompts_dir = test_data_dir / "default" / "prompts"
+        prompts_dir = (
+            test_data_dir / "default" / "projects" / source_project_name / "prompts"
+        )
         assert prompts_dir.exists(), f"Export directory not found: {prompts_dir}"
 
         prompt_files = list(prompts_dir.glob("prompt_*.json"))
@@ -366,10 +381,13 @@ class TestCLIImportExport:
         assert "downloaded_at" in prompt_data
 
         # Step 3: Import prompts using direct function call
-        source_dir = test_data_dir / "default" / "prompts"
+        source_dir = (
+            test_data_dir / "default" / "projects" / source_project_name / "prompts"
+        )
         stats = import_prompts_from_directory(
             client=opik_client,
             source_dir=source_dir,
+            project_name=source_project_name,
             dry_run=False,
             name_pattern=None,
             debug=False,
@@ -401,13 +419,13 @@ class TestCLIImportExport:
         """Test the complete export/import flow for all data types."""
         # Step 1: Prepare test data (minimal)
         self._create_test_traces(opik_client, source_project_name)
-        dataset_name = self._create_test_dataset(opik_client)
-        prompt_name = self._create_test_prompt(opik_client)
+        dataset_name = self._create_test_dataset(opik_client, source_project_name)
+        prompt_name = self._create_test_prompt(opik_client, source_project_name)
 
         # Step 2: Export all data types with limited results using direct function calls
-        # Export projects (traces)
-        export_project_by_name(
-            name=source_project_name,
+        # Export traces
+        export_project_traces(
+            project_name=source_project_name,
             workspace="default",
             output_path=str(test_data_dir),
             max_results=10,  # Limit to 10 traces
@@ -422,6 +440,7 @@ class TestCLIImportExport:
         export_dataset_by_name(
             name=dataset_name,
             workspace="default",
+            project_name=source_project_name,
             output_path=str(test_data_dir),
             max_results=5,  # Limit to 5 datasets
             force=False,
@@ -434,6 +453,7 @@ class TestCLIImportExport:
         export_prompt_by_name(
             name=prompt_name,
             workspace="default",
+            project_name=source_project_name,
             output_path=str(test_data_dir),
             max_results=5,  # Limit to 5 prompt versions
             force=False,
@@ -444,8 +464,12 @@ class TestCLIImportExport:
 
         # Verify export files were created
         project_dir = test_data_dir / "default" / "projects" / source_project_name
-        datasets_dir = test_data_dir / "default" / "datasets"
-        prompts_dir = test_data_dir / "default" / "prompts"
+        datasets_dir = (
+            test_data_dir / "default" / "projects" / source_project_name / "datasets"
+        )
+        prompts_dir = (
+            test_data_dir / "default" / "projects" / source_project_name / "prompts"
+        )
 
         assert project_dir.exists(), f"Export directory not found: {project_dir}"
         assert datasets_dir.exists(), f"Export directory not found: {datasets_dir}"
@@ -462,9 +486,10 @@ class TestCLIImportExport:
 
         # Step 3: Import all data types using direct function calls
         # Import projects (traces)
-        projects_stats = import_projects_from_directory(
+        projects_stats = import_traces_from_directory(
             client=opik_client,
-            source_dir=test_data_dir / "default" / "projects",
+            project_dir=test_data_dir / "default" / "projects" / source_project_name,
+            project_name=source_project_name,
             dry_run=False,
             name_pattern=None,
             debug=False,
@@ -477,7 +502,12 @@ class TestCLIImportExport:
         # Import datasets
         datasets_stats = import_datasets_from_directory(
             client=opik_client,
-            source_dir=test_data_dir / "default" / "datasets",
+            source_dir=test_data_dir
+            / "default"
+            / "projects"
+            / source_project_name
+            / "datasets",
+            project_name=source_project_name,
             dry_run=False,
             name_pattern=None,
             debug=False,
@@ -489,7 +519,12 @@ class TestCLIImportExport:
         # Import prompts
         prompts_stats = import_prompts_from_directory(
             client=opik_client,
-            source_dir=test_data_dir / "default" / "prompts",
+            source_dir=test_data_dir
+            / "default"
+            / "projects"
+            / source_project_name
+            / "prompts",
+            project_name=source_project_name,
             dry_run=False,
             name_pattern=None,
             debug=False,
@@ -505,8 +540,8 @@ class TestCLIImportExport:
 
         # Test export with name filter using direct function call
         # OQL syntax: use = not ==, and double quotes for string values
-        export_project_by_name(
-            name=source_project_name,
+        export_project_traces(
+            project_name=source_project_name,
             workspace="default",
             output_path=str(test_data_dir),
             max_results=None,
@@ -534,8 +569,8 @@ class TestCLIImportExport:
         # Create test data and export it using direct function call
         self._create_test_traces(opik_client, source_project_name)
 
-        export_project_by_name(
-            name=source_project_name,
+        export_project_traces(
+            project_name=source_project_name,
             workspace="default",
             output_path=str(test_data_dir),
             max_results=None,
@@ -547,15 +582,16 @@ class TestCLIImportExport:
         )
 
         # Test dry run import using direct function call
-        source_dir = test_data_dir / "default" / "projects"
+        project_dir = test_data_dir / "default" / "projects" / source_project_name
 
         # Count traces before dry run
         traces_before = opik_client.search_traces(project_name=source_project_name)
         count_before = len(traces_before)
 
-        _ = import_projects_from_directory(
+        _ = import_traces_from_directory(
             client=opik_client,
-            source_dir=source_dir,
+            project_dir=project_dir,
+            project_name=source_project_name,
             dry_run=True,  # Dry run mode
             name_pattern=None,
             debug=False,
@@ -588,8 +624,8 @@ class TestCLIImportExport:
         export_cmd = [
             "export",
             "default",
-            "project",
             source_project_name,
+            "traces",
             "--path",
             str(test_data_dir),
         ]
@@ -607,8 +643,8 @@ class TestCLIImportExport:
         import_cmd = [
             "import",
             "default",
-            "project",
-            ".*",
+            source_project_name,
+            "traces",
             "--path",
             str(test_data_dir / "default"),
         ]
@@ -622,8 +658,8 @@ class TestCLIImportExport:
         """Test error handling for invalid commands."""
         # Test export with non-existent project - should fail gracefully
         try:
-            export_project_by_name(
-                name="non-existent-project",
+            export_project_traces(
+                project_name="non-existent-project",
                 workspace="default",
                 output_path=str(test_data_dir),
                 max_results=None,
@@ -647,9 +683,10 @@ class TestCLIImportExport:
 
         # Test import with non-existent directory - should fail gracefully
         try:
-            import_projects_from_directory(
+            import_traces_from_directory(
                 client=opik_client,
-                source_dir=test_data_dir / "non-existent",
+                project_dir=test_data_dir / "non-existent",
+                project_name="non-existent",
                 dry_run=False,
                 name_pattern=None,
                 debug=False,
@@ -673,10 +710,14 @@ class TestCLIImportExport:
         dataset2_name = f"cli-test-dataset2-{random_chars()}"
 
         dataset1 = opik_client.create_dataset(
-            dataset1_name, description="CLI test dataset 1"
+            dataset1_name,
+            description="CLI test dataset 1",
+            project_name=source_project_name,
         )
         dataset2 = opik_client.create_dataset(
-            dataset2_name, description="CLI test dataset 2"
+            dataset2_name,
+            description="CLI test dataset 2",
+            project_name=source_project_name,
         )
 
         # Add items to datasets
@@ -705,10 +746,12 @@ class TestCLIImportExport:
         experiment1 = opik_client.create_experiment(
             name=exp1_name,
             dataset_name=dataset1_name,
+            project_name=source_project_name,
         )
         experiment2 = opik_client.create_experiment(
             name=exp2_name,
             dataset_name=dataset2_name,
+            project_name=source_project_name,
         )
 
         # Add items to experiments
@@ -752,6 +795,7 @@ class TestCLIImportExport:
         export_experiment_by_name(
             name=exp1_name,
             workspace="default",
+            project_name=source_project_name,
             output_path=str(test_data_dir),
             dataset=dataset1_name,  # Filter by dataset1
             max_traces=None,
@@ -762,7 +806,9 @@ class TestCLIImportExport:
         )
 
         # Step 4: Verify only experiment1 was exported
-        experiments_dir = test_data_dir / "default" / "experiments"
+        experiments_dir = (
+            test_data_dir / "default" / "projects" / source_project_name / "experiments"
+        )
         assert experiments_dir.exists(), (
             f"Export directory not found: {experiments_dir}"
         )
@@ -794,7 +840,7 @@ class TestCLIImportExport:
     ) -> None:
         """Test the complete export/import flow for chat prompts."""
         # Step 1: Create a test chat prompt
-        prompt_name = self._create_test_chat_prompt(opik_client)
+        prompt_name = self._create_test_chat_prompt(opik_client, source_project_name)
 
         # Verify chat prompt was created
         prompts = opik_client.search_prompts()
@@ -807,6 +853,7 @@ class TestCLIImportExport:
         export_prompt_by_name(
             name=prompt_name,
             workspace="default",
+            project_name=source_project_name,
             output_path=str(test_data_dir),
             max_results=None,
             force=False,
@@ -816,7 +863,9 @@ class TestCLIImportExport:
         )
 
         # Verify export files were created
-        prompts_dir = test_data_dir / "default" / "prompts"
+        prompts_dir = (
+            test_data_dir / "default" / "projects" / source_project_name / "prompts"
+        )
         assert prompts_dir.exists(), f"Export directory not found: {prompts_dir}"
 
         prompt_files = list(prompts_dir.glob("prompt_*.json"))
@@ -840,10 +889,13 @@ class TestCLIImportExport:
         assert current_version["template_structure"] == "chat"
 
         # Step 3: Import chat prompt using direct function call
-        source_dir = test_data_dir / "default" / "prompts"
+        source_dir = (
+            test_data_dir / "default" / "projects" / source_project_name / "prompts"
+        )
         stats = import_prompts_from_directory(
             client=opik_client,
             source_dir=source_dir,
+            project_name=source_project_name,
             dry_run=False,
             name_pattern=None,
             debug=False,
@@ -874,13 +926,13 @@ class TestCLIImportExport:
     ) -> None:
         """Test import projects automatically recreates experiments."""
         # Step 1: Prepare test data with experiments
-        dataset_name = self._create_test_dataset(opik_client)
+        dataset_name = self._create_test_dataset(opik_client, source_project_name)
         self._create_test_traces(opik_client, source_project_name)
         self._create_test_experiment(opik_client, source_project_name, dataset_name)
 
         # Step 2: Export the project data (traces) using direct function call
-        export_project_by_name(
-            name=source_project_name,
+        export_project_traces(
+            project_name=source_project_name,
             workspace="default",
             output_path=str(test_data_dir),
             max_results=None,
@@ -896,10 +948,11 @@ class TestCLIImportExport:
         assert project_dir.exists(), f"Export directory not found: {project_dir}"
 
         # Step 3: Test import (experiments are automatically recreated) using direct function call
-        source_dir = test_data_dir / "default" / "projects"
-        stats = import_projects_from_directory(
+        project_dir = test_data_dir / "default" / "projects" / source_project_name
+        stats = import_traces_from_directory(
             client=opik_client,
-            source_dir=source_dir,
+            project_dir=project_dir,
+            project_name=source_project_name,
             dry_run=False,
             name_pattern=None,
             debug=False,
@@ -1000,8 +1053,8 @@ class TestCLIImportExport:
         print(f"Original cost: {original_cost}")
 
         # Export the project
-        export_project_by_name(
-            name=project_name,
+        export_project_traces(
+            project_name=project_name,
             workspace="default",
             output_path=str(test_data_dir),
             max_results=None,
@@ -1056,12 +1109,12 @@ class TestCLIImportExport:
             json.dump(trace_data, f)
 
         # Import the project
-        source_dir = test_data_dir / "default" / "projects"
-        stats = import_projects_from_directory(
+        stats = import_traces_from_directory(
             client=opik_client,
-            source_dir=source_dir,
+            project_dir=imported_project_dir,
+            project_name=imported_project_name,
             dry_run=False,
-            name_pattern=imported_project_name,
+            name_pattern=None,
             debug=True,
             recreate_experiments_flag=False,
         )
@@ -1075,8 +1128,9 @@ class TestCLIImportExport:
 
         # Wait for the imported trace to appear in the new project.
         assert synchronization.until(
-            lambda: len(opik_client.search_traces(project_name=imported_project_name))
-            >= 1,
+            lambda: (
+                len(opik_client.search_traces(project_name=imported_project_name)) >= 1
+            ),
             allow_errors=True,
         ), f"No imported traces found in project {imported_project_name}"
 

--- a/sdks/python/tests/e2e/test_cli_import_export.py
+++ b/sdks/python/tests/e2e/test_cli_import_export.py
@@ -653,7 +653,7 @@ class TestCLIImportExport:
             source_project_name,
             "traces",
             "--path",
-            str(test_data_dir / "default"),
+            str(test_data_dir),
         ]
 
         result = self._run_cli_command(import_cmd)

--- a/sdks/python/tests/e2e/test_cli_import_export.py
+++ b/sdks/python/tests/e2e/test_cli_import_export.py
@@ -296,7 +296,9 @@ class TestCLIImportExport:
         dataset_name = self._create_test_dataset(opik_client, source_project_name)
 
         # Verify dataset was created
-        datasets = opik_client.get_datasets(max_results=100)
+        datasets = opik_client.get_datasets(
+            max_results=100, project_name=source_project_name
+        )
         assert len(datasets) >= 1, "Expected at least 1 dataset to be created"
 
         # Step 2: Export datasets using direct function call
@@ -359,7 +361,7 @@ class TestCLIImportExport:
         prompt_name = self._create_test_prompt(opik_client, source_project_name)
 
         # Verify prompt was created
-        prompts = opik_client.search_prompts()
+        prompts = opik_client.search_prompts(project_name=source_project_name)
         prompt_names = [p.name for p in prompts]
         assert prompt_name in prompt_names, (
             f"Expected prompt {prompt_name} to be created"
@@ -412,7 +414,7 @@ class TestCLIImportExport:
         assert stats.get("prompts", 0) >= 1, "Expected at least 1 prompt to be imported"
 
         # Verify prompt was correctly imported to backend
-        imported_prompts = opik_client.search_prompts()
+        imported_prompts = opik_client.search_prompts(project_name=source_project_name)
         imported_prompt_names = [p.name for p in imported_prompts]
         assert prompt_name in imported_prompt_names, (
             f"Expected prompt {prompt_name} to be imported"
@@ -858,7 +860,7 @@ class TestCLIImportExport:
         prompt_name = self._create_test_chat_prompt(opik_client, source_project_name)
 
         # Verify chat prompt was created
-        prompts = opik_client.search_prompts()
+        prompts = opik_client.search_prompts(project_name=source_project_name)
         prompt_names = [p.name for p in prompts]
         assert prompt_name in prompt_names, (
             f"Expected chat prompt {prompt_name} to be created"
@@ -916,14 +918,16 @@ class TestCLIImportExport:
         assert stats.get("prompts", 0) >= 1, "Expected at least 1 prompt to be imported"
 
         # Verify chat prompt was correctly imported to backend
-        imported_prompts = opik_client.search_prompts()
+        imported_prompts = opik_client.search_prompts(project_name=source_project_name)
         imported_prompt_names = [p.name for p in imported_prompts]
         assert prompt_name in imported_prompt_names, (
             f"Expected chat prompt {prompt_name} to be imported"
         )
 
         # Get the imported chat prompt and verify its content
-        imported_chat_prompt = opik_client.get_chat_prompt(name=prompt_name)
+        imported_chat_prompt = opik_client.get_chat_prompt(
+            name=prompt_name, project_name=source_project_name
+        )
         verifiers.verify_chat_prompt_version(
             imported_chat_prompt,
             name=prompt_name,

--- a/sdks/python/tests/unit/cli/test_attachments.py
+++ b/sdks/python/tests/unit/cli/test_attachments.py
@@ -13,7 +13,7 @@ from opik.cli.exports.project import (
 )
 from opik.cli.imports.project import (
     _upload_attachments_for_trace,
-    import_projects_from_directory,
+    import_traces_from_directory,
 )
 
 
@@ -395,7 +395,7 @@ class TestUploadAttachmentsForTrace:
     """Unit tests for the _upload_attachments_for_trace helper.
 
     This private helper is tested directly (rather than solely via
-    import_projects_from_directory) because it contains security-critical path
+    import_traces_from_directory) because it contains security-critical path
     validation logic (traversal prevention) and ID-translation rules that are
     difficult to observe through the public API without significant fixture
     overhead.  The integration-level behaviour (attachment uploads wired into
@@ -729,7 +729,7 @@ class TestExportTracesWritesAttachmentMetadata:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Integration tests: import_projects_from_directory() uploads attachments
+# Integration tests: import_traces_from_directory() uploads attachments
 # ─────────────────────────────────────────────────────────────────────────────
 
 _TRACE_WITH_ATTACHMENTS = {
@@ -816,9 +816,10 @@ class TestImportProjectsUploadsAttachments:
             project_dir, "span", "orig-span-id", "span_data.csv", b"csv bytes"
         )
 
-        import_projects_from_directory(
+        import_traces_from_directory(
             client=client,
-            source_dir=tmp_path,
+            project_dir=project_dir,
+            project_name="test-project",
             dry_run=False,
             name_pattern=None,
             debug=False,
@@ -844,9 +845,10 @@ class TestImportProjectsUploadsAttachments:
         _write_attachment_file(project_dir, "trace", "orig-trace-id", "trace_img.png")
         _write_attachment_file(project_dir, "span", "orig-span-id", "span_data.csv")
 
-        import_projects_from_directory(
+        import_traces_from_directory(
             client=client,
-            source_dir=tmp_path,
+            project_dir=project_dir,
+            project_name="test-project",
             dry_run=False,
             name_pattern=None,
             debug=False,
@@ -868,9 +870,10 @@ class TestImportProjectsUploadsAttachments:
         _write_attachment_file(project_dir, "trace", "orig-trace-id", "trace_img.png")
         _write_attachment_file(project_dir, "span", "orig-span-id", "span_data.csv")
 
-        import_projects_from_directory(
+        import_traces_from_directory(
             client=client,
-            source_dir=tmp_path,
+            project_dir=project_dir,
+            project_name="test-project",
             dry_run=False,
             name_pattern=None,
             debug=False,
@@ -885,9 +888,10 @@ class TestImportProjectsUploadsAttachments:
         _write_trace_file(project_dir, _TRACE_WITH_ATTACHMENTS)
         _write_attachment_file(project_dir, "trace", "orig-trace-id", "trace_img.png")
 
-        import_projects_from_directory(
+        import_traces_from_directory(
             client=client,
-            source_dir=tmp_path,
+            project_dir=project_dir,
+            project_name="test-project",
             dry_run=False,
             name_pattern=None,
             debug=False,
@@ -906,9 +910,10 @@ class TestImportProjectsUploadsAttachments:
         _write_trace_file(project_dir, _TRACE_WITH_ATTACHMENTS)
         # Do NOT write attachment files — simulate export with --no-attachments
 
-        import_projects_from_directory(
+        import_traces_from_directory(
             client=client,
-            source_dir=tmp_path,
+            project_dir=project_dir,
+            project_name="test-project",
             dry_run=False,
             name_pattern=None,
             debug=False,
@@ -927,9 +932,10 @@ class TestImportProjectsUploadsAttachments:
         _write_trace_file(project_dir, _TRACE_WITH_ATTACHMENTS)
         _write_attachment_file(project_dir, "trace", "orig-trace-id", "trace_img.png")
 
-        import_projects_from_directory(
+        import_traces_from_directory(
             client=client,
-            source_dir=tmp_path,
+            project_dir=project_dir,
+            project_name="test-project",
             dry_run=True,
             name_pattern=None,
             debug=False,
@@ -963,9 +969,10 @@ class TestImportProjectsUploadsAttachments:
         project_dir = tmp_path / "test-project"
         _write_trace_file(project_dir, trace_data)
 
-        import_projects_from_directory(
+        import_traces_from_directory(
             client=client,
-            source_dir=tmp_path,
+            project_dir=project_dir,
+            project_name="test-project",
             dry_run=False,
             name_pattern=None,
             debug=False,
@@ -985,18 +992,16 @@ class TestImportProjectsUploadsAttachments:
 class TestNoAttachmentsCliFlag:
     """Verify --no-attachments is wired through the CLI commands."""
 
-    def test_export_project__no_attachments_flag__accepted(self):
+    def test_export_traces__no_attachments_flag__accepted(self):
         from click.testing import CliRunner
-        from opik.cli.exports.project import export_project_command
+        from opik.cli.exports.project import export_traces_command
 
         runner = CliRunner()
-        with patch(
-            "opik.cli.exports.project.export_project_by_name_or_id"
-        ) as mock_export:
+        with patch("opik.cli.exports.project.export_project_traces") as mock_export:
             result = runner.invoke(
-                export_project_command,
-                ["my-project", "--no-attachments"],
-                obj={"workspace": "ws", "api_key": None},
+                export_traces_command,
+                ["--no-attachments"],
+                obj={"workspace": "ws", "project_name": "my-project", "api_key": None},
                 catch_exceptions=False,
             )
 
@@ -1004,18 +1009,16 @@ class TestNoAttachmentsCliFlag:
         _, kwargs = mock_export.call_args
         assert kwargs.get("include_attachments") is False
 
-    def test_export_project__default__includes_attachments(self):
+    def test_export_traces__default__includes_attachments(self):
         from click.testing import CliRunner
-        from opik.cli.exports.project import export_project_command
+        from opik.cli.exports.project import export_traces_command
 
         runner = CliRunner()
-        with patch(
-            "opik.cli.exports.project.export_project_by_name_or_id"
-        ) as mock_export:
+        with patch("opik.cli.exports.project.export_project_traces") as mock_export:
             result = runner.invoke(
-                export_project_command,
-                ["my-project"],
-                obj={"workspace": "ws", "api_key": None},
+                export_traces_command,
+                [],
+                obj={"workspace": "ws", "project_name": "my-project", "api_key": None},
                 catch_exceptions=False,
             )
 
@@ -1023,7 +1026,7 @@ class TestNoAttachmentsCliFlag:
         _, kwargs = mock_export.call_args
         assert kwargs.get("include_attachments") is True
 
-    def test_import_project__no_attachments_flag__accepted(self):
+    def test_import_traces__no_attachments_flag__accepted(self):
         from click.testing import CliRunner
         from opik.cli.imports import import_group
 
@@ -1033,7 +1036,7 @@ class TestNoAttachmentsCliFlag:
         with patch("opik.cli.imports._import_by_type") as mock_import:
             result = runner.invoke(
                 import_group,
-                ["my-workspace", "project", "my-project", "--no-attachments"],
+                ["my-workspace", "my-project", "traces", "--no-attachments"],
                 catch_exceptions=False,
             )
 
@@ -1042,7 +1045,7 @@ class TestNoAttachmentsCliFlag:
         _, kwargs = mock_import.call_args
         assert kwargs.get("include_attachments") is False
 
-    def test_import_project__default__includes_attachments(self):
+    def test_import_traces__default__includes_attachments(self):
         from click.testing import CliRunner
         from opik.cli.imports import import_group
 
@@ -1050,7 +1053,7 @@ class TestNoAttachmentsCliFlag:
         with patch("opik.cli.imports._import_by_type") as mock_import:
             result = runner.invoke(
                 import_group,
-                ["my-workspace", "project", "my-project"],
+                ["my-workspace", "my-project", "traces"],
                 catch_exceptions=False,
             )
 

--- a/sdks/python/tests/unit/cli/test_cli.py
+++ b/sdks/python/tests/unit/cli/test_cli.py
@@ -17,34 +17,34 @@ class TestDownloadCommand:
         runner = CliRunner()
         result = runner.invoke(cli, ["export", "--help"])
         assert result.exit_code == 0
-        assert "Export data from Opik workspace" in result.output
+        assert "Export data from an Opik project" in result.output
         assert "dataset" in result.output
-        assert "project" in result.output
+        assert "traces" in result.output
         assert "experiment" in result.output
 
     def test_export_dataset_help(self):
         """Test that the export dataset command shows help."""
         runner = CliRunner()
-        result = runner.invoke(cli, ["export", "default", "dataset", "--help"])
+        result = runner.invoke(cli, ["export", "default", "proj", "dataset", "--help"])
         assert result.exit_code == 0
         assert "Export a dataset by exact name" in result.output
         assert "--force" in result.output
 
-    def test_export_project_help(self):
-        """Test that the export project command shows help."""
+    def test_export_traces_help(self):
+        """Test that the export traces command shows help."""
         runner = CliRunner()
-        result = runner.invoke(cli, ["export", "default", "project", "--help"])
+        result = runner.invoke(cli, ["export", "default", "proj", "traces", "--help"])
         assert result.exit_code == 0
-        assert "Export a project by name or ID" in result.output
-        assert "NAME" in result.output
+        assert "Export the project's traces" in result.output
 
     def test_export_experiment_help(self):
         """Test that the export experiment command shows help."""
         runner = CliRunner()
-        result = runner.invoke(cli, ["export", "default", "experiment", "--help"])
+        result = runner.invoke(
+            cli, ["export", "default", "proj", "experiment", "--help"]
+        )
         assert result.exit_code == 0
         assert "Export an experiment by exact name" in result.output
-        assert "NAME" in result.output
 
 
 class TestUploadCommand:
@@ -55,35 +55,35 @@ class TestUploadCommand:
         runner = CliRunner()
         result = runner.invoke(cli, ["import", "--help"])
         assert result.exit_code == 0
-        assert "Import data to Opik workspace" in result.output
+        assert "Import data into an Opik project" in result.output
         assert "dataset" in result.output
-        assert "project" in result.output
+        assert "traces" in result.output
         assert "experiment" in result.output
 
     def test_import_dataset_help(self):
         """Test that the import dataset command shows help."""
         runner = CliRunner()
-        result = runner.invoke(cli, ["import", "default", "dataset", "--help"])
+        result = runner.invoke(cli, ["import", "default", "proj", "dataset", "--help"])
         assert result.exit_code == 0
-        assert "Import datasets from workspace/datasets directory" in result.output
+        assert "Import datasets from" in result.output
         assert "--dry-run" in result.output
 
-    def test_import_project_help(self):
-        """Test that the import project command shows help."""
+    def test_import_traces_help(self):
+        """Test that the import traces command shows help."""
         runner = CliRunner()
-        result = runner.invoke(cli, ["import", "default", "project", "--help"])
+        result = runner.invoke(cli, ["import", "default", "proj", "traces", "--help"])
         assert result.exit_code == 0
-        assert "Import projects from workspace/projects directory" in result.output
+        assert "Import the project's traces" in result.output
         assert "--dry-run" in result.output
 
     def test_import_experiment_help(self):
         """Test that the import experiment command shows help."""
         runner = CliRunner()
-        result = runner.invoke(cli, ["import", "default", "experiment", "--help"])
-        assert result.exit_code == 0
-        assert (
-            "Import experiments from workspace/experiments directory" in result.output
+        result = runner.invoke(
+            cli, ["import", "default", "proj", "experiment", "--help"]
         )
+        assert result.exit_code == 0
+        assert "Import experiments from" in result.output
         assert "--dry-run" in result.output
 
 

--- a/sdks/python/tests/unit/cli/test_export_project_rate_limiting.py
+++ b/sdks/python/tests/unit/cli/test_export_project_rate_limiting.py
@@ -455,8 +455,8 @@ class TestExportSingleProjectReturnValues:
                 mock_export.return_value = (3, 0, False)
                 result = export_single_project(
                     client=mock_client,
-                    project=self._make_project(),
-                    output_dir=projects_dir,
+                    project_name="test-proj",
+                    project_dir=projects_dir,
                     filter_string=None,
                     max_results=None,
                     force=False,
@@ -485,8 +485,8 @@ class TestExportSingleProjectReturnValues:
                 mock_export.return_value = (2, 1, True)
                 result = export_single_project(
                     client=mock_client,
-                    project=self._make_project(),
-                    output_dir=projects_dir,
+                    project_name="test-proj",
+                    project_dir=projects_dir,
                     filter_string=None,
                     max_results=None,
                     force=False,
@@ -515,8 +515,8 @@ class TestExportSingleProjectReturnValues:
                 mock_export.return_value = (0, 0, False)  # nothing exported or skipped
                 result = export_single_project(
                     client=mock_client,
-                    project=self._make_project(),
-                    output_dir=projects_dir,
+                    project_name="test-proj",
+                    project_dir=projects_dir,
                     filter_string=None,
                     max_results=None,
                     force=False,
@@ -542,8 +542,8 @@ class TestExportSingleProjectReturnValues:
                 mock_export.side_effect = RuntimeError("unexpected failure")
                 result = export_single_project(
                     client=mock_client,
-                    project=self._make_project(),
-                    output_dir=projects_dir,
+                    project_name="test-proj",
+                    project_dir=projects_dir,
                     filter_string=None,
                     max_results=None,
                     force=False,

--- a/sdks/python/tests/unit/cli/test_import_experiment.py
+++ b/sdks/python/tests/unit/cli/test_import_experiment.py
@@ -17,7 +17,7 @@ from opik.cli.imports.experiment import (  # noqa: E402
     ExperimentData,
     load_experiment_data,
     recreate_experiment,
-    _import_traces_from_projects_directory,
+    _import_traces_for_project,
 )
 from opik.cli.imports.utils import (  # noqa: E402
     translate_trace_id as utils_translate_trace_id,
@@ -488,8 +488,8 @@ class TestImportTracesWithSpans:
             json.dump(trace_data, f)
 
         # Import traces
-        trace_id_map, _ = _import_traces_from_projects_directory(
-            mock_client, tmp_path, dry_run=False, debug=False
+        trace_id_map, _ = _import_traces_for_project(
+            mock_client, projects_dir, "test-project", dry_run=False, debug=False
         )
 
         # Verify spans were created
@@ -572,8 +572,8 @@ class TestImportTracesWithSpans:
             json.dump(trace_data, f)
 
         # Import traces
-        trace_id_map, _ = _import_traces_from_projects_directory(
-            mock_client, tmp_path, dry_run=False, debug=False
+        trace_id_map, _ = _import_traces_for_project(
+            mock_client, projects_dir, "test-project", dry_run=False, debug=False
         )
 
         # Verify all spans were created
@@ -635,8 +635,8 @@ class TestImportTracesWithSpans:
             json.dump(trace_data, f)
 
         # Import traces
-        _, _ = _import_traces_from_projects_directory(
-            mock_client, tmp_path, dry_run=False, debug=False
+        _, _ = _import_traces_for_project(
+            mock_client, projects_dir, "test-project", dry_run=False, debug=False
         )  # Returns (trace_id_map, stats), but we don't need them for this test
 
         # Verify spans were created in correct order
@@ -843,8 +843,8 @@ class TestModuleNameUsage:
         assert isinstance(id_helpers_module, types.ModuleType)
 
 
-class TestProjectInference:
-    """Test trace-to-project mapping built from project directory filenames."""
+class TestProjectTraceImport:
+    """Test importing a project's traces from its project directory."""
 
     @pytest.fixture
     def mock_client(self) -> Mock:
@@ -857,12 +857,12 @@ class TestProjectInference:
         client.span = Mock()
         return client
 
-    def test_project_inference__trace_filename_maps_to_project__happyflow(
+    def test_trace_files_in_project_dir_are_imported(
         self, mock_client: Mock, tmp_path: Path
     ) -> None:
-        """A trace_{id}.json file under projects/my-project/ should map the trace
-        ID to 'my-project' in the trace_to_project_map returned by
-        _import_traces_from_projects_directory."""
+        """trace_{id}.json files directly under the project dir are imported and
+        appear in the returned trace_id_map, and the trace is created in the
+        named project."""
         project_dir = tmp_path / "projects" / "my-project"
         project_dir.mkdir(parents=True)
 
@@ -875,35 +875,26 @@ class TestProjectInference:
         with open(trace_file, "w") as f:
             json.dump(trace_data, f)
 
-        trace_id_map, _ = _import_traces_from_projects_directory(
-            mock_client, tmp_path, dry_run=False, debug=False
+        trace_id_map, _ = _import_traces_for_project(
+            mock_client, project_dir, "my-project", dry_run=False, debug=False
         )
 
         # The original trace ID must appear in the returned map
         assert trace_id in trace_id_map
+        # The trace must be created in the named project (no "default" fallback)
+        assert mock_client.trace.call_args.kwargs.get("project_name") == "my-project"
 
-    def test_project_inference__no_filename_no_metadata__uses_default(
+    def test_empty_project_dir_returns_empty_map(
         self, mock_client: Mock, tmp_path: Path
     ) -> None:
-        """When a trace file has no project_name in metadata and does not sit
-        under a named projects/ sub-directory, the importer should still
-        complete without raising an exception (using the fallback 'default'
-        project internally)."""
-        # Place a trace directly in tmp_path (no projects/ sub-dir) —
-        # _import_traces_from_projects_directory only scans projects/**,
-        # so this trace is simply not found and the function returns an
-        # empty map without error.
-        trace_data: Dict[str, Any] = {
-            "trace": {"id": "orphan-trace", "name": "t", "input": {}, "output": {}},
-            "spans": [],
-        }
-        orphan_file = tmp_path / "trace_orphan-trace.json"
-        with open(orphan_file, "w") as f:
-            json.dump(trace_data, f)
+        """A project dir with no trace files yields an empty map without error."""
+        project_dir = tmp_path / "projects" / "empty-project"
+        project_dir.mkdir(parents=True)
 
-        # Should not raise; returns empty map when no projects/ dir exists
-        trace_id_map, _ = _import_traces_from_projects_directory(
-            mock_client, tmp_path, dry_run=False, debug=False
+        trace_id_map, stats = _import_traces_for_project(
+            mock_client, project_dir, "empty-project", dry_run=False, debug=False
         )
 
-        assert "orphan-trace" not in trace_id_map
+        assert trace_id_map == {}
+        assert stats["traces"] == 0
+        assert not mock_client.trace.called

--- a/sdks/python/tests/unit/test_cli_changes.py
+++ b/sdks/python/tests/unit/test_cli_changes.py
@@ -122,7 +122,15 @@ class TestValidateIncludeExport:
         runner = CliRunner()
         result = runner.invoke(
             cli,
-            ["export", "default", "all", "--include", "datasets,prompts", "--help"],
+            [
+                "export",
+                "default",
+                "proj",
+                "all",
+                "--include",
+                "datasets,prompts",
+                "--help",
+            ],
         )
         # --help always exits 0 regardless of option values
         assert result.exit_code == 0
@@ -132,7 +140,7 @@ class TestValidateIncludeExport:
         with patch("opik.cli.exports.all.opik.Opik"):
             result = runner.invoke(
                 cli,
-                ["export", "default", "all", "--include", "invalid_type"],
+                ["export", "default", "proj", "all", "--include", "invalid_type"],
             )
         assert result.exit_code != 0
         assert "Invalid" in result.output or "invalid" in result.output.lower()
@@ -151,8 +159,8 @@ class TestValidateIncludeExport:
 
         ctx = MagicMock(spec=click.Context)
         param = MagicMock(spec=click.Parameter)
-        result = _validate_include(ctx, param, "datasets,prompts,projects,experiments")
-        assert set(result) == {"datasets", "prompts", "projects", "experiments"}
+        result = _validate_include(ctx, param, "datasets,prompts,traces,experiments")
+        assert set(result) == {"datasets", "prompts", "traces", "experiments"}
 
     def test_invalid_type_raises_bad_parameter(self):
         from opik.cli.exports.all import _validate_include
@@ -185,7 +193,7 @@ class TestValidateIncludeImport:
         ctx = MagicMock(spec=click.Context)
         param = MagicMock(spec=click.Parameter)
         with pytest.raises(click.BadParameter, match="Invalid"):
-            _validate_include(ctx, param, "traces")
+            _validate_include(ctx, param, "projects")
 
     def test_empty_segments_ignored(self):
         from opik.cli.imports.all import _validate_include
@@ -240,6 +248,7 @@ class TestPromptTypeResolution:
                 result = import_prompts_from_directory(
                     client=mock_client,
                     source_dir=Path(tmp),
+                    project_name="test-project",
                     dry_run=False,
                     name_pattern=None,
                     debug=False,
@@ -273,6 +282,7 @@ class TestPromptTypeResolution:
                 result = import_prompts_from_directory(
                     client=mock_client,
                     source_dir=Path(tmp),
+                    project_name="test-project",
                     dry_run=False,
                     name_pattern=None,
                     debug=False,
@@ -383,14 +393,14 @@ class TestExportTracesMaxResultsNone:
 class TestAllCommandRegistered:
     def test_export_all_help_is_accessible(self):
         runner = CliRunner()
-        result = runner.invoke(cli, ["export", "default", "all", "--help"])
+        result = runner.invoke(cli, ["export", "default", "proj", "all", "--help"])
         assert result.exit_code == 0
         assert "all" in result.output.lower()
         assert "--include" in result.output
 
     def test_import_all_help_is_accessible(self):
         runner = CliRunner()
-        result = runner.invoke(cli, ["import", "default", "all", "--help"])
+        result = runner.invoke(cli, ["import", "default", "proj", "all", "--help"])
         assert result.exit_code == 0
         assert "all" in result.output.lower()
         assert "--include" in result.output
@@ -410,7 +420,7 @@ class TestAllCommandRegistered:
     def test_export_missing_subcommand_error_mentions_all(self):
         """When no subcommand is given the error message should list 'all'."""
         runner = CliRunner()
-        result = runner.invoke(cli, ["export", "default"])
+        result = runner.invoke(cli, ["export", "default", "proj"])
         # Non-zero exit or the error message includes "all"
         assert "all" in result.output
 
@@ -484,7 +494,9 @@ class TestExportAllExperimentsSemaphore:
                     _had_errors,
                 ) = _export_all_experiments(
                     client=MagicMock(),
-                    workspace_root=workspace_root,
+                    project_dir=workspace_root,
+                    project_name="proj",
+                    project_id=None,
                     experiments_dir=experiments_dir,
                     max_results=None,
                     force=False,

--- a/sdks/python/tests/unit/test_cli_changes.py
+++ b/sdks/python/tests/unit/test_cli_changes.py
@@ -244,15 +244,14 @@ class TestPromptTypeResolution:
             prompt_file = Path(tmp) / "prompt_test.json"
             prompt_file.write_text(json.dumps(prompt_data))
 
-            with patch("opik.cli.imports.prompt.Prompt"):
-                result = import_prompts_from_directory(
-                    client=mock_client,
-                    source_dir=Path(tmp),
-                    project_name="test-project",
-                    dry_run=False,
-                    name_pattern=None,
-                    debug=False,
-                )
+            result = import_prompts_from_directory(
+                client=mock_client,
+                source_dir=Path(tmp),
+                project_name="test-project",
+                dry_run=False,
+                name_pattern=None,
+                debug=False,
+            )
 
             # Should have imported one prompt, not skipped it
             assert result.get("prompts", 0) == 1
@@ -278,15 +277,14 @@ class TestPromptTypeResolution:
             prompt_file = Path(tmp) / "prompt_test2.json"
             prompt_file.write_text(json.dumps(prompt_data))
 
-            with patch("opik.cli.imports.prompt.Prompt"):
-                result = import_prompts_from_directory(
-                    client=mock_client,
-                    source_dir=Path(tmp),
-                    project_name="test-project",
-                    dry_run=False,
-                    name_pattern=None,
-                    debug=False,
-                )
+            result = import_prompts_from_directory(
+                client=mock_client,
+                source_dir=Path(tmp),
+                project_name="test-project",
+                dry_run=False,
+                name_pattern=None,
+                debug=False,
+            )
 
             # Falls back to MUSTACHE → still imports successfully
             assert result.get("prompts", 0) == 1

--- a/sdks/python/tests/unit/test_export_import_all.py
+++ b/sdks/python/tests/unit/test_export_import_all.py
@@ -352,6 +352,36 @@ class TestMigrationManifest:
 
 
 # ---------------------------------------------------------------------------
+# resolve_import_base_path
+# ---------------------------------------------------------------------------
+
+
+class TestResolveImportBasePath:
+    """Import base-path resolution: workspace-scoped with cross-workspace fallback."""
+
+    def test_prefers_workspace_segment_when_present(self, tmp_path):
+        from opik.cli.imports.utils import resolve_import_base_path
+
+        (tmp_path / "ws" / "projects").mkdir(parents=True)
+        # Same-workspace round-trip: <path>/<workspace>/projects exists.
+        assert resolve_import_base_path(str(tmp_path), "ws") == tmp_path / "ws"
+
+    def test_falls_back_to_path_for_cross_workspace(self, tmp_path):
+        from opik.cli.imports.utils import resolve_import_base_path
+
+        # Data exported from workspace "src" lives at <path>/projects; importing
+        # into workspace "dst" (no <path>/dst/projects) falls back to <path>.
+        (tmp_path / "projects").mkdir(parents=True)
+        assert resolve_import_base_path(str(tmp_path), "dst") == tmp_path
+
+    def test_falls_back_when_nothing_present(self, tmp_path):
+        from opik.cli.imports.utils import resolve_import_base_path
+
+        # Neither layout exists → return <path> (caller surfaces a not-found error).
+        assert resolve_import_base_path(str(tmp_path), "ws") == tmp_path
+
+
+# ---------------------------------------------------------------------------
 # _merge_stats
 # ---------------------------------------------------------------------------
 

--- a/sdks/python/tests/unit/test_export_import_all.py
+++ b/sdks/python/tests/unit/test_export_import_all.py
@@ -392,6 +392,56 @@ class TestResolveImportBasePath:
 
 
 # ---------------------------------------------------------------------------
+# setup_import_manifest
+# ---------------------------------------------------------------------------
+
+
+class TestSetupImportManifest:
+    """The per-destination manifest must key files relative to project_root even
+    though the SQLite db lives in a per-destination subdir."""
+
+    def test_files_under_project_root_are_keyable(self, tmp_path):
+        from opik.cli.imports.utils import (
+            setup_import_manifest,
+            destination_manifest_dir,
+        )
+
+        project_root = tmp_path / _WORKSPACE / "projects" / _PROJECT
+        (project_root / "datasets").mkdir(parents=True)
+        ds_file = project_root / "datasets" / "dataset_x.json"
+        ds_file.write_text("{}")
+
+        manifest, already_completed = setup_import_manifest(
+            project_root, "dest", dry_run=False, force=False
+        )
+        assert manifest is not None
+        assert not already_completed
+
+        # Regression: file keys are relative to project_root, so marking a file
+        # under project_root/datasets must not raise ValueError.
+        manifest.mark_file_completed(ds_file)
+        manifest.save()
+        assert manifest.is_file_completed(ds_file)
+
+        # The SQLite db lives in the per-destination subdir, not at project_root.
+        assert (
+            destination_manifest_dir(project_root, "dest") / "migration_manifest.db"
+        ).exists()
+        assert not (project_root / "migration_manifest.db").exists()
+
+    def test_dry_run_creates_no_manifest(self, tmp_path):
+        from opik.cli.imports.utils import setup_import_manifest
+
+        project_root = tmp_path / _WORKSPACE / "projects" / _PROJECT
+        project_root.mkdir(parents=True)
+        manifest, already_completed = setup_import_manifest(
+            project_root, "dest", dry_run=True, force=False
+        )
+        assert manifest is None
+        assert not already_completed
+
+
+# ---------------------------------------------------------------------------
 # _merge_stats
 # ---------------------------------------------------------------------------
 

--- a/sdks/python/tests/unit/test_export_import_all.py
+++ b/sdks/python/tests/unit/test_export_import_all.py
@@ -54,6 +54,7 @@ from opik.cli.migration_manifest import MigrationManifest
 
 _PROJECT = "proj"
 _PROJECT_ID = "proj-id"
+_WORKSPACE = "ws"
 _IMPORT_MODULE = "opik.cli.imports.all"
 _EXPORT_MODULE = "opik.cli.exports.all"
 
@@ -80,7 +81,7 @@ def _seed_project_meta(tmp_path: Path) -> Path:
     the source project by its recorded name. Folders are keyed by id on disk; the
     folder name is irrelevant — find_project_export_dir matches project.json's name.
     """
-    proj = tmp_path / "projects" / _PROJECT
+    proj = tmp_path / _WORKSPACE / "projects" / _PROJECT
     proj.mkdir(parents=True, exist_ok=True)
     (proj / "project.json").write_text(
         json.dumps({"id": _PROJECT_ID, "name": _PROJECT})
@@ -389,7 +390,7 @@ class TestImportAll:
     def test_fresh_run_calls_all_phases_and_completes_manifest(self, tmp_path):
         """A fresh import runs all four phases and marks the manifest completed."""
         for d in ("datasets", "prompts", "experiments"):
-            (tmp_path / "projects" / _PROJECT / d).mkdir(parents=True)
+            (tmp_path / _WORKSPACE / "projects" / _PROJECT / d).mkdir(parents=True)
 
         client = _make_import_client()
         _seed_project_meta(tmp_path)
@@ -426,12 +427,12 @@ class TestImportAll:
         mock_proj.assert_called_once()
         mock_exp.assert_called_once()
 
-        m = MigrationManifest(tmp_path / "projects" / _PROJECT)
+        m = MigrationManifest(tmp_path / _WORKSPACE / "projects" / _PROJECT)
         assert m.is_completed
 
     def test_dry_run_skips_manifest_and_flush(self, tmp_path):
         """Dry-run must not create a manifest or flush the client."""
-        (tmp_path / "projects" / _PROJECT / "datasets").mkdir(parents=True)
+        (tmp_path / _WORKSPACE / "projects" / _PROJECT / "datasets").mkdir(parents=True)
         client = _make_import_client()
         _seed_project_meta(tmp_path)
 
@@ -459,12 +460,14 @@ class TestImportAll:
                 debug=False,
             )
 
-        assert not MigrationManifest.exists(tmp_path / "projects" / _PROJECT)
+        assert not MigrationManifest.exists(
+            tmp_path / _WORKSPACE / "projects" / _PROJECT
+        )
         client.flush.assert_not_called()
 
     def test_completed_manifest_returns_early_without_reimporting(self, tmp_path):
         """A completed manifest without --force causes immediate return."""
-        manifest = MigrationManifest(tmp_path / "projects" / _PROJECT)
+        manifest = MigrationManifest(tmp_path / _WORKSPACE / "projects" / _PROJECT)
         manifest.start()
         manifest.complete()
 
@@ -505,8 +508,8 @@ class TestImportAll:
 
     def test_force_flag_resets_completed_manifest_and_reimports(self, tmp_path):
         """--force discards a completed manifest and runs all requested phases."""
-        (tmp_path / "projects" / _PROJECT / "datasets").mkdir(parents=True)
-        manifest = MigrationManifest(tmp_path / "projects" / _PROJECT)
+        (tmp_path / _WORKSPACE / "projects" / _PROJECT / "datasets").mkdir(parents=True)
+        manifest = MigrationManifest(tmp_path / _WORKSPACE / "projects" / _PROJECT)
         manifest.start()
         manifest.complete()
 
@@ -543,11 +546,11 @@ class TestImportAll:
 
     def test_resume_in_progress_manifest_runs_phases_and_completes(self, tmp_path):
         """An in_progress manifest is treated as a resume; phases run and manifest completes."""
-        (tmp_path / "projects" / _PROJECT / "datasets").mkdir(parents=True)
-        (tmp_path / "projects" / _PROJECT / "prompts").mkdir(parents=True)
+        (tmp_path / _WORKSPACE / "projects" / _PROJECT / "datasets").mkdir(parents=True)
+        (tmp_path / _WORKSPACE / "projects" / _PROJECT / "prompts").mkdir(parents=True)
 
         # Simulate an interrupted import
-        manifest = MigrationManifest(tmp_path / "projects" / _PROJECT)
+        manifest = MigrationManifest(tmp_path / _WORKSPACE / "projects" / _PROJECT)
         manifest.start()
 
         client = _make_import_client()
@@ -581,12 +584,12 @@ class TestImportAll:
 
         mock_ds.assert_called_once()
         mock_pr.assert_called_once()
-        m = MigrationManifest(tmp_path / "projects" / _PROJECT)
+        m = MigrationManifest(tmp_path / _WORKSPACE / "projects" / _PROJECT)
         assert m.is_completed
 
     def test_include_filter_runs_only_specified_phases(self, tmp_path):
         """When include=['datasets'], only the dataset phase is called."""
-        (tmp_path / "projects" / _PROJECT / "datasets").mkdir(parents=True)
+        (tmp_path / _WORKSPACE / "projects" / _PROJECT / "datasets").mkdir(parents=True)
         client = _make_import_client()
         _seed_project_meta(tmp_path)
 
@@ -659,7 +662,7 @@ class TestImportAll:
 
     def test_flush_timeout_exits_with_code_1(self, tmp_path):
         """If client.flush() returns False (timeout), import_all raises SystemExit(1)."""
-        (tmp_path / "projects" / _PROJECT / "datasets").mkdir(parents=True)
+        (tmp_path / _WORKSPACE / "projects" / _PROJECT / "datasets").mkdir(parents=True)
         client = _make_import_client()
         _seed_project_meta(tmp_path)
         client.flush.return_value = False  # simulate timeout
@@ -693,7 +696,7 @@ class TestImportAll:
 
     def test_failed_uploads_exits_with_code_1(self, tmp_path):
         """If failed_uploads > 0, import_all raises SystemExit(1)."""
-        (tmp_path / "projects" / _PROJECT / "datasets").mkdir(parents=True)
+        (tmp_path / _WORKSPACE / "projects" / _PROJECT / "datasets").mkdir(parents=True)
         client = _make_import_client()
         _seed_project_meta(tmp_path)
         client.__internal_api__failed_uploads__ = MagicMock(return_value=3)
@@ -728,7 +731,7 @@ class TestImportAll:
     def test_intermediate_flush_after_prompts_imported(self, tmp_path):
         """client.flush() is called once after prompts phase (before end flush)
         when at least one prompt was imported."""
-        (tmp_path / "projects" / _PROJECT / "prompts").mkdir(parents=True)
+        (tmp_path / _WORKSPACE / "projects" / _PROJECT / "prompts").mkdir(parents=True)
         client = _make_import_client()
         _seed_project_meta(tmp_path)
 
@@ -762,7 +765,7 @@ class TestImportAll:
     def test_no_intermediate_flush_when_zero_prompts_imported(self, tmp_path):
         """client.flush() is called exactly once (end-of-import) when no prompts
         were imported — no intermediate flush is triggered."""
-        (tmp_path / "projects" / _PROJECT / "prompts").mkdir(parents=True)
+        (tmp_path / _WORKSPACE / "projects" / _PROJECT / "prompts").mkdir(parents=True)
         client = _make_import_client()
         _seed_project_meta(tmp_path)
 
@@ -812,7 +815,7 @@ class TestImportAll:
             from opik.cli.imports.all import import_all
 
             import_all(
-                workspace="my-ws",
+                workspace=_WORKSPACE,
                 project_name=_PROJECT,
                 path=str(tmp_path),
                 include=[],
@@ -825,7 +828,7 @@ class TestImportAll:
         mock_opik.assert_called_once()
         kwargs = mock_opik.call_args[1]
         assert kwargs.get("api_key") == "secret-key"
-        assert kwargs.get("workspace") == "my-ws"
+        assert kwargs.get("workspace") == _WORKSPACE
 
 
 # ---------------------------------------------------------------------------

--- a/sdks/python/tests/unit/test_export_import_all.py
+++ b/sdks/python/tests/unit/test_export_import_all.py
@@ -50,6 +50,7 @@ import pytest
 from opik.cli.export_manifest import ExportManifest
 from opik.cli.migration_manifest import MigrationManifest
 
+_PROJECT = "proj"
 _IMPORT_MODULE = "opik.cli.imports.all"
 _EXPORT_MODULE = "opik.cli.exports.all"
 
@@ -363,8 +364,8 @@ class TestImportAll:
 
     def test_fresh_run_calls_all_phases_and_completes_manifest(self, tmp_path):
         """A fresh import runs all four phases and marks the manifest completed."""
-        for d in ("datasets", "prompts", "projects", "experiments"):
-            (tmp_path / d).mkdir()
+        for d in ("datasets", "prompts", "experiments"):
+            (tmp_path / "projects" / _PROJECT / d).mkdir(parents=True)
 
         client = _make_import_client()
 
@@ -378,7 +379,7 @@ class TestImportAll:
                 return_value={"prompts": 0},
             ),
             patch(
-                f"{_IMPORT_MODULE}.import_projects_from_directory", return_value={}
+                f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}
             ) as mock_proj,
             patch(
                 f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
@@ -388,8 +389,9 @@ class TestImportAll:
 
             import_all(
                 workspace="ws",
+                project_name=_PROJECT,
                 path=str(tmp_path),
-                include=["datasets", "prompts", "projects", "experiments"],
+                include=["datasets", "prompts", "traces", "experiments"],
                 dry_run=False,
                 force=False,
                 debug=False,
@@ -399,12 +401,12 @@ class TestImportAll:
         mock_proj.assert_called_once()
         mock_exp.assert_called_once()
 
-        m = MigrationManifest(tmp_path)
+        m = MigrationManifest(tmp_path / "projects" / _PROJECT)
         assert m.is_completed
 
     def test_dry_run_skips_manifest_and_flush(self, tmp_path):
         """Dry-run must not create a manifest or flush the client."""
-        (tmp_path / "datasets").mkdir()
+        (tmp_path / "projects" / _PROJECT / "datasets").mkdir(parents=True)
         client = _make_import_client()
 
         with (
@@ -414,7 +416,7 @@ class TestImportAll:
                 f"{_IMPORT_MODULE}.import_prompts_from_directory",
                 return_value={"prompts": 0},
             ),
-            patch(f"{_IMPORT_MODULE}.import_projects_from_directory", return_value={}),
+            patch(f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}),
             patch(
                 f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
             ),
@@ -423,6 +425,7 @@ class TestImportAll:
 
             import_all(
                 workspace="ws",
+                project_name=_PROJECT,
                 path=str(tmp_path),
                 include=["datasets"],
                 dry_run=True,
@@ -430,12 +433,12 @@ class TestImportAll:
                 debug=False,
             )
 
-        assert not MigrationManifest.exists(tmp_path)
+        assert not MigrationManifest.exists(tmp_path / "projects" / _PROJECT)
         client.flush.assert_not_called()
 
     def test_completed_manifest_returns_early_without_reimporting(self, tmp_path):
         """A completed manifest without --force causes immediate return."""
-        manifest = MigrationManifest(tmp_path)
+        manifest = MigrationManifest(tmp_path / "projects" / _PROJECT)
         manifest.start()
         manifest.complete()
 
@@ -451,7 +454,7 @@ class TestImportAll:
                 return_value={"prompts": 0},
             ),
             patch(
-                f"{_IMPORT_MODULE}.import_projects_from_directory", return_value={}
+                f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}
             ) as mock_proj,
             patch(
                 f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
@@ -461,8 +464,9 @@ class TestImportAll:
 
             import_all(
                 workspace="ws",
+                project_name=_PROJECT,
                 path=str(tmp_path),
-                include=["datasets", "prompts", "projects", "experiments"],
+                include=["datasets", "prompts", "traces", "experiments"],
                 dry_run=False,
                 force=False,
                 debug=False,
@@ -474,8 +478,8 @@ class TestImportAll:
 
     def test_force_flag_resets_completed_manifest_and_reimports(self, tmp_path):
         """--force discards a completed manifest and runs all requested phases."""
-        (tmp_path / "datasets").mkdir()
-        manifest = MigrationManifest(tmp_path)
+        (tmp_path / "projects" / _PROJECT / "datasets").mkdir(parents=True)
+        manifest = MigrationManifest(tmp_path / "projects" / _PROJECT)
         manifest.start()
         manifest.complete()
 
@@ -490,7 +494,7 @@ class TestImportAll:
                 f"{_IMPORT_MODULE}.import_prompts_from_directory",
                 return_value={"prompts": 0},
             ),
-            patch(f"{_IMPORT_MODULE}.import_projects_from_directory", return_value={}),
+            patch(f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}),
             patch(
                 f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
             ),
@@ -499,6 +503,7 @@ class TestImportAll:
 
             import_all(
                 workspace="ws",
+                project_name=_PROJECT,
                 path=str(tmp_path),
                 include=["datasets"],
                 dry_run=False,
@@ -510,11 +515,11 @@ class TestImportAll:
 
     def test_resume_in_progress_manifest_runs_phases_and_completes(self, tmp_path):
         """An in_progress manifest is treated as a resume; phases run and manifest completes."""
-        (tmp_path / "datasets").mkdir()
-        (tmp_path / "prompts").mkdir()
+        (tmp_path / "projects" / _PROJECT / "datasets").mkdir(parents=True)
+        (tmp_path / "projects" / _PROJECT / "prompts").mkdir(parents=True)
 
         # Simulate an interrupted import
-        manifest = MigrationManifest(tmp_path)
+        manifest = MigrationManifest(tmp_path / "projects" / _PROJECT)
         manifest.start()
 
         client = _make_import_client()
@@ -528,7 +533,7 @@ class TestImportAll:
                 f"{_IMPORT_MODULE}.import_prompts_from_directory",
                 return_value={"prompts": 0},
             ) as mock_pr,
-            patch(f"{_IMPORT_MODULE}.import_projects_from_directory", return_value={}),
+            patch(f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}),
             patch(
                 f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
             ),
@@ -537,6 +542,7 @@ class TestImportAll:
 
             import_all(
                 workspace="ws",
+                project_name=_PROJECT,
                 path=str(tmp_path),
                 include=["datasets", "prompts"],
                 dry_run=False,
@@ -546,12 +552,12 @@ class TestImportAll:
 
         mock_ds.assert_called_once()
         mock_pr.assert_called_once()
-        m = MigrationManifest(tmp_path)
+        m = MigrationManifest(tmp_path / "projects" / _PROJECT)
         assert m.is_completed
 
     def test_include_filter_runs_only_specified_phases(self, tmp_path):
         """When include=['datasets'], only the dataset phase is called."""
-        (tmp_path / "datasets").mkdir()
+        (tmp_path / "projects" / _PROJECT / "datasets").mkdir(parents=True)
         client = _make_import_client()
 
         with (
@@ -564,7 +570,7 @@ class TestImportAll:
                 return_value={"prompts": 0},
             ) as mock_pr,
             patch(
-                f"{_IMPORT_MODULE}.import_projects_from_directory", return_value={}
+                f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}
             ) as mock_proj,
             patch(
                 f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
@@ -574,6 +580,7 @@ class TestImportAll:
 
             import_all(
                 workspace="ws",
+                project_name=_PROJECT,
                 path=str(tmp_path),
                 include=["datasets"],
                 dry_run=False,
@@ -600,7 +607,7 @@ class TestImportAll:
                 f"{_IMPORT_MODULE}.import_prompts_from_directory",
                 return_value={"prompts": 0},
             ),
-            patch(f"{_IMPORT_MODULE}.import_projects_from_directory", return_value={}),
+            patch(f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}),
             patch(
                 f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
             ),
@@ -609,6 +616,7 @@ class TestImportAll:
 
             import_all(
                 workspace="ws",
+                project_name=_PROJECT,
                 path=str(tmp_path),
                 include=["datasets"],
                 dry_run=False,
@@ -620,7 +628,7 @@ class TestImportAll:
 
     def test_flush_timeout_exits_with_code_1(self, tmp_path):
         """If client.flush() returns False (timeout), import_all raises SystemExit(1)."""
-        (tmp_path / "datasets").mkdir()
+        (tmp_path / "projects" / _PROJECT / "datasets").mkdir(parents=True)
         client = _make_import_client()
         client.flush.return_value = False  # simulate timeout
 
@@ -631,7 +639,7 @@ class TestImportAll:
                 f"{_IMPORT_MODULE}.import_prompts_from_directory",
                 return_value={"prompts": 0},
             ),
-            patch(f"{_IMPORT_MODULE}.import_projects_from_directory", return_value={}),
+            patch(f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}),
             patch(
                 f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
             ),
@@ -641,6 +649,7 @@ class TestImportAll:
 
             import_all(
                 workspace="ws",
+                project_name=_PROJECT,
                 path=str(tmp_path),
                 include=["datasets"],
                 dry_run=False,
@@ -652,7 +661,7 @@ class TestImportAll:
 
     def test_failed_uploads_exits_with_code_1(self, tmp_path):
         """If failed_uploads > 0, import_all raises SystemExit(1)."""
-        (tmp_path / "datasets").mkdir()
+        (tmp_path / "projects" / _PROJECT / "datasets").mkdir(parents=True)
         client = _make_import_client()
         client.__internal_api__failed_uploads__ = MagicMock(return_value=3)
 
@@ -663,7 +672,7 @@ class TestImportAll:
                 f"{_IMPORT_MODULE}.import_prompts_from_directory",
                 return_value={"prompts": 0},
             ),
-            patch(f"{_IMPORT_MODULE}.import_projects_from_directory", return_value={}),
+            patch(f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}),
             patch(
                 f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
             ),
@@ -673,6 +682,7 @@ class TestImportAll:
 
             import_all(
                 workspace="ws",
+                project_name=_PROJECT,
                 path=str(tmp_path),
                 include=["datasets"],
                 dry_run=False,
@@ -685,7 +695,7 @@ class TestImportAll:
     def test_intermediate_flush_after_prompts_imported(self, tmp_path):
         """client.flush() is called once after prompts phase (before end flush)
         when at least one prompt was imported."""
-        (tmp_path / "prompts").mkdir()
+        (tmp_path / "projects" / _PROJECT / "prompts").mkdir(parents=True)
         client = _make_import_client()
 
         with (
@@ -695,7 +705,7 @@ class TestImportAll:
                 f"{_IMPORT_MODULE}.import_prompts_from_directory",
                 return_value={"prompts": 2},
             ),
-            patch(f"{_IMPORT_MODULE}.import_projects_from_directory", return_value={}),
+            patch(f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}),
             patch(
                 f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
             ),
@@ -704,6 +714,7 @@ class TestImportAll:
 
             import_all(
                 workspace="ws",
+                project_name=_PROJECT,
                 path=str(tmp_path),
                 include=["prompts"],
                 dry_run=False,
@@ -717,7 +728,7 @@ class TestImportAll:
     def test_no_intermediate_flush_when_zero_prompts_imported(self, tmp_path):
         """client.flush() is called exactly once (end-of-import) when no prompts
         were imported — no intermediate flush is triggered."""
-        (tmp_path / "prompts").mkdir()
+        (tmp_path / "projects" / _PROJECT / "prompts").mkdir(parents=True)
         client = _make_import_client()
 
         with (
@@ -727,7 +738,7 @@ class TestImportAll:
                 f"{_IMPORT_MODULE}.import_prompts_from_directory",
                 return_value={"prompts": 0},
             ),
-            patch(f"{_IMPORT_MODULE}.import_projects_from_directory", return_value={}),
+            patch(f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}),
             patch(
                 f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
             ),
@@ -736,6 +747,7 @@ class TestImportAll:
 
             import_all(
                 workspace="ws",
+                project_name=_PROJECT,
                 path=str(tmp_path),
                 include=["prompts"],
                 dry_run=False,
@@ -756,7 +768,7 @@ class TestImportAll:
                 f"{_IMPORT_MODULE}.import_prompts_from_directory",
                 return_value={"prompts": 0},
             ),
-            patch(f"{_IMPORT_MODULE}.import_projects_from_directory", return_value={}),
+            patch(f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}),
             patch(
                 f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
             ),
@@ -765,6 +777,7 @@ class TestImportAll:
 
             import_all(
                 workspace="my-ws",
+                project_name=_PROJECT,
                 path=str(tmp_path),
                 include=[],
                 dry_run=False,
@@ -794,7 +807,8 @@ class TestExportAll:
             patch(f"{_EXPORT_MODULE}._export_all_datasets", return_value=(0, 0)),
             patch(f"{_EXPORT_MODULE}._export_all_prompts", return_value=(0, 0)),
             patch(
-                f"{_EXPORT_MODULE}._export_all_projects", return_value=(0, 0, 0, False)
+                f"{_EXPORT_MODULE}._export_project_traces",
+                return_value=(0, 0, 0, False),
             ),
             patch(
                 f"{_EXPORT_MODULE}._export_all_experiments",
@@ -805,15 +819,16 @@ class TestExportAll:
 
             export_all(
                 workspace="my-ws",
+                project_name=_PROJECT,
                 output_path=str(tmp_path),
-                include=["datasets", "prompts", "projects", "experiments"],
+                include=["datasets", "prompts", "traces", "experiments"],
                 max_results=None,
                 force=False,
                 debug=False,
                 format="json",
             )
 
-        assert (tmp_path / "my-ws").is_dir()
+        assert (tmp_path / "my-ws" / "projects" / _PROJECT).is_dir()
 
     def test_subdirectories_created_for_all_phases(self, tmp_path):
         client = _make_export_client()
@@ -822,7 +837,8 @@ class TestExportAll:
             patch(f"{_EXPORT_MODULE}._export_all_datasets", return_value=(0, 0)),
             patch(f"{_EXPORT_MODULE}._export_all_prompts", return_value=(0, 0)),
             patch(
-                f"{_EXPORT_MODULE}._export_all_projects", return_value=(0, 0, 0, False)
+                f"{_EXPORT_MODULE}._export_project_traces",
+                return_value=(0, 0, 0, False),
             ),
             patch(
                 f"{_EXPORT_MODULE}._export_all_experiments",
@@ -833,16 +849,17 @@ class TestExportAll:
 
             export_all(
                 workspace="ws",
+                project_name=_PROJECT,
                 output_path=str(tmp_path),
-                include=["datasets", "prompts", "projects", "experiments"],
+                include=["datasets", "prompts", "traces", "experiments"],
                 max_results=None,
                 force=False,
                 debug=False,
                 format="json",
             )
 
-        ws = tmp_path / "ws"
-        for subdir in ("datasets", "prompts", "projects", "experiments"):
+        ws = tmp_path / "ws" / "projects" / _PROJECT
+        for subdir in ("datasets", "prompts", "experiments"):
             assert (ws / subdir).is_dir(), f"Missing {subdir}/ directory"
 
     def test_only_included_phases_are_called(self, tmp_path):
@@ -857,7 +874,8 @@ class TestExportAll:
                 f"{_EXPORT_MODULE}._export_all_prompts", return_value=(0, 0)
             ) as mock_pr,
             patch(
-                f"{_EXPORT_MODULE}._export_all_projects", return_value=(0, 0, 0, False)
+                f"{_EXPORT_MODULE}._export_project_traces",
+                return_value=(0, 0, 0, False),
             ) as mock_proj,
             patch(
                 f"{_EXPORT_MODULE}._export_all_experiments",
@@ -868,6 +886,7 @@ class TestExportAll:
 
             export_all(
                 workspace="ws",
+                project_name=_PROJECT,
                 output_path=str(tmp_path),
                 include=["datasets"],
                 max_results=None,
@@ -889,7 +908,8 @@ class TestExportAll:
             patch(f"{_EXPORT_MODULE}._export_all_datasets", return_value=(1, 0)),
             patch(f"{_EXPORT_MODULE}._export_all_prompts", return_value=(2, 0)),
             patch(
-                f"{_EXPORT_MODULE}._export_all_projects", return_value=(1, 5, 0, False)
+                f"{_EXPORT_MODULE}._export_project_traces",
+                return_value=(1, 5, 0, False),
             ),
             patch(
                 f"{_EXPORT_MODULE}._export_all_experiments",
@@ -901,8 +921,9 @@ class TestExportAll:
 
             export_all(
                 workspace="ws",
+                project_name=_PROJECT,
                 output_path=str(tmp_path),
-                include=["datasets", "prompts", "projects", "experiments"],
+                include=["datasets", "prompts", "traces", "experiments"],
                 max_results=None,
                 force=False,
                 debug=False,
@@ -924,7 +945,8 @@ class TestExportAll:
             patch(f"{_EXPORT_MODULE}._export_all_datasets", return_value=(0, 0)),
             patch(f"{_EXPORT_MODULE}._export_all_prompts", return_value=(0, 0)),
             patch(
-                f"{_EXPORT_MODULE}._export_all_projects", return_value=(0, 0, 0, False)
+                f"{_EXPORT_MODULE}._export_project_traces",
+                return_value=(0, 0, 0, False),
             ),
             patch(
                 f"{_EXPORT_MODULE}._export_all_experiments",
@@ -935,6 +957,7 @@ class TestExportAll:
 
             export_all(
                 workspace="ws",
+                project_name=_PROJECT,
                 output_path=str(tmp_path),
                 include=[],
                 max_results=None,
@@ -1057,6 +1080,7 @@ class TestExportExperimentByIdJsonFastPath:
         stats, file_written, _ = export_experiment_by_id(
             mock_client,
             tmp_path,
+            _PROJECT,
             experiment_id,
             max_traces=None,
             force=False,
@@ -1097,6 +1121,7 @@ class TestExportExperimentByIdJsonFastPath:
         export_experiment_by_id(
             mock_client,
             tmp_path,
+            _PROJECT,
             experiment_id,
             max_traces=None,
             force=False,
@@ -1115,27 +1140,19 @@ class TestExportExperimentByIdJsonFastPath:
 # ---------------------------------------------------------------------------
 
 
-class TestFilenameBasedProjectInference:
-    """Verify trace_to_project_map is built from on-disk trace filenames and used
-    to infer project_for_logs when experiment metadata has no explicit project."""
+class TestImportExperimentsDryRun:
+    """Experiments now always import into the project named on the command line
+    (the old filename-based project inference was removed). Verify the importer
+    accepts the project_name positional and returns stats without error."""
 
-    def test_project_name_inferred_from_trace_filename(self, tmp_path):
-        """When a trace file exists under projects/my-project/, its project name
-        is inferred without opening the file."""
+    def test_dry_run_returns_stats_for_named_project(self, tmp_path):
         import json
 
         from opik.cli.imports.experiment import import_experiments_from_directory
 
-        # Build workspace layout: experiments/ and projects/my-project/
         experiments_dir = tmp_path / "experiments"
         experiments_dir.mkdir()
-        projects_dir = tmp_path / "projects" / "my-project"
-        projects_dir.mkdir(parents=True)
 
-        trace_id = "trace-abc-123"
-        (projects_dir / f"trace_{trace_id}.json").write_text("{}")
-
-        # Write a minimal experiment JSON that references the trace above.
         exp_data = {
             "experiment": {
                 "name": "test-exp",
@@ -1143,7 +1160,7 @@ class TestFilenameBasedProjectInference:
                 "dataset_name": "ds",
             },
             "items": [
-                {"trace_id": trace_id},
+                {"trace_id": "trace-abc-123"},
             ],
             "downloaded_at": "2024-01-01T00:00:00",
         }
@@ -1152,22 +1169,17 @@ class TestFilenameBasedProjectInference:
         )
 
         mock_client = MagicMock()
-        # create_experiment returns a mock with id
-        created_exp = MagicMock()
-        created_exp.id = "new-exp-id"
-        mock_client.create_experiment.return_value = created_exp
-        mock_client.get_experiment_by_id.return_value = MagicMock(id="new-exp-id")
         mock_client.flush.return_value = True
 
         result = import_experiments_from_directory(
             mock_client,
             experiments_dir,
+            _PROJECT,
             dry_run=True,  # dry_run avoids real API calls for import
             name_pattern=None,
             debug=False,
         )
 
-        # The function should complete without error regardless of dry_run;
-        # the key assertion is that no exception is raised and it returns stats.
+        # Completes without error and returns stats for the named project.
         assert isinstance(result, dict)
         assert "experiments" in result

--- a/sdks/python/tests/unit/test_export_import_all.py
+++ b/sdks/python/tests/unit/test_export_import_all.py
@@ -727,6 +727,44 @@ class TestImportAll:
 
         assert exc_info.value.code == 1
 
+    def test_phase_errors_leave_manifest_incomplete(self, tmp_path):
+        """A failed import must NOT mark the manifest completed, so a non---force
+        rerun resumes/retries instead of short-circuiting on is_completed."""
+        (tmp_path / _WORKSPACE / "projects" / _PROJECT / "datasets").mkdir(parents=True)
+        client = _make_import_client()
+        _seed_project_meta(tmp_path)
+
+        with (
+            patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client),
+            patch(
+                f"{_IMPORT_MODULE}.import_datasets_from_directory",
+                return_value={"datasets": 0, "datasets_errors": 1},
+            ),
+            patch(
+                f"{_IMPORT_MODULE}.import_prompts_from_directory",
+                return_value={"prompts": 0},
+            ),
+            patch(f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}),
+            patch(
+                f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
+            ),
+            pytest.raises(SystemExit),
+        ):
+            from opik.cli.imports.all import import_all
+
+            import_all(
+                workspace="ws",
+                project_name=_PROJECT,
+                path=str(tmp_path),
+                include=["datasets"],
+                dry_run=False,
+                force=False,
+                debug=False,
+            )
+
+        manifest = MigrationManifest(tmp_path / _WORKSPACE / "projects" / _PROJECT)
+        assert not manifest.is_completed
+
     def test_flush_timeout_exits_with_code_1(self, tmp_path):
         """If client.flush() returns False (timeout), import_all raises SystemExit(1)."""
         (tmp_path / _WORKSPACE / "projects" / _PROJECT / "datasets").mkdir(parents=True)

--- a/sdks/python/tests/unit/test_export_import_all.py
+++ b/sdks/python/tests/unit/test_export_import_all.py
@@ -43,6 +43,8 @@ _paginate helper
   - Empty first page
 """
 
+import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -51,6 +53,7 @@ from opik.cli.export_manifest import ExportManifest
 from opik.cli.migration_manifest import MigrationManifest
 
 _PROJECT = "proj"
+_PROJECT_ID = "proj-id"
 _IMPORT_MODULE = "opik.cli.imports.all"
 _EXPORT_MODULE = "opik.cli.exports.all"
 
@@ -70,6 +73,27 @@ def _make_import_client() -> MagicMock:
 
 def _make_export_client() -> MagicMock:
     return MagicMock()
+
+
+def _seed_project_meta(tmp_path: Path) -> Path:
+    """Create the on-disk project folder + project.json so import_all can resolve
+    the source project by its recorded name. Folders are keyed by id on disk; the
+    folder name is irrelevant — find_project_export_dir matches project.json's name.
+    """
+    proj = tmp_path / "projects" / _PROJECT
+    proj.mkdir(parents=True, exist_ok=True)
+    (proj / "project.json").write_text(
+        json.dumps({"id": _PROJECT_ID, "name": _PROJECT})
+    )
+    return proj
+
+
+def _fake_prepare_export_dir(client, output_path, workspace, project_name):
+    """Stand-in for prepare_project_export_dir that skips ID resolution (the
+    client is mocked) and returns a deterministic id-named project dir."""
+    project_dir = Path(output_path) / workspace / "projects" / _PROJECT_ID
+    project_dir.mkdir(parents=True, exist_ok=True)
+    return _PROJECT_ID, project_dir
 
 
 # ---------------------------------------------------------------------------
@@ -368,6 +392,7 @@ class TestImportAll:
             (tmp_path / "projects" / _PROJECT / d).mkdir(parents=True)
 
         client = _make_import_client()
+        _seed_project_meta(tmp_path)
 
         with (
             patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client),
@@ -408,6 +433,7 @@ class TestImportAll:
         """Dry-run must not create a manifest or flush the client."""
         (tmp_path / "projects" / _PROJECT / "datasets").mkdir(parents=True)
         client = _make_import_client()
+        _seed_project_meta(tmp_path)
 
         with (
             patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client),
@@ -443,6 +469,7 @@ class TestImportAll:
         manifest.complete()
 
         client = _make_import_client()
+        _seed_project_meta(tmp_path)
 
         with (
             patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client),
@@ -484,6 +511,7 @@ class TestImportAll:
         manifest.complete()
 
         client = _make_import_client()
+        _seed_project_meta(tmp_path)
 
         with (
             patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client),
@@ -523,6 +551,7 @@ class TestImportAll:
         manifest.start()
 
         client = _make_import_client()
+        _seed_project_meta(tmp_path)
 
         with (
             patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client),
@@ -559,6 +588,7 @@ class TestImportAll:
         """When include=['datasets'], only the dataset phase is called."""
         (tmp_path / "projects" / _PROJECT / "datasets").mkdir(parents=True)
         client = _make_import_client()
+        _seed_project_meta(tmp_path)
 
         with (
             patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client),
@@ -597,6 +627,7 @@ class TestImportAll:
         """If datasets/ does not exist, the dataset phase is silently skipped."""
         # Do NOT create (tmp_path / "datasets")
         client = _make_import_client()
+        _seed_project_meta(tmp_path)
 
         with (
             patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client),
@@ -630,6 +661,7 @@ class TestImportAll:
         """If client.flush() returns False (timeout), import_all raises SystemExit(1)."""
         (tmp_path / "projects" / _PROJECT / "datasets").mkdir(parents=True)
         client = _make_import_client()
+        _seed_project_meta(tmp_path)
         client.flush.return_value = False  # simulate timeout
 
         with (
@@ -663,6 +695,7 @@ class TestImportAll:
         """If failed_uploads > 0, import_all raises SystemExit(1)."""
         (tmp_path / "projects" / _PROJECT / "datasets").mkdir(parents=True)
         client = _make_import_client()
+        _seed_project_meta(tmp_path)
         client.__internal_api__failed_uploads__ = MagicMock(return_value=3)
 
         with (
@@ -697,6 +730,7 @@ class TestImportAll:
         when at least one prompt was imported."""
         (tmp_path / "projects" / _PROJECT / "prompts").mkdir(parents=True)
         client = _make_import_client()
+        _seed_project_meta(tmp_path)
 
         with (
             patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client),
@@ -730,6 +764,7 @@ class TestImportAll:
         were imported — no intermediate flush is triggered."""
         (tmp_path / "projects" / _PROJECT / "prompts").mkdir(parents=True)
         client = _make_import_client()
+        _seed_project_meta(tmp_path)
 
         with (
             patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client),
@@ -760,6 +795,7 @@ class TestImportAll:
     def test_api_key_passed_to_opik_constructor(self, tmp_path):
         """When api_key is provided it is forwarded to opik.Opik()."""
         client = _make_import_client()
+        _seed_project_meta(tmp_path)
 
         with (
             patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client) as mock_opik,
@@ -804,6 +840,10 @@ class TestExportAll:
         client = _make_export_client()
         with (
             patch(f"{_EXPORT_MODULE}.opik.Opik", return_value=client),
+            patch(
+                f"{_EXPORT_MODULE}.prepare_project_export_dir",
+                side_effect=_fake_prepare_export_dir,
+            ),
             patch(f"{_EXPORT_MODULE}._export_all_datasets", return_value=(0, 0)),
             patch(f"{_EXPORT_MODULE}._export_all_prompts", return_value=(0, 0)),
             patch(
@@ -828,12 +868,16 @@ class TestExportAll:
                 format="json",
             )
 
-        assert (tmp_path / "my-ws" / "projects" / _PROJECT).is_dir()
+        assert (tmp_path / "my-ws" / "projects" / _PROJECT_ID).is_dir()
 
     def test_subdirectories_created_for_all_phases(self, tmp_path):
         client = _make_export_client()
         with (
             patch(f"{_EXPORT_MODULE}.opik.Opik", return_value=client),
+            patch(
+                f"{_EXPORT_MODULE}.prepare_project_export_dir",
+                side_effect=_fake_prepare_export_dir,
+            ),
             patch(f"{_EXPORT_MODULE}._export_all_datasets", return_value=(0, 0)),
             patch(f"{_EXPORT_MODULE}._export_all_prompts", return_value=(0, 0)),
             patch(
@@ -858,7 +902,7 @@ class TestExportAll:
                 format="json",
             )
 
-        ws = tmp_path / "ws" / "projects" / _PROJECT
+        ws = tmp_path / "ws" / "projects" / _PROJECT_ID
         for subdir in ("datasets", "prompts", "experiments"):
             assert (ws / subdir).is_dir(), f"Missing {subdir}/ directory"
 
@@ -1058,7 +1102,7 @@ class TestExportExperimentByIdJsonFastPath:
         experiment_id = "exp-abc-123"
 
         # Create the experiment JSON file the fast path will read from disk.
-        experiment_file = tmp_path / f"experiment_my_exp_{experiment_id}.json"
+        experiment_file = tmp_path / f"experiment_{experiment_id}.json"
         experiment_data = {
             "id": experiment_id,
             "name": "my_exp",
@@ -1106,7 +1150,7 @@ class TestExportExperimentByIdJsonFastPath:
         experiment_id = "exp-corrupt-456"
 
         # Write a corrupt JSON file.
-        experiment_file = tmp_path / f"experiment_bad_{experiment_id}.json"
+        experiment_file = tmp_path / f"experiment_{experiment_id}.json"
         experiment_file.write_text("{ not valid json }")
 
         mock_client = MagicMock()

--- a/sdks/python/tests/unit/test_export_import_all.py
+++ b/sdks/python/tests/unit/test_export_import_all.py
@@ -400,7 +400,9 @@ class TestSetupImportManifest:
     """The per-destination manifest must key files relative to project_root even
     though the SQLite db lives in a per-destination subdir."""
 
-    def test_files_under_project_root_are_keyable(self, tmp_path):
+    def test_setup_import_manifest__files_under_project_root__allows_marking_files_completed_without_value_error(
+        self, tmp_path
+    ):
         from opik.cli.imports.utils import (
             setup_import_manifest,
             destination_manifest_dir,
@@ -429,7 +431,7 @@ class TestSetupImportManifest:
         ).exists()
         assert not (project_root / "migration_manifest.db").exists()
 
-    def test_dry_run_creates_no_manifest(self, tmp_path):
+    def test_setup_import_manifest__dry_run__returns_no_manifest(self, tmp_path):
         from opik.cli.imports.utils import setup_import_manifest
 
         project_root = tmp_path / _WORKSPACE / "projects" / _PROJECT
@@ -439,6 +441,45 @@ class TestSetupImportManifest:
         )
         assert manifest is None
         assert not already_completed
+
+    def test_setup_import_manifest__force_on_fresh_run__does_not_warn_about_discarding(
+        self, tmp_path, capsys
+    ):
+        from opik.cli.imports.utils import setup_import_manifest
+
+        project_root = tmp_path / _WORKSPACE / "projects" / _PROJECT
+        project_root.mkdir(parents=True)
+        # No manifest exists yet — constructing it must not make --force think it
+        # is discarding a prior manifest.
+        manifest, already_completed = setup_import_manifest(
+            project_root, "dest", dry_run=False, force=True
+        )
+        assert manifest is not None
+        assert not already_completed
+        assert "discarding existing manifest" not in capsys.readouterr().out
+
+    def test_setup_import_manifest__force_with_existing_manifest__warns_and_resets(
+        self, tmp_path, capsys
+    ):
+        from opik.cli.imports.utils import setup_import_manifest
+
+        project_root = tmp_path / _WORKSPACE / "projects" / _PROJECT
+        project_root.mkdir(parents=True)
+        # First run creates and completes a manifest.
+        first, _ = setup_import_manifest(
+            project_root, "dest", dry_run=False, force=False
+        )
+        assert first is not None
+        first.complete()
+        capsys.readouterr()  # discard output so far
+
+        # A --force run with a pre-existing manifest discards it and proceeds.
+        second, already_completed = setup_import_manifest(
+            project_root, "dest", dry_run=False, force=True
+        )
+        assert second is not None
+        assert not already_completed  # reset() cleared the completed status
+        assert "discarding existing manifest" in capsys.readouterr().out
 
 
 # ---------------------------------------------------------------------------

--- a/sdks/python/tests/unit/test_export_import_all.py
+++ b/sdks/python/tests/unit/test_export_import_all.py
@@ -690,6 +690,43 @@ class TestImportAll:
 
         mock_ds.assert_not_called()
 
+    def test_phase_errors_exit_with_code_1(self, tmp_path):
+        """If an importer reports *_errors, import_all exits non-zero (fail-fast)
+        rather than masking the failure with a 0 exit code."""
+        (tmp_path / _WORKSPACE / "projects" / _PROJECT / "datasets").mkdir(parents=True)
+        client = _make_import_client()
+        _seed_project_meta(tmp_path)
+
+        with (
+            patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client),
+            patch(
+                f"{_IMPORT_MODULE}.import_datasets_from_directory",
+                return_value={"datasets": 1, "datasets_errors": 2},
+            ),
+            patch(
+                f"{_IMPORT_MODULE}.import_prompts_from_directory",
+                return_value={"prompts": 0},
+            ),
+            patch(f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}),
+            patch(
+                f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            from opik.cli.imports.all import import_all
+
+            import_all(
+                workspace="ws",
+                project_name=_PROJECT,
+                path=str(tmp_path),
+                include=["datasets"],
+                dry_run=False,
+                force=False,
+                debug=False,
+            )
+
+        assert exc_info.value.code == 1
+
     def test_flush_timeout_exits_with_code_1(self, tmp_path):
         """If client.flush() returns False (timeout), import_all raises SystemExit(1)."""
         (tmp_path / _WORKSPACE / "projects" / _PROJECT / "datasets").mkdir(parents=True)

--- a/sdks/python/tests/unit/test_export_import_all.py
+++ b/sdks/python/tests/unit/test_export_import_all.py
@@ -89,6 +89,16 @@ def _seed_project_meta(tmp_path: Path) -> Path:
     return proj
 
 
+def _manifest_dir(tmp_path: Path) -> Path:
+    """Destination-keyed import-manifest dir for the default (no --to-project)
+    case, where the destination project == the source project name."""
+    from opik.cli.imports.utils import destination_manifest_dir
+
+    return destination_manifest_dir(
+        tmp_path / _WORKSPACE / "projects" / _PROJECT, _PROJECT
+    )
+
+
 def _fake_prepare_export_dir(client, output_path, workspace, project_name):
     """Stand-in for prepare_project_export_dir that skips ID resolution (the
     client is mocked) and returns a deterministic id-named project dir."""
@@ -457,7 +467,7 @@ class TestImportAll:
         mock_proj.assert_called_once()
         mock_exp.assert_called_once()
 
-        m = MigrationManifest(tmp_path / _WORKSPACE / "projects" / _PROJECT)
+        m = MigrationManifest(_manifest_dir(tmp_path))
         assert m.is_completed
 
     def test_dry_run_skips_manifest_and_flush(self, tmp_path):
@@ -497,7 +507,7 @@ class TestImportAll:
 
     def test_completed_manifest_returns_early_without_reimporting(self, tmp_path):
         """A completed manifest without --force causes immediate return."""
-        manifest = MigrationManifest(tmp_path / _WORKSPACE / "projects" / _PROJECT)
+        manifest = MigrationManifest(_manifest_dir(tmp_path))
         manifest.start()
         manifest.complete()
 
@@ -539,7 +549,7 @@ class TestImportAll:
     def test_force_flag_resets_completed_manifest_and_reimports(self, tmp_path):
         """--force discards a completed manifest and runs all requested phases."""
         (tmp_path / _WORKSPACE / "projects" / _PROJECT / "datasets").mkdir(parents=True)
-        manifest = MigrationManifest(tmp_path / _WORKSPACE / "projects" / _PROJECT)
+        manifest = MigrationManifest(_manifest_dir(tmp_path))
         manifest.start()
         manifest.complete()
 
@@ -580,7 +590,7 @@ class TestImportAll:
         (tmp_path / _WORKSPACE / "projects" / _PROJECT / "prompts").mkdir(parents=True)
 
         # Simulate an interrupted import
-        manifest = MigrationManifest(tmp_path / _WORKSPACE / "projects" / _PROJECT)
+        manifest = MigrationManifest(_manifest_dir(tmp_path))
         manifest.start()
 
         client = _make_import_client()
@@ -614,7 +624,7 @@ class TestImportAll:
 
         mock_ds.assert_called_once()
         mock_pr.assert_called_once()
-        m = MigrationManifest(tmp_path / _WORKSPACE / "projects" / _PROJECT)
+        m = MigrationManifest(_manifest_dir(tmp_path))
         assert m.is_completed
 
     def test_include_filter_runs_only_specified_phases(self, tmp_path):
@@ -781,6 +791,53 @@ class TestImportAll:
         # short-circuit and never call the importer.
         mock_ds_ok = _run_import_datasets({"datasets": 1})
         assert mock_ds_ok.called
+
+    def test_to_project_imports_are_independent(self, tmp_path):
+        """Importing one exported project into different --to-project targets must
+        keep independent resume/completion state: a clean import into A must not
+        short-circuit a later import into B (which would write nothing to B).
+        Verified via observable behavior — the importer runs on both A and B.
+        """
+        (tmp_path / _WORKSPACE / "projects" / _PROJECT / "datasets").mkdir(parents=True)
+        client = _make_import_client()
+        _seed_project_meta(tmp_path)
+
+        from opik.cli.imports.all import import_all
+
+        def _run_into(to_project):
+            mock_ds = MagicMock(return_value={"datasets": 1})
+            with (
+                patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client),
+                patch(f"{_IMPORT_MODULE}.import_datasets_from_directory", mock_ds),
+                patch(
+                    f"{_IMPORT_MODULE}.import_prompts_from_directory",
+                    return_value={"prompts": 0},
+                ),
+                patch(
+                    f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}
+                ),
+                patch(
+                    f"{_IMPORT_MODULE}.import_experiments_from_directory",
+                    return_value={},
+                ),
+            ):
+                import_all(
+                    workspace="ws",
+                    project_name=_PROJECT,
+                    path=str(tmp_path),
+                    include=["datasets"],
+                    dry_run=False,
+                    force=False,
+                    debug=False,
+                    to_project=to_project,
+                )
+            return mock_ds
+
+        # Clean import into A completes (and marks A's manifest completed).
+        assert _run_into("dest-a").called
+        # A later import into B must still run — its own (separate) manifest is
+        # not yet completed, so it does not short-circuit on "already completed".
+        assert _run_into("dest-b").called
 
     def test_flush_timeout_exits_with_code_1(self, tmp_path):
         """If client.flush() returns False (timeout), import_all raises SystemExit(1)."""

--- a/sdks/python/tests/unit/test_export_import_all.py
+++ b/sdks/python/tests/unit/test_export_import_all.py
@@ -727,43 +727,60 @@ class TestImportAll:
 
         assert exc_info.value.code == 1
 
-    def test_phase_errors_leave_manifest_incomplete(self, tmp_path):
-        """A failed import must NOT mark the manifest completed, so a non---force
-        rerun resumes/retries instead of short-circuiting on is_completed."""
+    def test_failed_import_is_retryable_without_force(self, tmp_path):
+        """A failed import must not be recorded as completed: re-running without
+        ``--force`` must re-attempt the phases instead of short-circuiting on
+        "already completed". Verified through observable behavior (the importer
+        is invoked again on the second run) rather than the internal manifest.
+        """
         (tmp_path / _WORKSPACE / "projects" / _PROJECT / "datasets").mkdir(parents=True)
         client = _make_import_client()
         _seed_project_meta(tmp_path)
 
-        with (
-            patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client),
-            patch(
-                f"{_IMPORT_MODULE}.import_datasets_from_directory",
-                return_value={"datasets": 0, "datasets_errors": 1},
-            ),
-            patch(
-                f"{_IMPORT_MODULE}.import_prompts_from_directory",
-                return_value={"prompts": 0},
-            ),
-            patch(f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}),
-            patch(
-                f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
-            ),
-            pytest.raises(SystemExit),
-        ):
-            from opik.cli.imports.all import import_all
+        from opik.cli.imports.all import import_all
 
-            import_all(
-                workspace="ws",
-                project_name=_PROJECT,
-                path=str(tmp_path),
-                include=["datasets"],
-                dry_run=False,
-                force=False,
-                debug=False,
-            )
+        def _run_import_datasets(datasets_result):
+            """Run `import_all` for the datasets phase with a patched importer.
 
-        manifest = MigrationManifest(tmp_path / _WORKSPACE / "projects" / _PROJECT)
-        assert not manifest.is_completed
+            Returns the dataset-importer mock so the caller can assert it was
+            invoked (i.e. the run was not short-circuited as already-completed).
+            """
+            mock_ds = MagicMock(return_value=datasets_result)
+            with (
+                patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client),
+                patch(f"{_IMPORT_MODULE}.import_datasets_from_directory", mock_ds),
+                patch(
+                    f"{_IMPORT_MODULE}.import_prompts_from_directory",
+                    return_value={"prompts": 0},
+                ),
+                patch(
+                    f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}
+                ),
+                patch(
+                    f"{_IMPORT_MODULE}.import_experiments_from_directory",
+                    return_value={},
+                ),
+            ):
+                import_all(
+                    workspace="ws",
+                    project_name=_PROJECT,
+                    path=str(tmp_path),
+                    include=["datasets"],
+                    dry_run=False,
+                    force=False,
+                    debug=False,
+                )
+            return mock_ds
+
+        # First run: the dataset import reports an error -> SystemExit(1).
+        with pytest.raises(SystemExit):
+            _run_import_datasets({"datasets": 0, "datasets_errors": 1})
+
+        # Second run (no --force): a clean dataset import must run AGAIN. If the
+        # failed run had wrongly marked the manifest completed, import_all would
+        # short-circuit and never call the importer.
+        mock_ds_ok = _run_import_datasets({"datasets": 1})
+        assert mock_ds_ok.called
 
     def test_flush_timeout_exits_with_code_1(self, tmp_path):
         """If client.flush() returns False (timeout), import_all raises SystemExit(1)."""


### PR DESCRIPTION
## Details

Moves the `opik export` / `opik import` CLI from the Opik **v1** model (datasets/prompts/experiments could exist without a project) to **v2**, where every dataset, prompt, and experiment belongs to a project. Project becomes a required positional, the on-disk layout is keyed by **ID**, and the v1 project-less code paths are removed.

### New CLI command format

Both commands now take a **`PROJECT`** positional right after `WORKSPACE`, and the positional after that is the **`ITEM`**:

```
# before (v1)
opik export WORKSPACE ITEM [NAME]
opik import WORKSPACE ITEM [NAME]

# after (v2)
opik export WORKSPACE PROJECT ITEM [NAME] [OPTIONS]
opik import WORKSPACE PROJECT ITEM [NAME] [OPTIONS]
```

- **`ITEM`** is one of `all`, `dataset`, `prompt`, `experiment`, `traces`. The old `project` item is renamed to **`traces`** (the project is the positional now, so it takes no `NAME`). `all --include` values are `datasets,prompts,traces,experiments`.
- **`--to-project <NAME>`** (import only) imports into a different destination project than the source; defaults to the source project's name. Enables cross-project / scratch restores.

```bash
opik export my-workspace my-project all
opik export my-workspace my-project dataset "my-dataset"
opik export my-workspace my-project traces --filter 'created_at >= "2024-01-01T00:00:00Z"'

opik import my-workspace my-project all                       # same --path round-trips
opik import my-workspace my-project all --to-project restore  # import into a different project
```

### Highlights

- **ID-based, self-describing layout** — `…/<workspace>/projects/<project_id>/` with a `project.json` (`{id, name}`) and id-named files (`dataset_<id>.json`, `prompt_<id>.json`, `experiment_<id>.json`, `trace_<id>.json`). Human names live *inside* the files, so project/dataset names containing `/`, `:`, or spaces (e.g. `scout:comet-ml/opik`) no longer break paths. You still pass **names** on the CLI — export resolves name→id, import resolves name→folder via `project.json`.
- **Symmetric `--path`** — export and import use the same `--path` (both resolve `<path>/<workspace>/projects/<id>/`); no workspace-dir juggling on import.
- **Cross-workspace import** — import resolves `<path>/<workspace>/projects/` and falls back to `<path>/projects/`, so you can export from workspace A and import into workspace B by pointing `--path` at the exported workspace dir.
- **Fail-fast imports** — import now sums all `*_errors` (including nested experiment-recreation failures), exits non-zero on any error, and only marks the manifest `completed` on a fully clean run (so failed imports stay resumable on a non-`--force` rerun).
- **v1 removed** — no `project_name=None`, no `"Default Project"`/`"default"` fallbacks, no per-trace project resolution; no backwards compatibility with old (name-based) export layouts or pre-`dataset_item_data` export files.
- **`opik migrate` unaffected** — `recreate_experiment` (shared with migrate) keeps its `target_project_name` path; the import-from-disk path was decoupled so migrate behavior is identical (migrate unit + e2e suites pass).

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- OPIK-6964

## AI-WATERMARK
AI-WATERMARK: yes
- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: full implementation (CLI export/import v2 rework, ID layout, cross-workspace/symmetric path, fail-fast), tests, docs, and PR-review fixes
- Human verification: pending review

## Testing

Run from `sdks/python`:
- `python -m pytest tests/unit/cli/ tests/unit/test_cli_changes.py tests/unit/test_export_import_all.py` — **452 passed** (includes the `opik migrate` unit suites that exercise the shared `recreate_experiment`).
- `ruff check` + `python -m mypy` on `src/opik/cli/exports` and `src/opik/cli/imports` — clean.
- **Live end-to-end** against a Comet cloud workspace: exported `scout:comet-ml/opik` (clean UUID folder), imported back **by name** into a scratch project via `--to-project` (no IDs typed), imported **cross-workspace** into another workspace, and re-exported to confirm traces+spans round-tripped.

Not run: `tests/e2e/test_cli_import_export.py` (requires a live backend) — updated for the new API/layout, `py_compile` + `ruff` clean. (Unrelated CI failures are external LLM-provider 429/rate-limit flakes; the SDK unit suites pass on 3.10–3.14.)

## Documentation

Updated `fern/docs/tracing/import_export_commands.mdx` and `fern/docs-v2/observability/export_data.mdx`: new `WORKSPACE PROJECT ITEM` grammar, the `traces` item, ID-based directory layout + `project.json`, the `--to-project` flag, and the symmetric/cross-workspace `--path` behavior.

