### PR TITLE
[OPIK-6855] [BE] Fix test suite items lost when saving after editing an item assertion

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
+import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Arrays;
@@ -218,18 +219,21 @@ public class DatasetItemResultMapper {
         }
         return Optional.ofNullable(row.get("evaluators", String.class))
                 .filter(s -> !s.isBlank() && !EvaluatorItem.EMPTY_LIST_JSON.equals(s))
-                .map(DatasetItemResultMapper::parseEvaluators)
+                .map(value -> parseEvaluators(value, row.get("id", String.class),
+                        row.get("dataset_id", String.class)))
                 .orElse(null);
     }
 
     // A row whose mapping function throws is silently dropped by the ClickHouse r2dbc driver,
-    // making the whole item vanish from the list. Degrade to null on unparseable JSON so the
-    // item stays visible (without its assertions) instead of disappearing.
-    private static List<EvaluatorItem> parseEvaluators(String value) {
+    // making the whole item vanish from the list. Degrade to null only on unparseable JSON
+    // (UncheckedIOException is what JsonUtils.readValue throws) so the item stays visible without
+    // its assertions; any other exception propagates instead of masking an unrelated bug.
+    private static List<EvaluatorItem> parseEvaluators(String value, String datasetItemId, String datasetId) {
         try {
             return JsonUtils.readValue(value, EVALUATOR_LIST_TYPE);
-        } catch (RuntimeException e) {
-            log.warn("Failed to parse stored evaluators JSON; returning null evaluators for this item", e);
+        } catch (UncheckedIOException e) {
+            log.warn("Failed to parse stored evaluators JSON for dataset item '{}' (dataset '{}'); "
+                    + "returning null evaluators", datasetItemId, datasetId, e);
             return null;
         }
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Row;
 import io.r2dbc.spi.RowMetadata;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -37,6 +38,7 @@ import static com.comet.opik.utils.ValidationUtils.CLICKHOUSE_FIXED_STRING_UUID_
 import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.toMap;
 
+@Slf4j
 public class DatasetItemResultMapper {
 
     private static final int COMMENT_INDEX = 11;
@@ -216,8 +218,20 @@ public class DatasetItemResultMapper {
         }
         return Optional.ofNullable(row.get("evaluators", String.class))
                 .filter(s -> !s.isBlank() && !EvaluatorItem.EMPTY_LIST_JSON.equals(s))
-                .map(s -> JsonUtils.readValue(s, EVALUATOR_LIST_TYPE))
+                .map(DatasetItemResultMapper::parseEvaluators)
                 .orElse(null);
+    }
+
+    // A row whose mapping function throws is silently dropped by the ClickHouse r2dbc driver,
+    // making the whole item vanish from the list. Degrade to null on unparseable JSON so the
+    // item stays visible (without its assertions) instead of disappearing.
+    private static List<EvaluatorItem> parseEvaluators(String value) {
+        try {
+            return JsonUtils.readValue(value, EVALUATOR_LIST_TYPE);
+        } catch (RuntimeException e) {
+            log.warn("Failed to parse stored evaluators JSON; returning null evaluators for this item", e);
+            return null;
+        }
     }
 
     static String getDescription(Row row, RowMetadata rowMetadata) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -45,8 +45,10 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1863,13 +1865,13 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                 {targetDatasetId:String} as dataset_id,
                 {newVersionId:String} as dataset_version_id,
                 <if(data)> mapFromArrays({data_keys:Array(String)}, {data_values:Array(String)}) <else> src.data <endif> as data,
-                <if(description)> {description:String} <else> src.description <endif> as description,
+                <if(description)> base64Decode({description:String}) <else> src.description <endif> as description,
                 src.metadata,
                 src.source,
                 src.trace_id,
                 src.span_id,
                 <if(tags)> {tags:Array(String)} <else> src.tags <endif> as tags,
-                <if(evaluators)> {evaluators:String} <else> src.evaluators <endif> as evaluators,
+                <if(evaluators)> base64Decode({evaluators:String}) <else> src.evaluators <endif> as evaluators,
                 <if(clear_execution_policy)> '' <else><if(execution_policy)> {execution_policy:String} <else> src.execution_policy <endif><endif> as execution_policy,
                 src.item_created_at,
                 now64(9) as item_last_updated_at,
@@ -3297,14 +3299,19 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             params.put("data_keys", FilterQueryBuilder.formatStringArrayLiteral(dataAsStrings.keySet()));
             params.put("data_values", FilterQueryBuilder.formatStringArrayLiteral(dataAsStrings.values()));
         }
+        // Free-text / JSON params bound via the v2-client {:String} substitution must be base64'd:
+        // ClickHouse processes backslash escapes in the substituted value, so a raw '\n' is turned
+        // into a literal newline — corrupting JSON (evaluators) or the stored text and even failing
+        // the write (description). base64Decode in the SQL restores the exact bytes. Add the same
+        // treatment to any new free-text/JSON {:String} param added here.
         if (edit.description() != null) {
-            params.put("description", edit.description());
+            params.put("description", base64Encode(edit.description()));
         }
         if (edit.tags() != null) {
             params.put("tags", FilterQueryBuilder.formatStringArrayLiteral(edit.tags()));
         }
         if (edit.evaluators() != null) {
-            params.put("evaluators", serializeEvaluators(edit.evaluators()));
+            params.put("evaluators", base64Encode(serializeEvaluators(edit.evaluators())));
         }
         if (!Boolean.TRUE.equals(edit.clearExecutionPolicy()) && edit.executionPolicy() != null) {
             params.put("execution_policy", serializeExecutionPolicy(edit.executionPolicy()));
@@ -3751,6 +3758,10 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             return Instant.now().toString().replace("Z", "");
         }
         return timestamp.toString().replace("Z", "");
+    }
+
+    private static String base64Encode(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
     }
 
     private static String serializeEvaluators(List<EvaluatorItem> evaluators) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -4367,6 +4367,79 @@ class DatasetVersionResourceTest {
         }
 
         @Test
