### PR TITLE
[OPIK-6956] [FE] test: add visual testing for empty states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ target/
 # Test suite reports
 opik_evaluation_suite_reports/
 opik_test_suite_reports/
+allure-results/
 
 # Opik opimizer related
 /sdks/opik_optimizer/artifacts

--- a/tests_end_to_end/visual-tests/global-setup.ts
+++ b/tests_end_to_end/visual-tests/global-setup.ts
@@ -5,20 +5,10 @@ import * as path from 'path';
 import * as fs from 'fs';
 
 export const AUTH_STATE_FILE = '.auth/user.json';
-const STATE_FILE = path.join(__dirname, '.test-state.json');
 const authFile = path.join(__dirname, AUTH_STATE_FILE);
 
 // Fixed names — no timestamp suffix so screenshots are identical across runs
 const PROJECT_NAME = 'visual-project';
-const DATASET_NAME = 'visual-dataset';
-const TEST_SUITE_NAME = 'visual-testsuite';
-const EXPERIMENT_NAME = 'visual-experiment';
-const TEST_SUITE_EXP_NAME = 'visual-testsuite-exp';
-
-interface TestState {
-  experimentId: string;
-  testSuiteExperimentId: string;
-}
 
 async function globalSetup(_config: FullConfig) {
   const envConfig = getEnvironmentConfig();
@@ -70,56 +60,18 @@ async function globalSetup(_config: FullConfig) {
 
   // Clean up any leftover data from a previous run
   console.log('Cleaning up any existing test data...');
-  try { await client.deleteDataset(DATASET_NAME); } catch { /* ignore */ }
-  try { await client.deleteDataset(TEST_SUITE_NAME); } catch { /* ignore */ }
   try {
     await client.deleteProject(PROJECT_NAME);
     await client.waitForProjectDeleted(PROJECT_NAME, 30);
   } catch { /* ignore */ }
 
-  console.log('Creating test data...');
+  console.log('Creating project...');
   await client.createProject(PROJECT_NAME);
   await client.waitForProjectVisible(PROJECT_NAME, 15);
 
-  await client.createTracesWithSpansClient(
-    PROJECT_NAME,
-    { count: 3, prefix: 'visual-trace-', tags: ['visual'], metadata: { env: 'visual-test' } },
-    { count: 2, prefix: 'visual-span-', tags: ['visual'], metadata: { step: '1' } },
-  );
-
-  await client.createThreadsClient(PROJECT_NAME, [
-    { thread_id: 'visual-thread-1', inputs: ['Hello, what is Opik?'], outputs: ['Opik is an LLM observability platform.'] },
-    { thread_id: 'visual-thread-2', inputs: ['How do traces work?'], outputs: ['Traces capture the full execution of an LLM call.'] },
-  ]);
-
-  await client.createDatasetForProject(DATASET_NAME, PROJECT_NAME);
-  await client.insertDatasetItems(DATASET_NAME, [
-    { input: 'What is 2 + 2?', output: '4' },
-    { input: 'What is the capital of France?', output: 'Paris' },
-    { input: 'Name a primary color.', output: 'Red' },
-  ]);
-  await client.waitForDatasetItemsCount(DATASET_NAME, 3, 15);
-
-  await client.createTestSuiteDatasetForProject(TEST_SUITE_NAME, PROJECT_NAME);
-  await client.insertDatasetItems(TEST_SUITE_NAME, [
-    { input: 'Test input A', output: 'Test output A' },
-    { input: 'Test input B', output: 'Test output B' },
-  ]);
-  await client.waitForDatasetItemsCount(TEST_SUITE_NAME, 2, 15);
-
-  const experiment = await client.createExperimentForProject(EXPERIMENT_NAME, DATASET_NAME, PROJECT_NAME);
-  const testSuiteExperiment = await client.createTestSuiteExperimentForProject(TEST_SUITE_EXP_NAME, TEST_SUITE_NAME, PROJECT_NAME);
-
-  const state: TestState = {
-    experimentId: experiment.id,
-    testSuiteExperimentId: testSuiteExperiment.id,
-  };
-  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
-
   process.env.VISUAL_PROJECT_NAME = PROJECT_NAME;
-  process.env.VISUAL_EXPERIMENT_NAME = EXPERIMENT_NAME;
 
-  console.log(`Test data ready: ${PROJECT_NAME}`);
+  console.log(`Project ready: ${PROJECT_NAME}`);
 }
 
 export default globalSetup;

--- a/tests_end_to_end/visual-tests/global-setup.ts
+++ b/tests_end_to_end/visual-tests/global-setup.ts
@@ -9,6 +9,8 @@ const authFile = path.join(__dirname, AUTH_STATE_FILE);
 
 // Fixed names — no timestamp suffix so screenshots are identical across runs
 const PROJECT_NAME = 'visual-project';
+const DATASET_NAME = 'visual-dataset';
+const TEST_SUITE_NAME = 'visual-testsuite';
 
 async function globalSetup(_config: FullConfig) {
   const envConfig = getEnvironmentConfig();
@@ -60,6 +62,8 @@ async function globalSetup(_config: FullConfig) {
 
   // Clean up any leftover data from a previous run
   console.log('Cleaning up any existing test data...');
+  try { await client.deleteDataset(TEST_SUITE_NAME); } catch { /* ignore */ }
+  try { await client.deleteDataset(DATASET_NAME); } catch { /* ignore */ }
   try {
     await client.deleteProject(PROJECT_NAME);
     await client.waitForProjectDeleted(PROJECT_NAME, 30);

--- a/tests_end_to_end/visual-tests/global-setup.ts
+++ b/tests_end_to_end/visual-tests/global-setup.ts
@@ -9,6 +9,7 @@ const authFile = path.join(__dirname, AUTH_STATE_FILE);
 
 // Fixed names — no timestamp suffix so screenshots are identical across runs
 const PROJECT_NAME = 'visual-project';
+const EMPTY_PROJECT_NAME = 'visual-empty-project';
 const DATASET_NAME = 'visual-dataset';
 const TEST_SUITE_NAME = 'visual-testsuite';
 
@@ -68,14 +69,22 @@ async function globalSetup(_config: FullConfig) {
     await client.deleteProject(PROJECT_NAME);
     await client.waitForProjectDeleted(PROJECT_NAME, 30);
   } catch { /* ignore */ }
+  try {
+    await client.deleteProject(EMPTY_PROJECT_NAME);
+    await client.waitForProjectDeleted(EMPTY_PROJECT_NAME, 30);
+  } catch { /* ignore */ }
 
-  console.log('Creating project...');
+  console.log('Creating projects...');
   await client.createProject(PROJECT_NAME);
   await client.waitForProjectVisible(PROJECT_NAME, 15);
 
-  process.env.VISUAL_PROJECT_NAME = PROJECT_NAME;
+  await client.createProject(EMPTY_PROJECT_NAME);
+  await client.waitForProjectVisible(EMPTY_PROJECT_NAME, 15);
 
-  console.log(`Project ready: ${PROJECT_NAME}`);
+  process.env.VISUAL_PROJECT_NAME = PROJECT_NAME;
+  process.env.VISUAL_EMPTY_PROJECT_NAME = EMPTY_PROJECT_NAME;
+
+  console.log(`Projects ready: ${PROJECT_NAME}, ${EMPTY_PROJECT_NAME}`);
 }
 
 export default globalSetup;

--- a/tests_end_to_end/visual-tests/global-teardown.ts
+++ b/tests_end_to_end/visual-tests/global-teardown.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 
 const PROJECT_NAME = 'visual-project';
+const EMPTY_PROJECT_NAME = 'visual-empty-project';
 const DATASET_NAME = 'visual-dataset';
 const TEST_SUITE_NAME = 'visual-testsuite';
 
@@ -27,6 +28,7 @@ async function globalTeardown() {
   try { await client.deleteDataset(TEST_SUITE_NAME); } catch { /* ignore */ }
   try { await client.deleteDataset(DATASET_NAME); } catch { /* ignore */ }
   try { await client.deleteProject(PROJECT_NAME); } catch { /* ignore */ }
+  try { await client.deleteProject(EMPTY_PROJECT_NAME); } catch { /* ignore */ }
 }
 
 export default globalTeardown;

--- a/tests_end_to_end/visual-tests/page-objects/agent-playground.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/agent-playground.page.ts
@@ -1,0 +1,18 @@
+import { Page } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class AgentPlaygroundPage extends BasePage {
+  constructor(page: Page, baseUrl: string, workspace: string) {
+    super(page, baseUrl, workspace);
+  }
+
+  async goto(projectId: string): Promise<void> {
+    await this.page.goto(this.url(`projects/${projectId}/agent-playground`));
+    await this.page.waitForLoadState('load');
+    await this.dismissWelcomeDialogIfPresent();
+  }
+
+  async waitForEmpty(): Promise<void> {
+    await this.page.getByRole('heading', { name: /connect your agent/i }).waitFor({ state: 'visible', timeout: 20000 });
+  }
+}

--- a/tests_end_to_end/visual-tests/page-objects/alerts.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/alerts.page.ts
@@ -1,0 +1,18 @@
+import { Page } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class AlertsPage extends BasePage {
+  constructor(page: Page, baseUrl: string, workspace: string) {
+    super(page, baseUrl, workspace);
+  }
+
+  async goto(projectId: string): Promise<void> {
+    await this.page.goto(this.url(`projects/${projectId}/alerts`));
+    await this.page.waitForLoadState('load');
+    await this.dismissWelcomeDialogIfPresent();
+  }
+
+  async waitForEmpty(): Promise<void> {
+    await this.page.getByRole('heading', { name: /no alerts yet/i }).waitFor({ state: 'visible', timeout: 20000 });
+  }
+}

--- a/tests_end_to_end/visual-tests/page-objects/annotation-queues.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/annotation-queues.page.ts
@@ -1,0 +1,18 @@
+import { Page } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class AnnotationQueuesPage extends BasePage {
+  constructor(page: Page, baseUrl: string, workspace: string) {
+    super(page, baseUrl, workspace);
+  }
+
+  async goto(projectId: string): Promise<void> {
+    await this.page.goto(this.url(`projects/${projectId}/annotation-queues`));
+    await this.page.waitForLoadState('load');
+    await this.dismissWelcomeDialogIfPresent();
+  }
+
+  async waitForEmpty(): Promise<void> {
+    await this.page.getByRole('heading', { name: /no annotation queues yet/i }).waitFor({ state: 'visible', timeout: 20000 });
+  }
+}

--- a/tests_end_to_end/visual-tests/page-objects/dashboards.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/dashboards.page.ts
@@ -12,7 +12,7 @@ export class DashboardsPage extends BasePage {
     await this.dismissWelcomeDialogIfPresent();
   }
 
-  async waitForEmpty(): Promise<void> {
+  async waitForLoaded(): Promise<void> {
     await this.page.getByText('At a glance').waitFor({ state: 'visible', timeout: 20000 });
   }
 }

--- a/tests_end_to_end/visual-tests/page-objects/dashboards.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/dashboards.page.ts
@@ -1,0 +1,18 @@
+import { Page } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class DashboardsPage extends BasePage {
+  constructor(page: Page, baseUrl: string, workspace: string) {
+    super(page, baseUrl, workspace);
+  }
+
+  async goto(projectId: string): Promise<void> {
+    await this.page.goto(this.url(`projects/${projectId}/dashboards`));
+    await this.page.waitForLoadState('load');
+    await this.dismissWelcomeDialogIfPresent();
+  }
+
+  async waitForEmpty(): Promise<void> {
+    await this.page.getByText('At a glance').waitFor({ state: 'visible', timeout: 20000 });
+  }
+}

--- a/tests_end_to_end/visual-tests/page-objects/datasets.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/datasets.page.ts
@@ -19,4 +19,9 @@ export class DatasetsPage extends BasePage {
       this.page.getByRole('heading', { name: /no datasets yet/i }).waitFor({ state: 'visible', timeout: 8000 }),
     ]);
   }
+
+  async waitForEmpty(): Promise<void> {
+    await this.page.getByRole('heading', { name: 'Datasets', exact: true }).waitFor({ state: 'visible', timeout: 10000 });
+    await this.page.getByRole('heading', { name: /no datasets yet/i }).waitFor({ state: 'visible', timeout: 20000 });
+  }
 }

