### PR TITLE
[OPIK-7036] [CI] chore: add CODEOWNERS entry for /.github/actions/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 *.mdx @comet-ml/product @comet-ml/comet-opik-devs
 
 /.github/ISSUE_TEMPLATE/ @comet-ml/product @comet-ml/comet-opik-devs
+/.github/actions/ @comet-ml/comet-devops @comet-ml/comet-qa @comet-ml/comet-opik-devs
 /.github/workflows/ @comet-ml/comet-devops @comet-ml/comet-qa @comet-ml/comet-opik-devs
 
 /apps/opik-documentation/ @comet-ml/product @comet-ml/comet-opik-devs


### PR DESCRIPTION
## Details

<img width="1920" height="1622" alt="image" src="https://github.com/user-attachments/assets/3694b6b0-16f5-4949-bcde-36d7c06a1c5c" />

The `.github/actions/` directory holds reusable composite actions used by our CI workflows, but it had no explicit CODEOWNERS entry — it fell back to the catch-all `* @comet-ml/comet-opik-devs`. As a result `@comet-ml/comet-devops`, who own CI/automation infrastructure (and already own `/.github/workflows/` and `/deployment/`), were not auto-requested and could not gate changes to their own actions. This adds a `/.github/actions/` ownership line mirroring the existing `/.github/workflows/` entry.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-7036

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: full implementation (single-line CODEOWNERS edit)
  - Human verification: code review

## Testing

No build/test impact — the change is limited to `.github/CODEOWNERS`.

- `git diff origin/main -- .github/CODEOWNERS` shows only the one added line.
- CODEOWNERS syntax follows the existing entries (same path + team-handle format as `/.github/workflows/`); all three teams are already referenced elsewhere in the file, so they resolve without GitHub validation warnings.
- After merge, a PR touching `.github/actions/**` will auto-request `@comet-ml/comet-devops`, `@comet-ml/comet-qa`, and `@comet-ml/comet-opik-devs`.

## Documentation

N/A
