### PR TITLE
[OPIK-7051] [DOCS] Add metrics-instrumentation agent skill

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -9,6 +9,7 @@ Domain-specific agent skills for the Opik monorepo. Each skill provides patterns
 | diagram-generation | `diagram-generation/` | Generate self-contained HTML architecture diagrams. Use when creating visual diagrams for PRs, task plans, or architectural explanations. |
 | documentation | `documentation/` | Feature documentation and release notes patterns. Use when documenting changes, writing PR descriptions, or preparing releases. |
 | local-dev | `local-dev/` | Local development environment setup and commands. Use when helping with dev server, Docker, or local testing. |
+| metrics-instrumentation | `metrics-instrumentation/` | Instrument an opik-backend workflow with operational OpenTelemetry metrics and a flow-ordered Grafana dashboard. Use when a pipeline is a black box and you need per-stage throughput/latency/error visibility plus a per-customer drill. Distinct from analytics-instrumentation (PostHog product events). |
 | opik-backend | `opik-backend/` | Java backend patterns for Opik. Use when working in `apps/opik-backend`, designing APIs, database operations, or services. |
 | opik-frontend | `opik-frontend/` | React frontend patterns for Opik. Use when working in `apps/opik-frontend`, on components, state, or data fetching. |
 | playwright-e2e | `playwright-e2e/` | Playwright E2E test generation workflow. Use when generating, fixing, or planning automated tests in `tests_end_to_end/`. |

