### PR TITLE
[OPIK-6982] Add reaper for orphaned Redis stream consumers

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1232,6 +1232,23 @@ localRunner:
   # Description: Maximum payload size in bytes for bridge command args and results
   bridgeMaxPayloadBytes: ${OPIK_RUNNER_BRIDGE_MAX_PAYLOAD_BYTES:-1048576}
 
+# Orphaned Redis stream-consumer reaper (OPIK-6982). Non-graceful pod exits (OOMKill/SIGKILL/crash) leak
+# stream consumers that Redis never removes; this job deletes consumers idle beyond the threshold with no
+# pending entries. One instance runs per cycle (distributed lock with hold-until-expiry).
+streamConsumerReaper:
+  # Default: true
+  # Description: Whether the orphaned stream-consumer reaper job is enabled
+  enabled: ${OPIK_STREAM_CONSUMER_REAPER_ENABLED:-true}
+  # Default: 1h
+  # Description: Interval between reaper job executions
+  jobInterval: ${OPIK_STREAM_CONSUMER_REAPER_JOB_INTERVAL:-1h}
+  # Default: 1d
+  # Description: Consumers idle beyond this (and with no pending entries) are removed
+  idleThreshold: ${OPIK_STREAM_CONSUMER_REAPER_IDLE_THRESHOLD:-1d}
+  # Default: 10m
+  # Description: How long the reaper holds its distributed lock (until expiry) to prevent concurrent fleet-wide runs
+  lockDuration: ${OPIK_STREAM_CONSUMER_REAPER_LOCK_DURATION:-10m}
+
 # Trace Thread configuration
 traceThreadConfig:
   # Default: true

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1242,9 +1242,12 @@ streamConsumerReaper:
   # Default: 1h
   # Description: Interval between reaper job executions
   jobInterval: ${OPIK_STREAM_CONSUMER_REAPER_JOB_INTERVAL:-1h}
-  # Default: 1d
+  # Default: 5m
+  # Description: Delay before the first reaper run after startup, to avoid reaping during warm-up
+  startupDelay: ${OPIK_STREAM_CONSUMER_REAPER_STARTUP_DELAY:-5m}
+  # Default: 3d
   # Description: Consumers idle beyond this (and with no pending entries) are removed
-  idleThreshold: ${OPIK_STREAM_CONSUMER_REAPER_IDLE_THRESHOLD:-1d}
+  idleThreshold: ${OPIK_STREAM_CONSUMER_REAPER_IDLE_THRESHOLD:-3d}
   # Default: 10m
   # Description: How long the reaper holds its distributed lock (until expiry) to prevent concurrent fleet-wide runs
   lockDuration: ${OPIK_STREAM_CONSUMER_REAPER_LOCK_DURATION:-10m}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
@@ -98,6 +98,13 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
     @Getter
     private final String consumerId;
 
+    /**
+     * Stream key this subscriber consumes. Exposed so the orphaned-consumer reaper job can enumerate the
+     * streams to clean without a keyspace scan; it then discovers each stream's groups via {@code XINFO GROUPS}.
+     */
+    @Getter
+    private final String streamName;
+
     protected final Meter meter;
     private final LongHistogram messageProcessingTime;
     private final LongHistogram messageQueueDelay;
@@ -131,6 +138,7 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
         this.redisson = redisson;
 
         this.payloadField = payloadField;
+        this.streamName = config.getStreamName();
 
         this.consumerId = "consumer-%s-%s".formatted(this.config.getConsumerGroupName(), UUID.randomUUID());
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/StreamConsumerReaperJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/StreamConsumerReaperJob.java
@@ -1,6 +1,7 @@
 package com.comet.opik.api.resources.v1.jobs;
 
 import com.comet.opik.api.resources.v1.events.BaseRedisSubscriber;
+import com.comet.opik.infrastructure.GuiceBindings;
 import com.comet.opik.infrastructure.StreamConsumerReaperConfig;
 import com.comet.opik.infrastructure.lock.LockService;
 import com.comet.opik.infrastructure.redis.StreamConsumerReaper;