--- a/tests_end_to_end/visual-tests/page-objects/experiments.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/experiments.page.ts
@@ -20,6 +20,11 @@ export class ExperimentsPage extends BasePage {
     ]);
   }
 
+  async waitForEmpty(): Promise<void> {
+    await this.page.getByRole('heading', { name: 'Experiments', exact: true }).waitFor({ state: 'visible', timeout: 10000 });
+    await this.page.getByRole('heading', { name: /no experiments yet/i }).waitFor({ state: 'visible', timeout: 20000 });
+  }
+
   async waitForExperiment(experimentName: string): Promise<void> {
     await this.page.getByText(experimentName).first().waitFor({ state: 'visible', timeout: 15000 });
   }

--- a/tests_end_to_end/visual-tests/page-objects/logs.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/logs.page.ts
@@ -31,4 +31,13 @@ export class LogsPage extends BasePage {
       this.page.getByRole('heading', { name: /no threads yet/i }).waitFor({ state: 'visible', timeout: 20000 }),
     ]);
   }
+
+  async waitForEmptyTraces(): Promise<void> {
+    await this.page.getByRole('radio', { name: 'Traces' }).waitFor({ state: 'visible', timeout: 10000 });
+    await this.page.getByRole('heading', { name: /no traces yet/i }).waitFor({ state: 'visible', timeout: 20000 });
+  }
+
+  async waitForEmptyThreads(): Promise<void> {
+    await this.page.getByRole('heading', { name: /no threads yet/i }).waitFor({ state: 'visible', timeout: 20000 });
+  }
 }

