### PR TITLE
[NA] [BE] feat: accept all-clear reports + track last scan time (agent insights)

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsJob.java
@@ -23,6 +23,7 @@ public record AgentInsightsJob(
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) UUID id,
         @Schema(accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.REQUIRED) UUID projectId,
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) Status status,
+        @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastScanAt,
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant createdAt,
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsReport.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsReport.java
@@ -22,8 +22,6 @@ import java.util.UUID;
 public record AgentInsightsReport(
         @NotNull UUID projectId,
         @NotNull LocalDate reportDay,
-        // May be empty: an "all clear" report (no issues detected) is valid and
-        // must be accepted so the run can complete cleanly instead of erroring.
         @NotNull List<@NotNull @Valid ReportedIssue> issues) {
 
     @Builder(toBuilder = true)

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsReport.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsReport.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
@@ -23,7 +22,9 @@ import java.util.UUID;
 public record AgentInsightsReport(
         @NotNull UUID projectId,
         @NotNull LocalDate reportDay,
-        @NotEmpty List<@NotNull @Valid ReportedIssue> issues) {
+        // May be empty: an "all clear" report (no issues detected) is valid and
+        // must be accepted so the run can complete cleanly instead of erroring.
+        @NotNull List<@NotNull @Valid ReportedIssue> issues) {
 
     @Builder(toBuilder = true)
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueService.java
@@ -73,18 +73,14 @@ class AgentInsightsIssueServiceImpl implements AgentInsightsIssueService {
 
         projectService.get(report.projectId(), workspaceId);
 
-        // An "all clear" report (no issues detected) is a valid outcome: validate
-        // the project, then return without touching the DB. Skipping the batch
-        // writes also avoids empty-batch failures in the DAO.
-        if (report.issues().isEmpty()) {
-            log.info(
-                    "No agent insights issues to store for project '{}' on report day '{}' in workspace '{}' (all clear)",
-                    report.projectId(), report.reportDay(), workspaceId);
-            return;
-        }
+        // An "all clear" report (no issues detected) is a valid outcome: skip the
+        // issue writes (also avoids empty-batch failures in the DAO) but still
+        // stamp the scan time below so the UI shows when the run last completed.
+        boolean allClear = report.issues().isEmpty();
 
-        log.info("Storing '{}' agent insights issues for project '{}' on report day '{}' in workspace '{}'",
-                report.issues().size(), report.projectId(), report.reportDay(), workspaceId);
+        log.info("{} agent insights issues for project '{}' on report day '{}' in workspace '{}'",
+                allClear ? "No (all clear)" : report.issues().size(), report.projectId(), report.reportDay(),
+                workspaceId);
 
         List<UUID> issueIds = report.issues().stream()
                 .map(issue -> issue.id() != null ? issue.id() : idGenerator.generateId())
@@ -99,9 +95,14 @@ class AgentInsightsIssueServiceImpl implements AgentInsightsIssueService {
         transactionTemplate.inTransaction(WRITE, handle -> {
             AgentInsightsIssueDAO dao = handle.attach(AgentInsightsIssueDAO.class);
 
-            dao.upsertIssues(workspaceId, report.projectId(), userName, issueIds, report.issues());
-            dao.upsertDetails(workspaceId, report.projectId(), report.reportDay(), userName,
-                    detailIds, issueIds, report.issues(), metadata);
+            if (!allClear) {
+                dao.upsertIssues(workspaceId, report.projectId(), userName, issueIds, report.issues());
+                dao.upsertDetails(workspaceId, report.projectId(), report.reportDay(), userName,
+                        detailIds, issueIds, report.issues(), metadata);
+            }
+
+            // Record when this project was last scanned (no-op if it has no job row).
+            handle.attach(AgentInsightsJobDAO.class).markScanned(workspaceId, report.projectId());
 
             return null;
         });

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueService.java
@@ -73,6 +73,16 @@ class AgentInsightsIssueServiceImpl implements AgentInsightsIssueService {
 
         projectService.get(report.projectId(), workspaceId);
 
+        // An "all clear" report (no issues detected) is a valid outcome: validate
+        // the project, then return without touching the DB. Skipping the batch
+        // writes also avoids empty-batch failures in the DAO.
+        if (report.issues().isEmpty()) {
+            log.info(
+                    "No agent insights issues to store for project '{}' on report day '{}' in workspace '{}' (all clear)",
+                    report.projectId(), report.reportDay(), workspaceId);
+            return;
+        }
+
         log.info("Storing '{}' agent insights issues for project '{}' on report day '{}' in workspace '{}'",
                 report.issues().size(), report.projectId(), report.reportDay(), workspaceId);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueService.java
@@ -76,11 +76,11 @@ class AgentInsightsIssueServiceImpl implements AgentInsightsIssueService {
         // An "all clear" report (no issues detected) is a valid outcome: skip the
         // issue writes (also avoids empty-batch failures in the DAO) but still
         // stamp the scan time below so the UI shows when the run last completed.
-        boolean allClear = report.issues().isEmpty();
+        int issueCount = report.issues().size();
+        boolean allClear = issueCount == 0;
 
-        log.info("{} agent insights issues for project '{}' on report day '{}' in workspace '{}'",
-                allClear ? "No (all clear)" : report.issues().size(), report.projectId(), report.reportDay(),
-                workspaceId);
+        log.info("Reporting agent insights issues for project '{}' on report day '{}' in workspace '{}': {}",
+                report.projectId(), report.reportDay(), workspaceId, allClear ? "all clear" : issueCount);
 
         List<UUID> issueIds = report.issues().stream()
                 .map(issue -> issue.id() != null ? issue.id() : idGenerator.generateId())
@@ -101,8 +101,10 @@ class AgentInsightsIssueServiceImpl implements AgentInsightsIssueService {
                         detailIds, issueIds, report.issues(), metadata);
             }
 
-            // Record when this project was last scanned (no-op if it has no job row).
-            handle.attach(AgentInsightsJobDAO.class).markScanned(workspaceId, report.projectId());
+            // Record when this project was last scanned (no-op if it has no job row,
+            // which can't happen via the trigger flow — it 404s without a job).
+            handle.attach(AgentInsightsJobDAO.class)
+                    .markScanned(workspaceId, report.projectId(), userName);
 
             return null;
         });

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsIssueService.java
@@ -73,9 +73,6 @@ class AgentInsightsIssueServiceImpl implements AgentInsightsIssueService {
 
         projectService.get(report.projectId(), workspaceId);
 
-        // An "all clear" report (no issues detected) is a valid outcome: skip the
-        // issue writes (also avoids empty-batch failures in the DAO) but still
-        // stamp the scan time below so the UI shows when the run last completed.
         int issueCount = report.issues().size();
         boolean allClear = issueCount == 0;
 
@@ -101,8 +98,6 @@ class AgentInsightsIssueServiceImpl implements AgentInsightsIssueService {
                         detailIds, issueIds, report.issues(), metadata);
             }
 
-            // Record when this project was last scanned (no-op if it has no job row,
-            // which can't happen via the trigger flow — it 404s without a job).
             handle.attach(AgentInsightsJobDAO.class)
                     .markScanned(workspaceId, report.projectId(), userName);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobDAO.java
@@ -43,6 +43,15 @@ interface AgentInsightsJobDAO {
     Optional<AgentInsightsJob> findByProject(@Bind("workspaceId") String workspaceId,
             @Bind("projectId") UUID projectId);
 
+    // Stamp the time a diagnostic report was last generated. Called on every
+    // report (including "all clear"); a no-op if the project has no job row.
+    @SqlUpdate("""
+            UPDATE agent_insights_jobs SET last_scan_at = CURRENT_TIMESTAMP(6)
+            WHERE workspace_id = :workspaceId AND project_id = :projectId
+            """)
+    int markScanned(@Bind("workspaceId") String workspaceId,
+            @Bind("projectId") UUID projectId);
+
     // Cross-workspace — used only by the daily sweep (system context), never from a request thread.
     // INNER JOIN projects so jobs whose project was deleted are filtered out at the source (no per-job
     // existence check in the sweep loop).

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobDAO.java
@@ -43,10 +43,6 @@ interface AgentInsightsJobDAO {
     Optional<AgentInsightsJob> findByProject(@Bind("workspaceId") String workspaceId,
             @Bind("projectId") UUID projectId);
 
-    // Stamp the time a diagnostic report was last generated. Called on every
-    // report (including "all clear"); a no-op if the project has no job row.
-    // last_updated_by is set alongside so the audit actor stays in sync with the
-    // last_updated_at bumped by ON UPDATE.
     @SqlUpdate("""
             UPDATE agent_insights_jobs
             SET last_scan_at = CURRENT_TIMESTAMP(6), last_updated_by = :userName

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobDAO.java
@@ -45,12 +45,16 @@ interface AgentInsightsJobDAO {
 
     // Stamp the time a diagnostic report was last generated. Called on every
     // report (including "all clear"); a no-op if the project has no job row.
+    // last_updated_by is set alongside so the audit actor stays in sync with the
+    // last_updated_at bumped by ON UPDATE.
     @SqlUpdate("""
-            UPDATE agent_insights_jobs SET last_scan_at = CURRENT_TIMESTAMP(6)
+            UPDATE agent_insights_jobs
+            SET last_scan_at = CURRENT_TIMESTAMP(6), last_updated_by = :userName
             WHERE workspace_id = :workspaceId AND project_id = :projectId
             """)
     int markScanned(@Bind("workspaceId") String workspaceId,
-            @Bind("projectId") UUID projectId);
+            @Bind("projectId") UUID projectId,
+            @Bind("userName") String userName);
 
     // Cross-workspace — used only by the daily sweep (system context), never from a request thread.
     // INNER JOIN projects so jobs whose project was deleted are filtered out at the source (no per-job

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000086_add_last_scan_at_to_agent_insights_jobs.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000086_add_last_scan_at_to_agent_insights_jobs.sql
@@ -3,6 +3,6 @@
 --comment: Track when a diagnostic report was last generated for a project (stamped on every report, including "all clear"), so the UI can show an accurate "Last scan" time that is unaffected by user-driven status changes.
 
 ALTER TABLE agent_insights_jobs
-    ADD COLUMN last_scan_at TIMESTAMP(6) NULL DEFAULT NULL AFTER last_triggered_at;
+    ADD COLUMN last_scan_at TIMESTAMP(6) NULL DEFAULT NULL AFTER status;
 
 --rollback ALTER TABLE agent_insights_jobs DROP COLUMN last_scan_at;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000086_add_last_scan_at_to_agent_insights_jobs.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000086_add_last_scan_at_to_agent_insights_jobs.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 --changeset aadereiko:000086_add_last_scan_at_to_agent_insights_jobs
---comment: Track when a diagnostic report was last generated for a project (stamped on every report, including "all clear"), so the UI can show an accurate "Last scan" time that is unaffected by user-driven status changes.
+--comment: Add last_scan_at to agent_insights_jobs — time a diagnostic report was last generated
 
 ALTER TABLE agent_insights_jobs
     ADD COLUMN last_scan_at TIMESTAMP(6) NULL DEFAULT NULL AFTER status;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000086_add_last_scan_at_to_agent_insights_jobs.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000086_add_last_scan_at_to_agent_insights_jobs.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+--changeset aadereiko:000086_add_last_scan_at_to_agent_insights_jobs
+--comment: Track when a diagnostic report was last generated for a project (stamped on every report, including "all clear"), so the UI can show an accurate "Last scan" time that is unaffected by user-driven status changes.
+
+ALTER TABLE agent_insights_jobs
+    ADD COLUMN last_scan_at TIMESTAMP(6) NULL DEFAULT NULL AFTER last_triggered_at;
+
+--rollback ALTER TABLE agent_insights_jobs DROP COLUMN last_scan_at;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000086_add_last_scan_at_to_agent_insights_jobs.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000086_add_last_scan_at_to_agent_insights_jobs.sql
@@ -6,3 +6,4 @@ ALTER TABLE agent_insights_jobs
     ADD COLUMN last_scan_at TIMESTAMP(6) NULL DEFAULT NULL AFTER status;
 
 --rollback ALTER TABLE agent_insights_jobs DROP COLUMN last_scan_at;
+

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentInsightsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentInsightsResourceTest.java
@@ -263,6 +263,16 @@ class AgentInsightsResourceTest {
         }
 
         @Test
+        @DisplayName("All clear: an empty report is accepted and persists nothing")
+        void reportIssuesWhenEmptyThenAcceptedAndNothingPersisted() {
+            var projectId = createProject();
+
+            report(projectId, DAY_1, List.of());
+
+            assertThat(findIssues(projectId, DAY_1, DAY_1).content()).isEmpty();
+        }
+
+        @Test
         @DisplayName("Idempotency: re-reporting with the same id replaces metrics instead of duplicating")
         void reportIssuesWhenSameDayReportedTwiceThenMetricsAreReplaced() {
             var projectId = createProject();
@@ -408,9 +418,6 @@ class AgentInsightsResourceTest {
                     AgentInsightsReport.builder().projectId(UUID.randomUUID()).issues(List.of(validIssue)).build(),
                     // missing project_id
                     AgentInsightsReport.builder().reportDay(DAY_1).issues(List.of(validIssue)).build(),
-                    // empty issues
-                    AgentInsightsReport.builder().projectId(UUID.randomUUID()).reportDay(DAY_1).issues(List.of())
-                            .build(),
                     // blank issue name
                     AgentInsightsReport.builder().projectId(UUID.randomUUID()).reportDay(DAY_1)
                             .issues(List.of(validIssue.toBuilder().name(" ").build())).build(),


### PR DESCRIPTION
## Details

Two related backend fixes for Agent Insights diagnostics, both touching `reportIssues`:

- **Accept "all clear" reports.** The report endpoint rejected an empty `issues` list with 422 `"issues must not be empty"`, so a run that finds nothing couldn't record completion — the reporting agent treated the 422 as retryable and looped until it exhausted its token budget. `issues` is now `@NotNull` (a null body is still rejected; an empty list is a valid "all clear") and `reportIssues` skips the issue writes when empty.
- **Track last scan time.** Added `last_scan_at` on the job, stamped on every report (including all-clear) in the same transaction as the issue upserts. The UI uses it for an accurate "Last scan" time that — unlike an issue's `last_updated_at` — is not affected by users resolving/reopening issues.

Detail:
- Migration `000086`: add `last_scan_at` to `agent_insights_jobs` (anchored `AFTER status`).
- `AgentInsightsReport`: `issues` `@NotEmpty` → `@NotNull`.
- `AgentInsightsJob`: expose read-only `last_scan_at`.
- `AgentInsightsJobDAO.markScanned`: stamp `last_scan_at` + `last_updated_by` (no-op if the project has no job row — unreachable via the trigger flow, which 404s without a job).
- `AgentInsightsIssueService.reportIssues`: skip writes when all-clear; always stamp the scan time.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- No associated ticket (`[NA]`).

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Implemented the validation/service/DAO/model changes and migration; addressed automated review feedback; authored this description.
  - Human verification: Rebuilt and restarted the local backend, applied migration `000086`; confirmed an empty report returns 204 (was 422) and the job endpoint returns `last_scan_at` set to the report time, unchanged by resolving an issue.

## Testing

- `mvn -o -DskipTests test-compile` (main + tests compile).
- Tests: added `reportIssuesWhenEmptyThenAcceptedAndNothingPersisted` (empty report → 204, persists nothing); removed the now-invalid "empty issues" case from `invalidReports()`.
- Manual (local, process mode): rebuilt the jar, applied migration `000086`, restarted opik-backend. `POST /v1/private/agent-insights/issues` with `"issues":[]` → **204** (was **422**); `GET /v1/private/agent-insights/jobs/{projectId}` returns `last_scan_at` = report time; resolving/reopening an issue leaves `last_scan_at` unchanged.
- Not run: full `mvn verify` integration suite (testcontainers).

## Documentation

No documentation changes required.
