### PR TITLE
[OPIK-7006] Recover from stale chunk preload errors after deploy

### DIFF
--- a/apps/opik-frontend/src/index.tsx
+++ b/apps/opik-frontend/src/index.tsx
@@ -7,6 +7,7 @@ import WorkspaceVersionGate from "@/WorkspaceVersionGate";
 import usePluginsStore from "@/store/PluginsStore";
 import { APP_VERSION } from "@/constants/app";
 import { runLocalStorageMigrations } from "@/lib/ls-migrations";
+import { setupPreloadErrorHandler } from "@/lib/preload-error";
 
 import "./main.scss";
 import { IS_SENTRY_ENABLED, SENTRY_DSN, SENTRY_MODE } from "@/config";
@@ -14,6 +15,8 @@ import { IS_SENTRY_ENABLED, SENTRY_DSN, SENTRY_MODE } from "@/config";
 // other styles
 import "react18-json-view/src/style.css";
 import "react18-json-view/src/dark.css";
+
+setupPreloadErrorHandler();
 
 const container = document.getElementById("root") as HTMLDivElement;
 const root = createRoot(container);

--- a/apps/opik-frontend/src/lib/preload-error.test.ts
+++ b/apps/opik-frontend/src/lib/preload-error.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setupPreloadErrorHandler } from "./preload-error";
+
+describe("setupPreloadErrorHandler", () => {
+  const reload = vi.fn();
+
+  beforeEach(() => {
+    reload.mockClear();
+    window.sessionStorage.clear();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    vi.stubGlobal("location", { reload });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  const dispatchPreloadError = () => {
+    const event = new Event("vite:preloadError", { cancelable: true });
+    window.dispatchEvent(event);
+    return event;
+  };
+
+  it("reloads the page and prevents the default error on a preload failure", () => {
+    setupPreloadErrorHandler();
+
+    const event = dispatchPreloadError();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("does not reload again within the guard window to avoid a reload loop", () => {
+    setupPreloadErrorHandler();
+
+    dispatchPreloadError();
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(5 * 1000);
+    const event = dispatchPreloadError();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("reloads again once the guard window has elapsed", () => {
+    setupPreloadErrorHandler();
+
+    dispatchPreloadError();
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(11 * 1000);
+    dispatchPreloadError();
+
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/opik-frontend/src/lib/preload-error.test.ts
+++ b/apps/opik-frontend/src/lib/preload-error.test.ts
@@ -56,4 +56,23 @@ describe("setupPreloadErrorHandler", () => {
 
     expect(reload).toHaveBeenCalledTimes(2);
   });
+
+  it("still recovers when sessionStorage access throws", () => {
+    const securityError = () => {
+      throw new DOMException("blocked", "SecurityError");
+    };
+    vi.spyOn(window.sessionStorage, "getItem").mockImplementation(
+      securityError,
+    );
+    vi.spyOn(window.sessionStorage, "setItem").mockImplementation(
+      securityError,
+    );
+
+    setupPreloadErrorHandler();
+
+    const event = dispatchPreloadError();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
 });

--- a/apps/opik-frontend/src/lib/preload-error.ts
+++ b/apps/opik-frontend/src/lib/preload-error.ts
@@ -4,6 +4,26 @@ const RELOAD_GUARD_KEY = "opik-preload-error-reloaded-at";
 // within this window, stop reloading and let the error surface instead.
 const RELOAD_GUARD_WINDOW = 10 * 1000;
 
+// `sessionStorage` can throw (e.g. SecurityError in a sandboxed iframe or when
+// storage is blocked in strict privacy mode). Recovery must not depend on it,
+// so reads/writes are guarded: a failed read allows the reload, a failed write
+// just loses the loop guard for that case.
+const readLastReloadAt = (): number => {
+  try {
+    return Number(window.sessionStorage.getItem(RELOAD_GUARD_KEY) ?? 0);
+  } catch {
+    return 0;
+  }
+};
+
+const writeLastReloadAt = (value: number): void => {
+  try {
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(value));
+  } catch {
+    // Storage unavailable — reload still proceeds without the time-based guard.
+  }
+};
+
 /**
  * Handles Vite's `vite:preloadError` event, which fires when a lazily-imported
  * chunk fails to load. The most common cause in production is a new deploy:
@@ -21,11 +41,8 @@ const RELOAD_GUARD_WINDOW = 10 * 1000;
 export const setupPreloadErrorHandler = () => {
   window.addEventListener("vite:preloadError", (event) => {
     const now = Date.now();
-    const lastReloadAt = Number(
-      window.sessionStorage.getItem(RELOAD_GUARD_KEY) ?? 0,
-    );
 
-    if (now - lastReloadAt < RELOAD_GUARD_WINDOW) {
+    if (now - readLastReloadAt() < RELOAD_GUARD_WINDOW) {
       // We already reloaded very recently and still hit a preload error — stop
       // reloading and let the error propagate to the error boundary.
       return;
@@ -34,7 +51,7 @@ export const setupPreloadErrorHandler = () => {
     // Prevent Vite from throwing the error so the page can recover quietly.
     event.preventDefault();
 
-    window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(now));
+    writeLastReloadAt(now);
     window.location.reload();
   });
 };

--- a/apps/opik-frontend/src/lib/preload-error.ts
+++ b/apps/opik-frontend/src/lib/preload-error.ts
@@ -1,0 +1,40 @@
+const RELOAD_GUARD_KEY = "opik-preload-error-reloaded-at";
+
+// Avoid an infinite reload loop: if reloading didn't resolve the failed import
+// within this window, stop reloading and let the error surface instead.
+const RELOAD_GUARD_WINDOW = 10 * 1000;
+
+/**
+ * Handles Vite's `vite:preloadError` event, which fires when a lazily-imported
+ * chunk fails to load. The most common cause in production is a new deploy:
+ * the content-hashed chunk a long-lived tab is referencing (e.g.
+ * `PlaygroundPage-CuYvVjy3.js`) gets removed from the server, so navigating to
+ * a not-yet-loaded route requests a file that no longer exists and the import
+ * rejects.
+ *
+ * Reloading the page fetches a fresh `index.html` with the current asset hashes
+ * and transparently recovers, so the user never sees the generic error screen.
+ *
+ * A short time-based guard prevents a reload loop in the rare case where the
+ * chunk is genuinely unreachable for another reason (offline, server outage).
+ */
+export const setupPreloadErrorHandler = () => {
+  window.addEventListener("vite:preloadError", (event) => {
+    const now = Date.now();
+    const lastReloadAt = Number(
+      window.sessionStorage.getItem(RELOAD_GUARD_KEY) ?? 0,
+    );
+
+    if (now - lastReloadAt < RELOAD_GUARD_WINDOW) {
+      // We already reloaded very recently and still hit a preload error — stop
+      // reloading and let the error propagate to the error boundary.
+      return;
+    }
+
+    // Prevent Vite from throwing the error so the page can recover quietly.
+    event.preventDefault();
+
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(now));
+    window.location.reload();
+  });
+};


### PR DESCRIPTION
## Details

Users intermittently hit a full-page "Something went wrong! Failed to fetch dynamically imported module: .../assets/PlaygroundPage-XXXX.js" error in production. The app is code-split, so each route is a content-hash-named chunk; a tab opened before a deploy still references old hashes, and navigating to a not-yet-loaded route requests a chunk that was removed on deploy (404 → import rejects → error boundary).

This adds a global `vite:preloadError` handler that reloads the page to pull a fresh `index.html` with current asset hashes, transparently recovering instead of showing the error screen.
- A time-based `sessionStorage` guard prevents a reload loop if a chunk is genuinely unreachable (offline/outage): a preload error recurring within 10s of a reload is allowed to surface.
- `sessionStorage` access is wrapped in try/catch so the handler still recovers when storage is blocked (sandboxed iframe / strict privacy mode).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-7006

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Full implementation (handler, wiring, unit tests) and PR description
  - Human verification: Author reviewed the diff, confirmed tests/lint/tsc pass locally

## Testing

- `npx vitest run src/lib/preload-error.test.ts` — 4 tests pass (reload on error, loop guard within window, reload again after window, recovery when sessionStorage throws).
- `npx eslint` and `tsc --noEmit` clean on changed files (the one pre-existing tsc error in the repo is unrelated to this change).
- One global handler covers all lazy routes, so no per-route changes were needed.

## Documentation

No documentation changes required — internal resilience fix with no user-facing API or behavior to document.