### PR TITLE
[OPIK-6777] [FE] Improve Logs search discoverability & visual consistency

### DIFF
--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -93,6 +93,7 @@
     --chart-red: #ef6868;
     --chart-burgundy: #bf399e;
     --chart-purple: #945fcf;
+    --chart-violet: #7c3aed;
     --chart-pink: #ed4a7b;
     --chart-orange: #fb9341;
     --chart-teal: #12a4b4;
@@ -398,6 +399,7 @@
     --chart-red: #ef6868;
     --chart-burgundy: #bf399e;
     --chart-purple: #945fcf;
+    --chart-violet: #7c3aed;
     --chart-pink: #ed4a7b;
     --chart-orange: #fb9341;
     --chart-teal: #12a4b4;

--- a/apps/opik-frontend/src/shared/ColumnsButton/ColumnsButton.tsx
+++ b/apps/opik-frontend/src/shared/ColumnsButton/ColumnsButton.tsx
@@ -51,7 +51,7 @@ const ColumnsButton = <TColumnData,>({
               variant="outline"
               size={size}
               data-testid="columns-button"
-              className="font-normal"
+              className="font-normal focus-visible:border-primary focus-visible:ring-0"
             >
               Columns
               <div className="ml-1 rounded bg-muted-disabled px-1 text-muted-slate">

--- a/apps/opik-frontend/src/shared/ColumnsButton/ColumnsButton.tsx
+++ b/apps/opik-frontend/src/shared/ColumnsButton/ColumnsButton.tsx
@@ -47,7 +47,12 @@ const ColumnsButton = <TColumnData,>({
       <TooltipWrapper content="Columns">
         <DropdownMenuTrigger asChild>
           {layout === "labeled" ? (
-            <Button variant="outline" size={size} data-testid="columns-button">
+            <Button
+              variant="outline"
+              size={size}
+              data-testid="columns-button"
+              className="font-normal"
+            >
               Columns
               <div className="ml-1 rounded bg-muted-disabled px-1 text-muted-slate">
                 {selectedCount}/{totalCount}

--- a/apps/opik-frontend/src/shared/DataTableCells/ListCell.tsx
+++ b/apps/opik-frontend/src/shared/DataTableCells/ListCell.tsx
@@ -96,7 +96,7 @@ const ListCell = (context: CellContext<unknown, unknown>) => {
               <div key={item}>
                 <ColoredTag
                   label={item}
-                  variant="lavender"
+                  variant="green"
                   className="shrink-0"
                   size={tagSize}
                 />
@@ -107,7 +107,7 @@ const ListCell = (context: CellContext<unknown, unknown>) => {
             const tagProps = {
               label: item,
               tooltip: getItemTooltip?.(item),
-              variant: "lavender" as const,
+              variant: "green" as const,
               className: "block min-w-0 max-w-full",
               size: tagSize,
             };
@@ -133,14 +133,14 @@ const ListCell = (context: CellContext<unknown, unknown>) => {
               content={
                 <TagListTooltipContent
                   tags={hiddenItems}
-                  variant="lavender"
+                  variant="green"
                   size={tagSize}
                 />
               }
             >
               <div
                 className={cn(
-                  "flex items-center rounded-sm text-[var(--tag-lavender-text)]",
+                  "flex items-center rounded-sm text-[var(--tag-green-text)]",
                   isSmall
                     ? "comet-body-xs h-4 px-2"
                     : "comet-body-s h-6 rounded-md px-1.5",

--- a/apps/opik-frontend/src/shared/DataTableCells/PrettyCell.tsx
+++ b/apps/opik-frontend/src/shared/DataTableCells/PrettyCell.tsx
@@ -74,7 +74,7 @@ const PrettyCell = <TData,>(context: CellContext<TData, string | object>) => {
   const indicatorColor = colorIndicator
     ? fieldType === "input"
       ? "var(--color-green)"
-      : "var(--color-primary)"
+      : "var(--chart-violet)"
     : null;
 
   return (

--- a/apps/opik-frontend/src/shared/DataTableHeaders/FeedbackScoreHeader.tsx
+++ b/apps/opik-frontend/src/shared/DataTableHeaders/FeedbackScoreHeader.tsx
@@ -7,7 +7,6 @@ import { FeedbackScoreCustomMeta } from "@/types/feedback-scores";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { formatScoreDisplay } from "@/lib/feedback-scores";
 import useWorkspaceColorMap from "@/hooks/useWorkspaceColorMap";
-import { cn } from "@/lib/utils";
 
 const FeedbackScoreHeader = <TData,>(
   context: HeaderContext<TData, unknown>,
@@ -21,11 +20,9 @@ const FeedbackScoreHeader = <TData,>(
   const effectiveColorKey = scoreName ?? header ?? "";
   const color = getColor(effectiveColorKey, colorMap);
 
-  const { className, onClickHandler, renderSort, isSorted } = useSortableHeader(
-    {
-      column,
-    },
-  );
+  const { className, onClickHandler, renderSort } = useSortableHeader({
+    column,
+  });
 
   const formattedScore =
     scoreValue !== undefined ? formatScoreDisplay(scoreValue) : null;
@@ -46,11 +43,7 @@ const FeedbackScoreHeader = <TData,>(
       />
       {header ? (
         <TooltipWrapper content={header} side="top">
-          <span
-            className={cn("truncate", isSorted && "text-foreground-secondary")}
-          >
-            {header}
-          </span>
+          <span className="truncate">{header}</span>
         </TooltipWrapper>
       ) : (
         <span className="truncate"></span>

--- a/apps/opik-frontend/src/shared/DataTableHeaders/HeaderWrapper.tsx
+++ b/apps/opik-frontend/src/shared/DataTableHeaders/HeaderWrapper.tsx
@@ -53,7 +53,7 @@ const HeaderWrapper = <TData,>({
     return (
       <div
         className={cn(
-          "flex flex-col justify-center px-3",
+          "flex flex-col justify-center px-3 text-muted-slate",
           isSmall ? "h-11" : "h-12",
           className,
         )}
@@ -91,7 +91,7 @@ const HeaderWrapper = <TData,>({
   return (
     <div
       className={cn(
-        "flex size-full items-center gap-1 px-3",
+        "flex size-full items-center gap-1 px-3 text-muted-slate",
         nameClass,
         isSmall ? "h-8" : "h-11",
         horizontalAlignClass,

--- a/apps/opik-frontend/src/shared/DataTableHeaders/TypeHeader.tsx
+++ b/apps/opik-frontend/src/shared/DataTableHeaders/TypeHeader.tsx
@@ -5,17 +5,14 @@ import HeaderWrapper from "@/shared/DataTableHeaders/HeaderWrapper";
 import useSortableHeader from "@/shared/DataTableHeaders/useSortableHeader";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import { cn } from "@/lib/utils";
-
 const TypeHeader = <TData,>(context: HeaderContext<TData, unknown>) => {
   const { column } = context;
   const { header, headerCheckbox, explainer } = column.columnDef.meta ?? {};
 
-  const { className, onClickHandler, renderSort, isSorted, isSortable } =
-    useSortableHeader({
-      column,
-      withSeparator: Boolean(explainer),
-    });
+  const { className, onClickHandler, renderSort } = useSortableHeader({
+    column,
+    withSeparator: Boolean(explainer),
+  });
 
   const textRef = useRef<HTMLSpanElement>(null);
   const [isTruncated, setIsTruncated] = useState(false);
@@ -50,23 +47,11 @@ const TypeHeader = <TData,>(context: HeaderContext<TData, unknown>) => {
         />
       )}
       <TooltipWrapper content={isTruncated ? header : null}>
-        <span
-          ref={textRef}
-          className={cn(
-            "truncate",
-            isSortable && isSorted && "text-foreground-secondary",
-          )}
-          onMouseEnter={checkTruncation}
-        >
+        <span ref={textRef} className="truncate" onMouseEnter={checkTruncation}>
           {header}
         </span>
       </TooltipWrapper>
-      {explainer && (
-        <ExplainerIcon
-          {...explainer}
-          className={cn(isSortable && isSorted && "text-foreground-secondary")}
-        />
-      )}
+      {explainer && <ExplainerIcon {...explainer} />}
       {renderSort()}
     </HeaderWrapper>
   );

--- a/apps/opik-frontend/src/shared/DataTableHeaders/useSortableHeader.tsx
+++ b/apps/opik-frontend/src/shared/DataTableHeaders/useSortableHeader.tsx
@@ -41,7 +41,7 @@ export const useSortableHeader = <TData,>({
         <Icon
           className={cn(
             "hidden size-3.5 shrink-0 group-hover:inline",
-            direction && "inline text-foreground-secondary",
+            direction && "inline",
           )}
         />
       </>

--- a/apps/opik-frontend/src/shared/DataTableRowHeightSelector/DataTableRowHeightSelector.tsx
+++ b/apps/opik-frontend/src/shared/DataTableRowHeightSelector/DataTableRowHeightSelector.tsx
@@ -25,7 +25,7 @@ const OPTIONS: DropdownOption<ROW_HEIGHT>[] = [
 
 const DataTableRowHeightSelector: React.FunctionComponent<
   DataTableRowHeightSelectorProps
-> = ({ type, setType, layout = "icon", size = "sm" }) => {
+> = ({ type, setType, layout = "icon", size = "icon-sm" }) => {
   const handleSelect = useCallback(
     (value: ROW_HEIGHT) => {
       setType(value);

--- a/apps/opik-frontend/src/shared/DataTableRowHeightSelector/DataTableRowHeightSelector.tsx
+++ b/apps/opik-frontend/src/shared/DataTableRowHeightSelector/DataTableRowHeightSelector.tsx
@@ -35,7 +35,7 @@ const DataTableRowHeightSelector: React.FunctionComponent<
 
   return (
     <DropdownMenu>
-      <TooltipWrapper content="Rows">
+      <TooltipWrapper content="Row size">
         <DropdownMenuTrigger asChild>
           {layout === "labeled" ? (
             <Button variant="outline" size={size}>
@@ -43,7 +43,11 @@ const DataTableRowHeightSelector: React.FunctionComponent<
               Row size
             </Button>
           ) : (
-            <Button variant="outline" size={size}>
+            <Button
+              variant="outline"
+              size={size}
+              className="focus-visible:border-primary focus-visible:ring-0"
+            >
               <Rows3 />
             </Button>
           )}

--- a/apps/opik-frontend/src/shared/DataTableRowHeightSelector/DataTableRowHeightSelector.tsx
+++ b/apps/opik-frontend/src/shared/DataTableRowHeightSelector/DataTableRowHeightSelector.tsx
@@ -43,8 +43,8 @@ const DataTableRowHeightSelector: React.FunctionComponent<
               Row size
             </Button>
           ) : (
-            <Button variant="outline" size="icon-sm">
-              <Rows3 className="size-3.5" />
+            <Button variant="outline" size={size}>
+              <Rows3 />
             </Button>
           )}
         </DropdownMenuTrigger>

--- a/apps/opik-frontend/src/shared/RefreshButton/RefreshButton.tsx
+++ b/apps/opik-frontend/src/shared/RefreshButton/RefreshButton.tsx
@@ -31,7 +31,10 @@ const RefreshButton: React.FC<RefreshButtonProps> = ({
       <Button
         variant={variant}
         size={size}
-        className={cn("shrink-0", className)}
+        className={cn(
+          "shrink-0 focus-visible:border-primary focus-visible:ring-0",
+          className,
+        )}
         onClick={() => {
           setSpin(true);
           onRefresh();

--- a/apps/opik-frontend/src/shared/filter-chips/FilterChipBar/FilterChipBar.tsx
+++ b/apps/opik-frontend/src/shared/filter-chips/FilterChipBar/FilterChipBar.tsx
@@ -34,6 +34,7 @@ export interface FilterChipBarProps {
   onClearAll: () => void;
   openChipId: string | null;
   onOpenChipIdChange: (id: string | null) => void;
+  prefix?: React.ReactNode;
 }
 
 const FilterChipBar: React.FC<FilterChipBarProps> = ({
@@ -49,6 +50,7 @@ const FilterChipBar: React.FC<FilterChipBarProps> = ({
   onClearAll,
   openChipId,
   onOpenChipIdChange,
+  prefix,
 }) => {
   const appliedCount = useMemo(() => {
     let count = 0;
@@ -68,6 +70,7 @@ const FilterChipBar: React.FC<FilterChipBarProps> = ({
 
   return (
     <div className="flex flex-wrap items-center gap-2">
+      {prefix}
       {chipsPinned.map((def) => {
         const isOpen = def.id === openChipId;
         const handleOpenChange = buildOnOpenChange(def.id);

--- a/apps/opik-frontend/src/ui/toggle.tsx
+++ b/apps/opik-frontend/src/ui/toggle.tsx
@@ -20,6 +20,7 @@ const toggleVariants = cva(
       },
       size: {
         default: "h-8 px-4",
+        xs: "h-5 px-2",
         sm: "h-6 px-2",
         md: "h-7 px-2",
         lg: "h-9 px-5",

--- a/apps/opik-frontend/src/v2/pages-shared/traces/EnvironmentFilterSelect/EnvironmentFilterSelect.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/EnvironmentFilterSelect/EnvironmentFilterSelect.tsx
@@ -52,7 +52,7 @@ const EnvironmentFilterSelect: React.FC<EnvironmentFilterSelectProps> = ({
       <DropdownMenuTrigger asChild>
         <Button
           variant="outline"
-          size="sm"
+          size="xs"
           className="min-w-40 justify-between gap-2 font-normal focus-visible:border-primary focus-visible:ring-0"
         >
           <span className="flex min-w-0 items-center gap-1.5 truncate">

--- a/apps/opik-frontend/src/v2/pages-shared/traces/MetricDateRangeSelect/MetricDateRangeSelect.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/MetricDateRangeSelect/MetricDateRangeSelect.tsx
@@ -31,7 +31,7 @@ const MetricDateRangeSelect: React.FC<MetricDateRangeSelectProps> = ({
       minDate={minDate}
       maxDate={maxDate}
     >
-      <DateRangeSelect.Trigger />
+      <DateRangeSelect.Trigger className="h-7" />
       <DateRangeSelect.Content>
         <DateRangeSelect.PresetOption value={DATE_RANGE_PRESET_PAST_24_HOURS} />
         <DateRangeSelect.PresetOption value={DATE_RANGE_PRESET_PAST_3_DAYS} />

--- a/apps/opik-frontend/src/v2/pages-shared/traces/MetricsSummary/MetricsSummary.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/MetricsSummary/MetricsSummary.tsx
@@ -87,7 +87,7 @@ type ChartMetricConfig = {
   labelsMap?: Record<string, string>;
 };
 
-const CHART_GREEN = "var(--chart-green)";
+const CHART_VIOLET = "var(--chart-violet)";
 const CHART_RED = "var(--chart-red)";
 const CHART_BLUE = "var(--chart-blue)";
 const CHART_TEAL = "var(--chart-teal)";
@@ -130,7 +130,7 @@ const getChartConfig = (
       return {
         metricName: COUNT_METRIC_MAP[entityType],
         chartType: CHART_TYPE.bar,
-        colorMap: { [entityType]: CHART_GREEN },
+        colorMap: { [entityType]: CHART_VIOLET },
       };
     case "errors":
       return {

--- a/apps/opik-frontend/src/v2/pages/LogsPage/LogsTypeToggle.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/LogsTypeToggle.tsx
@@ -19,13 +19,13 @@ const LogsTypeToggle: React.FC<LogsTypeToggleProps> = ({
       variant="secondary"
       className="w-fit"
     >
-      <ToggleGroupItem value={LOGS_TYPE.threads} size="sm">
+      <ToggleGroupItem value={LOGS_TYPE.threads} size="xs">
         Threads
       </ToggleGroupItem>
-      <ToggleGroupItem value={LOGS_TYPE.traces} size="sm">
+      <ToggleGroupItem value={LOGS_TYPE.traces} size="xs">
         Traces
       </ToggleGroupItem>
-      <ToggleGroupItem value={LOGS_TYPE.spans} size="sm">
+      <ToggleGroupItem value={LOGS_TYPE.spans} size="xs">
         Spans
       </ToggleGroupItem>
     </ToggleGroup>

--- a/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
@@ -836,12 +836,35 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
           <LogsTypeToggle value={logsType} onValueChange={onLogsTypeChange} />
         </div>
         <div className="flex items-center gap-2">
+          <DataTableRowHeightSelector
+            type={height as ROW_HEIGHT}
+            setType={setHeight}
+            size="icon-xs"
+          />
+          <ColumnsButton
+            columns={DEFAULT_COLUMNS}
+            selectedColumns={selectedColumns}
+            onSelectionChange={setSelectedColumns}
+            order={columnsOrder}
+            onOrderChange={setColumnsOrder}
+            sections={columnSections}
+            layout="labeled"
+            size="xs"
+          />
+          <Separator orientation="vertical" className="mx-2 h-6" />
           <MetricDateRangeSelect
             value={dateRange}
             onChangeValue={handleDateRangeChange}
             minDate={minDate}
             maxDate={maxDate}
             hideAlltime
+          />
+          <Separator orientation="vertical" className="mx-2 h-6" />
+          <RefreshButton
+            tooltip="Refresh threads list"
+            size="2xs"
+            isFetching={isFetching}
+            onRefresh={() => refetch()}
           />
         </div>
       </PageBodyStickyContainer>
@@ -860,49 +883,6 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
           dateRange={dateRange}
           logsSource={LOGS_SOURCE.sdk}
         />
-      </PageBodyStickyContainer>
-      <PageBodyStickyContainer
-        className="pb-0 pt-3"
-        direction="bidirectional"
-        limitWidth
-      >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <SearchInput
-              searchText={search as string}
-              setSearchText={setSearch}
-              placeholder="Search threads..."
-              className="w-[320px]"
-              dimension="xs"
-            />
-          </div>
-          <div className="flex items-center gap-2">
-            <DataTableRowHeightSelector
-              type={height as ROW_HEIGHT}
-              setType={setHeight}
-              layout="labeled"
-              size="2xs"
-            />
-            <ColumnsButton
-              columns={DEFAULT_COLUMNS}
-              selectedColumns={selectedColumns}
-              onSelectionChange={setSelectedColumns}
-              order={columnsOrder}
-              onOrderChange={setColumnsOrder}
-              sections={columnSections}
-              layout="labeled"
-              size="2xs"
-            />
-            <Separator orientation="vertical" className="mx-1 h-6" />
-            <RefreshButton
-              tooltip="Refresh threads list"
-              size="2xs"
-              label="Refresh"
-              isFetching={isFetching}
-              onRefresh={() => refetch()}
-            />
-          </div>
-        </div>
       </PageBodyStickyContainer>
 
       {selectedRows.length > 0 ? (
@@ -938,6 +918,15 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
             onClearAll={clearAllThreadChips}
             openChipId={threadOpenChipId}
             onOpenChipIdChange={setThreadOpenChipId}
+            prefix={
+              <SearchInput
+                searchText={search as string}
+                setSearchText={setSearch}
+                placeholder="Search by anything"
+                className="w-[200px] shrink-0"
+                dimension="xs"
+              />
+            }
           />
         </PageBodyStickyContainer>
       )}

--- a/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
@@ -862,7 +862,7 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
           <Separator orientation="vertical" className="mx-2 h-6" />
           <RefreshButton
             tooltip="Refresh threads list"
-            size="2xs"
+            size="icon-xs"
             isFetching={isFetching}
             onRefresh={() => refetch()}
           />

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -1678,6 +1678,27 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
           <LogsTypeToggle value={logsType} onValueChange={onLogsTypeChange} />
         </div>
         <div className="flex items-center gap-2">
+          <DataTableRowHeightSelector
+            type={height as ROW_HEIGHT}
+            setType={setHeight}
+            size="icon-xs"
+          />
+          <ColumnsButton
+            columns={columnData}
+            selectedColumns={selectedColumns}
+            onSelectionChange={setSelectedColumns}
+            order={columnsOrder}
+            onOrderChange={setColumnsOrder}
+            sections={columnSections}
+            layout="labeled"
+            size="xs"
+            excludeFromSelectAll={
+              metadataColumnsData.length > 0
+                ? metadataColumnsData.map((col) => col.id)
+                : []
+            }
+          />
+          <Separator orientation="vertical" className="mx-2 h-6" />
           <EnvironmentFilterSelect
             value={environment ?? ""}
             onChange={(next) => {
@@ -1691,6 +1712,18 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
             minDate={minDate}
             maxDate={maxDate}
             hideAlltime
+          />
+          <Separator orientation="vertical" className="mx-2 h-6" />
+          <RefreshButton
+            tooltip={`Refresh ${
+              type === TRACE_DATA_TYPE.traces ? "traces" : "spans"
+            } list`}
+            size="icon-xs"
+            isFetching={isFetching}
+            onRefresh={() => {
+              refetch();
+              refetchStatistic();
+            }}
           />
         </div>
       </PageBodyStickyContainer>
@@ -1709,59 +1742,6 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
           dateRange={dateRange}
           logsSource={LOGS_SOURCE.sdk}
         />
-      </PageBodyStickyContainer>
-      <PageBodyStickyContainer
-        className="pb-0 pt-3"
-        direction="bidirectional"
-        limitWidth
-      >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <SearchInput
-              searchText={search as string}
-              setSearchText={setSearch}
-              placeholder={`Search ${type}...`}
-              className="w-[320px]"
-              dimension="xs"
-            />
-          </div>
-          <div className="flex items-center gap-2">
-            <DataTableRowHeightSelector
-              type={height as ROW_HEIGHT}
-              setType={setHeight}
-              layout="labeled"
-              size="2xs"
-            />
-            <ColumnsButton
-              columns={columnData}
-              selectedColumns={selectedColumns}
-              onSelectionChange={setSelectedColumns}
-              order={columnsOrder}
-              onOrderChange={setColumnsOrder}
-              sections={columnSections}
-              layout="labeled"
-              size="2xs"
-              excludeFromSelectAll={
-                metadataColumnsData.length > 0
-                  ? metadataColumnsData.map((col) => col.id)
-                  : []
-              }
-            />
-            <Separator orientation="vertical" className="mx-1 h-6" />
-            <RefreshButton
-              tooltip={`Refresh ${
-                type === TRACE_DATA_TYPE.traces ? "traces" : "spans"
-              } list`}
-              size="2xs"
-              label="Refresh"
-              isFetching={isFetching}
-              onRefresh={() => {
-                refetch();
-                refetchStatistic();
-              }}
-            />
-          </div>
-        </div>
       </PageBodyStickyContainer>
 
       {selectedRows.length > 0 ? (
@@ -1799,6 +1779,15 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
             onClearAll={clearAllChips}
             openChipId={openChipId}
             onOpenChipIdChange={setOpenChipId}
+            prefix={
+              <SearchInput
+                searchText={search as string}
+                setSearchText={setSearch}
+                placeholder="Search by anything"
+                className="w-[200px] shrink-0"
+                dimension="xs"
+              />
+            }
           />
         </PageBodyStickyContainer>
       )}


### PR DESCRIPTION
## Details

Improves the Logs page UX by repositioning the search bar next to filter chips, moving toolbar controls to the tab row, and applying visual/color updates to align with the newer design language.

### Search & filter UX
- Search bar repositioned next to filter chips (shares the same flex-wrap row via new `prefix` prop on `FilterChipBar`)
- Placeholder updated to "Search by anything"
- Chips that overflow wrap to the next line under the search bar

### Toolbar & controls
- Columns, Row size, and Refresh buttons moved from the search row to the tab row
- Button order: RowHeight (icon) → Columns (labeled) → separator → Environment → Date Range → separator → Refresh (icon)
- Columns button text set to `font-normal`
- All tab row controls resized to `xs`/`icon-xs` for consistency
- `DataTableRowHeightSelector` icon layout now respects the `size` prop (was hardcoded to `icon-sm`)

### Visual / Color updates
- New `--chart-violet: #7C3AED` CSS variable (light + dark themes)
- Main chart (count) color changed from green to violet
- Output column indicator color changed from `--color-primary` to `--chart-violet`
- Table tags changed from lavender to green variant
- All column headers now use `text-muted-slate` via `HeaderWrapper`
- Sorted column header regression fixed (was `text-foreground-secondary` ≈ black)
- Removed redundant sorted-state color overrides from `TypeHeader` and `FeedbackScoreHeader`

### Sizing updates
- `LogsTypeToggle`: new `xs` toggle size variant, group height 28px
- `EnvironmentFilterSelect`: trigger size changed from `sm` to `xs`
- `MetricDateRangeSelect`: trigger height changed from `h-8` to `h-7`

Applied to both `TracesSpansTab` and `ThreadsTab`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-6777

## Testing
- Open any project's Logs page (Traces, Spans, Threads tabs)
- Verify search bar sits inline with filter chips, overflow chips wrap to full width
- Verify Columns, Row size, Refresh buttons are in the tab row
- Verify chart bars are purple (#7C3AED), output indicator is purple, tags are light green
- Sort a column and verify the header text stays muted gray (not black)
- Resize the browser to test chip wrapping behavior

## Documentation
N/A