--- a/.agents/skills/metrics-instrumentation/SKILL.md
+++ b/.agents/skills/metrics-instrumentation/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: metrics-instrumentation
+description: Instrument an opik-backend workflow with operational OpenTelemetry metrics and a flow-ordered Grafana dashboard. Use when a pipeline (scoring, ingestion, experiments, jobs) is a black box and you need per-stage throughput/latency/error visibility plus a per-customer (workspace) drill. Distinct from analytics-instrumentation (PostHog product events).
+---
+
+# Metrics Instrumentation
+
+Give a backend workflow end-to-end operational observability the way **online scoring** has it: per-stage OpenTelemetry metrics in `apps/opik-backend`, then a flow-ordered Grafana dashboard (in the internal `comet-monitoring` repo) with operational and per-customer views. The goal is a funnel you read top-to-bottom where the failing stage is where the numbers break.
+
+Reference implementation (read these for live examples):
+- `apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java` — consumer-side counters + native histograms.
+- `apps/opik-backend/.../events/OnlineScoringSampler.java`, `OnlineScoringSpanSampler.java`, `OnlineScoringSamplerSupport.java` — producer counters + the fire-and-forget enqueue seam.
+- `apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/OnlineScorePublisher.java` — reactive enqueue returning `Mono<Void>` + the enqueue counter.
+- `apps/opik-backend/src/main/java/com/comet/opik/infrastructure/metrics/ErrorMetricsResolver.java` — shared metric label keys + workspace resolution.
+
+Pair this with the `opik-backend` skill for general backend conventions and `.agents/skills/opik-backend/SKILL.md`'s logging rule.
+
+---
+
+## Phase 0 — Map the workflow into stages
+
+Read the code and draw the pipeline as ordered stages, each with: what enters, what leaves, where it can fail, what's already instrumented. Online scoring's stages were **Ingestion → Sampling → Enqueue (push to Redis) → Queue processing → Outcome**. The funnel shape is the goal: the dashboard reads top-to-bottom so the broken stage is obvious.
+
+Per stage, pick the signal type:
+- **counter** for "how many" (throughput, decisions, errors, results),
+- **native histogram** for "how long" (latency, queue delay),
+- **gauge** for "how full" (batch / queue size).
+
+Pick identity dimensions that drill without exploding cardinality: `workspace_id` + `workspace_name` (the customer drill), a stage/type label, a `result` (success|error). Bounded by #workspaces × #types.
+
+---
+
+## Phase 1 — Backend metrics (OpenTelemetry)
+
+**1.1 Build meters with the OTel API** (not Micrometer), one meter per namespace:
+```java
+private static final String METRIC_NAMESPACE = "<workflow>";   // e.g. online_scoring
+var meter = GlobalOpenTelemetry.getMeter(METRIC_NAMESPACE);
+meter.counterBuilder("%s_<stage>_total".formatted(METRIC_NAMESPACE)).setDescription("…").build();      // counter
+meter.histogramBuilder("%s_<stage>_time".formatted(METRIC_NAMESPACE)).setUnit("ms").ofLongs().build();  // NATIVE histogram (no buckets)
+meter.gaugeBuilder("%s_<stage>_size".formatted(METRIC_NAMESPACE)).build();                              // gauge
+```
+Counters surface in Prometheus with a `_total` suffix; native histograms have **no** `_bucket`/`_sum`/`_count`/`le`.
+
+**1.2 Encode the stage/type dimension as a LABEL, not the metric name.** The legacy online-scoring metrics bake the scorer into the name (`online_scoring_<scorer>_processing_time`), which forces awkward multi-name `rate()` workarounds on the dashboard (see Gotchas). For new metrics prefer a label — e.g. `online_scoring_enqueue_total{evaluator_type, result}` — so the dashboard can simply `sum by(evaluator_type)(rate(...))`. Only use the name when joining an existing metric family.
+
+**1.3 Get `workspace_id` + `workspace_name` from the REACTIVE CONTEXT, never a service lookup.** The ingest endpoint already puts `RequestContext.WORKSPACE_ID` / `WORKSPACE_NAME` on the request context. Thread them through events → messages so the metric site reads them. Reuse `ErrorMetricsResolver.WORKSPACE_ID_KEY` / `WORKSPACE_NAME_KEY` and these fallbacks:
+```java
+var workspaceId   = StringUtils.defaultIfBlank(ctx.getOrDefault(RequestContext.WORKSPACE_ID, UNKNOWN), UNKNOWN);
+var workspaceName = StringUtils.defaultIfBlank(ctx.getOrDefault(RequestContext.WORKSPACE_NAME, workspaceId), workspaceId);
+counter.add(1, Attributes.of(TYPE_KEY, type, WORKSPACE_ID_KEY, workspaceId, WORKSPACE_NAME_KEY, workspaceName, RESULT_KEY, "success"));
+```
+- `workspace_name` falls back to the **id**, never the literal `"unknown"` — a blank name from the context must resolve to the id so the dashboard's id-fallback works.
+- If an event doesn't carry the name yet, add a nullable `workspaceName` and populate it from `ctx.getOrDefault(RequestContext.WORKSPACE_NAME, "")` at the publish site — that's how `TracesCreated` / `SpansCreated` do it. **Do not** add a `WorkspaceNameService` lookup on the producer path when the context already has the value.
+
+**1.4 Make the instrumented path reactive; read the context with `deferContextual`:**
+```java
+public Mono<Void> enqueue(List<?> messages, Type type) {
+    return Flux.deferContextual(ctx -> { /* resolve workspace as in 1.3 */
+        return Flux.fromIterable(messages).flatMap(m -> redisAdd(m)
+            .doOnNext(id -> counter.add(1, successAttrs))
+            .doOnError(e -> { counter.add(1, errorAttrs); log.error("Error … id='{}'", id, e); }));
+    }).then();
+}
+```
+- Return `Mono<Void>` — **do not self-subscribe.** A Mono does nothing until subscribed, so every caller must subscribe/compose or the work silently stops (and unit tests that `verify(...)` the call break — Phase 3).
+- **Reactive, request-scoped callers** compose it (`.then(...)` / `flatMap`) so it inherits `WORKSPACE_NAME` from the request context.
+- **Event-driven / synchronous callers** (EventBus handlers) fire-and-forget: subscribe with an explicit `.contextWrite(ctx -> ctx.put(WORKSPACE_ID, id).put(WORKSPACE_NAME, defaultIfBlank(name, id)))` and an error-logging consumer. Extract this seam into one shared helper so multiple samplers don't duplicate it (see `OnlineScoringSamplerSupport.publishSampled`).
+- Wrap blocking lookups (`findById`, JDBC) in `Mono.fromCallable(...).subscribeOn(Schedulers.boundedElastic())`. If a caller already holds the resolved object, add an overload that skips the lookup.
+
+**1.5 Logging:** single-quote every placeholder per `.agents/skills/opik-backend/SKILL.md` — `log.error("… evaluator='{}' workspaceId='{}'", type, workspaceId, error)`.
+
+**1.6 Verify:** `cd apps/opik-backend && mvn -o compile` → BUILD SUCCESS (spotless clean).
+
+---
+
+## Phase 2 — Grafana dashboard (in `comet-monitoring`, internal repo)
+
+Generate it with a small Python generator; commit the JSON under `dashboards/comet/<workflow>.json`. Layout = the funnel.
+
+- **One row per stage** + a **glance strip** of `stat` tiles (one per stage; the red tile marks the break) + a **per-customer funnel** row at the bottom + a short `text` "what happens here / what a problem looks like" per stage.
+- **Native-histogram PromQL:** `histogram_quantile(0.95, sum(rate(m[$__rate_interval])))` (NO `by(le)`); throughput `histogram_count(rate(m[...]))`.
+- **Multi-name `rate()` pitfall** (only if you baked type into the name): `rate({__name__=~"a|b"})` fails ("vector cannot contain metrics with the same labelset"). Use per-target sums, guarded scalar sums `(sum(rate(A)) or vector(0)) + …`, or `sum by(G)(label_replace(sum by(G)(rate(A)),"_x","0",..) or …)`. **Avoid it by using a label (1.2).**
+- **Error panels: raw `sum(_total)`, not `increase()`/`$__rate_interval`** (rate intervals inflate short windows). Note the reset-on-restart caveat.
+- **Per-customer name resolution** — names live in Prometheus / MySQL, never in ClickHouse:
+  - Prometheus panels carry `workspace_name` → `sum by(workspace_name)(rate(...{workspace_id=~"$ws"}))`.
+  - ClickHouse instant tables/pies: resolve in-query with `transform(workspace_id, ['id1',…], ['name1',…], workspace_id)` from a **baked id→name map** captured at generate-time (`group by(workspace_id,workspace_name)(last_over_time({__name__=~"…_total", NS}[14d]))`). Build-time snapshot — unmapped/new workspaces show the id; regenerate to refresh.
+  - A Grafana mixed-datasource `joinByField` on `workspace_id` works for **instant** queries, but a **timeseries can't be join-relabeled** (its series key *is* the id) — timeseries must use the in-query `transform()`.
+  - vertamedia ClickHouse macros: `$timeSeries`, `$timeFilter`, `$columns(key, value)`, and `$from`/`$to` (epoch-ms; per-minute = `count()*60000/($to-$from)`).
+- **Workspace filter:** a single Grafana **custom** var `ws` (text = name, value = workspace_id, `"All" → ".*"`) from the same baked map. CH panels filter `('$ws'='.*' OR workspace_id='$ws')`; Prometheus panels filter `workspace_id=~"$ws"`. No raw-UUID picker.
+
+---
+
+## Phase 3 — Validate, then fix the tests
+
+- **Validate every panel query against prod through the Grafana proxy before committing** — Prometheus `/api/v1/query`, ClickHouse `?query=` with macros manually substituted (`$timeFilter`→concrete `created_at >=` range, `$to-$from`→ms, `$ws`→`.*`). A 400 or wrong-shape result is the most common defect.
+- New metrics return empty until the backend deploys — confirm the PromQL is **syntactically valid** (`status:"success"`, empty result) and label the panel "activates after deploy".
+- **Backend tests:** making a method return `Mono<Void>` (lazy) breaks tests that called it for its side effect. Fix by: stub the reactive method (`lenient().when(pub.enqueue(any(),any())).thenReturn(Mono.empty())`) where production code chains on it; `.block()` the returned Mono in unit tests that assert on downstream effects; replace `verifyNoInteractions(mock)` with `verify(mock, never()).method(...)` where a lenient stub now exists. Run the affected `*Test` classes green.
+
+---
+
+## Phase 4 — Deliver (two PRs)
+
+- **opik (this repo, PUBLIC):** the metrics PR. No customer names / cluster / RDS identifiers. Follow `.github/pull_request_template.md` — include `## Details`, `## Change checklist`, **`## Documentation`** (the PR linter fails without it), `## Issues` (`Resolves OPIK-XXXX`), `## AI-WATERMARK: yes` (tools/model/scope/human-verification), `## Testing`. Title `[OPIK-XXXX] [BE] …`. Announce with `.agents/commands/comet/send-code-review-slack.md` → #code-review.
+- **comet-monitoring (INTERNAL):** the dashboard PR. Workspace/customer names in the baked map are acceptable there. Commit the JSON to `dashboards/comet/`. The panel for a new metric ships now (filter by `$ws`) but stays empty until the backend deploys.
+- Use a worktree per repo; branch `<user>/<TASK>-<name>`.
+
+---
+
+## Gotchas (hard-won from online scoring)
+
+- **Lazy Mono = silent no-op.** Returning `Mono<Void>` without a subscriber stops the work. Compose or fire-and-forget-subscribe at every call site.
+- **`workspace_name` default must be the id, not `"unknown"`** — else `defaultIfBlank(name, id)` never triggers and you emit `workspace_name=unknown`.
+- **ClickHouse has no workspace name** anywhere (`opik_prod.workspace_configurations` holds only `workspace_id`); the full id→name map is in MySQL, not reachable from Grafana — hence the baked `transform()` snapshot.
+- **A timeseries can't be name-joined** at the widget level (series key is the id) — bake the names in-query.
+- **Multi-name `rate()` throws** — prefer a label over name-encoding to avoid it.
+- **`backpressure_drops_total`-style poll-tick counters ≠ lost work** — they count skipped poll ticks while a consumer is busy; don't alarm on them. Real loss = rising queue delay + non-retryable errors + stream length vs `streamMaxLen`.
+- **Don't self-subscribe in the publisher; don't add a name-service lookup when the reactive context already has the name; quote log placeholders.**
+- **Instrument the current code:** create the worktree from `origin/main`, not a possibly-stale local checkout.

--- a/.agents/skills/metrics-instrumentation/SKILL.md
+++ b/.agents/skills/metrics-instrumentation/SKILL.md
@@ -1,119 +1,139 @@
 ---
 name: metrics-instrumentation
-description: Instrument an opik-backend workflow with operational OpenTelemetry metrics and a flow-ordered Grafana dashboard. Use when a pipeline (scoring, ingestion, experiments, jobs) is a black box and you need per-stage throughput/latency/error visibility plus a per-customer (workspace) drill. Distinct from analytics-instrumentation (PostHog product events).
+description: Specification for instrumenting an opik-backend workflow with operational OpenTelemetry metrics and a flow-ordered Grafana dashboard. Use when a pipeline (scoring, ingestion, experiments, jobs) needs per-stage throughput/latency/error visibility and a per-customer (workspace) drill. Distinct from analytics-instrumentation (PostHog product events).
 ---
 
 # Metrics Instrumentation
 
