### PR TITLE
[OPIK-7101] Make project stats opt-in on /projects/retrieve

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProjectRetrieve.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProjectRetrieve.java
@@ -1,10 +1,11 @@
 package com.comet.opik.api;
 
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
-public record ProjectRetrieve(@NotBlank String name, Boolean includeStats) {
+public record ProjectRetrieve(@NotBlank String name, @Nullable Boolean includeStats) {
 
     /**
      * Whether the response should be enriched with project-level statistics

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProjectRetrieve.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProjectRetrieve.java
@@ -4,5 +4,17 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
-public record ProjectRetrieve(@NotBlank String name) {
+public record ProjectRetrieve(@NotBlank String name, Boolean includeStats) {
+
+    /**
+     * Whether the response should be enriched with project-level statistics
+     * (feedback scores, trace/span aggregations, duration, cost, counts).
+     * <p>
+     * Defaults to {@code false}: callers that only need to resolve a project
+     * name to its id (the SDK and the UI redirect path) should not trigger the
+     * expensive ClickHouse aggregations. See OPIK-7101.
+     */
+    public boolean shouldIncludeStats() {
+        return Boolean.TRUE.equals(includeStats);
+    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProjectRetrieve.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProjectRetrieve.java
@@ -13,9 +13,12 @@ public record ProjectRetrieve(@NotBlank String name, @Nullable Boolean includeSt
      * <p>
      * Defaults to {@code false}: callers that only need to resolve a project
      * name to its id (the SDK and the UI redirect path) should not trigger the
-     * expensive ClickHouse aggregations. See OPIK-7101.
+     * expensive ClickHouse aggregations. The canonical accessor is overridden to
+     * coalesce {@code null} to {@code false}, so it never returns {@code null}.
+     * See OPIK-7101.
      */
-    public boolean shouldIncludeStats() {
+    @Override
+    public Boolean includeStats() {
         return Boolean.TRUE.equals(includeStats);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
@@ -216,7 +216,7 @@ public class ProjectsResource {
             @RequestBody(content = @Content(schema = @Schema(implementation = ProjectRetrieve.class))) @Valid ProjectRetrieve retrieve) {
         String workspaceId = requestContext.get().getWorkspaceId();
         log.info("Retrieve project by name '{}', on workspace_id '{}'", retrieve.name(), workspaceId);
-        Project project = projectService.retrieveByName(retrieve.name(), retrieve.shouldIncludeStats());
+        Project project = projectService.retrieveByName(retrieve.name(), retrieve.includeStats());
         log.info("Retrieved project id '{}' by name '{}', on workspace_id '{}'", project.id(), retrieve.name(),
                 workspaceId);
         return Response.ok().entity(project).build();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
@@ -216,7 +216,7 @@ public class ProjectsResource {
             @RequestBody(content = @Content(schema = @Schema(implementation = ProjectRetrieve.class))) @Valid ProjectRetrieve retrieve) {
         String workspaceId = requestContext.get().getWorkspaceId();
         log.info("Retrieve project by name '{}', on workspace_id '{}'", retrieve.name(), workspaceId);
-        Project project = projectService.retrieveByName(retrieve.name());
+        Project project = projectService.retrieveByName(retrieve.name(), retrieve.shouldIncludeStats());
         log.info("Retrieved project id '{}' by name '{}', on workspace_id '{}'", project.id(), retrieve.name(),
                 workspaceId);
         return Response.ok().entity(project).build();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -100,7 +100,7 @@ public interface ProjectService {
 
     Project getOrCreate(String workspaceId, String projectName, String userName);
 
-    Project retrieveByName(String projectName);
+    Project retrieveByName(String projectName, boolean includeStats);
 
     Mono<List<Project>> retrieveByNamesOrCreate(Set<String> projectNames);
 
@@ -620,7 +620,7 @@ class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
-    public Project retrieveByName(@NonNull String projectName) {
+    public Project retrieveByName(@NonNull String projectName, boolean includeStats) {
         var workspaceId = requestContext.get().getWorkspaceId();
 
         Optional<Project> projects = template.inTransaction(READ_ONLY, handle -> {
@@ -631,32 +631,34 @@ class ProjectServiceImpl implements ProjectService {
 
         return projects
                 .flatMap(project -> verifyVisibility(project, requestContext.get().getVisibility()))
-                .map(project -> {
-                    Map<UUID, Instant> projectLastUpdatedTraceAtMap = transactionTemplateAsync
-                            .nonTransaction(connection -> {
-                                Set<UUID> projectIds = Set.of(project.id());
-                                return traceDAO.getLastUpdatedTraceAt(projectIds, workspaceId, connection);
-                            }).block();
-
-                    Map<UUID, Map<String, Object>> projectStats = getProjectStats(List.of(project.id()),
-                            workspaceId, ProjectCriteria.builder().build());
-
-                    return project.toBuilder()
-                            .lastUpdatedTraceAt(projectLastUpdatedTraceAtMap.get(project.id()))
-                            .feedbackScores(StatsMapper.getStatsFeedbackScores(projectStats.get(project.id())))
-                            .usage(StatsMapper.getStatsUsage(projectStats.get(project.id())))
-                            .duration(StatsMapper.getStatsDuration(projectStats.get(project.id())))
-                            .totalEstimatedCost(
-                                    StatsMapper.getStatsTotalEstimatedCost(projectStats.get(project.id())))
-                            .totalEstimatedCostSum(
-                                    StatsMapper.getStatsTotalEstimatedCostSum(projectStats.get(project.id())))
-                            .traceCount(StatsMapper.getStatsTraceCount(projectStats.get(project.id())))
-                            .guardrailsFailedCount(
-                                    StatsMapper.getStatsGuardrailsFailedCount(projectStats.get(project.id())))
-                            .errorCount(StatsMapper.getStatsErrorCount(projectStats.get(project.id())))
-                            .build();
-                })
+                .map(project -> includeStats ? enrichWithStats(project, workspaceId) : project)
                 .orElseThrow(this::createNotFoundError);
+    }
+
+    private Project enrichWithStats(Project project, String workspaceId) {
+        Map<UUID, Instant> projectLastUpdatedTraceAtMap = transactionTemplateAsync
+                .nonTransaction(connection -> {
+                    Set<UUID> projectIds = Set.of(project.id());
+                    return traceDAO.getLastUpdatedTraceAt(projectIds, workspaceId, connection);
+                }).block();
+
+        Map<UUID, Map<String, Object>> projectStats = getProjectStats(List.of(project.id()),
+                workspaceId, ProjectCriteria.builder().build());
+
+        return project.toBuilder()
+                .lastUpdatedTraceAt(projectLastUpdatedTraceAtMap.get(project.id()))
+                .feedbackScores(StatsMapper.getStatsFeedbackScores(projectStats.get(project.id())))
+                .usage(StatsMapper.getStatsUsage(projectStats.get(project.id())))
+                .duration(StatsMapper.getStatsDuration(projectStats.get(project.id())))
+                .totalEstimatedCost(
+                        StatsMapper.getStatsTotalEstimatedCost(projectStats.get(project.id())))
+                .totalEstimatedCostSum(
+                        StatsMapper.getStatsTotalEstimatedCostSum(projectStats.get(project.id())))
+                .traceCount(StatsMapper.getStatsTraceCount(projectStats.get(project.id())))
+                .guardrailsFailedCount(
+                        StatsMapper.getStatsGuardrailsFailedCount(projectStats.get(project.id())))
+                .errorCount(StatsMapper.getStatsErrorCount(projectStats.get(project.id())))
+                .build();
     }
 
     @Override

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -804,6 +804,21 @@ class ProjectsResourceTest {
             // Seed traces/spans so stats would be non-null if they were computed.
             buildProjectStats(project.toBuilder().id(id).build(), apiKey, workspaceName);
 
+            // Without stats requested (OPIK-7101), no ClickHouse aggregation runs on the hot name-resolution path:
+            // identity/core fields are resolved while every stats field stays null. lastUpdatedTraceAt is a `projects`
+            // table column (set on ingestion), not part of the stats aggregation, so it is ignored via IGNORED_FIELD_MIN.
+            var expectedProject = project.toBuilder()
+                    .id(id)
+                    .feedbackScores(null)
+                    .duration(null)
+                    .totalEstimatedCost(null)
+                    .totalEstimatedCostSum(null)
+                    .usage(null)
+                    .traceCount(null)
+                    .guardrailsFailedCount(null)
+                    .errorCount(null)
+                    .build();
+
             try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
                     .path("retrieve")
                     .request()
@@ -815,22 +830,11 @@ class ProjectsResourceTest {
                 assertThat(actualResponse.hasEntity()).isTrue();
 
                 var actualEntity = actualResponse.readEntity(Project.class);
-
-                // Identity fields are still resolved (this endpoint is used for name -> id resolution).
-                assertThat(actualEntity.id()).isEqualTo(id);
-                assertThat(actualEntity.name()).isEqualTo(project.name());
-
-                // Stats are not computed by default (OPIK-7101): no ClickHouse aggregation on the hot name-resolution path.
-                // Note: lastUpdatedTraceAt is a `projects` table column (set on ingestion), not part of the ClickHouse
-                // stats aggregation, so it is intentionally not asserted here.
-                assertThat(actualEntity.feedbackScores()).isNull();
-                assertThat(actualEntity.duration()).isNull();
-                assertThat(actualEntity.totalEstimatedCost()).isNull();
-                assertThat(actualEntity.totalEstimatedCostSum()).isNull();
-                assertThat(actualEntity.usage()).isNull();
-                assertThat(actualEntity.traceCount()).isNull();
-                assertThat(actualEntity.guardrailsFailedCount()).isNull();
-                assertThat(actualEntity.errorCount()).isNull();
+                assertThat(actualEntity)
+                        .usingRecursiveComparison()
+                        .ignoringFields(IGNORED_FIELD_MIN)
+                        .ignoringCollectionOrder()
+                        .isEqualTo(expectedProject);
             }
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -772,7 +772,7 @@ class ProjectsResourceTest {
                     .request()
                     .header(HttpHeaders.AUTHORIZATION, apiKey)
                     .header(WORKSPACE_HEADER, workspaceName)
-                    .post(Entity.json(ProjectRetrieve.builder().name(project.name()).build()))) {
+                    .post(Entity.json(ProjectRetrieve.builder().name(project.name()).includeStats(true).build()))) {
 
                 assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
                 assertThat(actualResponse.hasEntity()).isTrue();
@@ -785,6 +785,51 @@ class ProjectsResourceTest {
                         .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
                         .withComparatorForFields(StatsUtils::closeToEpsilonComparator, "totalEstimatedCost")
                         .isEqualTo(project);
+            }
+        }
+
+        @Test
+        @DisplayName("when project exists and stats are not requested, then return project without stats")
+        void getProjectByName__whenStatsNotRequested__thenReturnProjectWithoutStats() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var project = factory.manufacturePojo(Project.class);
+
+            var id = createProject(project, apiKey, workspaceName);
+
+            // Seed traces/spans so stats would be non-null if they were computed.
+            buildProjectStats(project.toBuilder().id(id).build(), apiKey, workspaceName);
+
+            try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
+                    .path("retrieve")
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, apiKey)
+                    .header(WORKSPACE_HEADER, workspaceName)
+                    .post(Entity.json(ProjectRetrieve.builder().name(project.name()).build()))) {
+
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
+                assertThat(actualResponse.hasEntity()).isTrue();
+
+                var actualEntity = actualResponse.readEntity(Project.class);
+
+                // Identity fields are still resolved (this endpoint is used for name -> id resolution).
+                assertThat(actualEntity.id()).isEqualTo(id);
+                assertThat(actualEntity.name()).isEqualTo(project.name());
+
+                // Stats are not computed by default (OPIK-7101): no ClickHouse aggregation on the hot name-resolution path.
+                assertThat(actualEntity.lastUpdatedTraceAt()).isNull();
+                assertThat(actualEntity.feedbackScores()).isNull();
+                assertThat(actualEntity.duration()).isNull();
+                assertThat(actualEntity.totalEstimatedCost()).isNull();
+                assertThat(actualEntity.totalEstimatedCostSum()).isNull();
+                assertThat(actualEntity.usage()).isNull();
+                assertThat(actualEntity.traceCount()).isNull();
+                assertThat(actualEntity.guardrailsFailedCount()).isNull();
+                assertThat(actualEntity.errorCount()).isNull();
             }
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -821,7 +821,8 @@ class ProjectsResourceTest {
                 assertThat(actualEntity.name()).isEqualTo(project.name());
 
                 // Stats are not computed by default (OPIK-7101): no ClickHouse aggregation on the hot name-resolution path.
-                assertThat(actualEntity.lastUpdatedTraceAt()).isNull();
+                // Note: lastUpdatedTraceAt is a `projects` table column (set on ingestion), not part of the ClickHouse
+                // stats aggregation, so it is intentionally not asserted here.
                 assertThat(actualEntity.feedbackScores()).isNull();
                 assertThat(actualEntity.duration()).isNull();
                 assertThat(actualEntity.totalEstimatedCost()).isNull();


### PR DESCRIPTION
## Details

`POST /v1/private/projects/retrieve` (`ProjectService.retrieveByName`) is used by callers only to resolve a project name to its id, but on every call it recomputed full project analytics (feedback scores, traces/spans aggregation, duration, cost, counts) over ClickHouse. This caused a platform-wide Opik slowdown in prod: at SDK name-resolution call rates it saturated ClickHouse CPU (~90% on both nodes), since each call fanned out into multi-million-row aggregations (~20 CPU-seconds per call).

No first-party caller reads those stat fields from this endpoint:
- TS SDK (`getProjectIdByName`) and Python SDK (`resolve_project_id_by_name`) return `project.id` only.
- Frontend `useProjectByName` reads only `.id` (RedirectProjects, Playground, GetStarted); it predates the stats and never read them.
- Internal ingestion uses the stats-free `retrieveByNamesOrCreate`; `retrieveByName` has no internal callers.

The stats were added in OPIK-287 for the projects table + dashboards, which are served by the dedicated `GET /v1/private/projects/stats` endpoint (`ProjectService.getStats`, FE hook `useProjectStatisticList`). Note: the list endpoint (`GET /v1/private/projects`) and `getById` enrich only with `lastUpdatedTraceAt`, **not** the heavy stats. `/retrieve` was the one other path that recomputed the full stats, and it was swept into the OPIK-287 change. This PR adds an `includeStats` flag (default `false`) to `ProjectRetrieve`, so `/retrieve` skips the ClickHouse aggregations unless explicitly requested. The response contract is preserved: the stat fields are already `@Nullable`, so omitted stats simply serialize as `null`; consumers that need them opt in with `{"name": "...", "includeStats": true}`.

- `ProjectRetrieve`: add `@Nullable includeStats` + `shouldIncludeStats()` (coalesces null to false)
- `ProjectService.retrieveByName(name, includeStats)`; stats enrichment extracted into `enrichWithStats(...)`
- `ProjectsResource.retrieveProject` passes `retrieve.shouldIncludeStats()`

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7101

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Investigation of the prod ClickHouse saturation, root-cause analysis, and authoring this change (backend + tests) under human direction.
- Human verification: Author reviewed the diff and the verification (no first-party caller reads the stats; provenance traced via git history). CI compiles/tests.

## Testing

- Updated `ProjectsResourceTest.RetrieveProjectTest`:
  - Existing happy path now sends `includeStats(true)` and still asserts the populated stats (proves opt-in works).
  - New `getProjectByName__whenStatsNotRequested__thenReturnProjectWithoutStats` asserts the default (no flag) returns the project with null stat fields (feedbackScores/duration/totalEstimatedCost/totalEstimatedCostSum/usage/traceCount/guardrailsFailedCount/errorCount) and no ClickHouse aggregation. `lastUpdatedTraceAt` is intentionally not asserted: it is a `projects` table column (set on ingestion), not part of the stats aggregation.
- Relying on PR CI for compile + full integration suite (Java 25 + Maven not run locally).

## Documentation

No public docs change. The new request field is optional and backward compatible; the OpenAPI/Fern spec will pick up `includeStats` on the next codegen.
