### PR TITLE
[NA] [BE] Cost Intell Query Optimization

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AiSpendResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AiSpendResource.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.annotation.Timed;
 import com.comet.opik.api.error.ErrorMessage;
 import com.comet.opik.api.sorting.SpendUserSortingFactory;
 import com.comet.opik.api.spend.SpendBreakdownResponse;
+import com.comet.opik.api.spend.SpendBreakdownsResponse;
 import com.comet.opik.api.spend.SpendCompositionResponse;
 import com.comet.opik.api.spend.SpendMetricRequest;
 import com.comet.opik.api.spend.SpendSummaryResponse;
@@ -109,6 +110,26 @@ public class AiSpendResource {
                 .contextWrite(ctx -> setRequestContext(ctx, requestContext))
                 .block();
         log.info("Retrieved spend breakdown for lane '{}' on workspace_id '{}'", laneKey, workspaceId);
+
+        return Response.ok().entity(response).build();
+    }
+
+    @POST
+    @Path("/composition/breakdowns")
+    @Operation(operationId = "getSpendAllBreakdowns", summary = "Get all spend lane breakdowns", description = "Get the per-item breakdown for every composition lane in one request", responses = {
+            @ApiResponse(responseCode = "200", description = "Lane breakdowns", content = @Content(schema = @Schema(implementation = SpendBreakdownsResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class)))
+    })
+    @RequiredPermissions(WorkspaceUserPermission.PROJECT_DATA_VIEW)
+    public Response getSpendAllBreakdowns(
+            @RequestBody(content = @Content(schema = @Schema(implementation = SpendMetricRequest.class))) @NotNull @Valid SpendMetricRequest request) {
+
+        String workspaceId = requestContext.get().getWorkspaceId();
+        log.info("Retrieve all spend breakdowns on workspace_id '{}'", workspaceId);
+        var response = aiSpendService.getAllBreakdowns(request)
+                .contextWrite(ctx -> setRequestContext(ctx, requestContext))
+                .block();
+        log.info("Retrieved all spend breakdowns on workspace_id '{}'", workspaceId);
 
         return Response.ok().entity(response).build();
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/spend/SpendBreakdownsResponse.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/spend/SpendBreakdownsResponse.java
@@ -1,0 +1,16 @@
+package com.comet.opik.api.spend;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SpendBreakdownsResponse(List<SpendBreakdownResponse> breakdowns) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AiSpendDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AiSpendDAO.java
@@ -29,7 +29,9 @@ import reactor.core.publisher.Mono;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -47,6 +49,8 @@ public interface AiSpendDAO {
     Mono<SpendBreakdownResponse> getBreakdown(SpendMetricRequest request, SpendLane lane);
 
     Mono<SpendBreakdownResponse> getOutputBreakdown(SpendMetricRequest request, OutputLane lane);
+
+    Mono<List<SpendBreakdownResponse>> getAllBreakdowns(SpendMetricRequest request);
 
     Mono<SpendUserPage> getUsers(SpendMetricRequest request, List<SortingField> sortingFields, String name, int page,
             int size);
@@ -148,6 +152,54 @@ class AiSpendDAOImpl implements AiSpendDAO {
                         getLong(row.get("group_count", Long.class)),
                         getLong(row.get("total_events", Long.class))))
                 .map(rows -> mapper.breakdown(laneKey, title, subtitle, itemUnit, rows));
+    }
+
+    @Override
+    public Mono<List<SpendBreakdownResponse>> getAllBreakdowns(@NonNull SpendMetricRequest request) {
+        Optional<String> userUuid = resolveUserUuid(request);
+        return queryList(queryBuilder.allBreakdowns(), "ai_spend_all_breakdowns", request.resolvedProjectId(),
+                userFlag(userUuid),
+                statement -> {
+                    bindComposition(statement, request, userUuid);
+                    statement.bind("limit", queryBuilder.breakdownItemLimit());
+                },
+                (row, metadata) -> new LaneBreakdownRow(
+                        row.get("lane", String.class),
+                        new AiSpendMapper.BreakdownRow(
+                                row.get("label", String.class),
+                                row.get("model", String.class),
+                                getLong(row.get("total_tokens", Double.class)),
+                                getLong(row.get("definition_tokens", Double.class)),
+                                getLong(row.get("usage_tokens", Double.class)),
+                                getLong(row.get("events", Long.class)),
+                                getLong(row.get("input_tokens", Double.class)),
+                                getLong(row.get("cache_read_tokens", Double.class)),
+                                getLong(row.get("cache_creation_tokens", Double.class)),
+                                getLong(row.get("output_tokens", Double.class)),
+                                getLong(row.get("grand_total", Double.class)),
+                                getLong(row.get("group_count", Long.class)),
+                                getLong(row.get("total_events", Long.class)))))
+                .map(this::toBreakdownResponses);
+    }
+
+    private List<SpendBreakdownResponse> toBreakdownResponses(List<LaneBreakdownRow> rows) {
+        Map<String, List<AiSpendMapper.BreakdownRow>> byLane = new LinkedHashMap<>();
+        for (LaneBreakdownRow row : rows) {
+            byLane.computeIfAbsent(row.lane(), key -> new ArrayList<>()).add(row.row());
+        }
+        List<SpendBreakdownResponse> responses = new ArrayList<>();
+        for (SpendLane lane : SpendLane.values()) {
+            if (!lane.hasBreakdown()) {
+                continue;
+            }
+            responses.add(mapper.breakdown(lane.getKey(), lane.getLabel(), lane.getDescription(), lane.getItemUnit(),
+                    byLane.getOrDefault(lane.getKey(), List.of())));
+        }
+        for (OutputLane lane : OutputLane.values()) {
+            responses.add(mapper.breakdown(lane.getKey(), lane.getLabel(), null, lane.getItemUnit(),
+                    byLane.getOrDefault(lane.getKey(), List.of())));
+        }
+        return responses;
     }
 
     @Override
