### PR TITLE
fix: recover ADK trace output when context caching detaches the LLM span (#5524)

### DIFF
--- a/sdks/python/src/opik/integrations/adk/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/opik_tracer.py
@@ -285,9 +285,38 @@ class OpikTracer:
 
             current_span = context_storage.top_span_data()
             if current_span is None:
+                # The span pushed in before_model_callback is invisible here: ADK's
+                # ContextCacheConfig wraps the LLM call in its own OTel span, which
+                # forks the async context under SSE streaming, so the ContextVar
+                # mutation isn't visible and top_span_data() returns None (#5524).
+                #
+                # We can't finalize the per-LLM span, but we recover the model
+                # OUTPUT into the per-invocation, bounded _last_model_output cache
+                # (added in #7266) so after_agent_callback still stamps the trace
+                # output instead of dropping the whole answer. Keying by
+                # invocation_id keeps this safe across concurrent SSE sessions.
+                #
+                # Discard up front (mirroring the non-detached path below) so a
+                # failed conversion leaves no stale value; partial chunks never
+                # cache — we wait for the final response. The recovered output
+                # keeps its usage metadata (the non-detached path pops that onto the
+                # span, but there is no span here): harmless on the display-only
+                # trace output, and it preserves usage info that's otherwise lost.
                 self._last_model_output.discard(callback_context.invocation_id)
-                LOGGER.warning(
-                    "No current span found in context for model output update"
+                if not is_partial:
+                    try:
+                        self._last_model_output.set(
+                            callback_context.invocation_id,
+                            adk_helpers.convert_adk_base_model_to_dict(llm_response),
+                        )
+                    except Exception:
+                        LOGGER.debug(
+                            "Failed to recover model output without a current span",
+                            exc_info=True,
+                        )
+                LOGGER.debug(
+                    "No current span in context (detached async context, e.g. "
+                    "ContextCacheConfig); recovered model output via the cache"
                 )
                 return
 

--- a/sdks/python/tests/library_integration/adk/test_adk_concurrency.py
+++ b/sdks/python/tests/library_integration/adk/test_adk_concurrency.py
@@ -100,32 +100,35 @@ def test_after_agent_callback__no_cached_output__stamps_none():
     assert trace.output is None
 
 
+def _model_response(text: str, *, partial: bool) -> LlmResponse:
+    return LlmResponse(
+        content=genai_types.Content(
+            role="model", parts=[genai_types.Part(text=text)]
+        ),
+        partial=partial,
+    )
+
+
 @helpers.pytest_skip_for_adk_older_than_1_3_0
 def test_after_model_callback__recovers_output_when_span_detached():
     # ContextCacheConfig (issue #5524) wraps the LLM call in its own OTel span,
     # which forks the async context under SSE streaming — so the span pushed in
     # before_model_callback is invisible here and top_span_data() is None. The
     # actual model output must still be recovered and land on the trace output.
+    # Verified through the public callbacks only: after_model recovers, then
+    # after_agent stamps the recovered answer onto the trace.
     tracer = OpikTracer(project_name="adk-test")
     assert context_storage.top_span_data() is None  # detached: no current span
 
-    llm_response = LlmResponse(
-        content=genai_types.Content(
-            role="model", parts=[genai_types.Part(text="RECOVERED ANSWER")]
-        ),
-        partial=False,
+    tracer.after_model_callback(
+        _callback_context("inv-detached"),
+        _model_response("RECOVERED ANSWER", partial=False),
     )
-    tracer.after_model_callback(_callback_context("inv-detached"), llm_response)
 
-    # The real answer is recovered (not just "something" cached) ...
-    recovered = tracer._last_model_output.get("inv-detached")
-    assert recovered is not None
-    assert "RECOVERED ANSWER" in str(recovered)
-
-    # ... and after_agent_callback stamps it on the trace output end-to-end.
     trace = TraceData(name="agent")
     context_storage.set_trace_data(trace)
     tracer.after_agent_callback(_callback_context("inv-detached"))
+
     assert "RECOVERED ANSWER" in str(trace.output)
 
 
@@ -133,17 +136,24 @@ def test_after_model_callback__recovers_output_when_span_detached():
 def test_after_model_callback__detached_span__partial_chunk_discards():
     # Partial streaming chunks must not cache — and they clear any prior value for
     # the invocation (discard up front), so a stale earlier output can't leak onto
-    # the trace before the final response arrives.
+    # the trace before the final response arrives. Driven entirely through the
+    # public callbacks: a recovered final response, then a partial chunk for the
+    # same invocation, must leave the trace output empty.
     tracer = OpikTracer(project_name="adk-test")
     assert context_storage.top_span_data() is None
-    tracer._last_model_output.set("inv-partial", {"stale": "earlier"})
 
-    partial = LlmResponse(
-        content=genai_types.Content(
-            role="model", parts=[genai_types.Part(text="strea")]
-        ),
-        partial=True,
+    # An earlier final response was recovered for this invocation...
+    tracer.after_model_callback(
+        _callback_context("inv-partial"),
+        _model_response("EARLIER ANSWER", partial=False),
     )
-    tracer.after_model_callback(_callback_context("inv-partial"), partial)
+    # ...then a partial chunk arrives (still detached): it must discard, not stamp.
+    tracer.after_model_callback(
+        _callback_context("inv-partial"), _model_response("strea", partial=True)
+    )
 
-    assert tracer._last_model_output.get("inv-partial") is None
+    trace = TraceData(name="agent")
+    context_storage.set_trace_data(trace)
+    tracer.after_agent_callback(_callback_context("inv-partial"))
+
+    assert trace.output is None  # no stale "EARLIER ANSWER" leaked through

--- a/sdks/python/tests/library_integration/adk/test_adk_concurrency.py
+++ b/sdks/python/tests/library_integration/adk/test_adk_concurrency.py
@@ -16,6 +16,8 @@ the modern ``OpikTracer`` (skipped on ADK < 1.3.0, which uses
 
 import types
 
+from google.adk.models import LlmResponse
+from google.genai import types as genai_types
 from opik import context_storage
 from opik.api_objects.trace.trace_data import TraceData
 from opik.integrations.adk import OpikTracer
@@ -96,3 +98,52 @@ def test_after_agent_callback__no_cached_output__stamps_none():
     tracer.after_agent_callback(_callback_context("invocation-without-output"))
 
     assert trace.output is None
+
+
+@helpers.pytest_skip_for_adk_older_than_1_3_0
+def test_after_model_callback__recovers_output_when_span_detached():
+    # ContextCacheConfig (issue #5524) wraps the LLM call in its own OTel span,
+    # which forks the async context under SSE streaming — so the span pushed in
+    # before_model_callback is invisible here and top_span_data() is None. The
+    # actual model output must still be recovered and land on the trace output.
+    tracer = OpikTracer(project_name="adk-test")
+    assert context_storage.top_span_data() is None  # detached: no current span
+
+    llm_response = LlmResponse(
+        content=genai_types.Content(
+            role="model", parts=[genai_types.Part(text="RECOVERED ANSWER")]
+        ),
+        partial=False,
+    )
+    tracer.after_model_callback(_callback_context("inv-detached"), llm_response)
+
+    # The real answer is recovered (not just "something" cached) ...
+    recovered = tracer._last_model_output.get("inv-detached")
+    assert recovered is not None
+    assert "RECOVERED ANSWER" in str(recovered)
+
+    # ... and after_agent_callback stamps it on the trace output end-to-end.
+    trace = TraceData(name="agent")
+    context_storage.set_trace_data(trace)
+    tracer.after_agent_callback(_callback_context("inv-detached"))
+    assert "RECOVERED ANSWER" in str(trace.output)
+
+
+@helpers.pytest_skip_for_adk_older_than_1_3_0
+def test_after_model_callback__detached_span__partial_chunk_discards():
+    # Partial streaming chunks must not cache — and they clear any prior value for
+    # the invocation (discard up front), so a stale earlier output can't leak onto
+    # the trace before the final response arrives.
+    tracer = OpikTracer(project_name="adk-test")
+    assert context_storage.top_span_data() is None
+    tracer._last_model_output.set("inv-partial", {"stale": "earlier"})
+
+    partial = LlmResponse(
+        content=genai_types.Content(
+            role="model", parts=[genai_types.Part(text="strea")]
+        ),
+        partial=True,
+    )
+    tracer.after_model_callback(_callback_context("inv-partial"), partial)
+
+    assert tracer._last_model_output.get("inv-partial") is None


### PR DESCRIPTION
## Details

When using `OpikTracer` + `track_adk_agent_recursive` with ADK's `ContextCacheConfig` enabled, the **trace output is silently dropped** in SSE streaming mode — the trace shows an empty answer.

**Root cause.** `GeminiContextCacheManager` wraps the LLM call in its own OTel `start_as_current_span`. Under SSE streaming this crosses an async-context boundary, so the span pushed in `before_model_callback` is not visible in `after_model_callback` — `context_storage.top_span_data()` returns `None`. The callback then `discard`s the model output and returns, so `after_agent_callback` reads an empty `_last_model_output` and stamps `output=None` on the trace. (Same root cause as the `_OPIK_SPAN_STATUS: started` symptom in #5524 — the log line `No current span found in context for model output update` is emitted on every call.)

**Production evidence (opik 2.1.8, Cloud Run / SSE, `gemini-3-flash-preview`).** We toggled `CONTEXT_CACHE_ENABLED` live and bucketed trace-output presence by 2-minute windows:

| window | context caching | traces with output |
|---|---|---|
| before | OFF | **100%** |
| during | **ON** | **0%** (every bucket) |
| after | OFF | **100%** (recovered within ~2 min) |

So this is not cosmetic — with context caching on, **every** trace loses its answer.

**Fix.** In the detached-span path of `after_model_callback`, recover the model output: convert the `llm_response` and store it in the existing per-invocation, bounded `_last_model_output` cache (added in #7266). `after_agent_callback` then stamps the real answer via its normal path. Partial chunks are skipped; the normal (non-detached) path is unchanged.

Reusing the invocation-keyed cache means **no new shared state** and it's **safe under concurrent SSE sessions**. This is deliberately different from #5531's instance-level `_pending_llm_spans` LIFO list: a single shared stack would mix output/spans across concurrent invocations — the exact race that #7266 fixed for model output.

**Scope.** This restores the **trace-level output**, which is the user-impactful symptom. Finalizing the detached per-LLM child spans (so they leave `started` with their own output/usage) is a larger change, left as a follow-up — and it should recover the span via the same invocation-keyed bounded cache pattern, not a single shared LIFO (cf. the closed #5531).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves the trace-output loss in #5524 (per-span finalization follow-up tracked separately)

## Testing

`tests/library_integration/adk/test_adk_concurrency.py`:
- `test_after_model_callback__recovers_output_when_span_detached` — with no current span, the actual model output is recovered into `_last_model_output` **and** `after_agent_callback` stamps it onto `trace.output` end-to-end (asserts the recovered text, not just non-`None`).
- `test_after_model_callback__detached_span__partial_chunk_discards` — partial chunks don't cache and clear any prior value for the invocation (discard-up-front), so a stale earlier output can't leak.

End-to-end: deploy an ADK agent with `ContextCacheConfig` to Cloud Run with SSE streaming; trace output is now present (previously empty).

## Documentation

No documentation updates required — internal bug fix, no API changes.
