### PR TITLE
[NA] [QA] fix: realign dataset & test-suite E2E POMs with revamped detail header

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPageHeader.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsPage/DatasetItemsPageHeader.tsx
@@ -125,6 +125,7 @@ const DatasetItemsPageHeader: React.FunctionComponent<
                 size="icon-sm"
                 onClick={onExpand}
                 disabled={!dataset}
+                data-testid="dataset-header-expand-button"
               >
                 <Sparkles />
               </Button>
@@ -145,6 +146,7 @@ const DatasetItemsPageHeader: React.FunctionComponent<
                 variant="outline"
                 size="icon-sm"
                 onClick={onSettingsClick}
+                data-testid="dataset-header-settings-button"
               >
                 <Settings2 />
               </Button>
@@ -156,6 +158,7 @@ const DatasetItemsPageHeader: React.FunctionComponent<
               size="sm"
               onClick={onAddItem}
               disabled={!dataset}
+              data-testid="dataset-header-add-button"
             >
               <Plus className="mr-1.5 size-3.5" />
               {isTestSuite ? "Test case" : "Record"}

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsTab/DatasetItemsTab.tsx
@@ -656,6 +656,7 @@ function DatasetItemsTab({
               <button
                 onClick={onAddItem}
                 className="comet-body-s underline underline-offset-4 hover:text-primary"
+                data-testid="dataset-items-empty-add-button"
               >
                 Add new {itemName}
               </button>

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/UseDatasetDropdown.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/UseDatasetDropdown.tsx
@@ -104,7 +104,11 @@ function UseDatasetDropdown({
         <DropdownMenu>
           <TooltipWrapper content="Run in">
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="icon-sm">
+              <Button
+                variant="outline"
+                size="icon-sm"
+                data-testid="dataset-header-run-in-trigger"
+              >
                 <Play />
               </Button>
             </DropdownMenuTrigger>

--- a/tests_end_to_end/e2e/pom/dataset-items.page.ts
+++ b/tests_end_to_end/e2e/pom/dataset-items.page.ts
@@ -16,9 +16,9 @@ export class DatasetItemsPage {
   }
 
   async waitForReady(): Promise<void> {
-    await this.page.getByRole('tab', { name: 'Items', selected: true }).waitFor({ state: 'visible' });
+    await this.page.getByRole('tab', { name: 'Records', selected: true }).waitFor({ state: 'visible' });
     const realRow = this.itemsTableBody.locator('tr[data-row-id]').first();
-    const emptyState = this.page.getByText('No dataset items yet');
+    const emptyState = this.page.getByText('No records yet');
     await Promise.race([
       realRow.waitFor({ state: 'visible' }),
       emptyState.waitFor({ state: 'visible' }),
@@ -47,8 +47,7 @@ export class DatasetItemsPage {
   }
 
   async clickAddItem(): Promise<void> {
-    const button = await this.preferTestid('dataset-items-add-button', { role: 'button', name: 'Add item' });
-    await button.click();
+    await this.page.getByTestId('dataset-header-add-button').click();
     await this.addItemPanel.waitFor({ state: 'visible' });
     await this.waitForPanelTransform('translateX(0');
   }
@@ -106,18 +105,17 @@ export class DatasetItemsPage {
    */
   async addItemViaEmptyStateModal(fields: Record<string, unknown>): Promise<void> {
     const triggers = this.page
-      .getByRole('button', { name: 'Add new item' })
-      .or(this.page.getByTestId('dataset-items-add-button'))
-      .or(this.page.getByRole('button', { name: 'Add item' }));
+      .getByTestId('dataset-header-add-button')
+      .or(this.page.getByTestId('dataset-items-empty-add-button'));
     await triggers.first().click();
-    const modal = this.page.getByRole('dialog', { name: 'Add dataset item' });
+    const modal = this.page.getByRole('dialog', { name: 'Add record' });
     await modal.waitFor({ state: 'visible' });
     const editor = modal.getByRole('textbox');
     await editor.click();
     await this.page.keyboard.press('ControlOrMeta+A');
     await this.page.keyboard.press('Delete');
     await this.page.keyboard.type(JSON.stringify(fields));
-    await modal.getByRole('button', { name: 'Add dataset item' }).click();
+    await modal.getByRole('button', { name: 'Add record' }).click();
     await modal.waitFor({ state: 'hidden' });
     await this.itemsTableBody.locator('tr[data-row-id]').first().waitFor({ state: 'visible' });
   }
@@ -127,7 +125,7 @@ export class DatasetItemsPage {
   }
 
   private get itemsTableBody(): Locator {
-    return this.page.getByRole('tabpanel', { name: 'Items' }).locator('tbody');
+    return this.page.getByRole('tabpanel', { name: 'Records' }).locator('tbody');
   }
 
   /** Panel stays mounted; open/closed is animated via CSS transform, not display/visibility. */

--- a/tests_end_to_end/e2e/pom/dataset-items.page.ts
+++ b/tests_end_to_end/e2e/pom/dataset-items.page.ts
@@ -1,3 +1,4 @@
+import { test } from '@playwright/test';
 import type { Page, Locator } from '@playwright/test';
 import { loadEnvConfig } from '../config/env.config';
 
@@ -9,25 +10,31 @@ export class DatasetItemsPage {
   ) {}
 
   async goto(): Promise<void> {
-    const env = loadEnvConfig();
-    await this.page.goto(
-      `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/datasets/${this.datasetId}/items`,
-    );
+    return test.step('Open dataset items page', async () => {
+      const env = loadEnvConfig();
+      await this.page.goto(
+        `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/datasets/${this.datasetId}/items`,
+      );
+    });
   }
 
   async waitForReady(): Promise<void> {
-    await this.page.getByRole('tab', { name: 'Records', selected: true }).waitFor({ state: 'visible' });
-    const realRow = this.itemsTableBody.locator('tr[data-row-id]').first();
-    const emptyState = this.page.getByText('No records yet');
-    await Promise.race([
-      realRow.waitFor({ state: 'visible' }),
-      emptyState.waitFor({ state: 'visible' }),
-    ]);
+    return test.step('Wait for Records tab ready', async () => {
+      await this.page.getByRole('tab', { name: 'Records', selected: true }).waitFor({ state: 'visible' });
+      const realRow = this.itemsTableBody.locator('tr[data-row-id]').first();
+      const emptyState = this.page.getByText('No records yet');
+      await Promise.race([
+        realRow.waitFor({ state: 'visible' }),
+        emptyState.waitFor({ state: 'visible' }),
+      ]);
+    });
   }
 
   /** Rendered row count on the current page. Table is paginated (default 10/page); the "Showing X of Y" text is stale during drafts. */
   async countItems(): Promise<number> {
-    return this.itemsTableBody.locator('tr[data-row-id]').count();
+    return test.step('Read dataset item count', async () => {
+      return this.itemsTableBody.locator('tr[data-row-id]').count();
+    });
   }
 
   draftBadge(): Locator {
@@ -47,56 +54,68 @@ export class DatasetItemsPage {
   }
 
   async clickAddItem(): Promise<void> {
-    await this.page.getByTestId('dataset-header-add-button').click();
-    await this.addItemPanel.waitFor({ state: 'visible' });
-    await this.waitForPanelTransform('translateX(0');
+    return test.step('Open add-item panel', async () => {
+      await this.page.getByTestId('dataset-header-add-button').click();
+      await this.addItemPanel.waitFor({ state: 'visible' });
+      await this.waitForPanelTransform('translateX(0');
+    });
   }
 
   async fillAddItemPanel(fields: Record<string, string>): Promise<void> {
-    for (const [column, value] of Object.entries(fields)) {
-      await this.addItemPanel
-        .getByRole('region', { name: column })
-        .getByPlaceholder('Enter text for this field…')
-        .fill(value);
-    }
+    return test.step('Fill add-item panel', async () => {
+      for (const [column, value] of Object.entries(fields)) {
+        await this.addItemPanel
+          .getByRole('region', { name: column })
+          .getByPlaceholder('Enter text for this field…')
+          .fill(value);
+      }
+    });
   }
 
   /** Stages the new item as a draft; commitDraft() persists it. */
   async submitAddItemPanel(): Promise<void> {
-    await this.addItemPanel.getByRole('button', { name: 'Save changes' }).click();
-    await this.waitForPanelTransform('translateX(100%)');
-    await this.draftBadge().waitFor({ state: 'visible' });
+    return test.step('Submit add-item panel (stage draft)', async () => {
+      await this.addItemPanel.getByRole('button', { name: 'Save changes' }).click();
+      await this.waitForPanelTransform('translateX(100%)');
+      await this.draftBadge().waitFor({ state: 'visible' });
+    });
   }
 
   /** Commits all staged drafts as a new dataset version via the confirmation modal. */
   async commitDraft(opts: { versionNote?: string } = {}): Promise<void> {
-    await this.pageLevelCommitButton().click();
-    const modal = await this.versionCommitModal();
-    await modal.waitFor({ state: 'visible' });
-    if (opts.versionNote !== undefined) {
-      await modal.getByRole('textbox', { name: 'Version note (optional)' }).fill(opts.versionNote);
-    }
-    await modal.getByRole('button', { name: 'Save changes' }).click();
-    await modal.waitFor({ state: 'hidden' });
-    await this.draftBadge().waitFor({ state: 'hidden' });
+    return test.step('Commit draft as new version', async () => {
+      await this.pageLevelCommitButton().click();
+      const modal = await this.versionCommitModal();
+      await modal.waitFor({ state: 'visible' });
+      if (opts.versionNote !== undefined) {
+        await modal.getByRole('textbox', { name: 'Version note (optional)' }).fill(opts.versionNote);
+      }
+      await modal.getByRole('button', { name: 'Save changes' }).click();
+      await modal.waitFor({ state: 'hidden' });
+      await this.draftBadge().waitFor({ state: 'hidden' });
+    });
   }
 
   async discardDraft(): Promise<void> {
-    const button = await this.preferTestid('dataset-items-discard-button', { role: 'button', name: 'Discard changes' });
-    await button.click();
-    await this.draftBadge().waitFor({ state: 'hidden' });
+    return test.step('Discard draft', async () => {
+      const button = await this.preferTestid('dataset-items-discard-button', { role: 'button', name: 'Discard changes' });
+      await button.click();
+      await this.draftBadge().waitFor({ state: 'hidden' });
+    });
   }
 
   /** Confirmation dialog title reads "Remove suite items" — component is shared with Test Suites. */
   async deleteItemByIndex(index: number): Promise<void> {
-    const row = this.itemRow(index);
-    await row.getByRole('button', { name: 'Actions menu' }).click();
-    await this.page.getByRole('menuitem', { name: 'Delete' }).click();
-    const dialog = this.page.getByRole('dialog', { name: 'Remove suite items' });
-    await dialog.waitFor({ state: 'visible' });
-    await dialog.getByRole('button', { name: 'Remove suite items' }).click();
-    await dialog.waitFor({ state: 'hidden' });
-    await this.draftBadge().waitFor({ state: 'visible' });
+    return test.step(`Delete dataset item at index ${index}`, async () => {
+      const row = this.itemRow(index);
+      await row.getByRole('button', { name: 'Actions menu' }).click();
+      await this.page.getByRole('menuitem', { name: 'Delete' }).click();
+      const dialog = this.page.getByRole('dialog', { name: 'Remove suite items' });
+      await dialog.waitFor({ state: 'visible' });
+      await dialog.getByRole('button', { name: 'Remove suite items' }).click();
+      await dialog.waitFor({ state: 'hidden' });
+      await this.draftBadge().waitFor({ state: 'visible' });
+    });
   }
 
   /**
@@ -104,20 +123,22 @@ export class DatasetItemsPage {
    * commits directly (no draft staging) instead of the sliding side-panel.
    */
   async addItemViaEmptyStateModal(fields: Record<string, unknown>): Promise<void> {
-    const triggers = this.page
-      .getByTestId('dataset-header-add-button')
-      .or(this.page.getByTestId('dataset-items-empty-add-button'));
-    await triggers.first().click();
-    const modal = this.page.getByRole('dialog', { name: 'Add record' });
-    await modal.waitFor({ state: 'visible' });
-    const editor = modal.getByRole('textbox');
-    await editor.click();
-    await this.page.keyboard.press('ControlOrMeta+A');
-    await this.page.keyboard.press('Delete');
-    await this.page.keyboard.type(JSON.stringify(fields));
-    await modal.getByRole('button', { name: 'Add record' }).click();
-    await modal.waitFor({ state: 'hidden' });
-    await this.itemsTableBody.locator('tr[data-row-id]').first().waitFor({ state: 'visible' });
+    return test.step('Add item via empty-state modal', async () => {
+      const triggers = this.page
+        .getByTestId('dataset-header-add-button')
+        .or(this.page.getByTestId('dataset-items-empty-add-button'));
+      await triggers.first().click();
+      const modal = this.page.getByRole('dialog', { name: 'Add record' });
+      await modal.waitFor({ state: 'visible' });
+      const editor = modal.getByRole('textbox');
+      await editor.click();
+      await this.page.keyboard.press('ControlOrMeta+A');
+      await this.page.keyboard.press('Delete');
+      await this.page.keyboard.type(JSON.stringify(fields));
+      await modal.getByRole('button', { name: 'Add record' }).click();
+      await modal.waitFor({ state: 'hidden' });
+      await this.itemsTableBody.locator('tr[data-row-id]').first().waitFor({ state: 'visible' });
+    });
   }
 
   get addItemPanel(): Locator {

--- a/tests_end_to_end/e2e/pom/test-suite-items.page.ts
+++ b/tests_end_to_end/e2e/pom/test-suite-items.page.ts
@@ -6,7 +6,7 @@ import { PlaygroundPage } from './playground.page';
  * Per-suite items page. The underlying FE component is shared with DatasetItemsPage
  * (both routes resolve to the same DatasetDetailPage React component, discriminated
  * by URL prefix). Mechanics for items add/delete + draft staging are identical;
- * the surface difference is the "Use test suite" dropdown in the header and the
+ * the surface difference is the "Run in" header dropdown and the
  * "<N> global assertions" pill.
  */
 export class TestSuiteItemsPage {
@@ -24,9 +24,9 @@ export class TestSuiteItemsPage {
   }
 
   async waitForReady(): Promise<void> {
-    await this.page.getByRole('tab', { name: 'Items', selected: true }).waitFor({ state: 'visible' });
+    await this.page.getByRole('tab', { name: 'Test cases', selected: true }).waitFor({ state: 'visible' });
     const realRow = this.itemsTableBody.locator('tr[data-row-id]').first();
-    const emptyState = this.page.getByText('No test suite items yet');
+    const emptyState = this.page.getByText('No test cases yet');
     await Promise.race([
       realRow.waitFor({ state: 'visible' }),
       emptyState.waitFor({ state: 'visible' }),
@@ -66,8 +66,7 @@ export class TestSuiteItemsPage {
   }
 
   async clickAddItem(): Promise<void> {
-    const button = await this.preferTestid('dataset-items-add-button', { role: 'button', name: 'Add item' });
-    await button.click();
+    await this.page.getByTestId('dataset-header-add-button').click();
     // Wait for the Data JSON editor inside the Add panel to be interactive.
     // This is more reliable than waitForPanelTransform on a multi-mount testid.
     await this.addItemPanel.locator('.cm-content').first().waitFor({ state: 'visible' });
@@ -114,7 +113,7 @@ export class TestSuiteItemsPage {
   }
 
   /**
-   * Open the suite in the Prompt Playground via the "Use test suite" → "Open in Playground" menu path.
+   * Open the suite in the Prompt Playground via the "Run in" → "Open in Playground" menu path.
    *
    * The confirm dialog "Load test suite into playground" only appears when the
    * playground already has unsaved state (per UseDatasetDropdown.tsx:60-67).
@@ -125,7 +124,7 @@ export class TestSuiteItemsPage {
    * never happened.
    */
   async openInPlayground(): Promise<PlaygroundPage> {
-    await this.page.getByRole('button', { name: 'Use test suite' }).click();
+    await this.page.getByTestId('dataset-header-run-in-trigger').click();
     await this.page.getByRole('menuitem', { name: /^Open in Playground/ }).click();
 
     const confirm = this.page.getByRole('dialog', { name: 'Load test suite into playground' });
@@ -152,7 +151,7 @@ export class TestSuiteItemsPage {
   }
 
   private get itemsTableBody(): Locator {
-    return this.page.getByRole('tabpanel', { name: 'Items' }).locator('tbody');
+    return this.page.getByRole('tabpanel', { name: 'Test cases' }).locator('tbody');
   }
 
   private pageLevelCommitButton(): Locator {
@@ -164,14 +163,5 @@ export class TestSuiteItemsPage {
     const byTestid = this.page.getByTestId('dataset-version-commit-dialog');
     if ((await byTestid.count()) > 0) return byTestid;
     return this.page.getByRole('dialog', { name: 'Save changes' });
-  }
-
-  private async preferTestid(
-    testid: string,
-    role: { role: 'button'; name: string },
-  ): Promise<Locator> {
-    const byTestid = this.page.getByTestId(testid);
-    if ((await byTestid.count()) > 0) return byTestid;
-    return this.page.getByRole(role.role, { name: role.name });
   }
 }

--- a/tests_end_to_end/e2e/pom/test-suite-items.page.ts
+++ b/tests_end_to_end/e2e/pom/test-suite-items.page.ts
@@ -1,3 +1,4 @@
+import { test } from '@playwright/test';
 import type { Page, Locator } from '@playwright/test';
 import { loadEnvConfig } from '../config/env.config';
 import { PlaygroundPage } from './playground.page';
@@ -17,40 +18,50 @@ export class TestSuiteItemsPage {
   ) {}
 
   async goto(): Promise<void> {
-    const env = loadEnvConfig();
-    await this.page.goto(
-      `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/test-suites/${this.suiteId}/items`,
-    );
+    return test.step('Open test-suite items page', async () => {
+      const env = loadEnvConfig();
+      await this.page.goto(
+        `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/test-suites/${this.suiteId}/items`,
+      );
+    });
   }
 
   async waitForReady(): Promise<void> {
-    await this.page.getByRole('tab', { name: 'Test cases', selected: true }).waitFor({ state: 'visible' });
-    const realRow = this.itemsTableBody.locator('tr[data-row-id]').first();
-    const emptyState = this.page.getByText('No test cases yet');
-    await Promise.race([
-      realRow.waitFor({ state: 'visible' }),
-      emptyState.waitFor({ state: 'visible' }),
-    ]);
+    return test.step('Wait for Test cases tab ready', async () => {
+      await this.page.getByRole('tab', { name: 'Test cases', selected: true }).waitFor({ state: 'visible' });
+      const realRow = this.itemsTableBody.locator('tr[data-row-id]').first();
+      const emptyState = this.page.getByText('No test cases yet');
+      await Promise.race([
+        realRow.waitFor({ state: 'visible' }),
+        emptyState.waitFor({ state: 'visible' }),
+      ]);
+    });
   }
 
   /** Rendered row count on the current page. */
   async countItems(): Promise<number> {
-    return this.itemsTableBody.locator('tr[data-row-id]').count();
+    return test.step('Read test-suite item count', async () => {
+      return this.itemsTableBody.locator('tr[data-row-id]').count();
+    });
   }
 
   /** Read the global-assertions count from the header pill (test-suite-only pill). */
   async countGlobalAssertions(): Promise<number> {
-    const pill = this.page.getByTestId('dataset-detail-global-assertions-pill');
-    if ((await pill.count()) === 0) return 0;
-    const value = await pill.first().getAttribute('data-count');
-    return parseInt(value ?? '0', 10);
+    return test.step('Read global-assertions count', async () => {
+      const pill = this.page.getByTestId('dataset-detail-global-assertions-pill');
+      if ((await pill.count()) === 0) return 0;
+      const value = await pill.first().getAttribute('data-count');
+      return parseInt(value ?? '0', 10);
+    });
   }
 
   /** Read the version label (e.g. "v1", "v2") from the header. */
   async readVersionLabel(): Promise<string> {
-    const tag = this.page.getByTestId('dataset-detail-version-label');
-    await tag.waitFor({ state: 'visible' });
-    return (await tag.textContent())?.trim() ?? '';
+    return test.step('Read version label', async () => {
+      const tag = this.page.getByTestId('dataset-detail-version-label');
+      await tag.waitFor({ state: 'visible' });
+      return (await tag.textContent())?.trim() ?? '';
+    });
   }
 
   itemRow(index: number): Locator {
@@ -66,10 +77,12 @@ export class TestSuiteItemsPage {
   }
 
   async clickAddItem(): Promise<void> {
-    await this.page.getByTestId('dataset-header-add-button').click();
-    // Wait for the Data JSON editor inside the Add panel to be interactive.
-    // This is more reliable than waitForPanelTransform on a multi-mount testid.
-    await this.addItemPanel.locator('.cm-content').first().waitFor({ state: 'visible' });
+    return test.step('Open add-item panel', async () => {
+      await this.page.getByTestId('dataset-header-add-button').click();
+      // Wait for the Data JSON editor inside the Add panel to be interactive.
+      // This is more reliable than waitForPanelTransform on a multi-mount testid.
+      await this.addItemPanel.locator('.cm-content').first().waitFor({ state: 'visible' });
+    });
   }
 
   /**
@@ -80,36 +93,42 @@ export class TestSuiteItemsPage {
    * types it into the editor.
    */
   async fillAddItemPanel(data: Record<string, unknown>): Promise<void> {
-    const editor = this.addItemPanel.locator('.cm-content').first();
-    await editor.click();
-    // Clear placeholder, then type the JSON object.
-    await this.page.keyboard.press('ControlOrMeta+A');
-    await this.page.keyboard.press('Delete');
-    await this.page.keyboard.type(JSON.stringify(data, null, 2));
+    return test.step('Fill add-item panel', async () => {
+      const editor = this.addItemPanel.locator('.cm-content').first();
+      await editor.click();
+      // Clear placeholder, then type the JSON object.
+      await this.page.keyboard.press('ControlOrMeta+A');
+      await this.page.keyboard.press('Delete');
+      await this.page.keyboard.type(JSON.stringify(data, null, 2));
+    });
   }
 
   /** Stages the new item as a draft; commitDraft() persists it as a new version. */
   async submitAddItemPanel(): Promise<void> {
-    await this.addItemPanel.getByRole('button', { name: 'Save changes' }).click();
-    // The panel slides out — its `Save changes` button becomes hidden when closed.
-    await this.addItemPanel
-      .getByRole('button', { name: 'Save changes' })
-      .waitFor({ state: 'hidden' })
-      .catch(() => {});
-    await this.draftBadge().waitFor({ state: 'visible' });
+    return test.step('Submit add-item panel (stage draft)', async () => {
+      await this.addItemPanel.getByRole('button', { name: 'Save changes' }).click();
+      // The panel slides out — its `Save changes` button becomes hidden when closed.
+      await this.addItemPanel
+        .getByRole('button', { name: 'Save changes' })
+        .waitFor({ state: 'hidden' })
+        .catch(() => {});
+      await this.draftBadge().waitFor({ state: 'visible' });
+    });
   }
 
   /** Commits all staged drafts as a new suite version via the confirmation modal. */
   async commitDraft(opts: { versionNote?: string } = {}): Promise<void> {
-    await this.pageLevelCommitButton().click();
-    const modal = await this.versionCommitModal();
-    await modal.waitFor({ state: 'visible' });
-    if (opts.versionNote !== undefined) {
-      await modal.getByRole('textbox', { name: 'Version note (optional)' }).fill(opts.versionNote);
-    }
-    await modal.getByRole('button', { name: 'Save changes' }).click();
-    await modal.waitFor({ state: 'hidden' });
-    await this.draftBadge().waitFor({ state: 'hidden' });
+    return test.step('Commit draft as new version', async () => {
+      await this.pageLevelCommitButton().click();
+      const modal = await this.versionCommitModal();
+      await modal.waitFor({ state: 'visible' });
+      if (opts.versionNote !== undefined) {
+        await modal.getByRole('textbox', { name: 'Version note (optional)' }).fill(opts.versionNote);
+      }
+      await modal.getByRole('button', { name: 'Save changes' }).click();
+      await modal.waitFor({ state: 'hidden' });
+      await this.draftBadge().waitFor({ state: 'hidden' });
+    });
   }
 
   /**
@@ -124,21 +143,23 @@ export class TestSuiteItemsPage {
    * never happened.
    */
   async openInPlayground(): Promise<PlaygroundPage> {
-    await this.page.getByTestId('dataset-header-run-in-trigger').click();
-    await this.page.getByRole('menuitem', { name: /^Open in Playground/ }).click();
+    return test.step('Open suite in Playground', async () => {
+      await this.page.getByTestId('dataset-header-run-in-trigger').click();
+      await this.page.getByRole('menuitem', { name: /^Open in Playground/ }).click();
 
-    const confirm = this.page.getByRole('dialog', { name: 'Load test suite into playground' });
-    await Promise.race([
-      confirm.waitFor({ state: 'visible', timeout: 5_000 }).then(async () => {
-        await confirm.getByRole('button', { name: 'Load test suite' }).click();
-      }),
-      this.page.waitForURL((url) => url.pathname.endsWith('/playground'), { timeout: 5_000 }),
-    ]).catch(() => {});
+      const confirm = this.page.getByRole('dialog', { name: 'Load test suite into playground' });
+      await Promise.race([
+        confirm.waitFor({ state: 'visible', timeout: 5_000 }).then(async () => {
+          await confirm.getByRole('button', { name: 'Load test suite' }).click();
+        }),
+        this.page.waitForURL((url) => url.pathname.endsWith('/playground'), { timeout: 5_000 }),
+      ]).catch(() => {});
 
-    // Wait for the playground to be on the right URL.
-    await this.page.waitForURL((url) => url.pathname.endsWith('/playground'), { timeout: 15_000 });
-    const playground = new PlaygroundPage(this.page, this.projectId);
-    return playground;
+      // Wait for the playground to be on the right URL.
+      await this.page.waitForURL((url) => url.pathname.endsWith('/playground'), { timeout: 15_000 });
+      const playground = new PlaygroundPage(this.page, this.projectId);
+      return playground;
+    });
   }
 
   get addItemPanel(): Locator {

--- a/tests_end_to_end/e2e/pom/test-suites.page.ts
+++ b/tests_end_to_end/e2e/pom/test-suites.page.ts
@@ -126,7 +126,7 @@ export class TestSuitesPage {
       return;
     }
 
-    await this.page.getByRole('button', { name: 'Test settings' }).click();
+    await this.page.getByTestId('dataset-header-settings-button').click();
     const dialog = this.page.getByRole('dialog', { name: 'Test settings' });
     await dialog.waitFor({ state: 'visible' });
 

--- a/tests_end_to_end/e2e/pom/test-suites.page.ts
+++ b/tests_end_to_end/e2e/pom/test-suites.page.ts
@@ -1,3 +1,4 @@
+import { test } from '@playwright/test';
 import type { Page, Locator } from '@playwright/test';
 import { loadEnvConfig } from '../config/env.config';
 import { TestSuiteItemsPage } from './test-suite-items.page';
@@ -25,18 +26,22 @@ export class TestSuitesPage {
   constructor(private readonly page: Page) {}
 
   async goto(projectId: string): Promise<void> {
-    this.projectId = projectId;
-    const env = loadEnvConfig();
-    await this.page.goto(`${env.baseUrl}/${env.workspace}/projects/${projectId}/test-suites/`);
+    return test.step('Open Test Suites list page', async () => {
+      this.projectId = projectId;
+      const env = loadEnvConfig();
+      await this.page.goto(`${env.baseUrl}/${env.workspace}/projects/${projectId}/test-suites/`);
+    });
   }
 
   async waitForReady(): Promise<void> {
-    const realRow = this.page.locator('tbody tr[data-row-id]').first();
-    const emptyState = this.page.getByText('No test suites yet');
-    await Promise.race([
-      realRow.waitFor({ state: 'visible' }),
-      emptyState.waitFor({ state: 'visible' }),
-    ]);
+    return test.step('Wait for Test Suites list ready', async () => {
+      const realRow = this.page.locator('tbody tr[data-row-id]').first();
+      const emptyState = this.page.getByText('No test suites yet');
+      await Promise.race([
+        realRow.waitFor({ state: 'visible' }),
+        emptyState.waitFor({ state: 'visible' }),
+      ]);
+    });
   }
 
   testSuiteRow(name: string): Locator {
@@ -46,18 +51,20 @@ export class TestSuitesPage {
   }
 
   async openTestSuiteByName(name: string): Promise<TestSuiteItemsPage> {
-    const projectId = this.resolveProjectId();
-    const row = this.testSuiteRow(name);
-    await row.waitFor({ state: 'visible' });
-    const suiteId = await row.getAttribute('data-row-id');
-    if (!suiteId) {
-      throw new Error(`TestSuitesPage.openTestSuiteByName: row for "${name}" has no data-row-id`);
-    }
-    await row.getByRole('cell', { name, exact: true }).click();
-    await this.page.waitForURL((url) =>
-      url.pathname.includes(`/test-suites/${suiteId}/items`),
-    );
-    return new TestSuiteItemsPage(this.page, projectId, suiteId);
+    return test.step(`Open test suite "${name}"`, async () => {
+      const projectId = this.resolveProjectId();
+      const row = this.testSuiteRow(name);
+      await row.waitFor({ state: 'visible' });
+      const suiteId = await row.getAttribute('data-row-id');
+      if (!suiteId) {
+        throw new Error(`TestSuitesPage.openTestSuiteByName: row for "${name}" has no data-row-id`);
+      }
+      await row.getByRole('cell', { name, exact: true }).click();
+      await this.page.waitForURL((url) =>
+        url.pathname.includes(`/test-suites/${suiteId}/items`),
+      );
+      return new TestSuiteItemsPage(this.page, projectId, suiteId);
+    });
   }
 
   /**
@@ -67,15 +74,17 @@ export class TestSuitesPage {
    * regardless of list state.
    */
   async clickCreateTestSuite(): Promise<void> {
-    const emptyStateUseSdk = this.page.getByRole('button', { name: 'Use SDK' });
-    if (await emptyStateUseSdk.count()) {
-      await emptyStateUseSdk.first().click();
-    } else {
-      await this.page.getByRole('button', { name: 'Create test suite' }).click();
-      await this.page.getByRole('menuitem', { name: 'Use SDK' }).click();
-    }
-    await this.createDialog.waitFor({ state: 'visible' });
-    await this.waitForCreateDialogTransform('translateX(0');
+    return test.step('Open create-test-suite sidebar (SDK mode)', async () => {
+      const emptyStateUseSdk = this.page.getByRole('button', { name: 'Use SDK' });
+      if (await emptyStateUseSdk.count()) {
+        await emptyStateUseSdk.first().click();
+      } else {
+        await this.page.getByRole('button', { name: 'Create test suite' }).click();
+        await this.page.getByRole('menuitem', { name: 'Use SDK' }).click();
+      }
+      await this.createDialog.waitFor({ state: 'visible' });
+      await this.waitForCreateDialogTransform('translateX(0');
+    });
   }
 
   /**
@@ -84,17 +93,19 @@ export class TestSuitesPage {
    * the in-suite Test settings dialog (see submitCreateDialog).
    */
   async fillCreateDialog(fields: CreateTestSuiteDialogFields): Promise<void> {
-    await this.createDialog.getByRole('textbox', { name: 'Name' }).fill(fields.name);
-    if (fields.description !== undefined) {
-      await this.createDialog
-        .getByRole('textbox', { name: 'Description (optional)' })
-        .fill(fields.description);
-    }
-    this.pendingCriteria = {
-      assertions: fields.assertions,
-      runsPerItem: fields.runsPerItem,
-      passThreshold: fields.passThreshold,
-    };
+    return test.step('Fill create-test-suite dialog', async () => {
+      await this.createDialog.getByRole('textbox', { name: 'Name' }).fill(fields.name);
+      if (fields.description !== undefined) {
+        await this.createDialog
+          .getByRole('textbox', { name: 'Description (optional)' })
+          .fill(fields.description);
+      }
+      this.pendingCriteria = {
+        assertions: fields.assertions,
+        runsPerItem: fields.runsPerItem,
+        passThreshold: fields.passThreshold,
+      };
+    });
   }
 
   /**
@@ -103,19 +114,21 @@ export class TestSuitesPage {
    * through the Test settings dialog. Returns the new suite's items page.
    */
   async submitCreateDialog(name: string): Promise<TestSuiteItemsPage> {
-    const projectId = this.resolveProjectId();
-    await this.createDialog.getByRole('button', { name: 'Create test suite' }).click();
-    await this.waitForCreateDialogTransform('translateX(100%)');
+    return test.step(`Submit create-test-suite dialog for "${name}"`, async () => {
+      const projectId = this.resolveProjectId();
+      await this.createDialog.getByRole('button', { name: 'Create test suite' }).click();
+      await this.waitForCreateDialogTransform('translateX(100%)');
 
-    await this.openTestSuiteByName(name);
-    const match = this.page.url().match(/\/test-suites\/([0-9a-f-]+)/);
-    if (!match) {
-      throw new Error('TestSuitesPage.submitCreateDialog: could not derive suiteId from URL');
-    }
-    const items = new TestSuiteItemsPage(this.page, projectId, match[1]);
+      await this.openTestSuiteByName(name);
+      const match = this.page.url().match(/\/test-suites\/([0-9a-f-]+)/);
+      if (!match) {
+        throw new Error('TestSuitesPage.submitCreateDialog: could not derive suiteId from URL');
+      }
+      const items = new TestSuiteItemsPage(this.page, projectId, match[1]);
 
-    await this.applyTestSettings();
-    return items;
+      await this.applyTestSettings();
+      return items;
+    });
   }
 
   /** Apply the criteria stashed by fillCreateDialog via the in-suite Test settings dialog. */
@@ -126,31 +139,33 @@ export class TestSuitesPage {
       return;
     }
 
-    await this.page.getByTestId('dataset-header-settings-button').click();
-    const dialog = this.page.getByRole('dialog', { name: 'Test settings' });
-    await dialog.waitFor({ state: 'visible' });
+    return test.step('Apply test settings (assertions / pass criteria)', async () => {
+      await this.page.getByTestId('dataset-header-settings-button').click();
+      const dialog = this.page.getByRole('dialog', { name: 'Test settings' });
+      await dialog.waitFor({ state: 'visible' });
 
-    if (runsPerItem !== undefined) {
-      await dialog.getByRole('spinbutton', { name: 'Default runs per item' }).fill(String(runsPerItem));
-    }
-    if (passThreshold !== undefined) {
-      await dialog.getByRole('spinbutton', { name: 'Default pass threshold' }).fill(String(passThreshold));
-    }
-    for (const assertion of assertions ?? []) {
-      // Trigger button is "Add assertion" before any are added; becomes
-      // "Assertion" (with a plus icon) once at least one exists.
-      const addAssertionTrigger = dialog
-        .getByRole('button', { name: 'Add assertion' })
-        .or(dialog.getByRole('button', { name: 'Assertion', exact: true }));
-      await addAssertionTrigger.first().click();
-      const inputs = dialog.getByRole('textbox', {
-        name: /Response should be factually accurate/,
-      });
-      await inputs.last().fill(assertion);
-    }
+      if (runsPerItem !== undefined) {
+        await dialog.getByRole('spinbutton', { name: 'Default runs per item' }).fill(String(runsPerItem));
+      }
+      if (passThreshold !== undefined) {
+        await dialog.getByRole('spinbutton', { name: 'Default pass threshold' }).fill(String(passThreshold));
+      }
+      for (const assertion of assertions ?? []) {
+        // Trigger button is "Add assertion" before any are added; becomes
+        // "Assertion" (with a plus icon) once at least one exists.
+        const addAssertionTrigger = dialog
+          .getByRole('button', { name: 'Add assertion' })
+          .or(dialog.getByRole('button', { name: 'Assertion', exact: true }));
+        await addAssertionTrigger.first().click();
+        const inputs = dialog.getByRole('textbox', {
+          name: /Response should be factually accurate/,
+        });
+        await inputs.last().fill(assertion);
+      }
 
-    await dialog.getByRole('button', { name: 'Save' }).click();
-    await dialog.waitFor({ state: 'hidden' });
+      await dialog.getByRole('button', { name: 'Save' }).click();
+      await dialog.waitFor({ state: 'hidden' });
+    });
   }
 
   /** Read projectId from the instance (set by goto) or fall back to the current URL. */


### PR DESCRIPTION
## Details

The post-merge `t1` E2E run ([launch 79500](https://comet.testops.cloud/launch/79500)) went red on 4 dataset/test-suite smoke tests. Root cause: the merged child-page top-section revamp (#7254) renamed the detail-page tabs (`Items` → `Records` / `Test cases`), turned the header actions into icon-only tooltip buttons with no accessible name, renamed the primary add button to `Record` / `Test case`, and renamed the empty state and the add-record dialog. The dataset/test-suite POMs still targeted the old strings, so `waitForReady` / `applyTestSettings` / `openInPlayground` timed out.

- **FE**: add stable `data-testid`s to the icon-only header buttons (Test settings, Run in, Expand with AI), the primary add button, and the empty-state add CTA — the icon buttons expose their label only via a hover tooltip, so they had no accessible name to target.
- **POMs**: match the renamed tabs/tabpanels (`Records` / `Test cases`), the empty-state text (`No records yet` / `No test cases yet`), and the `Add record` dialog; target the new testids for Test settings and Run in; drop the now-dead `preferTestid` helper and the removed `dataset-items-add-button`.

No production behaviour changes — the FE diff is `data-testid` additions only.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- Related: #7254 (regression source); OPIK_6639 (the revamp ticket — not resolved here)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Diagnosis of the failing launch, FE `data-testid` additions, POM selector realignment, local verification.
- Human verification: Diff reviewed; reproduced the failure and confirmed the fix locally (see Testing).

## Testing

Ran against a source-served frontend (dev-runner, FE on `:5207`, backend `:8113`) so the new `data-testid`s are live:

- `npx playwright test tests/datasets/dataset-crud-smoke.spec.ts` → **2 passed** (was 2 failed). Exercises the `Records` tab, `No records yet` empty state, header add button, sliding panel, and the `Add record` dialog.
- Test-suite selector changes confirmed live via the Playwright MCP against a seeded suite (no LLM key needed): `Test cases` tab selected, tabpanel + rows render, `dataset-header-settings-button` opens the **Test settings** dialog (Save + Add assertion present), `dataset-header-run-in-trigger` opens the dropdown with **Open in Playground**.
- `test-suites-smoke.spec.ts` skips locally without `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` (LLM-judge + playground run); CI's keyed post-merge run is the end-to-end check. The selector path those tests depend on is verified above.
- FE `eslint` clean on the 3 changed files; e2e `tsc --noEmit` clean.

## Documentation

N/A — internal E2E test maintenance.

