### PR TITLE
[OPIK-7051] [BE] Reactive online-scoring enqueue + enqueue metric with workspace labels

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/events/SpansCreated.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/events/SpansCreated.java
@@ -2,6 +2,7 @@ package com.comet.opik.api.events;
 
 import com.comet.opik.api.Span;
 import com.comet.opik.infrastructure.events.BaseEvent;
+import jakarta.annotation.Nullable;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
@@ -15,10 +16,19 @@ import java.util.stream.Collectors;
 @Accessors(fluent = true)
 public class SpansCreated extends BaseEvent {
     private final @NonNull List<Span> spans;
+    // Resolved from RequestContext.WORKSPACE_NAME at publish time (SpanService). May be null/blank
+    // for callers that don't carry it; consumers fall back to workspaceId.
+    private final @Nullable String workspaceName;
 
     public SpansCreated(@NonNull List<Span> spans, @NonNull String workspaceId, @NonNull String userName) {
+        this(spans, workspaceId, userName, null);
+    }
+
+    public SpansCreated(@NonNull List<Span> spans, @NonNull String workspaceId, @NonNull String userName,
+            @Nullable String workspaceName) {
         super(workspaceId, userName);
         this.spans = spans;
+        this.workspaceName = workspaceName;
     }
 
     public Set<UUID> projectIds() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/events/SpansCreated.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/events/SpansCreated.java
@@ -16,8 +16,10 @@ import java.util.stream.Collectors;
 @Accessors(fluent = true)
 public class SpansCreated extends BaseEvent {
     private final @NonNull List<Span> spans;
-    // Resolved from RequestContext.WORKSPACE_NAME at publish time (SpanService). May be null/blank
-    // for callers that don't carry it; consumers fall back to workspaceId.
+    /**
+     * Resolved from {@code RequestContext.WORKSPACE_NAME} at publish time ({@code SpanService}). May be
+     * null/blank for callers that don't carry it; consumers fall back to {@code workspaceId}.
+     */
     private final @Nullable String workspaceName;
 
     public SpansCreated(@NonNull List<Span> spans, @NonNull String workspaceId, @NonNull String userName) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
@@ -134,21 +134,6 @@ public class OnlineScoringSampler {
     }
 
     /**
-     * Subscribes the reactive enqueue, seeding the reactive context with the workspace so the publisher's
-     * enqueue metric is labelled with it. Fire-and-forget: enqueueing is a side effect of sampling and must
-     * not block the sampler.
-     */
-    private void publishSampled(List<?> messages, AutomationRuleEvaluatorType type, String workspaceId,
-            String workspaceName) {
-        onlineScorePublisher.enqueueMessage(messages, type)
-                .contextWrite(ctx -> ctx
-                        .put(RequestContext.WORKSPACE_ID, workspaceId)
-                        .put(RequestContext.WORKSPACE_NAME, StringUtils.defaultIfBlank(workspaceName, workspaceId)))
-                .subscribe(unused -> {
-                }, error -> log.error("Error enqueueing sampled online-scoring messages into redis", error));
-    }
-
-    /**
      * Listen for trace batches to check for existent Automation Rules to score them. It samples the trace batch and
      * enqueues the sample into Redis Stream.
      *
@@ -272,8 +257,8 @@ public class OnlineScoringSampler {
                         logSampledTrace(evaluator, messages, scorableTraces.size());
                         if (!messages.isEmpty()) {
                             recordDecision(workspaceId, workspaceName, evaluator, DECISION_SAMPLED, messages.size());
-                            publishSampled(messages, AutomationRuleEvaluatorType.LLM_AS_JUDGE, workspaceId,
-                                    workspaceName);
+                            OnlineScoringSamplerSupport.publishSampled(onlineScorePublisher, log, messages,
+                                    AutomationRuleEvaluatorType.LLM_AS_JUDGE, workspaceId, workspaceName);
                         }
                     }
                     case USER_DEFINED_METRIC_PYTHON -> {
@@ -286,8 +271,9 @@ public class OnlineScoringSampler {
                             if (!messages.isEmpty()) {
                                 recordDecision(workspaceId, workspaceName, evaluator, DECISION_SAMPLED,
                                         messages.size());
-                                publishSampled(messages, AutomationRuleEvaluatorType.USER_DEFINED_METRIC_PYTHON,
-                                        workspaceId, workspaceName);
+                                OnlineScoringSamplerSupport.publishSampled(onlineScorePublisher, log, messages,
+                                        AutomationRuleEvaluatorType.USER_DEFINED_METRIC_PYTHON, workspaceId,
+                                        workspaceName);
                             }
                         } else {
                             log.warn("Python evaluator is disabled. Skipping sampling for evaluator type '{}'",

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSampler.java
@@ -134,6 +134,21 @@ public class OnlineScoringSampler {
     }
 
     /**
+     * Subscribes the reactive enqueue, seeding the reactive context with the workspace so the publisher's
+     * enqueue metric is labelled with it. Fire-and-forget: enqueueing is a side effect of sampling and must
+     * not block the sampler.
+     */
+    private void publishSampled(List<?> messages, AutomationRuleEvaluatorType type, String workspaceId,
+            String workspaceName) {
+        onlineScorePublisher.enqueueMessage(messages, type)
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.WORKSPACE_ID, workspaceId)
+                        .put(RequestContext.WORKSPACE_NAME, StringUtils.defaultIfBlank(workspaceName, workspaceId)))
+                .subscribe(unused -> {
+                }, error -> log.error("Error enqueueing sampled online-scoring messages into redis", error));
+    }
+
+    /**
      * Listen for trace batches to check for existent Automation Rules to score them. It samples the trace batch and
      * enqueues the sample into Redis Stream.
      *
@@ -257,7 +272,8 @@ public class OnlineScoringSampler {
                         logSampledTrace(evaluator, messages, scorableTraces.size());
                         if (!messages.isEmpty()) {
                             recordDecision(workspaceId, workspaceName, evaluator, DECISION_SAMPLED, messages.size());
-                            onlineScorePublisher.enqueueMessage(messages, AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+                            publishSampled(messages, AutomationRuleEvaluatorType.LLM_AS_JUDGE, workspaceId,
+                                    workspaceName);
                         }
                     }
                     case USER_DEFINED_METRIC_PYTHON -> {
@@ -270,8 +286,8 @@ public class OnlineScoringSampler {
                             if (!messages.isEmpty()) {
                                 recordDecision(workspaceId, workspaceName, evaluator, DECISION_SAMPLED,
                                         messages.size());
-                                onlineScorePublisher.enqueueMessage(messages,
-                                        AutomationRuleEvaluatorType.USER_DEFINED_METRIC_PYTHON);
+                                publishSampled(messages, AutomationRuleEvaluatorType.USER_DEFINED_METRIC_PYTHON,
+                                        workspaceId, workspaceName);
                             }
                         } else {
                             log.warn("Python evaluator is disabled. Skipping sampling for evaluator type '{}'",

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSamplerSupport.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSamplerSupport.java
@@ -1,0 +1,35 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
+import com.comet.opik.domain.evaluators.OnlineScorePublisher;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+
+import java.util.List;
+
+/**
+ * Shared enqueue wiring for the (non-reactive) online-scoring samplers. The trace and span samplers run on the
+ * EventBus thread, not inside a reactive chain, so they can't compose {@link OnlineScorePublisher#enqueueMessage}
+ * themselves — they fire-and-forget. This centralizes the subscription, the workspace context seeding (so the
+ * publisher's enqueue metric is labelled) and the error logging so the two samplers don't each duplicate it.
+ */
+@UtilityClass
+class OnlineScoringSamplerSupport {
+
+    /**
+     * Subscribes the reactive enqueue, seeding the reactive context with the workspace (id + name, falling back
+     * to the id when the name is blank) and logging any failure. Fire-and-forget.
+     */
+    static void publishSampled(OnlineScorePublisher publisher, Logger log, List<?> messages,
+            AutomationRuleEvaluatorType type, String workspaceId, String workspaceName) {
+        publisher.enqueueMessage(messages, type)
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.WORKSPACE_ID, workspaceId)
+                        .put(RequestContext.WORKSPACE_NAME, StringUtils.defaultIfBlank(workspaceName, workspaceId)))
+                .subscribe(unused -> {
+                }, error -> log.error("Error enqueueing sampled online-scoring messages for evaluator={} "
+                        + "workspaceId={} workspaceName={}", type, workspaceId, workspaceName, error));
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSamplerSupport.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSamplerSupport.java
@@ -29,7 +29,8 @@ class OnlineScoringSamplerSupport {
                         .put(RequestContext.WORKSPACE_ID, workspaceId)
                         .put(RequestContext.WORKSPACE_NAME, StringUtils.defaultIfBlank(workspaceName, workspaceId)))
                 .subscribe(unused -> {
-                }, error -> log.error("Error enqueueing sampled online-scoring messages for evaluator='{}' "
-                        + "workspaceId='{}' workspaceName='{}'", type, workspaceId, workspaceName, error));
+                }, error -> log.error("Error enqueueing '{}' sampled online-scoring messages for evaluator='{}' "
+                        + "workspaceId='{}' workspaceName='{}'", messages.size(), type, workspaceId, workspaceName,
+                        error));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSamplerSupport.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSamplerSupport.java
@@ -29,7 +29,7 @@ class OnlineScoringSamplerSupport {
                         .put(RequestContext.WORKSPACE_ID, workspaceId)
                         .put(RequestContext.WORKSPACE_NAME, StringUtils.defaultIfBlank(workspaceName, workspaceId)))
                 .subscribe(unused -> {
-                }, error -> log.error("Error enqueueing sampled online-scoring messages for evaluator={} "
-                        + "workspaceId={} workspaceName={}", type, workspaceId, workspaceName, error));
+                }, error -> log.error("Error enqueueing sampled online-scoring messages for evaluator='{}' "
+                        + "workspaceId='{}' workspaceName='{}'", type, workspaceId, workspaceName, error));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSampler.java
@@ -19,14 +19,12 @@ import com.comet.opik.domain.evaluators.OnlineScorePublisher;
 import com.comet.opik.domain.evaluators.SpanFilterEvaluationService;
 import com.comet.opik.domain.evaluators.UserLog;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
