### PR TITLE
fix(frontend): scope logs existence probes by time range

### DIFF
--- a/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
@@ -621,6 +621,8 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
       projectId,
       page: 1,
       size: 1,
+      fromTime: intervalStart,
+      toTime: intervalEnd,
       logsSource: LOGS_SOURCE.sdk,
     },
     {

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -1217,6 +1217,8 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
       page: 1,
       size: 1,
       stripAttachments: true,
+      fromTime: intervalStart,
+      toTime: intervalEnd,
       logsSource: LOGS_SOURCE.sdk,
     },
     {


### PR DESCRIPTION
## Summary

This updates the Logs page SDK existence probes to use the currently selected time range.

The traces/spans tab already applies `fromTime` / `toTime` to the main table, stats, and CSV export queries, but its `size=1` existence probe did not include those fields. The threads tab had the same gap. On large projects, those probes can scan all historical SDK traces/threads even when the user is looking at a bounded range such as past 24 hours.

Fixes #7298.

## Changes

- Pass `fromTime: intervalStart` and `toTime: intervalEnd` to the traces/spans SDK existence probe.
- Pass `fromTime: intervalStart` and `toTime: intervalEnd` to the threads SDK existence probe.

## Testing

- `cd apps/opik-frontend && npm ci`
- `cd apps/opik-frontend && npm run typecheck`
- `cd apps/opik-frontend && npm run lint`