-Give a backend workflow end-to-end operational observability the way **online scoring** has it: per-stage OpenTelemetry metrics in `apps/opik-backend`, then a flow-ordered Grafana dashboard (in the internal `comet-monitoring` repo) with operational and per-customer views. The goal is a funnel you read top-to-bottom where the failing stage is where the numbers break.
+Normative spec for adding operational observability to a backend workflow: per-stage OpenTelemetry metrics in `apps/opik-backend`, plus a flow-ordered Grafana dashboard (maintained in the deployment/monitoring configuration, outside this repo). The deliverable is a funnel that reads top-to-bottom so the failing stage is the one whose numbers break, and that supports a per-workspace drill.
 
-Reference implementation (read these for live examples):
-- `apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java` — consumer-side counters + native histograms.
-- `apps/opik-backend/.../events/OnlineScoringSampler.java`, `OnlineScoringSpanSampler.java`, `OnlineScoringSamplerSupport.java` — producer counters + the fire-and-forget enqueue seam.
-- `apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/OnlineScorePublisher.java` — reactive enqueue returning `Mono<Void>` + the enqueue counter.
-- `apps/opik-backend/src/main/java/com/comet/opik/infrastructure/metrics/ErrorMetricsResolver.java` — shared metric label keys + workspace resolution.
+Conformant reference implementations:
+- `apps/opik-backend/.../events/BaseRedisSubscriber.java` — consumer counters + native histograms.
+- `apps/opik-backend/.../events/OnlineScoringSampler.java`, `OnlineScoringSpanSampler.java`, `OnlineScoringSamplerSupport.java` — producer counters + the shared fire-and-forget enqueue helper.
+- `apps/opik-backend/.../domain/evaluators/OnlineScorePublisher.java` — reactive enqueue (`Mono<Void>`) + counter.
+- `apps/opik-backend/.../infrastructure/metrics/ErrorMetricsResolver.java` — shared metric label keys.
 
-Pair this with the `opik-backend` skill for general backend conventions and `.agents/skills/opik-backend/SKILL.md`'s logging rule.
-
----
-
-## Phase 0 — Map the workflow into stages
-
-Read the code and draw the pipeline as ordered stages, each with: what enters, what leaves, where it can fail, what's already instrumented. Online scoring's stages were **Ingestion → Sampling → Enqueue (push to Redis) → Queue processing → Outcome**. The funnel shape is the goal: the dashboard reads top-to-bottom so the broken stage is obvious.
-
-Per stage, pick the signal type:
-- **counter** for "how many" (throughput, decisions, errors, results),
-- **native histogram** for "how long" (latency, queue delay),
-- **gauge** for "how full" (batch / queue size).
-
-Pick identity dimensions that drill without exploding cardinality: `workspace_id` + `workspace_name` (the customer drill), a stage/type label, a `result` (success|error). Bounded by #workspaces × #types.
+Apply alongside the `opik-backend` skill (general conventions, logging rule).
 
 ---
 
-## Phase 1 — Backend metrics (OpenTelemetry)
+## 1. Model
 
-**1.1 Build meters with the OTel API** (not Micrometer), one meter per namespace:
+1.1 Decompose the workflow into ordered stages, each defined by: input, output, failure mode, existing instrumentation.
+
+1.2 Assign each stage a signal type: **counter** (counts: throughput, decisions, errors, results), **native histogram** (durations: latency, queue delay), or **gauge** (levels: batch/queue size).
+
+1.3 Define identity dimensions bounded in cardinality: `workspace_id` + `workspace_name` (customer drill), a stage/type label, and `result` ∈ {`success`, `error`}. Cardinality MUST stay bounded by `#workspaces × #types`.
+
+---
+
+## 2. Backend metrics (OpenTelemetry)
+
+2.1 Meters MUST be created via the OTel API (`GlobalOpenTelemetry.getMeter(namespace)`), one namespace per workflow:
 ```java
-private static final String METRIC_NAMESPACE = "<workflow>";   // e.g. online_scoring
+private static final String METRIC_NAMESPACE = "<workflow>";
 var meter = GlobalOpenTelemetry.getMeter(METRIC_NAMESPACE);
-meter.counterBuilder("%s_<stage>_total".formatted(METRIC_NAMESPACE)).setDescription("…").build();      // counter
-meter.histogramBuilder("%s_<stage>_time".formatted(METRIC_NAMESPACE)).setUnit("ms").ofLongs().build();  // NATIVE histogram (no buckets)
-meter.gaugeBuilder("%s_<stage>_size".formatted(METRIC_NAMESPACE)).build();                              // gauge
+meter.counterBuilder("%s_<stage>_total".formatted(METRIC_NAMESPACE)).setDescription("…").build();
+meter.histogramBuilder("%s_<stage>_time".formatted(METRIC_NAMESPACE)).setUnit("ms").ofLongs().build(); // native histogram
+meter.gaugeBuilder("%s_<stage>_size".formatted(METRIC_NAMESPACE)).build();
 ```
-Counters surface in Prometheus with a `_total` suffix; native histograms have **no** `_bucket`/`_sum`/`_count`/`le`.
+Counters surface in Prometheus with a `_total` suffix. Native histograms MUST NOT define explicit buckets (no `_bucket`/`_sum`/`_count`/`le`).
 
-**1.2 Encode the stage/type dimension as a LABEL, not the metric name.** The legacy online-scoring metrics bake the scorer into the name (`online_scoring_<scorer>_processing_time`), which forces awkward multi-name `rate()` workarounds on the dashboard (see Gotchas). For new metrics prefer a label — e.g. `online_scoring_enqueue_total{evaluator_type, result}` — so the dashboard can simply `sum by(evaluator_type)(rate(...))`. Only use the name when joining an existing metric family.
+2.2 The stage/type dimension MUST be a **label**, not part of the metric name (e.g. `online_scoring_enqueue_total{evaluator_type, result}`), so the dashboard can `sum by(evaluator_type)(rate(...))`. Name-encoding the dimension is permitted ONLY to extend an existing metric family, and triggers the §6.3 constraint.
 
-**1.3 Get `workspace_id` + `workspace_name` from the REACTIVE CONTEXT, never a service lookup.** The ingest endpoint already puts `RequestContext.WORKSPACE_ID` / `WORKSPACE_NAME` on the request context. Thread them through events → messages so the metric site reads them. Reuse `ErrorMetricsResolver.WORKSPACE_ID_KEY` / `WORKSPACE_NAME_KEY` and these fallbacks:
+2.3 `workspace_id` and `workspace_name` MUST be read from the reactive context (`RequestContext.WORKSPACE_ID` / `WORKSPACE_NAME`), reusing `ErrorMetricsResolver.WORKSPACE_ID_KEY` / `WORKSPACE_NAME_KEY`:
 ```java
 var workspaceId   = StringUtils.defaultIfBlank(ctx.getOrDefault(RequestContext.WORKSPACE_ID, UNKNOWN), UNKNOWN);
 var workspaceName = StringUtils.defaultIfBlank(ctx.getOrDefault(RequestContext.WORKSPACE_NAME, workspaceId), workspaceId);
 counter.add(1, Attributes.of(TYPE_KEY, type, WORKSPACE_ID_KEY, workspaceId, WORKSPACE_NAME_KEY, workspaceName, RESULT_KEY, "success"));
 ```
