### PR TITLE
[OPIK-7173] [GHA] chore: whitelist org-hosted ubuntu-latest-m runner label for actionlint

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  labels:
+    # Org-hosted larger runner. Not a public GitHub label, so actionlint
+    # needs it declared here to avoid a false "unknown label" error.
+    - ubuntu-latest-m


### PR DESCRIPTION
## Details

<img width="727" height="680" alt="image" src="https://github.com/user-attachments/assets/bab5a8a2-121a-4c00-8d37-33ab6ac5c970" />

actionlint flags `ubuntu-latest-m` as an unknown runner label, because it only ships the built-in list of public GitHub runner labels and cannot recognize org-hosted larger-runner labels. `ubuntu-latest-m` is a legitimate org-hosted runner label used in `load_tests.yml` and `build_and_push_docker.yaml`. This PR adds a repo-level `.github/actionlint.yaml` declaring the label under `self-hosted-runner.labels` — actionlint's sanctioned mechanism for custom/larger-runner labels ([config docs](https://github.com/rhysd/actionlint/blob/main/docs/config.md)).
- DRY: one declaration silences all current and future usages, rather than per-file `# actionlint: ignore` comments.
- Still catches genuine typos: only the exact label is whitelisted, so e.g. `ubuntu-latest-xyz` still errors.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-7173

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: code review + local actionlint verification

## Testing

Verified locally with `actionlint`, replicating CI's `actionlint -- <file>` invocation (root-relative, no `--config-file` override → default `.github/actionlint.yaml` discovery):
- With the config present, `actionlint .github/workflows/load_tests.yml .github/workflows/build_and_push_docker.yaml` reports no runner-label findings; repo-wide `actionlint` no longer flags `ubuntu-latest-m` anywhere.
- Removing the config restores the exact `label "ubuntu-latest-m" is unknown` error — confirming the config is what silences it.
- Whitelist scope: a workflow using a bogus `ubuntu-latest-xyz` label still errors, and `ubuntu-latest-m` now appears in actionlint's available-labels list — this is a scoped whitelist, not a blanket suppression.

Note: the `actionlint` CI job only lints workflow files changed in a PR, so this config-only PR's actionlint check is a green no-op; the fix takes effect on the next PR that touches `load_tests.yml` / `build_and_push_docker.yaml`.

No application code changed; no unit tests applicable.

## Documentation

N/A
