### PR TITLE
[OPIK-6856] [FE] Surface assertion scoring errors in the UI

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/experiments/TestSuiteExperiment/PassedCell.test.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/TestSuiteExperiment/PassedCell.test.ts
@@ -40,7 +40,7 @@ describe("getStatusFromExperimentItems", () => {
     it("returns SKIPPED with 'no experiment item' reason when experiment_items is empty", () => {
       const result = getStatusFromExperimentItems(makeRow());
       expect(result.status).toBe(RunStatus.SKIPPED);
-      expect(result.skippedReason).toBe("No experiment item defined");
+      expect(result.reason).toBe("No experiment item defined");
     });
   });
 
@@ -51,7 +51,7 @@ describe("getStatusFromExperimentItems", () => {
       });
       const result = getStatusFromExperimentItems(row);
       expect(result.status).toBe(RunStatus.SKIPPED);
-      expect(result.skippedReason).toBe("No assertions defined");
+      expect(result.reason).toBe("No assertions defined");
     });
   });
 
@@ -116,6 +116,29 @@ describe("getStatusFromExperimentItems", () => {
       const result = getStatusFromExperimentItems(row);
       expect(result.evaluating).toBe(false);
       expect(result.status).toBe(RunStatus.PASSED);
+    });
+  });
+
+  describe("scoring error state", () => {
+    it("returns error when experiment finished with evaluators but no assertion results", () => {
+      const row = makeRow({
+        experiment_items: [makeItem({ id: "i1" })],
+        evaluators: [{ name: "judge", type: "LLM_AS_JUDGE", config: {} }],
+      });
+      const result = getStatusFromExperimentItems(row, true);
+      expect(result.status).toBe(RunStatus.SKIPPED);
+      expect(result.isError).toBe(true);
+      expect(result.reason).toBeDefined();
+    });
+
+    it("returns evaluating (not error) when experiment is still running", () => {
+      const row = makeRow({
+        experiment_items: [makeItem({ id: "i1" })],
+        evaluators: [{ name: "judge", type: "LLM_AS_JUDGE", config: {} }],
+      });
+      const result = getStatusFromExperimentItems(row, false);
+      expect(result.evaluating).toBe(true);
+      expect(result.isError).toBeFalsy();
     });
   });
 
@@ -193,7 +216,7 @@ describe("getStatusInfoForExperiment", () => {
     it("returns SKIPPED with 'no experiment item' reason when item is undefined", () => {
       const result = getStatusInfoForExperiment(makeRow(), "exp-1", undefined);
       expect(result.status).toBe(RunStatus.SKIPPED);
-      expect(result.skippedReason).toBe("No experiment item defined");
+      expect(result.reason).toBe("No experiment item defined");
     });
   });
 
@@ -202,7 +225,7 @@ describe("getStatusInfoForExperiment", () => {
       const item = makeItem({ id: "i1" });
       const result = getStatusInfoForExperiment(makeRow(), "exp-1", item);
       expect(result.status).toBe(RunStatus.SKIPPED);
-      expect(result.skippedReason).toBe("No assertions defined");
+      expect(result.reason).toBe("No assertions defined");
     });
   });
 