--- a/tests_end_to_end/visual-tests/page-objects/online-evaluation.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/online-evaluation.page.ts
@@ -1,0 +1,18 @@
+import { Page } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class OnlineEvaluationPage extends BasePage {
+  constructor(page: Page, baseUrl: string, workspace: string) {
+    super(page, baseUrl, workspace);
+  }
+
+  async goto(projectId: string): Promise<void> {
+    await this.page.goto(this.url(`projects/${projectId}/online-evaluation`));
+    await this.page.waitForLoadState('load');
+    await this.dismissWelcomeDialogIfPresent();
+  }
+
+  async waitForEmpty(): Promise<void> {
+    await this.page.getByRole('heading', { name: /no online evaluations yet/i }).waitFor({ state: 'visible', timeout: 20000 });
+  }
+}

--- a/tests_end_to_end/visual-tests/page-objects/optimizations.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/optimizations.page.ts
@@ -1,0 +1,18 @@
+import { Page } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class OptimizationsPage extends BasePage {
+  constructor(page: Page, baseUrl: string, workspace: string) {
+    super(page, baseUrl, workspace);
+  }
+
+  async goto(projectId: string): Promise<void> {
+    await this.page.goto(this.url(`projects/${projectId}/optimizations`));
+    await this.page.waitForLoadState('load');
+    await this.dismissWelcomeDialogIfPresent();
+  }
+
+  async waitForEmpty(): Promise<void> {
+    await this.page.getByRole('heading', { name: /no optimization runs yet/i }).waitFor({ state: 'visible', timeout: 20000 });
+  }
+}

