### PR TITLE
[OPIK-6639] [FE] feat: revamp child-page top sections (experiment, dataset, test suite)

### DIFF
--- a/apps/opik-frontend/src/shared/BackButton/BackButton.tsx
+++ b/apps/opik-frontend/src/shared/BackButton/BackButton.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { ArrowLeft } from "lucide-react";
+import { Link, LinkProps } from "@tanstack/react-router";
+
+import { cn } from "@/lib/utils";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
+
+export type BackButtonProps = {
+  to: LinkProps["to"];
+  params?: Record<string, string>;
+  search?: LinkProps["search"];
+  tooltip: string;
+  className?: string;
+};
+
+const BackButton: React.FunctionComponent<BackButtonProps> = ({
+  to,
+  params,
+  search,
+  tooltip,
+  className,
+}) => {
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const activeProjectId = useActiveProjectId();
+
+  const linkParams: Record<string, string> = {
+    workspaceName,
+    ...(activeProjectId ? { projectId: activeProjectId } : {}),
+    ...params,
+  };
+
+  return (
+    <TooltipWrapper content={tooltip}>
+      <Link
+        to={to}
+        params={linkParams}
+        search={search}
+        className={cn(
+          "flex size-6 shrink-0 items-center justify-center rounded-md text-foreground hover:bg-primary-foreground",
+          className,
+        )}
+      >
+        <ArrowLeft className="size-4" />
+      </Link>
+    </TooltipWrapper>
+  );
+};
+
+export default BackButton;

--- a/apps/opik-frontend/src/shared/DateTag/DateTag.tsx
+++ b/apps/opik-frontend/src/shared/DateTag/DateTag.tsx
@@ -1,6 +1,5 @@
-import { Clock } from "lucide-react";
+import { History } from "lucide-react";
 import { formatDate } from "@/lib/date";
-import { Tag } from "@/ui/tag";
 import TooltipWrapper from "../TooltipWrapper/TooltipWrapper";
 import capitalize from "lodash/capitalize";
 import { RESOURCE_MAP, RESOURCE_TYPE } from "../ResourceLink/ResourceLink";
@@ -19,16 +18,10 @@ const DateTag = ({ date, resource }: DateTagProps) => {
 
   return (
     <TooltipWrapper content={`${capitalize(label)} creation time`}>
-      <Tag
-        size="md"
-        variant="transparent"
-        className="flex shrink-0 items-center gap-1"
-      >
-        <Clock className="size-3 shrink-0 text-[var(--color-blue)]" />
-        <div className="comet-body-s-accented truncate text-muted-slate">
-          {formatDate(date)}
-        </div>
-      </Tag>
+      <div className="comet-body-s flex h-6 shrink-0 items-center text-foreground">
+        <History className="mx-1 size-3.5 shrink-0 text-muted-slate" />
+        <span className="truncate">{formatDate(date)}</span>
+      </div>
     </TooltipWrapper>
   );
 };

--- a/apps/opik-frontend/src/shared/ExperimentTag/ExperimentTag.tsx
+++ b/apps/opik-frontend/src/shared/ExperimentTag/ExperimentTag.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { FlaskConical } from "lucide-react";
 import { Tag } from "@/ui/tag";