-- `workspace_name` falls back to the **id**, never the literal `"unknown"` — a blank name from the context must resolve to the id so the dashboard's id-fallback works.
-- If an event doesn't carry the name yet, add a nullable `workspaceName` and populate it from `ctx.getOrDefault(RequestContext.WORKSPACE_NAME, "")` at the publish site — that's how `TracesCreated` / `SpansCreated` do it. **Do not** add a `WorkspaceNameService` lookup on the producer path when the context already has the value.
+- `workspace_name` MUST fall back to `workspace_id`, never to the literal `"unknown"`.
+- A service lookup (e.g. `WorkspaceNameService`) MUST NOT be used to resolve the name on a path where the reactive context already carries it.
+- If an event does not yet carry the name, add a nullable `workspaceName` and populate it from `ctx.getOrDefault(RequestContext.WORKSPACE_NAME, "")` at the publish site (see `TracesCreated` / `SpansCreated`).
 
-**1.4 Make the instrumented path reactive; read the context with `deferContextual`:**
+2.4 The instrumented operation MUST be reactive and read the context with `deferContextual`:
 ```java
 public Mono<Void> enqueue(List<?> messages, Type type) {
-    return Flux.deferContextual(ctx -> { /* resolve workspace as in 1.3 */
+    return Flux.deferContextual(ctx -> { /* resolve workspace per 2.3 */
         return Flux.fromIterable(messages).flatMap(m -> redisAdd(m)
             .doOnNext(id -> counter.add(1, successAttrs))
             .doOnError(e -> { counter.add(1, errorAttrs); log.error("Error … id='{}'", id, e); }));
-    }).then();
+    }).then().subscribeOn(Schedulers.boundedElastic());
 }
 ```
-- Return `Mono<Void>` — **do not self-subscribe.** A Mono does nothing until subscribed, so every caller must subscribe/compose or the work silently stops (and unit tests that `verify(...)` the call break — Phase 3).
-- **Reactive, request-scoped callers** compose it (`.then(...)` / `flatMap`) so it inherits `WORKSPACE_NAME` from the request context.
-- **Event-driven / synchronous callers** (EventBus handlers) fire-and-forget: subscribe with an explicit `.contextWrite(ctx -> ctx.put(WORKSPACE_ID, id).put(WORKSPACE_NAME, defaultIfBlank(name, id)))` and an error-logging consumer. Extract this seam into one shared helper so multiple samplers don't duplicate it (see `OnlineScoringSamplerSupport.publishSampled`).
-- Wrap blocking lookups (`findById`, JDBC) in `Mono.fromCallable(...).subscribeOn(Schedulers.boundedElastic())`. If a caller already holds the resolved object, add an overload that skips the lookup.
+- The method MUST return `Mono<Void>` and MUST NOT self-subscribe. Callers MUST subscribe or compose it.
+- Request-scoped reactive callers MUST compose it (`.then(...)` / `flatMap`) so it inherits the workspace context.
+- Event-driven / synchronous callers MUST fire-and-forget via a single shared helper that subscribes with an explicit `.contextWrite(ctx -> ctx.put(WORKSPACE_ID, id).put(WORKSPACE_NAME, defaultIfBlank(name, id)))` and an error-logging consumer (one helper, not duplicated per caller).
+- Blocking lookups (JDBC/`findById`) MUST run via `Mono.fromCallable(...).subscribeOn(Schedulers.boundedElastic())`. The enqueue/IO work MUST run on a bounded scheduler, not the caller's (e.g. EventBus) thread. Where a caller already holds a resolved object, provide an overload that skips the lookup.
 
-**1.5 Logging:** single-quote every placeholder per `.agents/skills/opik-backend/SKILL.md` — `log.error("… evaluator='{}' workspaceId='{}'", type, workspaceId, error)`.
+2.5 Log statements MUST single-quote placeholders (`evaluator='{}' workspaceId='{}'`) per `.agents/skills/opik-backend/SKILL.md`, and SHOULD include the batch size on enqueue logs.
 
-**1.6 Verify:** `cd apps/opik-backend && mvn -o compile` → BUILD SUCCESS (spotless clean).
-
----
-
-## Phase 2 — Grafana dashboard (in `comet-monitoring`, internal repo)
-
-Generate it with a small Python generator; commit the JSON under `dashboards/comet/<workflow>.json`. Layout = the funnel.
-
-- **One row per stage** + a **glance strip** of `stat` tiles (one per stage; the red tile marks the break) + a **per-customer funnel** row at the bottom + a short `text` "what happens here / what a problem looks like" per stage.
-- **Native-histogram PromQL:** `histogram_quantile(0.95, sum(rate(m[$__rate_interval])))` (NO `by(le)`); throughput `histogram_count(rate(m[...]))`.
-- **Multi-name `rate()` pitfall** (only if you baked type into the name): `rate({__name__=~"a|b"})` fails ("vector cannot contain metrics with the same labelset"). Use per-target sums, guarded scalar sums `(sum(rate(A)) or vector(0)) + …`, or `sum by(G)(label_replace(sum by(G)(rate(A)),"_x","0",..) or …)`. **Avoid it by using a label (1.2).**
-- **Error panels: raw `sum(_total)`, not `increase()`/`$__rate_interval`** (rate intervals inflate short windows). Note the reset-on-restart caveat.
-- **Per-customer name resolution** — names live in Prometheus / MySQL, never in ClickHouse:
-  - Prometheus panels carry `workspace_name` → `sum by(workspace_name)(rate(...{workspace_id=~"$ws"}))`.
-  - ClickHouse instant tables/pies: resolve in-query with `transform(workspace_id, ['id1',…], ['name1',…], workspace_id)` from a **baked id→name map** captured at generate-time (`group by(workspace_id,workspace_name)(last_over_time({__name__=~"…_total", NS}[14d]))`). Build-time snapshot — unmapped/new workspaces show the id; regenerate to refresh.
-  - A Grafana mixed-datasource `joinByField` on `workspace_id` works for **instant** queries, but a **timeseries can't be join-relabeled** (its series key *is* the id) — timeseries must use the in-query `transform()`.
-  - vertamedia ClickHouse macros: `$timeSeries`, `$timeFilter`, `$columns(key, value)`, and `$from`/`$to` (epoch-ms; per-minute = `count()*60000/($to-$from)`).
-- **Workspace filter:** a single Grafana **custom** var `ws` (text = name, value = workspace_id, `"All" → ".*"`) from the same baked map. CH panels filter `('$ws'='.*' OR workspace_id='$ws')`; Prometheus panels filter `workspace_id=~"$ws"`. No raw-UUID picker.
+2.6 `mvn -o compile` MUST succeed (spotless clean) before delivery.
 
 ---
 
-## Phase 3 — Validate, then fix the tests
+## 3. Dashboard (Grafana)
 
