### PR TITLE
[NA] [BE] feat: promote severity to first-class field on agent insights issues

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsIssue.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsIssue.java
@@ -21,6 +21,7 @@ public record AgentInsightsIssue(
         String cause,
         String suggestedFix,
         AgentInsightsIssueStatus status,
+        AgentInsightsIssueSeverity severity,
         String tracesQuery,
         @Schema(description = "SUM(count) over the requested window") long totalOccurrences,
         @Schema(description = "SUM(total_count) over the requested window") long total,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsIssueSeverity.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsIssueSeverity.java
@@ -1,0 +1,31 @@
+package com.comet.opik.api;
+
+import com.comet.opik.infrastructure.db.HasValue;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import jakarta.ws.rs.BadRequestException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum AgentInsightsIssueSeverity implements HasValue {
+    CRITICAL("critical"),
+    HIGH("high"),
+    MEDIUM("medium"),
+    LOW("low");
+
+    @JsonValue
+    private final String value;
+
+    @JsonCreator
+    public static AgentInsightsIssueSeverity fromString(String value) {
+        return Arrays.stream(values())
+                .filter(severity -> severity.value.equals(value))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException("Unknown issue severity: '%s'".formatted(value)));
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsIssueWithDetails.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsIssueWithDetails.java
@@ -20,6 +20,7 @@ public record AgentInsightsIssueWithDetails(
         String cause,
         String suggestedFix,
         AgentInsightsIssueStatus status,
+        AgentInsightsIssueSeverity severity,
         String tracesQuery,
         String createdBy,
         Instant createdAt,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsReport.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsReport.java
@@ -35,6 +35,7 @@ public record AgentInsightsReport(
             String cause,
             String suggestedFix,
             String tracesQuery,
+            @NotNull AgentInsightsIssueSeverity severity,
             @NotNull @PositiveOrZero Long count,
             @NotNull @PositiveOrZero Long totalCount,
             @NotNull @PositiveOrZero Long usersImpacted,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AgentInsightsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AgentInsightsResource.java
@@ -2,6 +2,7 @@ package com.comet.opik.api.resources.v1.priv;
 
 import com.codahale.metrics.annotation.Timed;
 import com.comet.opik.api.AgentInsightsIssue;
+import com.comet.opik.api.AgentInsightsIssueSeverity;
 import com.comet.opik.api.AgentInsightsIssueStatus;
 import com.comet.opik.api.AgentInsightsIssueUpdate;
 import com.comet.opik.api.AgentInsightsIssueWithDetails;
@@ -64,6 +65,7 @@ public class AgentInsightsResource {
             @QueryParam("from_date") LocalDate fromDate,
             @QueryParam("to_date") LocalDate toDate,
             @QueryParam("status") AgentInsightsIssueStatus status,
+            @QueryParam("severity") AgentInsightsIssueSeverity severity,
             @QueryParam("sorting") String sorting,
             @QueryParam("page") @Min(1) @DefaultValue("1") int page,
             @QueryParam("size") @Min(1) @Max(100) @DefaultValue("10") int size) {
@@ -72,7 +74,7 @@ public class AgentInsightsResource {
 
         List<SortingField> sortingFields = sortingFactory.newSorting(sorting);
         AgentInsightsIssue.AgentInsightsIssuePage issuesPage = agentInsightsIssueService.findIssues(
-                projectId, fromDate, toDate, status, sortingFields, page, size);
+                projectId, fromDate, toDate, status, severity, sortingFields, page, size);
 
         return Response.ok(issuesPage).build();
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/AgentInsightsIssueSortingFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/AgentInsightsIssueSortingFactory.java
@@ -3,6 +3,7 @@ package com.comet.opik.api.sorting;
 import java.util.List;
 
 import static com.comet.opik.api.sorting.SortableFields.LAST_SEEN;
+import static com.comet.opik.api.sorting.SortableFields.SEVERITY;
 import static com.comet.opik.api.sorting.SortableFields.TOTAL_OCCURRENCES;
 
 public class AgentInsightsIssueSortingFactory extends SortingFactory {
@@ -10,6 +11,7 @@ public class AgentInsightsIssueSortingFactory extends SortingFactory {
     public List<String> getSortableFields() {
         return List.of(
                 LAST_SEEN,
-                TOTAL_OCCURRENCES);
+                TOTAL_OCCURRENCES,
+                SEVERITY);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortableFields.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortableFields.java
@@ -65,6 +65,7 @@ public class SortableFields {
     public static final String ENVIRONMENT = "environment";
     public static final String LAST_SEEN = "last_seen";
     public static final String TOTAL_OCCURRENCES = "total_occurrences";
+    public static final String SEVERITY = "severity";
 
     /** Wide text columns deferred past pagination by the TraceDAO/SpanDAO page_wide optimization. */
     private static final Set<String> WIDE_TEXT_FIELDS = Set.of(INPUT, OUTPUT, METADATA);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueDAO.java
@@ -2,9 +2,11 @@ package com.comet.opik.domain;
 
 import com.comet.opik.api.AgentInsightsIssue;
 import com.comet.opik.api.AgentInsightsIssueDetail;
+import com.comet.opik.api.AgentInsightsIssueSeverity;
 import com.comet.opik.api.AgentInsightsIssueStatus;
 import com.comet.opik.api.AgentInsightsIssueWithDetails;
 import com.comet.opik.api.AgentInsightsReport;
+import com.comet.opik.infrastructure.db.AgentInsightsIssueSeverityColumnMapper;
 import com.comet.opik.infrastructure.db.AgentInsightsIssueStatusColumnMapper;
 import com.comet.opik.infrastructure.db.UUIDArgumentFactory;
 import com.comet.opik.utils.JsonUtils;
@@ -36,19 +38,22 @@ import java.util.UUID;
 @RegisterArgumentFactory(UUIDArgumentFactory.class)
 @RegisterArgumentFactory(AgentInsightsIssueStatusColumnMapper.class)
 @RegisterColumnMapper(AgentInsightsIssueStatusColumnMapper.class)
+@RegisterArgumentFactory(AgentInsightsIssueSeverityColumnMapper.class)
+@RegisterColumnMapper(AgentInsightsIssueSeverityColumnMapper.class)
 interface AgentInsightsIssueDAO {
 
     @SqlBatch("""
             INSERT INTO agent_insights_issues
-                (id, workspace_id, project_id, name, description, cause, suggested_fix, traces_query, created_by, last_updated_by)
+                (id, workspace_id, project_id, name, description, cause, suggested_fix, traces_query, severity, created_by, last_updated_by)
             VALUES (:id, :workspace_id, :project_id, :bean.name, :bean.description, :bean.cause, :bean.suggestedFix,
-                    :bean.tracesQuery, :user_name, :user_name)
+                    :bean.tracesQuery, :bean.severity, :user_name, :user_name)
             ON DUPLICATE KEY UPDATE
                 name = :bean.name,
                 description = :bean.description,
                 cause = :bean.cause,
                 suggested_fix = :bean.suggestedFix,
                 traces_query = :bean.tracesQuery,
+                severity = :bean.severity,
                 last_updated_by = :user_name
             """)
     void upsertIssues(
@@ -83,7 +88,7 @@ interface AgentInsightsIssueDAO {
             @Bind("metadata") List<String> metadata);
 
     @SqlQuery("""
-            SELECT i.id, i.name, i.description, i.cause, i.suggested_fix, i.status, i.traces_query,
+            SELECT i.id, i.name, i.description, i.cause, i.suggested_fix, i.status, i.severity, i.traces_query,
                    SUM(d.`count`) AS total_occurrences,
                    SUM(d.total_count) AS total,
                    SUM(d.users_impacted) AS users_impacted,
@@ -101,6 +106,7 @@ interface AgentInsightsIssueDAO {
                 AND i.project_id = :project_id
                 AND d.report_day BETWEEN :from_date AND :to_date
                 <if(status)> AND i.status = :status <endif>
+                <if(severity)> AND i.severity = :severity <endif>
             GROUP BY i.id
             ORDER BY <if(sort_fields)> <sort_fields>, <endif> last_seen DESC, total_occurrences DESC, i.id DESC
             LIMIT :limit OFFSET :offset
@@ -113,6 +119,7 @@ interface AgentInsightsIssueDAO {
             @Bind("from_date") LocalDate fromDate,
             @Bind("to_date") LocalDate toDate,
             @Define("status") @Bind("status") AgentInsightsIssueStatus status,
+            @Define("severity") @Bind("severity") AgentInsightsIssueSeverity severity,
             @Define("sort_fields") String sortFields,
             @Bind("limit") int limit,
             @Bind("offset") int offset);
@@ -128,6 +135,7 @@ interface AgentInsightsIssueDAO {
                 AND i.project_id = :project_id
                 AND d.report_day BETWEEN :from_date AND :to_date
                 <if(status)> AND i.status = :status <endif>
+                <if(severity)> AND i.severity = :severity <endif>
             """)
     @UseStringTemplateEngine
     @AllowUnusedBindings
@@ -136,10 +144,11 @@ interface AgentInsightsIssueDAO {
             @Bind("project_id") UUID projectId,
             @Bind("from_date") LocalDate fromDate,
             @Bind("to_date") LocalDate toDate,
-            @Define("status") @Bind("status") AgentInsightsIssueStatus status);
+            @Define("status") @Bind("status") AgentInsightsIssueStatus status,
+            @Define("severity") @Bind("severity") AgentInsightsIssueSeverity severity);
 
     @SqlQuery("""
-            SELECT id, name, description, cause, suggested_fix, status, traces_query, created_by, created_at, last_updated_by, last_updated_at
+            SELECT id, name, description, cause, suggested_fix, status, severity, traces_query, created_by, created_at, last_updated_by, last_updated_at
             FROM agent_insights_issues
             WHERE workspace_id = :workspace_id AND project_id = :project_id AND id = :id
             """)
@@ -180,6 +189,7 @@ interface AgentInsightsIssueDAO {
 
         @Override
         public AgentInsightsIssueWithDetails map(ResultSet rs, StatementContext ctx) throws SQLException {
+            String severityStr = rs.getString("severity");
             return AgentInsightsIssueWithDetails.builder()
                     .id(UUID.fromString(rs.getString("id")))
                     .name(rs.getString("name"))
@@ -187,6 +197,7 @@ interface AgentInsightsIssueDAO {
                     .cause(rs.getString("cause"))
                     .suggestedFix(rs.getString("suggested_fix"))
                     .status(AgentInsightsIssueStatus.fromString(rs.getString("status")))
+                    .severity(severityStr != null ? AgentInsightsIssueSeverity.fromString(severityStr) : null)
                     .tracesQuery(rs.getString("traces_query"))
                     .createdBy(rs.getString("created_by"))
                     .createdAt(rs.getTimestamp("created_at").toInstant())

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueService.java
@@ -2,6 +2,7 @@ package com.comet.opik.domain;
 
 import com.comet.opik.api.AgentInsightsIssue;
 import com.comet.opik.api.AgentInsightsIssueDetail;
+import com.comet.opik.api.AgentInsightsIssueSeverity;
 import com.comet.opik.api.AgentInsightsIssueStatus;
 import com.comet.opik.api.AgentInsightsIssueUpdate;
 import com.comet.opik.api.AgentInsightsIssueWithDetails;
@@ -36,7 +37,8 @@ public interface AgentInsightsIssueService {
     void reportIssues(AgentInsightsReport report);
 
     AgentInsightsIssue.AgentInsightsIssuePage findIssues(UUID projectId, LocalDate fromDate, LocalDate toDate,
-            AgentInsightsIssueStatus status, List<SortingField> sortingFields, int page, int size);
+            AgentInsightsIssueStatus status, AgentInsightsIssueSeverity severity, List<SortingField> sortingFields,
+            int page, int size);
 
     AgentInsightsIssueWithDetails getIssue(UUID issueId, UUID projectId, LocalDate fromDate, LocalDate toDate);
 
@@ -97,8 +99,8 @@ class AgentInsightsIssueServiceImpl implements AgentInsightsIssueService {
 
     @Override
     public AgentInsightsIssue.AgentInsightsIssuePage findIssues(@NonNull UUID projectId, LocalDate fromDate,
-            LocalDate toDate, AgentInsightsIssueStatus status, List<SortingField> sortingFields, int page,
-            int size) {
+            LocalDate toDate, AgentInsightsIssueStatus status, AgentInsightsIssueSeverity severity,
+            List<SortingField> sortingFields, int page, int size) {
         String workspaceId = requestContext.get().getWorkspaceId();
 
         DateWindow window = resolveWindow(fromDate, toDate);
@@ -112,8 +114,8 @@ class AgentInsightsIssueServiceImpl implements AgentInsightsIssueService {
 
             int offset = (page - 1) * size;
             List<AgentInsightsIssue> issues = dao.findIssues(workspaceId, projectId, window.from(), window.to(),
-                    status, sortFields, size, offset);
-            long total = dao.countIssues(workspaceId, projectId, window.from(), window.to(), status);
+                    status, severity, sortFields, size, offset);
+            long total = dao.countIssues(workspaceId, projectId, window.from(), window.to(), status, severity);
 
             return AgentInsightsIssue.AgentInsightsIssuePage.builder()
                     .page(page)

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/AgentInsightsIssueSeverityColumnMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/AgentInsightsIssueSeverityColumnMapper.java
@@ -1,0 +1,16 @@
+package com.comet.opik.infrastructure.db;
+
+import com.comet.opik.api.AgentInsightsIssueSeverity;
+import jakarta.ws.rs.WebApplicationException;
+
+public class AgentInsightsIssueSeverityColumnMapper extends AbstractEnumColumnMapper<AgentInsightsIssueSeverity> {
+    public AgentInsightsIssueSeverityColumnMapper() {
+        super(value -> {
+            try {
+                return AgentInsightsIssueSeverity.fromString(value);
+            } catch (WebApplicationException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }, "agent_insights_issue_severity");
+    }
+}

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000084_add_severity_to_agent_insights_issues.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000084_add_severity_to_agent_insights_issues.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+--changeset petrot:000084_add_severity_to_agent_insights_issues
+--comment: Promote severity to a first-class column on agent_insights_issues. Previously stored inside the metadata JSON blob on the details table; now persisted at the issue level and returned in all fetch endpoints.
+
+ALTER TABLE agent_insights_issues
+    ADD COLUMN severity ENUM ('critical','high','medium','low') NULL DEFAULT NULL AFTER status;
+
+--rollback ALTER TABLE agent_insights_issues DROP COLUMN severity;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000084_add_severity_to_agent_insights_issues.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000084_add_severity_to_agent_insights_issues.sql
@@ -6,3 +6,4 @@ ALTER TABLE agent_insights_issues
     ADD COLUMN severity ENUM ('critical','high','medium','low') NULL DEFAULT NULL AFTER status;
 
 --rollback ALTER TABLE agent_insights_issues DROP COLUMN severity;
+

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AgentInsightsResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AgentInsightsResourceClient.java
@@ -1,6 +1,7 @@
 package com.comet.opik.api.resources.utils.resources;
 
 import com.comet.opik.api.AgentInsightsIssue;
+import com.comet.opik.api.AgentInsightsIssueSeverity;
 import com.comet.opik.api.AgentInsightsIssueStatus;
 import com.comet.opik.api.AgentInsightsIssueUpdate;
 import com.comet.opik.api.AgentInsightsIssueWithDetails;
@@ -57,12 +58,13 @@ public class AgentInsightsResourceClient {
     }
 
     public AgentInsightsIssue.AgentInsightsIssuePage findIssues(UUID projectId, LocalDate fromDate, LocalDate toDate,
-            AgentInsightsIssueStatus status, List<SortingField> sorting, Integer page, Integer size,
-            String apiKey, String workspaceName, int expectedStatus) {
+            AgentInsightsIssueStatus status, AgentInsightsIssueSeverity severity, List<SortingField> sorting,
+            Integer page, Integer size, String apiKey, String workspaceName, int expectedStatus) {
         try (var actualResponse = findIssuesWithResponse(projectId,
                 fromDate == null ? null : fromDate.toString(),
                 toDate == null ? null : toDate.toString(),
                 status == null ? null : status.getValue(),
+                severity == null ? null : severity.getValue(),
                 CollectionUtils.isEmpty(sorting) ? null : JsonUtils.writeValueAsString(sorting),
                 page, size, apiKey, workspaceName)) {
 
@@ -77,7 +79,7 @@ public class AgentInsightsResourceClient {
     }
 
     public Response findIssuesWithResponse(UUID projectId, String fromDate, String toDate, String status,
-            String sorting, Integer page, Integer size, String apiKey, String workspaceName) {
+            String severity, String sorting, Integer page, Integer size, String apiKey, String workspaceName) {
         WebTarget target = client.target(ISSUES_PATH.formatted(baseURI));
 
         if (projectId != null) {
@@ -91,6 +93,9 @@ public class AgentInsightsResourceClient {
         }
         if (status != null) {
             target = target.queryParam("status", status);
+        }
+        if (severity != null) {
+            target = target.queryParam("severity", severity);
         }
         if (sorting != null) {
             target = target.queryParam("sorting", URLEncoder.encode(sorting, StandardCharsets.UTF_8));

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentInsightsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentInsightsResourceTest.java
@@ -1,6 +1,7 @@
 package com.comet.opik.api.resources.v1.priv;
 
 import com.comet.opik.api.AgentInsightsIssue;
+import com.comet.opik.api.AgentInsightsIssueSeverity;
 import com.comet.opik.api.AgentInsightsIssueStatus;
 import com.comet.opik.api.AgentInsightsIssueUpdate;
 import com.comet.opik.api.AgentInsightsReport;
@@ -162,6 +163,7 @@ class AgentInsightsResourceTest {
                 .cause("Cause of " + name)
                 .suggestedFix("Fix for " + name)
                 .tracesQuery("SELECT 1")
+                .severity(AgentInsightsIssueSeverity.MEDIUM)
                 .count(count)
                 .totalCount(totalCount)
                 .usersImpacted(usersImpacted)
@@ -181,7 +183,7 @@ class AgentInsightsResourceTest {
 
     private AgentInsightsIssue.AgentInsightsIssuePage findIssues(UUID projectId, LocalDate fromDate,
             LocalDate toDate) {
-        return agentInsightsResourceClient.findIssues(projectId, fromDate, toDate, null, null, null, null,
+        return agentInsightsResourceClient.findIssues(projectId, fromDate, toDate, null, null, null, null, null,
                 API_KEY, TEST_WORKSPACE, HttpStatus.SC_OK);
     }
 
@@ -426,6 +428,9 @@ class AgentInsightsResourceTest {
                     // null issue element
                     AgentInsightsReport.builder().projectId(UUID.randomUUID()).reportDay(DAY_1)
                             .issues(Collections.singletonList(null)).build(),
+                    // missing severity (required field)
+                    AgentInsightsReport.builder().projectId(UUID.randomUUID()).reportDay(DAY_1)
+                            .issues(List.of(validIssue.toBuilder().severity(null).build())).build(),
                     // metadata exceeding the column byte limit
                     AgentInsightsReport.builder().projectId(UUID.randomUUID()).reportDay(DAY_1)
                             .issues(List.of(validIssue.toBuilder()
@@ -528,7 +533,7 @@ class AgentInsightsResourceTest {
             report(projectId, DAY_3,
                     List.of(reportedIssue(nameB, rndOccurrences(), rndTotalCount(), rndUserCount(), rndUserCount())));
 
-            var page = agentInsightsResourceClient.findIssues(projectId, null, null, null, null, null, null,
+            var page = agentInsightsResourceClient.findIssues(projectId, null, null, null, null, null, null, null,
                     API_KEY, TEST_WORKSPACE, HttpStatus.SC_OK);
             assertThat(page.total()).isEqualTo(2);
             assertThat(page.content()).extracting(AgentInsightsIssue::name)
@@ -557,14 +562,14 @@ class AgentInsightsResourceTest {
                     .extracting(AgentInsightsIssue::name)
                     .containsExactly(nameC, nameB, nameA);
 
-            var byOccurrences = agentInsightsResourceClient.findIssues(projectId, DAY_1, DAY_3, null,
+            var byOccurrences = agentInsightsResourceClient.findIssues(projectId, DAY_1, DAY_3, null, null,
                     sortBy(SortableFields.TOTAL_OCCURRENCES, Direction.DESC), null, null, API_KEY, TEST_WORKSPACE,
                     HttpStatus.SC_OK);
             assertThat(byOccurrences.content())
                     .extracting(AgentInsightsIssue::name)
                     .containsExactly(nameA, nameB, nameC);
 
-            var byLastSeen = agentInsightsResourceClient.findIssues(projectId, DAY_1, DAY_3, null,
+            var byLastSeen = agentInsightsResourceClient.findIssues(projectId, DAY_1, DAY_3, null, null,
                     sortBy(SortableFields.LAST_SEEN, Direction.DESC), null, null, API_KEY, TEST_WORKSPACE,
                     HttpStatus.SC_OK);
             assertThat(byLastSeen.content())
@@ -596,7 +601,8 @@ class AgentInsightsResourceTest {
                     API_KEY, TEST_WORKSPACE, HttpStatus.SC_NO_CONTENT);
 
             var resolvedPage = agentInsightsResourceClient.findIssues(projectId, DAY_1, DAY_1,
-                    AgentInsightsIssueStatus.RESOLVED, null, null, null, API_KEY, TEST_WORKSPACE, HttpStatus.SC_OK);
+                    AgentInsightsIssueStatus.RESOLVED, null, null, null, null, API_KEY, TEST_WORKSPACE,
+                    HttpStatus.SC_OK);
             assertThat(resolvedPage.total()).isEqualTo(1);
             assertThat(resolvedPage.content().getFirst().name()).isEqualTo(nameB);
 
@@ -620,7 +626,7 @@ class AgentInsightsResourceTest {
                     reportedIssue(nameB, countB, totalCount, impacted, totalUsers),
                     reportedIssue(nameC, countC, totalCount, impacted, totalUsers)));
 
-            var firstPage = agentInsightsResourceClient.findIssues(projectId, DAY_1, DAY_1, null,
+            var firstPage = agentInsightsResourceClient.findIssues(projectId, DAY_1, DAY_1, null, null,
                     sortBy(SortableFields.TOTAL_OCCURRENCES, Direction.DESC), 1, 2, API_KEY, TEST_WORKSPACE,
                     HttpStatus.SC_OK);
             assertThat(firstPage.total()).isEqualTo(3);
@@ -629,7 +635,7 @@ class AgentInsightsResourceTest {
                     .extracting(AgentInsightsIssue::name)
                     .containsExactly(nameA, nameB);
 
-            var secondPage = agentInsightsResourceClient.findIssues(projectId, DAY_1, DAY_1, null,
+            var secondPage = agentInsightsResourceClient.findIssues(projectId, DAY_1, DAY_1, null, null,
                     sortBy(SortableFields.TOTAL_OCCURRENCES, Direction.DESC), 2, 2, API_KEY, TEST_WORKSPACE,
                     HttpStatus.SC_OK);
             assertThat(secondPage.content())
@@ -646,7 +652,7 @@ class AgentInsightsResourceTest {
                     List.of(reportedIssue(rndName(), rndOccurrences(), rndTotalCount(), rndUserCount(),
                             rndUserCount())));
 
-            var page = agentInsightsResourceClient.findIssues(projectId, DAY_1, DAY_1, null, null, null, null,
+            var page = agentInsightsResourceClient.findIssues(projectId, DAY_1, DAY_1, null, null, null, null, null,
                     OTHER_API_KEY, OTHER_WORKSPACE, HttpStatus.SC_OK);
             assertThat(page.total()).isZero();
             assertThat(page.content()).isEmpty();
@@ -666,7 +672,7 @@ class AgentInsightsResourceTest {
         void findIssuesWhenQueryParamsAreInvalidThenBadRequest(String fromDate, String toDate, String status,
                 String sorting) {
             try (var response = agentInsightsResourceClient.findIssuesWithResponse(UUID.randomUUID(), fromDate,
-                    toDate, status, sorting, null, null, API_KEY, TEST_WORKSPACE)) {
+                    toDate, status, null, sorting, null, null, API_KEY, TEST_WORKSPACE)) {
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
             }
         }
@@ -683,7 +689,7 @@ class AgentInsightsResourceTest {
         @DisplayName("Out-of-bounds page or size returns 400")
         void findIssuesWhenPaginationOutOfBoundsThenBadRequest(int page, int size) {
             try (var response = agentInsightsResourceClient.findIssuesWithResponse(UUID.randomUUID(), null, null,
-                    null, null, page, size, API_KEY, TEST_WORKSPACE)) {
+                    null, null, null, page, size, API_KEY, TEST_WORKSPACE)) {
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
             }
         }
@@ -692,7 +698,7 @@ class AgentInsightsResourceTest {
         @DisplayName("Missing required project_id returns 400")
         void findIssuesWhenProjectIdMissingThenBadRequest() {
             try (var response = agentInsightsResourceClient.findIssuesWithResponse(null, null, null, null, null,
-                    null, null, API_KEY, TEST_WORKSPACE)) {
+                    null, null, null, API_KEY, TEST_WORKSPACE)) {
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
             }
         }
@@ -891,6 +897,92 @@ class AgentInsightsResourceTest {
     }
 
     @Nested
+    @DisplayName("Severity Behavior:")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class SeverityBehavior {
+
+        @Test
+        @DisplayName("Reported severity is returned in both the list and detail responses")
+        void severityIsStoredAndReturnedInListAndDetailResponse() {
+            var projectId = createProject();
+            var name = rndName();
+
+            report(projectId, DAY_1, List.of(
+                    reportedIssue(name, rndOccurrences(), rndTotalCount(), rndUserCount(), rndUserCount())
+                            .toBuilder().severity(AgentInsightsIssueSeverity.CRITICAL).build()));
+
+            var page = findIssues(projectId, DAY_1, DAY_1);
+            assertThat(page.total()).isEqualTo(1);
+            assertThat(page.content().getFirst().severity()).isEqualTo(AgentInsightsIssueSeverity.CRITICAL);
+
+            var issueId = page.content().getFirst().id();
+            var detail = agentInsightsResourceClient.getIssue(issueId, projectId, DAY_1, DAY_1,
+                    API_KEY, TEST_WORKSPACE, HttpStatus.SC_OK);
+            assertThat(detail.severity()).isEqualTo(AgentInsightsIssueSeverity.CRITICAL);
+        }
+
+        Stream<Arguments> severityFilterCases() {
+            return Stream.of(
+                    Arguments.of(AgentInsightsIssueSeverity.CRITICAL, 1),
+                    Arguments.of(AgentInsightsIssueSeverity.HIGH, 1),
+                    // edge: LOW was never reported — filter must return zero results, not an error
+                    Arguments.of(AgentInsightsIssueSeverity.LOW, 0));
+        }
+
+        @ParameterizedTest
+        @MethodSource("severityFilterCases")
+        @DisplayName("Severity filter returns only issues with the matching severity")
+        void findIssuesWhenSeverityFilterIsSetThenOnlyMatchingIssues(
+                AgentInsightsIssueSeverity filterSeverity, int expectedCount) {
+            var projectId = createProject();
+
+            report(projectId, DAY_1, List.of(
+                    reportedIssue(rndName(), rndOccurrences(), rndTotalCount(), rndUserCount(), rndUserCount())
+                            .toBuilder().severity(AgentInsightsIssueSeverity.CRITICAL).build(),
+                    reportedIssue(rndName(), rndOccurrences(), rndTotalCount(), rndUserCount(), rndUserCount())
+                            .toBuilder().severity(AgentInsightsIssueSeverity.HIGH).build()));
+
+            var page = agentInsightsResourceClient.findIssues(projectId, DAY_1, DAY_1, null,
+                    filterSeverity, null, null, null, API_KEY, TEST_WORKSPACE, HttpStatus.SC_OK);
+            assertThat(page.total()).isEqualTo(expectedCount);
+        }
+
+        @Test
+        @DisplayName("Sorting by severity ASC places critical (highest priority) first")
+        void findIssuesSortBySeverityAscGivesCriticalFirst() {
+            var projectId = createProject();
+            var nameLow = rndName();
+            var nameCritical = rndName();
+            var nameMedium = rndName();
+            long totalCount = rndTotalCount(), impacted = rndUserCount(), totalUsers = rndUserCount();
+
+            report(projectId, DAY_1, List.of(
+                    reportedIssue(nameLow, rndOccurrences(), totalCount, impacted, totalUsers)
+                            .toBuilder().severity(AgentInsightsIssueSeverity.LOW).build(),
+                    reportedIssue(nameCritical, rndOccurrences(), totalCount, impacted, totalUsers)
+                            .toBuilder().severity(AgentInsightsIssueSeverity.CRITICAL).build(),
+                    reportedIssue(nameMedium, rndOccurrences(), totalCount, impacted, totalUsers)
+                            .toBuilder().severity(AgentInsightsIssueSeverity.MEDIUM).build()));
+
+            var ascPage = agentInsightsResourceClient.findIssues(projectId, DAY_1, DAY_1, null, null,
+                    sortBy(SortableFields.SEVERITY, Direction.ASC), null, null, API_KEY, TEST_WORKSPACE,
+                    HttpStatus.SC_OK);
+            assertThat(ascPage.content())
+                    .extracting(AgentInsightsIssue::name)
+                    .containsExactly(nameCritical, nameMedium, nameLow);
+        }
+
+        @Test
+        @DisplayName("Unknown severity query param value returns 400")
+        void findIssuesWhenUnknownSeverityParamThenBadRequest() {
+            try (var response = agentInsightsResourceClient.findIssuesWithResponse(UUID.randomUUID(), null, null,
+                    null, "unknown-severity", null, null, null, API_KEY, TEST_WORKSPACE)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+            }
+        }
+    }
+
+    @Nested
     @DisplayName("Date Range Validation:")
     class DateRangeValidation {
 
@@ -902,7 +994,7 @@ class AgentInsightsResourceTest {
             var fromDate = DAY_2;
             var toDate = DAY_1;
 
-            agentInsightsResourceClient.findIssues(projectId, fromDate, toDate, null, null, null, null,
+            agentInsightsResourceClient.findIssues(projectId, fromDate, toDate, null, null, null, null, null,
                     API_KEY, TEST_WORKSPACE, HttpStatus.SC_BAD_REQUEST);
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentInsightsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentInsightsResourceTest.java
@@ -233,6 +233,7 @@ class AgentInsightsResourceTest {
                     .cause("Cause of " + nameA)
                     .suggestedFix("Fix for " + nameA)
                     .status(AgentInsightsIssueStatus.OPEN)
+                    .severity(AgentInsightsIssueSeverity.MEDIUM)
                     .tracesQuery("SELECT 1")
                     .totalOccurrences(occurrences)
                     .total(totalCount)


### PR DESCRIPTION
## Details

Severity is computed by the insights agent and was previously stored only in the free-form `metadata` JSON blob on `agent_insights_issues_details`. The list endpoint aggregates details but never surfaces `metadata`, so severity was invisible to all API consumers on the most-used endpoint.

This change promotes `severity` to a typed `ENUM` column on `agent_insights_issues`, making it:
- **Required** on the ingest payload (`ReportedIssue.severity @NotNull`)
- **Returned** in both the list (`GET /issues`) and single-issue (`GET /issues/{id}`) responses
- **Filterable** via `?severity=` query param (matching the existing `status` filter pattern)
- **Sortable** via the sorting param (ENUM ordinal order: `critical → high → medium → low`)

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Sonnet 4.6 (1M context)
  - Scope: full implementation
  - Human verification: code review pending

## Testing

- `mvn compile -DskipTests` — passes
- `mvn spotless:check` — passes (no formatting violations)
- Manual end-to-end testing pending (requires running DB migration and hitting endpoints):
  1. POST report with `severity: "high"` → confirm 200
  2. POST report without `severity` → confirm 400 (required field)
  3. GET issues list → confirm `severity` appears per issue
  4. GET issues list with `?severity=critical` → confirm filter works
  5. Existing rows with NULL severity → confirm list still returns without error

## Documentation

N/A — internal API used by the insights agent only