-import {
-  RESOURCE_MAP,
-  RESOURCE_TYPE,
-} from "@/shared/ResourceLink/ResourceLink";
 
 interface ExperimentTagProps {
   experimentName?: string;
@@ -15,12 +11,13 @@ const ExperimentTag: React.FC<ExperimentTagProps> = ({
   experimentName,
   count,
 }) => {
-  const { color } = RESOURCE_MAP[RESOURCE_TYPE.experiment];
-
   if (experimentName) {
     return (
       <Tag size="md" variant="transparent" className="flex items-center gap-1">
-        <FlaskConical className="size-3 shrink-0" style={{ color }} />
+        <FlaskConical
+          className="size-3 shrink-0"
+          style={{ color: "var(--color-burgundy)" }}
+        />
         <div className="comet-body-s-accented min-w-0 truncate text-muted-slate">
           {experimentName}
         </div>

--- a/apps/opik-frontend/src/shared/NavigationTag/NavigationTag.tsx
+++ b/apps/opik-frontend/src/shared/NavigationTag/NavigationTag.tsx
@@ -11,7 +11,7 @@ type NavigationTagProps = {
   name: string;
   resource: RESOURCE_TYPE;
   search?: Record<string, string | number | string[] | Filter[]>;
-  tooltipContent?: string;
+  tooltipContent?: string | false;
   className?: string;
   isSmall?: boolean;
   prefix?: string;

--- a/apps/opik-frontend/src/shared/NavigationTag/NavigationTag.tsx
+++ b/apps/opik-frontend/src/shared/NavigationTag/NavigationTag.tsx
@@ -3,12 +3,8 @@ import React from "react";
 import ResourceLink, {
   RESOURCE_TYPE,
   RESOURCE_MAP,
-  ResourceLinkProps,
 } from "@/shared/ResourceLink/ResourceLink";
 import { Filter } from "@/types/filters";
-import { TagProps } from "@/ui/tag";
-
-const DEFAULT_ICON_SIZE = 3;
 
 type NavigationTagProps = {
   id: string;
@@ -18,9 +14,8 @@ type NavigationTagProps = {
   tooltipContent?: string;
   className?: string;
   isSmall?: boolean;
-  iconSize?: ResourceLinkProps["iconSize"];
-  size?: TagProps["size"];
-  variant?: TagProps["variant"];
+  prefix?: string;
+  suffix?: React.ReactNode;
 };
 
 const NavigationTag: React.FunctionComponent<NavigationTagProps> = ({
@@ -31,9 +26,8 @@ const NavigationTag: React.FunctionComponent<NavigationTagProps> = ({
   tooltipContent,
   className,
   isSmall = false,
-  iconSize = DEFAULT_ICON_SIZE,
-  size = "md",
-  variant = "transparent",
+  prefix,
+  suffix,
 }) => {
   const resourceLabel = RESOURCE_MAP[resource].label;
   const defaultTooltipContent = `Navigate to ${resourceLabel}: ${name}`;
@@ -45,13 +39,11 @@ const NavigationTag: React.FunctionComponent<NavigationTagProps> = ({
       resource={resource}
       search={search}
       tooltipContent={tooltipContent ?? defaultTooltipContent}
-      variant={variant}
       className={className}
-      iconSize={iconSize}
-      gapSize={1}
       asTag
       isSmall={isSmall}
-      size={size}
+      prefix={prefix}
+      suffix={suffix}
     />
   );
 };

--- a/apps/opik-frontend/src/shared/ResourceLink/ResourceLink.tsx
+++ b/apps/opik-frontend/src/shared/ResourceLink/ResourceLink.tsx
@@ -136,7 +136,7 @@ export type ResourceLinkProps = {
   resource: RESOURCE_TYPE;
   search?: Record<string, string | number | string[] | Filter[]>;
   params?: Record<string, string | number | string[]>;
-  tooltipContent?: string;
+  tooltipContent?: string | false;
   asTag?: boolean;
   isSmall?: boolean;
   isDeleted?: boolean;
@@ -196,7 +196,10 @@ function ResourceLink({
       disabled={deleted}
     >
       {asTag ? (
-        <TooltipWrapper content={tooltipContent || text} stopClickPropagation>
+        <TooltipWrapper
+          content={tooltipContent === false ? "" : tooltipContent || text}
+          stopClickPropagation
+        >
           <Tag
             size="md"
             variant="transparent"

--- a/apps/opik-frontend/src/shared/ResourceLink/ResourceLink.tsx
+++ b/apps/opik-frontend/src/shared/ResourceLink/ResourceLink.tsx
@@ -1,22 +1,12 @@
 import React from "react";
 import { Link } from "@tanstack/react-router";
-import {
-  ChartLine,
-  Database,
-  FileTerminal,
-  FlaskConical,
-  LayoutGrid,
-  ListTree,
-  MessagesSquare,
-  SparklesIcon,
-  UserPen,
-} from "lucide-react";
+import { ArrowUpRight } from "lucide-react";
 import isUndefined from "lodash/isUndefined";
 
 import { cn } from "@/lib/utils";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import useAppStore, { useActiveProjectId } from "@/store/AppStore";
-import { Tag, TagProps } from "@/ui/tag";
+import { Tag } from "@/ui/tag";
 import { Button } from "@/ui/button";
 import { Filter } from "@/types/filters";
 import { LOGS_TYPE, PROJECT_TAB } from "@/constants/traces";
@@ -41,105 +31,83 @@ export const RESOURCE_MAP = {
   [RESOURCE_TYPE.project]: {
     url: "/$workspaceName/projects/$projectId/traces",
     projectUrl: "/$workspaceName/projects/$projectId/home",
-    icon: LayoutGrid,
     param: "projectId",
     deleted: "Deleted project",
     label: "project",
-    color: "var(--color-green)",
   },
   [RESOURCE_TYPE.dataset]: {
     url: "/$workspaceName/datasets/$datasetId/items",
     projectUrl: "/$workspaceName/projects/$projectId/datasets/$datasetId/items",
-    icon: Database,
     param: "datasetId",
     deleted: "Deleted dataset",
     label: "dataset",
-    color: "var(--color-yellow)",
   },
   [RESOURCE_TYPE.datasetItem]: {
     url: "/$workspaceName/datasets/$datasetId/items",
     projectUrl: "/$workspaceName/projects/$projectId/datasets/$datasetId/items",
-    icon: Database,
     param: "datasetId",
     deleted: "Deleted dataset item",
     label: "dataset item",
-    color: "var(--color-yellow)",
   },
   [RESOURCE_TYPE.prompt]: {
     url: "/$workspaceName/prompts/$promptId",
     projectUrl: "/$workspaceName/projects/$projectId/prompts/$promptId",
-    icon: FileTerminal,
     param: "promptId",
     deleted: "Deleted prompt",
     label: "prompt",
-    color: "var(--color-purple)",
   },
   [RESOURCE_TYPE.experiment]: {
     url: "/$workspaceName/experiments/$datasetId/compare",
     projectUrl:
       "/$workspaceName/projects/$projectId/experiments/$datasetId/compare",
-    icon: FlaskConical,
     param: "datasetId",
     deleted: "Deleted experiment",
     label: "experiment",
-    color: "var(--color-burgundy)",
   },
   [RESOURCE_TYPE.experimentItem]: {
     url: "/$workspaceName/experiments/$datasetId/compare",
     projectUrl:
       "/$workspaceName/projects/$projectId/experiments/$datasetId/compare",
-    icon: FlaskConical,
     param: "datasetId",
     deleted: "Deleted experiment item",
     label: "experiment item",
-    color: "var(--color-burgundy)",
   },
   [RESOURCE_TYPE.optimization]: {
     url: "/$workspaceName/optimizations/$optimizationId",
     projectUrl:
       "/$workspaceName/projects/$projectId/optimizations/$optimizationId",
-    icon: SparklesIcon,
     param: "optimizationId",
     deleted: "Deleted optimization",
     label: "optimization run",
-    color: "var(--color-orange)",
   },
   [RESOURCE_TYPE.trial]: {
     url: "/$workspaceName/optimizations/$optimizationId/trials",
     projectUrl:
       "/$workspaceName/projects/$projectId/optimizations/$optimizationId/trials",
-    icon: SparklesIcon,
     param: "optimizationId",
     deleted: "Deleted optimization",
     label: "trial",
-    color: "var(--color-orange)",
   },
   [RESOURCE_TYPE.annotationQueue]: {
     url: "/$workspaceName/annotation-queues/$annotationQueueId",
     projectUrl:
       "/$workspaceName/projects/$projectId/annotation-queues/$annotationQueueId",
-    icon: UserPen,
     param: "annotationQueueId",
     deleted: "Deleted annotation queue",
     label: "annotation queue",
-    color: "var(--color-pink)",
   },
   [RESOURCE_TYPE.dashboard]: {
     url: "/$workspaceName/dashboards/$dashboardId",
-    icon: ChartLine,
     param: "dashboardId",
     deleted: "Deleted dashboard",
     label: "dashboard",
-    color: "var(--color-blue)",
   },
   [RESOURCE_TYPE.traces]: {
     url: "/$workspaceName/projects/$projectId/traces",
     projectUrl: "/$workspaceName/projects/$projectId/logs",
-    icon: ListTree,
     param: "projectId",
     deleted: "Deleted traces",
     label: "traces",
-    color: "var(--color-green)",
     search: { tab: PROJECT_TAB.logs, logsType: LOGS_TYPE.traces },
     projectSearch: { logsType: LOGS_TYPE.traces },
   },
@@ -147,20 +115,16 @@ export const RESOURCE_MAP = {
     url: "/$workspaceName/test-suites/$suiteId/items",
     projectUrl:
       "/$workspaceName/projects/$projectId/test-suites/$suiteId/items",
-    icon: Database,
     param: "suiteId",
     deleted: "Deleted test suite",
     label: "test suite",
-    color: "var(--color-yellow)",
   },
   [RESOURCE_TYPE.threads]: {
     url: "/$workspaceName/projects/$projectId/traces",
     projectUrl: "/$workspaceName/projects/$projectId/logs",
-    icon: MessagesSquare,
     param: "projectId",
     deleted: "Deleted threads",
     label: "threads",
-    color: "var(--thread-icon-text)",
     search: { tab: PROJECT_TAB.logs, logsType: LOGS_TYPE.threads },
     projectSearch: { logsType: LOGS_TYPE.threads },
   },
@@ -172,14 +136,12 @@ export type ResourceLinkProps = {
   resource: RESOURCE_TYPE;
   search?: Record<string, string | number | string[] | Filter[]>;
   params?: Record<string, string | number | string[]>;
-  variant?: TagProps["variant"];
-  size?: TagProps["size"];
-  iconSize?: 3 | 3.5 | 4 | 5;
-  gapSize?: number;
   tooltipContent?: string;
   asTag?: boolean;
   isSmall?: boolean;
   isDeleted?: boolean;
+  prefix?: string;
+  suffix?: React.ReactNode;
   className?: string;
 };
 
@@ -189,14 +151,12 @@ function ResourceLink({
   id,
   search,
   params,
-  variant = "gray",
-  size = "md",
-  iconSize = 4,
-  gapSize = 2,
   tooltipContent = "",
   asTag = false,
   isSmall = false,
   isDeleted = false,
+  prefix,
+  suffix,
   className,
 }: ResourceLinkProps): React.ReactElement {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
@@ -238,14 +198,10 @@ function ResourceLink({
       {asTag ? (
         <TooltipWrapper content={tooltipContent || text} stopClickPropagation>
           <Tag
-            size={size}
-            variant={variant}
+            size="md"
+            variant="transparent"
             className={cn(
-              "flex items-center",
-              gapSize === 1 && "gap-1",
-              gapSize === 2 && "gap-2",
-              gapSize === 3 && "gap-3",
-              gapSize === 4 && "gap-4",
+              "flex items-center gap-1",
               deleted && "opacity-50 cursor-default",
               !deleted &&
                 "hover:bg-primary-foreground hover:text-foreground active:bg-primary-100 active:text-foreground",
@@ -253,29 +209,19 @@ function ResourceLink({
               className,
             )}
           >
-            <props.icon
-              className={cn(
-                "shrink-0",
-                iconSize === 3 && "size-3",
-                iconSize === 3.5 && "size-3.5",
-                iconSize === 4 && "size-4",
-                iconSize === 5 && "size-5",
-              )}
-              style={{ color: props.color }}
-            />
-            {!isSmall && (
-              <div
-                className={cn(
-                  "truncate",
-                  variant === "transparent" && [
-                    "text-muted-slate",
-                    "comet-body-s-accented",
-                  ],
-                )}
-              >
-                {text}
-              </div>
-            )}
+            {!isSmall &&
+              (deleted ? (
+                <div className="comet-body-s-accented truncate text-foreground">
+                  {text}
+                </div>
+              ) : (
+                <div className="comet-body-s truncate text-foreground">
+                  {prefix ? `${prefix}: ` : ""}
+                  <span className="comet-body-s-accented">{text}</span>
+                </div>
+              ))}
+            {!isSmall && !deleted && suffix}
+            <ArrowUpRight className="size-3 shrink-0 text-foreground" />
           </Tag>
         </TooltipWrapper>
       ) : (

--- a/apps/opik-frontend/src/ui/tag.tsx
+++ b/apps/opik-frontend/src/ui/tag.tsx
@@ -27,7 +27,7 @@ const tagVariants = cva("inline-block truncate rounded-sm transition-colors", {
     size: {
       default: "comet-body-xs h-5 px-2 leading-5",
       sm: "comet-body-xs h-4 px-2 text-[11px] leading-4",
-      md: "comet-body-s h-6 rounded-md px-1.5 leading-6",
+      md: "comet-body-s h-6 px-2 leading-6",
       lg: "comet-body-s h-7 rounded-md px-3 leading-7",
     },
   },

--- a/apps/opik-frontend/src/v2/pages-shared/FeedbackScoresList/FeedbackScoresList.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/FeedbackScoresList/FeedbackScoresList.tsx
@@ -20,7 +20,7 @@ const FeedbackScoresList: React.FunctionComponent<FeedbackScoresListProps> = ({
   return (
     <div className={cn("flex min-h-7 items-center gap-2", className)}>
       <TooltipWrapper content="Feedback scores">
-        <PenLine className="mx-1 size-4 shrink-0 text-muted-slate" />
+        <PenLine className="mx-1 size-3.5 shrink-0 text-muted-slate" />
       </TooltipWrapper>
       <div className="flex gap-1 overflow-x-auto">
         {scores.map((score) => (

--- a/apps/opik-frontend/src/v2/pages-shared/FeedbackScoresList/FeedbackScoresList.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/FeedbackScoresList/FeedbackScoresList.tsx
@@ -18,11 +18,11 @@ const FeedbackScoresList: React.FunctionComponent<FeedbackScoresListProps> = ({
   if (scores.length === 0) return null;
 
   return (
-    <div className={cn("flex min-h-7 items-center gap-2", className)}>
+    <div className={cn("flex min-h-7 items-center", className)}>
       <TooltipWrapper content="Feedback scores">
         <PenLine className="mx-1 size-3.5 shrink-0 text-muted-slate" />
       </TooltipWrapper>
-      <div className="flex gap-1 overflow-x-auto">
+      <div className="flex gap-1.5 overflow-x-auto">
         {scores.map((score) => (
           <FeedbackScoreTag
             key={score.name + score.value}

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemActionsDropdown/DatasetItemActionsDropdown.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemActionsDropdown/DatasetItemActionsDropdown.tsx
@@ -13,6 +13,7 @@ import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 
 type DatasetItemActionsDropdownProps = {
   datasetItemId: string;
+  itemName: string;
   onShare: () => void;
   onCopyId: () => void;
   onDelete: () => void;
@@ -20,6 +21,7 @@ type DatasetItemActionsDropdownProps = {
 
 const DatasetItemActionsDropdown: React.FC<DatasetItemActionsDropdownProps> = ({
   datasetItemId,
+  itemName,
   onShare,
   onCopyId,
   onDelete,
@@ -35,18 +37,18 @@ const DatasetItemActionsDropdown: React.FC<DatasetItemActionsDropdownProps> = ({
       <DropdownMenuContent align="end" className="w-52">
         <DropdownMenuItem onClick={onShare}>
           <Share className="mr-2 size-4" />
-          Share item
+          Share {itemName}
         </DropdownMenuItem>
         <TooltipWrapper content={datasetItemId} side="left">
           <DropdownMenuItem onClick={onCopyId}>
             <Copy className="mr-2 size-4" />
-            Copy item ID
+            Copy {itemName} ID
           </DropdownMenuItem>
         </TooltipWrapper>
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={onDelete}>
           <Trash className="mr-2 size-4" />
-          Delete item
+          Delete {itemName}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemEditor/DatasetItemEditorAutosaveLayout.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemEditor/DatasetItemEditorAutosaveLayout.tsx
@@ -58,7 +58,7 @@ const DatasetItemEditorAutosaveLayout: React.FC<
 
   const handleCopyId = useCallback(() => {
     toast({
-      description: "Item ID successfully copied to clipboard",
+      description: "Record ID successfully copied to clipboard",
     });
     copy(datasetItemId);
   }, [datasetItemId, toast]);
@@ -81,7 +81,7 @@ const DatasetItemEditorAutosaveLayout: React.FC<
           title={
             <TooltipWrapper content={datasetItemId}>
               <span>
-                Dataset item{" "}
+                Record{" "}
                 <span className="comet-body-s text-muted-slate">
                   {truncateId(datasetItemId)}
                 </span>
@@ -92,6 +92,7 @@ const DatasetItemEditorAutosaveLayout: React.FC<
         >
           <DatasetItemActionsDropdown
             datasetItemId={datasetItemId}
+            itemName="record"
             onShare={handleShare}
             onCopyId={handleCopyId}
             onDelete={handleDeleteItemConfirm}

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemPanel/AddDatasetItemDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemPanel/AddDatasetItemDialog.tsx
@@ -75,7 +75,7 @@ const AddDatasetItemDialog: React.FC<AddDatasetItemDialogProps> = ({
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent className="max-w-lg sm:max-w-[560px]">
         <DialogHeader>
-          <DialogTitle>Add dataset item</DialogTitle>
+          <DialogTitle>Add record</DialogTitle>
         </DialogHeader>
         <div className="max-h-[70vh] overflow-y-auto">
           <div className="flex flex-col gap-2 pb-4">
@@ -107,7 +107,7 @@ const AddDatasetItemDialog: React.FC<AddDatasetItemDialogProps> = ({
             <Button variant="outline">Cancel</Button>
           </DialogClose>
           <Button type="submit" disabled={!isValid} onClick={submitHandler}>
-            Add dataset item
+            Add record
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemPanel/AddDatasetItemPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemPanel/AddDatasetItemPanel.tsx
@@ -70,6 +70,7 @@ const AddDatasetItemPanel: React.FC<AddDatasetItemPanelProps> = ({
   <AddItemPanelWrapper
     panelId="dataset-item-panel"
     formId={ADD_DATASET_ITEM_FORM_ID}
+    title="Add record"
     open={open}
     onClose={onClose}
     initialWidth={0.4}

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemPanel/AddItemPanelWrapper.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemPanel/AddItemPanelWrapper.tsx
@@ -15,6 +15,7 @@ export interface AddItemPanelContext {
 interface AddItemPanelWrapperProps {
   panelId: string;
   formId: string;
+  title: string;
   open: boolean;
   onClose: () => void;
   initialWidth?: number;
@@ -99,6 +100,7 @@ const AddItemPanelWrapperContent: React.FC<{
 const AddItemPanelWrapper: React.FC<AddItemPanelWrapperProps> = ({
   panelId,
   formId,
+  title,
   open,
   onClose,
   initialWidth,
@@ -116,7 +118,7 @@ const AddItemPanelWrapper: React.FC<AddItemPanelWrapperProps> = ({
       header={
         <ResizableSidePanelTopBar
           variant="form"
-          title="Add item"
+          title={title}
           onClose={onClose}
         />
       }

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsActionsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef, useState } from "react";
-import { Trash, Sparkles, Tag } from "lucide-react";
+import { Trash, Tag } from "lucide-react";
 import get from "lodash/get";
 import slugify from "slugify";
 
@@ -8,7 +8,6 @@ import { DatasetItem } from "@/types/datasets";
 import useDatasetItemBatchDeleteMutation from "@/api/datasets/useDatasetItemBatchDeleteMutation";
 import ExportToButton from "@/shared/ExportToButton/ExportToButton";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
-import GeneratedSamplesDialog from "./GeneratedSamplesDialog";
 import AddTagDialog from "./AddTagDialog";
 import { DATASET_ITEM_DATA_PREFIX } from "@/constants/datasets";
 import { extractAssertions } from "@/lib/assertion-converters";
@@ -18,18 +17,9 @@ import { FeatureToggleKeys } from "@/types/feature-toggles";
 import { Filters } from "@/types/filters";
 import {
   useBulkDeleteItems,
-  useBulkAddItems,
   useIsAllItemsSelected,
 } from "@/store/TestSuiteDraftStore";
-import { useToast } from "@/ui/use-toast";
-import { buildDraftItemFromSample } from "@/lib/dataset-item-utils";
 import { usePermissions } from "@/contexts/PermissionsContext";
-
-export type ExpansionDialogRenderProps = {
-  open: boolean;
-  setOpen: (open: boolean) => void;
-  onSamplesGenerated: (samples: DatasetItem[]) => void;
-};
 
 type DatasetItemsActionsPanelProps = {
   getDataForExport: () => Promise<DatasetItem[]>;
@@ -43,8 +33,6 @@ type DatasetItemsActionsPanelProps = {
   totalCount?: number;
   isDraftMode?: boolean;
   entityName?: string;
-  renderExpansionDialog: (props: ExpansionDialogRenderProps) => React.ReactNode;
-  compact?: boolean;
 };
 
 const DatasetItemsActionsPanel: React.FunctionComponent<
@@ -61,24 +49,15 @@ const DatasetItemsActionsPanel: React.FunctionComponent<
   totalCount = 0,
   isDraftMode = false,
   entityName = "dataset",
-  renderExpansionDialog,
-  compact = false,
 }) => {
   const resetKeyRef = useRef(0);
-  const [expansionDialogOpen, setExpansionDialogOpen] =
-    useState<boolean>(false);
-  const [generatedSamplesDialogOpen, setGeneratedSamplesDialogOpen] =
-    useState<boolean>(false);
-  const [generatedSamples, setGeneratedSamples] = useState<DatasetItem[]>([]);
   const [addTagDialogOpen, setAddTagDialogOpen] = useState<boolean>(false);
   const disabled = !selectedDatasetItems?.length;
 
   const { mutate } = useDatasetItemBatchDeleteMutation();
   const isExportEnabled = useIsFeatureEnabled(FeatureToggleKeys.EXPORT_ENABLED);
   const bulkDeleteItems = useBulkDeleteItems();
-  const bulkAddItems = useBulkAddItems();
   const isAllItemsSelected = useIsAllItemsSelected();
-  const { toast } = useToast();
 
   const {
     permissions: { canEditDatasets },
@@ -109,25 +88,6 @@ const DatasetItemsActionsPanel: React.FunctionComponent<
     search,
     bulkDeleteItems,
   ]);
-
-  const handleSamplesGenerated = useCallback((samples: DatasetItem[]) => {
-    setGeneratedSamples(samples);
-    setGeneratedSamplesDialogOpen(true);
-  }, []);
-
-  const handleAddGeneratedItems = useCallback(
-    (items: DatasetItem[]) => {
-      const now = new Date().toISOString();
-      bulkAddItems(items.map((item) => buildDraftItemFromSample(item, now)));
-
-      const plural = items.length !== 1 ? "s" : "";
-      toast({
-        title: "Samples added to draft",
-        description: `${items.length} sample${plural} added to your draft changes`,
-      });
-    },
-    [bulkAddItems, toast],
-  );
 
   const mapRowData = useCallback(async () => {
     const normalizeExportValue = (value: unknown): unknown => {
@@ -173,21 +133,6 @@ const DatasetItemsActionsPanel: React.FunctionComponent<
 
   return (
     <div className="flex items-center gap-2">
-      {renderExpansionDialog({
-        open: expansionDialogOpen,
-        setOpen: setExpansionDialogOpen,
-        onSamplesGenerated: handleSamplesGenerated,
-      })}
-
-      <GeneratedSamplesDialog
-        key={`generate-samples-${resetKeyRef.current}`}
-        samples={generatedSamples}
-        open={generatedSamplesDialogOpen}
-        setOpen={setGeneratedSamplesDialogOpen}
-        onAddItems={handleAddGeneratedItems}
-        entityName={entityName}
-      />
-
       <AddTagDialog
         key={`tag-${resetKeyRef.current}`}
         datasetId={datasetId}
@@ -200,40 +145,19 @@ const DatasetItemsActionsPanel: React.FunctionComponent<
         totalCount={totalCount}
       />
       {canEditDatasets && (
-        <>
-          <TooltipWrapper content={compact ? "Expand with AI" : undefined}>
-            <Button
-              variant="secondary"
-              size={compact ? "icon-sm" : "sm"}
-              onClick={() => {
-                setExpansionDialogOpen(true);
-                resetKeyRef.current = resetKeyRef.current + 1;
-              }}
-            >
-              {compact ? (
-                <Sparkles className="size-4" />
-              ) : (
-                <>
-                  <Sparkles className="mr-2 size-4" />
-                  Expand with AI
-                </>
-              )}
-            </Button>
-          </TooltipWrapper>
-          <TooltipWrapper content="Manage tags">
-            <Button
-              variant="outline"
-              size="icon-sm"
-              onClick={() => {
-                setAddTagDialogOpen(true);
-                resetKeyRef.current = resetKeyRef.current + 1;
-              }}
-              disabled={disabled}
-            >
-              <Tag />
-            </Button>
-          </TooltipWrapper>
-        </>
+        <TooltipWrapper content="Manage tags">
+          <Button
+            variant="outline"
+            size="icon-sm"
+            onClick={() => {
+              setAddTagDialogOpen(true);
+              resetKeyRef.current = resetKeyRef.current + 1;
+            }}
+            disabled={disabled}
+          >
+            <Tag />
+          </Button>
+        </TooltipWrapper>
       )}
       <ExportToButton
         disabled={

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPage.tsx
@@ -1,13 +1,15 @@
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { StringParam, useQueryParam } from "use-query-params";
 
 import useDatasetById from "@/api/datasets/useDatasetById";
 import useDatasetUpdateMutation from "@/api/datasets/useDatasetUpdateMutation";
 import useDatasetVersionsList from "@/api/datasets/useDatasetVersionsList";
+import useDatasetItemsList from "@/api/datasets/useDatasetItemsList";
 import DatasetItemsTab, {
   EditPanelRenderProps,
   AddPanelRenderProps,
   AddDialogRenderProps,
+  ExpansionDialogRenderProps,
 } from "@/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab";
 import EditTestSuiteSettingsDialog from "@/v2/pages-shared/datasets/TestSuiteComponents/EditTestSuiteSettingsDialog";
 import TestSuiteItemPanel from "@/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/TestSuiteItemPanel";
@@ -19,15 +21,22 @@ import AddVersionDialog from "@/v2/pages-shared/datasets/VersionHistoryTab/AddVe
 import VersionHistoryTab from "@/v2/pages-shared/datasets/VersionHistoryTab/VersionHistoryTab";
 import OverrideVersionDialog from "@/v2/pages-shared/datasets/OverrideVersionDialog";
 import DatasetExpansionDialog from "@/v2/pages-shared/datasets/DatasetExpansionDialog";
-import { ExpansionDialogRenderProps } from "@/v2/pages-shared/datasets/DatasetItemsActionsPanel";
+import GeneratedSamplesDialog from "@/v2/pages-shared/datasets/GeneratedSamplesDialog";
 import ConfirmDialog from "@/shared/ConfirmDialog/ConfirmDialog";
 import { usePermissions } from "@/contexts/PermissionsContext";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/ui/tabs";
 import useNavigationBlocker from "@/hooks/useNavigationBlocker";
 import { useTestSuiteSavePayload } from "@/hooks/useTestSuiteSavePayload";
 import { useDatasetEntityIdFromURL } from "@/v2/hooks/useDatasetEntityIdFromURL";
-import { useClearDraft, useHasDraft } from "@/store/TestSuiteDraftStore";
 import {
+  useClearDraft,
+  useHasDraft,
+  useBulkAddItems,
+} from "@/store/TestSuiteDraftStore";
+import { buildDraftItemFromSample } from "@/lib/dataset-item-utils";
+import { useToast } from "@/ui/use-toast";
+import {
+  DatasetItem,
   DatasetItemColumn,
   DATASET_STATUS,
   DATASET_TYPE,
@@ -81,6 +90,7 @@ function DatasetItemsPage(): React.ReactElement {
   const datasetType = dataset?.type;
   const isTestSuite = datasetType === DATASET_TYPE.TEST_SUITE;
   const entityName = isTestSuite ? "test suite" : "dataset";
+  const itemName = isTestSuite ? "test case" : "record";
 
   const { data: versionsData } = useDatasetVersionsList(
     { datasetId, page: 1, size: 1 },
@@ -203,19 +213,73 @@ function DatasetItemsPage(): React.ReactElement {
     [isTestSuite],
   );
 
+  const bulkAddItems = useBulkAddItems();
+  const { toast } = useToast();
+  const [generatedSamples, setGeneratedSamples] = useState<DatasetItem[]>([]);
+  const [generatedSamplesDialogOpen, setGeneratedSamplesDialogOpen] =
+    useState(false);
+  const samplesResetKeyRef = useRef(0);
+
+  const handleSamplesGenerated = useCallback((samples: DatasetItem[]) => {
+    setGeneratedSamples(samples);
+    samplesResetKeyRef.current += 1;
+    setGeneratedSamplesDialogOpen(true);
+  }, []);
+
+  const handleAddGeneratedItems = useCallback(
+    (items: DatasetItem[]) => {
+      const now = new Date().toISOString();
+      bulkAddItems(items.map((item) => buildDraftItemFromSample(item, now)));
+      const plural = items.length !== 1 ? "s" : "";
+      toast({
+        title: "Samples added to draft",
+        description: `${items.length} sample${plural} added to your draft changes`,
+      });
+    },
+    [bulkAddItems, toast],
+  );
+
   const renderExpansionDialog = useCallback(
-    ({ open, setOpen, onSamplesGenerated }: ExpansionDialogRenderProps) => (
+    ({ open, setOpen }: ExpansionDialogRenderProps) => (
       <DatasetExpansionDialog
         datasetId={datasetId}
         open={open}
         setOpen={setOpen}
-        onSamplesGenerated={onSamplesGenerated}
+        onSamplesGenerated={handleSamplesGenerated}
         datasetType={datasetType}
         suiteAssertions={isTestSuite ? effectiveAssertions : undefined}
       />
     ),
-    [datasetId, datasetType, isTestSuite, effectiveAssertions],
+    [
+      datasetId,
+      datasetType,
+      isTestSuite,
+      effectiveAssertions,
+      handleSamplesGenerated,
+    ],
   );
+
+  const { data: addItemsMeta } = useDatasetItemsList(
+    { datasetId, page: 1, size: 1 },
+    { enabled: canEditDatasets && !!datasetId },
+  );
+  const addItemColumns = addItemsMeta?.columns ?? [];
+
+  const [openCreatePanel, setOpenCreatePanel] = useState(false);
+  const [openDialog, setOpenDialog] = useState(false);
+  const [openExpansion, setOpenExpansion] = useState(false);
+  const resetDialogKeyRef = useRef(0);
+
+  const handleAddItem = useCallback(() => {
+    if (renderAddDialog && (dataset?.dataset_items_count ?? 0) === 0) {
+      setOpenDialog(true);
+      resetDialogKeyRef.current += 1;
+    } else {
+      setOpenCreatePanel(true);
+    }
+  }, [renderAddDialog, dataset?.dataset_items_count]);
+
+  const handleExpand = useCallback(() => setOpenExpansion(true), []);
 
   return (
     <div className="pt-4">
@@ -243,6 +307,14 @@ function DatasetItemsPage(): React.ReactElement {
         open={settingsDialogOpen}
         setOpen={setSettingsDialogOpen}
       />
+      <GeneratedSamplesDialog
+        key={`generate-samples-${samplesResetKeyRef.current}`}
+        samples={generatedSamples}
+        open={generatedSamplesDialogOpen}
+        setOpen={setGeneratedSamplesDialogOpen}
+        onAddItems={handleAddGeneratedItems}
+        entityName={entityName}
+      />
       {DialogComponent}
       <DatasetItemsPageHeader
         dataset={dataset}
@@ -258,13 +330,30 @@ function DatasetItemsPage(): React.ReactElement {
         onDiscardClick={() => setDiscardDialogOpen(true)}
         onSaveClick={() => setAddVersionDialogOpen(true)}
         onSettingsClick={() => setSettingsDialogOpen(true)}
+        onAddItem={handleAddItem}
+        onExpand={handleExpand}
       />
+      {renderAddPanel({
+        open: openCreatePanel,
+        onClose: () => setOpenCreatePanel(false),
+        columns: addItemColumns,
+      })}
+      {renderAddDialog?.({
+        key: resetDialogKeyRef.current,
+        datasetId,
+        open: openDialog,
+        setOpen: setOpenDialog,
+      })}
+      {renderExpansionDialog({
+        open: openExpansion,
+        setOpen: setOpenExpansion,
+      })}
       <Tabs value={tab ?? "items"} onValueChange={setTab}>
-        <TabsList variant="underline">
-          <TabsTrigger variant="underline" value="items">
-            Items
+        <TabsList variant="segmented-primary">
+          <TabsTrigger variant="segmented-primary" value="items">
+            {isTestSuite ? "Test cases" : "Records"}
           </TabsTrigger>
-          <TabsTrigger variant="underline" value="version-history">
+          <TabsTrigger variant="segmented-primary" value="version-history">
             Version history
           </TabsTrigger>
         </TabsList>
@@ -284,9 +373,8 @@ function DatasetItemsPage(): React.ReactElement {
             entityName={entityName}
             buildColumns={buildColumns}
             renderEditPanel={renderEditPanel}
-            renderAddPanel={renderAddPanel}
-            renderAddDialog={renderAddDialog}
-            renderExpansionDialog={renderExpansionDialog}
+            onAddItem={handleAddItem}
+            itemName={itemName}
           />
         </TabsContent>
         <TabsContent value="version-history">

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPage.tsx
@@ -271,13 +271,14 @@ function DatasetItemsPage(): React.ReactElement {
   const resetDialogKeyRef = useRef(0);
 
   const handleAddItem = useCallback(() => {
-    if (renderAddDialog && (dataset?.dataset_items_count ?? 0) === 0) {
+    if (!dataset) return;
+    if (renderAddDialog && dataset.dataset_items_count === 0) {
       setOpenDialog(true);
       resetDialogKeyRef.current += 1;
     } else {
       setOpenCreatePanel(true);
     }
-  }, [renderAddDialog, dataset?.dataset_items_count]);
+  }, [renderAddDialog, dataset]);
 
   const handleExpand = useCallback(() => setOpenExpansion(true), []);
 

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPageHeader.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPageHeader.tsx
@@ -3,10 +3,13 @@ import {
   Check,
   CheckCheck,
   GitCommitVertical,
+  Plus,
   Settings2,
+  Sparkles,
   X,
 } from "lucide-react";
 
+import BackButton from "@/shared/BackButton/BackButton";
 import ColoredTag from "@/shared/ColoredTag/ColoredTag";
 import DateTag from "@/shared/DateTag/DateTag";
 import { RESOURCE_TYPE } from "@/shared/ResourceLink/ResourceLink";
@@ -14,7 +17,6 @@ import TagListRenderer from "@/shared/TagListRenderer/TagListRenderer";
 import UseDatasetDropdown from "@/v2/pages-shared/datasets/UseDatasetDropdown";
 import { AssertionsListTooltipContent } from "@/v2/pages-shared/experiments/TestSuiteExperiment/AssertionsListTooltipContent";
 import { Button } from "@/ui/button";
-import { Separator } from "@/ui/separator";
 import { Tag } from "@/ui/tag";
 import {
   Tooltip,
@@ -38,6 +40,8 @@ interface DatasetItemsPageHeaderProps {
   onDiscardClick: () => void;
   onSaveClick: () => void;
   onSettingsClick: () => void;
+  onAddItem: () => void;
+  onExpand: () => void;
 }
 
 const DatasetItemsPageHeader: React.FunctionComponent<
@@ -56,6 +60,8 @@ const DatasetItemsPageHeader: React.FunctionComponent<
   onDiscardClick,
   onSaveClick,
   onSettingsClick,
+  onAddItem,
+  onExpand,
 }) => {
   const datasetTags = dataset?.tags ?? [];
   const showTags = canEditDatasets || datasetTags.length > 0;
@@ -68,13 +74,21 @@ const DatasetItemsPageHeader: React.FunctionComponent<
   return (
     <div className="mb-4">
       <div className="mb-4 flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <BackButton
+            to={
+              isTestSuite
+                ? "/$workspaceName/projects/$projectId/test-suites"
+                : "/$workspaceName/projects/$projectId/datasets"
+            }
+            tooltip={isTestSuite ? "Back to test suites" : "Back to datasets"}
+          />
           {hasDraft && (
             <Tag variant="orange" size="md">
               Draft
             </Tag>
           )}
-          <h1 className="comet-body-accented truncate break-words">
+          <h1 className="comet-title-xs truncate break-words">
             {dataset?.name ?? (isTestSuite ? "Test suite" : "Dataset")}
           </h1>
         </div>
@@ -101,6 +115,12 @@ const DatasetItemsPageHeader: React.FunctionComponent<
               </Button>
             </>
           )}
+          {canEditDatasets && (
+            <Button variant="outline" size="sm" onClick={onExpand}>
+              <Sparkles className="mr-1.5 size-3.5" />
+              Expand with AI
+            </Button>
+          )}
           <UseDatasetDropdown
             datasetName={dataset?.name}
             datasetId={datasetId}
@@ -121,12 +141,18 @@ const DatasetItemsPageHeader: React.FunctionComponent<
               Test settings
             </Button>
           )}
+          {canEditDatasets && (
+            <Button variant="default" size="sm" onClick={onAddItem}>
+              <Plus className="mr-1.5 size-3.5" />
+              {isTestSuite ? "Test case" : "Record"}
+            </Button>
+          )}
         </div>
       </div>
       {dataset?.description && (
         <div className="-mt-3 mb-4 text-muted-slate">{dataset.description}</div>
       )}
-      <div className="flex gap-2 overflow-x-auto">
+      <div className="mb-2 flex gap-1.5 overflow-x-auto">
         {dataset?.created_at && (
           <DateTag
             date={dataset.created_at}
@@ -137,20 +163,23 @@ const DatasetItemsPageHeader: React.FunctionComponent<
         )}
         {latestVersion && (
           <>
-            <Tag
+            <div
               data-testid="dataset-detail-version-label"
-              size="md"
-              variant="transparent"
-              className="flex shrink-0 items-center gap-1"
+              className="flex h-6 shrink-0 items-center gap-1 rounded-md border border-border bg-primary-foreground pl-1 pr-1.5"
             >
-              <GitCommitVertical className="size-3 text-green-500" />
-              {latestVersion.version_name}
-            </Tag>
+              <span className="flex size-3 shrink-0 items-center justify-center">
+                <span className="size-1.5 rounded-full bg-light-slate" />
+              </span>
+              <span className="comet-body-xs-accented text-foreground">
+                {latestVersion.version_name}
+              </span>
+            </div>
             {latestVersion.tags?.map((tag) => (
               <ColoredTag
                 key={tag}
                 label={tag}
                 size="md"
+                variant="gray"
                 IconComponent={GitCommitVertical}
               />
             ))}
@@ -162,11 +191,11 @@ const DatasetItemsPageHeader: React.FunctionComponent<
               <div
                 data-testid="dataset-detail-global-assertions-pill"
                 data-count={effectiveAssertions.length}
-                className="flex shrink-0 cursor-pointer items-center gap-1 rounded bg-thread-active px-1.5 py-0.5"
+                className="flex h-6 shrink-0 cursor-pointer items-center gap-1 rounded-md border border-border bg-primary-foreground pl-1 pr-1.5"
                 onClick={onSettingsClick}
               >
-                <CheckCheck className="size-3 text-muted-foreground" />
-                <span className="comet-body-s-accented text-muted-foreground">
+                <CheckCheck className="size-3 shrink-0 text-muted-slate" />
+                <span className="comet-body-xs-accented text-foreground">
                   {effectiveAssertions.length} global assertion
                   {effectiveAssertions.length !== 1 ? "s" : ""}
                 </span>
@@ -185,20 +214,18 @@ const DatasetItemsPageHeader: React.FunctionComponent<
             </TooltipPortal>
           </Tooltip>
         )}
-        {showTags && (
-          <>
-            <Separator orientation="vertical" className="ml-1.5 mt-1 h-4" />
-            <TagListRenderer
-              {...tagListProps}
-              onAddTag={onAddTag}
-              onDeleteTag={onDeleteTag}
-              canAdd={canEditDatasets}
-              align="start"
-              className="min-h-0 w-auto"
-            />
-          </>
-        )}
       </div>
+      {showTags && (
+        <TagListRenderer
+          {...tagListProps}
+          onAddTag={onAddTag}
+          onDeleteTag={onDeleteTag}
+          canAdd={canEditDatasets}
+          align="start"
+          className="[&>:first-child]:-mr-1"
+          tagVariant="green"
+        />
+      )}
     </div>
   );
 };

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPageHeader.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPageHeader.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   Check,
   CheckCheck,
+  FilePen,
   GitCommitVertical,
   Plus,
   Settings2,
@@ -13,7 +14,9 @@ import BackButton from "@/shared/BackButton/BackButton";
 import ColoredTag from "@/shared/ColoredTag/ColoredTag";
 import DateTag from "@/shared/DateTag/DateTag";
 import { RESOURCE_TYPE } from "@/shared/ResourceLink/ResourceLink";
+import SingleLineExpandableText from "@/shared/SingleLineExpandableText/SingleLineExpandableText";
 import TagListRenderer from "@/shared/TagListRenderer/TagListRenderer";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import UseDatasetDropdown from "@/v2/pages-shared/datasets/UseDatasetDropdown";
 import { AssertionsListTooltipContent } from "@/v2/pages-shared/experiments/TestSuiteExperiment/AssertionsListTooltipContent";
 import { Button } from "@/ui/button";
@@ -88,7 +91,7 @@ const DatasetItemsPageHeader: React.FunctionComponent<
               Draft
             </Tag>
           )}
-          <h1 className="comet-title-xs truncate break-words">
+          <h1 className="comet-body-accented truncate break-words">
             {dataset?.name ?? (isTestSuite ? "Test suite" : "Dataset")}
           </h1>
         </div>
@@ -116,15 +119,16 @@ const DatasetItemsPageHeader: React.FunctionComponent<
             </>
           )}
           {canEditDatasets && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onExpand}
-              disabled={!dataset}
-            >
-              <Sparkles className="mr-1.5 size-3.5" />
-              Expand with AI
-            </Button>
+            <TooltipWrapper content="Expand with AI">
+              <Button
+                variant="outline"
+                size="icon-sm"
+                onClick={onExpand}
+                disabled={!dataset}
+              >
+                <Sparkles />
+              </Button>
+            </TooltipWrapper>
           )}
           <UseDatasetDropdown
             datasetName={dataset?.name}
@@ -136,15 +140,15 @@ const DatasetItemsPageHeader: React.FunctionComponent<
             isTestSuite={isTestSuite}
           />
           {isTestSuite && (
-            <Button
-              variant="outline"
-              size="sm"
-              className="gap-1.5"
-              onClick={onSettingsClick}
-            >
-              <Settings2 className="size-3.5 shrink-0" />
-              Test settings
-            </Button>
+            <TooltipWrapper content="Test settings">
+              <Button
+                variant="outline"
+                size="icon-sm"
+                onClick={onSettingsClick}
+              >
+                <Settings2 />
+              </Button>
+            </TooltipWrapper>
           )}
           {canEditDatasets && (
             <Button
@@ -159,9 +163,6 @@ const DatasetItemsPageHeader: React.FunctionComponent<
           )}
         </div>
       </div>
-      {dataset?.description && (
-        <div className="-mt-3 mb-4 text-muted-slate">{dataset.description}</div>
-      )}
       <div className="mb-2 flex gap-1.5 overflow-x-auto">
         {dataset?.created_at && (
           <DateTag
@@ -235,6 +236,14 @@ const DatasetItemsPageHeader: React.FunctionComponent<
           className="[&>:first-child]:-mr-1"
           tagVariant="green"
         />
+      )}
+      {dataset?.description && (
+        <div className="mt-2 flex items-start gap-1">
+          <FilePen className="ml-1 mt-[3px] size-3.5 shrink-0 text-muted-slate" />
+          <SingleLineExpandableText className="comet-body-s text-foreground">
+            {dataset.description}
+          </SingleLineExpandableText>
+        </div>
       )}
     </div>
   );

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPageHeader.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPageHeader.tsx
@@ -116,7 +116,12 @@ const DatasetItemsPageHeader: React.FunctionComponent<
             </>
           )}
           {canEditDatasets && (
-            <Button variant="outline" size="sm" onClick={onExpand}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onExpand}
+              disabled={!dataset}
+            >
               <Sparkles className="mr-1.5 size-3.5" />
               Expand with AI
             </Button>
@@ -142,7 +147,12 @@ const DatasetItemsPageHeader: React.FunctionComponent<
             </Button>
           )}
           {canEditDatasets && (
-            <Button variant="default" size="sm" onClick={onAddItem}>
+            <Button
+              variant="default"
+              size="sm"
+              onClick={onAddItem}
+              disabled={!dataset}
+            >
               <Plus className="mr-1.5 size-3.5" />
               {isTestSuite ? "Test case" : "Record"}
             </Button>

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
@@ -9,7 +9,7 @@ import {
 } from "use-query-params";
 import useLocalStorageState from "use-local-storage-state";
 import { keepPreviousData } from "@tanstack/react-query";
-import { Check, Loader2, Plus } from "lucide-react";
+import { Check, Loader2 } from "lucide-react";
 
 import DataTable from "@/shared/DataTable/DataTable";
 import DataTablePagination from "@/shared/DataTablePagination/DataTablePagination";
@@ -35,13 +35,10 @@ import {
   ColumnData,
   ROW_HEIGHT,
 } from "@/types/shared";
-import DatasetItemsActionsPanel, {
-  ExpansionDialogRenderProps,
-} from "@/v2/pages-shared/datasets/DatasetItemsActionsPanel";
+import DatasetItemsActionsPanel from "@/v2/pages-shared/datasets/DatasetItemsActionsPanel";
 import { DatasetItemRowActionsCell } from "@/v2/pages-shared/datasets/DatasetItemRowActionsCell";
 import DataTableRowHeightSelector from "@/shared/DataTableRowHeightSelector/DataTableRowHeightSelector";
 import SelectAllBanner from "@/shared/SelectAllBanner/SelectAllBanner";
-import { Button } from "@/ui/button";
 import { Separator } from "@/ui/separator";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
@@ -113,6 +110,11 @@ export interface AddDialogRenderProps {
   setOpen: (open: boolean) => void;
 }
 
+export interface ExpansionDialogRenderProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
 interface DatasetItemsTabProps {
   datasetId: string;
   datasetName?: string;
@@ -125,9 +127,8 @@ interface DatasetItemsTabProps {
     dynamicDatasetColumns: DynamicColumn[],
   ) => ColumnData<DatasetItem>[];
   renderEditPanel: (props: EditPanelRenderProps) => React.ReactNode;
-  renderAddPanel: (props: AddPanelRenderProps) => React.ReactNode;
-  renderAddDialog?: (props: AddDialogRenderProps) => React.ReactNode;
-  renderExpansionDialog: (props: ExpansionDialogRenderProps) => React.ReactNode;
+  onAddItem: () => void;
+  itemName: string;
 }
 
 const POLLING_INTERVAL_MS = 3000;
@@ -147,9 +148,8 @@ function DatasetItemsTab({
   entityName,
   buildColumns,
   renderEditPanel,
-  renderAddPanel,
-  renderAddDialog,
-  renderExpansionDialog,
+  onAddItem,
+  itemName,
 }: DatasetItemsTabProps): React.ReactElement | null {
   const {
     permissions: { canEditDatasets },
@@ -202,10 +202,6 @@ function DatasetItemsTab({
     queryParamConfig: StringParam,
     syncQueryWithLocalStorageOnInit: true,
   });
-
-  const [openCreatePanel, setOpenCreatePanel] = useState<boolean>(false);
-  const [openDialog, setOpenDialog] = useState<boolean>(false);
-  const resetDialogKeyRef = useRef(0);
 
   const [isCompactToolbar, setIsCompactToolbar] = useState(false);
   const [isSearchExpanded, setIsSearchExpanded] = useState(Boolean(search));
@@ -331,10 +327,10 @@ function DatasetItemsTab({
 
   const noDataText = useMemo(() => {
     if (isDraftMode && deletedIds.size > 0) {
-      return `All ${entityName} items on this page have been deleted`;
+      return `All ${itemName}s on this page have been deleted`;
     }
-    return `No ${entityName} items yet`;
-  }, [isDraftMode, deletedIds.size, entityName]);
+    return `No ${itemName}s yet`;
+  }, [isDraftMode, deletedIds.size, itemName]);
 
   const handleSearchChange = useCallback(
     (newSearch: string | null) => {
@@ -503,15 +499,6 @@ function DatasetItemsTab({
     [columns, selectedColumns],
   );
 
-  const handleNewDatasetItemClick = useCallback(() => {
-    if (renderAddDialog && totalCount === 0) {
-      setOpenDialog(true);
-      resetDialogKeyRef.current += 1;
-    } else {
-      setOpenCreatePanel(true);
-    }
-  }, [renderAddDialog, totalCount]);
-
   const handleClose = useCallback(() => setActiveRowId(""), [setActiveRowId]);
 
   const resizeConfig = useMemo(
@@ -601,8 +588,6 @@ function DatasetItemsTab({
             totalCount={totalCount}
             isDraftMode={isDraftMode}
             entityName={entityName}
-            renderExpansionDialog={renderExpansionDialog}
-            compact={isCompactToolbar}
           />
           <Separator orientation="vertical" className="mx-2 h-4" />
           <DataTableRowHeightSelector
@@ -616,18 +601,6 @@ function DatasetItemsTab({
             order={columnsOrder}
             onOrderChange={setColumnsOrder}
           />
-          {canEditDatasets && (
-            <TooltipWrapper content={isCompactToolbar ? "Add item" : undefined}>
-              <Button
-                variant="default"
-                size={isCompactToolbar ? "icon-sm" : "sm"}
-                onClick={handleNewDatasetItemClick}
-                data-testid="dataset-items-add-button"
-              >
-                {isCompactToolbar ? <Plus /> : "Add item"}
-              </Button>
-            </TooltipWrapper>
-          )}
         </div>
       </div>
       {isProcessing && (
@@ -676,15 +649,15 @@ function DatasetItemsTab({
             description={
               isDraftMode && deletedIds.size > 0
                 ? ""
-                : "Add test cases to run evaluations and measure performance."
+                : `Add ${itemName}s to run evaluations and measure performance.`
             }
           >
             {!(isDraftMode && deletedIds.size > 0) && (
               <button
-                onClick={handleNewDatasetItemClick}
+                onClick={onAddItem}
                 className="comet-body-s underline underline-offset-4 hover:text-primary"
               >
-                Add new item
+                Add new {itemName}
               </button>
             )}
           </DataTableEmptyContent>
@@ -715,17 +688,6 @@ function DatasetItemsTab({
         isOpen: Boolean(activeRowId),
         rows,
         setActiveRowId,
-      })}
-      {renderAddPanel({
-        open: openCreatePanel,
-        onClose: () => setOpenCreatePanel(false),
-        columns: datasetColumns,
-      })}
-      {renderAddDialog?.({
-        key: resetDialogKeyRef.current,
-        datasetId,
-        open: openDialog,
-        setOpen: setOpenDialog,
       })}
     </>
   );

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/AddTestSuiteItemPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/AddTestSuiteItemPanel.tsx
@@ -112,6 +112,7 @@ const AddTestSuiteItemPanel: React.FC<AddTestSuiteItemPanelProps> = ({
   <AddItemPanelWrapper
     panelId="test-suite-item-panel"
     formId={ADD_SUITE_ITEM_FORM_ID}
+    title="Add test case"
     open={open}
     onClose={onClose}
     initialWidth={0.4}

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/TestSuiteItemForm.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/TestSuiteItemForm.tsx
@@ -37,7 +37,7 @@ const DescriptionSection: React.FC = () => {
       <h3 className="comet-body-s-accented mb-2">Description</h3>
       <TextareaAutosize
         {...register("description")}
-        placeholder="Describe this item..."
+        placeholder="Describe this test case..."
         className={cn(TEXT_AREA_CLASSES, "min-h-0 resize-none")}
         minRows={1}
       />

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/TestSuiteItemPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/TestSuiteComponents/TestSuiteItemPanel/TestSuiteItemPanel.tsx
@@ -161,12 +161,13 @@ const TestSuiteItemPanelLayout: React.FC<TestSuiteItemPanelLayoutProps> = ({
       header={
         <ResizableSidePanelTopBar
           variant="info"
-          title={isNewItem ? "Add item" : "Edit item"}
+          title={isNewItem ? "Add test case" : "Edit test case"}
           onClose={onClose}
         >
           {!isNewItem && (
             <DatasetItemActionsDropdown
               datasetItemId={datasetItemId}
+              itemName="test case"
               onShare={handleShare}
               onCopyId={handleCopyId}
               onDelete={handleDeleteItemConfirm}

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/UseDatasetDropdown.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/UseDatasetDropdown.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from "react";
-import { Blocks, ChevronDown, Code2 } from "lucide-react";
+import { Blocks, Code2, Play } from "lucide-react";
 import { Button } from "@/ui/button";
 import {
   DropdownMenu,
@@ -99,8 +99,8 @@ function UseDatasetDropdown({
                 size="sm"
                 disabled={disabled || isEmpty}
               >
-                Use {entityName}
-                <ChevronDown className="ml-2 size-4" />
+                <Play className="mr-1.5 size-3.5" />
+                Run in
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-80">

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/UseDatasetDropdown.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/UseDatasetDropdown.tsx
@@ -90,57 +90,66 @@ function UseDatasetDropdown({
           confirmText={`Load ${entityName}`}
         />
       )}
-      <TooltipWrapper content={isEmpty ? `This ${entityName} is empty` : null}>
-        <div>
-          <DropdownMenu>
+      {disabled || isEmpty ? (
+        <TooltipWrapper
+          content={isEmpty ? `This ${entityName} is empty` : "Run in"}
+        >
+          <span className="inline-flex">
+            <Button variant="outline" size="icon-sm" disabled>
+              <Play />
+            </Button>
+          </span>
+        </TooltipWrapper>
+      ) : (
+        <DropdownMenu>
+          <TooltipWrapper content="Run in">
             <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={disabled || isEmpty}
-              >
-                <Play className="mr-1.5 size-3.5" />
-                Run in
+              <Button variant="outline" size="icon-sm">
+                <Play />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-80">
-              {canUsePlayground && (
-                <DropdownMenuItem
-                  onClick={handleOpenPlaygroundClick}
-                  disabled={disabled || isPendingProviderKeys}
-                >
-                  <Blocks className="mr-2 mt-0.5 size-4 shrink-0 self-start" />
-                  <div className="comet-body-s flex flex-col">
-                    <span>Open in Playground</span>
-                    <span className="text-light-slate">
-                      Test prompts over your {entityName} and run evaluations
-                      interactively
-                    </span>
-                  </div>
-                </DropdownMenuItem>
-              )}
-              {canCreateExperiments && (
-                <DropdownMenuItem
-                  onClick={() => {
-                    resetDialogKeyRef.current += 1;
-                    setOpenExperimentDialog(true);
-                  }}
-                  disabled={disabled}
-                >
-                  <Code2 className="mr-2 mt-0.5 size-4 shrink-0 self-start" />
-                  <div className="comet-body-s flex flex-col">
-                    <span>Run an experiment</span>
-                    <span className="text-light-slate">
-                      Use this {entityName} to run an experiment using the
-                      Python SDK
-                    </span>
-                  </div>
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </TooltipWrapper>
+          </TooltipWrapper>
+          <DropdownMenuContent
+            align="end"
+            className="w-80"
+            onCloseAutoFocus={(e) => e.preventDefault()}
+          >
+            {canUsePlayground && (
+              <DropdownMenuItem
+                onClick={handleOpenPlaygroundClick}
+                disabled={disabled || isPendingProviderKeys}
+              >
+                <Blocks className="mr-2 mt-0.5 size-4 shrink-0 self-start" />
+                <div className="comet-body-s flex flex-col">
+                  <span>Open in Playground</span>
+                  <span className="text-light-slate">
+                    Test prompts over your {entityName} and run evaluations
+                    interactively
+                  </span>
+                </div>
+              </DropdownMenuItem>
+            )}
+            {canCreateExperiments && (
+              <DropdownMenuItem
+                onClick={() => {
+                  resetDialogKeyRef.current += 1;
+                  setOpenExperimentDialog(true);
+                }}
+                disabled={disabled}
+              >
+                <Code2 className="mr-2 mt-0.5 size-4 shrink-0 self-start" />
+                <div className="comet-body-s flex flex-col">
+                  <span>Run an experiment</span>
+                  <span className="text-light-slate">
+                    Use this {entityName} to run an experiment using the Python
+                    SDK
+                  </span>
+                </div>
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
     </>
   );
 }

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/VersionForm.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/VersionForm.tsx
@@ -79,6 +79,7 @@ const VersionForm: React.FC<VersionFormProps> = ({
                     )
                   }
                   align="start"
+                  tagVariant="gray"
                 />
               </FormControl>
             </FormItem>

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebarButton.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebarButton.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { ListTree } from "lucide-react";
+import { ArrowUpRight, ListTree } from "lucide-react";
 import {
   BooleanParam,
   JsonParam,
@@ -78,13 +78,10 @@ const TraceLogsSidebarButton: React.FunctionComponent<
           className="flex shrink-0 cursor-pointer items-center gap-1 hover:bg-primary-foreground hover:text-foreground active:bg-primary-100 active:text-foreground"
           onClick={handleOpen}
         >
-          <ListTree
-            className="size-3 shrink-0"
-            style={{ color: "var(--color-green)" }}
-          />
-          <div className="comet-body-s-accented truncate text-muted-slate">
-            Go to logs
+          <div className="comet-body-s-accented truncate text-foreground">
+            Logs
           </div>
+          <ArrowUpRight className="size-3 shrink-0 text-foreground" />
         </Tag>
       </TooltipWrapper>
     );

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebarButton.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebarButton.tsx
@@ -71,19 +71,17 @@ const TraceLogsSidebarButton: React.FunctionComponent<
         </Button>
       </TooltipWrapper>
     ) : (
-      <TooltipWrapper content="Go to logs">
-        <Tag
-          size="md"
-          variant="transparent"
-          className="flex shrink-0 cursor-pointer items-center gap-1 hover:bg-primary-foreground hover:text-foreground active:bg-primary-100 active:text-foreground"
-          onClick={handleOpen}
-        >
-          <div className="comet-body-s-accented truncate text-foreground">
-            Logs
-          </div>
-          <ArrowUpRight className="size-3 shrink-0 text-foreground" />
-        </Tag>
-      </TooltipWrapper>
+      <Tag
+        size="md"
+        variant="transparent"
+        className="flex shrink-0 cursor-pointer items-center gap-1 hover:bg-primary-foreground hover:text-foreground active:bg-primary-100 active:text-foreground"
+        onClick={handleOpen}
+      >
+        <div className="comet-body-s-accented truncate text-foreground">
+          Logs
+        </div>
+        <ArrowUpRight className="size-3 shrink-0 text-foreground" />
+      </Tag>
     );
 
   return (

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/AnnotationQueuePage.tsx
@@ -137,8 +137,9 @@ const AnnotationQueuePage: React.FunctionComponent = () => {
           {annotationQueue?.project_id && (
             <NavigationTag
               id={annotationQueue.project_id}
-              name={`Go to ${annotationQueue.project_name}`}
+              name={annotationQueue.project_name}
               resource={RESOURCE_TYPE.project}
+              prefix="Project"
             />
           )}
           {annotationQueue && (

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
@@ -4,7 +4,6 @@ import slugify from "slugify";
 import uniq from "lodash/uniq";
 import first from "lodash/first";
 
-import CompareExperimentsButton from "@/v2/pages/CompareExperimentsPage/CompareExperimentsButton/CompareExperimentsButton";
 import EvaluateExperimentTracesButton from "@/v2/pages/CompareExperimentsPage/EvaluateExperimentTracesButton/EvaluateExperimentTracesButton";
 import ExportToButton from "@/shared/ExportToButton/ExportToButton";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
@@ -26,7 +25,6 @@ import {
   EXPERIMENT_ITEM_OUTPUT_PREFIX,
   EXPERIMENT_ITEM_DATASET_PREFIX,
 } from "@/constants/experiments";
-import { Separator } from "@/ui/separator";
 
 const COLUMN_PASSED_ID = "passed";
 const COLUMN_TOTAL_ESTIMATED_COST_ID = "total_estimated_cost";
@@ -194,24 +192,20 @@ const CompareExperimentsActionsPanel: React.FC<
 
   return (
     <div className="flex items-center gap-2">
-      <CompareExperimentsButton />
       <EvaluateExperimentTracesButton experiment={singleExperiment} />
       {columnsToExport && (
-        <>
-          <Separator orientation="vertical" className="mx-2 h-4" />
-          <ExportToButton
-            disabled={
-              disabled || columnsToExport.length === 0 || !isExportEnabled
-            }
-            getData={mapRowData}
-            generateFileName={generateFileName}
-            tooltipContent={
-              !isExportEnabled
-                ? "Export functionality is disabled for this installation"
-                : undefined
-            }
-          />
-        </>
+        <ExportToButton
+          disabled={
+            disabled || columnsToExport.length === 0 || !isExportEnabled
+          }
+          getData={mapRowData}
+          generateFileName={generateFileName}
+          tooltipContent={
+            !isExportEnabled
+              ? "Export functionality is disabled for this installation"
+              : undefined
+          }
+        />
       )}
     </div>
   );

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsButton/CompareExperimentsButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsButton/CompareExperimentsButton.tsx
@@ -41,6 +41,12 @@ const CompareExperimentsButton: React.FunctionComponent<
         setOpen={setOpen}
       />
       <div className="inline-flex items-center gap-2">
+        <ExplainerIcon
+          className="-mr-0.5"
+          {...EXPLAINERS_MAP[
+            EXPLAINER_ID.what_does_it_mean_to_compare_my_experiments
+          ]}
+        />
         <TooltipWrapper content={tooltipContent}>
           <Button
             size={size}
@@ -55,12 +61,6 @@ const CompareExperimentsButton: React.FunctionComponent<
             Compare
           </Button>
         </TooltipWrapper>
-        <ExplainerIcon
-          className="-ml-0.5"
-          {...EXPLAINERS_MAP[
-            EXPLAINER_ID.what_does_it_mean_to_compare_my_experiments
-          ]}
-        />
       </div>
     </>
   );

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
@@ -104,7 +104,7 @@ const CompareExperimentsDetails: React.FunctionComponent<
             to="/$workspaceName/projects/$projectId/experiments"
             tooltip="Back to experiments"
           />
-          <h1 className="comet-title-xs truncate break-words">{title}</h1>
+          <h1 className="comet-body-accented truncate break-words">{title}</h1>
         </div>
         <CompareExperimentsButton />
       </div>

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
@@ -84,7 +84,7 @@ const CompareExperimentsDetails: React.FunctionComponent<
         );
 
       return (
-        <div className="flex h-11 items-center gap-2">
+        <div className="mt-1 flex items-center gap-2">
           <span className="text-nowrap">Baseline of</span>
           <ExperimentTag experimentName={experiment?.name} />
           <span className="text-nowrap">compared against</span>
@@ -93,7 +93,7 @@ const CompareExperimentsDetails: React.FunctionComponent<
       );
     }
 
-    return <FeedbackScoresList scores={experimentScores} />;
+    return <FeedbackScoresList className="mt-1" scores={experimentScores} />;
   };
 
   return (
@@ -119,6 +119,7 @@ const CompareExperimentsDetails: React.FunctionComponent<
           <NavigationTag
             id={experiment.dataset_id}
             name={experiment.dataset_name}
+            tooltipContent={false}
             resource={
               isTestSuiteExperiment(experiment)
                 ? RESOURCE_TYPE.testSuite

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useMemo } from "react";
 import sortBy from "lodash/sortBy";
 import isNumber from "lodash/isNumber";
-import { CircleCheck, Database, GitCommitVertical } from "lucide-react";
+import { CircleCheck, GitCommitVertical } from "lucide-react";
 
 import useBreadcrumbsStore from "@/store/BreadcrumbsStore";
+import BackButton from "@/shared/BackButton/BackButton";
+import CompareExperimentsButton from "@/v2/pages/CompareExperimentsPage/CompareExperimentsButton/CompareExperimentsButton";
 import { Experiment } from "@/types/datasets";
 import { Tag } from "@/ui/tag";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
@@ -96,54 +98,52 @@ const CompareExperimentsDetails: React.FunctionComponent<
 
   return (
     <div className="py-4">
-      <div className="mb-4 flex min-h-8 items-center justify-between">
-        <h1 className="comet-title-xs truncate break-words">{title}</h1>
+      <div className="mb-3 flex min-h-8 items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <BackButton
+            to="/$workspaceName/projects/$projectId/experiments"
+            tooltip="Back to experiments"
+          />
+          <h1 className="comet-title-xs truncate break-words">{title}</h1>
+        </div>
+        <CompareExperimentsButton />
       </div>
-      <div className="mb-1 flex gap-2 overflow-x-auto">
+      <div className="mb-1 flex gap-1.5 overflow-x-auto">
         {!isCompare && (
           <DateTag
             date={experiment?.created_at}
             resource={RESOURCE_TYPE.experiment}
           />
         )}
-        {experiment?.dataset_id && (
-          <TooltipWrapper
-            content={[
-              isTestSuiteExperiment(experiment) ? "Test suite" : "Dataset",
-              ": ",
-              experiment.dataset_name || "Deleted",
-              experiment.dataset_version_summary?.version_name
-                ? ` ${experiment.dataset_version_summary.version_name}`
-                : "",
-            ].join("")}
-          >
-            <Tag
-              size="md"
-              variant="transparent"
-              className="flex shrink-0 items-center gap-1"
-            >
-              <Database
-                className="size-3 shrink-0"
-                style={{ color: "var(--color-yellow)" }}
-              />
-              <span className="comet-body-s-accented truncate text-muted-slate">
-                {experiment.dataset_name || "Deleted test suite"}
-              </span>
-              {experiment.dataset_version_summary?.version_name && (
+        {experiment?.dataset_id && experiment?.dataset_name && (
+          <NavigationTag
+            id={experiment.dataset_id}
+            name={experiment.dataset_name}
+            resource={
+              isTestSuiteExperiment(experiment)
+                ? RESOURCE_TYPE.testSuite
+                : RESOURCE_TYPE.dataset
+            }
+            prefix={
+              isTestSuiteExperiment(experiment) ? "Test suite" : "Dataset"
+            }
+            suffix={
+              experiment.dataset_version_summary?.version_name ? (
                 <span className="flex items-center gap-0 pt-px text-xs text-muted-slate">
                   <GitCommitVertical className="size-[10px]" />
                   {experiment.dataset_version_summary.version_name}
                 </span>
-              )}
-            </Tag>
-          </TooltipWrapper>
+              ) : undefined
+            }
+          />
         )}
         {experiment?.prompt_versions &&
           experiment.prompt_versions.length > 0 && (
             <NavigationTag
               id={experiment.prompt_versions[0].prompt_id}
-              name={`Go to ${experiment.prompt_versions[0].prompt_name}`}
+              name={experiment.prompt_versions[0].prompt_name}
               resource={RESOURCE_TYPE.prompt}
+              prefix="Prompt"
             />
           )}
         {experiment?.project_id && (

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
@@ -115,7 +115,7 @@ const CompareExperimentsDetails: React.FunctionComponent<
             resource={RESOURCE_TYPE.experiment}
           />
         )}
-        {experiment?.dataset_id && experiment?.dataset_name && (
+        {experiment?.dataset_id && (
           <NavigationTag
             id={experiment.dataset_id}
             name={experiment.dataset_name}

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPage.tsx
@@ -14,8 +14,6 @@ import useDeepMemo from "@/hooks/useDeepMemo";
 import { Experiment } from "@/types/datasets";
 import { isTestSuiteExperiment } from "@/lib/experiments";
 import CompareExperimentsDetails from "@/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails";
-import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 const CompareExperimentsPage: React.FunctionComponent = () => {
   const [tab = "items", setTab] = useQueryParam("tab", StringParam, {
@@ -80,10 +78,6 @@ const CompareExperimentsPage: React.FunctionComponent = () => {
             {showScoresTab && (
               <TabsTrigger variant="segmented-primary" value="scores">
                 Feedback scores
-                <ExplainerIcon
-                  className="ml-1"
-                  {...EXPLAINERS_MAP[EXPLAINER_ID.what_are_feedback_scores]}
-                />
               </TabsTrigger>
             )}
           </TabsList>

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPage.tsx
@@ -65,20 +65,20 @@ const CompareExperimentsPage: React.FunctionComponent = () => {
         className="min-w-min"
       >
         <PageBodyStickyContainer direction="horizontal" limitWidth>
-          <TabsList variant="underline">
-            <TabsTrigger variant="underline" value="items">
-              Experiment items
+          <TabsList variant="segmented-primary">
+            <TabsTrigger variant="segmented-primary" value="items">
+              Results
             </TabsTrigger>
             {!isTestSuite && (
-              <TabsTrigger variant="underline" value="insights">
+              <TabsTrigger variant="segmented-primary" value="insights">
                 Insights
               </TabsTrigger>
             )}
-            <TabsTrigger variant="underline" value="config">
+            <TabsTrigger variant="segmented-primary" value="config">
               Configuration
             </TabsTrigger>
             {showScoresTab && (
-              <TabsTrigger variant="underline" value="scores">
+              <TabsTrigger variant="segmented-primary" value="scores">
                 Feedback scores
                 <ExplainerIcon
                   className="ml-1"

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
@@ -19,7 +19,6 @@ import CompareExperimentsConfigCell, {
 } from "@/v2/pages-shared/experiments/CompareExperimentsConfigCell/CompareExperimentsConfigCell";
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
 import PageBodyStickyTableWrapper from "@/v2/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
-import ExplainerCallout from "@/shared/ExplainerCallout/ExplainerCallout";
 import { convertColumnDataToColumn } from "@/lib/table";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import NavigationTag from "@/shared/NavigationTag";
@@ -29,7 +28,6 @@ import { formatPromptVersionLabel } from "@/lib/experiments";
 import { Switch } from "@/ui/switch";
 import { Label } from "@/ui/label";
 import { Separator } from "@/ui/separator";
-import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 
 const COLUMNS_WIDTH_KEY = "compare-experiments-config-columns-width";
 
@@ -170,12 +168,6 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
 
   return (
     <>
-      <PageBodyStickyContainer direction="horizontal" limitWidth>
-        <ExplainerCallout
-          className="mb-4"
-          {...EXPLAINERS_MAP[EXPLAINER_ID.whats_the_experiment_configuration]}
-        />
-      </PageBodyStickyContainer>
       <PageBodyStickyContainer
         className="-mt-4 flex flex-wrap items-center justify-between gap-x-8 gap-y-2 pb-6 pt-4"
         direction="bidirectional"

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentFeedbackScoresTab/ExperimentFeedbackScoresTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentFeedbackScoresTab/ExperimentFeedbackScoresTab.tsx
@@ -215,15 +215,6 @@ const ExperimentFeedbackScoresTab: React.FunctionComponent<
 
   return (
     <>
-      <PageBodyStickyContainer
-        className="-mt-4 flex items-center justify-end gap-8 pb-6 pt-4"
-        direction="bidirectional"
-        limitWidth
-      >
-        <div className="flex items-center gap-2">
-          <CompareExperimentsActionsPanel />
-        </div>
-      </PageBodyStickyContainer>
       <DataTable
         columns={columns}
         data={rows}

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentFeedbackScoresTab/ExperimentFeedbackScoresTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentFeedbackScoresTab/ExperimentFeedbackScoresTab.tsx
@@ -17,7 +17,6 @@ import DataTableNoData from "@/shared/DataTableNoData/DataTableNoData";
 import TextCell from "@/shared/DataTableCells/TextCell";
 import FeedbackScoreNameCell from "@/shared/DataTableCells/FeedbackScoreNameCell";
 import CompareExperimentsHeader from "@/v2/pages-shared/experiments/CompareExperimentsHeader/CompareExperimentsHeader";
-import CompareExperimentsActionsPanel from "@/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel";
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
 import PageBodyStickyTableWrapper from "@/v2/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
 import { convertColumnDataToColumn } from "@/lib/table";

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentInsightsTab/ExperimentInsightsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentInsightsTab/ExperimentInsightsTab.tsx
@@ -13,8 +13,6 @@ import {
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
 import { EXPERIMENT_COMPARISON_TEMPLATE } from "@/lib/dashboard/templates";
 import { DASHBOARD_TYPE } from "@/types/dashboard";
-import CompareExperimentsButton from "@/v2/pages/CompareExperimentsPage/CompareExperimentsButton/CompareExperimentsButton";
-import { Separator } from "@/ui/separator";
 import { cn } from "@/lib/utils";
 
 interface ExperimentInsightsTabProps {
@@ -79,11 +77,6 @@ const ExperimentInsightsTab: React.FunctionComponent<
         </div>
 
         <div className="flex shrink-0 items-center gap-2">
-          <CompareExperimentsButton
-            variant="outline"
-            tooltipContent="Select experiments to compare"
-          />
-          <Separator orientation="vertical" className="mx-2 h-4" />
           <ShareDashboardButton />
         </div>
       </PageBodyStickyContainer>

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -39,7 +39,6 @@ import CompareExperimentsNameCell from "@/v2/pages-shared/experiments/CompareExp
 import CompareExperimentsNameHeader from "@/v2/pages-shared/experiments/CompareExperimentsNameHeader/CompareExperimentsNameHeader";
 import ColumnsButton from "@/shared/ColumnsButton/ColumnsButton";
 import FiltersButton from "@/shared/FiltersButton/FiltersButton";
-import ExplainerCallout from "@/shared/ExplainerCallout/ExplainerCallout";
 import useAppStore from "@/store/AppStore";
 import { Experiment, ExperimentsCompare } from "@/types/datasets";
 import { useDatasetIdFromCompareExperimentsURL } from "@/v2/pages/CompareExperimentsPage/useDatasetIdFromCompareExperimentsURL";
@@ -654,12 +653,6 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
 
   return (
     <>
-      <PageBodyStickyContainer direction="horizontal" limitWidth>
-        <ExplainerCallout
-          className="mb-4"
-          {...EXPLAINERS_MAP[EXPLAINER_ID.what_are_experiment_items]}
-        />
-      </PageBodyStickyContainer>
       <PageBodyStickyContainer
         className="-mt-4 flex flex-wrap items-center justify-between gap-x-8 gap-y-2 pb-6 pt-4"
         direction="bidirectional"

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentTagsList.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentTagsList.tsx
@@ -42,7 +42,7 @@ const ExperimentTagsList: React.FC<ExperimentTagsListProps> = ({
       onAddTag={handleAddTag}
       onDeleteTag={handleDeleteTag}
       align="start"
-      className={cn("min-h-7", className)}
+      className={cn("[&>:first-child]:-mr-1", className)}
       tagVariant="purple"
     />
   );

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentTagsList.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentTagsList.tsx
@@ -1,6 +1,7 @@
 import TagListRenderer from "@/shared/TagListRenderer/TagListRenderer";
 import useExperimentUpdateMutation from "@/api/datasets/useExperimentUpdate";
 import { Experiment } from "@/types/datasets";
+import { cn } from "@/lib/utils";
 
 type ExperimentTagsListProps = {
   tags: string[];
@@ -41,7 +42,8 @@ const ExperimentTagsList: React.FC<ExperimentTagsListProps> = ({
       onAddTag={handleAddTag}
       onDeleteTag={handleDeleteTag}
       align="start"
-      className={className}
+      className={cn("min-h-7", className)}
+      tagVariant="purple"
     />
   );
 };

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationHeader.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationHeader.tsx
@@ -77,8 +77,9 @@ const OptimizationHeader: React.FC<OptimizationHeaderProps> = ({
         {optimization?.dataset_id && optimization?.dataset_name && (
           <NavigationTag
             id={optimization.dataset_id}
-            name={`Go to ${optimization.dataset_name}`}
+            name={optimization.dataset_name}
             resource={RESOURCE_TYPE.dataset}
+            prefix="Dataset"
             className="w-fit"
           />
         )}

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptPage.tsx
@@ -1,6 +1,4 @@
 import React, { useEffect } from "react";
-import { ArrowLeft, History } from "lucide-react";
-import { Link } from "@tanstack/react-router";
 import { StringParam, useQueryParam } from "use-query-params";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/ui/tabs";
@@ -10,13 +8,13 @@ import usePromptById from "@/api/prompts/usePromptById";
 import PromptTab from "@/v2/pages/PromptPage/PromptTab/PromptTab";
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
-import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import BackButton from "@/shared/BackButton/BackButton";
+import DateTag from "@/shared/DateTag/DateTag";
+import { RESOURCE_TYPE } from "@/shared/ResourceLink/ResourceLink";
 import PromptTagsList from "@/v2/pages/PromptPage/PromptTagsList";
 import { Separator } from "@/ui/separator";
 import PageBodyScrollContainer from "@/v2/layout/PageBodyScrollContainer/PageBodyScrollContainer";
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
-import useAppStore, { useActiveProjectId } from "@/store/AppStore";
-import { formatDate } from "@/lib/date";
 import { usePermissions } from "@/contexts/PermissionsContext";
 import ExperimentsTab from "./ExperimentsTab/ExperimentsTab";
 
@@ -28,8 +26,6 @@ const PromptPage: React.FunctionComponent = () => {
   } = usePermissions();
 
   const promptId = usePromptIdFromURL();
-  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
-  const activeProjectId = useActiveProjectId();
 
   const { data: prompt } = usePromptById({ promptId }, { enabled: !!promptId });
   const promptName = prompt?.name || "";
@@ -54,15 +50,10 @@ const PromptPage: React.FunctionComponent = () => {
         direction="horizontal"
       >
         <div className="flex min-w-0 items-center gap-2">
-          <TooltipWrapper content="Back to prompts">
-            <Link
-              to="/$workspaceName/projects/$projectId/prompts"
-              params={{ workspaceName, projectId: activeProjectId! }}
-              className="flex size-6 shrink-0 items-center justify-center rounded-md text-foreground hover:bg-primary-foreground"
-            >
-              <ArrowLeft className="size-4" />
-            </Link>
-          </TooltipWrapper>
+          <BackButton
+            to="/$workspaceName/projects/$projectId/prompts"
+            tooltip="Back to prompts"
+          />
           <h1 className="comet-title-xs truncate break-words">{promptName}</h1>
         </div>
       </PageBodyStickyContainer>
@@ -83,12 +74,7 @@ const PromptPage: React.FunctionComponent = () => {
       >
         <div className="flex items-center overflow-x-auto">
           {prompt?.created_at && (
-            <TooltipWrapper content="Prompt creation time">
-              <div className="comet-body-s flex shrink-0 items-center gap-1.5 text-muted-slate">
-                <History className="size-3.5 shrink-0" />
-                <span>{formatDate(prompt.created_at)}</span>
-              </div>
-            </TooltipWrapper>
+            <DateTag date={prompt.created_at} resource={RESOURCE_TYPE.prompt} />
           )}
           <Separator orientation="vertical" className="mx-2 h-4" />
           <PromptTagsList

--- a/apps/opik-frontend/src/v2/pages/TrialPage/TrialDetails/TrialDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages/TrialPage/TrialDetails/TrialDetails.tsx
@@ -83,15 +83,16 @@ const TrialDetails: React.FC<TrialDetailsProps> = ({
       </div>
       <div className="mb-1 flex gap-2 overflow-x-auto">
         <DateTag date={experiment?.created_at} resource={RESOURCE_TYPE.trial} />
-        {canViewDatasets && (
-          <NavigationTag
-            id={experiment?.dataset_id}
-            name={
-              experiment?.dataset_name && `Go to ${experiment.dataset_name}`
-            }
-            resource={RESOURCE_TYPE.dataset}
-          />
-        )}
+        {canViewDatasets &&
+          experiment?.dataset_id &&
+          experiment?.dataset_name && (
+            <NavigationTag
+              id={experiment.dataset_id}
+              name={experiment.dataset_name}
+              resource={RESOURCE_TYPE.dataset}
+              prefix="Dataset"
+            />
+          )}
         {experiment?.project_id && (
           <TraceLogsSidebarButton
             projectId={experiment.project_id}


### PR DESCRIPTION
## Details

Revamp the top sections of the three child detail pages per OPIK-6639: a back action, primary actions moved into the header, restyled metadata row, and aligned copy.

- **Experiment details:** back action; `Compare` moved to the header; "Experiment items" → **Results** tab (`segmented-primary`); redesigned resource chips (trailing ↗ + prefix); "Logs ↗" chip; purple header tags.
- **Dataset & test-suite details:** back action; **Records** / **Test cases** tabs; primary actions in the header (`Expand with AI`, `Run in`, `Record`/`Test case`); restyled metadata chips (gray-dot version pill, bordered global-assertions pill); green dataset tags, gray version tags; **tags moved to their own row** (the inline layout didn't wrap correctly with many tags / on narrow screens).
- **Naming:** the item unit is now "record" (datasets) / "test case" (test suites) across the add/edit/delete dialogs, the kebab menu, and the empty state.
- A few **shared components** were touched (`ResourceLink`/`NavigationTag` chips, `DateTag`, the Logs chip, `Tag` md size) — worth sanity-checking their other usages.

Continuation of #6975 (closed — couldn't be reopened after a rebase rewrote its history).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-6639

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: assisted (iterative implementation under direction, Figma-verified)
- Human verification: code review + manual testing in the local dev app

## Testing

- `tsc --noEmit` clean; eslint clean on changed files.
- Manually verified all three headers in the dev app: back actions, tab labels + style, header action buttons, the metadata chips, the tags row, and the add flow (header button + empty-state CTA, including the guided dialog on empty datasets) — for both datasets and test suites.
- Pixel-checked chip colors/sizes + tabs against Figma.
- ⚠️ Pending UX/UI sign-off — please hold off on approving/merging until design approves.

## Documentation

N/A