### PR TITLE
[OPIK-7019] [BE] Fix lock heartbeat denied after user scores feedback

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueItemLockService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AnnotationQueueItemLockService.java
@@ -70,10 +70,6 @@ class AnnotationQueueItemLockServiceImpl implements AnnotationQueueItemLockServi
         long now = System.currentTimeMillis();
         long expiryMs = now + (long) lockTimeoutSeconds * 1000;
 
-        if (scoredCount >= annotatorsPerItem) {
-            return Mono.just(buildResponse(false, itemId, userName, expiryMs));
-        }
-
         var slotLock = new LockService.Lock(buildSlotKey(workspaceId, queueId, itemId));
         Duration lease = Duration.ofSeconds(lockTimeoutSeconds);
         String field = field(itemId, userName);
@@ -100,15 +96,19 @@ class AnnotationQueueItemLockServiceImpl implements AnnotationQueueItemLockServi
                 });
 
         return heartbeat
-                .switchIfEmpty(Mono.defer(() ->
-                // Fresh acquire: atomic semaphore tryAcquire, then store permitId in map
-                lockService.tryAcquireSlot(slotLock, effectiveCapacity, lease)
-                        .flatMap(newPermitId -> userMap
-                                .fastPutIfAbsent(field, packValue(newPermitId, expiryMs))
-                                .flatMap(stored -> stored
-                                        ? userMap.expire(lease).thenReturn(true)
-                                        : lockService.releaseSlot(slotLock, newPermitId).thenReturn(true)))
-                        .defaultIfEmpty(false)))
+                .switchIfEmpty(Mono.defer(() -> {
+                    if (scoredCount >= annotatorsPerItem) {
+                        return Mono.just(false);
+                    }
+                    // Fresh acquire: atomic semaphore tryAcquire, then store permitId in map
+                    return lockService.tryAcquireSlot(slotLock, effectiveCapacity, lease)
+                            .flatMap(newPermitId -> userMap
+                                    .fastPutIfAbsent(field, packValue(newPermitId, expiryMs))
+                                    .flatMap(stored -> stored
+                                            ? userMap.expire(lease).thenReturn(true)
+                                            : lockService.releaseSlot(slotLock, newPermitId).thenReturn(true)))
+                            .defaultIfEmpty(false);
+                }))
                 .map(acquired -> buildResponse(acquired, itemId, userName, expiryMs));
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/AnnotationQueueItemLockServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/AnnotationQueueItemLockServiceTest.java
@@ -78,13 +78,33 @@ class AnnotationQueueItemLockServiceTest {
     class TryLock {
 
         @Test
-        @DisplayName("should return denied when scoredCount >= annotatorsPerItem")
+        @DisplayName("should return denied when scoredCount >= annotatorsPerItem and user has no lock")
         void shouldDenyWhenFullyScored() {
+            when(mapCache.get(anyString())).thenReturn(Mono.empty());
+
             StepVerifier.create(service.tryLock(
                     WORKSPACE_ID, QUEUE_ID, ITEM_ID, USER_ALICE, 2, 2, 5))
                     .assertNext(result -> assertThat(result.acquired()).isFalse())
                     .verifyComplete();
 
+            verify(lockService, never()).tryAcquireSlot(any(), anyInt(), any());
+        }
+
+        @Test
+        @DisplayName("should allow heartbeat when user already scored but still holds a valid lock")
+        void shouldAllowHeartbeatWhenUserAlreadyScoredButHoldsLock() {
+            when(mapCache.get(field(ITEM_ID, USER_ALICE)))
+                    .thenReturn(Mono.just(packValue(PERMIT_ID, futureExpiry())));
+            when(lockService.refreshSlot(any(), eq(PERMIT_ID), any())).thenReturn(Mono.just(true));
+            when(mapCache.fastPut(anyString(), anyString()))
+                    .thenReturn(Mono.just(true));
+
+            StepVerifier.create(service.tryLock(
+                    WORKSPACE_ID, QUEUE_ID, ITEM_ID, USER_ALICE, 1, 1, 5))
+                    .assertNext(result -> assertThat(result.acquired()).isTrue())
+                    .verifyComplete();
+
+            verify(lockService).refreshSlot(any(), eq(PERMIT_ID), any());
             verify(lockService, never()).tryAcquireSlot(any(), anyInt(), any());
         }
 


### PR DESCRIPTION
## Details

Fixes a race condition where annotation queue users get a false "another annotator is reviewing this item" message after submitting a feedback score.

The `tryLock()` method in `AnnotationQueueItemLockService` had a `scoredCount >= annotatorsPerItem` early exit that fired before checking whether the requesting user already held a valid lock. After a user scores, their own score increments `scoredCount`, causing their next heartbeat to be denied even though they still hold the lock.

The fix moves the heartbeat check (does the user already hold a valid permit?) before the scored-count gate, so existing lock holders can always renew regardless of scored count.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-7019

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-opus-4-6
  - Scope: Investigation, implementation, test authoring
  - Human verification: Code reviewed, tests verified passing

## Testing

- `mvn test -Dtest=AnnotationQueueItemLockServiceTest` — 14/14 tests pass
- Added new test `shouldAllowHeartbeatWhenUserAlreadyScoredButHoldsLock` that verifies:
  - With `scoredCount=1, annotatorsPerItem=1` and user holding a valid lock
  - `refreshSlot` is called (heartbeat path taken)
  - `tryAcquireSlot` is never called (fresh acquire path skipped)
  - Result is `acquired: true`
- Updated existing `shouldDenyWhenFullyScored` test to mock the userMap returning empty (no existing lock), ensuring denial still works for users without a lock
- Manual reproduction: create queue with `annotatorsPerItem=1`, submit feedback score, confirm no "another annotator" message

## Documentation

N/A — bug fix only, no new configuration or user-facing API changes.