### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -20867,6 +20867,7 @@ components:
       - alertsEnabled
       - anthropicProviderEnabled
       - bedrockProviderEnabled
+      - costIntelligenceEnabled
       - customllmProviderEnabled
       - datasetExportEnabled
       - datasetVersioningEnabled
@@ -20880,7 +20881,6 @@ components:
       - openaiProviderEnabled
       - openrouterProviderEnabled
       - opikAIEnabled
-      - optimizationStudioEnabled
       - projectHomepageEnabled
       - pythonEvaluatorEnabled
       - spanLlmAsJudgeEnabled
@@ -20910,7 +20910,7 @@ components:
           type: boolean
         exportEnabled:
           type: boolean
-        optimizationStudioEnabled:
+        costIntelligenceEnabled:
           type: boolean
         datasetVersioningEnabled:
           type: boolean

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -20867,6 +20867,7 @@ components:
       - alertsEnabled
       - anthropicProviderEnabled
       - bedrockProviderEnabled
+      - costIntelligenceEnabled
       - customllmProviderEnabled
       - datasetExportEnabled
       - datasetVersioningEnabled
@@ -20880,7 +20881,6 @@ components:
       - openaiProviderEnabled
       - openrouterProviderEnabled
       - opikAIEnabled
-      - optimizationStudioEnabled
       - projectHomepageEnabled
       - pythonEvaluatorEnabled
       - spanLlmAsJudgeEnabled
@@ -20910,7 +20910,7 @@ components:
           type: boolean
         exportEnabled:
           type: boolean
-        optimizationStudioEnabled:
+        costIntelligenceEnabled:
           type: boolean
         datasetVersioningEnabled:
           type: boolean

--- a/sdks/python/src/opik/rest_api/types/service_toggles_config.py
+++ b/sdks/python/src/opik/rest_api/types/service_toggles_config.py
@@ -22,7 +22,7 @@ class ServiceTogglesConfig(UniversalBaseModel):
     alerts_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="alertsEnabled")]
     welcome_wizard_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="welcomeWizardEnabled")]
     export_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="exportEnabled")]
-    optimization_studio_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="optimizationStudioEnabled")]
+    cost_intelligence_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="costIntelligenceEnabled")]
     dataset_versioning_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="datasetVersioningEnabled")]
     dataset_export_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="datasetExportEnabled")]
     demo_data_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="demoDataEnabled")]

--- a/sdks/typescript/src/opik/rest_api/api/types/ServiceTogglesConfig.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/ServiceTogglesConfig.ts
@@ -10,7 +10,7 @@ export interface ServiceTogglesConfig {
     alertsEnabled: boolean;
     welcomeWizardEnabled: boolean;
     exportEnabled: boolean;
-    optimizationStudioEnabled: boolean;
+    costIntelligenceEnabled: boolean;
     datasetVersioningEnabled: boolean;
     datasetExportEnabled: boolean;
     demoDataEnabled: boolean;

--- a/sdks/typescript/src/opik/rest_api/serialization/types/ServiceTogglesConfig.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/ServiceTogglesConfig.ts
@@ -17,7 +17,7 @@ export const ServiceTogglesConfig: core.serialization.ObjectSchema<
     alertsEnabled: core.serialization.boolean(),
     welcomeWizardEnabled: core.serialization.boolean(),
     exportEnabled: core.serialization.boolean(),
-    optimizationStudioEnabled: core.serialization.boolean(),
+    costIntelligenceEnabled: core.serialization.boolean(),
     datasetVersioningEnabled: core.serialization.boolean(),
     datasetExportEnabled: core.serialization.boolean(),
     demoDataEnabled: core.serialization.boolean(),
@@ -52,7 +52,7 @@ export declare namespace ServiceTogglesConfig {
         alertsEnabled: boolean;
         welcomeWizardEnabled: boolean;
         exportEnabled: boolean;
-        optimizationStudioEnabled: boolean;
+        costIntelligenceEnabled: boolean;
         datasetVersioningEnabled: boolean;
         datasetExportEnabled: boolean;
         demoDataEnabled: boolean;


### PR DESCRIPTION
## Details
Automated update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

**Triggered by BE merge:** https://github.com/comet-ml/opik/pull/7206

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate