### PR TITLE
[OPIK-7083] test: harden Ollie/Agent-Playground local-runner E2E against prod latency

### DIFF
--- a/tests_end_to_end/e2e/pom/agent-playground.page.ts
+++ b/tests_end_to_end/e2e/pom/agent-playground.page.ts
@@ -39,9 +39,18 @@ export class AgentPlaygroundPage {
     return this.page.getByText('Test input');
   }
 
+  /**
+   * The entrypoint param's input control. The "Test input" panel label and the
+   * Connected badge render before the runner's introspected form mounts, so wait
+   * on the actual field (not the panel label) before driving a run.
+   */
+  inputField(fieldName: string): Locator {
+    return this.page.getByPlaceholder(`Enter ${fieldName}...`);
+  }
+
   async fillInput(fieldName: string, value: string): Promise<void> {
     return test.step(`fill input "${fieldName}"`, async () => {
-      await this.page.getByPlaceholder(`Enter ${fieldName}...`).fill(value);
+      await this.inputField(fieldName).fill(value);
     });
   }
 

--- a/tests_end_to_end/e2e/pom/agent-playground.page.ts
+++ b/tests_end_to_end/e2e/pom/agent-playground.page.ts
@@ -12,7 +12,11 @@ export class AgentPlaygroundPage {
     return test.step('open the Agent Playground page', async () => {
       const env = loadEnvConfig();
       const url = `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/agent-playground`;
-      await this.page.goto(url, { waitUntil: 'networkidle' });
+      // Don't wait for networkidle: the page embeds the Ollie assistant iframe,
+      // which holds a long-lived streaming connection, so the network never goes
+      // idle and the goto hangs to the test timeout. Readiness is asserted by
+      // waitForHeading() + the Connected badge instead.
+      await this.page.goto(url);
       await this.page.waitForURL(new RegExp('/agent-playground'));
     });
   }

--- a/tests_end_to_end/e2e/tests/agent-playground/agent-playground-local-runner.spec.ts
+++ b/tests_end_to_end/e2e/tests/agent-playground/agent-playground-local-runner.spec.ts
@@ -44,12 +44,15 @@ test.describe('Agent Playground — Local Runner', { tag: ['@t3-nightly', '@agen
         ).toBeVisible();
       });
 
+      const query = 'capital of france';
+
       await test.step('Wait for connected state', async () => {
         await expect(playground.connectionBadge()).toBeVisible({ timeout: 60_000 });
         await expect(playground.testInputPanel()).toBeVisible({ timeout: 60_000 });
+        // The runner introspects the entrypoint and mounts its input form after
+        // the panel label appears; wait for the actual field before filling it.
+        await expect(playground.inputField('query')).toBeVisible({ timeout: 60_000 });
       });
-
-      const query = 'capital of france';
 
       await test.step('Fill input and run', async () => {
         await playground.fillInput('query', query);

--- a/tests_end_to_end/e2e/tests/ollie/ollie-connect.spec.ts
+++ b/tests_end_to_end/e2e/tests/ollie/ollie-connect.spec.ts
@@ -145,9 +145,12 @@ test.describe('Ollie — Local Runner', { tag: ['@t3-nightly', '@ollie'] }, () =
       await test.step('Open Ollie and run /improve to completion', async () => {
         await ollie.goto();
         await ollie.waitForReady();
-        // The seeded traces are eventually consistent; wait for /improve to be
-        // offered before clicking it.
-        await expect(ollie.improveButton()).toBeVisible({ timeout: 60_000 });
+        // The seeded traces are eventually consistent and the assistant pod can
+        // be cold on production, so the greeting action buttons render well
+        // after the input is ready. Wait on the same generous budget the POM
+        // uses for pod provisioning rather than a tight 60s, which flaked when
+        // the pod was slow to warm.
+        await expect(ollie.improveButton()).toBeVisible({ timeout: 150_000 });
         await ollie.startImprove();
         // Analyse phase: approve tool calls while Ollie reads the traces + code.
         await ollie.approveUntilSettled();


### PR DESCRIPTION
## Details

Two t3-nightly E2E tests fail consistently on production while passing on staging. Both were reproduced as **passing on staging**, confirming the product works and the failures are test-resilience / production-timing issues, not product regressions.

- **Agent Playground** (`agent-playground-local-runner.spec.ts`): `AgentPlaygroundPage.goto()` used `waitUntil: 'networkidle'`. The page embeds the Ollie assistant iframe, which holds a long-lived streaming connection, so the network never goes idle and `page.goto` hung to the 300s test timeout (the page itself was fully rendered). Dropped `networkidle`; readiness is already asserted downstream by `waitForHeading()` + the `Connected` badge. It was the only `networkidle` usage in the suite.
- **Ollie `/improve`** (`ollie-connect.spec.ts`): the agentic loop (cold assistant-pod provisioning + eventually-consistent seed + real-LLM analyse/propose/apply) is slower and more variable on production, so the greeting action buttons can render after the tight 60s budget. Raised the `improveButton()` visibility wait to 150s (the same cold-pod tolerance the POM uses for `waitForReady`); the test's overall budget is already 600s.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7083

Related (not resolved here): OPIK_6922 — separate customer-reported `opik endpoint` runner connectivity investigation in the same feature area.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full investigation + fix (debugging-e2e-tests skill)
- Human verification: live staging reproduction of both tests pre- and post-fix, code review

## Testing

Reproduced and validated against live staging (`natzol` workspace), `WORKERS=1`:

- `npx playwright test tests/agent-playground/agent-playground-local-runner.spec.ts` — failed (300s hang) on the original `networkidle` wait against production trace; **passes in ~18s** after the fix on staging.
- `npx playwright test tests/ollie/ollie-connect.spec.ts --grep "improve raises"` — **passes in ~1.9m** on staging (full `/improve` loop completes end to end).
- `npx tsc --noEmit` clean; `pre-commit` on both changed files clean.

The `/improve` budget widening is best-effort for the worst-case cold prod pod (it could only ever be reproduced as passing on staging); if it still flakes on a prod nightly, the durable follow-up is polling an assistant-ready signal before asserting the action buttons.

## Documentation

N/A — internal E2E test resilience changes only.
