### PR TITLE
[NA] [SDK] feat: add opik-integrations assistant skill for building SDK integrations

### DIFF
--- a/.agents/commands/comet/build-opik-external-integration.md
+++ b/.agents/commands/comet/build-opik-external-integration.md
@@ -1,0 +1,83 @@
+# Build Opik External Integration
+
+**Command**: `cursor build-opik-external-integration`
+
+## Overview
+
+Drive the end-to-end workflow for building or updating an Opik integration that lives **outside this repo** — a standalone `opik-*` package (e.g. `opik-openclaw`, `opik-claude-code-plugin`) or Opik support contributed into a third-party project (e.g. LiteLLM, Dify). This command is the entry trigger for the `opik-external-integrations` skill.
+
+- **Use this, not `build-opik-integration`, when** the target lives in an external repo/package. For integrations that ship inside `sdks/python/src/opik/integrations/` or `sdks/typescript/src/opik/integrations/`, use `/comet:build-opik-integration`.
+- **Execution model**: Runs **autonomously** by default — acquires the repo, finds credentials, picks the backend, runs every phase, self-verifies against the live backend via the Opik MCP, and ends with a high-level report. Stops early only on a true blocker (no repo access, missing credential with no fallback, unreachable backend, ambiguous product decision). Add "let me review the design first" to run interactively with a design gate.
+- **Two principles**: follow the **host repo's** conventions (structure, deps, tests, docs, contribution guide), and consume Opik through its **published public API** — never this repo's internals.
+
+---
+
+## Step 0 — Questionnaire (ask first, before any work)
+
+Do **not** propose or pick a target. Ask the user these questions in plain language and wait for answers; keep names/links/paths free-form.
+
+1. **External target** — repo URL / package name + reference links (docs, contribution guide). If standalone, the intended Opik artifact name.
+2. **Integration shape** — standalone `opik-*` package/plugin · upstream contribution into a third-party project · tool/IDE plugin.
+3. **Host language / stack** — Python, TypeScript/Node, other; package manager + runtime.
+4. **Where the Opik code goes** — path inside the host repo, or a new standalone package layout.
+5. **Host conventions** — its `CONTRIBUTING`/`AGENTS.md`, test framework, docs location.
+6. **Verify + credentials** — how to run the host locally, and whether the provider + Opik API keys are available.
+
+Restate the answers in one line, then proceed.
+
+> Sanity check: if the answers reveal the target actually belongs inside `sdks/`, stop and switch to `/comet:build-opik-integration`.
+
+---
+
+## Steps
+
+### 1. Load the skill
+
+Read `.claude/skills/opik-external-integrations/SKILL.md` and `workflow.md`. For mechanism patterns (method patching / callback / OTel) and field mapping, also consult `.claude/skills/opik-integrations/python.md` or `typescript.md`, applied against the published SDK.
+
+### 2. Acquire (Phase 0)
+
+Clone/checkout the external repo into the scratchpad (or add it to the session if supported). Confirm it builds/installs before changing anything.
+
+### 3. Investigate the host (Phase 1)
+
+Find the host's observability extension point, its closest existing integration to clone, and its dependency / test / docs / contribution conventions.
+
+### 4. Investigate the Opik surface (Phase 2)
+
+Pick the public Opik API to use (`@opik.track` / `track_*` / client / REST). Confirm the published SDK version to depend on and how the host configures Opik via env.
+
+### 5. Design & gate (Phase 3)
+
+Decide the extension point, client lifecycle/flush, field mapping, file layout (mirroring the host sibling), and how a host user enables it. Autonomous: record in the report. Interactive: present and wait for approval.
+
+### 6. Implement (Phase 4)
+
+Mirror the host's closest sibling and style. Depend on the published Opik SDK. Keep it transparent (wrap, capture, re-raise; no behavior change when Opik is unconfigured).
+
+### 7. Verify via Opik MCP (Phase 5)
+
+Configure Opik env to log into the workspace the MCP reads, run the host with the integration enabled (main + streaming + extra flows, then flush), and read the trace/spans back. Loop until the tree matches the mapping.
+
+### 8. Test (Phase 6)
+
+Use the **host's** test framework and conventions (not this repo's `fake_backend`/`testlib`). Mirror how the host tests its other integrations. Cover the verified flows.
+
+### 9. Document (Phase 7)
+
+Follow the host's docs conventions. Optionally add/point an Opik-side docs page via the `write-docs` skill. Placeholders only for credentials.
+
+### 10. Report (Phase 8)
+
+Produce the high-level report from `workflow.md`: what was done, MCP + test evidence, a per-flow supported/tested table, limitations, and upstream-PR guidance. Back every "supported" claim with a passing test or a verified trace.
+
+### 11. Sync
+
+If any files under `.agents/` in *this* repo changed, run `make claude`.
+
+---
+
+## Notes
+
+- Never commit real API keys — placeholders only.
+- Branch/commit/PR naming follows the **host project's** contribution guide, not this repo's `git-workflow` rules.

--- a/.agents/commands/comet/build-opik-external-integration.md
+++ b/.agents/commands/comet/build-opik-external-integration.md
@@ -29,51 +29,13 @@ Restate the answers in one line, then proceed.
 
 ---
 
-## Steps
+## Run the workflow
 
-### 1. Load the skill
+Load `.claude/skills/opik-external-integrations/SKILL.md` and its `workflow.md` (the phase playbook, execution modes, MCP-verification loop, and report format). For mechanism patterns (method patching / callback / OTel) and field mapping, also consult `.claude/skills/opik-integrations/python.md` or `typescript.md`, applied against the **published** SDK. Then execute the workflow defined there — at a glance: acquire the repo → investigate the host → investigate the Opik surface → design → implement → verify → test → document → report.
 
-Read `.claude/skills/opik-external-integrations/SKILL.md` and `workflow.md`. For mechanism patterns (method patching / callback / OTel) and field mapping, also consult `.claude/skills/opik-integrations/python.md` or `typescript.md`, applied against the published SDK.
+**Do not restate the phases here.** `workflow.md` is the single source of truth for phase detail, the design gate, the verifiability hard gate, and the report format — follow it directly so the two never drift.
 
-### 2. Acquire (Phase 0)
-
-Clone/checkout the external repo into the scratchpad (or add it to the session if supported). Confirm it builds/installs before changing anything.
-
-### 3. Investigate the host (Phase 1)
-
-Find the host's observability extension point, its closest existing integration to clone, and its dependency / test / docs / contribution conventions.
-
-### 4. Investigate the Opik surface (Phase 2)
-
-Pick the public Opik API to use (`@opik.track` / `track_*` / client / REST). Confirm the published SDK version to depend on and how the host configures Opik via env.
-
-### 5. Design & gate (Phase 3)
-
-Decide the extension point, client lifecycle/flush, field mapping, file layout (mirroring the host sibling), and how a host user enables it. Autonomous: record in the report. Interactive: present and wait for approval.
-
-### 6. Implement (Phase 4)
-
-Mirror the host's closest sibling and style. Depend on the published Opik SDK. Keep it transparent (wrap, capture, re-raise; no behavior change when Opik is unconfigured).
-
-### 7. Verify via Opik MCP (Phase 5)
-
-Configure Opik env to log into the workspace the MCP reads, run the host with the integration enabled (main + streaming + extra flows, then flush), and read the trace/spans back. Loop until the tree matches the mapping.
-
-### 8. Test (Phase 6)
-
-Use the **host's** test framework and conventions (not this repo's `fake_backend`/`testlib`). Mirror how the host tests its other integrations. Cover the verified flows.
-
-### 9. Document (Phase 7)
-
-Follow the host's docs conventions. Optionally add/point an Opik-side docs page via the `write-docs` skill. Placeholders only for credentials.
-
-### 10. Report (Phase 8)
-
-Produce the high-level report from `workflow.md`: what was done, MCP + test evidence, a per-flow supported/tested table, limitations, and upstream-PR guidance. Back every "supported" claim with a passing test or a verified trace.
-
-### 11. Sync
-
-If any files under `.agents/` in *this* repo changed, run `make claude`.
+When done, if any files under `.agents/` in *this* repo changed, run `make claude` to sync them into `.claude/`.
 
 ---
 

--- a/.agents/commands/comet/build-opik-integration.md
+++ b/.agents/commands/comet/build-opik-integration.md
@@ -4,10 +4,10 @@
 
 ## Overview
 
