### PR TITLE
fix(e2e): drop greeting assertion from ollie-smoke t1

### DIFF
--- a/tests_end_to_end/e2e/tests/ollie/ollie-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/ollie/ollie-smoke.spec.ts
@@ -17,8 +17,7 @@ test.describe('Ollie — smoke', { tag: ['@t1-smoke', '@ollie'] }, () => {
       await ollie.waitForReady();
     });
 
-    await test.step('Ready state shows the greeting and a usable input', async () => {
-      await expect(ollie.greeting()).toBeVisible();
+    await test.step('Ready state shows a usable input', async () => {
       await expect(ollie.inputTextbox()).toBeEnabled();
     });
   });


### PR DESCRIPTION
## Details

Removes the `expect(ollie.greeting()).toBeVisible()` assertion from the `ollie-smoke` t1 test. The `waitForReady()` POM already keys on the input — not greeting copy — as the readiness signal (copy varies across pod states). The spec's second step re-asserted the greeting with no explicit timeout (default 10s). On a cold customer env, `waitForReady()` can consume nearly its full 150s budget, leaving the greeting check a 10s window it can't meet.

Root cause confirmed from launch 77921 (`statusTransition: regressed`, `flaky: false`, test duration 170s against a cold Ollie pod).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK_77921

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: Diagnosis (debugging-e2e-tests skill) + one-line spec fix
- Human verification: confirmed by @AndreiCautisanu

## Testing

- Ran `npx tsc --noEmit` — no type errors
- Locally the test skips cleanly on OSS (`OLLIE_ENABLED off`)
- Prior production/staging runs pass when Ollie is enabled and warm (launch history confirms: only fails cold)
- Fix cherry-picked to `e2e-compat/2.0.76` — deployment team's next run against 2.0.76 customer envs will pick it up

## Documentation

No documentation change needed.