### PR TITLE
[OPIK-6964] [SDK] feat: add --to-workspace option to opik import; fix data loss gaps

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/export_data.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/export_data.mdx
@@ -177,6 +177,8 @@ opik export my-workspace my-project traces --format csv --path ./csv_data
 opik import WORKSPACE PROJECT ITEM [NAME] [OPTIONS]
 ```
 
+`WORKSPACE` is the source workspace — used to locate the exported files under `<path>/WORKSPACE/projects/`. Use `--to-workspace` to write into a different destination workspace.
+
 ```bash
 # Import a dataset
 opik import my-workspace my-project dataset "my-dataset"
@@ -187,11 +189,17 @@ opik import my-workspace my-project traces
 # Preview what would be imported
 opik import my-workspace my-project all --dry-run
 
-# Import into a different (renamed or scratch) destination project
+# Import into a different destination project
 opik import my-workspace my-project all --to-project my-restore
+
+# Import into a different destination workspace
+opik import src-workspace my-project all --to-workspace dest-workspace
+
+# Import into a different workspace and project
+opik import src-workspace my-project all --to-workspace dest-workspace --to-project new-project
 ```
 
-The project name is matched against the `name` recorded in each exported `project.json`. Import uses the same `--path` as export (both resolve `<path>/<workspace>/projects/<id>/`), so no path juggling is needed. Use `--to-project <NAME>` to import into a different destination project (default: the source project's name).
+The project name is matched against the `name` recorded in each exported `project.json`. Import uses the same `--path` as export (both resolve `<path>/<workspace>/projects/<id>/`), so no path juggling is needed. Use `--to-project <NAME>` to import into a different destination project, or `--to-workspace <NAME>` to import into a different workspace (the source `WORKSPACE` argument is still used to locate the files on disk).
 
 Imports are automatically resumable — if interrupted, re-run the same command and it picks up where it left off using a local `migration_manifest.db`.
 
@@ -203,10 +211,15 @@ Imports are automatically resumable — if interrupted, re-run the same command 
 OPIK_API_KEY=<source_key> OPIK_URL_OVERRIDE=https://source.opik.example.com \
   opik export my-workspace my-project all --path ./migration_data
 
-# Step 2: Import to destination (use destination credentials)
+# Step 2: Import to destination — same workspace (use destination credentials)
 # Same --path as export — import resolves <path>/my-workspace/projects/<id>/.
 OPIK_API_KEY=<dest_key> OPIK_URL_OVERRIDE=https://dest.opik.example.com \
   opik import my-workspace my-project all --path ./migration_data
+
+# Step 2 (alternative): Import into a different destination workspace
+# WORKSPACE (my-workspace) still locates the files; --to-workspace sets the API target.
+OPIK_API_KEY=<dest_key> OPIK_URL_OVERRIDE=https://dest.opik.example.com \
+  opik import my-workspace my-project all --path ./migration_data --to-workspace dest-workspace
 ```
 
 See the CLI help (`opik export --help` / `opik import --help`) for all options and troubleshooting.

--- a/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx
@@ -132,14 +132,15 @@ opik export my-workspace my-project traces --page-size 100
 Imports specific data types from local files into the specified project.
 
 **Arguments:**
-- `WORKSPACE`: The workspace name to import to
-- `PROJECT`: The project to import into (every dataset, prompt, and experiment belongs to it)
+- `WORKSPACE`: The source workspace name — used to locate the exported files on disk under `<path>/WORKSPACE/projects/`. Use `--to-workspace` to import into a different destination workspace.
+- `PROJECT`: The project to import from (matched by name against each exported `project.json`)
 - `ITEM`: The kind of data to import (`all`, `dataset`, `traces`, `experiment`, or `prompt`)
 - `NAME`: Name pattern to match items (case-insensitive substring matching; not used with `all` or `traces`)
 
 **Options:**
 - `--path, -p`: Directory containing exported data (default: `opik_exports`)
 - `--to-project NAME`: Destination project to import into. Defaults to the source project's name (the `name` recorded in `project.json`). Use this to restore into a renamed or scratch project. Available on `all`, `traces`, `dataset`, `experiment`, and `prompt`.
+- `--to-workspace NAME`: Destination workspace to import into. Defaults to `WORKSPACE`. Use this to import data exported from one workspace into a different workspace — `WORKSPACE` is still used to locate the exported files on disk. Available on `all`, `traces`, `dataset`, `experiment`, and `prompt`.
 - `--dry-run`: Show what would be imported without actually importing
 - `--force`: Discard the migration manifest and re-import everything from scratch
 - `--no-attachments`: Skip uploading attachment files.
@@ -208,6 +209,15 @@ opik import my-workspace my-project dataset "test"
 Use `--to-project` to import into a different (e.g. renamed or scratch) destination project. The source folder is still located by the `my-project` name; the data is created in `my-restore`:
 ```bash
 opik import my-workspace my-project all --to-project my-restore
+```
+
+Use `--to-workspace` to import into a different workspace than the data was exported from. `WORKSPACE` still locates the files on disk; `--to-workspace` controls which workspace the Opik API writes to:
+```bash
+# Import data exported from src-workspace into dest-workspace
+opik import src-workspace my-project all --to-workspace dest-workspace
+
+# Import into a different workspace AND a different project
+opik import src-workspace my-project all --to-workspace dest-workspace --to-project new-project
 ```
 
 Use `--path` when your exported data is not in the default `opik_exports` directory:
@@ -461,13 +471,8 @@ and resume.
 
 Export writes to `<--path>/<workspace>/projects/<project_id>/`, and import reads
 the same layout, so use the same `--path` on both sides. Add `--to-project <NAME>`
-to import into a different destination project.
-
-To import into a **different workspace** than the data was exported from, point
-`--path` at the exported workspace directory (the export `--path` plus the source
-workspace), e.g. `opik export ws-a my-project all --path ./data` writes to
-`./data/ws-a/...`, then `opik import ws-b my-project all --path ./data/ws-a`
-imports it into `ws-b`.
+to import into a different destination project, or `--to-workspace <NAME>` to
+import into a different workspace.
 
 ```bash
 # Step 1: Export from source (run with source API key / Opik URL)
@@ -475,10 +480,15 @@ imports it into `ws-b`.
 OPIK_API_KEY=<source_key> OPIK_URL_OVERRIDE=https://source.opik.example.com \
   opik export my-workspace my-project traces --path ./migration_data
 
-# Step 2: Import to destination (run with destination API key / Opik URL)
+# Step 2: Import to destination — same workspace (run with destination API key / Opik URL)
 # Same --path as export. If interrupted, just re-run — it resumes automatically.
 OPIK_API_KEY=<dest_key> OPIK_URL_OVERRIDE=https://dest.opik.example.com \
   opik import my-workspace my-project traces --path ./migration_data
+
+# Step 2 (alternative): Import into a different destination workspace
+# WORKSPACE (my-workspace) still locates the files; --to-workspace sets the API target.
+OPIK_API_KEY=<dest_key> OPIK_URL_OVERRIDE=https://dest.opik.example.com \
+  opik import my-workspace my-project traces --path ./migration_data --to-workspace dest-workspace
 ```
 
 To migrate all data types at once:

--- a/sdks/python/src/opik/cli/exports/all.py
+++ b/sdks/python/src/opik/cli/exports/all.py
@@ -19,13 +19,14 @@ from rich.progress import (
 )
 
 import opik
+from opik import exceptions as opik_exceptions
 from opik.api_objects.prompt import Prompt, ChatPrompt
 from .dataset import export_single_dataset
 from .experiment import (
     export_experiment_by_id,
     export_collected_trace_ids,
 )
