### PR TITLE
[NA] [SDK] feat: enrich opik-vercel exporter for AI SDK v7 / Vercel eve

### DIFF
--- a/.github/workflows/typescript_sdk_library_integration_tests.yml
+++ b/.github/workflows/typescript_sdk_library_integration_tests.yml
@@ -1,0 +1,69 @@
+# Real library integration tests for the TypeScript SDK.
+#
+# Mirrors the Python `lib-integration-tests-runner.yml`: runs the integration
+# packages' test suites on TypeScript SDK PRs, with provider API keys supplied
+# from secrets so the gated live-LLM tests execute. Deterministic tests in the
+# same packages run regardless; the live tests skip themselves when their key
+# is absent (e.g. fork PRs), so the job stays green either way.
+name: TypeScript SDK Library Integration Tests
+run-name: "TypeScript SDK Library Integration Tests ${{ github.ref_name }} by @${{ github.actor }}"
+permissions:
+  contents: read
+on:
+  pull_request:
+    paths:
+      - "sdks/typescript/**"
+  push:
+    branches:
+      - "main"
+    paths:
+      - "sdks/typescript/**"
+  workflow_dispatch:
+  schedule:
+    # Daily at midnight UTC, Monday-Saturday.
+    - cron: "0 0 * * 1-6"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+jobs:
+  check_secrets:
+    name: Check Secrets
+    runs-on: ubuntu-latest
+    outputs:
+      has_anthropic_key: ${{ steps.check.outputs.has_anthropic_key }}
+    steps:
+      - name: Detect available provider keys
+        id: check
+        run: echo "has_anthropic_key=${{ secrets.ANTHROPIC_API_KEY != '' }}" >> "$GITHUB_OUTPUT"
+
+  vercel:
+    name: opik-vercel (Vercel AI SDK / eve)
+    needs: [check_secrets]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: sdks/typescript/src/opik/integrations/opik-vercel
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.2.0
+        with:
+          node-version: "22"
+
+      - name: Warn when ANTHROPIC_API_KEY is absent
+        if: ${{ needs.check_secrets.outputs.has_anthropic_key == 'false' }}
+        run: echo "::warning::ANTHROPIC_API_KEY is not set - live LLM tests will be skipped (deterministic tests still run)."
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/sdks/typescript/src/opik/integrations/opik-vercel/package-lock.json
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.70",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@ai-sdk/anthropic": "^3.0.85",
         "@eslint/js": "^9.38.0",
         "@opentelemetry/auto-instrumentations-node": "^0.66.0",
         "ai": "^6.0.13",
@@ -30,6 +31,54 @@
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/sdk-node": ">=0.56.0",
         "opik": "^1.8.75"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.85",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.85.tgz",
