### PR TITLE
[OPIK-6130][E2E] test: add Agent Playground local runner E2E

### DIFF
--- a/tests_end_to_end/e2e/agents/playground-entrypoint/agent.py
+++ b/tests_end_to_end/e2e/agents/playground-entrypoint/agent.py
@@ -1,0 +1,29 @@
+"""Entrypoint-decorated golden agent for the Agent playground E2E test.
+
+A small, deterministic agent with a typed `run(query: str) -> str` entrypoint
+marked with `@opik.track(entrypoint=True)`. The Agent playground page pairs
+against an `opik endpoint` runner, which introspects the entrypoint to expose
+its params in the playground's Test-input form and to invoke it from the Run
+button. The uninstrumented sibling agent (no entrypoint) is reserved for the
+Ollie /instrument flow.
+
+The script blocks on a long sleep so the `opik endpoint` runner — which
+processes jobs from a background thread in the same process — stays alive long
+enough for the test to drive a run through it. Deliberately dependency-free and
+offline; the output is deterministic so the test can match on it.
+"""
+
+import time
+
+import opik
+
+
+@opik.track(entrypoint=True, project_name="agent-playground-e2e")
+def run(query: str) -> str:
+    return f"Answer for: {query}"
+
+
+if __name__ == "__main__":
+    # Stay alive so the runner thread can serve jobs. The test stops the daemon
+    # in a finally block, which terminates this process via the parent.
+    time.sleep(3600)

--- a/tests_end_to_end/e2e/core/local-runner/connect.ts
+++ b/tests_end_to_end/e2e/core/local-runner/connect.ts
@@ -98,6 +98,129 @@ export async function startConnectRunner(opts: StartConnectOpts): Promise<Connec
   );
 }
 
