### PR TITLE
[OPIK-7037] [GHA] fix: dedupe Fern update PRs and post one daily Slack thread

### DIFF
--- a/.github/scripts/notify-slack-fern-update.sh
+++ b/.github/scripts/notify-slack-fern-update.sh
@@ -1,29 +1,64 @@
 #!/usr/bin/env bash
 #
-# Build and send the FERN update PR Slack notification.
+# Post the FERN update PR notification to #code-review as a single daily thread.
+#
+# The first FERN PR of a (UTC) day posts a parent message; every later PR that
+# day replies in that thread, so the channel sees one top-level message per day.
+# The thread anchor (date + Slack ts) is carried between workflow runs in the
+# `slack-thread-state` artifact — there is no GitHub state to mutate.
 #
 # Required env vars:
-#   SLACK_WEBHOOK_URL    — Slack incoming webhook URL
-#   PR_URL               — URL of the FERN PR
-#   PR_NUMBER            — PR number
-#   AUTHOR_DISPLAY       — GitHub username of the author
-#   GITHUB_SHA           — commit SHA (set by GitHub Actions)
-#   GITHUB_REPOSITORY    — owner/repo (set by GitHub Actions)
+#   SLACK_BOT_TOKEN_CODE_REVIEW    — bot token with chat:write + chat:write.customize
+#   SLACK_CODE_REVIEW_CHANNEL_ID   — channel ID of #code-review
+#   GH_TOKEN                       — token with actions:read (download prior artifact)
+#   GITHUB_REPOSITORY              — owner/repo (set by GitHub Actions)
+#   GITHUB_SHA                     — commit SHA (set by GitHub Actions)
+#   WORKFLOW_FILE                  — this workflow's filename (to find prior runs)
+#   STATE_ARTIFACT_NAME            — artifact name holding the thread state
+#   STATE_FILE                     — JSON filename inside the artifact / to write back
+#   PR_URL                         — URL of the FERN PR
+#   PR_NUMBER                      — FERN PR number
+#   AUTHOR_DISPLAY                 — GitHub username of the triggering author
 #
 # Optional env vars:
-#   ORIGINATING_PR       — URL of the BE PR that triggered FERN generation
-#   MENTION              — pre-resolved Slack mention (e.g. "<@U123>"), may be empty
+#   ORIGINATING_PR                 — URL of the BE PR that triggered FERN generation
+#   MENTION                        — pre-resolved Slack mention (e.g. "<@U123>"), may be empty
 #
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BOT_NAME="Fern Bot"
+BOT_ICON=":herb:"
+TODAY="$(date -u +%Y-%m-%d)"
 
+MISSING=""
+[ -z "${SLACK_BOT_TOKEN:-}" ] && MISSING="SLACK_BOT_TOKEN_CODE_REVIEW"
+[ -z "${SLACK_CODE_REVIEW_CHANNEL_ID:-}" ] && MISSING="${MISSING:+$MISSING, }SLACK_CODE_REVIEW_CHANNEL_ID"
+if [ -n "$MISSING" ]; then
+  echo "::warning title=Slack notification skipped::Missing repo secret(s): ${MISSING}. The FERN PR was still created. To enable the #code-review thread, set these (bot needs chat:write + chat:write.customize, invited to #code-review)."
+  exit 0
+fi
+
+# Resolve the day's thread ts from the previous run's artifact (absent = first post of the day).
+THREAD_TS=""
+PREV_RUN_ID="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow "$WORKFLOW_FILE" \
+  --status success --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || echo "")"
+if [ -n "$PREV_RUN_ID" ]; then
+  if gh run download "$PREV_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+      --name "$STATE_ARTIFACT_NAME" --dir /tmp/fern-state 2>/dev/null; then
+    PREV_DATE="$(jq -r '.date // ""' "/tmp/fern-state/$STATE_FILE" 2>/dev/null || echo "")"
+    if [ "$PREV_DATE" = "$TODAY" ]; then
+      THREAD_TS="$(jq -r '.ts // ""' "/tmp/fern-state/$STATE_FILE" 2>/dev/null || echo "")"
+    fi
+  fi
+fi
+
+# Build the message body. TRIGGER_BODY holds the part after the "Triggered by:"
+# label; jq joins them with a real newline (bash double quotes don't expand \n).
 SHORT_SHA="${GITHUB_SHA:0:7}"