@@ -103,11 +104,9 @@ public class StreamConsumerReaperJob extends Job implements InterruptableJob {
      * Package-private for testing against the real application Guice context.
      */
     List<String> discoverStreamNames() {
-        List<String> streamNames = injector.getAllBindings().keySet().stream()
-                .map(key -> key.getTypeLiteral().getRawType())
+        List<String> streamNames = GuiceBindings.boundRawTypes(injector)
                 .filter(BaseRedisSubscriber.class::isAssignableFrom)
                 .filter(type -> !Modifier.isAbstract(type.getModifiers()))
-                .distinct()
                 .map(type -> (BaseRedisSubscriber) injector.getInstance(type))
                 .map(BaseRedisSubscriber::getStreamName)
                 .distinct()

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/StreamConsumerReaperJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/StreamConsumerReaperJob.java
@@ -10,11 +10,14 @@ import io.dropwizard.jobs.Job;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.InterruptableJob;
 import org.quartz.JobExecutionContext;
+import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.lang.reflect.Modifier;
 import java.time.Duration;
@@ -35,29 +38,23 @@ import static com.comet.opik.infrastructure.lock.LockService.Lock;
 @Slf4j
 @Singleton
 @DisallowConcurrentExecution
+@RequiredArgsConstructor(onConstructor_ = @Inject)
 public class StreamConsumerReaperJob extends Job implements InterruptableJob {
 
     private static final Lock JOB_LOCK = new Lock("stream_consumer_reaper:lock");
 
-    private final Injector injector;
-    private final StreamConsumerReaper reaper;
-    private final LockService lockService;
-    private final StreamConsumerReaperConfig config;
+    private final @NonNull Injector injector;
+    private final @NonNull StreamConsumerReaper reaper;
+    private final @NonNull LockService lockService;
+    private final @NonNull StreamConsumerReaperConfig config;
 
     private final AtomicBoolean interrupted = new AtomicBoolean(false);
-    // Subscribers are fixed after startup, so the discovered stream names are computed once and cached.
+
+    /** Subscribers are fixed after startup, so the discovered stream names are computed once and cached. */
     private final AtomicReference<List<String>> streamNamesCache = new AtomicReference<>();
 
-    @Inject
-    public StreamConsumerReaperJob(@NonNull Injector injector,
-            @NonNull StreamConsumerReaper reaper,
-            @NonNull LockService lockService,
-            @NonNull StreamConsumerReaperConfig config) {
-        this.injector = injector;
-        this.reaper = reaper;
-        this.lockService = lockService;
-        this.config = config;
-    }
+    /** Tracks the in-flight reactive pass so {@link #interrupt()} can dispose it (cancels the actual chain). */
+    private final AtomicReference<Disposable> currentExecution = new AtomicReference<>();
 
     @Override
     public void doJob(JobExecutionContext context) {
@@ -74,28 +71,43 @@ public class StreamConsumerReaperJob extends Job implements InterruptableJob {
             return;
         }
 
-        lockService.bestEffortLock(
+        var subscription = lockService.bestEffortLock(
                 JOB_LOCK,
-                reaper.reap(streamNames, config.getIdleThreshold().toJavaDuration())
-                        .doOnSuccess(count -> {
-                            if (count > 0) {
-                                log.info(
-                                        "Stream consumer reaper removed '{}' orphaned consumer(s) across '{}' stream(s)",
-                                        count, streamNames.size());
-                            } else {
-                                log.debug("Stream consumer reaper found no orphaned consumers across '{}' stream(s)",
-                                        streamNames.size());
-                            }
-                        }),
-                Mono.fromRunnable(() -> log.info(
+                Mono.defer(() -> {
+                    if (interrupted.get()) {
+                        log.info("Stream consumer reaper interrupted before processing, skipping");
+                        return Mono.empty();
+                    }
+                    return reaper.reap(streamNames, config.idleThreshold().toJavaDuration())
+                            .doOnSuccess(count -> {
+                                if (count > 0) {
+                                    log.info(
+                                            "Stream consumer reaper removed orphaned consumer(s), removed='{}', streams='{}'",
+                                            count, streamNames.size());
+                                } else {
+                                    log.debug("Stream consumer reaper found no orphaned consumers, streams='{}'",
+                                            streamNames.size());
+                                }
+                            });
+                }),
+                Mono.fromRunnable(() -> log.debug(
                         "Could not acquire lock for stream consumer reaper, another instance is running")),
-                config.getLockDuration().toJavaDuration(),
+                config.lockDuration().toJavaDuration(),
                 Duration.ZERO,
                 true) // holdUntilExpiry: prevent redundant runs across instances until the next cycle
-                .subscribe(
-                        __ -> {
-                        },
-                        error -> log.error("Stream consumer reaper failed", error));
+                // Resume on errors so the recurring job stays alive.
+                .onErrorResume(throwable -> {
+                    if (interrupted.get()) {
+                        log.warn("Stream consumer reaper interrupted", throwable);
+                    } else {
+                        log.error("Stream consumer reaper failed", throwable);
+                    }
+                    return Mono.empty();
+                })
+                .doFinally(signal -> currentExecution.set(null))
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe();
+        currentExecution.set(subscription);
     }
 
     /**
@@ -111,7 +123,8 @@ public class StreamConsumerReaperJob extends Job implements InterruptableJob {
                 .map(BaseRedisSubscriber::getStreamName)
                 .distinct()
                 .toList();
-        log.info("Discovered '{}' stream(s) to reap orphaned consumers from: '{}'", streamNames.size(), streamNames);
+        log.info("Discovered stream(s) to reap orphaned consumers from, count='{}', streams='{}'",
+                streamNames.size(), streamNames);
         return streamNames;
     }
 
@@ -119,5 +132,10 @@ public class StreamConsumerReaperJob extends Job implements InterruptableJob {
     public void interrupt() {
         interrupted.set(true);
         log.info("Stream consumer reaper job interrupted");
+        var execution = currentExecution.get();
+        if (execution != null && !execution.isDisposed()) {
+            execution.dispose();
+            log.info("Stream consumer reaper job interrupted successfully");
+        }
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/StreamConsumerReaperJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/StreamConsumerReaperJob.java
@@ -1,0 +1,124 @@
+package com.comet.opik.api.resources.v1.jobs;
+
+import com.comet.opik.api.resources.v1.events.BaseRedisSubscriber;
+import com.comet.opik.infrastructure.StreamConsumerReaperConfig;
+import com.comet.opik.infrastructure.lock.LockService;
+import com.comet.opik.infrastructure.redis.StreamConsumerReaper;
+import com.google.inject.Injector;
+import io.dropwizard.jobs.Job;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.InterruptableJob;
+import org.quartz.JobExecutionContext;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.Modifier;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.comet.opik.infrastructure.lock.LockService.Lock;
+
+/**
+ * Periodically removes orphaned Redis stream consumers leaked by non-graceful pod exits (OPIK-6982).
+ * <p>
+ * The streams to clean are discovered from the registered {@link BaseRedisSubscriber} beans (no keyspace scan, no
+ * hand-maintained list) — mirroring how {@code EventListenerRegistrar} discovers event listeners. The actual
+ * reaping is delegated to {@link StreamConsumerReaper}. A distributed lock with hold-until-expiry ensures only one
+ * instance reaps per cycle, so the fleet does not redundantly re-scan the same groups.
+ */
+@Slf4j
+@Singleton
+@DisallowConcurrentExecution
+public class StreamConsumerReaperJob extends Job implements InterruptableJob {
+
+    private static final Lock JOB_LOCK = new Lock("stream_consumer_reaper:lock");
+
+    private final Injector injector;
+    private final StreamConsumerReaper reaper;
+    private final LockService lockService;
+    private final StreamConsumerReaperConfig config;
+
+    private final AtomicBoolean interrupted = new AtomicBoolean(false);
+    // Subscribers are fixed after startup, so the discovered stream names are computed once and cached.
+    private final AtomicReference<List<String>> streamNamesCache = new AtomicReference<>();
+
+    @Inject
+    public StreamConsumerReaperJob(@NonNull Injector injector,
+            @NonNull StreamConsumerReaper reaper,
+            @NonNull LockService lockService,
+            @NonNull StreamConsumerReaperConfig config) {
+        this.injector = injector;
+        this.reaper = reaper;
+        this.lockService = lockService;
+        this.config = config;
+    }
+
+    @Override
+    public void doJob(JobExecutionContext context) {
+        if (interrupted.get()) {
+            log.info("Stream consumer reaper job interrupted before execution, skipping");
+            return;
+        }
+
+        List<String> streamNames = streamNamesCache.updateAndGet(
+                cached -> cached != null ? cached : discoverStreamNames());
+
+        if (streamNames.isEmpty()) {
+            log.debug("No stream subscribers discovered, skipping stream consumer reaper");
+            return;
+        }
+
+        lockService.bestEffortLock(
+                JOB_LOCK,
+                reaper.reap(streamNames, config.getIdleThreshold().toJavaDuration())
+                        .doOnSuccess(count -> {
+                            if (count > 0) {
+                                log.info(
+                                        "Stream consumer reaper removed '{}' orphaned consumer(s) across '{}' stream(s)",
+                                        count, streamNames.size());
+                            } else {
+                                log.debug("Stream consumer reaper found no orphaned consumers across '{}' stream(s)",
+                                        streamNames.size());
+                            }
+                        }),
+                Mono.fromRunnable(() -> log.info(
+                        "Could not acquire lock for stream consumer reaper, another instance is running")),
+                config.getLockDuration().toJavaDuration(),
+                Duration.ZERO,
+                true) // holdUntilExpiry: prevent redundant runs across instances until the next cycle
+                .subscribe(
+                        __ -> {
+                        },
+                        error -> log.error("Stream consumer reaper failed", error));
+    }
+
+    /**
+     * Discovers the stream names of every registered {@link BaseRedisSubscriber} by scanning the Guice bindings,
+     * so new subscribers are covered automatically without registration. Mirrors {@code EventListenerRegistrar}.
+     * Package-private for testing against the real application Guice context.
+     */
+    List<String> discoverStreamNames() {
+        List<String> streamNames = injector.getAllBindings().keySet().stream()
+                .map(key -> key.getTypeLiteral().getRawType())
+                .filter(BaseRedisSubscriber.class::isAssignableFrom)
+                .filter(type -> !Modifier.isAbstract(type.getModifiers()))
+                .distinct()
+                .map(type -> (BaseRedisSubscriber) injector.getInstance(type))
+                .map(BaseRedisSubscriber::getStreamName)
+                .distinct()
+                .toList();
+        log.info("Discovered '{}' stream(s) to reap orphaned consumers from: '{}'", streamNames.size(), streamNames);
+        return streamNames;
+    }
+
+    @Override
+    public void interrupt() {
+        interrupted.set(true);
+        log.info("Stream consumer reaper job interrupted");
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/StreamConsumerReaperJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/StreamConsumerReaperJob.java
@@ -18,6 +18,7 @@ import org.quartz.JobExecutionContext;
 import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
 import java.lang.reflect.Modifier;
 import java.time.Duration;
@@ -46,7 +47,7 @@ public class StreamConsumerReaperJob extends Job implements InterruptableJob {
     private final @NonNull Injector injector;
     private final @NonNull StreamConsumerReaper reaper;
     private final @NonNull LockService lockService;
-    private final @NonNull StreamConsumerReaperConfig config;
+    private final @NonNull @Config("streamConsumerReaper") StreamConsumerReaperConfig config;
 
     private final AtomicBoolean interrupted = new AtomicBoolean(false);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/GuiceBindings.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/GuiceBindings.java
@@ -1,6 +1,8 @@
 package com.comet.opik.infrastructure;
 
 import com.google.inject.Injector;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
 
 import java.util.stream.Stream;
 
@@ -9,16 +11,14 @@ import java.util.stream.Stream;
  * (event listeners, stream subscribers, ...) so the traversal lives in one place and callers only add their own
  * type/annotation filter.
  */
-public final class GuiceBindings {
-
-    private GuiceBindings() {
-    }
+@UtilityClass
+public class GuiceBindings {
 
     /**
      * Distinct raw types of every explicit binding in the injector. Callers apply their own filter (assignability,
      * annotation, ...) and resolve instances as needed.
      */
-    public static Stream<Class<?>> boundRawTypes(Injector injector) {
+    public Stream<Class<?>> boundRawTypes(@NonNull Injector injector) {
         return injector.getAllBindings().keySet().stream()
                 .<Class<?>>map(key -> key.getTypeLiteral().getRawType())
                 .distinct();

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/GuiceBindings.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/GuiceBindings.java
@@ -1,0 +1,26 @@
+package com.comet.opik.infrastructure;
+
+import com.google.inject.Injector;
+
+import java.util.stream.Stream;
+
+/**
+ * Helpers for traversing Guice bindings. Centralizes the {@code getAllBindings()} walk used to auto-discover beans
+ * (event listeners, stream subscribers, ...) so the traversal lives in one place and callers only add their own
+ * type/annotation filter.
+ */
+public final class GuiceBindings {
+
+    private GuiceBindings() {
+    }
+
+    /**
+     * Distinct raw types of every explicit binding in the injector. Callers apply their own filter (assignability,
+     * annotation, ...) and resolve instances as needed.
+     */
+    public static Stream<Class<?>> boundRawTypes(Injector injector) {
+        return injector.getAllBindings().keySet().stream()
+                .<Class<?>>map(key -> key.getTypeLiteral().getRawType())
+                .distinct();
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
@@ -164,7 +164,7 @@ public class OpikConfiguration extends JobConfiguration {
     private LocalRunnerConfig localRunner = new LocalRunnerConfig();
 
     @Valid @NotNull @JsonProperty
-    private StreamConsumerReaperConfig streamConsumerReaper = new StreamConsumerReaperConfig();
+    private StreamConsumerReaperConfig streamConsumerReaper = StreamConsumerReaperConfig.builder().build();
 
     @Valid @NotNull @JsonProperty
     private ExperimentAggregatesConfig experimentAggregates = new ExperimentAggregatesConfig();

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
@@ -164,6 +164,9 @@ public class OpikConfiguration extends JobConfiguration {
     private LocalRunnerConfig localRunner = new LocalRunnerConfig();
 
     @Valid @NotNull @JsonProperty
+    private StreamConsumerReaperConfig streamConsumerReaper = new StreamConsumerReaperConfig();
+
+    @Valid @NotNull @JsonProperty
     private ExperimentAggregatesConfig experimentAggregates = new ExperimentAggregatesConfig();
 
     @Valid @NotNull @JsonProperty

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/StreamConsumerReaperConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/StreamConsumerReaperConfig.java
@@ -1,0 +1,53 @@
+package com.comet.opik.infrastructure;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.util.Duration;
+import io.dropwizard.validation.MinDuration;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Configuration for the orphaned-consumer reaper (OPIK-6982).
+ * <p>
+ * Each backend process registers a unique {@code consumer-<group>-<UUID>} that Redis only removes on graceful
+ * shutdown ({@code XGROUP DELCONSUMER}). Non-graceful exits (OOMKill, SIGKILL, crash, node eviction) leak the
+ * consumer permanently, so the online-scoring/stream consumer groups accumulate orphans across deploys and crashes.
+ * The reaper periodically removes consumers that are both idle beyond {@link #getIdleThreshold()} and have no
+ * pending entries (so it never drops un-acked work that {@code XAUTOCLAIM} would otherwise reclaim).
+ */
+@Data
+public class StreamConsumerReaperConfig {
+
+    @Valid @JsonProperty
+    private boolean enabled = true;
+
+    /**
+     * How often the reaper runs. A single instance runs per cycle (distributed lock with hold-until-expiry), so
+     * a low frequency keeps the {@code XINFO GROUPS}/{@code XINFO CONSUMERS} cost negligible.
+     */
+    @Valid @NotNull @JsonProperty
+    @MinDuration(value = 1, unit = TimeUnit.MINUTES)
+    private Duration jobInterval = Duration.hours(1);
+
+    /**
+     * Consumers idle longer than this (and with no pending entries) are deleted. Live consumers reset their idle
+     * time on every {@code XREADGROUP} (even empty long-poll returns), so their idle stays in the seconds range;
+     * the default is deliberately far above that to avoid reaping an active consumer.
+     */
+    @Valid @NotNull @JsonProperty
+    @MinDuration(value = 1, unit = TimeUnit.MINUTES)
+    private Duration idleThreshold = Duration.days(1);
+
+    /**
+     * Lock TTL, held until expiry, that suppresses concurrent fleet-wide runs. Also bounds how long a single reap
+     * pass may run. A reap pass is light (per-stream {@code XINFO GROUPS}/{@code XINFO CONSUMERS} + a few
+     * {@code XGROUP DELCONSUMER}), so this is well below {@link #getJobInterval()}; an occasional extra pass within
+     * a cycle is harmless since {@code XGROUP DELCONSUMER} is idempotent.
+     */
+    @Valid @NotNull @JsonProperty
+    @MinDuration(value = 1, unit = TimeUnit.SECONDS)
+    private Duration lockDuration = Duration.minutes(10);
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/StreamConsumerReaperConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/StreamConsumerReaperConfig.java
@@ -1,11 +1,10 @@
 package com.comet.opik.infrastructure;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.util.Duration;
+import io.dropwizard.validation.MaxDuration;
 import io.dropwizard.validation.MinDuration;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import lombok.Data;
+import lombok.Builder;
 
 import java.util.concurrent.TimeUnit;
 
@@ -15,40 +14,28 @@ import java.util.concurrent.TimeUnit;
  * Each backend process registers a unique {@code consumer-<group>-<UUID>} that Redis only removes on graceful
  * shutdown ({@code XGROUP DELCONSUMER}). Non-graceful exits (OOMKill, SIGKILL, crash, node eviction) leak the
  * consumer permanently, so the online-scoring/stream consumer groups accumulate orphans across deploys and crashes.
- * The reaper periodically removes consumers that are both idle beyond {@link #getIdleThreshold()} and have no
- * pending entries (so it never drops un-acked work that {@code XAUTOCLAIM} would otherwise reclaim).
+ * The reaper periodically removes consumers that are both idle beyond {@link #idleThreshold()} and have no pending
+ * entries (so it never drops un-acked work that {@code XAUTOCLAIM} would otherwise reclaim).
+ *
+ * @param enabled whether the reaper job is scheduled.
+ * @param startupDelay delay before the first reaper run after startup, to avoid reaping during warm-up and reduce
+ *        the chance of false positives.
+ * @param jobInterval how often the reaper runs. A single instance runs per cycle (distributed lock with
+ *        hold-until-expiry), so a low frequency keeps the {@code XINFO GROUPS}/{@code XINFO CONSUMERS} cost negligible.
+ * @param idleThreshold consumers idle longer than this (and with no pending entries) are deleted. Live consumers
+ *        reset their idle time on every {@code XREADGROUP} (even empty long-poll returns), so their idle stays in the
+ *        seconds range; the configured value is deliberately far above that to avoid reaping an active consumer.
+ * @param lockDuration lock TTL, held until expiry, that suppresses other instances from reaping until it elapses. It
+ *        does NOT cancel an in-flight reap pass ({@code bestEffortLock} does not bound the action) — the pass runs to
+ *        completion even if the lease expires first. Kept well below {@link #jobInterval()}; if the lease expires
+ *        mid-cycle and another instance runs an extra pass, that is harmless since {@code XGROUP DELCONSUMER} is
+ *        idempotent and a pass is light.
  */
-@Data
-public class StreamConsumerReaperConfig {
-
-    @JsonProperty
-    private boolean enabled = true;
-
-    /**
-     * How often the reaper runs. A single instance runs per cycle (distributed lock with hold-until-expiry), so
-     * a low frequency keeps the {@code XINFO GROUPS}/{@code XINFO CONSUMERS} cost negligible.
-     */
-    @Valid @NotNull @JsonProperty
-    @MinDuration(value = 1, unit = TimeUnit.MINUTES)
-    private Duration jobInterval = Duration.hours(1);
-
-    /**
-     * Consumers idle longer than this (and with no pending entries) are deleted. Live consumers reset their idle
-     * time on every {@code XREADGROUP} (even empty long-poll returns), so their idle stays in the seconds range;
-     * the default is deliberately far above that to avoid reaping an active consumer.
-     */
-    @Valid @NotNull @JsonProperty
-    @MinDuration(value = 1, unit = TimeUnit.MINUTES)
-    private Duration idleThreshold = Duration.days(1);
-
-    /**
-     * Lock TTL, held until expiry, that suppresses other instances from reaping until it elapses. It does NOT
-     * cancel an in-flight reap pass ({@code bestEffortLock} does not bound the action) — the pass runs to
-     * completion even if the lease expires first. Kept well below {@link #getJobInterval()}; if the lease expires
-     * mid-cycle and another instance runs an extra pass, that is harmless since {@code XGROUP DELCONSUMER} is
-     * idempotent and a pass is light (per-stream {@code XINFO GROUPS}/{@code XINFO CONSUMERS} + a few deletes).
-     */
-    @Valid @NotNull @JsonProperty
-    @MinDuration(value = 1, unit = TimeUnit.SECONDS)
-    private Duration lockDuration = Duration.minutes(10);
+@Builder(toBuilder = true)
+public record StreamConsumerReaperConfig(
+        boolean enabled,
+        @NotNull @MinDuration(value = 0, unit = TimeUnit.SECONDS) @MaxDuration(value = 10, unit = TimeUnit.MINUTES) Duration startupDelay,
+        @NotNull @MinDuration(value = 5, unit = TimeUnit.MINUTES) @MaxDuration(value = 24, unit = TimeUnit.HOURS) Duration jobInterval,
+        @NotNull @MinDuration(value = 1, unit = TimeUnit.HOURS) @MaxDuration(value = 30, unit = TimeUnit.DAYS) Duration idleThreshold,
+        @NotNull @MinDuration(value = 1, unit = TimeUnit.MINUTES) @MaxDuration(value = 1, unit = TimeUnit.HOURS) Duration lockDuration) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/StreamConsumerReaperConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/StreamConsumerReaperConfig.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 @Data
 public class StreamConsumerReaperConfig {
 
-    @Valid @JsonProperty
+    @JsonProperty
     private boolean enabled = true;
 
     /**
@@ -42,10 +42,11 @@ public class StreamConsumerReaperConfig {
     private Duration idleThreshold = Duration.days(1);
 
     /**
-     * Lock TTL, held until expiry, that suppresses concurrent fleet-wide runs. Also bounds how long a single reap
-     * pass may run. A reap pass is light (per-stream {@code XINFO GROUPS}/{@code XINFO CONSUMERS} + a few
-     * {@code XGROUP DELCONSUMER}), so this is well below {@link #getJobInterval()}; an occasional extra pass within
-     * a cycle is harmless since {@code XGROUP DELCONSUMER} is idempotent.
+     * Lock TTL, held until expiry, that suppresses other instances from reaping until it elapses. It does NOT
+     * cancel an in-flight reap pass ({@code bestEffortLock} does not bound the action) — the pass runs to
+     * completion even if the lease expires first. Kept well below {@link #getJobInterval()}; if the lease expires
+     * mid-cycle and another instance runs an extra pass, that is harmless since {@code XGROUP DELCONSUMER} is
+     * idempotent and a pass is light (per-stream {@code XINFO GROUPS}/{@code XINFO CONSUMERS} + a few deletes).
      */
     @Valid @NotNull @JsonProperty
     @MinDuration(value = 1, unit = TimeUnit.SECONDS)

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListener.java
@@ -155,13 +155,14 @@ public class OpikGuiceyLifecycleEventListener implements GuiceyLifecycleListener
         StreamConsumerReaperConfig reaperConfig = injector.get().getInstance(OpikConfiguration.class)
                 .getStreamConsumerReaper();
 
-        if (!reaperConfig.isEnabled()) {
+        if (!reaperConfig.enabled()) {
             log.info("Stream consumer reaper job is disabled, skipping job setup");
             return;
         }
 
         scheduleRepeatingJob(StreamConsumerReaperJob.class,
-                reaperConfig.getJobInterval().toJavaDuration(), null);
+                reaperConfig.jobInterval().toJavaDuration(),
+                reaperConfig.startupDelay().toJavaDuration());
     }
 
     private void setRetentionJobs() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListener.java
@@ -13,12 +13,14 @@ import com.comet.opik.api.resources.v1.jobs.PromptProjectMigrationJob;
 import com.comet.opik.api.resources.v1.jobs.RetentionCatchUpJob;
 import com.comet.opik.api.resources.v1.jobs.RetentionEstimationJob;
 import com.comet.opik.api.resources.v1.jobs.RetentionSlidingWindowJob;
+import com.comet.opik.api.resources.v1.jobs.StreamConsumerReaperJob;
 import com.comet.opik.api.resources.v1.jobs.TraceThreadsClosingJob;
 import com.comet.opik.infrastructure.ExperimentDenormalizationConfig;
 import com.comet.opik.infrastructure.LlmModelRegistryConfig;
 import com.comet.opik.infrastructure.LocalRunnerConfig;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.RetentionConfig;
+import com.comet.opik.infrastructure.StreamConsumerReaperConfig;
 import com.comet.opik.infrastructure.TraceThreadConfig;
 import com.comet.opik.infrastructure.llm.LlmModelRegistryRefreshJob;
 import com.google.inject.Injector;
@@ -60,6 +62,7 @@ public class OpikGuiceyLifecycleEventListener implements GuiceyLifecycleListener
                 setMetricsAlertJob();
                 setExperimentDenormalizationJob();
                 setLocalRunnerReaperJob();
+                setStreamConsumerReaperJob();
                 setRetentionJobs();
                 setLlmModelRegistryRefreshJob();
                 scheduleDatasetVersionItemsTotalMigrationJobIfEnabled();
@@ -146,6 +149,19 @@ public class OpikGuiceyLifecycleEventListener implements GuiceyLifecycleListener
 
         scheduleRepeatingJob(LocalRunnerReaperJob.class,
                 localRunnerConfig.getReaperJobInterval().toJavaDuration(), null);
+    }
+
+    private void setStreamConsumerReaperJob() {
+        StreamConsumerReaperConfig reaperConfig = injector.get().getInstance(OpikConfiguration.class)
+                .getStreamConsumerReaper();
+
+        if (!reaperConfig.isEnabled()) {
+            log.info("Stream consumer reaper job is disabled, skipping job setup");
+            return;
+        }
+
+        scheduleRepeatingJob(StreamConsumerReaperJob.class,
+                reaperConfig.getJobInterval().toJavaDuration(), null);
     }
 
     private void setRetentionJobs() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/events/EventListenerRegistrar.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/events/EventListenerRegistrar.java
@@ -70,7 +70,7 @@ public class EventListenerRegistrar implements GuiceyLifecycleListener {
                     try {
                         return new ListenerInfo(injector.get().getInstance(rawType), rawType);
                     } catch (Exception e) {
-                        log.error("Failed to get instance for {}: {}", rawType, e.getMessage());
+                        log.error("Failed to get instance for '{}'", rawType, e);
                         return null;
                     }
                 })

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/events/EventListenerRegistrar.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/events/EventListenerRegistrar.java
@@ -1,9 +1,9 @@
 package com.comet.opik.infrastructure.events;
 
+import com.comet.opik.infrastructure.GuiceBindings;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Injector;
-import com.google.inject.Key;
 import lombok.extern.slf4j.Slf4j;
 import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
 import ru.vyarus.dropwizard.guice.module.lifecycle.GuiceyLifecycle;
@@ -12,6 +12,7 @@ import ru.vyarus.dropwizard.guice.module.lifecycle.event.GuiceyLifecycleEvent;
 import ru.vyarus.dropwizard.guice.module.lifecycle.event.InjectorPhaseEvent;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -63,22 +64,22 @@ public class EventListenerRegistrar implements GuiceyLifecycleListener {
     }
 
     private Set<ListenerInfo> findAllEventListeners() {
-        return injector.get().getAllBindings().keySet().stream()
+        return GuiceBindings.boundRawTypes(injector.get())
                 .filter(this::isAnEventListener)
-                .map(key -> {
+                .map(rawType -> {
                     try {
-                        return new ListenerInfo(injector.get().getInstance(key), key.getTypeLiteral().getRawType());
+                        return new ListenerInfo(injector.get().getInstance(rawType), rawType);
                     } catch (Exception e) {
-                        log.error("Failed to get instance for {}: {}", key, e.getMessage());
+                        log.error("Failed to get instance for {}: {}", rawType, e.getMessage());
                         return null;
                     }
                 })
+                .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
     }
 
-    private boolean isAnEventListener(Key<?> key) {
-        return key.getTypeLiteral().getRawType().isAnnotationPresent(EagerSingleton.class) &&
-                hasSubscribeMethod(key.getTypeLiteral().getRawType());
+    private boolean isAnEventListener(Class<?> clazz) {
+        return clazz.isAnnotationPresent(EagerSingleton.class) && hasSubscribeMethod(clazz);
     }
 
     private boolean hasSubscribeMethod(Class<?> clazz) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/StreamConsumerReaper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/StreamConsumerReaper.java
@@ -15,8 +15,8 @@ import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * Removes orphaned Redis stream consumers — those left behind when a backend process exits non-gracefully
@@ -36,6 +36,9 @@ public class StreamConsumerReaper {
 
     private static final AttributeKey<String> STREAM_KEY = AttributeKey.stringKey("stream");
     private static final AttributeKey<String> GROUP_KEY = AttributeKey.stringKey("consumer_group");
+    private static final AttributeKey<String> RESULT_KEY = AttributeKey.stringKey("result");
+    private static final String RESULT_SUCCESS = "success";
+    private static final String RESULT_ERROR = "error";
 
     // When XINFO GROUPS targets a stream key that was never created, Redisson raises a generic
     // org.redisson.client.RedisException whose message is "ERR no such key. channel: ... command: (XINFO GROUPS)..."
@@ -43,20 +46,16 @@ public class StreamConsumerReaper {
     private static final String NO_SUCH_KEY = "no such key";
 
     private final RedissonReactiveClient redisson;
-    private final LongCounter reapedConsumers;
-    private final LongCounter reaperErrors;
+    private final LongCounter reaperConsumers;
 
     @Inject
     public StreamConsumerReaper(@NonNull RedissonReactiveClient redisson) {
         this.redisson = redisson;
         var meter = GlobalOpenTelemetry.getMeter("opik.redis");
-        this.reapedConsumers = meter
-                .counterBuilder("opik_redis_stream_reaped_consumers")
-                .setDescription("Orphaned (idle beyond threshold, no pending) stream consumers removed by the reaper")
-                .build();
-        this.reaperErrors = meter
-                .counterBuilder("opik_redis_stream_reaper_errors")
-                .setDescription("Errors while reaping orphaned stream consumers")
+        this.reaperConsumers = meter
+                .counterBuilder("opik_redis_stream_reaper_consumers")
+                .setDescription(
+                        "Stream consumer reaper outcomes, tagged by result: 'success' (orphan removed) or 'error'")
                 .build();
     }
 
@@ -65,10 +64,14 @@ public class StreamConsumerReaper {
      *
      * @return the total number of consumers removed
      */
-    public Mono<Long> reap(@NonNull Collection<String> streamNames, @NonNull Duration idleThreshold) {
+    public Mono<Long> reap(Collection<String> streamNames, @NonNull Duration idleThreshold) {
+        if (streamNames == null || streamNames.isEmpty()) {
+            return Mono.just(0L);
+        }
         long idleThresholdMillis = idleThreshold.toMillis();
-        // De-duplicate: online-scoring streams are distinct keys but multiple subscribers may report the same name.
-        return Flux.fromIterable(Set.copyOf(streamNames))
+        // De-duplicate while preserving order: online-scoring streams are distinct keys but multiple subscribers may
+        // report the same name.
+        return Flux.fromIterable(new LinkedHashSet<>(streamNames))
                 .flatMap(streamName -> reapStream(streamName, idleThresholdMillis))
                 .reduce(0L, Long::sum);
     }
@@ -86,7 +89,7 @@ public class StreamConsumerReaper {
                     } else {
                         // ACL/connection/timeout/etc.: surface it (metric + warn) instead of silently skipping,
                         // but still return 0 so the other streams are reaped.
-                        reaperErrors.add(1, Attributes.of(STREAM_KEY, streamName));
+                        reaperConsumers.add(1, Attributes.of(STREAM_KEY, streamName, RESULT_KEY, RESULT_ERROR));
                         log.warn("Failed to reap orphaned consumers for stream '{}'", streamName, throwable);
                     }
                     return Mono.just(0L);
@@ -100,20 +103,24 @@ public class StreamConsumerReaper {
                 .filter(consumer -> consumer.getIdleTime() > idleThresholdMillis && consumer.getPending() == 0)
                 .flatMap(consumer -> stream.removeConsumer(group, consumer.getName())
                         .doOnSuccess(pending -> {
-                            reapedConsumers.add(1, Attributes.of(STREAM_KEY, streamName, GROUP_KEY, group));
+                            reaperConsumers.add(1,
+                                    Attributes.of(STREAM_KEY, streamName, GROUP_KEY, group, RESULT_KEY,
+                                            RESULT_SUCCESS));
                             log.info("Reaped orphaned consumer '{}' from group '{}' on stream '{}', idle '{}' ms",
                                     consumer.getName(), group, streamName, consumer.getIdleTime());
                         })
                         .thenReturn(1L)
                         .onErrorResume(throwable -> {
-                            reaperErrors.add(1, Attributes.of(STREAM_KEY, streamName, GROUP_KEY, group));
+                            reaperConsumers.add(1,
+                                    Attributes.of(STREAM_KEY, streamName, GROUP_KEY, group, RESULT_KEY, RESULT_ERROR));
                             log.warn("Failed to reap consumer '{}' from group '{}' on stream '{}'",
                                     consumer.getName(), group, streamName, throwable);
                             return Mono.just(0L);
                         }))
                 .reduce(0L, Long::sum)
                 .onErrorResume(throwable -> {
-                    reaperErrors.add(1, Attributes.of(STREAM_KEY, streamName, GROUP_KEY, group));
+                    reaperConsumers.add(1,
+                            Attributes.of(STREAM_KEY, streamName, GROUP_KEY, group, RESULT_KEY, RESULT_ERROR));
                     log.warn("Failed to list consumers for group '{}' on stream '{}'", group, streamName, throwable);
                     return Mono.just(0L);
                 });

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/StreamConsumerReaper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/StreamConsumerReaper.java
@@ -37,7 +37,9 @@ public class StreamConsumerReaper {
     private static final AttributeKey<String> STREAM_KEY = AttributeKey.stringKey("stream");
     private static final AttributeKey<String> GROUP_KEY = AttributeKey.stringKey("consumer_group");
 
-    // Redis error when XINFO GROUPS targets a stream key that has never been created.
+    // When XINFO GROUPS targets a stream key that was never created, Redisson raises a generic
+    // org.redisson.client.RedisException whose message is "ERR no such key. channel: ... command: (XINFO GROUPS)..."
+    // There is no typed exception for this, so we match the stable Redis error token below.
     private static final String NO_SUCH_KEY = "no such key";
 
     private final RedissonReactiveClient redisson;
@@ -117,6 +119,14 @@ public class StreamConsumerReaper {
                 });
     }
 
+    /**
+     * Best-effort classification of the "stream key doesn't exist yet" case. Confirmed against a real Redis:
+     * Redisson raises a generic {@code org.redisson.client.RedisException} with message {@code "ERR no such key..."}
+     * — there is no typed exception to catch, so this is a substring match (mirroring the existing
+     * {@code NOGROUP}/{@code BUSYGROUP} handling in {@code BaseRedisSubscriber}) and could break on a Redis/Redisson
+     * version bump. The downside is bounded — a misclassification only changes the log level/metric of a best-effort
+     * cleanup job; correctness (which consumers get reaped) is unaffected.
+     */
     private static boolean isNoSuchKey(Throwable throwable) {
         return Objects.toString(throwable.getMessage(), "").contains(NO_SUCH_KEY);
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/StreamConsumerReaper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/StreamConsumerReaper.java
@@ -15,6 +15,7 @@ import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -35,6 +36,9 @@ public class StreamConsumerReaper {
 
     private static final AttributeKey<String> STREAM_KEY = AttributeKey.stringKey("stream");
     private static final AttributeKey<String> GROUP_KEY = AttributeKey.stringKey("consumer_group");
+
+    // Redis error when XINFO GROUPS targets a stream key that has never been created.
+    private static final String NO_SUCH_KEY = "no such key";
 
     private final RedissonReactiveClient redisson;
     private final LongCounter reapedConsumers;
@@ -74,9 +78,15 @@ public class StreamConsumerReaper {
                 .flatMap(group -> reapGroup(stream, streamName, group.getName(), idleThresholdMillis))
                 .reduce(0L, Long::sum)
                 .onErrorResume(throwable -> {
-                    // The stream may not exist yet (never created) — XINFO GROUPS returns "ERR no such key".
-                    // Nothing to reap; log at debug and move on.
-                    log.debug("Skipping reaper for stream '{}': '{}'", streamName, throwable.getMessage());
+                    if (isNoSuchKey(throwable)) {
+                        // The stream hasn't been created yet (no producer/consumer activity) — nothing to reap.
+                        log.info("Skipping reaper for stream '{}', stream may not exist", streamName, throwable);
+                    } else {
+                        // ACL/connection/timeout/etc.: surface it (metric + warn) instead of silently skipping,
+                        // but still return 0 so the other streams are reaped.
+                        reaperErrors.add(1, Attributes.of(STREAM_KEY, streamName));
+                        log.warn("Failed to reap orphaned consumers for stream '{}'", streamName, throwable);
+                    }
                     return Mono.just(0L);
                 });
     }
@@ -105,5 +115,9 @@ public class StreamConsumerReaper {
                     log.warn("Failed to list consumers for group '{}' on stream '{}'", group, streamName, throwable);
                     return Mono.just(0L);
                 });
+    }
+
+    private static boolean isNoSuchKey(Throwable throwable) {
+        return Objects.toString(throwable.getMessage(), "").contains(NO_SUCH_KEY);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/StreamConsumerReaper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/StreamConsumerReaper.java
@@ -1,0 +1,109 @@
+package com.comet.opik.infrastructure.redis;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RStreamReactive;
+import org.redisson.api.RedissonReactiveClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * Removes orphaned Redis stream consumers — those left behind when a backend process exits non-gracefully
+ * (OOMKill, SIGKILL, crash, node eviction) and never runs {@code XGROUP DELCONSUMER} (OPIK-6982).
+ * <p>
+ * For each stream it discovers groups via {@code XINFO GROUPS} (scoped to the stream — no keyspace scan) and,
+ * within each group, deletes consumers that are <b>both</b> idle beyond the threshold <b>and</b> have no pending
+ * entries. The {@code pending == 0} guard is the key safety property: a crashed consumer's pending entries are
+ * reclaimed by {@code XAUTOCLAIM} into a live consumer first; only once its PEL is empty is it removed. This means
+ * the reaper never destroys un-acked work (which {@code XGROUP DELCONSUMER} on a consumer with pending entries
+ * would do). Idle time is server-side, so a live consumer (idle ~ seconds) is never a candidate, regardless of
+ * which instance runs the reaper.
+ */
+@Slf4j
+@Singleton
+public class StreamConsumerReaper {
+
+    private static final AttributeKey<String> STREAM_KEY = AttributeKey.stringKey("stream");
+    private static final AttributeKey<String> GROUP_KEY = AttributeKey.stringKey("consumer_group");
+
+    private final RedissonReactiveClient redisson;
+    private final LongCounter reapedConsumers;
+    private final LongCounter reaperErrors;
+
+    @Inject
+    public StreamConsumerReaper(@NonNull RedissonReactiveClient redisson) {
+        this.redisson = redisson;
+        var meter = GlobalOpenTelemetry.getMeter("opik.redis");
+        this.reapedConsumers = meter
+                .counterBuilder("opik_redis_stream_reaped_consumers")
+                .setDescription("Orphaned (idle beyond threshold, no pending) stream consumers removed by the reaper")
+                .build();
+        this.reaperErrors = meter
+                .counterBuilder("opik_redis_stream_reaper_errors")
+                .setDescription("Errors while reaping orphaned stream consumers")
+                .build();
+    }
+
+    /**
+     * Reaps orphaned consumers across the given streams.
+     *
+     * @return the total number of consumers removed
+     */
+    public Mono<Long> reap(@NonNull Collection<String> streamNames, @NonNull Duration idleThreshold) {
+        long idleThresholdMillis = idleThreshold.toMillis();
+        // De-duplicate: online-scoring streams are distinct keys but multiple subscribers may report the same name.
+        return Flux.fromIterable(Set.copyOf(streamNames))
+                .flatMap(streamName -> reapStream(streamName, idleThresholdMillis))
+                .reduce(0L, Long::sum);
+    }
+
+    private Mono<Long> reapStream(String streamName, long idleThresholdMillis) {
+        RStreamReactive<Object, Object> stream = redisson.getStream(streamName);
+        return stream.listGroups()
+                .flatMapMany(Flux::fromIterable)
+                .flatMap(group -> reapGroup(stream, streamName, group.getName(), idleThresholdMillis))
+                .reduce(0L, Long::sum)
+                .onErrorResume(throwable -> {
+                    // The stream may not exist yet (never created) — XINFO GROUPS returns "ERR no such key".
+                    // Nothing to reap; log at debug and move on.
+                    log.debug("Skipping reaper for stream '{}': '{}'", streamName, throwable.getMessage());
+                    return Mono.just(0L);
+                });
+    }
+
+    private Mono<Long> reapGroup(RStreamReactive<Object, Object> stream, String streamName, String group,
+            long idleThresholdMillis) {
+        return stream.listConsumers(group)
+                .flatMapMany(Flux::fromIterable)
+                .filter(consumer -> consumer.getIdleTime() > idleThresholdMillis && consumer.getPending() == 0)
+                .flatMap(consumer -> stream.removeConsumer(group, consumer.getName())
+                        .doOnSuccess(pending -> {
+                            reapedConsumers.add(1, Attributes.of(STREAM_KEY, streamName, GROUP_KEY, group));
+                            log.info("Reaped orphaned consumer '{}' from group '{}' on stream '{}', idle '{}' ms",
+                                    consumer.getName(), group, streamName, consumer.getIdleTime());
+                        })
+                        .thenReturn(1L)
+                        .onErrorResume(throwable -> {
+                            reaperErrors.add(1, Attributes.of(STREAM_KEY, streamName, GROUP_KEY, group));
+                            log.warn("Failed to reap consumer '{}' from group '{}' on stream '{}'",
+                                    consumer.getName(), group, streamName, throwable);
+                            return Mono.just(0L);
+                        }))
+                .reduce(0L, Long::sum)
+                .onErrorResume(throwable -> {
+                    reaperErrors.add(1, Attributes.of(STREAM_KEY, streamName, GROUP_KEY, group));
+                    log.warn("Failed to list consumers for group '{}' on stream '{}'", group, streamName, throwable);
+                    return Mono.just(0L);
+                });
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/jobs/StreamConsumerReaperJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/jobs/StreamConsumerReaperJobTest.java
@@ -1,0 +1,99 @@
+package com.comet.opik.api.resources.v1.jobs;
+
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.redis.testcontainers.RedisContainer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import static com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Stream Consumer Reaper Job Test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class StreamConsumerReaperJobTest {
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final MySQLContainer MYSQL_CONTAINER = MySQLContainerUtils.newMySQLContainer();
+    private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE_CONTAINER = ClickHouseContainerUtils
+            .newClickHouseContainer(ZOOKEEPER_CONTAINER);
+
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    @RegisterApp
+    private final TestDropwizardAppExtension APP;
+
+    {
+        Startables.deepStart(REDIS, MYSQL_CONTAINER, CLICKHOUSE_CONTAINER, ZOOKEEPER_CONTAINER).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(
+                CLICKHOUSE_CONTAINER, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL_CONTAINER);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE_CONTAINER);
+
+        APP = newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(MYSQL_CONTAINER.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .runtimeInfo(wireMock.runtimeInfo())
+                        .redisUrl(REDIS.getRedisURI())
+                        .build());
+    }
+
+    // Stream names of every concrete BaseRedisSubscriber wired into the real application (config-test.yml).
+    // Auto-discovery must find all of them so their orphaned consumers get reaped (OPIK-6982).
+    private static final String[] EXPECTED_SUBSCRIBER_STREAMS = {
+            // online-scoring (the six groups from OPIK-6982)
+            "stream_scoring_llm_as_judge",
+            "stream_scoring_user_defined_metric_python",
+            "stream_scoring_trace_thread_llm_as_judge",
+            "stream_scoring_trace_thread_user_defined_metric_python",
+            "stream_scoring_span_llm_as_judge",
+            "stream_scoring_span_user_defined_metric_python",
+            // the remaining stream subscribers
+            "webhook-events", // WebhookSubscriber
+            "experiment_item_processing_stream", // ExperimentItemProcessingSubscriber
+            "experiment_denormalization_stream", // ExperimentAggregatesSubscriber
+            "trace_thread_closing_stream", // ClosingTraceThreadSubscriber
+            "dataset-export-test", // DatasetExportJobSubscriber
+    };
+
+    private StreamConsumerReaperJob reaperJob;
+
+    @BeforeAll
+    void setUpAll(ClientSupport client, StreamConsumerReaperJob reaperJob) {
+        this.reaperJob = reaperJob;
+    }
+
+    @Test
+    @DisplayName("Should discover every registered subscriber's stream from the Guice context")
+    void shouldDiscoverAllRegisteredSubscriberStreams() {
+        var discovered = reaperJob.discoverStreamNames();
+
+        assertThat(discovered)
+                .doesNotContainNull()
+                .doesNotHaveDuplicates()
+                .contains(EXPECTED_SUBSCRIBER_STREAMS);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/jobs/StreamConsumerReaperJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/jobs/StreamConsumerReaperJobTest.java
@@ -7,6 +7,7 @@ import com.comet.opik.api.resources.utils.RedisContainerUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
+import com.google.inject.Injector;
 import com.redis.testcontainers.RedisContainer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -82,8 +83,10 @@ class StreamConsumerReaperJobTest {
     private StreamConsumerReaperJob reaperJob;
 
     @BeforeAll
-    void setUpAll(ClientSupport client, StreamConsumerReaperJob reaperJob) {
-        this.reaperJob = reaperJob;
+    void setUpAll(ClientSupport client, Injector injector) {
+        // Resolve the job from the real application injector (the reaper is disabled in config-test.yml, so the
+        // job isn't scheduled — but the bean is still injectable, which is what we assert discovery against).
+        this.reaperJob = injector.getInstance(StreamConsumerReaperJob.class);
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/StreamConsumerReaperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/StreamConsumerReaperTest.java
@@ -71,6 +71,7 @@ class StreamConsumerReaperTest {
     void shouldReapIdleConsumerWithNoPendingEntries() {
         // A consumer that registered but never had work: idle grows, pending stays 0 — the orphan case.
         stream.createConsumer(GROUP, "orphan-consumer").block();
+        assertThat(listConsumerNames()).contains("orphan-consumer");
 
         // Let it become idle beyond the (tiny) threshold used by this test.
         waitForMillis(600);

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/StreamConsumerReaperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redis/StreamConsumerReaperTest.java
@@ -1,0 +1,145 @@
+package com.comet.opik.infrastructure.redis;
+
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.utils.JsonUtils;
+import com.redis.testcontainers.RedisContainer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.redisson.Redisson;
+import org.redisson.api.RStreamReactive;
+import org.redisson.api.RedissonReactiveClient;
+import org.redisson.api.stream.StreamAddArgs;
+import org.redisson.api.stream.StreamCreateGroupArgs;
+import org.redisson.api.stream.StreamReadGroupArgs;
+import org.redisson.codec.JsonJacksonCodec;
+import org.redisson.config.Config;
+
+import java.time.Duration;
+import java.util.List;
+
+import static com.comet.opik.api.resources.utils.TestUtils.waitForMillis;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link StreamConsumerReaper} using a real Redis test container.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class StreamConsumerReaperTest {
+
+    private static final String GROUP = "test-group";
+    private static final String PAYLOAD_FIELD = "message";
+
+    private final RedisContainer redis = RedisContainerUtils.newRedisContainer();
+
+    private RedissonReactiveClient redissonClient;
+    private StreamConsumerReaper reaper;
+
+    @BeforeAll
+    void setUpAll() {
+        redis.start();
+
+        var redissonConfig = new Config();
+        redissonConfig.useSingleServer()
+                .setAddress(redis.getRedisURI())
+                .setDatabase(0);
+        redissonConfig.setCodec(new JsonJacksonCodec(JsonUtils.getMapper()));
+        redissonClient = Redisson.create(redissonConfig).reactive();
+
+        reaper = new StreamConsumerReaper(redissonClient);
+    }
+
+    private String streamName;
+    private RStreamReactive<String, String> stream;
+
+    @BeforeEach
+    void setUp() {
+        // Unique stream per test so they don't interfere; create the group (and the stream via makeStream()).
+        streamName = "reaper-test-stream-%s".formatted(System.nanoTime());
+        stream = redissonClient.getStream(streamName);
+        stream.createGroup(StreamCreateGroupArgs.name(GROUP).makeStream()).block();
+    }
+
+    @AfterEach
+    void tearDown() {
+        stream.delete().block();
+    }
+
+    @Test
+    void shouldReapIdleConsumerWithNoPendingEntries() {
+        // A consumer that registered but never had work: idle grows, pending stays 0 — the orphan case.
+        stream.createConsumer(GROUP, "orphan-consumer").block();
+
+        // Let it become idle beyond the (tiny) threshold used by this test.
+        waitForMillis(600);
+
+        var reaped = reaper.reap(List.of(streamName), Duration.ofMillis(300)).block();
+
+        assertThat(reaped).isEqualTo(1L);
+        assertThat(listConsumerNames()).doesNotContain("orphan-consumer");
+    }
+
+    @Test
+    void shouldNotReapConsumerWithPendingEntries() {
+        // A consumer that read a message but never acked it: idle grows but pending > 0. Its entries must be left
+        // for XAUTOCLAIM to reclaim, so the reaper must NOT delete it (that would destroy the un-acked PEL entry).
+        stream.add(StreamAddArgs.entry(PAYLOAD_FIELD, "unacked")).block();
+        stream.readGroup(GROUP, "pending-consumer", StreamReadGroupArgs.neverDelivered().count(1)).block();
+
+        waitForMillis(600);
+
+        var reaped = reaper.reap(List.of(streamName), Duration.ofMillis(300)).block();
+
+        assertThat(reaped).isZero();
+        assertThat(listConsumerNames()).contains("pending-consumer");
+    }
+
+    @Test
+    void shouldNotReapConsumersWithinIdleThreshold() {
+        // Freshly created consumer (idle ~ 0) must survive a large idle threshold — the live-consumer case.
+        stream.createConsumer(GROUP, "active-consumer").block();
+
+        var reaped = reaper.reap(List.of(streamName), Duration.ofDays(1)).block();
+
+        assertThat(reaped).isZero();
+        assertThat(listConsumerNames()).contains("active-consumer");
+    }
+
+    @Test
+    void shouldReapOnlyOrphansLeavingActiveAndPendingConsumers() {
+        stream.add(StreamAddArgs.entry(PAYLOAD_FIELD, "unacked")).block();
+        stream.readGroup(GROUP, "pending-consumer", StreamReadGroupArgs.neverDelivered().count(1)).block();
+        stream.createConsumer(GROUP, "orphan-consumer").block();
+
+        waitForMillis(600);
+
+        // Created last so it is still within the idle threshold at reap time.
+        stream.createConsumer(GROUP, "active-consumer").block();
+
+        var reaped = reaper.reap(List.of(streamName), Duration.ofMillis(300)).block();
+
+        assertThat(reaped).isEqualTo(1L);
+        assertThat(listConsumerNames())
+                .contains("pending-consumer", "active-consumer")
+                .doesNotContain("orphan-consumer");
+    }
+
+    @Test
+    void shouldReturnZeroForNonExistentStream() {
+        var reaped = reaper.reap(List.of("stream-that-does-not-exist-%s".formatted(System.nanoTime())),
+                Duration.ofMillis(300)).block();
+
+        assertThat(reaped).isZero();
+    }
+
+    private List<String> listConsumerNames() {
+        return stream.listConsumers(GROUP)
+                .blockOptional()
+                .orElse(List.of())
+                .stream()
+                .map(consumer -> consumer.getName())
+                .toList();
+    }
+}

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -725,6 +725,7 @@ localRunner:
 streamConsumerReaper:
   enabled: false
   jobInterval: 1h
+  startupDelay: 0s
   idleThreshold: 1d
   lockDuration: 10m
 

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -720,6 +720,14 @@ localRunner:
   reaperLockWait: 2s
   nextJobAsyncTimeoutBuffer: 2s
 
+# Orphaned Redis stream-consumer reaper (OPIK-6982).
+# Disabled by default in tests so it does not auto-schedule when the app context boots; enable per-test if needed.
+streamConsumerReaper:
+  enabled: false
+  jobInterval: 1h
+  idleThreshold: 1d
+  lockDuration: 10m
+
 # Trace Thread configuration
 traceThreadConfig:
   # Default: false for testing. Should be enabled for specific test scenarios when needed.


### PR DESCRIPTION
## Details

Each backend process registers a unique `consumer-<group>-<UUID>` per process that Redis only removes on graceful shutdown (`XGROUP DELCONSUMER`). Non-graceful exits (OOMKill / SIGKILL / crash / node eviction) leak the consumer permanently, so stream consumer groups accumulate tens of thousands of orphaned consumers across deploys and crashes. This adds a periodic reaper that cleans them up so the count stays bounded.

- `StreamConsumerReaper`: for each stream, lists groups (`XINFO GROUPS`) and removes consumers that are **both** idle beyond a threshold **and** have no pending entries. The `pending == 0` guard leaves un-acked work for `XAUTOCLAIM` to reclaim, so it is never destroyed.
- `StreamConsumerReaperJob`: Quartz job that discovers the streams to clean from the registered `BaseRedisSubscriber` Guice bindings (no keyspace scan, no hand-maintained list — mirrors `EventListenerRegistrar`), guarded by a distributed lock with hold-until-expiry so only one instance reaps per cycle.
- `StreamConsumerReaperConfig`: `enabled` (true) / `jobInterval` (1h) / `idleThreshold` (1d) / `lockDuration` (10m), all env-overridable.
- `BaseRedisSubscriber` exposes `getStreamName()` for discovery.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6982

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Full implementation (reaper service, job, config, wiring) and tests, authored under human review.
  - Human verification: Design reviewed and steered interactively; tests run locally (see Testing).

## Testing

- `mvn test -Dtest=StreamConsumerReaperTest` — 5 tests, real Redis testcontainer: reaps idle+empty consumers; leaves consumers with pending entries; respects the idle threshold; mixed orphan/active/pending; no-op for non-existent streams.
- `mvn test -Dtest=StreamConsumerReaperJobTest` — full application Guice context: asserts the job discovers all registered subscriber streams (the six online-scoring streams plus webhook / experiment-item / experiment-aggregates / trace-thread-closing / dataset-export).
- Both pass locally (local process mode).

## Documentation

N/A