### PR TITLE
[OPIK-7050] [BE] fix: resolve ClickHouse query failures surfacing as IOException

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
@@ -2,6 +2,7 @@ package com.comet.opik.domain;
 
 import com.comet.opik.api.InstantToUUIDMapper;
 import com.comet.opik.api.filter.Filter;
+import com.comet.opik.api.filter.TraceThreadField;
 import com.comet.opik.api.metrics.KpiCardRequest.EntityType;
 import com.comet.opik.api.metrics.KpiCardResponse;
 import com.comet.opik.api.metrics.KpiCardResponse.KpiMetric;
@@ -434,6 +435,9 @@ class KpiCardDAOImpl implements KpiCardDAO {
                                AND notEquals(min(t.start_time), toDateTime64('1970-01-01 00:00:00.000', 9)),
                            (dateDiff('microsecond', min(t.start_time), max(t.end_time)) / 1000.0),
                            NULL) AS duration,
+                        count(DISTINCT t.id) * 2 as number_of_messages,
+                        <if(trace_thread_first_message_filter)>argMin(t.input, t.start_time) as first_message,<endif>
+                        <if(trace_thread_last_message_filter)>argMax(t.output, t.end_time) as last_message,<endif>
                         max(t.last_updated_at) as last_updated_at,
                         argMax(t.last_updated_by, t.last_updated_at) as last_updated_by,
                         argMin(t.created_by, t.created_at) as created_by,
