### PR TITLE
[NA] [QA] fix: realign dataset & test-suite E2E POMs with revamped detail header

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPageHeader.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPageHeader.tsx
@@ -125,6 +125,7 @@ const DatasetItemsPageHeader: React.FunctionComponent<
                 size="icon-sm"
                 onClick={onExpand}
                 disabled={!dataset}
+                data-testid="dataset-header-expand-button"
               >
                 <Sparkles />
               </Button>
@@ -145,6 +146,7 @@ const DatasetItemsPageHeader: React.FunctionComponent<
                 variant="outline"
                 size="icon-sm"
                 onClick={onSettingsClick}
+                data-testid="dataset-header-settings-button"
               >
                 <Settings2 />
               </Button>
@@ -156,6 +158,7 @@ const DatasetItemsPageHeader: React.FunctionComponent<
               size="sm"
               onClick={onAddItem}
               disabled={!dataset}
+              data-testid="dataset-header-add-button"
             >
               <Plus className="mr-1.5 size-3.5" />
               {isTestSuite ? "Test case" : "Record"}

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
@@ -656,6 +656,7 @@ function DatasetItemsTab({
               <button
                 onClick={onAddItem}
                 className="comet-body-s underline underline-offset-4 hover:text-primary"
+                data-testid="dataset-items-empty-add-button"
               >
                 Add new {itemName}
               </button>

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/UseDatasetDropdown.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/UseDatasetDropdown.tsx
@@ -104,7 +104,11 @@ function UseDatasetDropdown({
         <DropdownMenu>
           <TooltipWrapper content="Run in">
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="icon-sm">
+              <Button
+                variant="outline"
+                size="icon-sm"
+                data-testid="dataset-header-run-in-trigger"
+              >
                 <Play />
               </Button>
             </DropdownMenuTrigger>

--- a/tests_end_to_end/e2e/pom/dataset-items.page.ts
+++ b/tests_end_to_end/e2e/pom/dataset-items.page.ts
@@ -16,9 +16,9 @@ export class DatasetItemsPage {
   }
 
   async waitForReady(): Promise<void> {
-    await this.page.getByRole('tab', { name: 'Items', selected: true }).waitFor({ state: 'visible' });
+    await this.page.getByRole('tab', { name: 'Records', selected: true }).waitFor({ state: 'visible' });
     const realRow = this.itemsTableBody.locator('tr[data-row-id]').first();
-    const emptyState = this.page.getByText('No dataset items yet');
+    const emptyState = this.page.getByText('No records yet');
     await Promise.race([
       realRow.waitFor({ state: 'visible' }),
       emptyState.waitFor({ state: 'visible' }),
@@ -47,8 +47,7 @@ export class DatasetItemsPage {
   }
 
   async clickAddItem(): Promise<void> {
-    const button = await this.preferTestid('dataset-items-add-button', { role: 'button', name: 'Add item' });
-    await button.click();
+    await this.page.getByTestId('dataset-header-add-button').click();
     await this.addItemPanel.waitFor({ state: 'visible' });
     await this.waitForPanelTransform('translateX(0');
   }
@@ -106,18 +105,17 @@ export class DatasetItemsPage {
    */
   async addItemViaEmptyStateModal(fields: Record<string, unknown>): Promise<void> {
     const triggers = this.page
-      .getByRole('button', { name: 'Add new item' })
-      .or(this.page.getByTestId('dataset-items-add-button'))
-      .or(this.page.getByRole('button', { name: 'Add item' }));
+      .getByTestId('dataset-header-add-button')
+      .or(this.page.getByTestId('dataset-items-empty-add-button'));
     await triggers.first().click();
-    const modal = this.page.getByRole('dialog', { name: 'Add dataset item' });
+    const modal = this.page.getByRole('dialog', { name: 'Add record' });
     await modal.waitFor({ state: 'visible' });
     const editor = modal.getByRole('textbox');
     await editor.click();
     await this.page.keyboard.press('ControlOrMeta+A');
     await this.page.keyboard.press('Delete');
     await this.page.keyboard.type(JSON.stringify(fields));
-    await modal.getByRole('button', { name: 'Add dataset item' }).click();
+    await modal.getByRole('button', { name: 'Add record' }).click();
     await modal.waitFor({ state: 'hidden' });
     await this.itemsTableBody.locator('tr[data-row-id]').first().waitFor({ state: 'visible' });
   }
@@ -127,7 +125,7 @@ export class DatasetItemsPage {
   }
 
   private get itemsTableBody(): Locator {
-    return this.page.getByRole('tabpanel', { name: 'Items' }).locator('tbody');
+    return this.page.getByRole('tabpanel', { name: 'Records' }).locator('tbody');
   }
 
   /** Panel stays mounted; open/closed is animated via CSS transform, not display/visibility. */

--- a/tests_end_to_end/e2e/pom/test-suite-items.page.ts
+++ b/tests_end_to_end/e2e/pom/test-suite-items.page.ts
@@ -6,7 +6,7 @@ import { PlaygroundPage } from './playground.page';
  * Per-suite items page. The underlying FE component is shared with DatasetItemsPage
  * (both routes resolve to the same DatasetDetailPage React component, discriminated
  * by URL prefix). Mechanics for items add/delete + draft staging are identical;
- * the surface difference is the "Use test suite" dropdown in the header and the
+ * the surface difference is the "Run in" header dropdown and the
  * "<N> global assertions" pill.
  */
 export class TestSuiteItemsPage {
@@ -24,9 +24,9 @@ export class TestSuiteItemsPage {
   }
 
   async waitForReady(): Promise<void> {
-    await this.page.getByRole('tab', { name: 'Items', selected: true }).waitFor({ state: 'visible' });
+    await this.page.getByRole('tab', { name: 'Test cases', selected: true }).waitFor({ state: 'visible' });
     const realRow = this.itemsTableBody.locator('tr[data-row-id]').first();
-    const emptyState = this.page.getByText('No test suite items yet');
+    const emptyState = this.page.getByText('No test cases yet');
     await Promise.race([
       realRow.waitFor({ state: 'visible' }),
       emptyState.waitFor({ state: 'visible' }),
@@ -66,8 +66,7 @@ export class TestSuiteItemsPage {
   }
 
   async clickAddItem(): Promise<void> {
-    const button = await this.preferTestid('dataset-items-add-button', { role: 'button', name: 'Add item' });
-    await button.click();
+    await this.page.getByTestId('dataset-header-add-button').click();
     // Wait for the Data JSON editor inside the Add panel to be interactive.
     // This is more reliable than waitForPanelTransform on a multi-mount testid.
     await this.addItemPanel.locator('.cm-content').first().waitFor({ state: 'visible' });
@@ -114,7 +113,7 @@ export class TestSuiteItemsPage {
   }
 
   /**
-   * Open the suite in the Prompt Playground via the "Use test suite" → "Open in Playground" menu path.
+   * Open the suite in the Prompt Playground via the "Run in" → "Open in Playground" menu path.
    *
    * The confirm dialog "Load test suite into playground" only appears when the
    * playground already has unsaved state (per UseDatasetDropdown.tsx:60-67).
@@ -125,7 +124,7 @@ export class TestSuiteItemsPage {
    * never happened.
    */
   async openInPlayground(): Promise<PlaygroundPage> {
-    await this.page.getByRole('button', { name: 'Use test suite' }).click();
+    await this.page.getByTestId('dataset-header-run-in-trigger').click();
     await this.page.getByRole('menuitem', { name: /^Open in Playground/ }).click();
 
     const confirm = this.page.getByRole('dialog', { name: 'Load test suite into playground' });
@@ -152,7 +151,7 @@ export class TestSuiteItemsPage {
   }
 
   private get itemsTableBody(): Locator {
-    return this.page.getByRole('tabpanel', { name: 'Items' }).locator('tbody');
+    return this.page.getByRole('tabpanel', { name: 'Test cases' }).locator('tbody');
   }
 
   private pageLevelCommitButton(): Locator {
@@ -164,14 +163,5 @@ export class TestSuiteItemsPage {
     const byTestid = this.page.getByTestId('dataset-version-commit-dialog');
     if ((await byTestid.count()) > 0) return byTestid;
     return this.page.getByRole('dialog', { name: 'Save changes' });
-  }
-
-  private async preferTestid(
-    testid: string,
-    role: { role: 'button'; name: string },
-  ): Promise<Locator> {
-    const byTestid = this.page.getByTestId(testid);
-    if ((await byTestid.count()) > 0) return byTestid;
-    return this.page.getByRole(role.role, { name: role.name });
   }
 }

--- a/tests_end_to_end/e2e/pom/test-suites.page.ts
+++ b/tests_end_to_end/e2e/pom/test-suites.page.ts
@@ -126,7 +126,7 @@ export class TestSuitesPage {
       return;
     }
 
-    await this.page.getByRole('button', { name: 'Test settings' }).click();
+    await this.page.getByTestId('dataset-header-settings-button').click();
     const dialog = this.page.getByRole('dialog', { name: 'Test settings' });
     await dialog.waitFor({ state: 'visible' });
 


### PR DESCRIPTION
## Details

The post-merge `t1` E2E run ([launch 79500](https://comet.testops.cloud/launch/79500)) went red on 4 dataset/test-suite smoke tests. Root cause: the merged child-page top-section revamp (#7254) renamed the detail-page tabs (`Items` → `Records` / `Test cases`), turned the header actions into icon-only tooltip buttons with no accessible name, renamed the primary add button to `Record` / `Test case`, and renamed the empty state and the add-record dialog. The dataset/test-suite POMs still targeted the old strings, so `waitForReady` / `applyTestSettings` / `openInPlayground` timed out.

- **FE**: add stable `data-testid`s to the icon-only header buttons (Test settings, Run in, Expand with AI), the primary add button, and the empty-state add CTA — the icon buttons expose their label only via a hover tooltip, so they had no accessible name to target.
- **POMs**: match the renamed tabs/tabpanels (`Records` / `Test cases`), the empty-state text (`No records yet` / `No test cases yet`), and the `Add record` dialog; target the new testids for Test settings and Run in; drop the now-dead `preferTestid` helper and the removed `dataset-items-add-button`.

No production behaviour changes — the FE diff is `data-testid` additions only.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- Related: #7254 (regression source); OPIK_6639 (the revamp ticket — not resolved here)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Diagnosis of the failing launch, FE `data-testid` additions, POM selector realignment, local verification.
- Human verification: Diff reviewed; reproduced the failure and confirmed the fix locally (see Testing).

## Testing

Ran against a source-served frontend (dev-runner, FE on `:5207`, backend `:8113`) so the new `data-testid`s are live:

- `npx playwright test tests/datasets/dataset-crud-smoke.spec.ts` → **2 passed** (was 2 failed). Exercises the `Records` tab, `No records yet` empty state, header add button, sliding panel, and the `Add record` dialog.
- Test-suite selector changes confirmed live via the Playwright MCP against a seeded suite (no LLM key needed): `Test cases` tab selected, tabpanel + rows render, `dataset-header-settings-button` opens the **Test settings** dialog (Save + Add assertion present), `dataset-header-run-in-trigger` opens the dropdown with **Open in Playground**.
- `test-suites-smoke.spec.ts` skips locally without `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` (LLM-judge + playground run); CI's keyed post-merge run is the end-to-end check. The selector path those tests depend on is verified above.
- FE `eslint` clean on the 3 changed files; e2e `tsc --noEmit` clean.

## Documentation

N/A — internal E2E test maintenance.