-import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.log.LogContextAware;
 import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
 import com.google.common.eventbus.Subscribe;
 import jakarta.inject.Inject;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
 import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
@@ -142,8 +140,9 @@ public class OnlineScoringSpanSampler {
                                 .toList();
                         logSampledSpan(evaluator, messages, scorableSpans.size());
                         if (!messages.isEmpty()) {
-                            publishSampled(messages, AutomationRuleEvaluatorType.SPAN_LLM_AS_JUDGE,
-                                    spansBatch.workspaceId(), spansBatch.workspaceName());
+                            OnlineScoringSamplerSupport.publishSampled(onlineScorePublisher, log, messages,
+                                    AutomationRuleEvaluatorType.SPAN_LLM_AS_JUDGE, spansBatch.workspaceId(),
+                                    spansBatch.workspaceName());
                         }
                     }
                     case AutomationRuleEvaluatorLlmAsJudge rule -> logUnsupportedEvaluatorType(rule);
@@ -167,7 +166,8 @@ public class OnlineScoringSpanSampler {
                                 .toList();
                         logSampledSpan(evaluator, messages, scorableSpans.size());
                         if (!messages.isEmpty()) {
-                            publishSampled(messages, AutomationRuleEvaluatorType.SPAN_USER_DEFINED_METRIC_PYTHON,
+                            OnlineScoringSamplerSupport.publishSampled(onlineScorePublisher, log, messages,
+                                    AutomationRuleEvaluatorType.SPAN_USER_DEFINED_METRIC_PYTHON,
                                     spansBatch.workspaceId(), spansBatch.workspaceName());
                         }
                     }
@@ -179,21 +179,6 @@ public class OnlineScoringSpanSampler {
     private void logUnsupportedEvaluatorType(AutomationRuleEvaluator<?, ?> evaluator) {
         log.warn("Received unsupported evaluator type '{}' in span sampler. This should not happen.",
                 evaluator.getType());
-    }
-
-    /**
-     * Subscribes the reactive enqueue, seeding the reactive context with the workspace (id + name) so the
-     * publisher's enqueue metric is labelled with it. Falls back to the id when the name is absent.
-     * Fire-and-forget: enqueueing is a side effect of sampling and must not block the sampler.
-     */
-    private void publishSampled(List<?> messages, AutomationRuleEvaluatorType type, String workspaceId,
-            String workspaceName) {
-        onlineScorePublisher.enqueueMessage(messages, type)
-                .contextWrite(ctx -> ctx
-                        .put(RequestContext.WORKSPACE_ID, workspaceId)
-                        .put(RequestContext.WORKSPACE_NAME, StringUtils.defaultIfBlank(workspaceName, workspaceId)))
-                .subscribe(unused -> {
-                }, error -> log.error("Error enqueueing sampled online-scoring messages into redis", error));
     }
 
     private boolean shouldSampleSpan(AutomationRuleEvaluator<?, SpanFilter> evaluator,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSampler.java
@@ -19,6 +19,7 @@ import com.comet.opik.domain.evaluators.OnlineScorePublisher;
 import com.comet.opik.domain.evaluators.SpanFilterEvaluationService;
 import com.comet.opik.domain.evaluators.UserLog;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
+import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.log.LogContextAware;
 import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
 import com.google.common.eventbus.Subscribe;
@@ -140,8 +141,8 @@ public class OnlineScoringSpanSampler {
                                 .toList();
                         logSampledSpan(evaluator, messages, scorableSpans.size());
                         if (!messages.isEmpty()) {
-                            onlineScorePublisher.enqueueMessage(messages,
-                                    AutomationRuleEvaluatorType.SPAN_LLM_AS_JUDGE);
+                            publishSampled(messages, AutomationRuleEvaluatorType.SPAN_LLM_AS_JUDGE,
+                                    spansBatch.workspaceId());
                         }
                     }
                     case AutomationRuleEvaluatorLlmAsJudge rule -> logUnsupportedEvaluatorType(rule);
@@ -165,8 +166,8 @@ public class OnlineScoringSpanSampler {
                                 .toList();
                         logSampledSpan(evaluator, messages, scorableSpans.size());
                         if (!messages.isEmpty()) {
-                            onlineScorePublisher.enqueueMessage(messages,
-                                    AutomationRuleEvaluatorType.SPAN_USER_DEFINED_METRIC_PYTHON);
+                            publishSampled(messages, AutomationRuleEvaluatorType.SPAN_USER_DEFINED_METRIC_PYTHON,
+                                    spansBatch.workspaceId());
                         }
                     }
                 }
@@ -177,6 +178,17 @@ public class OnlineScoringSpanSampler {
     private void logUnsupportedEvaluatorType(AutomationRuleEvaluator<?, ?> evaluator) {
         log.warn("Received unsupported evaluator type '{}' in span sampler. This should not happen.",
                 evaluator.getType());
+    }
+
+    /**
+     * Subscribes the reactive enqueue, seeding the reactive context with the workspace so the publisher's
+     * enqueue metric is labelled with it. SpansCreated carries no workspace name, so the publisher falls back
+     * to the id for the name label. Fire-and-forget.
+     */
+    private void publishSampled(List<?> messages, AutomationRuleEvaluatorType type, String workspaceId) {
+        onlineScorePublisher.enqueueMessage(messages, type)
+                .contextWrite(ctx -> ctx.put(RequestContext.WORKSPACE_ID, workspaceId))
+                .subscribe();
     }
 
     private boolean shouldSampleSpan(AutomationRuleEvaluator<?, SpanFilter> evaluator,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSampler.java
@@ -26,6 +26,7 @@ import com.google.common.eventbus.Subscribe;
 import jakarta.inject.Inject;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
 import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
@@ -142,7 +143,7 @@ public class OnlineScoringSpanSampler {
                         logSampledSpan(evaluator, messages, scorableSpans.size());
                         if (!messages.isEmpty()) {
                             publishSampled(messages, AutomationRuleEvaluatorType.SPAN_LLM_AS_JUDGE,
-                                    spansBatch.workspaceId());
+                                    spansBatch.workspaceId(), spansBatch.workspaceName());
                         }
                     }
                     case AutomationRuleEvaluatorLlmAsJudge rule -> logUnsupportedEvaluatorType(rule);
@@ -167,7 +168,7 @@ public class OnlineScoringSpanSampler {
                         logSampledSpan(evaluator, messages, scorableSpans.size());
                         if (!messages.isEmpty()) {
                             publishSampled(messages, AutomationRuleEvaluatorType.SPAN_USER_DEFINED_METRIC_PYTHON,
-                                    spansBatch.workspaceId());
+                                    spansBatch.workspaceId(), spansBatch.workspaceName());
                         }
                     }
                 }
@@ -181,14 +182,18 @@ public class OnlineScoringSpanSampler {
     }
 
     /**
-     * Subscribes the reactive enqueue, seeding the reactive context with the workspace so the publisher's
-     * enqueue metric is labelled with it. SpansCreated carries no workspace name, so the publisher falls back
-     * to the id for the name label. Fire-and-forget.
+     * Subscribes the reactive enqueue, seeding the reactive context with the workspace (id + name) so the
+     * publisher's enqueue metric is labelled with it. Falls back to the id when the name is absent.
+     * Fire-and-forget: enqueueing is a side effect of sampling and must not block the sampler.
      */
-    private void publishSampled(List<?> messages, AutomationRuleEvaluatorType type, String workspaceId) {
+    private void publishSampled(List<?> messages, AutomationRuleEvaluatorType type, String workspaceId,
+            String workspaceName) {
         onlineScorePublisher.enqueueMessage(messages, type)
-                .contextWrite(ctx -> ctx.put(RequestContext.WORKSPACE_ID, workspaceId))
-                .subscribe();
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.WORKSPACE_ID, workspaceId)
+                        .put(RequestContext.WORKSPACE_NAME, StringUtils.defaultIfBlank(workspaceName, workspaceId)))
+                .subscribe(unused -> {
+                }, error -> log.error("Error enqueueing sampled online-scoring messages into redis", error));
     }
 
     private boolean shouldSampleSpan(AutomationRuleEvaluator<?, SpanFilter> evaluator,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TestSuiteAssertionSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TestSuiteAssertionSampler.java
@@ -150,7 +150,8 @@ public class TestSuiteAssertionSampler {
                     log.info("Enqueuing '{}' test suite assertion messages", messages.size());
                     return onlineScorePublisher.enqueueMessage(messages, AutomationRuleEvaluatorType.LLM_AS_JUDGE)
                             .onErrorResume(error -> {
-                                log.error("Error enqueueing test suite assertion messages into redis", error);
+                                log.error("Error enqueueing '{}' test suite assertion messages into redis",
+                                        messages.size(), error);
                                 return Mono.empty();
                             });
                 })

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TestSuiteAssertionSampler.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TestSuiteAssertionSampler.java
@@ -143,12 +143,16 @@ public class TestSuiteAssertionSampler {
                                 datasetEvaluatorsCache, modelName, fetchTimeout)))
                 .flatMapIterable(list -> list)
                 .collectList()
