### PR TITLE
fix(metrics): tokenize inputs in METEOR before calling NLTK

### DIFF
--- a/sdks/python/src/opik/evaluation/metrics/heuristics/meteor.py
+++ b/sdks/python/src/opik/evaluation/metrics/heuristics/meteor.py
@@ -82,10 +82,18 @@ class METEOR(base_metric.BaseMetric):
                         ) from download_error
 
             def _scorer(references: Sequence[str], hypothesis: str) -> float:
+                # NLTK's meteor_score expects pre-tokenized inputs:
+                # references as Iterable[Iterable[str]] and hypothesis as Iterable[str].
+                tokenized_references = [ref.split() for ref in references]
+                tokenized_hypothesis = hypothesis.split()
                 try:
                     return float(
                         nltk_meteor_score.meteor_score(
-                            references, hypothesis, alpha=alpha, beta=beta, gamma=gamma
+                            tokenized_references,
+                            tokenized_hypothesis,
+                            alpha=alpha,
+                            beta=beta,
+                            gamma=gamma,
                         )
                     )
                 except LookupError as error:

--- a/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
+++ b/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
@@ -433,11 +433,14 @@ def test_meteor_rejects_empty_inputs():
         metric.score(output="hyp", reference="   ")
 
 
-def test_meteor_default_scorer_tokenizes_inputs(monkeypatch):
-    """The built-in scorer must pass pre-tokenized inputs to NLTK.
+def test_meteor__default_scorer__passes_tokenized_inputs_to_nltk(monkeypatch):
+    """The built-in scorer must hand NLTK pre-tokenized inputs.
 
     NLTK's ``meteor_score`` requires ``references`` as ``Iterable[Iterable[str]]``
     and ``hypothesis`` as ``Iterable[str]``; passing raw strings raises ``TypeError``.
