### PR TITLE
[BE] fix: accept all-clear agent insights report (empty issues)

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsReport.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsReport.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
@@ -23,7 +22,9 @@ import java.util.UUID;
 public record AgentInsightsReport(
         @NotNull UUID projectId,
         @NotNull LocalDate reportDay,
-        @NotEmpty List<@NotNull @Valid ReportedIssue> issues) {
+        // May be empty: an "all clear" report (no issues detected) is valid and
+        // must be accepted so the run can complete cleanly instead of erroring.
+        @NotNull List<@NotNull @Valid ReportedIssue> issues) {
 
     @Builder(toBuilder = true)
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueService.java
@@ -73,6 +73,16 @@ class AgentInsightsIssueServiceImpl implements AgentInsightsIssueService {
 
         projectService.get(report.projectId(), workspaceId);
 
+        // An "all clear" report (no issues detected) is a valid outcome: validate
+        // the project, then return without touching the DB. Skipping the batch
+        // writes also avoids empty-batch failures in the DAO.
+        if (report.issues().isEmpty()) {
+            log.info(
+                    "No agent insights issues to store for project '{}' on report day '{}' in workspace '{}' (all clear)",
+                    report.projectId(), report.reportDay(), workspaceId);
+            return;
+        }
+
         log.info("Storing '{}' agent insights issues for project '{}' on report day '{}' in workspace '{}'",
                 report.issues().size(), report.projectId(), report.reportDay(), workspaceId);
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentInsightsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentInsightsResourceTest.java
@@ -263,6 +263,16 @@ class AgentInsightsResourceTest {
         }
 
         @Test
+        @DisplayName("All clear: an empty report is accepted and persists nothing")
+        void reportIssuesWhenEmptyThenAcceptedAndNothingPersisted() {
+            var projectId = createProject();
+
+            report(projectId, DAY_1, List.of());
+
+            assertThat(findIssues(projectId, DAY_1, DAY_1).content()).isEmpty();
+        }
+
+        @Test
         @DisplayName("Idempotency: re-reporting with the same id replaces metrics instead of duplicating")
         void reportIssuesWhenSameDayReportedTwiceThenMetricsAreReplaced() {
             var projectId = createProject();
@@ -408,9 +418,6 @@ class AgentInsightsResourceTest {
                     AgentInsightsReport.builder().projectId(UUID.randomUUID()).issues(List.of(validIssue)).build(),
                     // missing project_id
                     AgentInsightsReport.builder().reportDay(DAY_1).issues(List.of(validIssue)).build(),
-                    // empty issues
-                    AgentInsightsReport.builder().projectId(UUID.randomUUID()).reportDay(DAY_1).issues(List.of())
-                            .build(),
                     // blank issue name
                     AgentInsightsReport.builder().projectId(UUID.randomUUID()).reportDay(DAY_1)
                             .issues(List.of(validIssue.toBuilder().name(" ").build())).build(),


### PR DESCRIPTION
## Details

The agent insights report endpoint (`POST /v1/private/agent-insights/issues`) rejected an empty `issues` list with a 422 `"issues must not be empty"`. A diagnostic run that legitimately finds nothing ("all clear") therefore could not record completion, and the reporting agent treated the 422 as a retryable error and looped until it exhausted its token budget. This change makes an empty report a valid outcome.

- `AgentInsightsReport`: `issues` is now `@NotNull` instead of `@NotEmpty` — a null body is still rejected, but an empty list is accepted as "all clear".
- `AgentInsightsIssueService.reportIssues`: still validates the project, then returns early without touching the DB when `issues` is empty (also avoids empty-batch writes in the DAO).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Implemented the validation/service change and tests; authored the PR description.
  - Human verification: Reviewed the diff, rebuilt and restarted the local backend, and confirmed an empty report returns 204 (previously 422).

## Testing

- `mvn -o -DskipTests test-compile` (main + tests compile).
- Added `reportIssuesWhenEmptyThenAcceptedAndNothingPersisted`: an empty report returns 204 and `findIssues` returns no content. Removed the now-invalid "empty issues" case from `invalidReports()`.
- Manual (local, process mode): rebuilt the jar, restarted opik-backend, and posted `{"project_id":"…","report_day":"2026-06-22","issues":[]}` to `POST /v1/private/agent-insights/issues` → **204** (was **422** before the fix).
- Not run: full `mvn verify` integration suite (relies on testcontainers); the new test follows the existing `reportIssues` happy-path pattern in the same suite.

## Documentation

No documentation changes required.