-                .doOnNext(messages -> {
-                    if (!messages.isEmpty()) {
-                        log.info("Enqueuing '{}' test suite assertion messages", messages.size());
-                        onlineScorePublisher.enqueueMessage(messages,
-                                AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+                .flatMap(messages -> {
+                    if (messages.isEmpty()) {
+                        return Mono.empty();
                     }
+                    log.info("Enqueuing '{}' test suite assertion messages", messages.size());
+                    return onlineScorePublisher.enqueueMessage(messages, AutomationRuleEvaluatorType.LLM_AS_JUDGE)
+                            .onErrorResume(error -> {
+                                log.error("Error enqueueing test suite assertion messages into redis", error);
+                                return Mono.empty();
+                            });
                 })
                 .contextWrite(reactiveContext)
                 .block();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
@@ -175,6 +175,7 @@ public class SpanService {
     private Mono<UUID> create(Span span, Project project, UUID id) {
         return Mono.deferContextual(ctx -> {
             String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
+            String workspaceName = ctx.getOrDefault(RequestContext.WORKSPACE_NAME, "");
             String userName = ctx.get(RequestContext.USER_NAME);
             String projectName = project.name();
 
@@ -191,7 +192,7 @@ public class SpanService {
                                 .build();
                         return spanDAO.insert(processedSpan)
                                 .doOnSuccess(__ -> eventBus.post(
-                                        new SpansCreated(List.of(savedSpan), workspaceId, userName)))
+                                        new SpansCreated(List.of(savedSpan), workspaceId, userName, workspaceName)))
                                 .thenReturn(processedSpan.id());
                     });
         });
@@ -376,6 +377,7 @@ public class SpanService {
         return attachmentService.deleteAutoStrippedAttachments(SPAN, spanIds)
                 .then(Mono.deferContextual(ctx -> {
                     String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
+                    String workspaceName = ctx.getOrDefault(RequestContext.WORKSPACE_NAME, "");
                     String userName = ctx.get(RequestContext.USER_NAME);
 
                     Mono<List<Span>> resolveProjects = Flux.fromIterable(projectNames)
@@ -387,7 +389,7 @@ public class SpanService {
                             .flatMap(this::stripAttachmentsFromSpanBatch)
                             .flatMap(spans -> spanDAO.batchInsert(spans)
                                     .doOnSuccess(__ -> eventBus.post(
-                                            new SpansCreated(spans, workspaceId, userName))));
+                                            new SpansCreated(spans, workspaceId, userName, workspaceName))));
                 }));
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/ManualEvaluationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/ManualEvaluationService.java
@@ -26,6 +26,7 @@ import jakarta.ws.rs.BadRequestException;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
@@ -176,23 +177,22 @@ class ManualEvaluationServiceImpl implements ManualEvaluationService {
                     spanLevelPythonRules, projectId, workspaceId, userName);
         }
 
-        // Handle trace-thread evaluators - can use IDs directly
-        return spanLevelMono.then(Mono.fromCallable(() -> {
-            if (!traceThreadRules.isEmpty()) {
-                List<String> traceIdStrings = traceIds.stream()
-                        .map(UUID::toString)
-                        .toList();
-
-                traceThreadRules.forEach(rule -> {
+        // Handle trace-thread evaluators - can use IDs directly. Compose the enqueues into the returned chain so
+        // they inherit the request's reactive context (workspace id + name), which the publisher reads for its
+        // enqueue metric.
+        List<String> traceIdStrings = traceIds.stream()
+                .map(UUID::toString)
+                .toList();
+        Mono<Void> traceThreadMono = Flux.fromIterable(traceThreadRules)
+                .flatMap(rule -> {
                     log.info("Enqueueing trace-thread evaluation for rule '{}' with '{}' trace IDs", rule.getId(),
                             traceIdStrings.size());
-                    onlineScorePublisher.enqueueThreadMessage(traceIdStrings, rule.getId(), projectId, workspaceId,
-                            userName);
-                });
-            }
+                    return onlineScorePublisher.enqueueThreadMessage(traceIdStrings, rule.getId(), projectId,
+                            workspaceId, userName);
+                })
+                .then();
 
-            return traceIds.size();
-        }));
+        return spanLevelMono.then(traceThreadMono).thenReturn(traceIds.size());
     }
 
     /**
@@ -220,49 +220,51 @@ class ManualEvaluationServiceImpl implements ManualEvaluationService {
                     log.info("Successfully fetched '{}' traces for span-level evaluation", traces.size());
 
                     // Enqueue LLM as Judge evaluations
-                    llmAsJudgeRules.forEach(rule -> {
-                        List<TraceToScoreLlmAsJudge> messages = traces.stream()
-                                .map(trace -> TraceToScoreLlmAsJudge.builder()
-                                        .trace(trace.toBuilder().projectName(project.name()).build())
-                                        .ruleId(rule.getId())
-                                        .ruleName(rule.getName())
-                                        .llmAsJudgeCode(rule.getCode())
-                                        .workspaceId(workspaceId)
-                                        .userName(userName)
-                                        .scoreNameMapping(Map.of())
-                                        .promptType(PromptType.MUSTACHE)
-                                        .build())
-                                .toList();
-
-                        onlineScorePublisher.enqueueMessage(messages, rule.getType());
-                        log.info("Enqueued '{}' span-level LLM as Judge messages for rule '{}'", messages.size(),
-                                rule.getId());
-                    });
+                    var llmAsJudgeMono = Flux.fromIterable(llmAsJudgeRules)
+                            .flatMap(rule -> {
+                                List<TraceToScoreLlmAsJudge> messages = traces.stream()
+                                        .map(trace -> TraceToScoreLlmAsJudge.builder()
+                                                .trace(trace.toBuilder().projectName(project.name()).build())
+                                                .ruleId(rule.getId())
+                                                .ruleName(rule.getName())
+                                                .llmAsJudgeCode(rule.getCode())
+                                                .workspaceId(workspaceId)
+                                                .userName(userName)
+                                                .scoreNameMapping(Map.of())
+                                                .promptType(PromptType.MUSTACHE)
+                                                .build())
+                                        .toList();
+                                log.info("Enqueued '{}' span-level LLM as Judge messages for rule '{}'",
+                                        messages.size(), rule.getId());
+                                return onlineScorePublisher.enqueueMessage(messages, rule.getType());
+                            })
+                            .then();
 
                     // Enqueue Python evaluations (if enabled)
-                    pythonRules.forEach(rule -> {
-                        if (!serviceTogglesConfig.isPythonEvaluatorEnabled()) {
-                            log.warn("Span-level Python evaluator is disabled, skipping rule '{}'", rule.getId());
-                            return;
-                        }
+                    var pythonMono = Flux.fromIterable(pythonRules)
+                            .flatMap(rule -> {
+                                if (!serviceTogglesConfig.isPythonEvaluatorEnabled()) {
+                                    log.warn("Span-level Python evaluator is disabled, skipping rule '{}'",
+                                            rule.getId());
+                                    return Mono.<Void>empty();
+                                }
+                                List<TraceToScoreUserDefinedMetricPython> messages = traces.stream()
+                                        .map(trace -> TraceToScoreUserDefinedMetricPython.builder()
+                                                .trace(trace.toBuilder().projectName(project.name()).build())
+                                                .ruleId(rule.getId())
+                                                .ruleName(rule.getName())
+                                                .code(rule.getCode())
+                                                .workspaceId(workspaceId)
+                                                .userName(userName)
+                                                .build())
+                                        .toList();
+                                log.info("Enqueued '{}' span-level Python messages for rule '{}'", messages.size(),
+                                        rule.getId());
+                                return onlineScorePublisher.enqueueMessage(messages, rule.getType());
+                            })
+                            .then();
 
-                        List<TraceToScoreUserDefinedMetricPython> messages = traces.stream()
-                                .map(trace -> TraceToScoreUserDefinedMetricPython.builder()
-                                        .trace(trace.toBuilder().projectName(project.name()).build())
-                                        .ruleId(rule.getId())
-                                        .ruleName(rule.getName())
-                                        .code(rule.getCode())
-                                        .workspaceId(workspaceId)
-                                        .userName(userName)
-                                        .build())
-                                .toList();
-
-                        onlineScorePublisher.enqueueMessage(messages, rule.getType());
-                        log.info("Enqueued '{}' span-level Python messages for rule '{}'", messages.size(),
-                                rule.getId());
-                    });
-
-                    return Mono.empty();
+                    return Mono.when(llmAsJudgeMono, pythonMono);
                 });
     }
 
@@ -310,47 +312,48 @@ class ManualEvaluationServiceImpl implements ManualEvaluationService {
                     log.info("Successfully fetched '{}' spans for evaluation", spans.size());
 
                     // Enqueue Span LLM as Judge evaluations
-                    spanLlmAsJudgeRules.forEach(rule -> {
-                        List<SpanToScoreLlmAsJudge> messages = spans.stream()
-                                .map(span -> SpanToScoreLlmAsJudge.builder()
-                                        .span(span.toBuilder().projectName(project.name()).build())
-                                        .ruleId(rule.getId())
-                                        .ruleName(rule.getName())
-                                        .llmAsJudgeCode(rule.getCode())
-                                        .workspaceId(workspaceId)
-                                        .userName(userName)
-                                        .build())
-                                .toList();
-
-                        onlineScorePublisher.enqueueMessage(messages, rule.getType());
-                        log.info("Enqueued '{}' span LLM as Judge messages for rule '{}'", messages.size(),
-                                rule.getId());
-                    });
+                    var llmAsJudgeMono = Flux.fromIterable(spanLlmAsJudgeRules)
+                            .flatMap(rule -> {
+                                List<SpanToScoreLlmAsJudge> messages = spans.stream()
+                                        .map(span -> SpanToScoreLlmAsJudge.builder()
+                                                .span(span.toBuilder().projectName(project.name()).build())
+                                                .ruleId(rule.getId())
+                                                .ruleName(rule.getName())
+                                                .llmAsJudgeCode(rule.getCode())
+                                                .workspaceId(workspaceId)
+                                                .userName(userName)
+                                                .build())
+                                        .toList();
+                                log.info("Enqueued '{}' span LLM as Judge messages for rule '{}'", messages.size(),
+                                        rule.getId());
+                                return onlineScorePublisher.enqueueMessage(messages, rule.getType());
+                            })
+                            .then();
 
                     // Enqueue Span Python evaluations (if enabled)
-                    spanPythonRules.forEach(rule -> {
-                        if (!serviceTogglesConfig.isSpanUserDefinedMetricPythonEnabled()) {
-                            log.warn("Span Python evaluator is disabled, skipping rule '{}'", rule.getId());
-                            return;
-                        }
+                    var pythonMono = Flux.fromIterable(spanPythonRules)
+                            .flatMap(rule -> {
+                                if (!serviceTogglesConfig.isSpanUserDefinedMetricPythonEnabled()) {
+                                    log.warn("Span Python evaluator is disabled, skipping rule '{}'", rule.getId());
+                                    return Mono.<Void>empty();
+                                }
+                                List<SpanToScoreUserDefinedMetricPython> messages = spans.stream()
+                                        .map(span -> SpanToScoreUserDefinedMetricPython.builder()
+                                                .span(span.toBuilder().projectName(project.name()).build())
+                                                .ruleId(rule.getId())
+                                                .ruleName(rule.getName())
+                                                .code(rule.getCode())
+                                                .workspaceId(workspaceId)
+                                                .userName(userName)
+                                                .build())
+                                        .toList();
+                                log.info("Enqueued '{}' span Python messages for rule '{}'", messages.size(),
+                                        rule.getId());
+                                return onlineScorePublisher.enqueueMessage(messages, rule.getType());
+                            })
+                            .then();
 
-                        List<SpanToScoreUserDefinedMetricPython> messages = spans.stream()
-                                .map(span -> SpanToScoreUserDefinedMetricPython.builder()
-                                        .span(span.toBuilder().projectName(project.name()).build())
-                                        .ruleId(rule.getId())
-                                        .ruleName(rule.getName())
-                                        .code(rule.getCode())
-                                        .workspaceId(workspaceId)
-                                        .userName(userName)
-                                        .build())
-                                .toList();
-
-                        onlineScorePublisher.enqueueMessage(messages, rule.getType());
-                        log.info("Enqueued '{}' span Python messages for rule '{}'", messages.size(),
-                                rule.getId());
-                    });
-
-                    return Mono.just(spanIds.size());
+                    return Mono.when(llmAsJudgeMono, pythonMono).thenReturn(spanIds.size());
                 });
     }
 
@@ -377,15 +380,16 @@ class ManualEvaluationServiceImpl implements ManualEvaluationService {
                     // Extract thread ID strings
                     List<String> threadIds = List.copyOf(threadModelIdToThreadIdMap.values());
 
-                    // Enqueue messages for each rule
-                    rules.forEach(rule -> {
-                        log.info("Enqueueing evaluation for rule '{}' with '{}' thread IDs", rule.getId(),
-                                threadIds.size());
-                        onlineScorePublisher.enqueueThreadMessage(threadIds, rule.getId(), projectId, workspaceId,
-                                userName);
-                    });
-
-                    return Mono.just(threadModelIds.size());
+                    // Enqueue messages for each rule, composed into the chain so they inherit the request's
+                    // reactive context. enqueueThreadMessage does a blocking rule lookup, so defer onto boundedElastic.
+                    return Flux.fromIterable(rules)
+                            .flatMap(rule -> {
+                                log.info("Enqueueing evaluation for rule '{}' with '{}' thread IDs", rule.getId(),
+                                        threadIds.size());
+                                return onlineScorePublisher.enqueueThreadMessage(threadIds, rule.getId(), projectId,
+                                        workspaceId, userName);
+                            })
+                            .then(Mono.just(threadModelIds.size()));
                 });
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/ManualEvaluationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/ManualEvaluationService.java
@@ -187,8 +187,8 @@ class ManualEvaluationServiceImpl implements ManualEvaluationService {
                 .flatMap(rule -> {
                     log.info("Enqueueing trace-thread evaluation for rule '{}' with '{}' trace IDs", rule.getId(),
                             traceIdStrings.size());
-                    return onlineScorePublisher.enqueueThreadMessage(traceIdStrings, rule.getId(), projectId,
-                            workspaceId, userName);
+                    return onlineScorePublisher.enqueueThreadMessage(traceIdStrings, rule, projectId, workspaceId,
+                            userName);
                 })
                 .then();
 
@@ -386,7 +386,7 @@ class ManualEvaluationServiceImpl implements ManualEvaluationService {
                             .flatMap(rule -> {
                                 log.info("Enqueueing evaluation for rule '{}' with '{}' thread IDs", rule.getId(),
                                         threadIds.size());
-                                return onlineScorePublisher.enqueueThreadMessage(threadIds, rule.getId(), projectId,
+                                return onlineScorePublisher.enqueueThreadMessage(threadIds, rule, projectId,
                                         workspaceId, userName);
                             })
                             .then(Mono.just(threadModelIds.size()));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/OnlineScorePublisher.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/OnlineScorePublisher.java
@@ -149,7 +149,10 @@ class OnlineScorePublisherImpl implements OnlineScorePublisher {
                                 enqueueCounter.add(1, errorAttrs);
                                 log.error("Error sending message", throwable);
                             }));
-        }).then();
+        }).then()
+                // Run the enqueue (Redis stream writes) off the caller's thread — e.g. the EventBus thread for
+                // the samplers — on a bounded worker pool.
+                .subscribeOn(Schedulers.boundedElastic());
     }
 
     public Mono<Void> enqueueThreadMessage(@NonNull List<String> threadIds, @NonNull UUID ruleId,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/OnlineScorePublisher.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/OnlineScorePublisher.java
@@ -67,6 +67,20 @@ public interface OnlineScorePublisher {
      */
     Mono<Void> enqueueThreadMessage(List<String> threadIds, UUID ruleId, UUID projectId, String workspaceId,
             String userName);
