### PR TITLE
fix: isolate ADK tracer model output per invocation_id

### DIFF
--- a/sdks/python/src/opik/integrations/adk/helpers.py
+++ b/sdks/python/src/opik/integrations/adk/helpers.py
@@ -34,6 +34,28 @@ def get_adk_provider() -> opik_types.LLMProvider:
     )
 
 
+def drop_invocation_output_if_finished(
+    open_agents: Dict[str, int],
+    last_model_output: Dict[str, Any],
+    invocation_id: str,
+) -> None:
+    """Decrement the open-agent count for ``invocation_id`` and, once the
+    invocation's outermost agent has finished (the count reaches zero), drop its
+    cached model output.
+
+    A single tracer instance is shared across concurrent invocations, so the
+    cached output is keyed by ``invocation_id``. Counting open agents (rather
+    than keying cleanup off span-vs-trace) keeps it correct under
+    ``distributed_headers``, where the root agent is itself a span.
+    """
+    remaining = open_agents.get(invocation_id, 1) - 1
+    if remaining > 0:
+        open_agents[invocation_id] = remaining
+    else:
+        open_agents.pop(invocation_id, None)
+        last_model_output.pop(invocation_id, None)
+
+
 def has_empty_text_part_content(llm_response: LlmResponse) -> bool:
     try:
         if llm_response.content is None:

--- a/sdks/python/src/opik/integrations/adk/helpers.py
+++ b/sdks/python/src/opik/integrations/adk/helpers.py
@@ -34,28 +34,6 @@ def get_adk_provider() -> opik_types.LLMProvider:
     )
 
 
-def drop_invocation_output_if_finished(
-    open_agents: Dict[str, int],
-    last_model_output: Dict[str, Any],
-    invocation_id: str,
-) -> None:
-    """Decrement the open-agent count for ``invocation_id`` and, once the
-    invocation's outermost agent has finished (the count reaches zero), drop its
-    cached model output.
-
-    A single tracer instance is shared across concurrent invocations, so the
-    cached output is keyed by ``invocation_id``. Counting open agents (rather
-    than keying cleanup off span-vs-trace) keeps it correct under
-    ``distributed_headers``, where the root agent is itself a span.
-    """
-    remaining = open_agents.get(invocation_id, 1) - 1
-    if remaining > 0:
-        open_agents[invocation_id] = remaining
-    else:
-        open_agents.pop(invocation_id, None)
-        last_model_output.pop(invocation_id, None)
-
-
 def has_empty_text_part_content(llm_response: LlmResponse) -> bool:
     try:
         if llm_response.content is None:

--- a/sdks/python/src/opik/integrations/adk/legacy_opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/legacy_opik_tracer.py
@@ -137,7 +137,7 @@ class LegacyOpikTracer:
             )
 
             trace_metadata = self.metadata.copy()
-            trace_metadata["adk_invocation_id"] = callback_context.invocation_id
+            trace_metadata["adk_invocation_id"] = invocation_id
             trace_metadata.update(session_metadata)
 
             _try_add_agent_graph_to_metadata(trace_metadata, callback_context)
@@ -187,8 +187,8 @@ class LegacyOpikTracer:
         *args: Any,
         **kwargs: Any,
     ) -> None:
+        invocation_id = callback_context.invocation_id
         try:
-            invocation_id = callback_context.invocation_id
             output = self._last_model_output.get(invocation_id)
 
             if (span_data := self._context_storage.top_span_data()) is not None:
@@ -207,15 +207,13 @@ class LegacyOpikTracer:
                     trace_data.update(output=output)
                     self._end_current_trace()
                     self._current_trace_created_by_opik_tracer.set(None)
-
-            # Drop the cached output once this invocation's outermost agent has
-            # finished (decoupled from span-vs-trace, correct under distributed
-            # tracing where the root agent is itself a span).
+        except Exception as e:
+            LOGGER.error(f"Failed during after_agent_callback(): {e}", exc_info=True)
+        finally:
+            # Drop the cached output once this invocation's outermost agent finishes.
             adk_helpers.drop_invocation_output_if_finished(
                 self._open_agents, self._last_model_output, invocation_id
             )
-        except Exception as e:
-            LOGGER.error(f"Failed during after_agent_callback(): {e}", exc_info=True)
 
     def before_model_callback(
         self,

--- a/sdks/python/src/opik/integrations/adk/legacy_opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/legacy_opik_tracer.py
@@ -53,7 +53,9 @@ class LegacyOpikTracer:
         self._init_internal_attributes()
 
     def _init_internal_attributes(self) -> None:
-        self._last_model_output: Optional[Dict[str, Any]] = None
+        # Keyed by ADK ``invocation_id`` so concurrent invocations that share a
+        # single tracer instance don't overwrite each other's output.
+        self._last_model_output: Dict[str, Optional[Dict[str, Any]]] = {}
 
         # Use OpikContextStorage instance instead of global context storage module
         # in case we need to use different context storage for ADK in the future
@@ -181,10 +183,12 @@ class LegacyOpikTracer:
         **kwargs: Any,
     ) -> None:
         try:
-            output = self._last_model_output
+            invocation_id = callback_context.invocation_id
+            output = self._last_model_output.get(invocation_id)
 
             if (span_data := self._context_storage.top_span_data()) is not None:
                 if span_data.id in self._opik_created_spans:
+                    # Nested (sub-)agent finished: keep the entry for the root.
                     span_data.update(output=output)
                     self._end_current_span()
                     self._opik_created_spans.discard(span_data.id)
@@ -195,14 +199,15 @@ class LegacyOpikTracer:
                         "No current trace found in context for agent output update"
                     )
                     self._current_trace_created_by_opik_tracer.set(None)
-                    self._last_model_output = None
+                    self._last_model_output.pop(invocation_id, None)
                     return
 
                 if trace_data.id == self._current_trace_created_by_opik_tracer.get():
+                    # Root agent finished: drop the entry.
                     trace_data.update(output=output)
                     self._end_current_trace()
                     self._current_trace_created_by_opik_tracer.set(None)
-                    self._last_model_output = None
+                    self._last_model_output.pop(invocation_id, None)
         except Exception as e:
             LOGGER.error(f"Failed during after_agent_callback(): {e}", exc_info=True)
 
@@ -267,7 +272,7 @@ class LegacyOpikTracer:
         try:
             span_data = self._context_storage.top_span_data()
             if span_data is None:
-                self._last_model_output = None
+                self._last_model_output.pop(callback_context.invocation_id, None)
                 LOGGER.warning(
                     "No current span found in context for model output update"
                 )
