### PR TITLE
[NA] [GHA] feat: inject pre-PR code-review summary into PR description

### DIFF
--- a/.agents/commands/comet/_code-review-section.md
+++ b/.agents/commands/comet/_code-review-section.md
@@ -1,0 +1,100 @@
+# Code Review section (shared sub-skill)
+
+**Command**: not user-invocable. Renders the `## Code Review` section of a PR body from the
+local pre-PR review receipt. Called by `/comet:create-pr` (Step 7) and `_pr-description-sync`
+(Step 3). Keep both callers identical by editing only this file.
+
+## What it is
+
+`/comet-cra-review` (the Opik pre-PR reviewer) writes a **gitignored** receipt into the checkout
+at `.cra/reviews/<branch-slug>.json` when a developer reviews their branch — usually *before* the
+PR exists. This sub-skill turns that receipt into a compact `## Code Review` section (+ a hidden
+machine marker) so reviewers see what the reviewer flagged.
+
+The section is **informational, not a gate** — never block PR creation on it, and never fabricate
+counts when no receipt exists.
+
+## 1. Locate the receipt
+
+```bash
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+SLUG="$(printf '%s' "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-50)"
+RECEIPT="$(git rev-parse --show-toplevel)/.cra/reviews/${SLUG}.json"
+CURRENT_HEAD="$(git rev-parse HEAD)"
+[ -f "$RECEIPT" ] && cat "$RECEIPT" || echo "NO_RECEIPT"
+```
+
+The slug transform above MUST stay byte-identical to the reviewer's writer (same
+`[^a-z0-9]+ → -`, lowercased, `cut -c1-50` convention) or the receipt is never found. `.cra/` is
+gitignored, so the receipt never appears in the PR diff.
+
+## 2. Determine state
+
+- **`NO_RECEIPT`** (file absent), or not valid JSON, or missing `git.head_sha` → **none**.
+- Valid receipt and `git.head_sha == CURRENT_HEAD` → **fresh**.
+- Valid receipt and `git.head_sha != CURRENT_HEAD` (commits pushed after the review) → **stale**.
+
+## 3. Render
+
+Read counts from the receipt's `counts` object, the human line from `blurb`, findings from
+`findings[]` (`severity`, `title`, `file`, `line`), and the marker payload from `marker`. Never
+paste a finding's `message`/`suggestion` — only `title` + `file:line`. Cap the details list at 5.
+
+### fresh
+```markdown
+## Code Review
+
+✅ Reviewed with `/comet-cra-review` — {findings} findings — {high} high · {medium} medium · {low} low · {suppressed} suppressed · {fixed} fixed
+
+| High | Medium | Low | Suppressed | Fixed |
+|:----:|:------:|:---:|:----------:|:-----:|
+| {high} | {medium} | {low} | {suppressed} | {fixed} |
+
+{blurb}
+
+<details><summary>Top findings ({findings})</summary>
+
+- **[{severity}]** {title} — `{file}:{line}`
+  … up to 5; if there are more, add: `- …and {N} more (see the full review report)`
+
+</details>
+
+<!-- cra-review sha={marker.sha} rules={marker.rules} findings={marker.findings} high={marker.high} medium={marker.medium} low={marker.low} suppressed={marker.suppressed} fixed={marker.fixed} ts={marker.ts} status=fresh -->
+```
+- Omit the `{blurb}` line if the receipt has none. Omit the `<details>` block when there are no
+  findings (`findings=0`) — keep the ✅ line + table; a clean review is a positive signal.
+
+### stale
+```markdown
+## Code Review
+
+⚠️ Reviewed with `/comet-cra-review` at an earlier commit — {findings} findings — {high} high · {medium} medium · {low} low · {suppressed} suppressed · {fixed} fixed
+
+> **Stale review:** last reviewed `{git.head_short}` but HEAD is `{CURRENT_HEAD short}` — commits were pushed after the review. Re-run `/comet-cra-review` and refresh the PR to update this section.
+
+| High | Medium | Low | Suppressed | Fixed |
+|:----:|:------:|:---:|:----------:|:-----:|
+| {high} | {medium} | {low} | {suppressed} | {fixed} |
+
+<!-- cra-review sha={marker.sha} rules={marker.rules} findings={marker.findings} high={marker.high} medium={marker.medium} low={marker.low} suppressed={marker.suppressed} fixed={marker.fixed} ts={marker.ts} status=stale head={CURRENT_HEAD} -->
+```
+- `sha=` stays the **reviewed** SHA (`marker.sha`); add `head=<CURRENT_HEAD>` (full). Drop the
+  blurb (may be inaccurate now). The `<details>` block is optional here.
+- In `/comet:create-pr` only: after rendering stale, surface a **non-blocking** nudge — "you
+  committed after reviewing; re-run `/comet-cra-review` to refresh, or continue." Never block.
+
+### none
+Leave the template's `## Code Review` placeholder exactly as shipped in
+`.github/pull_request_template.md` — no marker, no table, no invented counts.
+
+## Rules
+
+- Exactly **one** `<!-- cra-review … -->` marker, always the **last line** of the section. On
+  regeneration, replace it in place — never append a second.
+- This section is **not** a pr-lint-required heading — never add it to the required-sections check.
+- Secrecy (same as `/comet:create-pr` Step 7): `title`/`file`/`line` are identifier-level and
+  safe; treat `blurb` like the Details section (redact customer names, internal URLs, secrets).
+
+---
+
+**End sub-skill**

