### PR TITLE
[OPIK-6896] [BE] feat: make async_insert_busy_timeout_max_ms configurable

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -86,6 +86,12 @@ databaseAnalytics:
   #   - custom_http_params=max_query_size=100000000
   #  Description: query parameters that will be added to the connection string
   queryParameters: ${ANALYTICS_DB_QUERY_PARAMETERS:-health_check_interval=2000&compress=1&auto_discovery=true&failover=3&custom_http_params=max_query_size=100000000,async_insert_busy_timeout_max_ms=250,async_insert_busy_timeout_min_ms=100,async_insert=1,wait_for_async_insert=1,async_insert_use_adaptive_busy_timeout=1,async_insert_deduplicate=1,use_skip_indexes_if_final=1}
+  #  Default: unset (inherits the async_insert_busy_timeout_max_ms=250 carried by queryParameters above)
+  #  Description: Optional override (ms) for async_insert_busy_timeout_max_ms in the custom_http_params chain of
+  #   queryParameters above; only applied when that setting is already present there, otherwise it is not injected.
+  #   Leave unset to keep the queryParameters value untouched. With async_insert_use_adaptive_busy_timeout=1 this is
+  #   a ceiling: the adaptive scheduler widens the buffer only while rows are queued.
+  asyncInsertBusyTimeoutMaxMs: ${ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS:-}
   #  Default: 1s
   #  Description: Timeout for the ClickHouse health check query (e.g. 1s, 500ms, 2 minutes)
   healthCheckTimeout: ${ANALYTICS_DB_HEALTH_CHECK_TIMEOUT:-1s}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatabaseAnalyticsFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatabaseAnalyticsFactory.java
