### PR TITLE
[OPIK-6833] Dataset created_at / last_updated_at skewed by host TZ when backend JVM is not in UTC

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -16,8 +16,7 @@ logging:
 # https://www.dropwizard.io/en/stable/manual/configuration.html#database
 database:
   #  Default: jdbc:mysql://localhost:3306/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true
-  #  Description: The URL of the server. connectionTimeZone=UTC + forceConnectionTimeZoneToSession=true make Instant reads
-  #   (created_at, last_updated_at, ...) independent of the JVM default timezone; without them a non-UTC host shifts values.
+  #  Description: The URL of the server.
   url: ${STATE_DB_PROTOCOL:-jdbc:mysql://}${STATE_DB_URL:-localhost:3306/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true}
   #  Default: opik
   #  Description: The username used to connect to the server

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -15,9 +15,10 @@ logging:
 # Description: state database configuration
 # https://www.dropwizard.io/en/stable/manual/configuration.html#database
 database:
-  #  Default: jdbc:mysql://localhost:3306/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true
-  #  Description: The URL of the server
-  url: ${STATE_DB_PROTOCOL:-jdbc:mysql://}${STATE_DB_URL:-localhost:3306/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true}
+  #  Default: jdbc:mysql://localhost:3306/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true
+  #  Description: The URL of the server. connectionTimeZone=UTC + forceConnectionTimeZoneToSession=true make Instant reads
+  #   (created_at, last_updated_at, ...) independent of the JVM default timezone; without them a non-UTC host shifts values.
+  url: ${STATE_DB_PROTOCOL:-jdbc:mysql://}${STATE_DB_URL:-localhost:3306/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true}
   #  Default: opik
   #  Description: The username used to connect to the server
   user: ${STATE_DB_USER:-opik}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/MySQLContainerUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/MySQLContainerUtils.java
@@ -15,7 +15,10 @@ public class MySQLContainerUtils {
         return new MySQLContainer(DockerImageName.parse("mysql:8.4.2"))
                 .withUrlParam("createDatabaseIfNotExist", "true")
                 .withUrlParam("rewriteBatchedStatements", "true")
-                .withUrlParam("serverTimezone", "UTC")
+                // Keep Instant reads independent of the JVM default timezone (connectionTimeZone replaces the
+                // deprecated serverTimezone alias; forceConnectionTimeZoneToSession pins the session time_zone to UTC).
+                .withUrlParam("connectionTimeZone", "UTC")
+                .withUrlParam("forceConnectionTimeZoneToSession", "true")
                 .withDatabaseName("opik")
                 .withPassword("opik")
                 .withUsername("opik")

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/MySQLContainerUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/MySQLContainerUtils.java
@@ -11,12 +11,17 @@ public class MySQLContainerUtils {
         return newMySQLContainer(true);
     }
 
+    /**
+     * Creates a new MySQL test container.
+     * <p>
+     * Keeps {@link java.time.Instant} reads independent of the JVM default timezone: {@code connectionTimeZone}
+     * replaces the deprecated {@code serverTimezone} alias, and {@code forceConnectionTimeZoneToSession} pins the
+     * session {@code time_zone} to UTC.
+     */
     public static MySQLContainer newMySQLContainer(boolean reusable) {
         return new MySQLContainer(DockerImageName.parse("mysql:8.4.2"))
                 .withUrlParam("createDatabaseIfNotExist", "true")
                 .withUrlParam("rewriteBatchedStatements", "true")
-                // Keep Instant reads independent of the JVM default timezone (connectionTimeZone replaces the
-                // deprecated serverTimezone alias; forceConnectionTimeZoneToSession pins the session time_zone to UTC).
                 .withUrlParam("connectionTimeZone", "UTC")
                 .withUrlParam("forceConnectionTimeZoneToSession", "true")
                 .withDatabaseName("opik")

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/aws/rds/MysqlRdsIamE2eTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/aws/rds/MysqlRdsIamE2eTest.java
@@ -39,7 +39,7 @@ class MysqlRdsIamE2eTest {
 
     /// See PR: https://github.com/comet-ml/opik/pull/306
     // RDS DB endpoint, port, and database name
-    // JDBC URL format: jdbc:aws-wrapper:mysql://<rds-endpoint>:<port>/<db-name>?createDatabaseIfNotExist=true&rewriteBatchedStatements=true
+    // JDBC URL format: jdbc:aws-wrapper:mysql://<rds-endpoint>:<port>/<db-name>?createDatabaseIfNotExist=true&rewriteBatchedStatements=true&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true
     // DB endpoint: <rds-instance>.<region>.rds.amazonaws.com
     // AWS Driver only supports rds.amazonaws.com endpoints, not custom endpoints
     private static final String MYSQL_TEMPLATE_URL = "jdbc:aws-wrapper:mysql://%s";
@@ -61,7 +61,7 @@ class MysqlRdsIamE2eTest {
         var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(CLICKHOUSE,
                 ClickHouseContainerUtils.DATABASE_NAME);
 
-        String rdsEndpoint = "<rds-instance>.<aws-region>.rds.amazonaws.com:3306/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true";
+        String rdsEndpoint = "<rds-instance>.<aws-region>.rds.amazonaws.com:3306/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true";
 
         APP = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
                 AppContextConfig.builder()

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -13,9 +13,9 @@ logging:
 # Description: state database configuration
 # https://www.dropwizard.io/en/stable/manual/configuration.html#database
 database:
-  #  Default: jdbc:mysql://localhost:3306/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true
+  #  Default: jdbc:mysql://localhost:3306/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true
   #  Description: The URL of the server
-  url: jdbc:mysql://localhost:3306/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true
+  url: jdbc:mysql://localhost:3306/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true
   #  Default: opik
   #  Description: The username used to connect to the server
   user: opik

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -154,7 +154,7 @@ services:
       # Persistent anonymous installation ID passed from launcher script
       OPIK_ANONYMOUS_ID: ${OPIK_ANONYMOUS_ID:-}
       STATE_DB_PROTOCOL: "jdbc:mysql://"
-      STATE_DB_URL: "mysql:3306/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true"
+      STATE_DB_URL: "mysql:3306/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true"
       STATE_DB_DATABASE_NAME: opik
       STATE_DB_USER: opik
       STATE_DB_PASS: opik

--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Comet Opik
 
-![Version: 2.0.73](https://img.shields.io/badge/Version-2.0.73-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.73](https://img.shields.io/badge/AppVersion-2.0.73-informational?style=flat-square)
+![Version: 2.0.74](https://img.shields.io/badge/Version-2.0.74-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.74](https://img.shields.io/badge/AppVersion-2.0.74-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opik)](https://artifacthub.io/packages/search?repo=opik)
 
 # Run Comet Opik with Helm
@@ -245,7 +245,7 @@ Call opik api on http://localhost:5173/api
 | component.backend.env.STATE_DB_DATABASE_NAME | string | `"opik"` |  |
 | component.backend.env.STATE_DB_PASS | string | `"opik"` |  |
 | component.backend.env.STATE_DB_PROTOCOL | string | `"jdbc:mysql://"` |  |
-| component.backend.env.STATE_DB_URL | string | `"opik-mysql:3306/opik?rewriteBatchedStatements=true"` |  |
+| component.backend.env.STATE_DB_URL | string | `"opik-mysql:3306/opik?rewriteBatchedStatements=true&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true"` |  |
 | component.backend.env.STATE_DB_USER | string | `"opik"` |  |
 | component.backend.env.UI_DEFAULT_PAGE_SIZE | string | `"100"` |  |
 | component.backend.envFrom[0].configMapRef.name | string | `"opik-backend"` |  |

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -163,7 +163,7 @@ component:
       enabled: false
     env:
       STATE_DB_PROTOCOL: "jdbc:mysql://"
-      STATE_DB_URL: "opik-mysql:3306/opik?rewriteBatchedStatements=true"
+      STATE_DB_URL: "opik-mysql:3306/opik?rewriteBatchedStatements=true&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true"
       STATE_DB_DATABASE_NAME: "opik"
       STATE_DB_USER: opik
       ANALYTICS_DB_MIGRATIONS_URL: "jdbc:clickhouse://clickhouse-opik-clickhouse:8123"

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -322,7 +322,7 @@ run_db_migrations() {
     # Set the database connection environment variables for MySQL migrations (using dynamic port)
     # Note: STATE_DB_URL format is "host:port/database?params" - the jdbc:mysql:// prefix is added by config.yml
     export STATE_DB_DATABASE_NAME="opik"
-    export STATE_DB_URL="localhost:${MYSQL_PORT}/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true"
+    export STATE_DB_URL="localhost:${MYSQL_PORT}/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true"
     log_debug "MySQL connection: localhost:${MYSQL_PORT}"
     if java -jar "$JAR_FILE" db migrate config.yml; then
         log_success "MySQL migrations completed successfully"
@@ -664,7 +664,7 @@ start_backend() {
     # Set worktree-specific ports for backend to connect to infrastructure
     export SERVER_APPLICATION_PORT="$BACKEND_PORT"
     export SERVER_ADMIN_PORT="$BACKEND_ADMIN_PORT"
-    export STATE_DB_URL="localhost:${MYSQL_PORT}/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true"
+    export STATE_DB_URL="localhost:${MYSQL_PORT}/opik?createDatabaseIfNotExist=true&rewriteBatchedStatements=true&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true"
     export REDIS_URL="${REDIS_URL:-redis://:opik@localhost:${REDIS_PORT}/0}"
     export ANALYTICS_DB_PORT="${CLICKHOUSE_HTTP_PORT}"
 


### PR DESCRIPTION
## Details
When the backend JVM runs in a timezone other than UTC, every Instant column read from MySQL (created_at, last_updated_at, etc.) is returned to the API shifted by the host's TZ offset. The UI shows datasets / experiments / etc. as created N hours ago even when they were just created. DB values are correct; only the JDBC read path is wrong.

## Summary

Fix `Instant` columns (`created_at`, `last_updated_at`, ...) being read back from MySQL shifted by the host's timezone offset when the backend JVM runs in a non-UTC timezone. The fix appends `connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true` to every MySQL JDBC URL the backend uses, making the JDBC TIMESTAMP→Instant conversion independent of the JVM default timezone. No DB backfill is needed — values were always stored correctly in UTC; only the read path was wrong.

## Changes by Component

### Backend
- `config.yml`: appended `&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true` to the default state-DB JDBC URL, with an explanatory comment.
- `config-test.yml`: same params added so CI test runs are TZ-independent regardless of the runner host.
- `MySQLContainerUtils.java` (test): replaced the deprecated `serverTimezone=UTC` alias with `connectionTimeZone=UTC` and added `forceConnectionTimeZoneToSession=true` to pin the Testcontainers session to UTC.
- `MysqlRdsIamE2eTest.java` (test): kept the example/placeholder RDS JDBC URLs consistent with the new params.

### Infrastructure
- `deployment/docker-compose/docker-compose.yaml`: added the params to the `STATE_DB_URL` default (no-op for prod where the JVM is already UTC, but guards against a future regression if `TZ=` is set on the container).
- `deployment/helm_chart/opik/values.yaml`: added the params to the `STATE_DB_URL` default.
- `scripts/dev-runner.sh`: added the params to both `STATE_DB_URL` exports (migration step + run step). This is the path where the dev-environment bug actually reproduces, since the script overrides `STATE_DB_URL` from `config.yml`.

## Files Changed

```
 apps/opik-backend/config.yml                                       | 7 ++++---
 .../com/comet/opik/api/resources/utils/MySQLContainerUtils.java    | 5 ++++-
 .../com/comet/opik/infrastructure/aws/rds/MysqlRdsIamE2eTest.java  | 4 ++--
 apps/opik-backend/src/test/resources/config-test.yml               | 4 ++--
 deployment/docker-compose/docker-compose.yaml                      | 2 +-
 deployment/helm_chart/opik/values.yaml                             | 2 +-
 scripts/dev-runner.sh                                              | 4 ++--
 7 files changed, 16 insertions(+), 12 deletions(-)
```

## Screencast after fix

https://github.com/user-attachments/assets/3e46177f-154a-4fe5-a029-4eec4d0c8640


## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6773

## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
Manual testing

## Documentation
NA