-Drive the end-to-end workflow for creating, updating, or maintaining an Opik SDK integration (Python or TypeScript). This command is the entry trigger for the `opik-integrations` skill — it loads that skill and walks the phased playbook with a human approval gate before any integration code is written.
+Entry trigger for the `opik-integrations` skill — create, update, or maintain an Opik SDK integration (Python or TypeScript) that ships **inside this repo**. This command collects the inputs (below) and then runs the skill's phased workflow; the workflow files are the single source of truth for the phases, gates, verification, and report format.
 
-- **Execution model**: Runs **autonomously** by default — makes its own preparations (installs deps, finds credentials, picks the backend), runs every phase without pausing, self-verifies against the live backend, and ends with a high-level report. Stops early only on a true blocker (missing credential with no fallback, unreachable backend, ambiguous product decision), reporting what was completed. Add "let me review the design first" to run interactively with a design gate. Re-runs from scratch each invocation.
-- **Scope**: integrations that live **inside this repo** — under `sdks/python/src/opik/integrations/` and `sdks/typescript/src/opik/integrations/`. This is SDK-contributor work — distinct from the user-facing `instrument` skill. For integrations that live in an **external** repo (a standalone `opik-*` package, or Opik support contributed into a third-party project like LiteLLM or Dify), use the `opik-external-integrations` skill / `/comet:build-opik-external-integration` command instead.
+- **Execution model**: Runs **autonomously** by default — makes its own preparations, runs every phase without pausing, self-verifies against the backend, and ends with a high-level report. The design/approval step (Phase 3) **only pauses in interactive mode** (ask "let me review the design first"); an autonomous run does not stop there — it records the design in the final report and proceeds. **Verifiability is a hard gate for `new`/`update`**: if there is no backend/credential path that can verify the integration (MCP or SDK read-back) and the user hasn't opted into an explicit unverified path, the run stops before writing integration code and reports what's blocked. Re-runs from scratch each invocation.
+- **Scope**: integrations under `sdks/python/src/opik/integrations/` and `sdks/typescript/src/opik/integrations/`. SDK-contributor work — distinct from the user-facing `instrument` skill. For integrations that live in an **external** repo (a standalone `opik-*` package, or Opik support contributed into a third-party project like LiteLLM or Dify), use `/comet:build-opik-external-integration` instead.
 
 ---
 
@@ -25,55 +25,13 @@ Once the answers are in, restate them in one line and proceed.
 
 ---
 
-## Steps
+## Run the workflow
 
-### 1. Load the skill
+Load `.claude/skills/opik-integrations/SKILL.md`, its `workflow.md` (the phase playbook, execution modes, MCP-verification loop, and report template), and the matching language reference (`python.md` / `typescript.md`). Then execute the workflow defined there — at a glance: prepare → investigate → collect → design → implement → verify → test → document → report.
 
-Read `.claude/skills/opik-integrations/SKILL.md` and the matching language reference (`python.md` or `typescript.md`). Read `workflow.md` for the phase definitions.
+**Do not restate the phases here.** `workflow.md` is the single source of truth for phase detail, the design gate, the verifiability hard gate, and the report format — follow it directly so the two never drift.
 
-### 2. Classify (Phase 0)
-
-Confirm mode, language, and the closest existing integration to clone. For `maintain` mode, skip to Investigate → Verify → Test.
-
-### 2.5. Prepare (Phase 0.5)
-
-Autonomously install/resolve the target library in the SDK venv (pinning a known-good version and restoring any disturbed core dep), locate credentials without printing them (`sdks/python/tests/pytest.ini` env block + shell env), and confirm which backend the Opik MCP reads and that it's reachable. Record blockers instead of stopping when a fallback exists.
-
-### 3. Investigate (Phase 1)
-
-Fan out exploration of the target library: entrypoint shape, methods to trace (sync + async), streaming, input/output/usage/error mapping. Read the closest sibling integration in full.
-
-### 4. Collect (Phase 2)
-
-Write a minimal runnable example script (scratchpad) and a field-mapping findings note.
-
-### 5. Design & gate (Phase 3)
-
-Decide the pattern, file layout, entrypoint signature, and field mapping. In autonomous mode, proceed and capture this in the final report; in interactive mode, present it and wait for approval before writing integration code.
-
-### 6. Implement (Phase 4)
-
-Clone the closest sibling and adapt, reusing the shared core utilities. Keep the framework import inside the integration module (Python) / as a peer dependency (TypeScript).
-
-### 7. Verify via Opik MCP (Phase 5)
-
-Configure the example's env to log into the workspace the Opik MCP reads, run it (non-streaming + streaming + each extra method, then `flush()`), and read the trace/spans back through the MCP. Check the trace tree against the field mapping. Loop until correct.
-
-### 8. Test (Phase 6)
-
-Add coverage with the language harness. Python: `tests/library_integration/<name>/` with `fake_backend` + `testlib` trees and an `ensure_<name>_configured` fixture. TypeScript: vitest `*.test.ts` mirroring the sibling package.
-
-### 9. Document (Phase 7)
-
-Author the Fern page at `docs-v2/integrations/<name>.mdx` (Python) / `<name>-typescript.mdx` (TS), route it in `fern/versions/latest.yml`, and add a `<Card>` to the integrations overview.
-
-### 10. Report (Phase 8)
-
-Produce the high-level report using the template in `workflow.md`: what was done, verification evidence (MCP trace ids + test results), a supported/not-supported table, limitations, follow-ups, and a usage snippet. Back every "supported" claim with a passing test or a verified trace.
-
-### 11. Sync
-
-If any files under `.agents/` changed, run `make claude`.
+When done, if any files under `.agents/` changed, run `make claude` to sync them into `.claude/`.
 
 ---
 

--- a/.agents/commands/comet/build-opik-integration.md
+++ b/.agents/commands/comet/build-opik-integration.md
@@ -1,0 +1,83 @@
+# Build Opik Integration
+
+**Command**: `cursor build-opik-integration`
+
+## Overview
+
+Drive the end-to-end workflow for creating, updating, or maintaining an Opik SDK integration (Python or TypeScript). This command is the entry trigger for the `opik-integrations` skill — it loads that skill and walks the phased playbook with a human approval gate before any integration code is written.
+
+- **Execution model**: Runs **autonomously** by default — makes its own preparations (installs deps, finds credentials, picks the backend), runs every phase without pausing, self-verifies against the live backend, and ends with a high-level report. Stops early only on a true blocker (missing credential with no fallback, unreachable backend, ambiguous product decision), reporting what was completed. Add "let me review the design first" to run interactively with a design gate. Re-runs from scratch each invocation.
+- **Scope**: integrations that live **inside this repo** — under `sdks/python/src/opik/integrations/` and `sdks/typescript/src/opik/integrations/`. This is SDK-contributor work — distinct from the user-facing `instrument` skill. For integrations that live in an **external** repo (a standalone `opik-*` package, or Opik support contributed into a third-party project like LiteLLM or Dify), use the `opik-external-integrations` skill / `/comet:build-opik-external-integration` command instead.
+
+---
+
+## Step 0 — Questionnaire (ask first, before any work)
+
+Do **not** propose or pick a library yourself, and do **not** present a menu of candidate integrations. The user decides what to build; your job is to collect it. Ask the questions below in plain language and wait for answers. Use a quick choice only for the genuinely categorical ones (language, mode); keep the target name and links free-form.
+
+1. **What to integrate** — the library / framework / provider name, plus any reference links you have (official docs, SDK source repo, API reference). Ask the user to paste names/links rather than guessing.
+2. **Where does it live** — inside this Opik repo, or an external repo? If the answer is external (standalone `opik-*` package, or a PR into a third-party project such as LiteLLM / Dify), **stop and switch to the `opik-external-integrations` skill** (`/comet:build-opik-external-integration`).
+3. **Language** — `python`, `typescript`, or `both`.
+4. **Mode** — `new` (default), `update`, or `maintain`.
+5. **Anything specific** (optional) — particular methods/flows to trace, or special behavior to handle (streaming, async, tools/agents, structured output, multimodal).
+
+Once the answers are in, restate them in one line and proceed.
+
+---
+
+## Steps
+
+### 1. Load the skill
+
+Read `.claude/skills/opik-integrations/SKILL.md` and the matching language reference (`python.md` or `typescript.md`). Read `workflow.md` for the phase definitions.
+
+### 2. Classify (Phase 0)
+
+Confirm mode, language, and the closest existing integration to clone. For `maintain` mode, skip to Investigate → Verify → Test.
+
+### 2.5. Prepare (Phase 0.5)
+
+Autonomously install/resolve the target library in the SDK venv (pinning a known-good version and restoring any disturbed core dep), locate credentials without printing them (`sdks/python/tests/pytest.ini` env block + shell env), and confirm which backend the Opik MCP reads and that it's reachable. Record blockers instead of stopping when a fallback exists.
+
+### 3. Investigate (Phase 1)
+
+Fan out exploration of the target library: entrypoint shape, methods to trace (sync + async), streaming, input/output/usage/error mapping. Read the closest sibling integration in full.
+
+### 4. Collect (Phase 2)
+
+Write a minimal runnable example script (scratchpad) and a field-mapping findings note.
+
+### 5. Design & gate (Phase 3)
+
+Decide the pattern, file layout, entrypoint signature, and field mapping. In autonomous mode, proceed and capture this in the final report; in interactive mode, present it and wait for approval before writing integration code.
+
+### 6. Implement (Phase 4)
+
+Clone the closest sibling and adapt, reusing the shared core utilities. Keep the framework import inside the integration module (Python) / as a peer dependency (TypeScript).
+
+### 7. Verify via Opik MCP (Phase 5)
+
+Configure the example's env to log into the workspace the Opik MCP reads, run it (non-streaming + streaming + each extra method, then `flush()`), and read the trace/spans back through the MCP. Check the trace tree against the field mapping. Loop until correct.
+
+### 8. Test (Phase 6)
+
+Add coverage with the language harness. Python: `tests/library_integration/<name>/` with `fake_backend` + `testlib` trees and an `ensure_<name>_configured` fixture. TypeScript: vitest `*.test.ts` mirroring the sibling package.
+
+### 9. Document (Phase 7)
+
+Author the Fern page at `docs-v2/integrations/<name>.mdx` (Python) / `<name>-typescript.mdx` (TS), route it in `fern/versions/latest.yml`, and add a `<Card>` to the integrations overview.
+
+### 10. Report (Phase 8)
+
+Produce the high-level report using the template in `workflow.md`: what was done, verification evidence (MCP trace ids + test results), a supported/not-supported table, limitations, follow-ups, and a usage snippet. Back every "supported" claim with a passing test or a verified trace.
+
+### 11. Sync
+
+If any files under `.agents/` changed, run `make claude`.
+
+---
+
+## Notes
+
+- Never commit real API keys in examples, tests, or docs — placeholders only.
+- Follow `git-workflow` rules for branch/commit naming if asked to commit.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -10,7 +10,9 @@ Domain-specific agent skills for the Opik monorepo. Each skill provides patterns
 | documentation | `documentation/` | Feature documentation and release notes patterns. Use when documenting changes, writing PR descriptions, or preparing releases. |
 | local-dev | `local-dev/` | Local development environment setup and commands. Use when helping with dev server, Docker, or local testing. |
 | opik-backend | `opik-backend/` | Java backend patterns for Opik. Use when working in `apps/opik-backend`, designing APIs, database operations, or services. |
+| opik-external-integrations | `opik-external-integrations/` | Build an Opik integration that lives outside this repo — a standalone `opik-*` package or Opik support contributed into a third-party project (LiteLLM, Dify, …). Activates only for external-repo targets. |
 | opik-frontend | `opik-frontend/` | React frontend patterns for Opik. Use when working in `apps/opik-frontend`, on components, state, or data fetching. |
+| opik-integrations | `opik-integrations/` | Build, update, test, and document Opik SDK integrations (Python & TypeScript) that ship under `sdks/`. Runs a questionnaire-first, autonomous workflow: investigate → design → implement → verify via the Opik MCP → test → document → report. |
 | playwright-pom-discovery | `playwright-pom-discovery/` | Choose stable selectors against the live UI when building a Page Object Model for the E2E suite (`tests_end_to_end/e2e/pom/`). Used as the discovery sub-step by `writing-e2e-tests`. |
 | python-sdk | `python-sdk/` | Python SDK patterns for Opik. Use when working in `sdks/python`, on SDK APIs, integrations, or message processing. |
 | typescript-sdk | `typescript-sdk/` | TypeScript SDK patterns for Opik. Use when working in `sdks/typescript`. |

--- a/.agents/skills/opik-external-integrations/SKILL.md
+++ b/.agents/skills/opik-external-integrations/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: opik-external-integrations
+description: Build or update an Opik integration that lives OUTSIDE this repo — a standalone opik-* package (e.g. opik-openclaw, opik-claude-code-plugin) or Opik support contributed into a third-party project (e.g. LiteLLM, Dify). Use ONLY when the user names an external repository or external package as the target; for integrations under sdks/ use the opik-integrations skill instead.
+---
+
+# Opik External Integrations
+
+This skill builds Opik integrations whose code **does not live in this repository**. Two shapes:
+
+- **Standalone `opik-*` package / plugin** — its own repo or package that depends on the *published* Opik SDK. Examples: `opik-openclaw`, `opik-claude-code-plugin`.
+- **Upstream contribution** — Opik support added into a third-party project that already has its own logging/callback/plugin system. Examples: an Opik callback in **LiteLLM**, an Opik integration in **Dify**.
+
+> **Activation gate — read this first.** Use this skill **only** when the target lives in an external repo or external package. If the user wants an integration that ships inside `sdks/python/src/opik/integrations/` or `sdks/typescript/src/opik/integrations/`, this is the wrong skill — use **`opik-integrations`**. When in doubt, ask the "where does it live" question (below) and route accordingly.
+
+## Two principles that make external work different
+
+1. **Follow the HOST repo's conventions, not this repo's.** Structure, dependency management, lint/format, test framework, docs, and the contribution guide are dictated by the target project. Do not impose `sdks/` layout, `fake_backend`, or Fern docs on an external repo. Read its `CONTRIBUTING`/`AGENTS.md` and mirror its closest existing integration/plugin.
+2. **Consume Opik through its PUBLISHED public API.** Use the released `opik` (Python) / `opik` (TypeScript) SDK or the REST API — the same surface end users get. Never import this repo's internal modules (`opik.decorator.*`, `rest_api`, message-processing internals); they are not available outside this repo and are not a stable contract.
+
+## Start with the questionnaire
+
+Collect everything up front, free-form — do not propose a target. See [workflow.md](workflow.md) Phase 0 for the full list. The essentials: **which external repo/package** (URL + links), **integration shape** (standalone package vs. upstream contribution vs. plugin), **host language/stack**, **where the Opik code goes**, **how the host tests and documents**, and **how to run it to verify**.
+
+## The workflow
+
+Multi-step and autonomous by default (front-load preparation, run through, self-verify, end with a report); ask for the interactive variant to approve the design first. Full playbook in **[workflow.md](workflow.md)**. At a glance:
+
+0. **Questionnaire + acquire** the external repo (clone/checkout into the scratchpad).
+1. **Investigate the host** — its integration/plugin conventions, dep management, test framework, docs, contribution guide. Find the closest existing integration to clone.
+2. **Investigate the Opik surface** — pick the public API to use: `@opik.track` / `track_*` wrappers, the low-level client, or REST. Lean on the `opik` and `instrument` skills for the public API.
+3. **Design** how Opik plugs into the host's extension point (callback hook, plugin entrypoint, middleware). Map host data → Opik trace/span fields.
+4. **Implement** in the host checkout, mirroring its closest sibling and its style.
+5. **Verify via the Opik MCP** — run the host with the integration active, log to the workspace the MCP reads, and read the trace/spans back. Loop until correct.
+6. **Test** using the host's test framework and conventions.
+7. **Document** following the host's docs conventions; optionally add/point an Opik docs page (`write-docs`).
+8. **Report** — what was done, verification evidence, a per-flow supported/tested table, limitations, and how to open the upstream PR.
+
+## How this maps to the internal skill
+
+The *mechanism* knowledge is shared — how a provider/framework exposes hooks, streaming, and usage is the same problem as in `opik-integrations`. Read that skill's [python.md](../opik-integrations/python.md) / [typescript.md](../opik-integrations/typescript.md) for the patterns (method patching, callback handler, OTel), but apply them against the **published** SDK surface and inside the **host repo's** structure.
+
+## Skills this one builds on (do not duplicate them)
+
+- `opik` / `instrument` — the user-facing public API surface (the right way to consume Opik from outside).
+- `opik-integrations` — the integration mechanism patterns (patching / callback / OTel) and field mapping.
+- `write-docs` — only if you also add an Opik-side docs page pointing at the external integration.