+    Asserting only the (stubbed) return value would not catch this regression,
+    since the stub ignores its arguments — so we also assert the inputs were
+    tokenized before the NLTK call.
     """
     from opik.evaluation.metrics.heuristics import meteor as meteor_module
 
@@ -449,15 +452,15 @@ def test_meteor_default_scorer_tokenizes_inputs(monkeypatch):
         return 0.5
 
     # Avoid the WordNet corpora requirement and stub the NLTK scorer so the test
-    # exercises only the default scorer's tokenization (no network/corpora needed).
+    # needs no network/corpora.
     monkeypatch.setattr(meteor_module.wordnet, "ensure_loaded", lambda: None)
     monkeypatch.setattr(
         meteor_module.nltk_meteor_score, "meteor_score", fake_meteor_score
     )
 
-    metric = METEOR(track=False)
-    metric.score(output="the cat sat", reference="the cat sat")
+    result = METEOR(track=False).score(output="the cat sat", reference="the cat sat")
 
+    assert result.value == pytest.approx(0.5)
     assert captured["hypothesis"] == ["the", "cat", "sat"]
     assert captured["references"] == [["the", "cat", "sat"]]
 

--- a/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
+++ b/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
@@ -433,6 +433,35 @@ def test_meteor_rejects_empty_inputs():
         metric.score(output="hyp", reference="   ")
 
 
+def test_meteor_default_scorer_tokenizes_inputs(monkeypatch):
+    """The built-in scorer must pass pre-tokenized inputs to NLTK.
+
+    NLTK's ``meteor_score`` requires ``references`` as ``Iterable[Iterable[str]]``
+    and ``hypothesis`` as ``Iterable[str]``; passing raw strings raises ``TypeError``.
+    """
+    from opik.evaluation.metrics.heuristics import meteor as meteor_module
+
+    captured = {}
+
+    def fake_meteor_score(references, hypothesis, **kwargs):
+        captured["references"] = references
+        captured["hypothesis"] = hypothesis
+        return 0.5
+
+    # Avoid the WordNet corpora requirement and stub the NLTK scorer so the test
+    # exercises only the default scorer's tokenization (no network/corpora needed).
+    monkeypatch.setattr(meteor_module.wordnet, "ensure_loaded", lambda: None)
+    monkeypatch.setattr(
+        meteor_module.nltk_meteor_score, "meteor_score", fake_meteor_score
+    )
+
+    metric = METEOR(track=False)
+    metric.score(output="the cat sat", reference="the cat sat")
+
+    assert captured["hypothesis"] == ["the", "cat", "sat"]
+    assert captured["references"] == [["the", "cat", "sat"]]
+
+
 def test_gleu_metric_with_custom_fn():
     def gleu_fn(references, hypothesis):
         return 0.5

--- a/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
+++ b/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
@@ -470,6 +470,25 @@ def test_meteor__default_scorer__passes_tokenized_inputs_to_nltk(monkeypatch):
     assert captured["references"] == [["the", "cat", "sat"]]
 
 
+def test_meteor__default_scorer__real_nltk_score():
+    """Exercise the real default scorer end-to-end (no mocking).
+
+    Complements the tokenization test above by catching regressions in the
+    actual NLTK integration. Requires the WordNet corpora, so it is skipped
+    when they are unavailable (e.g. a CI environment without the NLTK data).
+    """
+    pytest.importorskip("nltk")
+    try:
+        result = METEOR(track=False).score(
+            output="the cat sat on the mat",
+            reference="the cat sat on the mat",
+        )
+    except (LookupError, ImportError, MetricComputationError) as exc:
+        pytest.skip(f"NLTK WordNet corpora not available: {exc}")
+
+    assert result.value == pytest.approx(0.9977, abs=1e-3)
+
+
 def test_gleu_metric_with_custom_fn():
     def gleu_fn(references, hypothesis):
         return 0.5

--- a/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
+++ b/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
@@ -451,9 +451,14 @@ def test_meteor__default_scorer__passes_tokenized_inputs_to_nltk(monkeypatch):
         captured["hypothesis"] = hypothesis
         return 0.5
 
-    # Avoid the WordNet corpora requirement and stub the NLTK scorer so the test
-    # needs no network/corpora.
-    monkeypatch.setattr(meteor_module.wordnet, "ensure_loaded", lambda: None)
+    # Stub the NLTK scorer and WordNet loader so the test needs no corpora/network.
+    # Replace the whole ``wordnet`` object rather than setattr on it: touching the
+    # real NLTK LazyCorpusLoader forces a corpus load, raising LookupError in CI.
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        meteor_module, "wordnet", SimpleNamespace(ensure_loaded=lambda: None)
+    )
     monkeypatch.setattr(
         meteor_module.nltk_meteor_score, "meteor_score", fake_meteor_score
     )

--- a/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
+++ b/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
@@ -483,7 +483,10 @@ def test_meteor__default_scorer__real_nltk_score():
             output="the cat sat on the mat",
             reference="the cat sat on the mat",
         )
-    except (LookupError, ImportError, MetricComputationError) as exc:
+    except (LookupError, ImportError) as exc:
+        # Only skip when the NLTK corpora are genuinely unavailable. A
+        # MetricComputationError from a valid input is a real regression and
+        # must surface as a failure, not be skipped.
         pytest.skip(f"NLTK WordNet corpora not available: {exc}")
 
     assert result.value == pytest.approx(0.9977, abs=1e-3)


### PR DESCRIPTION
## Summary

The default `METEOR` scorer (`sdks/python/src/opik/evaluation/metrics/heuristics/meteor.py`) passes raw strings to `nltk.translate.meteor_score.meteor_score`, but NLTK requires **pre-tokenized** inputs — `references` as `Iterable[Iterable[str]]` and `hypothesis` as `Iterable[str]`.

On current NLTK (3.9.x) this raises `TypeError` for any normal string input, so `METEOR().score(...)` is **non-functional on its default path** (on older NLTK it silently iterated the strings character-by-character, producing garbage scores). The sibling heuristic metrics (BLEU, GLEU, chrF) already `.split()` before calling NLTK — METEOR was the lone exception.

## Reproduction (before fix)

```python
METEOR(track=False).score(output='the cat sat on the mat', reference='the cat sat on the mat')
# TypeError: "hypothesis" expects pre-tokenized hypothesis (Iterable[str]): the cat sat on the mat
```

After the fix the same call returns ~`0.9977`.

## Fix

Tokenize `references` and `hypothesis` inside the default scorer before the NLTK call (the public `score()` signature and the injectable `meteor_fn` contract are unchanged).

## Testing

Added `test_meteor_default_scorer_tokenizes_inputs` to `test_heuristics.py`, asserting the default scorer hands NLTK tokenized lists. It mocks the NLTK scorer (and WordNet load), so it needs no corpora/network. It fails on the current code (raw strings) and passes after the fix; `pytest -k meteor` → 3 passed.

(The existing METEOR tests inject a custom `meteor_fn`, which bypasses the default scorer — that's why the broken default path went unnoticed.)