-- **Validate every panel query against prod through the Grafana proxy before committing** — Prometheus `/api/v1/query`, ClickHouse `?query=` with macros manually substituted (`$timeFilter`→concrete `created_at >=` range, `$to-$from`→ms, `$ws`→`.*`). A 400 or wrong-shape result is the most common defect.
-- New metrics return empty until the backend deploys — confirm the PromQL is **syntactically valid** (`status:"success"`, empty result) and label the panel "activates after deploy".
-- **Backend tests:** making a method return `Mono<Void>` (lazy) breaks tests that called it for its side effect. Fix by: stub the reactive method (`lenient().when(pub.enqueue(any(),any())).thenReturn(Mono.empty())`) where production code chains on it; `.block()` the returned Mono in unit tests that assert on downstream effects; replace `verifyNoInteractions(mock)` with `verify(mock, never()).method(...)` where a lenient stub now exists. Run the affected `*Test` classes green.
+The dashboard is maintained in the deployment/monitoring configuration, not in this repo; this section specifies the query and layout contract the metrics must satisfy.
 
----
+3.1 The dashboard MUST be generated (committed JSON) and laid out as the funnel: one row per stage, a glance strip of `stat` tiles (one per stage, red = the break), a per-customer funnel row, and a per-stage `text` panel describing the stage and its failure signature.
 
-## Phase 4 — Deliver (two PRs)
+3.2 Native-histogram queries MUST use `histogram_quantile(0.95, sum(rate(m[$__rate_interval])))` (no `by(le)`) for percentiles and `histogram_count(rate(m[...]))` for throughput.
 
-- **opik (this repo, PUBLIC):** the metrics PR. No customer names / cluster / RDS identifiers. Follow `.github/pull_request_template.md` — include `## Details`, `## Change checklist`, **`## Documentation`** (the PR linter fails without it), `## Issues` (`Resolves OPIK-XXXX`), `## AI-WATERMARK: yes` (tools/model/scope/human-verification), `## Testing`. Title `[OPIK-XXXX] [BE] …`. Announce with `.agents/commands/comet/send-code-review-slack.md` → #code-review.
-- **comet-monitoring (INTERNAL):** the dashboard PR. Workspace/customer names in the baked map are acceptable there. Commit the JSON to `dashboards/comet/`. The panel for a new metric ships now (filter by `$ws`) but stays empty until the backend deploys.
-- Use a worktree per repo; branch `<user>/<TASK>-<name>`.
+3.3 Error-count panels MUST use raw `sum(<metric>_total)`, not `increase()`/`$__rate_interval` (which inflates short windows). The reset-on-restart caveat applies.
 
 ---
 
-## Gotchas (hard-won from online scoring)
+## 4. Per-customer name resolution
 
-- **Lazy Mono = silent no-op.** Returning `Mono<Void>` without a subscriber stops the work. Compose or fire-and-forget-subscribe at every call site.
-- **`workspace_name` default must be the id, not `"unknown"`** — else `defaultIfBlank(name, id)` never triggers and you emit `workspace_name=unknown`.
-- **ClickHouse has no workspace name** anywhere (`opik_prod.workspace_configurations` holds only `workspace_id`); the full id→name map is in MySQL, not reachable from Grafana — hence the baked `transform()` snapshot.
-- **A timeseries can't be name-joined** at the widget level (series key is the id) — bake the names in-query.
-- **Multi-name `rate()` throws** — prefer a label over name-encoding to avoid it.
-- **`backpressure_drops_total`-style poll-tick counters ≠ lost work** — they count skipped poll ticks while a consumer is busy; don't alarm on them. Real loss = rising queue delay + non-retryable errors + stream length vs `streamMaxLen`.
-- **Don't self-subscribe in the publisher; don't add a name-service lookup when the reactive context already has the name; quote log placeholders.**
-- **Instrument the current code:** create the worktree from `origin/main`, not a possibly-stale local checkout.
+4.1 Workspace names exist only in Prometheus labels and the metadata DB; the ClickHouse analytics tables key on `workspace_id` only (no name column).
+
+4.2 Prometheus panels MUST resolve names via the `workspace_name` label: `sum by(workspace_name)(rate(...{workspace_id=~"$ws"}))`.
+
+4.3 ClickHouse panels MUST resolve names in-query via `transform(workspace_id, ['id1',…], ['name1',…], workspace_id)`, keyed off an id→name map captured at generate time (`group by(workspace_id,workspace_name)(last_over_time({__name__=~"…_total", NS}[14d]))`). This map is a build-time snapshot; unmapped/new workspaces render as the id and a regenerate refreshes it.
+
+4.4 A Grafana mixed-datasource `joinByField` on `workspace_id` MAY be used for **instant** ClickHouse tables, but MUST NOT be used for timeseries (a timeseries series key is the id and cannot be join-relabeled) — timeseries MUST use the in-query `transform()`.
+
+4.5 The dashboard MUST expose a single Grafana **custom** variable `ws` (text = name, value = `workspace_id`, `"All" → ".*"`) built from the same map. ClickHouse panels filter `('$ws'='.*' OR workspace_id='$ws')`; Prometheus panels filter `workspace_id=~"$ws"`. A raw-UUID picker MUST NOT be used.
+
+4.6 vertamedia ClickHouse macros: `$timeSeries`, `$timeFilter`, `$columns(key, value)`, `$from`/`$to` (epoch-ms; per-minute = `count()*60000/($to-$from)`).
+
+---
+
+## 5. Validation
+
+5.1 Every panel query MUST be validated against a live datasource (via the Grafana datasource proxy) before delivery — Prometheus `/api/v1/query`, ClickHouse `?query=` with macros manually substituted (`$timeFilter`→a concrete `created_at >=` range, `$to-$from`→ms, `$ws`→`.*`).
+
+5.2 A metric not yet deployed returns empty; the PromQL MUST still be syntactically valid (`status:"success"`, empty result) and the panel labelled "activates after deploy".
+
+5.3 Tests: introducing a `Mono<Void>` (lazy) return breaks tests that called the method for its side effect. Restore green by stubbing the reactive method (`lenient().when(pub.enqueue(any(),any())).thenReturn(Mono.empty())`) where production composes it, `.block()`-ing the returned `Mono` in unit tests that assert downstream effects, and replacing `verifyNoInteractions(mock)` with `verify(mock, never()).method(...)` where a lenient stub now exists.
+
+---
+
+## 6. Constraints (normative)
+
+6.1 A returned `Mono` is inert until subscribed; an unsubscribed enqueue is a silent no-op. Every call site MUST compose or subscribe it.
+
+6.2 `workspace_name` MUST default to `workspace_id`, never `"unknown"`.
+
+6.3 `rate()`/`increase()` over a multi-name selector (`{__name__=~"a|b"}`) is invalid ("vector cannot contain metrics with the same labelset"). When a dimension is name-encoded (§2.2), per-target sums, guarded scalar sums (`(sum(rate(A)) or vector(0)) + …`), or `sum by(G)(label_replace(sum by(G)(rate(A)),"_x","0",..) or …)` MUST be used instead.
+
+6.4 ClickHouse timeseries MUST NOT rely on a widget-level join for names (§4.4).
+
+6.5 A poll-tick / backpressure counter (e.g. `backpressure_drops_total`) counts skipped scheduler ticks while a consumer is busy; it MUST NOT be interpreted as lost work or alerted on alone. Loss/backlog is indicated by rising queue delay, non-retryable errors, and stream length vs `streamMaxLen`.
+
+6.6 The workspace MUST be sourced from the reactive context, not a name-service lookup, where the context carries it (§2.3).
+
+6.7 IO/enqueue work MUST run on a bounded scheduler, off the caller's thread (§2.4).
+
+6.8 Work MUST be done against `origin/main` (create the worktree from it), not a possibly-stale local checkout.
+
+---
+
+## 7. Delivery
+
+7.1 The change is delivered as two PRs — the metrics PR in this repo and the dashboard PR in the monitoring/deployment configuration repository — each on its own branch `<user>/<TASK>-<name>`.
+
+7.2 The metrics PR (this repo) MUST contain no customer, cluster, or infrastructure identifiers, MUST follow `.github/pull_request_template.md` including a `## Documentation` section (the PR linter fails without it), `## Issues` (`Resolves OPIK-XXXX`), and `## AI-WATERMARK: yes` with tools/model/scope/human-verification. Title `[OPIK-XXXX] [BE] …`. Announce per `.agents/commands/comet/send-code-review-slack.md`.
+
+7.3 The dashboard PR is delivered to the monitoring/deployment configuration repository. The new metric's panel ships in that cut (filtered by `$ws`) and stays empty until the backend deploys.

