### PR TITLE
[NA] [DOCS] docs: document AI SDK v7 and Vercel eve support in opik-vercel

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/vercel-ai-sdk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/vercel-ai-sdk.mdx
@@ -128,28 +128,21 @@ Done! All traces that contain AI SDK spans are automatically captured in Opik.
 
 ## AI SDK versions and Vercel eve
 
-`OpikExporter` works across AI SDK versions with no extra setup — it detects the
-telemetry format each span emits and ingests it automatically:
-
-- **AI SDK v4, v5, and v6** — the original `ai.*` telemetry.
-- **AI SDK v7** — the OpenTelemetry GenAI (`gen_ai.*`) conventions.
-- **Vercel eve** — the agent framework built on AI SDK v7. Its multi-turn runs
-  are captured as nested LLM and tool spans.
-
-The `OpikExporter` setup shown above covers all of these, and existing v4–v6
-code keeps working unchanged.
+`OpikExporter` works with all current AI SDK versions — **v4, v5, v6, and v7** —
+with no extra setup. It also supports **Vercel eve**, the agent framework built
+on AI SDK v7, capturing each run as nested LLM and tool spans. The setup shown
+above is all you need, and your code keeps working as you upgrade.
 
 ### Multi-turn eve conversations
 
-When you run Vercel eve, a multi-turn conversation is grouped under a single
-session. The exporter maps that session to an Opik thread, so every turn lands
-in the same thread automatically — you don't need to set `threadId` yourself.
+When you run Vercel eve, a multi-turn conversation is grouped into a single Opik
+thread automatically, so every turn shows up together — you don't need to set
+`threadId` yourself.
 
 ### Cached token usage
 
-For models that report prompt caching, cache-read and cache-creation token
-counts are captured alongside the standard input and output usage, keeping token
-and cost metrics accurate for cached requests.
+If your model reports prompt caching, cached tokens are tracked alongside the
+usual input and output tokens, so your token and cost metrics stay accurate.
 
 ## Configuration
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/vercel-ai-sdk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/vercel-ai-sdk.mdx
@@ -126,6 +126,31 @@ main().catch(console.error);
 
 Done! All traces that contain AI SDK spans are automatically captured in Opik.
 
+## AI SDK versions and Vercel eve
+
+`OpikExporter` works across AI SDK versions with no extra setup — it detects the
+telemetry format each span emits and ingests it automatically:
+
+- **AI SDK v4, v5, and v6** — the original `ai.*` telemetry.
+- **AI SDK v7** — the OpenTelemetry GenAI (`gen_ai.*`) conventions.
+- **Vercel eve** — the agent framework built on AI SDK v7. Its multi-turn runs
+  are captured as nested LLM and tool spans.
+
+The `OpikExporter` setup shown above covers all of these, and existing v4–v6
+code keeps working unchanged.
+
+### Multi-turn eve conversations
+
+When you run Vercel eve, a multi-turn conversation is grouped under a single
+session. The exporter maps that session to an Opik thread, so every turn lands
+in the same thread automatically — you don't need to set `threadId` yourself.
+
+### Cached token usage
+
+For models that report prompt caching, cache-read and cache-creation token
+counts are captured alongside the standard input and output usage, keeping token
+and cost metrics accurate for cached requests.
+
 ## Configuration
 
 ### Custom Tags and Metadata


### PR DESCRIPTION
## Summary
- Adds an **AI SDK versions and Vercel eve** section to the Vercel AI SDK integration page.
- Documents that `OpikExporter` ingests AI SDK **v4–v7** plus **Vercel eve** automatically (the `ai` / `gen_ai` / `eve` OTel scopes), with no extra setup and no breaking change for existing v4–v6 code.
- Documents **multi-turn eve** conversations being grouped into a single Opik thread via the eve session id (no manual `threadId`), and **cached-token usage** capture for cost/token accuracy.

Reflects the exporter enrichment from #7177.

## Test Plan
- Content verified against the exporter source (`sdks/typescript/src/opik/integrations/opik-vercel/src/exporter.ts`): `SUPPORTED_SCOPES = {ai, gen_ai, eve}`, the `ai.eve.turn` root, eve session-id thread mapping, and cache-token handling.
- Kept user-facing (no exporter internals); the existing setup snippets are unchanged.
- Recommend a Fern `npm run dev` render check before merge.

## Related Issues
- Follows up on #7177 (opik-vercel exporter enrichment for AI SDK v7 / Vercel eve).