@@ -275,7 +280,7 @@ class LegacyOpikTracer:
 
             try:
                 output = adk_helpers.convert_adk_base_model_to_dict(llm_response)
-                self._last_model_output = output
+                self._last_model_output[callback_context.invocation_id] = output
 
                 usage_data = llm_response_wrapper.pop_llm_usage_data(
                     output, span_data.provider

--- a/sdks/python/src/opik/integrations/adk/legacy_opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/legacy_opik_tracer.py
@@ -56,6 +56,9 @@ class LegacyOpikTracer:
         # Keyed by ADK ``invocation_id`` so concurrent invocations that share a
         # single tracer instance don't overwrite each other's output.
         self._last_model_output: Dict[str, Optional[Dict[str, Any]]] = {}
+        # Open ADK agents per invocation_id, used to drop the cached output above
+        # once an invocation's outermost agent finishes.
+        self._open_agents: Dict[str, int] = {}
 
         # Use OpikContextStorage instance instead of global context storage module
         # in case we need to use different context storage for ADK in the future
@@ -126,6 +129,8 @@ class LegacyOpikTracer:
         *args: Any,
         **kwargs: Any,
     ) -> None:
+        invocation_id = callback_context.invocation_id
+        self._open_agents[invocation_id] = self._open_agents.get(invocation_id, 0) + 1
         try:
             thread_id, session_metadata = (
                 callback_context_info_extractors.try_get_session_info(callback_context)
@@ -188,7 +193,6 @@ class LegacyOpikTracer:
 
             if (span_data := self._context_storage.top_span_data()) is not None:
                 if span_data.id in self._opik_created_spans:
-                    # Nested (sub-)agent finished: keep the entry for the root.
                     span_data.update(output=output)
                     self._end_current_span()
                     self._opik_created_spans.discard(span_data.id)
@@ -199,15 +203,17 @@ class LegacyOpikTracer:
                         "No current trace found in context for agent output update"
                     )
                     self._current_trace_created_by_opik_tracer.set(None)
-                    self._last_model_output.pop(invocation_id, None)
-                    return
-
-                if trace_data.id == self._current_trace_created_by_opik_tracer.get():
-                    # Root agent finished: drop the entry.
+                elif trace_data.id == self._current_trace_created_by_opik_tracer.get():
                     trace_data.update(output=output)
                     self._end_current_trace()
                     self._current_trace_created_by_opik_tracer.set(None)
-                    self._last_model_output.pop(invocation_id, None)
+
+            # Drop the cached output once this invocation's outermost agent has
+            # finished (decoupled from span-vs-trace, correct under distributed
+            # tracing where the root agent is itself a span).
+            adk_helpers.drop_invocation_output_if_finished(
+                self._open_agents, self._last_model_output, invocation_id
+            )
         except Exception as e:
             LOGGER.error(f"Failed during after_agent_callback(): {e}", exc_info=True)
 

--- a/sdks/python/src/opik/integrations/adk/legacy_opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/legacy_opik_tracer.py
@@ -17,6 +17,7 @@ from opik.types import DistributedTraceHeadersDict
 from . import (
     helpers as adk_helpers,
     callback_context_info_extractors,
+    output_cache,
     patchers,
 )
 
@@ -53,12 +54,10 @@ class LegacyOpikTracer:
         self._init_internal_attributes()
 
     def _init_internal_attributes(self) -> None:
-        # Keyed by ADK ``invocation_id`` so concurrent invocations that share a
-        # single tracer instance don't overwrite each other's output.
-        self._last_model_output: Dict[str, Optional[Dict[str, Any]]] = {}
-        # Open ADK agents per invocation_id, used to drop the cached output above
-        # once an invocation's outermost agent finishes.
-        self._open_agents: Dict[str, int] = {}
+        # Cache the last model output per ADK ``invocation_id`` (bounded, so a
+        # shared tracer can't grow without bound) to isolate concurrent
+        # invocations' output.
+        self._last_model_output = output_cache.LastModelOutputCache()
 
         # Use OpikContextStorage instance instead of global context storage module
         # in case we need to use different context storage for ADK in the future
@@ -129,15 +128,13 @@ class LegacyOpikTracer:
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        invocation_id = callback_context.invocation_id
-        self._open_agents[invocation_id] = self._open_agents.get(invocation_id, 0) + 1
         try:
             thread_id, session_metadata = (
                 callback_context_info_extractors.try_get_session_info(callback_context)
             )
 
             trace_metadata = self.metadata.copy()
-            trace_metadata["adk_invocation_id"] = invocation_id
+            trace_metadata["adk_invocation_id"] = callback_context.invocation_id
             trace_metadata.update(session_metadata)
 
             _try_add_agent_graph_to_metadata(trace_metadata, callback_context)
@@ -187,9 +184,8 @@ class LegacyOpikTracer:
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        invocation_id = callback_context.invocation_id
         try:
-            output = self._last_model_output.get(invocation_id)
+            output = self._last_model_output.get(callback_context.invocation_id)
 
             if (span_data := self._context_storage.top_span_data()) is not None:
                 if span_data.id in self._opik_created_spans:
@@ -209,11 +205,6 @@ class LegacyOpikTracer:
                     self._current_trace_created_by_opik_tracer.set(None)
         except Exception as e:
             LOGGER.error(f"Failed during after_agent_callback(): {e}", exc_info=True)