--- a/.agents/skills/metrics-instrumentation/SKILL.md
+++ b/.agents/skills/metrics-instrumentation/SKILL.md
@@ -1,17 +1,26 @@
 ---
 name: metrics-instrumentation
-description: Specification for instrumenting an opik-backend workflow with operational OpenTelemetry metrics and a flow-ordered Grafana dashboard. Use when a pipeline (scoring, ingestion, experiments, jobs) needs per-stage throughput/latency/error visibility and a per-customer (workspace) drill. Distinct from analytics-instrumentation (PostHog product events).
+description: Specification for instrumenting an opik-backend workflow with operational OpenTelemetry metrics — per-stage throughput/latency/error counters and native histograms, dimensioned per-customer (workspace). Use when a pipeline (scoring, ingestion, experiments, jobs) needs per-stage visibility. Covers metric emission only; building the Grafana dashboard from these metrics is a separate skill. Distinct from analytics-instrumentation (PostHog product events).
 ---
 
 # Metrics Instrumentation
 
-Normative spec for adding operational observability to a backend workflow: per-stage OpenTelemetry metrics in `apps/opik-backend`, plus a flow-ordered Grafana dashboard (maintained in the deployment/monitoring configuration, outside this repo). The deliverable is a funnel that reads top-to-bottom so the failing stage is the one whose numbers break, and that supports a per-workspace drill.
+Normative spec for the backend half of operational observability: per-stage OpenTelemetry metrics in `apps/opik-backend`. The metrics are designed so a flow-ordered Grafana dashboard can read top-to-bottom — the failing stage is the one whose numbers break — with a per-workspace drill. Building that dashboard (layout, query contracts, per-customer name resolution, dependency panels, validation) is a separate concern, specified by the dashboard-authoring skill in comet monitoring tooling; this skill covers only what to emit.
 
-Conformant reference implementations:
-- `apps/opik-backend/.../events/BaseRedisSubscriber.java` — consumer counters + native histograms.
-- `apps/opik-backend/.../events/OnlineScoringSampler.java`, `OnlineScoringSpanSampler.java`, `OnlineScoringSamplerSupport.java` — producer counters + the shared fire-and-forget enqueue helper.
-- `apps/opik-backend/.../domain/evaluators/OnlineScorePublisher.java` — reactive enqueue (`Mono<Void>`) + counter.
-- `apps/opik-backend/.../infrastructure/metrics/ErrorMetricsResolver.java` — shared metric label keys.
+Patterns applied in this implementation (online scoring is the worked example):
+- **Producer metrics** — every stage that emits work is counted at the source: sampler decisions (`sampler_decisions_total{decision}`) and enqueue-to-Redis (`enqueue_total{result}`). A producer that emits nothing makes downstream starvation explainable rather than mysterious.
+- **Consumer metrics** — throughput and per-stage timing on the side that drains the queue (`processing_time`, plus per-Redis-op `read/claim/ack_and_remove/list_pending_time`).
+- **Entrypoint RED** — the workflow's front door (the HTTP ingest route) is measured Rate / Errors / Duration from `http_server_request_duration_seconds`, with 5xx broken down by endpoint × `error_type` × workspace, so an ingestion problem is never mistaken for a scoring problem.
+- **Errors** — a dedicated error counter per stage, dimensioned by `error_type` (the exception class) and, for shared async plumbing, by component (listener/subscriber): `processing_errors_total`, `unexpected_errors_total`, and `enqueue_total{result="error"}` (a push failure = real loss).
+- **Success** — success is derived, never double-counted: throughput − errors, surfaced as one "success rate" headline tile.
+- **Queue time & end-to-end latency** — `queue_delay` (enqueue→pickup) is kept separate from `processing_time` (scorer/LLM work) so a backlog is distinguishable from a slow scorer; end-to-end = queue_delay + processing_time.
+- **Backpressure** — poll-tick skips are counted but are benign (consumer busy), never lost work.
+- **Saturation & resource levels** — gauges for in-flight work (max per pod) and JVM heap used-vs-limit per pod expose the pipeline approaching a ceiling *before* it starts failing (the USE method — utilization / saturation / errors — complementing RED).
+- **Volume & payload size** — byte/char counters (bandwidth, total bytes) and payload-size distributions, broken down by content type and workspace, for cost and impact attribution.
+- **Per-workspace dimensioning** — the customer drill (§1.3) is a first-class label, not an afterthought.
+- **Infrastructure dependencies** — the datastores the flow leans on (Redis streams, ClickHouse, locks, MySQL) are surfaced on the dashboard from their exporters and `system.query_log`, so a "slow pipeline" resolves to the dependency causing it.
+
+To see these conventions already in practice, grep `apps/opik-backend` for the existing metric families rather than specific classes (metric names are the stable contract; class locations move): the online-scoring `*_sampler_decisions_total`, `*_enqueue_total{result}`, `*_processing_time_milliseconds`, `*_queue_delay_milliseconds`, `*_processing_errors_total{error_type}` / `*_unexpected_errors_total`, the per-Redis-op `*_{read,claim,ack_and_remove,list_pending}_time_milliseconds`, and the attachment upload byte/size families.
 
 Apply alongside the `opik-backend` skill (general conventions, logging rule).
 
@@ -21,9 +30,22 @@ Apply alongside the `opik-backend` skill (general conventions, logging rule).
 
 1.1 Decompose the workflow into ordered stages, each defined by: input, output, failure mode, existing instrumentation.
 
-1.2 Assign each stage a signal type: **counter** (counts: throughput, decisions, errors, results), **native histogram** (durations: latency, queue delay), or **gauge** (levels: batch/queue size).
+1.2 Choose the instrument by the question it answers. Most stages need a **counter** (did it happen, and how often?) and a **histogram** (how long did it take?); add a **gauge** only for a level you cannot derive from those.
 