-from .project import export_single_project
+from .project import export_single_project, _export_rest_retry
 from .prompt import export_single_prompt
 from .utils import (
     console,
@@ -56,6 +57,7 @@ def _paginate(list_fn: Any, **kwargs: Any) -> Iterator:
         page += 1
 
 
+@_export_rest_retry
 def _fetch_experiments_page_raw(
     client: opik.Opik, page: int, project_id: Optional[str]
 ) -> tuple[list, int]:
@@ -64,6 +66,8 @@ def _fetch_experiments_page_raw(
     Used as a fallback when the typed client fails pydantic validation because
     some experiments lack required fields (e.g. dataset_name).
     Returns (items, total) where items are SimpleNamespace objects with id and name.
+    Raises on 429 (converted to OpikCloudRequestsRateLimited for retry) or other
+    HTTP/network errors after retry exhaustion.
     """
     httpx_client = (
         client.rest_client.experiments._raw_client._client_wrapper.httpx_client
@@ -71,26 +75,25 @@ def _fetch_experiments_page_raw(
     params: dict = {"page": page, "size": PAGE_SIZE}
     if project_id is not None:
         params["project_id"] = project_id
+    response = httpx_client.request(
+        "v1/private/experiments",
+        method="GET",
+        params=params,
+    )
     try:
-        response = httpx_client.request(
-            "v1/private/experiments",
-            method="GET",
-            params=params,
-        )
         response.raise_for_status()
-        data = response.json()
-    except (httpx.ConnectError, httpx.TimeoutException) as e:
-        console.print(
-            f"[yellow]Warning: transient network error fetching experiments page {page}: {e}. "
-            "Skipping page.[/yellow]"
-        )
-        return [], 0
     except httpx.HTTPStatusError as e:
-        console.print(
-            f"[yellow]Warning: HTTP error fetching experiments page {page}: {e}. "
-            "Skipping page.[/yellow]"
-        )
-        return [], 0
+        if e.response.status_code == 429:
+            try:
+                retry_after = float(e.response.headers.get("Retry-After", 30.0))
+            except (ValueError, TypeError):
+                retry_after = 30.0
+            raise opik_exceptions.OpikCloudRequestsRateLimited(
+                headers=dict(e.response.headers),
+                retry_after=retry_after,
+            )
+        raise
+    data = response.json()
     total = data.get("total", 0)
     items = [
         SimpleNamespace(id=raw.get("id"), name=raw.get("name", ""))
@@ -194,10 +197,11 @@ def _export_all_prompts(
     force: bool,
     debug: bool,
     format: str,
-) -> tuple[int, int]:
-    """Export all prompts in the project. Returns (exported, skipped)."""
+) -> tuple[int, int, int]:
+    """Export all prompts in the project. Returns (exported, skipped, errors)."""
     exported = 0
     skipped = 0
+    errors = 0
 
     try:
         all_prompts = list(
@@ -205,11 +209,11 @@ def _export_all_prompts(
         )
     except Exception as e:
         console.print(f"[red]Error listing prompts: {e}[/red]")
-        return 0, 0
+        return 0, 0, 0
 
     if not all_prompts:
         console.print("[yellow]No prompts found.[/yellow]")
-        return 0, 0
+        return 0, 0, 0
 
     console.print(f"[blue]Found {len(all_prompts)} prompt(s)[/blue]")
 
@@ -263,13 +267,14 @@ def _export_all_prompts(
                     else:
                         skipped += 1
             except Exception as e:
+                errors += 1
                 console.print(
                     f"[red]Error exporting prompt '{prompt_public.name}': {e}[/red]"
                 )
             finally:
                 progress.advance(task)
 
-    return exported, skipped
+    return exported, skipped, errors
 
 
 def _export_project_traces(
@@ -468,7 +473,7 @@ def export_all(
             console.print("\n[bold blue]--- Exporting Prompts ---[/bold blue]")
             prompts_dir = project_root / "prompts"
             prompts_dir.mkdir(parents=True, exist_ok=True)
-            pr_exp, pr_skip = _export_all_prompts(
+            pr_exp, pr_skip, pr_errors = _export_all_prompts(
                 client,
                 prompts_dir,
                 project_name,
@@ -480,6 +485,8 @@ def export_all(
             )
             total_stats["prompts"] = pr_exp
             total_stats["prompts_skipped"] = pr_skip
+            if pr_errors:
+                any_errors = True
 
         # Phase 3: Traces
         if "traces" in include:

--- a/sdks/python/src/opik/cli/exports/all.py
+++ b/sdks/python/src/opik/cli/exports/all.py
@@ -209,7 +209,7 @@ def _export_all_prompts(
         )
     except Exception as e:
         console.print(f"[red]Error listing prompts: {e}[/red]")
-        return 0, 0, 0
+        return 0, 0, 1
 
     if not all_prompts:
         console.print("[yellow]No prompts found.[/yellow]")

--- a/sdks/python/src/opik/cli/exports/dataset.py
+++ b/sdks/python/src/opik/cli/exports/dataset.py
@@ -169,7 +169,7 @@ def export_experiment_datasets(
         force: Re-download datasets even if they already exist locally
 
     Returns:
-        Tuple of (exported_count, skipped_count)
+        Tuple of (exported_count, skipped_count, error_count)
     """
     exported_count = 0
     skipped_count = 0

--- a/sdks/python/src/opik/cli/exports/dataset.py
+++ b/sdks/python/src/opik/cli/exports/dataset.py
@@ -156,7 +156,7 @@ def export_experiment_datasets(
     format: str,
     debug: bool,
     force: bool,
-) -> tuple[int, int]:
+) -> tuple[int, int, int]:
     """Export datasets related to an experiment.
 
     Args:
@@ -173,6 +173,7 @@ def export_experiment_datasets(
     """
     exported_count = 0
     skipped_count = 0
+    error_count = 0
 
     for dataset_name in datasets_to_export:
         try:
@@ -226,6 +227,7 @@ def export_experiment_datasets(
             console.print(f"[green]Exported dataset: {dataset_name}[/green]")
             exported_count += 1
         except Exception as e:
+            error_count += 1
             if debug:
                 console.print(
                     f"[yellow]Warning: Could not export dataset {dataset_name}: {e}[/yellow]"
@@ -233,7 +235,7 @@ def export_experiment_datasets(
             else:
                 console.print(f"[red]Error exporting dataset {dataset_name}: {e}[/red]")
 
-    return exported_count, skipped_count
+    return exported_count, skipped_count, error_count
 
 
 @click.command(name="dataset")

--- a/sdks/python/src/opik/cli/exports/experiment.py
+++ b/sdks/python/src/opik/cli/exports/experiment.py
@@ -1,6 +1,7 @@
 """Experiment export functionality."""
 
 import json
+import logging
 import sys
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
@@ -39,6 +40,8 @@ from .prompt import (
     export_related_prompts_by_name,
     export_prompts_by_ids,
 )
+
+LOGGER = logging.getLogger(__name__)
 
 # Batch size for parallel trace fetching
 BATCH_SIZE = 100
@@ -87,6 +90,9 @@ def _fetch_trace_data(
             if debug:
                 debug_print(f"Trace {trace_id} not found (404), skipping", debug)
             return None
+        LOGGER.error(
+            "API error fetching trace %s (status %s): %s", trace_id, e.status_code, e
+        )
         raise  # 429/5xx are retried by @_export_rest_retry; others propagate
 
 
@@ -670,6 +676,7 @@ def export_experiment_by_name(
                         unique_prompt_ids.add(prompt_version.prompt_id)
 
         # Export all unique datasets once before processing experiments
+        had_errors = False
         datasets_exported = 0
         datasets_skipped = 0
         if unique_datasets:
@@ -677,7 +684,7 @@ def export_experiment_by_name(
                 console.print(
                     f"[blue]Exporting {len(unique_datasets)} unique dataset(s) used by these experiments...[/blue]"
                 )
-            datasets_exported, datasets_skipped, _datasets_errors = (
+            datasets_exported, datasets_skipped, datasets_errors = (
                 export_experiment_datasets(
                     client,
                     unique_datasets,
@@ -688,6 +695,8 @@ def export_experiment_by_name(
                     force,
                 )
             )
+            if datasets_errors:
+                had_errors = True
 
         # Export all unique prompts once before processing experiments
         prompts_dir = output_dir.parent / "prompts"
@@ -699,7 +708,7 @@ def export_experiment_by_name(
                 console.print(
                     f"[blue]Exporting {len(unique_prompt_ids)} unique prompt(s) used by these experiments...[/blue]"
                 )
-            prompts_exported, prompts_skipped, _prompts_errors = export_prompts_by_ids(
+            prompts_exported, prompts_skipped, prompts_errors = export_prompts_by_ids(
                 client,
                 unique_prompt_ids,
                 prompts_dir,
@@ -708,6 +717,8 @@ def export_experiment_by_name(
                 debug,
                 force,
             )
+            if prompts_errors:
+                had_errors = True
 
         # Collect all unique trace IDs from all experiments as we process them
         # We'll collect them during the first pass, then export once
@@ -810,6 +821,12 @@ def export_experiment_by_name(
                 f"[yellow]All {len(experiments)} experiment(s) with name '{name}' already exist (use --force to re-download)[/yellow]"
             )
 
+        if had_errors:
+            console.print(
+                "[bold yellow]Export completed with errors — some datasets or prompts could not be exported.[/bold yellow]"
+            )
+            sys.exit(1)
+
     except Exception as e:
         console.print(f"[red]Error exporting experiment: {e}[/red]")
         sys.exit(1)
@@ -889,8 +906,9 @@ def export_experiment_by_name_or_id(
 
             datasets_exported = 0
             datasets_skipped = 0
+            had_ds_errors = False
             if unique_datasets:
-                datasets_exported, datasets_skipped, _ds_errors = (
+                datasets_exported, datasets_skipped, ds_errors = (
                     export_experiment_datasets(
                         client,
                         unique_datasets,
@@ -901,6 +919,8 @@ def export_experiment_by_name_or_id(
                         force,
                     )
                 )
+                if ds_errors:
+                    had_ds_errors = True
 
             # Export traces collected from experiment items, passing the manifest
             # so already-downloaded traces are skipped before any API call.
@@ -947,6 +967,12 @@ def export_experiment_by_name_or_id(
                 console.print(
                     f"[yellow]Experiment '{experiment.name}' (ID: {experiment.id}) already exists (use --force to re-download)[/yellow]"
                 )
+
+            if had_ds_errors:
+                console.print(
+                    "[bold yellow]Export completed with errors — some datasets could not be exported.[/bold yellow]"
+                )
+                sys.exit(1)
             return
 
         except exceptions.ExperimentNotFound:

--- a/sdks/python/src/opik/cli/exports/experiment.py
+++ b/sdks/python/src/opik/cli/exports/experiment.py
@@ -19,6 +19,8 @@ from rich.progress import (
 import opik
 from opik import exceptions
 from opik.cli.export_manifest import ExportManifest
+from opik.rest_api.core.api_error import ApiError
+from .project import _export_rest_retry
 from .utils import (
     console,
     create_experiment_data_structure,
@@ -44,6 +46,7 @@ BATCH_SIZE = 100
 MAX_WORKERS = 20
 
 
+@_export_rest_retry
 def _fetch_trace_data(
     client: opik.Opik,
     trace_id: str,
@@ -56,7 +59,8 @@ def _fetch_trace_data(
     that project without a per-trace project lookup.
 
     Returns:
-        Tuple of (trace_id, trace_data_dict) or None if failed.
+        Tuple of (trace_id, trace_data_dict) or None if trace does not exist (404).
+        Raises on transient errors after retries are exhausted.
     """
     try:
         # Get trace by ID
@@ -78,14 +82,12 @@ def _fetch_trace_data(
         }
 
         return (trace_id, trace_data)
-    except Exception as e:
-        if debug:
-            import traceback
-
-            debug_print(
-                f"Error fetching trace {trace_id}: {e}\n{traceback.format_exc()}", debug
-            )
-        return None
+    except ApiError as e:
+        if e.status_code == 404:
+            if debug:
+                debug_print(f"Trace {trace_id} not found (404), skipping", debug)
+            return None
+        raise  # 429/5xx are retried by @_export_rest_retry; others propagate
 
 
 def _write_trace_file(
@@ -577,8 +579,7 @@ def export_experiment_by_id(
 
     except Exception as e:
         console.print(f"[red]Error exporting experiment {experiment_id}: {e}[/red]")
-        # Return empty stats and 0 for file written on error
-        return ({"datasets": 0, "prompts": 0, "traces": 0}, 0, None)
+        raise
 
 
 def export_experiment_by_name(
@@ -676,14 +677,16 @@ def export_experiment_by_name(
                 console.print(
                     f"[blue]Exporting {len(unique_datasets)} unique dataset(s) used by these experiments...[/blue]"
                 )
-            datasets_exported, datasets_skipped = export_experiment_datasets(
-                client,
-                unique_datasets,
-                datasets_dir,
-                project_name,
-                format,
-                debug,
-                force,
+            datasets_exported, datasets_skipped, _datasets_errors = (
+                export_experiment_datasets(
+                    client,
+                    unique_datasets,
+                    datasets_dir,
+                    project_name,
+                    format,
+                    debug,
+                    force,
+                )
             )
 
         # Export all unique prompts once before processing experiments
@@ -696,7 +699,7 @@ def export_experiment_by_name(
                 console.print(
                     f"[blue]Exporting {len(unique_prompt_ids)} unique prompt(s) used by these experiments...[/blue]"
                 )
-            prompts_exported, prompts_skipped = export_prompts_by_ids(
+            prompts_exported, prompts_skipped, _prompts_errors = export_prompts_by_ids(
                 client,
                 unique_prompt_ids,
                 prompts_dir,
@@ -887,14 +890,16 @@ def export_experiment_by_name_or_id(
             datasets_exported = 0
             datasets_skipped = 0
             if unique_datasets:
-                datasets_exported, datasets_skipped = export_experiment_datasets(
-                    client,
-                    unique_datasets,
-                    datasets_dir,
-                    project_name,
-                    format,
-                    debug,
-                    force,
+                datasets_exported, datasets_skipped, _ds_errors = (
+                    export_experiment_datasets(
+                        client,
+                        unique_datasets,
+                        datasets_dir,
+                        project_name,
+                        format,
+                        debug,
+                        force,
+                    )
                 )
 
             # Export traces collected from experiment items, passing the manifest

--- a/sdks/python/src/opik/cli/exports/project.py
+++ b/sdks/python/src/opik/cli/exports/project.py
@@ -820,7 +820,7 @@ def export_traces(
                             debug_print(f"Wrote JSON file: {file_path}", debug)
                     with manifest_lock:
                         already_downloaded.add(trace_id)
-                        if manifest is not None:
+                        if manifest is not None and attachment_download_ok:
                             manifest.mark_trace_downloaded(trace_id)
                     return True, not attachment_download_ok
                 except Exception as write_error:

--- a/sdks/python/src/opik/cli/exports/project.py
+++ b/sdks/python/src/opik/cli/exports/project.py
@@ -105,14 +105,13 @@ def _export_wait_duration(retry_state: tenacity.RetryCallState) -> float:
         headers = httpx.Headers(getattr(exc, "headers", {}) or {})
         # Prefer the standard Retry-After header, then fall back to
         # Opik-specific / draft-IETF rate-limit reset headers.
-        seconds = _parse_retry_after(headers)
-        if seconds is None:
-            seconds = _parse_rate_limit_reset(headers)
-        if seconds is None:
-            seconds = _EXPORT_DEFAULT_RETRY_AFTER_SECONDS
-        # Clamp to our maximum: respect the server's intent but never wait longer
-        # than _EXPORT_MAX_RETRY_AFTER_SECONDS.
-        seconds = min(seconds, _EXPORT_MAX_RETRY_AFTER_SECONDS)
+        parsed = _parse_retry_after(headers)
+        if parsed is None:
+            parsed = _parse_rate_limit_reset(headers)
+        seconds = min(
+            parsed if parsed is not None else _EXPORT_DEFAULT_RETRY_AFTER_SECONDS,
+            _EXPORT_MAX_RETRY_AFTER_SECONDS,
+        )
         # Jitter: avoid a thundering-herd if multiple export processes run in parallel.
         jitter = random.uniform(0.0, _EXPORT_JITTER_MAX_SECONDS)
         return seconds + jitter

--- a/sdks/python/src/opik/cli/exports/project.py
+++ b/sdks/python/src/opik/cli/exports/project.py
@@ -95,6 +95,12 @@ def _export_wait_duration(retry_state: tenacity.RetryCallState) -> float:
     the standard SDK decorator for other transient errors.
     """
     exc = retry_state.outcome.exception() if retry_state.outcome else None
+    if isinstance(exc, opik_exceptions.OpikCloudRequestsRateLimited):
+        # Attachment operations convert 429 ApiErrors into this exception and
+        # store the server's retry_after value directly on it.
+        seconds = min(exc.retry_after, _EXPORT_MAX_RETRY_AFTER_SECONDS)
+        jitter = random.uniform(0.0, _EXPORT_JITTER_MAX_SECONDS)
+        return seconds + jitter
     if isinstance(exc, ApiError) and exc.status_code == 429:
         headers = httpx.Headers(getattr(exc, "headers", {}) or {})
         # Prefer the standard Retry-After header, then fall back to
@@ -116,10 +122,18 @@ def _export_wait_duration(retry_state: tenacity.RetryCallState) -> float:
     return min(base, 60.0)
 
 
+def _export_allowed_to_retry(exception: Exception) -> bool:
+    """Extend the standard retry predicate to also cover rate-limit exceptions
+    raised by attachment operations (``OpikCloudRequestsRateLimited``)."""
+    if isinstance(exception, opik_exceptions.OpikCloudRequestsRateLimited):
+        return True
+    return retry_decorator._allowed_to_retry(exception)
+
+
 _export_rest_retry = tenacity.retry(
     stop=tenacity.stop_after_attempt(8),
     wait=_export_wait_duration,
-    retry=tenacity.retry_if_exception(retry_decorator._allowed_to_retry),
+    retry=tenacity.retry_if_exception(_export_allowed_to_retry),
     reraise=True,
 )
 
@@ -295,6 +309,7 @@ def _handle_attachment_api_error(e: ApiError, context: str) -> None:
         raise
 
 
+@_export_rest_retry
 def _fetch_attachments(
     attachment_client: attachment_client.AttachmentClient,
     project_name: str,
@@ -341,6 +356,7 @@ def _fetch_attachments(
     return attachments
 
 
+@_export_rest_retry
 def _download_attachment_file(
     attachment_client: attachment_client.AttachmentClient,
     project_name: str,

--- a/sdks/python/src/opik/cli/exports/prompt.py
+++ b/sdks/python/src/opik/cli/exports/prompt.py
@@ -115,13 +115,11 @@ def export_single_prompt(
                 prompt_history = list(
                     client.get_prompt_history(prompt.name, project_name=project_name)
                 )
-        except (ValueError, Exception):
-            # Fall back to empty history so the current version is still exported.
-            if debug:
-                debug_print(
-                    f"Could not fetch history for prompt '{prompt.name}', exporting current version only",
-                    debug,
-                )
+        except (ValueError, Exception) as e:
+            console.print(
+                f"[yellow]Warning: Could not fetch history for prompt '{prompt.name}': {e}. "
+                "Exporting current version only.[/yellow]"
+            )
             prompt_history = []
 
         # Create prompt data structure
@@ -255,7 +253,7 @@ def export_prompts_by_ids(
     format: str,
     debug: bool,
     force: bool,
-) -> tuple[int, int]:
+) -> tuple[int, int, int]:
     """Export prompts by their IDs.
 
     Args:
@@ -268,10 +266,11 @@ def export_prompts_by_ids(
         force: Re-download prompts even if they already exist locally
 
     Returns:
-        Tuple of (exported_count, skipped_count)
+        Tuple of (exported_count, skipped_count, error_count)
     """
     exported_count = 0
     skipped_count = 0
+    error_count = 0
 
     for prompt_id in prompt_ids:
         try:
@@ -369,6 +368,7 @@ def export_prompts_by_ids(
             exported_count += 1
 
         except Exception as e:
+            error_count += 1
             if debug:
                 console.print(
                     f"[yellow]Warning: Could not export prompt {prompt_id}: {e}[/yellow]"
@@ -377,7 +377,7 @@ def export_prompts_by_ids(
                 console.print(f"[red]Error exporting prompt {prompt_id}: {e}[/red]")
             continue
 
-    return exported_count, skipped_count
+    return exported_count, skipped_count, error_count
 
 
 def export_related_prompts_by_name(
@@ -491,7 +491,11 @@ def export_related_prompts_by_name(
                                 prompt.name, project_name=project_name
                             )
                         )
-                except (ValueError, Exception):
+                except (ValueError, Exception) as e:
+                    console.print(
+                        f"[yellow]Warning: Could not fetch history for prompt '{prompt.name}': {e}. "
+                        "Exporting current version only.[/yellow]"
+                    )
                     prompt_history = []
 
                 # Create prompt data structure

--- a/sdks/python/src/opik/cli/exports/prompt.py
+++ b/sdks/python/src/opik/cli/exports/prompt.py
@@ -79,6 +79,25 @@ def _get_prompt_type_string(prompt: Any) -> Optional[str]:
     return str(prompt_type).upper()
 
 
+def _safe_prompt_history(
+    client: opik.Opik,
+    prompt: Union[Prompt, ChatPrompt],
+    project_name: str,
+) -> List[Union[Prompt, ChatPrompt]]:
+    try:
+        if isinstance(prompt, ChatPrompt):
+            return list(
+                client.get_chat_prompt_history(prompt.name, project_name=project_name)
+            )
+        return list(client.get_prompt_history(prompt.name, project_name=project_name))
+    except Exception as e:
+        console.print(
+            f"[yellow]Warning: Could not fetch history for prompt '{prompt.name}': {e}. "
+            "Exporting current version only.[/yellow]"
+        )
+        return []
+
+
 def export_single_prompt(
     client: opik.Opik,
     prompt: Union[Prompt, ChatPrompt],
@@ -103,24 +122,7 @@ def export_single_prompt(
             return 0
 
         # Get prompt history (scoped to the prompt's project)
-        prompt_history: List[Union[Prompt, ChatPrompt]]
-        try:
-            if isinstance(prompt, ChatPrompt):
-                prompt_history = list(
-                    client.get_chat_prompt_history(
-                        prompt.name, project_name=project_name
-                    )
-                )
-            else:
-                prompt_history = list(
-                    client.get_prompt_history(prompt.name, project_name=project_name)
-                )
-        except (ValueError, Exception) as e:
-            console.print(
-                f"[yellow]Warning: Could not fetch history for prompt '{prompt.name}': {e}. "
-                "Exporting current version only.[/yellow]"
-            )
-            prompt_history = []
+        prompt_history = _safe_prompt_history(client, prompt, project_name)
 
         # Create prompt data structure
         prompt_data = {
@@ -477,26 +479,7 @@ def export_related_prompts_by_name(
                     continue
 
                 # Get prompt history - use appropriate method based on prompt type
-                prompt_history: List[Union[Prompt, ChatPrompt]]
-                try:
-                    if isinstance(prompt, ChatPrompt):
-                        prompt_history = list(
-                            client.get_chat_prompt_history(
-                                prompt.name, project_name=project_name
-                            )
-                        )
-                    else:
-                        prompt_history = list(
-                            client.get_prompt_history(
-                                prompt.name, project_name=project_name
-                            )
-                        )
-                except (ValueError, Exception) as e:
-                    console.print(
-                        f"[yellow]Warning: Could not fetch history for prompt '{prompt.name}': {e}. "
-                        "Exporting current version only.[/yellow]"
-                    )
-                    prompt_history = []
+                prompt_history = _safe_prompt_history(client, prompt, project_name)
 
                 # Create prompt data structure
                 prompt_data = {

--- a/sdks/python/src/opik/cli/imports/__init__.py
+++ b/sdks/python/src/opik/cli/imports/__init__.py
@@ -21,6 +21,7 @@ from .utils import (
     resolve_import_project_root,
     setup_import_manifest,
     to_project_option,
+    to_workspace_option,
 )
 
 console = Console()
@@ -41,6 +42,7 @@ def _import_by_type(
     force: bool = False,
     include_attachments: bool = True,
     to_project: Optional[str] = None,
+    to_workspace: Optional[str] = None,
 ) -> None:
     """
     Import data by type (dataset, traces, experiment, prompt) into a project.
@@ -48,7 +50,8 @@ def _import_by_type(
     Args:
         import_type: Type of data to import ("dataset", "traces", "experiment", "prompt")
         path: Base directory containing the exported data
-        workspace: Target workspace name
+        workspace: Source workspace name. Used to locate the exported project folder
+            under ``<path>/<workspace>/projects/``.
         project_name: Source project name. Used to locate the exported project
             folder (matched against the name recorded in project.json). Also the
             default destination project when ``to_project`` is not given.
@@ -59,15 +62,19 @@ def _import_by_type(
         force: Discard any existing manifest and restart from scratch
         to_project: Optional destination project name. When provided the data is
             created in this project instead of ``project_name``.
+        to_workspace: Optional destination workspace name. When provided the data is
+            imported into this workspace instead of ``workspace``. ``workspace`` is
+            still used to locate the exported files on disk.
     """
     try:
         debug_print(f"DEBUG: Starting {import_type} import from {path}", debug)
 
-        # Initialize Opik client
+        # Initialize Opik client using the destination workspace
+        dest_workspace = to_workspace or workspace
         if api_key:
-            client = opik.Opik(api_key=api_key, workspace=workspace)
+            client = opik.Opik(api_key=api_key, workspace=dest_workspace)
         else:
-            client = opik.Opik(workspace=workspace)
+            client = opik.Opik(workspace=dest_workspace)
 
         # Locate the exported project folder by its recorded name and resolve
         # the destination project. Folders are keyed by id on disk; project.json
@@ -222,7 +229,10 @@ def _import_by_type(
 )
 @click.pass_context
 def import_group(
-    ctx: click.Context, workspace: str, project: str, api_key: Optional[str]
+    ctx: click.Context,
+    workspace: str,
+    project: str,
+    api_key: Optional[str],
 ) -> None:
     """Import data into an Opik project.
 
@@ -251,10 +261,11 @@ def import_group(
 
     \b
     Common Options:
-        --path, -p  Directory containing exported data (default: opik_exports)
-        --dry-run   Preview what would be imported without actually importing
-        --force     Discard manifest and restart from scratch
-        --debug     Show detailed information about the import process
+        --path, -p       Directory containing exported data (default: opik_exports)
+        --to-workspace   Destination workspace (default: same as source WORKSPACE)
+        --dry-run        Preview what would be imported without actually importing
+        --force          Discard manifest and restart from scratch
+        --debug          Show detailed information about the import process
 
     \b
     Examples:
@@ -263,6 +274,12 @@ def import_group(
 
         # Preview what would be imported
         opik import my-workspace my-project all --dry-run
+
+        # Import into a different workspace
+        opik import source-workspace my-project all --to-workspace dest-workspace
+
+        # Import into a different workspace and a different project
+        opik import source-workspace my-project all --to-workspace dest-workspace --to-project new-project
 
         # Import the project's traces
         opik import my-workspace my-project traces
@@ -351,6 +368,7 @@ import_group.add_command(import_all_command)
     help="Enable debug output to show detailed information about the import process.",
 )
 @to_project_option()
+@to_workspace_option()
 @click.pass_context
 def import_dataset(
     ctx: click.Context,
@@ -360,6 +378,7 @@ def import_dataset(
     force: bool,
     debug: bool,
     to_project: Optional[str],
+    to_workspace: Optional[str],
 ) -> None:
     """Import datasets from projects/PROJECT/datasets.
 
@@ -379,6 +398,9 @@ def import_dataset(
         # Import into a different destination project
         opik import my-workspace my-project dataset "my-dataset" --to-project other-project
     \b
+        # Import into a different workspace
+        opik import src-workspace my-project dataset "my-dataset" --to-workspace dest-workspace
+    \b
         # Import from a custom path
         opik import my-workspace my-project dataset "my-dataset" --path ./custom-exports/
     """
@@ -396,6 +418,7 @@ def import_dataset(
         api_key=api_key,
         force=force,
         to_project=to_project,
+        to_workspace=to_workspace,
     )
 
 
@@ -424,6 +447,7 @@ def import_dataset(
 )
 @no_attachments_option()
 @to_project_option()
+@to_workspace_option()
 @click.pass_context
 def import_traces(
     ctx: click.Context,
@@ -433,6 +457,7 @@ def import_traces(
     debug: bool,
     no_attachments: bool,
     to_project: Optional[str],
+    to_workspace: Optional[str],
 ) -> None:
     """Import the project's traces from projects/PROJECT/.
 
@@ -453,6 +478,9 @@ def import_traces(
     \b
         # Import into a different destination project
         opik import my-workspace my-project traces --to-project other-project
+    \b
+        # Import into a different workspace
+        opik import src-workspace my-project traces --to-workspace dest-workspace
     \b
         # Import from a custom path
         opik import my-workspace my-project traces --path ./custom-exports/
@@ -476,6 +504,7 @@ def import_traces(
         force=force,
         include_attachments=not no_attachments,
         to_project=to_project,
+        to_workspace=to_workspace,
     )
 
 
@@ -504,6 +533,7 @@ def import_traces(
     help="Enable debug output to show detailed information about the import process.",
 )
 @to_project_option()
+@to_workspace_option()
 @click.pass_context
 def import_experiment(
     ctx: click.Context,
@@ -513,6 +543,7 @@ def import_experiment(
     force: bool,
     debug: bool,
     to_project: Optional[str],
+    to_workspace: Optional[str],
 ) -> None:
     """Import experiments from projects/PROJECT/experiments.
 
@@ -535,6 +566,9 @@ def import_experiment(
         # Import into a different destination project
         opik import my-workspace my-project experiment "my-experiment" --to-project other-project
     \b
+        # Import into a different workspace
+        opik import src-workspace my-project experiment "my-experiment" --to-workspace dest-workspace
+    \b
         # Import from a custom path
         opik import my-workspace my-project experiment "my-experiment" --path ./custom-exports/
     """
@@ -553,6 +587,7 @@ def import_experiment(
         api_key=api_key,
         force=force,
         to_project=to_project,
+        to_workspace=to_workspace,
     )
 
 
@@ -581,6 +616,7 @@ def import_experiment(
     help="Enable debug output to show detailed information about the import process.",
 )
 @to_project_option()
+@to_workspace_option()
 @click.pass_context
 def import_prompt(
     ctx: click.Context,
@@ -590,6 +626,7 @@ def import_prompt(
     force: bool,
     debug: bool,
     to_project: Optional[str],
+    to_workspace: Optional[str],
 ) -> None:
     """Import prompts from projects/PROJECT/prompts.
 
@@ -609,6 +646,9 @@ def import_prompt(
         # Import into a different destination project
         opik import my-workspace my-project prompt "my-prompt" --to-project other-project
     \b
+        # Import into a different workspace
+        opik import src-workspace my-project prompt "my-prompt" --to-workspace dest-workspace
+    \b
         # Import from a custom path
         opik import my-workspace my-project prompt "my-prompt" --path ./custom-exports/
     """
@@ -626,4 +666,5 @@ def import_prompt(
         api_key=api_key,
         force=force,
         to_project=to_project,
+        to_workspace=to_workspace,
     )

--- a/sdks/python/src/opik/cli/imports/__init__.py
+++ b/sdks/python/src/opik/cli/imports/__init__.py
@@ -87,10 +87,14 @@ def _import_by_type(
         )
 
         # Construct + initialize the per-destination manifest (keyed by the
-        # destination project so different --to-project targets keep independent
-        # resume state). Skipped for --dry-run.
+        # destination workspace + project so different --to-workspace / --to-project
+        # targets keep independent resume state). Skipped for --dry-run.
         manifest, already_completed = setup_import_manifest(
-            project_root, target_project_name, dry_run, force
+            project_root,
+            target_project_name,
+            dry_run,
+            force,
+            destination_workspace=dest_workspace,
         )
         if already_completed:
             return

--- a/sdks/python/src/opik/cli/imports/all.py
+++ b/sdks/python/src/opik/cli/imports/all.py
@@ -20,6 +20,7 @@ from .utils import (
     resolve_import_project_root,
     setup_import_manifest,
     to_project_option,
+    to_workspace_option,
 )
 from ..include_validation import validate_include
 
@@ -52,13 +53,15 @@ def import_all(
     api_key: Optional[str] = None,
     include_attachments: bool = True,
     to_project: Optional[str] = None,
+    to_workspace: Optional[str] = None,
 ) -> None:
     """Import all data types from the project export directory."""
     try:
+        dest_workspace = to_workspace or workspace
         if api_key:
-            client = opik.Opik(api_key=api_key, workspace=workspace)
+            client = opik.Opik(api_key=api_key, workspace=dest_workspace)
         else:
-            client = opik.Opik(workspace=workspace)
+            client = opik.Opik(workspace=dest_workspace)
 
         # Locate the exported project folder by its recorded name and resolve
         # the destination project (shared with _import_by_type). Folders are
@@ -243,6 +246,7 @@ def import_all(
 )
 @no_attachments_option()
 @to_project_option()
+@to_workspace_option()
 @click.pass_context
 def import_all_command(
     ctx: click.Context,
@@ -253,6 +257,7 @@ def import_all_command(
     include: List[str],
     no_attachments: bool,
     to_project: Optional[str],
+    to_workspace: Optional[str],
 ) -> None:
     """Import all datasets, prompts, traces, and experiments into the project.
 
@@ -275,6 +280,12 @@ def import_all_command(
         # Import only datasets and prompts
         opik import my-workspace my-project all --include datasets,prompts
 
+        # Import into a different workspace
+        opik import src-workspace my-project all --to-workspace dest-workspace
+
+        # Import into a different workspace and project
+        opik import src-workspace my-project all --to-workspace dest-workspace --to-project new-project
+
         # Restart from scratch, discarding previous progress
         opik import my-workspace my-project all --force
 
@@ -295,4 +306,5 @@ def import_all_command(
         api_key,
         include_attachments=not no_attachments,
         to_project=to_project,
+        to_workspace=to_workspace,
     )

--- a/sdks/python/src/opik/cli/imports/all.py
+++ b/sdks/python/src/opik/cli/imports/all.py
@@ -72,10 +72,14 @@ def import_all(
         )
 
         # Construct + initialize the per-destination manifest (shared with
-        # _import_by_type; keyed by the destination project). Skipped for
-        # --dry-run.
+        # _import_by_type; keyed by destination workspace + project). Skipped
+        # for --dry-run.
         manifest, already_completed = setup_import_manifest(
-            project_root, project_name, dry_run, force
+            project_root,
+            project_name,
+            dry_run,
+            force,
+            destination_workspace=dest_workspace,
         )
         if already_completed:
             return

--- a/sdks/python/src/opik/cli/imports/utils.py
+++ b/sdks/python/src/opik/cli/imports/utils.py
@@ -169,21 +169,26 @@ def resolve_import_project_root(
     return project_root, (to_project or project_name)
 
 
-def destination_manifest_dir(project_root: Path, destination_project_name: str) -> Path:
+def destination_manifest_dir(
+    project_root: Path,
+    destination_project_name: str,
+    destination_workspace: Optional[str] = None,
+) -> Path:
     """Return the per-destination import-manifest directory under the source folder.
 
-    The resume/completion manifest must be keyed by the *destination* project, not
-    just the source folder: importing the same exported project into different
-    ``--to-project`` targets must keep independent state (each destination gets its
-    own newly-created trace ids and completion status). Without this, a clean
-    import into A would make a later import into B short-circuit on
-    ``manifest.is_completed`` (and a partially-failed import into A would resume
-    into B, splitting one project's data across two destinations).
+    The resume/completion manifest must be keyed by both the *destination* workspace
+    and project, not just the source folder. Importing the same exported project into
+    different ``--to-project`` or ``--to-workspace`` targets must keep independent
+    state (each destination gets its own newly-created trace ids and completion
+    status). Without this, a clean import into workspace A / project X would make a
+    later import into workspace B / project X short-circuit on
+    ``manifest.is_completed``.
 
     Destination names may contain ``/``, ``:`` or whitespace, so the directory is
-    keyed by a short hash of the name rather than the name itself.
+    keyed by a short hash of the combined destination rather than the names themselves.
     """
-    dest_key = hashlib.sha256(destination_project_name.encode("utf-8")).hexdigest()[:16]
+    dest_str = f"{destination_workspace or ''}:{destination_project_name}"
+    dest_key = hashlib.sha256(dest_str.encode("utf-8")).hexdigest()[:16]
     return project_root / "import_manifests" / dest_key
 
 
@@ -192,6 +197,7 @@ def setup_import_manifest(
     destination_project_name: str,
     dry_run: bool,
     force: bool,
+    destination_workspace: Optional[str] = None,
 ) -> Tuple[Optional[MigrationManifest], bool]:
     """Construct and initialize the per-destination import manifest.
 
@@ -208,7 +214,9 @@ def setup_import_manifest(
         return None, False
 
     manifest_file = (
-        destination_manifest_dir(project_root, destination_project_name)
+        destination_manifest_dir(
+            project_root, destination_project_name, destination_workspace
+        )
         / MANIFEST_FILENAME
     )
     # Capture existence BEFORE constructing — the constructor creates the SQLite

--- a/sdks/python/src/opik/cli/imports/utils.py
+++ b/sdks/python/src/opik/cli/imports/utils.py
@@ -42,6 +42,25 @@ def to_project_option() -> Callable:
     )
 
 
+def to_workspace_option() -> Callable:
+    """Shared Click decorator for the ``--to-workspace`` flag.
+
+    Overrides the destination workspace. When omitted, data is imported into
+    the same workspace named on the command line (which is also used to locate
+    the exported files on disk under ``<path>/WORKSPACE/projects/``).
+    """
+    return click.option(
+        "--to-workspace",
+        "to_workspace",
+        type=str,
+        default=None,
+        help=(
+            "Import data into this workspace instead of WORKSPACE. "
+            "WORKSPACE is still used to locate the exported files on disk."
+        ),
+    )
+
+
 console = Console()
 
 

--- a/sdks/python/tests/unit/cli/test_attachments.py
+++ b/sdks/python/tests/unit/cli/test_attachments.py
@@ -249,7 +249,7 @@ class TestFetchAttachments:
 
         att_client = MagicMock()
         att_client.get_attachment_list.side_effect = ApiError(
-            status_code=503, body="unavailable"
+            status_code=400, body="bad request"
         )
 
         import pytest

--- a/sdks/python/tests/unit/cli/test_export_error_handling.py
+++ b/sdks/python/tests/unit/cli/test_export_error_handling.py
@@ -2,8 +2,10 @@
 
 Covers three HIGH-priority fixes to prevent silent data loss during export:
 
-  HIGH-1  experiment._fetch_trace_data: 429/5xx must be retried, not silently
-          dropped as a None result. Only genuine 404s should return None.
+  HIGH-1  experiment.export_traces_by_ids: when get_trace_content raises 429,
+          the internal _fetch_trace_data retry decorator must kick in so the
+          trace is eventually exported, not silently dropped. Only genuine 404s
+          should be skipped without retrying.
 
   HIGH-2  experiment.export_experiment_by_id: must re-raise on error so that
           the all.py caller can set had_errors=True (previously it swallowed
@@ -27,19 +29,20 @@ _ALL_MODULE = "opik.cli.exports.all"
 
 
 # ---------------------------------------------------------------------------
-# HIGH-1: _fetch_trace_data retries 429 rather than returning None
+# HIGH-1: export_traces_by_ids retries 429 rather than dropping the trace
 # ---------------------------------------------------------------------------
 
 
-class TestFetchTraceDataRetry:
+class TestExportTracesByIdsRetry:
     def _make_mock_trace(self, trace_id: str) -> MagicMock:
         t = MagicMock()
         t.model_dump.return_value = {"id": trace_id}
         return t
 
-    def test_fetch_trace_data__429_is_retried_not_returned_as_none(self):
-        """A 429 ApiError must trigger the retry decorator, not silently return None."""
-        from opik.cli.exports.experiment import _fetch_trace_data
+    def test_export_traces_by_ids__429_is_retried_not_dropped(self, tmp_path):
+        """A 429 ApiError must trigger the retry decorator so the trace is
+        exported, not silently dropped."""
+        from opik.cli.exports.experiment import export_traces_by_ids
 
         call_count = 0
 
@@ -55,14 +58,16 @@ class TestFetchTraceDataRetry:
         client.search_spans.return_value = []
 
         with patch(f"{_EXPERIMENT_MODULE}._fetch_trace_data.retry.sleep"):
-            result = _fetch_trace_data(client, "t1", "proj", False)
+            exported, skipped = export_traces_by_ids(
+                client, ["t1"], tmp_path, "proj", None, "json", False, False
+            )
 
-        assert result is not None, "429 must not be silently dropped as None"
+        assert exported == 1, "429 must not silently drop the trace"
         assert call_count == 2, "429 must trigger a retry"
 
-    def test_fetch_trace_data__rate_limited_exception_is_retried(self):
+    def test_export_traces_by_ids__rate_limited_exception_is_retried(self, tmp_path):
         """OpikCloudRequestsRateLimited must also be retried."""
-        from opik.cli.exports.experiment import _fetch_trace_data
+        from opik.cli.exports.experiment import export_traces_by_ids
 
         call_count = 0
 
@@ -80,14 +85,16 @@ class TestFetchTraceDataRetry:
         client.search_spans.return_value = []
 
         with patch(f"{_EXPERIMENT_MODULE}._fetch_trace_data.retry.sleep"):
-            result = _fetch_trace_data(client, "t2", "proj", False)
+            exported, skipped = export_traces_by_ids(
+                client, ["t2"], tmp_path, "proj", None, "json", False, False
+            )
 
-        assert result is not None, "rate-limit exception must not be silently dropped"
+        assert exported == 1, "rate-limit exception must not silently drop the trace"
         assert call_count == 2
 
-    def test_fetch_trace_data__404_returns_none(self):
-        """A genuine 404 (trace not found) should return None without retrying."""
-        from opik.cli.exports.experiment import _fetch_trace_data
+    def test_export_traces_by_ids__404_is_skipped_not_retried(self, tmp_path):
+        """A genuine 404 (trace not found) should be skipped cleanly without retrying."""
+        from opik.cli.exports.experiment import export_traces_by_ids
 
         call_count = 0
 
@@ -99,23 +106,26 @@ class TestFetchTraceDataRetry:
         client = MagicMock()
         client.get_trace_content.side_effect = get_trace_side_effect
 
-        result = _fetch_trace_data(client, "missing-id", "proj", False)
+        exported, skipped = export_traces_by_ids(
+            client, ["missing-id"], tmp_path, "proj", None, "json", False, False
+        )
 
-        assert result is None, "404 should return None (trace genuinely not found)"
-        assert call_count == 1, "404 should not be retried"
+        assert exported == 0, "404 trace must not be exported"
+        assert call_count == 1, "404 must not trigger a retry"
 
-    def test_fetch_trace_data__success__returns_tuple(self):
-        """Happy path: returns (trace_id, trace_data) on success."""
-        from opik.cli.exports.experiment import _fetch_trace_data
+    def test_export_traces_by_ids__success__exports_trace(self, tmp_path):
+        """Happy path: trace is written to disk and counted as exported."""
+        from opik.cli.exports.experiment import export_traces_by_ids
 
         client = MagicMock()
         client.get_trace_content.return_value = self._make_mock_trace("t3")
         client.search_spans.return_value = []
 
-        result = _fetch_trace_data(client, "t3", "proj", False)
+        exported, skipped = export_traces_by_ids(
+            client, ["t3"], tmp_path, "proj", None, "json", False, False
+        )
 
-        assert result is not None
-        assert result[0] == "t3"
+        assert exported == 1
 
 
 # ---------------------------------------------------------------------------

--- a/sdks/python/tests/unit/cli/test_export_error_handling.py
+++ b/sdks/python/tests/unit/cli/test_export_error_handling.py
@@ -1,0 +1,272 @@
+"""Unit tests for export error-handling fixes.
+
+Covers three HIGH-priority fixes to prevent silent data loss during export:
+
+  HIGH-1  experiment._fetch_trace_data: 429/5xx must be retried, not silently
+          dropped as a None result. Only genuine 404s should return None.
+
+  HIGH-2  experiment.export_experiment_by_id: must re-raise on error so that
+          the all.py caller can set had_errors=True (previously it swallowed
+          all exceptions and returned a zero-stats tuple).
+
+  HIGH-3  all._fetch_experiments_page_raw: 429 must trigger a retry via the
+          _export_rest_retry decorator instead of silently returning ([], 0)
+          and losing an entire page of experiments.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import httpx
+
+from opik.rest_api.core.api_error import ApiError
+from opik import exceptions as opik_exceptions
+
+_EXPERIMENT_MODULE = "opik.cli.exports.experiment"
+_ALL_MODULE = "opik.cli.exports.all"
+
+
+# ---------------------------------------------------------------------------
+# HIGH-1: _fetch_trace_data retries 429 rather than returning None
+# ---------------------------------------------------------------------------
+
+
+class TestFetchTraceDataRetry:
+    def _make_mock_trace(self, trace_id: str) -> MagicMock:
+        t = MagicMock()
+        t.model_dump.return_value = {"id": trace_id}
+        return t
+
+    def test_fetch_trace_data__429_is_retried_not_returned_as_none(self):
+        """A 429 ApiError must trigger the retry decorator, not silently return None."""
+        from opik.cli.exports.experiment import _fetch_trace_data
+
+        call_count = 0
+
+        def get_trace_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ApiError(status_code=429, headers={})
+            return self._make_mock_trace("t1")
+
+        client = MagicMock()
+        client.get_trace_content.side_effect = get_trace_side_effect
+        client.search_spans.return_value = []
+
+        with patch(f"{_EXPERIMENT_MODULE}._fetch_trace_data.retry.sleep"):
+            result = _fetch_trace_data(client, "t1", "proj", False)
+
+        assert result is not None, "429 must not be silently dropped as None"
+        assert call_count == 2, "429 must trigger a retry"
+
+    def test_fetch_trace_data__rate_limited_exception_is_retried(self):
+        """OpikCloudRequestsRateLimited must also be retried."""
+        from opik.cli.exports.experiment import _fetch_trace_data
+
+        call_count = 0
+
+        def get_trace_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise opik_exceptions.OpikCloudRequestsRateLimited(
+                    headers={}, retry_after=1.0
+                )
+            return self._make_mock_trace("t2")
+
+        client = MagicMock()
+        client.get_trace_content.side_effect = get_trace_side_effect
+        client.search_spans.return_value = []
+
+        with patch(f"{_EXPERIMENT_MODULE}._fetch_trace_data.retry.sleep"):
+            result = _fetch_trace_data(client, "t2", "proj", False)
+
+        assert result is not None, "rate-limit exception must not be silently dropped"
+        assert call_count == 2
+
+    def test_fetch_trace_data__404_returns_none(self):
+        """A genuine 404 (trace not found) should return None without retrying."""
+        from opik.cli.exports.experiment import _fetch_trace_data
+
+        call_count = 0
+
+        def get_trace_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise ApiError(status_code=404, headers={})
+
+        client = MagicMock()
+        client.get_trace_content.side_effect = get_trace_side_effect
+
+        result = _fetch_trace_data(client, "missing-id", "proj", False)
+
+        assert result is None, "404 should return None (trace genuinely not found)"
+        assert call_count == 1, "404 should not be retried"
+
+    def test_fetch_trace_data__success__returns_tuple(self):
+        """Happy path: returns (trace_id, trace_data) on success."""
+        from opik.cli.exports.experiment import _fetch_trace_data
+
+        client = MagicMock()
+        client.get_trace_content.return_value = self._make_mock_trace("t3")
+        client.search_spans.return_value = []
+
+        result = _fetch_trace_data(client, "t3", "proj", False)
+
+        assert result is not None
+        assert result[0] == "t3"
+
+
+# ---------------------------------------------------------------------------
+# HIGH-2: export_experiment_by_id propagates errors instead of swallowing them
+# ---------------------------------------------------------------------------
+
+
+class TestExportExperimentByIdPropagatesErrors:
+    def test_export_experiment_by_id__api_error_propagates(self, tmp_path):
+        """An unexpected error must propagate so the caller can set had_errors=True."""
+        from opik.cli.exports.experiment import export_experiment_by_id
+
+        client = MagicMock()
+        # Simulate a non-retriable API error (e.g. 403 Forbidden)
+        client.get_experiment_by_id.side_effect = ApiError(status_code=403, headers={})
+
+        with pytest.raises(ApiError):
+            export_experiment_by_id(
+                client=client,
+                output_dir=tmp_path,
+                project_name="proj",
+                experiment_id="exp-1",
+                max_traces=None,
+                force=True,
+                debug=False,
+                format="json",
+            )
+
+    def test_export_all_experiments__experiment_failure_sets_had_errors(self, tmp_path):
+        """When export_experiment_by_id raises, _export_all_experiments must set
+        had_errors=True rather than silently counting it as skipped."""
+        from opik.cli.exports.all import _export_all_experiments
+
+        client = MagicMock()
+        experiments_dir = tmp_path / "experiments"
+        experiments_dir.mkdir()
+
+        # Two experiments: first succeeds, second raises.
+        exp1 = MagicMock()
+        exp1.id = "e1"
+        exp1.name = "exp-one"
+        exp2 = MagicMock()
+        exp2.id = "e2"
+        exp2.name = "exp-two"
+
+        def export_side_effect(
+            client, output_dir, project_name, exp_id, *args, **kwargs
+        ):
+            if exp_id == "e2":
+                raise RuntimeError("transient failure")
+            m = MagicMock()
+            m.get_all_trace_ids.return_value = []
+            return {}, 1, m
+
+        with (
+            patch(
+                f"{_ALL_MODULE}._paginate_experiments",
+                return_value=[exp1, exp2],
+            ),
+            patch(
+                f"{_ALL_MODULE}.export_experiment_by_id",
+                side_effect=export_side_effect,
+            ),
+            patch(f"{_ALL_MODULE}.export_collected_trace_ids", return_value=(0, 0)),
+        ):
+            _, _, _, _, had_errors = _export_all_experiments(
+                client=client,
+                project_dir=tmp_path,
+                project_name="proj",
+                project_id=None,
+                experiments_dir=experiments_dir,
+                max_results=None,
+                force=False,
+                debug=False,
+                format="json",
+            )
+
+        assert had_errors is True, "a failed experiment must set had_errors=True"
+
+
+# ---------------------------------------------------------------------------
+# HIGH-3: _fetch_experiments_page_raw retries 429 instead of returning [], 0
+# ---------------------------------------------------------------------------
+
+
+class TestFetchExperimentsPageRawRetry:
+    def _make_httpx_response(self, status_code: int, headers=None, json_body=None):
+        """Build a minimal httpx.Response for raise_for_status() tests."""
+        headers = headers or {}
+        body = json_body or {"content": [], "total": 0}
+        import json as _json
+
+        # httpx.Response.raise_for_status() requires a request to be attached.
+        request = httpx.Request("GET", "http://test/v1/private/experiments")
+        response = httpx.Response(
+            status_code=status_code,
+            headers=headers,
+            content=_json.dumps(body).encode(),
+            request=request,
+        )
+        return response
+
+    def test_fetch_experiments_page_raw__429_raises_rate_limited_not_empty_list(
+        self,
+    ):
+        """A 429 response must raise OpikCloudRequestsRateLimited (for the retry
+        decorator), NOT silently return ([], 0)."""
+        from opik.cli.exports.all import _fetch_experiments_page_raw
+
+        client = MagicMock()
+        httpx_mock = MagicMock()
+        client.rest_client.experiments._raw_client._client_wrapper.httpx_client = (
+            httpx_mock
+        )
+        httpx_mock.request.return_value = self._make_httpx_response(
+            429, headers={"Retry-After": "5"}
+        )
+
+        with pytest.raises(opik_exceptions.OpikCloudRequestsRateLimited):
+            _fetch_experiments_page_raw.__wrapped__(client, 1, None)
+
+    def test_fetch_experiments_page_raw__429_is_retried_by_decorator(self):
+        """When the underlying call raises 429, the decorator retries rather
+        than letting a silent ([], 0) escape to the caller."""
+        from opik.cli.exports.all import _fetch_experiments_page_raw
+
+        call_count = 0
+
+        def request_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return self._make_httpx_response(429, headers={"Retry-After": "1"})
+            return self._make_httpx_response(
+                200,
+                json_body={
+                    "content": [{"id": "exp-1", "name": "my-exp"}],
+                    "total": 1,
+                },
+            )
+
+        client = MagicMock()
+        httpx_mock = MagicMock()
+        client.rest_client.experiments._raw_client._client_wrapper.httpx_client = (
+            httpx_mock
+        )
+        httpx_mock.request.side_effect = request_side_effect
+
+        with patch(f"{_ALL_MODULE}._fetch_experiments_page_raw.retry.sleep"):
+            items, total = _fetch_experiments_page_raw(client, 1, None)
+
+        assert call_count == 2, "429 must trigger a retry"
+        assert len(items) == 1, "successful retry must return the page contents"
+        assert total == 1

--- a/sdks/python/tests/unit/test_export_import_all.py
+++ b/sdks/python/tests/unit/test_export_import_all.py
@@ -89,13 +89,15 @@ def _seed_project_meta(tmp_path: Path) -> Path:
     return proj
 
 
-def _manifest_dir(tmp_path: Path) -> Path:
-    """Destination-keyed import-manifest dir for the default (no --to-project)
-    case, where the destination project == the source project name."""
+def _manifest_dir(tmp_path: Path, dest_workspace: str = _WORKSPACE) -> Path:
+    """Destination-keyed import-manifest dir for the default (no --to-project /
+    --to-workspace) case, where destination == source workspace + project name."""
     from opik.cli.imports.utils import destination_manifest_dir
 
     return destination_manifest_dir(
-        tmp_path / _WORKSPACE / "projects" / _PROJECT, _PROJECT
+        tmp_path / _WORKSPACE / "projects" / _PROJECT,
+        _PROJECT,
+        dest_workspace,
     )
 
 
@@ -1100,18 +1102,24 @@ class TestImportAll:
         assert kwargs.get("api_key") == "secret-key"
         assert kwargs.get("workspace") == _WORKSPACE
 
-    def test_to_workspace_used_for_client_not_for_path_resolution(self, tmp_path):
+    def test_import_all__to_workspace__uses_dest_workspace_for_opik_client(
+        self, tmp_path
+    ):
         """--to-workspace overrides the workspace passed to opik.Opik() while
         leaving the on-disk path lookup (which uses the source workspace) unchanged.
 
-        Scenario: data exported from 'src-ws', imported into 'dest-ws'.
-        The exported files live under <path>/src-ws/projects/. The Opik client
+        Scenario: data exported from 'ws', imported into 'dest-ws'.
+        The exported files live under <path>/ws/projects/. The Opik client
         must be constructed with workspace='dest-ws'.
         """
         # Seed export layout under the SOURCE workspace directory.
         _seed_project_meta(tmp_path)
         client = _make_import_client()
 
+        from click.testing import CliRunner
+        from opik.cli.imports import import_group
+
+        runner = CliRunner()
         with (
             patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client) as mock_opik,
             patch(f"{_IMPORT_MODULE}.import_datasets_from_directory", return_value={}),
@@ -1124,19 +1132,22 @@ class TestImportAll:
                 f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
             ),
         ):
-            from opik.cli.imports.all import import_all
-
-            import_all(
-                workspace=_WORKSPACE,  # source workspace: used for file lookup
-                project_name=_PROJECT,
-                path=str(tmp_path),
-                include=[],
-                dry_run=False,
-                force=False,
-                debug=False,
-                to_workspace="dest-ws",  # destination workspace: used for Opik client
+            result = runner.invoke(
+                import_group,
+                [
+                    _WORKSPACE,  # source workspace: used for file lookup
+                    _PROJECT,
+                    "all",
+                    "--path",
+                    str(tmp_path),
+                    "--to-workspace",
+                    "dest-ws",  # destination workspace: used for Opik client
+                    "--include",
+                    "",  # empty include → skip all phases, just test client construction
+                ],
             )
 
+        assert result.exit_code == 0, result.output
         mock_opik.assert_called_once()
         kwargs = mock_opik.call_args[1]
         assert kwargs.get("workspace") == "dest-ws"

--- a/sdks/python/tests/unit/test_export_import_all.py
+++ b/sdks/python/tests/unit/test_export_import_all.py
@@ -1100,6 +1100,47 @@ class TestImportAll:
         assert kwargs.get("api_key") == "secret-key"
         assert kwargs.get("workspace") == _WORKSPACE
 
+    def test_to_workspace_used_for_client_not_for_path_resolution(self, tmp_path):
+        """--to-workspace overrides the workspace passed to opik.Opik() while
+        leaving the on-disk path lookup (which uses the source workspace) unchanged.
+
+        Scenario: data exported from 'src-ws', imported into 'dest-ws'.
+        The exported files live under <path>/src-ws/projects/. The Opik client
+        must be constructed with workspace='dest-ws'.
+        """
+        # Seed export layout under the SOURCE workspace directory.
+        _seed_project_meta(tmp_path)
+        client = _make_import_client()
+
+        with (
+            patch(f"{_IMPORT_MODULE}.opik.Opik", return_value=client) as mock_opik,
+            patch(f"{_IMPORT_MODULE}.import_datasets_from_directory", return_value={}),
+            patch(
+                f"{_IMPORT_MODULE}.import_prompts_from_directory",
+                return_value={"prompts": 0},
+            ),
+            patch(f"{_IMPORT_MODULE}.import_traces_from_directory", return_value={}),
+            patch(
+                f"{_IMPORT_MODULE}.import_experiments_from_directory", return_value={}
+            ),
+        ):
+            from opik.cli.imports.all import import_all
+
+            import_all(
+                workspace=_WORKSPACE,  # source workspace: used for file lookup
+                project_name=_PROJECT,
+                path=str(tmp_path),
+                include=[],
+                dry_run=False,
+                force=False,
+                debug=False,
+                to_workspace="dest-ws",  # destination workspace: used for Opik client
+            )
+
+        mock_opik.assert_called_once()
+        kwargs = mock_opik.call_args[1]
+        assert kwargs.get("workspace") == "dest-ws"
+
 
 # ---------------------------------------------------------------------------
 # export_all

--- a/sdks/python/tests/unit/test_export_import_all.py
+++ b/sdks/python/tests/unit/test_export_import_all.py
@@ -1170,7 +1170,7 @@ class TestExportAll:
                 side_effect=_fake_prepare_export_dir,
             ),
             patch(f"{_EXPORT_MODULE}._export_all_datasets", return_value=(0, 0)),
-            patch(f"{_EXPORT_MODULE}._export_all_prompts", return_value=(0, 0)),
+            patch(f"{_EXPORT_MODULE}._export_all_prompts", return_value=(0, 0, 0)),
             patch(
                 f"{_EXPORT_MODULE}._export_project_traces",
                 return_value=(0, 0, 0, False),
@@ -1204,7 +1204,7 @@ class TestExportAll:
                 side_effect=_fake_prepare_export_dir,
             ),
             patch(f"{_EXPORT_MODULE}._export_all_datasets", return_value=(0, 0)),
-            patch(f"{_EXPORT_MODULE}._export_all_prompts", return_value=(0, 0)),
+            patch(f"{_EXPORT_MODULE}._export_all_prompts", return_value=(0, 0, 0)),
             patch(
                 f"{_EXPORT_MODULE}._export_project_traces",
                 return_value=(0, 0, 0, False),
@@ -1240,7 +1240,7 @@ class TestExportAll:
                 f"{_EXPORT_MODULE}._export_all_datasets", return_value=(2, 0)
             ) as mock_ds,
             patch(
-                f"{_EXPORT_MODULE}._export_all_prompts", return_value=(0, 0)
+                f"{_EXPORT_MODULE}._export_all_prompts", return_value=(0, 0, 0)
             ) as mock_pr,
             patch(
                 f"{_EXPORT_MODULE}._export_project_traces",
@@ -1275,7 +1275,7 @@ class TestExportAll:
         with (
             patch(f"{_EXPORT_MODULE}.opik.Opik", return_value=client),
             patch(f"{_EXPORT_MODULE}._export_all_datasets", return_value=(1, 0)),
-            patch(f"{_EXPORT_MODULE}._export_all_prompts", return_value=(2, 0)),
+            patch(f"{_EXPORT_MODULE}._export_all_prompts", return_value=(2, 0, 0)),
             patch(
                 f"{_EXPORT_MODULE}._export_project_traces",
                 return_value=(1, 5, 0, False),
@@ -1312,7 +1312,7 @@ class TestExportAll:
         with (
             patch(f"{_EXPORT_MODULE}.opik.Opik", return_value=client) as mock_opik,
             patch(f"{_EXPORT_MODULE}._export_all_datasets", return_value=(0, 0)),
-            patch(f"{_EXPORT_MODULE}._export_all_prompts", return_value=(0, 0)),
+            patch(f"{_EXPORT_MODULE}._export_all_prompts", return_value=(0, 0, 0)),
             patch(
                 f"{_EXPORT_MODULE}._export_project_traces",
                 return_value=(0, 0, 0, False),


### PR DESCRIPTION
## Details

This PR contains two independent sets of SDK export/import improvements.

**1. `opik import --to-workspace` (cross-workspace import)**

Adds `--to-workspace` as a subcommand-level option to all `opik import` subcommands (`all`, `traces`, `dataset`, `experiment`, `prompt`).

Previously, `WORKSPACE` served double duty — it located the exported files on disk (`<path>/WORKSPACE/projects/`) **and** set the destination API workspace. Importing into a different workspace required a workaround: pointing `--path` at the source workspace directory. This was confusing and undocumented.

With this change, the two concerns are separated cleanly:
- `WORKSPACE` (positional arg) — still used to find the exported files on disk
- `--to-workspace NAME` — overrides the destination workspace for API calls

```bash
opik import src-workspace "CRM Agent Observability" all \\
  --to-project test001 --to-workspace stevenm-opik2
```

**2. Export CLI: fix 8 silent data-loss gaps**

An audit of the export CLI found 8 places where API errors were silently swallowed, causing traces, experiments, datasets, or prompts to be dropped with no indication in the manifest or exit code. All 8 are now fixed:

- **HIGH** — `experiment._fetch_trace_data`: add `@_export_rest_retry` so 429/5xx trigger wait-and-retry instead of being caught and returned as `None` (which was counted as a skip and allowed `manifest.complete()` to fire even though data was missing). Only genuine 404s now return `None`.
- **HIGH** — `experiment.export_experiment_by_id`: re-raise instead of swallowing all exceptions; callers in `all.py` already set `had_errors=True` when the future raises.
- **HIGH** — `all._fetch_experiments_page_raw`: add `@_export_rest_retry` and convert 429 to `OpikCloudRequestsRateLimited`; remove silent `return [], 0` so an entire page of experiments is no longer silently dropped on 429.
- **MEDIUM** — `project._process_trace`: only call `manifest.mark_trace_downloaded()` when attachment download also succeeded, so a re-run can retry missing attachments without `--force`.
- **MEDIUM** — `dataset.export_experiment_datasets`: track and return an error count so callers can distinguish "0 exported" from "all failed".
- **MEDIUM** — `prompt.export_prompts_by_ids`: same — add error count to return tuple.
- **LOW** — `prompt.export_single_prompt` / `export_related_prompts_by_name`: upgrade history-fetch failure from debug-only to always-visible `[yellow]Warning` so users know the export is incomplete.
- **LOW** — `all._export_all_prompts`: add error counter; propagate to `had_errors` in `export_all` so the process exits with code 1 on prompt failures.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-6964

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: Implementation and docs
- Human verification: Command behaviour verified with CliRunner tests; all 126 unit tests pass

## Testing

```bash
cd sdks/python
python -m pytest tests/unit/test_export_import_all.py tests/unit/test_cli_changes.py tests/unit/cli/test_export_project_rate_limiting.py tests/unit/cli/test_export_error_handling.py -q
# 126 passed
```

New tests:
- `TestImportAll::test_to_workspace_used_for_client_not_for_path_resolution` — verifies `--to-workspace` is passed to `opik.Opik(workspace=...)` while `WORKSPACE` is still used for on-disk file lookup.
- `TestFetchTraceDataRetry` (4 tests) — 429/rate-limited are retried, 404 returns None, success returns tuple.
- `TestExportExperimentByIdPropagatesErrors` (2 tests) — API errors propagate; `_export_all_experiments` sets `had_errors=True`.
- `TestFetchExperimentsPageRawRetry` (2 tests) — 429 triggers retry, not silent `([], 0)`.

## Documentation

Updated:
- `apps/opik-documentation/documentation/fern/docs/tracing/import_export_commands.mdx` — added `--to-workspace` to the options table, updated `WORKSPACE` argument description, replaced the old `--path` cross-workspace workaround with `--to-workspace` examples
- `apps/opik-documentation/documentation/fern/docs-v2/observability/export_data.mdx` — added `--to-workspace` to import examples and the migration section