+      "integrity": "sha512-fNeDB644l5wbRNQU0FnI+F7UTtOenMnPtACfMPUJaS2zJfuBlseEa1TMg+otHkETZgaJB+6Na51NQEv0+m7czw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.30"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.30",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.30.tgz",
+      "integrity": "sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -4444,9 +4493,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/sdks/typescript/src/opik/integrations/opik-vercel/package.json
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/package.json
@@ -64,6 +64,7 @@
     "@opentelemetry/sdk-node": ">=0.56.0"
   },
   "devDependencies": {
+    "@ai-sdk/anthropic": "^3.0.85",
     "@eslint/js": "^9.38.0",
     "@opentelemetry/auto-instrumentations-node": "^0.66.0",
     "ai": "^6.0.13",

--- a/sdks/typescript/src/opik/integrations/opik-vercel/src/attributes.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/src/attributes.ts
@@ -311,15 +311,12 @@ const genAi = {
   metadata(attributes: Attributes): Record<string, unknown> {
     const metadata: Record<string, unknown> = {};
 
-    const model =
-      attributes["gen_ai.response.model"] ?? attributes["gen_ai.request.model"];
+    const model = getModel(attributes);
     if (model) {
       metadata.model = model;
     }
 
-    // `gen_ai.system` (v6) and `gen_ai.provider.name` (v7) both name the provider.
-    const provider =
-      attributes["gen_ai.system"] ?? attributes["gen_ai.provider.name"];
+    const provider = getProvider(attributes);
     if (provider) {
       metadata.provider = provider;
     }
@@ -380,6 +377,21 @@ const LLM_OPERATIONS = new Set([
   "generate_content",
   "embeddings",
 ]);
+
+// The model id and provider — the Opik backend needs both (plus usage) on the
+// LLM span to compute estimated cost. `gen_ai.system` (v6) and
+// `gen_ai.provider.name` (v7) both name the provider (e.g. "anthropic").
+export function getModel(attributes: Attributes): string | undefined {
+  const model =
+    attributes["gen_ai.response.model"] ?? attributes["gen_ai.request.model"];
+  return model != null ? String(model) : undefined;
+}
+
+export function getProvider(attributes: Attributes): string | undefined {
+  const provider =
+    attributes["gen_ai.system"] ?? attributes["gen_ai.provider.name"];
+  return provider != null ? String(provider) : undefined;
+}
 
 export function getSpanType(attributes: Attributes): SpanType {
   const operation = attributes["gen_ai.operation.name"];

--- a/sdks/typescript/src/opik/integrations/opik-vercel/src/attributes.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/src/attributes.ts
@@ -1,0 +1,430 @@
+import type { Attributes } from "@opentelemetry/api";
+import type { SpanType } from "opik";
+
+/**
+ * The Vercel AI SDK has shipped two OpenTelemetry conventions, and we support
+ * both:
+ *
+ * - `aiSdk` — AI SDK v4/v5/v6, which emit `ai.*` span attributes.
+ * - `genAi` — AI SDK v7 (and frameworks built on it, such as Vercel eve),
+ *   which emit OpenTelemetry GenAI `gen_ai.*` attributes (plus eve's own
+ *   `eve.*` / `ai.settings.context.eve.*` context).
+ *
+ * Each convention parser below reads only its own keys. The exported `getSpan*`
+ * helpers merge both, so a span is captured regardless of which version
+ * produced it, and a key from one convention can never shadow the other.
+ */
+
+function safeParseJson(value: unknown): unknown {
+  try {
+    return JSON.parse(value as string);
+  } catch {
+    return value;
+  }
+}
+
+function parseJsonObject(input: unknown): Record<string, unknown> | undefined {
+  if (typeof input !== "string") {
+    return undefined;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(input);
+
+    if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+type ChatMessage = {
+  role: string;
+  content?: unknown;
+  tool_calls?: Array<{
+    id?: string;
+    type: "function";
+    function: { name?: string; arguments: string };
+  }>;
+  tool_call_id?: string;
+};
+
+function stringifyContent(value: unknown): string {
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+// Normalize one AI SDK v7 GenAI message into OpenAI chat messages (the shape the
+// Opik UI pretty-renders). AI SDK / eve wrap content in `parts`, where each part
+// is text, a tool call, or a tool result; OpenAI expects `content`, `tool_calls`,
+// and separate `tool` messages. Messages already in `{ role, content }` shape
+// pass through unchanged.
+function normalizeMessage(message: unknown): ChatMessage[] {
+  if (message == null || typeof message !== "object") {
+    return [];
+  }
+
+  const { role, parts } = message as {
+    role?: string;
+    parts?: unknown;
+  };
+  const resolvedRole = role ?? "user";
+
+  if (!Array.isArray(parts)) {
+    // Already OpenAI/AI-SDK-native (`content` string or `[{type,text}]`).
+    return [message as ChatMessage];
+  }
+
+  const messages: ChatMessage[] = [];
+  const textChunks: string[] = [];
+  const toolCalls: NonNullable<ChatMessage["tool_calls"]> = [];
+
+  for (const part of parts) {
+    if (part == null || typeof part !== "object") {
+      continue;
+    }
+
+    const typed = part as Record<string, unknown>;
+
+    if (typed.type === "text") {
+      textChunks.push(String(typed.content ?? typed.text ?? ""));
+    } else if (typed.type === "tool_call") {
+      toolCalls.push({
+        id: typed.id as string | undefined,
+        type: "function",
+        function: {
+          name: typed.name as string | undefined,
+          arguments: stringifyContent(typed.arguments),
+        },
+      });
+    } else if (typed.type === "tool_call_response") {
+      // Tool results become their own `tool` message in OpenAI format.
+      messages.push({
+        role: "tool",
+        tool_call_id: typed.id as string | undefined,
+        content: stringifyContent(typed.response ?? typed.output),
+      });
+    }
+  }
+
+  if (textChunks.length > 0 || toolCalls.length > 0) {
+    const normalized: ChatMessage = { role: resolvedRole };
+
+    if (textChunks.length > 0 || toolCalls.length === 0) {
+      normalized.content = textChunks.join("");
+    }
+
+    if (toolCalls.length > 0) {
+      normalized.tool_calls = toolCalls;
+    }
+
+    messages.unshift(normalized);
+  }
+
+  return messages;
+}
+
+function toChatMessages(raw: unknown): ChatMessage[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return raw.flatMap(normalizeMessage);
+}
+
+// AI SDK v4/v5/v6 — `ai.*` attributes.
+const aiSdk = {
+  input(attributes: Attributes): Record<string, unknown> {
+    let input: Record<string, unknown> = {};
+
+    for (const key of Object.keys(attributes)) {
+      if (key === "ai.prompt") {
+        const parsed = parseJsonObject(attributes[key]);
+
+        if (parsed) {
+          input = { ...input, ...parsed };
+        }
+      } else if (key.startsWith("ai.prompt.")) {
+        input[key.slice("ai.prompt.".length)] = safeParseJson(attributes[key]);
+      }
+    }
+
+    if ("ai.toolCall.name" in attributes) {
+      input.toolName = attributes["ai.toolCall.name"];
+    }
+
+    if ("ai.toolCall.args" in attributes) {
+      input.args = safeParseJson(attributes["ai.toolCall.args"]);
+    }
+
+    return input;
+  },
+
+  output(attributes: Attributes): Record<string, unknown> {
+    const output: Record<string, unknown> = {};
+
+    if (attributes["ai.response.text"]) {
+      output.text = attributes["ai.response.text"];
+    }
+
+    if (attributes["ai.response.object"]) {
+      output.object = safeParseJson(attributes["ai.response.object"]);
+    }
+
+    if (attributes["ai.response.toolCalls"]) {
+      output.toolCalls = safeParseJson(attributes["ai.response.toolCalls"]);
+    }
+
+    if (attributes["ai.toolCall.result"]) {
+      output.result = safeParseJson(attributes["ai.toolCall.result"]);
+    }
+
+    return output;
+  },
+
+  usage(attributes: Attributes): Record<string, number> {
+    const usage: Record<string, number> = {};
+
+    if ("ai.usage.promptTokens" in attributes) {
+      usage.prompt_tokens = Number(attributes["ai.usage.promptTokens"]);
+    }
+
+    if ("ai.usage.completionTokens" in attributes) {
+      usage.completion_tokens = Number(attributes["ai.usage.completionTokens"]);
+    }
+
+    return usage;
+  },
+};
+
+// AI SDK v7 / OpenTelemetry GenAI — `gen_ai.*` attributes.
+const genAi = {
+  input(attributes: Attributes): Record<string, unknown> {
+    let input: Record<string, unknown> = {};
+
+    for (const key of Object.keys(attributes)) {
+      if (key === "gen_ai.request") {
+        const parsed = parseJsonObject(attributes[key]);
+
+        if (parsed) {
+          input = { ...input, ...parsed };
+        }
+      } else if (key.startsWith("gen_ai.request.")) {
+        input[key.slice("gen_ai.request.".length)] = safeParseJson(
+          attributes[key]
+        );
+      }
+    }
+
+    // The prompt arrives as a serialized message array; the system prompt is a
+    // separate attribute. Emit OpenAI-style `messages` so the UI pretty-renders
+    // the conversation, with the system prompt as the leading message.
+    if ("gen_ai.input.messages" in attributes) {
+      const systemMessages: ChatMessage[] = [];
+
+      if ("gen_ai.system_instructions" in attributes) {
+        const system = safeParseJson(attributes["gen_ai.system_instructions"]);
+        const content = Array.isArray(system)
+          ? system
+              .map((part) =>
+                part && typeof part === "object"
+                  ? String((part as Record<string, unknown>).content ?? (part as Record<string, unknown>).text ?? "")
+                  : String(part)
+              )
+              .join("")
+          : stringifyContent(system);
+
+        systemMessages.push({ role: "system", content });
+      }
+
+      input.messages = [
+        ...systemMessages,
+        ...toChatMessages(safeParseJson(attributes["gen_ai.input.messages"])),
+      ];
+    }
+
+    if ("gen_ai.tool.name" in attributes) {
+      input.toolName = attributes["gen_ai.tool.name"];
+    }
+
+    if ("gen_ai.tool.call.arguments" in attributes) {
+      input.args = safeParseJson(attributes["gen_ai.tool.call.arguments"]);
+    }
+
+    return input;
+  },
+
+  output(attributes: Attributes): Record<string, unknown> {
+    const output: Record<string, unknown> = {};
+
+    // Emit OpenAI-style `choices` so the UI pretty-renders the model response.
+    if ("gen_ai.output.messages" in attributes) {
+      const raw = safeParseJson(attributes["gen_ai.output.messages"]);
+      const rawList = Array.isArray(raw) ? raw : [];
+
+      output.choices = toChatMessages(raw).map((message, index) => {
+        const source = rawList[index];
+        const finishReason =
+          source && typeof source === "object"
+            ? ((source as Record<string, unknown>).finish_reason ?? null)
+            : null;
+
+        return { index, message, finish_reason: finishReason };
+      });
+    }
+
+    if ("gen_ai.tool.call.result" in attributes) {
+      output.result = safeParseJson(attributes["gen_ai.tool.call.result"]);
+    }
+
+    return output;
+  },
+
+  usage(attributes: Attributes): Record<string, number> {
+    const usage: Record<string, number> = {};
+
+    if ("gen_ai.usage.input_tokens" in attributes) {
+      usage.prompt_tokens = Number(attributes["gen_ai.usage.input_tokens"]);
+    }
+
+    if ("gen_ai.usage.output_tokens" in attributes) {
+      usage.completion_tokens = Number(attributes["gen_ai.usage.output_tokens"]);
+    }
+
+    if ("gen_ai.usage.cache_read.input_tokens" in attributes) {
+      usage["original_usage.cache_read_input_tokens"] = Number(
+        attributes["gen_ai.usage.cache_read.input_tokens"]
+      );
+    }
+
+    if ("gen_ai.usage.cache_creation.input_tokens" in attributes) {
+      usage["original_usage.cache_creation_input_tokens"] = Number(
+        attributes["gen_ai.usage.cache_creation.input_tokens"]
+      );
+    }
+
+    return usage;
+  },
+
+  metadata(attributes: Attributes): Record<string, unknown> {
+    const metadata: Record<string, unknown> = {};
+
+    const model =
+      attributes["gen_ai.response.model"] ?? attributes["gen_ai.request.model"];
+    if (model) {
+      metadata.model = model;
+    }
+
+    // `gen_ai.system` (v6) and `gen_ai.provider.name` (v7) both name the provider.
+    const provider =
+      attributes["gen_ai.system"] ?? attributes["gen_ai.provider.name"];
+    if (provider) {
+      metadata.provider = provider;
+    }
+
+    if ("gen_ai.operation.name" in attributes) {
+      metadata.operation = attributes["gen_ai.operation.name"];
+    }
+
+    if ("gen_ai.response.finish_reasons" in attributes) {
+      metadata.finish_reasons = safeParseJson(
+        attributes["gen_ai.response.finish_reasons"]
+      );
+    }
+
+    // eve framework context, exposed as `eve.*` on the turn root span and
+    // `ai.settings.context.eve.*` on model-call spans.
+    for (const key of Object.keys(attributes)) {
+      if (key.startsWith("eve.")) {
+        metadata[key] = attributes[key];
+      } else if (key.startsWith("ai.settings.context.eve.")) {
+        metadata[key.slice("ai.settings.context.".length)] = attributes[key];
+      }
+    }
+
+    return metadata;
+  },
+};
+
+export function getSpanInput(attributes: Attributes): Record<string, unknown> {
+  return { ...aiSdk.input(attributes), ...genAi.input(attributes) };
+}
+
+export function getSpanOutput(attributes: Attributes): Record<string, unknown> {
+  return { ...aiSdk.output(attributes), ...genAi.output(attributes) };
+}
+
+export function getSpanMetadata(
+  attributes: Attributes
+): Record<string, unknown> {
+  return genAi.metadata(attributes);
+}
+
+export function getSpanUsage(attributes: Attributes): Record<string, number> {
+  const usage = { ...aiSdk.usage(attributes), ...genAi.usage(attributes) };
+
+  if ("prompt_tokens" in usage || "completion_tokens" in usage) {
+    usage.total_tokens =
+      (usage.prompt_tokens || 0) + (usage.completion_tokens || 0);
+  }
+
+  return usage;
+}
+
+// Operations that represent an actual model call (OpenTelemetry GenAI).
+const LLM_OPERATIONS = new Set([
+  "chat",
+  "text_completion",
+  "generate_content",
+  "embeddings",
+]);
+
+export function getSpanType(attributes: Attributes): SpanType {
+  const operation = attributes["gen_ai.operation.name"];
+
+  if (
+    operation === "execute_tool" ||
+    "ai.toolCall.name" in attributes ||
+    "gen_ai.tool.name" in attributes
+  ) {
+    return "tool";
+  }
+
+  if (typeof operation === "string") {
+    // Model calls are "llm"; agent/step/other orchestration ops are "general".
+    return LLM_OPERATIONS.has(operation) ? "llm" : "general";
+  }
+
+  // No GenAI operation (AI SDK v4/v5/v6 `ai.*` spans, or eve's turn span):
+  // treat spans carrying model I/O as llm, everything else as general.
+  const isModelCall =
+    "ai.prompt" in attributes ||
+    "ai.response.text" in attributes ||
+    "ai.response.object" in attributes ||
+    "ai.usage.promptTokens" in attributes ||
+    "ai.usage.completionTokens" in attributes;
+
+  return isModelCall ? "llm" : "general";
+}
+
+// The session/thread id a span belongs to, if any. eve groups multi-turn
+// conversations under a session id, exposed on the turn root span
+// (`eve.session.id`) and on model-call spans
+// (`ai.settings.context.eve.session.id`).
+export function getThreadId(attributes: Attributes): string | undefined {
+  if (attributes["ai.telemetry.metadata.threadId"] != null) {
+    return attributes["ai.telemetry.metadata.threadId"].toString();
+  }
+
+  if (attributes["eve.session.id"] != null) {
+    return attributes["eve.session.id"].toString();
+  }
+
+  if (attributes["ai.settings.context.eve.session.id"] != null) {
+    return attributes["ai.settings.context.eve.session.id"].toString();
+  }
+
+  return undefined;
+}

--- a/sdks/typescript/src/opik/integrations/opik-vercel/src/exporter.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/src/exporter.ts
@@ -4,6 +4,8 @@ import type { ExportResultCode } from "@opentelemetry/core";
 import type { NodeSDKConfiguration } from "@opentelemetry/sdk-node";
 import { Opik, generateId, logger } from "opik";
 import {
+  getModel,
+  getProvider,
   getSpanInput,
   getSpanMetadata,
   getSpanOutput,
@@ -325,6 +327,17 @@ export class OpikExporter implements SpanExporter {
           : undefined;
       const spanErrorInfo = this.getErrorInfo(otelSpan);
       const spanType = getSpanType(otelSpan.attributes);
+      // Only LLM spans carry model/provider and token usage. The backend prices
+      // a span from its model + provider + usage; eve also repeats the model
+      // call's usage on the agent/step wrapper spans, so keeping any of these on
+      // non-LLM spans would mislabel them and double-count the trace total.
+      const llmFields =
+        spanType === "llm"
+          ? {
+              ...withModelProvider(otelSpan.attributes),
+              usage: getSpanUsage(otelSpan.attributes),
+            }
+          : {};
 
       this.client.spanBatchQueue.create({
         id: this.opikSpanId(otelSpanId),
@@ -337,13 +350,7 @@ export class OpikExporter implements SpanExporter {
         input: getSpanInput(otelSpan.attributes),
         output: getSpanOutput(otelSpan.attributes),
         metadata: getSpanMetadata(otelSpan.attributes),
-        // Only LLM spans carry token usage. eve emits the same usage on both
-        // the agent/step wrapper and the underlying model-call span, so keeping
-        // it on non-LLM spans would double-count when the trace usage is
-        // aggregated across spans.
-        ...(spanType === "llm"
-          ? { usage: getSpanUsage(otelSpan.attributes) }
-          : {}),
+        ...llmFields,
         projectName,
         ...(spanErrorInfo && { errorInfo: spanErrorInfo }),
       });
@@ -473,6 +480,20 @@ function mergeMetadata(otelSpans: ReadableSpan[]): Record<string, unknown> {
   }
 
   return metadata;
+}
+
+// The model/provider span fields the backend uses to price a span, omitting
+// either when unknown.
+function withModelProvider(
+  attributes: ReadableSpan["attributes"]
+): { model?: string; provider?: string } {
+  const model = getModel(attributes);
+  const provider = getProvider(attributes);
+
+  return {
+    ...(model ? { model } : {}),
+    ...(provider ? { provider } : {}),
+  };
 }
 
 // Each span's parent: a real OTel parent link when the parent is one of our

--- a/sdks/typescript/src/opik/integrations/opik-vercel/src/exporter.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/src/exporter.ts
@@ -231,10 +231,11 @@ export class OpikExporter implements SpanExporter {
     const rootOtelSpan = pickRootSpan(otelSpans, parentOf);
     const rootOtelSpanId = rootOtelSpan.spanContext().spanId;
 
-    // Prefer the root span's own input/output/usage — this preserves AI SDK
-    // v4/v5/v6, where the root model call carries them. Fall back to the
-    // model-call spans when the root is an orchestration span that carries none
-    // (e.g. eve's `ai.eve.turn`).
+    // Prefer the root span's own input/output — this preserves AI SDK v4/v5/v6,
+    // where the root model call carries them. Fall back to the model-call spans
+    // when the root is an orchestration span that carries none (e.g. eve's
+    // `ai.eve.turn`). Token usage is intentionally NOT set on the trace: it
+    // lives only on LLM spans, and the trace total is aggregated from them.
     const llmSpans = sortByStart(
       otelSpans.filter((otelSpan) => getSpanType(otelSpan.attributes) === "llm")
     );
@@ -244,9 +245,6 @@ export class OpikExporter implements SpanExporter {
     );
     const output = preferRoot(getSpanOutput(rootOtelSpan.attributes), () =>
       lastNonEmpty(llmSpans, getSpanOutput)
-    );
-    const usage = preferRoot(getSpanUsage(rootOtelSpan.attributes), () =>
-      firstNonEmpty(llmSpans, getSpanUsage)
     );
 
     const errorInfo =
@@ -264,7 +262,6 @@ export class OpikExporter implements SpanExporter {
       output,
       metadata: { ...mergeMetadata(otelSpans), ...this.metadata },
       tags: this.tags,
-      usage,
       threadId: this.resolveThreadId(otelSpans),
       projectName,
       ...(errorInfo && { errorInfo }),

--- a/sdks/typescript/src/opik/integrations/opik-vercel/src/exporter.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/src/exporter.ts
@@ -284,19 +284,26 @@ export class OpikExporter implements SpanExporter {
           ? this.opikSpanId(parentOtelSpanId)
           : undefined;
       const spanErrorInfo = this.getErrorInfo(otelSpan);
+      const spanType = getSpanType(otelSpan.attributes);
 
       this.client.spanBatchQueue.create({
         id: this.opikSpanId(otelSpanId),
         traceId,
         ...(parentSpanId ? { parentSpanId } : {}),
         name: otelSpan.name,
-        type: getSpanType(otelSpan.attributes),
+        type: spanType,
         startTime: new Date(startMs(otelSpan)),
         endTime: new Date(endMs(otelSpan)),
         input: getSpanInput(otelSpan.attributes),
         output: getSpanOutput(otelSpan.attributes),
         metadata: getSpanMetadata(otelSpan.attributes),
-        usage: getSpanUsage(otelSpan.attributes),
+        // Only LLM spans carry token usage. eve emits the same usage on both
+        // the agent/step wrapper and the underlying model-call span, so keeping
+        // it on non-LLM spans would double-count when the trace usage is
+        // aggregated across spans.
+        ...(spanType === "llm"
+          ? { usage: getSpanUsage(otelSpan.attributes) }
+          : {}),
         projectName,
         ...(spanErrorInfo && { errorInfo: spanErrorInfo }),
       });

--- a/sdks/typescript/src/opik/integrations/opik-vercel/src/exporter.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/src/exporter.ts
@@ -41,9 +41,20 @@ type OpikExporterOptions = {
   tags?: string[];
   metadata?: Record<string, AttributeValue>;
   threadId?: string;
+  /**
+   * How long (ms) to retain a trace's accumulated spans/ids after its last
+   * activity before pruning them, to bound memory in long-running processes.
+   * A trace idle longer than this is assumed complete. Defaults to 10 minutes.
+   */
+  traceTtlMs?: number;
 };
 
 const aiSDKClient = new Opik();
+
+// A turn's spans arrive across export batches; we keep accumulating until a
+// trace has been idle this long, then prune it. Generous enough not to drop
+// in-flight turns (durable eve sessions can pause between turns).
+const DEFAULT_TRACE_TTL_MS = 10 * 60 * 1000;
 
 // Instrumentation scopes we ingest. AI SDK v4/v5/v6 emit scope "ai"; AI SDK v7
 // (and frameworks built on it, such as Vercel eve) emit the OpenTelemetry GenAI
@@ -65,22 +76,27 @@ export class OpikExporter implements SpanExporter {
   // an upsert, so revising a trace/span never needs an update() call.
   private readonly traceIds = new Map<string, string>();
   private readonly spanIds = new Map<string, string>();
+  // Wall-clock of the last export that touched each otelTraceId, for TTL pruning.
+  private readonly lastSeenByTrace = new Map<string, number>();
 
   private readonly client: Opik;
   private readonly tags: string[];
   private readonly metadata: Record<string, AttributeValue>;
   private readonly threadId?: string;
+  private readonly traceTtlMs: number;
 
   constructor({
     client = aiSDKClient,
     tags = [],
     metadata = {},
     threadId,
+    traceTtlMs = DEFAULT_TRACE_TTL_MS,
   }: OpikExporterOptions = {}) {
     this.client = client;
     this.tags = [...tags];
     this.metadata = { ...metadata };
     this.threadId = threadId;
+    this.traceTtlMs = traceTtlMs;
   }
 
   private opikTraceId = (otelTraceId: string): string => {
@@ -103,6 +119,29 @@ export class OpikExporter implements SpanExporter {
     }
 
     return id;
+  };
+
+  // Drop accumulated spans and id mappings for traces idle longer than the TTL,
+  // so a long-running exporter doesn't retain every trace for the process'
+  // lifetime. A trace re-derives from all its spans on each batch, so we only
+  // prune once it has been quiet long enough to be considered complete.
+  private pruneStaleTraces = (now: number): void => {
+    for (const [otelTraceId, lastSeen] of this.lastSeenByTrace) {
+      if (now - lastSeen <= this.traceTtlMs) {
+        continue;
+      }
+
+      const spans = this.otelSpansByTrace.get(otelTraceId);
+      if (spans) {
+        for (const otelSpanId of spans.keys()) {
+          this.spanIds.delete(otelSpanId);
+        }
+      }
+
+      this.otelSpansByTrace.delete(otelTraceId);
+      this.traceIds.delete(otelTraceId);
+      this.lastSeenByTrace.delete(otelTraceId);
+    }
   };
 
   private getErrorInfo = (otelSpan: ReadableSpan): ErrorInfo | undefined => {
@@ -191,9 +230,13 @@ export class OpikExporter implements SpanExporter {
       spans.set(otelSpan.spanContext().spanId, otelSpan);
     }
 
+    const now = Date.now();
     for (const otelTraceId of affectedTraceIds) {
+      this.lastSeenByTrace.set(otelTraceId, now);
       this.exportTrace(otelTraceId);
     }
+
+    this.pruneStaleTraces(now);
 
     try {
       await this.client.flush();

--- a/sdks/typescript/src/opik/integrations/opik-vercel/src/exporter.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/src/exporter.ts
@@ -2,8 +2,15 @@ import type { AttributeValue, Tracer } from "@opentelemetry/api";
 import { SpanStatusCode } from "@opentelemetry/api";
 import type { ExportResultCode } from "@opentelemetry/core";
 import type { NodeSDKConfiguration } from "@opentelemetry/sdk-node";
-import type { Span, Trace } from "opik";
-import { Opik, logger } from "opik";
+import { Opik, generateId, logger } from "opik";
+import {
+  getSpanInput,
+  getSpanMetadata,
+  getSpanOutput,
+  getSpanType,
+  getSpanUsage,
+  getThreadId,
+} from "./attributes";
 
 /** Shape used for error_info when creating traces/spans; matches Opik API ErrorInfo. */
 type ErrorInfo = {
@@ -38,11 +45,27 @@ type OpikExporterOptions = {
 
 const aiSDKClient = new Opik();
 
+// Instrumentation scopes we ingest. AI SDK v4/v5/v6 emit scope "ai"; AI SDK v7
+// (and frameworks built on it, such as Vercel eve) emit the OpenTelemetry GenAI
+// scope "gen_ai" plus an "eve"-scoped turn root span. Everything else (e.g.
+// "workflow", "@vercel/otel/fetch") is framework noise and stays excluded.
+const SUPPORTED_SCOPES = new Set(["ai", "gen_ai", "eve"]);
+
+type SpanTiming = { id: string; start: number; end: number; duration: number };
+
 export class OpikExporter implements SpanExporter {
-  // <otelTraceId, opikTrace>
-  private readonly traces = new Map<string, Trace>();
-  // <otelSpanId, opikSpan>
-  private readonly spans = new Map<string, Span>();
+  // <otelTraceId, <otelSpanId, ReadableSpan>>. A turn's spans arrive across
+  // several export batches (the BatchSpanProcessor flushes as spans finish), so
+  // we accumulate them and re-derive the whole trace on every batch.
+  private readonly otelSpansByTrace = new Map<
+    string,
+    Map<string, ReadableSpan>
+  >();
+  // Stable Opik ids keyed by OTel id. Re-sending an entity with the same id is
+  // an upsert, so revising a trace/span never needs an update() call.
+  private readonly traceIds = new Map<string, string>();
+  private readonly spanIds = new Map<string, string>();
+
   private readonly client: Opik;
   private readonly tags: string[];
   private readonly metadata: Record<string, AttributeValue>;
@@ -60,129 +83,26 @@ export class OpikExporter implements SpanExporter {
     this.threadId = threadId;
   }
 
-  private getSpanInput = (otelSpan: ReadableSpan): Record<string, unknown> => {
-    let input: Record<string, unknown> = {};
-    const { attributes } = otelSpan;
-    const attributeKeys = Object.keys(attributes);
+  private opikTraceId = (otelTraceId: string): string => {
+    let id = this.traceIds.get(otelTraceId);
 
-    attributeKeys.forEach((key) => {
-      if (key === "ai.prompt" || key === "gen_ai.request") {
-        const parsedValue = tryParseJSON(attributes[key]);
-
-        if (parsedValue) {
-          input = { ...input, ...parsedValue };
-        }
-      }
-
-      if (key.startsWith("ai.prompt.")) {
-        const promptKey = key.replace("ai.prompt.", "");
-
-        input[promptKey] = safeParseJson(attributes[key]);
-      }
-
-      if (key.startsWith("gen_ai.request.")) {
-        const promptKey = key.replace("gen_ai.request.", "");
-
-        input[promptKey] = safeParseJson(attributes[key]);
-      }
-    });
-
-    if (Object.keys(input).length > 0) {
-      return input;
+    if (!id) {
+      id = generateId();
+      this.traceIds.set(otelTraceId, id);
     }
 
-    if ("ai.toolCall.name" in attributes) {
-      input.toolName = attributes["ai.toolCall.name"];
-    }
-
-    if ("ai.toolCall.args" in attributes) {
-      input.args = attributes["ai.toolCall.args"];
-    }
-
-    return input;
+    return id;
   };
 
-  private getSpanOutput = (otelSpan: ReadableSpan): Record<string, unknown> => {
-    const { attributes } = otelSpan;
+  private opikSpanId = (otelSpanId: string): string => {
+    let id = this.spanIds.get(otelSpanId);
 
-    if (attributes["ai.response.text"]) {
-      return { text: attributes["ai.response.text"] };
+    if (!id) {
+      id = generateId();
+      this.spanIds.set(otelSpanId, id);
     }
 
-    if (attributes["ai.response.object"]) {
-      return { object: safeParseJson(attributes["ai.response.object"]) };
-    }
-
-    if (attributes["ai.toolCall.result"]) {
-      return { result: attributes["ai.toolCall.result"] };
-    }
-
-    if (attributes["ai.response.toolCalls"]) {
-      return { toolCalls: safeParseJson(attributes["ai.response.toolCalls"]) };
-    }
-
-    return {};
-  };
-
-  private getSpanMetadata = (
-    otelSpan: ReadableSpan
-  ): Record<string, unknown> => {
-    const { attributes } = otelSpan;
-    const metadata: Record<string, unknown> = {};
-
-    if (attributes["gen_ai.response.model"]) {
-      metadata.model = attributes["gen_ai.response.model"];
-    }
-
-    if (attributes["gen_ai.system"]) {
-      metadata.system = attributes["gen_ai.system"];
-    }
-
-    return metadata;
-  };
-
-  private getSpanUsage = (otelSpan: ReadableSpan): Record<string, number> => {
-    const { attributes } = otelSpan;
-    const usage: Record<string, number> = {};
-
-    // prompt tokens
-    if ("ai.usage.promptTokens" in attributes) {
-      usage.prompt_tokens = attributes["ai.usage.promptTokens"] as number;
-    }
-    if ("gen_ai.usage.input_tokens" in attributes) {
-      usage.prompt_tokens = attributes["gen_ai.usage.input_tokens"] as number;
-    }
-
-    // completion tokens
-    if ("ai.usage.completionTokens" in attributes) {
-      usage.completion_tokens = attributes[
-        "ai.usage.completionTokens"
-      ] as number;
-    }
-    if ("gen_ai.usage.output_tokens" in attributes) {
-      usage.completion_tokens = attributes[
-        "gen_ai.usage.output_tokens"
-      ] as number;
-    }
-
-    if ("prompt_tokens" in usage || "completion_tokens" in usage) {
-      usage.total_tokens =
-        (usage.prompt_tokens || 0) + (usage.completion_tokens || 0);
-    }
-
-    return usage;
-  };
-
-  private getThreadId = (otelSpan: ReadableSpan): string | undefined => {
-    const { attributes } = otelSpan;
-
-    // Check for threadId in telemetry metadata
-    if (attributes["ai.telemetry.metadata.threadId"] != null) {
-      return attributes["ai.telemetry.metadata.threadId"]?.toString();
-    }
-
-    // Fallback to constructor-provided threadId
-    return this.threadId;
+    return id;
   };
 
   private getErrorInfo = (otelSpan: ReadableSpan): ErrorInfo | undefined => {
@@ -207,36 +127,23 @@ export class OpikExporter implements SpanExporter {
     const message = attributes?.["exception.message"]?.toString();
     const traceback = attributes?.["exception.stacktrace"]?.toString() || "";
 
-    return {
-      exceptionType,
-      message,
-      traceback,
-    };
+    return { exceptionType, message, traceback };
   };
 
-  processSpan = ({
-    otelSpan,
-    parentSpan,
-    trace,
-  }: {
-    otelSpan: ReadableSpan;
-    parentSpan?: Span;
-    trace: Trace;
-  }): Span => {
-    const errorInfo = this.getErrorInfo(otelSpan);
+  // eve groups multi-turn conversations under a session id that may live on any
+  // span of the turn, so scan the whole group before the constructor fallback.
+  private resolveThreadId = (
+    otelSpans: ReadableSpan[]
+  ): string | undefined => {
+    for (const otelSpan of otelSpans) {
+      const threadId = getThreadId(otelSpan.attributes);
 
-    return trace.span({
-      name: otelSpan.name,
-      startTime: new Date(hrTimeToMilliseconds(otelSpan.startTime)),
-      endTime: new Date(hrTimeToMilliseconds(otelSpan.endTime)),
-      parentSpanId: parentSpan?.data.id,
-      input: this.getSpanInput(otelSpan),
-      output: this.getSpanOutput(otelSpan),
-      metadata: this.getSpanMetadata(otelSpan),
-      usage: this.getSpanUsage(otelSpan),
-      type: "llm",
-      ...(errorInfo && { errorInfo }),
-    });
+      if (threadId != null) {
+        return threadId;
+      }
+    }
+
+    return this.threadId;
   };
 
   shutdown = async (): Promise<void> => {
@@ -248,8 +155,8 @@ export class OpikExporter implements SpanExporter {
   };
 
   export: ExportFunction = async (allOtelSpans, resultCallback) => {
-    const aiSDKOtelSpans = allOtelSpans.filter(
-      (span) => getInstrumentationScopeName(span) === "ai"
+    const aiSDKOtelSpans = allOtelSpans.filter((span: ReadableSpan) =>
+      SUPPORTED_SCOPES.has(getInstrumentationScopeName(span) ?? "")
     );
     const diffCount = allOtelSpans.length - aiSDKOtelSpans.length;
 
@@ -266,42 +173,27 @@ export class OpikExporter implements SpanExporter {
       return;
     }
 
-    const spanGroups = groupAndSortOtelSpans(aiSDKOtelSpans);
-
     logger.debug("Exporting spans", aiSDKOtelSpans);
 
-    Object.entries(spanGroups).forEach(([otelTraceId, otelSpans]) => {
-      const [rootOtelSpan, ...otherOtelSpans] = otelSpans;
+    const affectedTraceIds = new Set<string>();
 
-      const errorInfo = this.getErrorInfo(rootOtelSpan);
+    for (const otelSpan of aiSDKOtelSpans) {
+      const otelTraceId = otelSpan.spanContext().traceId;
+      affectedTraceIds.add(otelTraceId);
 
-      const trace = this.client.trace({
-        startTime: new Date(hrTimeToMilliseconds(rootOtelSpan.startTime)),
-        endTime: new Date(hrTimeToMilliseconds(rootOtelSpan.endTime)),
-        name:
-          rootOtelSpan.attributes[
-            "ai.telemetry.metadata.traceName"
-          ]?.toString() ?? rootOtelSpan.name,
-        input: this.getSpanInput(rootOtelSpan),
-        output: this.getSpanOutput(rootOtelSpan),
-        metadata: { ...this.getSpanMetadata(rootOtelSpan), ...this.metadata },
-        tags: this.tags,
-        usage: this.getSpanUsage(rootOtelSpan),
-        threadId: this.getThreadId(rootOtelSpan),
-        ...(errorInfo && { errorInfo }),
-      });
+      let spans = this.otelSpansByTrace.get(otelTraceId);
 
-      this.traces.set(otelTraceId, trace);
+      if (!spans) {
+        spans = new Map();
+        this.otelSpansByTrace.set(otelTraceId, spans);
+      }
 
-      otherOtelSpans.forEach((otelSpan) => {
-        const parentSpan = this.spans.get(
-          otelSpan.parentSpanContext?.spanId ?? ""
-        );
-        const span = this.processSpan({ parentSpan, otelSpan, trace });
+      spans.set(otelSpan.spanContext().spanId, otelSpan);
+    }
 
-        this.spans.set(otelSpan.spanContext().spanId, span);
-      });
-    });
+    for (const otelTraceId of affectedTraceIds) {
+      this.exportTrace(otelTraceId);
+    }
 
     try {
       await this.client.flush();
@@ -321,6 +213,96 @@ export class OpikExporter implements SpanExporter {
     }
   };
 
+  // Re-derive and (re)send a whole trace and its spans from every span seen for
+  // it so far. Uses create-only operations: the Opik ids are stable, so each
+  // send upserts the previous one — no update()/end() calls.
+  private exportTrace(otelTraceId: string): void {
+    const otelSpans = [...(this.otelSpansByTrace.get(otelTraceId)?.values() ?? [])];
+
+    if (otelSpans.length === 0) {
+      return;
+    }
+
+    const traceId = this.opikTraceId(otelTraceId);
+    const projectName = this.client.config.projectName;
+    const parentOf = resolveParents(otelSpans);
+
+    // The root span becomes the Opik trace itself; every other span is a child.
+    const rootOtelSpan = pickRootSpan(otelSpans, parentOf);
+    const rootOtelSpanId = rootOtelSpan.spanContext().spanId;
+
+    // Prefer the root span's own input/output/usage — this preserves AI SDK
+    // v4/v5/v6, where the root model call carries them. Fall back to the
+    // model-call spans when the root is an orchestration span that carries none
+    // (e.g. eve's `ai.eve.turn`).
+    const llmSpans = sortByStart(
+      otelSpans.filter((otelSpan) => getSpanType(otelSpan.attributes) === "llm")
+    );
+
+    const input = preferRoot(getSpanInput(rootOtelSpan.attributes), () =>
+      firstNonEmpty(llmSpans, getSpanInput)
+    );
+    const output = preferRoot(getSpanOutput(rootOtelSpan.attributes), () =>
+      lastNonEmpty(llmSpans, getSpanOutput)
+    );
+    const usage = preferRoot(getSpanUsage(rootOtelSpan.attributes), () =>
+      firstNonEmpty(llmSpans, getSpanUsage)
+    );
+
+    const errorInfo =
+      this.getErrorInfo(rootOtelSpan) ?? firstError(otelSpans, this.getErrorInfo);
+
+    this.client.traceBatchQueue.create({
+      id: traceId,
+      name:
+        rootOtelSpan.attributes["ai.telemetry.metadata.traceName"]?.toString() ??
+        rootOtelSpan.name,
+      // Span the whole turn even when the root span's own window is shorter.
+      startTime: new Date(Math.min(...otelSpans.map(startMs))),
+      endTime: new Date(Math.max(...otelSpans.map(endMs))),
+      input,
+      output,
+      metadata: { ...mergeMetadata(otelSpans), ...this.metadata },
+      tags: this.tags,
+      usage,
+      threadId: this.resolveThreadId(otelSpans),
+      projectName,
+      ...(errorInfo && { errorInfo }),
+    });
+
+    for (const otelSpan of otelSpans) {
+      const otelSpanId = otelSpan.spanContext().spanId;
+
+      if (otelSpanId === rootOtelSpanId) {
+        continue;
+      }
+
+      // Spans whose parent is the root attach directly to the trace.
+      const parentOtelSpanId = parentOf.get(otelSpanId);
+      const parentSpanId =
+        parentOtelSpanId != null && parentOtelSpanId !== rootOtelSpanId
+          ? this.opikSpanId(parentOtelSpanId)
+          : undefined;
+      const spanErrorInfo = this.getErrorInfo(otelSpan);
+
+      this.client.spanBatchQueue.create({
+        id: this.opikSpanId(otelSpanId),
+        traceId,
+        ...(parentSpanId ? { parentSpanId } : {}),
+        name: otelSpan.name,
+        type: getSpanType(otelSpan.attributes),
+        startTime: new Date(startMs(otelSpan)),
+        endTime: new Date(endMs(otelSpan)),
+        input: getSpanInput(otelSpan.attributes),
+        output: getSpanOutput(otelSpan.attributes),
+        metadata: getSpanMetadata(otelSpan.attributes),
+        usage: getSpanUsage(otelSpan.attributes),
+        projectName,
+        ...(spanErrorInfo && { errorInfo: spanErrorInfo }),
+      });
+    }
+  }
+
   static getSettings(settings: OpikExporterSettings): TelemetrySettings {
     const metadata = { ...settings.metadata };
 
@@ -338,29 +320,6 @@ export class OpikExporter implements SpanExporter {
   }
 }
 
-function groupAndSortOtelSpans(
-  otelSpans: ReadableSpan[]
-): Record<string, ReadableSpan[]> {
-  const spanGroupsByTraceId: Record<string, ReadableSpan[]> = {};
-
-  otelSpans.forEach((otelSpan) => {
-    const context = otelSpan.spanContext();
-
-    if (!spanGroupsByTraceId[context.traceId]) {
-      spanGroupsByTraceId[context.traceId] = [];
-    }
-
-    spanGroupsByTraceId[context.traceId].push(otelSpan);
-  });
-
-  Object.entries(spanGroupsByTraceId).forEach(([traceId, otelSpans]) => {
-    spanGroupsByTraceId[traceId] = sortSpansLevelOrder(otelSpans);
-  });
-
-  return spanGroupsByTraceId;
-}
-
-
 // Get instrumentation scope name with fallback for OpenTelemetry v1 compatibility.
 // OTel v1 (used by @vercel/otel) uses `instrumentationLibrary` while
 // OTel v2 uses `instrumentationScope`.
@@ -372,76 +331,157 @@ function getInstrumentationScopeName(span: ReadableSpan): string | undefined {
   );
 }
 
-// Convert hrTime ([seconds, nanoseconds]) to milliseconds
-function hrTimeToMilliseconds(hrTime: [number, number]) {
+// Convert hrTime ([seconds, nanoseconds]) to milliseconds.
+function hrTimeToMilliseconds(hrTime: [number, number]): number {
   return hrTime[0] * 1e3 + hrTime[1] / 1e6;
 }
 
-function safeParseJson(value: unknown): unknown {
-  try {
-    return JSON.parse(value as string) as Record<string, unknown>;
-  } catch {
-    return value;
-  }
+function startMs(otelSpan: ReadableSpan): number {
+  return hrTimeToMilliseconds(otelSpan.startTime);
 }
 
-function tryParseJSON(input: unknown): Record<string, unknown> | undefined {
-  if (typeof input !== "string") {
-    return undefined;
+function endMs(otelSpan: ReadableSpan): number {
+  return hrTimeToMilliseconds(otelSpan.endTime);
+}
+
+function sortByStart(otelSpans: ReadableSpan[]): ReadableSpan[] {
+  return [...otelSpans].sort((a, b) => startMs(a) - startMs(b));
+}
+
+// Frameworks built on the AI SDK (eve, Vercel Workflow) do not emit OTel
+// parent-child links, so reconstruct the hierarchy from time containment: a
+// span's parent is the smallest span that fully contains its time window.
+// Requiring a strictly longer parent keeps the relation acyclic.
+function computeParentsByContainment(
+  otelSpans: ReadableSpan[]
+): Map<string, string | undefined> {
+  const timings: SpanTiming[] = otelSpans.map((otelSpan) => {
+    const start = startMs(otelSpan);
+    const end = endMs(otelSpan);
+
+    return { id: otelSpan.spanContext().spanId, start, end, duration: end - start };
+  });
+
+  const parentOf = new Map<string, string | undefined>();
+
+  for (const span of timings) {
+    let parent: SpanTiming | undefined;
+
+    for (const candidate of timings) {
+      if (candidate.id === span.id) {
+        continue;
+      }
+
+      const contains =
+        candidate.start <= span.start &&
+        candidate.end >= span.end &&
+        candidate.duration > span.duration;
+
+      if (contains && (!parent || candidate.duration < parent.duration)) {
+        parent = candidate;
+      }
+    }
+
+    parentOf.set(span.id, parent?.id);
   }
 
-  try {
-    const parsed = JSON.parse(input);
+  return parentOf;
+}
 
-    if (
-      parsed !== null &&
-      typeof parsed === "object" &&
-      !Array.isArray(parsed)
-    ) {
-      return parsed as Record<string, unknown>;
+function firstNonEmpty<T extends object>(
+  otelSpans: ReadableSpan[],
+  extract: (attributes: ReadableSpan["attributes"]) => T
+): T {
+  for (const otelSpan of otelSpans) {
+    const value = extract(otelSpan.attributes);
+
+    if (Object.keys(value).length > 0) {
+      return value;
     }
-  } catch {
-    return undefined;
+  }
+
+  return {} as T;
+}
+
+function lastNonEmpty<T extends object>(
+  otelSpans: ReadableSpan[],
+  extract: (attributes: ReadableSpan["attributes"]) => T
+): T {
+  for (let index = otelSpans.length - 1; index >= 0; index--) {
+    const value = extract(otelSpans[index].attributes);
+
+    if (Object.keys(value).length > 0) {
+      return value;
+    }
+  }
+
+  return {} as T;
+}
+
+function mergeMetadata(otelSpans: ReadableSpan[]): Record<string, unknown> {
+  let metadata: Record<string, unknown> = {};
+
+  for (const otelSpan of otelSpans) {
+    metadata = { ...metadata, ...getSpanMetadata(otelSpan.attributes) };
+  }
+
+  return metadata;
+}
+
+// Each span's parent: a real OTel parent link when the parent is one of our
+// spans (AI SDK v4/v5/v6), otherwise the time-containment parent (eve, which
+// emits no parent links). The result is acyclic.
+function resolveParents(
+  otelSpans: ReadableSpan[]
+): Map<string, string | undefined> {
+  const keptIds = new Set(
+    otelSpans.map((otelSpan) => otelSpan.spanContext().spanId)
+  );
+  const containment = computeParentsByContainment(otelSpans);
+  const parentOf = new Map<string, string | undefined>();
+
+  for (const otelSpan of otelSpans) {
+    const spanId = otelSpan.spanContext().spanId;
+    const realParentId = otelSpan.parentSpanContext?.spanId;
+
+    parentOf.set(
+      spanId,
+      realParentId != null && keptIds.has(realParentId)
+        ? realParentId
+        : containment.get(spanId)
+    );
+  }
+
+  return parentOf;
+}
+
+// The trace's root span: an outermost (parent-less) span, earliest by start.
+function pickRootSpan(
+  otelSpans: ReadableSpan[],
+  parentOf: Map<string, string | undefined>
+): ReadableSpan {
+  const topLevel = otelSpans.filter(
+    (otelSpan) => parentOf.get(otelSpan.spanContext().spanId) == null
+  );
+
+  return sortByStart(topLevel.length > 0 ? topLevel : otelSpans)[0];
+}
+
+function preferRoot<T extends object>(rootValue: T, fallback: () => T): T {
+  return Object.keys(rootValue).length > 0 ? rootValue : fallback();
+}
+
+function firstError(
+  otelSpans: ReadableSpan[],
+  getErrorInfo: (otelSpan: ReadableSpan) => ErrorInfo | undefined
+): ErrorInfo | undefined {
+  for (const otelSpan of sortByStart(otelSpans)) {
+    const errorInfo = getErrorInfo(otelSpan);
+
+    if (errorInfo) {
+      return errorInfo;
+    }
   }
 
   return undefined;
-}
-
-function sortSpansLevelOrder(otelSpans: ReadableSpan[]): ReadableSpan[] {
-  // (spanId, otelSpan)
-  const idMap = new Map<string, ReadableSpan>();
-  // (parentSpanId, [childrenOtelSpans])
-  const childrenMap = new Map<string, ReadableSpan[]>();
-
-  for (const otelSpan of otelSpans) {
-    const { spanId } = otelSpan.spanContext();
-    const parentSpanId = otelSpan.parentSpanContext?.spanId ?? "";
-    idMap.set(spanId, otelSpan);
-
-    if (parentSpanId) {
-      if (!childrenMap.has(parentSpanId)) {
-        childrenMap.set(parentSpanId, []);
-      }
-      childrenMap.get(parentSpanId)!.push(otelSpan);
-    }
-  }
-
-  const roots = otelSpans.filter(
-    (span) =>
-      !span.parentSpanContext?.spanId ||
-      !idMap.has(span.parentSpanContext.spanId)
-  );
-
-  const result: ReadableSpan[] = [];
-  const queue: ReadableSpan[] = [...roots];
-
-  while (queue.length > 0) {
-    const current = queue.shift()!;
-    result.push(current);
-    const currentId = current.spanContext().spanId;
-    const children = childrenMap.get(currentId) || [];
-    queue.push(...children);
-  }
-
-  return result;
 }

--- a/sdks/typescript/src/opik/integrations/opik-vercel/tests/ai-sdk.test.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/tests/ai-sdk.test.ts
@@ -89,24 +89,28 @@ describe("Opik - Vercel AI SDK integration", () => {
     expect(createSpansSpy).toHaveBeenCalledTimes(1);
     expect(updateSpansSpy).toHaveBeenCalledTimes(0);
     expect(updateTracesSpy).toHaveBeenCalledTimes(0);
-    expect(createTracesSpy.mock.calls[0][0]).toMatchObject({
-      traces: [
-        {
-          input: {
-            prompt: input,
-          },
-          metadata: {},
-          name: traceName,
-          output: { text },
-          projectName: "opik-sdk-typescript",
-          usage: {
-            completion_tokens: 20,
-            prompt_tokens: 10,
-            total_tokens: 30,
-          },
-        },
-      ],
+
+    const trace = createTracesSpy.mock.calls[0][0].traces[0];
+    expect(trace).toMatchObject({
+      input: { prompt: input },
+      metadata: {},
+      name: traceName,
+      output: { text },
+      projectName: "opik-sdk-typescript",
     });
+    // Token usage lives only on the LLM span, never on the trace.
+    expect((trace as { usage?: unknown }).usage).toBeUndefined();
+
+    const spans = createSpansSpy.mock.calls.flatMap((call) => call[0].spans);
+    expect(
+      spans.some(
+        (span) =>
+          span.type === "llm" &&
+          span.usage?.prompt_tokens === 10 &&
+          span.usage?.completion_tokens === 20 &&
+          span.usage?.total_tokens === 30
+      )
+    ).toBe(true);
   });
 
   it("generateText with tools", async () => {
@@ -194,11 +198,6 @@ describe("Opik - Vercel AI SDK integration", () => {
           // @todo: if possible implement testing telemetry for tool calls
           output: {},
           projectName: "opik-sdk-typescript",
-          usage: {
-            completion_tokens: 20,
-            prompt_tokens: 10,
-            total_tokens: 30,
-          },
         },
       ],
     });
@@ -265,11 +264,6 @@ describe("Opik - Vercel AI SDK integration", () => {
           output: { text: output },
           projectName: "opik-sdk-typescript",
           threadId: threadId,
-          usage: {
-            completion_tokens: 20,
-            prompt_tokens: 10,
-            total_tokens: 30,
-          },
         },
       ],
     });
@@ -322,11 +316,6 @@ describe("Opik - Vercel AI SDK integration", () => {
           output: { text: output },
           projectName: "opik-sdk-typescript",
           threadId: threadId,
-          usage: {
-            completion_tokens: 20,
-            prompt_tokens: 10,
-            total_tokens: 30,
-          },
         },
       ],
     });
@@ -400,11 +389,6 @@ describe("Opik - Vercel AI SDK integration", () => {
           output: { text: output },
           projectName: "opik-sdk-typescript",
           threadId: metadataThreadId, // Should use metadata threadId, not constructor
-          usage: {
-            completion_tokens: 20,
-            prompt_tokens: 10,
-            total_tokens: 30,
-          },
         },
       ],
     });
@@ -489,23 +473,27 @@ describe("Opik - Vercel AI SDK integration", () => {
     expect(object).toEqual(objectOutput);
     expect(createTracesSpy).toHaveBeenCalledTimes(1);
     expect(createSpansSpy).toHaveBeenCalledTimes(1);
-    expect(createTracesSpy.mock.calls[0][0]).toMatchObject({
-      traces: [
-        {
-          input: {
-            prompt: input,
-          },
-          metadata: {},
-          name: traceName,
-          output: { object: objectOutput },
-          projectName: "opik-sdk-typescript",
-          usage: {
-            completion_tokens: 25,
-            prompt_tokens: 15,
-            total_tokens: 40,
-          },
-        },
-      ],
+
+    const trace = createTracesSpy.mock.calls[0][0].traces[0];
+    expect(trace).toMatchObject({
+      input: { prompt: input },
+      metadata: {},
+      name: traceName,
+      output: { object: objectOutput },
+      projectName: "opik-sdk-typescript",
     });
+    // Token usage lives only on the LLM span, never on the trace.
+    expect((trace as { usage?: unknown }).usage).toBeUndefined();
+
+    const spans = createSpansSpy.mock.calls.flatMap((call) => call[0].spans);
+    expect(
+      spans.some(
+        (span) =>
+          span.type === "llm" &&
+          span.usage?.prompt_tokens === 15 &&
+          span.usage?.completion_tokens === 25 &&
+          span.usage?.total_tokens === 40
+      )
+    ).toBe(true);
   });
 });

--- a/sdks/typescript/src/opik/integrations/opik-vercel/tests/gen-ai.test.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/tests/gen-ai.test.ts
@@ -383,4 +383,68 @@ describe("OpikExporter - AI SDK v7 / GenAI (eve) spans", () => {
     expect(updateSpanSpy).not.toHaveBeenCalled();
     expect(lastTrace()).toMatchObject({ threadId: SESSION_ID });
   });
+
+  // ── memory bounds (TTL pruning) ──
+
+  // A minimal chat span on its own trace; the span id derives from the trace id.
+  const chatOnTrace = (traceId: string) =>
+    makeSpan(
+      "gen_ai",
+      "chat claude-haiku-4-5",
+      {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.input.messages": JSON.stringify([
+          { role: "user", parts: [{ type: "text", content: "hi" }] },
+        ]),
+        "gen_ai.usage.input_tokens": 5,
+        "gen_ai.usage.output_tokens": 3,
+      },
+      { traceId, spanId: `${traceId}-chat`, startMs: 0, endMs: 10 }
+    );
+
+  const lastTraceId = () =>
+    createTracesSpy.mock.calls.at(-1)![0].traces.at(-1)!.id;
+
+  it("prunes a trace's cache after the TTL (re-export gets a fresh id)", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date(0));
+      const exporter = new OpikExporter({ client, traceTtlMs: 1000 });
+      const send = (span: unknown) =>
+        new Promise((resolve) => exporter.export([span] as never, resolve));
+
+      await send(chatOnTrace("A"));
+      const firstId = lastTraceId();
+
+      // Past the TTL: a new export (trace B) prunes the idle trace A.
+      vi.setSystemTime(new Date(2000));
+      await send(chatOnTrace("B"));
+
+      // A re-arrives → its cache was pruned, so it gets a brand-new Opik id.
+      await send(chatOnTrace("A"));
+      expect(lastTraceId()).not.toBe(firstId);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a trace's stable id while it stays active within the TTL", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date(0));
+      const exporter = new OpikExporter({ client, traceTtlMs: 1000 });
+      const send = (span: unknown) =>
+        new Promise((resolve) => exporter.export([span] as never, resolve));
+
+      await send(chatOnTrace("A"));
+      const firstId = lastTraceId();
+
+      // Within the TTL → not pruned → same id on re-export (upsert).
+      vi.setSystemTime(new Date(500));
+      await send(chatOnTrace("A"));
+      expect(lastTraceId()).toBe(firstId);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/sdks/typescript/src/opik/integrations/opik-vercel/tests/gen-ai.test.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/tests/gen-ai.test.ts
@@ -215,11 +215,14 @@ describe("OpikExporter - AI SDK v7 / GenAI (eve) spans", () => {
     expect((lastTrace() as { usage?: unknown }).usage).toBeUndefined();
   });
 
-  it("records token usage (incl. cache tokens) on the LLM span", async () => {
+  it("records model, provider and token usage on the LLM span (for cost)", async () => {
     await exportSpans(TURN_SPAN, CHAT_SPAN, TOOL_SPAN);
 
     const chat = createdSpans().find((span) => span.name?.startsWith("chat"));
     expect(chat!.type).toBe("llm");
+    // model + provider are the dedicated fields the backend prices from.
+    expect(chat!.model).toBe("claude-haiku-4-5");
+    expect(chat!.provider).toBe("anthropic");
     expect(chat!.usage).toMatchObject({
       prompt_tokens: 5170,
       completion_tokens: 54,
@@ -349,7 +352,11 @@ describe("OpikExporter - AI SDK v7 / GenAI (eve) spans", () => {
     const chat = spans.find((span) => span.name?.startsWith("chat"));
 
     expect(agent!.type).toBe("general");
-    expect(agent!.usage).toBeUndefined(); // no tokens on the orchestration span
+    // No tokens, model or provider on the orchestration span — only the LLM
+    // span is priced, so the trace total isn't double-counted.
+    expect(agent!.usage).toBeUndefined();
+    expect(agent!.model).toBeUndefined();
+    expect(agent!.provider).toBeUndefined();
     expect(chat!.type).toBe("llm");
     expect(chat!.usage).toMatchObject({ prompt_tokens: 5170, completion_tokens: 54 });
   });

--- a/sdks/typescript/src/opik/integrations/opik-vercel/tests/gen-ai.test.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/tests/gen-ai.test.ts
@@ -114,6 +114,19 @@ const CHAT_SPAN = makeSpan(
   { traceId: "trace1", spanId: "chat", startMs: 100, endMs: 1100 }
 );
 
+// eve wraps each model call in an `invoke_agent` span that repeats the call's
+// token usage. It is an orchestration span (type `general`), not a model call.
+const INVOKE_AGENT_SPAN = makeSpan(
+  "gen_ai",
+  "invoke_agent claude-haiku-4-5",
+  {
+    "gen_ai.operation.name": "invoke_agent",
+    "gen_ai.usage.input_tokens": 5170,
+    "gen_ai.usage.output_tokens": 54,
+  },
+  { traceId: "trace1", spanId: "agent", startMs: 50, endMs: 1150 }
+);
+
 const TOOL_SPAN = makeSpan(
   "gen_ai",
   "execute_tool get_weather",
@@ -311,6 +324,21 @@ describe("OpikExporter - AI SDK v7 / GenAI (eve) spans", () => {
       input: { messages: [{ role: "user", content: "hi" }] },
       errorInfo: { exceptionType: "APICallError", message: "Rate limit exceeded" },
     });
+  });
+
+  it("attaches token usage only to LLM spans (no double counting)", async () => {
+    // The agent wrapper and the model call report the same usage; counting both
+    // would double the trace total once usage is aggregated across spans.
+    await exportSpans(TURN_SPAN, INVOKE_AGENT_SPAN, CHAT_SPAN, TOOL_SPAN);
+
+    const spans = createdSpans();
+    const agent = spans.find((span) => span.name?.startsWith("invoke_agent"));
+    const chat = spans.find((span) => span.name?.startsWith("chat"));
+
+    expect(agent!.type).toBe("general");
+    expect(agent!.usage).toBeUndefined(); // no tokens on the orchestration span
+    expect(chat!.type).toBe("llm");
+    expect(chat!.usage).toMatchObject({ prompt_tokens: 5170, completion_tokens: 54 });
   });
 
   // ── create-only contract (upsert, never update) ──

--- a/sdks/typescript/src/opik/integrations/opik-vercel/tests/gen-ai.test.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/tests/gen-ai.test.ts
@@ -1,0 +1,345 @@
+import { SpanStatusCode } from "@opentelemetry/api";
+import { Opik } from "opik";
+import { MockInstance } from "vitest";
+import { OpikExporter } from "../src/exporter";
+import { mockAPIFunction } from "./mockUtils";
+
+/**
+ * Tests for AI SDK v7 / OpenTelemetry GenAI spans — the convention Vercel eve
+ * emits. The installed AI SDK is v6 (`ai.*` scope, covered by ai-sdk.test.ts),
+ * so real v7 spans can't be produced here; instead we feed the exporter spans
+ * built from attributes captured verbatim from a real eve + Anthropic turn.
+ *
+ * Being deterministic, these verify the core business logic exactly: expected
+ * input, output, token usage, error info, span types, hierarchy, and the
+ * create-only (upsert, never update) contract.
+ */
+
+// ─────────────────────────────── Fixtures ───────────────────────────────
+// eve emits no OTel parent links — spans carry only a trace id and a time
+// window, and the exporter reconstructs the hierarchy from time containment.
+
+type SpanSpec = {
+  traceId: string;
+  spanId: string;
+  startMs: number;
+  endMs: number;
+  error?: { type: string; message: string };
+};
+
+const hrTime = (ms: number): [number, number] => [0, ms * 1e6];
+
+function makeSpan(
+  scope: string,
+  name: string,
+  attributes: Record<string, unknown>,
+  { traceId, spanId, startMs, endMs, error }: SpanSpec
+) {
+  return {
+    name,
+    kind: 0,
+    spanContext: () => ({ traceId, spanId, traceFlags: 1 }),
+    parentSpanContext: undefined,
+    startTime: hrTime(startMs),
+    endTime: hrTime(endMs),
+    status: error
+      ? { code: SpanStatusCode.ERROR, message: error.message }
+      : { code: SpanStatusCode.UNSET },
+    attributes,
+    links: [],
+    events: error
+      ? [
+          {
+            name: "exception",
+            attributes: {
+              "exception.type": error.type,
+              "exception.message": error.message,
+              "exception.stacktrace": `${error.type}: ${error.message}`,
+            },
+          },
+        ]
+      : [],
+    duration: hrTime(endMs - startMs),
+    ended: true,
+    resource: { attributes: {} },
+    instrumentationScope: { name: scope, version: "1.0.0" },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+  };
+}
+
+const SESSION_ID = "wrun_01TESTSESSION";
+
+// A weather turn: the `eve` turn span wraps a model call (`chat`) that calls a
+// tool (`execute_tool`). Time windows establish containment: turn ⊃ chat ⊃ tool.
+const TURN_SPAN = makeSpan(
+  "eve",
+  "ai.eve.turn",
+  {
+    "eve.version": "0.11.5",
+    "eve.environment": "development",
+    "eve.session.id": SESSION_ID,
+    "eve.turn.id": "turn_0",
+  },
+  { traceId: "trace1", spanId: "turn", startMs: 0, endMs: 1200 }
+);
+
+const CHAT_SPAN = makeSpan(
+  "gen_ai",
+  "chat claude-haiku-4-5",
+  {
+    "gen_ai.operation.name": "chat",
+    "gen_ai.provider.name": "anthropic",
+    "gen_ai.request.model": "claude-haiku-4-5",
+    "gen_ai.input.messages": JSON.stringify([
+      {
+        role: "user",
+        parts: [{ type: "text", content: "What is the weather in Brooklyn?" }],
+      },
+    ]),
+    "gen_ai.output.messages": JSON.stringify([
+      {
+        role: "assistant",
+        parts: [{ type: "text", content: "It's sunny in Brooklyn, 72°F." }],
+        finish_reason: "stop",
+      },
+    ]),
+    "gen_ai.response.finish_reasons": JSON.stringify(["stop"]),
+    "gen_ai.usage.input_tokens": 5170,
+    "gen_ai.usage.output_tokens": 54,
+    "gen_ai.usage.cache_read.input_tokens": 5167,
+    "gen_ai.usage.cache_creation.input_tokens": 48,
+  },
+  { traceId: "trace1", spanId: "chat", startMs: 100, endMs: 1100 }
+);
+
+const TOOL_SPAN = makeSpan(
+  "gen_ai",
+  "execute_tool get_weather",
+  {
+    "gen_ai.operation.name": "execute_tool",
+    "gen_ai.tool.name": "get_weather",
+    "gen_ai.tool.call.id": "toolu_01",
+    "gen_ai.tool.call.arguments": JSON.stringify({ city: "Brooklyn" }),
+    "gen_ai.tool.call.result": JSON.stringify({
+      city: "Brooklyn",
+      condition: "Sunny",
+      temperatureF: 72,
+    }),
+  },
+  { traceId: "trace1", spanId: "tool", startMs: 1000, endMs: 1050 }
+);
+
+// ─────────────────────────────── Harness ────────────────────────────────
+
+describe("OpikExporter - AI SDK v7 / GenAI (eve) spans", () => {
+  let client: Opik;
+  let exporter: OpikExporter;
+  let createTracesSpy: MockInstance<typeof client.api.traces.createTraces>;
+  let createSpansSpy: MockInstance<typeof client.api.spans.createSpans>;
+  let updateTraceSpy: MockInstance<typeof client.api.traces.updateTrace>;
+  let updateSpanSpy: MockInstance<typeof client.api.spans.updateSpan>;
+
+  beforeEach(() => {
+    client = new Opik({ projectName: "opik-sdk-typescript" });
+    exporter = new OpikExporter({ client });
+
+    createTracesSpy = vi
+      .spyOn(client.api.traces, "createTraces")
+      .mockImplementation(mockAPIFunction as never);
+    createSpansSpy = vi
+      .spyOn(client.api.spans, "createSpans")
+      .mockImplementation(mockAPIFunction as never);
+    updateTraceSpy = vi
+      .spyOn(client.api.traces, "updateTrace")
+      .mockImplementation(mockAPIFunction as never);
+    updateSpanSpy = vi
+      .spyOn(client.api.spans, "updateSpan")
+      .mockImplementation(mockAPIFunction as never);
+  });
+
+  // Push spans through the exporter's SpanExporter.export contract.
+  const exportSpans = (...spans: unknown[]) =>
+    new Promise<{ code: number }>((resolve) =>
+      exporter.export(spans as never, resolve)
+    );
+  // The most recent trace payload sent to Opik.
+  const lastTrace = () => createTracesSpy.mock.calls.at(-1)![0].traces.at(-1)!;
+  // Every span payload sent to Opik, flattened across batches.
+  const createdSpans = () =>
+    createSpansSpy.mock.calls.flatMap((call) => call[0].spans);
+
+  // ──────────────────────────────── Tests ─────────────────────────────────
+
+  it("captures the prompt, answer and token usage in OpenAI chat shape", async () => {
+    const result = await exportSpans(TURN_SPAN, CHAT_SPAN, TOOL_SPAN);
+
+    expect(result.code).toBe(0);
+    expect(lastTrace()).toMatchObject({
+      // expected input — the user prompt, as OpenAI `messages`
+      input: {
+        messages: [{ role: "user", content: "What is the weather in Brooklyn?" }],
+      },
+      // output — the assistant answer, as OpenAI `choices`
+      output: {
+        choices: [
+          {
+            message: { role: "assistant", content: "It's sunny in Brooklyn, 72°F." },
+            finish_reason: "stop",
+          },
+        ],
+      },
+      // token usage, including cache tokens
+      usage: {
+        prompt_tokens: 5170,
+        completion_tokens: 54,
+        total_tokens: 5224,
+        "original_usage.cache_read_input_tokens": 5167,
+        "original_usage.cache_creation_input_tokens": 48,
+      },
+      // multi-turn grouping via the eve session id
+      threadId: SESSION_ID,
+    });
+  });
+
+  it("logs the tool execution as a tool-typed span with args and result", async () => {
+    await exportSpans(TURN_SPAN, CHAT_SPAN, TOOL_SPAN);
+
+    const toolSpan = createdSpans().find(
+      (span) => span.name === "execute_tool get_weather"
+    );
+
+    expect(toolSpan).toMatchObject({
+      type: "tool",
+      input: { toolName: "get_weather", args: { city: "Brooklyn" } },
+      output: { result: { city: "Brooklyn", condition: "Sunny", temperatureF: 72 } },
+    });
+  });
+
+  it("normalizes a tool-call conversation (text, tool_call, tool result)", async () => {
+    const conversation = makeSpan(
+      "gen_ai",
+      "chat claude-haiku-4-5",
+      {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.input.messages": JSON.stringify([
+          { role: "user", parts: [{ type: "text", content: "Weather in Brooklyn?" }] },
+          {
+            role: "assistant",
+            parts: [
+              {
+                type: "tool_call",
+                id: "call_1",
+                name: "get_weather",
+                arguments: { city: "Brooklyn" },
+              },
+            ],
+          },
+          {
+            role: "tool",
+            parts: [
+              { type: "tool_call_response", id: "call_1", response: { condition: "Sunny" } },
+            ],
+          },
+        ]),
+        "gen_ai.usage.input_tokens": 10,
+        "gen_ai.usage.output_tokens": 5,
+      },
+      { traceId: "conv", spanId: "chat", startMs: 0, endMs: 100 }
+    );
+
+    await exportSpans(conversation);
+
+    expect(lastTrace()).toMatchObject({
+      input: {
+        messages: [
+          { role: "user", content: "Weather in Brooklyn?" },
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: { name: "get_weather", arguments: '{"city":"Brooklyn"}' },
+              },
+            ],
+          },
+          { role: "tool", tool_call_id: "call_1", content: '{"condition":"Sunny"}' },
+        ],
+      },
+    });
+  });
+
+  it("types each span and nests them by time containment", async () => {
+    await exportSpans(TURN_SPAN, CHAT_SPAN, TOOL_SPAN);
+
+    const spans = createdSpans();
+    const chat = spans.find((span) => span.name?.startsWith("chat"));
+    const tool = spans.find((span) => span.name === "execute_tool get_weather");
+
+    // The eve turn span becomes the trace itself, not a child span.
+    expect(spans.some((span) => span.name === "ai.eve.turn")).toBe(false);
+    expect(chat!.type).toBe("llm");
+    expect(tool!.type).toBe("tool");
+    // The tool ran inside the model call (turn ⊃ chat ⊃ tool by time).
+    expect(tool!.parentSpanId).toBe(chat!.id);
+  });
+
+  it("captures error information from a failed model span", async () => {
+    const erroredChat = makeSpan(
+      "gen_ai",
+      "chat claude-haiku-4-5",
+      {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.input.messages": JSON.stringify([
+          { role: "user", parts: [{ type: "text", content: "hi" }] },
+        ]),
+      },
+      {
+        traceId: "err",
+        spanId: "chat",
+        startMs: 0,
+        endMs: 100,
+        error: { type: "APICallError", message: "Rate limit exceeded" },
+      }
+    );
+
+    await exportSpans(erroredChat);
+
+    expect(lastTrace()).toMatchObject({
+      input: { messages: [{ role: "user", content: "hi" }] },
+      errorInfo: { exceptionType: "APICallError", message: "Rate limit exceeded" },
+    });
+  });
+
+  // ── create-only contract (upsert, never update) ──
+
+  it("coalesces spans arriving across export batches into one trace", async () => {
+    // The BatchSpanProcessor flushes a single turn's spans across batches.
+    await exportSpans(TURN_SPAN, CHAT_SPAN);
+    await exportSpans(TOOL_SPAN);
+
+    // Re-sending may emit the trace once per batch, but always under one id.
+    const traceIds = new Set(
+      createTracesSpy.mock.calls.flatMap((call) =>
+        call[0].traces.map((trace) => trace.id)
+      )
+    );
+    expect(traceIds.size).toBe(1);
+    expect(
+      createdSpans().some((span) => span.name === "execute_tool get_weather")
+    ).toBe(true);
+  });
+
+  it("backfills a late thread id via create, never update", async () => {
+    // First batch: only the model call (no eve.session.id yet).
+    await exportSpans(CHAT_SPAN);
+    // Later batch: the eve turn span carries the session id.
+    await exportSpans(TURN_SPAN, TOOL_SPAN);
+
+    expect(updateTraceSpy).not.toHaveBeenCalled();
+    expect(updateSpanSpy).not.toHaveBeenCalled();
+    expect(lastTrace()).toMatchObject({ threadId: SESSION_ID });
+  });
+});

--- a/sdks/typescript/src/opik/integrations/opik-vercel/tests/gen-ai.test.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/tests/gen-ai.test.ts
@@ -114,8 +114,10 @@ const CHAT_SPAN = makeSpan(
   { traceId: "trace1", spanId: "chat", startMs: 100, endMs: 1100 }
 );
 
-// eve wraps each model call in an `invoke_agent` span that repeats the call's
-// token usage. It is an orchestration span (type `general`), not a model call.
+// eve wraps each model call in an `invoke_agent` span that repeats the model
+// call's full `gen_ai.usage` (verified against real eve telemetry). It is an
+// orchestration span (type `general`), not a model call — the exporter must
+// drop this usage so the trace total isn't double-counted.
 const INVOKE_AGENT_SPAN = makeSpan(
   "gen_ai",
   "invoke_agent claude-haiku-4-5",
@@ -123,6 +125,8 @@ const INVOKE_AGENT_SPAN = makeSpan(
     "gen_ai.operation.name": "invoke_agent",
     "gen_ai.usage.input_tokens": 5170,
     "gen_ai.usage.output_tokens": 54,
+    "gen_ai.usage.cache_read.input_tokens": 5167,
+    "gen_ai.usage.cache_creation.input_tokens": 48,
   },
   { traceId: "trace1", spanId: "agent", startMs: 50, endMs: 1150 }
 );

--- a/sdks/typescript/src/opik/integrations/opik-vercel/tests/gen-ai.test.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/tests/gen-ai.test.ts
@@ -185,7 +185,7 @@ describe("OpikExporter - AI SDK v7 / GenAI (eve) spans", () => {
 
   // ──────────────────────────────── Tests ─────────────────────────────────
 
-  it("captures the prompt, answer and token usage in OpenAI chat shape", async () => {
+  it("captures the prompt and answer in OpenAI chat shape on the trace", async () => {
     const result = await exportSpans(TURN_SPAN, CHAT_SPAN, TOOL_SPAN);
 
     expect(result.code).toBe(0);
@@ -203,16 +203,25 @@ describe("OpikExporter - AI SDK v7 / GenAI (eve) spans", () => {
           },
         ],
       },
-      // token usage, including cache tokens
-      usage: {
-        prompt_tokens: 5170,
-        completion_tokens: 54,
-        total_tokens: 5224,
-        "original_usage.cache_read_input_tokens": 5167,
-        "original_usage.cache_creation_input_tokens": 48,
-      },
       // multi-turn grouping via the eve session id
       threadId: SESSION_ID,
+    });
+    // The trace itself never carries token usage; the backend aggregates it
+    // from the LLM spans.
+    expect((lastTrace() as { usage?: unknown }).usage).toBeUndefined();
+  });
+
+  it("records token usage (incl. cache tokens) on the LLM span", async () => {
+    await exportSpans(TURN_SPAN, CHAT_SPAN, TOOL_SPAN);
+
+    const chat = createdSpans().find((span) => span.name?.startsWith("chat"));
+    expect(chat!.type).toBe("llm");
+    expect(chat!.usage).toMatchObject({
+      prompt_tokens: 5170,
+      completion_tokens: 54,
+      total_tokens: 5224,
+      "original_usage.cache_read_input_tokens": 5167,
+      "original_usage.cache_creation_input_tokens": 48,
     });
   });
 

--- a/sdks/typescript/src/opik/integrations/opik-vercel/tests/real-llm.test.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/tests/real-llm.test.ts
@@ -25,7 +25,7 @@ import { mockAPIFunction } from "./mockUtils";
 const MODEL = "claude-haiku-4-5";
 const PROMPT = "Reply with a one-sentence greeting.";
 
-// Minimal view of the trace payload the exporter sends to the Opik REST client.
+// Minimal views of the payloads the exporter sends to the Opik REST client.
 type TracePayload = {
   input?: unknown;
   output?: Record<string, unknown>;
@@ -33,8 +33,14 @@ type TracePayload = {
   errorInfo?: { exceptionType?: string };
 };
 
+type SpanPayload = {
+  type?: string;
+  usage?: Record<string, number>;
+};
+
 type Captured = {
   trace: TracePayload;
+  spans: SpanPayload[];
   updateCalled: boolean;
 };
 
@@ -73,9 +79,9 @@ describe.skipIf(!process.env.ANTHROPIC_API_KEY)(
       const updateSpan = vi
         .spyOn(client.api.spans, "updateSpan")
         .mockImplementation(mockAPIFunction as never);
-      vi.spyOn(client.api.spans, "createSpans").mockImplementation(
-        mockAPIFunction as never
-      );
+      const createSpans = vi
+        .spyOn(client.api.spans, "createSpans")
+        .mockImplementation(mockAPIFunction as never);
 
       sdk.start();
       await call();
@@ -84,18 +90,36 @@ describe.skipIf(!process.env.ANTHROPIC_API_KEY)(
       const traces = createTraces.mock.calls.flatMap(
         (c) => c[0].traces
       ) as TracePayload[];
+      const spans = createSpans.mock.calls.flatMap(
+        (c) => c[0].spans
+      ) as SpanPayload[];
 
       return {
         trace: traces.at(-1)!,
+        spans,
         updateCalled:
           updateTrace.mock.calls.length > 0 || updateSpan.mock.calls.length > 0,
       };
     }
 
+    // Token usage must live on an LLM span, never on the trace.
+    function expectUsageOnLlmSpanOnly(captured: Captured) {
+      expect((captured.trace as { usage?: unknown }).usage).toBeUndefined();
+      const llmWithUsage = captured.spans.filter(
+        (span) => span.type === "llm" && (span.usage?.total_tokens ?? 0) > 0
+      );
+      expect(llmWithUsage.length).toBeGreaterThan(0);
+      // No non-LLM span carries usage.
+      const nonLlmWithUsage = captured.spans.filter(
+        (span) => span.type !== "llm" && span.usage !== undefined
+      );
+      expect(nonLlmWithUsage).toHaveLength(0);
+    }
+
     // ─────────────────────────── Tests ───────────────────────────
 
     it("generateText logs the prompt, some output and token usage", async () => {
-      const { trace, updateCalled } = await capture(async () => {
+      const captured = await capture(async () => {
         await generateText({
           model: anthropic(MODEL),
           prompt: PROMPT,
@@ -103,14 +127,14 @@ describe.skipIf(!process.env.ANTHROPIC_API_KEY)(
         });
       });
 
-      expect(JSON.stringify(trace.input)).toContain(PROMPT); // expected input
-      expect(Object.keys(trace.output ?? {}).length).toBeGreaterThan(0); // some output
-      expect(trace.usage?.total_tokens ?? 0).toBeGreaterThan(0); // token usage
-      expect(updateCalled).toBe(false); // create-only
+      expect(JSON.stringify(captured.trace.input)).toContain(PROMPT); // expected input
+      expect(Object.keys(captured.trace.output ?? {}).length).toBeGreaterThan(0); // some output
+      expect(captured.updateCalled).toBe(false); // create-only
+      expectUsageOnLlmSpanOnly(captured); // token usage, LLM span only
     }, 60_000);
 
     it("streamText logs the prompt, some output and token usage", async () => {
-      const { trace, updateCalled } = await capture(async () => {
+      const captured = await capture(async () => {
         const result = streamText({
           model: anthropic(MODEL),
           prompt: PROMPT,
@@ -120,10 +144,10 @@ describe.skipIf(!process.env.ANTHROPIC_API_KEY)(
         await result.consumeStream();
       });
 
-      expect(JSON.stringify(trace.input)).toContain(PROMPT); // expected input
-      expect(Object.keys(trace.output ?? {}).length).toBeGreaterThan(0); // some output
-      expect(trace.usage?.total_tokens ?? 0).toBeGreaterThan(0); // token usage
-      expect(updateCalled).toBe(false); // create-only
+      expect(JSON.stringify(captured.trace.input)).toContain(PROMPT); // expected input
+      expect(Object.keys(captured.trace.output ?? {}).length).toBeGreaterThan(0); // some output
+      expect(captured.updateCalled).toBe(false); // create-only
+      expectUsageOnLlmSpanOnly(captured); // token usage, LLM span only
     }, 60_000);
 
     it("captures error information when the model call fails", async () => {

--- a/sdks/typescript/src/opik/integrations/opik-vercel/tests/real-llm.test.ts
+++ b/sdks/typescript/src/opik/integrations/opik-vercel/tests/real-llm.test.ts
@@ -1,0 +1,148 @@
+import { createAnthropic, type AnthropicProvider } from "@ai-sdk/anthropic";
+import { trace } from "@opentelemetry/api";
+import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { generateText, streamText } from "ai";
+import { Opik } from "opik";
+import { OpikExporter } from "../src/exporter";
+import { mockAPIFunction } from "./mockUtils";
+
+/**
+ * Real-LLM integration test.
+ *
+ * A live Anthropic call flows through the OpenTelemetry pipeline into
+ * OpikExporter; we assert the trace payloads the exporter produces. The Opik
+ * client is spied, so no Opik backend is required.
+ *
+ * Design for non-flakiness:
+ * - Skipped unless ANTHROPIC_API_KEY is set (CI without a key stays green).
+ * - Assertions are presence-based — the prompt is present, SOME output exists,
+ *   token usage is present, errors are captured. We never assert on the model's
+ *   wording or whether it chose to call a tool (that behavior is covered
+ *   deterministically in gen-ai.test.ts).
+ */
+
+const MODEL = "claude-haiku-4-5";
+const PROMPT = "Reply with a one-sentence greeting.";
+
+// Minimal view of the trace payload the exporter sends to the Opik REST client.
+type TracePayload = {
+  input?: unknown;
+  output?: Record<string, unknown>;
+  usage?: Record<string, number>;
+  errorInfo?: { exceptionType?: string };
+};
+
+type Captured = {
+  trace: TracePayload;
+  updateCalled: boolean;
+};
+
+describe.skipIf(!process.env.ANTHROPIC_API_KEY)(
+  "OpikExporter - real Anthropic call",
+  () => {
+    // ─────────────────────────── Setup ───────────────────────────
+    let client: Opik;
+    let sdk: NodeSDK;
+    let anthropic: AnthropicProvider;
+
+    beforeAll(() => {
+      // Claude Code injects ANTHROPIC_BASE_URL (a local proxy); clear it so the
+      // AI SDK reaches the real Anthropic API.
+      delete process.env.ANTHROPIC_BASE_URL;
+    });
+
+    beforeEach(() => {
+      trace.disable();
+      client = new Opik({ projectName: "opik-sdk-typescript" });
+      sdk = new NodeSDK({
+        traceExporter: new OpikExporter({ client }),
+        instrumentations: [getNodeAutoInstrumentations()],
+      });
+      anthropic = createAnthropic();
+    });
+
+    // Runs `call`, flushes telemetry, and returns the captured trace payload.
+    async function capture(call: () => Promise<void>): Promise<Captured> {
+      const createTraces = vi
+        .spyOn(client.api.traces, "createTraces")
+        .mockImplementation(mockAPIFunction as never);
+      const updateTrace = vi
+        .spyOn(client.api.traces, "updateTrace")
+        .mockImplementation(mockAPIFunction as never);
+      const updateSpan = vi
+        .spyOn(client.api.spans, "updateSpan")
+        .mockImplementation(mockAPIFunction as never);
+      vi.spyOn(client.api.spans, "createSpans").mockImplementation(
+        mockAPIFunction as never
+      );
+
+      sdk.start();
+      await call();
+      await sdk.shutdown();
+
+      const traces = createTraces.mock.calls.flatMap(
+        (c) => c[0].traces
+      ) as TracePayload[];
+
+      return {
+        trace: traces.at(-1)!,
+        updateCalled:
+          updateTrace.mock.calls.length > 0 || updateSpan.mock.calls.length > 0,
+      };
+    }
+
+    // ─────────────────────────── Tests ───────────────────────────
+
+    it("generateText logs the prompt, some output and token usage", async () => {
+      const { trace, updateCalled } = await capture(async () => {
+        await generateText({
+          model: anthropic(MODEL),
+          prompt: PROMPT,
+          experimental_telemetry: OpikExporter.getSettings({ name: "real-generate" }),
+        });
+      });
+
+      expect(JSON.stringify(trace.input)).toContain(PROMPT); // expected input
+      expect(Object.keys(trace.output ?? {}).length).toBeGreaterThan(0); // some output
+      expect(trace.usage?.total_tokens ?? 0).toBeGreaterThan(0); // token usage
+      expect(updateCalled).toBe(false); // create-only
+    }, 60_000);
+
+    it("streamText logs the prompt, some output and token usage", async () => {
+      const { trace, updateCalled } = await capture(async () => {
+        const result = streamText({
+          model: anthropic(MODEL),
+          prompt: PROMPT,
+          experimental_telemetry: OpikExporter.getSettings({ name: "real-stream" }),
+        });
+        // streamText telemetry only finalizes once the stream is drained.
+        await result.consumeStream();
+      });
+
+      expect(JSON.stringify(trace.input)).toContain(PROMPT); // expected input
+      expect(Object.keys(trace.output ?? {}).length).toBeGreaterThan(0); // some output
+      expect(trace.usage?.total_tokens ?? 0).toBeGreaterThan(0); // token usage
+      expect(updateCalled).toBe(false); // create-only
+    }, 60_000);
+
+    it("captures error information when the model call fails", async () => {
+      let threw = false;
+
+      const { trace } = await capture(async () => {
+        try {
+          await generateText({
+            model: anthropic("claude-nonexistent-model-xyz"),
+            prompt: PROMPT,
+            experimental_telemetry: OpikExporter.getSettings({ name: "real-error" }),
+          });
+        } catch {
+          threw = true; // the failing model call must surface to the caller
+        }
+      });
+
+      expect(threw).toBe(true);
+      expect(trace.errorInfo?.exceptionType).toBeTruthy(); // error information
+    }, 60_000);
+  }
+);


### PR DESCRIPTION
## Details

Reworks the `opik-vercel` OpenTelemetry exporter so it captures full, correctly-structured traces from **AI SDK v7 / Vercel eve** agents. Previously the exporter only understood AI SDK v4/v5/v6 (`ai.*` scope) and produced nearly-empty, flat, mistyped traces for v7/eve (which emit the OpenTelemetry GenAI `gen_ai.*` scope, eve's `eve.*` context, and **no** parent-child links).

- Ingest `gen_ai` + `eve` scopes (in addition to `ai`); capture prompts, answers, tool args/results, thread id (eve session), and `eve.*` metadata.
- Classify span types (`chat`→`llm`, `execute_tool`→`tool`, agent/step/turn→`general`); reconstruct the hierarchy by **time containment** since eve emits no parent links; set trace timestamps to span the whole turn.
- Normalize messages to **OpenAI chat shape** (`messages`/`choices`/`tool_calls`/`tool`) so the Opik UI pretty-renders the conversation.
- **Token usage is recorded only on `llm` spans** — not on the trace, tool, or orchestration (`general`) spans. eve repeats each model call's `gen_ai.usage` on its `invoke_agent`/`step` wrapper spans, so logging it there double-counted the trace total (a real turn showed `prompt_tokens` 20842 instead of 10421); the trace total is aggregated from the LLM spans.
- **Create-only** emission (upsert from stable ids); never `update()`/`end()`.
- Refactor: all attribute parsing extracted into `attributes.ts`, split by convention (`aiSdk` vs `genAi`), leaving `exporter.ts` to do OTel orchestration only.
- No regressions to the v4/v5/v6 path (existing `ai-sdk`/`otel` tests still pass, updated only to assert usage on the LLM span rather than the trace).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves # NA
- OPIK- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: exporter rework (`exporter.ts`, new `attributes.ts`), tests (`gen-ai.test.ts`, `real-llm.test.ts`, updates to `ai-sdk.test.ts`), and the new CI workflow
  - Human verification: ran the suite locally (incl. live Anthropic tests) and verified a real eve turn end-to-end against a local Opik backend via the Opik MCP — including that the trace token total is no longer doubled and that only LLM spans carry usage

## Testing

- `npm run typecheck`, `npm run lint`, `npm test` in `sdks/typescript/src/opik/integrations/opik-vercel` — `20 passed | 3 skipped` without a key; `23 passed` with `ANTHROPIC_API_KEY` (the gated live tests run).
- Deterministic tests (`gen-ai.test.ts`) over span attributes captured from a real eve run: input/output (OpenAI chat shape), error info, span types, time-containment nesting, create-only contract, and **usage only on LLM spans (no double counting)**.
- Live tests (`real-llm.test.ts`, gated on `ANTHROPIC_API_KEY`): real Anthropic `generateText`, `streamText`, and an error case — presence-based assertions (input present, some output, usage on the LLM span only, error info) so they are non-flaky.
- End-to-end against a local Opik backend, verified via the Opik MCP: a real eve turn produces one trace (7 spans), correct types/nesting/timestamps, FE chat format, and a correct (non-doubled) token total with usage only on the `chat` spans.

<img width="1938" height="916" alt="image" src="https://github.com/user-attachments/assets/dfde7b9e-9885-44c5-a24c-44694b3a00dd" />


## Documentation

N/A — no user-facing docs changed in this PR.
