### PR TITLE
[OPIK-6983] [BE][FE] Surface queue-scoped feedback scores in general views

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ValueEntry.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ValueEntry.java
@@ -13,23 +13,4 @@ import java.time.Instant;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record ValueEntry(BigDecimal value, String reason, String categoryName, ScoreSource source,
         Instant lastUpdatedAt, String spanType, String spanId, String sourceQueueId, String author) {
-    public ValueEntry(BigDecimal value, String reason, String categoryName, ScoreSource source,
-            Instant lastUpdatedAt) {
-        this(value, reason, categoryName, source, lastUpdatedAt, null, null, null, null);
-    }
-
-    public ValueEntry(BigDecimal value, String reason, String categoryName, ScoreSource source,
-            Instant lastUpdatedAt, String spanType) {
-        this(value, reason, categoryName, source, lastUpdatedAt, spanType, null, null, null);
-    }
-
-    public ValueEntry(BigDecimal value, String reason, String categoryName, ScoreSource source,
-            Instant lastUpdatedAt, String spanType, String spanId) {
-        this(value, reason, categoryName, source, lastUpdatedAt, spanType, spanId, null, null);
-    }
-
-    public ValueEntry(BigDecimal value, String reason, String categoryName, ScoreSource source,
-            Instant lastUpdatedAt, String spanType, String spanId, String sourceQueueId) {
-        this(value, reason, categoryName, source, lastUpdatedAt, spanType, spanId, sourceQueueId, null);
-    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ValueEntry.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ValueEntry.java
@@ -12,14 +12,19 @@ import java.time.Instant;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record ValueEntry(BigDecimal value, String reason, String categoryName, ScoreSource source,
-        Instant lastUpdatedAt, String spanType, String spanId) {
+        Instant lastUpdatedAt, String spanType, String spanId, String sourceQueueId) {
     public ValueEntry(BigDecimal value, String reason, String categoryName, ScoreSource source,
             Instant lastUpdatedAt) {
-        this(value, reason, categoryName, source, lastUpdatedAt, null, null);
+        this(value, reason, categoryName, source, lastUpdatedAt, null, null, null);
     }
 
     public ValueEntry(BigDecimal value, String reason, String categoryName, ScoreSource source,
             Instant lastUpdatedAt, String spanType) {
-        this(value, reason, categoryName, source, lastUpdatedAt, spanType, null);
+        this(value, reason, categoryName, source, lastUpdatedAt, spanType, null, null);
+    }
+
+    public ValueEntry(BigDecimal value, String reason, String categoryName, ScoreSource source,
+            Instant lastUpdatedAt, String spanType, String spanId) {
+        this(value, reason, categoryName, source, lastUpdatedAt, spanType, spanId, null);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ValueEntry.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ValueEntry.java
@@ -12,19 +12,24 @@ import java.time.Instant;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record ValueEntry(BigDecimal value, String reason, String categoryName, ScoreSource source,
-        Instant lastUpdatedAt, String spanType, String spanId, String sourceQueueId) {
+        Instant lastUpdatedAt, String spanType, String spanId, String sourceQueueId, String author) {
     public ValueEntry(BigDecimal value, String reason, String categoryName, ScoreSource source,
             Instant lastUpdatedAt) {
-        this(value, reason, categoryName, source, lastUpdatedAt, null, null, null);
+        this(value, reason, categoryName, source, lastUpdatedAt, null, null, null, null);
     }
 
     public ValueEntry(BigDecimal value, String reason, String categoryName, ScoreSource source,
             Instant lastUpdatedAt, String spanType) {
-        this(value, reason, categoryName, source, lastUpdatedAt, spanType, null, null);
+        this(value, reason, categoryName, source, lastUpdatedAt, spanType, null, null, null);
     }
 
     public ValueEntry(BigDecimal value, String reason, String categoryName, ScoreSource source,
             Instant lastUpdatedAt, String spanType, String spanId) {
-        this(value, reason, categoryName, source, lastUpdatedAt, spanType, spanId, null);
+        this(value, reason, categoryName, source, lastUpdatedAt, spanType, spanId, null, null);
+    }
+
+    public ValueEntry(BigDecimal value, String reason, String categoryName, ScoreSource source,
+            Instant lastUpdatedAt, String spanType, String spanId, String sourceQueueId) {
+        this(value, reason, categoryName, source, lastUpdatedAt, spanType, spanId, sourceQueueId, null);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CommentResultMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CommentResultMapper.java
@@ -55,14 +55,23 @@ public class CommentResultMapper {
         var commentItems = Arrays.stream(commentsArrays)
                 .filter(commentItem -> CollectionUtils.isNotEmpty(commentItem) &&
                         !CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE.equals(commentItem.get(0).toString()))
-                .map(commentItem -> Comment.builder()
-                        .id(UUID.fromString(commentItem.get(0).toString()))
-                        .text(commentItem.get(1).toString())
-                        .createdAt(Instant.parse(commentItem.get(2).toString()))
-                        .lastUpdatedAt(Instant.parse(commentItem.get(3).toString()))
-                        .createdBy(commentItem.get(4).toString())
-                        .lastUpdatedBy(commentItem.get(5).toString())
-                        .build())
+                .map(commentItem -> {
+                    var builder = Comment.builder()
+                            .id(UUID.fromString(commentItem.get(0).toString()))
+                            .text(commentItem.get(1).toString())
+                            .createdAt(Instant.parse(commentItem.get(2).toString()))
+                            .lastUpdatedAt(Instant.parse(commentItem.get(3).toString()))
+                            .createdBy(commentItem.get(4).toString())
+                            .lastUpdatedBy(commentItem.get(5).toString());
+                    if (commentItem.size() > 6 && commentItem.get(6) != null) {
+                        var sourceQueueId = commentItem.get(6).toString();
+                        if (StringUtils.isNotEmpty(sourceQueueId)
+                                && !CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE.equals(sourceQueueId)) {
+                            builder.sourceQueueId(UUID.fromString(sourceQueueId));
+                        }
+                    }
+                    return builder.build();
+                })
                 .sorted(Comparator.comparing(Comment::id))
                 .toList();
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CommentResultMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CommentResultMapper.java
@@ -65,7 +65,7 @@ public class CommentResultMapper {
                             .lastUpdatedBy(commentItem.get(5).toString());
                     if (commentItem.size() > 6 && commentItem.get(6) != null) {
                         var sourceQueueId = commentItem.get(6).toString();
-                        if (StringUtils.isNotEmpty(sourceQueueId)
+                        if (StringUtils.isNotBlank(sourceQueueId)
                                 && !CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE.equals(sourceQueueId)) {
                             builder.sourceQueueId(UUID.fromString(sourceQueueId));
                         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -273,7 +273,8 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                            name,
                            value,
                            last_updated_at,
-                           feedback_scores.last_updated_by AS author
+                           feedback_scores.last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'trace'
                       AND workspace_id = :workspace_id
@@ -284,13 +285,14 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                            name,
                            value,
                            last_updated_at,
-                           author
+                           author,
+                           source_queue_id
                      FROM authored_feedback_scores
                      WHERE entity_type = 'trace'
                        AND workspace_id = :workspace_id
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_final AS (
                 SELECT
                     workspace_id,
@@ -450,7 +452,8 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                     last_updated_by,
                     created_at,
                     last_updated_at,
-                    author
+                    author,
+                    source_queue_id
                 FROM (
                     SELECT
                         workspace_id,
@@ -465,7 +468,8 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                         last_updated_by,
                         created_at,
                         last_updated_at,
-                        feedback_scores.last_updated_by AS author
+                        feedback_scores.last_updated_by AS author,
+                        CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = :entityType
                       AND workspace_id = :workspace_id
@@ -484,21 +488,22 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                         last_updated_by,
                         created_at,
                         last_updated_at,
-                        author
+                        author,
+                        source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = :entityType
                       AND workspace_id = :workspace_id
                       AND entity_id IN (SELECT trace_id FROM experiment_items_scope)
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_grouped AS (
                 SELECT
                     workspace_id,
                     project_id,
                     entity_id,
                     name,
-                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at)) AS entries
+                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at, source_queue_id)) AS entries
                 FROM feedback_scores_deduped
                 GROUP BY workspace_id, project_id, entity_id, name
             ), feedback_scores_final AS (
@@ -512,8 +517,8 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                     IF(length(entries) = 1, arrayElement(entries, 1).2, arrayStringConcat(arrayMap(x -> if(x = '', '\\<no reason>', x), arrayMap(e -> e.2, entries)), ', ')) AS reason,
                     arrayElement(entries, 1).4 AS source,
                     mapFromArrays(
-                        arrayMap(e -> e.5, entries),
-                        arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9), entries)
+                        arrayMap(e -> if(e.10 = '', e.5, concat(e.5, '_', toString(e.10))), entries),
+                        arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, '', '', e.10, e.5), entries)
                     ) AS value_by_author,
                     arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                     arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -595,7 +595,8 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                            name,
                            value,
                            last_updated_at,
-                           feedback_scores.last_updated_by AS author
+                           feedback_scores.last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'trace'
                       AND workspace_id = :workspace_id
@@ -608,7 +609,8 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                            name,
                            value,
                            last_updated_at,
-                           author
+                           author,
+                           source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'trace'
                       AND workspace_id = :workspace_id
@@ -616,7 +618,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                       AND entity_id IN (SELECT trace_id FROM experiment_items_trace_scope)
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ),
             feedback_scores_final AS (
                 SELECT
@@ -1045,7 +1047,8 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     last_updated_by,
                     created_at,
                     last_updated_at,
-                    author
+                    author,
+                    source_queue_id
                 FROM (
                     SELECT
                         workspace_id,
@@ -1060,7 +1063,8 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                         last_updated_by,
                         created_at,
                         last_updated_at,
-                        feedback_scores.last_updated_by AS author
+                        feedback_scores.last_updated_by AS author,
+                        CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'trace'
                       AND workspace_id = :workspace_id
@@ -1080,7 +1084,8 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                         last_updated_by,
                         created_at,
                         last_updated_at,
-                        author
+                        author,
+                        source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'trace'
                       AND workspace_id = :workspace_id
@@ -1088,7 +1093,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                       AND entity_id IN (SELECT trace_id FROM experiment_items_trace_scope)
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ),
             feedback_scores_grouped AS (
                 SELECT
@@ -1096,7 +1101,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     project_id,
                     entity_id,
                     name,
-                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at)) AS entries
+                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at, source_queue_id)) AS entries
                 FROM feedback_scores_deduped
                 GROUP BY workspace_id, project_id, entity_id, name
             ),
@@ -1111,8 +1116,8 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     IF(length(entries) = 1, arrayElement(entries, 1).2, arrayStringConcat(arrayMap(x -> if(x = '', '\\<no reason>', x), arrayMap(e -> e.2, entries)), ', ')) AS reason,
                     arrayElement(entries, 1).4 AS source,
                     mapFromArrays(
-                        arrayMap(e -> e.5, entries),
-                        arrayMap(e -> tuple(e.1, e.2, e.3, e.4, CAST(e.9 AS DateTime64(9, 'UTC'))), entries)
+                        arrayMap(e -> if(e.10 = '', e.5, concat(e.5, '_', toString(e.10))), entries),
+                        arrayMap(e -> tuple(e.1, e.2, e.3, e.4, CAST(e.9 AS DateTime64(9, 'UTC')), '', '', e.10, e.5), entries)
                     ) AS value_by_author,
                     arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                     arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,
@@ -2186,7 +2191,8 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                            name,
                            value,
                            last_updated_at,
-                           feedback_scores.last_updated_by AS author
+                           feedback_scores.last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
@@ -2202,7 +2208,8 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                         name,
                         value,
                         last_updated_at,
-                        author
+                        author,
+                        source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
@@ -2212,7 +2219,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     AND entity_id IN (SELECT trace_id FROM experiment_items_trace_scope)
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_final AS (
                 SELECT
                     workspace_id,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -1574,14 +1574,22 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                                                             v.2,
                                                             v.3,
                                                             toString(v.4),
-                                                            concat(replaceOne(toString(v.5), ' ', 'T'), 'Z')
+                                                            concat(replaceOne(toString(v.5), ' ', 'T'), 'Z'),
+                                                            v.6,
+                                                            v.7,
+                                                            v.8,
+                                                            v.9
                                                         ),
                                                         'Tuple(
                                                             value Decimal(18,9),
                                                             reason String,
                                                             category_name String,
                                                             source String,
-                                                            last_updated_at String
+                                                            last_updated_at String,
+                                                            span_type String,
+                                                            span_id String,
+                                                            source_queue_id String,
+                                                            author String
                                                         )'
                                                     ),
                                                     mapValues(value_by_author)
@@ -1605,7 +1613,11 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                                                     reason String,
                                                     category_name String,
                                                     source String,
