### PR TITLE
[OPIK-7052] [BE] feat: add OpenTelemetry monitoring for Agent Insights pipeline

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgentInsightsReportSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgentInsightsReportSubscriber.java
@@ -1,9 +1,12 @@
 package com.comet.opik.api.resources.v1.events;
 
+import com.comet.opik.domain.AgentInsightsMetrics;
 import com.comet.opik.domain.AgentInsightsReportClient;
 import com.comet.opik.domain.AgentInsightsReportMessage;
 import com.comet.opik.infrastructure.AgentInsightsReportConfig;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
 import jakarta.inject.Inject;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +32,11 @@ public class AgentInsightsReportSubscriber extends BaseRedisSubscriber<AgentInsi
     private final ServiceTogglesConfig serviceToggles;
     private final AgentInsightsReportClient reportClient;
 
+    // The base class records every message as success because processEvent swallows failures (at-most-once
+    // drop), so its processing-errors metric never fires for a failed trigger. This counter restores the
+    // success/failure outcome signal for the platform trigger call.
+    private final LongCounter reportsTriggered;
+
     @Inject
     public AgentInsightsReportSubscriber(
             @NonNull @Config("agentInsightsReport") AgentInsightsReportConfig config,
@@ -39,6 +47,10 @@ public class AgentInsightsReportSubscriber extends BaseRedisSubscriber<AgentInsi
         this.config = config;
         this.serviceToggles = serviceToggles;
         this.reportClient = reportClient;
+        this.reportsTriggered = meter
+                .counterBuilder(AgentInsightsMetrics.REPORTS_TRIGGERED)
+                .setDescription(AgentInsightsMetrics.REPORTS_TRIGGERED_DESC)
+                .build();
     }
 
     @Override
@@ -70,9 +82,13 @@ public class AgentInsightsReportSubscriber extends BaseRedisSubscriber<AgentInsi
                 message.workspaceId(), message.periodStart(), message.periodEnd()))
                 .subscribeOn(Schedulers.boundedElastic())
                 .then()
