### PR TITLE
[Opik-7039] [SDK] feat: enhance offline replay with WAL and replay leader lock

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -59,6 +59,7 @@ setup(
         "tqdm",
         "uuid6",
         "jinja2",
+        "filelock>=3.0.0",
         "watchfiles>=1.0.0,<2.0.0",
         # tree-sitter is used for JS/TS syntax checking in bridge handlers.
         # Pre-built wheels are missing for musllinux_aarch64 (Alpine on ARM64),

--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -259,6 +259,7 @@ class Opik:
             ping_interval=self._config.connection_monitor_ping_interval,
             check_timeout=self._config.connection_monitor_check_timeout,
             probe=probe,
+            assume_connected=self._config.offline_db_file is None,
         )
 
         fallback_replay = replay_manager.ReplayManager(
@@ -266,6 +267,7 @@ class Opik:
             batch_size=self._config.replay_batch_size,
             batch_replay_delay=self._config.replay_batch_replay_delay,
             tick_interval_seconds=self._config.replay_tick_interval,
+            db_file=self._config.offline_db_file,
         )
         return fallback_replay
 

--- a/sdks/python/src/opik/config.py
+++ b/sdks/python/src/opik/config.py
@@ -308,6 +308,18 @@ class OpikConfig(pydantic_settings.BaseSettings):
     Env var: OPIK_PROMPT_CACHE_TTL_SECONDS
     """
 
+    offline_db_file: Optional[str] = None
+    """
+    Path to a persistent SQLite file used by the offline replay manager.
+
+    When set, the SDK stores failed messages in this file. Multiple processes
+    on the same host can share the file using SQLite WAL mode; only one process
+    at a time is elected as the replay leader and replays failed messages.
+
+    When not set, the SDK uses a temporary file that is cleaned on shutdown
+    (default behavior).
+    """
+
     @property
     def config_file_fullpath(self) -> pathlib.Path:
         config_file_path = os.getenv("OPIK_CONFIG_PATH", CONFIG_FILE_PATH_DEFAULT)

--- a/sdks/python/src/opik/healthcheck/connection_monitor.py
+++ b/sdks/python/src/opik/healthcheck/connection_monitor.py
@@ -45,6 +45,7 @@ class OpikConnectionMonitor:
         ping_interval: float,
         check_timeout: float,
         probe: connection_probe.ConnectionProbe,
+        assume_connected: bool = True,
     ):
         """
         Initializes an instance of the class to handle connection probing and monitoring.
@@ -56,9 +57,13 @@ class OpikConnectionMonitor:
                 considered lost if no response is received.
             probe: An instance of the ``connection_probe.ConnectionProbe`` class used for
                 sending probe requests and handling connectivity checks.
+            assume_connected: Whether to assume the server is connected at startup.
+                Defaults to True to preserve existing behavior. When using a persistent
+                offline replay db, set this to False so the first successful ping returns
+                connection_restored and triggers replay of failed messages.
         """
         self._check_timeout = check_timeout
-        self._has_server_connection = True
+        self._has_server_connection = assume_connected
         self._probe = probe
 
         self.last_beat = float("-inf")
@@ -86,10 +91,11 @@ class OpikConnectionMonitor:
             failure_reason: Optional reason for the connection failure. Defaults to None if no reason
                 is provided.
         """
-        if self._has_server_connection:
+        if self._has_server_connection or self.disconnect_time == 0.0:
             # save the first disconnection time and reason
             self.disconnect_time = time.time()
-            self.disconnect_reason = failure_reason
+            if failure_reason is not None:
+                self.disconnect_reason = failure_reason
 
         self._has_server_connection = False
 

--- a/sdks/python/src/opik/message_processing/replay/db_manager.py
+++ b/sdks/python/src/opik/message_processing/replay/db_manager.py
@@ -37,11 +37,13 @@ class MessageStatus(IntEnum):
         registered: Message queued for delivery.
         delivered: Message delivered successfully.
         failed: Delivery failed.
+        replaying: Message is currently being replayed by the leader.
     """
 
     registered = 1
     delivered = 2
     failed = 3
+    replaying = 4
 
 
 @unique
@@ -373,9 +375,10 @@ class DBManager:
         total_replayed = 0
         for db_messages in self.fetch_failed_messages_batched(self.batch_size):
             params = [
-                (int(MessageStatus.registered), message.id) for message in db_messages
+                (int(MessageStatus.replaying), message.id) for message in db_messages
             ]
-            # Mark the batch as in-progress so it is not re-fetched concurrently.
+            # Mark the batch as being replayed so it is not re-fetched concurrently
+            # and a new leader can later identify messages left behind by a dead one.
             with self.__lock__:
                 if self.closed:
                     LOGGER.debug(
@@ -536,6 +539,38 @@ class DBManager:
                 LOGGER.error(msg)
                 self._mark_as_db_failed(msg)
                 return -1
+
+    def reset_replaying_messages(self) -> int:
+        """Reset messages left in the replaying state back to failed.
+
+        Called when a new replay leader acquires the lock. Messages that were
+        marked ``replaying`` by a previous leader may not have been delivered if
+        that leader died, so they must be eligible for replay again.
+        """
+        if not self.initialized:
+            LOGGER.debug("Not initialized - reset replaying messages ignored")
+            return 0
+
+        with self.__lock__:
+            if self.closed:
+                LOGGER.warning("Already closed - reset replaying messages ignored")
+                return 0
+
+            try:
+                with self.conn:
+                    c = self.conn.execute(
+                        "UPDATE messages SET status = ? WHERE status = ?",
+                        (MessageStatus.failed, MessageStatus.replaying),
+                    )
+                    LOGGER.debug(
+                        "Reset %d replaying message(s) back to failed", c.rowcount
+                    )
+                    return c.rowcount
+            except Exception as ex:
+                msg = f"reset_replaying_messages: failed to reset replaying messages, reason: {ex}"
+                LOGGER.error(msg)
+                self._mark_as_db_failed(msg)
+                raise
 
     def _mark_as_db_failed(self, message: str) -> None:
         self.status = DBManagerStatus.error

--- a/sdks/python/src/opik/message_processing/replay/db_manager.py
+++ b/sdks/python/src/opik/message_processing/replay/db_manager.py
@@ -46,6 +46,20 @@ class MessageStatus(IntEnum):
     replaying = 4
 
 
+def _message_status_from_int(value: int) -> MessageStatus:
+    """Return the MessageStatus for an integer value.
+
+    If the value is unknown (e.g. written by a newer/older SDK version), fall
+    back to ``failed`` so the message remains eligible for replay rather than
+    crashing the reader.
+    """
+    try:
+        return MessageStatus(value)
+    except ValueError:
+        LOGGER.warning("Unknown message status value %r, treating as failed", value)
+        return MessageStatus.failed
+
+
 @unique
 class DBManagerStatus(IntEnum):
     """Lifecycle states for DBManager."""
@@ -374,56 +388,71 @@ class DBManager:
 
         total_replayed = 0
         for db_messages in self.fetch_failed_messages_batched(self.batch_size):
-            params = [
-                (int(MessageStatus.replaying), message.id) for message in db_messages
-            ]
-            # Mark the batch as being replayed so it is not re-fetched concurrently
-            # and a new leader can later identify messages left behind by a dead one.
-            with self.__lock__:
-                if self.closed:
-                    LOGGER.debug(
-                        "Closed during replay - stopping after %d replayed",
-                        total_replayed,
-                    )
-                    break
-                try:
-                    with self.conn:
-                        c = self.conn.executemany(
-                            "UPDATE messages SET status = ? WHERE message_id = ?",
-                            params,
-                        )
-                        LOGGER.debug(
-                            "Updated %d DB message records for %d failed messages",
-                            c.rowcount,
-                            len(db_messages),
-                        )
-                except Exception as ex:
-                    self._mark_as_db_failed(
-                        f"replay_failed_messages: failed to update messages in the DB, reason: {ex}"
-                    )
-                    raise
-
-            replayed = self._replay_messages(
+            # Replay first, then mark the accepted messages as replaying. This
+            # keeps rows in the FAILED state if the callback cannot accept the
+            # message (e.g. the streamer is draining or preprocessing failed).
+            accepted_ids = self._replay_messages(
                 db_messages=db_messages, replay_callback=replay_callback
             )
-            total_replayed += replayed
+
+            if accepted_ids:
+                with self.__lock__:
+                    if self.closed:
+                        LOGGER.debug(
+                            "Closed during replay - stopping after %d replayed",
+                            total_replayed,
+                        )
+                        break
+                    try:
+                        with self.conn:
+                            params = [
+                                (int(MessageStatus.replaying), message_id)
+                                for message_id in accepted_ids
+                            ]
+                            c = self.conn.executemany(
+                                "UPDATE messages SET status = ? WHERE message_id = ?",
+                                params,
+                            )
+                            LOGGER.debug(
+                                "Marked %d DB message records as replaying",
+                                c.rowcount,
+                            )
+                    except Exception as ex:
+                        self._mark_as_db_failed(
+                            f"replay_failed_messages: failed to mark replaying messages in the DB, reason: {ex}"
+                        )
+                        raise
+
+            total_replayed += len(accepted_ids)
 
             # Pause between full batches without holding the lock.
-            if replayed >= self.batch_size:
+            if len(accepted_ids) >= self.batch_size:
                 time.sleep(self.batch_replay_delay)
 
         return total_replayed
 
     def _replay_messages(
         self, db_messages: List[DBMessage], replay_callback: ReplayCallback
-    ) -> int:
+    ) -> List[int]:
+        """Invoke the replay callback for each failed message.
+
+        Returns the list of message ids that the callback accepted. Rows stay
+        FAILED if the callback declines the message or raises.
+        """
         LOGGER.debug("Replaying %d failed messages to streamer", len(db_messages))
-        replayed = 0
+        accepted_ids: List[int] = []
         for message in db_messages:
             try:
                 base_message = db_message_to_message(message)
-                replay_callback(base_message)
-                replayed += 1
+                accepted = replay_callback(base_message)
+                if accepted is False:
+                    LOGGER.warning(
+                        "Replay callback declined message with id=%r, type=%r, leaving as failed",
+                        message.id,
+                        message.type,
+                    )
+                    continue
+                accepted_ids.append(message.id)
             except Exception as e:
                 LOGGER.error(
                     "Failed to replay message with id=%r, type=%r, status=%r, reason: %s",
@@ -433,9 +462,8 @@ class DBManager:
                     e,
                     exc_info=True,
                 )
-                self.update_message(message.id, MessageStatus.failed)
 
-        return replayed
+        return accepted_ids
 
     def get_message(self, message_id: int) -> Optional[messages.BaseMessage]:
         """Fetch a single message by id."""
@@ -461,7 +489,7 @@ class DBManager:
                             id=row[0],
                             type=row[1],
                             json=row[2],
-                            status=MessageStatus(row[3]),
+                            status=_message_status_from_int(row[3]),
                         )
                     return None
             except Exception as ex:
@@ -567,10 +595,13 @@ class DBManager:
                     )
                     return c.rowcount
             except Exception as ex:
+                # Bootstrap errors during leader election should not crash the
+                # application. Mark the DB as failed (which disables offline replay
+                # resiliency) and swallow the error so the caller can continue.
                 msg = f"reset_replaying_messages: failed to reset replaying messages, reason: {ex}"
                 LOGGER.error(msg)
                 self._mark_as_db_failed(msg)
-                raise
+                return 0
 
     def _mark_as_db_failed(self, message: str) -> None:
         self.status = DBManagerStatus.error

--- a/sdks/python/src/opik/message_processing/replay/db_manager.py
+++ b/sdks/python/src/opik/message_processing/replay/db_manager.py
@@ -2,10 +2,9 @@
 that failed to reach the Opik server. DBManager exposes helpers for the full
 message lifecycle: register_message(s), fetch_failed_messages_batched, and
 replay_failed_messages (which accepts a ReplayCallback, typically Streamer.put,
-to re-inject messages). The manager tracks three states — undefined, initialized, closed,
-and error — and if the underlying database becomes unavailable, it marks itself
-as failed (error) and logs that resiliency features are disabled. The standalone helper
-db_message_to_message raises ValueError for unsupported message types.
+to re-inject messages). The manager tracks three states — undefined, initialized,
+closed, and error — and if the underlying database becomes unavailable, it marks
+itself as failed (error) and logs that resiliency features are disabled.
 """
 
 import logging
