### PR TITLE
[OPIK-7040] [FE] feat: shared PromptComparison (Compare against baseline/parent) + Optimization runs rename

### DIFF
--- a/apps/opik-frontend/src/shared/CodeDiff/PromptComparison.test.tsx
+++ b/apps/opik-frontend/src/shared/CodeDiff/PromptComparison.test.tsx
@@ -1,94 +1,98 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 
 import PromptComparison from "./PromptComparison";
 import { PromptComparisonTarget } from "./promptComparisonTargets";
 
+const current = [
+  { role: "system", content: "current system text" },
+  { role: "user", content: "hello" },
+];
+
 const baselineTarget: PromptComparisonTarget = {
   id: "base",
   label: "Baseline",
-  prompt: "alpha baseline prompt",
+  prompt: [{ role: "system", content: "baseline system text" }],
 };
 
 const parentTarget: PromptComparisonTarget = {
   id: "p-1",
-  label: "Parent (Trial #3)",
-  prompt: "parent prompt",
+  label: "Parent",
+  prompt: [{ role: "system", content: "parent system text" }],
 };
 
 describe("PromptComparison", () => {
-  it("renders nothing when there are no targets", () => {
-    const { container } = render(
-      <PromptComparison current="bravo current prompt" targets={[]} />,
-    );
-
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  describe("single target", () => {
-    it("shows the target label as static text instead of a selector", () => {
-      render(
-        <PromptComparison
-          current="bravo current prompt"
-          targets={[baselineTarget]}
-        />,
-      );
-
-      expect(screen.getByText("Compare against:")).toBeInTheDocument();
-      expect(screen.getByText("Baseline")).toBeInTheDocument();
-      expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
-    });
-
-    it("renders the diff against the target prompt", () => {
+  describe("without targets", () => {
+    it("shows the current prompt as role cards with no compare control", () => {
       const { container } = render(
-        <PromptComparison
-          current="bravo current prompt"
-          targets={[baselineTarget]}
-        />,
+        <PromptComparison current={current} targets={[]} />,
       );
 
-      // String prompts fall through to the text diff, which renders both sides.
-      expect(container.textContent).toContain("bravo");
-      expect(container.textContent).toContain("baseline");
+      expect(container.textContent).toContain("current system text");
+      expect(container.textContent).toContain("hello");
+      expect(screen.queryByText("Hide diff")).not.toBeInTheDocument();
+    });
+
+    it("renders nothing when the current prompt is empty", () => {
+      const { container } = render(
+        <PromptComparison current={null} targets={[]} />,
+      );
+
+      expect(container).toBeEmptyDOMElement();
     });
   });
 
-  describe("multiple targets", () => {
-    it("renders a selector to choose the comparison target", () => {
-      render(
-        <PromptComparison
-          current="bravo current prompt"
-          targets={[baselineTarget, parentTarget]}
-        />,
+  describe("with targets", () => {
+    it("renders the compare control and diffs against the target", () => {
+      const { container } = render(
+        <PromptComparison current={current} targets={[baselineTarget]} />,
       );
 
-      expect(screen.getByRole("combobox")).toBeInTheDocument();
+      // Trigger shows the selected target; current side labelled after the arrow.
+      expect(screen.getByText("Baseline")).toBeInTheDocument();
+      expect(screen.getByText("→ Trial")).toBeInTheDocument();
+      expect(screen.getByText("Hide diff")).toBeInTheDocument();
+
+      // Both sides of the diff render (target removed, current added).
+      expect(container.textContent).toContain("baseline system text");
+      expect(container.textContent).toContain("current system text");
     });
 
-    it("defaults to the first target when defaultTargetId is not provided", () => {
-      render(
-        <PromptComparison
-          current="bravo current prompt"
-          targets={[baselineTarget, parentTarget]}
-        />,
+    it("hides the diff and shows only the current prompt when toggled", () => {
+      const { container } = render(
+        <PromptComparison current={current} targets={[baselineTarget]} />,
       );
 
-      // Radix renders the selected item's text inside the trigger.
-      expect(screen.getByRole("combobox")).toHaveTextContent("Baseline");
+      fireEvent.click(screen.getByText("Hide diff"));
+
+      expect(screen.getByText("Show diff")).toBeInTheDocument();
+      expect(container.textContent).toContain("current system text");
+      expect(container.textContent).not.toContain("baseline system text");
     });
 
-    it("honors defaultTargetId when it matches a target", () => {
+    it("honors defaultTargetId", () => {
       render(
         <PromptComparison
-          current="bravo current prompt"
+          current={current}
           targets={[baselineTarget, parentTarget]}
           defaultTargetId="p-1"
         />,
       );
 
-      expect(screen.getByRole("combobox")).toHaveTextContent(
-        "Parent (Trial #3)",
+      expect(screen.getByText("Parent")).toBeInTheDocument();
+      expect(screen.queryByText("Baseline")).not.toBeInTheDocument();
+    });
+
+    it("uses a custom currentLabel", () => {
+      render(
+        <PromptComparison
+          current={current}
+          currentLabel="Best trial"
+          targets={[baselineTarget]}
+        />,
       );
+
+      expect(screen.getByText("→ Best trial")).toBeInTheDocument();
     });
   });
 });

--- a/apps/opik-frontend/src/shared/CodeDiff/PromptComparison.test.tsx
+++ b/apps/opik-frontend/src/shared/CodeDiff/PromptComparison.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import PromptComparison from "./PromptComparison";
+import { PromptComparisonTarget } from "./promptComparisonTargets";
+
+const baselineTarget: PromptComparisonTarget = {
+  id: "base",
+  label: "Baseline",
+  prompt: "alpha baseline prompt",
+};
+
+const parentTarget: PromptComparisonTarget = {
+  id: "p-1",
+  label: "Parent (Trial #3)",
+  prompt: "parent prompt",
+};
+
+describe("PromptComparison", () => {
+  it("renders nothing when there are no targets", () => {
+    const { container } = render(
+      <PromptComparison current="bravo current prompt" targets={[]} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  describe("single target", () => {
+    it("shows the target label as static text instead of a selector", () => {
+      render(
+        <PromptComparison
+          current="bravo current prompt"
+          targets={[baselineTarget]}
+        />,
+      );
+
+      expect(screen.getByText("Compare against:")).toBeInTheDocument();
+      expect(screen.getByText("Baseline")).toBeInTheDocument();
+      expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    });
+
+    it("renders the diff against the target prompt", () => {
+      const { container } = render(
+        <PromptComparison
+          current="bravo current prompt"
+          targets={[baselineTarget]}
+        />,
+      );
+
+      // String prompts fall through to the text diff, which renders both sides.
+      expect(container.textContent).toContain("bravo");
+      expect(container.textContent).toContain("baseline");
+    });
+  });
+
+  describe("multiple targets", () => {
+    it("renders a selector to choose the comparison target", () => {
+      render(
+        <PromptComparison
+          current="bravo current prompt"
+          targets={[baselineTarget, parentTarget]}
+        />,
+      );
+
+      expect(screen.getByRole("combobox")).toBeInTheDocument();
+    });
+
+    it("defaults to the first target when defaultTargetId is not provided", () => {
+      render(
+        <PromptComparison
+          current="bravo current prompt"
+          targets={[baselineTarget, parentTarget]}
+        />,
+      );
+
+      // Radix renders the selected item's text inside the trigger.
+      expect(screen.getByRole("combobox")).toHaveTextContent("Baseline");
+    });
+
+    it("honors defaultTargetId when it matches a target", () => {
+      render(
+        <PromptComparison
+          current="bravo current prompt"
+          targets={[baselineTarget, parentTarget]}
+          defaultTargetId="p-1"
+        />,
+      );
+
+      expect(screen.getByRole("combobox")).toHaveTextContent(
+        "Parent (Trial #3)",
+      );
+    });
+  });
+});

--- a/apps/opik-frontend/src/shared/CodeDiff/PromptComparison.tsx
+++ b/apps/opik-frontend/src/shared/CodeDiff/PromptComparison.tsx
@@ -1,0 +1,89 @@
+import React, { useMemo, useState } from "react";
+
+import { cn } from "@/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/ui/select";
+import PromptDiff from "./PromptDiff";
+import { PromptComparisonTarget } from "./promptComparisonTargets";
+
+type PromptComparisonProps = {
+  /** The prompt being inspected (rendered as the "current" side of the diff). */
+  current: unknown;
+  /**
+   * Comparison targets, typically built via
+   * {@link ./promptComparison#buildPromptComparisonTargets}. Baseline first,
+   * then parents. Renders nothing when empty.
+   */
+  targets: PromptComparisonTarget[];
+  /** Target selected initially; falls back to the first target. */
+  defaultTargetId?: string;
+  className?: string;
+};
+
+/**
+ * Shared prompt-diff surface with a "Compare against: Baseline / Parent"
+ * control. Wraps {@link PromptDiff} and owns the target selection so the three
+ * optimization surfaces (overview best-prompt panel, trials prompt cell, trial
+ * sidebar) can drop it in without re-implementing the picker or the diff.
+ */
+const PromptComparison: React.FunctionComponent<PromptComparisonProps> = ({
+  current,
+  targets,
+  defaultTargetId,
+  className,
+}) => {
+  const fallbackId = targets[0]?.id;
+  const initialId =
+    defaultTargetId && targets.some((t) => t.id === defaultTargetId)
+      ? defaultTargetId
+      : fallbackId;
+
+  const [selectedId, setSelectedId] = useState<string | undefined>(initialId);
+
+  // Always derive from the live targets so a removed/stale selection can't
+  // point at a target that no longer exists.
+  const selectedTarget = useMemo(
+    () => targets.find((t) => t.id === selectedId) ?? targets[0],
+    [targets, selectedId],
+  );
+
+  if (!selectedTarget) {
+    return null;
+  }
+
+  const showSelector = targets.length > 1;
+
+  return (
+    <div className={cn("flex flex-col gap-3", className)}>
+      <div className="flex items-center gap-2">
+        <span className="comet-body-s shrink-0 text-muted-slate">
+          Compare against:
+        </span>
+        {showSelector ? (
+          <Select value={selectedTarget.id} onValueChange={setSelectedId}>
+            <SelectTrigger className="h-7 w-auto gap-1 px-2">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {targets.map((target) => (
+                <SelectItem key={target.id} value={target.id}>
+                  {target.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <span className="comet-body-s-accented">{selectedTarget.label}</span>
+        )}
+      </div>
+      <PromptDiff baseline={selectedTarget.prompt} current={current} />
+    </div>
+  );
+};
+
+export default PromptComparison;

--- a/apps/opik-frontend/src/shared/CodeDiff/PromptComparison.tsx
+++ b/apps/opik-frontend/src/shared/CodeDiff/PromptComparison.tsx
@@ -1,23 +1,31 @@
 import React, { useMemo, useState } from "react";
+import { diffLines } from "diff";
+import { ChevronDown, GitCompareArrows } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { LLM_MESSAGE_ROLE_NAME_MAP } from "@/constants/llm";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/ui/select";
-import PromptDiff from "./PromptDiff";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/ui/dropdown-menu";
 import { PromptComparisonTarget } from "./promptComparisonTargets";
+import {
+  buildRoleDiffRows,
+  groupMessageContentByRole,
+} from "./promptMessageDiff";
 
 type PromptComparisonProps = {
-  /** The prompt being inspected (rendered as the "current" side of the diff). */
+  /** The prompt being inspected — the "current" side of the diff. */
   current: unknown;
+  /** Label for the current side, shown after the arrow (e.g. "Trial"). */
+  currentLabel?: string;
   /**
-   * Comparison targets, typically built via
-   * {@link ./promptComparison#buildPromptComparisonTargets}. Baseline first,
-   * then parents. Renders nothing when empty.
+   * Comparison targets (baseline first, then parents), typically built via
+   * {@link ./promptComparisonTargets#buildPromptComparisonTargets}. With no
+   * targets the current prompt is shown on its own (no diff).
    */
   targets: PromptComparisonTarget[];
   /** Target selected initially; falls back to the first target. */
@@ -25,14 +33,74 @@ type PromptComparisonProps = {
   className?: string;
 };
 
+const promptToText = (prompt: unknown): string => {
+  if (prompt === null || prompt === undefined) return "";
+  if (typeof prompt === "string") return prompt;
+  return JSON.stringify(prompt, null, 2);
+};
+
+const roleLabel = (role: string): string =>
+  LLM_MESSAGE_ROLE_NAME_MAP[role as keyof typeof LLM_MESSAGE_ROLE_NAME_MAP] ??
+  role;
+
 /**
- * Shared prompt-diff surface with a "Compare against: Baseline / Parent"
- * control. Wraps {@link PromptDiff} and owns the target selection so the three
- * optimization surfaces (overview best-prompt panel, trials prompt cell, trial
- * sidebar) can drop it in without re-implementing the picker or the diff.
+ * Line-level diff: unchanged lines keep the full foreground color, added lines
+ * get a green band and removed lines a struck-through red band (matching the
+ * Figma trial-details diff — no word-level inline highlighting, no tag pills).
+ */
+const LineDiff: React.FC<{ base: string; current: string }> = ({
+  base,
+  current,
+}) => {
+  const parts = useMemo(() => diffLines(base, current), [base, current]);
+
+  return (
+    <div className="comet-body-s whitespace-pre-wrap break-words text-foreground">
+      {parts.map((part, index) => (
+        <div
+          key={index}
+          className={cn({
+            "bg-diff-added-bg text-diff-added-text": part.added,
+            "bg-diff-removed-bg text-diff-removed-text line-through":
+              part.removed,
+          })}
+        >
+          {part.value.replace(/\n$/, "")}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const RoleCard: React.FC<{ role: string; children: React.ReactNode }> = ({
+  role,
+  children,
+}) => (
+  <div className="flex w-full flex-col rounded-md border bg-primary-foreground px-3 py-2">
+    <div className="pb-1.5 pt-0.5">
+      <span className="comet-body-xs-accented capitalize text-muted-slate">
+        {roleLabel(role)}
+      </span>
+    </div>
+    {children}
+  </div>
+);
+
+const PlainText: React.FC<{ text: string }> = ({ text }) => (
+  <div className="comet-body-s whitespace-pre-wrap break-words text-foreground">
+    {text}
+  </div>
+);
+
+/**
+ * Shared prompt-diff surface for the Optimization Runs screens (trial sidebar,
+ * overview best-prompt panel, trials prompt cell). Renders a "[target] → [current]"
+ * control with a Baseline/Parent picker, a Hide/Show diff toggle, and the prompt
+ * grouped into per-role cards — diffed line by line against the chosen target.
  */
 const PromptComparison: React.FunctionComponent<PromptComparisonProps> = ({
   current,
+  currentLabel = "Trial",
   targets,
   defaultTargetId,
   className,
@@ -44,44 +112,102 @@ const PromptComparison: React.FunctionComponent<PromptComparisonProps> = ({
       : fallbackId;
 
   const [selectedId, setSelectedId] = useState<string | undefined>(initialId);
+  const [showDiff, setShowDiff] = useState(true);
 
-  // Always derive from the live targets so a removed/stale selection can't
-  // point at a target that no longer exists.
+  // Always derive from the live targets so a stale selection can't point at a
+  // target that no longer exists.
   const selectedTarget = useMemo(
     () => targets.find((t) => t.id === selectedId) ?? targets[0],
     [targets, selectedId],
   );
 
-  if (!selectedTarget) {
+  const hasTargets = targets.length > 0;
+  const diffActive = hasTargets && showDiff && Boolean(selectedTarget);
+
+  const body = useMemo(() => {
+    if (diffActive && selectedTarget) {
+      const rows = buildRoleDiffRows(selectedTarget.prompt, current);
+      if (rows) {
+        return rows.map((row) => (
+          <RoleCard key={row.role} role={row.role}>
+            <LineDiff base={row.baseContent} current={row.currentContent} />
+          </RoleCard>
+        ));
+      }
+      return (
+        <RoleCard role="prompt">
+          <LineDiff
+            base={promptToText(selectedTarget.prompt)}
+            current={promptToText(current)}
+          />
+        </RoleCard>
+      );
+    }
+
+    const rows = groupMessageContentByRole(current);
+    if (rows) {
+      return rows.map((row) => (
+        <RoleCard key={row.role} role={row.role}>
+          <PlainText text={row.content} />
+        </RoleCard>
+      ));
+    }
+
+    const text = promptToText(current);
+    return text ? (
+      <RoleCard role="prompt">
+        <PlainText text={text} />
+      </RoleCard>
+    ) : null;
+  }, [diffActive, selectedTarget, current]);
+
+  if (!body || (Array.isArray(body) && body.length === 0)) {
     return null;
   }
 
-  const showSelector = targets.length > 1;
-
   return (
     <div className={cn("flex flex-col gap-3", className)}>
-      <div className="flex items-center gap-2">
-        <span className="comet-body-s shrink-0 text-muted-slate">
-          Compare against:
-        </span>
-        {showSelector ? (
-          <Select value={selectedTarget.id} onValueChange={setSelectedId}>
-            <SelectTrigger className="h-7 w-auto gap-1 px-2">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {targets.map((target) => (
-                <SelectItem key={target.id} value={target.id}>
-                  {target.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        ) : (
-          <span className="comet-body-s-accented">{selectedTarget.label}</span>
-        )}
-      </div>
-      <PromptDiff baseline={selectedTarget.prompt} current={current} />
+      {hasTargets && selectedTarget && (
+        <div className="flex items-center justify-between pl-1">
+          <div className="flex items-center gap-1.5">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="comet-body-s-accented inline-flex items-center gap-0.5 border-b border-foreground pb-px text-foreground outline-none"
+                >
+                  {selectedTarget.label}
+                  <ChevronDown className="size-3.5" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                <DropdownMenuRadioGroup
+                  value={selectedTarget.id}
+                  onValueChange={setSelectedId}
+                >
+                  {targets.map((target) => (
+                    <DropdownMenuRadioItem key={target.id} value={target.id}>
+                      {target.label}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <span className="comet-body-s-accented text-foreground">
+              → {currentLabel}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowDiff((prev) => !prev)}
+            className="comet-body-s inline-flex items-center gap-1 text-foreground"
+          >
+            <GitCompareArrows className="size-3.5" />
+            {showDiff ? "Hide diff" : "Show diff"}
+          </button>
+        </div>
+      )}
+      <div className="flex flex-col gap-1.5">{body}</div>
     </div>
   );
 };

--- a/apps/opik-frontend/src/shared/CodeDiff/promptComparisonTargets.test.ts
+++ b/apps/opik-frontend/src/shared/CodeDiff/promptComparisonTargets.test.ts
@@ -66,7 +66,7 @@ describe("buildPromptComparisonTargets", () => {
   });
 
   describe("parent targets", () => {
-    it("offers each parent labelled by its trial number, baseline first", () => {
+    it("offers a single parent labelled simply 'Parent', baseline first", () => {
       const baseline = createCandidate({ id: "base", stepIndex: 0 });
       const parent = createCandidate({
         id: "p-1",
@@ -92,11 +92,11 @@ describe("buildPromptComparisonTargets", () => {
 
       expect(targets).toEqual([
         { id: "base", label: "Baseline", prompt: "baseline prompt" },
-        { id: "p-1", label: "Parent (Trial #4)", prompt: "parent prompt" },
+        { id: "p-1", label: "Parent", prompt: "parent prompt" },
       ]);
     });
 
-    it("preserves the order of multiple parents", () => {
+    it("disambiguates multiple parents by trial number, preserving order", () => {
       const parentA = createCandidate({ id: "p-a", trialNumber: 2 });
       const parentB = createCandidate({ id: "p-b", trialNumber: 3 });
       const candidate = createCandidate({
@@ -192,7 +192,7 @@ describe("buildPromptComparisonTargets", () => {
       });
 
       expect(targets).toEqual([
-        { id: "p-1", label: "Parent (Trial #3)", prompt: "parent prompt" },
+        { id: "p-1", label: "Parent", prompt: "parent prompt" },
       ]);
     });
   });

--- a/apps/opik-frontend/src/shared/CodeDiff/promptComparisonTargets.test.ts
+++ b/apps/opik-frontend/src/shared/CodeDiff/promptComparisonTargets.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  buildPromptComparisonTargets,
+  ComparisonCandidate,
+} from "./promptComparisonTargets";
+
+const createCandidate = (
+  overrides: Partial<ComparisonCandidate> = {},
+): ComparisonCandidate => ({
+  id: "c-1",
+  stepIndex: 1,
+  parentCandidateIds: [],
+  trialNumber: 1,
+  ...overrides,
+});
+
+// Prompt resolver keyed by candidate id; unknown ids resolve to null.
+const promptResolver =
+  (prompts: Record<string, unknown>) => (candidate: ComparisonCandidate) =>
+    candidate.id in prompts ? prompts[candidate.id] : null;
+
+describe("buildPromptComparisonTargets", () => {
+  describe("baseline target", () => {
+    it("offers the baseline (step 0) candidate for a non-baseline candidate", () => {
+      const baseline = createCandidate({ id: "base", stepIndex: 0 });
+      const candidate = createCandidate({ id: "c-2", trialNumber: 2 });
+
+      const targets = buildPromptComparisonTargets({
+        candidate,
+        candidates: [baseline, candidate],
+        getPrompt: promptResolver({
+          base: "baseline prompt",
+          "c-2": "current",
+        }),
+      });
+
+      expect(targets).toEqual([
+        { id: "base", label: "Baseline", prompt: "baseline prompt" },
+      ]);
+    });
+
+    it("returns no targets when the candidate is itself the baseline", () => {
+      const baseline = createCandidate({ id: "base", stepIndex: 0 });
+
+      const targets = buildPromptComparisonTargets({
+        candidate: baseline,
+        candidates: [baseline],
+        getPrompt: promptResolver({ base: "baseline prompt" }),
+      });
+
+      expect(targets).toEqual([]);
+    });
+
+    it("omits the baseline when no step-0 candidate exists", () => {
+      const candidate = createCandidate({ id: "c-2", trialNumber: 2 });
+
+      const targets = buildPromptComparisonTargets({
+        candidate,
+        candidates: [candidate],
+        getPrompt: promptResolver({ "c-2": "current" }),
+      });
+
+      expect(targets).toEqual([]);
+    });
+  });
+
+  describe("parent targets", () => {
+    it("offers each parent labelled by its trial number, baseline first", () => {
+      const baseline = createCandidate({ id: "base", stepIndex: 0 });
+      const parent = createCandidate({
+        id: "p-1",
+        stepIndex: 1,
+        trialNumber: 4,
+      });
+      const candidate = createCandidate({
+        id: "c-3",
+        stepIndex: 2,
+        trialNumber: 7,
+        parentCandidateIds: ["p-1"],
+      });
+
+      const targets = buildPromptComparisonTargets({
+        candidate,
+        candidates: [baseline, parent, candidate],
+        getPrompt: promptResolver({
+          base: "baseline prompt",
+          "p-1": "parent prompt",
+          "c-3": "current prompt",
+        }),
+      });
+
+      expect(targets).toEqual([
+        { id: "base", label: "Baseline", prompt: "baseline prompt" },
+        { id: "p-1", label: "Parent (Trial #4)", prompt: "parent prompt" },
+      ]);
+    });
+
+    it("preserves the order of multiple parents", () => {
+      const parentA = createCandidate({ id: "p-a", trialNumber: 2 });
+      const parentB = createCandidate({ id: "p-b", trialNumber: 3 });
+      const candidate = createCandidate({
+        id: "c-3",
+        trialNumber: 5,
+        parentCandidateIds: ["p-b", "p-a"],
+      });
+
+      const targets = buildPromptComparisonTargets({
+        candidate,
+        candidates: [parentA, parentB, candidate],
+        getPrompt: promptResolver({
+          "p-a": "a",
+          "p-b": "b",
+          "c-3": "current",
+        }),
+      });
+
+      expect(targets.map((t) => t.id)).toEqual(["p-b", "p-a"]);
+      expect(targets.map((t) => t.label)).toEqual([
+        "Parent (Trial #3)",
+        "Parent (Trial #2)",
+      ]);
+    });
+
+    it("skips parent ids that are not present in the candidate list", () => {
+      const candidate = createCandidate({
+        id: "c-3",
+        parentCandidateIds: ["missing"],
+      });
+
+      const targets = buildPromptComparisonTargets({
+        candidate,
+        candidates: [candidate],
+        getPrompt: promptResolver({ "c-3": "current" }),
+      });
+
+      expect(targets).toEqual([]);
+    });
+  });
+
+  describe("deduplication & exclusions", () => {
+    it("does not duplicate the baseline when it is also a parent", () => {
+      const baseline = createCandidate({ id: "base", stepIndex: 0 });
+      const candidate = createCandidate({
+        id: "c-2",
+        parentCandidateIds: ["base"],
+      });
+
+      const targets = buildPromptComparisonTargets({
+        candidate,
+        candidates: [baseline, candidate],
+        getPrompt: promptResolver({
+          base: "baseline prompt",
+          "c-2": "current",
+        }),
+      });
+
+      expect(targets).toEqual([
+        { id: "base", label: "Baseline", prompt: "baseline prompt" },
+      ]);
+    });
+
+    it("never offers the candidate as its own comparison target", () => {
+      const baseline = createCandidate({ id: "base", stepIndex: 0 });
+      const candidate = createCandidate({
+        id: "c-2",
+        parentCandidateIds: ["c-2"],
+      });
+
+      const targets = buildPromptComparisonTargets({
+        candidate,
+        candidates: [baseline, candidate],
+        getPrompt: promptResolver({ base: "baseline", "c-2": "current" }),
+      });
+
+      expect(targets.map((t) => t.id)).toEqual(["base"]);
+    });
+
+    it("skips targets whose prompt cannot be resolved", () => {
+      const baseline = createCandidate({ id: "base", stepIndex: 0 });
+      const parent = createCandidate({ id: "p-1", trialNumber: 3 });
+      const candidate = createCandidate({
+        id: "c-2",
+        parentCandidateIds: ["p-1"],
+      });
+
+      const targets = buildPromptComparisonTargets({
+        candidate,
+        candidates: [baseline, parent, candidate],
+        // baseline prompt missing -> baseline target dropped; parent kept
+        getPrompt: promptResolver({ "p-1": "parent prompt", "c-2": "current" }),
+      });
+
+      expect(targets).toEqual([
+        { id: "p-1", label: "Parent (Trial #3)", prompt: "parent prompt" },
+      ]);
+    });
+  });
+});

--- a/apps/opik-frontend/src/shared/CodeDiff/promptComparisonTargets.ts
+++ b/apps/opik-frontend/src/shared/CodeDiff/promptComparisonTargets.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared helpers for the {@link ./PromptComparison} component.
+ *
+ * Optimization trials are compared against either the run's baseline (the
+ * step-0 candidate) or the candidate's direct parent(s). This module turns a
+ * candidate + the full candidate list into the list of comparison targets the
+ * UI offers in its "Compare against" control, so the three surfaces that render
+ * a prompt diff (overview best-prompt panel, trials prompt cell, trial sidebar)
+ * resolve targets the same way.
+ */
+
+export type PromptComparisonTarget = {
+  /** Stable id of the target candidate (used as the Select value). */
+  id: string;
+  /** Human-readable label, e.g. "Baseline" or "Parent (Trial #3)". */
+  label: string;
+  /** The prompt to diff the current prompt against. */
+  prompt: unknown;
+};
+
+/**
+ * Minimal shape needed to resolve comparison targets. Kept structural (rather
+ * than importing `AggregatedCandidate`) so the helper stays pure and trivially
+ * testable, and so callers can pass any candidate-like row.
+ */
+export type ComparisonCandidate = {
+  id: string;
+  /** 0 marks the baseline candidate. */
+  stepIndex: number;
+  /** Ids of the candidates this one was derived from. */
+  parentCandidateIds: string[];
+  /** 1-indexed trial number, used to label parent targets. */
+  trialNumber: number;
+};
+
+export const BASELINE_TARGET_LABEL = "Baseline";
+
+export const buildParentTargetLabel = (trialNumber: number): string =>
+  `Parent (Trial #${trialNumber})`;
+
+type BuildTargetsParams<T extends ComparisonCandidate> = {
+  /** The candidate whose prompt is being compared. */
+  candidate: T;
+  /** Every candidate in the run (used to look up baseline + parents). */
+  candidates: T[];
+  /**
+   * Resolves a candidate to its prompt. The prompt does not live on the
+   * candidate itself (it comes from the trial experiment), so the caller
+   * supplies the lookup. Targets whose prompt resolves to `null`/`undefined`
+   * are skipped — there is nothing meaningful to diff against.
+   */
+  getPrompt: (candidate: T) => unknown;
+};
+
+/**
+ * Builds the ordered list of comparison targets for a candidate: the baseline
+ * first (when it isn't the candidate itself), then each resolvable parent.
+ *
+ * The candidate itself, duplicates, missing parents, and targets without a
+ * resolvable prompt are all excluded. Returns an empty array when there is
+ * nothing to compare against (e.g. the candidate IS the baseline).
+ */
+export const buildPromptComparisonTargets = <T extends ComparisonCandidate>({
+  candidate,
+  candidates,
+  getPrompt,
+}: BuildTargetsParams<T>): PromptComparisonTarget[] => {
+  const byId = new Map(candidates.map((c) => [c.id, c]));
+  const targets: PromptComparisonTarget[] = [];
+  const seen = new Set<string>();
+
+  const pushTarget = (target: T, label: string) => {
+    if (target.id === candidate.id || seen.has(target.id)) return;
+    const prompt = getPrompt(target);
+    if (prompt === null || prompt === undefined) return;
+    seen.add(target.id);
+    targets.push({ id: target.id, label, prompt });
+  };
+
+  const baseline = candidates.find((c) => c.stepIndex === 0);
+  if (baseline) {
+    pushTarget(baseline, BASELINE_TARGET_LABEL);
+  }
+
+  candidate.parentCandidateIds.forEach((parentId) => {
+    const parent = byId.get(parentId);
+    if (parent) {
+      pushTarget(parent, buildParentTargetLabel(parent.trialNumber));
+    }
+  });
+
+  return targets;
+};

--- a/apps/opik-frontend/src/shared/CodeDiff/promptComparisonTargets.ts
+++ b/apps/opik-frontend/src/shared/CodeDiff/promptComparisonTargets.ts
@@ -34,9 +34,16 @@ export type ComparisonCandidate = {
 };
 
 export const BASELINE_TARGET_LABEL = "Baseline";
+export const PARENT_TARGET_LABEL = "Parent";
 
+/**
+ * A candidate usually has a single parent, shown simply as "Parent" (matching
+ * the Figma design). Evolutionary crossover can produce multiple parents, so we
+ * disambiguate those by trial number — otherwise the dropdown would list two
+ * identical "Parent" options.
+ */
 export const buildParentTargetLabel = (trialNumber: number): string =>
-  `Parent (Trial #${trialNumber})`;
+  `${PARENT_TARGET_LABEL} (Trial #${trialNumber})`;
 
 type BuildTargetsParams<T extends ComparisonCandidate> = {
   /** The candidate whose prompt is being compared. */
@@ -82,10 +89,16 @@ export const buildPromptComparisonTargets = <T extends ComparisonCandidate>({
     pushTarget(baseline, BASELINE_TARGET_LABEL);
   }
 
+  const hasMultipleParents = candidate.parentCandidateIds.length > 1;
   candidate.parentCandidateIds.forEach((parentId) => {
     const parent = byId.get(parentId);
     if (parent) {
-      pushTarget(parent, buildParentTargetLabel(parent.trialNumber));
+      pushTarget(
+        parent,
+        hasMultipleParents
+          ? buildParentTargetLabel(parent.trialNumber)
+          : PARENT_TARGET_LABEL,
+      );
     }
   });
 

--- a/apps/opik-frontend/src/shared/CodeDiff/promptMessageDiff.test.ts
+++ b/apps/opik-frontend/src/shared/CodeDiff/promptMessageDiff.test.ts
@@ -34,6 +34,43 @@ describe("groupMessageContentByRole", () => {
     expect(groupMessageContentByRole(null)).toBeNull();
     expect(groupMessageContentByRole({ foo: "bar" })).toBeNull();
   });
+
+  it("emits a placeholder for media-only content instead of a blank card", () => {
+    const prompt = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/x.png" },
+          },
+        ],
+      },
+    ];
+
+    expect(groupMessageContentByRole(prompt)).toEqual([
+      { role: "user", content: "[image_url]" },
+    ]);
+  });
+
+  it("keeps text when a message mixes text and media", () => {
+    const prompt = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "describe this" },
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/x.png" },
+          },
+        ],
+      },
+    ];
+
+    expect(groupMessageContentByRole(prompt)).toEqual([
+      { role: "user", content: "describe this" },
+    ]);
+  });
 });
 
 describe("buildRoleDiffRows", () => {

--- a/apps/opik-frontend/src/shared/CodeDiff/promptMessageDiff.test.ts
+++ b/apps/opik-frontend/src/shared/CodeDiff/promptMessageDiff.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  groupMessageContentByRole,
+  buildRoleDiffRows,
+} from "./promptMessageDiff";
+
+describe("groupMessageContentByRole", () => {
+  it("groups messages by role in display order", () => {
+    const prompt = [
+      { role: "user", content: "hi" },
+      { role: "system", content: "be helpful" },
+    ];
+
+    expect(groupMessageContentByRole(prompt)).toEqual([
+      { role: "system", content: "be helpful" },
+      { role: "user", content: "hi" },
+    ]);
+  });
+
+  it("concatenates multiple messages of the same role", () => {
+    const prompt = [
+      { role: "system", content: "first" },
+      { role: "system", content: "second" },
+    ];
+
+    expect(groupMessageContentByRole(prompt)).toEqual([
+      { role: "system", content: "first\nsecond" },
+    ]);
+  });
+
+  it("returns null for prompts that are not message arrays", () => {
+    expect(groupMessageContentByRole("just a string")).toBeNull();
+    expect(groupMessageContentByRole(null)).toBeNull();
+    expect(groupMessageContentByRole({ foo: "bar" })).toBeNull();
+  });
+});
+
+describe("buildRoleDiffRows", () => {
+  it("pairs base and current content over the union of roles", () => {
+    const baseline = [{ role: "system", content: "old system" }];
+    const current = [
+      { role: "system", content: "new system" },
+      { role: "user", content: "added user" },
+    ];
+
+    expect(buildRoleDiffRows(baseline, current)).toEqual([
+      {
+        role: "system",
+        baseContent: "old system",
+        currentContent: "new system",
+      },
+      { role: "user", baseContent: "", currentContent: "added user" },
+    ]);
+  });
+
+  it("returns empty base content for roles only present in current", () => {
+    const baseline = [{ role: "system", content: "sys" }];
+    const current = [{ role: "assistant", content: "assist" }];
+
+    const rows = buildRoleDiffRows(baseline, current);
+
+    expect(rows).toEqual([
+      { role: "system", baseContent: "sys", currentContent: "" },
+      { role: "assistant", baseContent: "", currentContent: "assist" },
+    ]);
+  });
+
+  it("returns null when either side is not a message array", () => {
+    const messages = [{ role: "system", content: "sys" }];
+
+    expect(buildRoleDiffRows("string baseline", messages)).toBeNull();
+    expect(buildRoleDiffRows(messages, "string current")).toBeNull();
+  });
+});

--- a/apps/opik-frontend/src/shared/CodeDiff/promptMessageDiff.ts
+++ b/apps/opik-frontend/src/shared/CodeDiff/promptMessageDiff.ts
@@ -8,6 +8,9 @@
  * line by line).
  */
 
+import isArray from "lodash/isArray";
+import isObject from "lodash/isObject";
+
 import {
   OpenAIMessage,
   extractMessageContent,
@@ -30,13 +33,34 @@ export type RoleDiffRow = {
   currentContent: string;
 };
 
+/**
+ * Text of a message. `extractMessageContent` only pulls `type: "text"` blocks,
+ * so a media-only message (image/audio/video parts) would collapse to "" and
+ * render a blank card. When that happens, fall back to a "[type]" placeholder
+ * per block so the message is still represented in the diff.
+ */
+const messageContentToText = (content: OpenAIMessage["content"]): string => {
+  const text = extractMessageContent(content);
+  if (text || !isArray(content)) return text;
+
+  return content
+    .map((block) => {
+      const type =
+        isObject(block) && "type" in block
+          ? String((block as { type: unknown }).type)
+          : "content";
+      return `[${type}]`;
+    })
+    .join(" ");
+};
+
 const groupByRole = (messages: OpenAIMessage[]): Map<string, string> => {
   const map = new Map<string, string>();
   messages.forEach((msg) => {
     const existing = map.get(msg.role) ?? "";
     map.set(
       msg.role,
-      existing + (existing ? "\n" : "") + extractMessageContent(msg.content),
+      existing + (existing ? "\n" : "") + messageContentToText(msg.content),
     );
   });
   return map;

--- a/apps/opik-frontend/src/shared/CodeDiff/promptMessageDiff.ts
+++ b/apps/opik-frontend/src/shared/CodeDiff/promptMessageDiff.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure model helpers for {@link ./PromptComparison}.
+ *
+ * Optimization prompts are OpenAI-style message arrays. For the diff view we
+ * group message content by role (system / user / assistant / …) and pair the
+ * comparison target's content against the current prompt's, role by role —
+ * matching the Figma trial-details diff (one card per role, content diffed
+ * line by line).
+ */
+
+import {
+  OpenAIMessage,
+  extractMessageContent,
+  extractPromptData,
+} from "@/lib/prompt";
+
+/** Roles render in this order; anything else falls after, sorted alphabetically. */
+export const ROLE_DISPLAY_ORDER = ["system", "user", "assistant"];
+
+export type RoleContent = {
+  role: string;
+  content: string;
+};
+
+export type RoleDiffRow = {
+  role: string;
+  /** Comparison-target content for this role (empty when the role was added). */
+  baseContent: string;
+  /** Current-prompt content for this role (empty when the role was removed). */
+  currentContent: string;
+};
+
+const groupByRole = (messages: OpenAIMessage[]): Map<string, string> => {
+  const map = new Map<string, string>();
+  messages.forEach((msg) => {
+    const existing = map.get(msg.role) ?? "";
+    map.set(
+      msg.role,
+      existing + (existing ? "\n" : "") + extractMessageContent(msg.content),
+    );
+  });
+  return map;
+};
+
+export const sortRoles = (roles: Iterable<string>): string[] =>
+  Array.from(roles).sort((a, b) => {
+    const aIndex = ROLE_DISPLAY_ORDER.indexOf(a);
+    const bIndex = ROLE_DISPLAY_ORDER.indexOf(b);
+    if (aIndex === -1 && bIndex === -1) return a.localeCompare(b);
+    if (aIndex === -1) return 1;
+    if (bIndex === -1) return -1;
+    return aIndex - bIndex;
+  });
+
+const asSingleMessages = (prompt: unknown): OpenAIMessage[] | null => {
+  const extracted = extractPromptData(prompt);
+  return extracted?.type === "single" ? extracted.data : null;
+};
+
+/**
+ * Groups a single message-array prompt into ordered {role, content} entries.
+ * Returns null when the prompt is not a plain OpenAI message array (e.g. named
+ * multi-prompts or raw strings), letting the caller fall back to a text view.
+ */
+export const groupMessageContentByRole = (
+  prompt: unknown,
+): RoleContent[] | null => {
+  const messages = asSingleMessages(prompt);
+  if (!messages) return null;
+
+  const byRole = groupByRole(messages);
+  return sortRoles(byRole.keys()).map((role) => ({
+    role,
+    content: byRole.get(role) ?? "",
+  }));
+};
+
+/**
+ * Pairs a baseline/target prompt against the current prompt, role by role, over
+ * the union of roles. Returns null when either side is not a plain message
+ * array, so the caller can fall back to a whole-text diff.
+ */
+export const buildRoleDiffRows = (
+  baseline: unknown,
+  current: unknown,
+): RoleDiffRow[] | null => {
+  const baseMessages = asSingleMessages(baseline);
+  const currentMessages = asSingleMessages(current);
+  if (!baseMessages || !currentMessages) return null;
+
+  const baseByRole = groupByRole(baseMessages);
+  const currentByRole = groupByRole(currentMessages);
+  const roles = sortRoles(
+    new Set([...baseByRole.keys(), ...currentByRole.keys()]),
+  );
+
+  return roles.map((role) => ({
+    role,
+    baseContent: baseByRole.get(role) ?? "",
+    currentContent: currentByRole.get(role) ?? "",
+  }));
+};

--- a/apps/opik-frontend/src/v2/pages-shared/optimizations/OptimizationConfigForm/schema.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/optimizations/OptimizationConfigForm/schema.ts
@@ -233,7 +233,7 @@ export const convertOptimizationStudioToFormData = (
       : defaultConfig;
 
   return {
-    name: optimization?.name || "Optimization studio run",
+    name: optimization?.name || "Optimization run",
     datasetId: optimization?.dataset_id || "",
     optimizerType,
     optimizerParams:

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsEmptyState.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsEmptyState.tsx
@@ -69,7 +69,7 @@ const OptimizationsEmptyState: React.FC<OptimizationsEmptyStateProps> = ({
     {
       icon: SquareDashedMousePointer,
       iconClassName: "text-chart-purple",
-      title: "Use the Optimization Studio",
+      title: "Start an optimization run",
       description:
         "Create a custom optimization workflow to test and improve your prompts.",
       onClick: () => navigateToStudio(),

--- a/apps/opik-frontend/src/v2/router.tsx
+++ b/apps/opik-frontend/src/v2/router.tsx
@@ -409,7 +409,7 @@ const optimizationsRoute = createRoute({
   getParentRoute: () => projectScopedRoute,
   component: OptimizationsPageGuard,
   staticData: {
-    title: "Optimization studio",
+    title: "Optimization runs",
   },
 });
 


### PR DESCRIPTION
## Details

Foundations PR for the Optimization Runs cleanup (part of OPIK_6528). Two things:

1. **New shared `PromptComparison`** — the prompt-diff surface the redesign puts on three later screens (overview "Best trial prompt", trials prompt cell, trial-details sidebar). It shows what the optimizer changed about a prompt: a **`[target] → Trial`** control with a **Baseline / Parent** picker, a **Hide/Show diff** toggle, and per-role cards diffed line by line. Built to the Figma trial-details design (nodes `705:69927` / `705:70751` / `705:70733`).
2. **Finishes the v2 `"Optimization studio" → "Optimization runs"` rename** (the nav + list heading already used the new name; this mops up the rest).

### Files
- `shared/CodeDiff/PromptComparison.tsx` — the diff surface. Control row matches Figma: underlined `Baseline ▾` target trigger + `→ Trial`, and a `Hide/Show diff` toggle. Cards: `bg-primary-foreground` / `border` / `rounded-md` / `px-3 py-2`; role label `comet-body-xs-accented text-muted-slate`; body `comet-body-s text-foreground`. Diff via `diffLines`: unchanged stays full foreground, added = `diff-added-*` green band, removed = `diff-removed-*` struck red (no word-level pills). The `diff-*` tokens equal the Figma hex (`#e2fde6`/`#1d6728`/`#fde2e7`) and are dark-mode aware.
- `shared/CodeDiff/promptComparisonTargets.ts` — pure `buildPromptComparisonTargets()`: resolves a candidate + the candidate list into ordered targets (Baseline first, then parents; plain "Parent", disambiguated to "Parent (Trial #N)" only for multi-parent crossover). Decoupled from data fetching via a `getPrompt` callback.
- `shared/CodeDiff/promptMessageDiff.ts` — pure role-grouping + diff-row model (`groupMessageContentByRole`, `buildRoleDiffRows`), with a `[type]` placeholder so media-only messages don't render blank.
- Rename (v2 user-facing strings only): route title (`v2/router.tsx`), empty-state card (`"Use the Optimization Studio"` → `"Start an optimization run"`), default run name (`schema.ts`: `"Optimization studio run"` → `"Optimization run"`).

### Notes for reviewers
- **Scope.** The parent plan framed PR 1 as "bring the shared card / table / sidebar-shell / PromptDiff into v2." Those already exist and are shared on `main`, so this PR does **not** re-introduce them — it adds the one genuinely-missing piece (the prompt-compare surface) plus the rename.
- **Dependencies.** This only gates **PR 4** (overview diff) and **PR 5** (trials/sidebar diff) — the surfaces that render `PromptComparison`. **PR 2 (Runs list) and PR 3 (New-run) do not depend on it** and can proceed in parallel.
- **v1 is untouched.** The shared `PromptDiff`/`TextDiff` are rendered by frozen `v1`, so this component renders its **own** diff (via the `diff` lib) rather than restyling them. v2 only; no backend, no migrations.
- **Verification — read this.** The component is styled to the Figma frames/tokens but is **not yet pixel-verified in a render**: there is no Storybook, and it is intentionally **not mounted on any screen** in this PR (PR 1 ships no screen changes). It gets mounted and pixel-checked against Figma in **PR 5**, in its designed home (the trial-details sidebar Prompt tab) — not via throwaway interim wiring. Behavior here is covered by unit + render tests.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-7040

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Opus 4.8 (1M context)
- Scope: Full implementation — planning, the `PromptComparison` component + `promptComparisonTargets`/`promptMessageDiff` helpers, tests, and the rename. Component styled to the Figma spec via the Figma MCP (nodes `705:69927`, `705:70751`, `705:70733`) using design-system tokens.
- Human verification: Author directed the scope and the "1:1 with Figma" requirement and reviewed the design decisions. **Not pixel-verified in a render** (unmounted; no Storybook) — final pixel fidelity is confirmed in PR 5 where the component is mounted on its surface. Logic covered by tests; typecheck/lint clean.

## Testing

Commands (from `apps/opik-frontend`):
- `vitest run src/shared/CodeDiff` — **23 tests passing** (9 `buildPromptComparisonTargets`, 8 `promptMessageDiff`, 6 `PromptComparison` render/interaction).
- `tsc --project tsconfig.json --noEmit` — clean.
- `eslint` on all changed files — 0 problems.

Render tests cover: current-only (no targets) view, the empty state, the compare control + diff against a target, the Hide/Show-diff toggle, `defaultTargetId`, and a custom `currentLabel`. Helper tests cover target resolution (baseline/parent ordering, dedup, self-exclusion, missing parents, unresolvable prompts), role grouping, diff-row pairing, and the media placeholder. **Not exercised in the running app** (unmounted foundation) — styling matched against the Figma frames; live verification happens in PR 5.

## Documentation

N/A — internal shared component plus a user-facing string rename only; no documentation change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
