### PR TITLE
[OPIK-7089] [CI] fix: increase timeout for Test Suites page heading wait in visual tests

### DIFF
--- a/tests_end_to_end/visual-tests/page-objects/logs.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/logs.page.ts
@@ -33,7 +33,7 @@ export class LogsPage extends BasePage {
   }
 
   async waitForEmptyTraces(): Promise<void> {
-    await this.page.getByRole('radio', { name: 'Traces' }).waitFor({ state: 'visible', timeout: 10000 });
+    await this.page.getByRole('radio', { name: 'Thraces' }).waitFor({ state: 'visible', timeout: 10000 });
     await this.page.getByRole('heading', { name: /no traces yet/i }).waitFor({ state: 'visible', timeout: 20000 });
   }
 

--- a/tests_end_to_end/visual-tests/page-objects/logs.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/logs.page.ts
@@ -33,7 +33,7 @@ export class LogsPage extends BasePage {
   }
 
   async waitForEmptyTraces(): Promise<void> {
-    await this.page.getByRole('radio', { name: 'Thraces' }).waitFor({ state: 'visible', timeout: 10000 });
+    await this.page.getByRole('radio', { name: 'Traces' }).waitFor({ state: 'visible', timeout: 10000 });
     await this.page.getByRole('heading', { name: /no traces yet/i }).waitFor({ state: 'visible', timeout: 20000 });
   }
 

--- a/tests_end_to_end/visual-tests/page-objects/test-suites.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/test-suites.page.ts
@@ -13,7 +13,7 @@ export class TestSuitesPage extends BasePage {
   }
 
   async waitForReady(expectedCellText: string): Promise<void> {
-    await this.page.getByRole('heading', { name: 'Test suites', exact: true }).waitFor({ state: 'visible', timeout: 10000 });
+    await this.page.getByRole('heading', { name: 'Test suites', exact: true }).waitFor({ state: 'visible', timeout: 30000 });
     await Promise.race([
       this.page.locator('tbody tr td').filter({ hasText: expectedCellText }).first().waitFor({ state: 'visible', timeout: 10000 }),
       this.page.getByRole('heading', { name: /no test suites yet/i }).waitFor({ state: 'visible', timeout: 8000 }),
@@ -21,7 +21,7 @@ export class TestSuitesPage extends BasePage {
   }
 
   async waitForEmpty(): Promise<void> {
-    await this.page.getByRole('heading', { name: 'Test suites', exact: true }).waitFor({ state: 'visible', timeout: 10000 });
+    await this.page.getByRole('heading', { name: 'Test suites', exact: true }).waitFor({ state: 'visible', timeout: 30000 });
     await this.page.getByRole('heading', { name: /no test suites yet/i }).waitFor({ state: 'visible', timeout: 20000 });
   }
 }


### PR DESCRIPTION
## Details
Increases the `waitFor` timeout on the \"Test suites\" heading from 10 s to 30 s in the visual-test page object (`test-suites.page.ts`). The previous 10 s limit caused intermittent failures in CI when the page took longer to render under load.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7089

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-sonnet-4-6
  - Scope: assisted (commit generation + PR creation)
  - Human verification: code review

## Testing
Timeout value adjusted in the page object; no new test logic. The change prevents flaky CI failures where the heading appeared after the original 10 s window.

## Documentation
N/A