-                .doOnSuccess(unused -> log.info("Triggered Agent Insights report: reportId='{}', project='{}'",
-                        message.reportId(), message.projectId()))
+                .doOnSuccess(unused -> {
+                    reportsTriggered.add(1, Attributes.of(AgentInsightsMetrics.OUTCOME, AgentInsightsMetrics.SUCCESS));
+                    log.info("Triggered Agent Insights report: reportId='{}', project='{}'",
+                            message.reportId(), message.projectId());
+                })
                 .onErrorResume(throwable -> {
+                    reportsTriggered.add(1, Attributes.of(AgentInsightsMetrics.OUTCOME, AgentInsightsMetrics.FAILURE));
                     // At-most-once on purpose: report generation is a non-idempotent side effect (Ollie
                     // compute + a user-facing report), and the trigger isn't deduplicated downstream, so a
                     // redelivery would run the same report twice. We ack on failure (log + complete) rather

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgentInsightsReportSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgentInsightsReportSubscriber.java
@@ -6,7 +6,6 @@ import com.comet.opik.domain.AgentInsightsReportMessage;
 import com.comet.opik.infrastructure.AgentInsightsReportConfig;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.LongCounter;
 import jakarta.inject.Inject;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -32,11 +31,6 @@ public class AgentInsightsReportSubscriber extends BaseRedisSubscriber<AgentInsi
     private final ServiceTogglesConfig serviceToggles;
     private final AgentInsightsReportClient reportClient;
 
-    // The base class records every message as success because processEvent swallows failures (at-most-once
-    // drop), so its processing-errors metric never fires for a failed trigger. This counter restores the
-    // success/failure outcome signal for the platform trigger call.
-    private final LongCounter reportsTriggered;
-
     @Inject
     public AgentInsightsReportSubscriber(
             @NonNull @Config("agentInsightsReport") AgentInsightsReportConfig config,
@@ -47,10 +41,6 @@ public class AgentInsightsReportSubscriber extends BaseRedisSubscriber<AgentInsi
         this.config = config;
         this.serviceToggles = serviceToggles;
         this.reportClient = reportClient;
-        this.reportsTriggered = meter
-                .counterBuilder(AgentInsightsMetrics.REPORTS_TRIGGERED)
-                .setDescription(AgentInsightsMetrics.REPORTS_TRIGGERED_DESC)
-                .build();
     }
 
     @Override
@@ -83,12 +73,17 @@ public class AgentInsightsReportSubscriber extends BaseRedisSubscriber<AgentInsi
                 .subscribeOn(Schedulers.boundedElastic())
                 .then()
                 .doOnSuccess(unused -> {
-                    reportsTriggered.add(1, Attributes.of(AgentInsightsMetrics.OUTCOME, AgentInsightsMetrics.SUCCESS));
+                    // The base class records every message as success because processEvent swallows failures
+                    // (at-most-once drop), so its processing-errors metric never fires for a failed trigger.
+                    // This counter restores the success/failure outcome signal for the platform trigger call.
+                    AgentInsightsMetrics.REPORTS_TRIGGERED.add(1,
+                            Attributes.of(AgentInsightsMetrics.OUTCOME, AgentInsightsMetrics.SUCCESS));
                     log.info("Triggered Agent Insights report: reportId='{}', project='{}'",
                             message.reportId(), message.projectId());
                 })
                 .onErrorResume(throwable -> {
-                    reportsTriggered.add(1, Attributes.of(AgentInsightsMetrics.OUTCOME, AgentInsightsMetrics.FAILURE));
+                    AgentInsightsMetrics.REPORTS_TRIGGERED.add(1,
+                            Attributes.of(AgentInsightsMetrics.OUTCOME, AgentInsightsMetrics.FAILURE));
                     // At-most-once on purpose: report generation is a non-idempotent side effect (Ollie
                     // compute + a user-facing report), and the trigger isn't deduplicated downstream, so a
                     // redelivery would run the same report twice. We ack on failure (log + complete) rather

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgentInsightsReportSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgentInsightsReportSubscriber.java
@@ -5,7 +5,6 @@ import com.comet.opik.domain.AgentInsightsReportClient;
 import com.comet.opik.domain.AgentInsightsReportMessage;
 import com.comet.opik.infrastructure.AgentInsightsReportConfig;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
-import io.opentelemetry.api.common.Attributes;
 import jakarta.inject.Inject;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -76,14 +75,12 @@ public class AgentInsightsReportSubscriber extends BaseRedisSubscriber<AgentInsi
                     // The base class records every message as success because processEvent swallows failures
                     // (at-most-once drop), so its processing-errors metric never fires for a failed trigger.
                     // This counter restores the success/failure outcome signal for the platform trigger call.
-                    AgentInsightsMetrics.REPORTS_TRIGGERED.add(1,
-                            Attributes.of(AgentInsightsMetrics.OUTCOME, AgentInsightsMetrics.SUCCESS));
+                    AgentInsightsMetrics.REPORTS_TRIGGERED.add(1, AgentInsightsMetrics.OUTCOME_SUCCESS);
                     log.info("Triggered Agent Insights report: reportId='{}', project='{}'",
                             message.reportId(), message.projectId());
                 })
                 .onErrorResume(throwable -> {
-                    AgentInsightsMetrics.REPORTS_TRIGGERED.add(1,
-                            Attributes.of(AgentInsightsMetrics.OUTCOME, AgentInsightsMetrics.FAILURE));
+                    AgentInsightsMetrics.REPORTS_TRIGGERED.add(1, AgentInsightsMetrics.OUTCOME_FAILURE);
                     // At-most-once on purpose: report generation is a non-idempotent side effect (Ollie
                     // compute + a user-facing report), and the trigger isn't deduplicated downstream, so a
                     // redelivery would run the same report twice. We ack on failure (log + complete) rather

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/AgentInsightsReportJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/AgentInsightsReportJob.java
@@ -103,12 +103,12 @@ public class AgentInsightsReportJob extends Job {
                             .concatMap(job -> reportPublisher
                                     .enqueue(job.projectId(), job.workspaceId(), periodStart, periodEnd)
                                     .doOnNext(__ -> AgentInsightsMetrics.REPORTS_ENQUEUED.add(1,
-                                            AgentInsightsMetrics.TRIGGER_SCHEDULED))
+                                            AgentInsightsMetrics.ENQUEUE_SCHEDULED_SUCCESS))
                                     .then()
                                     .onErrorResume(e -> {
                                         // Per-job isolation: a failed enqueue must not skip the rest.
-                                        AgentInsightsMetrics.TRIGGER_ERRORS.add(1,
-                                                AgentInsightsMetrics.TRIGGER_SCHEDULED);
+                                        AgentInsightsMetrics.REPORTS_ENQUEUED.add(1,
+                                                AgentInsightsMetrics.ENQUEUE_SCHEDULED_FAILURE);
                                         log.error("Failed to enqueue Agent Insights run for project '{}'",
                                                 job.projectId(), e);
                                         return Mono.empty();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/AgentInsightsReportJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/AgentInsightsReportJob.java
@@ -8,11 +8,7 @@ import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.lock.LockService;
 import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.jobs.Job;
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.LongCounter;
-import io.opentelemetry.api.metrics.LongHistogram;
-import io.opentelemetry.api.metrics.Meter;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -47,23 +43,6 @@ public class AgentInsightsReportJob extends Job {
 
     private static final Lock JOB_LOCK = new Lock("agent_insights_report_job:lock");
 
-    private static final Meter METER = GlobalOpenTelemetry.get().getMeter(AgentInsightsMetrics.METER_NAME);
-
-    private final LongHistogram sweepDuration = METER
-            .histogramBuilder(AgentInsightsMetrics.SWEEP_DURATION)
-            .setDescription(AgentInsightsMetrics.SWEEP_DURATION_DESC)
-            .setUnit("ms")
-            .ofLongs()
-            .build();
-    private final LongCounter reportsEnqueued = METER
-            .counterBuilder(AgentInsightsMetrics.REPORTS_ENQUEUED)
-            .setDescription(AgentInsightsMetrics.REPORTS_ENQUEUED_DESC)
-            .build();
-    private final LongCounter triggerErrors = METER
-            .counterBuilder(AgentInsightsMetrics.TRIGGER_ERRORS)
-            .setDescription(AgentInsightsMetrics.TRIGGER_ERRORS_DESC)
-            .build();
-
     private final @NonNull AgentInsightsJobService agentInsightsJobService;
     private final @NonNull TraceService traceService;
     private final @NonNull AgentInsightsReportPublisher reportPublisher;
@@ -78,12 +57,23 @@ public class AgentInsightsReportJob extends Job {
 
         log.info("Agent Insights report job running for previous UTC day ['{}', '{}')", periodStart, periodEnd);
 
-        long startMillis = System.currentTimeMillis();
         var reportConfig = config.getAgentInsightsReport();
+        // Record duration only when the sweep actually runs (lock acquired), so a lock miss is not counted
+        // as a successful sweep. Timing starts at sweep subscription, excluding the lock-wait.
+        Mono<Void> timedSweep = Mono.defer(() -> {
+            long startMillis = System.currentTimeMillis();
+            return runSweep(periodStart, periodEnd)
+                    .doFinally(signalType -> AgentInsightsMetrics.SWEEP_DURATION_MS.record(
+                            System.currentTimeMillis() - startMillis,
+                            Attributes.of(AgentInsightsMetrics.OUTCOME,
+                                    signalType == SignalType.ON_COMPLETE
+                                            ? AgentInsightsMetrics.SUCCESS
+                                            : AgentInsightsMetrics.FAILURE)));
+        });
         // holdUntilExpiry: only one replica runs the sweep per day (idempotent across replicas).
         lockService.bestEffortLock(
                 JOB_LOCK,
-                runSweep(periodStart, periodEnd),
+                timedSweep,
                 Mono.defer(() -> {
                     log.debug("Could not acquire lock for Agent Insights report job, another instance is running");
                     return Mono.empty();
@@ -91,11 +81,6 @@ public class AgentInsightsReportJob extends Job {
                 reportConfig.getJobTimeout().toJavaDuration(),
                 reportConfig.getLockWaitTime().toJavaDuration(),
                 true)
-                .doFinally(signalType -> sweepDuration.record(System.currentTimeMillis() - startMillis,
-                        Attributes.of(AgentInsightsMetrics.OUTCOME,
-                                signalType == SignalType.ON_COMPLETE
-                                        ? AgentInsightsMetrics.SUCCESS
-                                        : AgentInsightsMetrics.FAILURE)))
                 .subscribe(
                         __ -> log.info("Agent Insights report job completed"),
                         error -> log.error("Agent Insights report job failed", error));
@@ -119,14 +104,15 @@ public class AgentInsightsReportJob extends Job {
                                     .filter(job -> withTraces.contains(job.projectId())))
                             .concatMap(job -> reportPublisher
                                     .enqueue(job.projectId(), job.workspaceId(), periodStart, periodEnd)
-                                    .doOnNext(__ -> reportsEnqueued.add(1,
+                                    .doOnNext(__ -> AgentInsightsMetrics.REPORTS_ENQUEUED.add(1,
                                             Attributes.of(AgentInsightsMetrics.TRIGGER,
                                                     AgentInsightsMetrics.SCHEDULED)))
                                     .then()
                                     .onErrorResume(e -> {
                                         // Per-job isolation: a failed enqueue must not skip the rest.
-                                        triggerErrors.add(1, Attributes.of(AgentInsightsMetrics.TRIGGER,
-                                                AgentInsightsMetrics.SCHEDULED));
+                                        AgentInsightsMetrics.TRIGGER_ERRORS.add(1,
+                                                Attributes.of(AgentInsightsMetrics.TRIGGER,
+                                                        AgentInsightsMetrics.SCHEDULED));
                                         log.error("Failed to enqueue Agent Insights run for project '{}'",
                                                 job.projectId(), e);
                                         return Mono.empty();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/AgentInsightsReportJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/AgentInsightsReportJob.java
@@ -8,7 +8,6 @@ import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.lock.LockService;
 import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.jobs.Job;
-import io.opentelemetry.api.common.Attributes;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -65,10 +64,9 @@ public class AgentInsightsReportJob extends Job {
             return runSweep(periodStart, periodEnd)
                     .doFinally(signalType -> AgentInsightsMetrics.SWEEP_DURATION_MS.record(
                             System.currentTimeMillis() - startMillis,
-                            Attributes.of(AgentInsightsMetrics.OUTCOME,
-                                    signalType == SignalType.ON_COMPLETE
-                                            ? AgentInsightsMetrics.SUCCESS
-                                            : AgentInsightsMetrics.FAILURE)));
+                            signalType == SignalType.ON_COMPLETE
+                                    ? AgentInsightsMetrics.OUTCOME_SUCCESS
+                                    : AgentInsightsMetrics.OUTCOME_FAILURE));
         });
         // holdUntilExpiry: only one replica runs the sweep per day (idempotent across replicas).
         lockService.bestEffortLock(
@@ -105,14 +103,12 @@ public class AgentInsightsReportJob extends Job {
                             .concatMap(job -> reportPublisher
                                     .enqueue(job.projectId(), job.workspaceId(), periodStart, periodEnd)
                                     .doOnNext(__ -> AgentInsightsMetrics.REPORTS_ENQUEUED.add(1,
-                                            Attributes.of(AgentInsightsMetrics.TRIGGER,
-                                                    AgentInsightsMetrics.SCHEDULED)))
+                                            AgentInsightsMetrics.TRIGGER_SCHEDULED))
                                     .then()
                                     .onErrorResume(e -> {
                                         // Per-job isolation: a failed enqueue must not skip the rest.
                                         AgentInsightsMetrics.TRIGGER_ERRORS.add(1,
-                                                Attributes.of(AgentInsightsMetrics.TRIGGER,
-                                                        AgentInsightsMetrics.SCHEDULED));
+                                                AgentInsightsMetrics.TRIGGER_SCHEDULED);
                                         log.error("Failed to enqueue Agent Insights run for project '{}'",
                                                 job.projectId(), e);
                                         return Mono.empty();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/AgentInsightsReportJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/AgentInsightsReportJob.java
@@ -1,12 +1,18 @@
 package com.comet.opik.api.resources.v1.jobs;
 
 import com.comet.opik.domain.AgentInsightsJobService;
+import com.comet.opik.domain.AgentInsightsMetrics;
 import com.comet.opik.domain.AgentInsightsReportPublisher;
 import com.comet.opik.domain.TraceService;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.lock.LockService;
 import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.jobs.Job;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.Meter;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -17,6 +23,7 @@ import org.quartz.DisallowConcurrentExecution;
 import org.quartz.JobExecutionContext;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
 import reactor.core.scheduler.Schedulers;
 
 import java.time.Instant;
@@ -40,6 +47,23 @@ public class AgentInsightsReportJob extends Job {
 
     private static final Lock JOB_LOCK = new Lock("agent_insights_report_job:lock");
 
+    private static final Meter METER = GlobalOpenTelemetry.get().getMeter(AgentInsightsMetrics.METER_NAME);
+
+    private final LongHistogram sweepDuration = METER
+            .histogramBuilder(AgentInsightsMetrics.SWEEP_DURATION)
+            .setDescription(AgentInsightsMetrics.SWEEP_DURATION_DESC)
+            .setUnit("ms")
+            .ofLongs()
+            .build();
+    private final LongCounter reportsEnqueued = METER
+            .counterBuilder(AgentInsightsMetrics.REPORTS_ENQUEUED)
+            .setDescription(AgentInsightsMetrics.REPORTS_ENQUEUED_DESC)
+            .build();
+    private final LongCounter triggerErrors = METER
+            .counterBuilder(AgentInsightsMetrics.TRIGGER_ERRORS)
+            .setDescription(AgentInsightsMetrics.TRIGGER_ERRORS_DESC)
+            .build();
+
     private final @NonNull AgentInsightsJobService agentInsightsJobService;
     private final @NonNull TraceService traceService;
     private final @NonNull AgentInsightsReportPublisher reportPublisher;
@@ -54,6 +78,7 @@ public class AgentInsightsReportJob extends Job {
 
         log.info("Agent Insights report job running for previous UTC day ['{}', '{}')", periodStart, periodEnd);
 
+        long startMillis = System.currentTimeMillis();
         var reportConfig = config.getAgentInsightsReport();
         // holdUntilExpiry: only one replica runs the sweep per day (idempotent across replicas).
         lockService.bestEffortLock(
@@ -65,7 +90,13 @@ public class AgentInsightsReportJob extends Job {
                 }),
                 reportConfig.getJobTimeout().toJavaDuration(),
                 reportConfig.getLockWaitTime().toJavaDuration(),
-                true).subscribe(
+                true)
+                .doFinally(signalType -> sweepDuration.record(System.currentTimeMillis() - startMillis,
+                        Attributes.of(AgentInsightsMetrics.OUTCOME,
+                                signalType == SignalType.ON_COMPLETE
+                                        ? AgentInsightsMetrics.SUCCESS
+                                        : AgentInsightsMetrics.FAILURE)))
+                .subscribe(
                         __ -> log.info("Agent Insights report job completed"),
                         error -> log.error("Agent Insights report job failed", error));
     }
@@ -88,9 +119,14 @@ public class AgentInsightsReportJob extends Job {
                                     .filter(job -> withTraces.contains(job.projectId())))
                             .concatMap(job -> reportPublisher
                                     .enqueue(job.projectId(), job.workspaceId(), periodStart, periodEnd)
+                                    .doOnNext(__ -> reportsEnqueued.add(1,
+                                            Attributes.of(AgentInsightsMetrics.TRIGGER,
+                                                    AgentInsightsMetrics.SCHEDULED)))
                                     .then()
                                     .onErrorResume(e -> {
                                         // Per-job isolation: a failed enqueue must not skip the rest.
+                                        triggerErrors.add(1, Attributes.of(AgentInsightsMetrics.TRIGGER,
+                                                AgentInsightsMetrics.SCHEDULED));
                                         log.error("Failed to enqueue Agent Insights run for project '{}'",
                                                 job.projectId(), e);
                                         return Mono.empty();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueService.java
@@ -12,6 +12,9 @@ import com.comet.opik.domain.sorting.SortingQueryBuilder;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.utils.JsonUtils;
 import com.google.inject.ImplementedBy;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
@@ -51,6 +54,17 @@ public interface AgentInsightsIssueService {
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 class AgentInsightsIssueServiceImpl implements AgentInsightsIssueService {
+
+    private static final Meter METER = GlobalOpenTelemetry.get().getMeter(AgentInsightsMetrics.METER_NAME);
+
+    private final LongCounter reportsReceived = METER
+            .counterBuilder(AgentInsightsMetrics.REPORTS_RECEIVED)
+            .setDescription(AgentInsightsMetrics.REPORTS_RECEIVED_DESC)
+            .build();
+    private final LongCounter issuesReported = METER
+            .counterBuilder(AgentInsightsMetrics.ISSUES_REPORTED)
+            .setDescription(AgentInsightsMetrics.ISSUES_REPORTED_DESC)
+            .build();
 
     private final @NonNull Provider<RequestContext> requestContext;
     private final @NonNull IdGenerator idGenerator;
@@ -95,6 +109,9 @@ class AgentInsightsIssueServiceImpl implements AgentInsightsIssueService {
 
             return null;
         });
+
+        reportsReceived.add(1);
+        issuesReported.add(report.issues().size());
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueService.java
@@ -12,9 +12,6 @@ import com.comet.opik.domain.sorting.SortingQueryBuilder;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.utils.JsonUtils;
 import com.google.inject.ImplementedBy;
-import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.metrics.LongCounter;
-import io.opentelemetry.api.metrics.Meter;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
@@ -54,17 +51,6 @@ public interface AgentInsightsIssueService {
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 class AgentInsightsIssueServiceImpl implements AgentInsightsIssueService {
-
-    private static final Meter METER = GlobalOpenTelemetry.get().getMeter(AgentInsightsMetrics.METER_NAME);
-
-    private final LongCounter reportsReceived = METER
-            .counterBuilder(AgentInsightsMetrics.REPORTS_RECEIVED)
-            .setDescription(AgentInsightsMetrics.REPORTS_RECEIVED_DESC)
-            .build();
-    private final LongCounter issuesReported = METER
-            .counterBuilder(AgentInsightsMetrics.ISSUES_REPORTED)
-            .setDescription(AgentInsightsMetrics.ISSUES_REPORTED_DESC)
-            .build();
 
     private final @NonNull Provider<RequestContext> requestContext;
     private final @NonNull IdGenerator idGenerator;
@@ -110,8 +96,8 @@ class AgentInsightsIssueServiceImpl implements AgentInsightsIssueService {
             return null;
         });
 
-        reportsReceived.add(1);
-        issuesReported.add(report.issues().size());
+        AgentInsightsMetrics.REPORTS_RECEIVED.add(1);
+        AgentInsightsMetrics.ISSUES_REPORTED.add(report.issues().size());
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobService.java
@@ -5,7 +5,6 @@ import com.comet.opik.api.AgentInsightsJob.EnabledJob;
 import com.comet.opik.api.error.EntityAlreadyExistsException;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import io.dropwizard.jersey.errors.ErrorMessage;
-import io.opentelemetry.api.common.Attributes;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
@@ -97,14 +96,12 @@ public class AgentInsightsJobService {
         reportPublisher.enqueue(job.projectId(), workspaceId, periodEnd.minus(TRIGGER_WINDOW), periodEnd)
                 .subscribe(
                         reportId -> {
-                            AgentInsightsMetrics.REPORTS_ENQUEUED.add(1,
-                                    Attributes.of(AgentInsightsMetrics.TRIGGER, AgentInsightsMetrics.MANUAL));
+                            AgentInsightsMetrics.REPORTS_ENQUEUED.add(1, AgentInsightsMetrics.TRIGGER_MANUAL);
                             log.info("Enqueued Agent Insights run reportId='{}' for project '{}'",
                                     reportId, projectId);
                         },
                         error -> {
-                            AgentInsightsMetrics.TRIGGER_ERRORS.add(1,
-                                    Attributes.of(AgentInsightsMetrics.TRIGGER, AgentInsightsMetrics.MANUAL));
+                            AgentInsightsMetrics.TRIGGER_ERRORS.add(1, AgentInsightsMetrics.TRIGGER_MANUAL);
                             log.error("Failed to enqueue Agent Insights run for project '{}'", projectId,
                                     error);
                         });

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobService.java
@@ -5,6 +5,10 @@ import com.comet.opik.api.AgentInsightsJob.EnabledJob;
 import com.comet.opik.api.error.EntityAlreadyExistsException;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import io.dropwizard.jersey.errors.ErrorMessage;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
@@ -28,6 +32,17 @@ import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
 public class AgentInsightsJobService {
 
     private static final Duration TRIGGER_WINDOW = Duration.ofHours(24);
+
+    private static final Meter METER = GlobalOpenTelemetry.get().getMeter(AgentInsightsMetrics.METER_NAME);
+
+    private final LongCounter reportsEnqueued = METER
+            .counterBuilder(AgentInsightsMetrics.REPORTS_ENQUEUED)
+            .setDescription(AgentInsightsMetrics.REPORTS_ENQUEUED_DESC)
+            .build();
+    private final LongCounter triggerErrors = METER
+            .counterBuilder(AgentInsightsMetrics.TRIGGER_ERRORS)
+            .setDescription(AgentInsightsMetrics.TRIGGER_ERRORS_DESC)
+            .build();
 
     private final @NonNull TransactionTemplate transactionTemplate;
     private final @NonNull IdGenerator idGenerator;
@@ -95,10 +110,18 @@ public class AgentInsightsJobService {
         Instant periodEnd = Instant.now();
         reportPublisher.enqueue(job.projectId(), workspaceId, periodEnd.minus(TRIGGER_WINDOW), periodEnd)
                 .subscribe(
-                        reportId -> log.info("Enqueued Agent Insights run reportId='{}' for project '{}'",
-                                reportId, projectId),
-                        error -> log.error("Failed to enqueue Agent Insights run for project '{}'", projectId,
-                                error));
+                        reportId -> {
+                            reportsEnqueued.add(1,
+                                    Attributes.of(AgentInsightsMetrics.TRIGGER, AgentInsightsMetrics.MANUAL));
+                            log.info("Enqueued Agent Insights run reportId='{}' for project '{}'",
+                                    reportId, projectId);
+                        },
+                        error -> {
+                            triggerErrors.add(1,
+                                    Attributes.of(AgentInsightsMetrics.TRIGGER, AgentInsightsMetrics.MANUAL));
+                            log.error("Failed to enqueue Agent Insights run for project '{}'", projectId,
+                                    error);
+                        });
     }
 
     // Cross-workspace; used by the daily sweep (OPIK-6853), never from a request thread. The DAO's JOIN

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobService.java
@@ -96,12 +96,12 @@ public class AgentInsightsJobService {
         reportPublisher.enqueue(job.projectId(), workspaceId, periodEnd.minus(TRIGGER_WINDOW), periodEnd)
                 .subscribe(
                         reportId -> {
-                            AgentInsightsMetrics.REPORTS_ENQUEUED.add(1, AgentInsightsMetrics.TRIGGER_MANUAL);
+                            AgentInsightsMetrics.REPORTS_ENQUEUED.add(1, AgentInsightsMetrics.ENQUEUE_MANUAL_SUCCESS);
                             log.info("Enqueued Agent Insights run reportId='{}' for project '{}'",
                                     reportId, projectId);
                         },
                         error -> {
-                            AgentInsightsMetrics.TRIGGER_ERRORS.add(1, AgentInsightsMetrics.TRIGGER_MANUAL);
+                            AgentInsightsMetrics.REPORTS_ENQUEUED.add(1, AgentInsightsMetrics.ENQUEUE_MANUAL_FAILURE);
                             log.error("Failed to enqueue Agent Insights run for project '{}'", projectId,
                                     error);
                         });

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobService.java
@@ -5,10 +5,7 @@ import com.comet.opik.api.AgentInsightsJob.EnabledJob;
 import com.comet.opik.api.error.EntityAlreadyExistsException;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import io.dropwizard.jersey.errors.ErrorMessage;
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.LongCounter;
-import io.opentelemetry.api.metrics.Meter;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
@@ -32,17 +29,6 @@ import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
 public class AgentInsightsJobService {
 
     private static final Duration TRIGGER_WINDOW = Duration.ofHours(24);
-
-    private static final Meter METER = GlobalOpenTelemetry.get().getMeter(AgentInsightsMetrics.METER_NAME);
-
-    private final LongCounter reportsEnqueued = METER
-            .counterBuilder(AgentInsightsMetrics.REPORTS_ENQUEUED)
-            .setDescription(AgentInsightsMetrics.REPORTS_ENQUEUED_DESC)
-            .build();
-    private final LongCounter triggerErrors = METER
-            .counterBuilder(AgentInsightsMetrics.TRIGGER_ERRORS)
-            .setDescription(AgentInsightsMetrics.TRIGGER_ERRORS_DESC)
-            .build();
 
     private final @NonNull TransactionTemplate transactionTemplate;
     private final @NonNull IdGenerator idGenerator;
@@ -111,13 +97,13 @@ public class AgentInsightsJobService {
         reportPublisher.enqueue(job.projectId(), workspaceId, periodEnd.minus(TRIGGER_WINDOW), periodEnd)
                 .subscribe(
                         reportId -> {
-                            reportsEnqueued.add(1,
+                            AgentInsightsMetrics.REPORTS_ENQUEUED.add(1,
                                     Attributes.of(AgentInsightsMetrics.TRIGGER, AgentInsightsMetrics.MANUAL));
                             log.info("Enqueued Agent Insights run reportId='{}' for project '{}'",
                                     reportId, projectId);
                         },
                         error -> {
-                            triggerErrors.add(1,
+                            AgentInsightsMetrics.TRIGGER_ERRORS.add(1,
                                     Attributes.of(AgentInsightsMetrics.TRIGGER, AgentInsightsMetrics.MANUAL));
                             log.error("Failed to enqueue Agent Insights run for project '{}'", projectId,
                                     error);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsMetrics.java
@@ -30,12 +30,7 @@ public class AgentInsightsMetrics {
 
     public static final LongCounter REPORTS_ENQUEUED = METER
             .counterBuilder("opik_agent_insights_reports_enqueued_total")
-            .setDescription("Report runs enqueued onto the trigger queue, by trigger source")
-            .build();
-
-    public static final LongCounter TRIGGER_ERRORS = METER
-            .counterBuilder("opik_agent_insights_trigger_errors_total")
-            .setDescription("Failures enqueueing a report run, by trigger source")
+            .setDescription("Report run enqueue attempts onto the trigger queue, by trigger source and outcome")
             .build();
 
     public static final LongCounter REPORTS_TRIGGERED = METER
@@ -65,6 +60,8 @@ public class AgentInsightsMetrics {
     // so the counters/histogram reuse one immutable Attributes instance per outcome instead of allocating.
     public static final Attributes OUTCOME_SUCCESS = Attributes.of(OUTCOME, SUCCESS);
     public static final Attributes OUTCOME_FAILURE = Attributes.of(OUTCOME, FAILURE);
-    public static final Attributes TRIGGER_SCHEDULED = Attributes.of(TRIGGER, SCHEDULED);
-    public static final Attributes TRIGGER_MANUAL = Attributes.of(TRIGGER, MANUAL);
+    public static final Attributes ENQUEUE_SCHEDULED_SUCCESS = Attributes.of(TRIGGER, SCHEDULED, OUTCOME, SUCCESS);
+    public static final Attributes ENQUEUE_SCHEDULED_FAILURE = Attributes.of(TRIGGER, SCHEDULED, OUTCOME, FAILURE);
+    public static final Attributes ENQUEUE_MANUAL_SUCCESS = Attributes.of(TRIGGER, MANUAL, OUTCOME, SUCCESS);
+    public static final Attributes ENQUEUE_MANUAL_FAILURE = Attributes.of(TRIGGER, MANUAL, OUTCOME, FAILURE);
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsMetrics.java
@@ -1,0 +1,42 @@
+package com.comet.opik.domain;
+
+import io.opentelemetry.api.common.AttributeKey;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Shared OpenTelemetry instrument names and attribute keys for the Agent Insights pipeline (OPIK-7052).
+ * The enqueue/error counters in particular are emitted from both the daily sweep
+ * ({@code AgentInsightsReportJob}) and the manual {@code /trigger} ({@code AgentInsightsJobService}), so
+ * keeping the names here makes that shared usage explicit instead of duplicating string literals.
+ */
+@UtilityClass
+public class AgentInsightsMetrics {
+
+    public static final String METER_NAME = "opik.agent_insights";
+
+    public static final String SWEEP_DURATION = "opik_agent_insights_sweep_duration_ms";
+    public static final String SWEEP_DURATION_DESC = "Wall time of the daily Agent Insights sweep; _count by outcome gives run totals";
+
+    public static final String REPORTS_ENQUEUED = "opik_agent_insights_reports_enqueued_total";
+    public static final String REPORTS_ENQUEUED_DESC = "Report runs enqueued onto the trigger queue, by trigger source";
+
+    public static final String TRIGGER_ERRORS = "opik_agent_insights_trigger_errors_total";
+    public static final String TRIGGER_ERRORS_DESC = "Failures enqueueing a report run, by trigger source";
+
+    public static final String REPORTS_TRIGGERED = "opik_agent_insights_reports_triggered_total";
+    public static final String REPORTS_TRIGGERED_DESC = "Report trigger calls to the platform, by outcome";
+
+    public static final String REPORTS_RECEIVED = "opik_agent_insights_reports_received_total";
+    public static final String REPORTS_RECEIVED_DESC = "Generated reports received on the reporting endpoint";
+
+    public static final String ISSUES_REPORTED = "opik_agent_insights_issues_reported_total";
+    public static final String ISSUES_REPORTED_DESC = "Issues persisted from generated reports";
+
+    public static final AttributeKey<String> TRIGGER = AttributeKey.stringKey("trigger");
+    public static final AttributeKey<String> OUTCOME = AttributeKey.stringKey("outcome");
+
+    public static final String SCHEDULED = "scheduled";
+    public static final String MANUAL = "manual";
+    public static final String SUCCESS = "success";
+    public static final String FAILURE = "failure";
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsMetrics.java
@@ -22,29 +22,29 @@ public class AgentInsightsMetrics {
     private static final Meter METER = GlobalOpenTelemetry.get().getMeter(METER_NAME);
 
     public static final LongHistogram SWEEP_DURATION_MS = METER
-            .histogramBuilder("opik_agent_insights_sweep_duration_ms")
+            .histogramBuilder("sweep_duration_ms")
             .setDescription("Wall time of the daily Agent Insights sweep; _count by outcome gives run totals")
             .setUnit("ms")
             .ofLongs()
             .build();
 
     public static final LongCounter REPORTS_ENQUEUED = METER
-            .counterBuilder("opik_agent_insights_reports_enqueued_total")
+            .counterBuilder("reports_enqueued_total")
             .setDescription("Report run enqueue attempts onto the trigger queue, by trigger source and outcome")
             .build();
 
     public static final LongCounter REPORTS_TRIGGERED = METER
-            .counterBuilder("opik_agent_insights_reports_triggered_total")
+            .counterBuilder("reports_triggered_total")
             .setDescription("Report trigger calls to the platform, by outcome")
             .build();
 
     public static final LongCounter REPORTS_RECEIVED = METER
-            .counterBuilder("opik_agent_insights_reports_received_total")
+            .counterBuilder("reports_received_total")
             .setDescription("Generated reports received on the reporting endpoint")
             .build();
 
     public static final LongCounter ISSUES_REPORTED = METER
-            .counterBuilder("opik_agent_insights_issues_reported_total")
+            .counterBuilder("issues_reported_total")
             .setDescription("Issues persisted from generated reports")
             .build();
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsMetrics.java
@@ -1,36 +1,56 @@
 package com.comet.opik.domain;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.Meter;
 import lombok.experimental.UtilityClass;
 
 /**
- * Shared OpenTelemetry instrument names and attribute keys for the Agent Insights pipeline (OPIK-7052).
- * The enqueue/error counters in particular are emitted from both the daily sweep
- * ({@code AgentInsightsReportJob}) and the manual {@code /trigger} ({@code AgentInsightsJobService}), so
- * keeping the names here makes that shared usage explicit instead of duplicating string literals.
+ * Shared OpenTelemetry instruments and attribute keys for the Agent Insights pipeline (OPIK-7052).
+ * The instruments are built once here from a single meter so every path emits under the same
+ * instrumentation scope; the enqueue/error counters in particular are shared by the daily sweep
+ * ({@code AgentInsightsReportJob}) and the manual {@code /trigger} ({@code AgentInsightsJobService}).
  */
 @UtilityClass
 public class AgentInsightsMetrics {
 
     public static final String METER_NAME = "opik.agent_insights";
 
-    public static final String SWEEP_DURATION = "opik_agent_insights_sweep_duration_ms";
-    public static final String SWEEP_DURATION_DESC = "Wall time of the daily Agent Insights sweep; _count by outcome gives run totals";
+    private static final Meter METER = GlobalOpenTelemetry.get().getMeter(METER_NAME);
 
-    public static final String REPORTS_ENQUEUED = "opik_agent_insights_reports_enqueued_total";
-    public static final String REPORTS_ENQUEUED_DESC = "Report runs enqueued onto the trigger queue, by trigger source";
+    public static final LongHistogram SWEEP_DURATION_MS = METER
+            .histogramBuilder("opik_agent_insights_sweep_duration_ms")
+            .setDescription("Wall time of the daily Agent Insights sweep; _count by outcome gives run totals")
+            .setUnit("ms")
+            .ofLongs()
+            .build();
 
-    public static final String TRIGGER_ERRORS = "opik_agent_insights_trigger_errors_total";
-    public static final String TRIGGER_ERRORS_DESC = "Failures enqueueing a report run, by trigger source";
+    public static final LongCounter REPORTS_ENQUEUED = METER
+            .counterBuilder("opik_agent_insights_reports_enqueued_total")
+            .setDescription("Report runs enqueued onto the trigger queue, by trigger source")
+            .build();
 
-    public static final String REPORTS_TRIGGERED = "opik_agent_insights_reports_triggered_total";
-    public static final String REPORTS_TRIGGERED_DESC = "Report trigger calls to the platform, by outcome";
+    public static final LongCounter TRIGGER_ERRORS = METER
+            .counterBuilder("opik_agent_insights_trigger_errors_total")
+            .setDescription("Failures enqueueing a report run, by trigger source")
+            .build();
 
-    public static final String REPORTS_RECEIVED = "opik_agent_insights_reports_received_total";
-    public static final String REPORTS_RECEIVED_DESC = "Generated reports received on the reporting endpoint";
+    public static final LongCounter REPORTS_TRIGGERED = METER
+            .counterBuilder("opik_agent_insights_reports_triggered_total")
+            .setDescription("Report trigger calls to the platform, by outcome")
+            .build();
 
-    public static final String ISSUES_REPORTED = "opik_agent_insights_issues_reported_total";
-    public static final String ISSUES_REPORTED_DESC = "Issues persisted from generated reports";
+    public static final LongCounter REPORTS_RECEIVED = METER
+            .counterBuilder("opik_agent_insights_reports_received_total")
+            .setDescription("Generated reports received on the reporting endpoint")
+            .build();
+
+    public static final LongCounter ISSUES_REPORTED = METER
+            .counterBuilder("opik_agent_insights_issues_reported_total")
+            .setDescription("Issues persisted from generated reports")
+            .build();
 
     public static final AttributeKey<String> TRIGGER = AttributeKey.stringKey("trigger");
     public static final AttributeKey<String> OUTCOME = AttributeKey.stringKey("outcome");

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsMetrics.java
@@ -2,6 +2,7 @@ package com.comet.opik.domain;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.Meter;
@@ -59,4 +60,11 @@ public class AgentInsightsMetrics {
     public static final String MANUAL = "manual";
     public static final String SUCCESS = "success";
     public static final String FAILURE = "failure";
+
+    // Cached attribute sets for the fixed label combinations emitted on hot paths (sweep/trigger/enqueue),
+    // so the counters/histogram reuse one immutable Attributes instance per outcome instead of allocating.
+    public static final Attributes OUTCOME_SUCCESS = Attributes.of(OUTCOME, SUCCESS);
+    public static final Attributes OUTCOME_FAILURE = Attributes.of(OUTCOME, FAILURE);
+    public static final Attributes TRIGGER_SCHEDULED = Attributes.of(TRIGGER, SCHEDULED);
+    public static final Attributes TRIGGER_MANUAL = Attributes.of(TRIGGER, MANUAL);
 }


### PR DESCRIPTION
## Details

Adds OpenTelemetry instrumentation across the Agent Insights pipeline so the daily
sweep, the manual trigger, and the results-reporting endpoint emit operational
metrics. Instrument names and attribute keys are centralized in a new
`AgentInsightsMetrics` utility class, since the enqueue/error counters are emitted
from both the scheduled sweep and the manual trigger path.

Metrics added:
- **`opik_agent_insights_sweep_duration_ms`** — wall time of the daily sweep,
  recorded in `doFinally` and tagged with `outcome` (success/failure); its `_count`
  gives run totals per outcome.
- **`opik_agent_insights_reports_enqueued_total`** — report runs enqueued onto the
  trigger queue, tagged with `trigger` (scheduled/manual).
- **`opik_agent_insights_trigger_errors_total`** — enqueue failures, tagged with
  `trigger` (scheduled/manual).
- **`opik_agent_insights_reports_triggered_total`** — platform trigger calls from the
  subscriber, tagged with `outcome` (success/failure). This restores the
  success/failure signal that the base subscriber loses because it swallows failures
  (at-most-once drop) and records every message as a success.
- **`opik_agent_insights_reports_received_total`** and
  **`opik_agent_insights_issues_reported_total`** — generated reports received and
  issues persisted on the reporting endpoint.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-7052

## Testing

No new automated tests; this is observability-only instrumentation that does not alter
pipeline behavior (at-most-once trigger semantics and per-job enqueue isolation are
unchanged). Verified via build/compile and manual inspection that counters/histograms
fire on the success, failure, scheduled, and manual paths.

## Documentation

N/A — no documentation changes.