--- a/tests_end_to_end/visual-tests/page-objects/prompts.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/prompts.page.ts
@@ -1,0 +1,18 @@
+import { Page } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export class PromptsPage extends BasePage {
+  constructor(page: Page, baseUrl: string, workspace: string) {
+    super(page, baseUrl, workspace);
+  }
+
+  async goto(projectId: string): Promise<void> {
+    await this.page.goto(this.url(`projects/${projectId}/prompts`));
+    await this.page.waitForLoadState('load');
+    await this.dismissWelcomeDialogIfPresent();
+  }
+
+  async waitForEmpty(): Promise<void> {
+    await this.page.getByRole('heading', { name: /no prompts yet/i }).waitFor({ state: 'visible', timeout: 20000 });
+  }
+}

--- a/tests_end_to_end/visual-tests/page-objects/test-suites.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/test-suites.page.ts
@@ -19,4 +19,9 @@ export class TestSuitesPage extends BasePage {
       this.page.getByRole('heading', { name: /no test suites yet/i }).waitFor({ state: 'visible', timeout: 8000 }),
     ]);
   }
+
+  async waitForEmpty(): Promise<void> {
+    await this.page.getByRole('heading', { name: 'Test suites', exact: true }).waitFor({ state: 'visible', timeout: 10000 });
+    await this.page.getByRole('heading', { name: /no test suites yet/i }).waitFor({ state: 'visible', timeout: 20000 });
+  }
 }

--- a/tests_end_to_end/visual-tests/tests/empty-states.spec.ts
+++ b/tests_end_to_end/visual-tests/tests/empty-states.spec.ts
@@ -5,6 +5,13 @@ import { LogsPage } from '../page-objects/logs.page';
 import { DatasetsPage } from '../page-objects/datasets.page';
 import { TestSuitesPage } from '../page-objects/test-suites.page';
 import { ExperimentsPage } from '../page-objects/experiments.page';
+import { DashboardsPage } from '../page-objects/dashboards.page';
+import { PromptsPage } from '../page-objects/prompts.page';
+import { AgentPlaygroundPage } from '../page-objects/agent-playground.page';
+import { OptimizationsPage } from '../page-objects/optimizations.page';
+import { AnnotationQueuesPage } from '../page-objects/annotation-queues.page';
+import { OnlineEvaluationPage } from '../page-objects/online-evaluation.page';
+import { AlertsPage } from '../page-objects/alerts.page';
 import { screenshot } from './utils/screenshot';
 
 test.setTimeout(300000);
@@ -58,5 +65,54 @@ test.describe('Visual Comparison - Empty States', () => {
     await experimentsPage.goto(projectId);
     await experimentsPage.waitForEmpty();
     await screenshot(page, 'E05-experiments-empty');
+  });
+
+  test('E06: Dashboards empty state', async ({ page }) => {
+    const dashboardsPage = new DashboardsPage(page, baseUrl, workspace);
+    await dashboardsPage.goto(projectId);
+    await dashboardsPage.waitForEmpty();
+    await screenshot(page, 'E06-dashboards-empty');
+  });
+
+  test('E07: Prompt Library empty state', async ({ page }) => {
+    const promptsPage = new PromptsPage(page, baseUrl, workspace);
+    await promptsPage.goto(projectId);
+    await promptsPage.waitForEmpty();
+    await screenshot(page, 'E07-prompts-empty');
+  });
+
+  test('E08: Agent Playground empty state', async ({ page }) => {
+    const agentPlaygroundPage = new AgentPlaygroundPage(page, baseUrl, workspace);
+    await agentPlaygroundPage.goto(projectId);
+    await agentPlaygroundPage.waitForEmpty();
+    await screenshot(page, 'E08-agent-playground-empty');
+  });
+
+  test('E09: Optimization runs empty state', async ({ page }) => {
+    const optimizationsPage = new OptimizationsPage(page, baseUrl, workspace);
+    await optimizationsPage.goto(projectId);
+    await optimizationsPage.waitForEmpty();
+    await screenshot(page, 'E09-optimizations-empty');
+  });
+
+  test('E10: Annotation queues empty state', async ({ page }) => {
+    const annotationQueuesPage = new AnnotationQueuesPage(page, baseUrl, workspace);
+    await annotationQueuesPage.goto(projectId);
+    await annotationQueuesPage.waitForEmpty();
+    await screenshot(page, 'E10-annotation-queues-empty');
+  });
+
+  test('E11: Online evaluation empty state', async ({ page }) => {
+    const onlineEvaluationPage = new OnlineEvaluationPage(page, baseUrl, workspace);
+    await onlineEvaluationPage.goto(projectId);
+    await onlineEvaluationPage.waitForEmpty();
+    await screenshot(page, 'E11-online-evaluation-empty');
+  });
+
+  test('E12: Alerts empty state', async ({ page }) => {
+    const alertsPage = new AlertsPage(page, baseUrl, workspace);
+    await alertsPage.goto(projectId);
+    await alertsPage.waitForEmpty();
+    await screenshot(page, 'E12-alerts-empty');
   });
 });

--- a/tests_end_to_end/visual-tests/tests/empty-states.spec.ts
+++ b/tests_end_to_end/visual-tests/tests/empty-states.spec.ts
@@ -1,0 +1,62 @@
+import { test } from '@playwright/test';
+import { getEnvironmentConfig } from '../../typescript-tests/config/env.config';
+import { ProjectsPage } from '../page-objects/projects.page';
+import { LogsPage } from '../page-objects/logs.page';
+import { DatasetsPage } from '../page-objects/datasets.page';
+import { TestSuitesPage } from '../page-objects/test-suites.page';
+import { ExperimentsPage } from '../page-objects/experiments.page';
+import { screenshot } from './utils/screenshot';
+
+test.setTimeout(300000);
+
+test.describe('Visual Comparison - Empty States', () => {
+  let projectId = '';
+  const { baseUrl, workspace } = getEnvironmentConfig().getConfig();
+  const projectName = () => process.env.VISUAL_PROJECT_NAME!;
+
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    const projectsPage = new ProjectsPage(page, baseUrl, workspace);
+    await projectsPage.goto();
+    await projectsPage.searchAndWait(projectName());
+    await projectsPage.waitForProject(projectName());
+    projectId = await projectsPage.clickProjectAndGetId(projectName());
+    await page.close();
+  });
+
+  test('E01: Logs - Traces empty state', async ({ page }) => {
+    const logsPage = new LogsPage(page, baseUrl, workspace);
+    await logsPage.goto(projectId);
+    await logsPage.waitForEmptyTraces();
+    await screenshot(page, 'E01-logs-traces-empty');
+  });
+
+  test('E02: Logs - Threads empty state', async ({ page }) => {
+    const logsPage = new LogsPage(page, baseUrl, workspace);
+    await logsPage.goto(projectId);
+    await logsPage.switchToThreads();
+    await logsPage.waitForEmptyThreads();
+    await screenshot(page, 'E02-logs-threads-empty');
+  });
+
+  test('E03: Datasets empty state', async ({ page }) => {
+    const datasetsPage = new DatasetsPage(page, baseUrl, workspace);
+    await datasetsPage.goto(projectId);
+    await datasetsPage.waitForEmpty();
+    await screenshot(page, 'E03-datasets-empty');
+  });
+
+  test('E04: Test Suites empty state', async ({ page }) => {
+    const testSuitesPage = new TestSuitesPage(page, baseUrl, workspace);
+    await testSuitesPage.goto(projectId);
+    await testSuitesPage.waitForEmpty();
+    await screenshot(page, 'E04-testsuites-empty');
+  });
+
+  test('E05: Experiments empty state', async ({ page }) => {
+    const experimentsPage = new ExperimentsPage(page, baseUrl, workspace);
+    await experimentsPage.goto(projectId);
+    await experimentsPage.waitForEmpty();
+    await screenshot(page, 'E05-experiments-empty');
+  });
+});

