### PR TITLE
[NA] [BE] feat: add config toggle to disable skip indexes for last-trace lookup query

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -124,6 +124,13 @@ databaseAnalyticsReadOnlyFreeFormSql:
   #   above the read-only profile's max_execution_time (180s) so the server-side cap fires first.
   socketTimeout: ${ANALYTICS_DB_READ_ONLY_FREEFORM_SQL_SOCKET_TIMEOUT:-200s}
 
+traceQuery:
+  # Default: true
+  # Description: Whether ClickHouse skip indexes are used for the last-updated-trace-at lookup query. When false,
+  #   `use_skip_indexes = 0` is appended to force a full project-partition scan instead of pruning via the
+  #   `idx_traces_last_updated_at` minmax index. Operational escape hatch; keep enabled in normal operation.
+  lastUpdatedTraceAtSkipIndexesEnabled: ${TRACE_QUERY_LAST_UPDATED_TRACE_AT_SKIP_INDEXES_ENABLED:-true}
+
 # https://www.dropwizard.io/en/stable/manual/configuration.html#health
 health:
   # Default: ["/health-check"]

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -2022,7 +2022,7 @@ class TraceDAOImpl implements TraceDAO {
             AND t.project_id IN :project_ids
             <if(last_updated_after)> AND t.last_updated_at > parseDateTime64BestEffort(:last_updated_after, 9) <endif>
             GROUP BY t.project_id
-            SETTINGS log_comment = '<log_comment>'
+            SETTINGS log_comment = '<log_comment>'<if(disable_skip_indexes)>, use_skip_indexes = 0<endif>
             ;
             """;
 
@@ -4215,6 +4215,10 @@ class TraceDAOImpl implements TraceDAO {
 
         if (lastUpdatedAfter != null) {
             template.add("last_updated_after", true);
+        }
+
+        if (!configuration.getTraceQuery().isLastUpdatedTraceAtSkipIndexesEnabled()) {
+            template.add("disable_skip_indexes", true);
         }
 
         var statement = connection.createStatement(template.render())

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
@@ -27,6 +27,9 @@ public class OpikConfiguration extends JobConfiguration {
     private DatabaseAnalyticsReadOnlyFreeFormSqlConfig databaseAnalyticsReadOnlyFreeFormSql = new DatabaseAnalyticsReadOnlyFreeFormSqlConfig();
 
     @Valid @NotNull @JsonProperty
+    private TraceQueryConfig traceQuery = new TraceQueryConfig();
+
+    @Valid @NotNull @JsonProperty
     private UuidValidationConfig uuidValidation = UuidValidationConfig.builder().build();
 
     @Valid @NotNull @JsonProperty

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/TraceQueryConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/TraceQueryConfig.java
@@ -1,0 +1,16 @@
+package com.comet.opik.infrastructure;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class TraceQueryConfig {
+
+    /**
+     * When false, the last-updated-trace-at lookup query appends {@code use_skip_indexes = 0}, forcing ClickHouse to
+     * skip the {@code idx_traces_last_updated_at} minmax index and scan the project partition in full. This is an
+     * operational escape hatch for when the skip index misbehaves; leave enabled in normal operation.
+     */
+    @JsonProperty
+    private boolean lastUpdatedTraceAtSkipIndexesEnabled = true;
+}


### PR DESCRIPTION
## Details

Adds an operational escape hatch for the last-trace lookup query (`get_last_updated_trace_at` in `TraceDAO`). A new dedicated `TraceQueryConfig` exposes `lastUpdatedTraceAtSkipIndexesEnabled` (default `true`); when set to `false`, the query appends `use_skip_indexes = 0`, forcing ClickHouse to scan the project partition in full instead of pruning via the `idx_traces_last_updated_at` minmax index.

- The optimization that bounds this query by `last_updated_at` relies on that minmax skip index for granule pruning. This flag lets operators disable skip-index usage for this one query without a deploy, as a safety valve if the index ever misbehaves (e.g. during heavy merge backlogs).
- New config section `traceQuery` (env `TRACE_QUERY_LAST_UPDATED_TRACE_AT_SKIP_INDEXES_ENABLED`, default `true`); read in `TraceDAO.getLastUpdatedTraceAt` to conditionally add the setting.
- Default behavior is unchanged (skip indexes remain enabled).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Related to OPIK_7144 (operational toggle for the last-trace scan optimization; not resolved by this PR)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: code review + targeted backend integration test

## Testing

- `mvn compile -DskipTests` and `mvn spotless:check` — pass.
- `ProjectsResourceTest$FindProject` (27) — green; exercises `get_last_updated_trace_at` end-to-end via trace events with the default config (skip indexes enabled), confirming no behavior change on the default path.
- The `use_skip_indexes = 0` branch is a ClickHouse SETTINGS hint that does not alter query results, so it is gated by config and not separately asserted; default path is covered by the test above.
- Environment: local process mode, Testcontainers (MySQL + ClickHouse).

## Documentation

N/A — internal config toggle, no API or user-facing behavior change.