-1.3 Define identity dimensions bounded in cardinality: `workspace_id` + `workspace_name` (customer drill), a stage/type label, and `result` ∈ {`success`, `error`}. Cardinality MUST stay bounded by `#workspaces × #types`.
+- **Counter** — a monotonically increasing total, read as a rate. Use for **events**: throughput, decisions, results, errors, and cumulative volume (messages, bytes). Anything you phrase "per second" or "how many since start". Surfaces with a `_total` suffix. MUST NOT be used for a value that can decrease.
+- **Native histogram** — a latency/size distribution, read with `histogram_quantile`. Use whenever a **p95/p99 matters, not just an average**: processing time, queue delay, per-dependency op time, end-to-end latency, and payload size (bytes/chars). Prefer native (no explicit buckets, §2.1) over classic `le`-bucketed histograms; reach for classic buckets only when a downstream consumer (e.g. an existing exporter) forces them. Do NOT use a histogram where a counter suffices — a plain success/error tally needs no distribution.
+- **Gauge** — an instantaneous level, read as-is. Use for a quantity that **rises and falls and can't be reconstructed from a counter**: current queue depth / backlog, in-flight / in-progress count (saturation), batch/read/claim size, lock waiters, heap used. If you actually want a trend, count events with a counter rather than sampling a level with a gauge.
+- **UpDownCounter** (OTel) — when the level is naturally maintained as signed +1/−1 deltas (in-flight = increment on start, decrement on finish) rather than sampled. Exports like a gauge but is cheaper and less racy than reading a size on every observation.
+
+Rule of thumb: "how many happened" → counter; "how long / how big" → histogram; "how much is there right now" → gauge (or UpDownCounter). Cover each stage with **RED** (Rate, Errors, Duration) for the work flowing through it and **USE** (Utilization, Saturation, Errors) for the resource it runs on.
+
+1.3 Define identity dimensions, each bounded in cardinality:
+- `workspace_id` **and** `workspace_name` — the customer drill. Always paired; `workspace_name` falls back to `workspace_id` when the name is absent (§2.3).
+- a **stage/type** label — what kind of work this is (`evaluator_type`, `decision`, the Redis op, content/mime type). Lets the dashboard `sum by(...)` per stage (§2.2).
+- `result` ∈ {`success`, `error`} on outcome counters.
+- `error_type` on every error counter — the exception class / failure category — plus a component label (listener/subscriber/endpoint) where one counter serves many call sites, so the outcome panel breaks errors down by both cause and origin.
+
+Cardinality MUST stay bounded by `#workspaces × #types × #error_types`; an unbounded value (trace id, user input, raw message, full URL) MUST NOT be placed on a label.
 
 ---
 
@@ -36,20 +58,21 @@ var meter = GlobalOpenTelemetry.getMeter(METRIC_NAMESPACE);
 meter.counterBuilder("%s_<stage>_total".formatted(METRIC_NAMESPACE)).setDescription("…").build();
 meter.histogramBuilder("%s_<stage>_time".formatted(METRIC_NAMESPACE)).setUnit("ms").ofLongs().build(); // native histogram
 meter.gaugeBuilder("%s_<stage>_size".formatted(METRIC_NAMESPACE)).build();
+meter.upDownCounterBuilder("%s_<stage>_in_flight".formatted(METRIC_NAMESPACE)).build(); // signed level (inc/dec)
 ```
 Counters surface in Prometheus with a `_total` suffix. Native histograms MUST NOT define explicit buckets (no `_bucket`/`_sum`/`_count`/`le`).
 
-2.2 The stage/type dimension MUST be a **label**, not part of the metric name (e.g. `online_scoring_enqueue_total{evaluator_type, result}`), so the dashboard can `sum by(evaluator_type)(rate(...))`. Name-encoding the dimension is permitted ONLY to extend an existing metric family, and triggers the §6.3 constraint.
+2.2 The stage/type dimension MUST be a **label**, not part of the metric name (e.g. `online_scoring_enqueue_total{evaluator_type, result}`), so the dashboard can `sum by(evaluator_type)(rate(...))`. Name-encoding the dimension is permitted ONLY to extend an existing metric family; it complicates dashboard aggregation (a name-encoded dimension cannot be `rate()`d across names in one selector), so prefer a label.
 
-2.3 `workspace_id` and `workspace_name` MUST be read from the reactive context (`RequestContext.WORKSPACE_ID` / `WORKSPACE_NAME`), reusing `ErrorMetricsResolver.WORKSPACE_ID_KEY` / `WORKSPACE_NAME_KEY`:
+2.3 `workspace_id` and `workspace_name` MUST be read from the reactive request context (the workspace-id / workspace-name context keys), reusing the shared workspace attribute-key constants rather than redeclaring them per call site:
 ```java
-var workspaceId   = StringUtils.defaultIfBlank(ctx.getOrDefault(RequestContext.WORKSPACE_ID, UNKNOWN), UNKNOWN);
-var workspaceName = StringUtils.defaultIfBlank(ctx.getOrDefault(RequestContext.WORKSPACE_NAME, workspaceId), workspaceId);
+var workspaceId   = ctx.getOrDefault(WORKSPACE_ID, "");
+var workspaceName = StringUtils.defaultIfBlank(ctx.getOrDefault(WORKSPACE_NAME, workspaceId), workspaceId);
 counter.add(1, Attributes.of(TYPE_KEY, type, WORKSPACE_ID_KEY, workspaceId, WORKSPACE_NAME_KEY, workspaceName, RESULT_KEY, "success"));
 ```
-- `workspace_name` MUST fall back to `workspace_id`, never to the literal `"unknown"`.
-- A service lookup (e.g. `WorkspaceNameService`) MUST NOT be used to resolve the name on a path where the reactive context already carries it.
-- If an event does not yet carry the name, add a nullable `workspaceName` and populate it from `ctx.getOrDefault(RequestContext.WORKSPACE_NAME, "")` at the publish site (see `TracesCreated` / `SpansCreated`).
+- `workspace_name` MUST fall back to `workspace_id` when the name is absent.
+- A name-service lookup MUST NOT be used to resolve the name on a path where the reactive context already carries it.
+- If an event does not yet carry the name, add a nullable `workspaceName` field and populate it from the workspace-name context key at the publish site (as the entity-created events feeding this workflow already do).
 
 2.4 The instrumented operation MUST be reactive and read the context with `deferContextual`:
 ```java
