### PR TITLE
[OPIK-7090] [QA] test(e2e): thread / conversation logging coverage

### DIFF
--- a/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
+++ b/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
@@ -5,6 +5,7 @@ export interface PythonSdkClient {
     name: string;
     input: string;
     output: string;
+    thread_id?: string;
     workspace?: string;
   }): Promise<{ id: string; name: string; project_id: string }>;
   createNestedTrace(args: {

--- a/tests_end_to_end/e2e/fixtures/conversation.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/conversation.fixture.ts
@@ -1,0 +1,73 @@
+import { test as baseTest } from './traced-agent.fixture';
+
+export interface ConversationTurnRef {
+  traceId: string;
+  input: string;
+  output: string;
+}
+
+export interface ConversationRef {
+  threadId: string;
+  projectId: string;
+  projectName: string;
+  /** Turns in the order they were logged (oldest first). */
+  turns: ConversationTurnRef[];
+}
+
+export interface ConversationFixtures {
+  conversation: ConversationRef;
+}
+
+/** Plain-string turns so the conversation view renders them verbatim (a string
+ * input/output bypasses the chat-shape prettifiers and shows as-is). */
+const TURNS = [
+  { input: 'What is the capital of France?', output: 'The capital of France is Paris.' },
+  { input: 'What is its population?', output: 'Paris has about 2.1 million residents.' },
+  { input: 'Name a famous landmark there.', output: 'The Eiffel Tower is its most famous landmark.' },
+] as const;
+
+/**
+ * A multi-turn conversation: each turn is a single trace, and all turns share
+ * one thread_id so the Logs Threads view groups them into one conversation.
+ * Turns are seeded sequentially with a short gap so their chronological order
+ * is deterministic. Seeded through the public SDK bridge so the same shape
+ * lands on OSS and Cloud.
+ */
+export const test = baseTest.extend<ConversationFixtures>({
+  conversation: async ({ sdkClient, project, testNamespace }, use, testInfo) => {
+    const threadId = `${testNamespace}-thread`;
+
+    const turns: ConversationTurnRef[] = [];
+    for (let i = 0; i < TURNS.length; i++) {
+      const { input, output } = TURNS[i];
+      const created = await sdkClient.python.createTrace({
+        project_name: project.name,
+        name: `${testNamespace}-turn-${i + 1}`,
+        input,
+        output,
+        thread_id: threadId,
+      });
+      turns.push({ traceId: created.id, input, output });
+      if (i < TURNS.length - 1) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+    }
+
+    const ref: ConversationRef = {
+      threadId,
+      projectId: project.id,
+      projectName: project.name,
+      turns,
+    };
+
+    await testInfo.attach('opik.conversation', {
+      body: JSON.stringify(ref, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use(ref);
+    // No explicit teardown — the project fixture's deleteProject cascades.
+  },
+});
+
+export { expect } from './traced-agent.fixture';

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-export { test, expect } from './traced-agent.fixture';
+export { test, expect } from './conversation.fixture';
 export type { ProjectFixtures } from './project.fixture';
 export type { ScratchDir, ScratchDirFixtures } from './scratch-dir.fixture';
 export type {
@@ -29,4 +29,9 @@ export type {
   TracedAgentSpanRef,
   TracedAgentFixtures,
 } from './traced-agent.fixture';
+export type {
+  ConversationRef,
+  ConversationTurnRef,
+  ConversationFixtures,
+} from './conversation.fixture';
 export type { ProjectRef } from '../core/backend';

--- a/tests_end_to_end/e2e/pom/logs.page.ts
+++ b/tests_end_to_end/e2e/pom/logs.page.ts
@@ -1,6 +1,7 @@
 import { test, type Page, type Locator } from '@playwright/test';
 import { loadEnvConfig } from '../config/env.config';
 import { TracePanelPage } from './trace-panel.page';
+import { ThreadPanelPage } from './thread-panel.page';
 
 export class LogsPage {
   private projectId: string | null = null;
@@ -12,6 +13,17 @@ export class LogsPage {
       this.projectId = projectId;
       const env = loadEnvConfig();
       await this.page.goto(`${env.baseUrl}/${env.workspace}/projects/${projectId}/logs`);
+    });
+  }
+
+  /** Open Logs with the Threads tab active for the given project. */
+  async gotoThreads(projectId: string): Promise<void> {
+    return test.step(`Open Logs (Threads) for project ${projectId}`, async () => {
+      this.projectId = projectId;
+      const env = loadEnvConfig();
+      await this.page.goto(
+        `${env.baseUrl}/${env.workspace}/projects/${projectId}/logs?logsType=threads`,
+      );
     });
   }
 
@@ -96,5 +108,79 @@ export class LogsPage {
 
   get traceRows(): Locator {
     return this.page.locator('tr[data-row-id]');
+  }
+
+  // --- Threads tab ---
+
+  /** The Threads/Traces/Spans tab toggle for "Threads". */
+  get threadsTab(): Locator {
+    return this.page.getByRole('radio', { name: 'Threads' });
+  }
+
+  /** Wait for the Threads table to have rendered at least one row. */
+  async waitForThreadsReady(): Promise<void> {
+    return test.step('Wait for Threads table ready', async () => {
+      await this.page.locator('tr[data-row-id]').first().waitFor({ state: 'visible' });
+    });
+  }
+
+  /**
+   * The number shown in the "Threads" metrics card. The Threads view reuses the
+   * same count-card testid as the Traces view; with the tab active this is the
+   * thread count.
+   */
+  async countThreads(): Promise<number> {
+    return test.step('Read thread count', async () => {
+      const valueEl = this.page.getByTestId('metrics-card-count-value');
+      await valueEl.waitFor({ state: 'visible' });
+      const text = (await valueEl.textContent()) ?? '';
+      const digits = text.replace(/\D/g, '');
+      return digits ? Number(digits) : 0;
+    });
+  }
+
+  /** A thread row, keyed by thread id (the row's data-row-id IS the thread id). */
+  threadRow(threadId: string): Locator {
+    return this.page.locator(`tr[data-row-id="${threadId}"]`);
+  }
+
+  /**
+   * Read the "Message count" cell for a thread. Note: the Threads view counts
+   * messages, so a conversation of N turns (N traces) reports 2*N messages
+   * (each trace contributes an input and an output message).
+   */
+  async readThreadMessageCount(threadId: string): Promise<number> {
+    return test.step(`Read message count for thread ${threadId}`, async () => {
+      const cell = this.threadRow(threadId).locator(
+        `[data-cell-id="${threadId}_number_of_messages"]`,
+      );
+      await cell.waitFor({ state: 'visible' });
+      const text = (await cell.textContent()) ?? '';
+      const digits = text.replace(/\D/g, '');
+      return digits ? Number(digits) : 0;
+    });
+  }
+
+  /** The "First message" cell text for a thread. */
+  threadFirstMessageCell(threadId: string): Locator {
+    return this.threadRow(threadId).locator(`[data-cell-id="${threadId}_first_message"]`);
+  }
+
+  /** The "Last message" cell text for a thread. */
+  threadLastMessageCell(threadId: string): Locator {
+    return this.threadRow(threadId).locator(`[data-cell-id="${threadId}_last_message"]`);
+  }
+
+  /** Open a thread's detail panel by id, returning the conversation panel POM. */
+  async openThreadById(threadId: string): Promise<ThreadPanelPage> {
+    return test.step(`Open thread ${threadId}`, async () => {
+      if (!this.projectId) {
+        throw new Error('LogsPage.openThreadById: call gotoThreads(projectId) first');
+      }
+      const env = loadEnvConfig();
+      const url = `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/logs?logsType=threads&thread=${threadId}`;
+      await this.page.goto(url);
+      return new ThreadPanelPage(this.page, threadId);
+    });
   }
 }

--- a/tests_end_to_end/e2e/pom/thread-panel.page.ts
+++ b/tests_end_to_end/e2e/pom/thread-panel.page.ts
@@ -1,0 +1,68 @@
+import { test, type Page, type Locator } from '@playwright/test';
+
+/**
+ * The thread detail side-panel: a chat-style view of a conversation. Each turn
+ * is one trace, rendered as a `[data-trace-message-id={traceId}]` block holding
+ * the turn's input (a right-aligned bubble) and output. The panel opens when
+ * `?thread={id}` is present in the URL.
+ */
+export class ThreadPanelPage {
+  constructor(
+    private readonly page: Page,
+    private readonly threadId: string,
+  ) {}
+
+  /** Root locator for the panel content, scoped to the panel testid. */
+  get root(): Locator {
+    return this.page.getByTestId('thread');
+  }
+
+  async waitForFullyLoaded(): Promise<void> {
+    return test.step(`Wait for thread panel ${this.threadId} to load`, async () => {
+      await this.page.waitForURL((url) => url.searchParams.get('thread') === this.threadId);
+      await this.root.waitFor({ state: 'visible', timeout: 30_000 });
+      await this.turns.first().waitFor({ state: 'visible', timeout: 30_000 });
+    });
+  }
+
+  /** All conversation turns, in render (chronological) order. */
+  get turns(): Locator {
+    return this.root.locator('[data-trace-message-id]');
+  }
+
+  async countTurns(): Promise<number> {
+    return test.step('Count conversation turns', async () => {
+      await this.turns.first().waitFor({ state: 'visible' });
+      return this.turns.count();
+    });
+  }
+
+  /** Read the trace ids of the turns in render order. */
+  async readTurnTraceIdsInOrder(): Promise<string[]> {
+    return test.step('Read turn trace ids in order', async () => {
+      await this.turns.first().waitFor({ state: 'visible' });
+      const handles = await this.turns.all();
+      const ids: string[] = [];
+      for (const t of handles) {
+        const id = await t.getAttribute('data-trace-message-id');
+        if (id) ids.push(id);
+      }
+      return ids;
+    });
+  }
+
+  /** A single turn block, located by the trace id it was logged under. */
+  turn(traceId: string): Locator {
+    return this.root.locator(`[data-trace-message-id="${traceId}"]`);
+  }
+
+  /** Locator for the turn's input text within the turn block. */
+  turnInput(traceId: string, input: string): Locator {
+    return this.turn(traceId).getByText(input, { exact: true });
+  }
+
+  /** Locator for the turn's output text within the turn block. */
+  turnOutput(traceId: string, output: string): Locator {
+    return this.turn(traceId).getByText(output, { exact: true });
+  }
+}

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/traces.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/traces.py
@@ -29,6 +29,11 @@ def create_trace(
 
     @opik.track(name=body.name, project_name=body.project_name)
     def _emit(_input_value: str) -> str:
+        # thread_id is set on the live trace from within the tracked function so
+        # the decorator code path (the one users invoke) still owns trace
+        # creation; @opik.track itself takes no thread_id argument.
+        if body.thread_id is not None:
+            opik.opik_context.update_current_trace(thread_id=body.thread_id)
         return body.output
 
     try:

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/traces.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/traces.py
@@ -31,8 +31,9 @@ def create_trace(
     def _emit(_input_value: str) -> str:
         # thread_id is set on the live trace from within the tracked function so
         # the decorator code path (the one users invoke) still owns trace
-        # creation; @opik.track itself takes no thread_id argument.
-        if body.thread_id is not None:
+        # creation; @opik.track itself takes no thread_id argument. A blank value
+        # is treated as absent so empty strings don't collapse into one thread.
+        if body.thread_id:
             opik.opik_context.update_current_trace(thread_id=body.thread_id)
         return body.output
 

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
@@ -24,6 +24,9 @@ class TraceCreate(BaseModel):
     name: str
     input: str
     output: str
+    # Groups this trace with others sharing the same value into a conversation
+    # thread, the unit the Logs Threads view renders.
+    thread_id: str | None = None
     workspace: str | None = None
 
 

--- a/tests_end_to_end/e2e/tests/trace-explore/thread-logging-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/thread-logging-smoke.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@e2e/fixtures';
+import { LogsPage } from '@e2e/pom/logs.page';
+
+test.describe('Thread logging — smoke', { tag: ['@t1-smoke', '@trace-explore'] }, () => {
+  test('Threads view groups a multi-turn conversation with the correct message count and endpoints', async ({
+    conversation,
+    page,
+  }) => {
+    const logs = new LogsPage(page);
+
+    await test.step('Open Logs Threads view', async () => {
+      await logs.gotoThreads(conversation.projectId);
+      await logs.waitForThreadsReady();
+    });
+
+    await test.step('Verify a single thread is present', async () => {
+      await expect(logs.threadsTab).toBeChecked();
+      expect(await logs.countThreads()).toBe(1);
+      await expect(logs.threadRow(conversation.threadId)).toBeVisible();
+    });
+
+    await test.step('Verify message count and first/last message', async () => {
+      // The Threads view counts messages: each turn contributes an input and an
+      // output, so N turns report 2*N messages.
+      expect(await logs.readThreadMessageCount(conversation.threadId)).toBe(
+        conversation.turns.length * 2,
+      );
+      const firstTurn = conversation.turns[0];
+      const lastTurn = conversation.turns[conversation.turns.length - 1];
+      await expect(logs.threadFirstMessageCell(conversation.threadId)).toHaveText(firstTurn.input);
+      await expect(logs.threadLastMessageCell(conversation.threadId)).toHaveText(lastTurn.output);
+    });
+  });
+
+  test('Thread detail panel renders the conversation turns in order with the right input and output', async ({
+    conversation,
+    page,
+  }) => {
+    const logs = new LogsPage(page);
+
+    const panel = await test.step('Open the thread detail panel', async () => {
+      await logs.gotoThreads(conversation.projectId);
+      await logs.waitForThreadsReady();
+      const panel = await logs.openThreadById(conversation.threadId);
+      await panel.waitForFullyLoaded();
+      return panel;
+    });
+
+    await test.step('Verify the turns render in chronological order', async () => {
+      expect(await panel.countTurns()).toBe(conversation.turns.length);
+      expect(await panel.readTurnTraceIdsInOrder()).toEqual(
+        conversation.turns.map((t) => t.traceId),
+      );
+    });
+
+    await test.step('Verify each turn shows its own input and output', async () => {
+      for (const turn of conversation.turns) {
+        await expect(panel.turnInput(turn.traceId, turn.input)).toBeVisible();
+        await expect(panel.turnOutput(turn.traceId, turn.output)).toBeVisible();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Details

Adds E2E coverage for thread / conversation logging in the v2 suite (`tests_end_to_end/e2e/`), closing a gap where threads (traces sharing a `thread_id`, grouped into a conversation) had zero E2E coverage. The test seeds a multi-turn conversation via the SDK bridge and verifies the Logs → Threads view groups it into one thread with the correct message count and renders the conversation turns in order with the right input/output per turn.

- SDK bridge: add `thread_id` to the lightweight `/traces` seed (set from within the `@opik.track` path via `opik_context.update_current_trace`, keeping the user-facing decorator code path); `/traces/nested` already supported it.
- New `conversation` fixture seeds 3 turns under one `thread_id`; wired into the fixture chain.
- POM: `LogsPage` Threads-tab navigation / count / row lookup / message-count + first/last-message cells; new `ThreadPanelPage` for the conversation panel (turns are `[data-trace-message-id]`, one per trace).
- New spec `tests/trace-explore/thread-logging-smoke.spec.ts` (`@t1-smoke @trace-explore`).
- Note on counts: the Threads list counts messages (input+output = 2 per turn), so N turns report 2N in the message-count column, while the panel shows N turns. No FE `data-testid` additions were needed — all selectors use existing FE contracts (`data-row-id`, `data-cell-id`, `data-testid="thread"`, `data-trace-message-id`).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7098
- OPIK-7090

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation (test, POM, fixture, bridge change)
- Human verification: code review + local test runs

## Testing

Local runs from `tests_end_to_end/e2e/` (OSS target, `http://localhost:5173`, workspace `default`):

- `npx playwright test tests/trace-explore/thread-logging-smoke.spec.ts --reporter=list` — **2 passed** (18.6s).
- `npx playwright test tests/trace-explore/ --reporter=list` — **8 passed** (22.1s); the 6 existing trace-explore tests confirm no regression from the shared `LogsPage` / fixture-chain changes.
- `npx tsc --noEmit` — clean (exit 0).

Scenarios validated: thread grouping + count, message-count semantics, first/last message cells, thread-detail panel turn ordering, per-turn input/output rendering. The SDK bridge auto-spawns via Playwright's `webServer`; the new `thread_id` field was exercised end-to-end (`POST /traces` 201, no 422).

## Documentation

N/A — internal E2E test coverage; no user-facing docs affected.