@@ -34,16 +33,10 @@ class MessageStatus(IntEnum):
     """
     Represents the status of a message.
 
-    This enumeration defines the potential statuses that a message can
-    have in a messaging system. Used for categorizing messages based on
-    their lifecycle stage or outcome.
-
     Attributes:
-        registered: Represents a message that has been successfully
-            registered but not yet processed or delivered.
-        delivered : Represents a message that has been successfully
-            delivered to its recipient.
-        failed: Represents a message for which delivery has failed.
+        registered: Message queued for delivery.
+        delivered: Message delivered successfully.
+        failed: Delivery failed.
     """
 
     registered = 1
@@ -53,11 +46,7 @@ class MessageStatus(IntEnum):
 
 @unique
 class DBManagerStatus(IntEnum):
-    """Represents various status values for a manager.
-
-    Defines a set of distinct states that a manager can occupy during its lifecycle.
-    This can be used to track and manage the status of a manager in an application.
-    """
+    """Lifecycle states for DBManager."""
 
     undefined = 1
     initialized = 2
@@ -66,20 +55,7 @@ class DBManagerStatus(IntEnum):
 
 
 class DBMessage(NamedTuple):
-    """
-    Represents a database message entity.
-
-    This class is used to encapsulate information about messages stored in
-    or retrieved from a database. It provides a structured format for handling
-    message data, including its unique identifier, type, JSON content, and
-    current status.
-
-    Attributes:
-        id: The unique identifier of the message.
-        type: The type/category of the message.
-        json: The JSON-encoded content of the message.
-        status: The current status of the message.
-    """
+    """Database row representation of a stored message."""
 
     id: int
     type: str
@@ -87,22 +63,20 @@ class DBMessage(NamedTuple):
     status: MessageStatus
 
 
-def _preprocess_registered_message(message: messages.BaseMessage) -> str:
-    if message.message_id is None:
-        raise ValueError("Message ID expected")
-
+def _serialize_message(message: messages.BaseMessage) -> str:
     return message_serialization.serialize_message(message)
 
 
 class DBManager:
     """
-    Manages message storage, batch processing, and database operations within a replay
-    system.
+    Thread-safe SQLite store for replay messages.
 
-    This class provides functionalities to handle message registrations, batch updates,
-    and database schema management. It ensures thread-safe operations, cleans up
-    temporary files, and handles database connections as part of its lifecycle.
+    When ``db_file`` is provided, it is used as a single shared SQLite file.
+    Multiple processes can write concurrently because the connection runs in
+    WAL (write-ahead logging) mode.
 
+    When ``db_file`` is ``None``, a temporary directory and file are created and
+    cleaned up on close.
     """
 
     def __init__(
@@ -113,27 +87,23 @@ class DBManager:
         conn: Optional[sqlite3.Connection] = None,
         sync_lock: Optional[threading.RLock] = None,
     ) -> None:
-        """
-        Initializes the Manager class, setting up the database connection, temporary
-        directory, and other necessary properties for managing batch operations.
-
-        Args:
-            batch_size: The size of batches for processing.
-            batch_replay_delay: The delay (in seconds) between replaying batches of messages.
-            db_file: Path to the database file. If not provided, a
-                temporary file will be created in a temporary directory.
-            conn: A pre-existing database connection.
-                If not provided, a new connection is created.
-        """
         self.batch_size = batch_size
         self.batch_replay_delay = batch_replay_delay
         self.status = DBManagerStatus.undefined
-        self.tmp_dir = tempfile.mkdtemp()
+        self.tmp_dir: Optional[str] = None
+
         if db_file is None:
+            # Default mode: temporary file + automatic cleanup.
+            self.tmp_dir = tempfile.mkdtemp()
             db_file = os.path.join(self.tmp_dir, DEFAULT_DB_FILE)
+        else:
+            # Single shared file mode: ensure the parent directory exists.
+            parent_dir = os.path.dirname(os.path.abspath(db_file))
+            if parent_dir:
+                os.makedirs(parent_dir, exist_ok=True)
 
         self.db_file = db_file
-        # open DB connection if appropriate
+
         if conn is None:
             conn = sqlite3.connect(self.db_file, check_same_thread=False)
         self.conn = conn
@@ -144,22 +114,28 @@ class DBManager:
             self.__lock__ = sync_lock
 
         # Non-reentrant mutex that serializes concurrent replay_failed_messages
-        # calls. Producers (register_message / update_message) use self.__lock__,
-        # so they are never affected by this mutex.
+        # calls. Producers use self.__lock__, so they are never blocked by replay.
         self._replay_mutex = threading.Lock()
 
         self._create_db_schema()
 
+    def _configure_wal(self) -> None:
+        """Enable WAL mode so multiple processes can write concurrently."""
+        with self.conn:
+            self.conn.execute("PRAGMA journal_mode=WAL")
+            self.conn.execute("PRAGMA busy_timeout=5000")
+
     def _create_db_schema(self) -> None:
         try:
+            self._configure_wal()
             with self.__lock__:
                 with self.conn:
                     self.conn.execute(
                         """CREATE TABLE IF NOT EXISTS messages
-                                            (message_id INTEGER NOT NULL PRIMARY KEY,
-                                            status INTEGER NOT NULL,
-                                            message_type TEXT NOT NULL,
-                                            message_json TEXT NOT NULL)"""
+                            (message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                             status INTEGER NOT NULL,
+                             message_type TEXT NOT NULL,
+                             message_json TEXT NOT NULL)"""
                     )
                     self.status = DBManagerStatus.initialized
         except Exception as ex:
@@ -168,14 +144,7 @@ class DBManager:
             LOGGER.warning(msg, exc_info=True)
 
     def close(self) -> None:
-        """
-        Closes the current manager, releasing all associated resources.
-
-        This method ensures the proper cleanup of resources such as database connections
-        and temporary directories. It performs the operations within a thread-safe context
-        by acquiring an internal lock. If the manager is already closed, the method will
-        return immediately without performing any actions.
-        """
+        """Release all associated resources."""
         if self.closed:
             return
 
@@ -190,7 +159,7 @@ class DBManager:
                     "Failed to close messages DB connection: %s", e, exc_info=True
                 )
 
-            # delete temporary data
+            # Delete temporary data.
             if self.tmp_dir is not None:
                 try:
                     LOGGER.debug("Cleaning temporary data dir: %r", self.tmp_dir)
@@ -209,18 +178,8 @@ class DBManager:
         status: MessageStatus = MessageStatus.registered,
     ) -> None:
         """
-        Registers a message into the database if the system is initialized and not closed.
-
-        This method processes the given message, converts it into a JSON format, and
-        inserts it into the database with the provided or default status. If the system
-        is either not initialized or already closed, the message registration will be
-        ignored.
-
-        Args:
-            message: The message object to be registered. This
-                object must have attributes such as `message_id` and `message_type`.
-            status: The status of the message to be registered.
-                Defaults to `MessageStatus.registered`.
+        Persist a message. If ``message.message_id`` is ``None``, SQLite assigns
+        an auto-increment primary key and updates ``message.message_id`` with it.
         """
         if not self.initialized:
             LOGGER.debug("Not initialized - register message ignored")
@@ -231,21 +190,23 @@ class DBManager:
                 LOGGER.warning("Already closed - register message ignored")
                 return
 
-            message_json = _preprocess_registered_message(message)
-            # insert into DB
-            values = (
-                message.message_id,
-                status,
-                message.message_type,
-                message_json,
-            )
+            message_json = _serialize_message(message)
+
             try:
                 with self.conn:
-                    self.conn.execute(
-                        "INSERT INTO messages(message_id, status, message_type, message_json) VALUES (?,?,?,?)"
-                        " ON CONFLICT(message_id) DO UPDATE SET status = excluded.status, message_type = excluded.message_type, message_json = excluded.message_json",
-                        values,
-                    )
+                    if message.message_id is None:
+                        cursor = self.conn.execute(
+                            "INSERT INTO messages(status, message_type, message_json) VALUES (?, ?, ?)",
+                            (status, message.message_type, message_json),
+                        )
+                        message.message_id = cursor.lastrowid
+                    else:
+                        self.conn.execute(
+                            "INSERT INTO messages(message_id, status, message_type, message_json) VALUES (?, ?, ?, ?)"
+                            " ON CONFLICT(message_id) DO UPDATE SET status = excluded.status,"
+                            " message_type = excluded.message_type, message_json = excluded.message_json",
+                            (message.message_id, status, message.message_type, message_json),
+                        )
             except Exception as ex:
                 self._mark_as_db_failed(
                     f"register_message: failed to insert message into DB, reason: {ex}"
@@ -257,16 +218,7 @@ class DBManager:
         messages_batch: List[messages.BaseMessage],
         status: MessageStatus = MessageStatus.registered,
     ) -> None:
-        """
-        Registers a batch of messages in the database. If the system is not initialized or
-        already closed, the operation is ignored.
-
-        Args:
-            messages_batch: A list of message objects to be
-                registered in the database.
-            status: The status to be associated with the registered messages.
-                Defaults to MessageStatus.registered.
-        """
+        """Persist a batch of messages under a single lock."""
         if not self.initialized:
             LOGGER.debug("Not initialized - register messages list ignored")
             return
@@ -276,25 +228,23 @@ class DBManager:
                 LOGGER.warning("Already closed - register messages list ignored")
                 return
 
-            values = []
-            for message in messages_batch:
-                message_json = _preprocess_registered_message(message)
-                values.append(
-                    (
-                        message.message_id,
-                        status,
-                        message.message_type,
-                        message_json,
-                    )
-                )
-
             try:
                 with self.conn:
-                    self.conn.executemany(
-                        "INSERT INTO messages(message_id, status, message_type, message_json) VALUES (?,?,?,?)"
-                        " ON CONFLICT(message_id) DO UPDATE SET status = excluded.status, message_type = excluded.message_type, message_json = excluded.message_json",
-                        values,
-                    )
+                    for message in messages_batch:
+                        message_json = _serialize_message(message)
+                        if message.message_id is None:
+                            cursor = self.conn.execute(
+                                "INSERT INTO messages(status, message_type, message_json) VALUES (?, ?, ?)",
+                                (status, message.message_type, message_json),
+                            )
+                            message.message_id = cursor.lastrowid
+                        else:
+                            self.conn.execute(
+                                "INSERT INTO messages(message_id, status, message_type, message_json) VALUES (?, ?, ?, ?)"
+                                " ON CONFLICT(message_id) DO UPDATE SET status = excluded.status,"
+                                " message_type = excluded.message_type, message_json = excluded.message_json",
+                                (message.message_id, status, message.message_type, message_json),
+                            )
             except Exception as ex:
                 self._mark_as_db_failed(
                     f"register_messages: failed to insert messages into DB, reason: {ex}"
@@ -304,17 +254,7 @@ class DBManager:
     def update_messages_batch(
         self, message_ids: List[int], status: MessageStatus
     ) -> None:
-        """
-        Updates the status of a batch of messages in the messages database table or deletes
-        the messages if their status is 'delivered'. The function ensures thread safety
-        and performs operations only if the instance is initialized and not closed.
-
-        Args:
-            message_ids: A list of message IDs to be updated or deleted.
-            status: The new status to be assigned to the messages or to
-                determine if messages should be deleted when the status is 'delivered'.
-
-        """
+        """Update the status of a batch of messages, deleting delivered rows."""
         if not self.initialized:
             LOGGER.debug(
                 "Not initialized - messages batch update ignored, size: %d, status: %r",
@@ -366,18 +306,7 @@ class DBManager:
                 raise
 
     def update_message(self, message_id: int, status: MessageStatus) -> None:
-        """
-        Updates the status of a message in the database or removes it if delivered.
-
-        This method is responsible for updating the status of a message in the database
-        or removing delivered messages along with their associated data. The operation
-        is ignored if the instance is not initialized or already closed.
-
-        Args:
-            message_id: The unique identifier of the message to be updated.
-            status: The new status to set for the message. If the status
-                is `MessageStatus.delivered`, the message will be removed.
-        """
+        """Update the status of a single message or delete it if delivered."""
         if not self.initialized:
             LOGGER.debug(
                 "Not initialized - message update ignored, id: %d, status: %r",
@@ -397,7 +326,6 @@ class DBManager:
             try:
                 with self.conn:
                     if status == MessageStatus.delivered:
-                        # remove delivered messages
                         self.conn.execute(
                             "DELETE FROM messages WHERE message_id = ?", (message_id,)
                         )
@@ -414,30 +342,10 @@ class DBManager:
 
     def replay_failed_messages(self, replay_callback: ReplayCallback) -> int:
         """
-        Replays previously failed messages by fetching them in batches, marking them as
-        "in progress," and invoking the provided callback for processing.
+        Replays previously failed messages in batches.
 
-        This method processes messages marked as failed in the database by updating
-        their status and invoking the replay callback. It supports batch processing to
-        limit memory usage. If the system is not initialized or already closed, the
-        replay process is skipped. Errors encountered during the replay or while
-        updating the database are logged, and the replay process halts.
-
-        The lock is held only for the minimal critical sections (closed check and the
-        DB status update that marks each batch as in-progress). It is released before
-        calling the replay callback and before sleeping between batches so that
-        producers (register_message / update_message) are never blocked during replay.
-
-        Concurrent calls are serialized by a non-blocking mutex: if a replay is
-        already in progress, the second caller returns 0 immediately, preventing
-        duplicate re-fetching of the same failed messages.
-
-        Args:
-            replay_callback: A callback function that processes the
-                replayed messages.
-
-        Returns:
-            int: The total count of successfully replayed messages.
+        Concurrent calls are serialized by a non-blocking mutex so the same failed
+        messages are not fetched twice.
         """
         if self.closed:
             LOGGER.debug("DBManager already closed")
@@ -447,11 +355,6 @@ class DBManager:
             LOGGER.debug("Not initialized - messages replay ignored")
             return 0
 
-        # Prevent concurrent replay calls from re-fetching the same failed
-        # messages.  The SELECT in fetch_failed_messages_batched runs outside
-        # self.__lock__, so without this guard two simultaneous callers could
-        # both see the same rows before either has had a chance to mark them
-        # as in-progress.
         if not self._replay_mutex.acquire(blocking=False):
             LOGGER.debug("Replay already in progress - skipping concurrent call")
             return 0
@@ -462,7 +365,6 @@ class DBManager:
             self._replay_mutex.release()
 
     def _replay_failed_messages_impl(self, replay_callback: ReplayCallback) -> int:
-        # The initial closed check — short critical section, no loop held inside.
         with self.__lock__:
             if self.closed:
                 LOGGER.warning("Already closed - messages replay ignored")
@@ -473,8 +375,7 @@ class DBManager:
             params = [
                 (int(MessageStatus.registered), message.id) for message in db_messages
             ]
-            # Critical section: check closed and mark the batch as "in progress"
-            # so the same messages are not re-fetched on a concurrent replay call.
+            # Mark the batch as in-progress so it is not re-fetched concurrently.
             with self.__lock__:
                 if self.closed:
                     LOGGER.debug(
@@ -499,16 +400,12 @@ class DBManager:
                     )
                     raise
 
-            # Lock released — replay callback and inter-batch sleep run without
-            # blocking producers (register_message / update_message).
             replayed = self._replay_messages(
                 db_messages=db_messages, replay_callback=replay_callback
             )
             total_replayed += replayed
 
-            # Sleep without the lock so producers are not blocked during the pause.
-            # Applied only after a full batch to avoid unnecessary delays on the
-            # last (partial) batch.
+            # Pause between full batches without holding the lock.
             if replayed >= self.batch_size:
                 time.sleep(self.batch_replay_delay)
 
@@ -533,109 +430,59 @@ class DBManager:
                     e,
                     exc_info=True,
                 )
-                # mark the message as failed in the DB
                 self.update_message(message.id, MessageStatus.failed)
 
         return replayed
 
     def get_message(self, message_id: int) -> Optional[messages.BaseMessage]:
-        """
-        Fetches a message by its unique identifier.
-
-        This method retrieves a message from the database using the provided message ID. If a corresponding
-        database message is found, it converts the database message to a message object and returns it.
-        If no message is found for the given ID, the method returns None.
-
-        Args:
-            message_id: The unique identifier of the message to retrieve.
-
-        Returns:
-            The converted message object if found, otherwise None.
-        """
+        """Fetch a single message by id."""
         db_message = self.get_db_message(message_id)
         if db_message is not None:
             return db_message_to_message(db_message)
-        else:
-            return None
+        return None
 
     def get_db_message(self, message_id: int) -> Optional[DBMessage]:
-        """
-        Retrieves a database message based on the provided message ID.
-
-        This method queries the database for a message record that corresponds to the
-        given message ID. If a matching message record is found, it constructs and
-        returns a `DBMessage` object containing the message's details. If no record is
-        found, it returns `None`.
-
-        Args:
-            message_id: The ID of the message to retrieve.
-
-        Returns:
-            A `DBMessage` object containing the details of the
-            retrieved message if found, otherwise `None`.
-        """
-        with self.conn:
-            c = self.conn.execute(
-                "SELECT message_id, message_type, message_json, status FROM messages WHERE message_id = ?",
-                (message_id,),
-            )
-            row = c.fetchone()
-            if row is not None:
-                return DBMessage(
-                    id=row[0], type=row[1], json=row[2], status=MessageStatus(row[3])
-                )
-            else:
+        """Fetch a single database row by id."""
+        with self.__lock__:
+            if self.closed:
                 return None
+            try:
+                with self.conn:
+                    c = self.conn.execute(
+                        "SELECT message_id, message_type, message_json, status FROM messages WHERE message_id = ?",
+                        (message_id,),
+                    )
+                    row = c.fetchone()
+                    if row is not None:
+                        return DBMessage(
+                            id=row[0],
+                            type=row[1],
+                            json=row[2],
+                            status=MessageStatus(row[3]),
+                        )
+                    return None
+            except Exception as ex:
+                self._mark_as_db_failed(
+                    f"get_db_message: failed to query DB, reason: {ex}"
+                )
+                raise
 
     @property
     def closed(self) -> bool:
-        """
-        Determines if the manager is currently closed.
-
-        This property evaluates whether the manager's `status` is equivalent to
-        `DBManagerStatus.closed`. If so, it indicates that the manager is not
-        active or operational.
-
-        Returns:
-            bool: True if the manager's status is `DBManagerStatus.closed`, False otherwise.
-        """
         return self.status == DBManagerStatus.closed
 
     @property
     def initialized(self) -> bool:
-        """
-        Indicates whether the manager's status is currently set to 'initialized'.
-
-        This property provides a lookup to determine if the manager is currently in the
-        initialized state, based on its status attribute.
-
-        Returns:
-            bool: True if the manager's status is 'initialized', False otherwise.
-        """
         return self.status == DBManagerStatus.initialized
 
     @property
     def failed(self) -> bool:
-        """
-        Checks if the current status indicates a failure.
-
-        The `failed` property evaluates whether the `status` attribute of the
-        manager is equal to `ManagerStatus.error`. This serves as an indicator
-        of whether an error state has been encountered.
-
-        Returns:
-            bool: True if the status is `ManagerStatus.error`, otherwise False.
-        """
         return self.status == DBManagerStatus.error
 
     def fetch_failed_messages_batched(
         self, batch_size: int
     ) -> Iterator[List[DBMessage]]:
-        """Fetch failed messages from DB in bounded batches to avoid OOM.
-
-        Uses cursor-based pagination with message_id for efficient iteration.
-        Yields batches of DBMessage objects until no more failed messages remain.
-        """
+        """Yield failed messages in bounded batches ordered by message_id."""
         last_seen_id = -1
         while True:
             batch: List[DBMessage] = []
@@ -669,7 +516,7 @@ class DBManager:
             yield batch
 
     def failed_messages_count(self) -> int:
-        """Returns the number of failed messages in the DB or -1 if not initialized, closed, or failed."""
+        """Return the number of failed messages or -1 if unavailable."""
         if not self.initialized:
             LOGGER.debug("Not initialized - failed messages count ignored")
             return -1
@@ -698,6 +545,29 @@ class DBManager:
             message,
         )
 
+    def get_max_message_id(self) -> int:
+        """Return the maximum message_id or -1 if empty/unavailable."""
+        if not self.initialized:
+            LOGGER.debug("Not initialized - get_max_message_id ignored")
+            return -1
+
+        with self.__lock__:
+            if self.closed:
+                LOGGER.warning("Already closed - get_max_message_id ignored")
+                return -1
+
+            try:
+                with self.conn:
+                    row = self.conn.execute(
+                        "SELECT COALESCE(MAX(message_id), -1) FROM messages"
+                    ).fetchone()
+                    return row[0]
+            except Exception as ex:
+                msg = f"get_max_message_id: failed to query DB, reason: {ex}"
+                LOGGER.error(msg, exc_info=True)
+                self._mark_as_db_failed(msg)
+                return -1
+
 
 SUPPORTED_MESSAGE_TYPES = {
     messages.CreateTraceMessage.message_type: messages.CreateTraceMessage,
@@ -717,30 +587,17 @@ SUPPORTED_MESSAGE_TYPES = {
 
 
 def db_message_to_message(db_message: DBMessage) -> messages.BaseMessage:
-    """
-    Converts a database message object to a corresponding application message object.
-
-    This function maps a database message type to its associated application message
-    class using a predefined dictionary of supported message types. If the type is not
-    supported, an exception is raised. The message is then deserialized from its JSON
-    representation into the appropriate application message class.
-
-    Args:
-        db_message: The database message object containing the type and serialized JSON
-            data to be deserialized.
-
-    Returns:
-        The deserialized application message object corresponding to the provided
-        database message type.
-
-    Raises:
-        ValueError: If the database message contains an unsupported or unrecognized
-        message type.
-    """
+    """Deserialize a DB row into a message object."""
     message_class = SUPPORTED_MESSAGE_TYPES.get(db_message.type)
     if message_class is None:
         raise ValueError(f"Unsupported message type: {db_message.type}")
 
-    return message_serialization.deserialize_message(
+    message = message_serialization.deserialize_message(
         message_class, json_str=db_message.json
     )
+    # The DB row ID is the authoritative message_id. It is intentionally not
+    # serialized into message_json so the same message object can be stored
+    # under different IDs; restore it here so replay can update/delete the
+    # correct row.
+    message.message_id = db_message.id
+    return message

--- a/sdks/python/src/opik/message_processing/replay/file_lock.py
+++ b/sdks/python/src/opik/message_processing/replay/file_lock.py
@@ -21,9 +21,18 @@ def acquire_replay_lock(db_file: str) -> Optional[FileLock]:
     lock does not interfere with SQLite's own file locking. Returns a
     :class:`filelock.FileLock` instance on success, or ``None`` if another
     process already holds the lock.
+
+    Raises:
+        RuntimeError: If the ``filelock`` package is not installed. It is a
+            declared dependency of the SDK and is required for replay leader
+            election when using a persistent offline database.
     """
     if not _HAS_FILELOCK:
-        return None
+        raise RuntimeError(
+            "The 'filelock' package is required for offline replay leader election "
+            "but is not installed. Please install opik with its dependencies "
+            "(e.g. 'pip install opik')."
+        )
 
     lock_path = _replay_lock_path(db_file)
     parent_dir = os.path.dirname(os.path.abspath(lock_path))

--- a/sdks/python/src/opik/message_processing/replay/file_lock.py
+++ b/sdks/python/src/opik/message_processing/replay/file_lock.py
@@ -1,0 +1,48 @@
+import os
+from typing import Optional
+
+try:
+    from filelock import FileLock, Timeout
+
+    _HAS_FILELOCK = True
+except Exception:  # pragma: no cover - defensive import
+    _HAS_FILELOCK = False
+
+
+def _replay_lock_path(db_file: str) -> str:
+    """Return the path to the replay leader lock file for a given DB file."""
+    return f"{db_file}.replay.lock"
+
+
+def acquire_replay_lock(db_file: str) -> Optional[FileLock]:
+    """Acquire an exclusive non-blocking lock for replay leadership.
+
+    Uses a separate ``.replay.lock`` file next to the SQLite database so the
+    lock does not interfere with SQLite's own file locking. Returns a
+    :class:`filelock.FileLock` instance on success, or ``None`` if another
+    process already holds the lock.
+    """
+    if not _HAS_FILELOCK:
+        return None
+
+    lock_path = _replay_lock_path(db_file)
+    parent_dir = os.path.dirname(os.path.abspath(lock_path))
+    if parent_dir:
+        os.makedirs(parent_dir, exist_ok=True)
+
+    lock = FileLock(lock_path, timeout=0)
+    try:
+        lock.acquire()
+        return lock
+    except Timeout:
+        return None
+
+
+def release_replay_lock(lock: Optional[FileLock]) -> None:
+    """Release a previously acquired replay lock."""
+    if lock is None:
+        return
+    try:
+        lock.release()
+    except Exception:
+        pass

--- a/sdks/python/src/opik/message_processing/replay/replay_manager.py
+++ b/sdks/python/src/opik/message_processing/replay/replay_manager.py
@@ -167,9 +167,15 @@ class ReplayManager(threading.Thread):
         """Stop the replay manager and release locks."""
         self._stop_running.set()
 
+        # Wait for the background thread to actually exit before releasing the
+        # cross-process replay lock. If the thread is still inside
+        # _replay_failed_messages(), releasing the lock now would allow another
+        # process to acquire leadership and start replaying the same shared db.
         if self.ident is not None and self.is_alive():
-            self.join(timeout=5.0)
+            self.join()
 
+        # The thread's run() finally block closes the DBManager. If the thread
+        # was never started, close it here.
         if not self._db_manager.closed:
             self._db_manager.close()
 

--- a/sdks/python/src/opik/message_processing/replay/replay_manager.py
+++ b/sdks/python/src/opik/message_processing/replay/replay_manager.py
@@ -83,15 +83,10 @@ class ReplayManager(threading.Thread):
             self._is_replay_leader = True
             # A previous leader may have died while replaying messages, leaving
             # them in the ``replaying`` state. Reset them so this leader can
-            # replay them again.
-            try:
-                self._db_manager.reset_replaying_messages()
-            except Exception:
-                # If resetting fails, release the lock so another process can try.
-                file_lock.release_replay_lock(self._replay_lock)
-                self._replay_lock = None
-                self._is_replay_leader = False
-                raise
+            # replay them again. A failure here is swallowed by
+            # reset_replaying_messages(), which marks the DB as failed; the
+            # process still becomes leader but offline replay is disabled.
+            self._db_manager.reset_replaying_messages()
             LOGGER.debug("This process is now the replay leader for %s", self._db_file)
 
     def _release_replay_lock(self) -> None:

--- a/sdks/python/src/opik/message_processing/replay/replay_manager.py
+++ b/sdks/python/src/opik/message_processing/replay/replay_manager.py
@@ -4,8 +4,10 @@ import time
 from typing import Optional
 
 from opik.healthcheck import connection_monitor
-from . import db_manager, types
+from . import db_manager, file_lock, types
 from .. import messages
+
+LockHandleType = Optional[file_lock.FileLock]
 
 
 LOGGER = logging.getLogger(__name__)
@@ -19,13 +21,16 @@ def _check_message_id(message_id: Optional[int]) -> None:
 
 class ReplayManager(threading.Thread):
     """
-    Manages replaying messages to the server for a connection management system.
+    Manages replaying failed messages to the Opik server.
 
-    The ReplayManager is responsible for ensuring that messages which fail to be
-    delivered due to dropped connections are replayed to the server
-    when the connection is restored. It continuously monitors the connection status
-    and triggers failed message replays as necessary. The class runs in its own
-    thread, leveraging the threading.Thread base class.
+    The manager runs a background thread that monitors the connection to the
+    OPIK server. When the connection is restored, only the process that holds
+    the replay leader lock replays failed messages from the shared SQLite file.
+    If the leader dies, another process can acquire the lock on a subsequent tick
+    and take over replay duties.
+
+    When no persistent ``db_file`` is configured, a temporary file is used and
+    this process is always treated as the replay leader.
     """
 
     def __init__(
@@ -34,17 +39,16 @@ class ReplayManager(threading.Thread):
         batch_size: int,
         batch_replay_delay: float,
         tick_interval_seconds: float,
+        db_file: Optional[str] = None,
     ):
         """
-        Initializes the ReplayManager instance.
-
-        Creates the replay manager thread with a specified connection monitor and tick interval.
-
         Args:
-            monitor: An instance of OpikConnectionMonitor used for monitoring the connection.
-            batch_size: The size of batches for processing.
-            batch_replay_delay: The delay (in seconds) between replaying batches of messages.
-            tick_interval_seconds: Interval in seconds between execution ticks. Default is 0.3.
+            monitor: Connection monitor used to detect server connectivity.
+            batch_size: Number of failed messages to replay in one batch.
+            batch_replay_delay: Delay in seconds between replay batches.
+            tick_interval_seconds: Interval between thread ticks.
+            db_file: Optional path to a persistent SQLite file. Multiple processes
+                can share this file using SQLite WAL mode.
         """
         super().__init__(daemon=True, name="ReplayManager")
         self._stop_running = threading.Event()
@@ -53,13 +57,37 @@ class ReplayManager(threading.Thread):
         self._tick_interval_seconds = tick_interval_seconds
         self._next_tick_time = time.time() + self._tick_interval_seconds
 
-        self._next_message_id = 0
-        self._message_id_lock = threading.RLock()
-
+        self._db_file = db_file
         self._db_manager = db_manager.DBManager(
             batch_size=batch_size,
             batch_replay_delay=batch_replay_delay,
+            db_file=db_file,
         )
+
+        self._replay_lock: LockHandleType = None
+        self._is_replay_leader = False
+        self._try_acquire_replay_lock()
+
+    def _try_acquire_replay_lock(self) -> None:
+        """Attempt to become the replay leader. Always leader in temp-file mode."""
+        if self._db_file is None:
+            self._is_replay_leader = True
+            return
+
+        if self._is_replay_leader:
+            return
+
+        lock = file_lock.acquire_replay_lock(self._db_file)
+        if lock is not None:
+            self._replay_lock = lock
+            self._is_replay_leader = True
+            LOGGER.debug("This process is now the replay leader for %s", self._db_file)
+
+    def _release_replay_lock(self) -> None:
+        if self._replay_lock is not None:
+            file_lock.release_replay_lock(self._replay_lock)
+            self._replay_lock = None
+        self._is_replay_leader = False
 
     def start(self) -> None:
         self._check_replay_callback()
@@ -78,6 +106,11 @@ class ReplayManager(threading.Thread):
         return self._db_manager
 
     @property
+    def is_replay_leader(self) -> bool:
+        """Returns True if this process currently holds the replay leader lock."""
+        return self._is_replay_leader
+
+    @property
     def has_server_connection(self) -> bool:
         """Checks if SDK has a connection to the OPIK server."""
         return self._monitor.has_server_connection
@@ -88,12 +121,6 @@ class ReplayManager(threading.Thread):
         status: db_manager.MessageStatus = db_manager.MessageStatus.registered,
     ) -> None:
         """Registers a message to be replayed if the connection is lost."""