@@ -72,68 +95,30 @@ public Mono<Void> enqueue(List<?> messages, Type type) {
 
 ---
 
-## 3. Dashboard (Grafana)
+## 3. Tests
 
-The dashboard is maintained in the deployment/monitoring configuration, not in this repo; this section specifies the query and layout contract the metrics must satisfy.
-
-3.1 The dashboard MUST be generated (committed JSON) and laid out as the funnel: one row per stage, a glance strip of `stat` tiles (one per stage, red = the break), a per-customer funnel row, and a per-stage `text` panel describing the stage and its failure signature.
-
-3.2 Native-histogram queries MUST use `histogram_quantile(0.95, sum(rate(m[$__rate_interval])))` (no `by(le)`) for percentiles and `histogram_count(rate(m[...]))` for throughput.
-
-3.3 Error-count panels MUST use raw `sum(<metric>_total)`, not `increase()`/`$__rate_interval` (which inflates short windows). The reset-on-restart caveat applies.
+3.1 Introducing a `Mono<Void>` (lazy) return breaks tests that called the method for its side effect. Restore green by stubbing the reactive method (`lenient().when(pub.enqueue(any(),any())).thenReturn(Mono.empty())`) where production composes it, `.block()`-ing the returned `Mono` in unit tests that assert downstream effects, and replacing `verifyNoInteractions(mock)` with `verify(mock, never()).method(...)` where a lenient stub now exists.
 
 ---
 
-## 4. Per-customer name resolution
+## 4. Constraints (normative)
 
-4.1 Workspace names exist only in Prometheus labels and the metadata DB; the ClickHouse analytics tables key on `workspace_id` only (no name column).
+4.1 A returned `Mono` is inert until subscribed; an unsubscribed enqueue is a silent no-op. Every call site MUST compose or subscribe it.
 
-4.2 Prometheus panels MUST resolve names via the `workspace_name` label: `sum by(workspace_name)(rate(...{workspace_id=~"$ws"}))`.
+4.2 The workspace MUST be sourced from the reactive context, not a name-service lookup, where the context carries it (§2.3).
 
-4.3 ClickHouse panels MUST resolve names in-query via `transform(workspace_id, ['id1',…], ['name1',…], workspace_id)`, keyed off an id→name map captured at generate time (`group by(workspace_id,workspace_name)(last_over_time({__name__=~"…_total", NS}[14d]))`). This map is a build-time snapshot; unmapped/new workspaces render as the id and a regenerate refreshes it.
+4.3 IO/enqueue work MUST run on a bounded scheduler, off the caller's thread (§2.4).
 
-4.4 A Grafana mixed-datasource `joinByField` on `workspace_id` MAY be used for **instant** ClickHouse tables, but MUST NOT be used for timeseries (a timeseries series key is the id and cannot be join-relabeled) — timeseries MUST use the in-query `transform()`.
+4.4 A backpressure / poll-tick counter (e.g. `backpressure_drops_total`) counts skipped scheduler ticks while a consumer is busy; it is NOT lost work and MUST NOT be alerted on alone. Emit it, but document it as benign for whoever builds the dashboard.
 
-4.5 The dashboard MUST expose a single Grafana **custom** variable `ws` (text = name, value = `workspace_id`, `"All" → ".*"`) built from the same map. ClickHouse panels filter `('$ws'='.*' OR workspace_id='$ws')`; Prometheus panels filter `workspace_id=~"$ws"`. A raw-UUID picker MUST NOT be used.
-
-4.6 vertamedia ClickHouse macros: `$timeSeries`, `$timeFilter`, `$columns(key, value)`, `$from`/`$to` (epoch-ms; per-minute = `count()*60000/($to-$from)`).
+4.5 Work MUST be done against `origin/main` (create the worktree from it), not a possibly-stale local checkout.
 
 ---
 
-## 5. Validation
+## 5. Delivery
 
-5.1 Every panel query MUST be validated against a live datasource (via the Grafana datasource proxy) before delivery — Prometheus `/api/v1/query`, ClickHouse `?query=` with macros manually substituted (`$timeFilter`→a concrete `created_at >=` range, `$to-$from`→ms, `$ws`→`.*`).
+5.1 The change is delivered as two PRs on their own branches `<user>/<TASK>-<name>`: this metrics PR (opik repo) and a companion dashboard PR built per the dashboard-authoring skill and delivered to comet monitoring.
 
-5.2 A metric not yet deployed returns empty; the PromQL MUST still be syntactically valid (`status:"success"`, empty result) and the panel labelled "activates after deploy".
+5.2 The metrics PR (this repo) MUST contain no customer, cluster, or infrastructure identifiers, MUST follow `.github/pull_request_template.md` including a `## Documentation` section (the PR linter fails without it), `## Issues` (`Resolves OPIK-XXXX`), and `## AI-WATERMARK: yes` with tools/model/scope/human-verification. Title `[OPIK-XXXX] [BE] …`. Announce per `.agents/commands/comet/send-code-review-slack.md`.
 
-5.3 Tests: introducing a `Mono<Void>` (lazy) return breaks tests that called the method for its side effect. Restore green by stubbing the reactive method (`lenient().when(pub.enqueue(any(),any())).thenReturn(Mono.empty())`) where production composes it, `.block()`-ing the returned `Mono` in unit tests that assert downstream effects, and replacing `verifyNoInteractions(mock)` with `verify(mock, never()).method(...)` where a lenient stub now exists.
-
----
-
-## 6. Constraints (normative)
-
-6.1 A returned `Mono` is inert until subscribed; an unsubscribed enqueue is a silent no-op. Every call site MUST compose or subscribe it.
-
-6.2 `workspace_name` MUST default to `workspace_id`, never `"unknown"`.
-
-6.3 `rate()`/`increase()` over a multi-name selector (`{__name__=~"a|b"}`) is invalid ("vector cannot contain metrics with the same labelset"). When a dimension is name-encoded (§2.2), per-target sums, guarded scalar sums (`(sum(rate(A)) or vector(0)) + …`), or `sum by(G)(label_replace(sum by(G)(rate(A)),"_x","0",..) or …)` MUST be used instead.
-
-6.4 ClickHouse timeseries MUST NOT rely on a widget-level join for names (§4.4).
-
-6.5 A poll-tick / backpressure counter (e.g. `backpressure_drops_total`) counts skipped scheduler ticks while a consumer is busy; it MUST NOT be interpreted as lost work or alerted on alone. Loss/backlog is indicated by rising queue delay, non-retryable errors, and stream length vs `streamMaxLen`.
-
-6.6 The workspace MUST be sourced from the reactive context, not a name-service lookup, where the context carries it (§2.3).
-
-6.7 IO/enqueue work MUST run on a bounded scheduler, off the caller's thread (§2.4).
-
-6.8 Work MUST be done against `origin/main` (create the worktree from it), not a possibly-stale local checkout.
-
----
-
-## 7. Delivery
-
-7.1 The change is delivered as two PRs — the metrics PR in this repo and the dashboard PR in the monitoring/deployment configuration repository — each on its own branch `<user>/<TASK>-<name>`.
-
-7.2 The metrics PR (this repo) MUST contain no customer, cluster, or infrastructure identifiers, MUST follow `.github/pull_request_template.md` including a `## Documentation` section (the PR linter fails without it), `## Issues` (`Resolves OPIK-XXXX`), and `## AI-WATERMARK: yes` with tools/model/scope/human-verification. Title `[OPIK-XXXX] [BE] …`. Announce per `.agents/commands/comet/send-code-review-slack.md`.
-
-7.3 The dashboard PR is delivered to the monitoring/deployment configuration repository. The new metric's panel ships in that cut (filtered by `$ws`) and stays empty until the backend deploys.
+5.3 The dashboard panel for a new metric stays empty until this backend PR deploys — so the two PRs are independent and can land in either order.


### PR DESCRIPTION
## Details

Adds a `metrics-instrumentation` agent skill (`.agents/skills/metrics-instrumentation/`) that captures the end-to-end pattern used to instrument **online scoring**, so the next workflow can be made observable the same way without rediscovering the gotchas.

- Per-stage OpenTelemetry counters + native histograms, with `workspace_id`/`workspace_name` read from the **reactive context** (not a service lookup) and a `result` label.
- Reactive (`Mono<Void>`, non-self-subscribing) enqueue with a shared fire-and-forget seam for event-driven callers.
- A flow-ordered Grafana dashboard (in the internal `comet-monitoring` repo) with a per-customer funnel, in-query ClickHouse `transform()` name resolution, and a workspace filter.
- Documents the hard-won pitfalls (lazy Mono no-op, multi-name `rate()`, `workspace_name` id-fallback, CH has no name column, poll-tick counters ≠ loss).

Indexed in `.agents/skills/README.md`. Docs-only; no code or behavior changes.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Documentation

This PR *is* documentation — a new agent skill under `.agents/skills/`. No product/API/SDK surface changes.

## Issues

- Resolves OPIK-7051

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Authoring the skill document and its index entry.
- Human verification: Author reviewed the skill against the as-merged online-scoring instrumentation and dashboard work.

## Testing

- Docs-only change; no build/test impact. Verified the skill cross-references resolve to real files (`BaseRedisSubscriber`, `OnlineScorePublisher`, `OnlineScoringSamplerSupport`, `ErrorMetricsResolver`, `.agents/skills/opik-backend/SKILL.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