--- a/.agents/skills/opik-external-integrations/SKILL.md
+++ b/.agents/skills/opik-external-integrations/SKILL.md
@@ -21,6 +21,8 @@ This skill builds Opik integrations whose code **does not live in this repositor
 
 Collect everything up front, free-form — do not propose a target. See [workflow.md](workflow.md) Phase 0 for the full list. The essentials: **which external repo/package** (URL + links), **integration shape** (standalone package vs. upstream contribution vs. plugin), **host language/stack**, **where the Opik code goes**, **how the host tests and documents**, and **how to run it to verify**.
 
+Once you know the target, check **[references.md](references.md)** — a curated list of known external integrations (standalone `opik-*` plugins incl. the cookiecutter template, and third-party host repos like LiteLLM / Dify / n8n) with their repo and Opik-docs URLs. If the target is listed or resembles one, start from its links and clone the closest sibling instead of researching blind.
+
 ## The workflow
 
 Multi-step and autonomous by default (front-load preparation, run through, self-verify, end with a report); ask for the interactive variant to approve the design first. Full playbook in **[workflow.md](workflow.md)**. At a glance:

--- a/.agents/skills/opik-external-integrations/references.md
+++ b/.agents/skills/opik-external-integrations/references.md
@@ -1,0 +1,35 @@
+# External Integration References
+
+Known external Opik integrations, to seed the research phase. When the target is (or resembles) one of these, start from its repo and docs instead of investigating from scratch — and use the closest one as the "clone the sibling" source.
+
+> Verify before relying on specifics: repos change. Treat the **paths** below as starting hints, not guarantees, and confirm against the live repo. Add new entries here whenever you build or discover one.
+
+## Standalone `opik-*` packages & plugins (comet-ml org)
+
+For the **standalone package** shape — its own repo depending on the published Opik SDK.
+
+| Repo | What it is | URL |
+|---|---|---|
+| `opik-project-template` | Cookiecutter scaffold for a new Opik project — **the starting point for a brand-new standalone package** | https://github.com/comet-ml/opik-project-template |
+| `opik-openclaw` | Official OpenClaw plugin exporting agent traces to Opik (traces, cost, tokens, errors) | https://github.com/comet-ml/opik-openclaw |
+| `opik-claude-code-plugin` | Opik plugin for Claude Code | https://github.com/comet-ml/opik-claude-code-plugin |
+| `opik-codex-plugin` | Opik plugin for Codex | https://github.com/comet-ml/opik-codex-plugin |
+| `opik-kong-plugin` | Opik plugin for the Kong AI Gateway | https://github.com/comet-ml/opik-kong-plugin |
+
+## Upstream contributions (Opik support inside a third-party repo)
+
+For the **upstream contribution** shape — Opik logging/callback added into a third-party project that owns its own plugin/observability system. Host repo (where the Opik code lives) + the Opik-side docs page.
+
+| Host | Host repo | Opik docs |
+|---|---|---|
+| LiteLLM | https://github.com/BerriAI/litellm (Opik logger under `litellm/integrations/opik/`) | https://www.comet.com/docs/opik/integrations/litellm |
+| Dify | https://github.com/langgenius/dify | https://www.comet.com/docs/opik/integrations/dify |
+| n8n | https://github.com/n8n-io/n8n | https://www.comet.com/docs/opik/integrations/n8n |
+| Flowise | https://github.com/FlowiseAI/Flowise | https://www.comet.com/docs/opik/integrations/flowise |
+| Langflow | https://github.com/langflow-ai/langflow | https://www.comet.com/docs/opik/integrations/langflow |
+
+## Discovering others
+
+- **Opik docs integrations index** — the canonical list of published integrations (many are external/host-side): https://www.comet.com/docs/opik/integrations/overview
+- **comet-ml GitHub org** — search for `opik-` repos (plugins, templates): https://github.com/orgs/comet-ml/repositories?q=opik-
+- In this repo, the docs sources under `apps/opik-documentation/documentation/fern/docs-v2/integrations/` list every integration slug; host-side ones (e.g. `litellm`, `dify`, `n8n`, `flowise`, `langflow`) map to the docs URLs above.

