### PR TITLE
[OPIK-6982] [BE] fix: stream consumer reaper job fails to instantiate under Quartz

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/StreamConsumerReaperJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/StreamConsumerReaperJob.java
@@ -10,7 +10,6 @@ import io.dropwizard.jobs.Job;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.InterruptableJob;
@@ -39,15 +38,14 @@ import static com.comet.opik.infrastructure.lock.LockService.Lock;
 @Slf4j
 @Singleton
 @DisallowConcurrentExecution
-@RequiredArgsConstructor(onConstructor_ = @Inject)
 public class StreamConsumerReaperJob extends Job implements InterruptableJob {
 
     private static final Lock JOB_LOCK = new Lock("stream_consumer_reaper:lock");
 
-    private final @NonNull Injector injector;
-    private final @NonNull StreamConsumerReaper reaper;
-    private final @NonNull LockService lockService;
-    private final @NonNull @Config("streamConsumerReaper") StreamConsumerReaperConfig config;
+    private final Injector injector;
+    private final StreamConsumerReaper reaper;
+    private final LockService lockService;
+    private final StreamConsumerReaperConfig config;
 
     private final AtomicBoolean interrupted = new AtomicBoolean(false);
 
@@ -56,6 +54,17 @@ public class StreamConsumerReaperJob extends Job implements InterruptableJob {
 
     /** Tracks the in-flight reactive pass so {@link #interrupt()} can dispose it (cancels the actual chain). */
     private final AtomicReference<Disposable> currentExecution = new AtomicReference<>();
+
+    @Inject
+    public StreamConsumerReaperJob(@NonNull Injector injector,
+            @NonNull StreamConsumerReaper reaper,
+            @NonNull LockService lockService,
+            @NonNull @Config("streamConsumerReaper") StreamConsumerReaperConfig config) {
+        this.injector = injector;
+        this.reaper = reaper;
+        this.lockService = lockService;
+        this.config = config;
+    }
 
     @Override
     public void doJob(JobExecutionContext context) {


### PR DESCRIPTION
## Details

Follow-up fix to #7154 (merged): the orphaned-consumer reaper job ships in `main` but never runs — it fails to instantiate on every Quartz trigger. The job has no `@Every`/`@On` annotation, so `JobGuiceyInstaller` doesn't bind it and Quartz's `GuiceJobFactory` JIT-resolves it via `injector.getInstance(...)`, falling back to a no-arg reflective constructor on any `ConfigurationException`. The `@Config("streamConsumerReaper")` qualifier copied by Lombok onto the `@RequiredArgsConstructor` parameter is not honored on that JIT path in the packaged app, so resolution fails with `NoSuchMethodException: <init>()` and the job never executes.
- Fix: declare the constructor explicitly with `@Config` on the parameter (same pattern as `ExperimentProjectMigrationJob`); one file changed.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Follow-up to #7154
- OPIK-6982

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Root-cause investigation and the one-line constructor change in `StreamConsumerReaperJob`; PR authoring.
  - Human verification: Author identified the Lombok-constructor root cause and verified the fix end-to-end in a local packaged Docker build (`./opik.sh --build`).

## Testing

Verified against the **packaged Docker image** (`./opik.sh --build`), because the unit test does not reproduce Quartz's JIT instantiation path (its injector resolves the qualifier that the packaged app's `GuiceJobFactory` path does not).

- Commands: `mvn spotless:apply compile` (backend); `./opik.sh --build` (full stack).
- Scenario: reaper fires at startup (temporarily set `startupDelay=0s` for the test, reverted before commit).
- Result after fix:
  ```
  StreamConsumerReaper: Reaped orphaned consumer 'consumer-online_scoring-...' from group 'online_scoring' on stream '...'
  StreamConsumerReaperJob: Stream consumer reaper removed orphaned consumer(s), removed='30', streams='11'
  ```
- Before fix, the same image logged `NoSuchMethodException: com.comet.opik.api.resources.v1.jobs.StreamConsumerReaperJob.<init>()`.
- Environment: local Docker via `opik.sh`, macOS.
- Not run: no new automated test added — the existing `StreamConsumerReaperJobTest` cannot reproduce the packaged JIT path; a smoke test that boots the packaged app to assert scheduled jobs instantiate is proposed as a follow-up.

## Documentation

N/A — internal background job; no user-facing or API changes.