-                                                    last_updated_at String
+                                                    last_updated_at String,
+                                                    span_type String,
+                                                    span_id String,
+                                                    source_queue_id String,
+                                                    author String
                                                 )
                                             )
                                         )'

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -405,7 +405,8 @@ public class ExperimentDAO {
                            name,
                            value,
                            last_updated_at,
-                           feedback_scores.last_updated_by AS author
+                           feedback_scores.last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
@@ -421,7 +422,8 @@ public class ExperimentDAO {
                         name,
                         value,
                         last_updated_at,
-                        author
+                        author,
+                        source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
@@ -431,7 +433,7 @@ public class ExperimentDAO {
                     AND entity_id IN (SELECT trace_id FROM experiment_items_final)
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_final AS (
                 SELECT
                     workspace_id,
@@ -488,7 +490,7 @@ public class ExperimentDAO {
                     <endif>
                     AND entity_id IN (SELECT trace_id FROM experiment_items_final)
                     ORDER BY last_updated_at DESC
-                    LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                    LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
                 )
                 GROUP BY entity_id, name
             ),
@@ -856,7 +858,8 @@ public class ExperimentDAO {
                            name,
                            value,
                            last_updated_at,
-                           feedback_scores.last_updated_by AS author
+                           feedback_scores.last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
@@ -872,7 +875,8 @@ public class ExperimentDAO {
                         name,
                         value,
                         last_updated_at,
-                        author
+                        author,
+                        source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
@@ -882,7 +886,7 @@ public class ExperimentDAO {
                     AND entity_id IN (SELECT trace_id FROM experiment_items_final)
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_final AS (
                 SELECT
                     workspace_id,
@@ -1337,7 +1341,8 @@ public class ExperimentDAO {
                            name,
                            value,
                            last_updated_at,
-                           feedback_scores.last_updated_by AS author
+                           feedback_scores.last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
@@ -1353,7 +1358,8 @@ public class ExperimentDAO {
                         name,
                         value,
                         last_updated_at,
-                        author
+                        author,
+                        source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
@@ -1363,7 +1369,7 @@ public class ExperimentDAO {
                     AND entity_id IN (SELECT trace_id FROM experiment_items_final)
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_final AS (
                 SELECT
                     fsc.workspace_id,
@@ -1419,7 +1425,7 @@ public class ExperimentDAO {
                     <endif>
                     AND entity_id IN (SELECT trace_id FROM experiment_items_final)
                     ORDER BY last_updated_at DESC
-                    LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                    LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
                 )
                 GROUP BY entity_id, name
             ),

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -490,7 +490,7 @@ public class ExperimentDAO {
                     <endif>
                     AND entity_id IN (SELECT trace_id FROM experiment_items_final)
                     ORDER BY last_updated_at DESC
-                    LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
+                    LIMIT 1 BY workspace_id, project_id, entity_id, name, author
                 )
                 GROUP BY entity_id, name
             ),
@@ -1425,7 +1425,7 @@ public class ExperimentDAO {
                     <endif>
                     AND entity_id IN (SELECT trace_id FROM experiment_items_final)
                     ORDER BY last_updated_at DESC
-                    LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
+                    LIMIT 1 BY workspace_id, project_id, entity_id, name, author
                 )
                 GROUP BY entity_id, name
             ),

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
@@ -166,7 +166,8 @@ class ExperimentItemDAO {
                       last_updated_by,
                       created_at,
                       last_updated_at,
-                      author
+                      author,
+                      source_queue_id
                   FROM (
                       SELECT
                           workspace_id,
@@ -181,7 +182,8 @@ class ExperimentItemDAO {
                           last_updated_by,
                           created_at,
                           last_updated_at,
-                          feedback_scores.last_updated_by AS author
+                          feedback_scores.last_updated_by AS author,
+                          CAST('' AS FixedString(36)) AS source_queue_id
                       FROM feedback_scores
                       WHERE entity_type = 'trace'
                         AND workspace_id = :workspace_id
@@ -201,7 +203,8 @@ class ExperimentItemDAO {
                           last_updated_by,
                           created_at,
                           last_updated_at,
-                          author
+                          author,
+                          source_queue_id
                       FROM authored_feedback_scores
                       WHERE entity_type = 'trace'
                         AND workspace_id = :workspace_id
@@ -209,14 +212,14 @@ class ExperimentItemDAO {
                         AND entity_id IN (SELECT trace_id FROM experiment_items_ids)
                   )
                   ORDER BY last_updated_at DESC
-                  LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                  LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_grouped AS (
                   SELECT
                       workspace_id,
                       project_id,
                       entity_id,
                       name,
-                      groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at)) AS entries
+                      groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at, source_queue_id)) AS entries
                   FROM feedback_scores_deduped
                   GROUP BY workspace_id, project_id, entity_id, name
             ), feedback_scores_final AS (
@@ -230,8 +233,8 @@ class ExperimentItemDAO {
                       arrayStringConcat(arrayMap(e -> e.2, entries), ', ') AS reason,
                       arrayElement(entries, 1).4 AS source,
                       mapFromArrays(
-                          arrayMap(e -> e.5, entries),
-                          arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9), entries)
+                          arrayMap(e -> if(e.10 = '', e.5, concat(e.5, '_', toString(e.10))), entries),
+                          arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, '', '', e.10, e.5), entries)
                       ) AS value_by_author,
                       arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                       arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
@@ -281,14 +281,22 @@ class ExperimentItemDAO {
                                                   v.2,
                                                   v.3,
                                                   toString(v.4),
-                                                  concat(replaceOne(toString(v.5), ' ', 'T'), 'Z')
+                                                  concat(replaceOne(toString(v.5), ' ', 'T'), 'Z'),
+                                                  v.6,
+                                                  v.7,
+                                                  v.8,
+                                                  v.9
                                               ),
                                               'Tuple(
                                                   value Decimal(18,9),
                                                   reason String,
                                                   category_name String,
                                                   source String,
-                                                  last_updated_at String
+                                                  last_updated_at String,
+                                                  span_type String,
+                                                  span_id String,
+                                                  source_queue_id String,
+                                                  author String
                                               )'
                                           ),
                                           mapValues(value_by_author)
@@ -312,7 +320,11 @@ class ExperimentItemDAO {
                                               reason String,
                                               category_name String,
                                               source String,
-                                              last_updated_at String
+                                              last_updated_at String,
+                                              span_type String,
+                                              span_id String,
+                                              source_queue_id String,
+                                              author String
                                           )
                                       )
                                   )'

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
@@ -35,6 +35,7 @@ import static com.comet.opik.domain.AsyncContextUtils.bindUserNameAndWorkspace;
 import static com.comet.opik.infrastructure.FilterUtils.getLogComment;
 import static com.comet.opik.infrastructure.FilterUtils.getSTWithLogComment;
 import static com.comet.opik.utils.AsyncUtils.makeMonoContextAware;
+import static com.comet.opik.utils.ValidationUtils.CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE;
 
 @ImplementedBy(FeedbackScoreDAOImpl.class)
 public interface FeedbackScoreDAO {
@@ -415,9 +416,7 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
                     .filter(StringUtils::isNotBlank)
                     .ifPresent(author -> deleteAuthoredFeedbackScore.add("author", "author"));
 
-            if (score.sourceQueueId() != null) {
-                deleteAuthoredFeedbackScore.add("source_queue_id", "source_queue_id");
-            }
+            deleteAuthoredFeedbackScore.add("source_queue_id", "source_queue_id");
 
             var statement2 = connection.createStatement(deleteAuthoredFeedbackScore.render());
             statement2
@@ -429,9 +428,10 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
                     .filter(StringUtils::isNotBlank)
                     .ifPresent(author -> statement2.bind("author", author));
 
-            if (score.sourceQueueId() != null) {
-                statement2.bind("source_queue_id", score.sourceQueueId().toString());
-            }
+            statement2.bind("source_queue_id",
+                    score.sourceQueueId() != null
+                            ? score.sourceQueueId().toString()
+                            : CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE);
 
             return deleteNonAuthoredOperation
                     .then(Mono.from(statement2.execute()))

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
@@ -491,9 +491,7 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
             Optional.ofNullable(author)
                     .filter(StringUtils::isNotBlank)
                     .ifPresent(a -> template2.add("author", "author"));
-            if (sourceQueueId != null) {
-                template2.add("source_queue_id", "source_queue_id");
-            }
+            template2.add("source_queue_id", "source_queue_id");
 
             var statement2 = connection.createStatement(template2.render())
                     .bind("entity_ids", Set.of(entityId))
@@ -503,9 +501,10 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
             Optional.ofNullable(author)
                     .filter(StringUtils::isNotBlank)
                     .ifPresent(a -> statement2.bind("author", a));
-            if (sourceQueueId != null) {
-                statement2.bind("source_queue_id", sourceQueueId.toString());
-            }
+            statement2.bind("source_queue_id",
+                    sourceQueueId != null
+                            ? sourceQueueId.toString()
+                            : CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE);
 
             return deleteNonAuthoredOperation
                     .then(Mono.from(statement2.execute()))

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreMapper.java
@@ -144,7 +144,7 @@ public interface FeedbackScoreMapper {
             // source_queue_id is the 8th element (index 7)
             if (tuple.size() > 7 && tuple.get(7) != null) {
                 String sourceQueueId = tuple.get(7).toString();
-                if (StringUtils.isNotEmpty(sourceQueueId)
+                if (StringUtils.isNotBlank(sourceQueueId)
                         && !CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE.equals(sourceQueueId)) {
                     builder.sourceQueueId(sourceQueueId);
                 }
@@ -225,6 +225,7 @@ public interface FeedbackScoreMapper {
 
             if (tuple.isArray() && !tuple.isEmpty()) {
                 ValueEntry.ValueEntryBuilder builder = ValueEntry.builder()
+                        .author(author)
                         .value(tuple.get(0).decimalValue())
                         .reason(getJsonTextOrNull(tuple.get(1)))
                         .categoryName(getJsonTextOrNull(tuple.get(2)))
@@ -239,7 +240,7 @@ public interface FeedbackScoreMapper {
                 }
                 if (tuple.size() > 7 && tuple.get(7) != null && !tuple.get(7).isNull()) {
                     String sourceQueueId = tuple.get(7).asText();
-                    if (StringUtils.isNotEmpty(sourceQueueId)
+                    if (StringUtils.isNotBlank(sourceQueueId)
                             && !CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE.equals(sourceQueueId)) {
                         builder.sourceQueueId(sourceQueueId);
                     }
@@ -251,6 +252,7 @@ public interface FeedbackScoreMapper {
                 result.put(author, builder.build());
             } else if (tuple.isObject() && !tuple.isEmpty()) {
                 ValueEntry.ValueEntryBuilder builder = ValueEntry.builder()
+                        .author(author)
                         .value(tuple.get("value").decimalValue())
                         .reason(getJsonTextOrNull(tuple.get("reason")))
                         .categoryName(getJsonTextOrNull(tuple.get("category_name")))
@@ -265,7 +267,7 @@ public interface FeedbackScoreMapper {
                 }
                 if (tuple.has("source_queue_id") && !tuple.get("source_queue_id").isNull()) {
                     String sourceQueueId = tuple.get("source_queue_id").asText();
-                    if (StringUtils.isNotEmpty(sourceQueueId)
+                    if (StringUtils.isNotBlank(sourceQueueId)
                             && !CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE.equals(sourceQueueId)) {
                         builder.sourceQueueId(sourceQueueId);
                     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreMapper.java
@@ -149,7 +149,7 @@ public interface FeedbackScoreMapper {
                     builder.sourceQueueId(sourceQueueId);
                 }
             }
-            // source_queue_id is the 9th element (index 8)
+            // author is the 9th element (index 8)
             if (tuple.size() > 8 && tuple.get(8) != null) {
                 builder.author(getIfNotEmpty(tuple.get(8)));
             }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreMapper.java
@@ -149,6 +149,10 @@ public interface FeedbackScoreMapper {
                     builder.sourceQueueId(sourceQueueId);
                 }
             }
+            // source_queue_id is the 9th element (index 8)
+            if (tuple.size() > 8 && tuple.get(8) != null) {
+                builder.author(getIfNotEmpty(tuple.get(8)));
+            }
 
             ValueEntry valueEntry = builder.build();
 
@@ -240,6 +244,9 @@ public interface FeedbackScoreMapper {
                         builder.sourceQueueId(sourceQueueId);
                     }
                 }
+                if (tuple.size() > 8 && tuple.get(8) != null && !tuple.get(8).isNull()) {
+                    builder.author(tuple.get(8).asText());
+                }
 
                 result.put(author, builder.build());
             } else if (tuple.isObject() && !tuple.isEmpty()) {
@@ -262,6 +269,9 @@ public interface FeedbackScoreMapper {
                             && !CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE.equals(sourceQueueId)) {
                         builder.sourceQueueId(sourceQueueId);
                     }
+                }
+                if (tuple.has("author") && !tuple.get("author").isNull()) {
+                    builder.author(tuple.get("author").asText());
                 }
 
                 result.put(author, builder.build());

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreMapper.java
@@ -141,6 +141,14 @@ public interface FeedbackScoreMapper {
             if (tuple.size() > 6 && tuple.get(6) != null) {
                 builder.spanId((String) tuple.get(6));
             }
+            // source_queue_id is the 8th element (index 7)
+            if (tuple.size() > 7 && tuple.get(7) != null) {
+                String sourceQueueId = tuple.get(7).toString();
+                if (StringUtils.isNotEmpty(sourceQueueId)
+                        && !CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE.equals(sourceQueueId)) {
+                    builder.sourceQueueId(sourceQueueId);
+                }
+            }
 
             ValueEntry valueEntry = builder.build();
 
@@ -225,6 +233,13 @@ public interface FeedbackScoreMapper {
                 if (tuple.size() > 6 && tuple.get(6) != null && !tuple.get(6).isNull()) {
                     builder.spanId(tuple.get(6).asText());
                 }
+                if (tuple.size() > 7 && tuple.get(7) != null && !tuple.get(7).isNull()) {
+                    String sourceQueueId = tuple.get(7).asText();
+                    if (StringUtils.isNotEmpty(sourceQueueId)
+                            && !CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE.equals(sourceQueueId)) {
+                        builder.sourceQueueId(sourceQueueId);
+                    }
+                }
 
                 result.put(author, builder.build());
             } else if (tuple.isObject() && !tuple.isEmpty()) {
@@ -240,6 +255,13 @@ public interface FeedbackScoreMapper {
                 }
                 if (tuple.has("span_id") && !tuple.get("span_id").isNull()) {
                     builder.spanId(tuple.get("span_id").asText());
+                }
+                if (tuple.has("source_queue_id") && !tuple.get("source_queue_id").isNull()) {
+                    String sourceQueueId = tuple.get("source_queue_id").asText();
+                    if (StringUtils.isNotEmpty(sourceQueueId)
+                            && !CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE.equals(sourceQueueId)) {
+                        builder.sourceQueueId(sourceQueueId);
+                    }
                 }
 
                 result.put(author, builder.build());

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
@@ -60,7 +60,8 @@ class KpiCardDAOImpl implements KpiCardDAO {
                        name,
                        value,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM (
                     SELECT workspace_id,
                            project_id,
@@ -68,7 +69,8 @@ class KpiCardDAOImpl implements KpiCardDAO {
                            name,
                            value,
                            last_updated_at,
-                           last_updated_by AS author
+                           last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'trace'
                       AND workspace_id = :workspace_id
@@ -82,7 +84,8 @@ class KpiCardDAOImpl implements KpiCardDAO {
                            name,
                            value,
                            last_updated_at,
-                           author
+                           author,
+                           source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'trace'
                       AND workspace_id = :workspace_id
@@ -91,7 +94,7 @@ class KpiCardDAOImpl implements KpiCardDAO {
                       AND entity_id \\<= :uuid_to_time
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
              ), feedback_scores_final AS (
                 SELECT
                     workspace_id,
@@ -213,7 +216,8 @@ class KpiCardDAOImpl implements KpiCardDAO {
                        name,
                        value,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM (
                     SELECT workspace_id,
                            project_id,
@@ -221,7 +225,8 @@ class KpiCardDAOImpl implements KpiCardDAO {
                            name,
                            value,
                            last_updated_at,
-                           last_updated_by AS author
+                           last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
@@ -235,7 +240,8 @@ class KpiCardDAOImpl implements KpiCardDAO {
                            name,
                            value,
                            last_updated_at,
-                           author
+                           author,
+                           source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
@@ -244,7 +250,7 @@ class KpiCardDAOImpl implements KpiCardDAO {
                       AND entity_id \\<= :uuid_to_time
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
              ), feedback_scores_final AS (
                 SELECT
                     workspace_id,
@@ -363,7 +369,8 @@ class KpiCardDAOImpl implements KpiCardDAO {
                        name,
                        value,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM (
                     SELECT
                         workspace_id,
@@ -372,7 +379,8 @@ class KpiCardDAOImpl implements KpiCardDAO {
                         name,
                         value,
                         last_updated_at,
-                        last_updated_by AS author
+                        last_updated_by AS author,
+                        CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'thread'
                        AND workspace_id = :workspace_id
@@ -385,7 +393,8 @@ class KpiCardDAOImpl implements KpiCardDAO {
                            name,
                            value,
                            last_updated_at,
-                           author
+                           author,
+                           source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'thread'
                        AND workspace_id = :workspace_id
@@ -393,7 +402,7 @@ class KpiCardDAOImpl implements KpiCardDAO {
                        AND entity_id IN (SELECT thread_model_id FROM trace_threads_final)
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_final AS (
                 SELECT
                     workspace_id,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
@@ -314,7 +314,8 @@ class OptimizationDAOImpl implements OptimizationDAO {
                            name,
                            value,
                            last_updated_at,
-                           last_updated_by AS author
+                           last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = :entity_type
                       AND workspace_id = :workspace_id
@@ -326,14 +327,15 @@ class OptimizationDAOImpl implements OptimizationDAO {
                            name,
                            value,
                            last_updated_at,
-                           author
+                           author,
+                           source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = :entity_type
                       AND workspace_id = :workspace_id
                       AND entity_id IN (SELECT trace_id FROM experiment_items_final)
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_final AS (
                 SELECT
                     workspace_id,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
@@ -167,7 +167,8 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                        name,
                        value,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM (
                     SELECT workspace_id,
                            project_id,
@@ -175,7 +176,8 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                            name,
                            value,
                            last_updated_at,
-                           last_updated_by AS author
+                           last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'trace'
                       AND workspace_id = :workspace_id
@@ -189,7 +191,8 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                            name,
                            value,
                            last_updated_at,
-                           author
+                           author,
+                           source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'trace'
                       AND workspace_id = :workspace_id
@@ -198,7 +201,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                       <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time<endif>
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
              ), feedback_scores_final AS (
                 SELECT
                     workspace_id,
@@ -305,7 +308,8 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                        name,
                        value,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM (
                     SELECT workspace_id,
                            project_id,
@@ -313,7 +317,8 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                            name,
                            value,
                            last_updated_at,
-                           last_updated_by AS author
+                           last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
@@ -327,7 +332,8 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                            name,
                            value,
                            last_updated_at,
-                           author
+                           author,
+                           source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
@@ -336,7 +342,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                       <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time<endif>
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
              ), feedback_scores_final AS (
                 SELECT
                     workspace_id,
@@ -455,7 +461,8 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                        name,
                        value,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM (
                     SELECT
                         workspace_id,
@@ -464,7 +471,8 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                         name,
                         value,
                         last_updated_at,
-                        last_updated_by AS author
+                        last_updated_by AS author,
+                        CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'thread'
                        AND workspace_id = :workspace_id
@@ -477,7 +485,8 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                            name,
                            value,
                            last_updated_at,
-                           author
+                           author,
+                           source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'thread'
                        AND workspace_id = :workspace_id
@@ -485,7 +494,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                        AND entity_id IN (SELECT thread_model_id FROM trace_threads_final)
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_final AS (
                 SELECT
                     workspace_id,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -687,7 +687,7 @@ public class SpanDAO {
                     entries[1].4 AS source,
                     mapFromArrays(
                             arrayMap(e -> e.5, entries),
-                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9), entries)
+                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, '', '', '', e.5), entries)
                     ) AS value_by_author,
                     arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                     arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,
@@ -698,7 +698,15 @@ public class SpanDAO {
             SELECT
                 s.*,
                 s.project_id as project_id,
-                groupArray(tuple(c.*)) AS comments,
+                groupArray(tuple(
+                    c.comment_id,
+                    c.text,
+                    c.comment_created_at,
+                    c.comment_last_updated_at,
+                    c.comment_created_by,
+                    c.comment_last_updated_by,
+                    c.source_queue_id
+                )) AS comments,
                 any(fs.feedback_scores) as feedback_scores_list
             FROM (
                 SELECT
@@ -719,6 +727,7 @@ public class SpanDAO {
                     last_updated_at AS comment_last_updated_at,
                     created_by AS comment_created_by,
                     last_updated_by AS comment_last_updated_by,
+                    source_queue_id,
                     entity_id
                 FROM comments
                 WHERE workspace_id = :workspace_id
@@ -831,7 +840,8 @@ public class SpanDAO {
                        created_at AS comment_created_at,
                        last_updated_at AS comment_last_updated_at,
                        created_by AS comment_created_by,
-                       last_updated_by AS comment_last_updated_by
+                       last_updated_by AS comment_last_updated_by,
+                       source_queue_id
                    )) as comments
               FROM (
                 SELECT
@@ -841,6 +851,7 @@ public class SpanDAO {
                     last_updated_at,
                     created_by,
                     last_updated_by,
+                    source_queue_id,
                     entity_id,
                     workspace_id,
                     project_id
@@ -940,7 +951,7 @@ public class SpanDAO {
                     entries[1].4 AS source,
                     mapFromArrays(
                             arrayMap(e -> e.5, entries),
-                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9), entries)
+                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, '', '', '', e.5), entries)
                     ) AS value_by_author,
                     arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                     arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,
@@ -1311,7 +1322,7 @@ public class SpanDAO {
                     entries[1].4 AS source,
                     mapFromArrays(
                             arrayMap(e -> e.5, entries),
-                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9), entries)
+                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, '', '', '', e.5), entries)
                     ) AS value_by_author,
                     arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                     arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
@@ -249,7 +249,8 @@ class ThreadDAOImpl implements ThreadDAO {
                         last_updated_by,
                         created_at,
                         last_updated_at,
-                        feedback_scores.last_updated_by AS author
+                        feedback_scores.last_updated_by AS author,
+                        CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'thread'
                       AND workspace_id = :workspace_id
@@ -269,7 +270,8 @@ class ThreadDAOImpl implements ThreadDAO {
                         last_updated_by,
                         created_at,
                         last_updated_at,
-                        author
+                        author,
+                        source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'thread'
                        AND workspace_id = :workspace_id
@@ -278,14 +280,14 @@ class ThreadDAOImpl implements ThreadDAO {
                        <if(annotation_queue_id)>AND source_queue_id = :annotation_queue_id<endif>
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_grouped AS (
                 SELECT
                     workspace_id,
                     project_id,
                     entity_id,
                     name,
-                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at)) AS entries
+                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at, source_queue_id)) AS entries
                 FROM feedback_scores_deduped
                 GROUP BY workspace_id, project_id, entity_id, name
             ), feedback_scores_final AS (
@@ -299,8 +301,8 @@ class ThreadDAOImpl implements ThreadDAO {
                     IF(length(entries) = 1, entries[1].2, arrayStringConcat(arrayMap(e -> if(e.2 = '', '\\<no reason>', e.2), entries), ', ')) AS reason,
                     entries[1].4 AS source,
                     mapFromArrays(
-                        arrayMap(e -> e.5, entries),
-                        arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9), entries)
+                        arrayMap(e -> if(e.10 = '', e.5, concat(e.5, '_', toString(e.10))), entries),
+                        arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, '', '', e.10, e.5), entries)
                     ) AS value_by_author,
                     arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                     arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,
@@ -575,7 +577,8 @@ class ThreadDAOImpl implements ThreadDAO {
                         last_updated_by,
                         created_at,
                         last_updated_at,
-                        feedback_scores.last_updated_by AS author
+                        feedback_scores.last_updated_by AS author,
+                        CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'thread'
                        AND workspace_id = :workspace_id
@@ -595,7 +598,8 @@ class ThreadDAOImpl implements ThreadDAO {
                         last_updated_by,
                         created_at,
                         last_updated_at,
-                        author
+                        author,
+                        source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'thread'
                        AND workspace_id = :workspace_id
@@ -604,14 +608,14 @@ class ThreadDAOImpl implements ThreadDAO {
                        <if(annotation_queue_id)>AND source_queue_id = :annotation_queue_id<endif>
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_grouped AS (
                 SELECT
                     workspace_id,
                     project_id,
                     entity_id,
                     name,
-                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at)) AS entries
+                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at, source_queue_id)) AS entries
                 FROM feedback_scores_deduped
                 GROUP BY workspace_id, project_id, entity_id, name
             ), feedback_scores_final AS (
@@ -625,8 +629,8 @@ class ThreadDAOImpl implements ThreadDAO {
                     IF(length(entries) = 1, entries[1].2, arrayStringConcat(arrayMap(e -> if(e.2 = '', '\\<no reason>', e.2), entries), ', ')) AS reason,
                     entries[1].4 AS source,
                     mapFromArrays(
-                        arrayMap(e -> e.5, entries),
-                        arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9), entries)
+                        arrayMap(e -> if(e.10 = '', e.5, concat(e.5, '_', toString(e.10))), entries),
+                        arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, '', '', e.10, e.5), entries)
                     ) AS value_by_author,
                     arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                     arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,
@@ -827,7 +831,8 @@ class ThreadDAOImpl implements ThreadDAO {
                            last_updated_by,
                            created_at,
                            last_updated_at,
-                           feedback_scores.last_updated_by AS author
+                           feedback_scores.last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'thread'
                       AND workspace_id = :workspace_id
@@ -847,7 +852,8 @@ class ThreadDAOImpl implements ThreadDAO {
                         last_updated_by,
                         created_at,
                         last_updated_at,
-                        author
+                        author,
+                        source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'thread'
                        AND workspace_id = :workspace_id
@@ -855,14 +861,14 @@ class ThreadDAOImpl implements ThreadDAO {
                        AND entity_id IN (SELECT thread_model_id FROM trace_threads_ids)
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_grouped AS (
                 SELECT
                     workspace_id,
                     project_id,
                     entity_id,
                     name,
-                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at)) AS entries
+                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at, source_queue_id)) AS entries
                 FROM feedback_scores_deduped
                 GROUP BY workspace_id, project_id, entity_id, name
             ), feedback_scores_final AS (
@@ -876,8 +882,8 @@ class ThreadDAOImpl implements ThreadDAO {
                     IF(length(entries) = 1, entries[1].2, arrayStringConcat(arrayMap(e -> if(e.2 = '', '\\<no reason>', e.2), entries), ', ')) AS reason,
                     entries[1].4 AS source,
                     mapFromArrays(
-                        arrayMap(e -> e.5, entries),
-                        arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9), entries)
+                        arrayMap(e -> if(e.10 = '', e.5, concat(e.5, '_', toString(e.10))), entries),
+                        arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, '', '', e.10, e.5), entries)
                     ) AS value_by_author,
                     arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                     arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,
@@ -1145,7 +1151,8 @@ class ThreadDAOImpl implements ThreadDAO {
                             last_updated_by,
                             created_at,
                             last_updated_at,
-                            feedback_scores.last_updated_by AS author
+                            feedback_scores.last_updated_by AS author,
+                            CAST('' AS FixedString(36)) AS source_queue_id
                         FROM feedback_scores
                         WHERE entity_type = 'thread'
                           AND workspace_id = :workspace_id
@@ -1165,7 +1172,8 @@ class ThreadDAOImpl implements ThreadDAO {
                             last_updated_by,
                             created_at,
                             last_updated_at,
-                            author
+                            author,
+                            source_queue_id
                         FROM authored_feedback_scores
                         WHERE entity_type = 'thread'
                            AND workspace_id = :workspace_id
@@ -1174,14 +1182,14 @@ class ThreadDAOImpl implements ThreadDAO {
                            <if(annotation_queue_id)>AND source_queue_id = :annotation_queue_id<endif>
                     )
                     ORDER BY last_updated_at DESC
-                    LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                    LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
                 ), feedback_scores_grouped AS (
                     SELECT
                         workspace_id,
                         project_id,
                         entity_id,
                         name,
-                        groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at)) AS entries
+                        groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at, source_queue_id)) AS entries
                     FROM feedback_scores_deduped
                     GROUP BY workspace_id, project_id, entity_id, name
                 ), feedback_scores_final AS (
@@ -1195,8 +1203,8 @@ class ThreadDAOImpl implements ThreadDAO {
                         IF(length(entries) = 1, entries[1].2, arrayStringConcat(arrayMap(e -> if(e.2 = '', '\\<no reason>', e.2), entries), ', ')) AS reason,
                         entries[1].4 AS source,
                         mapFromArrays(
-                            arrayMap(e -> e.5, entries),
-                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9), entries)
+                            arrayMap(e -> if(e.10 = '', e.5, concat(e.5, '_', toString(e.10))), entries),
+                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, '', '', e.10, e.5), entries)
                         ) AS value_by_author,
                         arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                         arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
@@ -342,6 +342,7 @@ class ThreadDAOImpl implements ThreadDAO {
                     last_updated_at,
                     created_by,
                     last_updated_by,
+                    source_queue_id,
                     entity_id,
                     workspace_id,
                     project_id
@@ -923,6 +924,7 @@ class ThreadDAOImpl implements ThreadDAO {
                     last_updated_at,
                     created_by,
                     last_updated_by,
+                    source_queue_id,
                     entity_id,
                     workspace_id,
                     project_id

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -453,10 +453,9 @@ class TraceDAOImpl implements TraceDAO {
             ;
             """;
 
-    // Build value_by_author map with composite keys (author_spanId) for span feedback scores.
-    // The composite key format ensures uniqueness when multiple spans have the same author.
-    // Format: if span_id exists, use 'author_spanId', otherwise use 'author'.
-    // The tuple contains: (value, reason, category_name, source, last_updated_at, span_type, span_id)
+    // Build value_by_author map with composite keys for feedback scores.
+    // Key format: author + optional _queueId + optional _spanId (ensures uniqueness across queues/spans).
+    // Value tuple: (value, reason, category_name, source, last_updated_at, span_type, span_id, source_queue_id, author)
     private static final String SELECT_BY_IDS = """
             WITH target_spans AS (
                 SELECT id, trace_id, type
@@ -865,7 +864,8 @@ class TraceDAOImpl implements TraceDAO {
                        last_updated_by,
                        created_at,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM (
                     SELECT workspace_id,
                            project_id,
@@ -879,7 +879,8 @@ class TraceDAOImpl implements TraceDAO {
                            last_updated_by,
                            created_at,
                            last_updated_at,
-                           feedback_scores.last_updated_by AS author
+                           feedback_scores.last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'trace'
                       AND workspace_id = :workspace_id
@@ -902,7 +903,8 @@ class TraceDAOImpl implements TraceDAO {
                            last_updated_by,
                            created_at,
                            last_updated_at,
-                           author
+                           author,
+                           source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'trace'
                       AND workspace_id = :workspace_id
@@ -915,7 +917,7 @@ class TraceDAOImpl implements TraceDAO {
                       <endif>
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
              ),
              feedback_scores_grouped AS (
                  SELECT
@@ -923,7 +925,7 @@ class TraceDAOImpl implements TraceDAO {
                      project_id,
                      entity_id,
                      name,
-                     groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at)) AS entries
+                     groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at, source_queue_id)) AS entries
                  FROM feedback_scores_deduped
                  GROUP BY workspace_id, project_id, entity_id, name
              ), feedback_scores_final AS (
@@ -937,8 +939,8 @@ class TraceDAOImpl implements TraceDAO {
                     IF(length(entries) = 1, entries[1].2, arrayStringConcat(arrayMap(e -> if(e.2 = '', '\\<no reason>', e.2), entries), ', ')) AS reason,
                     entries[1].4 AS source,
                     mapFromArrays(
-                            arrayMap(e -> e.5, entries),
-                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9), entries)
+                            arrayMap(e -> if(e.10 = '', e.5, concat(e.5, '_', toString(e.10))), entries),
+                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, '', '', e.10, e.5), entries)
                     ) AS value_by_author,
                     arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                     arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,
@@ -1018,7 +1020,8 @@ class TraceDAOImpl implements TraceDAO {
                        last_updated_by,
                        created_at,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM (
                     SELECT workspace_id,
                            project_id,
@@ -1032,7 +1035,8 @@ class TraceDAOImpl implements TraceDAO {
                            last_updated_by,
                            created_at,
                            last_updated_at,
-                           feedback_scores.last_updated_by AS author
+                           feedback_scores.last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
@@ -1056,7 +1060,8 @@ class TraceDAOImpl implements TraceDAO {
                            last_updated_by,
                            created_at,
                            last_updated_at,
-                           author
+                           author,
+                           source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
@@ -1069,7 +1074,7 @@ class TraceDAOImpl implements TraceDAO {
                       <endif>
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), span_feedback_scores_with_trace_id AS (
                 SELECT workspace_id,
                        project_id,
@@ -1083,7 +1088,8 @@ class TraceDAOImpl implements TraceDAO {
                        last_updated_by,
                        created_at,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM span_feedback_scores_deduped sfs
                 INNER JOIN target_spans s ON sfs.entity_id = s.id
             ), span_feedback_scores_grouped AS (
@@ -1092,7 +1098,7 @@ class TraceDAOImpl implements TraceDAO {
                     project_id,
                     trace_id,
                     name,
-                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at)) AS entries
+                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at, source_queue_id)) AS entries
                 FROM span_feedback_scores_with_trace_id
                 GROUP BY workspace_id, project_id, trace_id, name
             ), span_feedback_scores_final AS (
@@ -1106,8 +1112,8 @@ class TraceDAOImpl implements TraceDAO {
                     IF(length(entries) = 1, entries[1].2, arrayStringConcat(arrayMap(e -> if(e.2 = '', '\\<no reason>', e.2), entries), ', ')) AS reason,
                     entries[1].4 AS source,
                     mapFromArrays(
-                            arrayMap(e -> e.5, entries),
-                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9), entries)
+                            arrayMap(e -> if(e.10 = '', e.5, concat(e.5, '_', toString(e.10))), entries),
+                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, '', '', e.10, e.5), entries)
                     ) AS value_by_author,
                     arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                     arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,
@@ -1437,7 +1443,8 @@ class TraceDAOImpl implements TraceDAO {
                            name,
                            value,
                            last_updated_at,
-                       feedback_scores.last_updated_by AS author
+                       feedback_scores.last_updated_by AS author,
+                       CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'trace'
                       AND workspace_id = :workspace_id
@@ -1451,7 +1458,8 @@ class TraceDAOImpl implements TraceDAO {
                            name,
                            value,
                            last_updated_at,
-                           author
+                           author,
+                           source_queue_id
                      FROM authored_feedback_scores
                      WHERE entity_type = 'trace'
                        AND workspace_id = :workspace_id
@@ -1461,7 +1469,7 @@ class TraceDAOImpl implements TraceDAO {
                        <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
              ), feedback_scores_final AS (
                 SELECT
                     workspace_id,
@@ -1524,7 +1532,8 @@ class TraceDAOImpl implements TraceDAO {
                        last_updated_by,
                        created_at,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM (
                     SELECT workspace_id,
                            project_id,
@@ -1538,7 +1547,8 @@ class TraceDAOImpl implements TraceDAO {
                            last_updated_by,
                            created_at,
                            last_updated_at,
-                           feedback_scores.last_updated_by AS author
+                           feedback_scores.last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
@@ -1557,7 +1567,8 @@ class TraceDAOImpl implements TraceDAO {
                            last_updated_by,
                            created_at,
                            last_updated_at,
-                           author
+                           author,
+                           source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
@@ -1565,7 +1576,7 @@ class TraceDAOImpl implements TraceDAO {
                       AND entity_id IN (SELECT id FROM target_spans)
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), span_feedback_scores_with_trace_id AS (
                 SELECT workspace_id,
                        project_id,
@@ -1579,7 +1590,8 @@ class TraceDAOImpl implements TraceDAO {
                        last_updated_by,
                        created_at,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM span_feedback_scores_deduped sfs
                 INNER JOIN target_spans s ON sfs.entity_id = s.id
             ), span_feedback_scores_grouped AS (
@@ -1588,7 +1600,7 @@ class TraceDAOImpl implements TraceDAO {
                     project_id,
                     trace_id,
                     name,
-                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at)) AS entries
+                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at, source_queue_id)) AS entries
                 FROM span_feedback_scores_with_trace_id
                 GROUP BY workspace_id, project_id, trace_id, name
             ), span_feedback_scores_final AS (
@@ -1602,8 +1614,8 @@ class TraceDAOImpl implements TraceDAO {
                     IF(length(entries) = 1, entries[1].2, arrayStringConcat(arrayMap(e -> if(e.2 = '', '\\<no reason>', e.2), entries), ', ')) AS reason,
                     entries[1].4 AS source,
                     mapFromArrays(
-                            arrayMap(e -> e.5, entries),
-                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9), entries)
+                            arrayMap(e -> if(e.10 = '', e.5, concat(e.5, '_', toString(e.10))), entries),
+                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, '', '', e.10, e.5), entries)
                     ) AS value_by_author,
                     arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                     arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,
@@ -2055,7 +2067,8 @@ class TraceDAOImpl implements TraceDAO {
                        last_updated_by,
                        created_at,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM (
                     <if(has_legacy_scores)>
                     SELECT
@@ -2071,7 +2084,8 @@ class TraceDAOImpl implements TraceDAO {
                         last_updated_by,
                         created_at,
                         last_updated_at,
-                        feedback_scores.last_updated_by AS author
+                        feedback_scores.last_updated_by AS author,
+                        CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'trace'
                       AND workspace_id = :workspace_id
@@ -2093,7 +2107,8 @@ class TraceDAOImpl implements TraceDAO {
                         last_updated_by,
                         created_at,
                         last_updated_at,
-                        author
+                        author,
+                        source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'trace'
                        AND workspace_id = :workspace_id
@@ -2103,7 +2118,7 @@ class TraceDAOImpl implements TraceDAO {
                        <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
              ),
              feedback_scores_grouped AS (
                  SELECT
@@ -2111,7 +2126,7 @@ class TraceDAOImpl implements TraceDAO {
                      project_id,
                      entity_id,
                      name,
-                     groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at)) AS entries
+                     groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at, source_queue_id)) AS entries
                  FROM feedback_scores_deduped
                  GROUP BY workspace_id, project_id, entity_id, name
             ), feedback_scores_final AS (
@@ -2125,8 +2140,8 @@ class TraceDAOImpl implements TraceDAO {
                    IF(length(entries) = 1, entries[1].2, arrayStringConcat(arrayMap(e -> if(e.2 = '', '\\<no reason>', e.2), entries), ', ')) AS reason,
                    entries[1].4 AS source,
                    mapFromArrays(
-                       arrayMap(e -> e.5, entries),
-                       arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9), entries)
+                       arrayMap(e -> if(e.10 = '', e.5, concat(e.5, '_', toString(e.10))), entries),
+                       arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, '', '', e.10, e.5), entries)
                    ) AS value_by_author,
                    arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                    arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,
@@ -2189,7 +2204,8 @@ class TraceDAOImpl implements TraceDAO {
                        last_updated_by,
                        created_at,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM (
                     <if(has_legacy_scores)>
                     SELECT workspace_id,
@@ -2204,7 +2220,8 @@ class TraceDAOImpl implements TraceDAO {
                            last_updated_by,
                            created_at,
                            last_updated_at,
-                           feedback_scores.last_updated_by AS author
+                           feedback_scores.last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
@@ -2229,7 +2246,8 @@ class TraceDAOImpl implements TraceDAO {
                            last_updated_by,
                            created_at,
                            last_updated_at,
-                           author
+                           author,
+                           source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
@@ -2242,7 +2260,7 @@ class TraceDAOImpl implements TraceDAO {
                       <endif>
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), span_feedback_scores_with_trace_id AS (
                 SELECT workspace_id,
                        project_id,
@@ -2256,7 +2274,8 @@ class TraceDAOImpl implements TraceDAO {
                        last_updated_by,
                        created_at,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM span_feedback_scores_deduped sfs
                 INNER JOIN spans_data s ON sfs.entity_id = s.id
             ), span_feedback_scores_grouped AS (
@@ -2265,7 +2284,7 @@ class TraceDAOImpl implements TraceDAO {
                     project_id,
                     trace_id,
                     name,
-                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at)) AS entries
+                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at, source_queue_id)) AS entries
                 FROM span_feedback_scores_with_trace_id
                 GROUP BY workspace_id, project_id, trace_id, name
             ), span_feedback_scores_final AS (
@@ -2279,8 +2298,8 @@ class TraceDAOImpl implements TraceDAO {
                     IF(length(entries) = 1, entries[1].2, arrayStringConcat(arrayMap(e -> if(e.2 = '', '\\<no reason>', e.2), entries), ', ')) AS reason,
                     entries[1].4 AS source,
                     mapFromArrays(
-                            arrayMap(e -> e.5, entries),
-                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9), entries)
+                            arrayMap(e -> if(e.10 = '', e.5, concat(e.5, '_', toString(e.10))), entries),
+                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, '', '', e.10, e.5), entries)
                     ) AS value_by_author,
                     arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                     arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,
@@ -2484,7 +2503,8 @@ class TraceDAOImpl implements TraceDAO {
                        last_updated_by,
                        created_at,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM (
                     <if(has_legacy_scores)>
                     SELECT
@@ -2500,7 +2520,8 @@ class TraceDAOImpl implements TraceDAO {
                         last_updated_by,
                         created_at,
                         last_updated_at,
-                        feedback_scores.last_updated_by AS author
+                        feedback_scores.last_updated_by AS author,
+                        CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'trace'
                       AND workspace_id = :workspace_id
@@ -2522,7 +2543,8 @@ class TraceDAOImpl implements TraceDAO {
                         last_updated_by,
                         created_at,
                         last_updated_at,
-                        author
+                        author,
+                        source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'trace'
                        AND workspace_id = :workspace_id
@@ -2532,7 +2554,7 @@ class TraceDAOImpl implements TraceDAO {
                        <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ),
             feedback_scores_grouped AS (
                 SELECT
@@ -2540,7 +2562,7 @@ class TraceDAOImpl implements TraceDAO {
                     project_id,
                     entity_id,
                     name,
-                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at)) AS entries
+                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at, source_queue_id)) AS entries
                 FROM feedback_scores_deduped
                 GROUP BY workspace_id, project_id, entity_id, name
             ), feedback_scores_final AS (
@@ -2592,7 +2614,8 @@ class TraceDAOImpl implements TraceDAO {
                        name,
                        value,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM (
                     <if(has_legacy_scores)>
                     SELECT workspace_id,
@@ -2601,7 +2624,8 @@ class TraceDAOImpl implements TraceDAO {
                            name,
                            value,
                            last_updated_at,
-                           feedback_scores.last_updated_by AS author
+                           feedback_scores.last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
@@ -2620,7 +2644,8 @@ class TraceDAOImpl implements TraceDAO {
                            name,
                            value,
                            last_updated_at,
-                           author
+                           author,
+                           source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
@@ -2633,7 +2658,7 @@ class TraceDAOImpl implements TraceDAO {
                       <endif>
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), span_feedback_scores_with_trace_id AS (
                 SELECT workspace_id,
                        project_id,
@@ -2641,7 +2666,8 @@ class TraceDAOImpl implements TraceDAO {
                        name,
                        value,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM span_feedback_scores_deduped sfs
                 INNER JOIN spans_data s ON sfs.entity_id = s.id
             ), span_feedback_scores_grouped AS (

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -478,7 +478,8 @@ class TraceDAOImpl implements TraceDAO {
                        last_updated_by,
                        created_at,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM (
                     SELECT workspace_id,
                            project_id,
@@ -492,7 +493,8 @@ class TraceDAOImpl implements TraceDAO {
                            last_updated_by,
                            created_at,
                            last_updated_at,
-                       feedback_scores.last_updated_by AS author
+                       feedback_scores.last_updated_by AS author,
+                       CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
@@ -512,7 +514,8 @@ class TraceDAOImpl implements TraceDAO {
                         last_updated_by,
                         created_at,
                         last_updated_at,
-                        author
+                        author,
+                        source_queue_id
                    FROM authored_feedback_scores
                    WHERE entity_type = 'trace'
                      AND workspace_id = :workspace_id
@@ -520,7 +523,7 @@ class TraceDAOImpl implements TraceDAO {
                      AND entity_id IN :ids
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
              ),
              feedback_scores_grouped AS (
                  SELECT
@@ -528,7 +531,7 @@ class TraceDAOImpl implements TraceDAO {
                      project_id,
                      entity_id,
                      name,
-                     groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at)) AS entries
+                     groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at, source_queue_id)) AS entries
                  FROM feedback_scores_deduped
                  GROUP BY workspace_id, project_id, entity_id, name
              ), feedback_scores_final AS (
@@ -542,8 +545,8 @@ class TraceDAOImpl implements TraceDAO {
                      IF(length(entries) = 1, entries[1].2, arrayStringConcat(arrayMap(e -> if(e.2 = '', '\\<no reason>', e.2), entries), ', ')) AS reason,
                      entries[1].4 AS source,
                      mapFromArrays(
-                             arrayMap(e -> e.5, entries),
-                             arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9), entries)
+                             arrayMap(e -> if(e.10 = '', e.5, concat(e.5, '_', toString(e.10))), entries),
+                             arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, '', '', e.10, e.5), entries)
                      ) AS value_by_author,
                      arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                      arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,
@@ -565,7 +568,8 @@ class TraceDAOImpl implements TraceDAO {
                        last_updated_by,
                        created_at,
                        last_updated_at,
-                       author
+                       author,
+                       source_queue_id
                 FROM (
                     SELECT fs.workspace_id,
                            fs.project_id,
@@ -581,7 +585,8 @@ class TraceDAOImpl implements TraceDAO {
                            fs.last_updated_by,
                            fs.created_at,
                            fs.last_updated_at,
-                           fs.last_updated_by AS author
+                           fs.last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores AS fs
                     INNER JOIN target_spans s ON fs.entity_id = s.id
                     WHERE fs.entity_type = 'span'
@@ -602,7 +607,8 @@ class TraceDAOImpl implements TraceDAO {
                            afs.last_updated_by,
                            afs.created_at,
                            afs.last_updated_at,
-                           afs.author
+                           afs.author,
+                           afs.source_queue_id
                     FROM authored_feedback_scores AS afs
                     INNER JOIN target_spans s ON afs.entity_id = s.id
                     WHERE afs.entity_type = 'span'
@@ -610,14 +616,14 @@ class TraceDAOImpl implements TraceDAO {
                     <if(has_target_projects)>AND afs.project_id IN :target_project_ids<endif>
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, span_id, name, author
+                LIMIT 1 BY workspace_id, project_id, span_id, name, author, source_queue_id
             ), span_feedback_scores_grouped AS (
                 SELECT
                     workspace_id,
                     project_id,
                     trace_id,
                     name,
-                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at, span_type, span_id)) AS entries
+                    groupArray(tuple(value, reason, category_name, source, author, created_by, last_updated_by, created_at, last_updated_at, span_type, span_id, source_queue_id)) AS entries
                 FROM span_feedback_scores_deduped
                 GROUP BY workspace_id, project_id, trace_id, name
             ), span_feedback_scores_final AS (
@@ -637,8 +643,8 @@ class TraceDAOImpl implements TraceDAO {
                     ) AS reason,
                     entries[1].4 AS source,
                     mapFromArrays(
-                            arrayMap(e -> if(e.11 IS NULL OR e.11 = '', e.5, concat(e.5, '_', toString(e.11))), entries),
-                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, e.10, e.11), entries)
+                            arrayMap(e -> concat(e.5, if(e.12 = '', '', concat('_', toString(e.12))), if(e.11 IS NULL OR e.11 = '', '', concat('_', toString(e.11)))), entries),
+                            arrayMap(e -> tuple(e.1, e.2, e.3, e.4, e.9, e.10, e.11, e.12, e.5), entries)
                     ) AS value_by_author,
                     arrayStringConcat(arrayMap(e -> e.6, entries), ', ') AS created_by,
                     arrayStringConcat(arrayMap(e -> e.7, entries), ', ') AS last_updated_by,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -453,9 +453,12 @@ class TraceDAOImpl implements TraceDAO {
             ;
             """;
 
-    // Build value_by_author map with composite keys for feedback scores.
-    // Key format: author + optional _queueId + optional _spanId (ensures uniqueness across queues/spans).
-    // Value tuple: (value, reason, category_name, source, last_updated_at, span_type, span_id, source_queue_id, author)
+    /**
+     * Builds the {@code value_by_author} map with composite keys for feedback scores.
+     * Key format: {@code author} + optional {@code _queueId} + optional {@code _spanId} (ensures uniqueness across
+     * queues/spans). Value tuple: (value, reason, category_name, source, last_updated_at, span_type, span_id,
+     * source_queue_id, author).
+     */
     private static final String SELECT_BY_IDS = """
             WITH target_spans AS (
                 SELECT id, trace_id, type

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -741,6 +741,7 @@ class TraceDAOImpl implements TraceDAO {
                             last_updated_at,
                             created_by,
                             last_updated_by,
+                            source_queue_id,
                             entity_id
                         FROM comments
                         WHERE workspace_id = :workspace_id
@@ -1158,7 +1159,7 @@ class TraceDAOImpl implements TraceDAO {
             ), comments_agg AS (
                 SELECT
                     entity_id,
-                    groupArray(tuple(id, text, created_at, last_updated_at, created_by, last_updated_by)) AS comments_array
+                    groupArray(tuple(id, text, created_at, last_updated_at, created_by, last_updated_by, source_queue_id)) AS comments_array
                 FROM (
                     SELECT
                         id,
@@ -1167,6 +1168,7 @@ class TraceDAOImpl implements TraceDAO {
                         last_updated_at,
                         created_by,
                         last_updated_by,
+                        source_queue_id,
                         entity_id,
                         workspace_id,
                         project_id

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
@@ -768,7 +768,8 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                     last_updated_by,
                     created_at,
                     last_updated_at,
-                    author
+                    author,
+                    source_queue_id
                 FROM (
                     SELECT
                         workspace_id,
@@ -783,7 +784,8 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                         last_updated_by,
                         created_at,
                         last_updated_at,
-                        feedback_scores.last_updated_by AS author
+                        feedback_scores.last_updated_by AS author,
+                        CAST('' AS FixedString(36)) AS source_queue_id
                     FROM feedback_scores
                     WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
@@ -803,7 +805,8 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                         last_updated_by,
                         created_at,
                         last_updated_at,
-                        author
+                        author,
+                        source_queue_id
                     FROM authored_feedback_scores
                     WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
@@ -811,12 +814,12 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                     AND entity_id IN :trace_ids
                 )
                 ORDER BY last_updated_at DESC
-                LIMIT 1 BY workspace_id, project_id, entity_id, name, author
+                LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_grouped_agg AS (
                 SELECT
                     entity_id,
                     name,
-                    count(DISTINCT author) AS n,
+                    count(*) AS n,
                     avg(value) AS avg_value,
                     any(value) AS any_value,
                     any(reason) AS any_reason,
@@ -828,8 +831,8 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                     min(created_at) AS created_at_min,
                     max(last_updated_at) AS last_updated_at_max,
                     mapFromArrays(
-                        groupArray(author),
-                        groupArray(tuple(value, reason, category_name, source, last_updated_at))
+                        groupArray(if(source_queue_id = '', author, concat(author, '_', toString(source_queue_id)))),
+                        groupArray(tuple(value, reason, category_name, source, last_updated_at, '', '', source_queue_id, author))
                     ) AS value_by_author
                 FROM feedback_scores_deduped
                 GROUP BY entity_id, name

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
@@ -315,7 +315,7 @@ class MultiValueFeedbackScoresE2ETest {
                     .ignoringFields("createdAt", "lastUpdatedAt", "createdBy", "lastUpdatedBy",
                             "sourceQueueId", "valueByAuthor")
                     .isEqualTo(score);
-            assertThat(actual.valueByAuthor().keySet()).containsExactly(USER1);
+            assertThat(actual.valueByAuthor().keySet()).containsExactly(USER1 + "_" + queueIdA);
         });
 
         // Delete scoped to correct queue A — should remove the score
@@ -627,7 +627,7 @@ class MultiValueFeedbackScoresE2ETest {
                     .ignoringFields("createdAt", "lastUpdatedAt", "createdBy", "lastUpdatedBy",
                             "sourceQueueId", "valueByAuthor")
                     .isEqualTo(score);
-            assertThat(actual.valueByAuthor().keySet()).containsExactly(USER1);
+            assertThat(actual.valueByAuthor().keySet()).containsExactly(USER1 + "_" + queueIdA);
         });
 
         // Delete scoped to correct queue A — should remove the score

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
@@ -95,6 +95,8 @@ class MultiValueFeedbackScoresE2ETest {
     private static final String WORKSPACE_ID = randomUUID().toString();
     private static final String TEST_WORKSPACE = randomUUID().toString();
     private static final String EMPTY_REASON_PLACEHOLDER = "<no reason>";
+    private static final String[] IGNORED_FEEDBACK_SCORE_FIELDS = {"createdAt", "lastUpdatedAt", "createdBy",
+            "lastUpdatedBy", "sourceQueueId", "valueByAuthor"};
 
     private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
     private final MySQLContainer MYSQL_CONTAINER = MySQLContainerUtils.newMySQLContainer();
@@ -312,10 +314,11 @@ class MultiValueFeedbackScoresE2ETest {
             assertThat(actual)
                     .usingRecursiveComparison()
                     .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
-                    .ignoringFields("createdAt", "lastUpdatedAt", "createdBy", "lastUpdatedBy",
-                            "sourceQueueId", "valueByAuthor")
+                    .ignoringFields(IGNORED_FEEDBACK_SCORE_FIELDS)
                     .isEqualTo(score);
             assertThat(actual.valueByAuthor().keySet()).containsExactly(USER1 + "_" + queueIdA);
+            assertThat(actual.valueByAuthor().get(USER1 + "_" + queueIdA).sourceQueueId())
+                    .isEqualTo(queueIdA.toString());
         });
 
         // Delete scoped to correct queue A — should remove the score
@@ -330,7 +333,7 @@ class MultiValueFeedbackScoresE2ETest {
 
     @Test
     @DisplayName("same author scores from two queues: both visible with correct average")
-    void testSameAuthorTwoQueuesProducesAverage() {
+    void sameAuthorTwoQueuesProducesAverage() {
         var trace = factory.manufacturePojo(Trace.class).toBuilder()
                 .id(null)
                 .projectName(DEFAULT_PROJECT)
@@ -624,10 +627,11 @@ class MultiValueFeedbackScoresE2ETest {
             assertThat(actual)
                     .usingRecursiveComparison()
                     .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
-                    .ignoringFields("createdAt", "lastUpdatedAt", "createdBy", "lastUpdatedBy",
-                            "sourceQueueId", "valueByAuthor")
+                    .ignoringFields(IGNORED_FEEDBACK_SCORE_FIELDS)
                     .isEqualTo(score);
             assertThat(actual.valueByAuthor().keySet()).containsExactly(USER1 + "_" + queueIdA);
+            assertThat(actual.valueByAuthor().get(USER1 + "_" + queueIdA).sourceQueueId())
+                    .isEqualTo(queueIdA.toString());
         });
 
         // Delete scoped to correct queue A — should remove the score
@@ -1233,12 +1237,17 @@ class MultiValueFeedbackScoresE2ETest {
     }
 
     private void assertAuthorValue(Map<String, ValueEntry> valueByAuthor, String author, FeedbackScore expected) {
-        assertThat(valueByAuthor.get(author).categoryName()).isEqualTo(expected.categoryName());
-        assertThat(valueByAuthor.get(author).value())
-                .usingComparator(StatsUtils::bigDecimalComparator)
-                .isEqualTo(expected.value());
-        assertThat(valueByAuthor.get(author).reason()).isEqualTo(expected.reason());
-        assertThat(valueByAuthor.get(author).source()).isEqualTo(expected.source());
+        var expectedEntry = ValueEntry.builder()
+                .value(expected.value())
+                .reason(expected.reason())
+                .categoryName(expected.categoryName())
+                .source(expected.source())
+                .build();
+        assertThat(valueByAuthor.get(author))
+                .usingRecursiveComparison()
+                .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
+                .ignoringFields("lastUpdatedAt", "spanType", "spanId", "sourceQueueId", "author")
+                .isEqualTo(expectedEntry);
     }
 
     private BigDecimal calcAverage(List<BigDecimal> scores) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MultiValueFeedbackScoresE2ETest.java
@@ -329,6 +329,55 @@ class MultiValueFeedbackScoresE2ETest {
     }
 
     @Test
+    @DisplayName("same author scores from two queues: both visible with correct average")
+    void testSameAuthorTwoQueuesProducesAverage() {
+        var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                .id(null)
+                .projectName(DEFAULT_PROJECT)
+                .usage(null)
+                .feedbackScores(null)
+                .startTime(Instant.now().truncatedTo(ChronoUnit.HOURS))
+                .build();
+        var traceId = traceResourceClient.createTrace(trace, API_KEY1, TEST_WORKSPACE);
+
+        var queueIdA = randomUUID();
+        var queueIdB = randomUUID();
+        var scoreName = randomUUID().toString();
+
+        var scoreFromQueueA = factory.manufacturePojo(FeedbackScore.class).toBuilder()
+                .name(scoreName)
+                .value(BigDecimal.valueOf(87))
+                .sourceQueueId(queueIdA)
+                .build();
+        traceResourceClient.feedbackScore(traceId, scoreFromQueueA, TEST_WORKSPACE, API_KEY1);
+
+        var scoreFromQueueB = factory.manufacturePojo(FeedbackScore.class).toBuilder()
+                .name(scoreName)
+                .value(BigDecimal.valueOf(33))
+                .sourceQueueId(queueIdB)
+                .build();
+        traceResourceClient.feedbackScore(traceId, scoreFromQueueB, TEST_WORKSPACE, API_KEY1);
+
+        var actualTrace = traceResourceClient.getById(traceId, TEST_WORKSPACE, API_KEY1);
+        assertThat(actualTrace.feedbackScores()).hasSize(1);
+
+        var actualScore = actualTrace.feedbackScores().getFirst();
+        assertThat(actualScore.name()).isEqualTo(scoreName);
+        assertThat(actualScore.value()).usingComparator(StatsUtils::bigDecimalComparator)
+                .isEqualTo(BigDecimal.valueOf(60));
+
+        var queueAKey = USER1 + "_" + queueIdA;
+        var queueBKey = USER1 + "_" + queueIdB;
+        assertThat(actualScore.valueByAuthor())
+                .hasSize(2)
+                .containsOnlyKeys(queueAKey, queueBKey);
+        assertAuthorValue(actualScore.valueByAuthor(), queueAKey, scoreFromQueueA);
+        assertAuthorValue(actualScore.valueByAuthor(), queueBKey, scoreFromQueueB);
+        assertThat(actualScore.valueByAuthor().get(queueAKey).author()).isEqualTo(USER1);
+        assertThat(actualScore.valueByAuthor().get(queueBKey).author()).isEqualTo(USER1);
+    }
+
+    @Test
     @DisplayName("test score span by multiple authors")
     void testScoreSpanByMultipleAuthors() {
         // create spans

--- a/apps/opik-backend/src/test/java/com/comet/opik/podam/PodamFactoryUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/podam/PodamFactoryUtils.java
@@ -3,6 +3,9 @@ package com.comet.opik.podam;
 import com.comet.opik.api.DatasetItem;
 import com.comet.opik.api.ExperimentItem;
 import com.comet.opik.api.ExperimentType;
+import com.comet.opik.api.FeedbackScore;
+import com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
+import com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItemThread;
 import com.comet.opik.api.Guardrail;
 import com.comet.opik.api.Project;
 import com.comet.opik.api.PromptVersion;
@@ -17,6 +20,7 @@ import com.comet.opik.podam.manufacturer.BigDecimalTypeManufacturer;
 import com.comet.opik.podam.manufacturer.CategoricalFeedbackDetailTypeManufacturer;
 import com.comet.opik.podam.manufacturer.DatasetItemTypeManufacturer;
 import com.comet.opik.podam.manufacturer.ExperimentItemTypeManufacturer;
+import com.comet.opik.podam.manufacturer.FeedbackScoreTypeManufacturer;
 import com.comet.opik.podam.manufacturer.GuardrailCheckTypeManufacturer;
 import com.comet.opik.podam.manufacturer.JsonNodeTypeManufacturer;
 import com.comet.opik.podam.manufacturer.LlmAsJudgeMessageContentManufacturer;
@@ -96,6 +100,10 @@ public class PodamFactoryUtils {
         strategy.addOrReplaceTypeManufacturer(LlmAsJudgeMessageContent.class,
                 LlmAsJudgeMessageContentManufacturer.INSTANCE);
         strategy.addOrReplaceTypeManufacturer(LlmAsJudgeMessage.class, LlmAsJudgeMessageManufacturer.INSTANCE);
+        strategy.addOrReplaceTypeManufacturer(FeedbackScore.class, FeedbackScoreTypeManufacturer.SCORE);
+        strategy.addOrReplaceTypeManufacturer(FeedbackScoreBatchItem.class, FeedbackScoreTypeManufacturer.BATCH_ITEM);
+        strategy.addOrReplaceTypeManufacturer(FeedbackScoreBatchItemThread.class,
+                FeedbackScoreTypeManufacturer.BATCH_ITEM_THREAD);
 
         return podamFactory;
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/podam/manufacturer/FeedbackScoreTypeManufacturer.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/podam/manufacturer/FeedbackScoreTypeManufacturer.java
@@ -1,0 +1,70 @@
+package com.comet.opik.podam.manufacturer;
+
+import com.comet.opik.api.FeedbackScore;
+import com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
+import com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItemThread;
+import com.comet.opik.api.ScoreSource;
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.common.ManufacturingContext;
+import uk.co.jemos.podam.typeManufacturers.AbstractTypeManufacturer;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * sourceQueueId must be null by default — only set explicitly for queue-scoped tests.
+ * PODAM's UUIDTypeManufacturer can't distinguish field names reliably, so we manufacture
+ * these types explicitly.
+ */
+public class FeedbackScoreTypeManufacturer {
+
+    public static final AbstractTypeManufacturer<FeedbackScore> SCORE = new AbstractTypeManufacturer<>() {
+        @Override
+        public FeedbackScore getType(DataProviderStrategy strategy, AttributeMetadata metadata,
+                ManufacturingContext context) {
+            return FeedbackScore.builder()
+                    .name(strategy.getTypeValue(metadata, context, String.class))
+                    .categoryName(strategy.getTypeValue(metadata, context, String.class))
+                    .value(strategy.getTypeValue(metadata, context, BigDecimal.class))
+                    .reason(strategy.getTypeValue(metadata, context, String.class))
+                    .source(ScoreSource.values()[Math.abs(
+                            strategy.getTypeValue(metadata, context, Integer.class)) % ScoreSource.values().length])
+                    .build();
+        }
+    };
+
+    public static final AbstractTypeManufacturer<FeedbackScoreBatchItem> BATCH_ITEM = new AbstractTypeManufacturer<>() {
+        @Override
+        public FeedbackScoreBatchItem getType(DataProviderStrategy strategy, AttributeMetadata metadata,
+                ManufacturingContext context) {
+            return FeedbackScoreBatchItem.builder()
+                    .id(strategy.getTypeValue(metadata, context, UUID.class))
+                    .projectName(strategy.getTypeValue(metadata, context, String.class))
+                    .name(strategy.getTypeValue(metadata, context, String.class))
+                    .categoryName(strategy.getTypeValue(metadata, context, String.class))
+                    .value(strategy.getTypeValue(metadata, context, BigDecimal.class))
+                    .reason(strategy.getTypeValue(metadata, context, String.class))
+                    .source(ScoreSource.values()[Math.abs(
+                            strategy.getTypeValue(metadata, context, Integer.class)) % ScoreSource.values().length])
+                    .build();
+        }
+    };
+
+    public static final AbstractTypeManufacturer<FeedbackScoreBatchItemThread> BATCH_ITEM_THREAD = new AbstractTypeManufacturer<>() {
+        @Override
+        public FeedbackScoreBatchItemThread getType(DataProviderStrategy strategy, AttributeMetadata metadata,
+                ManufacturingContext context) {
+            return FeedbackScoreBatchItemThread.builder()
+                    .threadId(strategy.getTypeValue(metadata, context, String.class))
+                    .projectName(strategy.getTypeValue(metadata, context, String.class))
+                    .name(strategy.getTypeValue(metadata, context, String.class))
+                    .categoryName(strategy.getTypeValue(metadata, context, String.class))
+                    .value(strategy.getTypeValue(metadata, context, BigDecimal.class))
+                    .reason(strategy.getTypeValue(metadata, context, String.class))
+                    .source(ScoreSource.values()[Math.abs(
+                            strategy.getTypeValue(metadata, context, Integer.class)) % ScoreSource.values().length])
+                    .build();
+        }
+    };
+}

--- a/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreDeleteMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreDeleteMutation.ts
@@ -72,7 +72,11 @@ const useTraceFeedbackScoreDeleteMutation = () => {
       };
 
       const authorToUse = params.author ?? currentUserName;
-      const deleteMutation = generateDeleteMutation(params.name, authorToUse);
+      const deleteMutation = generateDeleteMutation(
+        params.name,
+        authorToUse,
+        params.sourceQueueId,
+      );
 
       if (params.spanId) {
         const spanId = params.spanId; // TypeScript guard: ensure spanId is defined

--- a/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreSetMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreSetMutation.ts
@@ -87,6 +87,7 @@ const useTraceFeedbackScoreSetMutation = () => {
           reason: params.reason,
         },
         currentUserName,
+        params.sourceQueueId,
       );
 
       if (params.spanId) {

--- a/apps/opik-frontend/src/hooks/useFeedbackScoreSourceLabel.ts
+++ b/apps/opik-frontend/src/hooks/useFeedbackScoreSourceLabel.ts
@@ -1,0 +1,46 @@
+import { AxiosError, HttpStatusCode } from "axios";
+import useAnnotationQueueById from "@/api/annotation-queues/useAnnotationQueueById";
+import { FEEDBACK_SCORE_SOURCE_MAP } from "@/lib/feedback-scores";
+import { FEEDBACK_SCORE_TYPE } from "@/types/traces";
+
+export type FeedbackScoreSource = {
+  isLoading: boolean;
+  queueId?: string;
+  label: string;
+};
+
+const useFeedbackScoreSourceLabel = (
+  sourceQueueId: string | undefined,
+  source: FEEDBACK_SCORE_TYPE,
+): FeedbackScoreSource => {
+  const {
+    data: queue,
+    isLoading,
+    error,
+  } = useAnnotationQueueById(
+    { annotationQueueId: sourceQueueId ?? "" },
+    { enabled: !!sourceQueueId },
+  );
+
+  if (!sourceQueueId) {
+    return { isLoading: false, label: FEEDBACK_SCORE_SOURCE_MAP[source] };
+  }
+
+  if (queue?.name) {
+    return { isLoading: false, queueId: sourceQueueId, label: queue.name };
+  }
+
+  if (isLoading) {
+    return { isLoading: true, label: "" };
+  }
+
+  if (
+    (error as AxiosError | null)?.response?.status === HttpStatusCode.NotFound
+  ) {
+    return { isLoading: false, label: "<deleted queue>" };
+  }
+
+  return { isLoading: false, label: "<unknown queue>" };
+};
+
+export default useFeedbackScoreSourceLabel;

--- a/apps/opik-frontend/src/lib/annotation-queues.ts
+++ b/apps/opik-frontend/src/lib/annotation-queues.ts
@@ -119,7 +119,9 @@ export const getCommentsByUser = (
 
   return comments
     .filter((comment) => comment.created_by === userName)
-    .filter((comment) => !sourceQueueId || comment.source_queue_id === sourceQueueId)
+    .filter(
+      (comment) => !sourceQueueId || comment.source_queue_id === sourceQueueId,
+    )
     .map((comment) => comment.text);
 };
 

--- a/apps/opik-frontend/src/lib/annotation-queues.ts
+++ b/apps/opik-frontend/src/lib/annotation-queues.ts
@@ -5,7 +5,11 @@ import isNumber from "lodash/isNumber";
 import omit from "lodash/omit";
 import { isObjectThread } from "@/lib/traces";
 import { CommentItem, CommentItems } from "@/types/comment";
-import { findValueByAuthor, hasValuesByAuthor } from "@/lib/feedback-scores";
+import {
+  findValueByAuthor,
+  hasAnyValueByAuthor,
+  hasValuesByAuthor,
+} from "@/lib/feedback-scores";
 import { formatDate } from "@/lib/date";
 
 export const DEFAULT_LOCK_TIMEOUT_SECONDS = 300;
@@ -52,6 +56,7 @@ export const getFeedbackScoresByUser = (
   feedbackScores: TraceFeedbackScore[],
   userName: string | undefined,
   feedbackDefinitionNames: string[],
+  sourceQueueId?: string,
 ): TraceFeedbackScore[] => {
   if (!userName) return [];
 
@@ -65,6 +70,7 @@ export const getFeedbackScoresByUser = (
         const userValue = findValueByAuthor(
           feedbackScore.value_by_author,
           userName,
+          sourceQueueId,
         );
         if (userValue) {
           const rawValue = userValue.value;
@@ -137,7 +143,7 @@ export const isItemProcessedByUser = (
   const hasFeedbackScores = (item.feedback_scores || []).some((score) => {
     if (!feedbackScoreNames.includes(score.name)) return false;
     return hasValuesByAuthor(score)
-      ? Boolean(findValueByAuthor(score.value_by_author, userName))
+      ? hasAnyValueByAuthor(score.value_by_author, userName)
       : score.last_updated_by === userName;
   });
 

--- a/apps/opik-frontend/src/lib/annotation-queues.ts
+++ b/apps/opik-frontend/src/lib/annotation-queues.ts
@@ -113,11 +113,13 @@ export const getLastCommentByUser = (
 export const getCommentsByUser = (
   comments: CommentItems | undefined,
   userName: string | undefined,
+  sourceQueueId?: string,
 ): string[] => {
   if (!comments || !userName) return [];
 
   return comments
     .filter((comment) => comment.created_by === userName)
+    .filter((comment) => !sourceQueueId || comment.source_queue_id === sourceQueueId)
     .map((comment) => comment.text);
 };
 

--- a/apps/opik-frontend/src/lib/feedback-scores.tsx
+++ b/apps/opik-frontend/src/lib/feedback-scores.tsx
@@ -328,13 +328,18 @@ export const setTraceSpanFeedbackScoresCache = async (
   });
 };
 
+const buildValueByAuthorKey = (
+  author?: string,
+  sourceQueueId?: string,
+): string | undefined =>
+  author && sourceQueueId ? `${author}_${sourceQueueId}` : author;
+
 export const generateUpdateMutation =
   (score: TraceFeedbackScore, author?: string, sourceQueueId?: string) =>
   (feedbackScores?: TraceFeedbackScore[]) => {
     let retVal = feedbackScores || [];
 
-    const mapKey =
-      author && sourceQueueId ? `${author}_${sourceQueueId}` : author;
+    const mapKey = buildValueByAuthorKey(author, sourceQueueId);
 
     let isUpdated = false;
     retVal = retVal.map((feedbackScore) => {
@@ -388,13 +393,13 @@ export const generateDeleteMutation =
       return retVal.filter((feedbackScore) => feedbackScore.name !== name);
     }
 
-    const mapKey = sourceQueueId ? `${author}_${sourceQueueId}` : author;
+    const mapKey = buildValueByAuthorKey(author, sourceQueueId);
 
     return retVal
       .map((feedbackScore) => {
         if (feedbackScore.name === name && hasValuesByAuthor(feedbackScore)) {
           const updatedValueByAuthor = { ...feedbackScore.value_by_author };
-          delete updatedValueByAuthor[mapKey];
+          delete updatedValueByAuthor[mapKey!];
 
           if (Object.keys(updatedValueByAuthor).length === 0) {
             return null;

--- a/apps/opik-frontend/src/lib/feedback-scores.tsx
+++ b/apps/opik-frontend/src/lib/feedback-scores.tsx
@@ -64,32 +64,46 @@ export function findValueByAuthor(
   value_by_author: FeedbackScoreValueByAuthorMap | undefined,
   userName: string,
   sourceQueueId?: string,
+  options?: { prefixMatch?: boolean },
 ): FeedbackScoreValueByAuthorMap[string] | undefined {
   if (!value_by_author || !userName) {
     return undefined;
   }
+
+  const { prefixMatch = false } = options ?? {};
 
   if (sourceQueueId) {
     const compositeKey = `${userName}_${sourceQueueId}`;
     if (value_by_author[compositeKey]) {
       return value_by_author[compositeKey];
     }
-    // Try with span suffix: userName_queueId_spanId
     const matchingKey = Object.keys(value_by_author).find((key) =>
       key.startsWith(`${compositeKey}_`),
     );
     return matchingKey ? value_by_author[matchingKey] : undefined;
   }
 
-  // No sourceQueueId: try exact match, then prefix
   if (value_by_author[userName]) {
     return value_by_author[userName];
+  }
+
+  if (!prefixMatch) {
+    return undefined;
   }
 
   const matchingKey = Object.keys(value_by_author).find((key) =>
     key.startsWith(`${userName}_`),
   );
   return matchingKey ? value_by_author[matchingKey] : undefined;
+}
+
+export function hasAnyValueByAuthor(
+  value_by_author: FeedbackScoreValueByAuthorMap | undefined,
+  userName: string,
+): boolean {
+  return !!findValueByAuthor(value_by_author, userName, undefined, {
+    prefixMatch: true,
+  });
 }
 
 export const setExperimentsCompareCache = async (

--- a/apps/opik-frontend/src/lib/feedback-scores.tsx
+++ b/apps/opik-frontend/src/lib/feedback-scores.tsx
@@ -449,8 +449,8 @@ export const extractReasonsFromValueByAuthor = (
   if (!valueByAuthor) return [];
 
   return Object.entries(valueByAuthor)
-    .map(([author, { reason, last_updated_at, value }]) => ({
-      author,
+    .map(([key, { author, reason, last_updated_at, value }]) => ({
+      author: author ?? key,
       reason: reason || "",
       lastUpdatedAt: last_updated_at,
       value,

--- a/apps/opik-frontend/src/lib/feedback-scores.tsx
+++ b/apps/opik-frontend/src/lib/feedback-scores.tsx
@@ -57,30 +57,39 @@ export function hasValuesByAuthor(
 
 /**
  * Finds a value in value_by_author by userName, handling both regular keys (userName)
- * and composite keys (userName_spanId) used for span feedback scores.
+ * and composite keys (userName_queueId, userName_spanId, userName_queueId_spanId).
+ * When sourceQueueId is provided, looks for the entry from that specific queue.
  */
 export function findValueByAuthor(
   value_by_author: FeedbackScoreValueByAuthorMap | undefined,
   userName: string,
+  sourceQueueId?: string,
 ): FeedbackScoreValueByAuthorMap[string] | undefined {
   if (!value_by_author || !userName) {
     return undefined;
   }
 
-  // First try exact match
+  if (sourceQueueId) {
+    const compositeKey = `${userName}_${sourceQueueId}`;
+    if (value_by_author[compositeKey]) {
+      return value_by_author[compositeKey];
+    }
+    // Try with span suffix: userName_queueId_spanId
+    const matchingKey = Object.keys(value_by_author).find((key) =>
+      key.startsWith(`${compositeKey}_`),
+    );
+    return matchingKey ? value_by_author[matchingKey] : undefined;
+  }
+
+  // No sourceQueueId: try exact match, then prefix
   if (value_by_author[userName]) {
     return value_by_author[userName];
   }
 
-  // Then try composite keys (userName_spanId)
   const matchingKey = Object.keys(value_by_author).find((key) =>
     key.startsWith(`${userName}_`),
   );
-  if (matchingKey) {
-    return value_by_author[matchingKey];
-  }
-
-  return undefined;
+  return matchingKey ? value_by_author[matchingKey] : undefined;
 }
 
 export const setExperimentsCompareCache = async (
@@ -306,24 +315,28 @@ export const setTraceSpanFeedbackScoresCache = async (
 };
 
 export const generateUpdateMutation =
-  (score: TraceFeedbackScore, author?: string) =>
+  (score: TraceFeedbackScore, author?: string, sourceQueueId?: string) =>
   (feedbackScores?: TraceFeedbackScore[]) => {
     let retVal = feedbackScores || [];
+
+    const mapKey =
+      author && sourceQueueId ? `${author}_${sourceQueueId}` : author;
 
     let isUpdated = false;
     retVal = retVal.map((feedbackScore) => {
       if (feedbackScore.name === score.name) {
         isUpdated = true;
 
-        if (hasValuesByAuthor(feedbackScore) && author) {
+        if (hasValuesByAuthor(feedbackScore) && mapKey) {
           const updatedValueByAuthor: FeedbackScoreValueByAuthorMap = {
             ...feedbackScore.value_by_author,
-            [author]: {
+            [mapKey]: {
               value: score.value,
               reason: score.reason,
               category_name: score.category_name,
               source: score.source || FEEDBACK_SCORE_TYPE.ui,
               last_updated_at: new Date().toISOString(),
+              source_queue_id: sourceQueueId,
             },
           };
 
@@ -354,18 +367,20 @@ export const generateUpdateMutation =
   };
 
 export const generateDeleteMutation =
-  (name: string, author?: string) =>
+  (name: string, author?: string, sourceQueueId?: string) =>
   (feedbackScores?: TraceFeedbackScore[]): TraceFeedbackScore[] => {
     const retVal = feedbackScores || [];
     if (!author) {
       return retVal.filter((feedbackScore) => feedbackScore.name !== name);
     }
 
+    const mapKey = sourceQueueId ? `${author}_${sourceQueueId}` : author;
+
     return retVal
       .map((feedbackScore) => {
         if (feedbackScore.name === name && hasValuesByAuthor(feedbackScore)) {
           const updatedValueByAuthor = { ...feedbackScore.value_by_author };
-          delete updatedValueByAuthor[author];
+          delete updatedValueByAuthor[mapKey];
 
           if (Object.keys(updatedValueByAuthor).length === 0) {
             return null;

--- a/apps/opik-frontend/src/shared/DataTableCells/FeedbackScoreCellValue.tsx
+++ b/apps/opik-frontend/src/shared/DataTableCells/FeedbackScoreCellValue.tsx
@@ -13,8 +13,6 @@ import {
   getCategoricFeedbackScoreValuesMap,
   getIsCategoricFeedbackScore,
 } from "@/shared/FeedbackScoreTag/utils";
-import { isAggregatedScore, getTrialAvgTooltip } from "@/lib/trials";
-import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import useWorkspaceColorMap from "@/hooks/useWorkspaceColorMap";
 
 const MAX_DISPLAY_CATEGORIES = 2;
@@ -42,14 +40,14 @@ const FeedbackScoreCellValue = ({
   feedbackScore,
   color: customColor,
   onValueChange,
-  showTooltip = false,
+  footer,
   size = "md",
 }: {
   isUserFeedbackColumn?: boolean;
   feedbackScore?: TraceFeedbackScore;
   color?: string;
   onValueChange?: (name: string, value: number) => void;
-  showTooltip?: boolean;
+  footer?: string;
   size?: "sm" | "md";
 }) => {
   const { getColor } = useWorkspaceColorMap();
@@ -86,24 +84,12 @@ const FeedbackScoreCellValue = ({
   const isMultiValue = getIsMultiValueFeedbackScore(valueByAuthor);
   const formattedValue = formatScoreDisplay(value);
 
-  const displayText = isMultiValue && valueByAuthor
-    ? formatMultiValueDisplay(valueByAuthor, category, value)
-    : category
-      ? `${category} (${formattedValue})`
-      : String(formattedValue);
-
-  const tooltipContent = (() => {
-    if (!showTooltip) return undefined;
-    const fullPrecision = category ? `${category} (${value})` : String(value);
-    if (isAggregatedScore(feedbackScore)) {
-      const trialInfo = getTrialAvgTooltip(
-        feedbackScore.trialValues.length,
-        feedbackScore.stdDev,
-      );
-      return `${fullPrecision} | ${trialInfo}`;
-    }
-    return fullPrecision;
-  })();
+  const displayText =
+    isMultiValue && valueByAuthor
+      ? formatMultiValueDisplay(valueByAuthor, category, value)
+      : category
+        ? `${category} (${formattedValue})`
+        : String(formattedValue);
 
   return (
     <div className="flex min-w-0 shrink-0 items-center gap-1 overflow-hidden">
@@ -114,27 +100,20 @@ const FeedbackScoreCellValue = ({
           size={size}
         />
       )}
-      {showTooltip ? (
-        <TooltipWrapper content={tooltipContent}>
-          <div className={size === "sm" ? "truncate" : "break-words"}>
-            {displayText}
-          </div>
-        </TooltipWrapper>
-      ) : (
-        <MultiValueFeedbackScoreHoverCard
-          color={color}
-          valueByAuthor={valueByAuthor}
-          label={label}
-          value={value}
-          category={category}
-          open={openHoverCard}
-          onOpenChange={setOpenHoverCard}
-        >
-          <div className={size === "sm" ? "truncate" : "break-words"}>
-            {displayText}
-          </div>
-        </MultiValueFeedbackScoreHoverCard>
-      )}
+      <MultiValueFeedbackScoreHoverCard
+        color={color}
+        valueByAuthor={valueByAuthor}
+        label={label}
+        value={value}
+        category={category}
+        footer={footer}
+        open={openHoverCard}
+        onOpenChange={setOpenHoverCard}
+      >
+        <div className={size === "sm" ? "truncate" : "break-words"}>
+          {displayText}
+        </div>
+      </MultiValueFeedbackScoreHoverCard>
     </div>
   );
 };

--- a/apps/opik-frontend/src/shared/DataTableCells/FeedbackScoreCellValue.tsx
+++ b/apps/opik-frontend/src/shared/DataTableCells/FeedbackScoreCellValue.tsx
@@ -1,27 +1,55 @@
 import MultiValueFeedbackScoreHoverCard from "../FeedbackScoreTag/MultiValueFeedbackScoreHoverCard";
-import { TraceFeedbackScore } from "@/types/traces";
+import {
+  FeedbackScoreValueByAuthorMap,
+  TraceFeedbackScore,
+} from "@/types/traces";
 import { useState } from "react";
 import FeedbackScoreEditDropdown from "./FeedbackScoreEditDropdown";
 import {
   formatScoreDisplay,
   getIsMultiValueFeedbackScore,
 } from "@/lib/feedback-scores";
+import {
+  getCategoricFeedbackScoreValuesMap,
+  getIsCategoricFeedbackScore,
+} from "@/shared/FeedbackScoreTag/utils";
+import { isAggregatedScore, getTrialAvgTooltip } from "@/lib/trials";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import useWorkspaceColorMap from "@/hooks/useWorkspaceColorMap";
+
+const MAX_DISPLAY_CATEGORIES = 2;
+
+const formatMultiValueDisplay = (
+  valueByAuthor: FeedbackScoreValueByAuthorMap,
+  category: string | undefined,
+  avgValue: number | string,
+): string => {
+  if (getIsCategoricFeedbackScore(category)) {
+    const scoreMap = getCategoricFeedbackScoreValuesMap(valueByAuthor);
+    const entries = Array.from(scoreMap.values());
+    const displayed = entries
+      .slice(0, MAX_DISPLAY_CATEGORIES)
+      .map(({ users, value }) => `${users.length}x ${value}`)
+      .join(", ");
+    const remaining = entries.length - MAX_DISPLAY_CATEGORIES;
+    return remaining > 0 ? `${displayed}, +${remaining}` : displayed;
+  }
+  return `avg ${formatScoreDisplay(avgValue)}`;
+};
 
 const FeedbackScoreCellValue = ({
   isUserFeedbackColumn = false,
   feedbackScore,
   color: customColor,
   onValueChange,
-  tooltipSuffix,
+  showTooltip = false,
   size = "md",
 }: {
   isUserFeedbackColumn?: boolean;
   feedbackScore?: TraceFeedbackScore;
   color?: string;
   onValueChange?: (name: string, value: number) => void;
-  tooltipSuffix?: string;
+  showTooltip?: boolean;
   size?: "sm" | "md";
 }) => {
   const { getColor } = useWorkspaceColorMap();
@@ -55,15 +83,27 @@ const FeedbackScoreCellValue = ({
   const value = feedbackScore.value;
   const category = feedbackScore.category_name;
 
+  const isMultiValue = getIsMultiValueFeedbackScore(valueByAuthor);
   const formattedValue = formatScoreDisplay(value);
-  const displayText = category
-    ? `${category} (${formattedValue})`
-    : String(formattedValue);
-  const fullPrecisionText = category ? `${category} (${value})` : String(value);
-  const tooltipContent = tooltipSuffix
-    ? `${fullPrecisionText} | ${tooltipSuffix}`
-    : fullPrecisionText;
-  const showTooltip = !getIsMultiValueFeedbackScore(valueByAuthor);
+
+  const displayText = isMultiValue && valueByAuthor
+    ? formatMultiValueDisplay(valueByAuthor, category, value)
+    : category
+      ? `${category} (${formattedValue})`
+      : String(formattedValue);
+
+  const tooltipContent = (() => {
+    if (!showTooltip) return undefined;
+    const fullPrecision = category ? `${category} (${value})` : String(value);
+    if (isAggregatedScore(feedbackScore)) {
+      const trialInfo = getTrialAvgTooltip(
+        feedbackScore.trialValues.length,
+        feedbackScore.stdDev,
+      );
+      return `${fullPrecision} | ${trialInfo}`;
+    }
+    return fullPrecision;
+  })();
 
   return (
     <div className="flex min-w-0 shrink-0 items-center gap-1 overflow-hidden">
@@ -74,25 +114,27 @@ const FeedbackScoreCellValue = ({
           size={size}
         />
       )}
-      <MultiValueFeedbackScoreHoverCard
-        color={color}
-        valueByAuthor={valueByAuthor}
-        label={label}
-        value={value}
-        category={category}
-        open={openHoverCard}
-        onOpenChange={setOpenHoverCard}
-      >
-        {showTooltip && size === "sm" ? (
-          <TooltipWrapper content={tooltipContent}>
-            <div className="truncate">{displayText}</div>
-          </TooltipWrapper>
-        ) : (
+      {showTooltip ? (
+        <TooltipWrapper content={tooltipContent}>
           <div className={size === "sm" ? "truncate" : "break-words"}>
             {displayText}
           </div>
-        )}
-      </MultiValueFeedbackScoreHoverCard>
+        </TooltipWrapper>
+      ) : (
+        <MultiValueFeedbackScoreHoverCard
+          color={color}
+          valueByAuthor={valueByAuthor}
+          label={label}
+          value={value}
+          category={category}
+          open={openHoverCard}
+          onOpenChange={setOpenHoverCard}
+        >
+          <div className={size === "sm" ? "truncate" : "break-words"}>
+            {displayText}
+          </div>
+        </MultiValueFeedbackScoreHoverCard>
+      )}
     </div>
   );
 };

--- a/apps/opik-frontend/src/shared/FeedbackScoreTag/MultiValueFeedbackScoreHoverCard.tsx
+++ b/apps/opik-frontend/src/shared/FeedbackScoreTag/MultiValueFeedbackScoreHoverCard.tsx
@@ -10,10 +10,11 @@ import {
   getIsCategoricFeedbackScore,
 } from "./utils";
 import {
+  FEEDBACK_SCORE_SOURCE_MAP,
   formatScoreDisplay,
-  getIsMultiValueFeedbackScore,
 } from "@/lib/feedback-scores";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import useAnnotationQueueById from "@/api/annotation-queues/useAnnotationQueueById";
 
 const Header = ({ color, label }: { color: string; label: string }) => {
   return (
@@ -22,6 +23,35 @@ const Header = ({ color, label }: { color: string; label: string }) => {
       <div className="comet-body-xs-accented truncate text-foreground">
         {label}
       </div>
+    </div>
+  );
+};
+
+const AuthorLabel = ({
+  mapKey,
+  entry,
+}: {
+  mapKey: string;
+  entry: FeedbackScoreValueByAuthorMap[string];
+}) => {
+  const { data: queue } = useAnnotationQueueById(
+    { annotationQueueId: entry.source_queue_id ?? "" },
+    { enabled: !!entry.source_queue_id },
+  );
+
+  const authorName = entry.author ?? mapKey;
+  const sourceLabel = entry.source_queue_id
+    ? (queue?.name ?? "<deleted queue>")
+    : FEEDBACK_SCORE_SOURCE_MAP[entry.source];
+
+  return (
+    <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
+      <span className="comet-body-xs truncate text-muted-slate">
+        {authorName}
+      </span>
+      <span className="comet-body-xs shrink-0 text-light-slate">
+        {sourceLabel}
+      </span>
     </div>
   );
 };
@@ -42,10 +72,25 @@ const NumericScoreContent = ({
       <Header color={color} label={label} />
       <Separator />
       <div className="flex flex-col">
-        {Object.entries(valueByAuthor).map(([author, { value }]) => (
-          <div key={author} className="flex h-6 items-center gap-1.5 px-2">
+        {Object.entries(valueByAuthor).map(([key, entry]) => (
+          <div key={key} className="flex h-6 items-center gap-1.5 px-2">
+            <AuthorLabel mapKey={key} entry={entry} />
+            <TooltipWrapper
+              content={isNumber(entry.value) ? String(entry.value) : undefined}
+            >
+              <span className="comet-body-xs-accented text-foreground">
+                {formatScoreDisplay(entry.value)}
+              </span>
+            </TooltipWrapper>
+          </div>
+        ))}
+      </div>
+      {Object.keys(valueByAuthor).length > 1 && (
+        <>
+          <Separator />
+          <div className="flex h-6 items-center gap-1.5 px-2">
             <span className="comet-body-xs min-w-0 flex-1 truncate text-muted-slate">
-              {author}
+              Average
             </span>
             <TooltipWrapper
               content={isNumber(value) ? String(value) : undefined}
@@ -55,19 +100,8 @@ const NumericScoreContent = ({
               </span>
             </TooltipWrapper>
           </div>
-        ))}
-      </div>
-      <Separator />
-      <div className="flex h-6 items-center gap-1.5 px-2">
-        <span className="comet-body-xs min-w-0 flex-1 truncate text-muted-slate">
-          Average
-        </span>
-        <TooltipWrapper content={isNumber(value) ? String(value) : undefined}>
-          <span className="comet-body-xs-accented text-foreground">
-            {formatScoreDisplay(value)}
-          </span>
-        </TooltipWrapper>
-      </div>
+        </>
+      )}
     </div>
   );
 };
@@ -101,10 +135,8 @@ const CategoricalScoreContent = ({
               </div>
               <div className="flex flex-col pl-2">
                 {users.map((user) => (
-                  <div key={user} className="flex h-6 items-center">
-                    <span className="comet-body-xs text-muted-slate">
-                      {user}
-                    </span>
+                  <div key={user.mapKey} className="flex h-6 items-center">
+                    <AuthorLabel mapKey={user.mapKey} entry={user.entry} />
                   </div>
                 ))}
               </div>
@@ -141,9 +173,12 @@ const MultiValueFeedbackScoreHoverCard: React.FC<
   onOpenChange,
 }) => {
   const isCategoricFeedbackScore = getIsCategoricFeedbackScore(category);
-  const isMultiValueFeedbackScore = getIsMultiValueFeedbackScore(valueByAuthor);
+  const hasEntries =
+    valueByAuthor &&
+    typeof valueByAuthor === "object" &&
+    Object.keys(valueByAuthor).length > 0;
 
-  if (!isMultiValueFeedbackScore) {
+  if (!hasEntries) {
     return children;
   }
 

--- a/apps/opik-frontend/src/shared/FeedbackScoreTag/MultiValueFeedbackScoreHoverCard.tsx
+++ b/apps/opik-frontend/src/shared/FeedbackScoreTag/MultiValueFeedbackScoreHoverCard.tsx
@@ -2,6 +2,7 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/ui/hover-card";
 import { FeedbackScoreValueByAuthorMap } from "@/types/traces";
 import ColorIndicator from "@/shared/ColorIndicator/ColorIndicator";
 import React from "react";
+import { Loader2 } from "lucide-react";
 import isNumber from "lodash/isNumber";
 import { Separator } from "@/ui/separator";
 
@@ -9,12 +10,9 @@ import {
   getCategoricFeedbackScoreValuesMap,
   getIsCategoricFeedbackScore,
 } from "./utils";
-import {
-  FEEDBACK_SCORE_SOURCE_MAP,
-  formatScoreDisplay,
-} from "@/lib/feedback-scores";
+import { formatScoreDisplay } from "@/lib/feedback-scores";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import useAnnotationQueueById from "@/api/annotation-queues/useAnnotationQueueById";
+import useFeedbackScoreSourceLabel from "@/hooks/useFeedbackScoreSourceLabel";
 
 const Header = ({ color, label }: { color: string; label: string }) => {
   return (
@@ -34,15 +32,12 @@ const AuthorLabel = ({
   mapKey: string;
   entry: FeedbackScoreValueByAuthorMap[string];
 }) => {
-  const { data: queue } = useAnnotationQueueById(
-    { annotationQueueId: entry.source_queue_id ?? "" },
-    { enabled: !!entry.source_queue_id },
+  const { isLoading, label } = useFeedbackScoreSourceLabel(
+    entry.source_queue_id,
+    entry.source,
   );
 
   const authorName = entry.author ?? mapKey;
-  const sourceLabel = entry.source_queue_id
-    ? queue?.name ?? "<deleted queue>"
-    : FEEDBACK_SCORE_SOURCE_MAP[entry.source];
 
   return (
     <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
@@ -50,7 +45,11 @@ const AuthorLabel = ({
         {authorName}
       </span>
       <span className="comet-body-xs shrink-0 text-light-slate">
-        {sourceLabel}
+        {isLoading ? (
+          <Loader2 className="size-3.5 animate-spin text-light-slate" />
+        ) : (
+          label
+        )}
       </span>
     </div>
   );

--- a/apps/opik-frontend/src/shared/FeedbackScoreTag/MultiValueFeedbackScoreHoverCard.tsx
+++ b/apps/opik-frontend/src/shared/FeedbackScoreTag/MultiValueFeedbackScoreHoverCard.tsx
@@ -41,7 +41,7 @@ const AuthorLabel = ({
 
   const authorName = entry.author ?? mapKey;
   const sourceLabel = entry.source_queue_id
-    ? (queue?.name ?? "<deleted queue>")
+    ? queue?.name ?? "<deleted queue>"
     : FEEDBACK_SCORE_SOURCE_MAP[entry.source];
 
   return (
@@ -155,6 +155,7 @@ type MultiValueFeedbackScoreHoverCardProps = {
   label: string;
   value: number | string;
   category?: string;
+  footer?: string;
   children: React.ReactNode;
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -168,6 +169,7 @@ const MultiValueFeedbackScoreHoverCard: React.FC<
   label,
   value,
   category = "",
+  footer,
   children,
   open,
   onOpenChange,
@@ -205,6 +207,14 @@ const MultiValueFeedbackScoreHoverCard: React.FC<
             label={label}
             value={value}
           />
+        )}
+        {footer && (
+          <>
+            <Separator />
+            <div className="px-2 py-1">
+              <span className="comet-body-xs text-light-slate">{footer}</span>
+            </div>
+          </>
         )}
       </HoverCardContent>
     </HoverCard>

--- a/apps/opik-frontend/src/shared/FeedbackScoreTag/utils.ts
+++ b/apps/opik-frontend/src/shared/FeedbackScoreTag/utils.ts
@@ -1,6 +1,11 @@
 import { categoryOptionLabelRenderer } from "@/lib/feedback-scores";
 import { FeedbackScoreValueByAuthorMap } from "@/types/traces";
 
+export type UserEntry = {
+  mapKey: string;
+  entry: FeedbackScoreValueByAuthorMap[string];
+};
+
 export const getIsCategoricFeedbackScore = (categoryNames = "") => {
   return !!categoryNames.split(",").filter((v) => !!v?.trim()).length;
 };
@@ -8,9 +13,10 @@ export const getIsCategoricFeedbackScore = (categoryNames = "") => {
 export const getCategoricFeedbackScoreValuesMap = (
   valueByAuthor: FeedbackScoreValueByAuthorMap,
 ) => {
-  const scoreMap: Map<string, { users: string[]; value: string }> = new Map();
+  const scoreMap: Map<string, { users: UserEntry[]; value: string }> =
+    new Map();
 
-  Object.entries(valueByAuthor).forEach(([author, score]) => {
+  Object.entries(valueByAuthor).forEach(([mapKey, score]) => {
     if (!score.category_name) return;
 
     if (!scoreMap.has(score.category_name)) {
@@ -19,7 +25,7 @@ export const getCategoricFeedbackScoreValuesMap = (
         value: categoryOptionLabelRenderer(score.category_name, score.value),
       });
     }
-    scoreMap.get(score.category_name)?.users.push(author);
+    scoreMap.get(score.category_name)?.users.push({ mapKey, entry: score });
   });
 
   return scoreMap;

--- a/apps/opik-frontend/src/types/comment.ts
+++ b/apps/opik-frontend/src/types/comment.ts
@@ -5,6 +5,7 @@ export type CommentItem = {
   last_updated_at: string;
   created_by: string;
   last_updated_by: string;
+  source_queue_id?: string;
 };
 
 export type CommentItems = CommentItem[];

--- a/apps/opik-frontend/src/types/traces.ts
+++ b/apps/opik-frontend/src/types/traces.ts
@@ -37,6 +37,7 @@ export type FeedbackScoreValueByAuthorMap = Record<
     span_type?: string;
     span_id?: string;
     source_queue_id?: string;
+    author?: string;
   }
 >;
 

--- a/apps/opik-frontend/src/types/traces.ts
+++ b/apps/opik-frontend/src/types/traces.ts
@@ -36,6 +36,7 @@ export type FeedbackScoreValueByAuthorMap = Record<
     last_updated_at: string;
     span_type?: string;
     span_id?: string;
+    source_queue_id?: string;
   }
 >;
 

--- a/apps/opik-frontend/src/v1/pages-shared/experiments/CompareExperimentsFeedbackScoreCell/CompareExperimentsFeedbackScoreCell.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/experiments/CompareExperimentsFeedbackScoreCell/CompareExperimentsFeedbackScoreCell.tsx
@@ -98,7 +98,6 @@ const CompareExperimentsFeedbackScoreCell: React.FC<
           color={color}
           isUserFeedbackColumn={isUserFeedbackColumn}
           onValueChange={handleValueChange}
-          showTooltip
         />
         {reasons.length > 0 && (
           <FeedbackScoreReasonTooltip reasons={reasons}>

--- a/apps/opik-frontend/src/v1/pages-shared/experiments/CompareExperimentsFeedbackScoreCell/CompareExperimentsFeedbackScoreCell.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/experiments/CompareExperimentsFeedbackScoreCell/CompareExperimentsFeedbackScoreCell.tsx
@@ -5,7 +5,6 @@ import { ExperimentItem, ExperimentsCompare } from "@/types/datasets";
 import VerticallySplitCellWrapper, {
   CustomMeta,
 } from "@/shared/DataTableCells/VerticallySplitCellWrapper";
-import { isAggregatedScore, getTrialAvgTooltip } from "@/lib/trials";
 import { MessageSquareMore } from "lucide-react";
 import FeedbackScoreReasonTooltip from "@/shared/FeedbackScoreTag/FeedbackScoreReasonTooltip";
 import {
@@ -99,14 +98,7 @@ const CompareExperimentsFeedbackScoreCell: React.FC<
           color={color}
           isUserFeedbackColumn={isUserFeedbackColumn}
           onValueChange={handleValueChange}
-          tooltipSuffix={
-            isAggregatedScore(feedbackScore)
-              ? getTrialAvgTooltip(
-                  feedbackScore.trialValues.length,
-                  feedbackScore.stdDev,
-                )
-              : undefined
-          }
+          showTooltip
         />
         {reasons.length > 0 && (
           <FeedbackScoreReasonTooltip reasons={reasons}>

--- a/apps/opik-frontend/src/v2/pages-shared/ExperimentFeedbackScoresViewer/ExperimentFeedbackScoresViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/ExperimentFeedbackScoresViewer/ExperimentFeedbackScoresViewer.tsx
@@ -38,8 +38,13 @@ const ExperimentFeedbackScoresViewer: React.FunctionComponent<
     });
   };
 
-  const onDeleteFeedbackScore = (name: string, author?: string) => {
-    feedbackScoreDelete({ name, traceId, spanId, author });
+  const onDeleteFeedbackScore = (
+    name: string,
+    author?: string,
+    _spanId?: string,
+    sourceQueueId?: string,
+  ) => {
+    feedbackScoreDelete({ name, traceId, spanId, author, sourceQueueId });
   };
 
   return (

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/CompareExperimentsFeedbackScoreCell/CompareExperimentsFeedbackScoreCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/CompareExperimentsFeedbackScoreCell/CompareExperimentsFeedbackScoreCell.tsx
@@ -6,6 +6,7 @@ import VerticallySplitCellWrapper, {
   CustomMeta,
 } from "@/shared/DataTableCells/VerticallySplitCellWrapper";
 import { MessageSquareMore } from "lucide-react";
+import { isAggregatedScore, getTrialAvgTooltip } from "@/lib/trials";
 import FeedbackScoreReasonTooltip from "@/shared/FeedbackScoreTag/FeedbackScoreReasonTooltip";
 import {
   extractReasonsFromValueByAuthor,
@@ -101,7 +102,14 @@ const CompareExperimentsFeedbackScoreCell: React.FC<
           isUserFeedbackColumn={isUserFeedbackColumn}
           onValueChange={handleValueChange}
           size={isCompact ? "sm" : "md"}
-          showTooltip
+          footer={
+            isAggregatedScore(feedbackScore)
+              ? getTrialAvgTooltip(
+                  feedbackScore.trialValues.length,
+                  feedbackScore.stdDev,
+                )
+              : undefined
+          }
         />
         {reasons.length > 0 &&
           (isCompact ? (

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/CompareExperimentsFeedbackScoreCell/CompareExperimentsFeedbackScoreCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/CompareExperimentsFeedbackScoreCell/CompareExperimentsFeedbackScoreCell.tsx
@@ -5,7 +5,6 @@ import { ExperimentItem, ExperimentsCompare } from "@/types/datasets";
 import VerticallySplitCellWrapper, {
   CustomMeta,
 } from "@/shared/DataTableCells/VerticallySplitCellWrapper";
-import { isAggregatedScore, getTrialAvgTooltip } from "@/lib/trials";
 import { MessageSquareMore } from "lucide-react";
 import FeedbackScoreReasonTooltip from "@/shared/FeedbackScoreTag/FeedbackScoreReasonTooltip";
 import {
@@ -102,14 +101,7 @@ const CompareExperimentsFeedbackScoreCell: React.FC<
           isUserFeedbackColumn={isUserFeedbackColumn}
           onValueChange={handleValueChange}
           size={isCompact ? "sm" : "md"}
-          tooltipSuffix={
-            isAggregatedScore(feedbackScore)
-              ? getTrialAvgTooltip(
-                  feedbackScore.trialValues.length,
-                  feedbackScore.stdDev,
-                )
-              : undefined
-          }
+          showTooltip
         />
         {reasons.length > 0 &&
           (isCompact ? (

--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadAnnotatePanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadAnnotatePanel.tsx
@@ -57,13 +57,19 @@ const ThreadAnnotatePanel: React.FC<ThreadAnnotatePanelProps> = ({
   );
 
   const onDeleteFeedbackScore = useCallback(
-    (name: string, author?: string) => {
+    (
+      name: string,
+      author?: string,
+      _spanId?: string,
+      sourceQueueId?: string,
+    ) => {
       threadFeedbackScoreDelete({
         names: [name],
         threadId,
         projectName,
         projectId,
         author,
+        sourceQueueId,
       });
     },
     [threadFeedbackScoreDelete, threadId, projectName, projectId],

--- a/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadAnnotations.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadAnnotations.tsx
@@ -49,12 +49,18 @@ const ThreadAnnotations: React.FC<ThreadAnnotationsProps> = ({
     });
   };
 
-  const onDeleteFeedbackScore = (name: string, author?: string) => {
+  const onDeleteFeedbackScore = (
+    name: string,
+    author?: string,
+    _spanId?: string,
+    sourceQueueId?: string,
+  ) => {
     threadFeedbackScoreDelete({
       names: [name],
       threadId,
       projectName,
       projectId,
+      sourceQueueId,
       author,
     });
   };

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/AnnotatePanel/AnnotatePanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/AnnotatePanel/AnnotatePanel.tsx
@@ -57,7 +57,12 @@ const AnnotatePanel: React.FC<AnnotatePanelProps> = ({
   );
 
   const onDeleteFeedbackScore = useCallback(
-    (name: string, author?: string, spanIdToDelete?: string) => {
+    (
+      name: string,
+      author?: string,
+      spanIdToDelete?: string,
+      sourceQueueId?: string,
+    ) => {
       let targetSpanId = spanIdToDelete ?? spanId;
       if (isTrace && !spanIdToDelete) {
         const score = filteredFeedbackScores.find((s) => s.name === name);
@@ -68,7 +73,13 @@ const AnnotatePanel: React.FC<AnnotatePanelProps> = ({
           targetSpanId = metadata.span_id;
         }
       }
-      feedbackScoreDelete({ name, traceId, spanId: targetSpanId, author });
+      feedbackScoreDelete({
+        name,
+        traceId,
+        spanId: targetSpanId,
+        author,
+        sourceQueueId,
+      });
     },
     [isTrace, spanId, filteredFeedbackScores, feedbackScoreDelete, traceId],
   );

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/DeleteFeedbackScoreValueDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/DeleteFeedbackScoreValueDialog.tsx
@@ -20,6 +20,7 @@ type SetInactiveConfirmDialogProps = {
     name: string,
     author?: string,
     spanId?: string,
+    sourceQueueId?: string,
   ) => void;
   entityType: "trace" | "thread" | "span" | "experiment";
   row: ExpandingFeedbackScoreRow;
@@ -38,7 +39,12 @@ const DeleteFeedbackScoreValueDialog: React.FunctionComponent<
   const [dontAskAgain, setDontAskAgain] = useFeedbackScoreDeletePreference();
 
   const onConfirm = () => {
-    onDeleteFeedbackScore(row.name, row.author, row.span_id);
+    onDeleteFeedbackScore(
+      row.name,
+      row.author,
+      row.span_id,
+      row.source_queue_id,
+    );
   };
 
   return (

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/FeedbackScoreTable.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/FeedbackScoreTable.tsx
@@ -26,6 +26,7 @@ export type FeedbackScoreTableProps = {
     name: string,
     author?: string,
     spanId?: string,
+    sourceQueueId?: string,
   ) => void;
   onAddHumanReview: () => void;
   feedbackScores?: TraceFeedbackScore[];
@@ -83,7 +84,12 @@ const FeedbackScoreTable: React.FunctionComponent<FeedbackScoreTableProps> = ({
       if (!onDeleteFeedbackScore) return;
       if (dontAskAgain) {
         // For child rows grouped by span type, pass span_id
-        onDeleteFeedbackScore(row.name, row.author, row.span_id);
+        onDeleteFeedbackScore(
+          row.name,
+          row.author,
+          row.span_id,
+          row.source_queue_id,
+        );
       } else {
         setRowToDelete(row);
       }

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/AuthorCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/AuthorCell.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { CellContext } from "@tanstack/react-table";
 import CellWrapper from "@/shared/DataTableCells/CellWrapper";
 import { ExpandingFeedbackScoreRow } from "../types";
-import { extractAuthorName, getIsParentFeedbackScoreRow } from "../utils";
+import { getAuthorName, getIsParentFeedbackScoreRow } from "../utils";
 import { cn } from "@/lib/utils";
 
 const AuthorCell = (
@@ -20,8 +20,8 @@ const AuthorCell = (
       // For span feedback scores, keys might be composite (author_spanId)
       // Extract unique author names by removing the _spanId suffix
       const authorSet = new Set<string>();
-      Object.keys(row.value_by_author).forEach((key) => {
-        authorSet.add(extractAuthorName(key));
+      Object.entries(row.value_by_author).forEach(([key, entry]) => {
+        authorSet.add(getAuthorName(key, entry));
       });
       authors = Array.from(authorSet);
     } else {

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/SourceCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/SourceCell.tsx
@@ -1,10 +1,11 @@
+import { ReactNode } from "react";
 import { CellContext } from "@tanstack/react-table";
+import { Loader2 } from "lucide-react";
 import CellWrapper from "@/shared/DataTableCells/CellWrapper";
 import { ExpandingFeedbackScoreRow } from "../types";
-import { FEEDBACK_SCORE_SOURCE_MAP } from "@/lib/feedback-scores";
 import { getIsParentFeedbackScoreRow } from "../utils";
 import { cn } from "@/lib/utils";
-import useAnnotationQueueById from "@/api/annotation-queues/useAnnotationQueueById";
+import useFeedbackScoreSourceLabel from "@/hooks/useFeedbackScoreSourceLabel";
 import ResourceLink, {
   RESOURCE_TYPE,
 } from "@/shared/ResourceLink/ResourceLink";
@@ -15,33 +16,40 @@ const SourceCell = (
   const row = context.row.original;
   const isParentFeedbackScoreRow = getIsParentFeedbackScoreRow(row);
 
-  const { data: queue } = useAnnotationQueueById(
-    { annotationQueueId: row.source_queue_id ?? "" },
-    { enabled: !!row.source_queue_id },
+  const { isLoading, queueId, label } = useFeedbackScoreSourceLabel(
+    row.source_queue_id,
+    row.source,
   );
+
+  let content: ReactNode;
+  if (isLoading) {
+    content = <Loader2 className="size-3.5 animate-spin text-light-slate" />;
+  } else if (queueId) {
+    content = (
+      <ResourceLink
+        id={queueId}
+        name={label}
+        resource={RESOURCE_TYPE.annotationQueue}
+      />
+    );
+  } else {
+    content = (
+      <span
+        className={cn("truncate", {
+          "text-light-slate": isParentFeedbackScoreRow,
+        })}
+      >
+        {label}
+      </span>
+    );
+  }
 
   return (
     <CellWrapper
       metadata={context.column.columnDef.meta}
       tableMetadata={context.table.options.meta}
     >
-      {row.source_queue_id && queue?.name ? (
-        <ResourceLink
-          id={row.source_queue_id}
-          name={queue.name}
-          resource={RESOURCE_TYPE.annotationQueue}
-        />
-      ) : (
-        <span
-          className={cn("truncate", {
-            "text-light-slate": isParentFeedbackScoreRow,
-          })}
-        >
-          {row.source_queue_id
-            ? "<deleted queue>"
-            : FEEDBACK_SCORE_SOURCE_MAP[row.source]}
-        </span>
-      )}
+      {content}
     </CellWrapper>
   );
 };

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/SourceCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/cells/SourceCell.tsx
@@ -4,27 +4,44 @@ import { ExpandingFeedbackScoreRow } from "../types";
 import { FEEDBACK_SCORE_SOURCE_MAP } from "@/lib/feedback-scores";
 import { getIsParentFeedbackScoreRow } from "../utils";
 import { cn } from "@/lib/utils";
+import useAnnotationQueueById from "@/api/annotation-queues/useAnnotationQueueById";
+import ResourceLink, {
+  RESOURCE_TYPE,
+} from "@/shared/ResourceLink/ResourceLink";
 
 const SourceCell = (
   context: CellContext<ExpandingFeedbackScoreRow, string>,
 ) => {
   const row = context.row.original;
-  const sourceText = FEEDBACK_SCORE_SOURCE_MAP[row.source];
-
   const isParentFeedbackScoreRow = getIsParentFeedbackScoreRow(row);
+
+  const { data: queue } = useAnnotationQueueById(
+    { annotationQueueId: row.source_queue_id ?? "" },
+    { enabled: !!row.source_queue_id },
+  );
 
   return (
     <CellWrapper
       metadata={context.column.columnDef.meta}
       tableMetadata={context.table.options.meta}
     >
-      <span
-        className={cn("truncate", {
-          "text-light-slate": isParentFeedbackScoreRow,
-        })}
-      >
-        {sourceText}
-      </span>
+      {row.source_queue_id && queue?.name ? (
+        <ResourceLink
+          id={row.source_queue_id}
+          name={queue.name}
+          resource={RESOURCE_TYPE.annotationQueue}
+        />
+      ) : (
+        <span
+          className={cn("truncate", {
+            "text-light-slate": isParentFeedbackScoreRow,
+          })}
+        >
+          {row.source_queue_id
+            ? "<deleted queue>"
+            : FEEDBACK_SCORE_SOURCE_MAP[row.source]}
+        </span>
+      )}
     </CellWrapper>
   );
 };

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/types.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/types.ts
@@ -6,4 +6,5 @@ export type ExpandingFeedbackScoreRow = TraceFeedbackScore & {
   author?: string;
   span_type?: string;
   span_id?: string; // Single span ID for child rows grouped by type
+  source_queue_id?: string;
 };

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/utils.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/utils.ts
@@ -6,21 +6,15 @@ import { ExpandingFeedbackScoreRow } from "./types";
 import { getIsMultiValueFeedbackScore } from "@/lib/feedback-scores";
 import { PARENT_ROW_ID_PREFIX } from "./constants";
 
-/**
- * Extracts the author name from a composite key (author_spanId) or returns the key as-is.
- * This is used for span feedback scores where the backend uses composite keys to uniquely identify
- * each span's feedback score even when multiple spans have the same author.
- *
- * The format is guaranteed to be `author_spanId`, so we extract the author part by splitting
- * from the right (using lastIndexOf) to handle author names that may contain underscores.
- */
-export const extractAuthorName = (key: string): string => {
-  // Extract just the author part before the last underscore
-  const lastUnderscore = key.lastIndexOf("_");
-  if (lastUnderscore !== -1) {
-    return key.substring(0, lastUnderscore);
+export const getAuthorName = (
+  key: string,
+  entry?: FeedbackScoreValueByAuthorMap[string],
+): string => {
+  if (entry?.author) {
+    return entry.author;
   }
-  return key;
+  const lastUnderscore = key.lastIndexOf("_");
+  return lastUnderscore !== -1 ? key.substring(0, lastUnderscore) : key;
 };
 
 /**
@@ -45,9 +39,7 @@ const createChildRow = (
     isSpanFeedbackScores = false,
     useAuthorKeyInId = false,
   } = options;
-  const authorName = isSpanFeedbackScores
-    ? extractAuthorName(authorKey)
-    : authorKey;
+  const authorName = score.author ?? getAuthorName(authorKey, score);
 
   // Generate ID based on context
   let id: string;
@@ -66,15 +58,17 @@ const createChildRow = (
     id,
     ...parentScore,
     value: score.value,
+    reason: score.reason,
     category_name: score.category_name,
     value_by_author: isSpanFeedbackScores
       ? { [authorKey]: score }
       : parentScore.value_by_author,
     name: parentScore.name,
     author: authorName,
+    source_queue_id: score.source_queue_id,
+    source: score.source || parentScore.source,
   };
 
-  // Add span metadata if this is a span feedback score
   if (isSpanFeedbackScores) {
     baseRow.span_id = score.span_id;
     baseRow.span_type = spanType || score.span_type;

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/utils.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/FeedbackScoreTable/utils.ts
@@ -279,11 +279,17 @@ export const mapFeedbackScoresToRowsWithExpanded = (
       ? extractSpanMetadataFromValueByAuthor(feedbackScore.value_by_author)
       : {};
 
+    // source_queue_id lives on the entry, not the top-level score; multi-value rows
+    // get it via createChildRow, so lift it here too or single-reviewer queue scores
+    // lose their queue attribution in the Source column (and the delete key).
+    const singleEntry = Object.values(feedbackScore.value_by_author ?? {})[0];
+
     rows.push({
       id: feedbackScore.name,
       author: feedbackScore.created_by,
       ...feedbackScore,
       ...spanMetadata,
+      source_queue_id: singleEntry?.source_queue_id,
     });
   });
 

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -136,12 +136,18 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
   const feedbackScoreDeleteMutation = useTraceFeedbackScoreDeleteMutation();
 
   const onDeleteFeedbackScore = useCallback(
-    (name: string, author?: string, spanIdToDelete?: string) => {
+    (
+      name: string,
+      author?: string,
+      spanIdToDelete?: string,
+      sourceQueueId?: string,
+    ) => {
       feedbackScoreDeleteMutation.mutate({
         traceId,
         spanId: spanIdToDelete ?? spanId,
         name,
         author,
+        sourceQueueId,
       });
     },
     [traceId, spanId, feedbackScoreDeleteMutation],

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
@@ -131,7 +131,11 @@ const ExportAnnotatedDataButton: React.FC<ExportAnnotatedDataButtonProps> = ({
         reviewers.forEach((reviewerName) => {
           const reviewerData: ReviewerData = {};
 
-          const comments = getCommentsByUser(trace.comments, reviewerName);
+          const comments = getCommentsByUser(
+            trace.comments,
+            reviewerName,
+            annotationQueue.id,
+          );
           if (comments.length > 0) {
             reviewerData.comment = comments.join("; ");
           }
@@ -140,6 +144,7 @@ const ExportAnnotatedDataButton: React.FC<ExportAnnotatedDataButtonProps> = ({
             trace.feedback_scores ?? [],
             reviewerName,
             feedbackDefinitionNames,
+            annotationQueue.id,
           );
 
           feedbackScores.forEach((score) => {
@@ -177,7 +182,11 @@ const ExportAnnotatedDataButton: React.FC<ExportAnnotatedDataButtonProps> = ({
         reviewers.forEach((reviewerName) => {
           const reviewerData: ReviewerData = {};
 
-          const comments = getCommentsByUser(thread.comments, reviewerName);
+          const comments = getCommentsByUser(
+            thread.comments,
+            reviewerName,
+            annotationQueue.id,
+          );
           if (comments.length > 0) {
             reviewerData.comment = comments.join("; ");
           }
@@ -186,6 +195,7 @@ const ExportAnnotatedDataButton: React.FC<ExportAnnotatedDataButtonProps> = ({
             thread.feedback_scores ?? [],
             reviewerName,
             feedbackDefinitionNames,
+            annotationQueue.id,
           );
 
           feedbackScores.forEach((score) => {

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
@@ -162,7 +162,7 @@ const ExportAnnotatedDataButton: React.FC<ExportAnnotatedDataButtonProps> = ({
         return baseData;
       });
     },
-    [reviewers, feedbackDefinitionNames],
+    [reviewers, feedbackDefinitionNames, annotationQueue.id],
   );
 
   const getThreadsExportData = useCallback(
@@ -213,7 +213,7 @@ const ExportAnnotatedDataButton: React.FC<ExportAnnotatedDataButtonProps> = ({
         return baseData;
       });
     },
-    [reviewers, feedbackDefinitionNames],
+    [reviewers, feedbackDefinitionNames, annotationQueue.id],
   );
 
   const getData = useCallback(async () => {

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/SMEFlowContext.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/SMEFlowContext.tsx
@@ -471,6 +471,7 @@ export const SMEFlowProvider: React.FunctionComponent<{
     currentItem,
     currentUserName,
     annotationQueue?.feedback_definition_names,
+    annotationQueue?.id,
     resetLastSaved,
   ]);
 

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/SMEFlowContext.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/SMEFlowContext.tsx
@@ -457,6 +457,7 @@ export const SMEFlowProvider: React.FunctionComponent<{
       currentItem.feedback_scores || [],
       currentUserName,
       annotationQueue?.feedback_definition_names ?? [],
+      annotationQueue?.id,
     );
 
     const comment = lastComment ? { text: lastComment.text } : undefined;


### PR DESCRIPTION
## Details

After OPIK-6791 added `source_queue_id` to `authored_feedback_scores` ORDER BY, the same user can score the same item from multiple annotation queues. However, general views used `LIMIT 1 BY (entity_id, name, author)` without `source_queue_id`, collapsing multi-queue scores to just the latest.

This PR surfaces all queue-scoped scores across every view:

### Backend
- **All DAO LIMIT 1 BY clauses** updated to include `source_queue_id` — TraceDAO, ThreadDAO, ProjectMetricsDAO, KpiCardDAO, ExperimentItemDAO, DatasetItemDAO, DatasetItemVersionDAO, ExperimentDAO, ExperimentAggregatesDAO, OptimizationDAO
- **ValueEntry** — added `sourceQueueId` and `author` fields so the frontend reads entry.author directly instead of parsing composite map keys
- **FeedbackScoreMapper** — parses `sourceQueueId` (index 7) and `author` (index 8) from the value tuple
- **Composite map keys** — `value_by_author` key format: `author` (no queue), `author_queueId` (queue-scoped), `author_queueId_spanId` (span + queue)
- **Delete scoping** — `FeedbackScoreDAO.deleteScoreFrom` and `deleteByEntityIdAndNames` always scope by `source_queue_id` to prevent deleting queue-scoped scores when removing a direct score
- **Comments** — `source_queue_id` added to comment CTEs in TraceDAO/ThreadDAO + CommentResultMapper parsing
- **ExperimentAggregatesDAO** — fixed `count(DISTINCT author)` → `count(*)` so same-author multi-queue scores compute avg instead of picking any_value
- **SpanDAO intentionally NOT changed** — annotation queues never target spans

### Frontend
- **FeedbackScoreTable** (v2) — `getAuthorName` reads `entry.author` directly, `SourceCell` renders as `ResourceLink` to the annotation queue (falls back to `<deleted queue>` or generic source label), per-entry `reason` and `source` propagated to child rows
- **MultiValueFeedbackScoreHoverCard** — `AuthorLabel` component with queue name resolution via `useAnnotationQueueById`, source label right-aligned in lighter color, shows for single entries too, Average row only for multi-entry, `footer` prop for trial info
- **FeedbackScoreCellValue** — multi-value display (categorical count format `3x 👍, 2x 👎`, numeric `avg X`), `footer` prop replaces `showTooltip`
- **findValueByAuthor** — defaults to exact match (safe), `prefixMatch` opt-in via `hasAnyValueByAuthor` helper
- **generateUpdate/DeleteMutation** — composite keys with `sourceQueueId`
- **Queue export** — `getFeedbackScoresByUser` and `getCommentsByUser` filter by `source_queue_id`
- **SME flow** — pre-fill uses `sourceQueueId` to find queue-specific scores

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-6983
- Also addresses OPIK-6723

## Testing
- E2E test: `testSameAuthorTwoQueuesProducesAverage` — verifies same author scoring from two queues produces correct average and composite keys in `value_by_author`
- Manual testing: trace detail panel, list table score columns, hover cards, annotation queue export, experiment compare grid, delete scoping, SME flow pre-fill

## Documentation
N/A — internal ClickHouse query changes, no new user-facing configuration

## Screenshots
<img width="1228" height="865" alt="Screenshot 2026-06-22 at 18 20 21" src="https://github.com/user-attachments/assets/e91a6cae-273f-4b7c-8ef5-f60bb5af5c75" />
<img width="709" height="471" alt="Screenshot 2026-06-22 at 18 15 28" src="https://github.com/user-attachments/assets/e31ecfca-bd13-4a17-8cb0-00dd6dffefcc" />

