### PR TITLE
[OPIK-6971] Treat insufficient_quota (429) as non-retryable for OpenAI providers

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/DelegatingHttpClientBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/DelegatingHttpClientBuilder.java
@@ -1,0 +1,53 @@
+package com.comet.opik.infrastructure.llm;
+
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Duration;
+
+/**
+ * Base {@link HttpClientBuilder} that forwards timeout configuration to a delegate builder and wraps
+ * the {@link HttpClient} it produces. Subclasses only implement {@link #wrap(HttpClient)} to apply
+ * their specific decoration; the delegation/forwarding logic is shared here so each decorator does not
+ * re-implement it.
+ */
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class DelegatingHttpClientBuilder implements HttpClientBuilder {
+
+    private final @NonNull HttpClientBuilder delegate;
+
+    @Override
+    public Duration connectTimeout() {
+        return delegate.connectTimeout();
+    }
+
+    @Override
+    public HttpClientBuilder connectTimeout(Duration connectTimeout) {
+        delegate.connectTimeout(connectTimeout);
+        return this;
+    }
+
+    @Override
+    public Duration readTimeout() {
+        return delegate.readTimeout();
+    }
+
+    @Override
+    public HttpClientBuilder readTimeout(Duration readTimeout) {
+        delegate.readTimeout(readTimeout);
+        return this;
+    }
+
+    @Override
+    public final HttpClient build() {
+        return wrap(delegate.build());
+    }
+
+    /**
+     * Wraps the {@link HttpClient} produced by the delegate builder with this builder's decoration.
+     */
+    protected abstract HttpClient wrap(HttpClient delegate);
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/InterceptingHttpClientBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/InterceptingHttpClientBuilder.java
@@ -1,11 +1,10 @@
 package com.comet.opik.infrastructure.llm.customllm;
 
+import com.comet.opik.infrastructure.llm.DelegatingHttpClientBuilder;
 import dev.langchain4j.http.client.HttpClient;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 
-import java.time.Duration;
 import java.util.Map;
 
 /**
@@ -13,40 +12,23 @@ import java.util.Map;
  * wrapped with {@link InterceptingHttpClient} to apply Custom LLM-specific
  * request mutations (query params, auth headers, {@code {model}} substitution).
  *
- * <p>Timeout setter calls are forwarded to the delegate so existing
- * configuration behavior (LC4j connect/read timeouts) is preserved intact.
+ * <p>Timeout forwarding is inherited from {@link DelegatingHttpClientBuilder}; only the
+ * {@link #wrap(HttpClient)} step is specific to this builder.
  */
-@RequiredArgsConstructor
-class InterceptingHttpClientBuilder implements HttpClientBuilder {
+class InterceptingHttpClientBuilder extends DelegatingHttpClientBuilder {
 
-    private final @NonNull HttpClientBuilder delegate;
     private final Map<String, String> configuration;
     private final String apiKey;
 
-    @Override
-    public Duration connectTimeout() {
-        return delegate.connectTimeout();
+    InterceptingHttpClientBuilder(@NonNull HttpClientBuilder delegate, Map<String, String> configuration,
+            String apiKey) {
+        super(delegate);
+        this.configuration = configuration;
+        this.apiKey = apiKey;
     }
 
     @Override
-    public HttpClientBuilder connectTimeout(Duration connectTimeout) {
-        delegate.connectTimeout(connectTimeout);
-        return this;
-    }
-
-    @Override
-    public Duration readTimeout() {
-        return delegate.readTimeout();
-    }
-
-    @Override
-    public HttpClientBuilder readTimeout(Duration readTimeout) {
-        delegate.readTimeout(readTimeout);
-        return this;
-    }
-
-    @Override
-    public HttpClient build() {
-        return new InterceptingHttpClient(delegate.build(), configuration, apiKey);
+    protected HttpClient wrap(HttpClient delegate) {
+        return new InterceptingHttpClient(delegate, configuration, apiKey);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/freemodel/FreeModelServiceProvider.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/freemodel/FreeModelServiceProvider.java
@@ -9,6 +9,7 @@ import com.comet.opik.infrastructure.LlmProviderClientConfig;
 import com.comet.opik.infrastructure.llm.LlmProviderClientApiConfig;
 import com.comet.opik.infrastructure.llm.LlmServiceProvider;
 import com.comet.opik.infrastructure.llm.openai.OpenAIClientGenerator;
+import com.comet.opik.infrastructure.llm.openai.QuotaAwareHttpClient;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import lombok.NonNull;
@@ -73,6 +74,9 @@ public class FreeModelServiceProvider implements LlmServiceProvider {
         var builder = OpenAiChatModel.builder()
                 .modelName(transformedParameters.name())
                 .apiKey(config.apiKey())
+                // Treat insufficient_quota (429, out-of-credits) as non-retryable so the model's
+                // internal retry does not keep hitting an exhausted key.
+                .httpClientBuilder(QuotaAwareHttpClient.builder())
                 .logRequests(true)
                 .logResponses(true);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/OpenAIClientGenerator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/OpenAIClientGenerator.java
@@ -43,6 +43,9 @@ public class OpenAIClientGenerator implements LlmProviderClientGenerator<OpenAiC
     public OpenAiClient newOpenAiClient(@NonNull LlmProviderClientApiConfig config) {
         var openAiClientBuilder = OpenAiClient.builder()
                 .baseUrl(DEFAULT_OPENAI_URL)
+                // Treat insufficient_quota (429, out-of-credits) as non-retryable, so the outer retry
+                // policy in ChatCompletionService does not keep hitting an exhausted key.
+                .httpClientBuilder(QuotaAwareHttpClient.builder())
                 .logRequests(llmProviderClientConfig.getLogRequests())
                 .logResponses(llmProviderClientConfig.getLogResponses());
 
@@ -109,6 +112,9 @@ public class OpenAIClientGenerator implements LlmProviderClientGenerator<OpenAiC
         var builder = OpenAiChatModel.builder()
                 .modelName(modelParameters.name())
                 .apiKey(config.apiKey())
+                // Treat insufficient_quota (429, out-of-credits) as non-retryable so neither the model's
+                // internal retry nor the outer retry policy keeps hitting an exhausted key.
+                .httpClientBuilder(QuotaAwareHttpClient.builder())
                 .logRequests(true)
                 .logResponses(true);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/QuotaAwareHttpClient.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/QuotaAwareHttpClient.java
@@ -1,0 +1,118 @@
+package com.comet.opik.infrastructure.llm.openai;
+
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.exception.NonRetriableException;
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.http.client.HttpClientBuilderLoader;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import dev.langchain4j.http.client.sse.ServerSentEventParser;
+import lombok.NonNull;
+
+import java.time.Duration;
+
+/**
+ * {@link HttpClient} decorator that marks OpenAI {@code insufficient_quota} (HTTP 429, out-of-credits)
+ * as non-retryable.
+ * <p>
+ * OpenAI returns both transient rate-limits and out-of-credits as HTTP 429. LangChain4j maps any 429 to
+ * a retryable {@link dev.langchain4j.exception.RateLimitException} — both in the model's internal
+ * {@code RetryUtils.withRetryMappingExceptions} and in Opik's outer retry policy — so a key that is
+ * permanently out of quota gets retried repeatedly per request (inner attempts x outer attempts),
+ * generating an error storm against a key that will keep failing. This decorator inspects 429 responses
+ * and, when the body identifies {@code insufficient_quota}, rethrows a {@link NonRetriableException} so
+ * both retry layers stop immediately.
+ * <p>
+ * Two details are required for correct downstream handling:
+ * <ul>
+ *   <li>the original response body is carried as the exception <b>message</b>, so the provider-error
+ *       mapping ({@code getLlmProviderError} -> {@link OpenAiCompatStatusCodes}) still parses it and
+ *       surfaces HTTP 402; and</li>
+ *   <li>the {@link HttpException} is <b>not</b> retained as the cause — otherwise LangChain4j's
+ *       {@code ExceptionMapper.findRoot()} would unwrap to it and re-map the 429 back to a retryable
+ *       {@code RateLimitException}, defeating the guard.</li>
+ * </ul>
+ * Rate-limit 429s and every other status are passed through unchanged and remain retryable.
+ */
+public class QuotaAwareHttpClient implements HttpClient {
+
+    private static final int TOO_MANY_REQUESTS = 429;
+    private static final String INSUFFICIENT_QUOTA = "insufficient_quota";
+
+    private final HttpClient delegate;
+
+    public QuotaAwareHttpClient(@NonNull HttpClient delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public SuccessfulHttpResponse execute(HttpRequest request) {
+        try {
+            return delegate.execute(request);
+        } catch (HttpException httpException) {
+            if (isInsufficientQuota(httpException)) {
+                // Body as message (so it still maps to 402 downstream); no HttpException cause (so the
+                // inner ExceptionMapper cannot unwrap and re-map the 429 to a retryable error).
+                throw new NonRetriableException(httpException.getMessage());
+            }
+            throw httpException;
+        }
+    }
+
+    @Override
+    public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
+        // Streaming responses are not wrapped in a retry policy, so there is nothing to short-circuit.
+        delegate.execute(request, parser, listener);
+    }
+
+    private static boolean isInsufficientQuota(HttpException httpException) {
+        return httpException.statusCode() == TOO_MANY_REQUESTS
+                && httpException.getMessage() != null
+                && httpException.getMessage().contains(INSUFFICIENT_QUOTA);
+    }
+
+    /**
+     * Wraps the default (classpath) {@link HttpClientBuilder} so every client it builds is quota-aware.
+     */
+    public static HttpClientBuilder builder() {
+        return new Builder(HttpClientBuilderLoader.loadHttpClientBuilder());
+    }
+
+    private static final class Builder implements HttpClientBuilder {
+
+        private final HttpClientBuilder delegate;
+
+        private Builder(@NonNull HttpClientBuilder delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Duration connectTimeout() {
+            return delegate.connectTimeout();
+        }
+
+        @Override
+        public HttpClientBuilder connectTimeout(Duration connectTimeout) {
+            delegate.connectTimeout(connectTimeout);
+            return this;
+        }
+
+        @Override
+        public Duration readTimeout() {
+            return delegate.readTimeout();
+        }
+
+        @Override
+        public HttpClientBuilder readTimeout(Duration readTimeout) {
+            delegate.readTimeout(readTimeout);
+            return this;
+        }
+
+        @Override
+        public HttpClient build() {
+            return new QuotaAwareHttpClient(delegate.build());
+        }
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/QuotaAwareHttpClient.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/QuotaAwareHttpClient.java
@@ -1,5 +1,6 @@
 package com.comet.opik.infrastructure.llm.openai;
 
+import com.comet.opik.infrastructure.llm.DelegatingHttpClientBuilder;
 import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.exception.NonRetriableException;
 import dev.langchain4j.http.client.HttpClient;
@@ -9,9 +10,10 @@ import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
+import jakarta.ws.rs.core.Response;
 import lombok.NonNull;
-
-import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * {@link HttpClient} decorator that marks OpenAI {@code insufficient_quota} (HTTP 429, out-of-credits)
@@ -36,16 +38,12 @@ import java.time.Duration;
  * </ul>
  * Rate-limit 429s and every other status are passed through unchanged and remain retryable.
  */
+@RequiredArgsConstructor
 public class QuotaAwareHttpClient implements HttpClient {
 
-    private static final int TOO_MANY_REQUESTS = 429;
     private static final String INSUFFICIENT_QUOTA = "insufficient_quota";
 
-    private final HttpClient delegate;
-
-    public QuotaAwareHttpClient(@NonNull HttpClient delegate) {
-        this.delegate = delegate;
-    }
+    private final @NonNull HttpClient delegate;
 
     @Override
     public SuccessfulHttpResponse execute(HttpRequest request) {
@@ -68,9 +66,8 @@ public class QuotaAwareHttpClient implements HttpClient {
     }
 
     private static boolean isInsufficientQuota(HttpException httpException) {
-        return httpException.statusCode() == TOO_MANY_REQUESTS
-                && httpException.getMessage() != null
-                && httpException.getMessage().contains(INSUFFICIENT_QUOTA);
+        return httpException.statusCode() == Response.Status.TOO_MANY_REQUESTS.getStatusCode()
+                && StringUtils.containsIgnoreCase(httpException.getMessage(), INSUFFICIENT_QUOTA);
     }
 
     /**
@@ -80,39 +77,15 @@ public class QuotaAwareHttpClient implements HttpClient {
         return new Builder(HttpClientBuilderLoader.loadHttpClientBuilder());
     }
 
-    private static final class Builder implements HttpClientBuilder {
+    private static final class Builder extends DelegatingHttpClientBuilder {
 
-        private final HttpClientBuilder delegate;
-
-        private Builder(@NonNull HttpClientBuilder delegate) {
-            this.delegate = delegate;
+        private Builder(HttpClientBuilder delegate) {
+            super(delegate);
         }
 
         @Override
-        public Duration connectTimeout() {
-            return delegate.connectTimeout();
-        }
-
-        @Override
-        public HttpClientBuilder connectTimeout(Duration connectTimeout) {
-            delegate.connectTimeout(connectTimeout);
-            return this;
-        }
-
-        @Override
-        public Duration readTimeout() {
-            return delegate.readTimeout();
-        }
-
-        @Override
-        public HttpClientBuilder readTimeout(Duration readTimeout) {
-            delegate.readTimeout(readTimeout);
-            return this;
-        }
-
-        @Override
-        public HttpClient build() {
-            return new QuotaAwareHttpClient(delegate.build());
+        protected HttpClient wrap(HttpClient delegate) {
+            return new QuotaAwareHttpClient(delegate);
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/openai/QuotaAwareHttpClientTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/openai/QuotaAwareHttpClientTest.java
@@ -8,8 +8,15 @@ import dev.langchain4j.http.client.SuccessfulHttpResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -19,10 +26,10 @@ import static org.mockito.Mockito.when;
 @DisplayName("Quota Aware HttpClient")
 class QuotaAwareHttpClientTest {
 
-    private static final String QUOTA_BODY = "{\"error\":{\"message\":\"You exceeded your current quota, please check "
-            + "your plan and billing details.\",\"type\":\"insufficient_quota\",\"code\":\"insufficient_quota\"}}";
-    private static final String RATE_LIMIT_BODY = "{\"error\":{\"message\":\"Rate limit reached\",\"type\":\"requests\","
-            + "\"code\":\"rate_limit_exceeded\"}}";
+    private static final int TOO_MANY_REQUESTS = 429;
+
+    private static final String RATE_LIMIT_BODY = """
+            {"error":{"message":"Rate limit reached","type":"requests","code":"rate_limit_exceeded"}}""";
 
     @Mock
     private HttpClient delegate;
@@ -30,36 +37,38 @@ class QuotaAwareHttpClientTest {
     @Mock
     private HttpRequest request;
 
-    @Test
-    @DisplayName("when 429 insufficient_quota, then rethrow as NonRetriableException carrying the body and no cause")
-    void execute__when429InsufficientQuota__thenNonRetriableWithBodyAndNoHttpCause() {
-        var client = new QuotaAwareHttpClient(delegate);
-        when(delegate.execute(request)).thenThrow(new HttpException(429, QUOTA_BODY));
+    @InjectMocks
+    private QuotaAwareHttpClient client;
 
+    @ParameterizedTest(name = "429 insufficient_quota with code casing ''{0}'' is non-retryable")
+    @ValueSource(strings = {"insufficient_quota", "INSUFFICIENT_QUOTA", "Insufficient_Quota"})
+    @DisplayName("when 429 insufficient_quota (any casing), then rethrow as NonRetriableException with body and no cause")
+    void execute__when429InsufficientQuota__thenNonRetriableWithBodyAndNoCause(String code) {
         // Both LangChain4j's internal retry and Opik's outer retry skip NonRetriableException. The body must be
         // the message (so it still maps to 402 downstream) and there must be no HttpException cause (otherwise
         // ExceptionMapper.findRoot() would unwrap it and re-map the 429 to a retryable RateLimitException).
+        var body = """
+                {"error":{"message":"You exceeded your current quota","type":"%s","code":"%s"}}""".formatted(code,
+                code);
+        when(delegate.execute(request)).thenThrow(new HttpException(TOO_MANY_REQUESTS, body));
+
         assertThatThrownBy(() -> client.execute(request))
                 .isInstanceOf(NonRetriableException.class)
-                .hasMessage(QUOTA_BODY)
+                .hasMessage(body)
                 .hasNoCause();
     }
 
-    @Test
-    @DisplayName("when 429 rate_limit_exceeded, then rethrow the original HttpException (stays retryable)")
-    void execute__when429RateLimit__thenRethrowHttpException() {
-        var client = new QuotaAwareHttpClient(delegate);
-        var original = new HttpException(429, RATE_LIMIT_BODY);
-        when(delegate.execute(request)).thenThrow(original);
-
-        assertThatThrownBy(() -> client.execute(request)).isSameAs(original);
+    private static Stream<Arguments> retryablePassThrough() {
+        return Stream.of(
+                Arguments.of("429 rate_limit_exceeded", new HttpException(TOO_MANY_REQUESTS, RATE_LIMIT_BODY)),
+                Arguments.of("400 invalid_request", new HttpException(400, """
+                        {"error":{"code":"invalid_request_error"}}""")));
     }
 
-    @Test
-    @DisplayName("when a non-429 client error, then rethrow the original HttpException")
-    void execute__whenOtherClientError__thenRethrowHttpException() {
-        var client = new QuotaAwareHttpClient(delegate);
-        var original = new HttpException(400, "{\"error\":{\"code\":\"invalid_request_error\"}}");
+    @ParameterizedTest(name = "{0} is passed through unchanged (stays retryable)")
+    @MethodSource("retryablePassThrough")
+    @DisplayName("when a non-quota error, then rethrow the original HttpException")
+    void execute__whenNonQuotaError__thenRethrowOriginal(String name, HttpException original) {
         when(delegate.execute(request)).thenThrow(original);
 
         assertThatThrownBy(() -> client.execute(request)).isSameAs(original);
@@ -68,7 +77,6 @@ class QuotaAwareHttpClientTest {
     @Test
     @DisplayName("when successful, then return the delegate response")
     void execute__whenSuccessful__thenReturnResponse() {
-        var client = new QuotaAwareHttpClient(delegate);
         var response = SuccessfulHttpResponse.builder().statusCode(200).body("ok").build();
         when(delegate.execute(request)).thenReturn(response);
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/openai/QuotaAwareHttpClientTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/openai/QuotaAwareHttpClientTest.java
@@ -13,7 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -40,9 +39,7 @@ class QuotaAwareHttpClientTest {
         // Both LangChain4j's internal retry and Opik's outer retry skip NonRetriableException. The body must be
         // the message (so it still maps to 402 downstream) and there must be no HttpException cause (otherwise
         // ExceptionMapper.findRoot() would unwrap it and re-map the 429 to a retryable RateLimitException).
-        var thrown = catchThrowable(() -> client.execute(request));
-
-        assertThat(thrown)
+        assertThatThrownBy(() -> client.execute(request))
                 .isInstanceOf(NonRetriableException.class)
                 .hasMessage(QUOTA_BODY)
                 .hasNoCause();

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/openai/QuotaAwareHttpClientTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/openai/QuotaAwareHttpClientTest.java
@@ -1,0 +1,80 @@
+package com.comet.opik.infrastructure.llm.openai;
+
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.exception.NonRetriableException;
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Quota Aware HttpClient")
+class QuotaAwareHttpClientTest {
+
+    private static final String QUOTA_BODY = "{\"error\":{\"message\":\"You exceeded your current quota, please check "
+            + "your plan and billing details.\",\"type\":\"insufficient_quota\",\"code\":\"insufficient_quota\"}}";
+    private static final String RATE_LIMIT_BODY = "{\"error\":{\"message\":\"Rate limit reached\",\"type\":\"requests\","
+            + "\"code\":\"rate_limit_exceeded\"}}";
+
+    @Mock
+    private HttpClient delegate;
+
+    @Mock
+    private HttpRequest request;
+
+    @Test
+    @DisplayName("when 429 insufficient_quota, then rethrow as NonRetriableException carrying the body and no cause")
+    void execute__when429InsufficientQuota__thenNonRetriableWithBodyAndNoHttpCause() {
+        var client = new QuotaAwareHttpClient(delegate);
+        when(delegate.execute(request)).thenThrow(new HttpException(429, QUOTA_BODY));
+
+        // Both LangChain4j's internal retry and Opik's outer retry skip NonRetriableException. The body must be
+        // the message (so it still maps to 402 downstream) and there must be no HttpException cause (otherwise
+        // ExceptionMapper.findRoot() would unwrap it and re-map the 429 to a retryable RateLimitException).
+        var thrown = catchThrowable(() -> client.execute(request));
+
+        assertThat(thrown)
+                .isInstanceOf(NonRetriableException.class)
+                .hasMessage(QUOTA_BODY)
+                .hasNoCause();
+    }
+
+    @Test
+    @DisplayName("when 429 rate_limit_exceeded, then rethrow the original HttpException (stays retryable)")
+    void execute__when429RateLimit__thenRethrowHttpException() {
+        var client = new QuotaAwareHttpClient(delegate);
+        var original = new HttpException(429, RATE_LIMIT_BODY);
+        when(delegate.execute(request)).thenThrow(original);
+
+        assertThatThrownBy(() -> client.execute(request)).isSameAs(original);
+    }
+
+    @Test
+    @DisplayName("when a non-429 client error, then rethrow the original HttpException")
+    void execute__whenOtherClientError__thenRethrowHttpException() {
+        var client = new QuotaAwareHttpClient(delegate);
+        var original = new HttpException(400, "{\"error\":{\"code\":\"invalid_request_error\"}}");
+        when(delegate.execute(request)).thenThrow(original);
+
+        assertThatThrownBy(() -> client.execute(request)).isSameAs(original);
+    }
+
+    @Test
+    @DisplayName("when successful, then return the delegate response")
+    void execute__whenSuccessful__thenReturnResponse() {
+        var client = new QuotaAwareHttpClient(delegate);
+        var response = SuccessfulHttpResponse.builder().statusCode(200).body("ok").build();
+        when(delegate.execute(request)).thenReturn(response);
+
+        assertThat(client.execute(request)).isSameAs(response);
+    }
+}


### PR DESCRIPTION
## Details

When an LLM provider key returns HTTP 429 `insufficient_quota` (out of credits), the request keeps failing the same way. LangChain4j maps any 429 to a retryable `RateLimitException` — both in the `OpenAiChatModel` internal retry (`withRetryMappingExceptions`, default `maxRetries=2`) and in the outer `ChatCompletionService` retry policy — so an exhausted key was retried repeatedly per request (inner × outer attempts), generating a sustained error storm against a key that cannot recover.

This adds a `QuotaAwareHttpClient` decorator that inspects 429 responses and, when the body is `insufficient_quota`, rethrows a `NonRetriableException` so both retry layers stop immediately.
- The original response body is carried as the exception **message**, so the existing provider-error mapping still surfaces it as HTTP 402.
- The `HttpException` is **not** kept as the cause, so LangChain4j's `ExceptionMapper.findRoot()` cannot unwrap and re-map the 429 back to a retryable error.
- `rate_limit_exceeded` (429) and all other statuses pass through unchanged and remain retryable.
- Wired into the free-model and OpenAI completions chat models and the raw OpenAI client.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6971

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8 (1M context)
  - Scope: Investigation, root-cause analysis, implementation, and tests
  - Human verification: Author reviewed the diff and ran the build/tests locally

## Testing

- `mvn -o -Dtest=QuotaAwareHttpClientTest test` → `Tests run: 4, Failures: 0, Errors: 0` (BUILD SUCCESS)
- `mvn -o compile` → clean
- Scenarios validated:
  - 429 `insufficient_quota` → rethrown as `NonRetriableException`, body preserved as message, no cause
  - 429 `rate_limit_exceeded` → original `HttpException` passed through (stays retryable)
  - non-429 4xx → original `HttpException` passed through
  - success → delegate response returned unchanged
- Not run: full backend integration suite (change is unit-scoped; verified the exception-handling path against the LangChain4j 1.16 sources).

## Documentation

N/A — internal resilience fix, no public API change.