@@ -5,20 +5,26 @@ import com.google.common.base.Splitter;
 import io.dropwizard.util.Duration;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Data
 public class DatabaseAnalyticsFactory {
 
     private static final String URL_TEMPLATE = "r2dbc:clickhouse:%s://%s:%s@%s:%d/%s%s";
     private static final String CUSTOM_HTTP_PARAMS_KEY = "custom_http_params";
+    private static final String ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS = "async_insert_busy_timeout_max_ms";
+    private static final String KEY_VALUE_FORMAT = "%s=%s";
 
     // Split each `&`/`,`-chunk on the FIRST `=` only — values may themselves contain `=`,
     // e.g. `custom_http_params=max_query_size=100000000,async_insert=1`.
@@ -35,10 +41,20 @@ public class DatabaseAnalyticsFactory {
     private @NotNull String password;
     private @NotBlank String databaseName;
     private String queryParameters;
+
+    /**
+     * Optional override (ms) for {@code async_insert_busy_timeout_max_ms} in the {@link #queryParameters}
+     * {@code custom_http_params} chain; when unset the value carried by {@code queryParameters} is left untouched.
+     * With {@code async_insert_use_adaptive_busy_timeout=1} this is a ceiling on the buffer window — the adaptive
+     * scheduler widens it only while rows are queued.
+     */
+    private @Min(1) Integer asyncInsertBusyTimeoutMaxMs;
+
     private Duration healthCheckTimeout = Duration.seconds(1);
 
     public ConnectionFactory build() {
-        var options = queryParameters == null ? "" : "?%s".formatted(queryParameters);
+        var queryParametersOverrides = getQueryParametersOverrides(queryParameters);
+        var options = queryParametersOverrides == null ? "" : "?%s".formatted(queryParametersOverrides);
         var url = URL_TEMPLATE.formatted(protocol.getValue(), username, password, host, port, databaseName, options);
         return ConnectionFactories.get(url);
     }
@@ -49,7 +65,7 @@ public class DatabaseAnalyticsFactory {
      *
      * <p>Credentials, host, port, database and {@code queryParameters} mirror {@link #build()}
      * so the two clients share a single source of truth. Connection pool, timeouts and other
-     * driver-level behaviour are intentionally left at library defaults unless explicitly set
+     * driver-level behavior are intentionally left at library defaults unless explicitly set
      * via {@code queryParameters} (e.g. {@code compress=1}, {@code health_check_interval=2000}).
      *
      * <p>{@code queryParameters} parsing: top-level {@code &}-separated keys are applied as
@@ -78,9 +94,62 @@ public class DatabaseAnalyticsFactory {
         // are R2DBC-specific and do not translate to the v2 driver surface; connection pool,
         // timeouts and compression are owned by the v2 Client.Builder methods above. Values
         // are still returned by parseQueryParameters() for tests/observability.
-        ParsedQueryParameters parsed = parseQueryParameters(queryParameters);
+        var parsed = parseQueryParameters(getQueryParametersOverrides(queryParameters));
         parsed.serverSettings().forEach(builder::serverSetting);
         return builder.build();
+    }
+
+    /**
+     * Returns {@code queryParameters} with each {@link #configurableQueryParameters() configurable server setting}
+     * present in {@code custom_http_params} replaced by its config-field value; unchanged when none are present.
+     */
+    private String getQueryParametersOverrides(String queryParameters) {
+        if (StringUtils.isBlank(queryParameters)) {
+            return queryParameters;
+        }
+        var parsed = parseQueryParameters(queryParameters);
+        var overrides = configurableQueryParameters().entrySet().stream()
+                .filter(override -> parsed.serverSettings().containsKey(override.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        if (overrides.isEmpty()) {
+            return queryParameters;
+        }
+        var serverSettings = new LinkedHashMap<>(parsed.serverSettings());
+        serverSettings.putAll(overrides);
+        return serialize(parsed.driverOptions(), serverSettings);
+    }
+
+    /**
+     * Server settings whose values come from dedicated config fields, included only when the field is set. Applied
+     * only when already present in {@code custom_http_params}, so settings absent from {@link #queryParameters} are
+     * never injected.
+     */
+    private Map<String, String> configurableQueryParameters() {
+        if (asyncInsertBusyTimeoutMaxMs == null) {
+            return Map.of();
+        }
+        return Map.of(ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS, String.valueOf(asyncInsertBusyTimeoutMaxMs));
+    }
+
+    private String serialize(Map<String, String> driverOptions, Map<String, String> serverSettings) {
+        var topLevel = driverOptions.entrySet().stream()
+                .map(this::formatEntry)
+                .collect(Collectors.toCollection(ArrayList::new));
+        if (!serverSettings.isEmpty()) {
+            var customHttpParams = serverSettings.entrySet().stream()
+                    .map(this::formatEntry)
+                    .collect(Collectors.joining(","));
+            topLevel.add(formatEntry(CUSTOM_HTTP_PARAMS_KEY, customHttpParams));
+        }
+        return String.join("&", topLevel);
+    }
+
+    private String formatEntry(Map.Entry<String, String> entry) {
+        return formatEntry(entry.getKey(), entry.getValue());
+    }
+
+    private String formatEntry(String key, String value) {
+        return KEY_VALUE_FORMAT.formatted(key, value);
     }
 
     /**
@@ -121,5 +190,4 @@ public class DatabaseAnalyticsFactory {
 
         private final String value;
     }
-
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/DatabaseAnalyticsFactoryIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/DatabaseAnalyticsFactoryIntegrationTest.java
@@ -5,23 +5,31 @@ import com.clickhouse.client.api.insert.InsertSettings;
 import com.clickhouse.client.api.query.GenericRecord;
 import com.clickhouse.data.ClickHouseFormat;
 import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.lifecycle.Startables;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisplayName("DatabaseAnalyticsFactory.buildClient — ClickHouse wiring")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class DatabaseAnalyticsFactoryIntegrationTest {
 
@@ -46,26 +54,90 @@ class DatabaseAnalyticsFactoryIntegrationTest {
         return factory;
     }
 
-    @Test
-    @DisplayName("custom_http_params entries land as real ClickHouse server settings")
-    void serverSettingsFromCustomHttpParamsAreAppliedByClickHouse() throws Exception {
-        var factory = factoryWith(
-                "custom_http_params=max_query_size=123456789,async_insert=1,wait_for_async_insert=1");
+    private Stream<Arguments> queryParametersScenarios() {
+        return Stream.of(
+                // custom_http_params entries are applied as ClickHouse server settings
+                Arguments.of("server settings applied",
+                        "custom_http_params=max_query_size=123456789,async_insert=1,wait_for_async_insert=1",
+                        null,
+                        Map.of("max_query_size", "123456789", "async_insert", "1", "wait_for_async_insert", "1")),
+                // top-level driver option coexists with custom_http_params; server settings still apply
+                Arguments.of("mixed driver and server params",
+                        "compress=1&custom_http_params=max_query_size=7777777,async_insert=1",
+                        null,
+                        Map.of("max_query_size", "7777777", "async_insert", "1")),
+                // the field overrides async_insert_busy_timeout_max_ms; siblings and driver options are preserved
+                Arguments.of("override applied",
+                        "auto_discovery=true&failover=3&custom_http_params=async_insert_busy_timeout_max_ms=250,max_query_size=123456789",
+                        7000,
+                        Map.of("async_insert_busy_timeout_max_ms", "7000", "max_query_size", "123456789")),
+                // no top-level driver options: the override is serialized as custom_http_params only
+                Arguments.of("override applied without driver options",
+                        "custom_http_params=async_insert_busy_timeout_max_ms=250,max_query_size=123456789",
+                        7000,
+                        Map.of("async_insert_busy_timeout_max_ms", "7000", "max_query_size", "123456789")),
+                // blank queryParameters: nothing to override, ClickHouse keeps its default (200)
+                Arguments.of("blank query parameters",
+                        null,
+                        7000,
+                        Map.of("async_insert_busy_timeout_max_ms", "200")),
+                // field unset: the queryParameters value is kept
+                Arguments.of("value kept",
+                        "custom_http_params=async_insert_busy_timeout_max_ms=250,max_query_size=123456789",
+                        null,
+                        Map.of("async_insert_busy_timeout_max_ms", "250", "max_query_size", "123456789")),
+                // the setting is absent from queryParameters, so the field is not injected and ClickHouse keeps its default (200)
+                Arguments.of("not injected when absent",
+                        "custom_http_params=max_query_size=123456789",
+                        7000,
+                        Map.of("async_insert_busy_timeout_max_ms", "200", "max_query_size", "123456789")));
+    }
 
-        try (Client client = factory.buildClient()) {
-            Map<String, String> observed = readSettings(client, "max_query_size", "async_insert",
-                    "wait_for_async_insert");
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("queryParametersScenarios")
+    void appliesQueryParametersOverridesWithR2dbcClient(
+            String name,
+            String queryParameters,
+            Integer asyncInsertBusyTimeoutMaxMsOverride,
+            Map<String, String> expectedSettings) {
+        var factory = factoryWith(queryParameters);
+        factory.setAsyncInsertBusyTimeoutMaxMs(asyncInsertBusyTimeoutMaxMsOverride);
 
-            assertThat(observed)
-                    .containsEntry("max_query_size", "123456789")
-                    .containsEntry("async_insert", "1")
-                    .containsEntry("wait_for_async_insert", "1");
+        var actualSettings = readSettings(factory.build(), expectedSettings.keySet());
+
+        assertThat(actualSettings).isEqualTo(expectedSettings);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("queryParametersScenarios")
+    void appliesQueryParametersOverridesWithV2Client(
+            String name,
+            String queryParameters,
+            Integer asyncInsertBusyTimeoutMaxMsOverride,
+            Map<String, String> expectedSettings) {
+        var factory = factoryWith(queryParameters);
+        factory.setAsyncInsertBusyTimeoutMaxMs(asyncInsertBusyTimeoutMaxMsOverride);
+
+        try (var client = factory.buildClient()) {
+            var actualSettings = readSettings(client, expectedSettings.keySet());
+
+            assertThat(actualSettings).isEqualTo(expectedSettings);
         }
     }
 
     @Test
+    @DisplayName("R2DBC connection factory: driver-level options do not leak into ClickHouse server settings")
+    void driverOptionsAreNotAppliedAsServerSettingsWithR2dbc() {
+        var factory = factoryWith("compress=1&auto_discovery=true&failover=3");
+
+        var actualSettings = readSettings(factory.build(), "auto_discovery", "failover");
+
+        assertThat(actualSettings).isEmpty();
+    }
+
+    @Test
     @DisplayName("driver-level top-level entries do not leak into ClickHouse server settings")
-    void driverOptionsAreNotAppliedAsServerSettings() throws Exception {
+    void driverOptionsAreNotAppliedAsServerSettingsWithV2Client() {
         var factory = factoryWith("compress=1&auto_discovery=true&failover=3");
 
         try (Client client = factory.buildClient()) {
@@ -75,21 +147,6 @@ class DatabaseAnalyticsFactoryIntegrationTest {
             Map<String, String> observed = readSettings(client, "auto_discovery", "failover");
 
             assertThat(observed).isEmpty();
-        }
-    }
-
-    @Test
-    @DisplayName("mixed top-level + custom_http_params are correctly split")
-    void mixedQueryParametersAreSplit() throws Exception {
-        var factory = factoryWith(
-                "compress=1&custom_http_params=max_query_size=7777777,async_insert=1");
-
-        try (Client client = factory.buildClient()) {
-            Map<String, String> observed = readSettings(client, "max_query_size", "async_insert");
-
-            assertThat(observed)
-                    .containsEntry("max_query_size", "7777777")
-                    .containsEntry("async_insert", "1");
         }
     }
 
@@ -115,16 +172,38 @@ class DatabaseAnalyticsFactoryIntegrationTest {
 
             List<GenericRecord> records = client.queryAll("SELECT count() AS c FROM t_factory_it");
             assertThat(records).hasSize(1);
-            assertThat(records.get(0).getLong("c")).isEqualTo(2L);
+            assertThat(records.getFirst().getLong("c")).isEqualTo(2L);
         }
     }
 
+    private Map<String, String> readSettings(ConnectionFactory connectionFactory, String... names) {
+        return readSettings(connectionFactory, List.of(names));
+    }
+
+    private Map<String, String> readSettings(ConnectionFactory connectionFactory, Collection<String> names) {
+        var inClause = names.stream().map(name -> "'" + name + "'")
+                .collect(Collectors.joining(","));
+        return Mono.usingWhen(
+                connectionFactory.create(),
+                connection -> Flux.from(connection.createStatement(
+                        "SELECT name, value FROM system.settings WHERE name IN (" + inClause + ")").execute())
+                        .flatMap(result -> result.map((row, _) -> Map.entry(
+                                row.get("name", String.class), row.get("value", String.class))))
+                        .collectMap(Map.Entry::getKey, Map.Entry::getValue),
+                Connection::close)
+                .block();
+    }
+
     private Map<String, String> readSettings(Client client, String... names) {
+        return readSettings(client, List.of(names));
+    }
+
+    private Map<String, String> readSettings(Client client, Collection<String> names) {
         // Names come from trusted call-sites in this test; inline to avoid v2 param-binding
         // quirks around Array(String) serialization. We return the *current* value of each
         // requested setting (regardless of whether it matches the server default), so the
         // caller can assert the value seen by ClickHouse for the running query.
-        String inClause = java.util.Arrays.stream(names).map(n -> "'" + n + "'")
+        var inClause = names.stream().map(name -> "'" + name + "'")
                 .collect(Collectors.joining(","));
         List<GenericRecord> records = client.queryAll(
                 "SELECT name, value FROM system.settings WHERE name IN (" + inClause + ")");

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -70,6 +70,12 @@ databaseAnalytics:
   #   - custom_http_params=max_query_size=100000000
   #  Description: query parameters that will be added to the connection string
   queryParameters: health_check_interval=2000&compress=1&auto_discovery=true&failover=3&custom_http_params=max_query_size=100000000,async_insert_busy_timeout_max_ms=60,async_insert_busy_timeout_min_ms=50,async_insert=1,wait_for_async_insert=1,async_insert_use_adaptive_busy_timeout=1,async_insert_deduplicate=1,use_skip_indexes_if_final=1
+  #  Default: unset (inherits the async_insert_busy_timeout_max_ms=60 carried by queryParameters above)
+  #  Description: Optional override (ms) for async_insert_busy_timeout_max_ms in the custom_http_params chain of
+  #   queryParameters above; only applied when that setting is already present there, otherwise it is not injected.
+  #   Leave unset to keep the queryParameters value untouched. With async_insert_use_adaptive_busy_timeout=1 this is
+  #   a ceiling: the adaptive scheduler widens the buffer only while rows are queued.
+  asyncInsertBusyTimeoutMaxMs: # Empty - inherits the queryParameters value above
   #  Default: 1s
   #  Description: Timeout for the ClickHouse health check query (e.g. 1s, 500ms, 2 minutes)
   healthCheckTimeout: 1s


### PR DESCRIPTION
## Details

Adds an optional `databaseAnalytics.asyncInsertBusyTimeoutMaxMs` config field (env `ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS`) that overrides `async_insert_busy_timeout_max_ms` in the `queryParameters` `custom_http_params` chain used by both the R2DBC connection factory (the Trace/Span write path) and the v2 bulk-insert client. Because `async_insert_use_adaptive_busy_timeout=1` is already enabled, this value is a *ceiling* on the async-insert buffer window — the adaptive scheduler widens the buffer only while rows are queued. The knob lets us raise that ceiling for a buffered partition-migration cutover without hand-editing the full connection query string.

- Override is applied **only when** `async_insert_busy_timeout_max_ms` is already present in `queryParameters`; otherwise it is not injected — so the read-only free-form-SQL connection (which rejects per-query server settings) is left untouched.
- **Unset by default**, which inherits the value carried by `queryParameters` — backwards-compatible, so an existing `ANALYTICS_DB_QUERY_PARAMETERS` override is honored unless the new env var is explicitly set. Validated `@Min(1)`.
- Naming/default note (deviates from the ticket's working name): the field is `asyncInsertBusyTimeoutMaxMs` (aligned with the ClickHouse setting it controls, since the knob stays generally useful beyond the cutover) rather than `cutoverBufferMaxMs`, and the default is "unset → inherits" rather than a literal `250`, to preserve backwards-compatibility.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6896

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.x
  - Scope: full implementation + tests
  - Human verification: iterative code review + CI

## Testing

Covered by integration tests against a real ClickHouse (TestContainers) plus the existing parser unit tests:

- `mvn test -Dtest='DatabaseAnalyticsFactoryTest,DatabaseAnalyticsFactoryIntegrationTest'` — 7 unit + 17 integration, all green locally.
- Scenarios validated for **both** the R2DBC connection factory and the v2 client (parameterized over a shared scenario source): server settings applied, mixed driver/server params split, override applied (with and without top-level driver options), value kept when unset, not injected when the setting is absent, and blank `queryParameters`.
- Driver-level options confirmed not to leak into ClickHouse server settings on both clients.

## Documentation

Inline configuration documentation for the new knob was added to `apps/opik-backend/config.yml` and `config-test.yml`. No documentation-site (Fern/MDX) changes.
