### PR TITLE
[OPIK-6895] [BE] feat: add id_week predicate to trace read paths

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AiSpendQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AiSpendQueryBuilder.java
@@ -55,10 +55,21 @@ class AiSpendQueryBuilder {
     private static final String ID_WINDOW = "id BETWEEN :id_prior_start AND :id_end";
     private static final String ID_RANGE = "id BETWEEN :id_start AND :id_end";
 
+    /**
+     * Weekly-partition pruning bounds for the {@code traces} table, appended to the {@code WINDOW} / {@code RANGE}
+     * fragments. {@code toMonday(id_at)} is a strict consequence of the id-range (it can't drop a row the id-range
+     * wouldn't) but lets the planner prune partitions, which it can't infer through {@code UUIDv7ToDateTime}.
+     */
+    private static final String ID_WEEK_WINDOW = "toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:id_prior_start), 'UTC'))"
+            + " AND toMonday(id_at) <= toMonday(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'))";
+    /** Current-range counterpart of {@link #ID_WEEK_WINDOW}. */
+    private static final String ID_WEEK_RANGE = "toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:id_start), 'UTC'))"
+            + " AND toMonday(id_at) <= toMonday(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'))";
+
     private static final String CURRENT = ID_CURRENT + " AND " + TS_CURRENT;
     private static final String PREVIOUS = ID_PREVIOUS + " AND " + TS_PREVIOUS;
-    private static final String WINDOW = ID_WINDOW + " AND " + TS_WINDOW;
-    private static final String RANGE = ID_RANGE + " AND " + TS_RANGE;
+    private static final String WINDOW = ID_WINDOW + " AND " + TS_WINDOW + " AND " + ID_WEEK_WINDOW;
+    private static final String RANGE = ID_RANGE + " AND " + TS_RANGE + " AND " + ID_WEEK_RANGE;
 
     // The spans table is ordered by (workspace_id, project_id, trace_id, parent_span_id, id),
     // so adding trace_id BETWEEN — the per-call span_id and the trace_id are both

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
@@ -158,6 +158,8 @@ class KpiCardDAOImpl implements KpiCardDAO {
                     AND workspace_id = :workspace_id
                     AND id >= :uuid_from_time
                     AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))
                     <if(trace_filters)> AND <trace_filters> <endif>
                     <if(trace_feedback_scores_filters)>
                     AND id in (
@@ -338,6 +340,8 @@ class KpiCardDAOImpl implements KpiCardDAO {
                 WHERE workspace_id = :workspace_id
                   AND project_id = :project_id
                   AND id >= :uuid_from_time AND id \\<= :uuid_to_time
+                  AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))
+                  AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))
                   AND thread_id \\<> ''
             ), trace_threads_final AS (
                 SELECT

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
@@ -273,8 +273,10 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                     <endif>
                     WHERE project_id = :project_id
                     AND workspace_id = :workspace_id
-                    <if(uuid_from_time)> AND id >= :uuid_from_time<endif>
-                    <if(uuid_to_time)> AND id \\<= :uuid_to_time<endif>
+                    <if(uuid_from_time)> AND id >= :uuid_from_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                    <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
                     <if(trace_filters)> AND <trace_filters> <endif>
                     <if(trace_feedback_scores_filters)>
                     AND id in (
@@ -1062,8 +1064,10 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             FROM traces final
             WHERE workspace_id = :workspace_id
                 <if(project_ids)> AND project_id IN :project_ids <endif>
-                <if(uuid_from_time)>AND id >= :uuid_from_time<endif>
-                <if(uuid_to_time)>AND id \\<= :uuid_to_time<endif>
+                <if(uuid_from_time)>AND id >= :uuid_from_time
+                AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                <if(uuid_to_time)>AND id \\<= :uuid_to_time
+                AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
             SETTINGS log_comment = '<log_comment>';
             """;
 
@@ -1074,8 +1078,10 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             WHERE workspace_id = :workspace_id
                 AND length(error_info) > 0
                 <if(project_ids)> AND project_id IN :project_ids <endif>
-                <if(uuid_from_time)>AND id >= :uuid_from_time<endif>
-                <if(uuid_to_time)>AND id \\<= :uuid_to_time<endif>
+                <if(uuid_from_time)>AND id >= :uuid_from_time
+                AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                <if(uuid_to_time)>AND id \\<= :uuid_to_time
+                AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
             SETTINGS log_comment = '<log_comment>';
             """;
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
@@ -83,8 +83,8 @@ class ThreadDAOImpl implements ThreadDAO {
                     WHERE workspace_id = :workspace_id
                     AND project_id = :project_id
                     AND thread_id \\<> ''
-                    <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
-                    <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                    <if(uuid_from_time)> AND id >= :uuid_from_time AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                    <if(uuid_to_time)> AND id \\<= :uuid_to_time AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                     <if(traces_pushdown_filter)> AND thread_id = :thread_id_pushdown <endif>
                 )
                 WHERE 1 = 1
@@ -162,9 +162,11 @@ class ThreadDAOImpl implements ThreadDAO {
                       <else>
                           <if(traces_final_ids)>
                               AND id IN (SELECT id FROM traces_final_ids)
+                              <if(uuid_from_time)> AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                              <if(uuid_to_time)> AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                           <else>
-                              <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
-                              <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                              <if(uuid_from_time)> AND id >= :uuid_from_time AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                              <if(uuid_to_time)> AND id \\<= :uuid_to_time AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                               <if(traces_pushdown_filter)> AND thread_id = :thread_id_pushdown <endif>
                           <endif>
                       <endif>
@@ -494,8 +496,8 @@ class ThreadDAOImpl implements ThreadDAO {
                     WHERE workspace_id = :workspace_id
                     AND project_id = :project_id
                     AND thread_id \\<> ''
-                    <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
-                    <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                    <if(uuid_from_time)> AND id >= :uuid_from_time AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                    <if(uuid_to_time)> AND id \\<= :uuid_to_time AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                     <if(traces_pushdown_filter)> AND thread_id = :thread_id_pushdown <endif>
                 )
                 WHERE 1 = 1
@@ -523,9 +525,11 @@ class ThreadDAOImpl implements ThreadDAO {
                       AND thread_id \\<> ''
                       <if(traces_final_ids)>
                           AND id IN (SELECT id FROM traces_final_ids)
+                          <if(uuid_from_time)> AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                          <if(uuid_to_time)> AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                       <else>
-                          <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
-                          <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                          <if(uuid_from_time)> AND id >= :uuid_from_time AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                          <if(uuid_to_time)> AND id \\<= :uuid_to_time AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                           <if(traces_pushdown_filter)> AND thread_id = :thread_id_pushdown <endif>
                       <endif>
                     ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
@@ -1035,8 +1039,8 @@ class ThreadDAOImpl implements ThreadDAO {
                         WHERE workspace_id = :workspace_id
                         AND project_id = :project_id
                         AND thread_id \\<> ''
-                        <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
-                        <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                        <if(uuid_from_time)> AND id >= :uuid_from_time AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                        <if(uuid_to_time)> AND id \\<= :uuid_to_time AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                         <if(traces_pushdown_filter)> AND thread_id = :thread_id_pushdown <endif>
                     )
                     WHERE 1 = 1
@@ -1064,9 +1068,11 @@ class ThreadDAOImpl implements ThreadDAO {
                           AND thread_id \\<> ''
                           <if(traces_final_ids)>
                               AND id IN (SELECT id FROM traces_final_ids)
+                              <if(uuid_from_time)> AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                              <if(uuid_to_time)> AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                           <else>
-                              <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
-                              <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                              <if(uuid_from_time)> AND id >= :uuid_from_time AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                              <if(uuid_to_time)> AND id \\<= :uuid_to_time AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                               <if(traces_pushdown_filter)> AND thread_id = :thread_id_pushdown <endif>
                           <endif>
                         ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -814,12 +814,18 @@ class TraceDAOImpl implements TraceDAO {
             ;
             """;
 
+    /**
+     * {@code toMonday(id_at) = ...} pins the scan to the single week that can hold {@code :id}: a strict consequence
+     * of {@code id = :id} (never hides the row) that engages partition pruning once {@code traces} is partitioned,
+     * which the planner can't infer from the id filter alone.
+     */
     private static final String SELECT_DETAILS_BY_ID = """
             SELECT DISTINCT
                 workspace_id,
                 project_id
             FROM traces
             WHERE id = :id
+            AND toMonday(id_at) = toMonday(UUIDv7ToDateTime(toUUID(:id), 'UTC'))
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
@@ -834,6 +840,10 @@ class TraceDAOImpl implements TraceDAO {
      * picks the right page) and the final ORDER BY (so the page is returned in order); {@code page_wide}'s own order is
      * immaterial since it is id-bounded and {@code LIMIT 1 BY id}. Field exclusion ({@code exclude_fields}) and
      * truncation are layered on top without dropping the sort key.
+     * <p>
+     * Each {@code traces} id-range bound carries a parallel {@code toMonday(id_at)} bound: a strict consequence of
+     * the id-range — and, unlike a {@code created_at} predicate, safe against late-arriving rows since it derives
+     * from {@code id} — that lets the planner prune partitions once {@code traces} is partitioned.
      */
     private static final String SELECT_BY_PROJECT_ID = """
             WITH <if(trace_id_prefilter)>trace_id_prefilter AS (
@@ -841,9 +851,12 @@ class TraceDAOImpl implements TraceDAO {
                 FROM traces
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
-                <if(last_received_id)> AND id \\< :last_received_id <endif>
-                <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
-                <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                <if(last_received_id)> AND id \\< :last_received_id
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:last_received_id), 'UTC')) <endif>
+                <if(uuid_from_time)> AND id >= :uuid_from_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                 <if(filters)> AND <filters> <endif>
                 <if(search_text)> AND <search_text> <endif>
             ), <endif><if(!exclude_feedback_scores)>feedback_scores_deduped AS (
@@ -1265,9 +1278,12 @@ class TraceDAOImpl implements TraceDAO {
                 <endif>
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
-                <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
-                <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
-                <if(last_received_id)> AND id \\< :last_received_id <endif>
+                <if(uuid_from_time)> AND id >= :uuid_from_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
+                <if(last_received_id)> AND id \\< :last_received_id
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:last_received_id), 'UTC')) <endif>
                 <if(filters)> AND <filters> <endif>
                 <if(search_text)> AND <search_text> <endif>
                 <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>
@@ -1349,6 +1365,9 @@ class TraceDAOImpl implements TraceDAO {
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
                 AND id IN (SELECT id FROM page_ids)
+                <if(uuid_from_time)> AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                <if(uuid_to_time)> AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
+                <if(last_received_id)> AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:last_received_id), 'UTC')) <endif>
                 ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
                 LIMIT 1 BY id
             )
@@ -1663,8 +1682,10 @@ class TraceDAOImpl implements TraceDAO {
                     <endif>
                     WHERE project_id = :project_id
                     AND workspace_id = :workspace_id
-                    <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
-                    <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                    <if(uuid_from_time)> AND id >= :uuid_from_time
+                        AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                    <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                        AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                     <if(filters)> AND <filters> <endif>
                     <if(search_text)> AND <search_text> <endif>
                     <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>
@@ -1786,11 +1807,17 @@ class TraceDAOImpl implements TraceDAO {
             ;
             """;
 
+    /**
+     * The {@code toMonday(id_at)} bounds mirror the {@code [range_start, range_end)} id-range: a strict consequence
+     * that doesn't change which rows are scanned but engages partition pruning once {@code traces} is partitioned.
+     */
     private static final String SCOUT_FIRST_DAY_WITH_DATA = """
             SELECT toDate(UUIDv7ToDateTime(toUUID(id))) AS day
             FROM traces
             WHERE workspace_id = :workspace_id
             AND id >= :range_start AND id \\< :range_end
+            AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:range_start), 'UTC'))
+            AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:range_end), 'UTC'))
             GROUP BY day
             ORDER BY day
             LIMIT 1
@@ -1954,6 +1981,7 @@ class TraceDAOImpl implements TraceDAO {
                 start_time
             FROM traces
             WHERE id = :id
+            AND toMonday(id_at) = toMonday(UUIDv7ToDateTime(toUUID(:id), 'UTC'))
             AND workspace_id = :workspace_id
             ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
             LIMIT 1
@@ -1987,6 +2015,7 @@ class TraceDAOImpl implements TraceDAO {
                 DISTINCT project_id
             FROM traces
             WHERE id = :id
+            AND toMonday(id_at) = toMonday(UUIDv7ToDateTime(toUUID(:id), 'UTC'))
             AND workspace_id = :workspace_id
             SETTINGS log_comment = '<log_comment>'
             ;
@@ -2344,8 +2373,10 @@ class TraceDAOImpl implements TraceDAO {
                 <endif>
                 WHERE workspace_id = :workspace_id
                 AND project_id IN :project_ids
-                <if(uuid_from_time)>AND id >= :uuid_from_time<endif>
-                <if(uuid_to_time)>AND id \\<= :uuid_to_time<endif>
+                <if(uuid_from_time)>AND id >= :uuid_from_time
+                AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                <if(uuid_to_time)>AND id \\<= :uuid_to_time
+                AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
                 <if(filters)> AND <filters> <endif>
                 <if(search_text)> AND <search_text> <endif>
                 <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>
@@ -2687,8 +2718,10 @@ class TraceDAOImpl implements TraceDAO {
                 <endif>
                 WHERE workspace_id = :workspace_id
                 AND project_id IN :project_ids
-                <if(uuid_from_time)>AND id >= :uuid_from_time<endif>
-                <if(uuid_to_time)>AND id \\<= :uuid_to_time<endif>
+                <if(uuid_from_time)>AND id >= :uuid_from_time
+                AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                <if(uuid_to_time)>AND id \\<= :uuid_to_time
+                AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
                 <if(filters)> AND <filters> <endif>
                 <if(search_text)> AND <search_text> <endif>
                 <if(annotation_queue_filters)> AND <annotation_queue_filters> <endif>

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
@@ -65,6 +65,8 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
                 WHERE workspace_id = :workspace_id
                   <if(project_ids)> AND project_id IN :project_ids <endif>
                   AND id BETWEEN :id_prior_start AND :id_end
+                  AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:id_prior_start), 'UTC'))
+                  AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'))
                   AND start_time BETWEEN parseDateTime64BestEffort(:timestamp_prior_start, 9) AND parseDateTime64BestEffort(:timestamp_end, 9)
             ) t ON t.id = fs.entity_id
             WHERE workspace_id = :workspace_id
@@ -99,6 +101,8 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
                     WHERE workspace_id = :workspace_id
                       AND project_id IN :project_ids
                       AND id BETWEEN :id_start AND :id_end
+                      AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:id_start), 'UTC'))
+                      AND toMonday(id_at) <= toMonday(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'))
                       AND start_time BETWEEN parseDateTime64BestEffort(:timestamp_start, 9) AND parseDateTime64BestEffort(:timestamp_end, 9)
                 ) t ON t.id = fs.entity_id
                 WHERE workspace_id = :workspace_id
@@ -133,6 +137,8 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
                     FROM traces final
                     WHERE workspace_id = :workspace_id
                       AND id BETWEEN :id_start AND :id_end
+                      AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:id_start), 'UTC'))
+                      AND toMonday(id_at) <= toMonday(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'))
                       AND start_time BETWEEN parseDateTime64BestEffort(:timestamp_start, 9) AND parseDateTime64BestEffort(:timestamp_end, 9)
                 ) t ON t.id = fs.entity_id
                 WHERE workspace_id = :workspace_id


### PR DESCRIPTION
## Details

Adds a `toMonday(id_at)` ("id_week") predicate alongside the existing id-range / time filters on every `traces`-table read scan that does a time-bounded or id-range query, across `TraceDAO`, `ThreadDAO`, `ProjectMetricsDAO`, `KpiCardDAO`, `WorkspaceMetricsDAO`, and `AiSpendQueryBuilder`. `id_at` is a MATERIALIZED column derived from the UUIDv7 `id` (added earlier), so the predicate is a strict consequence of the existing id-range filter — a no-op on the current unpartitioned table. Once `traces` is partitioned by `toMonday(id_at)` it engages partition pruning, which the planner cannot infer through `UUIDv7ToDateTime` on its own; this matters most for cold-tier reads, where out-of-window partitions are skipped before their marks are loaded.

- Covers the UI list + count, trace detail / lookup-by-id, the time-bounded stats/aggregation queries, the thread list/count/stats queries, the project/workspace/KPI metrics, the AI-spend window/range fragments, and the retention first-day scout.
- Applied only to `traces`-table scans (the one table with `id_at`); `spans` / feedback-score / `trace_threads` / CTE scans are intentionally untouched. `created_at` / `last_updated_at`-windowed queries and arbitrary `id IN (...)` lookups are excluded, since an `id_week` bound can't be safely derived from server-stamped time or a non-contiguous id set.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-6895

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: code review + test-coverage audit

## Testing

No new tests were added: the change is a semantic no-op (the `toMonday(id_at)` bound is a strict consequence of the existing id-range filter and cannot drop a row the id-range wouldn't), and every modified query is already executed with the predicate rendered by pre-existing integration tests. We audited coverage across the affected paths:

- `GetTracesByProjectResourceTest.GetTracesByProjectTimeFilteringTests` — parameterized over `/traces` (list + count), `/traces/stream` (search) and `/traces/stats` with `from_time`/`to_time`, asserting boundary inclusion (traces at the exact lower/upper bound) and exclusion of out-of-window traces.
- `FindTraceThreadsResourceTest` time-filtering (stream + paged, asserts page totals) and `GetThreadStats` — thread list/count/stats.
- `ProjectMetricsResourceTest`, `KpiCardsResourceTest`, `AiSpendResourceTest`, `WorkspacesResourceTest` — the metrics / spend windowed queries (these endpoints are inherently time-bounded).
- By-id equality paths run on every trace create/update (`getPartialById`), trace redirect (`getTraceDetailsById`) and feedback/comment on a trace (`getProjectIdFromTrace`).

`EXPLAIN PARTITIONS` verification is deferred to post-cutover staging per the ticket, since `traces` is not yet partitioned. Full test suite and quality checks run in CI.

## Documentation

N/A
