### PR TITLE
[OPIK-7051] [BE] Fix: thread online-scoring errors as processing_errors, resilient per thread id

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -123,8 +123,18 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                 message.projectId(), message.ruleId(), message.threadIds(), message.workspaceId());
 
         return Flux.fromIterable(message.threadIds())
-                .flatMap(threadId -> processThreadScores(message, threadId))
-                .then()
+                // Score each thread id independently: a single thread's failure must not stop scoring the
+                // sibling thread ids. Per-thread errors are materialized (onErrorResume) so the flatMap
+                // completes for every thread; the batch's first failure is then re-surfaced below. This keeps
+                // the failure on the Mono error path handled by BaseRedisSubscriber.processMessage's
+                // onErrorResume — classified as a processing error, following the normal retryable/
+                // non-retryable path — instead of leaking into the enclosing onErrorContinue via Flux.flatMap
+                // (which would drop the element and count it as an "unexpected" error).
+                .flatMap(threadId -> processThreadScores(message, threadId)
+                        .then(Mono.<Throwable>empty())
+                        .onErrorResume(Mono::just))
+                .collectList()
+                .flatMap(errors -> errors.isEmpty() ? Mono.<Void>empty() : Mono.error(errors.getFirst()))
                 .contextWrite(context -> context.put(RequestContext.WORKSPACE_ID, message.workspaceId())
                         .put(RequestContext.USER_NAME, message.userName())
                         .put(RequestContext.VISIBILITY, Visibility.PRIVATE))

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
@@ -103,8 +103,18 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
                 message.projectId(), message.ruleId(), message.workspaceId());
 
         return Flux.fromIterable(message.threadIds())
-                .flatMap(threadId -> processThreadScores(message, threadId))
-                .then()
+                // Score each thread id independently: a single thread's failure must not stop scoring the
+                // sibling thread ids. Per-thread errors are materialized (onErrorResume) so the flatMap
+                // completes for every thread; the batch's first failure is then re-surfaced below. This keeps
+                // the failure on the Mono error path handled by BaseRedisSubscriber.processMessage's
+                // onErrorResume — classified as a processing error, following the normal retryable/
+                // non-retryable path — instead of leaking into the enclosing onErrorContinue via Flux.flatMap
+                // (which would drop the element and count it as an "unexpected" error).
+                .flatMap(threadId -> processThreadScores(message, threadId)
+                        .then(Mono.<Throwable>empty())
+                        .onErrorResume(Mono::just))
+                .collectList()
+                .flatMap(errors -> errors.isEmpty() ? Mono.<Void>empty() : Mono.error(errors.getFirst()))
                 .contextWrite(context -> context.put(RequestContext.WORKSPACE_ID, message.workspaceId())
                         .put(RequestContext.USER_NAME, message.userName())
                         .put(RequestContext.VISIBILITY, Visibility.PRIVATE))


### PR DESCRIPTION
## Details

On the online-scoring dashboard, client/config errors (`BadRequestException`, `ClientErrorException`) on the **trace-thread** streams appear under *Unexpected errors/s*, while the same errors on the trace/span streams correctly appear under *Scoring errors/s* (`processing_errors`).

Root cause: the thread scorers build their per-message chain from `Flux.fromIterable(threadIds).flatMap(...)`, whereas the trace/span scorers build from a `Mono`. `Flux.flatMap` is `onErrorContinue`-aware, so the enclosing `onErrorContinue` in `BaseRedisSubscriber.setupStreamListener` reaches into the scorer's `flatMap`, drops the failing element and records the failure via `*_unexpected_errors_total` — bypassing `processMessage`'s per-message `onErrorResume`.

Fix (both `OnlineScoringTraceThreadLlmAsJudgeScorer` and `OnlineScoringTraceThreadUserDefinedMetricPythonScorer`):
- Score each `thread_id` independently and **materialize** per-thread errors with `onErrorResume`, so a single thread's failure no longer stops scoring the sibling thread ids in the same message.
- After the batch, re-surface the first failure on the `Mono` error path (`collectList().flatMap(... Mono.error ...)`), so the message is still handled by `processMessage`'s `onErrorResume` — classified as a `processing_error` and following the normal retryable/non-retryable path, consistent with the trace/span scorers.

This both fixes the misclassification (no longer counted as "unexpected") and makes per-thread scoring resilient. Successfully-scored threads persist regardless; for the observed cause (a rule missing its provider API key, which fails every thread) the whole message fails as a non-retryable processing error, as expected.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8 (1M context)
  - Scope: Diagnosed the Flux-vs-Mono `onErrorContinue` interaction from the prod metrics, authored the per-thread-resilient error-materialization fix in both thread scorers, and this description.
  - Human verification: Author reviewed the diff. `mvn compile` + `spotless:check` on `opik-backend` pass (BUILD SUCCESS). Root cause confirmed against prod metrics: trace/span scorers carry `ClientErrorException`/`BadRequestException` under `processing_errors`, while the thread scorer's `BadRequestException` appeared only under `unexpected_errors`.

## Testing

- `mvn -o -DskipTests compile` and `mvn -o spotless:check` on `apps/opik-backend` → BUILD SUCCESS.
- Error-routing/resilience change only; no scoring logic added. Full resource/integration suite left to CI.

## Documentation

None.