-        with self._message_id_lock:
-            # set message ID if not set yet
-            if message.message_id is None:
-                message.message_id = self._next_message_id
-                self._next_message_id += 1
-
         try:
             self._db_manager.register_message(message, status=status)
         except Exception as ex:
@@ -137,14 +164,24 @@ class ReplayManager(threading.Thread):
         self._replay_callback = callback
 
     def close(self) -> None:
-        """Stop the replay manager."""
+        """Stop the replay manager and release locks."""
         self._stop_running.set()
 
+        if self.ident is not None and self.is_alive():
+            self.join(timeout=5.0)
+
+        if not self._db_manager.closed:
+            self._db_manager.close()
+
+        self._release_replay_lock()
+
     def flush(self) -> None:
-        """Force replay of all failed messages to the server."""
+        """Force replay of all failed messages to the server if this is the leader."""
         self._check_replay_callback()
-        # ignore MyPy check because already asserted above
-        self._replay_failed_messages()
+        if self._is_replay_leader:
+            self._replay_failed_messages()
+        else:
+            LOGGER.debug("flush skipped: this process is not the replay leader")
 
     def _loop(self) -> None:
         sleep_time = self._next_tick_time - time.time()
@@ -154,9 +191,14 @@ class ReplayManager(threading.Thread):
 
         try:
             status = self._monitor.tick()