-
 if [ -n "${ORIGINATING_PR:-}" ]; then
-  TRIGGER_TEXT="*Triggered by:*\n<${ORIGINATING_PR}|BE PR> by ${AUTHOR_DISPLAY}"
+  TRIGGER_BODY="<${ORIGINATING_PR}|BE PR> by ${AUTHOR_DISPLAY}"
 else
-  TRIGGER_TEXT="*Triggered by:*\nCommit <https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}|\`${SHORT_SHA}\`> by ${AUTHOR_DISPLAY}"
+  TRIGGER_BODY="Commit <https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}|\`${SHORT_SHA}\`> by ${AUTHOR_DISPLAY}"
 fi
 
 MENTION_TEXT=""
@@ -31,22 +66,29 @@ if [ -n "${MENTION:-}" ]; then
   MENTION_TEXT="${MENTION} Your BE merge triggered FERN changes. Please review."
 fi
 
-jq -n \
+PAYLOAD="$(jq -n \
+  --arg channel "$SLACK_CODE_REVIEW_CHANNEL_ID" \
+  --arg username "$BOT_NAME" \
+  --arg icon "$BOT_ICON" \
+  --arg thread_ts "$THREAD_TS" \
   --arg pr_url "$PR_URL" \
   --arg pr_num "$PR_NUMBER" \
-  --arg trigger "$TRIGGER_TEXT" \
+  --arg trigger_body "$TRIGGER_BODY" \
   --arg mention "$MENTION_TEXT" \
   '
   {
-    "attachments": [{
-      "color": "#36a64f",
-      "blocks": (
+    channel: $channel,
+    username: $username,
+    icon_emoji: $icon,
+    text: ("FERN Update PR #" + $pr_num + " — review needed"),
+    attachments: [{
+      color: "#36a64f",
+      blocks: (
         [
-          {"type": "header", "text": {"type": "plain_text", "text": "FERN Update PR \u2014 Review Needed", "emoji": true}},
           {"type": "section", "text": {"type": "mrkdwn", "text": "A BE merge to main changed the OpenAPI spec. FERN SDK code has been regenerated."}},
           {"type": "section", "fields": [
             {"type": "mrkdwn", "text": ("*FERN PR:*\n<" + $pr_url + "|#" + $pr_num + ">")},
-            {"type": "mrkdwn", "text": $trigger}
+            {"type": "mrkdwn", "text": ("*Triggered by:*\n" + $trigger_body)}
           ]}
         ]
         + (if $mention != "" then [{"type": "section", "text": {"type": "mrkdwn", "text": $mention}}] else [] end)
@@ -61,6 +103,21 @@ jq -n \
       )
     }]
   }
-  ' > /tmp/slack-payload.json
+  + (if $thread_ts != "" then {thread_ts: $thread_ts} else {} end)
+  ')"
 
-exec "$SCRIPT_DIR/send-slack-message.sh" /tmp/slack-payload.json
+RESPONSE="$(curl -sS -X POST https://slack.com/api/chat.postMessage \
+  -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+  -H 'Content-type: application/json; charset=utf-8' \
+  --data "$PAYLOAD")"
+
+if [ "$(jq -r '.ok' <<<"$RESPONSE")" != "true" ]; then
+  echo "::error::Slack chat.postMessage failed: $(jq -r '.error // "unknown"' <<<"$RESPONSE")"
+  exit 1
+fi
+echo "Slack message posted ($([ -n "$THREAD_TS" ] && echo "threaded reply" || echo "new daily parent"))"
+
+# Persist the day's anchor for the next run. The parent ts is the thread root;
+# on a reply we keep the existing root, so the thread stays one-per-day.
+ROOT_TS="${THREAD_TS:-$(jq -r '.ts' <<<"$RESPONSE")}"
+jq -n --arg date "$TODAY" --arg ts "$ROOT_TS" '{date: $date, ts: $ts}' > "$STATE_FILE"

--- a/.github/scripts/notify-slack-fern-update.sh
+++ b/.github/scripts/notify-slack-fern-update.sh
@@ -13,7 +13,6 @@
 #   GH_TOKEN                       — token with actions:read (download prior artifact)
 #   GITHUB_REPOSITORY              — owner/repo (set by GitHub Actions)
 #   GITHUB_SHA                     — commit SHA (set by GitHub Actions)
-#   WORKFLOW_FILE                  — this workflow's filename (to find prior runs)
 #   STATE_ARTIFACT_NAME            — artifact name holding the thread state
 #   STATE_FILE                     — JSON filename inside the artifact / to write back
 #   PR_URL                         — URL of the FERN PR
@@ -38,13 +37,16 @@ if [ -n "$MISSING" ]; then
   exit 0
 fi
 
-# Resolve the day's thread ts from the previous run's artifact (absent = first post of the day).
+# Resolve the day's thread ts from the most recent state artifact. Each run uploads its
+# own artifact, so we ask for the latest one by name (the API returns artifacts newest
+# first) rather than the latest run, which may have uploaded nothing. None / expired ->
+# first post of the day / fresh thread.
 THREAD_TS=""
-PREV_RUN_ID="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow "$WORKFLOW_FILE" \
-  --status success --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || echo "")"
-if [ -n "$PREV_RUN_ID" ]; then
-  if gh run download "$PREV_RUN_ID" --repo "$GITHUB_REPOSITORY" \
-      --name "$STATE_ARTIFACT_NAME" --dir /tmp/fern-state 2>/dev/null; then
+ARTIFACT_ID="$(gh api "repos/$GITHUB_REPOSITORY/actions/artifacts?name=$STATE_ARTIFACT_NAME&per_page=1" \
+  --jq '.artifacts[0] | select(.expired == false) | .id' 2>/dev/null || echo "")"
+if [ -n "$ARTIFACT_ID" ] && [ "$ARTIFACT_ID" != "null" ]; then
+  if gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" > /tmp/fern-state.zip 2>/dev/null \
+      && unzip -o -q /tmp/fern-state.zip -d /tmp/fern-state 2>/dev/null; then
     PREV_DATE="$(jq -r '.date // ""' "/tmp/fern-state/$STATE_FILE" 2>/dev/null || echo "")"
     if [ "$PREV_DATE" = "$TODAY" ]; then
       THREAD_TS="$(jq -r '.ts // ""' "/tmp/fern-state/$STATE_FILE" 2>/dev/null || echo "")"

--- a/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
+++ b/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
@@ -50,6 +50,7 @@ jobs:
     outputs:
       pr_url: ${{ steps.create-pr.outputs.pull-request-url }}
       pr_number: ${{ steps.create-pr.outputs.pull-request-number }}
+      pr_operation: ${{ steps.create-pr.outputs.pull-request-operation }}
 
     steps:
       - name: Checkout Repository
@@ -80,7 +81,7 @@ jobs:
 
       - name: Set branch name
         run: |
-          echo "BRANCH_NAME=github-actions/NA-automatically-update-openapi-spec-and-fern-code-$(date +%Y-%m-%d-%H-%M-%S)" >> "$GITHUB_ENV"
+          echo "BRANCH_NAME=github-actions/NA-automatically-update-openapi-spec-and-fern-code" >> "$GITHUB_ENV"
 
       - name: Run Generate OpenAPI spec and Fern code
         env:
@@ -139,6 +140,7 @@ jobs:
         with:
           token: ${{ secrets.COMET_ACTION_CREATE_PR }}
           branch: ${{ env.BRANCH_NAME }}
+          reviewers: ${{ needs.resolve-trigger-context.outputs.trigger_author }}
           title: "[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code"
           body: |
             ## Details
@@ -163,12 +165,13 @@ jobs:
   notify-slack:
     name: Notify #code-review
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      actions: read # download the previous run's slack-thread-state artifact
     needs: [update-open-api-spec-and-fern-code, resolve-trigger-context]
     if: >-
       !failure() &&
       github.event_name == 'push' &&
-      needs.update-open-api-spec-and-fern-code.outputs.pr_url != ''
+      needs.update-open-api-spec-and-fern-code.outputs.pr_operation == 'created'
 
     steps:
       - name: Checkout
@@ -193,12 +196,27 @@ jobs:
           echo "mention=$AUTHOR_MENTION" >> "$GITHUB_OUTPUT"
           echo "author_display=$AUTHOR" >> "$GITHUB_OUTPUT"
 
-      - name: Send Slack notification
+      - name: Post to #code-review (daily thread)
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_CODE_REVIEW }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_CODE_REVIEW }}
+          SLACK_CODE_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_CODE_REVIEW_CHANNEL_ID }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          WORKFLOW_FILE: sdks_generate_openapi_spec_and_fern_code.yml
+          STATE_ARTIFACT_NAME: slack-thread-state
+          STATE_FILE: slack_code_review_fern_prs.json
           PR_URL: ${{ needs.update-open-api-spec-and-fern-code.outputs.pr_url }}
           PR_NUMBER: ${{ needs.update-open-api-spec-and-fern-code.outputs.pr_number }}
           ORIGINATING_PR: ${{ needs.resolve-trigger-context.outputs.originating_pr_url }}
           AUTHOR_DISPLAY: ${{ steps.resolve-mention.outputs.author_display }}
           MENTION: ${{ steps.resolve-mention.outputs.mention }}
         run: .github/scripts/notify-slack-fern-update.sh