--- a/tests_end_to_end/visual-tests/tests/empty-states.spec.ts
+++ b/tests_end_to_end/visual-tests/tests/empty-states.spec.ts
@@ -19,7 +19,7 @@ test.setTimeout(300000);
 test.describe('Visual Comparison - Empty States', () => {
   let projectId = '';
   const { baseUrl, workspace } = getEnvironmentConfig().getConfig();
-  const projectName = () => process.env.VISUAL_PROJECT_NAME!;
+  const projectName = () => process.env.VISUAL_EMPTY_PROJECT_NAME!;
 
   test.beforeAll(async ({ browser }) => {
     const page = await browser.newPage();
@@ -67,11 +67,11 @@ test.describe('Visual Comparison - Empty States', () => {
     await screenshot(page, 'E05-experiments-empty');
   });
 
-  test('E06: Dashboards empty state', async ({ page }) => {
+  test('E06: Dashboards default view', async ({ page }) => {
     const dashboardsPage = new DashboardsPage(page, baseUrl, workspace);
     await dashboardsPage.goto(projectId);
-    await dashboardsPage.waitForEmpty();
-    await screenshot(page, 'E06-dashboards-empty');
+    await dashboardsPage.waitForLoaded();
+    await screenshot(page, 'E06-dashboards-default');
   });
 
   test('E07: Prompt Library empty state', async ({ page }) => {

--- a/tests_end_to_end/visual-tests/tests/utils/screenshot.ts
+++ b/tests_end_to_end/visual-tests/tests/utils/screenshot.ts
@@ -1,0 +1,52 @@
+import { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import * as path from 'path';
+import * as fs from 'fs';
+
+const IS_COMPARISON_RUN = process.env.SKIP_TEARDOWN !== '1';
+const COMPARISON_DIR = path.join(__dirname, '../../screenshots/comparison');
+
+export function dynamicMasks(page: Page) {
+  return [
+    page.locator('time'),
+    page.locator('[data-testid="timestamp"]'),
+    page.locator('[data-testid="date"]'),
+    page.locator('td').filter({ hasText: /\d+ (second|minute|hour|day)s? ago/ }),
+    page.locator('td').filter({ hasText: /\d{4}-\d{2}-\d{2}/ }),
+    page.locator('td').filter({ hasText: /\d+ mins? ago/ }),
+    // mask absolute date cells — format "D MMM YYYY, h:mm A" used by TimeCell (e.g., "15 May 2026, 3:26 PM")
+    page.locator('td').filter({ hasText: /\d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4},/ }),
+    // mask UUID columns
+    page.locator('td').filter({ hasText: /[0-9a-f]{8}-[0-9a-f]{4}/ }),
+    // mask breadcrumb — shows dynamic project/dataset names on sub-pages
+    page.locator('nav[aria-label="breadcrumb"]'),
+    // mask pagination "Showing X-Y of Z" — counts differ between environments
+    page.locator('span').filter({ hasText: /^Showing \d/ }),
+    // mask duration cells (e.g. "1.23s") — timing varies between environments
+    page.locator('td').filter({ hasText: /^\d+\.?\d*s$/ }),
+  ];
+}
+
+export const screenshotOpts = (page: Page) => ({
+  mask: dynamicMasks(page),
+  animations: 'disabled' as const,
+});
+
+export async function hideDemoBanner(page: Page) {
+  await page.addStyleTag({
+    content: '.z-10.h-8.bg-primary { display: none !important; }',
+  });
+}
+
+export async function screenshot(page: Page, name: string) {
+  await hideDemoBanner(page);
+  if (IS_COMPARISON_RUN) {
+    fs.mkdirSync(COMPARISON_DIR, { recursive: true });
+    await page.screenshot({
+      path: path.join(COMPARISON_DIR, `${name}.png`),
+      mask: dynamicMasks(page),
+      animations: 'disabled',
+    });
+  }
+  await expect(page).toHaveScreenshot(`${name}.png`, screenshotOpts(page));
+}

--- a/tests_end_to_end/visual-tests/tests/visual-comparison.spec.ts
+++ b/tests_end_to_end/visual-tests/tests/visual-comparison.spec.ts
@@ -54,6 +54,8 @@ test.describe('Visual Comparison - Opik UI', () => {
     await client.waitForDatasetItemsCount(TEST_SUITE_NAME, 2, 15);
 
     const experiment = await client.createExperimentForProject(EXPERIMENT_NAME, DATASET_NAME, projectName());
+    fs.writeFileSync(STATE_FILE, JSON.stringify({ experimentId: experiment.id }, null, 2));
+
     const testSuiteExperiment = await client.createTestSuiteExperimentForProject(TEST_SUITE_EXP_NAME, TEST_SUITE_NAME, projectName());
     fs.writeFileSync(STATE_FILE, JSON.stringify({ experimentId: experiment.id, testSuiteExperimentId: testSuiteExperiment.id }, null, 2));
 

--- a/tests_end_to_end/visual-tests/tests/visual-comparison.spec.ts
+++ b/tests_end_to_end/visual-tests/tests/visual-comparison.spec.ts
@@ -1,60 +1,20 @@
-import { test, expect, Page } from '@playwright/test';
+import { test } from '@playwright/test';
 import { getEnvironmentConfig } from '../../typescript-tests/config/env.config';
+import { TestHelperClient } from '../../typescript-tests/helpers/test-helper-client';
 import { ProjectsPage } from '../page-objects/projects.page';
 import { LogsPage } from '../page-objects/logs.page';
 import { DatasetsPage } from '../page-objects/datasets.page';
 import { TestSuitesPage } from '../page-objects/test-suites.page';
 import { ExperimentsPage } from '../page-objects/experiments.page';
+import { screenshot } from './utils/screenshot';
 import * as path from 'path';
 import * as fs from 'fs';
 
-const IS_COMPARISON_RUN = process.env.SKIP_TEARDOWN !== '1';
-const COMPARISON_DIR = path.join(__dirname, '../screenshots/comparison');
-
-function dynamicMasks(page: Page) {
-  return [
-    page.locator('time'),
-    page.locator('[data-testid="timestamp"]'),
-    page.locator('[data-testid="date"]'),
-    page.locator('td').filter({ hasText: /\d+ (second|minute|hour|day)s? ago/ }),
-    page.locator('td').filter({ hasText: /\d{4}-\d{2}-\d{2}/ }),
-    page.locator('td').filter({ hasText: /\d+ mins? ago/ }),
-    // mask absolute date cells — format "D MMM YYYY, h:mm A" used by TimeCell (e.g., "15 May 2026, 3:26 PM")
-    page.locator('td').filter({ hasText: /\d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4},/ }),
-    // mask UUID columns
-    page.locator('td').filter({ hasText: /[0-9a-f]{8}-[0-9a-f]{4}/ }),
-    // mask breadcrumb — shows dynamic project/dataset names on sub-pages
-    page.locator('nav[aria-label="breadcrumb"]'),
-    // mask pagination "Showing X-Y of Z" — counts differ between environments
-    page.locator('span').filter({ hasText: /^Showing \d/ }),
-    // mask duration cells (e.g. "1.23s") — timing varies between environments
-    page.locator('td').filter({ hasText: /^\d+\.?\d*s$/ }),
-  ];
-}
-
-const screenshotOpts = (page: Page) => ({
-  mask: dynamicMasks(page),
-  animations: 'disabled' as const,
-});
-
-async function hideDemoBanner(page: Page) {
-  await page.addStyleTag({
-    content: '.z-10.h-8.bg-primary { display: none !important; }',
-  });
-}
-
-async function screenshot(page: Page, name: string) {
-  await hideDemoBanner(page);
-  if (IS_COMPARISON_RUN) {
-    fs.mkdirSync(COMPARISON_DIR, { recursive: true });
-    await page.screenshot({
-      path: path.join(COMPARISON_DIR, `${name}.png`),
-      mask: dynamicMasks(page),
-      animations: 'disabled',
-    });
-  }
-  await expect(page).toHaveScreenshot(`${name}.png`, screenshotOpts(page));
-}
+const DATASET_NAME = 'visual-dataset';
+const TEST_SUITE_NAME = 'visual-testsuite';
+const EXPERIMENT_NAME = 'visual-experiment';
+const TEST_SUITE_EXP_NAME = 'visual-testsuite-exp';
+const STATE_FILE = path.join(__dirname, '../.test-state.json');
 
 test.setTimeout(300000);
 
@@ -62,9 +22,41 @@ test.describe('Visual Comparison - Opik UI', () => {
   let projectId = '';
   const { baseUrl, workspace } = getEnvironmentConfig().getConfig();
   const projectName = () => process.env.VISUAL_PROJECT_NAME!;
-  const experimentName = () => process.env.VISUAL_EXPERIMENT_NAME!;
+  const experimentName = () => EXPERIMENT_NAME;
 
   test.beforeAll(async ({ browser }) => {
+    const client = new TestHelperClient();
+
+    await client.createTracesWithSpansClient(
+      projectName(),
+      { count: 3, prefix: 'visual-trace-', tags: ['visual'], metadata: { env: 'visual-test' } },
+      { count: 2, prefix: 'visual-span-', tags: ['visual'], metadata: { step: '1' } },
+    );
+
+    await client.createThreadsClient(projectName(), [
+      { thread_id: 'visual-thread-1', inputs: ['Hello, what is Opik?'], outputs: ['Opik is an LLM observability platform.'] },
+      { thread_id: 'visual-thread-2', inputs: ['How do traces work?'], outputs: ['Traces capture the full execution of an LLM call.'] },
+    ]);
+
+    await client.createDatasetForProject(DATASET_NAME, projectName());
+    await client.insertDatasetItems(DATASET_NAME, [
+      { input: 'What is 2 + 2?', output: '4' },
+      { input: 'What is the capital of France?', output: 'Paris' },
+      { input: 'Name a primary color.', output: 'Red' },
+    ]);
+    await client.waitForDatasetItemsCount(DATASET_NAME, 3, 15);
+
+    await client.createTestSuiteDatasetForProject(TEST_SUITE_NAME, projectName());
+    await client.insertDatasetItems(TEST_SUITE_NAME, [
+      { input: 'Test input A', output: 'Test output A' },
+      { input: 'Test input B', output: 'Test output B' },
+    ]);
+    await client.waitForDatasetItemsCount(TEST_SUITE_NAME, 2, 15);
+
+    const experiment = await client.createExperimentForProject(EXPERIMENT_NAME, DATASET_NAME, projectName());
+    const testSuiteExperiment = await client.createTestSuiteExperimentForProject(TEST_SUITE_EXP_NAME, TEST_SUITE_NAME, projectName());
+    fs.writeFileSync(STATE_FILE, JSON.stringify({ experimentId: experiment.id, testSuiteExperimentId: testSuiteExperiment.id }, null, 2));
+
     const page = await browser.newPage();
     const projectsPage = new ProjectsPage(page, baseUrl, workspace);
     await projectsPage.goto();


### PR DESCRIPTION
## Details

Adds visual regression testing for empty states across multiple application pages. A new `empty-states.spec.ts` test suite navigates to each page, triggers the empty state, and captures screenshots for comparison. Changes include:
- New page objects for Agent Playground, Alerts, Annotation Queues, Dashboards, Online Evaluation, and Optimizations pages with empty-state navigation helpers
- Extended existing page objects (Datasets, Experiments, Logs, Prompts, Test Suites) with empty-state support
- Shared screenshot utility (`tests/utils/screenshot.ts`) for consistent capture and diffing
- Refactored `visual-comparison.spec.ts` to use the shared screenshot utility

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6956

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-sonnet-4-6
  - Scope: assisted (PR creation workflow)
  - Human verification: code review + manual testing

## Testing

TypeScript type check passed: `npx tsc --noEmit` (in `tests_end_to_end/visual-tests/`)

Visual tests are run against a live Opik instance:
- `npm run test:baseline` — captures baseline screenshots for all empty states
- `npm run test:compare` — compares screenshots against baseline

## Documentation

N/A