### PR TITLE
[OPIK-7068] [SDK] fix: bound export span fetch by trace_id range

### DIFF
--- a/sdks/python/src/opik/cli/exports/project.py
+++ b/sdks/python/src/opik/cli/exports/project.py
@@ -9,7 +9,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Optional, Set
+from typing import Any, Iterable, Optional, Set
 
 import random
 
@@ -197,7 +197,7 @@ def _fetch_traces_page(
     )
 
 
-def _spans_trace_id_range_filter(trace_ids) -> Optional[str]:
+def _spans_trace_id_range_filter(trace_ids: Iterable[str]) -> Optional[str]:
     """Build a parsed (JSON) spans filter bounding the scan to the trace_id
     range covering the matched traces.
 

--- a/sdks/python/src/opik/cli/exports/project.py
+++ b/sdks/python/src/opik/cli/exports/project.py
@@ -4,6 +4,7 @@ import logging
 import sys
 import threading
 import time
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
@@ -212,8 +213,6 @@ def _spans_trace_id_range_filter(trace_ids) -> Optional[str]:
     Returns ``None`` (unfiltered scan, prior behaviour) when the set is empty or
     any id is not a UUIDv7.
     """
-    import uuid
-
     from opik.api_objects import opik_query_language
 
     # Derive the timestamp per id from the parsed UUID rather than lexicographic

--- a/sdks/python/src/opik/cli/exports/project.py
+++ b/sdks/python/src/opik/cli/exports/project.py
@@ -196,23 +196,66 @@ def _fetch_traces_page(
     )
 
 
+def _spans_trace_id_range_filter(trace_ids) -> Optional[str]:
+    """Build a parsed (JSON) spans filter bounding the scan to the trace_id
+    range covering the matched traces.
+
+    Spans are sorted by ``(workspace_id, project_id, trace_id, ...)``, so a
+    ``trace_id`` range lets the backend prune by primary key instead of paging
+    through every span in the project (which never completes for large
+    projects). ``trace_id`` is a STRING_EXACT field that only supports strict
+    ``>`` / ``<`` (``>=`` / ``<=`` are rejected by the backend), so we widen the
+    bounds by 1 ms on each side via the UUIDv7 timestamp prefix. Callers still
+    filter spans by exact trace_id membership, so the range only needs to be a
+    correct *superset*.
+
+    Returns ``None`` (unfiltered scan, prior behaviour) when the set is empty or
+    any id is not a UUIDv7.
+    """
+    from opik.api_objects import opik_query_language
+
+    ids = [t for t in trace_ids if t]
+    if not ids:
+        return None
+    try:
+        lo_ms = int(min(ids).replace("-", "")[:12], 16)
+        hi_ms = int(max(ids).replace("-", "")[:12], 16)
+    except ValueError:
+        return None  # non-UUIDv7 ids: don't risk an incorrect bound
+
+    def _floor_uuid7(ms: int) -> str:
+        h = f"{max(ms, 0):012x}"
+        return f"{h[:8]}-{h[8:12]}-0000-0000-000000000000"
+
+    lower = _floor_uuid7(lo_ms - 1)  # strictly < min(trace_id)
+    upper = _floor_uuid7(hi_ms + 1)  # strictly > max(trace_id)
+    return opik_query_language.OpikQueryLanguage.for_spans(
+        f'trace_id > "{lower}" AND trace_id < "{upper}"'
+    ).parsed_filters
+
+
 @_export_rest_retry
 def _fetch_spans_page(
     client: opik.Opik,
     project_name: str,
     page: int,
     page_size: int,
+    parsed_filter: Optional[str] = None,
 ) -> Any:
-    """Fetch one page of all spans for a project (no trace_id filter).
+    """Fetch one page of spans for a project.
 
     Using GET /v1/private/spans avoids the much stricter rate limit on
     POST /v1/private/spans/search.  Each span includes its trace_id so
     callers can group client-side.