+
+      - name: Upload thread state
+        uses: actions/upload-artifact@v7
+        with:
+          name: slack-thread-state
+          path: slack_code_review_fern_prs.json
+          if-no-files-found: ignore
+          overwrite: true
+          retention-days: 7

--- a/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
+++ b/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
@@ -48,9 +48,9 @@ jobs:
       contents: write
     timeout-minutes: 15
     outputs:
-      pr_url: ${{ steps.create-pr.outputs.pull-request-url }}
-      pr_number: ${{ steps.create-pr.outputs.pull-request-number }}
-      pr_operation: ${{ steps.create-pr.outputs.pull-request-operation }}
+      pr_url: ${{ steps.upsert-pr.outputs.pull-request-url }}
+      pr_number: ${{ steps.upsert-pr.outputs.pull-request-number }}
+      pr_operation: ${{ steps.upsert-pr.outputs.pull-request-operation }}
 
     steps:
       - name: Checkout Repository
@@ -133,9 +133,9 @@ jobs:
           git add apps/opik-documentation/documentation/fern/docs/agent_optimization/opik_optimizer/reference.mdx
           git commit -m "[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code"
 
-      - name: Create Pull Request
+      - name: Upsert Pull Request (create or update)
         if: steps.check_changes.outputs.has_changes == 'true'