@@ -320,5 +372,8 @@ class AiSpendDAOImpl implements AiSpendDAO {
     }
 
     private record LeaderboardRow(SpendUserRow user, long total) {
+    }
+
+    private record LaneBreakdownRow(String lane, AiSpendMapper.BreakdownRow row) {
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AiSpendQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AiSpendQueryBuilder.java
@@ -411,6 +411,84 @@ class AiSpendQueryBuilder {
             ;
             """).replace("__FANOUT_CTES__", BLOCKS_FANOUT_CTES);
 
+    // All-lane breakdown — the per-lane BREAKDOWN_TEMPLATE folded over every
+    // lane in one pass. The blocks fan-out (the expensive part: read each span's
+    // cipx.blocks[], ARRAY JOIN, allocate by chars-share) runs once and feeds
+    // every lane, instead of re-scanning the metadata blob once per lane. Each
+    // block is projected to its lane/label/is_definition via multiIfs rendered
+    // from the same INPUT_LANE_CONFIGS/OUTPUT_LANE_CONFIGS the per-lane queries
+    // use, so the projection stays single-source. tier_chars (the allocation
+    // denominator) is the full-tier chars over all blocks just as in the
+    // per-lane query, so per-lane and combined produce identical allocations.
+    private static final String COMBINED_BREAKDOWN_TEMPLATE = ("""
+            WITH
+            __FANOUT_CTES__,
+                rows AS (
+                    SELECT
+                        <bd_lane> AS lane,
+                        <bd_label> AS label,
+                        model,
+                        <bd_def> AS is_definition,
+                        if(tier_chars > 0, chars * tier_tokens / tier_chars, 0) AS alloc,
+                        tier
+                    FROM allocated
+                ),
+                agg AS (
+                    SELECT
+                        lane,
+                        label,
+                        model,
+                        SUM(alloc) AS total_tokens,
+                        SUMIf(alloc, is_definition = 1) AS definition_tokens,
+                        SUMIf(alloc, is_definition = 0) AS usage_tokens,
+                        SUMIf(alloc, tier = 'input') AS input_tokens,
+                        SUMIf(alloc, tier = 'cache_read') AS cache_read_tokens,
+                        SUMIf(alloc, tier = 'cache_creation') AS cache_creation_tokens,
+                        SUMIf(alloc, tier = 'output') AS output_tokens,
+                        countIf(is_definition = 0) AS events
+                    FROM rows
+                    WHERE lane != ''
+                    GROUP BY lane, label, model
+                    HAVING label != ''
+                ),
+                label_totals AS (
+                    SELECT lane, label, SUM(total_tokens) AS lt, SUM(events) AS le
+                    FROM agg
+                    GROUP BY lane, label
+                ),
+                ranked AS (
+                    SELECT lane, label, row_number() OVER (PARTITION BY lane ORDER BY lt DESC) AS rn
+                    FROM label_totals
+                ),
+                totals AS (
+                    SELECT lane, SUM(lt) AS grand_total, COUNT() AS group_count, SUM(le) AS total_events
+                    FROM label_totals
+                    GROUP BY lane
+                )
+            SELECT
+                a.lane AS lane,
+                if(r.rn > :limit, '__other__', a.label) AS label,
+                a.model AS model,
+                SUM(a.total_tokens) AS total_tokens,
+                SUM(a.definition_tokens) AS definition_tokens,
+                SUM(a.usage_tokens) AS usage_tokens,
+                SUM(a.events) AS events,
+                SUM(a.input_tokens) AS input_tokens,
+                SUM(a.cache_read_tokens) AS cache_read_tokens,
+                SUM(a.cache_creation_tokens) AS cache_creation_tokens,
+                SUM(a.output_tokens) AS output_tokens,
+                min(r.rn) AS rank,
+                any(t.grand_total) AS grand_total,
+                any(t.group_count) AS group_count,
+                any(t.total_events) AS total_events
+            FROM agg a
+            INNER JOIN ranked r ON a.lane = r.lane AND a.label = r.label
+            INNER JOIN totals t ON a.lane = t.lane
+            GROUP BY lane, label, a.model
+            ORDER BY lane ASC, rank ASC, total_tokens DESC
+            ;
+            """).replace("__FANOUT_CTES__", BLOCKS_FANOUT_CTES);
+
     // Users — leaderboard pivots on cipx.session.identity.user_uuid (Item 1).
     // Per-user totals come from cipx.call.usage on LLM-call spans joined to
     // their trace's identity. skills/mcps/mcp_calls derive from cipx.blocks[].
@@ -592,6 +670,40 @@ class AiSpendQueryBuilder {
             st.add("label_expr", config.labelExpr());
             st.add("def_expr", config.defExpr());
         });
+    }
+
+    TemplatedQuery allBreakdowns() {
+        var laneCase = new StringBuilder("multiIf(\n");
+        var labelCase = new StringBuilder("multiIf(\n");
+        var defCase = new StringBuilder("multiIf(\n");
+        for (SpendLane lane : SpendLane.values()) {
+            appendLaneCase(laneCase, labelCase, defCase, INPUT_LANE_CONFIGS.get(lane), lane.getKey());
+        }
+        for (OutputLane lane : OutputLane.values()) {
+            appendLaneCase(laneCase, labelCase, defCase, OUTPUT_LANE_CONFIGS.get(lane), lane.getKey());
+        }
+        laneCase.append("    ''\n)");
+        labelCase.append("    ''\n)");
+        defCase.append("    toUInt8(0)\n)");
+        return new TemplatedQuery(COMBINED_BREAKDOWN_TEMPLATE, st -> {
+            st.add("range", RANGE);
+            st.add("span_range", SPAN_RANGE);
+            st.add("user_uuid_expr", CIPX_USER_UUID_EXPR);
+            st.add("version_guard", CIPX_TRACE_VERSION_GUARD);
+            st.add("bd_lane", laneCase.toString());
+            st.add("bd_label", labelCase.toString());
+            st.add("bd_def", defCase.toString());
+        });
+    }
+
+    private static void appendLaneCase(StringBuilder laneCase, StringBuilder labelCase, StringBuilder defCase,
+            LaneBreakdownConfig config, String laneKey) {
+        if (config == null) {
+            return;
+        }
+        laneCase.append("    ").append(config.filter()).append(", '").append(laneKey).append("',\n");
+        labelCase.append("    ").append(config.filter()).append(", ").append(config.labelExpr()).append(",\n");
+        defCase.append("    ").append(config.filter()).append(", ").append(config.defExpr()).append(",\n");
     }
 
     TemplatedQuery users(List<SortingField> sortingFields) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AiSpendService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AiSpendService.java
@@ -4,6 +4,7 @@ import com.comet.opik.api.sorting.SortingField;
 import com.comet.opik.api.sorting.SpendUserSortingFactory;
 import com.comet.opik.api.spend.OutputLane;
 import com.comet.opik.api.spend.SpendBreakdownResponse;
+import com.comet.opik.api.spend.SpendBreakdownsResponse;
 import com.comet.opik.api.spend.SpendCompositionResponse;
 import com.comet.opik.api.spend.SpendLane;
 import com.comet.opik.api.spend.SpendMetricRequest;
@@ -29,6 +30,8 @@ public interface AiSpendService {
     Mono<SpendCompositionResponse> getComposition(SpendMetricRequest request);
 
     Mono<SpendBreakdownResponse> getBreakdown(SpendMetricRequest request, String laneKey);
+
+    Mono<SpendBreakdownsResponse> getAllBreakdowns(SpendMetricRequest request);
 
     Mono<SpendUserPage> getUsers(SpendMetricRequest request, List<SortingField> sortingFields, String name, int page,
             int size);
@@ -64,6 +67,13 @@ class AiSpendServiceImpl implements AiSpendService {
                 .filter(OutputLane::hasBreakdown)
                 .orElseThrow(() -> new BadRequestException("No breakdown available for lane: %s".formatted(laneKey)));
         return resolveProject(request).flatMap(resolved -> aiSpendDAO.getOutputBreakdown(resolved, outputLane));
+    }
+
+    @Override
+    public Mono<SpendBreakdownsResponse> getAllBreakdowns(@NonNull SpendMetricRequest request) {
+        return resolveProject(request)
+                .flatMap(aiSpendDAO::getAllBreakdowns)
+                .map(breakdowns -> SpendBreakdownsResponse.builder().breakdowns(breakdowns).build());
     }
 
     @Override


### PR DESCRIPTION
## Details

Optimizes the AI Spend (cost intelligence) backend queries. A full spend page previously issued one ClickHouse breakdown query **per lane** (~14 lanes), and each query independently re-scanned and re-parsed the large `cipx` span `metadata` blob (the blocks fan-out: read `metadata.cipx.blocks[]`, `ARRAY JOIN`, allocate per-call tokens by chars-share). That per-lane fan-out — not the row count — was the dominant cost (~11.8s on representative data even with a small number of rows).

This change collapses the fan-out into a single combined query that runs the blocks fan-out **once** and emits every lane's breakdown in one pass:

- New `AiSpendQueryBuilder.allBreakdowns()` + `COMBINED_BREAKDOWN_TEMPLATE`. The per-lane `lane` / `label` / `is_definition` projections are rendered from the existing `INPUT_LANE_CONFIGS` / `OUTPUT_LANE_CONFIGS` so the lane mapping stays single-source.
- `tier_chars` (the proportional-allocation denominator) is computed over all blocks exactly as in the per-lane query, so allocations are identical.
- New `AiSpendDAO.getAllBreakdowns()` groups the combined rows into one `SpendBreakdownResponse` per lane.
- New endpoint `POST /v1/private/ai-spend/composition/breakdowns` returning `SpendBreakdownsResponse`. The existing per-lane endpoint is retained for compatibility.

Measured on representative data: breakdown portion ~11.8s → ~1.0s (~11x). Results are byte-identical to the per-lane queries.

Investigation also ruled out two changes that looked promising but regressed or were marginal: switching `FINAL` → `LIMIT 1 BY id` dedup was ~3x slower (it drags the large metadata column through a sort), and parse-once via `JSONExtractRaw` was only marginal — so neither was adopted. `FINAL` is retained.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- NA

## Testing
- Validated against ClickHouse that the combined query returns identical per-lane results (label, total/definition/usage tokens, events) to the existing per-lane breakdown queries across representative lanes: `user_prompts` (char buckets), `mcp_servers` (definition/usage split, 54 labels), `built_in_tool_calls` (output lane).
- `AiSpendQueryBuilderTest` passes (27 tests).
- Benchmarked combined vs per-lane latency on representative data (~11x improvement on the breakdown portion).

## Documentation
- N/A — no new configuration; new endpoint is documented via its OpenAPI annotations.