+export interface StartEndpointOpts extends StartConnectOpts {
+  /**
+   * Command (and args) the endpoint runner spawns to host the agent process —
+   * what goes after the `--` separator in `opik endpoint --project X -- …`.
+   * The runner introspects the entrypoint inside this process to expose it to
+   * the Agent Playground.
+   */
+  command: string[];
+  /**
+   * Opik backend API base URL (e.g. http://localhost:5173/api). Used to poll
+   * `/v1/private/local-runners` until the runner appears as type=endpoint and
+   * status=connected.
+   */
+  apiBaseUrl: string;
+  /** Project id the runner attaches to — used as the poll filter. */
+  projectId: string;
+}
+
+export interface EndpointRunner {
+  /** Id of the registered runner (from the backend list). */
+  runnerId: string;
+  /** Accumulated daemon stdout/stderr, for diagnostics. */
+  output(): string;
+  /** Stop the daemon. */
+  stop(): void;
+}
+
+/**
+ * Start an `opik endpoint` daemon in `--headless` mode and return once the
+ * runner appears as type="endpoint" + status="connected" in the backend.
+ *
+ * `--headless` self-activates without browser pairing and emits no pairing URL
+ * (Rich Live suppresses output on non-TTY). Readiness is therefore discovered
+ * by polling `GET <apiBaseUrl>/v1/private/local-runners?project_id=<id>`,
+ * which is the same endpoint the Agent Playground polls.
+ *
+ * The runner discovers the agent via `has_entrypoint(Path.cwd())`, which scans
+ * git-tracked files first. The scratch dir lives under `.test-scratch/` in
+ * the opik repo, which is gitignored — so we `git init` the scratch dir to
+ * make it a standalone repo. Without this, the scan inherits the parent repo
+ * and skips agent.py, producing "No entrypoint found".
+ */
+export async function startEndpointRunner(opts: StartEndpointOpts): Promise<EndpointRunner> {
+  const scrapeTimeoutMs = opts.scrapeTimeoutMs ?? 40_000;
+  let out = '';
+
+  await execFileAsync('git', ['init', '-q'], { cwd: opts.cwd });
+
+  const proc: ChildProcess = spawn(
+    'uv',
+    [
+      'run',
+      'opik',
+      '--api-key',
+      opts.apiKey,
+      'endpoint',
+      '--project',
+      opts.projectName,
+      '--workspace',
+      opts.workspace,
+      '--headless',
+      '--non-interactive',
+      '--',
+      ...opts.command,
+    ],
+    {
+      cwd: opts.cwd,
+      env: {
+        ...process.env,
+        OPIK_API_KEY: opts.apiKey,
+        OPIK_WORKSPACE: opts.workspace,
+        UV_PROJECT: BRIDGE_DIR,
+      },
+    },
+  );
+  proc.stdout?.on('data', (d) => (out += d.toString()));
+  proc.stderr?.on('data', (d) => (out += d.toString()));
+
+  const stop = () => {
+    try {
+      proc.kill();
+    } catch {
+      /* already gone */
+    }
+  };
+
+  const apiBase = opts.apiBaseUrl.replace(/\/+$/, '');
+  const url = `${apiBase}/v1/private/local-runners?project_id=${encodeURIComponent(opts.projectId)}&size=50`;
+  const headers: Record<string, string> = {
+    'Comet-Workspace': opts.workspace,
+    Accept: 'application/json',
+  };
+  if (opts.apiKey) headers['Authorization'] = opts.apiKey;
+
+  const deadline = Date.now() + scrapeTimeoutMs;
+  while (Date.now() < deadline) {
+    if (proc.exitCode !== null) {
+      throw new Error(
+        `startEndpointRunner: opik endpoint exited (code=${proc.exitCode}) before runner connected. Output:\n${out.slice(0, 2000)}`,
+      );
+    }
+    try {
+      const res = await fetch(url, { headers });
+      if (res.ok) {
+        const body = (await res.json()) as { content?: Array<{ id: string; type?: string; status?: string }> };
+        const runner = (body.content ?? []).find(
+          (r) => r.type === 'endpoint' && r.status === 'connected',
+        );
+        if (runner) {
+          return { runnerId: runner.id, output: () => out, stop };
+        }
+      }
+    } catch {
+      /* transient — keep polling until deadline */
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  stop();
+  throw new Error(
+    `startEndpointRunner: no connected endpoint runner appeared within ${scrapeTimeoutMs}ms. Daemon output:\n${out.slice(0, 2000)}`,
+  );
+}
+
 /**
  * Run an inline Python snippet under `uv run` in the bridge project, so it uses
  * the same pinned opik the suite seeds with (agents decorated with

--- a/tests_end_to_end/e2e/pom/agent-playground.page.ts
+++ b/tests_end_to_end/e2e/pom/agent-playground.page.ts
@@ -1,0 +1,65 @@
+import type { Page, Locator } from '@playwright/test';
+import { test } from '@playwright/test';
+import { loadEnvConfig } from '../config/env.config';
+
+export class AgentPlaygroundPage {
+  constructor(
+    private readonly page: Page,
+    private readonly projectId: string,
+  ) {}
+
+  async goto(): Promise<void> {
+    return test.step('open the Agent Playground page', async () => {
+      const env = loadEnvConfig();
+      const url = `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/agent-playground`;
+      await this.page.goto(url, { waitUntil: 'networkidle' });
+      await this.page.waitForURL(new RegExp('/agent-playground'));
+    });
+  }
+
+  async waitForHeading(): Promise<void> {
+    return test.step('wait for the Agent playground heading', async () => {
+      await this.page.getByRole('heading', { name: 'Agent playground', level: 1 }).waitFor();
+    });
+  }
+
+  connectionBadge(): Locator {
+    return this.page.getByText('Connected', { exact: true });
+  }
+
+  async isConnected(): Promise<boolean> {
+    return (await this.connectionBadge().count()) > 0;
+  }
+
+  testInputPanel(): Locator {
+    return this.page.getByText('Test input');
+  }
+
+  async fillInput(fieldName: string, value: string): Promise<void> {
+    return test.step(`fill input "${fieldName}"`, async () => {
+      await this.page.getByPlaceholder(`Enter ${fieldName}...`).fill(value);
+    });
+  }
+
+  async clickRun(): Promise<void> {
+    return test.step('click Run', async () => {
+      await this.page.getByRole('button', { name: /^Run/ }).first().click();
+    });
+  }
+
+  runningIndicator(): Locator {
+    return this.page.getByText('Running your agent...');
+  }
+
+  resultPanel(): Locator {
+    return this.page.locator('span').filter({ hasText: 'Result' });
+  }
+
+  resultText(query: string): Locator {
+    return this.page.getByText(`Answer for: ${query}`);
+  }
+
+  viewTraceButton(): Locator {
+    return this.page.getByRole('button', { name: 'View trace' });
+  }
+}

--- a/tests_end_to_end/e2e/tests/agent-playground/agent-playground-local-runner.spec.ts
+++ b/tests_end_to_end/e2e/tests/agent-playground/agent-playground-local-runner.spec.ts
@@ -1,0 +1,67 @@
+import * as path from 'node:path';
+import { test, expect } from '@e2e/fixtures';
+import { AgentPlaygroundPage } from '@e2e/pom/agent-playground.page';
+import { startEndpointRunner, type EndpointRunner } from '@e2e/core/local-runner/connect';
+
+const AGENTS_DIR = path.resolve(__dirname, '../../agents');
+
+test.describe('Agent Playground — Local Runner', { tag: ['@t3-nightly', '@agent-playground'] }, () => {
+  test('drives a connected entrypoint agent from the Agent Playground', async ({
+    project,
+    scratchDir,
+    envConfig,
+    page,
+  }) => {
+    test.setTimeout(300_000);
+    const playground = new AgentPlaygroundPage(page, project.id);
+    let runner: EndpointRunner | null = null;
+
+    try {
+      await test.step('Clone the entrypoint golden agent into a scratch dir', async () => {
+        await scratchDir.clone(path.join(AGENTS_DIR, 'playground-entrypoint'));
+      });
+
+      // OSS local stack accepts any API key (no auth wall); the cloud envs mint a real
+      // one via globalSetup and propagate it through OPIK_API_KEY.
+      const apiKey = envConfig.apiKey ?? 'opik-local-key';
+
+      runner = await test.step('Start opik endpoint against the scratch agent', async () =>
+        startEndpointRunner({
+          projectName: project.name,
+          projectId: project.id,
+          workspace: envConfig.workspace,
+          apiKey,
+          cwd: scratchDir.path,
+          command: ['python', path.join(scratchDir.path, 'agent.py')],
+          apiBaseUrl: envConfig.apiBaseUrl,
+        }));
+
+      await test.step('Navigate to Agent Playground', async () => {
+        await playground.goto();
+        await playground.waitForHeading();
+        await expect(
+          page.getByRole('heading', { name: 'Agent playground', level: 1 }),
+        ).toBeVisible();
+      });
+
+      await test.step('Wait for connected state', async () => {
+        await expect(playground.connectionBadge()).toBeVisible({ timeout: 60_000 });
+        await expect(playground.testInputPanel()).toBeVisible({ timeout: 60_000 });
+      });
+
+      const query = 'capital of france';
+
+      await test.step('Fill input and run', async () => {
+        await playground.fillInput('query', query);
+        await playground.clickRun();
+      });
+
+      await test.step('Wait for result', async () => {
+        await expect(playground.runningIndicator()).toHaveCount(0, { timeout: 180_000 });
+        await expect(playground.resultText(query)).toBeVisible({ timeout: 30_000 });
+      });
+    } finally {
+      runner?.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Details
Adds Agent Playground local runner E2E coverage for the `opik endpoint` flow. The test starts a headless endpoint runner for an entrypoint-decorated golden agent, waits for the backend to report an `endpoint` runner as connected, drives the Agent Playground UI, and verifies the rendered deterministic agent result.

- Adds a reusable `startEndpointRunner` helper alongside the existing `startConnectRunner` without changing the Ollie connect flow.
- Adds a golden entrypoint agent, Agent Playground POM, and targeted Playwright spec for the local runner journey.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6130

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Hermes Agent, Claude Code
- Model(s): gpt-5.5 via OpenAI Codex, Claude Opus 4.8 via Claude Code

## Testing
- `cd tests_end_to_end/e2e && npm ci`
- `cd tests_end_to_end/e2e && npx tsc --noEmit`
- `cd tests_end_to_end/e2e && OPIK_BASE_URL=http://localhost:5173/api OPIK_WORKSPACE=default OPIK_API_KEY=*** OPIK_DEPLOYMENT=oss CI=true npx playwright test tests/agent-playground/agent-playground-local-runner.spec.ts --reporter=list --workers=1 --timeout=300000`

Validated locally on the OSS stack at `http://localhost:5173` with Chromium. Final Playwright result: `1 passed (24.1s)`.

## Documentation
N/A

