### PR TITLE
[OPIK-7035] [BE] Thread query optimizations: listing page-pushdown + close/feedback thread-id resolution

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreService.java
@@ -451,10 +451,8 @@ class FeedbackScoreServiceImpl implements FeedbackScoreService {
                             .map(FeedbackScoreItem::threadId)
                             .collect(Collectors.toSet());
 
-                    return Flux.fromIterable(threadIds)
-                            // resolve thread model IDs for each thread ID
-                            .flatMap(threadId -> getOrCreateThread(projectDto, threadId))
-                            .collectMap(Map.Entry::getKey, Map.Entry::getValue)
+                    // resolve all thread model IDs in a single bulk get-or-create instead of one per thread
+                    return traceThreadService.getOrCreateThreadIds(projectDto.project().id(), threadIds)
                             .map(threadIdMap -> bindThreadModelId(projectDto, threadIdMap))
                             .filter(projectDtoWithThreads -> !projectDtoWithThreads.scores().isEmpty())
                             // Thread status validation removed - feedback scores can now be added to threads
@@ -465,12 +463,6 @@ class FeedbackScoreServiceImpl implements FeedbackScoreService {
                                             author));
                 })
                 .reduce(0L, Long::sum);
-    }
-
-    private Mono<Map.Entry<String, UUID>> getOrCreateThread(ProjectDto<FeedbackScoreBatchItemThread> projectDto,
-            String threadId) {
-        return traceThreadService.getOrCreateThreadId(projectDto.project().id(), threadId)
-                .map(threadModelId -> Map.entry(threadId, threadModelId));
     }
 
     private ProjectDto<FeedbackScoreBatchItemThread> bindThreadModelId(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
@@ -90,6 +90,40 @@ class ThreadDAOImpl implements ThreadDAO {
                 WHERE 1 = 1
                 <if(filters)> AND <filters> <endif>
                 <if(search_text)> AND <search_text> <endif>
+            ), <endif><if(page_pushdown)>page_thread_ids AS (
+                SELECT thread_id
+                FROM (
+                    SELECT
+                        thread_id,
+                        min(start_time) AS start_time,
+                        max(end_time) AS end_time,
+                        max(last_updated_at) AS trace_last_updated_at
+                    FROM (
+                        SELECT id, thread_id, start_time, end_time, last_updated_at
+                        FROM traces
+                        WHERE workspace_id = :workspace_id
+                          AND project_id = :project_id
+                          AND thread_id \\<> ''
+                          <if(filters)> AND <filters> <endif>
+                          <if(search_text)> AND <search_text> <endif>
+                        ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
+                        LIMIT 1 BY id
+                    )
+                    GROUP BY thread_id
+                ) AS pt
+                LEFT JOIN (
+                    SELECT thread_id, id, last_updated_at
+                    FROM trace_threads
+                    WHERE workspace_id = :workspace_id
+                      AND project_id = :project_id
+                    ORDER BY (workspace_id, project_id, thread_id, id) DESC, last_updated_at DESC
+                    LIMIT 1 BY id
+                ) AS ptt ON pt.thread_id = ptt.thread_id
+                ORDER BY if(ptt.last_updated_at = toDateTime64(0, 6, 'UTC'), pt.trace_last_updated_at, ptt.last_updated_at) DESC,
+                    pt.start_time ASC,
+                    pt.end_time DESC,
+                    pt.thread_id
+                LIMIT :limit <if(offset)>OFFSET :offset<endif>
             ), <endif>traces_final AS (
                 SELECT
                     id,
@@ -121,12 +155,18 @@ class ThreadDAOImpl implements ThreadDAO {
                     WHERE workspace_id = :workspace_id
                       AND project_id = :project_id
                       AND thread_id \\<> ''
-                      <if(traces_final_ids)>
-                          AND id IN (SELECT id FROM traces_final_ids)
+                      <if(page_pushdown)>
+                          AND thread_id IN (SELECT thread_id FROM page_thread_ids)
+                          <if(filters)> AND <filters> <endif>
+                          <if(search_text)> AND <search_text> <endif>
                       <else>
-                          <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
-                          <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
-                          <if(traces_pushdown_filter)> AND thread_id = :thread_id_pushdown <endif>
+                          <if(traces_final_ids)>
+                              AND id IN (SELECT id FROM traces_final_ids)
+                          <else>
+                              <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
+                              <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                              <if(traces_pushdown_filter)> AND thread_id = :thread_id_pushdown <endif>
+                          <endif>
                       <endif>
                     ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
                     LIMIT 1 BY id
@@ -145,11 +185,15 @@ class ThreadDAOImpl implements ThreadDAO {
                 FROM spans
                 WHERE workspace_id = :workspace_id
                   AND project_id = :project_id
-                  <if(traces_final_ids)>
-                      AND trace_id IN (SELECT id FROM traces_final_ids)
+                  <if(page_pushdown)>
+                      AND trace_id IN (SELECT id FROM traces_final)
                   <else>
-                      <if(uuid_from_time)> AND trace_id >= :uuid_from_time <endif>
-                      <if(uuid_to_time)> AND trace_id \\<= :uuid_to_time <endif>
+                      <if(traces_final_ids)>
+                          AND trace_id IN (SELECT id FROM traces_final_ids)
+                      <else>
+                          <if(uuid_from_time)> AND trace_id >= :uuid_from_time <endif>
+                          <if(uuid_to_time)> AND trace_id \\<= :uuid_to_time <endif>
+                      <endif>
                   <endif>
                 ORDER BY (workspace_id, project_id, trace_id, parent_span_id, id) DESC, last_updated_at DESC
                 LIMIT 1 BY id
@@ -186,6 +230,7 @@ class ThreadDAOImpl implements ThreadDAO {
                     <endif>
                 <endif>
                 <if(traces_pushdown_filter)> AND thread_id = :thread_id_pushdown <endif>
+                <if(page_pushdown)> AND thread_id IN (SELECT thread_id FROM traces_final) <endif>
                 ORDER BY (workspace_id, project_id, thread_id, id) DESC, last_updated_at DESC
                 LIMIT 1 BY id
             ), feedback_scores_deduped AS (
@@ -430,7 +475,7 @@ class ThreadDAOImpl implements ThreadDAO {
             <else>
             <if(sort_fields)> ORDER BY <sort_fields>, last_updated_at DESC <else> ORDER BY last_updated_at DESC, start_time ASC, end_time DESC <endif>
             <endif>
-            LIMIT :limit <if(offset)>OFFSET :offset<endif>
+            LIMIT :limit <if(page_pushdown)><else><if(offset)>OFFSET :offset<endif><endif>
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
@@ -1293,6 +1338,34 @@ class ThreadDAOImpl implements ThreadDAO {
         return criteria.searchText() != null || template.getAttribute("filters") != null;
     }
 
+    /**
+     * OPIK-7035: template attributes that make the page-pushdown unsafe. The pushdown resolves the page in
+     * one narrow {@code traces} scan ({@code page_thread_ids}: per-thread min/max sort keys + the filter,
+     * joined to {@code trace_threads} for the {@code last_updated_at} coalesce, limit pushed early), then
+     * enriches only that page so the wide {@code input}/{@code output} columns and spans are read for
+     * ~page-size threads instead of the whole project. It is only output-equivalent when page membership
+     * and ordering are fully determined by that narrow {@code traces}+{@code trace_threads} scan. Any of
+     * these attributes means the page can only be resolved by the full enrichment query (filters/sorts
+     * that need the spans/feedback/annotation joins, or the uuid time-range path that uses a different
+     * INNER join), so we fall back.
+     */
+    private static final List<String> PAGE_PUSHDOWN_DISQUALIFIERS = List.of(
+            "sort_fields", "uuid_from_time", "uuid_to_time", "traces_pushdown_filter",
+            "feedback_scores_filters", "feedback_scores_empty_filters",
+            "span_feedback_scores_filters", "span_feedback_scores_empty_filters",
+            "trace_aggregation_filters", "trace_thread_filters", "annotation_queue_filters",
+            "annotation_queue_id", "experiment_filters", "guardrails_filters", "last_retrieved_id",
+            "stream");
+
+    /**
+     * The page-pushdown is eligible only for the common listing case: default sort over {@code trace_threads}
+     * recency, with no filter/sort that needs the wide-column / spans / feedback / annotation joins to
+     * determine which threads land on the page. Otherwise the full scan query runs unchanged.
+     */
+    private static boolean isPagePushdownEligible(ST template) {
+        return PAGE_PUSHDOWN_DISQUALIFIERS.stream().noneMatch(attr -> template.getAttribute(attr) != null);
+    }
+
     @Override
     @WithSpan
     public Mono<TraceThread.TraceThreadPage> find(int size, int page, @NonNull TraceSearchCriteria criteria) {
@@ -1312,15 +1385,24 @@ class ThreadDAOImpl implements ThreadDAO {
                                     .add("log_comment", getLogComment("find_threads_by_project", workspaceId, userName,
                                             "page:" + page + ":size:" + size));
 
-                            if (shouldUseTracesFinalIdsPrefilter(criteria, template)) {
-                                template.add("traces_final_ids", true);
-                            }
-
                             var finalTemplate = template;
                             Optional.ofNullable(sortingQueryBuilder.toOrderBySql(criteria.sortingFields()))
                                     .ifPresent(sortFields -> finalTemplate.add("sort_fields", sortFields));
 
                             var hasDynamicKeys = sortingQueryBuilder.hasDynamicKeys(criteria.sortingFields());
+
+                            // OPIK-7035: resolve the page first (one narrow filter+order scan over traces,
+                            // limit pushed early), then enrich only that page so the wide input/output columns
+                            // and spans are read for ~page-size threads instead of the whole project. The page
+                            // resolver applies the filter itself, so it is mutually exclusive with the
+                            // traces_final_ids prefilter — enabling both would scan the project traces twice and
+                            // compound under ClickHouse CTE re-evaluation. Falls back to the full query for any
+                            // filter/sort that needs the joined sources to determine the page.
+                            if (isPagePushdownEligible(finalTemplate)) {
+                                finalTemplate.add("page_pushdown", true);
+                            } else if (shouldUseTracesFinalIdsPrefilter(criteria, finalTemplate)) {
+                                finalTemplate.add("traces_final_ids", true);
+                            }
 
                             var statement = connection.createStatement(template.render())
                                     .bind("project_id", criteria.projectId())

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
@@ -136,8 +136,8 @@ class TraceThreadServiceImpl implements TraceThreadService {
     }
 
     @Override
-    public Mono<Map<String, UUID>> getOrCreateThreadIds(@NonNull UUID projectId, @NonNull Set<String> threadIds) {
-        if (threadIds.isEmpty()) {
+    public Mono<Map<String, UUID>> getOrCreateThreadIds(@NonNull UUID projectId, Set<String> threadIds) {
+        if (CollectionUtils.isEmpty(threadIds)) {
             return Mono.just(Map.of());
         }
         // Bulk get-or-create in a single query instead of one round-trip per thread. Null timestamps match

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
@@ -33,6 +33,7 @@ import reactor.util.context.ContextView;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -64,6 +65,8 @@ public interface TraceThreadService {
     Mono<Void> closeThreads(UUID projectId, String projectName, Set<String> threadIds);
 
     Mono<UUID> getOrCreateThreadId(UUID projectId, String threadId);
+
+    Mono<Map<String, UUID>> getOrCreateThreadIds(UUID projectId, Set<String> threadIds);
 
     Mono<UUID> getThreadModelId(UUID projectId, String threadId);
 
@@ -130,6 +133,24 @@ class TraceThreadServiceImpl implements TraceThreadService {
         return Mono.deferContextual(context -> traceThreadIdService
                 .getOrCreateTraceThreadId(context.get(RequestContext.WORKSPACE_ID), projectId, threadId, timestamp)
                 .map(TraceThreadIdModel::id));
+    }
+
+    @Override
+    public Mono<Map<String, UUID>> getOrCreateThreadIds(@NonNull UUID projectId, @NonNull Set<String> threadIds) {
+        if (threadIds.isEmpty()) {
+            return Mono.just(Map.of());
+        }
+        // Bulk get-or-create in a single query instead of one round-trip per thread. Null timestamps match
+        // getOrCreateThreadId(projectId, threadId): a missing thread's model id is generated from the current time.
+        return Mono.deferContextual(context -> {
+            Map<String, Instant> threadIdToTimestamp = new HashMap<>();
+            threadIds.forEach(threadId -> threadIdToTimestamp.put(threadId, null));
+            return traceThreadIdService
+                    .getOrCreateTraceThreadIds(context.get(RequestContext.WORKSPACE_ID), projectId, threadIdToTimestamp)
+                    .map(models -> models.stream()
+                            .collect(Collectors.toMap(TraceThreadIdModel::threadId, TraceThreadIdModel::id,
+                                    (existing, duplicate) -> existing)));
+        });
     }
 
     @Override
@@ -448,7 +469,12 @@ class TraceThreadServiceImpl implements TraceThreadService {
     private Mono<Void> createMissingThreads(UUID projectId, String workspaceId, String userName,
             List<TraceThread> threads) {
         List<UUID> modelIds = threads.stream().map(TraceThread::threadModelId).toList();
-        var criteria = TraceThreadCriteria.builder().projectId(projectId).ids(modelIds).build();
+        // OPIK-7035: also constrain by thread_id so the (workspace_id, project_id, thread_id, id) primary key
+        // can seek instead of scanning the whole project's trace_threads. Filtering by id alone leaves thread_id
+        // (the 3rd PK column) unbound, forcing a full-project scan (~750K rows in prod to find a handful).
+        // thread_model_id maps 1:1 to thread_id, so this excludes no matching row.
+        Set<String> threadIds = threads.stream().map(TraceThread::id).collect(Collectors.toSet());
+        var criteria = TraceThreadCriteria.builder().projectId(projectId).ids(modelIds).threadIds(threadIds).build();
 
         return traceThreadDAO.findThreadsByProject(1, modelIds.size(), criteria)
                 .flatMap(existing -> {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindTraceThreadsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindTraceThreadsResourceTest.java
@@ -481,22 +481,23 @@ class FindTraceThreadsResourceTest {
                     List.of(), List.of(), Map.of("page", "1", "size", String.valueOf(threadCount + 5)));
             assertThat(fullPage.total()).isEqualTo(threadCount);
             assertThat(fullPage.content()).hasSize(threadCount);
-            var fullOrder = fullPage.content().stream().map(TraceThread::id).toList();
 
             // page through with a size that forces multiple pages (offset > 0 on pages 2..N)
             int size = 3;
             int pages = (threadCount + size - 1) / size;
-            List<String> pagedOrder = new ArrayList<>();
+            List<TraceThread> pagedContent = new ArrayList<>();
             for (int page = 1; page <= pages; page++) {
                 var p = traceResourceClient.getTraceThreads(projectId, null, API_KEY, TEST_WORKSPACE,
                         List.of(), List.of(), Map.of("page", String.valueOf(page), "size", String.valueOf(size)));
                 assertThat(p.total()).isEqualTo(threadCount);
                 assertThat(p.page()).isEqualTo(page);
                 assertThat(p.content()).hasSize(Math.min(size, threadCount - (page - 1) * size));
-                pagedOrder.addAll(p.content().stream().map(TraceThread::id).toList());
+                pagedContent.addAll(p.content());
             }
 
-            assertThat(pagedOrder).containsExactlyElementsOf(fullOrder);
+            // pages must reconstruct the full single-page result exactly — full payload (not just ids),
+            // same order, no overlap, no gaps
+            TraceAssertions.assertThreads(fullPage.content(), pagedContent);
         }
 
         @ParameterizedTest

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindTraceThreadsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindTraceThreadsResourceTest.java
@@ -451,6 +451,54 @@ class FindTraceThreadsResourceTest {
                     TEST_WORKSPACE);
         }
 
+        @Test
+        @DisplayName("when paginating threads with default sort, then pages partition the full ordered list")
+        void whenPaginatingThreadsWithDefaultSort__thenPagesPartitionFullOrderedList() {
+            // Exercises the OPIK-7035 page-pushdown path (default sort, no filters): the page_thread_ids CTE
+            // applies LIMIT/OFFSET and the outer query drops its OFFSET, so offset>0 (page >= 2) is only
+            // covered here. Pages must reconstruct the exact full ordered list (no double/missing offset,
+            // no overlaps, no gaps).
+            var projectName = RandomStringUtils.secure().nextAlphanumeric(10);
+            int threadCount = 7;
+            var baseTime = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+
+            // one single-trace thread per distinct threadId, with distinct start/end times so the default-sort
+            // order is deterministic even if last_updated_at ties on batch insert
+            var traces = IntStream.range(0, threadCount)
+                    .mapToObj(i -> createTrace().toBuilder()
+                            .projectName(projectName)
+                            .threadId(UUID.randomUUID().toString())
+                            .startTime(baseTime.minusSeconds(i + 1L))
+                            .endTime(baseTime.minusSeconds(i + 1L).plusMillis(500))
+                            .build())
+                    .toList();
+            traceResourceClient.batchCreateTraces(traces, API_KEY, TEST_WORKSPACE);
+
+            var projectId = getProjectId(projectName, TEST_WORKSPACE, API_KEY);
+
+            // authoritative full ordered list (single page large enough to hold all threads)
+            var fullPage = traceResourceClient.getTraceThreads(projectId, null, API_KEY, TEST_WORKSPACE,
+                    List.of(), List.of(), Map.of("page", "1", "size", String.valueOf(threadCount + 5)));
+            assertThat(fullPage.total()).isEqualTo(threadCount);
+            assertThat(fullPage.content()).hasSize(threadCount);
+            var fullOrder = fullPage.content().stream().map(TraceThread::id).toList();
+
+            // page through with a size that forces multiple pages (offset > 0 on pages 2..N)
+            int size = 3;
+            int pages = (threadCount + size - 1) / size;
+            List<String> pagedOrder = new ArrayList<>();
+            for (int page = 1; page <= pages; page++) {
+                var p = traceResourceClient.getTraceThreads(projectId, null, API_KEY, TEST_WORKSPACE,
+                        List.of(), List.of(), Map.of("page", String.valueOf(page), "size", String.valueOf(size)));
+                assertThat(p.total()).isEqualTo(threadCount);
+                assertThat(p.page()).isEqualTo(page);
+                assertThat(p.content()).hasSize(Math.min(size, threadCount - (page - 1) * size));
+                pagedOrder.addAll(p.content().stream().map(TraceThread::id).toList());
+            }
+
+            assertThat(pagedOrder).containsExactlyElementsOf(fullOrder);
+        }
+
         @ParameterizedTest
         @MethodSource("getUnsupportedOperations")
         void whenFilterUnsupportedOperation__thenReturn400(boolean stream, TraceThreadField field, Operator operator,


### PR DESCRIPTION
## Details

Three output-equivalent optimizations to thread query paths, all reducing how much of a project's `traces`/`trace_threads` is scanned. Motivated by prod profiling (started from the `/threads/close` latency that #7158 partially fixed): each query was reading hundreds of thousands to millions of ClickHouse rows (or a GiB+ of wide columns) to return a page/handful of threads.

- **Threads listing** (`ThreadDAO`, `GET /v1/private/traces/threads`): aggregated every thread in the project from the wide `traces`+`spans` tables, then applied `LIMIT/OFFSET` at the end. Now resolves the page first in one narrow filter+order scan (`page_thread_ids`, limit pushed early), then enriches only that page — wide `input`/`output` and spans read for ~page-size threads. Mutually exclusive with the `traces_final_ids` prefilter so the project `traces` are scanned once (no CTE-re-evaluation compounding). Gated to default-sort listing; spans/feedback/annotation filters, the uuid time-range path, single-thread pushdown, and streaming fall back to the unchanged query.
- **Close path** (`TraceThreadService.createMissingThreads`): `findThreadsByProject` filtered by `id` alone left `thread_id` (3rd PK column) unbound, scanning the whole project's `trace_threads`. Now also passes `thread_id` so the `(workspace_id, project_id, thread_id, id)` PK seeks (`thread_model_id` maps 1:1 to `thread_id`, so output is unchanged).
- **Feedback path** (`FeedbackScoreService.scoreBatchOfThreads`, `PUT /v1/private/traces/threads/feedback-scores`): resolved thread-model-ids one-per-thread in a `flatMap`; now one bulk `getOrCreateThreadIds` (single `findByProjectIdAndThreadIds`) via the batch path the close flow already uses.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7035

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: investigation, ClickHouse/DAO query analysis & rewrites, and prod read-only validation (system.query_log, EXPLAIN ESTIMATE, full-row fingerprints)
  - Human verification: reviewed diffs; ran the backend test suites below; equivalence + cost confirmed against the prod read replica

## Testing

Run from `apps/opik-backend`:
- `mvn -Dtest=FindTraceThreadsResourceTest test` → **466/466** pass (default-sort pagination exercises the page-pushdown; sort/filter/time-range/stream exercise the unchanged fallback).
- `mvn -Dtest='TracesResourceTest$ThreadFeedbackScoresCreation,TracesResourceTest$TraceThreadManualOpenClose,TracesResourceTest$TraceThreadCreation' test` → **17/17** pass (feedback bulk resolution + close `createMissingThreads` + thread creation).
- `mvn -DskipTests compile` clean.

Prod validation (read-only, against `system.query_log` / `EXPLAIN ESTIMATE` / full-row `groupBitXor(cityHash64(*))` fingerprints, ~1M-trace project):
- **Listing**: rewritten query output **identical** to current (page 1, deep page, source filter, back-to-back). Cost: memory **946 MiB → 167 MiB (5.7×)**, bytes read **2.75 GiB → 1.02 GiB (2.7×)**, ~1.5× faster; plans/runs within budget.
- **Close `createMissingThreads`**: single-thread read **278K → 82K rows, 39ms → 13ms** (the PK now seeks; ~14× fewer rows on the worst prod cases that scanned ~1.16M).
- **Feedback bulk**: N per-thread MySQL resolutions → 1 (`performance_schema` not accessible to measure latency directly; reduction is structural and scales with batch size).

Not run locally: full backend integration suite (left to CI). HTTP-endpoint p50/p95 (Prometheus-only metric, not reachable from the validation environment).

## Documentation

No documentation changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)