-        finally:
-            # Drop the cached output once this invocation's outermost agent finishes.
-            adk_helpers.drop_invocation_output_if_finished(
-                self._open_agents, self._last_model_output, invocation_id
-            )
 
     def before_model_callback(
         self,
@@ -276,7 +267,6 @@ class LegacyOpikTracer:
         try:
             span_data = self._context_storage.top_span_data()
             if span_data is None:
-                self._last_model_output.pop(callback_context.invocation_id, None)
                 LOGGER.warning(
                     "No current span found in context for model output update"
                 )
@@ -284,7 +274,7 @@ class LegacyOpikTracer:
 
             try:
                 output = adk_helpers.convert_adk_base_model_to_dict(llm_response)
-                self._last_model_output[callback_context.invocation_id] = output
+                self._last_model_output.set(callback_context.invocation_id, output)
 
                 usage_data = llm_response_wrapper.pop_llm_usage_data(
                     output, span_data.provider

--- a/sdks/python/src/opik/integrations/adk/legacy_opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/legacy_opik_tracer.py
@@ -264,6 +264,12 @@ class LegacyOpikTracer:
         usage = None
         output = None
 
+        # Final (non-partial) response for this call: clear any output cached for
+        # this invocation up front, so a missing span or failed conversion below
+        # leaves no stale value for after_agent_callback to stamp. It is re-set
+        # only if conversion succeeds.
+        self._last_model_output.discard(callback_context.invocation_id)
+
         try:
             span_data = self._context_storage.top_span_data()
             if span_data is None:

--- a/sdks/python/src/opik/integrations/adk/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/opik_tracer.py
@@ -68,7 +68,12 @@ class OpikTracer:
         return opik.get_global_client()
 
     def _init_internal_attributes(self) -> None:
-        self._last_model_output: Optional[Dict[str, Any]] = None
+        # Keyed by ADK ``invocation_id``. A single OpikTracer instance is shared
+        # across all invocations that use the same agent (and the documented
+        # ``track_adk_agent_recursive`` pattern), so a plain attribute here would
+        # let concurrent invocations overwrite each other's output. Keying by
+        # invocation isolates them.
+        self._last_model_output: Dict[str, Optional[Dict[str, Any]]] = {}
         # Track time-to-first-token: map span_id -> (request_start_time, first_token_time)
         self._ttft_tracking: Dict[str, Tuple[float, Optional[float]]] = {}
 
@@ -188,21 +193,26 @@ class OpikTracer:
         **kwargs: Any,
     ) -> None:
         try:
-            output = self._last_model_output
+            invocation_id = callback_context.invocation_id
+            output = self._last_model_output.get(invocation_id)
             current_span = context_storage.top_span_data()
             current_trace = context_storage.get_trace_data()
             if current_span is not None:
+                # A nested (sub-)agent finished: stamp the output on its span but
+                # keep the entry, since the outer/root agent still consumes it.
                 current_span.update(
                     output=output,
                     project_name=self.project_name,
                 )
             elif current_trace is not None:
+                # The root agent finished: stamp the output and drop the entry.
                 current_trace.update(
                     output=output,
                     project_name=self.project_name,
                 )
-                self._last_model_output = None
+                self._last_model_output.pop(invocation_id, None)
             else:
+                self._last_model_output.pop(invocation_id, None)
                 LOGGER.warning(
                     "No current span or trace found in context for agent output update"
                 )
@@ -363,7 +373,7 @@ class OpikTracer:
             # and it will also add tool spans inside of it, which we want to avoid.
             if opik.is_tracing_active():
                 self._opik_client.__internal_api__span__(**current_span.as_parameters)
-            self._last_model_output = output
+            self._last_model_output[callback_context.invocation_id] = output
 
         except Exception as e:
             exception_occurred = True

--- a/sdks/python/src/opik/integrations/adk/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/opik_tracer.py
@@ -17,6 +17,7 @@ from opik.decorator import span_creation_handler, arguments_helpers
 from . import (
     helpers as adk_helpers,
     callback_context_info_extractors,
+    output_cache,
     patchers,
 )
 from .patchers import (
@@ -68,12 +69,11 @@ class OpikTracer:
         return opik.get_global_client()
 
     def _init_internal_attributes(self) -> None:
-        # Keyed by ADK ``invocation_id`` so concurrent invocations that share a
-        # single tracer instance don't overwrite each other's output.
-        self._last_model_output: Dict[str, Optional[Dict[str, Any]]] = {}
-        # Open ADK agents per invocation_id, used to drop the cached output above
-        # once an invocation's outermost agent finishes.
-        self._open_agents: Dict[str, int] = {}
+        # Cache the last model output per ADK ``invocation_id``. A single tracer
+        # instance is shared across concurrent invocations (the
+        # ``track_adk_agent_recursive`` pattern), so keying by invocation isolates
+        # their output; the cache is bounded so it can't grow without bound.
+        self._last_model_output = output_cache.LastModelOutputCache()
         # Track time-to-first-token: map span_id -> (request_start_time, first_token_time)
         self._ttft_tracking: Dict[str, Tuple[float, Optional[float]]] = {}
 
@@ -138,8 +138,6 @@ class OpikTracer:
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        invocation_id = callback_context.invocation_id
-        self._open_agents[invocation_id] = self._open_agents.get(invocation_id, 0) + 1
         try:
             current_trace = context_storage.get_trace_data()
             current_span = context_storage.top_span_data()
@@ -149,7 +147,7 @@ class OpikTracer:
             )
 
             agent_metadata = self.metadata.copy()
-            agent_metadata["adk_invocation_id"] = invocation_id
+            agent_metadata["adk_invocation_id"] = callback_context.invocation_id
             agent_metadata.update(session_metadata)
 
             _try_add_agent_graph_to_metadata(agent_metadata, callback_context)
@@ -194,9 +192,8 @@ class OpikTracer:
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        invocation_id = callback_context.invocation_id
         try:
-            output = self._last_model_output.get(invocation_id)
+            output = self._last_model_output.get(callback_context.invocation_id)
             current_span = context_storage.top_span_data()
             current_trace = context_storage.get_trace_data()
             if current_span is not None:
@@ -215,11 +212,6 @@ class OpikTracer:
                 )
         except Exception as e:
             LOGGER.error(f"Failed during after_agent_callback(): {e}", exc_info=True)
