### PR TITLE
[OPIK-000] [BE] fix: log Agent Insights report job completion on success signal

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/AgentInsightsReportJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/AgentInsightsReportJob.java
@@ -62,6 +62,7 @@ public class AgentInsightsReportJob extends Job {
         Mono<Void> timedSweep = Mono.defer(() -> {
             long startMillis = System.currentTimeMillis();
             return runSweep(periodStart, periodEnd)
+                    .doOnSuccess(__ -> log.info("Agent Insights report job completed"))
                     .doFinally(signalType -> AgentInsightsMetrics.SWEEP_DURATION_MS.record(
                             System.currentTimeMillis() - startMillis,
                             signalType == SignalType.ON_COMPLETE
@@ -79,7 +80,6 @@ public class AgentInsightsReportJob extends Job {
                 reportConfig.getJobTimeout().toJavaDuration(),
                 reportConfig.getLockWaitTime().toJavaDuration(),
                 true)
-                .doOnSuccess(__ -> log.info("Agent Insights report job completed"))
                 .subscribe(
                         __ -> {
                         },

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/AgentInsightsReportJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/AgentInsightsReportJob.java
@@ -79,8 +79,10 @@ public class AgentInsightsReportJob extends Job {
                 reportConfig.getJobTimeout().toJavaDuration(),
                 reportConfig.getLockWaitTime().toJavaDuration(),
                 true)
+                .doOnSuccess(__ -> log.info("Agent Insights report job completed"))
                 .subscribe(
-                        __ -> log.info("Agent Insights report job completed"),
+                        __ -> {
+                        },
                         error -> log.error("Agent Insights report job failed", error));
     }
 


### PR DESCRIPTION
## Details
The Agent Insights daily cron logs its start line but never logged completion
or failure, despite running and enqueuing reports successfully.

`runSweep(...)` returns a `Mono<Void>`, which only ever signals `onComplete` —
it never emits an `onNext`. The terminal `subscribe(...)` bound the
"Agent Insights report job completed" message to the **onNext** consumer, so it
was never invoked on the normal (empty) completion path. The error consumer was
correct but only fires on propagated errors (per-job failures are already
isolated via `onErrorResume` inside the sweep), so neither terminal line ever
appeared in logs.

Fix: move the completion log to `doOnSuccess`, which fires on the `Mono<Void>`
normal completion, and keep error handling on the `onError` consumer. No
behavioral change to the sweep itself — this is observability only.

Note: `OllieDailyReportJob` shares the same copied pattern and has the same dead
completion log; left out of scope here.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves # 
- OPIK-000
- NA

## Testing
No new tests. The sweep logic is unchanged; only the terminal log binding was
corrected. Verified by inspection of the reactive signal flow: `Mono<Void>`
completes empty, so `doOnSuccess` now fires the completion log on the normal
path. Confirmed via metrics that the sweep was already running successfully
(`reports_enqueued_total{trigger="scheduled", outcome="success"}` increments).

## Documentation
N/A
