### PR TITLE
[OPIK-7135] [GHA] fix: dedup docs-preview broken-link report by URL

### DIFF
--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
         - 'apps/opik-documentation/documentation/**'
+        - '.github/workflows/documentation_preview_link.yml'
 
 
 concurrency:
@@ -39,10 +40,17 @@ jobs:
               working-directory: apps/opik-documentation/documentation
               run: |
                 echo -e "\n\n" >> preview_url.txt
-                
+
                 # Use JSON output for reliable parsing (CSV breaks with URLs containing commas/brackets)
+                # --concurrency 500: the preview CDN serves bursts without rate-limiting
+                # (no 429s observed), and the recurse over thousands of pages otherwise
+                # brushes the job's 15-minute timeout. Higher concurrency shortens the crawl.
+                # linkinator exits non-zero both when it finds broken links AND when it
+                # crashes mid-crawl (e.g. an unhandled ECONNRESET on a response stream),
+                # so the exit code alone can't be trusted — we validate the JSON below.
                 npx linkinator ${{ steps.generate-docs.outputs.URL }} \
                   --recurse \
+                  --concurrency 500 \
                   --skip "search\/v2\/key" \
                   --skip "https://ai.google.dev/gemini-api" \
                   --skip "https://ai.google.dev/aistudio" \
@@ -52,20 +60,65 @@ jobs:
                   --skip "googletagmanager.com" \
                   --skip "insights/script.js" \
                   --format json > linkinator_results.json || true