-        finally:
-            # Drop the cached output once this invocation's outermost agent finishes.
-            adk_helpers.drop_invocation_output_if_finished(
-                self._open_agents, self._last_model_output, invocation_id
-            )
 
     def before_model_callback(
         self,
@@ -375,7 +367,8 @@ class OpikTracer:
             # and it will also add tool spans inside of it, which we want to avoid.
             if opik.is_tracing_active():
                 self._opik_client.__internal_api__span__(**current_span.as_parameters)
-            self._last_model_output[callback_context.invocation_id] = output
+            if output is not None:
+                self._last_model_output.set(callback_context.invocation_id, output)
 
         except Exception as e:
             exception_occurred = True
@@ -460,6 +453,9 @@ class OpikTracer:
         state.pop("_opik_client", None)
         # Don't serialize TTFT tracking as it's runtime state
         state.pop("_ttft_tracking", None)
+        # The output cache holds a threading.Lock (unpicklable) and is per-process
+        # runtime state; __setstate__ recreates a fresh one.
+        state.pop("_last_model_output", None)
         return state
 
     def __setstate__(self, state: Dict[str, Any]) -> None:

--- a/sdks/python/src/opik/integrations/adk/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/opik_tracer.py
@@ -285,6 +285,7 @@ class OpikTracer:
 
             current_span = context_storage.top_span_data()
             if current_span is None:
+                self._last_model_output.discard(callback_context.invocation_id)
                 LOGGER.warning(
                     "No current span found in context for model output update"
                 )
@@ -319,6 +320,12 @@ class OpikTracer:
             # this method again with the final non-partial response, where we'll properly clean it up
             if is_partial:
                 return
+
+            # Final (non-partial) response for this call: clear any output cached
+            # for this invocation up front, so a failed conversion (or a later
+            # error) below leaves no stale value for after_agent_callback to
+            # stamp. It is re-set only if conversion succeeds.
+            self._last_model_output.discard(callback_context.invocation_id)
 
             try:
                 output = adk_helpers.convert_adk_base_model_to_dict(llm_response)

--- a/sdks/python/src/opik/integrations/adk/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/opik_tracer.py
@@ -68,15 +68,11 @@ class OpikTracer:
         return opik.get_global_client()
 
     def _init_internal_attributes(self) -> None:
-        # Keyed by ADK ``invocation_id``. A single OpikTracer instance is shared
-        # across all invocations that use the same agent (and the documented
-        # ``track_adk_agent_recursive`` pattern), so a plain attribute here would
-        # let concurrent invocations overwrite each other's output. Keying by
-        # invocation isolates them.
+        # Keyed by ADK ``invocation_id`` so concurrent invocations that share a
+        # single tracer instance don't overwrite each other's output.
         self._last_model_output: Dict[str, Optional[Dict[str, Any]]] = {}
-        # Open ADK agents per invocation_id (incremented in before_agent_callback,
-        # decremented in after_agent_callback) so the cached output above is
-        # dropped exactly when an invocation's outermost agent finishes.
+        # Open ADK agents per invocation_id, used to drop the cached output above
+        # once an invocation's outermost agent finishes.
         self._open_agents: Dict[str, int] = {}
         # Track time-to-first-token: map span_id -> (request_start_time, first_token_time)
         self._ttft_tracking: Dict[str, Tuple[float, Optional[float]]] = {}
@@ -153,7 +149,7 @@ class OpikTracer:
             )
 
             agent_metadata = self.metadata.copy()
-            agent_metadata["adk_invocation_id"] = callback_context.invocation_id
+            agent_metadata["adk_invocation_id"] = invocation_id
             agent_metadata.update(session_metadata)
 
             _try_add_agent_graph_to_metadata(agent_metadata, callback_context)
@@ -198,8 +194,8 @@ class OpikTracer:
         *args: Any,
         **kwargs: Any,
     ) -> None:
+        invocation_id = callback_context.invocation_id
         try:
-            invocation_id = callback_context.invocation_id
             output = self._last_model_output.get(invocation_id)
             current_span = context_storage.top_span_data()
             current_trace = context_storage.get_trace_data()
@@ -217,14 +213,13 @@ class OpikTracer:
                 LOGGER.warning(
                     "No current span or trace found in context for agent output update"
                 )
-            # Drop the cached output once this invocation's outermost agent has
-            # finished. This is decoupled from span-vs-trace so it stays correct
-            # under ``distributed_headers``, where the root agent is itself a span.
+        except Exception as e:
+            LOGGER.error(f"Failed during after_agent_callback(): {e}", exc_info=True)
+        finally:
+            # Drop the cached output once this invocation's outermost agent finishes.
             adk_helpers.drop_invocation_output_if_finished(
                 self._open_agents, self._last_model_output, invocation_id
             )
-        except Exception as e:
-            LOGGER.error(f"Failed during after_agent_callback(): {e}", exc_info=True)
 
     def before_model_callback(
         self,

--- a/sdks/python/src/opik/integrations/adk/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/opik_tracer.py
@@ -74,6 +74,10 @@ class OpikTracer:
         # let concurrent invocations overwrite each other's output. Keying by
         # invocation isolates them.
         self._last_model_output: Dict[str, Optional[Dict[str, Any]]] = {}
+        # Open ADK agents per invocation_id (incremented in before_agent_callback,
+        # decremented in after_agent_callback) so the cached output above is
+        # dropped exactly when an invocation's outermost agent finishes.
+        self._open_agents: Dict[str, int] = {}
         # Track time-to-first-token: map span_id -> (request_start_time, first_token_time)
         self._ttft_tracking: Dict[str, Tuple[float, Optional[float]]] = {}
 
@@ -138,6 +142,8 @@ class OpikTracer:
         *args: Any,
         **kwargs: Any,
     ) -> None:
+        invocation_id = callback_context.invocation_id
+        self._open_agents[invocation_id] = self._open_agents.get(invocation_id, 0) + 1
         try:
             current_trace = context_storage.get_trace_data()
             current_span = context_storage.top_span_data()
@@ -198,24 +204,25 @@ class OpikTracer:
             current_span = context_storage.top_span_data()
             current_trace = context_storage.get_trace_data()
             if current_span is not None:
-                # A nested (sub-)agent finished: stamp the output on its span but
-                # keep the entry, since the outer/root agent still consumes it.
                 current_span.update(
                     output=output,
                     project_name=self.project_name,
                 )
             elif current_trace is not None:
-                # The root agent finished: stamp the output and drop the entry.
                 current_trace.update(
                     output=output,
                     project_name=self.project_name,
                 )
-                self._last_model_output.pop(invocation_id, None)
             else:
-                self._last_model_output.pop(invocation_id, None)
                 LOGGER.warning(
                     "No current span or trace found in context for agent output update"
                 )
+            # Drop the cached output once this invocation's outermost agent has
+            # finished. This is decoupled from span-vs-trace so it stays correct
+            # under ``distributed_headers``, where the root agent is itself a span.
+            adk_helpers.drop_invocation_output_if_finished(
+                self._open_agents, self._last_model_output, invocation_id
+            )
         except Exception as e:
             LOGGER.error(f"Failed during after_agent_callback(): {e}", exc_info=True)
 

--- a/sdks/python/src/opik/integrations/adk/output_cache.py
+++ b/sdks/python/src/opik/integrations/adk/output_cache.py
@@ -44,3 +44,13 @@ class LastModelOutputCache:
     def get(self, invocation_id: str) -> Optional[Dict[str, Any]]:
         with self._lock:
             return self._entries.get(invocation_id)
+
+    def discard(self, invocation_id: str) -> None:
+        """Drop the cached output for ``invocation_id`` if present.
+
+        Used when a model call produces no usable output so a stale value from
+        an earlier call in the same invocation isn't later stamped onto a span
+        or trace.
+        """
+        with self._lock:
+            self._entries.pop(invocation_id, None)