+        @DisplayName("Success: Editing an item's evaluator and description containing JSON escape sequences round-trips (OPIK-6855)")
+        void applyChanges__whenEvaluatorAndDescriptionContainJsonEscapeSequences__thenItemNotLostAndRoundTrips() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+
+            var items = List.of(DatasetItem.builder()
+                    .source(DatasetItemSource.SDK)
+                    .data(Map.of("input", JsonUtils.getJsonNodeFromString("\"" + UUID.randomUUID() + "\"")))
+                    .build());
+
+            var batch = DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .items(items)
+                    .batchGroupId(UUID.randomUUID())
+                    .build();
+            datasetResourceClient.createDatasetItems(batch, TEST_WORKSPACE, API_KEY);
+
+            var version1 = getLatestVersion(datasetId);
+            datasetResourceClient.createVersionTag(datasetId, version1.versionHash(),
+                    DatasetVersionTag.builder().tag("v1").build(), API_KEY, TEST_WORKSPACE);
+
+            var v1Items = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 10, "v1", API_KEY, TEST_WORKSPACE).content();
+            assertThat(v1Items).hasSize(1);
+
+            // Edit the item with an evaluator prompt AND a description that contain newlines, an
+            // escaped quote and a backslash — the characters ClickHouse's {:String} param
+            // substitution would unescape. Before the fix this corrupted the stored evaluator JSON
+            // (item silently dropped on read by the r2dbc driver) and made the description write
+            // fail outright, so both fields are exercised here.
+            var newEvaluators = List.of(
+                    EvaluatorItem.builder()
+                            .name(UUID.randomUUID().toString())
+                            .type(EvaluatorType.LLM_JUDGE)
+                            .config(JsonUtils.getJsonNodeFromString(
+                                    "{\"messages\":[{\"role\":\"SYSTEM\",\"content\":\"Line one.\\n\\nLine two with an agent's \\\"quoted\\\" word and a back\\\\slash.\"}],"
+                                            + "\"schema\":[{\"name\":\"my assertion\",\"type\":\"BOOLEAN\",\"description\":\"my assertion\"}]}"))
+                            .build());
+
+            var newDescription = "Desc with \\n newline, \\t tab, a \\\"quote\\\" and a back\\\\slash";
+
+            var editedItem = DatasetItemEdit.builder()
+                    .id(v1Items.getFirst().id())
+                    .evaluators(newEvaluators)
+                    .description(newDescription)
+                    .build();
+
+            var changes = DatasetItemChanges.builder()
+                    .baseVersion(version1.id())
+                    .editedItems(List.of(editedItem))
+                    .tags(List.of("v2"))
+                    .build();
+
+            var version2 = datasetResourceClient.applyDatasetItemChanges(
+                    datasetId, changes, false, API_KEY, TEST_WORKSPACE);
+
+            assertThat(version2.itemsTotal()).isEqualTo(1);
+            assertThat(version2.itemsModified()).isEqualTo(1);
+
+            var v2Items = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 10, "v2", API_KEY, TEST_WORKSPACE).content();
+
+            // Full-item comparison: the row must survive the round-trip and every field must be
+            // preserved, with the new evaluators and description applied (volatile fields ignored).
+            var expectedItem = v1Items.getFirst().toBuilder()
+                    .evaluators(newEvaluators)
+                    .description(newDescription)
+                    .build();
+            assertThat(v2Items)
+                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS_DATA_ITEM)
+                    .containsExactly(expectedItem);
+        }
+
+        @Test
         @DisplayName("Success: Editing only executionPolicy bumps dataset version as modified")
         void applyChanges__whenOnlyExecutionPolicyChanged__thenItemIsModified() {
             var datasetId = createDataset(UUID.randomUUID().toString());


### PR DESCRIPTION
## Details

Editing a test-suite item to add/change an assertion (or its description) could produce a new dataset version that shows **zero items** — the item appeared lost.

Root cause is in the backend item-level edit path (`EDIT_ITEM_VIA_SELECT_INSERT`, run via the ClickHouse v2 client): `evaluators` and `description` were bound through `{:String}` query-parameter substitution, which processes backslash escape sequences. The default `llm_judge` prompt template contains newlines (`\n`), so the stored `evaluators` JSON ended up with **literal** newlines — invalid JSON. On read, the ClickHouse r2dbc driver silently drops any row whose mapping function throws, so the whole item disappeared from the list (the version's item count still reported it, masking the loss). A backslash in a `description` failed the write outright (500).

Fix:
- **Write**: base64-encode `evaluators` and `description` before binding and `base64Decode(...)` them in the SQL, so the values cross the `{:String}` substitution intact. The stored column remains plain JSON/text, so the read path is unchanged. A comment at the binding site flags that any new free-text/JSON `{:String}` param needs the same treatment.
- **Read resilience**: harden `getEvaluators` to degrade to `null` (with a WARN) on unparseable stored JSON, so a corrupt row stays visible instead of being silently dropped by the driver.

`execution_policy` is intentionally left unencoded — it serializes to integers-only JSON with no escape sequences, so it cannot be corrupted by this mechanism.

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6855

## Testing

Added an end-to-end regression test in `DatasetVersionResourceTest` that edits an item with an evaluator prompt **and** a description containing a newline, an escaped quote, and a backslash, then asserts (full-item recursive comparison) that the item survives the round-trip with every field intact. Verified it **fails without** the fix (item dropped / evaluators null) and **passes with** it. `mvn compile` + `spotless:check` clean.

## Documentation

N/A