@@ -266,6 +289,29 @@ describe("getStatusInfoForExperiment", () => {
       const result = getStatusInfoForExperiment(row, "exp-1", item);
       expect(result.evaluating).toBe(false);
       expect(result.status).toBe(RunStatus.PASSED);
+    });
+  });
+
+  describe("scoring error state", () => {
+    it("returns error when experiment finished with evaluators but no assertion results", () => {
+      const row = makeRow({
+        evaluators: [{ name: "judge", type: "LLM_AS_JUDGE", config: {} }],
+      });
+      const item = makeItem({ id: "i1" });
+      const result = getStatusInfoForExperiment(row, "exp-1", item, true);
+      expect(result.status).toBe(RunStatus.SKIPPED);
+      expect(result.isError).toBe(true);
+      expect(result.reason).toBeDefined();
+    });
+
+    it("returns evaluating (not error) when experiment is still running", () => {
+      const row = makeRow({
+        evaluators: [{ name: "judge", type: "LLM_AS_JUDGE", config: {} }],
+      });
+      const item = makeItem({ id: "i1" });
+      const result = getStatusInfoForExperiment(row, "exp-1", item, false);
+      expect(result.evaluating).toBe(true);
+      expect(result.isError).toBeFalsy();
     });
   });
 

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/TestSuiteExperiment/PassedCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/TestSuiteExperiment/PassedCell.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { CircleCheck, CircleX, Loader2 } from "lucide-react";
+import {
+  AlertTriangle,
+  CircleCheck,
+  CircleMinus,
+  CircleX,
+  Loader2,
+} from "lucide-react";
 import { CellContext } from "@tanstack/react-table";
 import CellWrapper from "@/shared/DataTableCells/CellWrapper";
 import VerticallySplitCellWrapper, {
@@ -27,20 +33,57 @@ type StatusInfo = {
   status: RunStatus | undefined;
   evaluating: boolean;
   assertionsByRun: AssertionResult[][];
-  skippedReason: string | undefined;
+  reason: string | undefined;
+  isError?: boolean;
   passThreshold: number | undefined;
   runsPerItem: number | undefined;
 };
 
 const NO_EXPERIMENT_ITEM_REASON = "No experiment item defined";
 const NO_ASSERTIONS_REASON = "No assertions defined";
-const SCORING_FAILED_REASON = "Scoring failed";
+const SCORING_ERROR_REASON =
+  "Assertion scoring failed. Check that the configured model is available and try again.";
+
+type DisplayState = "error" | "skipped" | "passed" | "failed";
+
+const STATUS_DISPLAY = {
+  error: {
+    Icon: AlertTriangle,
+    label: "Scoring error",
+    colorClass: "bg-[var(--tag-orange-bg)] text-[var(--tag-orange-text)]",
+  },
+  skipped: {
+    Icon: CircleMinus,
+    label: "Skipped",
+    colorClass: "bg-muted text-muted-foreground",
+  },
+  passed: {
+    Icon: CircleCheck,
+    label: "Passed",
+    colorClass: "bg-[var(--tag-green-bg)] text-[var(--tag-green-text)]",
+  },
+  failed: {
+    Icon: CircleX,
+    label: "Failed",
+    colorClass: "bg-[var(--tag-red-bg)] text-[var(--tag-red-text)]",
+  },
+} as const;
 
 const SKIPPED_RESULT = (reason: string): StatusInfo => ({
   status: RunStatus.SKIPPED,
   evaluating: false,
   assertionsByRun: [],
-  skippedReason: reason,
+  reason: reason,
+  passThreshold: undefined,
+  runsPerItem: undefined,
+});
+
+const ERROR_RESULT = (reason: string): StatusInfo => ({
+  status: RunStatus.SKIPPED,
+  evaluating: false,
+  assertionsByRun: [],
+  reason: reason,
+  isError: true,
   passThreshold: undefined,
   runsPerItem: undefined,
 });
@@ -53,7 +96,7 @@ function resolveSkippedStatus(
   if (!status) {
     const hasEvaluators = (row.evaluators?.length ?? 0) > 0;
     if (!hasEvaluators) return SKIPPED_RESULT(NO_ASSERTIONS_REASON);
-    if (experimentFinished) return SKIPPED_RESULT(SCORING_FAILED_REASON);
+    if (experimentFinished) return ERROR_RESULT(SCORING_ERROR_REASON);
   }
   return null;
 }
@@ -99,7 +142,7 @@ export function getStatusFromExperimentItems(
     status,
     evaluating: !status,
     assertionsByRun: items.map((item) => item.assertion_results ?? []),
-    skippedReason: undefined,
+    reason: undefined,
     passThreshold,
     runsPerItem,
   };
@@ -139,7 +182,7 @@ export function getStatusInfoForExperiment(
     status,
     evaluating: !status,
     assertionsByRun: expItems.map((item) => item.assertion_results ?? []),
-    skippedReason: undefined,
+    reason: undefined,
     passThreshold,
     runsPerItem,
   };
@@ -149,7 +192,8 @@ export const StatusTag: React.FC<StatusInfo & { className?: string }> = ({
   status,
   evaluating,
   assertionsByRun,
-  skippedReason,
+  reason,
+  isError,
   passThreshold,
   runsPerItem,
   className,
@@ -169,42 +213,41 @@ export const StatusTag: React.FC<StatusInfo & { className?: string }> = ({
     return null;
   }
 
-  const isSkipped = status === RunStatus.SKIPPED;
-  const isPassed = status === RunStatus.PASSED;
-  const Icon = isPassed ? CircleCheck : CircleX;
+  const displayState: DisplayState = isError
+    ? "error"
+    : status === RunStatus.SKIPPED
+      ? "skipped"
+      : status === RunStatus.PASSED
+        ? "passed"
+        : "failed";
+
+  const { Icon, label, colorClass } = STATUS_DISPLAY[displayState];
 
   const tag = (
     <span
       className={cn(
-        "inline-flex items-center gap-1 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium transition-colors",
-        isPassed
-          ? "bg-[var(--tag-green-bg)] text-[var(--tag-green-text)]"
-          : isSkipped
-            ? "bg-muted text-muted-foreground"
-            : "bg-[var(--tag-red-bg)] text-[var(--tag-red-text)]",
-        "cursor-default",
+        "inline-flex items-center gap-1 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium transition-colors cursor-default",
+        colorClass,
         className,
       )}
     >
-      {isSkipped ? (
-        "Skipped"
-      ) : (
-        <>
-          <Icon className="size-3 shrink-0" />
-          {isPassed ? "Passed" : "Failed"}
-        </>
-      )}
+      <Icon className="size-3 shrink-0" />
+      {label}
     </span>
   );
 
-  if (isSkipped) {
+  if (displayState === "error" || displayState === "skipped") {
     return (
       <Tooltip>
         <TooltipTrigger asChild>{tag}</TooltipTrigger>
-        {skippedReason && (
+        {reason && (
           <TooltipPortal>
-            <TooltipContent side="bottom" collisionPadding={16}>
-              {skippedReason}
+            <TooltipContent
+              side="bottom"
+              collisionPadding={16}
+              className="max-w-xs"
+            >
+              {reason}
             </TooltipContent>
           </TooltipPortal>
         )}

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptsSelectBox/PromptsSelectBox.tsx
@@ -186,7 +186,7 @@ const PromptsSelectBox: React.FC<PromptsSelectBoxProps> = ({
             <TooltipWrapper content="Load prompt">
               <Button
                 variant="minimal"
-                size="icon-sm"
+                size="icon-2xs"
                 disabled={disabled}
                 data-testid="load-text-prompt-button"
               >

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputScores/PlaygroundOutputAssertionStatus.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputScores/PlaygroundOutputAssertionStatus.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useMemo } from "react";
+import React, { useRef, useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { getExperimentById } from "@/api/datasets/useExperimentById";
@@ -28,11 +28,13 @@ const PlaygroundOutputAssertionStatus: React.FunctionComponent<
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const pollingStartTimeRef = useRef<number | null>(null);
   const lastStatusRef = useRef<StatusInfo | undefined>(undefined);
+  const [pollingTimedOut, setPollingTimedOut] = useState(false);
 
   useEffect(() => {
     if (experimentId) {
       pollingStartTimeRef.current = Date.now();
       lastStatusRef.current = undefined;
+      setPollingTimedOut(false);
     }
   }, [experimentId]);
 
@@ -51,6 +53,15 @@ const PlaygroundOutputAssertionStatus: React.FunctionComponent<
   });
 
   const experimentFinished = isExperimentTerminal(experimentData?.status);
+
+  useEffect(() => {
+    if (!experimentId || experimentFinished) {
+      setPollingTimedOut(false);
+      return;
+    }
+    const timer = setTimeout(() => setPollingTimedOut(true), MAX_REFETCH_TIME);
+    return () => clearTimeout(timer);
+  }, [experimentId, experimentFinished]);
 
   const { data } = useCompareExperimentsList(
     {
@@ -76,6 +87,8 @@ const PlaygroundOutputAssertionStatus: React.FunctionComponent<
     },
   );
 
+  const effectiveExperimentFinished = experimentFinished || pollingTimedOut;
+
   const statusInfo = useMemo(() => {
     const items = data?.content ?? [];
     const matchingRow = items.find(
@@ -89,11 +102,11 @@ const PlaygroundOutputAssertionStatus: React.FunctionComponent<
 
     const result = getStatusFromExperimentItems(
       matchingRow,
-      experimentFinished,
+      effectiveExperimentFinished,
     );
     lastStatusRef.current = result;
     return result;
-  }, [data?.content, datasetItemId, experimentFinished]);
+  }, [data?.content, datasetItemId, effectiveExperimentFinished]);
 
   if (!experimentId) return null;
   if (!statusInfo?.status && !statusInfo?.evaluating) return null;


### PR DESCRIPTION
## Details

When LLM-as-judge assertion scoring fails (e.g. model unavailable or misconfigured), the UI previously gave no clear indication — the Playground showed an infinite "Evaluating assertions" spinner, and the Experiments page showed a generic gray "Skipped" badge with a vague tooltip.

This PR introduces a distinct **"Scoring error"** state:

- **Orange badge** with `AlertTriangle` icon and "Scoring error" label — visually distinct from "Skipped" (gray), "Passed" (green), and "Failed" (red)
- **Actionable tooltip**: "Assertion scoring failed. Check that the configured model is available and try again."
- **Polling timeout handling** in the Playground: when assertion polling times out (5 min) without the experiment reaching terminal state, the spinner is replaced with the error badge instead of spinning forever
- **Refactored `StatusTag`**: unified `STATUS_DISPLAY` map for all four display states (error, skipped, passed, failed) with consistent icon + label + color structure
- **4 new unit tests** covering the error state for both `getStatusFromExperimentItems` and `getStatusInfoForExperiment`

Also includes a minor unrelated fix: icon size adjustment in `PromptsSelectBox` (`icon-sm` → `icon-2xs`).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-6856

## Testing
- Configure a test suite with LLM-as-judge assertions
- Invalidate the provider API key used by the assertion scorer (Anthropic has priority; invalidate Anthropic key while keeping OpenAI working for the prompt)
- Run the test suite in the Playground
- After the polling timeout, verify the orange "Scoring error" badge appears with the actionable tooltip
- Verify normal pass/fail/skipped flows are unaffected
- Run `vitest run PassedCell.test.ts` — 27 tests pass (including 4 new error state tests)

## Documentation
N/A