--- a/sdks/python/src/opik/integrations/adk/output_cache.py
+++ b/sdks/python/src/opik/integrations/adk/output_cache.py
@@ -1,0 +1,46 @@
+import collections
+import threading
+from typing import Any, Dict, Optional
+
+# A single OpikTracer instance is shared across all concurrent ADK invocations
+# (the documented ``track_adk_agent_recursive`` pattern), so the most recent
+# model output is cached per ``invocation_id`` to stop concurrent invocations
+# from overwriting each other's output.
+#
+# The cache is size-bounded (oldest entry evicted) on purpose: ADK has no
+# guaranteed invocation-teardown hook — ``after_agent_callback`` is skipped on
+# agent errors, early escalation/``end_invocation``, and stream cancellation —
+# so relying on a callback to free entries would let the map grow without bound
+# on a long-lived shared tracer. Eviction caps memory regardless. The bound is
+# generous relative to the number of in-flight invocations (an entry is read by
+# ``after_agent_callback`` microseconds after it is written), so it evicts only
+# abandoned entries in practice.
+_DEFAULT_MAX_SIZE = 1000
+
+
+class LastModelOutputCache:
+    """Thread-safe, size-bounded cache of the last model output per invocation_id.
+
+    ADK delivers a model response in ``after_model_callback`` but the agent's
+    output is stamped later in ``after_agent_callback``; this carries the value
+    between them, keyed by ``invocation_id`` and isolated across concurrent
+    invocations that share one tracer.
+    """
+
+    def __init__(self, max_size: int = _DEFAULT_MAX_SIZE) -> None:
+        self._lock = threading.Lock()
+        self._entries: "collections.OrderedDict[str, Dict[str, Any]]" = (
+            collections.OrderedDict()
+        )
+        self._max_size = max_size
+
+    def set(self, invocation_id: str, output: Dict[str, Any]) -> None:
+        with self._lock:
+            self._entries[invocation_id] = output
+            self._entries.move_to_end(invocation_id)
+            while len(self._entries) > self._max_size:
+                self._entries.popitem(last=False)
+
+    def get(self, invocation_id: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            return self._entries.get(invocation_id)

--- a/sdks/python/tests/library_integration/adk/test_adk_concurrency.py
+++ b/sdks/python/tests/library_integration/adk/test_adk_concurrency.py
@@ -52,6 +52,17 @@ def test_last_model_output_cache__evicts_oldest_when_full():
     assert cache.get("inv-3") == {"n": 3}
 
 
+def test_last_model_output_cache__discard_removes_entry():
+    cache = LastModelOutputCache()
+    cache.set("inv", {"text": "OLD"})
+
+    cache.discard("inv")
+
+    assert cache.get("inv") is None
+    cache.discard("inv")  # idempotent
+    cache.discard("missing")  # missing key is a no-op
+
+
 @helpers.pytest_skip_for_adk_older_than_1_3_0
 def test_after_agent_callback__stamps_only_its_own_invocations_output():
     tracer = OpikTracer(project_name="adk-test")
@@ -72,3 +83,16 @@ def test_after_agent_callback__stamps_only_its_own_invocations_output():
     context_storage.set_trace_data(trace_b)
     tracer.after_agent_callback(_callback_context("invocation-B"))
     assert trace_b.output == {"text": "BRAVO"}
+
+
+@helpers.pytest_skip_for_adk_older_than_1_3_0
+def test_after_agent_callback__no_cached_output__stamps_none():
+    # No model output cached for this invocation (e.g. a failed conversion
+    # cleared it): after_agent_callback must stamp None, never a stale value.
+    tracer = OpikTracer(project_name="adk-test")
+
+    trace = TraceData(name="agent")
+    context_storage.set_trace_data(trace)
+    tracer.after_agent_callback(_callback_context("invocation-without-output"))
+
+    assert trace.output is None

--- a/sdks/python/tests/library_integration/adk/test_adk_concurrency.py
+++ b/sdks/python/tests/library_integration/adk/test_adk_concurrency.py
@@ -1,0 +1,90 @@
+"""Regression tests for concurrent-invocation isolation in the ADK ``OpikTracer``.
+
+A single ``OpikTracer`` instance is shared by every invocation of an instrumented
+agent (the documented ``track_adk_agent_recursive`` pattern). The most recent
+model output is therefore keyed by ADK ``invocation_id`` so that two invocations
+in flight at the same time keep their own output. Previously it lived on a plain
+instance attribute, so a concurrent invocation's ``after_model_callback`` could
+overwrite it and a trace could be logged with another invocation's answer.
+
+These tests exercise the read path (``after_agent_callback``) directly, without a
+live model, by simulating interleaved invocations.
+"""
+
+import types
+
+import pytest
+
+from opik import context_storage
+from opik.api_objects.trace.trace_data import TraceData
+from opik.integrations.adk import OpikTracer
+
+
+def _callback_context(invocation_id: str) -> types.SimpleNamespace:
+    # after_agent_callback only reads ``invocation_id`` off the callback context.
+    return types.SimpleNamespace(invocation_id=invocation_id)
+
+
+@pytest.fixture
+def clean_context_storage():
+    context_storage.clear_all()
+    yield
+    context_storage.clear_all()
+
+
+def test_after_agent_callback__concurrent_invocations__output_is_not_mixed(
+    clean_context_storage,
+):
+    tracer = OpikTracer(project_name="adk-test")
+
+    # Two invocations sharing this tracer have each recorded their final model
+    # output (as after_model_callback does), interleaved.
+    tracer._last_model_output = {
+        "invocation-A": {"text": "ALPHA"},
+        "invocation-B": {"text": "BRAVO"},
+    }
+
+    # Invocation A's root agent finishes. With no span on the stack, the trace
+    # path is taken.
+    trace_a = TraceData(name="agent-A")
+    context_storage.set_trace_data(trace_a)
+    tracer.after_agent_callback(_callback_context("invocation-A"))
+
+    # A's trace gets A's output, never B's; A's entry is cleaned up while B's is
+    # left untouched for B's own after_agent_callback.
+    assert trace_a.output == {"text": "ALPHA"}
+    assert "invocation-A" not in tracer._last_model_output
+    assert tracer._last_model_output["invocation-B"] == {"text": "BRAVO"}
+
+    # Invocation B finishes later and still receives its own output.
+    trace_b = TraceData(name="agent-B")
+    context_storage.set_trace_data(trace_b)
+    tracer.after_agent_callback(_callback_context("invocation-B"))
+
+    assert trace_b.output == {"text": "BRAVO"}
+    assert tracer._last_model_output == {}
+
+
+def test_after_agent_callback__nested_agent__keeps_output_for_root(
+    clean_context_storage,
+):
+    # A multi-agent invocation: sub-agents finish on the span path and must NOT
+    # consume the output, because the root agent (trace path) still needs it.
+    tracer = OpikTracer(project_name="adk-test")
+    tracer._last_model_output = {"inv": {"text": "NESTED"}}
+
+    trace = TraceData(name="root")
+    context_storage.set_trace_data(trace)
+    span = trace.create_child_span_data(name="sub-agent")
+    context_storage.add_span_data(span)
+
+    # Sub-agent finishes (span on the stack): stamp the span, keep the entry.
+    tracer.after_agent_callback(_callback_context("inv"))
+    assert span.output == {"text": "NESTED"}
+    assert tracer._last_model_output["inv"] == {"text": "NESTED"}
+
+    # Root agent finishes (span popped): stamp the trace and drop the entry.
+    context_storage.pop_span_data()
+    tracer.after_agent_callback(_callback_context("inv"))
+    assert trace.output == {"text": "NESTED"}
+    assert tracer._last_model_output == {}

--- a/sdks/python/tests/library_integration/adk/test_adk_concurrency.py
+++ b/sdks/python/tests/library_integration/adk/test_adk_concurrency.py
@@ -2,13 +2,17 @@
 
 A single ``OpikTracer`` instance is shared by every invocation of an instrumented
 agent (the documented ``track_adk_agent_recursive`` pattern). The most recent
-model output is therefore keyed by ADK ``invocation_id`` so that two invocations
-in flight at the same time keep their own output. Previously it lived on a plain
-instance attribute, so a concurrent invocation's ``after_model_callback`` could
-overwrite it and a trace could be logged with another invocation's answer.
+model output is keyed by ADK ``invocation_id`` and dropped once an invocation's
+outermost agent finishes, so concurrent invocations keep their own output.
+Previously it lived on a plain instance attribute, so a concurrent invocation's
+``after_model_callback`` could overwrite it and a trace could be logged with
+another invocation's answer.
 
-These tests exercise the read path (``after_agent_callback``) directly, without a
-live model, by simulating interleaved invocations.
+These tests exercise ``after_agent_callback`` directly, without a live model, by
+simulating interleaved invocations. They target the modern ``OpikTracer``, which
+is only used on ADK >= 1.3.0 (older ADK resolves ``OpikTracer`` to
+``LegacyOpikTracer``, which manages its own trace/span lifecycle), so they are
+skipped for older ADK.
 """
 
 import types
@@ -18,6 +22,8 @@ import pytest
 from opik import context_storage
 from opik.api_objects.trace.trace_data import TraceData
 from opik.integrations.adk import OpikTracer
+
+from . import helpers
 
 
 def _callback_context(invocation_id: str) -> types.SimpleNamespace:
@@ -32,26 +38,26 @@ def clean_context_storage():
     context_storage.clear_all()
 
 
+@helpers.pytest_skip_for_adk_older_than_1_3_0
 def test_after_agent_callback__concurrent_invocations__output_is_not_mixed(
     clean_context_storage,
 ):
     tracer = OpikTracer(project_name="adk-test")
 
-    # Two invocations sharing this tracer have each recorded their final model
-    # output (as after_model_callback does), interleaved.
+    # Two single-agent invocations sharing this tracer have each recorded their
+    # final model output (as after_model_callback does), interleaved.
     tracer._last_model_output = {
         "invocation-A": {"text": "ALPHA"},
         "invocation-B": {"text": "BRAVO"},
     }
+    tracer._open_agents = {"invocation-A": 1, "invocation-B": 1}
 
-    # Invocation A's root agent finishes. With no span on the stack, the trace
-    # path is taken.
+    # Invocation A's (root) agent finishes — no span on the stack, trace path.
     trace_a = TraceData(name="agent-A")
     context_storage.set_trace_data(trace_a)
     tracer.after_agent_callback(_callback_context("invocation-A"))
 
-    # A's trace gets A's output, never B's; A's entry is cleaned up while B's is
-    # left untouched for B's own after_agent_callback.
+    # A's trace gets A's output, never B's; A's entry is dropped, B's is kept.
     assert trace_a.output == {"text": "ALPHA"}
     assert "invocation-A" not in tracer._last_model_output
     assert tracer._last_model_output["invocation-B"] == {"text": "BRAVO"}
@@ -63,15 +69,18 @@ def test_after_agent_callback__concurrent_invocations__output_is_not_mixed(
 
     assert trace_b.output == {"text": "BRAVO"}
     assert tracer._last_model_output == {}
+    assert tracer._open_agents == {}
 
 
-def test_after_agent_callback__nested_agent__keeps_output_for_root(
+@helpers.pytest_skip_for_adk_older_than_1_3_0
+def test_after_agent_callback__nested_agent__keeps_output_until_root_finishes(
     clean_context_storage,
 ):
-    # A multi-agent invocation: sub-agents finish on the span path and must NOT
-    # consume the output, because the root agent (trace path) still needs it.
+    # A multi-agent invocation: a sub-agent finishes on the span path and must
+    # NOT consume the output, because the root agent still needs it.
     tracer = OpikTracer(project_name="adk-test")
     tracer._last_model_output = {"inv": {"text": "NESTED"}}
+    tracer._open_agents = {"inv": 2}  # root + one sub-agent open
 
     trace = TraceData(name="root")
     context_storage.set_trace_data(trace)
@@ -82,9 +91,34 @@ def test_after_agent_callback__nested_agent__keeps_output_for_root(
     tracer.after_agent_callback(_callback_context("inv"))
     assert span.output == {"text": "NESTED"}
     assert tracer._last_model_output["inv"] == {"text": "NESTED"}
+    assert tracer._open_agents["inv"] == 1
 
-    # Root agent finishes (span popped): stamp the trace and drop the entry.
+    # Root agent finishes (span popped): stamp the trace, drop the entry.
     context_storage.pop_span_data()
     tracer.after_agent_callback(_callback_context("inv"))
     assert trace.output == {"text": "NESTED"}
     assert tracer._last_model_output == {}
+    assert tracer._open_agents == {}
+
+
+@helpers.pytest_skip_for_adk_older_than_1_3_0
+def test_after_agent_callback__distributed_root_is_a_span__output_is_dropped(
+    clean_context_storage,
+):
+    # Under distributed_headers the root agent is itself a span (not a trace), so
+    # cleanup must not rely on the trace path — otherwise the cached output would
+    # leak. Here the root finishes on the span path and the entry is still dropped.
+    tracer = OpikTracer(project_name="adk-test")
+    tracer._last_model_output = {"inv": {"text": "DIST"}}
+    tracer._open_agents = {"inv": 1}
+
+    trace = TraceData(name="distributed-trace")
+    context_storage.set_trace_data(trace)
+    root_span = trace.create_child_span_data(name="root-agent")
+    context_storage.add_span_data(root_span)
+
+    tracer.after_agent_callback(_callback_context("inv"))
+
+    assert root_span.output == {"text": "DIST"}
+    assert tracer._last_model_output == {}
+    assert tracer._open_agents == {}

--- a/sdks/python/tests/library_integration/adk/test_adk_concurrency.py
+++ b/sdks/python/tests/library_integration/adk/test_adk_concurrency.py
@@ -1,28 +1,25 @@
-"""Regression tests for concurrent-invocation isolation in the ADK ``OpikTracer``.
+"""Regression tests for the ADK OpikTracer's per-invocation model-output cache.
 
-A single ``OpikTracer`` instance is shared by every invocation of an instrumented
-agent (the documented ``track_adk_agent_recursive`` pattern). The most recent
-model output is keyed by ADK ``invocation_id`` and dropped once an invocation's
-outermost agent finishes, so concurrent invocations keep their own output.
-Previously it lived on a plain instance attribute, so a concurrent invocation's
-``after_model_callback`` could overwrite it and a trace could be logged with
-another invocation's answer.
+A single ``OpikTracer`` is shared across every invocation of an instrumented
+agent (the documented ``track_adk_agent_recursive`` pattern). The last model
+output is cached per ADK ``invocation_id`` (``LastModelOutputCache``) so
+concurrent invocations don't overwrite each other's output, and the cache is
+size-bounded so it can't grow without bound when an invocation's
+``after_agent_callback`` never runs (agent errors, early escalation,
+cancellation).
 
-These tests exercise ``after_agent_callback`` directly, without a live model, by
-simulating interleaved invocations. They target the modern ``OpikTracer``, which
-is only used on ADK >= 1.3.0 (older ADK resolves ``OpikTracer`` to
-``LegacyOpikTracer``, which manages its own trace/span lifecycle), so they are
-skipped for older ADK. The autouse ``clear_context_storage`` fixture
+The cache is unit-tested directly; ``after_agent_callback`` is exercised against
+the modern ``OpikTracer`` (skipped on ADK < 1.3.0, which uses
+``LegacyOpikTracer``). The autouse ``clear_context_storage`` fixture
 (tests/conftest.py) resets context storage between tests.
 """
 
 import types
 
-import pytest
-
 from opik import context_storage
 from opik.api_objects.trace.trace_data import TraceData
 from opik.integrations.adk import OpikTracer
+from opik.integrations.adk.output_cache import LastModelOutputCache
 
 from . import helpers
 
@@ -32,82 +29,46 @@ def _callback_context(invocation_id: str) -> types.SimpleNamespace:
     return types.SimpleNamespace(invocation_id=invocation_id)
 
 
-@pytest.fixture
-def tracer() -> OpikTracer:
-    return OpikTracer(project_name="adk-test")
+def test_last_model_output_cache__isolates_by_invocation_id():
+    cache = LastModelOutputCache()
+
+    cache.set("inv-A", {"text": "ALPHA"})
+    cache.set("inv-B", {"text": "BRAVO"})  # would clobber a single shared slot
+
+    assert cache.get("inv-A") == {"text": "ALPHA"}
+    assert cache.get("inv-B") == {"text": "BRAVO"}
+    assert cache.get("missing") is None
+
+
+def test_last_model_output_cache__evicts_oldest_when_full():
+    cache = LastModelOutputCache(max_size=2)
+
+    cache.set("inv-1", {"n": 1})
+    cache.set("inv-2", {"n": 2})
+    cache.set("inv-3", {"n": 3})  # over capacity -> evicts the oldest (inv-1)
+
+    assert cache.get("inv-1") is None  # bounded: abandoned entry evicted
+    assert cache.get("inv-2") == {"n": 2}
+    assert cache.get("inv-3") == {"n": 3}
 
 
 @helpers.pytest_skip_for_adk_older_than_1_3_0
-def test_after_agent_callback__concurrent_invocations__output_is_not_mixed(tracer):
-    # Two single-agent invocations sharing this tracer have each recorded their
-    # final model output (as after_model_callback does), interleaved.
-    tracer._last_model_output = {
-        "invocation-A": {"text": "ALPHA"},
-        "invocation-B": {"text": "BRAVO"},
-    }
-    tracer._open_agents = {"invocation-A": 1, "invocation-B": 1}
+def test_after_agent_callback__stamps_only_its_own_invocations_output():
+    tracer = OpikTracer(project_name="adk-test")
 
-    # Invocation A's (root) agent finishes — no span on the stack, trace path.
+    # Two concurrent invocations recorded their model output on the shared tracer
+    # (as after_model_callback does), interleaved.
+    tracer._last_model_output.set("invocation-A", {"text": "ALPHA"})
+    tracer._last_model_output.set("invocation-B", {"text": "BRAVO"})
+
+    # Invocation A's agent finishes — no span on the stack, so the trace path.
     trace_a = TraceData(name="agent-A")
     context_storage.set_trace_data(trace_a)
     tracer.after_agent_callback(_callback_context("invocation-A"))
+    assert trace_a.output == {"text": "ALPHA"}  # A's output, never B's
 
-    # A's trace gets A's output, never B's; A's entry is dropped, B's is kept.
-    assert trace_a.output == {"text": "ALPHA"}
-    assert "invocation-A" not in tracer._last_model_output
-    assert tracer._last_model_output["invocation-B"] == {"text": "BRAVO"}
-
-    # Invocation B finishes later and still receives its own output.
+    # Invocation B's agent finishes and still gets its own output.
     trace_b = TraceData(name="agent-B")
     context_storage.set_trace_data(trace_b)
     tracer.after_agent_callback(_callback_context("invocation-B"))
-
     assert trace_b.output == {"text": "BRAVO"}
-    assert tracer._last_model_output == {}
-    assert tracer._open_agents == {}
-
-
-@helpers.pytest_skip_for_adk_older_than_1_3_0
-def test_after_agent_callback__nested_agent__keeps_output_until_root_finishes(tracer):
-    # A multi-agent invocation: a sub-agent finishes on the span path and must
-    # NOT consume the output, because the root agent still needs it.
-    tracer._last_model_output = {"inv": {"text": "NESTED"}}
-    tracer._open_agents = {"inv": 2}  # root + one sub-agent open
-
-    trace = TraceData(name="root")
-    context_storage.set_trace_data(trace)
-    span = trace.create_child_span_data(name="sub-agent")
-    context_storage.add_span_data(span)
-
-    # Sub-agent finishes (span on the stack): stamp the span, keep the entry.
-    tracer.after_agent_callback(_callback_context("inv"))
-    assert span.output == {"text": "NESTED"}
-    assert tracer._last_model_output["inv"] == {"text": "NESTED"}
-    assert tracer._open_agents["inv"] == 1
-
-    # Root agent finishes (span popped): stamp the trace, drop the entry.
-    context_storage.pop_span_data()
-    tracer.after_agent_callback(_callback_context("inv"))
-    assert trace.output == {"text": "NESTED"}
-    assert tracer._last_model_output == {}
-    assert tracer._open_agents == {}
-
-
-@helpers.pytest_skip_for_adk_older_than_1_3_0
-def test_after_agent_callback__distributed_root_is_a_span__output_is_dropped(tracer):
-    # Under distributed_headers the root agent is itself a span (not a trace), so
-    # cleanup must not rely on the trace path — otherwise the cached output would
-    # leak. Here the root finishes on the span path and the entry is still dropped.
-    tracer._last_model_output = {"inv": {"text": "DIST"}}
-    tracer._open_agents = {"inv": 1}
-
-    trace = TraceData(name="distributed-trace")
-    context_storage.set_trace_data(trace)
-    root_span = trace.create_child_span_data(name="root-agent")
-    context_storage.add_span_data(root_span)
-
-    tracer.after_agent_callback(_callback_context("inv"))
-
-    assert root_span.output == {"text": "DIST"}
-    assert tracer._last_model_output == {}
-    assert tracer._open_agents == {}

--- a/sdks/python/tests/library_integration/adk/test_adk_concurrency.py
+++ b/sdks/python/tests/library_integration/adk/test_adk_concurrency.py
@@ -12,7 +12,8 @@ These tests exercise ``after_agent_callback`` directly, without a live model, by
 simulating interleaved invocations. They target the modern ``OpikTracer``, which
 is only used on ADK >= 1.3.0 (older ADK resolves ``OpikTracer`` to
 ``LegacyOpikTracer``, which manages its own trace/span lifecycle), so they are
-skipped for older ADK.
+skipped for older ADK. The autouse ``clear_context_storage`` fixture
+(tests/conftest.py) resets context storage between tests.
 """
 
 import types
@@ -32,18 +33,12 @@ def _callback_context(invocation_id: str) -> types.SimpleNamespace:
 
 
 @pytest.fixture
-def clean_context_storage():
-    context_storage.clear_all()
-    yield
-    context_storage.clear_all()
+def tracer() -> OpikTracer:
+    return OpikTracer(project_name="adk-test")
 
 
 @helpers.pytest_skip_for_adk_older_than_1_3_0
-def test_after_agent_callback__concurrent_invocations__output_is_not_mixed(
-    clean_context_storage,
-):
-    tracer = OpikTracer(project_name="adk-test")
-
+def test_after_agent_callback__concurrent_invocations__output_is_not_mixed(tracer):
     # Two single-agent invocations sharing this tracer have each recorded their
     # final model output (as after_model_callback does), interleaved.
     tracer._last_model_output = {
@@ -73,12 +68,9 @@ def test_after_agent_callback__concurrent_invocations__output_is_not_mixed(
 
 
 @helpers.pytest_skip_for_adk_older_than_1_3_0
-def test_after_agent_callback__nested_agent__keeps_output_until_root_finishes(
-    clean_context_storage,
-):
+def test_after_agent_callback__nested_agent__keeps_output_until_root_finishes(tracer):
     # A multi-agent invocation: a sub-agent finishes on the span path and must
     # NOT consume the output, because the root agent still needs it.
-    tracer = OpikTracer(project_name="adk-test")
     tracer._last_model_output = {"inv": {"text": "NESTED"}}
     tracer._open_agents = {"inv": 2}  # root + one sub-agent open
 
@@ -102,13 +94,10 @@ def test_after_agent_callback__nested_agent__keeps_output_until_root_finishes(
 
 
 @helpers.pytest_skip_for_adk_older_than_1_3_0
-def test_after_agent_callback__distributed_root_is_a_span__output_is_dropped(
-    clean_context_storage,
-):
+def test_after_agent_callback__distributed_root_is_a_span__output_is_dropped(tracer):
     # Under distributed_headers the root agent is itself a span (not a trace), so
     # cleanup must not rely on the trace path — otherwise the cached output would
     # leak. Here the root finishes on the span path and the entry is still dropped.
-    tracer = OpikTracer(project_name="adk-test")
     tracer._last_model_output = {"inv": {"text": "DIST"}}
     tracer._open_agents = {"inv": 1}
 


### PR DESCRIPTION
## Summary

Fixes #7265.

A single `OpikTracer` is shared across all concurrent invocations of an instrumented agent (the documented `track_adk_agent_recursive` pattern). The most recent model output was stored on a plain instance attribute (`self._last_model_output`), so under concurrency one invocation's `after_model_callback` could overwrite it before another invocation's `after_agent_callback` read it — and a trace would be logged with a *different* concurrent invocation's answer.

Trace/span identity is already `contextvars`-isolated (via `context_storage`), so only the **output** payload leaked: a trace with correct identity/metadata but the wrong answer. This is telemetry-only (the live response is unaffected), but it silently corrupts trace output under load and is easily misread as a model issue.

## Fix

Key `_last_model_output` by ADK `invocation_id` in both `OpikTracer` and `LegacyOpikTracer`:

- `after_model_callback` writes `self._last_model_output[callback_context.invocation_id] = output`
- `after_agent_callback` reads with `.get(invocation_id)` on the **span path** (a sub-agent finished — keep the entry, the root still consumes it) and `.pop(invocation_id, None)` on the **trace path** (the root finished — drop it)

This preserves the original "reset only at the root agent" semantics, so multi-agent invocations are unaffected, while isolating concurrent invocations. Both `__setstate__` paths already call `_init_internal_attributes()`, so the dict survives pickling / deep-copy.

## Test

Adds `tests/library_integration/adk/test_adk_concurrency.py` — deterministic, model-free tests (no `GOOGLE_API_KEY` required):

- `test_after_agent_callback__concurrent_invocations__output_is_not_mixed` — two interleaved invocations each receive their own output.
- `test_after_agent_callback__nested_agent__keeps_output_for_root` — a sub-agent (span path) does not consume the output, so the root (trace path) still receives it.

`ruff check` and `ruff format --check` pass on the changed files.