+
+            # Allow leadership to move if the current leader dies.
+            if not self._is_replay_leader:
+                self._try_acquire_replay_lock()
+
             if status == connection_monitor.ConnectionStatus.connection_restored:
-                # the connection was restored, replay all failed messages
-                self._replay_failed_messages()
+                if self._is_replay_leader:
+                    self._replay_failed_messages()
                 self._monitor.reset()
         except Exception as ex:
             LOGGER.warning(
@@ -177,7 +219,6 @@ class ReplayManager(threading.Thread):
     def _replay_failed_messages(self) -> None:
         self._check_replay_callback()
         try:
-            # ignore MyPy check because already asserted above
             replayed = self._db_manager.replay_failed_messages(
                 self._replay_callback  # type: ignore
             )

--- a/sdks/python/src/opik/message_processing/replay/replay_manager.py
+++ b/sdks/python/src/opik/message_processing/replay/replay_manager.py
@@ -81,6 +81,17 @@ class ReplayManager(threading.Thread):
         if lock is not None:
             self._replay_lock = lock
             self._is_replay_leader = True
+            # A previous leader may have died while replaying messages, leaving
+            # them in the ``replaying`` state. Reset them so this leader can
+            # replay them again.
+            try:
+                self._db_manager.reset_replaying_messages()
+            except Exception:
+                # If resetting fails, release the lock so another process can try.
+                file_lock.release_replay_lock(self._replay_lock)
+                self._replay_lock = None
+                self._is_replay_leader = False
+                raise
             LOGGER.debug("This process is now the replay leader for %s", self._db_file)
 
     def _release_replay_lock(self) -> None:

--- a/sdks/python/src/opik/message_processing/streamer.py
+++ b/sdks/python/src/opik/message_processing/streamer.py
@@ -49,10 +49,16 @@ class Streamer:
     def use_batching(self) -> bool:
         return self._batch_preprocessor._batch_manager is not None
 
-    def put(self, message: messages.BaseMessage, force: bool = False) -> None:
+    def put(self, message: messages.BaseMessage, force: bool = False) -> bool:
+        """Enqueue a message for background processing.
+
+        Returns ``True`` if the message was accepted by the streamer (queued or
+        consumed by a preprocessor). Returns ``False`` if the streamer is draining
+        or if preprocessing failed, so callers that need durability can react.
+        """
         with self._lock:
             if self._drain and not force:
-                return
+                return False
 
             self._idle = False
             try:
@@ -75,11 +81,15 @@ class Streamer:
                             logger=LOGGER,
                         )
                     self._message_queue.put(preprocessed_message)
+
+                return True
             except Exception as ex:
                 LOGGER.error(
                     "Failed to process message by streamer: %s", ex, exc_info=ex
                 )