+
+    /**
+     * Enqueues a thread message for an already-resolved rule, avoiding the blocking rule lookup that the
+     * {@code ruleId} overload performs. Prefer this when the caller already holds the {@link AutomationRuleEvaluator}.
+     *
+     * @param threadIds   the IDs of the threads to score
+     * @param rule        the already-resolved automation rule evaluator
+     * @param projectId   the ID of the project
+     * @param workspaceId the ID of the workspace
+     * @param userName    the name of the user who initiated the scoring
+     * @return a {@link Mono} that completes once the message is enqueued
+     */
+    Mono<Void> enqueueThreadMessage(List<String> threadIds, AutomationRuleEvaluator<?, ?> rule, UUID projectId,
+            String workspaceId, String userName);
 }
 
 @Singleton
@@ -113,13 +127,13 @@ class OnlineScorePublisherImpl implements OnlineScorePublisher {
         var codec = config.getCodec();
         var stream = redisClient.getStream(config.getStreamName(), codec);
         // Resolve the workspace from the reactive context — populated upstream from RequestContext at the
-        // trace/span ingest endpoint and carried down through the sampler/manual-eval chains. Falls back to
-        // "unknown" (then to the id) so the metric label is always present.
+        // trace/span ingest endpoint and carried down through the sampler/manual-eval chains. workspace_id
+        // falls back to "unknown"; workspace_name falls back to the id (so it's never the literal "unknown").
         return Flux.deferContextual(ctx -> {
             var workspaceId = StringUtils.defaultIfBlank(ctx.getOrDefault(RequestContext.WORKSPACE_ID, UNKNOWN),
                     UNKNOWN);
             var workspaceName = StringUtils.defaultIfBlank(
-                    ctx.getOrDefault(RequestContext.WORKSPACE_NAME, UNKNOWN), workspaceId);
+                    ctx.getOrDefault(RequestContext.WORKSPACE_NAME, workspaceId), workspaceId);
             var successAttrs = Attributes.of(EVALUATOR_TYPE_KEY, type.getType(),
                     WORKSPACE_ID_KEY, workspaceId, WORKSPACE_NAME_KEY, workspaceName, RESULT_KEY, "success");
             var errorAttrs = Attributes.of(EVALUATOR_TYPE_KEY, type.getType(),
@@ -141,31 +155,40 @@ class OnlineScorePublisherImpl implements OnlineScorePublisher {
     public Mono<Void> enqueueThreadMessage(@NonNull List<String> threadIds, @NonNull UUID ruleId,
             @NonNull UUID projectId, @NonNull String workspaceId, @NonNull String userName) {
 
-        // findById is a blocking JDBC lookup, so resolve it lazily on a worker thread; the rest is reactive.
+        // Only the id is known here, so resolve the rule first. findById is a blocking JDBC lookup, so do it
+        // lazily on a worker thread, then delegate to the rule-based overload (which holds all enqueue logic).
         return Mono.<AutomationRuleEvaluator<?, ?>>fromCallable(
                 () -> automationRuleEvaluatorService.findById(ruleId, Set.of(projectId), workspaceId))
                 .subscribeOn(Schedulers.boundedElastic())
-                .flatMap(rule -> switch (rule) {
-                    case AutomationRuleEvaluatorTraceThreadLlmAsJudge llmAsJudge -> enqueueMessage(
-                            List.of(toLlmAsJudgeMessage(threadIds, ruleId, projectId, workspaceId, userName,
-                                    llmAsJudge.getCode())),
-                            rule.getType());
-                    case AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython definedMetricPython -> {
-                        if (serviceTogglesConfig.isTraceThreadPythonEvaluatorEnabled()) {
-                            yield enqueueMessage(List.of(toDefinedMetricPython(threadIds, ruleId, projectId,
-                                    workspaceId, userName, definedMetricPython.getCode())), rule.getType());
-                        }
-                        log.warn("Trace Thread online scoring python evaluator is disabled, skipping enqueueing "
-                                + "for ruleId: '{}'", ruleId);
-                        yield Mono.<Void>empty();
-                    }
-                    default -> Mono.<Void>error(new IllegalStateException("Unknown rule evaluator type: " + rule));
-                })
+                .flatMap(rule -> enqueueThreadMessage(threadIds, rule, projectId, workspaceId, userName))
                 .onErrorResume(NotFoundException.class, ex -> {
                     log.warn("Rule with ID '{}' not found for projectId '{}' and workspaceId '{}'", ruleId, projectId,
                             workspaceId, ex);
                     return Mono.empty();
                 });
+    }
+
+    public Mono<Void> enqueueThreadMessage(@NonNull List<String> threadIds,
+            @NonNull AutomationRuleEvaluator<?, ?> rule, @NonNull UUID projectId, @NonNull String workspaceId,
+            @NonNull String userName) {
+
+        // Caller already holds the resolved rule — no findById needed.
+        return switch (rule) {
+            case AutomationRuleEvaluatorTraceThreadLlmAsJudge llmAsJudge -> enqueueMessage(
+                    List.of(toLlmAsJudgeMessage(threadIds, rule.getId(), projectId, workspaceId, userName,
+                            llmAsJudge.getCode())),
+                    rule.getType());
+            case AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython definedMetricPython -> {
+                if (serviceTogglesConfig.isTraceThreadPythonEvaluatorEnabled()) {
+                    yield enqueueMessage(List.of(toDefinedMetricPython(threadIds, rule.getId(), projectId,
+                            workspaceId, userName, definedMetricPython.getCode())), rule.getType());
+                }
+                log.warn("Trace Thread online scoring python evaluator is disabled, skipping enqueueing "
+                        + "for ruleId: '{}'", rule.getId());
+                yield Mono.<Void>empty();
+            }
+            default -> Mono.<Void>error(new IllegalStateException("Unknown rule evaluator type: " + rule));
+        };
     }
 
     private TraceThreadToScoreLlmAsJudge toLlmAsJudgeMessage(List<String> threadIds, UUID ruleId, UUID projectId,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/OnlineScorePublisher.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/OnlineScorePublisher.java
@@ -11,6 +11,10 @@ import com.comet.opik.infrastructure.OnlineScoringStreamConfigurationAdapter;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import com.comet.opik.infrastructure.redis.RedisStreamUtils;
 import com.google.inject.ImplementedBy;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.NotFoundException;
@@ -56,10 +60,15 @@ public interface OnlineScorePublisher {
 @Slf4j
 class OnlineScorePublisherImpl implements OnlineScorePublisher {
 
+    private static final String METRIC_NAMESPACE = "online_scoring";
+    private static final AttributeKey<String> EVALUATOR_TYPE_KEY = AttributeKey.stringKey("evaluator_type");
+    private static final AttributeKey<String> RESULT_KEY = AttributeKey.stringKey("result");
+
     private final RedissonReactiveClient redisClient;
     private final AutomationRuleEvaluatorService automationRuleEvaluatorService;
     private final Map<AutomationRuleEvaluatorType, OnlineScoringStreamConfigurationAdapter> streamConfigurations;
     private final ServiceTogglesConfig serviceTogglesConfig;
+    private final LongCounter enqueueCounter;
 
     @Inject
     public OnlineScorePublisherImpl(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
@@ -69,6 +78,11 @@ class OnlineScorePublisherImpl implements OnlineScorePublisher {
         this.redisClient = redisClient;
         this.automationRuleEvaluatorService = automationRuleEvaluatorService;
         this.serviceTogglesConfig = serviceTogglesConfig;
+        this.enqueueCounter = GlobalOpenTelemetry.getMeter(METRIC_NAMESPACE)
+                .counterBuilder("%s_enqueue_total".formatted(METRIC_NAMESPACE))
+                .setDescription("Messages pushed to the online-scoring Redis stream, by evaluator type and result "
+                        + "(success|error). result=error counts publish failures that were previously only logged.")
+                .build();
         this.streamConfigurations = config.getStreams().stream()
                 .map(streamConfiguration -> {
                     var evaluatorType = AutomationRuleEvaluatorType.fromString(streamConfiguration.getScorer());
@@ -85,13 +99,20 @@ class OnlineScorePublisherImpl implements OnlineScorePublisher {
         var config = streamConfigurations.get(type);
         var codec = config.getCodec();
         var stream = redisClient.getStream(config.getStreamName(), codec);
+        var successAttrs = Attributes.of(EVALUATOR_TYPE_KEY, type.getType(), RESULT_KEY, "success");
+        var errorAttrs = Attributes.of(EVALUATOR_TYPE_KEY, type.getType(), RESULT_KEY, "error");
         Flux.fromIterable(messages)
                 .flatMap(message -> {
                     return stream.add(RedisStreamUtils.buildAddArgs(
                             OnlineScoringConfig.PAYLOAD_FIELD, message, config))
-                            .doOnNext(id -> log.debug("Message sent with ID: '{}' into stream '{}'",
-                                    id, config.getStreamName()))
-                            .doOnError(throwable -> log.error("Error sending message", throwable));
+                            .doOnNext(id -> {
+                                enqueueCounter.add(1, successAttrs);
+                                log.debug("Message sent with ID: '{}' into stream '{}'", id, config.getStreamName());
+                            })
+                            .doOnError(throwable -> {
+                                enqueueCounter.add(1, errorAttrs);
+                                log.error("Error sending message", throwable);
+                            });
                 })
                 .subscribe(id -> {
                     // noop

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/OnlineScorePublisher.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/OnlineScorePublisher.java
@@ -9,6 +9,7 @@ import com.comet.opik.api.events.TraceThreadToScoreUserDefinedMetricPython;
 import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.infrastructure.OnlineScoringStreamConfigurationAdapter;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
+import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.redis.RedisStreamUtils;
 import com.google.inject.ImplementedBy;
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -20,8 +21,11 @@ import jakarta.inject.Singleton;
 import jakarta.ws.rs.NotFoundException;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.redisson.api.RedissonReactiveClient;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
 import java.util.List;
@@ -32,28 +36,37 @@ import java.util.stream.Collectors;
 
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadLlmAsJudge.TraceThreadLlmAsJudgeCode;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython.TraceThreadUserDefinedMetricPythonCode;
+import static com.comet.opik.infrastructure.metrics.ErrorMetricsResolver.UNKNOWN;
+import static com.comet.opik.infrastructure.metrics.ErrorMetricsResolver.WORKSPACE_ID_KEY;
+import static com.comet.opik.infrastructure.metrics.ErrorMetricsResolver.WORKSPACE_NAME_KEY;
 
 @ImplementedBy(OnlineScorePublisherImpl.class)
 public interface OnlineScorePublisher {
 
     /**
-     * Enqueues messages into the Redis stream for online scoring.
+     * Enqueues messages into the Redis stream for online scoring. The returned publisher must be subscribed for
+     * the enqueue to happen; subscribe it within a reactive context carrying the workspace (WORKSPACE_ID /
+     * WORKSPACE_NAME) so the enqueue metric is labelled with it.
      *
      * @param messages the messages to enqueue
      * @param type     the type of evaluator for which the messages are intended
+     * @return a {@link Mono} that completes once all messages are enqueued
      */
-    void enqueueMessage(List<?> messages, AutomationRuleEvaluatorType type);
+    Mono<Void> enqueueMessage(List<?> messages, AutomationRuleEvaluatorType type);
 
     /**
-     * Enqueues a thread message for scoring based on the provided rule.
+     * Enqueues a thread message for scoring based on the provided rule. The returned publisher must be subscribed
+     * for the enqueue to happen.
      *
      * @param threadIds   the IDs of the threads to score
      * @param ruleId      the ID of the rule to apply
      * @param projectId   the ID of the project
      * @param workspaceId the ID of the workspace
      * @param userName    the name of the user who initiated the scoring
+     * @return a {@link Mono} that completes once the message is enqueued
      */
-    void enqueueThreadMessage(List<String> threadIds, UUID ruleId, UUID projectId, String workspaceId, String userName);
+    Mono<Void> enqueueThreadMessage(List<String> threadIds, UUID ruleId, UUID projectId, String workspaceId,
+            String userName);
 }
 
 @Singleton
@@ -80,8 +93,8 @@ class OnlineScorePublisherImpl implements OnlineScorePublisher {
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.enqueueCounter = GlobalOpenTelemetry.getMeter(METRIC_NAMESPACE)
                 .counterBuilder("%s_enqueue_total".formatted(METRIC_NAMESPACE))
-                .setDescription("Messages pushed to the online-scoring Redis stream, by evaluator type and result "
-                        + "(success|error). result=error counts publish failures that were previously only logged.")
+                .setDescription("Messages pushed to the online-scoring Redis stream, by evaluator type, workspace and "
+                        + "result (success|error). result=error counts publish failures that were previously only logged.")
                 .build();
         this.streamConfigurations = config.getStreams().stream()
                 .map(streamConfiguration -> {
@@ -95,15 +108,24 @@ class OnlineScorePublisherImpl implements OnlineScorePublisher {
                 .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    public void enqueueMessage(List<?> messages, AutomationRuleEvaluatorType type) {
+    public Mono<Void> enqueueMessage(List<?> messages, AutomationRuleEvaluatorType type) {
         var config = streamConfigurations.get(type);
         var codec = config.getCodec();
         var stream = redisClient.getStream(config.getStreamName(), codec);
-        var successAttrs = Attributes.of(EVALUATOR_TYPE_KEY, type.getType(), RESULT_KEY, "success");
-        var errorAttrs = Attributes.of(EVALUATOR_TYPE_KEY, type.getType(), RESULT_KEY, "error");
-        Flux.fromIterable(messages)
-                .flatMap(message -> {
-                    return stream.add(RedisStreamUtils.buildAddArgs(
+        // Resolve the workspace from the reactive context — populated upstream from RequestContext at the
+        // trace/span ingest endpoint and carried down through the sampler/manual-eval chains. Falls back to
+        // "unknown" (then to the id) so the metric label is always present.
+        return Flux.deferContextual(ctx -> {
+            var workspaceId = StringUtils.defaultIfBlank(ctx.getOrDefault(RequestContext.WORKSPACE_ID, UNKNOWN),
+                    UNKNOWN);
+            var workspaceName = StringUtils.defaultIfBlank(
+                    ctx.getOrDefault(RequestContext.WORKSPACE_NAME, UNKNOWN), workspaceId);
+            var successAttrs = Attributes.of(EVALUATOR_TYPE_KEY, type.getType(),
+                    WORKSPACE_ID_KEY, workspaceId, WORKSPACE_NAME_KEY, workspaceName, RESULT_KEY, "success");
+            var errorAttrs = Attributes.of(EVALUATOR_TYPE_KEY, type.getType(),
+                    WORKSPACE_ID_KEY, workspaceId, WORKSPACE_NAME_KEY, workspaceName, RESULT_KEY, "error");
+            return Flux.fromIterable(messages)
+                    .flatMap(message -> stream.add(RedisStreamUtils.buildAddArgs(
                             OnlineScoringConfig.PAYLOAD_FIELD, message, config))
                             .doOnNext(id -> {
                                 enqueueCounter.add(1, successAttrs);
@@ -112,47 +134,38 @@ class OnlineScorePublisherImpl implements OnlineScorePublisher {
                             .doOnError(throwable -> {
                                 enqueueCounter.add(1, errorAttrs);
                                 log.error("Error sending message", throwable);
-                            });
-                })
-                .subscribe(id -> {
-                    // noop
-                }, throwable -> log.error("Unexpected error when enqueueing messages into redis", throwable));
+                            }));
+        }).then();
     }
 
-    public void enqueueThreadMessage(@NonNull List<String> threadIds, @NonNull UUID ruleId, @NonNull UUID projectId,
-            @NonNull String workspaceId, @NonNull String userName) {
+    public Mono<Void> enqueueThreadMessage(@NonNull List<String> threadIds, @NonNull UUID ruleId,
+            @NonNull UUID projectId, @NonNull String workspaceId, @NonNull String userName) {
 
-        AutomationRuleEvaluator<?, ?> rule;
-
-        try {
-            rule = automationRuleEvaluatorService.findById(ruleId, Set.of(projectId), workspaceId);
-        } catch (NotFoundException ex) {
-            log.warn("Rule with ID '{}' not found for projectId '{}' and workspaceId '{}'", ruleId, projectId,
-                    workspaceId, ex);
-            return;
-        }
-
-        switch (rule) {
-            case AutomationRuleEvaluatorTraceThreadLlmAsJudge llmAsJudge -> {
-                var message = toLlmAsJudgeMessage(threadIds, ruleId, projectId, workspaceId, userName,
-                        llmAsJudge.getCode());
-                enqueueMessage(List.of(message), rule.getType());
-            }
-            case AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython definedMetricPython -> {
-                var message = toDefinedMetricPython(threadIds, ruleId, projectId, workspaceId, userName,
-                        definedMetricPython.getCode());
-
-                if (serviceTogglesConfig.isTraceThreadPythonEvaluatorEnabled()) {
-                    enqueueMessage(List.of(message), rule.getType());
-                } else {
-                    log.warn(
-                            "Trace Thread online scoring python evaluator is disabled, skipping enqueueing for ruleId: '{}'",
-                            ruleId);
-                }
-            }
-            default -> throw new IllegalStateException("Unknown rule evaluator type: " + rule);
-        }
-
+        // findById is a blocking JDBC lookup, so resolve it lazily on a worker thread; the rest is reactive.
+        return Mono.<AutomationRuleEvaluator<?, ?>>fromCallable(
+                () -> automationRuleEvaluatorService.findById(ruleId, Set.of(projectId), workspaceId))
+                .subscribeOn(Schedulers.boundedElastic())
+                .flatMap(rule -> switch (rule) {
+                    case AutomationRuleEvaluatorTraceThreadLlmAsJudge llmAsJudge -> enqueueMessage(
+                            List.of(toLlmAsJudgeMessage(threadIds, ruleId, projectId, workspaceId, userName,
+                                    llmAsJudge.getCode())),
+                            rule.getType());
+                    case AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython definedMetricPython -> {
+                        if (serviceTogglesConfig.isTraceThreadPythonEvaluatorEnabled()) {
+                            yield enqueueMessage(List.of(toDefinedMetricPython(threadIds, ruleId, projectId,
+                                    workspaceId, userName, definedMetricPython.getCode())), rule.getType());
+                        }
+                        log.warn("Trace Thread online scoring python evaluator is disabled, skipping enqueueing "
+                                + "for ruleId: '{}'", ruleId);
+                        yield Mono.<Void>empty();
+                    }
+                    default -> Mono.<Void>error(new IllegalStateException("Unknown rule evaluator type: " + rule));
+                })
+                .onErrorResume(NotFoundException.class, ex -> {
+                    log.warn("Rule with ID '{}' not found for projectId '{}' and workspaceId '{}'", ruleId, projectId,
+                            workspaceId, ex);
+                    return Mono.empty();
+                });
     }
 
     private TraceThreadToScoreLlmAsJudge toLlmAsJudgeMessage(List<String> threadIds, UUID ruleId, UUID projectId,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadOnlineScorerPublisher.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadOnlineScorerPublisher.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import java.util.List;
 import java.util.Map;
@@ -45,8 +44,7 @@ class TraceThreadOnlineScorerPublisher {
                             Collectors.mapping(Map.Entry::getValue, Collectors.toSet())));
 
             return Flux.fromIterable(sampledThreadByRule.entrySet())
-                    .flatMap(ruleIdToThreadIds -> Mono.fromCallable(() -> {
-
+                    .flatMap(ruleIdToThreadIds -> {
                         UUID ruleId = ruleIdToThreadIds.getKey();
                         Set<String> threadIds = ruleIdToThreadIds.getValue();
 
@@ -54,19 +52,13 @@ class TraceThreadOnlineScorerPublisher {
                                 "Enqueuing threads: '{}' trace threads for ruleId: '{}' in projectId '{}' for workspaceId '{}'",
                                 threadIds, ruleId, projectId, workspaceId);
 
-                        onlineScorePublisher.enqueueThreadMessage(
-                                List.copyOf(threadIds),
-                                ruleId,
-                                projectId,
-                                workspaceId,
-                                userName);
-
-                        log.info(
-                                "Enqueued threads: '{}' trace threads for ruleId: '{}' in projectId '{}' for workspaceId '{}'",
-                                threadIds, ruleId, projectId, workspaceId);
-
-                        return ruleId;
-                    }).subscribeOn(Schedulers.boundedElastic()))
+                        // Composed into the deferContextual chain so the enqueue inherits this workspace context.
+                        return onlineScorePublisher.enqueueThreadMessage(List.copyOf(threadIds), ruleId, projectId,
+                                workspaceId, userName)
+                                .doOnSuccess(unused -> log.info(
+                                        "Enqueued threads: '{}' trace threads for ruleId: '{}' in projectId '{}' for workspaceId '{}'",
+                                        threadIds, ruleId, projectId, workspaceId));
+                    })
                     .then();
         });
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSamplerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSamplerTest.java
@@ -40,6 +40,7 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import uk.co.jemos.podam.api.PodamFactory;
 
 import java.security.NoSuchAlgorithmException;
@@ -53,8 +54,10 @@ import static com.comet.opik.api.resources.utils.AutomationRuleEvaluatorTestUtil
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -101,6 +104,9 @@ class OnlineScoringSamplerTest {
                 traceService,
                 projectService);
 
+        // enqueueMessage is reactive now; the sampler chains .contextWrite(...).subscribe() on the result.
+        lenient().when(onlineScorePublisher.enqueueMessage(any(), any())).thenReturn(Mono.empty());
+
         projectId = UUID.randomUUID();
         workspaceId = UUID.randomUUID().toString();
         userName = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
@@ -146,7 +152,7 @@ class OnlineScoringSamplerTest {
 
             onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
 
-            verifyNoInteractions(onlineScorePublisher);
+            verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
         }
     }
 
@@ -175,7 +181,7 @@ class OnlineScoringSamplerTest {
             onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
 
             verifyNoInteractions(ruleEvaluatorService);
-            verifyNoInteractions(onlineScorePublisher);
+            verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
         }
     }
 
@@ -289,7 +295,7 @@ class OnlineScoringSamplerTest {
             onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
 
             verifyNoInteractions(ruleEvaluatorService);
-            verifyNoInteractions(onlineScorePublisher);
+            verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
         }
 
         @Test
@@ -301,7 +307,7 @@ class OnlineScoringSamplerTest {
             onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
 
             verifyNoInteractions(ruleEvaluatorService);
-            verifyNoInteractions(onlineScorePublisher);
+            verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
         }
 
         @Test
@@ -332,7 +338,7 @@ class OnlineScoringSamplerTest {
 
             onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
 
-            verifyNoInteractions(onlineScorePublisher);
+            verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
         }
 
         @Test
@@ -348,7 +354,7 @@ class OnlineScoringSamplerTest {
 
             onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
 
-            verifyNoInteractions(onlineScorePublisher);
+            verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
         }
 
         @Test
@@ -380,7 +386,7 @@ class OnlineScoringSamplerTest {
 
             onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
 
-            verifyNoInteractions(onlineScorePublisher);
+            verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
         }
 
         @Test
@@ -392,7 +398,7 @@ class OnlineScoringSamplerTest {
 
             onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
 
-            verifyNoInteractions(onlineScorePublisher);
+            verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
         }
 
         @Test
@@ -446,7 +452,7 @@ class OnlineScoringSamplerTest {
             onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(), workspaceId, userName));
 
             verifyNoInteractions(ruleEvaluatorService);
-            verifyNoInteractions(onlineScorePublisher);
+            verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
         }
 
         @Test
@@ -470,7 +476,7 @@ class OnlineScoringSamplerTest {
 
             onlineScoringSampler.onTracesCreated(new TracesCreated(List.of(trace), workspaceId, userName));
 
-            verifyNoInteractions(onlineScorePublisher);
+            verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
         }
     }
 
@@ -506,7 +512,7 @@ class OnlineScoringSamplerTest {
 
             verifyNoInteractions(traceService);
             verifyNoInteractions(ruleEvaluatorService);
-            verifyNoInteractions(onlineScorePublisher);
+            verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
         }
 
         @Test
@@ -521,7 +527,7 @@ class OnlineScoringSamplerTest {
             onlineScoringSampler.onTracesUpdated(event);
 
             verifyNoInteractions(ruleEvaluatorService);
-            verifyNoInteractions(onlineScorePublisher);
+            verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
         }
 
         @ParameterizedTest
@@ -537,7 +543,7 @@ class OnlineScoringSamplerTest {
             onlineScoringSampler.onTracesUpdated(event);
 
             verifyNoInteractions(ruleEvaluatorService);
-            verifyNoInteractions(onlineScorePublisher);
+            verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSamplerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanSamplerTest.java
@@ -34,6 +34,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
 import uk.co.jemos.podam.api.PodamFactory;
 
 import java.security.NoSuchAlgorithmException;
@@ -94,6 +95,9 @@ class OnlineScoringSpanSamplerTest {
                 ruleEvaluatorService,
                 filterEvaluationService,
                 onlineScorePublisher);
+
+        // enqueueMessage is reactive now; the sampler chains .contextWrite(...).subscribe() on the result.
+        lenient().when(onlineScorePublisher.enqueueMessage(any(), any())).thenReturn(Mono.empty());
 
         projectId = UUID.randomUUID();
         workspaceId = "workspace-123";

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TestSuiteAssertionSamplerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/TestSuiteAssertionSamplerTest.java
@@ -88,6 +88,9 @@ class TestSuiteAssertionSamplerTest {
             sampler = new TestSuiteAssertionSampler(
                     datasetItemService, datasetVersionService, onlineScorePublisher, idGenerator,
                     testSuiteConfig, evaluatorMapper, llmProviderApiKeyService, testSuiteAssertionCounterService);
+
+            // enqueueMessage is reactive now; the sampler composes it into the scoring chain.
+            lenient().when(onlineScorePublisher.enqueueMessage(any(), any())).thenReturn(Mono.empty());
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/OnlineScorePublisherTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/OnlineScorePublisherTest.java
@@ -53,7 +53,7 @@ class OnlineScorePublisherTest {
         var publisher = createPublisher(config);
 
         var message = podamFactory.manufacturePojo(String.class);
-        publisher.enqueueMessage(List.of(message), AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+        publisher.enqueueMessage(List.of(message), AutomationRuleEvaluatorType.LLM_AS_JUDGE).block();
 
         await().untilAsserted(() -> {
             var streamAddParams = captureStreamAddParams();
@@ -69,7 +69,7 @@ class OnlineScorePublisherTest {
         var publisher = createPublisher(config);
 
         var messages = PodamFactoryUtils.manufacturePojoList(podamFactory, String.class);
-        publisher.enqueueMessage(messages, AutomationRuleEvaluatorType.LLM_AS_JUDGE);
+        publisher.enqueueMessage(messages, AutomationRuleEvaluatorType.LLM_AS_JUDGE).block();
 
         await().untilAsserted(() -> {
             var streamAddParams = captureStreamAddParams();


### PR DESCRIPTION
## Details

The online-scoring **enqueue** stage had no metric — `OnlineScorePublisher.enqueueMessage` pushed to the Redis stream but only logged the outcome, so publish failures were invisible. This adds an OpenTelemetry counter and makes the enqueue reactive so the workspace is read from the reactive context.

- New counter `online_scoring_enqueue_total{evaluator_type, workspace_id, workspace_name, result}` (`result` = `success` | `error`); `result="error"` counts the publish failures that were previously only logged.
- `workspace_id` / `workspace_name` are resolved from the **reactive context** (`deferContextual`) — the workspace the ingest endpoint / sampler already place on the context. `workspace_id` falls back to `unknown`; `workspace_name` falls back to the id (never the literal `unknown`). No `WorkspaceNameService` lookup.
- `enqueueMessage` / `enqueueThreadMessage` now return `Mono<Void>` instead of self-subscribing; `enqueueThreadMessage` resolves its blocking rule lookup via `Mono.fromCallable(...).subscribeOn(boundedElastic())`. A second `enqueueThreadMessage` overload takes an already-resolved rule so callers that hold it (`ManualEvaluationService`) skip the redundant `findById`.
- Callers subscribe/compose the returned `Mono` (so the enqueue still runs): the trace/span samplers seed the workspace context from the event and fire-and-forget with error logging; `ManualEvaluationService` and the thread-close publisher compose the enqueue into their request-scoped reactive chains so it inherits the full workspace context.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Documentation

No user-facing docs. Operational only: the new `online_scoring_enqueue_total` metric is consumed by the internal Opik Online Scoring Grafana dashboard (an "Enqueue errors/s" panel in the Queue-ingestion stage, filterable by workspace). No SDK/API/product surface changes.

## Issues

- Resolves OPIK-7051

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Counter instrumentation, the reactive refactor of the enqueue path, the unit-test updates, review-feedback fixes, and this PR description.
- Human verification: Author reviewed the diff; confirmed `mvn -o compile` BUILD SUCCESS and the affected unit tests pass.

## Testing

- `cd apps/opik-backend && mvn -o compile` → BUILD SUCCESS (spotless clean).
- `mvn -o test -Dtest='OnlineScoringSamplerTest,OnlineScoringSpanSamplerTest,TestSuiteAssertionSamplerTest,OnlineScorePublisherTest'` → 70 tests, 0 failures, 0 errors (incl. `OnlineScoringSamplerTest$ProjectNameEnrichmentTests`).
- Test changes: stub the reactive `enqueueMessage` to return `Mono.empty()` where the sampler chains on it; `.block()` the returned `Mono` in the publisher unit test so the now-lazy enqueue runs before asserting on the Redis stream params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
