### PR TITLE
[OPIK-7163] [SDK] fix: reformat test_adk_concurrency.py with pinned ruff-format

### DIFF
--- a/sdks/python/tests/library_integration/adk/test_adk_concurrency.py
+++ b/sdks/python/tests/library_integration/adk/test_adk_concurrency.py
@@ -102,9 +102,7 @@ def test_after_agent_callback__no_cached_output__stamps_none():
 
 def _model_response(text: str, *, partial: bool) -> LlmResponse:
     return LlmResponse(
-        content=genai_types.Content(
-            role="model", parts=[genai_types.Part(text=text)]
-        ),
+        content=genai_types.Content(role="model", parts=[genai_types.Part(text=text)]),
         partial=partial,
     )
 


### PR DESCRIPTION
## Details

<img width="818" height="752" alt="image" src="https://github.com/user-attachments/assets/bef85f14-fde6-43be-84a9-25cb93fa075b" />

The **SDK Linter** workflow (`.github/workflows/python_sdk_linter.yml`) runs `pre-commit run --all-files` from `sdks/python` with the pinned `ruff-format` hook (ruff `v0.14.14`). `tests/library_integration/adk/test_adk_concurrency.py` was merged without the pinned formatter applied, so the baseline was red — every PR touching `sdks/python/**` failed the lint check through no fault of its own (local pre-commit runs changed-files-only, so a contributor on a different ruff can miss what CI's `--all-files` catches).

This reformats only that one CI-flagged file: a single over-wrapped call is collapsed onto one line (it fits within 88 columns under the pinned ruff). No functional or behavioral change. Scope is intentionally limited to the file the pinned `v0.14.14` reports — not a repo-wide reformat.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7163

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: full implementation
  - Human verification: code review + local pre-commit run

## Testing

Verified against the ticket's acceptance criteria, from `sdks/python` with the pinned `.pre-commit-config.yaml`:

- `pre-commit run ruff-format --all-files` → **Passed**, no files modified.
- `uvx ruff@0.14.14 format --check tests/library_integration/adk/test_adk_concurrency.py` → already formatted.
- `make precommit-sdks` (changed-files) → all hooks pass / skipped.
- Confirmed the diff is one file, whitespace-only (`git diff --stat`: 1 file, +1/-3).

The green SDK Linter check on this PR is the authoritative signal.

## Documentation

N/A — test-file formatting only.
