### PR TITLE
[NA] [SDK] test: make pydantic-ai E2E tolerant of OTel GenAI span names

### DIFF
--- a/sdks/python/tests/e2e_library_integration/pydantic_ai/test_pydantic_ai_logfire.py
+++ b/sdks/python/tests/e2e_library_integration/pydantic_ai/test_pydantic_ai_logfire.py
@@ -34,6 +34,23 @@ from opik.integrations.otel import OpikSpanProcessor
 from ...e2e import verifiers
 
 
+# PydanticAI instrumentation v<=2 names the agent root span "agent run" and the
+# tool span "running tool". v3+ follows the OpenTelemetry GenAI semantic
+# conventions: "invoke_agent {agent_name}" and "execute_tool {tool_name}". The
+# deps are unpinned, so accept either naming so the test survives version drift.
+def _is_agent_run_span(name: str) -> bool:
+    return name == "agent run" or name.startswith("invoke_agent")
+
+
+def _is_tool_span(name: str) -> bool:
+    return name == "running tool" or name.startswith("execute_tool")
+
+
+# Tool result attribute key: "tool_response" (v<=2) or the GenAI semconv
+# "gen_ai.tool.call.result" (v3+).
+_TOOL_RESULT_KEYS = ("tool_response", "gen_ai.tool.call.result")
+
+
 def _build_otlp_exporter(config: opik_config.OpikConfig) -> OTLPSpanExporter:
     parsed = urllib.parse.urlparse(config.url_override)
     # different port for local dev vs test CI environment