@@ -606,6 +610,14 @@ class KpiCardDAOImpl implements KpiCardDAO {
         Optional.ofNullable(filters).ifPresent(f -> {
             FilterQueryBuilder.toAnalyticsDbFilters(f, FilterStrategy.TRACE_THREAD)
                     .ifPresent(threadFilters -> template.add("trace_thread_filters", threadFilters));
+            // first_message/last_message aggregate the full input/output payloads, so only project
+            // them in threads_filtered when a filter actually references them (otherwise the thread
+            // KPI query would needlessly materialize large columns). number_of_messages is cheap and
+            // always projected. See OPIK-7050.
+            FilterQueryBuilder.hasField(f, TraceThreadField.FIRST_MESSAGE)
+                    .ifPresent(present -> template.add("trace_thread_first_message_filter", true));
+            FilterQueryBuilder.hasField(f, TraceThreadField.LAST_MESSAGE)
+                    .ifPresent(present -> template.add("trace_thread_last_message_filter", true));
             FilterQueryBuilder.toAnalyticsDbFilters(f, FilterStrategy.FEEDBACK_SCORES)
                     .ifPresent(scoresFilters -> template.add("thread_feedback_scores_filters", scoresFilters));
             FilterQueryBuilder.toAnalyticsDbFilters(f, FilterStrategy.FEEDBACK_SCORES_IS_EMPTY)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -398,7 +398,7 @@ public class SpanDAO {
             	<if(total_estimated_cost)> toDecimal128(:total_estimated_cost, 12) <else> total_estimated_cost <endif> as total_estimated_cost,
             	<if(total_estimated_cost_version)> :total_estimated_cost_version <else> total_estimated_cost_version <endif> as total_estimated_cost_version,
             	<if(tags)> :tags <else> tags <endif> as tags,
-            	<if(usage)> CAST((:usageKeys, :usageValues), 'Map(String, Int64)') <else> usage <endif> as usage,
+            	<if(usage)> CAST((:usage_keys, :usage_values), 'Map(String, Int64)') <else> usage <endif> as usage,
             	<if(error_info)> :error_info <else> error_info <endif> as error_info,
             	created_at,
             	created_by,
@@ -573,7 +573,7 @@ public class SpanDAO {
                     <if(total_estimated_cost)> toDecimal128(:total_estimated_cost, 12) <else> toDecimal128(0, 12) <endif> as total_estimated_cost,
                     <if(total_estimated_cost_version)> :total_estimated_cost_version <else> '' <endif> as total_estimated_cost_version,
                     <if(tags)> :tags <else> [] <endif> as tags,
-                    <if(usage)> CAST((:usageKeys, :usageValues), 'Map(String, Int64)') <else>  mapFromArrays([], []) <endif> as usage,
+                    <if(usage)> CAST((:usage_keys, :usage_values), 'Map(String, Int64)') <else>  mapFromArrays([], []) <endif> as usage,
                     <if(error_info)> :error_info <else> '' <endif> as error_info,
                     now64(9) as created_at,
                     :user_name as created_by,
@@ -1635,7 +1635,7 @@ public class SpanDAO {
             + TagOperations.tagUpdateFragment("s.tags")
             + """
                         as tags,
-                        <if(usage)> CAST((:usageKeys, :usageValues), 'Map(String, Int64)') <else> s.usage <endif> as usage,
+                        <if(usage)> CAST((:usage_keys, :usage_values), 'Map(String, Int64)') <else> s.usage <endif> as usage,
                         <if(error_info)> :error_info <else> s.error_info <endif> as error_info,
                         s.created_at,
                         s.created_by,
@@ -2809,8 +2809,8 @@ public class SpanDAO {
     // drops null token counts (a null value would fail the CAST with CANNOT_CONVERT_TYPE, code 70).
     private static void bindUsage(Statement statement, Map<String, Integer> usage) {
         var sanitized = UsageUtils.sanitizeUsage(usage);
-        statement.bind("usageKeys", sanitized.keySet().toArray(String[]::new));
-        statement.bind("usageValues", sanitized.values().toArray(Integer[]::new));
+        statement.bind("usage_keys", sanitized.keySet().toArray(String[]::new));
+        statement.bind("usage_values", sanitized.values().toArray(Integer[]::new));
     }
 
     private void bindCost(Span span, Statement statement, String index) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -1974,6 +1974,13 @@ public class SpanDAO {
                     var usageKeys = new ArrayList<String>();
                     var usageValues = new ArrayList<Integer>();
                     for (var entry : usage.entrySet()) {
+                        // Skip null token counts: the SQL CASTs these arrays into a
+                        // Map(String, Int64) whose value type is non-nullable, so a null value
+                        // triggers ClickHouse CANNOT_CONVERT_TYPE (code 70). Matches the batch
+                        // insert path, which already drops null usage values.
+                        if (entry.getValue() == null) {
+                            continue;
+                        }
                         usageKeys.add(entry.getKey());
                         usageValues.add(entry.getValue());
                     }
@@ -2927,6 +2934,13 @@ public class SpanDAO {
                     var usageKeys = new ArrayList<String>();
                     var usageValues = new ArrayList<Integer>();
                     for (var entry : usage.entrySet()) {
+                        // Skip null token counts: the SQL CASTs these arrays into a
+                        // Map(String, Int64) whose value type is non-nullable, so a null value
+                        // triggers ClickHouse CANNOT_CONVERT_TYPE (code 70). Matches the batch
+                        // insert path, which already drops null usage values.
+                        if (entry.getValue() == null) {
+                            continue;
+                        }
                         usageKeys.add(entry.getKey());
                         usageValues.add(entry.getValue());
                     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -22,6 +22,7 @@ import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.utils.ClickHouseDateTimeFormat;
 import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.TruncationUtils;
+import com.comet.opik.utils.UsageUtils;
 import com.comet.opik.utils.template.TemplateUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
@@ -46,7 +47,6 @@ import reactor.core.publisher.Mono;
 
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -1728,12 +1728,7 @@ public class SpanDAO {
                     statement.bindNull("end_time" + i, String.class);
                 }
 
-                Map<String, Integer> usageMap = span.usage() == null
-                        ? Map.of()
-                        : span.usage().entrySet().stream()
-                                .filter(e -> e.getValue() != null)
-                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-                statement.bind("usage" + i, usageMap);
+                statement.bind("usage" + i, UsageUtils.sanitizeUsage(span.usage()));
 
                 // Format the timestamp client-side so the SQL contains a plain string literal in the
                 // last_updated_at cell. Fall back to "now" when the client did not provide a value —
@@ -2810,21 +2805,12 @@ public class SpanDAO {
                 spanUpdate.metadata()).compareTo(BigDecimal.ZERO) > 0;
     }
 
-    // Bind the usage map as parallel key/value arrays for the Map(String, Int64) CAST, dropping null
-    // token counts: a null value makes the CAST fail with ClickHouse CANNOT_CONVERT_TYPE (code 70).
-    // Matches the batch insert path, which also drops null usage values. Cost calculation is guarded
-    // separately in CostService.
+    // Bind the usage map as parallel key/value arrays for the Map(String, Int64) CAST. UsageUtils
+    // drops null token counts (a null value would fail the CAST with CANNOT_CONVERT_TYPE, code 70).
     private static void bindUsage(Statement statement, Map<String, Integer> usage) {
-        var usageKeys = new ArrayList<String>();
-        var usageValues = new ArrayList<Integer>();
-        usage.forEach((key, value) -> {
-            if (value != null) {
-                usageKeys.add(key);
-                usageValues.add(value);
-            }
-        });
-        statement.bind("usageKeys", usageKeys.toArray(String[]::new));
-        statement.bind("usageValues", usageValues.toArray(Integer[]::new));
+        var sanitized = UsageUtils.sanitizeUsage(usage);
+        statement.bind("usageKeys", sanitized.keySet().toArray(String[]::new));
+        statement.bind("usageValues", sanitized.values().toArray(Integer[]::new));
     }
 
     private void bindCost(Span span, Statement statement, String index) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -1969,24 +1969,7 @@ public class SpanDAO {
         Optional.ofNullable(spanUpdate.tags())
                 .ifPresent(tags -> statement.bind("tags", tags.toArray(String[]::new)));
         Optional.ofNullable(spanUpdate.usage())
-                .ifPresent(usage -> {
-                    // Need to convert the map to two arrays to bind to the statement
-                    var usageKeys = new ArrayList<String>();
-                    var usageValues = new ArrayList<Integer>();
-                    for (var entry : usage.entrySet()) {
-                        // Skip null token counts: the SQL CASTs these arrays into a
-                        // Map(String, Int64) whose value type is non-nullable, so a null value
-                        // triggers ClickHouse CANNOT_CONVERT_TYPE (code 70). Matches the batch
-                        // insert path, which already drops null usage values.
-                        if (entry.getValue() == null) {
-                            continue;
-                        }
-                        usageKeys.add(entry.getKey());
-                        usageValues.add(entry.getValue());
-                    }
-                    statement.bind("usageKeys", usageKeys.toArray(String[]::new));
-                    statement.bind("usageValues", usageValues.toArray(Integer[]::new));
-                });
+                .ifPresent(usage -> bindUsage(statement, usage));
         Optional.ofNullable(spanUpdate.endTime())
                 .ifPresent(endTime -> statement.bind("end_time", endTime.toString()));
         Optional.ofNullable(spanUpdate.metadata())
@@ -2827,6 +2810,23 @@ public class SpanDAO {
                 spanUpdate.metadata()).compareTo(BigDecimal.ZERO) > 0;
     }
 
+    // Bind the usage map as parallel key/value arrays for the Map(String, Int64) CAST, dropping null
+    // token counts: a null value makes the CAST fail with ClickHouse CANNOT_CONVERT_TYPE (code 70).
+    // Matches the batch insert path, which also drops null usage values. Cost calculation is guarded
+    // separately in CostService.
+    private static void bindUsage(Statement statement, Map<String, Integer> usage) {
+        var usageKeys = new ArrayList<String>();
+        var usageValues = new ArrayList<Integer>();
+        usage.forEach((key, value) -> {
+            if (value != null) {
+                usageKeys.add(key);
+                usageValues.add(value);
+            }
+        });
+        statement.bind("usageKeys", usageKeys.toArray(String[]::new));
+        statement.bind("usageValues", usageValues.toArray(Integer[]::new));
+    }
+
     private void bindCost(Span span, Statement statement, String index) {
         if (span.totalEstimatedCost() != null) {
             // Cost is set manually by the user
@@ -2930,23 +2930,7 @@ public class SpanDAO {
         TagOperations.bindTagParams(statement, spanUpdate);
 
         Optional.ofNullable(spanUpdate.usage())
-                .ifPresent(usage -> {
-                    var usageKeys = new ArrayList<String>();
-                    var usageValues = new ArrayList<Integer>();
-                    for (var entry : usage.entrySet()) {
-                        // Skip null token counts: the SQL CASTs these arrays into a
-                        // Map(String, Int64) whose value type is non-nullable, so a null value
-                        // triggers ClickHouse CANNOT_CONVERT_TYPE (code 70). Matches the batch
-                        // insert path, which already drops null usage values.
-                        if (entry.getValue() == null) {
-                            continue;
-                        }
-                        usageKeys.add(entry.getKey());
-                        usageValues.add(entry.getValue());
-                    }
-                    statement.bind("usageKeys", usageKeys.toArray(String[]::new));
-                    statement.bind("usageValues", usageValues.toArray(Integer[]::new));
-                });
+                .ifPresent(usage -> bindUsage(statement, usage));
         Optional.ofNullable(spanUpdate.endTime())
                 .ifPresent(endTime -> statement.bind("end_time", endTime.toString()));
         Optional.ofNullable(spanUpdate.metadata())

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -2,6 +2,7 @@ package com.comet.opik.domain.cost;
 
 import com.comet.opik.api.ModelCostData;
 import com.comet.opik.utils.JsonUtils;
+import com.comet.opik.utils.UsageUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
@@ -67,25 +68,12 @@ public class CostService {
             @Nullable Map<String, Integer> usage, @Nullable JsonNode metadata) {
         ModelPrice modelPrice = findModelPrice(modelName, provider);
 
-        BigDecimal estimatedCost = modelPrice.calculator().apply(modelPrice, sanitizeUsage(usage));
+        // Drop null token counts before pricing: calculators read usage via getOrDefault(key, 0),
+        // which returns null (not the default) for a key present with a null value, then NPEs
+        // unboxing it in BigDecimal.valueOf(...).
+        BigDecimal estimatedCost = modelPrice.calculator().apply(modelPrice, UsageUtils.sanitizeUsage(usage));
 
         return estimatedCost.compareTo(BigDecimal.ZERO) > 0 ? estimatedCost : getCostFromMetadata(metadata);
-    }
-
-    // Drop null token counts before pricing. Calculators read usage via getOrDefault(key, 0), which
-    // returns null (not the default) for a key present with a null value, then NPEs unboxing it in
-    // BigDecimal.valueOf(...). A null or absent usage map becomes empty.
-    private static Map<String, Integer> sanitizeUsage(@Nullable Map<String, Integer> usage) {
-        if (usage == null || usage.isEmpty()) {
-            return Map.of();
-        }
-        var sanitized = new HashMap<String, Integer>(usage.size());
-        usage.forEach((key, value) -> {
-            if (value != null) {
-                sanitized.put(key, value);
-            }
-        });
-        return sanitized;
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -67,10 +67,25 @@ public class CostService {
             @Nullable Map<String, Integer> usage, @Nullable JsonNode metadata) {
         ModelPrice modelPrice = findModelPrice(modelName, provider);
 
-        BigDecimal estimatedCost = modelPrice.calculator().apply(modelPrice,
-                Optional.ofNullable(usage).orElse(Map.of()));
+        BigDecimal estimatedCost = modelPrice.calculator().apply(modelPrice, sanitizeUsage(usage));
 
         return estimatedCost.compareTo(BigDecimal.ZERO) > 0 ? estimatedCost : getCostFromMetadata(metadata);
+    }
+
+    // Drop null token counts before pricing. Calculators read usage via getOrDefault(key, 0), which
+    // returns null (not the default) for a key present with a null value, then NPEs unboxing it in
+    // BigDecimal.valueOf(...). A null or absent usage map becomes empty.
+    private static Map<String, Integer> sanitizeUsage(@Nullable Map<String, Integer> usage) {
+        if (usage == null || usage.isEmpty()) {
+            return Map.of();
+        }
+        var sanitized = new HashMap<String, Integer>(usage.size());
+        usage.forEach((key, value) -> {
+            if (value != null) {
+                sanitized.put(key, value);
+            }
+        });
+        return sanitized;
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -851,8 +851,12 @@ public class FilterQueryBuilder {
     }
 
     public static Optional<Boolean> hasGuardrailsFilter(@NonNull List<? extends Filter> filters) {
+        return hasField(filters, TraceField.GUARDRAILS);
+    }
+
+    public static Optional<Boolean> hasField(@NonNull List<? extends Filter> filters, @NonNull Field field) {
         return filters.stream()
-                .filter(filter -> filter.field() == TraceField.GUARDRAILS)
+                .filter(filter -> filter.field() == field)
                 .findFirst()
                 .map(filter -> true);
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/UsageUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/UsageUtils.java
@@ -1,0 +1,37 @@
+package com.comet.opik.utils;
+
+import lombok.experimental.UtilityClass;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Helpers for span/trace usage (token-count) maps.
+ */
+@UtilityClass
+public class UsageUtils {
+
+    /**
+     * Returns a copy of the usage map with null-valued entries removed.
+     * <p>
+     * Null token counts must never reach ClickHouse: the {@code Map(String, Int64)} CAST in the span
+     * insert/update queries rejects null values (CANNOT_CONVERT_TYPE, code 70), and the cost
+     * calculators read usage via {@code getOrDefault(key, 0)}, which returns null (not the default)
+     * for a key present with a null value and then NPEs unboxing it in {@code BigDecimal.valueOf}.
+     * A null or empty input map yields an empty map.
+     */
+    public Map<String, Integer> sanitizeUsage(@Nullable Map<String, Integer> usage) {
+        if (usage == null || usage.isEmpty()) {
+            return Map.of();
+        }
+        var sanitized = new HashMap<String, Integer>(usage.size());
+        usage.forEach((key, value) -> {
+            if (value != null) {
+                sanitized.put(key, value);
+            }
+        });
+        return sanitized;
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/KpiCardsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/KpiCardsResourceTest.java
@@ -41,6 +41,7 @@ import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -848,6 +849,55 @@ class KpiCardsResourceTest {
                 expectedPreviousCount, expectedCurrentCount, 0, 0);
     }
 
+    @Test
+    @DisplayName("thread KPI metrics support first/last message filters (conditional projection)")
+    void threadFiltersByMessageContent() {
+        mockTargetWorkspace();
+        var projectName = RandomStringUtils.secure().nextAlphabetic(10);
+        var projectId = projectResourceClient.createProject(projectName, API_KEY, WORKSPACE_NAME);
+
+        createFilterEntities(EntityType.THREADS, projectName, 3);
+
+        Instant intervalStart = Instant.now();
+
+        var currentEntities = createFilterEntities(EntityType.THREADS, projectName, 3);
+
+        Instant intervalEnd = Instant.now().plus(1, ChronoUnit.MINUTES);
+
+        // Build the filter from the original trace of the first thread so the substring reliably
+        // matches exactly that thread's first/last message. Before the fix these filters failed with
+        // ClickHouse UNKNOWN_IDENTIFIER (code 47) because threads_filtered never projected
+        // first_message/last_message. They are now projected only when filtered. See OPIK-7050.
+        String firstThreadId = currentEntities.threadIds().getFirst();
+        Trace firstThreadTrace = currentEntities.traces().stream()
+                .filter(trace -> firstThreadId.equals(trace.threadId()))
+                .findFirst()
+                .orElseThrow();
+
+        var messageFilters = List.of(
+                TraceThreadFilter.builder()
+                        .field(TraceThreadField.FIRST_MESSAGE)
+                        .operator(Operator.CONTAINS)
+                        .value(firstThreadTrace.input().toString().substring(0, 20))
+                        .build(),
+                TraceThreadFilter.builder()
+                        .field(TraceThreadField.LAST_MESSAGE)
+                        .operator(Operator.CONTAINS)
+                        .value(firstThreadTrace.output().toString().substring(0, 20))
+                        .build());
+
+        for (var filter : messageFilters) {
+            KpiCardResponse response = projectResourceClient.getKpiCards(projectId, KpiCardRequest.builder()
+                    .entityType(EntityType.THREADS)
+                    .intervalStart(intervalStart)
+                    .intervalEnd(intervalEnd)
+                    .filters(JsonUtils.writeValueAsString(List.of(filter)))
+                    .build(), API_KEY, WORKSPACE_NAME);
+
+            assertFilteredMetrics(response, EntityType.THREADS, 1, 0, 0, 0);
+        }
+    }
+
     static Stream<Arguments> threadFilterArguments() {
         return Stream.of(
                 Arguments.of(
@@ -897,6 +947,16 @@ class KpiCardsResourceTest {
                                 .field(TraceThreadField.LAST_UPDATED_AT)
                                 .operator(Operator.GREATER_THAN)
                                 .value(thread.lastUpdatedAt().minusSeconds(1).toString())
+                                .build(),
+                        3, 3),
+                // Regression for the threads_filtered CTE not projecting number_of_messages:
+                // a number_of_messages thread filter previously failed with ClickHouse
+                // UNKNOWN_IDENTIFIER (code 47). Every thread has number_of_messages > 0.
+                Arguments.of(
+                        (Function<TraceThread, TraceThreadFilter>) thread -> TraceThreadFilter.builder()
+                                .field(TraceThreadField.NUMBER_OF_MESSAGES)
+                                .operator(Operator.GREATER_THAN)
+                                .value("0")
                                 .build(),
                         3, 3),
                 Arguments.of(

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -110,6 +110,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -2361,6 +2362,35 @@ class SpansResourceTest {
                     .projectName(DEFAULT_PROJECT);
             SpanMapper.INSTANCE.updateSpanBuilder(expectedSpanBuilder, expectedSpanUpdate);
             getAndAssert(expectedSpanBuilder.build(), API_KEY, TEST_WORKSPACE);
+        }
+
+        @Test
+        @DisplayName("when span update usage has a null value, then drop it and accept the update")
+        void update__whenUsageHasNullValue__thenDropNullAndAccept() {
+            var expectedSpan = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .projectName(null)
+                    .parentSpanId(null)
+                    .feedbackScores(null)
+                    .build();
+            spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
+
+            // A null token count must not reach the Map(String, Int64) CAST in the update query,
+            // which would otherwise fail with ClickHouse CANNOT_CONVERT_TYPE (code 70). The null
+            // entry is dropped, matching the batch insert path. See OPIK-7050.
+            var usageWithNull = new HashMap<String, Integer>();
+            usageWithNull.put("completion_tokens", 7);
+            usageWithNull.put("prompt_tokens", null);
+
+            var spanUpdate = SpanUpdate.builder()
+                    .usage(usageWithNull)
+                    .parentSpanId(expectedSpan.parentSpanId())
+                    .traceId(expectedSpan.traceId())
+                    .projectName(expectedSpan.projectName())
+                    .build();
+            spanResourceClient.updateSpan(expectedSpan.id(), spanUpdate, API_KEY, TEST_WORKSPACE);
+
+            var actualSpan = spanResourceClient.getById(expectedSpan.id(), TEST_WORKSPACE, API_KEY);
+            assertThat(actualSpan.usage()).isEqualTo(Map.of("completion_tokens", 7));
         }
 
         @ParameterizedTest

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -2374,15 +2374,18 @@ class SpansResourceTest {
                     .build();
             spanResourceClient.createSpan(expectedSpan, API_KEY, TEST_WORKSPACE);
 
-            // A null token count must not reach the Map(String, Int64) CAST in the update query,
-            // which would otherwise fail with ClickHouse CANNOT_CONVERT_TYPE (code 70). The null
-            // entry is dropped, matching the batch insert path. See OPIK-7050.
+            // A null token count must not reach (a) the Map(String, Int64) CAST in the update query
+            // — ClickHouse CANNOT_CONVERT_TYPE (code 70) — nor (b) the cost recalculation, where
+            // SpanCostCalculator unboxes usage.getOrDefault(key, 0) and NPEs on a present-null value.
+            // model+provider are set so the cost recalculation path actually runs. See OPIK-7050.
             var usageWithNull = new HashMap<String, Integer>();
             usageWithNull.put("completion_tokens", 7);
             usageWithNull.put("prompt_tokens", null);
 
             var spanUpdate = SpanUpdate.builder()
                     .usage(usageWithNull)
+                    .model("gpt-4")
+                    .provider("openai")
                     .parentSpanId(expectedSpan.parentSpanId())
                     .traceId(expectedSpan.traceId())
                     .projectName(expectedSpan.projectName())


### PR DESCRIPTION
## Details

Fixes two deterministic, request-scoped ClickHouse query failures in `opik-backend` that surfaced as `error_type=IOException` (the ClickHouse client wraps server-side SQL errors as `java.io.IOException`). Each failed an individual request with a 500 while the service stayed healthy.

- **Thread KPI cards (code 47, `UNKNOWN_IDENTIFIER`):** `KpiCardDAO`'s `threads_filtered` CTE did not project `number_of_messages`, so a thread filter on it failed (`Unknown expression or function identifier 'number_of_messages'`). It is now always projected (`count(DISTINCT id) * 2` — reads only `id`, cheap). `first_message`/`last_message` are projected **only when a filter references them**, since `argMin/argMax` over `input`/`output` materializes the full message payloads — added via a `hasField` flag so the common KPI query pays nothing extra.
- **Span updates (code 70, `CANNOT_CONVERT_TYPE`):** the span partial-update binding passed null `usage` map values into `CAST((:usageKeys, :usageValues), 'Map(String, Int64)')`, whose value type is non-nullable, failing with `Cannot convert NULL to a non-nullable type`. Null values are now dropped, matching the batch insert path (which already filters them).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-7050

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: investigation (metrics + logs), code changes, and tests
- Human verification: full diff reviewed; `mvn test-compile` passes; functional validation runs in CI (the local resource-test harness hits an unrelated Dropwizard bootstrap error on this machine — see Testing)

## Testing

Added regression tests that reproduce both failures:

- `KpiCardsResourceTest`
  - `threadFilterArguments` now includes a `NUMBER_OF_MESSAGES` thread filter (the field from the production failure).
  - `threadFiltersByMessageContent` exercises the conditional `first_message`/`last_message` projection path.
- `SpansResourceTest#update__whenUsageHasNullValue__thenDropNullAndAccept` — a span update whose `usage` map contains a null value succeeds and the null entry is dropped.

Commands:
- `mvn -o test-compile` — BUILD SUCCESS (main + test sources).
- `mvn -o test -Dtest='KpiCardsResourceTest#...' / 'SpansResourceTest#...'` — the resource-test harness fails at Dropwizard app bootstrap on this machine with `A health check named clickhouse already exists` (thrown in `@BeforeAll`, before any test logic, and unrelated to this change). The full integration suite runs in CI.

## Documentation

N/A — internal bug fix with no user-facing API or behavior contract change (filters/updates that previously 500'd now succeed).