--- a/.agents/commands/comet/_pr-description-sync.md
+++ b/.agents/commands/comet/_pr-description-sync.md
@@ -57,6 +57,7 @@ Apply the same logic as `/comet:create-pr` Step 6 (Extract Change Information) a
 - Keep the existing **AI-WATERMARK** answers verbatim — never silently flip `yes`↔`no`.
 - Re-derive **Testing** from commit messages and test files changed.
 - Re-derive **Documentation** from docs files changed.
+- **`## Code Review`** is NOT derived from the diff. Regenerate it per `.agents/commands/comet/_code-review-section.md`: re-read `.cra/reviews/<branch-slug>.json` and recompute freshness against the current HEAD. Because HEAD advances on each push, a section that was `fresh` at PR-open correctly flips to `stale` after a later push until the developer re-reviews — the desired behavior. If no receipt exists, restore the template placeholder verbatim.
 
 Apply the same secrecy rules as `/comet:create-pr` Step 7: never include customer/client names, internal hostnames, internal URLs, IPs, bucket names, or credentials.
 
@@ -65,7 +66,7 @@ Apply the same secrecy rules as `/comet:create-pr` Step 7: never include custome
 The sub-skill stores a hidden HTML comment at the bottom of every body it writes:
 
 ```html
-<!-- pr-sync: {"Details":"<sha1>","Change checklist":"<sha1>","Issues":"<sha1>","AI-WATERMARK":"<sha1>","Testing":"<sha1>","Documentation":"<sha1>"} -->
+<!-- pr-sync: {"Details":"<sha1>","Change checklist":"<sha1>","Issues":"<sha1>","AI-WATERMARK":"<sha1>","Code Review":"<sha1>","Testing":"<sha1>","Documentation":"<sha1>"} -->
 ```
 
 Each value is `sha1(<section content with leading/trailing whitespace trimmed>)`. The marker lets the next run distinguish *agent-generated content the user hasn't touched* from *content the user has edited*.

--- a/.agents/commands/comet/create-pr.md
+++ b/.agents/commands/comet/create-pr.md
@@ -160,6 +160,7 @@ This workflow will:
 - **Check feature toggles**: Specifically analyze configuration files for added/removed feature toggles
 - **Extract commit history**: Review commit messages for context
 - **Generate summary**: Create meaningful description of what was implemented
+- **Load the code-review receipt (optional)**: If the developer ran `/comet-cra-review`, a gitignored receipt exists at `.cra/reviews/<branch-slug>.json`. Load it and classify it `fresh`/`stale`/`none` per `.agents/commands/comet/_code-review-section.md`; it feeds the `## Code Review` section in Step 7. `.cra/` is gitignored, so it never appears in the diff.
 
 ---
 
@@ -180,6 +181,7 @@ This workflow will:
   ```
   - **Fill every `##` section** in the template — the PR linter requires all sections to be present
   - If a section is not applicable, write "N/A" rather than removing it
