### PR TITLE
[OPIK-7144] [BE] perf: read project last_updated_trace_at from MySQL and bound the last-trace scan

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ProjectEventListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ProjectEventListener.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api.resources.v1.events;
 
+import com.comet.opik.api.Project;
 import com.comet.opik.api.ProjectIdLastUpdated;
 import com.comet.opik.api.events.TracesCreated;
 import com.comet.opik.api.events.TracesUpdated;
@@ -11,6 +12,9 @@ import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -39,7 +43,11 @@ public class ProjectEventListener {
     private void updateProjectsLastUpdatedTraceAt(String workspaceId, Set<UUID> projectIds) {
         log.info("Recording last traces for projects '{}'", projectIds);
 
-        traceService.getLastUpdatedTraceAt(projectIds, workspaceId)
+        // The recorded last_updated_trace_at is the lower bound for the ClickHouse scan: only traces newer than what
+        // we already stored can move it forward, so we skip rescanning the project's full history.
+        Instant lastUpdatedAfter = resolveLastUpdatedAfter(workspaceId, projectIds);
+
+        traceService.getLastUpdatedTraceAt(projectIds, workspaceId, lastUpdatedAfter)
                 .flatMap(lastTraceByProjectId -> Mono.fromRunnable(() -> projectService.recordLastUpdatedTrace(
                         workspaceId,
                         lastTraceByProjectId.entrySet().stream()
@@ -47,5 +55,22 @@ public class ProjectEventListener {
                 .block();
 
         log.info("Recorded last traces for projects '{}'", projectIds);
+    }
+
+    private Instant resolveLastUpdatedAfter(String workspaceId, Set<UUID> projectIds) {
+        List<Project> projects = projectService.findByIds(workspaceId, projectIds);
+
+        // A project without a recorded timestamp (e.g. its first traces) must be scanned from the start, so we can
+        // only apply the lower bound when every project already has one; otherwise scan without it.
+        if (projects.size() < projectIds.size()
+                || projects.stream().anyMatch(project -> project.lastUpdatedTraceAt() == null)) {
+            return null;
+        }
+
+        return projects.stream()
+                .map(Project::lastUpdatedTraceAt)
+                .filter(Objects::nonNull)
+                .min(Instant::compareTo)
+                .orElse(null);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.UUID;
 
 @RegisterConstructorMapper(Project.class)
-@RegisterConstructorMapper(ProjectIdLastUpdated.class)
 @RegisterArgumentFactory(UUIDArgumentFactory.class)
 interface ProjectDAO {
 
@@ -79,16 +78,6 @@ interface ProjectDAO {
             @Define("name") @Bind("name") String name,
             @Define("visibility") @Bind("visibility") Visibility visibility,
             @Define("sort_fields") @Bind("sort_fields") String sortingFields);
-
-    @SqlQuery("SELECT id, last_updated_at FROM projects" +
-            " WHERE workspace_id = :workspaceId" +
-            " <if(name)> AND name like concat('%', :name, '%') <endif>" +
-            " <if(visibility)> AND visibility = :visibility <endif> ")
-    @UseStringTemplateEngine
-    @AllowUnusedBindings
-    List<ProjectIdLastUpdated> getAllProjectIdsLastUpdated(@Bind("workspaceId") String workspaceId,
-            @Define("name") @Bind("name") String name,
-            @Define("visibility") @Bind("visibility") Visibility visibility);
 
     default Optional<Project> fetch(UUID id, String workspaceId) {
         return Optional.ofNullable(findById(id, workspaceId));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -9,7 +9,6 @@ import com.comet.opik.api.ProjectUpdate;
 import com.comet.opik.api.Visibility;
 import com.comet.opik.api.error.EntityAlreadyExistsException;
 import com.comet.opik.api.error.ErrorMessage;
-import com.comet.opik.api.sorting.Direction;
 import com.comet.opik.api.sorting.SortableFields;
 import com.comet.opik.api.sorting.SortingFactoryProjects;
 import com.comet.opik.api.sorting.SortingField;
@@ -17,10 +16,8 @@ import com.comet.opik.domain.sorting.SortingQueryBuilder;
 import com.comet.opik.domain.stats.StatsMapper;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.bi.AnalyticsService;
-import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.utils.BinaryOperatorUtils;
 import com.comet.opik.utils.ErrorUtils;
-import com.comet.opik.utils.PaginationUtils;
 import com.google.inject.ImplementedBy;
 import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
@@ -31,7 +28,6 @@ import jakarta.ws.rs.core.Response;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import reactor.core.publisher.Mono;
@@ -41,8 +37,6 @@ import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -57,10 +51,7 @@ import static com.comet.opik.api.ProjectStatsSummary.ProjectStatsSummaryItem;
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
 import static com.comet.opik.utils.AsyncUtils.makeMonoContextAware;
-import static java.util.Collections.reverseOrder;
 import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toSet;
-import static java.util.stream.Collectors.toUnmodifiableSet;
 
 @ImplementedBy(ProjectServiceImpl.class)
 public interface ProjectService {
@@ -137,11 +128,18 @@ class ProjectServiceImpl implements ProjectService {
     }
 
     private static final String PROJECT_ALREADY_EXISTS = "Project already exists";
+
+    // recordLastUpdatedTrace populates projects.last_updated_trace_at from the trace timestamp, so sorting by last
+    // trace reads it straight from MySQL instead of querying ClickHouse. Projects without traces have it NULL, so we
+    // fall back to last_updated_at, matching the previous behavior while keeping this a single DB query.
+    private static final String LAST_UPDATED_TRACE_AT_SORT = "COALESCE(last_updated_trace_at, last_updated_at)";
+    private static final Map<String, String> SORTING_FIELD_MAPPING = Map.of(
+            SortableFields.LAST_UPDATED_TRACE_AT, LAST_UPDATED_TRACE_AT_SORT);
+
     private final @NonNull TransactionTemplate template;
     private final @NonNull IdGenerator idGenerator;
     private final @NonNull Provider<RequestContext> requestContext;
     private final @NonNull TraceDAO traceDAO;
-    private final @NonNull TransactionTemplateAsync transactionTemplateAsync;
     private final @NonNull SortingFactoryProjects sortingFactory;
     private final @NonNull SortingQueryBuilder sortingQueryBuilder;
     private final @NonNull AnalyticsService analyticsService;
@@ -267,21 +265,12 @@ class ProjectServiceImpl implements ProjectService {
 
     @Override
     public Project get(@NonNull UUID id, @NonNull String workspaceId) {
-        Project project = template.inTransaction(READ_ONLY, handle -> {
+        return template.inTransaction(READ_ONLY, handle -> {
 
             var repository = handle.attach(ProjectDAO.class);
 
             return repository.fetch(id, workspaceId).orElseThrow(this::createNotFoundError);
         });
-
-        //TODO: make it async
-        Map<UUID, Instant> lastUpdatedTraceAt = transactionTemplateAsync
-                .nonTransaction(connection -> traceDAO.getLastUpdatedTraceAt(Set.of(id), workspaceId, connection))
-                .block();
-
-        return project.toBuilder()
-                .lastUpdatedTraceAt(lastUpdatedTraceAt.get(project.id()))
-                .build();
     }
 
     @Override
@@ -366,10 +355,6 @@ class ProjectServiceImpl implements ProjectService {
         String workspaceId = requestContext.get().getWorkspaceId();
         Visibility visibility = requestContext.get().getVisibility();
 
-        if (!sortingFields.isEmpty() && sortingFields.getFirst().field().equals(SortableFields.LAST_UPDATED_TRACE_AT)) {
-            return findWithLastTraceSorting(page, size, criteria, sortingFields.getFirst());
-        }
-
         ProjectRecordSet projectRecordSet = template.inTransaction(READ_ONLY, handle -> {
 
             ProjectDAO repository = handle.attach(ProjectDAO.class);
@@ -378,7 +363,7 @@ class ProjectServiceImpl implements ProjectService {
 
             return new ProjectRecordSet(
                     repository.find(size, offset, workspaceId, criteria.projectName(), visibility,
-                            sortingQueryBuilder.toOrderBySql(sortingFields)),
+                            sortingQueryBuilder.toOrderBySql(sortingFields, SORTING_FIELD_MAPPING)),
                     repository.findCount(workspaceId, criteria.projectName(), visibility));
         });
 
@@ -386,24 +371,8 @@ class ProjectServiceImpl implements ProjectService {
             return ProjectPage.empty(page);
         }
 
-        Set<UUID> projectIds = projectRecordSet.content().stream().map(Project::id).collect(toSet());
-
-        Map<UUID, Instant> projectLastUpdatedTraceAtMap = transactionTemplateAsync
-                .nonTransaction(connection -> traceDAO.getLastUpdatedTraceAt(projectIds, workspaceId, connection))
-                .block();
-
-        List<Project> projects = projectRecordSet.content()
-                .stream()
-                .map(project -> {
-                    Instant lastUpdatedTraceAt = projectLastUpdatedTraceAtMap.get(project.id());
-                    return project.toBuilder()
-                            .lastUpdatedTraceAt(lastUpdatedTraceAt)
-                            .build();
-                })
-                .toList();
-
-        return new ProjectPage(page, projects.size(), projectRecordSet.total(), projects,
-                sortingFactory.getSortableFields());
+        return new ProjectPage(page, projectRecordSet.content().size(), projectRecordSet.total(),
+                projectRecordSet.content(), sortingFactory.getSortableFields());
     }
 
     private Map<UUID, Map<String, Object>> getProjectStats(List<UUID> projectIds, String workspaceId,
@@ -429,82 +398,6 @@ class ProjectServiceImpl implements ProjectService {
         }
 
         return template.inTransaction(READ_ONLY, handle -> handle.attach(ProjectDAO.class).findByIds(ids, workspaceId));
-    }
-
-    private Page<Project> findWithLastTraceSorting(int page, int size, @NonNull ProjectCriteria criteria,
-            @NonNull SortingField sortingField) {
-        String workspaceId = requestContext.get().getWorkspaceId();
-        Visibility visibility = requestContext.get().getVisibility();
-        String userName = requestContext.get().getUserName();
-
-        // get all project ids and last updated
-        List<ProjectIdLastUpdated> allProjectIdsLastUpdated = template.inTransaction(READ_ONLY, handle -> {
-            ProjectDAO repository = handle.attach(ProjectDAO.class);
-
-            return repository.getAllProjectIdsLastUpdated(workspaceId, criteria.projectName(), visibility);
-        });
-
-        if (allProjectIdsLastUpdated.isEmpty()) {
-            return ProjectPage.empty(page);
-        }
-
-        // get last trace for each project id
-        Set<UUID> allProjectIds = allProjectIdsLastUpdated.stream().map(ProjectIdLastUpdated::id)
-                .collect(toUnmodifiableSet());
-
-        Map<UUID, Instant> projectLastUpdatedTraceAtMap = transactionTemplateAsync
-                .nonTransaction(connection -> traceDAO.getLastUpdatedTraceAt(allProjectIds, workspaceId, connection))
-                .block();
-
-        if (projectLastUpdatedTraceAtMap == null) {
-            return ProjectPage.empty(page);
-        }
-
-        // sort and paginate
-        List<UUID> sorted = sortByLastTrace(allProjectIdsLastUpdated, projectLastUpdatedTraceAtMap, sortingField);
-        List<UUID> finalIds = PaginationUtils.paginate(page, size, sorted);
-
-        if (CollectionUtils.isEmpty(finalIds)) {
-            // pagination might return an empty list
-            return ProjectPage.empty(page);
-        }
-
-        // get all project properties for the final list of ids
-        Map<UUID, Project> projectsById = template.inTransaction(READ_ONLY, handle -> {
-            ProjectDAO repository = handle.attach(ProjectDAO.class);
-
-            return repository.findByIds(new HashSet<>(finalIds), workspaceId);
-        }).stream().collect(Collectors.toMap(Project::id, Function.identity()));
-
-        // compose the final projects list by the correct order and add last trace to it
-        List<Project> projects = finalIds.stream()
-                .map(projectsById::get)
-                .map(project -> project.toBuilder()
-                        .lastUpdatedTraceAt(projectLastUpdatedTraceAtMap.get(project.id()))
-                        .build())
-                .toList();
-
-        return new ProjectPage(page, projects.size(), allProjectIdsLastUpdated.size(), projects,
-                sortingFactory.getSortableFields());
-    }
-
-    private List<UUID> sortByLastTrace(
-            @NonNull List<ProjectIdLastUpdated> allProjectIdsLastUpdated,
-            @NonNull Map<UUID, Instant> projectLastUpdatedTraceAtMap,
-            @NonNull SortingField sortingField) {
-        // for projects with no traces - use last_updated_at
-        allProjectIdsLastUpdated.forEach(
-                project -> projectLastUpdatedTraceAtMap.computeIfAbsent(project.id(), key -> project.lastUpdatedAt()));
-
-        Comparator<Map.Entry<UUID, Instant>> comparator = sortingField.direction() == Direction.DESC
-                ? reverseOrder(Map.Entry.comparingByValue())
-                : Map.Entry.comparingByValue();
-
-        return projectLastUpdatedTraceAtMap.entrySet()
-                .stream()
-                .sorted(comparator)
-                .map(Map.Entry::getKey)
-                .toList();
     }
 
     @Override
@@ -636,17 +529,10 @@ class ProjectServiceImpl implements ProjectService {
     }
 
     private Project enrichWithStats(Project project, String workspaceId) {
-        Map<UUID, Instant> projectLastUpdatedTraceAtMap = transactionTemplateAsync
-                .nonTransaction(connection -> {
-                    Set<UUID> projectIds = Set.of(project.id());
-                    return traceDAO.getLastUpdatedTraceAt(projectIds, workspaceId, connection);
-                }).block();
-
         Map<UUID, Map<String, Object>> projectStats = getProjectStats(List.of(project.id()),
                 workspaceId, ProjectCriteria.builder().build());
 
         return project.toBuilder()
-                .lastUpdatedTraceAt(projectLastUpdatedTraceAtMap.get(project.id()))
                 .feedbackScores(StatsMapper.getStatsFeedbackScores(projectStats.get(project.id())))
                 .usage(StatsMapper.getStatsUsage(projectStats.get(project.id())))
                 .duration(StatsMapper.getStatsDuration(projectStats.get(project.id())))

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -115,7 +115,8 @@ public interface TraceDAO {
 
     Flux<WorkspaceTraceCount> countTracesPerWorkspace(Map<UUID, Instant> excludedProjectIds);
 
-    Mono<Map<UUID, Instant>> getLastUpdatedTraceAt(Set<UUID> projectIds, String workspaceId, Connection connection);
+    Mono<Map<UUID, Instant>> getLastUpdatedTraceAt(Set<UUID> projectIds, String workspaceId,
+            Instant lastUpdatedAfter, Connection connection);
 
     Mono<Set<UUID>> getProjectsWithTracesInRange(Collection<Pair<String, UUID>> workspaceProjectPairs, Instant from,
             Instant to, Connection connection);
@@ -2019,6 +2020,7 @@ class TraceDAOImpl implements TraceDAO {
             FROM traces t
             WHERE t.workspace_id = :workspace_id
             AND t.project_id IN :project_ids
+            <if(last_updated_after)> AND t.last_updated_at > parseDateTime64BestEffort(:last_updated_after, 9) <endif>
             GROUP BY t.project_id
             SETTINGS log_comment = '<log_comment>'
             ;
@@ -4202,7 +4204,8 @@ class TraceDAOImpl implements TraceDAO {
     @Override
     @WithSpan
     public Mono<Map<UUID, Instant>> getLastUpdatedTraceAt(
-            @NonNull Set<UUID> projectIds, @NonNull String workspaceId, @NonNull Connection connection) {
+            @NonNull Set<UUID> projectIds, @NonNull String workspaceId, Instant lastUpdatedAfter,
+            @NonNull Connection connection) {
 
         log.info("Getting last updated trace at for projectIds, size '{}'", projectIds.size());
 
@@ -4210,9 +4213,17 @@ class TraceDAOImpl implements TraceDAO {
                 "",
                 projectIds.size());
 
+        if (lastUpdatedAfter != null) {
+            template.add("last_updated_after", true);
+        }
+
         var statement = connection.createStatement(template.render())
                 .bind("project_ids", projectIds.toArray(UUID[]::new))
                 .bind("workspace_id", workspaceId);
+
+        if (lastUpdatedAfter != null) {
+            statement.bind("last_updated_after", lastUpdatedAfter.toString());
+        }
 
         return Mono.from(statement.execute())
                 .flatMapMany(result -> result.map((row, rowMetadata) -> Map.entry(row.get("project_id", UUID.class),

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -101,7 +101,7 @@ public interface TraceService {
 
     Mono<Long> getDailyCreatedCount();
 
-    Mono<Map<UUID, Instant>> getLastUpdatedTraceAt(Set<UUID> projectIds, String workspaceId);
+    Mono<Map<UUID, Instant>> getLastUpdatedTraceAt(Set<UUID> projectIds, String workspaceId, Instant lastUpdatedAfter);
 
     Mono<Set<UUID>> getProjectsWithTracesInRange(@NonNull Collection<Pair<String, UUID>> workspaceProjectPairs,
             @NonNull Instant from, @NonNull Instant to);
@@ -569,9 +569,11 @@ class TraceServiceImpl implements TraceService {
     }
 
     @Override
-    public Mono<Map<UUID, Instant>> getLastUpdatedTraceAt(Set<UUID> projectIds, String workspaceId) {
+    public Mono<Map<UUID, Instant>> getLastUpdatedTraceAt(Set<UUID> projectIds, String workspaceId,
+            Instant lastUpdatedAfter) {
         return template
-                .nonTransaction(connection -> dao.getLastUpdatedTraceAt(projectIds, workspaceId, connection));
+                .nonTransaction(
+                        connection -> dao.getLastUpdatedTraceAt(projectIds, workspaceId, lastUpdatedAfter, connection));
     }
 
     @Override


### PR DESCRIPTION
## Details

The project list/get/retrieve endpoints queried ClickHouse on every request just to obtain each project's `last_updated_trace_at`, even though the `projects` MySQL table already maintains that column (populated on trace events by `ProjectEventListener` → `recordLastUpdatedTrace`). This reads it straight from MySQL instead, sorts by last trace in SQL via `COALESCE(last_updated_trace_at, last_updated_at)`, and removes the bespoke in-memory sorting path.

It also bounds the one remaining ClickHouse population query (`SELECT_TRACE_LAST_UPDATED_AT`) with the project's previously recorded timestamp, so the `last_updated_at` minmax skip index prunes old granules instead of scanning the project's full trace history on every trace event.

- Read path: dropped the per-request ClickHouse `getLastUpdatedTraceAt` calls from `find`, `get`, and `retrieveByName`; the value now comes from the `SELECT *` already returned by the projects DAO.
- Sorting: `LAST_UPDATED_TRACE_AT` maps to `COALESCE(last_updated_trace_at, last_updated_at)` in the SQL `ORDER BY` (same fallback semantics as before — `last_updated_at` only applies to projects with no traces). Removed `findWithLastTraceSorting`, `sortByLastTrace`, `ProjectDAO.getAllProjectIdsLastUpdated`, and the now-unused `transactionTemplateAsync` field.
- Write path: added an optional `AND t.last_updated_at > :last_updated_after` filter; `ProjectEventListener` passes the minimum recorded timestamp across the event's projects, falling back to a full scan when any project has no recorded value yet (e.g. its first traces) or was deleted.
- Measured on a large production project (~16M traces): ~12× faster and ~90× less I/O (≈1.3 GiB → ≈15 MiB read per call), result-equivalent to the previous full scan. Detailed production metrics are in OPIK-7144.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7144

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: code review + targeted backend integration tests

## Testing

- `mvn compile -DskipTests` and `mvn spotless:check` — pass.
- Targeted backend integration tests (Testcontainers, MySQL + ClickHouse), all green:
  - `ProjectsResourceTest$FindProject` (27) — covers last-trace sorting (incl. the no-trace fallback) and displayed `lastUpdatedTraceAt`, exercising the event-driven column population through the now-bounded query.
  - `ProjectsResourceTest$GetProject` (3) and `ProjectsResourceTest$RetrieveProjectTest` (6) — the single-project read paths.
- Scenarios validated: sort ASC/DESC by last trace; projects with vs without traces; multiple trace batches per project (the bound advances across successive events); displayed value unchanged vs prior behavior.
- Environment: local process mode, Testcontainers for MySQL/ClickHouse.
- Not run locally: full backend suite (runs in CI). New query path additionally validated against production data (see OPIK-7144).

## Documentation

N/A — internal performance change, no API or user-facing behavior change.
