### PR TITLE
[NA] [SDK] fix: strip /api suffix in get_ui_url instead of char set

### DIFF
--- a/sdks/python/src/opik/url_helpers.py
+++ b/sdks/python/src/opik/url_helpers.py
@@ -24,7 +24,7 @@ def get_ui_url() -> str:
     config = opik.config.OpikConfig()
     opik_url_override = config.url_override
 
-    return opik_url_override.rstrip("/api") + "/"
+    return opik_url_override.rstrip("/").removesuffix("/api") + "/"
 
 
 def get_experiment_url_by_id(

--- a/sdks/python/tests/unit/test_url_helpers.py
+++ b/sdks/python/tests/unit/test_url_helpers.py
@@ -1,5 +1,6 @@
 import pytest
 from opik import url_helpers
+from opik.config import OpikConfig
 
 
 @pytest.mark.parametrize(
@@ -31,3 +32,26 @@ def test_get_is_alive_ping_url__base_url__returns_expected_ping_url(
     base_url: str, expected_ping_url: str
 ) -> None:
     assert url_helpers.get_is_alive_ping_url(base_url) == expected_ping_url
+
+
+@pytest.mark.parametrize(
+    ("url_override", "expected_ui_url"),
+    [
+        # Shipped defaults must keep working.
+        ("http://localhost:5173/api", "http://localhost:5173/"),
+        ("https://www.comet.com/opik/api/", "https://www.comet.com/opik/"),
+        # Only the trailing "/api" segment is dropped: characters that merely
+        # belong to the {/, a, p, i} set are no longer stripped one by one.
+        ("https://foo.com/papi", "https://foo.com/papi/"),
+        ("https://team.io/instance-pi/api", "https://team.io/instance-pi/"),
+    ],
+)
+def test_get_ui_url__url_override__only_strips_api_suffix(
+    url_override: str, expected_ui_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        url_helpers.opik.config,
+        "OpikConfig",
+        lambda: OpikConfig(url_override=url_override),
+    )
+    assert url_helpers.get_ui_url() == expected_ui_url


### PR DESCRIPTION
## Details

`url_helpers.get_ui_url()` built the UI base URL with `opik_url_override.rstrip("/api")`, but `str.rstrip` strips a trailing *character set* (`/`, `a`, `p`, `i`), not the literal `/api` suffix. The two shipped defaults survive by coincidence, but any custom / self-hosted `url_override` whose path before `/api` ends in those characters is silently corrupted. This swaps in `rstrip("/").removesuffix("/api")` so only a trailing `/api` segment is dropped.
- `https://foo.com/papi` previously became `https://foo.com/` (ate `papi`); now `https://foo.com/papi/`.
- `https://team.io/instance-pi/api` previously became `https://team.io/instance-/`; now `https://team.io/instance-pi/`.
- The leading `rstrip("/")` keeps the trailing-slash cloud default `https://www.comet.com/opik/api/` correct (a bare `removesuffix("/api")` would have left `/api//`).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #7286
- OPIK-

## Testing

- `cd sdks/python && uv run --no-sync python -m pytest tests/unit/test_url_helpers.py -p no:cacheprovider -q` -> 9 passed.
- `ruff check` and `ruff format --check` on the two changed files -> clean; `mypy --python-version 3.10` on `url_helpers.py` -> clean.
- Scenarios validated:
  - Regressions: both shipped defaults stay byte-identical, including the trailing-slash cloud default `https://www.comet.com/opik/api/` -> `https://www.comet.com/opik/`.
  - Bug fixes: `https://foo.com/papi` and `https://team.io/instance-pi/api` keep their path segment.
- Environment: local Python SDK unit tests, no Docker/backend needed (pure string change).
- Not run: integration / e2e suites (no behavior crosses into the backend; this is an internal URL-helper string fix). No video evidence (no user-visible UI change).

## Documentation

None needed (internal helper behavior; no public API or docs change).