+
+    ``parsed_filter`` (parsed OQL JSON) optionally bounds the scan by
+    ``trace_id`` range so the backend prunes by primary key.
     """
     return client.rest_client.spans.get_spans_by_project(
         project_name=project_name,
         page=page,
         size=page_size,
+        filters=parsed_filter,
         truncate=False,
     )
 
@@ -606,6 +649,13 @@ def export_traces(
             if progress and task is not None:
                 progress.update(task, description="Fetching spans...")
 
+            # Bound the span scan to the trace_id range of the matched traces so
+            # the backend prunes by primary key instead of paging every span in
+            # the project. Exactness is still guaranteed by the membership check
+            # (`tid in spans_by_trace_id`) below, so this only needs to be a
+            # superset of the matched trace_ids.
+            spans_filter = _spans_trace_id_range_filter(traces_to_fetch.keys())
+
             span_page = 1
             span_consecutive_failures = 0
 
@@ -614,7 +664,7 @@ def export_traces(
                     debug_print(f"DEBUG: Fetching span page {span_page}", debug)
                 try:
                     span_result = _fetch_spans_page(
-                        client, project_name, span_page, page_size
+                        client, project_name, span_page, page_size, spans_filter
                     )
                     span_consecutive_failures = 0
                 except (

--- a/sdks/python/src/opik/cli/exports/project.py
+++ b/sdks/python/src/opik/cli/exports/project.py
@@ -212,16 +212,29 @@ def _spans_trace_id_range_filter(trace_ids) -> Optional[str]:
     Returns ``None`` (unfiltered scan, prior behaviour) when the set is empty or
     any id is not a UUIDv7.
     """
+    import uuid
+
     from opik.api_objects import opik_query_language
 
-    ids = [t for t in trace_ids if t]
-    if not ids:
+    # Derive the timestamp per id from the parsed UUID rather than lexicographic
+    # min/max over raw strings: ids may arrive non-canonical (uppercase or
+    # hyphenless, e.g. preset/custom trace ids), which breaks string ordering and
+    # could yield a too-narrow bound that drops a matched trace's spans (the
+    # client-side membership check can only discard, never recover).
+    ms_values = []
+    for t in trace_ids:
+        if not t:
+            continue
+        try:
+            parsed = uuid.UUID(str(t))
+        except ValueError:
+            return None  # non-UUID id: don't risk an incorrect bound
+        if parsed.version != 7:
+            return None  # non-UUIDv7: timestamp prefix isn't meaningful
+        ms_values.append(parsed.int >> 80)  # UUIDv7: top 48 bits = unix ms
+    if not ms_values:
         return None
-    try:
-        lo_ms = int(min(ids).replace("-", "")[:12], 16)
-        hi_ms = int(max(ids).replace("-", "")[:12], 16)
-    except ValueError:
-        return None  # non-UUIDv7 ids: don't risk an incorrect bound
+    lo_ms, hi_ms = min(ms_values), max(ms_values)
 
     def _floor_uuid7(ms: int) -> str:
         h = f"{max(ms, 0):012x}"


### PR DESCRIPTION
## Details

`opik export project` Phase 2 fetches **all** spans in the project (`GET /v1/private/spans`, paged) and filters by `trace_id` membership client-side, so the trace `--filter` never constrains the span scan — for large projects it pages through millions of spans and effectively never completes (`Fetching spans... (page N, 0 matched)`). This bounds the span fetch by a `trace_id` range derived from the matched trace ids, passed via the existing `filters` param, so the backend prunes by primary key.
- Spans are sorted by `(workspace_id, project_id, trace_id, ...)`, so a `trace_id` range prunes (~100× fewer granules in testing on a ~7M-span project).
- `trace_id` is `STRING_EXACT` (strict `>`/`<` only), so bounds are widened 1 ms each side via the UUIDv7 timestamp prefix; the existing client-side membership check keeps results exact, so the range only needs to be a superset (works for any trace filter, not just `id`).
- Falls back to the prior unfiltered scan when the matched set is empty or any id is not a UUIDv7.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7068

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Root-cause analysis (query-plan/EXPLAIN review of the export's generated queries), patch to `_fetch_spans_page` + Phase-2 caller, and this PR description.
  - Human verification: Pending — maintainer to run an export against a large project and confirm span counts match an unfiltered (pre-patch) run.

## Testing

Not yet run by the author. Suggested before merge:
- Exact commands: `cd sdks/python && pytest tests/ -k export`; `python -m py_compile src/opik/cli/exports/project.py` (passes).
- Scenarios: `opik export project <name> --filter 'id > "<lo>" AND id < "<hi>"'` against a large project — confirm it completes and per-trace span counts match a full (pre-patch) export; a non-`id` filter (metadata/name) — confirm spans are still complete; edge cases — empty result, single matched trace, non-UUIDv7 ids (helper returns `None` → unfiltered fallback).
- Environment: Python SDK CLI against an Opik backend.
- Not run: end-to-end export against a large project (needs maintainer with suitable data).

Video evidence: N/A (CLI/behavioral change; no UI).

## Documentation

No documentation change required — this is an internal export-performance fix with no change to user-facing flags or API. (A separate `--skip-spans` flag is proposed as a follow-up in OPIK-7068.)