@@ -93,12 +110,14 @@ def test_pydantic_ai_logfire_with_opik_track__single_merged_trace(
 
     # entrypoint + at least the "agent run" and a model span all under one trace
     if not synchronization.until(
-        lambda: len(
-            opik_client.search_spans(
-                project_name=opik_client.config.project_name, trace_id=trace_id
+        lambda: (
+            len(
+                opik_client.search_spans(
+                    project_name=opik_client.config.project_name, trace_id=trace_id
+                )
             )
-        )
-        >= 3,
+            >= 3
+        ),
         max_try_seconds=15,
     ):
         raise AssertionError(
@@ -125,11 +144,11 @@ def test_pydantic_ai_logfire_with_opik_track__single_merged_trace(
         (span for span in spans if span.parent_span_id == entrypoint_span_id), None
     )
     assert otel_root is not None, (
-        "PydanticAI 'agent run' span was not nested under the tracked entrypoint"
+        "PydanticAI agent-run span was not nested under the tracked entrypoint"
     )
-    # logfire's PydanticAI instrumentation names the agent root span "agent run";
-    # assert it so a future hierarchy change can't pass on parentage alone
-    assert otel_root.name == "agent run"
+    # assert the name matches the agent-run span so a future hierarchy change
+    # can't pass on parentage alone
+    assert _is_agent_run_span(otel_root.name)
 
     # and the model/LLM span chained below the OTel root (descendant chaining)
     span_ids = {span.id for span in spans}
@@ -179,12 +198,14 @@ def test_pydantic_ai_logfire_with_opik_track__two_agent_calls__correct_nesting(
 
     # entrypoint + 2x (agent run + model span) = 5 spans in a single trace
     if not synchronization.until(
-        lambda: len(
-            opik_client.search_spans(
-                project_name=opik_client.config.project_name, trace_id=trace_id
+        lambda: (
+            len(
+                opik_client.search_spans(
+                    project_name=opik_client.config.project_name, trace_id=trace_id
+                )
             )
-        )
-        == 5,
+            == 5
+        ),
         max_try_seconds=15,
     ):
         raise AssertionError(
@@ -206,8 +227,8 @@ def test_pydantic_ai_logfire_with_opik_track__two_agent_calls__correct_nesting(
         name="run_entrypoint",
     )
 
-    # both 'agent run' subtrees are siblings directly under the entrypoint
-    agent_runs = [span for span in spans if span.name == "agent run"]
+    # both agent-run subtrees are siblings directly under the entrypoint
+    agent_runs = [span for span in spans if _is_agent_run_span(span.name)]
     assert len(agent_runs) == 2
     for agent_run in agent_runs:
         verifiers.verify_span(
@@ -215,7 +236,6 @@ def test_pydantic_ai_logfire_with_opik_track__two_agent_calls__correct_nesting(
             span_id=agent_run.id,
             trace_id=trace_id,
             parent_span_id=entrypoint_span_id,
-            name="agent run",
         )
 
     # each 'agent run' owns exactly one model span parented to that run alone —
@@ -278,12 +298,14 @@ def test_pydantic_ai_logfire__nested_track_and_otel__cross_origin_nesting(
 
     # outer + inner (native) + 2x (agent run + model) = 6 spans in one trace
     if not synchronization.until(
-        lambda: len(
-            opik_client.search_spans(
-                project_name=opik_client.config.project_name, trace_id=trace_id
+        lambda: (
+            len(
+                opik_client.search_spans(
+                    project_name=opik_client.config.project_name, trace_id=trace_id
+                )
             )
-        )
-        == 6,
+            == 6
+        ),
         max_try_seconds=15,
     ):
         raise AssertionError(
@@ -312,9 +334,9 @@ def test_pydantic_ai_logfire__nested_track_and_otel__cross_origin_nesting(
         name="inner_step",
     )
 
-    # the two OTel 'agent run' spans attach to the innermost native span that was
+    # the two OTel agent-run spans attach to the innermost native span that was
     # active when each was started: one under inner_step, one under outer.
-    agent_runs = [span for span in spans if span.name == "agent run"]
+    agent_runs = [span for span in spans if _is_agent_run_span(span.name)]
     assert len(agent_runs) == 2
     assert {run.parent_span_id for run in agent_runs} == {inner_span_id, outer_span_id}
     for agent_run in agent_runs:
@@ -323,7 +345,6 @@ def test_pydantic_ai_logfire__nested_track_and_otel__cross_origin_nesting(
             span_id=agent_run.id,
             trace_id=trace_id,
             parent_span_id=agent_run.parent_span_id,
-            name="agent run",
         )
         children = [span for span in spans if span.parent_span_id == agent_run.id]
         assert len(children) == 1, "each agent run should own exactly one model span"
@@ -340,9 +361,10 @@ def test_pydantic_ai_logfire__tool_span_logs_its_output(
 ):
     """A PydanticAI tool's return value must land on the tool span's OUTPUT.
 
-    The logfire instrumentation emits the result under the ``tool_response``
-    attribute; without an explicit mapping it falls into the default INPUT
-    bucket, so the tool span renders no output in the UI.
+    The logfire instrumentation emits the result under a tool-result attribute
+    (``tool_response`` in v<=2, ``gen_ai.tool.call.result`` in v3+); without an
+    explicit mapping it falls into the default INPUT bucket, so the tool span
+    renders no output in the UI.
     """
     config = opik_config.OpikConfig()
     exporter = _build_otlp_exporter(config)
@@ -380,7 +402,7 @@ def test_pydantic_ai_logfire__tool_span_logs_its_output(
         spans = opik_client.search_spans(
             project_name=opik_client.config.project_name, trace_id=trace_id
         )
-        tool_span = next((span for span in spans if span.name == "running tool"), None)
+        tool_span = next((span for span in spans if _is_tool_span(span.name)), None)
         return tool_span if tool_span is not None and tool_span.output else None
 
     if not synchronization.until(lambda: _tool_span() is not None, max_try_seconds=15):
@@ -391,9 +413,9 @@ def test_pydantic_ai_logfire__tool_span_logs_its_output(
 
     tool_span = _tool_span()
     # the tool's return value is mapped to OUTPUT, not INPUT
-    assert "tool_response" in tool_span.output
+    assert any(key in tool_span.output for key in _TOOL_RESULT_KEYS)
     assert "Sunny in" in json.dumps(tool_span.output)
-    assert "tool_response" not in (tool_span.input or {})
+    assert all(key not in (tool_span.input or {}) for key in _TOOL_RESULT_KEYS)
 
 
 def test_pydantic_ai_logfire__tool_error_is_logged_as_error_info(


### PR DESCRIPTION
## Details

The `test_pydantic_ai_logfire.py` E2E tests fail on `main` because `pydantic-ai`/`logfire` are unpinned in the test `requirements.txt`, and a recent PydanticAI release moved the default instrumentation to **v3+**, which follows the OpenTelemetry GenAI semantic conventions and renames the spans the tests assert on:

| span | legacy (v≤2) | new (v3+) |
|---|---|---|
| agent root | `agent run` | `invoke_agent {agent_name}` |
| tool | `running tool` | `execute_tool {tool_name}` |
| tool-result attr | `tool_response` | `gen_ai.tool.call.result` |

The Opik OTel integration itself is unaffected — the OTel spans are still correctly nested under the `@opik.track` entrypoint (the parentage assertions pass). Only the hardcoded span-name / attribute-key assertions were stale. This change makes those assertions accept either naming scheme via small helper predicates, so the test survives version drift in the unpinned deps.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA — test maintenance from upstream dependency drift; no ticket.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: test-only change making span-name/attribute assertions version-tolerant
- Human verification: investigated the root cause in the installed `pydantic_ai._instrumentation` (versioned span naming); ran ruff (check + format) and `pytest --collect-only` locally. The full E2E suite requires a running backend and the newer pydantic-ai and runs in CI.

## Testing

- `ruff check` and `ruff format --check` on the changed test file — pass
- `pytest --collect-only` — 5 tests collected, no errors
- Locally `pydantic_ai==1.106.0` still defaults to instrumentation v2 (legacy names), so the helpers match `"agent run"`/`"running tool"` here; CI (newer release, v3) exercises the `invoke_agent`/`execute_tool` branch. Full E2E requires a backend + the newer dependency and runs in CI.

## Documentation

- None — test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)