+  - **`## Code Review`** is present in the template but is **not** a pr-lint-required section: fill it from the receipt when one exists, otherwise keep its placeholder. Never add it to the required-sections check and never remove the heading.
 - **Section guidance**:
   - **Details**: Implementation summary from git analysis (replace the HTML comment placeholder)
   - **Change checklist**: Auto-check based on file types changed (user-facing for UI changes, documentation for docs)
@@ -188,6 +190,7 @@ This workflow will:
   - **AI-WATERMARK**: Fill with `AI-WATERMARK: yes`, then list: Tools (e.g., "Claude Code"), Model(s), Scope (e.g., "full implementation" or "assisted"), Human verification (e.g., "code review + manual testing")
   - **Testing**: Extract from commit messages or set based on test files changed (replace the HTML comment placeholder)
   - **Documentation**: List docs updated or set "N/A" if no documentation changes
+  - **Code Review**: Render per `.agents/commands/comet/_code-review-section.md` from the receipt loaded in Step 6 — `fresh` → ✅ summary + counts table + marker (`status=fresh`); `stale` → ⚠️ note + marker (`status=stale head=<HEAD>`) plus a non-blocking nudge to re-review; `none` → keep the template placeholder untouched. Never fabricate counts; never paste finding message bodies.
 
 ---
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,6 +30,14 @@ AI-WATERMARK: [yes|no]
   - Scope:
   - Human verification:
 
+## Code Review
+<!--
+Auto-filled by `/comet:create-pr` from your local `.cra/reviews/<branch>.json` receipt
+(written by `/comet-cra-review`). To populate it: run `/comet-cra-review` in your checkout,
+then open/refresh the PR with `/comet:create-pr`. Not applicable? Leave the line below or write "N/A".
+-->
+_No pre-PR review recorded. Run `/comet-cra-review`, then re-open with `/comet:create-pr` — or N/A._
+
 ## Testing
 <!--
 REPLACE ME WITH:

--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,9 @@ AGENTS.override.md
 .cursor
 !tests_end_to_end/.cursor/
 
+# Local pre-PR code-review receipts (written by /comet-cra-review; never committed)
+.cra/
+
 # charts
 deployment/helm_chart/opik/charts
 deployment/helm_chart/opik/values-*.yaml


### PR DESCRIPTION
## Details

Surfaces the Opik pre-PR reviewer's results in the PR description. When a developer runs `/comet-cra-review`, it writes a gitignored receipt at `.cra/reviews/<branch-slug>.json`; this change teaches the PR tooling to read it and fill a new `## Code Review` section — compact counts (findings / high / medium / low / suppressed / fixed), a one-line blurb, and a hidden machine marker.

- New shared sub-skill `_code-review-section.md` is the single source of truth for the section format + `fresh`/`stale`/`none` logic; both `create-pr` and `_pr-description-sync` reference it (no format drift).
- `/comet:create-pr` fills the section at PR-open; `_pr-description-sync` regenerates it from the receipt on every push, so a `fresh` review correctly flips to a **non-blocking** `stale` note once more commits land (until the dev re-reviews).
- No receipt → the template placeholder renders. Nothing is ever blocked; the section is informational (a GitHub gate is intentionally out of scope for now).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA (internal tooling integration)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation of the PR-tooling integration
- Human verification: contract verified end-to-end (writer→reader) against a real checkout; pr-lint required-sections confirmed unaffected

## Code Review

N/A — this PR introduces the `## Code Review` section itself; there is no pre-PR review receipt for the tooling change.

## Testing

- Verified the writer→reader contract end-to-end: the receipt writer produced `.cra/reviews/yarivh-cra-review-pr-summary.json` and the sub-skill's `locate` snippet found it (branch→slug parity on a real branch name).
- Confirmed the receipt exposes every field the section renders (counts, blurb, head SHA, marker, per-finding severity/title/file:line) and that fresh/stale is computed from `git.head_sha` vs current `HEAD`.
- Confirmed `.github/workflows/pr-lint.yml` `requiredHeadings` does not include `## Code Review`, so the added section does not affect linting; `.cra/` is gitignored.

## Documentation

- New `.agents/commands/comet/_code-review-section.md` documents the section contract; `create-pr.md` and `_pr-description-sync.md` updated to reference it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)