### PR TITLE
[NA] [DOCS] Remove changelog date-hierarchy redirects

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs.yml
+++ b/apps/opik-documentation/documentation/fern/docs.yml
@@ -554,16 +554,6 @@ redirects:
   - source: "/docs/opik/agent-optimization"
     destination: "/docs/opik/development/optimization-runs/overview"
     permanent: true
-  # Catch-all for old changelog date URLs (e.g., /changelog/2025/8/2, /changelog/2025/6/7)
-  - source: "/docs/opik/changelog/2025/:slug*"
-    destination: "/docs/opik/changelog"
-    permanent: true
-  - source: "/docs/opik/changelog/2024/:slug*"
-    destination: "/docs/opik/changelog"
-    permanent: true
-  - source: "/docs/opik/changelog/2026/:slug*"
-    destination: "/docs/opik/changelog"
-    permanent: true
   # Configuration to Workspace Settings redirects (configuration section was renamed and moved)
   - source: "/docs/opik/configuration"
     destination: "/docs/opik/administration/workspace-settings/overview"


### PR DESCRIPTION
## Details

Removes the three catch-all changelog redirects (`/docs/opik/changelog/{2024,2025,2026}/:slug*`). Their `:slug*` (zero-or-more) source matched Fern's current single-segment changelog slugs (e.g. `/changelog/2025-08-01`), 301-ing every changelog item link back to the changelog root. They were originally added in #4382 to catch old `/year/month/day` URLs that Fern never actually generates, so removing them simply lets each changelog entry resolve to its real page.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Diagnosed the redirect/slug collision and removed the three redirect rules in `docs.yml`.
- Human verification: Reviewed the redirect change and confirmed Fern serves single-segment changelog slugs.

## Testing

Docs-only change to Fern `docs.yml` redirects; no automated tests apply. Pre-commit hooks passed on commit. Verified the removed rules were the only ones matching `/docs/opik/changelog/<year>/...` and that the surrounding redirect list remains valid YAML.

## Documentation

This change is itself a documentation-site fix (changelog item links now resolve to their pages instead of redirecting to the changelog root).
