### PR TITLE
[OPIK-7034] [BE] Fix thread annotation queue JOIN conditional in COUNT and STATS queries

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
@@ -590,7 +590,7 @@ class ThreadDAOImpl implements ThreadDAO {
                 FROM feedback_scores_grouped
             )
             <endif>
-            <if(annotation_queue_filters)>
+            <if(annotation_queue_filters || annotation_queue_id)>
             , thread_annotation_queue_ids AS (
                  SELECT thread_id,
                         groupArray(id) AS annotation_queue_ids
@@ -664,7 +664,7 @@ class ThreadDAOImpl implements ThreadDAO {
                 <if(uuid_from_time)>INNER<else>LEFT<endif> JOIN trace_threads_final AS tt ON t.workspace_id = tt.workspace_id
                     AND t.project_id = tt.project_id
                     AND t.id = tt.thread_id
-                <if(annotation_queue_filters)>
+                <if(annotation_queue_filters || annotation_queue_id)>
                 LEFT JOIN thread_annotation_queue_ids as ttaqi ON ttaqi.thread_id = tt.thread_model_id
                 <endif>
                 WHERE workspace_id = :workspace_id
@@ -1243,7 +1243,7 @@ class ThreadDAOImpl implements ThreadDAO {
                     AND t.project_id = tt.project_id
                     AND t.id = tt.thread_id
                 LEFT JOIN feedback_scores_agg fsagg ON fsagg.entity_id = tt.thread_model_id
-                <if(annotation_queue_filters)>
+                <if(annotation_queue_filters || annotation_queue_id)>
                 LEFT JOIN thread_annotation_queue_ids as ttaqi ON ttaqi.thread_id = tt.thread_model_id
                 <endif>
                 WHERE workspace_id = :workspace_id


### PR DESCRIPTION
## Details

Opening a thread-scoped annotation queue in the SME flow crashes with `Unknown expression or function identifier 'ttaqi.annotation_queue_ids'` because the COUNT and STATS queries in `ThreadDAO.java` gate the `ttaqi` JOIN on `<if(annotation_queue_filters)>` only, while the WHERE clause references `ttaqi` under `<if(annotation_queue_id)>`. When the SME flow sets `annotation_queue_id` without `annotation_queue_filters`, the JOIN is skipped but the WHERE still tries to use the unjoined alias.

Fix: widen the conditional from `<if(annotation_queue_filters)>` to `<if(annotation_queue_filters || annotation_queue_id)>` on the CTE (COUNT query) and JOIN (COUNT + STATS queries), matching the LIST query and TraceDAO pattern.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-7034

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-4-6
- Scope: Investigation, fix, PR creation
- Human verification: Root cause confirmed, fix reviewed and adjusted per feedback

## Testing

- `mvn compile -DskipTests` — passes
- Manual verification: confirmed that with `annotation_queue_id` set and no `annotation_queue_filters`, all three queries (LIST, COUNT, STATS) now produce valid SQL with the `ttaqi` alias properly joined

## Documentation

N/A