-        id: create-pr
+        id: upsert-pr
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.COMET_ACTION_CREATE_PR }}

--- a/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
+++ b/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
@@ -171,7 +171,7 @@ jobs:
     if: >-
       !failure() &&
       github.event_name == 'push' &&
-      needs.update-open-api-spec-and-fern-code.outputs.pr_operation == 'created'
+      contains(fromJSON('["created", "updated"]'), needs.update-open-api-spec-and-fern-code.outputs.pr_operation)
 
     steps:
       - name: Checkout
@@ -202,7 +202,6 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_CODE_REVIEW }}
           SLACK_CODE_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_CODE_REVIEW_CHANNEL_ID }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          WORKFLOW_FILE: sdks_generate_openapi_spec_and_fern_code.yml
           STATE_ARTIFACT_NAME: slack-thread-state
           STATE_FILE: slack_code_review_fern_prs.json
           PR_URL: ${{ needs.update-open-api-spec-and-fern-code.outputs.pr_url }}


### PR DESCRIPTION
## Details

The "SDKs Generate OpenAPI spec and Fern code" workflow opened a brand-new PR (and posted a brand-new Slack message to #code-review) on every BE merge to `main` that changed the OpenAPI spec — so a busy day produced many duplicate Fern PRs that had to be closed by hand, plus one channel post each.

This change makes the automation converge on a single rolling PR and a single daily Slack thread:
- **Date-less branch**: drop the per-second timestamp from the PR branch so `peter-evans/create-pull-request` updates the one open PR in place instead of opening a duplicate; after it merges the action recreates a fresh branch from `main` on the next spec change.
- **One daily Slack thread**: gate the notification on `pull-request-operation` being `created` or `updated` (so each spec-changing BE merge notifies and tags its author, whether it opens a new Fern PR or pushes into the open one) and post via `chat.postMessage` as a branded "Fern Bot"; the first Fern PR of the day starts a thread and the rest reply under it. The thread anchor (`{date, ts}`) is carried between runs in the most recent `slack-thread-state` workflow artifact, resolved by name (no PAT / repo variable needed).
- **Per-author reviewers**: each triggering author is requested as a reviewer on the open PR.

> [!NOTE]
> Requires two repo secrets, now provisioned: `SLACK_BOT_TOKEN_CODE_REVIEW` (bot token with `chat:write` + `chat:write.customize`, bot invited to #code-review) and `SLACK_CODE_REVIEW_CHANNEL_ID`. If either is ever absent the script exits early with a CI `::warning::` naming the missing secret (the FERN PR is still created); branch-dedup and reviewers work regardless.

## Diagrams

<img width="789" height="949" alt="image" src="https://github.com/user-attachments/assets/62398855-f6dd-4fc5-a340-f7666fa852c0" />

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-7037

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: full implementation (design + workflow/script changes)
- Human verification: code review + local actionlint / shellcheck / pre-commit

## Testing

Static checks (clean): `shellcheck` on the script, `actionlint` on the workflow (also run by the pre-commit hook), and `pre-commit` on the changed files.

End-to-end validated on real CI via `workflow_dispatch` against the branch (temporary test scaffold, since removed):
- First dispatch posted a branded "Fern Bot" parent to #code-review and uploaded the `slack-thread-state` artifact (`new daily parent`).
- Subsequent same-day dispatches downloaded the artifact and replied in-thread (`threaded reply`) — confirming the artifact round-trip and one-thread-per-day behavior.
- Verified the branded :herb: icon overrides the default app icon, the "Triggered by:" line renders on its own line, author display preserves GitHub-username casing, and the `SLACK_USER_MAPPING` @-mention resolves on the real lookup path.

Real created→updated lifecycle verified end-to-end (via a temporary dispatch scaffold that forced a real spec diff, since removed):
- Run #1 → `Created pull request #7183` on the fixed branch (`pull-request-operation == 'created'`), posted to the daily thread.
- Run #2 (after #1 fully finished, to avoid the concurrency cancel) → `Updated pull request #7183` (`pull-request-operation == 'updated'`) — the **same** PR, force-updated in place, posted another threaded reply.
- Throughout, exactly **one** open Fern PR existed (no duplicate). Test PR #7183 and its branch were then closed/deleted.

The artifact-by-name lookup was also live-tested against the real artifacts. Production `push` trigger will run on the first real BE merge after this lands.

## Documentation

- N/A (internal CI automation; behavior documented in OPIK-7037 and the design diagrams)