--- a/.agents/skills/opik-external-integrations/workflow.md
+++ b/.agents/skills/opik-external-integrations/workflow.md
@@ -1,0 +1,79 @@
+# External Integration Workflow
+
+End-to-end playbook for building an Opik integration that lives in an external repo or package. Runs autonomously by default; pause at the design gate only if the user asks to review first. **Always end with the Phase 8 report**, and back every "supported" claim with a passing test or an MCP-verified trace.
+
+## Execution modes
+
+- **Autonomous (default)** — make every preparation yourself (acquire the repo, find credentials, pick the backend), run all phases, self-verify, and report. Stop early only on a true blocker (no repo access, missing credential with no fallback, unreachable backend, an ambiguous product decision), reporting what you completed.
+- **Interactive** — pause at Phase 3 for design approval before writing code.
+
+## Phase 0 — Questionnaire + acquire
+
+Ask the user, in plain language, and wait for answers. Do **not** propose a target.
+
+1. **External target** — the repo URL / package name, plus reference links (docs, the host project's contribution guide). If it's a standalone package, the intended Opik artifact name (e.g. `opik-openclaw`).
+2. **Integration shape** — standalone `opik-*` package/plugin · upstream contribution into a third-party project (LiteLLM, Dify, …) · tool/IDE plugin.
+3. **Host language / stack** — Python, TypeScript/Node, other; package manager and runtime.
+4. **Where the Opik code goes** — path inside the host repo (which plugin/integration dir), or a new standalone package layout.
+5. **Host conventions** — link to its `CONTRIBUTING`/`AGENTS.md`; its test framework; its docs location.
+6. **Verify + credentials** — how to run the host locally to exercise the integration, and whether the needed API keys (provider + Opik) are available.
+
+Then **acquire the repo**: clone/checkout into the scratchpad (or add it to the session if supported). Confirm it builds/installs before changing anything. Restate the answers in one line and proceed.
+
+## Phase 1 — Investigate the host
+
+- The host's **extension point** for observability: a callback/hook interface, a plugin/entrypoint registry, middleware, or an env-driven logger. This is where Opik attaches.
+- The **closest existing integration** in the host (e.g. how it integrates another observability/logging vendor) — clone its structure, registration, and style.
+- The host's **dependency rules** (how it declares optional/extra deps), **test framework**, **lint/format**, and **docs** conventions.
+- What host data is available at the hook (inputs, outputs, model, usage, errors, timing) and its shape.
+
+## Phase 2 — Investigate the Opik surface
+
+Pick the **public** Opik API to use — never this repo's internals:
+
+- **Python**: `import opik`, `@opik.track`, `track_*` wrappers, or `opik.Opik()` client; `opik.opik_context` for span data; `client.flush()`.
+- **TypeScript**: the `opik` package — `Opik` client, `track`, domain objects; `flushAll()`.
+- **REST** when no SDK fits the host runtime.
+
+Confirm the published SDK version to depend on, and how the host will configure Opik (env vars: `OPIK_API_KEY`, base URL, workspace, project).
+
+## Phase 3 — Design (gate)
+
+Write down: the host extension point used; how the Opik client is created/configured and flushed; the mapping from host data → Opik trace/span fields (input/output/model/provider/usage/error/span-type); the file layout inside the host (mirroring its sibling); and the public registration the host user performs to enable it. In autonomous mode, record this in the report; in interactive mode, present and wait for approval.
+
+## Phase 4 — Implement
+
+Mirror the host's closest sibling and its style. Depend on the **published** Opik SDK. Keep the integration transparent (wrap, capture, re-raise; no behavior change when Opik is unconfigured). Flush appropriately for the host's lifecycle (request end, process exit, explicit hook).
+
+## Phase 5 — Verify via Opik MCP
+
+The proof the integration logs correctly — do not rely on reading code.
+
+1. Configure Opik env to log into the workspace the connected Opik MCP reads.
+2. Run the host with the integration enabled, exercising the main flow(s) — non-streaming, streaming, and any extra path — then flush.
+3. Read the trace/spans back through the MCP (`list` then `read`).
+4. Check the tree against the Phase 3 mapping: one trace per top-level call; correct span hierarchy and `type`; input/output well-shaped; usage with token counts; model/provider set; errors recorded and re-raised.
+5. Loop until it matches.
+
+## Phase 6 — Test
+
+Use the **host's** test framework and conventions (not `fake_backend`/`testlib`, which are this repo's). Mirror how the host tests its other integrations — mock the Opik client/HTTP at the host's boundary where the host does, or assert against captured calls. Cover the same flows you verified in Phase 5.
+
+## Phase 7 — Document
+
+Follow the **host's** docs conventions (its README / docs site / examples dir). Optionally add or update an Opik-side docs page that points to the external integration, using the `write-docs` skill. Credential placeholders only.
+
+## Phase 8 — Report
+
+Produce a high-level report:
+
+- **Integration** — external target, shape, host extension point, Opik public API used, published SDK version depended on.
+- **What was done** — repo acquired, files added/changed (with paths in the host), how a host user enables it.
+- **Verification** — MCP trace ids + project, and host test results.
+- **Flows supported & test coverage** — a table: every user-facing flow × implemented? × host test (by name) × MCP-verified? Flag any flow implemented but untested, and any not implemented.
+- **What's NOT supported / limitations** — out-of-scope hooks, host-version constraints, env/backend blockers.
+- **Follow-ups & PR** — how to open the upstream PR (branch/commit per the host's contribution guide), and any maintainer review notes.
+
+## Definition of done
+
+Implementation merged-quality in the host checkout, MCP verification passed, tests added per host conventions and passing, host docs updated, report produced. If you changed files under `.agents/` in *this* repo, run `make claude`.

--- a/.agents/skills/opik-external-integrations/workflow.md
+++ b/.agents/skills/opik-external-integrations/workflow.md
@@ -18,6 +18,8 @@ Ask the user, in plain language, and wait for answers. Do **not** propose a targ
 5. **Host conventions** — link to its `CONTRIBUTING`/`AGENTS.md`; its test framework; its docs location.
 6. **Verify + credentials** — how to run the host locally to exercise the integration, and whether the needed API keys (provider + Opik) are available.
 
+Before acquiring, check **[references.md](references.md)** — known external integrations (standalone `opik-*` plugins + the cookiecutter template, and third-party hosts like LiteLLM / Dify / n8n / Flowise / Langflow) with their repo and Opik-docs URLs. If the target is listed or resembles one, start from those links and pick the closest as the clone source; a brand-new standalone package starts from `opik-project-template`.
+
 Then **acquire the repo**: clone/checkout into the scratchpad (or add it to the session if supported). Confirm it builds/installs before changing anything. Restate the answers in one line and proceed.
 
 ## Phase 1 — Investigate the host

--- a/.agents/skills/opik-integrations/SKILL.md
+++ b/.agents/skills/opik-integrations/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: opik-integrations
+description: Build, update, test, and document Opik SDK integrations (Python & TypeScript). Use when adding a new framework/provider integration under sdks/python/src/opik/integrations or sdks/typescript/src/opik/integrations, updating an existing one, or verifying that an integration logs traces correctly.
+---
+
+# Opik SDK Integrations
+
+This skill is for **building integrations into the Opik SDK itself** — the code that ships inside `opik` / `opik-*` packages so that *users* can trace a framework (OpenAI, LangChain, Mistral, …) with one call.
+
+> Do not confuse this with the user-facing `instrument` / `opik` skills, which add Opik tracing to *someone else's* application. This skill is for SDK contributors editing `sdks/python` and `sdks/typescript`.
+>
+> If the integration lives **outside this repo** — a standalone `opik-*` package, or Opik support contributed into a third-party project (LiteLLM, Dify, a plugin, …) — use the **`opik-external-integrations`** skill instead. This skill assumes the code ships inside `sdks/`.
+
+## Start with the questionnaire
+
+Never assume or suggest a target. Collect, from the user, before doing anything: **what** to integrate (name + reference links), **where** it lives (this repo vs. external — route external requests to `opik-external-integrations`), **language** (python/typescript/both), **mode** (new/update/maintain), and any **specific flows** to cover. Do not present a menu of candidate libraries — the user names the target.
+
+## When to use
+
+- **New integration** — a framework/provider has no dedicated integration yet (today it's reachable only via LiteLLM, the OpenAI-compatible shim, or OpenTelemetry, or not at all).
+- **Update** — an integration must track new methods, capture new fields, or follow an upstream SDK change.
+- **Maintain / verify** — confirm an existing integration still logs the correct trace/span tree after a dependency bump or refactor.
+
+## The workflow
+
+Integration work is multi-step. By default this skill runs **autonomously**: it makes its own preparations (deps, credentials, backend), runs every phase, self-verifies, and ends with a high-level report — only stopping early on a true blocker. Ask for the interactive variant if you want to approve the design before any code is written. The full playbook — phases, execution modes, the Opik-MCP verification loop, and the report template — lives in **[workflow.md](workflow.md)**. At a glance:
+
+0. **Prepare** — install/resolve the target library, locate credentials (without printing them), pick a backend the MCP can read.
+1. **Investigate** the target library (API surface, hooks/callbacks, streaming shape, usage/token format, errors).
+2. **Collect** findings + a minimal runnable example script.
+3. **Design** — pick the pattern, file layout, entrypoint. (Interactive mode pauses for approval here; autonomous mode records it in the report.)
+4. **Implement** by cloning the closest existing same-pattern integration.
+5. **Verify** the logged data through the Opik MCP (`read`/`list` the trace & spans).
+6. **Test** with the language's integration-test harness.
+7. **Document** the Fern page and wire its routing.
+8. **Report** — a high-level summary: what was done, what's supported (with evidence), what's not, and how to use it.
+
+## Golden rule: clone the closest sibling
+
+Never build an integration from a blank file. Identify the existing integration that shares the target's mechanism, copy its structure, and adapt. The decision tree:
+
+| Target shape | Python pattern | TS pattern | Clone from |
+|---|---|---|---|
+| SDK client with methods to wrap (most providers) | Method patching (`BaseTrackDecorator` subclass) | Proxy wrapper | `openai/` · `opik-openai` |
+| Framework with a callback/tracer interface | Pure callback (`BaseTracer`) | Callback handler | `langchain/` · `opik-langchain` |
+| Framework already emitting OpenTelemetry spans | OTel | OTel exporter | `otel/` · `opik-vercel` |
+| Callbacks exist but are unreliable / need method hooks too | Hybrid | (rare) | `adk/` |
+
+If the target exposes an **OpenAI-compatible endpoint**, first check whether `track_openai(..., provider=...)` already covers the need before building a dedicated integration — sometimes the right answer is a docs page, not new code.
+
+**OpenTelemetry is backend-first.** If the target already emits OpenTelemetry spans, the heavy lifting is done by Opik's OTLP ingestion endpoint on the backend — many such integrations are *docs-only* (point the framework's OTLP exporter at Opik with auth headers; no SDK code). Build a client-side piece only when you must shape what the backend receives — set Opik semantics, remap attributes, or bridge a framework that won't export raw OTLP. The client-side building block is a `SpanProcessor` in Python (`integrations/otel/`) or a `SpanExporter` in TypeScript (`opik-vercel`); a framework-specific OTel tracer wrapper (`adk/patchers/adk_otel_tracer/`) is the heavier variant. See the OTel sections in [python.md](python.md) / [typescript.md](typescript.md).
+
+## Language references
+
+- **Python** → [python.md](python.md) — integration anatomy, shared core modules, mechanism templates, dependency/import rules, test specifics.
+- **TypeScript** → [typescript.md](typescript.md) — package anatomy, patterns, build/peer-dep rules. Delegates to the canonical `sdks/typescript/design/INTEGRATIONS.md`.
+
+## Skills this one builds on (do not duplicate them)
+
+- `python-sdk` — three-layer architecture, batching, `fake_backend`, `testlib` verifiers, error handling.
+- `typescript-sdk` — layered client, flush semantics, testing with vitest.
+- `write-docs` — Fern MDX authoring, routing YAML, callouts, images.

--- a/.agents/skills/opik-integrations/python.md
+++ b/.agents/skills/opik-integrations/python.md
@@ -1,0 +1,108 @@
+# Python Integration Anatomy
+
+Reference for building integrations under `sdks/python/src/opik/integrations/<name>/`. Read this alongside the `python-sdk` skill (architecture, batching, testing fixtures).
+
+## Directory skeleton
+
+```
+sdks/python/src/opik/integrations/<name>/
+├── __init__.py                 # exports the public entrypoint, nothing else
+├── opik_tracker.py             # the entrypoint: track_<name>() (patching) or the tracer class
+├── <name>_decorator.py         # BaseTrackDecorator subclass(es) — patching integrations
+└── <name>_chunks_aggregator.py # merges streamed chunks into one response — if streaming
+```
+
+Callback integrations (LangChain-style) replace the decorator file with an `opik_tracer.py` holding a `BaseTracer` subclass plus helpers (`run_parse_helpers.py`, provider usage extractors). Hybrid integrations (ADK) add a `patchers/` package and callback injectors.
+
+## Mechanism templates — clone, don't invent
+
+| Mechanism | When | Canonical template |
+|---|---|---|
+| **Method patching** | SDK client with methods to wrap (most providers) | `integrations/openai/` |
+| **Pure callback** | framework exposes a callback/tracer interface | `integrations/langchain/` |
+| **Hybrid** | callbacks unreliable / also need method hooks | `integrations/adk/` |
+| **OTel** | framework already emits OpenTelemetry spans | `integrations/otel/` |
+
+### Method patching (the common case)
+
+The entrypoint mutates the client in place and returns it. Study `openai/opik_tracker.py` — the shape is:
+
+```python
+def track_<name>(client, project_name=None, provider=None):
+    if hasattr(client, "opik_tracked"):   # idempotency guard
+        return client
+    client.opik_tracked = True
+    # resolve provider, then patch each method via a decorator factory
+    _patch_<name>(client, provider, project_name)
+    return client
+```
+
+Each method is wrapped by a `BaseTrackDecorator` subclass (`<name>_decorator.py`). You implement two preprocessors; everything else (span/trace creation, context nesting, error capture, generator handling) comes from the base class. Read `openai/openai_chat_completions_decorator.py` as the template:
+
+- `_start_span_inputs_preprocessor(...)` → returns `StartSpanParameters` (type, name, input, metadata, tags, model, provider).
+- `_end_span_inputs_preprocessor(...)` → returns `EndSpanParameters` (output, usage, model, provider, metadata).
+- Streaming: pass a `generations_aggregator` to `.track(...)` and override the stream handler so chunks are accumulated and the span finalizes after iteration. Sync iterators, async iterators, and stream context managers each need patching — see `openai/stream_patchers.py`.
+
+Wrapped calls check `opik.is_tracing_active()` at call time and no-op the telemetry if tracing is off, while still running the underlying call.
+
+### OpenTelemetry (backend-first)
+
+When the target already emits OpenTelemetry, most of the work lives on the **backend**: Opik exposes an OTLP ingestion endpoint that maps OTel spans to Opik traces. Many OTel "integrations" are therefore *docs-only* — the user points their framework's OTLP exporter at Opik with auth headers and writes no SDK code. Always check whether that covers the need before writing code.
+
+Add client-side code only when you must shape what the backend receives (set Opik semantics, remap attributes, bridge a framework that won't emit raw OTLP). The building block is `integrations/otel/`:
+
+- `OpikSpanProcessor` — an OTel `SpanProcessor` the user registers on their `TracerProvider` to forward/annotate spans.
+- distributed-trace helpers — `attach_to_parent`, `extract_opik_distributed_trace_attributes`.
+
+A framework-specific OTel **tracer wrapper** (see `adk/patchers/adk_otel_tracer/`) is the heavier variant, for intercepting a framework's own tracer rather than a generic processor.
+
+## Shared core — never re-derive these
+
+| Concern | Module |
+|---|---|
+| Decorator base class | `opik/decorator/base_track_decorator.py` |
+| Span/trace creation respecting context | `opik/decorator/span_creation_handler.py` |
+| Start/End span dataclasses | `opik/decorator/arguments_helpers.py` |
+| Error capture (`exception_type`, `traceback`) | `opik/decorator/error_info_collector.py` |
+| Generator/stream wrapping | `opik/decorator/generator_wrappers.py` |
+| Token usage normalization | `opik/llm_usage.py` → `try_build_opik_usage_or_log_error(provider=..., usage=...)` |
+| Recognized providers (cost tracking) | `opik/types.py` → `LLMProvider` |
+| Global client | `opik/api_objects/opik_client.py` → `get_global_client()` |
+| Context stack | `opik/context_storage.py` |
+
+For callback integrations, span/trace creation goes through `span_creation_handler` too; map each framework run id → `SpanData`/`TraceData` and set `metadata["created_from"] = "<name>"`.
+
+## Dependencies & imports
+
+- The framework library is **imported inside the integration module** (`import mistralai` at the top of `opik_tracker.py`). That is safe because the module is only reached when a user does `from opik.integrations.<name> import ...`. Never import an integration from the `opik` package top level.
+- Do **not** add the framework to `install_requires` unless it is already a core dependency (openai and litellm are; most are not). Users install the framework themselves.
+- `integrations/<name>/__init__.py` exports only the public entrypoint.
+- If the integration must support multiple incompatible framework versions, branch at import time on `opik.semantic_version` (see `adk/__init__.py`).
+
+## Tests
+
+Location: `sdks/python/tests/library_integration/<name>/`. Follow the `python-sdk` testing skill for fixtures; the integration-specific shape:
+
+```python
+def test_<name>_<method>__happyflow(fake_backend):
+    client = track_<name>(<lib>.Client())
+    response = client.<method>(...)          # real call, gated by env fixture
+    opik.flush_tracker()
+
+    EXPECTED = TraceModel(
+        id=ANY_BUT_NONE, name="...", input=ANY_DICT.containing({...}),
+        output=ANY_BUT_NONE, tags=["<name>"], spans=[
+            SpanModel(
+                id=ANY_BUT_NONE, type="llm", name="...",
+                usage=..., model=ANY_STRING.starting_with("..."),
+                provider="<name>", spans=[],
+            )
+        ],
+    )
+    assert len(fake_backend.trace_trees) == 1
+    assert_equal(EXPECTED, fake_backend.trace_trees[0])
+```
+
+- Real API calls are gated by an `ensure_<name>_configured` fixture (skip if the key is missing) — add one to `conftest.py` mirroring `ensure_openai_configured`.
+- Cover: happy flow, streaming, custom `provider`, and an error case.
+- Imports: `from tests.testlib import TraceModel, SpanModel, ANY_BUT_NONE, ANY_DICT, ANY_STRING, assert_equal`.

--- a/.agents/skills/opik-integrations/typescript.md
+++ b/.agents/skills/opik-integrations/typescript.md
@@ -1,0 +1,52 @@
+# TypeScript Integration Anatomy
+
+Reference for building integrations under `sdks/typescript/src/opik/integrations/opik-<name>/`. Read this alongside the `typescript-sdk` skill (layered client, flush semantics, testing).
+
+## The canonical guide comes first
+
+`sdks/typescript/design/INTEGRATIONS.md` is the authoritative, maintained guide: it has the three patterns with full code, the package structure, a step-by-step "Creating New Integrations" walkthrough, and streaming helpers. **Read it before writing anything.** This file only records the conventions that guide does not stress and that bite newcomers.
+
+Companion design docs: `design/API_AND_DATA_FLOW.md` (client/batching/context), `design/TESTING.md` (vitest + MSW), `design/README.md` (navigation).
+
+## Each integration is its own npm package
+
+Unlike Python (one package, many integration modules), every TS integration is a **separate published package** (`opik-openai`, `opik-langchain`, `opik-vercel`, `opik-gemini`). That means:
+
+- Its own `package.json`, `tsconfig.json`, `tsup.config.ts`, `vitest.config.ts`, `README.md`.
+- `opik` and the wrapped framework are **`peerDependencies`**, not `dependencies` — pin sane ranges and keep the `opik` range current.
+- Dual **CJS + ESM** build via `tsup`, emitting `dist/index.js` (ESM), `dist/index.cjs` (CJS), `dist/index.d.ts`.
+- A lazy `OpikClient` singleton (`singleton.ts`) so the integration doesn't spin up multiple clients.
+
+Clone the closest sibling package wholesale (its configs are correct) and rename, rather than hand-writing build config.
+
+## Patterns
+
+| Pattern | When | Template package |
+|---|---|---|
+| **Proxy wrapper** | SDK client with methods (most providers) | `opik-openai`, `opik-gemini` |
+| **Callback handler** | framework with a callback interface | `opik-langchain` |
+| **OTel exporter** | framework emitting OpenTelemetry spans | `opik-vercel` |
+
+See `design/INTEGRATIONS.md` for each pattern's code. Shared imports come from `opik`: `Opik`, `Trace`, `Span`, `OpikSpanType`, `generateId`, `logger`.
+
+**OpenTelemetry is backend-first.** Opik's backend ingests OTLP directly and maps spans to traces, so an OTel-instrumented framework can often be integrated with **docs alone** (point its exporter at Opik). Write a client-side `SpanExporter` — the `opik-vercel` pattern — only when you need to remap attributes/semantics, accumulate spans into trace trees, or bridge a framework that won't emit raw OTLP. Check the docs-only path first.
+
+## Conventions that bite
+
+- **Never leak `rest_api`.** Integrations wrap the public `opik` API only — never import generated clients from `opik/rest_api`.
+- **Provide a `flush()` escape hatch.** Proxy wrappers expose `flush` on the returned object; handlers/exporters expose a `flush()` method. Required for CLIs/tests where the process exits before the async queue drains.
+- **Keep adapters thin and non-blocking** — domain objects enqueue, they don't do HTTP.
+- **Version references in prose.** When you change a peer-dep range or minimum version, update the integration's `README.md` and the root `README.md` in the same change — the `typescript-sdk` skill calls this out as a recurring miss.
+
+## Tests
+
+`tests/*.test.ts` with **vitest**, per `design/TESTING.md` and the `typescript-sdk` testing skill. Integration-specific shape:
+
+- Mock the **API layer** (`vi.spyOn(client.api.spans, "createSpans")`) or use **MSW** to intercept HTTP — mirror the sibling package's `mockUtils.ts`.
+- `await client.flush()` (or advance fake timers) **before** asserting; data only persists after the queue drains.
+- Assert on captured spans with `toMatchObject({...})` — name, input, output, parentSpanId hierarchy, usage, model.
+- Keep `tests/setup.ts` (it disables the logger). Don't let ERROR logs leak in tests.
+
+## Examples
+
+Add a runnable example to `sdks/typescript/examples/` mirroring `track-decorator.ts` / `langchain-with-thread-id.ts`. This doubles as the script you run during Phase 5 MCP verification.

--- a/.agents/skills/opik-integrations/workflow.md
+++ b/.agents/skills/opik-integrations/workflow.md
@@ -1,0 +1,174 @@
+# Integration Workflow
+
+The end-to-end playbook for building or updating an Opik SDK integration. Run the phases in order.
+
+Pick the language reference up front — [python.md](python.md) or [typescript.md](typescript.md) — and keep it open throughout.
+
+## Execution modes
+
+- **Autonomous (default for this command)** — make every preparation yourself (install deps, find credentials, pick the backend), run all phases without stopping, self-verify, and finish with the **Phase 8 report**. Do not pause at the design gate; record the design in the report instead. Only stop early if you hit a true blocker you cannot resolve (missing API key with no fallback, an ambiguous product decision, a backend you cannot reach) — report what you completed and what's blocked.
+- **Interactive** — same phases, but pause at Phase 3 to get the design approved before writing code. Use this when the user asks to review the plan first.
+
+Either way, **always end with the high-level report** (Phase 8). Never invent results — every "supported" claim must be backed by a passing test or an MCP-verified trace; everything unverified goes under "not supported / not verified".
+
+## Phase 0 — Classify
+
+- **Mode**: `new` (no integration exists), `update` (extend an existing one), or `maintain` (verify/repair an existing one). Maintain mode skips Phases 2–4 and runs Investigate → Verify → Test against current code to catch drift.
+- **Language**: Python, TypeScript, or both. They are independent code paths; if both are requested, run the whole workflow once per language.
+- **Closest sibling**: name the existing integration you will clone (see the decision tree in [SKILL.md](SKILL.md)).
+
+## Phase 0.5 — Prepare (autonomous)
+
+Get the environment ready yourself before investigating. Record what you did for the report; never print secret values.
+
+- **Install / resolve the target library** into the SDK venv (`sdks/python/.venv` for Python; `npm i` in the integration package for TS). Capture the resolved version. If the install is broken or pulls an incompatible core dep (e.g. it bumps `pydantic` and breaks `litellm`), pin to a known-good version and restore the disturbed dep.
+- **Locate credentials** without printing them: Python tests read the env block in `sdks/python/tests/pytest.ini` (e.g. `MISTRALAI_API_KEY`); also check the shell env. If the library's own default env var differs from the test var (e.g. SDK wants `MISTRAL_API_KEY` but the test sets `MISTRALAI_API_KEY`), read the test var explicitly and pass it to the client.
+- **Pick the verification backend**: the connected Opik MCP reads one backend — confirm which (list its projects) and that it's reachable. Log the verification run there so the MCP can read it back. Use a dedicated scratch `OPIK_PROJECT_NAME` (e.g. `<name>-integration-demo`).
+- **Note blockers**: if a credential or backend is missing and has no fallback, record it — the run can still produce code + offline (`fake_backend`) tests, with live MCP verification marked "not verified".
+
+## Phase 1 — Investigate
+
+Understand the target library before touching Opik. Prefer fanning out parallel explore agents over the library's installed source / docs.
+
+Answer all of these:
+
+- **Entrypoint shape** — Is it a client object with methods (→ patching/proxy), a callback/tracer interface (→ callback), or already OpenTelemetry-instrumented? If it emits OTel, first decide whether a **docs-only OTLP-to-Opik** setup suffices (backend does the mapping) before committing to a client-side processor/exporter — see the OTel notes in the language reference.
+- **Methods to trace** — the specific calls users invoke (e.g. `chat.complete`, `embed`, `rerank`). List sync *and* async variants.
+- **Streaming** — does a streamed call return an iterator/async-iterator, a context manager, or emit events? How are chunks shaped, and where does usage land (final chunk? separate event?)?
+- **Input** — the request fields worth logging (messages, prompt, tools/functions, model params).
+- **Output** — where the completion text / choices / tool calls live in the response object.
+- **Usage** — the token-count field names, and whether the provider is one Opik recognizes for cost tracking (`opik.types.LLMProvider`).
+- **Errors** — what exceptions the library raises.
+
+Read the closest sibling integration in full — it is the template, and most decisions are already made there.
+
+**Clone-ability checkpoint (do this before designing).** "Clone the closest sibling" only holds if the target is actually a clean analog. Before committing, confirm it — and if any of these are true, surface it as a design decision **even in autonomous mode** instead of silently picking:
+
+- The library exposes **multiple incompatible client classes or versions** (e.g. a v1 `Client` and a v2 `ClientV2` with different method signatures and response shapes). Decide which to support, and whether both are in scope.
+- The **usage/token shape differs** from the sibling's (so the sibling's usage parser won't just work and you need custom mapping).
+- The **response/streaming shape** is materially different from the sibling's.
+
+A target that looks like "just another provider" but has any of the above is *not* a clean clone — say so before writing code.
+
+## Phase 2 — Collect
+
+Produce two artifacts in the scratchpad before designing:
+
+1. **A minimal runnable example script** that exercises the target library directly (no Opik yet) — one non-streaming call, one streaming call, and any second method you plan to trace. This is what you'll later run in Phase 5 to verify logging.
+2. **A findings note** — a short mapping table:
+
+   | Opik span field | Source in the library's request/response |
+   |---|---|
+   | input | … |
+   | output | … |
+   | usage | … |
+   | model | … |
+   | provider | … |
+   | span type | `llm` / `tool` / `general` |
+
+## Phase 3 — Design
+
+Decide and write down:
+
+- The **pattern** (from the decision tree) and **why** it fits.
+- The **file layout** (use the skeleton in the language reference).
+- The **public entrypoint** name and signature — match sibling conventions (`track_<name>` for Python patching; `trackXxx` / `XxxCallbackHandler` / `XxxExporter` for TS).
+- The methods to patch/handle and the field mapping from Phase 2.
+
+In **interactive mode**, present this and wait for approval before writing code. In **autonomous mode**, proceed — but capture the design and any open questions (e.g. dedicated integration vs. an OpenAI-compatible docs page) in the Phase 8 report so the reviewer sees the decisions.
+
+## Phase 4 — Implement
+
+- Copy the closest sibling's structure and adapt it. Reuse the shared core utilities listed in the language reference — never re-derive span/trace creation, error collection, or usage parsing.
+- Keep the framework import inside the integration module (Python) or as a `peerDependency` (TS); never import it at SDK package top level.
+- Preserve the library's original behavior: wrap, capture, re-raise. The integration must be transparent when tracing is disabled.
+
+## Phase 5 — Verify via Opik MCP
+
+This is the proof that the integration actually logs correctly. Do not rely on reading code.
+
+**Verifiability is a hard gate for `new`/`update`.** If you cannot run this phase — no API credential for the target, or no reachable backend the MCP can read — **stop and surface it before writing integration code**, in autonomous mode too. Do not produce an integration and then present it as done with verification "skipped": unverified integration code is the exact failure this skill exists to prevent. Offer the user the choice to supply a credential, proceed explicitly-unverified (clearly labelled, tests key-gated and skipped), or pick a different target. Only `maintain` mode on already-passing code may relax this.
+
+1. **Point at a backend the MCP can read — and confirm it.** The connected Opik MCP reads one specific backend/workspace, which is often **not** the one in `~/.opik.config` (e.g. MCP → a hosted `*.dev.comet.com`, local config → `localhost`). Before relying on the MCP, confirm they match: log a trace, then try to `read` its project through the MCP. If the MCP can't see it, the backends differ. Either reconfigure the script's env (`OPIK_API_KEY`, `OPIK_URL_OVERRIDE`/base URL, `OPIK_WORKSPACE`, `OPIK_PROJECT_NAME`) to log into the MCP's backend, **or** fall back to **SDK read-back** (next note). Don't silently assume the MCP sees your trace.
+2. **Run the Phase 2 example** through the new integration (wrap the client / attach the handler), exercising the non-streaming call, the streaming call, and each extra method. Call `flush()` before exit.
+3. **Read it back through the MCP** — use the opik-mcp `list` (entity_type `trace`, filtered by the project) then `read` (entity_type `trace`, which inlines spans; `read` `span` for detail).
+4. **Check the trace/span tree against the Phase 2 mapping:**
+   - one trace per top-level call; span hierarchy matches the call structure
+   - span `type` is correct (`llm` for model calls)
+   - `input` / `output` captured and well-shaped (not empty, not the raw object dump)
+   - `usage` present with prompt/completion/total tokens
+   - `model` and `provider` set correctly
+   - streamed calls produce the same shape as non-streamed (aggregated output + usage)
+   - an induced error records `error_info` and still re-raises
+5. **Loop** until the logged data matches. Fix the integration, re-run, re-read.
+
+**SDK read-back fallback (equivalent evidence).** When the MCP can't read the backend you can write to, verify against that backend over REST instead: `client = opik.Opik(); client.search_traces(project_name=...)` then `client.search_spans(trace_id=...)`, and assert the same checklist (type, input/output, usage, model, provider). This is a real backend round-trip — note in the report that read-back was via the SDK, not the MCP tool, and why.
+
+## Phase 6 — Test
+
+Add coverage with the language's harness — see the test section of the language reference, which delegates to the `python-sdk` / `typescript-sdk` testing skills.
+
+- **Python**: `sdks/python/tests/library_integration/<name>/`, using `fake_backend` and `testlib` `TraceModel`/`SpanModel` trees with `ANY_*` matchers. Assert input/output/usage/model/provider. Gate real API calls behind an `ensure_<name>_configured` fixture. Name tests `test_<what>__<case>__<expected>`.
+- **TypeScript**: `*.test.ts` with vitest, mocking the API layer (or MSW), `await flush()` before asserting, fake timers for batching. Mirror the sibling integration's test file.
+
+## Phase 7 — Document
+
+Author the Fern page following the `write-docs` skill for MDX/components, plus these integration-specific conventions:
+
+- **Check for an existing page first.** A provider often already has a docs page describing a *workaround* (OpenAI-compatibility endpoint via `track_openai`, or LiteLLM) and an entry already in `fern/versions/latest.yml`. If so, this is an **update**: lead the page with the new native integration and demote the workaround to an "Alternative" section (see how `mistral.mdx` keeps LiteLLM). Don't create a duplicate page or a second routing entry.
+- **File**: `apps/opik-documentation/documentation/fern/docs-v2/integrations/<name>.mdx` for Python, `<name>-typescript.mdx` for TypeScript.
+- **Title frontmatter** distinguishes language: `Observability for <Lib> (Python) with Opik` vs `(TypeScript)`.
+- **Page shape** (follow `openai.mdx` / `langchain.mdx`): intro/tips → account setup → getting started (install, configure Opik, configure the library) → basic usage (the wrap/handler call + a screenshot) → advanced usage → cost tracking → supported methods.
+- **Routing**: add a `- page:` entry under the right language → category section (`Frameworks`, `Model Providers`, …) in `fern/versions/latest.yml`. Do not edit `docs.yml`.
+- **Overview grid**: add a `<Card>` to `docs-v2/integrations/overview.mdx` under the matching section. Cards are title + href only; section icons are Font Awesome — there is no per-integration icon to create.
+- Use credential placeholders only (`<API_KEY>`), never real keys.
+
+## Phase 8 — Report (always)
+
+End every run with a high-level report. Keep it scannable — it's for a reviewer deciding whether to ship, not a changelog. Use this template:
+
+```markdown
+## <Library> integration — report
+
+**Mode:** new | update | maintain   **Language:** Python | TypeScript
+**Pattern:** method-patching | proxy | callback | OTel exporter   **Entrypoint:** `track_<name>(...)`
+**Library version prepared:** <name>==<version>
+
+### What was done
+- <files created/changed — bullets, grouped by integration / tests / docs>
+- <prep actions: deps installed, version pins, fixtures/env added>
+
+### Verification
+- **MCP:** <project name + trace ids read back, or "not verified — <reason>">
+- **Tests:** <N passing — list cases>; ruff/mypy <clean | issues>
+
+### Flows supported & test coverage
+
+Always enumerate **every user-facing flow** the integration handles and map each to its coverage — don't collapse this into a one-line "supported". A flow is a distinct way a user invokes the library; enumerate the cross-product that applies: each traced method, sync vs async, streaming vs non-streaming, nested under `@track`, the error path, and any option that changes behavior (custom `project_name`, `provider` override, tool/function calls, structured output). For each flow state whether it's implemented, which test covers it (by name), and whether it was MCP-verified.
+
+| Flow | Implemented | Test | MCP-verified |
+|---|---|---|---|
+| `chat.complete` (sync, non-stream) | ✅ | `test_<name>_complete__happyflow` | ✅ trace `<id>` |
+| `chat.complete_async` | ✅ | `test_<name>_complete_async__happyflow` | — |
+| `chat.stream` (sync) | ✅ | `test_<name>_stream__happyflow` | ✅ trace `<id>` |
+| `chat.stream_async` | ✅/❌ | … | … |
+| nested under `@track` | ✅/❌ | … | … |
+| error → `error_info` logged | ✅ | `test_<name>__error...` | — |
+| token usage captured | ✅ | asserted in above | ✅ |
+| custom `project_name` | ✅/❌ | param case | — |
+
+Explicitly flag the gaps: any flow **implemented but not covered by a test**, and any flow **not implemented at all** (list it in the next section). The goal is that a reviewer can see, per flow, exactly what was proven.
+
+### What's NOT supported / limitations
+- <methods intentionally not patched, flows implemented-but-untested, known gaps, provider-not-in-LLMProvider caveats, env/backend blockers>
+
+### Follow-ups
+- <suggested next steps: more methods, TS counterpart, PR split, etc.>
+
+### How to use
+<minimal code snippet>
+```
+
+## Definition of done
+
+Implementation merged-quality, MCP verification passed (Phase 5 checklist) or its absence reported, tests added and passing, docs page authored and routed, and the **Phase 8 report delivered**. Then run `make claude` if you added/edited files under `.agents/`.


### PR DESCRIPTION
## Summary
- Adds the **`opik-integrations`** skill + `/comet:build-opik-integration` command: a questionnaire-first, autonomous assistant that builds/updates/maintains integrations shipping inside `sdks/python` and `sdks/typescript`. It investigates the target library, picks a pattern (method-patching / callback / OpenTelemetry), implements by cloning the closest sibling, verifies logged traces via the Opik MCP (with an SDK REST read-back fallback), adds tests, updates the Fern docs page, and ends with a high-level report.
- Adds the **`opik-external-integrations`** skill + `/comet:build-opik-external-integration` command for integrations that live *outside* this repo (standalone `opik-*` packages, or upstream contributions such as LiteLLM / Dify), gated to activate only on external-repo requests.
- Includes Python/TypeScript anatomy references, an integration docs guide, and indexes both skills in `.agents/skills/README.md`.
- Source of truth is `.agents/`; run `make claude` to sync into `.claude/`. **No product or SDK code changes.**

## Test Plan
- `make claude` syncs the new skills/commands into `.claude/` without errors, and they appear via the Skill/command menus.
- The workflow was exercised end-to-end on a real target (a Python provider) in separate, unmerged work: the phased flow produced a working, MCP/REST-verified integration with tests and docs. That dry run surfaced and fixed four workflow gaps now encoded here — a hard stop on unverifiable new/update work, a clone-ability checkpoint, a bound-method-introspection caveat, and an MCP-vs-configured-backend mismatch handled by an SDK read-back fallback.

## Related Issues
- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)