### PR TITLE
[NA] [BUILD] ci: add ai_spend_plugin_ref input to build comet frontend from a plugin branch

### DIFF
--- a/.github/workflows/build_and_push_docker.yaml
+++ b/.github/workflows/build_and_push_docker.yaml
@@ -44,7 +44,7 @@ on:
         type: string
         required: false
         default: "main"
-        description: Git ref (branch/tag/SHA) of opik-plugin-ai-spend to bake into the comet frontend
+        description: ai-spend plugin ref
     secrets:
       OPIK_FE_SENTRY_DSN:
         required: false

--- a/.github/workflows/build_and_push_docker.yaml
+++ b/.github/workflows/build_and_push_docker.yaml
@@ -40,6 +40,11 @@ on:
         required: false
         description: Build multiarch images
         default: true
+      ai_spend_plugin_ref:
+        type: string
+        required: false
+        default: "main"
+        description: Git ref (branch/tag/SHA) of opik-plugin-ai-spend to bake into the comet frontend
     secrets:
       OPIK_FE_SENTRY_DSN:
         required: false
@@ -133,7 +138,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: comet-ml/opik-plugin-ai-spend
-          ref: main
+          ref: ${{ inputs.ai_spend_plugin_ref }}
           token: ${{ secrets.OPIK_PLUGIN_AI_SPEND_TOKEN }}
           path: .ai-spend-plugin
 

--- a/.github/workflows/build_apps.yml
+++ b/.github/workflows/build_apps.yml
@@ -31,6 +31,11 @@ on:
         required: false
         description: Build multiarch images
         default: true
+      ai_spend_plugin_ref:
+        type: string
+        required: false
+        description: opik-plugin-ai-spend ref (branch/tag/SHA) to bake into the comet frontend
+        default: "main"
   workflow_call:
     inputs:
       version:
@@ -61,6 +66,11 @@ on:
         required: false
         description: Build multiarch images
         default: true
+      ai_spend_plugin_ref:
+        type: string
+        required: false
+        description: opik-plugin-ai-spend ref (branch/tag/SHA) to bake into the comet frontend
+        default: "main"
 
     outputs:
       version:
@@ -195,6 +205,7 @@ jobs:
       is_release: ${{ inputs.is_release || false }}
       is_adhoc: ${{ inputs.is_adhoc || false }}
       build_arm64: ${{ github.event_name == 'push' || inputs.build_arm64 }}
+      ai_spend_plugin_ref: ${{ inputs.ai_spend_plugin_ref || 'main' }}
 
   create-git-tag:
     if: |

--- a/.github/workflows/build_apps.yml
+++ b/.github/workflows/build_apps.yml
@@ -34,7 +34,7 @@ on:
       ai_spend_plugin_ref:
         type: string
         required: false
-        description: opik-plugin-ai-spend ref (branch/tag/SHA) to bake into the comet frontend
+        description: ai-spend plugin ref
         default: "main"
   workflow_call:
     inputs:
@@ -69,7 +69,7 @@ on:
       ai_spend_plugin_ref:
         type: string
         required: false
-        description: opik-plugin-ai-spend ref (branch/tag/SHA) to bake into the comet frontend
+        description: ai-spend plugin ref
         default: "main"
 
     outputs:


### PR DESCRIPTION
## Details

<img width="497" height="585" alt="image" src="https://github.com/user-attachments/assets/6a501ec0-fe68-4916-8038-6ccf13e45a7e" />


Adds an `ai_spend_plugin_ref` input (default `main`) that is threaded through `build_apps.yml` into the reusable `build_and_push_docker.yaml`, where it sets the checkout `ref` of the private `comet-ml/opik-plugin-ai-spend` repo. Previously that ref was hardcoded to `main`, so a plugin feature branch could only reach a built image after merging to the plugin's `main`. With this change you can build a comet frontend image from any plugin branch — e.g. via a manual **Build Opik Docker Images** dispatch — and deploy it to a dev environment without merging first.

- Exposed as a `workflow_dispatch` input so it appears as a field in the GitHub "Run workflow" UI.
- Also added to `workflow_call` inputs so programmatic callers (e.g. the test-env trigger) keep working.
- Default stays `main`, so the `main` push build, the `test-environment` label path, and releases are all unchanged.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: full implementation
  - Human verification: code review + YAML parse/structure validation

## Testing

- Verified both workflow files parse as valid YAML (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Verified the input wiring via parsed YAML: `ai_spend_plugin_ref` present in both `workflow_dispatch.inputs` and `workflow_call.inputs` of `build_apps.yml`; `build-frontend` passes `${{ inputs.ai_spend_plugin_ref || 'main' }}`; `build_and_push_docker.yaml` declares the input with `default: main` / `required: false` and uses it at the plugin checkout `ref`.
- Not run: `actionlint` (not installed locally). The added expressions mirror the existing `github.event_name == 'push' || inputs.build_arm64` pattern already in the same file.
- End-to-end CI build/deploy not exercised yet — to be validated by a manual dispatch with a real plugin branch.

## Documentation

N/A