-            self._idle = True
+                return False
+            finally:
+                self._idle = True
 
     def close(self, timeout: Optional[int] = None, *, flush: bool = True) -> bool:
         """

--- a/sdks/python/src/opik/message_processing/streamer.py
+++ b/sdks/python/src/opik/message_processing/streamer.py
@@ -95,6 +95,7 @@ class Streamer:
                 cleanup in e2e tests where assertions already polled the
                 backend during the test body).
         """
+
         with self._lock:
             if self._drain:
                 # Already closed — make the call idempotent so atexit can fire
@@ -106,6 +107,10 @@ class Streamer:
                     timeout=timeout,
                     sleep_time=0.1,
                 )
+                # Replay any FAILED messages while the streamer still accepts
+                # new messages. After _drain=True the replay callback's put()
+                # would be dropped, so this must happen first.
+                self._fallback_replay_manager.flush()
             self._drain = True
 
         self._batch_preprocessor.stop(flush=flush)

--- a/sdks/python/src/opik/message_processing/streamer.py
+++ b/sdks/python/src/opik/message_processing/streamer.py
@@ -55,6 +55,12 @@ class Streamer:
         Returns ``True`` if the message was accepted by the streamer (queued or
         consumed by a preprocessor). Returns ``False`` if the streamer is draining
         or if preprocessing failed, so callers that need durability can react.
