### PR TITLE
[OPIK-6888] [BE] chore: disable uuidValidation by default

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -93,10 +93,10 @@ databaseAnalytics:
 # Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the
 #   window, protecting data quality.
 uuidValidation:
-  #  Default: true
+  #  Default: false
   #  Description: Operational kill-switch. When false, ids are not checked against the window (the
   #   window is still validated to be a sane value).
-  enabled: ${UUID_VALIDATION_ENABLED:-true}
+  enabled: ${UUID_VALIDATION_ENABLED:-false}
   #  Default: 24h
   #  Description: Validation window (between 12h and 45d). Writes whose `id` is a UUIDv7 with an
   #   embedded timestamp more than this far in the past or future are rejected.

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -77,7 +77,7 @@ databaseAnalytics:
 # Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the
 #   window, protecting data quality.
 uuidValidation:
-  #  Default: true
+  #  Default: true for tests
   #  Description: Operational kill-switch. When false, ids are not checked against the window (the
   #   window is still validated to be a sane value).
   enabled: true


### PR DESCRIPTION
## Details

Disables `uuidValidation` by default by flipping the `UUID_VALIDATION_ENABLED` env-var default from `true` to `false` in `apps/opik-backend/config.yml`. After enabling UUIDv7 ingestion validation in production (OPIK-6888), some integrations were found to send malformed ids with future-dated timestamps, which the validation rejects with HTTP 400. Defaulting the kill-switch off restores ingestion for those clients until the offending integrations are fixed, at which point the default can be flipped back on.

- The default-off is captured as comment.
- The test config (`config-test.yml`) keeps `enabled: true` so the validator's integration tests continue to exercise the validation path; only its doc comment was clarified to "Default: true for tests".

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6888

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: assisted (config change + rationale comment)
  - Human verification: code review

## Testing

No behavioral code changed — only the default value of the operational kill-switch. The validation logic and its tests are unchanged, and `config-test.yml` deliberately keeps validation enabled so `UuidV7TimestampValidator` tests still cover the on path. CI runs the backend suite (`mvn test`).

## Documentation

N/A — config defaults documented inline in `config.yml`.
