### PR TITLE
[OPIK-6968] [BE] perf: filter trace_threads join in getMinimalThreadInfoByIds

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -2833,7 +2833,13 @@ class TraceDAOImpl implements TraceDAO {
                 ) inner_t
                 GROUP BY inner_t.workspace_id, inner_t.project_id, inner_t.thread_id
             ) t
-            LEFT JOIN trace_threads tt ON t.workspace_id = tt.workspace_id
+            LEFT JOIN (
+                SELECT workspace_id, project_id, thread_id, id, status
+                FROM trace_threads
+                WHERE workspace_id = :workspace_id
+                  AND project_id = :project_id
+                  AND thread_id IN :thread_ids
+            ) tt ON t.workspace_id = tt.workspace_id
               AND t.project_id = tt.project_id
               AND t.id = tt.thread_id
             SETTINGS log_comment = '<log_comment>'


### PR DESCRIPTION
## Details
The trace-thread close path (`/v1/private/traces/threads/close`) calls `getMinimalThreadInfoByIds`, whose `LEFT JOIN trace_threads` had no filter on the joined side. Every call therefore built its join hash table from the **entire** `trace_threads` table, independent of how few `thread_id`s were requested. This pushes the existing `workspace_id` / `project_id` / `thread_id` predicate into the joined subquery so it reads only the matching rows.

- Output is unchanged: the filter columns are exactly the join keys, so filtering the joined side cannot drop or alter any match.
- Only `getMinimalThreadInfoByIds` is touched; the inner `traces` aggregation is unchanged.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6968

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Query analysis against a read-only ClickHouse replica, the query change in this PR, and this description.
  - Human verification: Output equivalence and per-call cost validated by the author; reviewer to confirm.

## Testing

- **Output equivalence (read-only ClickHouse):** ran the current and proposed query forms on production-representative parameters (a 60-thread batch). Identical row count and an order-independent fingerprint (`groupBitXor(cityHash64(...))` over every output column, including `thread_model_id` and `status`) matched exactly.
- **Per-call cost (same parameters):** ~20.4M rows / ~1.1s / ~3.7 GiB → ~108K rows / ~16ms / <1 MiB. The win is removing the full-table hash build; it is independent of the requested thread count.
- **Not run:** the full `mvn` backend integration suite (e.g. `TracesResourceTest` thread close). This is a SQL-only change with verified-identical output; recommend CI to exercise the existing thread-close ITs.

## Documentation
N/A — internal query optimization, no behavior change.