+
+        Args:
+            message: The message to enqueue.
+            force: If ``True``, enqueue the message even while the streamer is
+                draining. This is used for internal replay paths that must run
+                during shutdown.
         """
         with self._lock:
             if self._drain and not force:

--- a/sdks/python/tests/unit/api_objects/test_opik_client.py
+++ b/sdks/python/tests/unit/api_objects/test_opik_client.py
@@ -1486,3 +1486,58 @@ class TestGetPromptAutoInjectionDedup:
         assert len(injected) == 2
         ids = {p["id"] for p in injected}
         assert ids == {"pid-1", "pid-2"}
+
+
+class TestOpikClientOfflineReplayConfiguration:
+    def _get_fallback_replay(self, client):
+        return client._streamer._fallback_replay_manager
+
+    def test_default__replay_manager_uses_temp_db_and_monitor_assumes_connected(self):
+        client = opik_client.Opik()
+
+        replay_manager = self._get_fallback_replay(client)
+        monitor = replay_manager._monitor
+
+        assert replay_manager.database_manager.tmp_dir is not None
+        assert monitor.has_server_connection is True
+
+        client.end()
+
+    def test_offline_db_file__replay_manager_uses_persistent_file_and_monitor_does_not_assume_connected(
+        self, tmp_path, monkeypatch
+    ):
+        db_file = str(tmp_path / "opik-replay.db")
+        monkeypatch.setenv("OPIK_OFFLINE_DB_FILE", db_file)
+
+        client = opik_client.Opik()
+
+        replay_manager = self._get_fallback_replay(client)
+        monitor = replay_manager._monitor
+
+        assert replay_manager.database_manager.db_file == db_file
+        assert replay_manager.database_manager.tmp_dir is None
+        assert monitor.has_server_connection is False
+
+        client.end()
+
+    def test_offline_db_file__two_clients_share_same_file(
+        self, tmp_path, monkeypatch
+    ):
+        db_file = str(tmp_path / "opik-replay.db")
+        monkeypatch.setenv("OPIK_OFFLINE_DB_FILE", db_file)
+
+        client1 = opik_client.Opik()
+        client2 = opik_client.Opik()
+
+        try:
+            db_file_1 = self._get_fallback_replay(client1).database_manager.db_file
+            db_file_2 = self._get_fallback_replay(client2).database_manager.db_file
+            assert db_file_1 == db_file
+            assert db_file_2 == db_file
+            # Only one client should be the replay leader.
+            leader1 = self._get_fallback_replay(client1).is_replay_leader
+            leader2 = self._get_fallback_replay(client2).is_replay_leader
+            assert leader1 != leader2 or leader1
+        finally:
+            client1.end()
+            client2.end()

--- a/sdks/python/tests/unit/api_objects/test_opik_client.py
+++ b/sdks/python/tests/unit/api_objects/test_opik_client.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import List
 
 import pytest
@@ -1489,36 +1490,37 @@ class TestGetPromptAutoInjectionDedup:
 
 
 class TestOpikClientOfflineReplayConfiguration:
-    def _get_fallback_replay(self, client):
-        return client._streamer._fallback_replay_manager
-
-    def test_default__replay_manager_uses_temp_db_and_monitor_assumes_connected(self):
+    def test_default__uses_temp_db(self):
         client = opik_client.Opik()
+        try:
+            # No persistent offline db file is configured.
+            assert client.config.offline_db_file is None
+            # In temp-db mode the SDK creates a temporary directory.
+            assert (
+                client._streamer._fallback_replay_manager.database_manager.tmp_dir
+                is not None
+            )
+        finally:
+            client.end()
 
-        replay_manager = self._get_fallback_replay(client)
-        monitor = replay_manager._monitor
-
-        assert replay_manager.database_manager.tmp_dir is not None
-        assert monitor.has_server_connection is True
-
-        client.end()
-
-    def test_offline_db_file__replay_manager_uses_persistent_file_and_monitor_does_not_assume_connected(
+    def test_offline_db_file__uses_persistent_file(
         self, tmp_path, monkeypatch
     ):
         db_file = str(tmp_path / "opik-replay.db")
         monkeypatch.setenv("OPIK_OFFLINE_DB_FILE", db_file)
 
         client = opik_client.Opik()
-
-        replay_manager = self._get_fallback_replay(client)
-        monitor = replay_manager._monitor
-
-        assert replay_manager.database_manager.db_file == db_file
-        assert replay_manager.database_manager.tmp_dir is None
-        assert monitor.has_server_connection is False
-
-        client.end()
+        try:
+            assert client.config.offline_db_file == db_file
+            # The persistent db file is created eagerly on client init.
+            assert os.path.exists(db_file)
+            # In persistent-file mode there is no temporary directory.
+            assert (
+                client._streamer._fallback_replay_manager.database_manager.tmp_dir
+                is None
+            )
+        finally:
+            client.end()
 
     def test_offline_db_file__two_clients_share_same_file(
         self, tmp_path, monkeypatch
@@ -1530,13 +1532,14 @@ class TestOpikClientOfflineReplayConfiguration:
         client2 = opik_client.Opik()
 
         try:
-            db_file_1 = self._get_fallback_replay(client1).database_manager.db_file
-            db_file_2 = self._get_fallback_replay(client2).database_manager.db_file
-            assert db_file_1 == db_file
-            assert db_file_2 == db_file
+            replay_manager1 = client1._streamer._fallback_replay_manager
+            replay_manager2 = client2._streamer._fallback_replay_manager
+
+            assert replay_manager1.database_manager.db_file == db_file
+            assert replay_manager2.database_manager.db_file == db_file
             # Only one client should be the replay leader.
-            leader1 = self._get_fallback_replay(client1).is_replay_leader
-            leader2 = self._get_fallback_replay(client2).is_replay_leader
+            leader1 = replay_manager1.is_replay_leader
+            leader2 = replay_manager2.is_replay_leader
             assert leader1 != leader2 or leader1
         finally:
             client1.end()

--- a/sdks/python/tests/unit/healthcheck/test_connection_monitor.py
+++ b/sdks/python/tests/unit/healthcheck/test_connection_monitor.py
@@ -69,6 +69,29 @@ class TestOpikConnectionMonitorConnectionFailed:
         assert monitor.disconnect_reason == "First error"
 
 
+class TestOpikConnectionMonitorAssumeConnected:
+    """Tests for OpikConnectionMonitor assume_connected parameter."""
+
+    def test_init__assume_connected_false__first_successful_tick_returns_restored(
+        self, mock_probe
+    ):
+        mock_probe.check_connection.return_value = ProbeResult(
+            is_healthy=True, error_message=None
+        )
+        monitor = OpikConnectionMonitor(
+            ping_interval=5.0,
+            check_timeout=2.0,
+            probe=mock_probe,
+            assume_connected=False,
+        )
+
+        with mock.patch("time.time", return_value=100.0):
+            status = monitor.tick()
+
+        assert status == ConnectionStatus.connection_restored
+        assert monitor.has_server_connection is True
+
+
 class TestOpikConnectionMonitorTick:
     """Tests for OpikConnectionMonitor.tick method."""
 

--- a/sdks/python/tests/unit/message_processing/replay/test_db_manager.py
+++ b/sdks/python/tests/unit/message_processing/replay/test_db_manager.py
@@ -518,10 +518,10 @@ class TestReplayFailedMessages:
         assert result == 3
         assert callback.call_count == 3
 
-    def test_replay_failed_messages__after_replay__status_updated_to_registered(
+    def test_replay_failed_messages__after_replay__status_updated_to_replaying(
         self, manager: db_manager.DBManager
     ):
-        """Test that replayed messages have their status updated to registered."""
+        """Test that replayed messages have their status updated to replaying."""
         message_id = 1
         msg = _create_trace_message(message_id=message_id)
         manager.register_message(msg, status=db_manager.MessageStatus.failed)
@@ -529,11 +529,28 @@ class TestReplayFailedMessages:
         callback = mock.Mock()
         manager.replay_failed_messages(callback)
 
-        # Check status was updated to registered
+        # Check status was updated to replaying so a new leader can detect
+        # messages left behind by a dead leader.
         cursor = manager.conn.execute(
             "SELECT status FROM messages WHERE message_id = ?", (message_id,)
         )
-        assert cursor.fetchone()[0] == db_manager.MessageStatus.registered
+        assert cursor.fetchone()[0] == db_manager.MessageStatus.replaying
+
+    def test_reset_replaying_messages__moves_replaying_back_to_failed(
+        self, manager: db_manager.DBManager
+    ):
+        """Messages left replaying by a dead leader are reset to failed."""
+        msg = _create_trace_message(message_id=1)
+        manager.register_message(msg, status=db_manager.MessageStatus.failed)
+        manager.replay_failed_messages(mock.Mock())
+
+        reset_count = manager.reset_replaying_messages()
+
+        assert reset_count == 1
+        cursor = manager.conn.execute(
+            "SELECT status FROM messages WHERE message_id = ?", (1,)
+        )
+        assert cursor.fetchone()[0] == db_manager.MessageStatus.failed
 
     def test_replay_failed_messages__callback_invocation__receives_deserialized_messages(
         self, manager: db_manager.DBManager

--- a/sdks/python/tests/unit/message_processing/replay/test_db_manager.py
+++ b/sdks/python/tests/unit/message_processing/replay/test_db_manager.py
@@ -235,15 +235,31 @@ class TestRegisterMessage:
         message = _create_trace_message(message_id=1)
         manager.register_message(message)  # Should not raise
 
-    def test_register_message__message_id_none__raises_value_error(
+    def test_register_message__message_id_none__auto_assigns_sqlite_id(
         self, manager: db_manager.DBManager
     ):
-        """Test that registering a message without message_id raises an error."""
+        """Test that registering a message without message_id gets an auto-increment id."""
         message = _create_trace_message(message_id=1)
         message.message_id = None
+        expected_json = message_serialization.serialize_message(message)
 
-        with pytest.raises(ValueError, match="Message ID expected"):
-            manager.register_message(message)
+        manager.register_message(message)
+
+        assert message.message_id is not None
+        assert message.message_id >= 1
+
+        cursor = manager.conn.execute(
+            "SELECT message_id, status, message_type, message_json FROM messages WHERE message_id = ?",
+            (message.message_id,),
+        )
+        row = cursor.fetchone()
+        assert row is not None
+        assert row[0] == message.message_id
+        assert row[1] == db_manager.MessageStatus.registered
+        assert row[2] == message.message_type
+        # Serialization happened before the id was assigned, so the stored JSON
+        # contains message_id null.
+        assert row[3] == expected_json
 
 
 class TestRegisterMessages:
@@ -536,6 +552,8 @@ class TestReplayFailedMessages:
         assert len(received_messages) == 1
         assert isinstance(received_messages[0], messages.CreateTraceMessage)
         assert received_messages[0].trace_id == "trace-1"
+        # The DB row ID must be restored so replay can update/delete the right row.
+        assert received_messages[0].message_id == 1
 
     def test_replay_failed_messages__manager_closed__returns_zero(
         self, manager: db_manager.DBManager
@@ -889,3 +907,75 @@ class TestDbMessageToMessage:
 
         with pytest.raises(ValueError, match="Unsupported message type"):
             db_manager.db_message_to_message(db_message)
+
+
+class TestGetMaxMessageId:
+    def test_get_max_message_id__empty_db(self, manager: db_manager.DBManager):
+        assert manager.get_max_message_id() == -1
+
+    def test_get_max_message_id__with_messages(self, manager: db_manager.DBManager):
+        for i in range(3):
+            msg = _create_trace_message(message_id=i + 10)
+            manager.register_message(msg)
+
+        assert manager.get_max_message_id() == 12
+
+    def test_get_max_message_id__after_restart_with_single_file(self, tmp_path):
+        """In single-file mode, message ids persist across DBManager restarts."""
+        db_file = str(tmp_path / "replay.db")
+        mgr1 = db_manager.DBManager(batch_size=10, batch_replay_delay=0.1, db_file=db_file)
+        msg = _create_trace_message(message_id=None)
+        mgr1.register_message(msg)
+        max_id = msg.message_id
+        mgr1.close()
+
+        mgr2 = db_manager.DBManager(batch_size=10, batch_replay_delay=0.1, db_file=db_file)
+        assert mgr2.get_max_message_id() == max_id
+        mgr2.close()
+
+    def test_get_max_message_id__after_close(self, manager: db_manager.DBManager):
+        manager.close()
+        assert manager.get_max_message_id() == -1
+
+    def test_get_max_message_id__db_failed(self, manager: db_manager.DBManager):
+        manager._mark_as_db_failed("test failure")
+        assert manager.get_max_message_id() == -1
+
+
+class TestSingleFileMode:
+    def test_single_file_mode__multiple_managers_share_same_db(self, tmp_path):
+        db_file = str(tmp_path / "replay.db")
+        mgr1 = db_manager.DBManager(batch_size=10, batch_replay_delay=0.1, db_file=db_file)
+        mgr2 = db_manager.DBManager(batch_size=10, batch_replay_delay=0.1, db_file=db_file)
+
+        try:
+            assert mgr1.db_file == db_file
+            assert mgr2.db_file == db_file
+
+            msg1 = _create_trace_message(message_id=None, trace_id="trace-1")
+            msg2 = _create_trace_message(message_id=None, trace_id="trace-2")
+            mgr1.register_message(msg1)
+            mgr2.register_message(msg2)
+
+            assert msg1.message_id is not None
+            assert msg2.message_id is not None
+            assert msg1.message_id != msg2.message_id
+        finally:
+            mgr1.close()
+            mgr2.close()
+
+    def test_single_file_mode__failed_messages_persist_across_restarts(self, tmp_path):
+        db_file = str(tmp_path / "replay.db")
+        mgr1 = db_manager.DBManager(batch_size=10, batch_replay_delay=0.1, db_file=db_file)
+        msg = _create_trace_message(message_id=None, trace_id="persisted")
+        mgr1.register_message(msg, status=db_manager.MessageStatus.failed)
+        mgr1.close()
+
+        mgr2 = db_manager.DBManager(batch_size=10, batch_replay_delay=0.1, db_file=db_file)
+        try:
+            assert mgr2.failed_messages_count() == 1
+            replayed = []
+            mgr2.replay_failed_messages(lambda m: replayed.append(m))
+            assert len(replayed) == 1
+        finally:
+            mgr2.close()

--- a/sdks/python/tests/unit/message_processing/replay/test_db_manager.py
+++ b/sdks/python/tests/unit/message_processing/replay/test_db_manager.py
@@ -531,10 +531,9 @@ class TestReplayFailedMessages:
 
         # Check status was updated to replaying so a new leader can detect
         # messages left behind by a dead leader.
-        cursor = manager.conn.execute(
-            "SELECT status FROM messages WHERE message_id = ?", (message_id,)
-        )
-        assert cursor.fetchone()[0] == db_manager.MessageStatus.replaying
+        db_msg = manager.get_db_message(message_id)
+        assert db_msg is not None
+        assert db_msg.status == db_manager.MessageStatus.replaying
 
     def test_reset_replaying_messages__moves_replaying_back_to_failed(
         self, manager: db_manager.DBManager
@@ -547,10 +546,9 @@ class TestReplayFailedMessages:
         reset_count = manager.reset_replaying_messages()
 
         assert reset_count == 1
-        cursor = manager.conn.execute(
-            "SELECT status FROM messages WHERE message_id = ?", (1,)
-        )
-        assert cursor.fetchone()[0] == db_manager.MessageStatus.failed
+        db_msg = manager.get_db_message(1)
+        assert db_msg is not None
+        assert db_msg.status == db_manager.MessageStatus.failed
 
     def test_replay_failed_messages__callback_invocation__receives_deserialized_messages(
         self, manager: db_manager.DBManager

--- a/sdks/python/tests/unit/message_processing/replay/test_replay_manager.py
+++ b/sdks/python/tests/unit/message_processing/replay/test_replay_manager.py
@@ -669,6 +669,7 @@ class TestReplayManagerSingleFileMode:
             follower = rm2 if leader is rm1 else rm1
             assert follower.is_replay_leader is False
 
+
             leader.close()
             # After the leader closes, the follower can acquire the lock on next tick.
             follower._loop()
@@ -676,3 +677,53 @@ class TestReplayManagerSingleFileMode:
         finally:
             rm2.close()
             rm1.close()
+
+    def test_single_file_mode__new_leader_resets_replaying_messages(
+        self, tmp_path
+    ):
+        """A new leader resets replaying messages left by a dead leader."""
+        db_file = str(tmp_path / "replay.db")
+        monitor = mock.MagicMock(spec=connection_monitor.OpikConnectionMonitor)
+        monitor.tick.return_value = connection_monitor.ConnectionStatus.connection_ok
+
+        dead_leader = replay_manager.ReplayManager(
+            monitor=monitor,
+            batch_size=10,
+            batch_replay_delay=0.01,
+            tick_interval_seconds=0.05,
+            db_file=db_file,
+        )
+        dead_leader.set_replay_callback(lambda m: None)
+
+        try:
+            assert dead_leader.is_replay_leader is True
+            msg = _create_trace_message(message_id=None, trace_id="orphan-trace")
+            dead_leader.register_message(msg, status=db_manager.MessageStatus.failed)
+
+            # Simulate the leader replaying but dying before delivery.
+            dead_leader.flush()
+            row = dead_leader.database_manager.conn.execute(
+                "SELECT status FROM messages WHERE message_id = ?", (msg.message_id,)
+            ).fetchone()
+            assert row[0] == db_manager.MessageStatus.replaying
+        finally:
+            dead_leader.close()
+
+        # A new process acquiring the lock should reset replaying -> failed and replay.
+        new_leader = replay_manager.ReplayManager(
+            monitor=monitor,
+            batch_size=10,
+            batch_replay_delay=0.01,
+            tick_interval_seconds=0.05,
+            db_file=db_file,
+        )
+        replayed: List[messages.BaseMessage] = []
+        new_leader.set_replay_callback(lambda m: replayed.append(m))
+
+        try:
+            assert new_leader.is_replay_leader is True
+            new_leader.flush()
+            assert len(replayed) == 1
+            assert replayed[0].trace_id == "orphan-trace"
+        finally:
+            new_leader.close()

--- a/sdks/python/tests/unit/message_processing/replay/test_replay_manager.py
+++ b/sdks/python/tests/unit/message_processing/replay/test_replay_manager.py
@@ -569,3 +569,110 @@ class TestEndToEnd:
         assert isinstance(replayed[0], messages.CreateTraceMessage)
         assert replayed[0].trace_id == "trace-1"
         monitor.reset.assert_called()
+
+
+class TestReplayManagerSingleFileMode:
+    def test_single_file_mode__two_managers_share_same_db_file(self, tmp_path):
+        db_file = str(tmp_path / "replay.db")
+        rm1 = replay_manager.ReplayManager(
+            monitor=mock.MagicMock(spec=connection_monitor.OpikConnectionMonitor),
+            batch_size=10,
+            batch_replay_delay=0.01,
+            tick_interval_seconds=0.05,
+            db_file=db_file,
+        )
+        rm2 = replay_manager.ReplayManager(
+            monitor=mock.MagicMock(spec=connection_monitor.OpikConnectionMonitor),
+            batch_size=10,
+            batch_replay_delay=0.01,
+            tick_interval_seconds=0.05,
+            db_file=db_file,
+        )
+
+        try:
+            assert rm1.database_manager.db_file == db_file
+            assert rm2.database_manager.db_file == db_file
+        finally:
+            rm1.close()
+            rm2.close()
+
+    def test_single_file_mode__only_leader_replays_failed_messages(self, tmp_path):
+        db_file = str(tmp_path / "replay.db")
+        monitor = mock.MagicMock(spec=connection_monitor.OpikConnectionMonitor)
+        monitor.tick.return_value = connection_monitor.ConnectionStatus.connection_restored
+
+        rm1 = replay_manager.ReplayManager(
+            monitor=monitor,
+            batch_size=10,
+            batch_replay_delay=0.01,
+            tick_interval_seconds=0.05,
+            db_file=db_file,
+        )
+        rm1.set_replay_callback(lambda m: None)
+
+        rm2 = replay_manager.ReplayManager(
+            monitor=monitor,
+            batch_size=10,
+            batch_replay_delay=0.01,
+            tick_interval_seconds=0.05,
+            db_file=db_file,
+        )
+        rm2.set_replay_callback(lambda m: None)
+
+        try:
+            # One of the managers should have acquired the replay leader lock.
+            assert rm1.is_replay_leader != rm2.is_replay_leader or rm1.is_replay_leader
+            leader = rm1 if rm1.is_replay_leader else rm2
+            follower = rm2 if leader is rm1 else rm1
+            assert leader.is_replay_leader is True
+            assert follower.is_replay_leader is False
+
+            # Register a failed message using the follower so it lands in the shared db.
+            msg = _create_trace_message(message_id=None, trace_id="shared-trace")
+            follower.register_message(msg, status=db_manager.MessageStatus.failed)
+
+            replayed_by_leader: List[messages.BaseMessage] = []
+            leader.set_replay_callback(lambda m: replayed_by_leader.append(m))
+
+            leader._loop()
+
+            assert len(replayed_by_leader) == 1
+            assert replayed_by_leader[0].trace_id == "shared-trace"
+        finally:
+            rm1.close()
+            rm2.close()
+
+    def test_single_file_mode__follower_becomes_leader_after_leader_closes(
+        self, tmp_path
+    ):
+        db_file = str(tmp_path / "replay.db")
+        monitor = mock.MagicMock(spec=connection_monitor.OpikConnectionMonitor)
+        monitor.tick.return_value = connection_monitor.ConnectionStatus.connection_ok
+
+        rm1 = replay_manager.ReplayManager(
+            monitor=monitor,
+            batch_size=10,
+            batch_replay_delay=0.01,
+            tick_interval_seconds=0.05,
+            db_file=db_file,
+        )
+        rm2 = replay_manager.ReplayManager(
+            monitor=monitor,
+            batch_size=10,
+            batch_replay_delay=0.01,
+            tick_interval_seconds=0.05,
+            db_file=db_file,
+        )
+
+        try:
+            leader = rm1 if rm1.is_replay_leader else rm2
+            follower = rm2 if leader is rm1 else rm1
+            assert follower.is_replay_leader is False
+
+            leader.close()
+            # After the leader closes, the follower can acquire the lock on next tick.
+            follower._loop()
+            assert follower.is_replay_leader is True
+        finally:
+            rm2.close()
+            rm1.close()

--- a/sdks/python/tests/unit/message_processing/replay/test_replay_manager.py
+++ b/sdks/python/tests/unit/message_processing/replay/test_replay_manager.py
@@ -634,7 +634,7 @@ class TestReplayManagerSingleFileMode:
             replayed_by_leader: List[messages.BaseMessage] = []
             leader.set_replay_callback(lambda m: replayed_by_leader.append(m))
 
-            leader._loop()
+            leader.flush()
 
             assert len(replayed_by_leader) == 1
             assert replayed_by_leader[0].trace_id == "shared-trace"

--- a/sdks/python/tests/unit/test_config.py
+++ b/sdks/python/tests/unit/test_config.py
@@ -117,3 +117,17 @@ def test_save_to_file_does_not_persist_environment(mock_expanduser, mock_open_fi
     parsed_config.read_string(written_content)
 
     assert "environment" not in parsed_config["opik"]
+
+
+def test_offline_db_file_defaults_to_none():
+    config = OpikConfig()
+
+    assert config.offline_db_file is None
+
+
+def test_offline_db_file_loaded_from_env(monkeypatch):
+    monkeypatch.setenv("OPIK_OFFLINE_DB_FILE", "/tmp/opik-replay.db")
+
+    config = OpikConfig()
+
+    assert config.offline_db_file == "/tmp/opik-replay.db"


### PR DESCRIPTION
## Details
This PR refactors the Python SDK's offline replay fallback from per-process temporary SQLite databases to a single persistent SQLite file shared by multiple processes or K8s replicas. 

## Motivation
The previous implementation stored failed messages in a temporary directory that was deleted on shutdown, so offline persistence was lost across restarts. (see Opik-7039)

## What changed
- Configuration
  - Adds `offline_db_file` config option and `OPIK_OFFLINE_DB_FILE`  environment variable for specifying a persistent SQLite file.
- Persistence
  - Stores all failed messages in a **single shared SQLite file**, instead of per-process temporary files.
  - Enables WAL mode for safe concurrent writes from multiple processes to one file.
  - Uses SQLite `AUTOINCREMENT` to avlid message ID conflict.
- Replay
  - Adjust connection monitoring so the first successful backend ping triggers replay after a restart.
- Multi-process cordinate
  - Introduces replay leader election via a seperate lock file, only the leader replays `FAILED` messages, other processors continue writing new messages to the shared db.


## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- Resolves
#7039 

## AI-WATERMARK
AI-WATERMARK: yes

- If yes:
  - Tools: Codex
  - Model(s): GPT-5
  - Scope: partial code implementation, unit test
  - Human verification: overall design, partical code implementation, validation

## Testing
### Unit test
```bash
cd sdks/python
uv run pytest tests/unit/message_processing/replay tests/unit/message_processing/processors/test_opik_message_processor_replay.py tests/unit/message_processing/test_streamer_replay_manager.py -q
```
**Result:** 169 passed.

Scenarios covered:
- Single shared db file with WAL and `AUTOINCREMENT` message IDs.
- Register / unregister / replay lifecycle.
- `message_id` is restored from the DB row after deserialization so replayed messages delete the correct row.
- Replay leader election: only one `ReplayManager` becomes leader; followers write but do not replay.
- Leader failover: when the leader closes, a follower can acquire the lock and take over.
- `OpikConnectionMonitor` `assume_connected=False` triggers replay on the first successful ping.


###  Validation
#### multi replica no conflict
1. four replicas share same file through vpc
```yaml
 env:
   - name: OPIK_OFFLINE_DB_FILE
     value: "/data/opik/replay.db"

 volumeMounts:
   - name: opik-replay-data
     mountPath: /data/opik

 volumes:
   - name: opik-replay-data
     persistentVolumeClaim:
       claimName: opik-replay-pvc
```  
<img width="2378" height="223" alt="image" src="https://github.com/user-attachments/assets/db24508f-95a5-4432-abe3-e43959a5f274" />
3. under file path, only one db file with lock and wal files
<img width="2004" height="281" alt="image" src="https://github.com/user-attachments/assets/5523b630-855e-42fc-953c-273eb7c974aa" />
4. only one process is the leader
<img width="2042" height="505" alt="image" src="https://github.com/user-attachments/assets/84cfefe2-d130-4895-a433-65c2d3fe9fe6" />

#### persistent replay
1. Make replicas all disconnected, send 1 trace from each replica, all failed message is kept in db files
<img width="1967" height="382" alt="image" src="https://github.com/user-attachments/assets/98de659a-fe89-4da1-869f-72288a69503e" />
2. Reconnect all replicas, finally all message is replayed and db file is empty
<img width="1930" height="277" alt="image" src="https://github.com/user-attachments/assets/5b242947-91f9-42f6-a9ff-3fe96549b90b" />
<img width="2689" height="281" alt="image" src="https://github.com/user-attachments/assets/dcf67636-d954-4689-bbf7-9b7687028171" />