### PR TITLE
[NA] [BE] feat: enable online-scoring tracing by default

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1222,11 +1222,11 @@ serviceToggles:
   # Description: Whether or not the Agent Insights freeform SQL path is enabled. Gates the read-only ClickHouse client
   #   and the clickhouse-readonly-freeform-sql health check usage. When off, the read-only client is never queried.
   agentInsightsEnabled: ${TOGGLE_AGENT_INSIGHTS_ENABLED:-"false"}
-  # Default: false
+  # Default: true
   # Description: Whether the online-scoring (LLM-as-judge) evaluation loop is persisted as monitoring traces/spans.
   #   When on, each evaluation produces one trace (source=evaluator) with one llm span per LLM round, so cost and
   #   behavior are auditable inside Opik. When off, evaluations run exactly as before with no extra writes.
-  onlineScoringTracingEnabled: ${TOGGLE_ONLINE_SCORING_TRACING_ENABLED:-"false"}
+  onlineScoringTracingEnabled: ${TOGGLE_ONLINE_SCORING_TRACING_ENABLED:-"true"}
   # Default: "" (empty, no allowlisted workspaces)
   # Description: Comma-separated list of workspace IDs that should always receive V2 navigation.
   # Valid values: comma-separated workspace IDs (e.g. "ws-id-1,ws-id-2"), or "" (empty, disabled).

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -710,9 +710,9 @@ serviceToggles:
   # Default: false
   # Description: Master switch for the agentic-tools path on LLM-as-judge online scoring.
   agenticToolsEnabled: "false"
-  # Default: false
+  # Default: true
   # Description: Whether the online-scoring (LLM-as-judge) evaluation loop is persisted as monitoring traces.
-  onlineScoringTracingEnabled: "false"
+  onlineScoringTracingEnabled: "true"
   # Default: false
   # Description: Whether or not the Agent Insights freeform SQL path is enabled. Tests flip this on when exercising
   #   the read-only ClickHouse client and the clickhouse-readonly-freeform-sql health check.


### PR DESCRIPTION
## Summary
Enables the online-scoring (LLM-as-judge) tracing feature by default.

OPIK-6994 (#7244) shipped the feature behind a default-**off** toggle (`onlineScoringTracingEnabled`). This flips the default to **on**, so each online evaluation is persisted as a hidden monitoring trace (`source=evaluator`, `visibility=hidden`) with one `llm` span per LLM round — making evaluation cost and behavior auditable inside Opik out of the box. `TOGGLE_ONLINE_SCORING_TRACING_ENABLED` can still override it.

## Changes
- `config.yml`: `onlineScoringTracingEnabled` default `"false"` → `"true"`.
- `config-test.yml`: `"false"` → `"true"`, so CI exercises the enabled path.

## Note
Flipping the test config means integration tests now run with tracing on (extra hidden `source=evaluator` monitoring writes). Monitoring traces are `visibility=hidden` and skipped by the online-scoring samplers, so default-visibility reads are unaffected — but if any assertion counts raw rows, CI will surface it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)