### PR TITLE
[OPIK-7104] [BE] refactor: remove stats computation path from /projects/retrieve

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProjectRetrieve.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProjectRetrieve.java
@@ -1,24 +1,8 @@
 package com.comet.opik.api;
 
-import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
-public record ProjectRetrieve(@NotBlank String name, @Nullable Boolean includeStats) {
-
-    /**
-     * Whether the response should be enriched with project-level statistics
-     * (feedback scores, trace/span aggregations, duration, cost, counts).
-     * <p>
-     * Defaults to {@code false}: callers that only need to resolve a project
-     * name to its id (the SDK and the UI redirect path) should not trigger the
-     * expensive ClickHouse aggregations. The canonical accessor is overridden to
-     * coalesce {@code null} to {@code false}, so it never returns {@code null}.
-     * See OPIK-7101.
-     */
-    @Override
-    public Boolean includeStats() {
-        return Boolean.TRUE.equals(includeStats);
-    }
+public record ProjectRetrieve(@NotBlank String name) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
@@ -216,7 +216,7 @@ public class ProjectsResource {
             @RequestBody(content = @Content(schema = @Schema(implementation = ProjectRetrieve.class))) @Valid ProjectRetrieve retrieve) {
         String workspaceId = requestContext.get().getWorkspaceId();
         log.info("Retrieve project by name '{}', on workspace_id '{}'", retrieve.name(), workspaceId);
-        Project project = projectService.retrieveByName(retrieve.name(), retrieve.includeStats());
+        Project project = projectService.retrieveByName(retrieve.name());
         log.info("Retrieved project id '{}' by name '{}', on workspace_id '{}'", project.id(), retrieve.name(),
                 workspaceId);
         return Response.ok().entity(project).build();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -100,7 +100,7 @@ public interface ProjectService {
 
     Project getOrCreate(String workspaceId, String projectName, String userName);
 
-    Project retrieveByName(String projectName, boolean includeStats);
+    Project retrieveByName(String projectName);
 
     Mono<List<Project>> retrieveByNamesOrCreate(Set<String> projectNames);
 
@@ -620,7 +620,7 @@ class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
-    public Project retrieveByName(@NonNull String projectName, boolean includeStats) {
+    public Project retrieveByName(@NonNull String projectName) {
         var workspaceId = requestContext.get().getWorkspaceId();
 
         Optional<Project> projects = template.inTransaction(READ_ONLY, handle -> {
@@ -631,34 +631,7 @@ class ProjectServiceImpl implements ProjectService {
 
         return projects
                 .flatMap(project -> verifyVisibility(project, requestContext.get().getVisibility()))
-                .map(project -> includeStats ? enrichWithStats(project, workspaceId) : project)
                 .orElseThrow(this::createNotFoundError);
-    }
-
-    private Project enrichWithStats(Project project, String workspaceId) {
-        Map<UUID, Instant> projectLastUpdatedTraceAtMap = transactionTemplateAsync
-                .nonTransaction(connection -> {
-                    Set<UUID> projectIds = Set.of(project.id());
-                    return traceDAO.getLastUpdatedTraceAt(projectIds, workspaceId, connection);
-                }).block();
-
-        Map<UUID, Map<String, Object>> projectStats = getProjectStats(List.of(project.id()),
-                workspaceId, ProjectCriteria.builder().build());
-
-        return project.toBuilder()
-                .lastUpdatedTraceAt(projectLastUpdatedTraceAtMap.get(project.id()))
-                .feedbackScores(StatsMapper.getStatsFeedbackScores(projectStats.get(project.id())))
-                .usage(StatsMapper.getStatsUsage(projectStats.get(project.id())))
-                .duration(StatsMapper.getStatsDuration(projectStats.get(project.id())))
-                .totalEstimatedCost(
-                        StatsMapper.getStatsTotalEstimatedCost(projectStats.get(project.id())))
-                .totalEstimatedCostSum(
-                        StatsMapper.getStatsTotalEstimatedCostSum(projectStats.get(project.id())))
-                .traceCount(StatsMapper.getStatsTraceCount(projectStats.get(project.id())))
-                .guardrailsFailedCount(
-                        StatsMapper.getStatsGuardrailsFailedCount(projectStats.get(project.id())))
-                .errorCount(StatsMapper.getStatsErrorCount(projectStats.get(project.id())))
-                .build();
     }
 
     @Override

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -753,7 +753,7 @@ class ProjectsResourceTest {
     class RetrieveProjectTest {
 
         @Test
-        @DisplayName("when project exists, then return project")
+        @DisplayName("when project exists, then return project without stats")
         void getProjectById__whenProjectExists__thenReturnProject() {
             String workspaceName = UUID.randomUUID().toString();
             String apiKey = UUID.randomUUID().toString();
@@ -765,48 +765,12 @@ class ProjectsResourceTest {
 
             var id = createProject(project, apiKey, workspaceName);
 
-            project = buildProjectStats(project.toBuilder().id(id).build(), apiKey, workspaceName);
-
-            try (var actualResponse = client.target(URL_TEMPLATE.formatted(baseURI))
-                    .path("retrieve")
-                    .request()
-                    .header(HttpHeaders.AUTHORIZATION, apiKey)
-                    .header(WORKSPACE_HEADER, workspaceName)
-                    .post(Entity.json(ProjectRetrieve.builder().name(project.name()).includeStats(true).build()))) {
-
-                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
-                assertThat(actualResponse.hasEntity()).isTrue();
-
-                var actualEntity = actualResponse.readEntity(Project.class);
-                assertThat(actualEntity)
-                        .usingRecursiveComparison()
-                        .ignoringFields(IGNORED_FIELD_MIN)
-                        .ignoringCollectionOrder()
-                        .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
-                        .withComparatorForFields(StatsUtils::closeToEpsilonComparator, "totalEstimatedCost")
-                        .isEqualTo(project);
-            }
-        }
-
-        @Test
-        @DisplayName("when project exists and stats are not requested, then return project without stats")
-        void getProjectByName__whenStatsNotRequested__thenReturnProjectWithoutStats() {
-            String workspaceName = UUID.randomUUID().toString();
-            String apiKey = UUID.randomUUID().toString();
-            String workspaceId = UUID.randomUUID().toString();
-
-            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
-
-            var project = factory.manufacturePojo(Project.class);
-
-            var id = createProject(project, apiKey, workspaceName);
-
-            // Seed traces/spans so stats would be non-null if they were computed.
+            // Seed traces/spans so stats would be non-null if they were ever computed.
             buildProjectStats(project.toBuilder().id(id).build(), apiKey, workspaceName);
 
-            // Without stats requested (OPIK-7101), no ClickHouse aggregation runs on the hot name-resolution path:
-            // identity/core fields are resolved while every stats field stays null. lastUpdatedTraceAt is a `projects`
-            // table column (set on ingestion), not part of the stats aggregation, so it is ignored via IGNORED_FIELD_MIN.
+            // /retrieve resolves name -> id only; it never computes ClickHouse stats (OPIK-7104), so every stats field
+            // stays null even when traces exist. lastUpdatedTraceAt is a `projects` table column (set on ingestion),
+            // not part of the stats aggregation, so it is ignored via IGNORED_FIELD_MIN.
             var expectedProject = project.toBuilder()
                     .id(id)
                     .feedbackScores(null)


### PR DESCRIPTION
## Details

Follow-up to OPIK-7101 (#7231), which made project stats **opt-in** on `POST /v1/private/projects/retrieve` via an `includeStats` flag (default `false`). That stopped the heavy ClickHouse aggregations (feedback scores, trace/span aggregation, duration, cost, counts) from running on the hot SDK/UI name-resolution path, which had been saturating ClickHouse CPU in prod.

This PR completes the cleanup: `/retrieve` becomes **pure name → id resolution** and the stats code path is deleted, so the tech debt can't be re-triggered by a caller passing `includeStats: true`.

- `ProjectRetrieve`: drop the `includeStats` flag + accessor; back to `name`-only.
- `ProjectService.retrieveByName(String)`: drop the `includeStats` branch and the `enrichWithStats(...)` method (the ClickHouse aggregation + `block()`).
- `ProjectsResource`: call `retrieveByName(name)`.
- `ProjectsResourceTest`: collapse the two retrieve tests into one asserting the project is returned with all stats fields `null` even when traces/spans exist.

The response contract is unchanged: the stat fields are `@Nullable` and simply serialize as `null`. No first-party caller reads them from this endpoint (TS/Python SDK and FE `useProjectByName` read `.id` only) — verified during OPIK-7101.

## ⚠️ Merge gate

Per the OPIK-7104 plan, **do not merge until** the OPIK-7101 opt-in default has baked in prod and ClickHouse load is confirmed back to normal with no client relying on `includeStats: true`. Opening as **draft** until then.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7104
- Follow-up to OPIK-7101

## Testing

- `ProjectsResourceTest.RetrieveProjectTest`: single happy-path test seeds traces/spans via `buildProjectStats`, then asserts `/retrieve` returns the project with every stats field null (full-object recursive comparison, `lastUpdatedTraceAt` ignored as a `projects`-table column).
- Local: `mvn test-compile spotless:check` passes. Relying on PR CI for the full integration suite (needs Docker/Testcontainers).

## Documentation

No public docs change. Removing the optional `includeStats` request field is backward compatible (unknown JSON properties are ignored by the request deserializer); the OpenAPI/Fern spec will drop `includeStats` from the `ProjectRetrieve` schema on the next codegen.