-                
-                # Parse JSON and filter broken links (excluding 403s)
-                BROKEN_LINKS=$(jq -r '
-                  .links[]
-                  | select(.state != "OK" and .status != 403)
-                  | "Page: \(.parent)\n❌ Broken link: \(.url) (\(.status))\n"
+
+                # A crashed crawl leaves missing/truncated output. Don't trust it: if the
+                # result isn't valid JSON with a .links array, the crawl crashed/timed out.
+                # Post a warning AND fail the check (via the flag) so the red status forces
+                # a re-run rather than silently posting "No broken links found".
+                if ! jq -e 'type == "object" and (.links | type == "array")' linkinator_results.json > /dev/null 2>&1; then
+                  {
+                    echo "⚠️ The link check did not complete (linkinator produced no usable results — likely a crawl crash or timeout). Please re-run this check."
+                    echo ""
+                    echo "---"
+                    echo "📌 Results for commit ${{ github.sha }}"
+                  } >> preview_url.txt
+                  echo "true" > check_failed.flag
+                  exit 0
+                fi
+
+                # The preview host is ephemeral (torn down after the run), so strip it
+                # from the "on page" pointer — the stable relative doc path is what you
+                # grep for to find the source .mdx to fix.
+                PREVIEW_ORIGIN=$(echo "${{ steps.generate-docs.outputs.URL }}" | grep -oE '^https?://[^/]+')
+
+                # Parse JSON and filter broken links (excluding 403s).
+                # Dedup by URL: a single broken page linked from the sidebar can
+                # appear on hundreds of parent pages, which previously multiplied
+                # the report past GitHub's 65,536-char comment limit.
+                # Status 0 (crawl timeout/abort) is handled separately below — it
+                # is not an HTTP error, just "linkinator gave up mid-crawl", which
+                # produces false positives for healthy-but-slow pages.
+                BROKEN_LINKS=$(jq -r --arg origin "$PREVIEW_ORIGIN" '
+                  [.links[] | select(.state != "OK" and .status != 403 and .status != 0)]
+                  | group_by(.url)
+                  | map(.[0])
+                  | .[]
+                  | "❌ Broken link: \(.url) (\(.status))\n   ↳ on page: \((.parent // "") | sub("^" + $origin; ""))"
                 ' linkinator_results.json)
-                
+
+                # Re-verify each unique status-0 URL with a direct request: many are
+                # transient crawl timeouts on healthy pages (return 200 on recheck).
+                # Keep only those that are genuinely unreachable (non-2xx/3xx).
+                while IFS= read -r url; do
+                  [ -z "$url" ] && continue
+                  code=$(curl -s -L -o /dev/null -w "%{http_code}" --max-time 20 "$url" 2>/dev/null)
+                  [ -z "$code" ] && code=000
+                  if [ "$code" -lt 200 ] || [ "$code" -ge 400 ]; then
+                    parent=$(jq -r --arg u "$url" --arg origin "$PREVIEW_ORIGIN" '(first(.links[] | select(.url == $u)).parent // "") | sub("^" + $origin; "")' linkinator_results.json)
+                    entry=$(printf '❌ Broken link: %s (timeout, recheck %s)\n   ↳ on page: %s' "$url" "$code" "$parent")
+                    BROKEN_LINKS=$(printf '%s\n%s' "$BROKEN_LINKS" "$entry")
+                  fi
+                done <<< "$(jq -r '[.links[] | select(.status == 0) | .url] | unique | .[]' linkinator_results.json)"
+
                 if [ -n "$BROKEN_LINKS" ]; then
                   {
                     echo "**The following broken links were found:**"
                     echo ""
                     echo "$BROKEN_LINKS"
                   } >> preview_url.txt
+                  # Record the failure so the job goes red AFTER the comment is posted,
+                  # so reviewers see the list and the check blocks until the links are fixed.
+                  echo "true" > check_failed.flag
                 else
                   echo "No broken links found" >> preview_url.txt
                 fi
@@ -79,7 +132,17 @@ jobs:
                 } >> preview_url.txt
 
             - name: Comment URL in PR
+              if: always()
               uses: thollander/actions-comment-pull-request@v3
               with:
                   file-path: apps/opik-documentation/documentation/preview_url.txt
                   comment-tag: docs-preview
+
+            - name: Fail if the link check failed
+              if: always()
+              working-directory: apps/opik-documentation/documentation
+              run: |
+                if [ -f check_failed.flag ]; then
+                  echo "Link check failed — broken links were found, or the crawl did not complete. See the PR comment."
+                  exit 1
+                fi

--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -41,13 +41,8 @@ jobs:
               run: |
                 echo -e "\n\n" >> preview_url.txt
 
-                # Use JSON output for reliable parsing (CSV breaks with URLs containing commas/brackets)
-                # --concurrency 500: the preview CDN serves bursts without rate-limiting
-                # (no 429s observed), and the recurse over thousands of pages otherwise
-                # brushes the job's 15-minute timeout. Higher concurrency shortens the crawl.
-                # linkinator exits non-zero both when it finds broken links AND when it
-                # crashes mid-crawl (e.g. an unhandled ECONNRESET on a response stream),
-                # so the exit code alone can't be trusted — we validate the JSON below.
+                # --concurrency 500: the preview CDN serves bursts without rate-limiting;
+                # the recurse otherwise brushes the job's 15-minute timeout.
                 npx linkinator ${{ steps.generate-docs.outputs.URL }} \
                   --recurse \
                   --concurrency 500 \
@@ -61,13 +56,14 @@ jobs:
                   --skip "insights/script.js" \
                   --format json > linkinator_results.json || true
 
-                # A crashed crawl leaves missing/truncated output. Don't trust it: if the
-                # result isn't valid JSON with a .links array, the crawl crashed/timed out.
-                # Post a warning AND fail the check (via the flag) so the red status forces
-                # a re-run rather than silently posting "No broken links found".
+                PREVIEW_ORIGIN=$(echo "${{ steps.generate-docs.outputs.URL }}" | grep -oE '^https?://[^/]+')
+
+                # linkinator exits non-zero both when it finds broken links and when it
+                # crashes mid-crawl (e.g. unhandled ECONNRESET), so trust the output, not
+                # the exit code: invalid/missing JSON means the crawl didn't complete.
                 if ! jq -e 'type == "object" and (.links | type == "array")' linkinator_results.json > /dev/null 2>&1; then
                   {
-                    echo "⚠️ The link check did not complete (linkinator produced no usable results — likely a crawl crash or timeout). Please re-run this check."
+                    echo "⚠️ The link check did not complete (likely a crawl crash or timeout). Please re-run this check."
                     echo ""
                     echo "---"
                     echo "📌 Results for commit ${{ github.sha }}"
@@ -76,54 +72,41 @@ jobs:
                   exit 0
                 fi
 
-                # The preview host is ephemeral (torn down after the run), so strip it
-                # from the "on page" pointer — the stable relative doc path is what you
-                # grep for to find the source .mdx to fix.
-                PREVIEW_ORIGIN=$(echo "${{ steps.generate-docs.outputs.URL }}" | grep -oE '^https?://[^/]+')
+                # `↳ on page` strips the ephemeral preview host, leaving a stable,
+                # greppable doc path. Append one report entry for a status-0 url whose
+                # recheck label is computed by the caller.
+                report_timeout() {
+                  local url=$1 label=$2 parent
+                  parent=$(jq -r --arg u "$url" --arg origin "$PREVIEW_ORIGIN" \
+                    '(first(.links[] | select(.url == $u)).parent // "") | sub("^" + $origin; "")' linkinator_results.json)
+                  BROKEN_LINKS=$(printf '%s\n❌ Broken link: %s (%s)\n   ↳ on page: %s' "$BROKEN_LINKS" "$url" "$label" "$parent")
+                }
 
-                # Parse JSON and filter broken links (excluding 403s).
-                # Dedup by URL: a single broken page linked from the sidebar can
-                # appear on hundreds of parent pages, which previously multiplied
-                # the report past GitHub's 65,536-char comment limit.
-                # Status 0 (crawl timeout/abort) is handled separately below — it
-                # is not an HTTP error, just "linkinator gave up mid-crawl", which
-                # produces false positives for healthy-but-slow pages.
+                # Real HTTP errors (excluding 403s), deduped by url — one broken sidebar
+                # link otherwise multiplies into hundreds of lines and overflows GitHub's
+                # 65,536-char comment limit.
                 BROKEN_LINKS=$(jq -r --arg origin "$PREVIEW_ORIGIN" '
                   [.links[] | select(.state != "OK" and .status != 403 and .status != 0)]
-                  | group_by(.url)
-                  | map(.[0])
-                  | .[]
+                  | group_by(.url) | map(.[0]) | .[]
                   | "❌ Broken link: \(.url) (\(.status))\n   ↳ on page: \((.parent // "") | sub("^" + $origin; ""))"
                 ' linkinator_results.json)
 
-                # Re-verify each unique status-0 URL with a direct request: many are
-                # transient crawl timeouts on healthy pages (return 200 on recheck).
-                # Keep only those that are genuinely unreachable (non-2xx/3xx).
-                #
-                # Only re-check URLs on the preview origin: the false positives we are
-                # filtering are preview pages that timed out mid-crawl, and restricting
-                # the curl target to the trusted preview host avoids issuing requests to
-                # arbitrary PR-authored URLs (SSRF). A status-0 URL off the preview origin
-                # is reported as-is without a recheck.
+                # Status 0 is "crawl gave up", not an HTTP error — a false positive for
+                # healthy-but-slow pages. Re-check each (only on the preview origin, so a
+                # PR-authored link can't point curl at an arbitrary host) and keep it only
+                # if genuinely unreachable.
                 while IFS= read -r url; do
                   [ -z "$url" ] && continue
                   case "$url" in
-                    "$PREVIEW_ORIGIN"/*|"$PREVIEW_ORIGIN") ;;
+                    "$PREVIEW_ORIGIN"/*|"$PREVIEW_ORIGIN")
+                      code=$(curl -s -L -o /dev/null -w "%{http_code}" --max-time 20 "$url" 2>/dev/null)
+                      { [ -n "$code" ] && [ "$code" -ge 200 ] && [ "$code" -lt 400 ]; } && continue
+                      report_timeout "$url" "timeout, recheck ${code:-000}"
+                      ;;
                     *)
-                      # Off-origin: don't curl it, report it as a timeout as crawled.
-                      parent=$(jq -r --arg u "$url" --arg origin "$PREVIEW_ORIGIN" '(first(.links[] | select(.url == $u)).parent // "") | sub("^" + $origin; "")' linkinator_results.json)
-                      entry=$(printf '❌ Broken link: %s (timeout)\n   ↳ on page: %s' "$url" "$parent")
-                      BROKEN_LINKS=$(printf '%s\n%s' "$BROKEN_LINKS" "$entry")
-                      continue
+                      report_timeout "$url" "timeout"
                       ;;
                   esac
-                  code=$(curl -s -L -o /dev/null -w "%{http_code}" --max-time 20 "$url" 2>/dev/null)
-                  [ -z "$code" ] && code=000
-                  if [ "$code" -lt 200 ] || [ "$code" -ge 400 ]; then
-                    parent=$(jq -r --arg u "$url" --arg origin "$PREVIEW_ORIGIN" '(first(.links[] | select(.url == $u)).parent // "") | sub("^" + $origin; "")' linkinator_results.json)
-                    entry=$(printf '❌ Broken link: %s (timeout, recheck %s)\n   ↳ on page: %s' "$url" "$code" "$parent")
-                    BROKEN_LINKS=$(printf '%s\n%s' "$BROKEN_LINKS" "$entry")
-                  fi
                 done <<< "$(jq -r '[.links[] | select(.status == 0) | .url] | unique | .[]' linkinator_results.json)"
 
                 if [ -n "$BROKEN_LINKS" ]; then
@@ -132,8 +115,7 @@ jobs:
                     echo ""
                     echo "$BROKEN_LINKS"
                   } >> preview_url.txt
-                  # Record the failure so the job goes red AFTER the comment is posted,
-                  # so reviewers see the list and the check blocks until the links are fixed.
+                  # Fail the job AFTER the comment is posted (see the Fail step below).
                   echo "true" > check_failed.flag
                 else
                   echo "No broken links found" >> preview_url.txt

--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -99,8 +99,24 @@ jobs:
                 # Re-verify each unique status-0 URL with a direct request: many are
                 # transient crawl timeouts on healthy pages (return 200 on recheck).
                 # Keep only those that are genuinely unreachable (non-2xx/3xx).
+                #
+                # Only re-check URLs on the preview origin: the false positives we are
+                # filtering are preview pages that timed out mid-crawl, and restricting
+                # the curl target to the trusted preview host avoids issuing requests to
+                # arbitrary PR-authored URLs (SSRF). A status-0 URL off the preview origin
+                # is reported as-is without a recheck.
                 while IFS= read -r url; do
                   [ -z "$url" ] && continue
+                  case "$url" in
+                    "$PREVIEW_ORIGIN"/*|"$PREVIEW_ORIGIN") ;;
+                    *)
+                      # Off-origin: don't curl it, report it as a timeout as crawled.
+                      parent=$(jq -r --arg u "$url" --arg origin "$PREVIEW_ORIGIN" '(first(.links[] | select(.url == $u)).parent // "") | sub("^" + $origin; "")' linkinator_results.json)
+                      entry=$(printf '❌ Broken link: %s (timeout)\n   ↳ on page: %s' "$url" "$parent")
+                      BROKEN_LINKS=$(printf '%s\n%s' "$BROKEN_LINKS" "$entry")
+                      continue
+                      ;;
+                  esac
                   code=$(curl -s -L -o /dev/null -w "%{http_code}" --max-time 20 "$url" 2>/dev/null)
                   [ -z "$code" ] && code=000
                   if [ "$code" -lt 200 ] || [ "$code" -ge 400 ]; then


### PR DESCRIPTION
## Details

<img width="813" height="774" alt="image" src="https://github.com/user-attachments/assets/abf5328f-a298-471c-883a-16dbe75c806e" />

The `Docs - Preview link` workflow had several flaky / low-signal failure modes. This PR de-flakes the broken-link check and makes its result trustworthy.

- **Dedup the report by URL.** It built one comment line per *(parent page, broken url)* pair with no deduplication. A broken URL linked from the API sidebar appears on hundreds of pages, so a handful of unique broken URLs became thousands of report lines (observed ~937KB), overflowing GitHub's 65,536-char comment limit. Now deduped with `group_by(.url)` — each broken link appears once, with its status and one example page.
- **Re-verify `status: 0` (crawl timeouts), not report them blindly.** linkinator's `status: 0` is "I gave up mid-crawl", not an HTTP error — healthy-but-slow pages produced false-positive "broken" entries. Each unique `status: 0` URL is now re-checked with a direct request and kept only if genuinely unreachable.
- **Scope the recheck to the preview origin (SSRF).** The `status: 0` recheck only curls URLs on the preview origin, so a PR-authored link can't direct curl at an arbitrary internal/external host; off-origin status-0 URLs are reported as crawled without a recheck.
- **Guard against a crashed crawl.** linkinator can die mid-`--recurse` on an unhandled stream error (e.g. `ECONNRESET`), leaving missing/truncated output that the old `|| true` swallowed into a false "no broken links found". The JSON is now validated; if unusable, the check posts a "did not complete" comment and fails.
- **Fail the check (red) on real broken links or an incomplete crawl.** The comment (list of broken links, or the "did not complete" notice) is posted first, then the job fails — so the red status is actionable (points at a visible list) and forces a fix or re-run instead of being silently green.
- **Stable "on page" pointer.** The ephemeral preview host is stripped from the parent, leaving the relative doc path (greppable to the source `.mdx`).
- **`--concurrency 500`.** The preview CDN serves bursts without rate-limiting (no 429s observed across crawls); the recurse over thousands of pages otherwise brushes the job's 15-minute timeout.
- Workflow now triggers on changes to its own file, so this PR exercises the check end-to-end.

> **Expected red check on this PR:** the docs-preview check will fail red here — by design. The crawl surfaces genuine *pre-existing* doc 404s (external link rot on `ai-sdk.dev`/`sdk.vercel.ai`, an `mcp-server` page not published to the live site, and 3 changelog `canonical-url` entries using a hyphenated date that doesn't match the served route). These are not regressions from this PR (it touches no `.mdx`); they are tracked separately in OPIK_7136. The red is the new fail-on-broken-links behavior working correctly.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7135
- Follow-up (doc content): the genuine 404s surfaced by the check are tracked in OPIK_7136 — not fixed here to keep this PR scoped to the check infrastructure.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: code review + local crawl reproduction (real preview crawls, ~9.4k links) + jq/curl/actionlint validation

## Testing

- Reproduced the crawl locally against a live Fern preview (multiple runs, 5,187–9,429 links): confirmed the dedup collapses thousands of raw broken entries (~937KB) into a ~2KB comment, well under GitHub's limit.
- Verified the `status: 0` re-check on real data: transient-timeout preview pages return 200 on recheck and are dropped; off-origin status-0 URLs are reported without a curl (SSRF scope).
- Confirmed each reported genuine 404 with direct `curl` / browser (404 stays 404; the `status: 0` false positives return 200).
- Concurrency sweep (100/200/500) showed no 429s at any level; 500 keeps the crawl bounded.
- `actionlint` clean (also runs in the pre-commit hook); validated the JSON crash-guard against empty / truncated / valid-empty / valid-real inputs.

## Documentation

N/A — CI workflow change only.
