### PR TITLE
[OPIK-6892] [BE] feat: NaN-aware aggregate validation + sentinel translation framework

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -96,6 +96,16 @@ databaseAnalytics:
   #  Description: Timeout for the ClickHouse health check query (e.g. 1s, 500ms, 2 minutes)
   healthCheckTimeout: ${ANALYTICS_DB_HEALTH_CHECK_TIMEOUT:-1s}
 
+# Description: Cutover toggles migrating the trace analytics columns to non-nullable, sentinel-defaulted form.
+databaseAnalyticsDataModel:
+  #  Default: false
+  #  Description: Leave false while the traces table still has Nullable end_time/duration/ttft columns; trace writes
+  #   bind null for absent end_time/ttft. Set true once replaced with sentinel-defaulted
+  #   non-nullable columns so writes bind the sentinels (end_time->epoch, ttft->NaN) instead. Gates reads too, so
+  #   while false a legitimate epoch end time round-trips unchanged instead of reading as null.
+  #   Flip in lockstep with the cutover EXCHANGE.
+  traceColumnsNonNullable: ${ANALYTICS_DB_DATA_MODEL_TRACE_COLUMNS_NON_NULLABLE:-false}
+
 # Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the
 #   window, protecting data quality.
 uuidValidation:

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -658,7 +658,7 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                 FROM (
                     SELECT
                         id,
-                       if(end_time IS NOT NULL AND start_time IS NOT NULL
+                       if(end_time IS NOT NULL AND notEquals(end_time, toDateTime64('1970-01-01 00:00:00.000', 9)) AND start_time IS NOT NULL
                                              AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)),
                                          (dateDiff('microsecond', start_time, end_time) / 1000.0),
                                          NULL) AS duration,
@@ -938,7 +938,7 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                 LEFT JOIN (
                     SELECT
                         id,
-                        if(end_time IS NOT NULL AND start_time IS NOT NULL
+                        if(end_time IS NOT NULL AND notEquals(end_time, toDateTime64('1970-01-01 00:00:00.000', 9)) AND start_time IS NOT NULL
                             AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)),
                             (dateDiff('microsecond', start_time, end_time) / 1000.0),
                             NULL) as duration

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
@@ -208,7 +208,6 @@ public class DatasetItemResultMapper {
     }
 
     static Instant nullIfEpoch(Instant instant) {
-        // Delegates to the single SentinelTranslation definition.
         return SentinelTranslation.epochToNull(instant);
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemResultMapper.java
@@ -8,6 +8,7 @@ import com.comet.opik.api.ExecutionPolicy;
 import com.comet.opik.api.ExperimentItem;
 import com.comet.opik.api.VisibilityMode;
 import com.comet.opik.utils.JsonUtils;
+import com.comet.opik.utils.SentinelTranslation;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.r2dbc.spi.Result;
@@ -207,7 +208,8 @@ public class DatasetItemResultMapper {
     }
 
     static Instant nullIfEpoch(Instant instant) {
-        return instant == null || instant.equals(Instant.EPOCH) ? null : instant;
+        // Delegates to the single SentinelTranslation definition.
+        return SentinelTranslation.epochToNull(instant);
     }
 
     private static final TypeReference<List<EvaluatorItem>> EVALUATOR_LIST_TYPE = new TypeReference<>() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -994,7 +994,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             ), trace_data AS (
                 SELECT
                     id,
-                    duration,
+                    if(isNaN(duration), NULL, duration) AS duration,
                     <if(truncate)> replaceRegexpAll(if(notEmpty(input_slim), input_slim, truncated_input), '<truncate>', '"[image]"') as input <else> input <endif>,
                     <if(truncate)> replaceRegexpAll(if(notEmpty(output_slim), output_slim, truncated_output), '<truncate>', '"[image]"') as output <else> output <endif>,
                     output as full_output,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
@@ -436,7 +436,7 @@ class ExperimentItemDAO {
                       FROM (
                           SELECT
                               id,
-                              duration,
+                              if(isNaN(duration), NULL, duration) AS duration,
                               <if(truncate)> replaceRegexpAll(if(notEmpty(input_slim), input_slim, truncated_input), '<truncate>', '"[image]"') as input <else> input <endif>,
                               <if(truncate)> replaceRegexpAll(if(notEmpty(output_slim), output_slim, truncated_output), '<truncate>', '"[image]"') as output <else> output <endif>,
                               visibility_mode

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
@@ -12,6 +12,7 @@ import com.comet.opik.domain.filter.FilterStrategy;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils;
+import com.comet.opik.utils.SentinelTranslation;
 import com.google.inject.ImplementedBy;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.Result;
@@ -692,9 +693,7 @@ class KpiCardDAOImpl implements KpiCardDAO {
     }
 
     private Double filterNan(Double value) {
-        if (value == null) {
-            return null;
-        }
-        return value.isNaN() ? null : value;
+        // Delegates to the single SentinelTranslation definition.
+        return SentinelTranslation.nanToNull(value);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
@@ -9,6 +9,7 @@ import com.comet.opik.api.metrics.KpiCardResponse.KpiMetric;
 import com.comet.opik.api.metrics.KpiCardResponse.KpiMetricType;
 import com.comet.opik.domain.filter.FilterQueryBuilder;
 import com.comet.opik.domain.filter.FilterStrategy;
+import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils;
 import com.google.inject.ImplementedBy;
@@ -51,6 +52,7 @@ class KpiCardDAOImpl implements KpiCardDAO {
 
     private final @NonNull TransactionTemplateAsync template;
     private final @NonNull InstantToUUIDMapper instantToUUIDMapper;
+    private final @NonNull OpikConfiguration configuration;
 
     private static final String GET_TRACE_KPI_CARDS = """
             WITH feedback_scores_deduped AS (
@@ -145,7 +147,7 @@ class KpiCardDAOImpl implements KpiCardDAO {
                 FROM (
                     SELECT
                         id,
-                        if(end_time IS NOT NULL AND start_time IS NOT NULL
+                        if(end_time IS NOT NULL AND notEquals(end_time, toDateTime64('1970-01-01 00:00:00.000', 9)) AND start_time IS NOT NULL
                              AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)),
                          (dateDiff('microsecond', start_time, end_time) / 1000.0),
                          NULL) AS duration,
@@ -444,13 +446,13 @@ class KpiCardDAOImpl implements KpiCardDAO {
                         t.project_id as project_id,
                         min(t.start_time) as start_time,
                         max(t.end_time) as end_time,
-                        if(max(t.end_time) IS NOT NULL AND min(t.start_time) IS NOT NULL
+                        if(max(t.end_time) IS NOT NULL AND notEquals(max(t.end_time), toDateTime64('1970-01-01 00:00:00.000', 9)) AND min(t.start_time) IS NOT NULL
                                AND notEquals(min(t.start_time), toDateTime64('1970-01-01 00:00:00.000', 9)),
                            (dateDiff('microsecond', min(t.start_time), max(t.end_time)) / 1000.0),
                            NULL) AS duration,
                         count(DISTINCT t.id) * 2 as number_of_messages,
                         <if(trace_thread_first_message_filter)>argMin(t.input, t.start_time) as first_message,<endif>
-                        <if(trace_thread_last_message_filter)>argMax(t.output, t.end_time) as last_message,<endif>
+                        <if(trace_thread_last_message_filter)>argMax(t.output, nullIf(t.end_time, toDateTime64('1970-01-01 00:00:00.000', 9))) as last_message,<endif>
                         max(t.last_updated_at) as last_updated_at,
                         argMax(t.last_updated_by, t.last_updated_at) as last_updated_by,
                         argMin(t.created_by, t.created_at) as created_by,
@@ -581,7 +583,7 @@ class KpiCardDAOImpl implements KpiCardDAO {
 
     private void addTraceFilters(ST template, List<? extends Filter> filters) {
         Optional.ofNullable(filters).ifPresent(f -> {
-            FilterQueryBuilder.toAnalyticsDbFilters(f, FilterStrategy.TRACE)
+            FilterQueryBuilder.toAnalyticsDbFilters(f, FilterStrategy.TRACE, traceColumnsNonNullable())
                     .ifPresent(traceFilters -> template.add("trace_filters", traceFilters));
             FilterQueryBuilder.toAnalyticsDbFilters(f, FilterStrategy.FEEDBACK_SCORES)
                     .ifPresent(scoresFilters -> template.add("trace_feedback_scores_filters", scoresFilters));
@@ -590,6 +592,10 @@ class KpiCardDAOImpl implements KpiCardDAO {
             FilterQueryBuilder.hasGuardrailsFilter(f)
                     .ifPresent(hasGuardrails -> template.add("guardrails_filters", true));
         });
+    }
+
+    private boolean traceColumnsNonNullable() {
+        return configuration.getDatabaseAnalyticsDataModel().traceColumnsNonNullable();
     }
 
     private void bindTraceFilters(Statement statement, List<? extends Filter> filters) {
@@ -621,7 +627,7 @@ class KpiCardDAOImpl implements KpiCardDAO {
 
     private void addThreadFilters(ST template, List<? extends Filter> filters) {
         Optional.ofNullable(filters).ifPresent(f -> {
-            FilterQueryBuilder.toAnalyticsDbFilters(f, FilterStrategy.TRACE_THREAD)
+            FilterQueryBuilder.toAnalyticsDbFilters(f, FilterStrategy.TRACE_THREAD, traceColumnsNonNullable())
                     .ifPresent(threadFilters -> template.add("trace_thread_filters", threadFilters));
             // first_message/last_message aggregate the full input/output payloads, so only project
             // them in threads_filtered when a filter actually references them (otherwise the thread

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
@@ -693,7 +693,6 @@ class KpiCardDAOImpl implements KpiCardDAO {
     }
 
     private Double filterNan(Double value) {
-        // Delegates to the single SentinelTranslation definition.
         return SentinelTranslation.nanToNull(value);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
@@ -397,7 +397,7 @@ class OptimizationDAOImpl implements OptimizationDAO {
                     sum(s.total_estimated_cost) AS total_estimated_cost
                 FROM experiment_items_final ei
                 LEFT JOIN (
-                    SELECT id, duration
+                    SELECT id, if(isNaN(duration), NULL, duration) AS duration
                     FROM traces
                     WHERE workspace_id = :workspace_id
                     AND id IN (SELECT trace_id FROM experiment_items_final)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
@@ -8,6 +8,7 @@ import com.comet.opik.api.metrics.MetricType;
 import com.comet.opik.api.metrics.ProjectMetricRequest;
 import com.comet.opik.domain.filter.FilterQueryBuilder;
 import com.comet.opik.domain.filter.FilterStrategy;
+import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils;
 import com.comet.opik.utils.RowUtils;
@@ -150,6 +151,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
     private final @NonNull TransactionTemplateAsync template;
     private final @NonNull FilterQueryBuilder filterQueryBuilder;
     private final @NonNull InstantToUUIDMapper instantToUUIDMapper;
+    private final @NonNull OpikConfiguration configuration;
 
     private static final Map<TimeInterval, String> INTERVAL_TO_SQL = Map.of(
             TimeInterval.WEEKLY, "toIntervalWeek(1)",
@@ -545,12 +547,12 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                         t.project_id as project_id,
                         min(t.start_time) as start_time,
                         max(t.end_time) as end_time,
-                        if(max(t.end_time) IS NOT NULL AND min(t.start_time) IS NOT NULL
+                        if(max(t.end_time) IS NOT NULL AND notEquals(max(t.end_time), toDateTime64('1970-01-01 00:00:00.000', 9)) AND min(t.start_time) IS NOT NULL
                                AND notEquals(min(t.start_time), toDateTime64('1970-01-01 00:00:00.000', 9)),
                            (dateDiff('microsecond', min(t.start_time), max(t.end_time)) / 1000.0),
                            NULL) AS duration,
                         <if(truncate)> replaceRegexpAll(argMin(t.input, t.start_time), '<truncate>', '"[image]"') as first_message <else> argMin(t.input, t.start_time) as first_message<endif>,
-                        <if(truncate)> replaceRegexpAll(argMax(t.output, t.end_time), '<truncate>', '"[image]"') as last_message <else> argMax(t.output, t.end_time) as last_message<endif>,
+                        <if(truncate)> replaceRegexpAll(argMax(t.output, nullIf(t.end_time, toDateTime64('1970-01-01 00:00:00.000', 9))), '<truncate>', '"[image]"') as last_message <else> argMax(t.output, nullIf(t.end_time, toDateTime64('1970-01-01 00:00:00.000', 9))) as last_message<endif>,
                         count(DISTINCT t.id) * 2 as number_of_messages,
                         max(t.last_updated_at) as last_updated_at,
                         argMax(t.last_updated_by, t.last_updated_at) as last_updated_by,
@@ -1069,7 +1071,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
 
     private static final String GET_AVERAGE_DURATION = """
             SELECT
-                avg(duration) AS avg_duration
+                avg(if(isNaN(duration), NULL, duration)) AS avg_duration
             FROM traces final
             WHERE workspace_id = :workspace_id
                 <if(project_ids)> AND project_id IN :project_ids <endif>
@@ -1183,7 +1185,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
     private static final String GET_TRACE_AVERAGE_DURATION = """
             %s
             SELECT <bucket> AS bucket,
-                   avg(duration) AS avg_duration
+                   avg(if(isNaN(duration), NULL, duration)) AS avg_duration
             FROM traces_filtered
             GROUP BY bucket
             ORDER BY bucket
@@ -1741,7 +1743,8 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             if (THREAD_METRICS.contains(metricType)) {
                 Optional.ofNullable(request.threadFilters())
                         .ifPresent(filters -> {
-                            filterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.TRACE_THREAD)
+                            FilterQueryBuilder.toAnalyticsDbFilters(
+                                    filters, FilterStrategy.TRACE_THREAD, traceColumnsNonNullable())
                                     .ifPresent(threadFilters -> template.add("trace_thread_filters", threadFilters));
                             filterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.FEEDBACK_SCORES)
                                     .ifPresent(
@@ -1772,7 +1775,8 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             } else {
                 Optional.ofNullable(request.traceFilters())
                         .ifPresent(filters -> {
-                            filterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.TRACE)
+                            FilterQueryBuilder.toAnalyticsDbFilters(
+                                    filters, FilterStrategy.TRACE, traceColumnsNonNullable())
                                     .ifPresent(traceFilters -> template.add("trace_filters", traceFilters));
                             filterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.FEEDBACK_SCORES)
                                     .ifPresent(
@@ -1837,6 +1841,10 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             return Mono.from(statement.execute())
                     .doFinally(signalType -> endSegment(segment));
         });
+    }
+
+    private boolean traceColumnsNonNullable() {
+        return configuration.getDatabaseAnalyticsDataModel().traceColumnsNonNullable();
     }
 
     private static final Set<MetricType> SPAN_TIME_METRICS = EnumSet.of(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
@@ -3,9 +3,11 @@ package com.comet.opik.domain;
 import com.comet.opik.api.ProjectStats;
 import com.comet.opik.api.TraceThread;
 import com.comet.opik.api.TraceThreadStatus;
+import com.comet.opik.api.sorting.SortableFields;
 import com.comet.opik.api.sorting.TraceThreadSortingFactory;
 import com.comet.opik.domain.sorting.SortingQueryBuilder;
 import com.comet.opik.domain.stats.StatsMapper;
+import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils;
 import com.comet.opik.utils.TruncationUtils;
@@ -15,6 +17,7 @@ import com.google.inject.ImplementedBy;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Row;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -43,6 +46,7 @@ import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils
 import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils.startSegment;
 import static com.comet.opik.utils.AsyncUtils.makeFluxContextAware;
 import static com.comet.opik.utils.AsyncUtils.makeMonoContextAware;
+import static com.comet.opik.utils.SentinelTranslation.epochToNull;
 import static java.util.function.Predicate.not;
 
 @ImplementedBy(ThreadDAOImpl.class)
@@ -121,7 +125,7 @@ class ThreadDAOImpl implements ThreadDAO {
                 ) AS ptt ON pt.thread_id = ptt.thread_id
                 ORDER BY if(ptt.last_updated_at = toDateTime64(0, 6, 'UTC'), pt.trace_last_updated_at, ptt.last_updated_at) DESC,
                     pt.start_time ASC,
-                    pt.end_time DESC,
+                    nullIf(pt.end_time, toDateTime64('1970-01-01 00:00:00.000', 9)) DESC,
                     pt.thread_id
                 LIMIT :limit <if(offset)>OFFSET :offset<endif>
             ), <endif>traces_final AS (
@@ -416,18 +420,18 @@ class ThreadDAOImpl implements ThreadDAO {
                     t.project_id as project_id,
                     min(t.start_time) as start_time,
                     max(t.end_time) as end_time,
-                    if(end_time IS NOT NULL AND start_time IS NOT NULL
+                    if(end_time IS NOT NULL AND notEquals(end_time, toDateTime64('1970-01-01 00:00:00.000', 9)) AND start_time IS NOT NULL
                            AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)),
                        (dateDiff('microsecond', start_time, end_time) / 1000.0),
                        NULL) AS duration,
                     argMin(t.input, t.start_time) as first_message,
-                    argMax(t.output, t.end_time) as last_message,
+                    argMax(t.output, nullIf(t.end_time, toDateTime64('1970-01-01 00:00:00.000', 9))) as last_message,
                     argMin(t.truncated_input, t.start_time) as truncated_first_message,
-                    argMax(t.truncated_output, t.end_time) as truncated_last_message,
+                    argMax(t.truncated_output, nullIf(t.end_time, toDateTime64('1970-01-01 00:00:00.000', 9))) as truncated_last_message,
                     argMin(t.input_length, t.start_time) as first_message_length,
-                    argMax(t.output_length, t.end_time) as last_message_length,
+                    argMax(t.output_length, nullIf(t.end_time, toDateTime64('1970-01-01 00:00:00.000', 9))) as last_message_length,
                     argMin(t.truncation_threshold, t.start_time) as first_message_truncation_threshold,
-                    argMax(t.truncation_threshold, t.end_time) as last_message_truncation_threshold,
+                    argMax(t.truncation_threshold, nullIf(t.end_time, toDateTime64('1970-01-01 00:00:00.000', 9))) as last_message_truncation_threshold,
                     count(DISTINCT t.id) * 2 as number_of_messages,
                     sum(s.total_estimated_cost) as total_estimated_cost,
                     sumMap(s.usage) as usage,
@@ -478,7 +482,7 @@ class ThreadDAOImpl implements ThreadDAO {
             <if(stream)>
             ORDER BY workspace_id, project_id, thread_model_id DESC
             <else>
-            <if(sort_fields)> ORDER BY <sort_fields>, last_updated_at DESC <else> ORDER BY last_updated_at DESC, start_time ASC, end_time DESC <endif>
+            <if(sort_fields)> ORDER BY <sort_fields>, last_updated_at DESC <else> ORDER BY last_updated_at DESC, start_time ASC, nullIf(end_time, toDateTime64('1970-01-01 00:00:00.000', 9)) DESC <endif>
             <endif>
             LIMIT :limit <if(page_pushdown)><else><if(offset)>OFFSET :offset<endif><endif>
             SETTINGS log_comment = '<log_comment>'
@@ -700,12 +704,12 @@ class ThreadDAOImpl implements ThreadDAO {
                         t.project_id as project_id,
                         min(t.start_time) as start_time,
                         max(t.end_time) as end_time,
-                        if(end_time IS NOT NULL AND start_time IS NOT NULL
+                        if(end_time IS NOT NULL AND notEquals(end_time, toDateTime64('1970-01-01 00:00:00.000', 9)) AND start_time IS NOT NULL
                                AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)),
                            (dateDiff('microsecond', start_time, end_time) / 1000.0),
                            NULL) AS duration,
                         argMin(t.input, t.start_time) as first_message,
-                        argMax(t.output, t.end_time) as last_message,
+                        argMax(t.output, nullIf(t.end_time, toDateTime64('1970-01-01 00:00:00.000', 9))) as last_message,
                         count(DISTINCT t.id) * 2 as number_of_messages,
                         max(t.last_updated_at) as last_updated_at,
                         argMax(t.last_updated_by, t.last_updated_at) as last_updated_by,
@@ -973,18 +977,18 @@ class ThreadDAOImpl implements ThreadDAO {
                     t.project_id as project_id,
                     min(t.start_time) as start_time,
                     max(t.end_time) as end_time,
-                    if(end_time IS NOT NULL AND start_time IS NOT NULL
+                    if(end_time IS NOT NULL AND notEquals(end_time, toDateTime64('1970-01-01 00:00:00.000', 9)) AND start_time IS NOT NULL
                            AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)),
                        (dateDiff('microsecond', start_time, end_time) / 1000.0),
                        NULL) AS duration,
                     argMin(t.input, t.start_time) as first_message,
-                    argMax(t.output, t.end_time) as last_message,
+                    argMax(t.output, nullIf(t.end_time, toDateTime64('1970-01-01 00:00:00.000', 9))) as last_message,
                     argMin(t.truncated_input, t.start_time) as truncated_first_message,
-                    argMax(t.truncated_output, t.end_time) as truncated_last_message,
+                    argMax(t.truncated_output, nullIf(t.end_time, toDateTime64('1970-01-01 00:00:00.000', 9))) as truncated_last_message,
                     argMin(t.input_length, t.start_time) as first_message_length,
-                    argMax(t.output_length, t.end_time) as last_message_length,
+                    argMax(t.output_length, nullIf(t.end_time, toDateTime64('1970-01-01 00:00:00.000', 9))) as last_message_length,
                     argMin(t.truncation_threshold, t.start_time) as first_message_truncation_threshold,
-                    argMax(t.truncation_threshold, t.end_time) as last_message_truncation_threshold,
+                    argMax(t.truncation_threshold, nullIf(t.end_time, toDateTime64('1970-01-01 00:00:00.000', 9))) as last_message_truncation_threshold,
                     count(DISTINCT t.id) * 2 as number_of_messages,
                     sum(s.total_estimated_cost) as total_estimated_cost,
                     sumMap(s.usage) as usage,
@@ -1282,12 +1286,12 @@ class ThreadDAOImpl implements ThreadDAO {
                         t.project_id as project_id,
                         min(t.start_time) as start_time,
                         max(t.end_time) as end_time,
-                        if(max(t.end_time) IS NOT NULL AND min(t.start_time) IS NOT NULL
+                        if(max(t.end_time) IS NOT NULL AND notEquals(max(t.end_time), toDateTime64('1970-01-01 00:00:00.000', 9)) AND min(t.start_time) IS NOT NULL
                                AND notEquals(min(t.start_time), toDateTime64('1970-01-01 00:00:00.000', 9)),
                            (dateDiff('microsecond', min(t.start_time), max(t.end_time)) / 1000.0),
                            NULL) AS duration,
                         argMin(t.input, t.start_time) as first_message,
-                        argMax(t.output, t.end_time) as last_message,
+                        argMax(t.output, nullIf(t.end_time, toDateTime64('1970-01-01 00:00:00.000', 9))) as last_message,
                         count(DISTINCT t.id) * 2 as number_of_messages,
                         sum(s.total_estimated_cost) as total_estimated_cost,
                         sumMap(s.usage) as usage,
@@ -1341,6 +1345,16 @@ class ThreadDAOImpl implements ThreadDAO {
     private final @NonNull TransactionTemplateAsync asyncTemplate;
     private final @NonNull SortingQueryBuilder sortingQueryBuilder;
     private final @NonNull TraceThreadSortingFactory traceThreadSortingFactory;
+    private final @NonNull OpikConfiguration configuration;
+
+    /**
+     * Sort mapping applied under {@code traceColumnsNonNullable}: a thread's {@code end_time} is
+     * {@code max(traces.end_time)}, the epoch sentinel when every trace is unfinished; {@code nullIf} restores
+     * {@code NULL} so it sorts last in ASC like a Nullable column did. {@code duration} needs no entry — ClickHouse
+     * sorts {@code NaN} like {@code NULL}.
+     */
+    private static final Map<String, String> SORT_FIELD_MAPPING_END_TIME_SENTINEL = Map.of(
+            SortableFields.END_TIME, "nullIf(end_time, toDateTime64('1970-01-01 00:00:00.000', 9))");
 
     /**
      * Determines whether to activate the traces_final_ids CTE for narrowing the raw traces / spans scans
@@ -1392,8 +1406,10 @@ class ThreadDAOImpl implements ThreadDAO {
 
                             int offset = (page - 1) * size;
 
-                            var template = newTraceThreadFindTemplate(SELECT_TRACES_THREADS_BY_PROJECT_IDS, criteria,
-                                    THREAD_SEARCH_CLAUSE);
+                            var template = newTraceThreadFindTemplate(SELECT_TRACES_THREADS_BY_PROJECT_IDS,
+                                    criteria,
+                                    THREAD_SEARCH_CLAUSE,
+                                    traceColumnsNonNullable());
 
                             template = ImageUtils.addTruncateToTemplate(template, criteria.truncate());
 
@@ -1402,7 +1418,9 @@ class ThreadDAOImpl implements ThreadDAO {
                                             "page:" + page + ":size:" + size));
 
                             var finalTemplate = template;
-                            Optional.ofNullable(sortingQueryBuilder.toOrderBySql(criteria.sortingFields()))
+                            Optional.ofNullable(sortingQueryBuilder.toOrderBySql(
+                                    criteria.sortingFields(),
+                                    traceColumnsNonNullable() ? SORT_FIELD_MAPPING_END_TIME_SENTINEL : null))
                                     .ifPresent(sortFields -> finalTemplate.add("sort_fields", sortFields));
 
                             var hasDynamicKeys = sortingQueryBuilder.hasDynamicKeys(criteria.sortingFields());
@@ -1446,6 +1464,10 @@ class ThreadDAOImpl implements ThreadDAO {
                         })));
     }
 
+    private boolean traceColumnsNonNullable() {
+        return configuration.getDatabaseAnalyticsDataModel().traceColumnsNonNullable();
+    }
+
     @Override
     public Mono<TraceThread> findById(@NonNull UUID projectId, @NonNull String threadId, boolean truncate) {
         return makeMonoContextAware((userName, workspaceId) -> asyncTemplate.nonTransaction(connection -> {
@@ -1475,8 +1497,10 @@ class ThreadDAOImpl implements ThreadDAO {
 
         return makeFluxContextAware((userName, workspaceId) -> asyncTemplate.stream(connection -> {
 
-            var template = newTraceThreadFindTemplate(SELECT_TRACES_THREADS_BY_PROJECT_IDS, criteria,
-                    THREAD_SEARCH_CLAUSE);
+            var template = newTraceThreadFindTemplate(SELECT_TRACES_THREADS_BY_PROJECT_IDS,
+                    criteria,
+                    THREAD_SEARCH_CLAUSE,
+                    traceColumnsNonNullable());
             template = ImageUtils.addTruncateToTemplate(template, criteria.truncate());
 
             template.add("limit", limit)
@@ -1511,7 +1535,10 @@ class ThreadDAOImpl implements ThreadDAO {
     public Mono<ProjectStats> getThreadStats(@NonNull TraceSearchCriteria criteria) {
         return makeMonoContextAware((userName, workspaceId) -> asyncTemplate.nonTransaction(connection -> {
 
-            var statsSQL = newTraceThreadFindTemplate(SELECT_TRACE_THREADS_STATS, criteria, THREAD_SEARCH_CLAUSE);
+            var statsSQL = newTraceThreadFindTemplate(SELECT_TRACE_THREADS_STATS,
+                    criteria,
+                    THREAD_SEARCH_CLAUSE,
+                    traceColumnsNonNullable());
             statsSQL.add("log_comment", getLogComment("thread_stats", workspaceId, userName, ""));
 
             if (shouldUseTracesFinalIdsPrefilter(criteria, statsSQL)) {
@@ -1537,8 +1564,10 @@ class ThreadDAOImpl implements ThreadDAO {
 
     private Mono<Long> countThreadTotal(TraceSearchCriteria traceSearchCriteria, Connection connection,
             String userName, String workspaceId) {
-        var template = newTraceThreadFindTemplate(SELECT_COUNT_TRACES_THREADS_BY_PROJECT_IDS, traceSearchCriteria,
-                THREAD_SEARCH_CLAUSE);
+        var template = newTraceThreadFindTemplate(SELECT_COUNT_TRACES_THREADS_BY_PROJECT_IDS,
+                traceSearchCriteria,
+                THREAD_SEARCH_CLAUSE,
+                traceColumnsNonNullable());
         template.add("log_comment", getLogComment("count_threads_by_project", workspaceId, userName, ""));
 
         if (shouldUseTracesFinalIdsPrefilter(traceSearchCriteria, template)) {
@@ -1570,7 +1599,7 @@ class ThreadDAOImpl implements ThreadDAO {
                 .workspaceId(row.get("workspace_id", String.class))
                 .projectId(row.get("project_id", UUID.class))
                 .startTime(row.get("start_time", Instant.class))
-                .endTime(row.get("end_time", Instant.class))
+                .endTime(readEpochSentinel(row, "end_time"))
                 .duration(row.get("duration", Double.class))
                 .firstMessage(Optional.ofNullable(row.get("first_message", String.class))
                         .filter(it -> !it.isBlank())
@@ -1611,5 +1640,15 @@ class ThreadDAOImpl implements ThreadDAO {
                         .orElse(null))
                 .environment(row.get("environment", String.class))
                 .build());
+    }
+
+    /**
+     * Reads a {@code DateTime64} column, translating the epoch sentinel to {@code null} only once the columns are
+     * non-nullable — symmetric with {@code TraceDAO} so a legitimate epoch value is preserved while the columns
+     * are still {@code Nullable}.
+     */
+    private Instant readEpochSentinel(Row row, String fieldName) {
+        var value = row.get(fieldName, Instant.class);
+        return traceColumnsNonNullable() ? epochToNull(value) : value;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -67,6 +67,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.comet.opik.api.ErrorInfo.ERROR_INFO_TYPE;
 import static com.comet.opik.api.Trace.TracePage;
@@ -84,6 +85,10 @@ import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils
 import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils.startSegment;
 import static com.comet.opik.utils.AsyncUtils.makeFluxContextAware;
 import static com.comet.opik.utils.AsyncUtils.makeMonoContextAware;
+import static com.comet.opik.utils.SentinelTranslation.epochToNull;
+import static com.comet.opik.utils.SentinelTranslation.nanToNull;
+import static com.comet.opik.utils.SentinelTranslation.nullToEpoch;
+import static com.comet.opik.utils.SentinelTranslation.nullToNaN;
 import static com.comet.opik.utils.ValidationUtils.CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE;
 import static com.comet.opik.utils.template.TemplateUtils.getQueryItemPlaceHolder;
 import static java.util.function.Predicate.not;
@@ -304,7 +309,7 @@ class TraceDAOImpl implements TraceDAO {
                     new_trace.start_time
                 ) as start_time,
                 multiIf(
-                    isNotNull(old_trace.end_time), old_trace.end_time,
+                    notEquals(old_trace.end_time, toDateTime64('1970-01-01 00:00:00.000', 9)) AND old_trace.end_time >= toDateTime64('1970-01-01 00:00:00.000', 9), old_trace.end_time,
                     new_trace.end_time
                 ) as end_time,
                 multiIf(
@@ -354,7 +359,7 @@ class TraceDAOImpl implements TraceDAO {
                     new_trace.output_slim
                 ) as output_slim,
                 multiIf(
-                    isNotNull(old_trace.ttft), old_trace.ttft,
+                    NOT isNaN(old_trace.ttft), old_trace.ttft,
                     new_trace.ttft
                 ) as ttft,
                 multiIf(
@@ -372,7 +377,7 @@ class TraceDAOImpl implements TraceDAO {
                     :workspace_id as workspace_id,
                     :name as name,
                     parseDateTime64BestEffort(:start_time, 9) as start_time,
-                    <if(end_time)> parseDateTime64BestEffort(:end_time, 9) as end_time, <else> null as end_time, <endif>
+                    parseDateTime64BestEffort(:end_time, 9) as end_time,
                     :input as input,
                     :output as output,
                     :metadata as metadata,
@@ -1947,8 +1952,8 @@ class TraceDAOImpl implements TraceDAO {
                     new_trace.output_slim
                 ) as output_slim,
                 multiIf(
-                    isNotNull(new_trace.ttft), new_trace.ttft,
-                    isNotNull(old_trace.ttft), old_trace.ttft,
+                    NOT isNaN(new_trace.ttft), new_trace.ttft,
+                    NOT isNaN(old_trace.ttft), old_trace.ttft,
                     new_trace.ttft
                 ) as ttft,
                 multiIf(
@@ -1966,7 +1971,7 @@ class TraceDAOImpl implements TraceDAO {
                     :workspace_id as workspace_id,
                     <if(name)> :name <else> '' <endif> as name,
                     toDateTime64('1970-01-01 00:00:00.000', 9) as start_time,
-                    <if(end_time)> parseDateTime64BestEffort(:end_time, 9) <else> null <endif> as end_time,
+                    parseDateTime64BestEffort(:end_time, 9) as end_time,
                     <if(input)> :input <else> '' <endif> as input,
                     <if(output)> :output <else> '' <endif> as output,
                     <if(metadata)> :metadata <else> '' <endif> as metadata,
@@ -1980,7 +1985,7 @@ class TraceDAOImpl implements TraceDAO {
                     :truncation_threshold as truncation_threshold,
                     <if(input)> :input_slim <else> '' <endif> as input_slim,
                     <if(output)> :output_slim <else> '' <endif> as output_slim,
-                    <if(ttft)> :ttft <else> null <endif> as ttft,
+                    :ttft as ttft,
                     :source as source,
                     <if(environment)> :environment <else> '' <endif> as environment
             ) as new_trace
@@ -3022,12 +3027,23 @@ class TraceDAOImpl implements TraceDAO {
     private final @NonNull ConnectionFactory connectionFactory;
     private final @NonNull WorkspacesService workspacesService;
 
+    /**
+     * Sort mapping applied under {@code traceColumnsNonNullable}: {@code nullIf} restores an absent (epoch)
+     * {@code end_time} to {@code NULL} so it sorts last in ASC like a Nullable column did. {@code duration} needs no
+     * entry — ClickHouse sorts {@code NaN} like {@code NULL}. Merged with the experiment-id mapping the listing passes.
+     */
+    private static final Map<String, String> SORT_FIELD_MAPPING_END_TIME_SENTINEL = Stream
+            .concat(TraceSortingFactory.EXPERIMENT_FIELD_MAPPING.entrySet().stream(),
+                    Stream.of(Map.entry(SortableFields.END_TIME,
+                            "nullIf(end_time, toDateTime64('1970-01-01 00:00:00.000', 9))")))
+            .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
+
     @Override
     @WithSpan
     public Mono<UUID> insert(@NonNull Trace trace, @NonNull Connection connection) {
 
         return makeMonoContextAware((userName, workspaceId) -> {
-            var template = buildInsertTemplate(trace, workspaceId, userName);
+            var template = getSTWithLogComment(INSERT, "insert_trace", workspaceId, userName, "");
 
             Statement statement = buildInsertStatement(trace, connection, template);
             bindUserNameAndWorkspace(statement, userName, workspaceId);
@@ -3051,9 +3067,7 @@ class TraceDAOImpl implements TraceDAO {
 
         bindInputOutputMetadataAndSlim(statement, trace, null);
 
-        if (trace.endTime() != null) {
-            statement.bind("end_time", trace.endTime().toString());
-        }
+        bindEpochSentinel(statement, "end_time", trace.endTime());
 
         if (trace.tags() != null) {
             statement.bind("tags", trace.tags().toArray(String[]::new));
@@ -3083,13 +3097,41 @@ class TraceDAOImpl implements TraceDAO {
 
         TruncationUtils.bindTruncationThreshold(statement, "truncation_threshold", configuration);
 
-        if (trace.ttft() != null) {
-            statement.bind("ttft", trace.ttft());
-        } else {
-            statement.bindNull("ttft", Double.class);
-        }
+        bindNanSentinel(statement, "ttft", trace.ttft());
 
         return statement;
+    }
+
+    /**
+     * Binds a {@code DateTime64} write parameter, applying the epoch sentinel for an absent value once the column is
+     * non-nullable (a {@code null} bind would be rejected); while still Nullable an absent value binds {@code null}.
+     */
+    private void bindEpochSentinel(Statement statement, String parameter, Instant value) {
+        if (traceColumnsNonNullable()) {
+            statement.bind(parameter, ClickHouseDateTimeFormat.formatNanos(nullToEpoch(value)));
+        } else if (value != null) {
+            statement.bind(parameter, ClickHouseDateTimeFormat.formatNanos(value));
+        } else {
+            statement.bindNull(parameter, String.class);
+        }
+    }
+
+    /**
+     * Binds a {@code Float64} write parameter, applying the {@code NaN} sentinel for an absent value once the column is
+     * non-nullable; while still Nullable an absent value binds {@code null}.
+     */
+    private void bindNanSentinel(Statement statement, String parameter, Double value) {
+        if (traceColumnsNonNullable()) {
+            statement.bind(parameter, nullToNaN(value));
+        } else if (value != null) {
+            statement.bind(parameter, value);
+        } else {
+            statement.bindNull(parameter, Double.class);
+        }
+    }
+
+    private boolean traceColumnsNonNullable() {
+        return configuration.getDatabaseAnalyticsDataModel().traceColumnsNonNullable();
     }
 
     /**
@@ -3112,17 +3154,6 @@ class TraceDAOImpl implements TraceDAO {
                 .bind("metadata" + suffix, metadataValue)
                 .bind("input_slim" + suffix, TruncationUtils.createSlimJsonString(inputValue))
                 .bind("output_slim" + suffix, TruncationUtils.createSlimJsonString(outputValue));
-    }
-
-    private ST buildInsertTemplate(Trace trace, String workspaceId, String userName) {
-        var template = getSTWithLogComment(INSERT, "insert_trace", workspaceId, userName, "");
-
-        Optional.ofNullable(trace.endTime())
-                .ifPresent(endTime -> template.add("end_time", endTime));
-        Optional.ofNullable(trace.ttft())
-                .ifPresent(ttft -> template.add("ttft", ttft));
-
-        return template;
     }
 
     @Override
@@ -3402,7 +3433,7 @@ class TraceDAOImpl implements TraceDAO {
                 .name(StringUtils.defaultIfBlank(
                         getValue(exclude, Trace.TraceField.NAME, row, "name", String.class), null))
                 .startTime(getValue(exclude, Trace.TraceField.START_TIME, row, "start_time", Instant.class))
-                .endTime(getValue(exclude, Trace.TraceField.END_TIME, row, "end_time", Instant.class))
+                .endTime(readEpochSentinel(exclude, Trace.TraceField.END_TIME, row, "end_time"))
                 .input(Optional.ofNullable(getValue(exclude, Trace.TraceField.INPUT, row, "input", String.class))
                         .filter(str -> !str.isBlank())
                         .map(value -> TruncationUtils.getJsonNodeOrTruncatedString(rowMetadata, "input_truncated",
@@ -3475,8 +3506,8 @@ class TraceDAOImpl implements TraceDAO {
                 .createdBy(getValue(exclude, Trace.TraceField.CREATED_BY, row, "created_by", String.class))
                 .lastUpdatedBy(
                         getValue(exclude, Trace.TraceField.LAST_UPDATED_BY, row, "last_updated_by", String.class))
-                .duration(getValue(exclude, Trace.TraceField.DURATION, row, "duration", Double.class))
-                .ttft(getValue(exclude, Trace.TraceField.TTFT, row, "ttft", Double.class))
+                .duration(readNanSentinel(exclude, Trace.TraceField.DURATION, row, "duration"))
+                .ttft(readNanSentinel(exclude, Trace.TraceField.TTFT, row, "ttft"))
                 .threadId(StringUtils.defaultIfBlank(
                         getValue(exclude, Trace.TraceField.THREAD_ID, row, "thread_id", String.class), null))
                 .visibilityMode(Optional.ofNullable(
@@ -3490,6 +3521,28 @@ class TraceDAOImpl implements TraceDAO {
                 .environment(getValue(exclude, Trace.TraceField.ENVIRONMENT, row, "environment", String.class))
                 .experiment(mapExperiment(exclude, row))
                 .build();
+    }
+
+    /**
+     * Reads a {@code DateTime64} column, translating the epoch sentinel to {@code null} only once the columns are
+     * non-nullable. While still {@code Nullable}, the value is returned as-is: {@code null} stays {@code null} and a
+     * (legitimate) epoch timestamp is preserved — the column distinguishes the two, so translating unconditionally
+     * would corrupt a client-supplied {@code 1970-01-01} value. Symmetric with the flag-gated write binding.
+     */
+    private Instant readEpochSentinel(Set<Trace.TraceField> exclude, Trace.TraceField field, Row row,
+            String fieldName) {
+        var value = getValue(exclude, field, row, fieldName, Instant.class);
+        return traceColumnsNonNullable() ? epochToNull(value) : value;
+    }
+
+    /**
+     * Reads a {@code Float64} column and maps the {@code NaN} sentinel to {@code null}. No flag is needed (unlike
+     * {@code end_time}): neither {@code duration} (materialized, never {@code NaN} today) nor {@code ttft} (cannot
+     * arrive as {@code NaN} via JSON) is ever {@code NaN} while the column is still {@code Nullable}, so the
+     * translation is always a no-op today and correct once the column is non-nullable.
+     */
+    private Double readNanSentinel(Set<Trace.TraceField> exclude, Trace.TraceField field, Row row, String fieldName) {
+        return nanToNull(getValue(exclude, field, row, fieldName, Double.class));
     }
 
     private List<GuardrailsValidation> mapGuardrails(List<List<Object>> guardrails) {
@@ -3577,6 +3630,11 @@ class TraceDAOImpl implements TraceDAO {
             bindUserNameAndWorkspace(statement, userName, workspaceId);
             bindUpdateParams(traceUpdate, statement);
 
+            // INSERT_UPDATE builds the full new_trace row, so end_time/ttft are referenced unconditionally and must
+            // always be bound (sentinel or null for an absent value) — unlike the conditional UPDATE keep-column path.
+            bindEpochSentinel(statement, "end_time", traceUpdate.endTime());
+            bindNanSentinel(statement, "ttft", traceUpdate.ttft());
+
             if (traceUpdate.source() != null) {
                 statement.bind("source", traceUpdate.source().getValue());
             } else {
@@ -3633,7 +3691,8 @@ class TraceDAOImpl implements TraceDAO {
         return makeMonoContextAware((userName, workspaceId) -> {
             var logComment = getLogComment("find_traces_by_project_id", workspaceId, userName,
                     "page:" + page + ":size:" + size + ":" + traceSearchCriteria.toString());
-            var template = newTraceThreadFindTemplate(SELECT_BY_PROJECT_ID, traceSearchCriteria, TRACE_SEARCH_CLAUSE);
+            var template = newTraceThreadFindTemplate(
+                    SELECT_BY_PROJECT_ID, traceSearchCriteria, TRACE_SEARCH_CLAUSE, traceColumnsNonNullable());
 
             bindTemplateExcludeFieldVariables(traceSearchCriteria, template);
 
@@ -3643,7 +3702,9 @@ class TraceDAOImpl implements TraceDAO {
             addSortNeedsWideFlag(template, traceSearchCriteria.sortingFields());
 
             var orderBySql = sortingQueryBuilder.toOrderBySql(traceSearchCriteria.sortingFields(),
-                    TraceSortingFactory.EXPERIMENT_FIELD_MAPPING);
+                    traceColumnsNonNullable()
+                            ? SORT_FIELD_MAPPING_END_TIME_SENTINEL
+                            : TraceSortingFactory.EXPERIMENT_FIELD_MAPPING);
             boolean sortHasFeedbackScores = Optional.ofNullable(orderBySql)
                     .map(sortFields -> sortFields.contains("feedback_scores"))
                     .orElse(false);
@@ -3759,7 +3820,8 @@ class TraceDAOImpl implements TraceDAO {
         return makeMonoContextAware((userName, workspaceId) -> {
             var logComment = getLogComment("count_traces_by_project", workspaceId, userName,
                     traceSearchCriteria.toString());
-            var template = newTraceThreadFindTemplate(COUNT_BY_PROJECT_ID, traceSearchCriteria, TRACE_SEARCH_CLAUSE);
+            var template = newTraceThreadFindTemplate(
+                    COUNT_BY_PROJECT_ID, traceSearchCriteria, TRACE_SEARCH_CLAUSE, traceColumnsNonNullable());
             template.add("log_comment", logComment);
 
             var statement = connection.createStatement(template.render())
@@ -3841,11 +3903,7 @@ class TraceDAOImpl implements TraceDAO {
 
                 bindInputOutputMetadataAndSlim(statement, trace, i);
 
-                if (trace.endTime() != null) {
-                    statement.bind("end_time" + i, ClickHouseDateTimeFormat.formatNanos(trace.endTime()));
-                } else {
-                    statement.bindNull("end_time" + i, String.class);
-                }
+                bindEpochSentinel(statement, "end_time" + i, trace.endTime());
 
                 // Format the timestamp client-side so the SQL contains a plain string literal in the
                 // last_updated_at cell. Fall back to "now" when the client did not provide a value —
@@ -3860,11 +3918,7 @@ class TraceDAOImpl implements TraceDAO {
 
                 TruncationUtils.bindTruncationThreshold(statement, "truncation_threshold" + i, configuration);
 
-                if (trace.ttft() != null) {
-                    statement.bind("ttft" + i, trace.ttft());
-                } else {
-                    statement.bindNull("ttft" + i, Double.class);
-                }
+                bindNanSentinel(statement, "ttft" + i, trace.ttft());
 
                 if (trace.source() != null) {
                     statement.bind("source" + i, trace.source().getValue());
@@ -3970,8 +4024,8 @@ class TraceDAOImpl implements TraceDAO {
 
                     Mono<ProjectStats> tracesSpansMono = asyncTemplate.nonTransaction(connection -> {
                         var logComment = getLogComment("get_trace_stats_traces_spans", workspaceId, userName, "");
-                        var template = newTraceThreadFindTemplate(SELECT_TRACES_SPANS_STATS, criteria,
-                                TRACE_SEARCH_CLAUSE);
+                        var template = newTraceThreadFindTemplate(
+                                SELECT_TRACES_SPANS_STATS, criteria, TRACE_SEARCH_CLAUSE, traceColumnsNonNullable());
                         template.add("log_comment", logComment);
                         template.add("has_legacy_scores", hasLegacyScores);
 
@@ -4013,7 +4067,8 @@ class TraceDAOImpl implements TraceDAO {
     private Statement buildFeedbackStatementForCriteria(Connection connection, TraceSearchCriteria criteria,
             String workspaceId, String userName, boolean hasLegacyScores) {
         var logComment = getLogComment("get_trace_stats_feedback_scores", workspaceId, userName, "");
-        var template = newTraceThreadFindTemplate(SELECT_FEEDBACK_SCORES_STATS, criteria, TRACE_SEARCH_CLAUSE);
+        var template = newTraceThreadFindTemplate(
+                SELECT_FEEDBACK_SCORES_STATS, criteria, TRACE_SEARCH_CLAUSE, traceColumnsNonNullable());
         template.add("log_comment", logComment);
         if (hasAnyTraceFilter(template)) {
             template.add("filters_present", true);
@@ -4039,7 +4094,7 @@ class TraceDAOImpl implements TraceDAO {
         var template = TemplateUtils.newST(SELECT_FEEDBACK_SCORES_STATS).add("log_comment", logComment);
         template.add("has_legacy_scores", hasLegacyScores);
         if (!CollectionUtils.isEmpty(filters)) {
-            FilterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.TRACE)
+            FilterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.TRACE, traceColumnsNonNullable())
                     .ifPresent(traceFilters -> {
                         template.add("filters", traceFilters);
                         template.add("filters_present", true);
@@ -4127,7 +4182,8 @@ class TraceDAOImpl implements TraceDAO {
                         template.add("project_stats", true);
                         template.add("has_legacy_scores", hasLegacyScores);
                         if (!CollectionUtils.isEmpty(filters)) {
-                            FilterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.TRACE)
+                            FilterQueryBuilder
+                                    .toAnalyticsDbFilters(filters, FilterStrategy.TRACE, traceColumnsNonNullable())
                                     .ifPresent(traceFilters -> template.add("filters", traceFilters));
                         }
                         var statement = connection.createStatement(template.render())
@@ -4386,7 +4442,8 @@ class TraceDAOImpl implements TraceDAO {
         return makeFluxContextAware((userName, workspaceId) -> {
             var logComment = getLogComment("find_trace_stream", workspaceId, userName,
                     "limit:" + limit + ":" + criteria);
-            var template = newTraceThreadFindTemplate(SELECT_BY_PROJECT_ID, criteria, TRACE_SEARCH_CLAUSE);
+            var template = newTraceThreadFindTemplate(
+                    SELECT_BY_PROJECT_ID, criteria, TRACE_SEARCH_CLAUSE, traceColumnsNonNullable());
             template.add("log_comment", logComment);
 
             bindTemplateExcludeFieldVariables(criteria, template);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -359,7 +359,7 @@ class TraceDAOImpl implements TraceDAO {
                     new_trace.output_slim
                 ) as output_slim,
                 multiIf(
-                    NOT isNaN(old_trace.ttft), old_trace.ttft,
+                    old_trace.id != '' AND NOT isNaN(old_trace.ttft), old_trace.ttft,
                     new_trace.ttft
                 ) as ttft,
                 multiIf(
@@ -1953,7 +1953,7 @@ class TraceDAOImpl implements TraceDAO {
                 ) as output_slim,
                 multiIf(
                     NOT isNaN(new_trace.ttft), new_trace.ttft,
-                    NOT isNaN(old_trace.ttft), old_trace.ttft,
+                    old_trace.id != '' AND NOT isNaN(old_trace.ttft), old_trace.ttft,
                     new_trace.ttft
                 ) as ttft,
                 multiIf(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
@@ -6,6 +6,7 @@ import com.comet.opik.api.metrics.WorkspaceMetricResponse;
 import com.comet.opik.api.metrics.WorkspaceMetricsSummaryRequest;
 import com.comet.opik.api.metrics.WorkspaceMetricsSummaryResponse;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
+import com.comet.opik.utils.SentinelTranslation;
 import com.comet.opik.utils.template.TemplateUtils;
 import com.google.common.base.Preconditions;
 import com.google.inject.ImplementedBy;
@@ -345,10 +346,7 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
     }
 
     Double filterNan(Double value) {
-        if (value == null) {
-            return null;
-        }
-
-        return value.isNaN() ? null : value;
+        // Delegates to the single SentinelTranslation definition.
+        return SentinelTranslation.nanToNull(value);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
@@ -346,7 +346,6 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
     }
 
     Double filterNan(Double value) {
-        // Delegates to the single SentinelTranslation definition.
         return SentinelTranslation.nanToNull(value);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
@@ -711,7 +711,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
             SELECT
                 id as trace_id,
                 project_id,
-                duration,
+                if(isNaN(duration), NULL, duration) AS duration,
                 metadata,
                 input,
                 output,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -63,6 +63,13 @@ public class FilterQueryBuilder {
     private static final String DESCRIPTION_DB = "description";
     private static final String START_TIME_ANALYTICS_DB = "start_time";
     private static final String END_TIME_ANALYTICS_DB = "end_time";
+    /**
+     * Sentinel-aware {@code end_time} for trace/thread filtering once the column is non-nullable: {@code nullIf}
+     * collapses the epoch sentinel to {@code NULL} so range/inequality comparisons exclude an absent value. Applied
+     * only under {@code traceColumnsNonNullable} — while the column is Nullable a client-supplied epoch is a
+     * legitimate value that must keep matching.
+     */
+    private static final String END_TIME_NON_NULLABLE_ANALYTICS_DB = "nullIf(end_time, toDateTime64('1970-01-01 00:00:00.000', 9))";
     private static final String INPUT_ANALYTICS_DB = "input";
     private static final String OUTPUT_ANALYTICS_DB = "output";
     private static final String METADATA_ANALYTICS_DB = "metadata";
@@ -78,9 +85,19 @@ public class FilterQueryBuilder {
     private static final String USAGE_PROMPT_TOKENS_ANALYTICS_DB = "usage['prompt_tokens']";
     private static final String USAGE_TOTAL_TOKENS_ANALYTICS_DB = "usage['total_tokens']";
     private static final String VALUE_ANALYTICS_DB = "value";
-    private static final String DURATION_ANALYTICS_DB = "if(end_time IS NOT NULL AND start_time IS NOT NULL AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)), (dateDiff('microsecond', start_time, end_time) / 1000.0), 0)";
+    /**
+     * Duration (ms) derived from {@code start_time}/{@code end_time}. The {@code notEquals(end_time, epoch)} guard, as
+     * in every other duration calc, keeps an absent (epoch-sentinel) {@code end_time} from yielding a garbage negative
+     * duration once the column is non-nullable. No-op while it is Nullable (an absent value reads as {@code NULL}).
+     */
+    private static final String DURATION_ANALYTICS_DB = "if(end_time IS NOT NULL AND notEquals(end_time, toDateTime64('1970-01-01 00:00:00.000', 9)) AND start_time IS NOT NULL AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)), (dateDiff('microsecond', start_time, end_time) / 1000.0), 0)";
     private static final String NEW_DURATION_ANALYTICS_DB = "duration";
-    private static final String TTFT_ANALYTICS_DB = "ttft";
+    /**
+     * Sentinel-aware {@code ttft} for filtering: {@code isNaN} collapses the {@code NaN} sentinel to {@code NULL} so
+     * comparisons exclude an absent value — notably {@code !=}, since {@code NaN != x} is true. Unconditional, not
+     * flag-gated: {@code NaN} cannot occur while the column is Nullable, so it is a no-op today.
+     */
+    private static final String TTFT_ANALYTICS_DB = "if(isNaN(ttft), NULL, ttft)";
     private static final String THREAD_ID_ANALYTICS_DB = "thread_id";
     private static final String DATASET_ID_ANALYTICS_DB = "dataset_id";
     private static final String PROMPT_IDS_ANALYTICS_DB = "prompt_ids";
@@ -863,13 +880,25 @@ public class FilterQueryBuilder {
 
     public static Optional<String> toAnalyticsDbFilters(
             @NonNull List<? extends Filter> filters, @NonNull FilterStrategy filterStrategy) {
+        return toAnalyticsDbFilters(filters, filterStrategy, false);
+    }
+
+    /**
+     * @param traceColumnsNonNullable when {@code true}, filters use the sentinel-aware
+     *                                expression so an absent (epoch) value is excluded like a {@code NULL}; pass the
+     *                                cutover flag from callers, {@code false} elsewhere.
+     */
+    public static Optional<String> toAnalyticsDbFilters(
+            @NonNull List<? extends Filter> filters,
+            @NonNull FilterStrategy filterStrategy,
+            boolean traceColumnsNonNullable) {
         var stringJoiner = new StringJoiner(" %s ".formatted(ANALYTICS_DB_AND_OPERATOR));
         stringJoiner.setEmptyValue("");
         for (var i = 0; i < filters.size(); i++) {
             var filter = filters.get(i);
             if (getFieldsByStrategy(filterStrategy, filter).orElse(Set.of()).contains(filter.field())
                     || filter.field().isDynamic(filterStrategy)) {
-                stringJoiner.add(toAnalyticsDbFilter(filter, i, filterStrategy));
+                stringJoiner.add(toAnalyticsDbFilter(filter, i, filterStrategy, traceColumnsNonNullable));
             }
         }
         var analyticsDbFilters = stringJoiner.toString();
@@ -979,14 +1008,22 @@ public class FilterQueryBuilder {
         return FEEDBACK_SCORE_FIELDS.contains(filter.field());
     }
 
-    private static String toAnalyticsDbFilter(Filter filter, int i, FilterStrategy filterStrategy) {
+    private static String toAnalyticsDbFilter(
+            Filter filter, int i, FilterStrategy filterStrategy, boolean traceColumnsNonNullable) {
         var template = toAnalyticsDbOperator(filter, filterStrategy);
-        var dbField = getAnalyticsDbField(filter.field(), filterStrategy, i);
+        var dbField = getAnalyticsDbField(filter.field(), filterStrategy, i, traceColumnsNonNullable);
         var enumFallbackTemplate = ANALYTICS_DB_OPERATOR_MAP.get(filter.operator()).get(FieldType.ENUM);
         return filter.field().getType().buildFilter(template, dbField, i, filter.value(), enumFallbackTemplate);
     }
 
-    private static String getAnalyticsDbField(Field field, FilterStrategy filterStrategy, int i) {
+    private static String getAnalyticsDbField(
+            Field field, FilterStrategy filterStrategy, int i, boolean traceColumnsNonNullable) {
+        // Resolve end_time to the sentinel-aware expression so an absent (epoch) value is excluded like a
+        // NULL. Flag-gated (epoch is legitimate while the column is Nullable).
+        if (traceColumnsNonNullable && (field == TraceField.END_TIME || field == TraceThreadField.END_TIME)) {
+            return END_TIME_NON_NULLABLE_ANALYTICS_DB;
+        }
+
         // this is a special case where the DB field is determined by the filter strategy rather than the filter field
         if (filterStrategy == FilterStrategy.FEEDBACK_SCORES_IS_EMPTY) {
             return FEEDBACK_SCORE_COUNT_DB;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -91,7 +91,13 @@ public class FilterQueryBuilder {
      * duration once the column is non-nullable. No-op while it is Nullable (an absent value reads as {@code NULL}).
      */
     private static final String DURATION_ANALYTICS_DB = "if(end_time IS NOT NULL AND notEquals(end_time, toDateTime64('1970-01-01 00:00:00.000', 9)) AND start_time IS NOT NULL AND notEquals(start_time, toDateTime64('1970-01-01 00:00:00.000', 9)), (dateDiff('microsecond', start_time, end_time) / 1000.0), 0)";
-    private static final String NEW_DURATION_ANALYTICS_DB = "duration";
+    /**
+     * Sentinel-aware {@code duration} for the materialized column (experiment-comparison filtering): {@code isNaN}
+     * collapses the {@code NaN} sentinel to {@code NULL} so comparisons exclude an absent value — notably {@code !=},
+     * since {@code NaN != x} is true. Unconditional (mirrors {@code TTFT_ANALYTICS_DB}); a no-op while the column is
+     * Nullable since {@code NaN} cannot occur yet.
+     */
+    private static final String NEW_DURATION_ANALYTICS_DB = "if(isNaN(duration), NULL, duration)";
     /**
      * Sentinel-aware {@code ttft} for filtering: {@code isNaN} collapses the {@code NaN} sentinel to {@code NULL} so
      * comparisons exclude an absent value — notably {@code !=}, since {@code NaN != x} is true. Unconditional, not
@@ -914,7 +920,17 @@ public class FilterQueryBuilder {
      */
     public static Optional<String> toAnalyticsDbFiltersV2Client(
             @NonNull List<? extends Filter> filters, @NonNull FilterStrategy filterStrategy) {
-        return toAnalyticsDbFilters(filters, filterStrategy)
+        return toAnalyticsDbFiltersV2Client(filters, filterStrategy, false);
+    }
+
+    /**
+     * @param traceColumnsNonNullable threaded through so a v2-client caller can opt into sentinel-aware {@code end_time}
+     *                                just like the r2dbc path; without it this entry point could never enable the flag.
+     */
+    public static Optional<String> toAnalyticsDbFiltersV2Client(
+            @NonNull List<? extends Filter> filters, @NonNull FilterStrategy filterStrategy,
+            boolean traceColumnsNonNullable) {
+        return toAnalyticsDbFilters(filters, filterStrategy, traceColumnsNonNullable)
                 .map(sql -> rewritePlaceholdersForV2Client(sql, filters));
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatabaseAnalyticsDataModelConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatabaseAnalyticsDataModelConfig.java
@@ -1,0 +1,18 @@
+package com.comet.opik.infrastructure;
+
+import lombok.Builder;
+
+/**
+ * Toggles for the schema state of the analytics database (non-nullable trace-column migration).
+ *
+ * <p>{@code traceColumnsNonNullable}: while the {@code traces} table still has {@code Nullable(...)} columns (default,
+ * {@code false}) trace writes bind {@code null} for an absent {@code end_time}/{@code ttft}.
+ * Once replaced those columns with sentinel-defaulted non-nullable columns, set this {@code true} so writes bind the
+ * sentinels ({@code end_time}→epoch, {@code ttft}→{@code NaN}) instead — a {@code null} bind would be rejected by a
+ * non-nullable column. The flag gates reads too (sentinel→{@code null}), so while it is {@code false} a legitimate
+ * epoch end time round-trips unchanged rather than being read as {@code null}. Flip this in lockstep with the EXCHANGE
+ * step of the cutover. A sibling {@code spanColumnsNonNullable} follows later.</p>
+ */
+@Builder(toBuilder = true)
+public record DatabaseAnalyticsDataModelConfig(boolean traceColumnsNonNullable) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/FilterUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/FilterUtils.java
@@ -126,12 +126,15 @@ public class FilterUtils {
         }
     }
 
-    public static ST newTraceThreadFindTemplate(String query, TraceSearchCriteria traceSearchCriteria,
-            String searchClause) {
+    public static ST newTraceThreadFindTemplate(
+            String query,
+            TraceSearchCriteria traceSearchCriteria,
+            String searchClause,
+            boolean traceColumnsNonNullable) {
         var template = TemplateUtils.newST(query);
         Optional.ofNullable(traceSearchCriteria.filters())
                 .ifPresent(filters -> {
-                    FilterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.TRACE)
+                    FilterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.TRACE, traceColumnsNonNullable)
                             .ifPresent(traceFilters -> template.add("filters", traceFilters));
                     FilterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.TRACE_AGGREGATION)
                             .ifPresent(traceAggregationFilters -> template.add("trace_aggregation_filters",
@@ -147,7 +150,8 @@ public class FilterUtils {
                     FilterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.EXPERIMENT_AGGREGATION)
                             .ifPresent(traceExperimentFilters -> template.add("experiment_filters",
                                     traceExperimentFilters));
-                    FilterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.TRACE_THREAD)
+                    FilterQueryBuilder.toAnalyticsDbFilters(
+                            filters, FilterStrategy.TRACE_THREAD, traceColumnsNonNullable)
                             .ifPresent(threadFilters -> template.add("trace_thread_filters", threadFilters));
                     FilterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.FEEDBACK_SCORES_IS_EMPTY)
                             .ifPresent(feedbackScoreIsEmptyFilters -> template.add("feedback_scores_empty_filters",

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
@@ -24,6 +24,10 @@ public class OpikConfiguration extends JobConfiguration {
     private DatabaseAnalyticsFactory databaseAnalytics = new DatabaseAnalyticsFactory();
 
     @Valid @NotNull @JsonProperty
+    private DatabaseAnalyticsDataModelConfig databaseAnalyticsDataModel = DatabaseAnalyticsDataModelConfig.builder()
+            .build();
+
+    @Valid @NotNull @JsonProperty
     private DatabaseAnalyticsReadOnlyFreeFormSqlConfig databaseAnalyticsReadOnlyFreeFormSql = new DatabaseAnalyticsReadOnlyFreeFormSqlConfig();
 
     @Valid @NotNull @JsonProperty

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/SentinelTranslation.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/SentinelTranslation.java
@@ -29,7 +29,7 @@ import static com.comet.opik.utils.ValidationUtils.CLICKHOUSE_FIXED_STRING_UUID_
 @UtilityClass
 public class SentinelTranslation {
 
-    /** Sentinel for a non-nullable {@code DateTime64} column ({@code DEFAULT toDateTime64('1970-01-01 00:00:00', 6)}). */
+    /** Sentinel for a non-nullable {@code DateTime64(9)} column ({@code DEFAULT toDateTime64('1970-01-01 00:00:00', 9)}), matching the {@code precision-9} SQL fragments and the current {@code end_time} column. */
     public static final Instant EPOCH_SENTINEL = Instant.EPOCH;
 
     /** Sentinel for a non-nullable {@code FixedString(36)} column ({@code DEFAULT ''}). */

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/SentinelTranslation.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/SentinelTranslation.java
@@ -1,0 +1,84 @@
+package com.comet.opik.utils;
+
+import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.StringUtils;
+
+import java.time.Instant;
+
+import static com.comet.opik.utils.ValidationUtils.CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE;
+
+/**
+ * Single translation point between the API contract (Java {@code null} / {@code Optional<T>} ↔ JSON {@code null})
+ * and the sentinel values that back the non-nullable analytics columns.
+ *
+ * <p>{@code Nullable(...)} carries a per-row null-mask file and cannot back a table index, so it is dropped
+ * from the high-volume {@code traces}/{@code spans} columns in favour of a collision-free sentinel per type:</p>
+ * <ul>
+ *     <li>{@code DateTime64} → {@link Instant#EPOCH} ({@code 1970-01-01 00:00:00}); no real event timestamp collides
+ *     with the epoch, so it reads as "not yet ended" / "never scored".</li>
+ *     <li>{@code Float64} → {@link Double#NaN}; {@code 0} is a legitimate measurement (instant first token,
+ *     sub-millisecond span), so {@code NaN} is the only value that cannot collide with real data.</li>
+ *     <li>{@code FixedString(36)} → empty string; ClickHouse also surfaces the all-null-byte form
+ *     ({@link ValidationUtils#CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE}) from LEFT JOINs, so both read as absent.</li>
+ * </ul>
+ *
+ * <p>Keeping the {@code sentinel ↔ null} mapping in one place mirrors the codebase's existing idiom for {@code ''}
+ * -defaulted strings and guarantees every DAO that reads or writes one of these columns
+ * inherits the same contract instead of re-deriving it.</p>
+ */
+@UtilityClass
+public class SentinelTranslation {
+
+    /** Sentinel for a non-nullable {@code DateTime64} column ({@code DEFAULT toDateTime64('1970-01-01 00:00:00', 6)}). */
+    public static final Instant EPOCH_SENTINEL = Instant.EPOCH;
+
+    /** Sentinel for a non-nullable {@code FixedString(36)} column ({@code DEFAULT ''}). */
+    public static final String EMPTY_UUID_SENTINEL = "";
+
+    // Outbound: ClickHouse sentinel → API null.
+
+    /**
+     * @return {@code null} when the value is absent — {@code null} or the epoch sentinel — otherwise the value itself.
+     * The constant leads the equality check so a {@code null} value can never throw.
+     */
+    public static Instant epochToNull(Instant value) {
+        return EPOCH_SENTINEL.equals(value) ? null : value;
+    }
+
+    /**
+     * @return {@code null} when the value is absent — {@code null} or {@code NaN} — otherwise the value itself.
+     * Infinities are passed through unchanged: they signal a data defect, not the absent-value sentinel.
+     */
+    public static Double nanToNull(Double value) {
+        return value != null && value.isNaN() ? null : value;
+    }
+
+    /**
+     * @return {@code null} when the value is absent — {@code null}, empty, or the all-null-byte
+     * {@code FixedString(36)} form — otherwise the value itself.
+     */
+    public static String emptyUuidToNull(String value) {
+        return StringUtils.isBlank(value) || CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE.equals(value)
+                ? null
+                : value;
+    }
+
+    // Inbound: API null → ClickHouse sentinel.
+
+    public static Instant nullToEpoch(Instant value) {
+        return value == null ? EPOCH_SENTINEL : value;
+    }
+
+    public static double nullToNaN(Double value) {
+        return value == null ? Double.NaN : value;
+    }
+
+    /**
+     * @return the empty sentinel when the value is absent — {@code null}, empty, or blank — otherwise the value itself.
+     * Blank is folded in (not just {@code null}) to mirror {@link #emptyUuidToNull} and to stop a blank inbound value
+     * from being stored as a partial-NUL {@code FixedString(36)} that reads back as neither the sentinel nor a UUID.
+     */
+    public static String nullToEmptyUuid(String value) {
+        return StringUtils.isBlank(value) ? EMPTY_UUID_SENTINEL : value;
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/filter/FilterQueryBuilderSentinelTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/filter/FilterQueryBuilderSentinelTest.java
@@ -1,0 +1,106 @@
+package com.comet.opik.domain.filter;
+
+import com.comet.opik.api.filter.Filter;
+import com.comet.opik.api.filter.Operator;
+import com.comet.opik.api.filter.SpanField;
+import com.comet.opik.api.filter.SpanFilter;
+import com.comet.opik.api.filter.TraceField;
+import com.comet.opik.api.filter.TraceFilter;
+import com.comet.opik.api.filter.TraceThreadField;
+import com.comet.opik.api.filter.TraceThreadFilter;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+/**
+ * Verifies the flag-gated sentinel handling in the filter SQL {@link FilterQueryBuilder} generates for the trace-column
+ * non-nullable migration. Exercises the R2DBC entry point ({@code toAnalyticsDbFilters}); the v2-client placeholder
+ * machinery is covered separately in {@link FilterQueryBuilderV2ClientTest}. The post-cutover behavior cannot be
+ * exercised end-to-end while the columns are still {@code Nullable}, so the contract is asserted on the generated SQL.
+ */
+class FilterQueryBuilderSentinelTest {
+
+    private static final String EPOCH = "toDateTime64('1970-01-01 00:00:00.000', 9)";
+    private static final String END_TIME_SENTINEL_AWARE = "nullIf(end_time, %s)".formatted(EPOCH);
+    private static final String DURATION_EXPR = ("if(end_time IS NOT NULL AND notEquals(end_time, %1$s) AND "
+            + "start_time IS NOT NULL AND notEquals(start_time, %1$s), "
+            + "(dateDiff('microsecond', start_time, end_time) / 1000.0), 0)").formatted(EPOCH);
+    private static final String TTFT_EXPR = "if(isNaN(ttft), NULL, ttft)";
+
+    static Stream<Arguments> endTimeFilterWrapsSentinelOnlyUnderFlag() {
+        var value = Instant.now().toString();
+        return Stream.of(
+                arguments(FilterStrategy.TRACE, TraceFilter.builder()
+                        .field(TraceField.END_TIME).operator(Operator.LESS_THAN).value(value).build()),
+                arguments(FilterStrategy.TRACE_THREAD, TraceThreadFilter.builder()
+                        .field(TraceThreadField.END_TIME).operator(Operator.LESS_THAN).value(value).build()));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void endTimeFilterWrapsSentinelOnlyUnderFlag(FilterStrategy strategy, Filter filter) {
+        var expectedWithFlag = singleFilter(END_TIME_SENTINEL_AWARE, "< parseDateTime64BestEffort(:filter0, 9)");
+        var expectedWithoutFlag = singleFilter("end_time", "< parseDateTime64BestEffort(:filter0, 9)");
+
+        var actualWithFlag = toSql(filter, strategy, true);
+        var actualWithoutFlag = toSql(filter, strategy, false);
+
+        assertThat(actualWithFlag).isEqualTo(expectedWithFlag);
+        assertThat(actualWithoutFlag).isEqualTo(expectedWithoutFlag);
+    }
+
+    @Test
+    void spanEndTimeFilterIgnoresFlagKeepingRawColumn() {
+        var value = Instant.now().toString();
+        var filter = SpanFilter.builder()
+                .field(SpanField.END_TIME).operator(Operator.LESS_THAN).value(value).build();
+        var expected = singleFilter("end_time", "< parseDateTime64BestEffort(:filter0, 9)");
+
+        var actual = toSql(filter, FilterStrategy.SPAN, true);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> unconditionalSentinelFilterIgnoresFlag() {
+        return Stream.of(
+                arguments(TraceField.DURATION, Operator.GREATER_THAN, DURATION_EXPR, "> :filter0"),
+                arguments(TraceField.TTFT, Operator.NOT_EQUAL, TTFT_EXPR, "!= :filter0"));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void unconditionalSentinelFilterIgnoresFlag(
+            TraceField field, Operator operator, String columnExpr, String operatorAndPlaceholder) {
+        var value = RandomStringUtils.secure().nextNumeric(32);
+        var filter = TraceFilter.builder().field(field).operator(operator).value(value).build();
+        var expected = singleFilter(columnExpr, operatorAndPlaceholder);
+
+        var actualWithoutFlag = toSql(filter, FilterStrategy.TRACE, false);
+        var actualWithFlag = toSql(filter, FilterStrategy.TRACE, true);
+
+        assertThat(actualWithoutFlag).isEqualTo(expected);
+        assertThat(actualWithFlag).isEqualTo(expected);
+    }
+
+    /**
+     * Expected SQL for a single filter: toAnalyticsDbFilters wraps the AND-joined filters in (...), and each filter's
+     * own predicate is itself parenthesized — hence the double parentheses.
+     */
+    private String singleFilter(String columnExpr, String operatorAndPlaceholder) {
+        return "((%s %s))".formatted(columnExpr, operatorAndPlaceholder);
+    }
+
+    private String toSql(Filter filter, FilterStrategy strategy, boolean traceColumnsNonNullable) {
+        return FilterQueryBuilder.toAnalyticsDbFilters(List.of(filter), strategy, traceColumnsNonNullable)
+                .orElseThrow();
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/filter/FilterQueryBuilderSentinelTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/filter/FilterQueryBuilderSentinelTest.java
@@ -1,5 +1,7 @@
 package com.comet.opik.domain.filter;
 
+import com.comet.opik.api.filter.ExperimentsComparisonFilter;
+import com.comet.opik.api.filter.ExperimentsComparisonValidKnownField;
 import com.comet.opik.api.filter.Filter;
 import com.comet.opik.api.filter.Operator;
 import com.comet.opik.api.filter.SpanField;
@@ -86,6 +88,22 @@ class FilterQueryBuilderSentinelTest {
 
         var actualWithoutFlag = toSql(filter, FilterStrategy.TRACE, false);
         var actualWithFlag = toSql(filter, FilterStrategy.TRACE, true);
+
+        assertThat(actualWithoutFlag).isEqualTo(expected);
+        assertThat(actualWithFlag).isEqualTo(expected);
+    }
+
+    @Test
+    void experimentComparisonDurationFilterExcludesNaNSentinel() {
+        var filter = ExperimentsComparisonFilter.builder()
+                .field(ExperimentsComparisonValidKnownField.DURATION.getQueryParamField())
+                .operator(Operator.NOT_EQUAL)
+                .value(RandomStringUtils.secure().nextNumeric(32))
+                .build();
+        var expected = singleFilter("if(isNaN(duration), NULL, duration)", "!= :filter0");
+
+        var actualWithoutFlag = toSql(filter, FilterStrategy.EXPERIMENT_ITEM, false);
+        var actualWithFlag = toSql(filter, FilterStrategy.EXPERIMENT_ITEM, true);
 
         assertThat(actualWithoutFlag).isEqualTo(expected);
         assertThat(actualWithFlag).isEqualTo(expected);

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/filter/FilterQueryBuilderV2ClientTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/filter/FilterQueryBuilderV2ClientTest.java
@@ -3,10 +3,13 @@ package com.comet.opik.domain.filter;
 import com.comet.opik.api.filter.DatasetItemField;
 import com.comet.opik.api.filter.DatasetItemFilter;
 import com.comet.opik.api.filter.Operator;
+import com.comet.opik.api.filter.TraceField;
+import com.comet.opik.api.filter.TraceFilter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +60,27 @@ class FilterQueryBuilderV2ClientTest {
         void v2EntryPoint__emptyFilters__returnsEmpty() {
             assertThat(FilterQueryBuilder.toAnalyticsDbFiltersV2Client(List.of(), FilterStrategy.DATASET_ITEM))
                     .isEmpty();
+        }
+
+        @Test
+        @DisplayName("Threads traceColumnsNonNullable: trace end_time uses the sentinel-aware column under the flag")
+        void v2EntryPoint__threadsTraceColumnsNonNullableFlag() {
+            var filter = TraceFilter.builder()
+                    .field(TraceField.END_TIME)
+                    .operator(Operator.LESS_THAN)
+                    .value(Instant.now().toString())
+                    .build();
+            var withFlag = FilterQueryBuilder
+                    .toAnalyticsDbFiltersV2Client(List.of(filter), FilterStrategy.TRACE, true)
+                    .orElseThrow();
+            var withoutFlag = FilterQueryBuilder
+                    .toAnalyticsDbFiltersV2Client(List.of(filter), FilterStrategy.TRACE, false)
+                    .orElseThrow();
+
+            // Flag on -> sentinel-aware end_time; flag off -> raw column. Both emit v2 {name:Type} placeholders.
+            assertThat(withFlag).contains("nullIf(end_time, toDateTime64('1970-01-01 00:00:00.000', 9))");
+            assertThat(withoutFlag).doesNotContain("nullIf(end_time");
+            assertThat(withFlag).doesNotContain(":filter0");
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/NaNAwareAggregateIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/NaNAwareAggregateIntegrationTest.java
@@ -1,6 +1,8 @@
 package com.comet.opik.infrastructure;
 
 import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.domain.IdGenerator;
+import com.comet.opik.domain.TestIdGeneratorFactory;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.Result;
@@ -53,6 +55,8 @@ class NaNAwareAggregateIntegrationTest {
      * non-nullable {@code Float64} column, {@code NULL} on the legacy {@code Nullable(Float64)} column.
      */
     private static final String SYNTHETIC_TABLE = "nan_agg_synthetic_test";
+
+    private static final IdGenerator ID_GENERATOR = TestIdGeneratorFactory.create();
 
     private ClickHouseContainer clickHouseContainer;
     private ConnectionFactory connectionFactory;
@@ -147,6 +151,47 @@ class NaNAwareAggregateIntegrationTest {
         assertThat(aggregates.quantile()).isEqualTo(aggregates.quantileNullable());
     }
 
+    /**
+     * Post-cutover, a brand-new trace's dedup merge LEFT JOINs an absent old row. A non-nullable Float64 fills the
+     * join miss with 0.0 (the type zero — not the NaN default), so a bare NOT isNaN(old.ttft) guard wrongly keeps
+     * 0.0 and discards the new value. The id-presence guard (old.id != '') falls through to the new value. This
+     * pins why the ttft merge needs the id guard (end_time is safe only because its type zero is the epoch).
+     */
+    @Test
+    void nonNullableTtftMergeUsesNewValueOnJoinMiss() {
+        var id = ID_GENERATOR.generateId();
+        var newTtft = RandomUtils.secure().randomDouble(1.0, 1_000.0);
+        var expected = MergeMissResult.builder()
+                .missFill(0.0d)
+                .unguardedResult(0.0d)
+                .guardedResult(newTtft)
+                .build();
+        var actual = queryOne(
+                """
+                        WITH new_trace AS (
+                          SELECT toFixedString('%s', 36) AS id,
+                          %s AS ttft
+                        )
+                        SELECT old_trace.ttft                                                                            AS miss_fill,
+                               multiIf(NOT isNaN(old_trace.ttft), old_trace.ttft, new_trace.ttft)                        AS unguarded_result,
+                               multiIf(old_trace.id != '' AND NOT isNaN(old_trace.ttft), old_trace.ttft, new_trace.ttft) AS guarded_result
+                        FROM new_trace
+                        LEFT JOIN (
+                            SELECT toFixedString('', 36) AS id,
+                            CAST(0 AS Float64) AS ttft WHERE 1 = 0
+                        ) AS old_trace
+                        ON new_trace.id = old_trace.id
+                        """
+                        .formatted(id, newTtft),
+                row -> MergeMissResult.builder()
+                        .missFill(row.get("miss_fill", Double.class))
+                        .unguardedResult(row.get("unguarded_result", Double.class))
+                        .guardedResult(row.get("guarded_result", Double.class))
+                        .build());
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
     Stream<Arguments> guardedDurationFormula() {
         return Stream.of(
                 arguments("1.5s span -> 1500ms", "2026-01-01 00:00:00.000000", "2026-01-01 00:00:01.500000", 1500.0d),
@@ -179,39 +224,6 @@ class NaNAwareAggregateIntegrationTest {
                 SELECT if(end_time = epoch, nan, dateDiff('microsecond', start_time, end_time) / 1000.0) AS duration_ms
                 """.formatted(startTime, endTime),
                 row -> row.get("duration_ms", Double.class));
-    }
-
-    @Test
-    void nonNullableTtftMergeUsesNewValueOnJoinMiss() {
-        // Post-cutover, a brand-new trace's dedup merge LEFT JOINs an absent old row. A non-nullable Float64 fills the
-        // join miss with 0.0 (the type zero — not the NaN default), so a bare NOT isNaN(old.ttft) guard wrongly keeps
-        // 0.0 and discards the new value. The id-presence guard (old.id != '') falls through to the new value. This
-        // pins why the ttft merge needs the id guard (end_time is safe only because its type zero is the epoch).
-        var newTtft = RandomUtils.secure().randomDouble(1.0, 1_000.0);
-        var expected = MergeMissResult.builder()
-                .missFill(0.0d)
-                .unguardedResult(0.0d)
-                .guardedResult(newTtft)
-                .build();
-
-        var actual = queryOne(
-                """
-                        WITH new_trace AS (SELECT toFixedString('550e8400-e29b-41d4-a716-446655440000', 36) AS id, %s AS ttft)
-                        SELECT old_trace.ttft                                                                            AS miss_fill,
-                               multiIf(NOT isNaN(old_trace.ttft), old_trace.ttft, new_trace.ttft)                        AS unguarded_result,
-                               multiIf(old_trace.id != '' AND NOT isNaN(old_trace.ttft), old_trace.ttft, new_trace.ttft) AS guarded_result
-                        FROM new_trace
-                        LEFT JOIN (SELECT toFixedString('', 36) AS id, CAST(0 AS Float64) AS ttft WHERE 1 = 0) AS old_trace
-                            ON new_trace.id = old_trace.id
-                        """
-                        .formatted(newTtft),
-                row -> MergeMissResult.builder()
-                        .missFill(row.get("miss_fill", Double.class))
-                        .unguardedResult(row.get("unguarded_result", Double.class))
-                        .guardedResult(row.get("guarded_result", Double.class))
-                        .build());
-
-        assertThat(actual).isEqualTo(expected);
     }
 
     private <T> T queryOne(String sql, Function<Row, T> mapper) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/NaNAwareAggregateIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/NaNAwareAggregateIntegrationTest.java
@@ -6,6 +6,7 @@ import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Row;
 import lombok.Builder;
+import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -180,6 +181,39 @@ class NaNAwareAggregateIntegrationTest {
                 row -> row.get("duration_ms", Double.class));
     }
 
+    @Test
+    void nonNullableTtftMergeUsesNewValueOnJoinMiss() {
+        // Post-cutover, a brand-new trace's dedup merge LEFT JOINs an absent old row. A non-nullable Float64 fills the
+        // join miss with 0.0 (the type zero — not the NaN default), so a bare NOT isNaN(old.ttft) guard wrongly keeps
+        // 0.0 and discards the new value. The id-presence guard (old.id != '') falls through to the new value. This
+        // pins why the ttft merge needs the id guard (end_time is safe only because its type zero is the epoch).
+        var newTtft = RandomUtils.secure().randomDouble(1.0, 1_000.0);
+        var expected = MergeMissResult.builder()
+                .missFill(0.0d)
+                .unguardedResult(0.0d)
+                .guardedResult(newTtft)
+                .build();
+
+        var actual = queryOne(
+                """
+                        WITH new_trace AS (SELECT toFixedString('550e8400-e29b-41d4-a716-446655440000', 36) AS id, %s AS ttft)
+                        SELECT old_trace.ttft                                                                            AS miss_fill,
+                               multiIf(NOT isNaN(old_trace.ttft), old_trace.ttft, new_trace.ttft)                        AS unguarded_result,
+                               multiIf(old_trace.id != '' AND NOT isNaN(old_trace.ttft), old_trace.ttft, new_trace.ttft) AS guarded_result
+                        FROM new_trace
+                        LEFT JOIN (SELECT toFixedString('', 36) AS id, CAST(0 AS Float64) AS ttft WHERE 1 = 0) AS old_trace
+                            ON new_trace.id = old_trace.id
+                        """
+                        .formatted(newTtft),
+                row -> MergeMissResult.builder()
+                        .missFill(row.get("miss_fill", Double.class))
+                        .unguardedResult(row.get("unguarded_result", Double.class))
+                        .guardedResult(row.get("guarded_result", Double.class))
+                        .build());
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
     private <T> T queryOne(String sql, Function<Row, T> mapper) {
         return Mono.usingWhen(
                 connectionFactory.create(),
@@ -217,5 +251,9 @@ class NaNAwareAggregateIntegrationTest {
             Double max,
             Double quantile,
             Double quantileNullable) {
+    }
+
+    @Builder(toBuilder = true)
+    record MergeMissResult(Double missFill, Double unguardedResult, Double guardedResult) {
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/NaNAwareAggregateIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/NaNAwareAggregateIntegrationTest.java
@@ -1,0 +1,221 @@
+package com.comet.opik.infrastructure;
+
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Row;
+import lombok.Builder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.lifecycle.Startables;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+/**
+ * Executable guard, run on the target ClickHouse image against synthetic data, for the {@code Nullable}-removal of the
+ * {@code Float64} analytics columns: it pins how {@code NaN} sentinels behave under the aggregates Opik metrics use,
+ * and that the guarded {@code duration} MATERIALIZED formula emits {@code NaN} at the epoch sentinel. It reads results
+ * through the R2DBC client the DAOs use, so it also confirms R2DBC marshals a {@code NaN} {@code Float64} to Java
+ * {@code Double.NaN} — the exact operation the read path depends on once the columns are non-nullable.
+ *
+ * <p>ClickHouse does <em>not</em> treat {@code NaN} uniformly the way it treats {@code NULL} on a
+ * {@code Nullable(Float64)} column:</p>
+ * <ul>
+ *     <li>{@code min}, {@code max}, {@code quantile} skip {@code NaN} — matching {@code NULL} semantics.</li>
+ *     <li>{@code sum} and {@code avg} propagate {@code NaN} and {@code count} counts the {@code NaN} row — deviating
+ *     from {@code NULL} semantics.</li>
+ *     <li>The {@code <agg>If(x, NOT isNaN(x))} form reproduces {@code NULL}-skipping exactly, so non-nullable
+ *     {@code sum}/{@code avg}/{@code count} call sites must use it.</li>
+ * </ul>
+ *
+ * <p>The guarded formula must use the bare {@code nan} constant ({@code nan()} fails to parse on this ClickHouse
+ * version) and preserves sub-millisecond resolution.</p>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class NaNAwareAggregateIntegrationTest {
+
+    /**
+     * {@code sample_id} 1..4 carry real measurements; the 5th is the absent-value sentinel — {@code NaN} on the
+     * non-nullable {@code Float64} column, {@code NULL} on the legacy {@code Nullable(Float64)} column.
+     */
+    private static final String SYNTHETIC_TABLE = "nan_agg_synthetic_test";
+
+    private ClickHouseContainer clickHouseContainer;
+    private ConnectionFactory connectionFactory;
+
+    @BeforeAll
+    void setUp() {
+        clickHouseContainer = ClickHouseContainerUtils.newClickHouseContainer(false);
+        Startables.deepStart(clickHouseContainer).join();
+
+        // "default" (rather than the app database) because this lightweight test does not run the app migrations that
+        // create the app database; it only needs a place for its own synthetic table.
+        connectionFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(clickHouseContainer, "default")
+                .build();
+
+        execute("""
+                CREATE TABLE IF NOT EXISTS %s (
+                    sample_id             UInt8,
+                    value_non_nullable    Float64,
+                    value_nullable        Nullable(Float64)
+                ) ENGINE = Memory
+                """.formatted(SYNTHETIC_TABLE));
+        execute("TRUNCATE TABLE %s".formatted(SYNTHETIC_TABLE));
+        // INSERT ... SELECT so NaN reaches the column without round-tripping through JSON (which has no NaN literal).
+        execute("""
+                INSERT INTO %s SELECT
+                    toUInt8(number)                           AS sample_id,
+                    if(number = 5, nan, toFloat64(number))    AS value_non_nullable,
+                    if(number = 5, NULL, toFloat64(number))   AS value_nullable
+                FROM numbers(1, 5)
+                """.formatted(SYNTHETIC_TABLE));
+    }
+
+    @AfterAll
+    void tearDown() {
+        if (clickHouseContainer != null && clickHouseContainer.isRunning()) {
+            clickHouseContainer.stop();
+        }
+    }
+
+    @Test
+    void rangeAndQuantileAggregatesSkipNaNLikeNull() {
+        var aggregates = queryOne("""
+                SELECT min(value_nullable)                  AS min_nullable,
+                       max(value_nullable)                  AS max_nullable,
+                       quantile(0.9)(value_nullable)        AS quantile_nullable,
+                       min(value_non_nullable)              AS min_non_nullable,
+                       max(value_non_nullable)              AS max_non_nullable,
+                       quantile(0.9)(value_non_nullable)    AS quantile_non_nullable
+                FROM %s
+                """.formatted(SYNTHETIC_TABLE),
+                row -> RangeQuantileAggregates.builder()
+                        .minNullable(row.get("min_nullable", Double.class))
+                        .maxNullable(row.get("max_nullable", Double.class))
+                        .quantileNullable(row.get("quantile_nullable", Double.class))
+                        .minNonNullable(row.get("min_non_nullable", Double.class))
+                        .maxNonNullable(row.get("max_non_nullable", Double.class))
+                        .quantileNonNullable(row.get("quantile_non_nullable", Double.class))
+                        .build());
+
+        assertThat(aggregates.minNonNullable()).isEqualTo(aggregates.minNullable()).isEqualTo(1.0d);
+        assertThat(aggregates.maxNonNullable()).isEqualTo(aggregates.maxNullable()).isEqualTo(4.0d);
+        assertThat(aggregates.quantileNonNullable()).isEqualTo(aggregates.quantileNullable());
+    }
+
+    @Test
+    void wrappedAggregatesRestoreNullSemantics() {
+        var aggregates = queryOne("""
+                SELECT countIf(NOT isNaN(value_non_nullable))                               AS count_wrapped,
+                       sumIf(value_non_nullable, NOT isNaN(value_non_nullable))             AS sum_wrapped,
+                       avgIf(value_non_nullable, NOT isNaN(value_non_nullable))             AS avg_wrapped,
+                       minIf(value_non_nullable, NOT isNaN(value_non_nullable))             AS min_wrapped,
+                       maxIf(value_non_nullable, NOT isNaN(value_non_nullable))             AS max_wrapped,
+                       quantileIf(0.9)(value_non_nullable, NOT isNaN(value_non_nullable))   AS quantile_wrapped,
+                       quantile(0.9)(value_nullable)                                        AS quantile_nullable
+                FROM %s
+                """.formatted(SYNTHETIC_TABLE),
+                row -> WrappedAggregates.builder()
+                        .count(row.get("count_wrapped", Long.class))
+                        .sum(row.get("sum_wrapped", Double.class))
+                        .avg(row.get("avg_wrapped", Double.class))
+                        .min(row.get("min_wrapped", Double.class))
+                        .max(row.get("max_wrapped", Double.class))
+                        .quantile(row.get("quantile_wrapped", Double.class))
+                        .quantileNullable(row.get("quantile_nullable", Double.class))
+                        .build());
+
+        assertThat(aggregates.count()).isEqualTo(4L);
+        assertThat(aggregates.sum()).isEqualTo(10.0d);
+        assertThat(aggregates.avg()).isEqualTo(2.5d);
+        assertThat(aggregates.min()).isEqualTo(1.0d);
+        assertThat(aggregates.max()).isEqualTo(4.0d);
+        assertThat(aggregates.quantile()).isEqualTo(aggregates.quantileNullable());
+    }
+
+    Stream<Arguments> guardedDurationFormula() {
+        return Stream.of(
+                arguments("1.5s span -> 1500ms", "2026-01-01 00:00:00.000000", "2026-01-01 00:00:01.500000", 1500.0d),
+                arguments("333 microseconds span -> 0.333ms", "2026-01-01 00:00:00.000123",
+                        "2026-01-01 00:00:00.000456", 0.333d),
+                arguments("epoch end_time -> NaN", "2026-01-01 00:00:00.000000", "1970-01-01 00:00:00.000000", null));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void guardedDurationFormula(String label, String startTime, String endTime, Double expectedMs) {
+        var actual = durationMs(startTime, endTime);
+
+        if (expectedMs == null) {
+            assertThat(actual).isNaN();
+        } else {
+            assertThat(actual).isEqualTo(expectedMs);
+        }
+    }
+
+    /**
+     * Mirrors the guarded non-nullable duration MATERIALIZED expression (bare `nan`, since `nan()` does not parse
+     * on the target ClickHouse version).
+     */
+    private double durationMs(String startTime, String endTime) {
+        return queryOne("""
+                WITH toDateTime64('%s', 6)                                                               AS start_time,
+                     toDateTime64('%s', 6)                                                               AS end_time,
+                     toDateTime64('1970-01-01 00:00:00', 6)                                              AS epoch
+                SELECT if(end_time = epoch, nan, dateDiff('microsecond', start_time, end_time) / 1000.0) AS duration_ms
+                """.formatted(startTime, endTime),
+                row -> row.get("duration_ms", Double.class));
+    }
+
+    private <T> T queryOne(String sql, Function<Row, T> mapper) {
+        return Mono.usingWhen(
+                connectionFactory.create(),
+                connection -> Mono.from(connection.createStatement(sql).execute())
+                        .flatMap(result -> Mono.from(result.map((row, ignored) -> mapper.apply(row)))),
+                Connection::close)
+                .block();
+    }
+
+    private void execute(String sql) {
+        Mono.usingWhen(
+                connectionFactory.create(),
+                connection -> Flux.from(connection.createStatement(sql).execute())
+                        .flatMap(Result::getRowsUpdated)
+                        .then(),
+                Connection::close)
+                .block();
+    }
+
+    @Builder(toBuilder = true)
+    record RangeQuantileAggregates(
+            Double minNullable,
+            Double maxNullable,
+            Double quantileNullable,
+            Double minNonNullable,
+            Double maxNonNullable,
+            Double quantileNonNullable) {
+    }
+
+    @Builder(toBuilder = true)
+    record WrappedAggregates(Long count,
+            Double sum,
+            Double avg,
+            Double min,
+            Double max,
+            Double quantile,
+            Double quantileNullable) {
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TraceSentinelIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TraceSentinelIntegrationTest.java
@@ -1,0 +1,418 @@
+package com.comet.opik.infrastructure;
+
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.TraceUpdate;
+import com.comet.opik.api.filter.Operator;
+import com.comet.opik.api.filter.TraceField;
+import com.comet.opik.api.filter.TraceFilter;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.ClientSupportUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
+import com.comet.opik.api.sorting.Direction;
+import com.comet.opik.api.sorting.SortableFields;
+import com.comet.opik.api.sorting.SortingField;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.redis.testcontainers.RedisContainer;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.Row;
+import lombok.Builder;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import reactor.core.publisher.Mono;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static com.comet.opik.api.resources.utils.AuthTestUtils.mockTargetWorkspace;
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.api.resources.utils.traces.TraceAssertions.assertTraces;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+/**
+ * Exercises the trace sentinel-column wiring with {@code traceColumnsNonNullable} enabled. The flag is a runtime
+ * concern, not a schema one — the epoch/{@code NaN} sentinels are ordinary values the still-{@code Nullable} columns
+ * store — so the flag-ON path (which the flag-OFF suites never reach) is verifiable before the non-nullable DDL ships:
+ * writes bind the sentinels, reads translate them back to {@code null}, and filters use the sentinel-aware SQL.
+ *
+ * <p>Tests are grouped by write path — single create, batch create, and update ({@code partialInsert}) — because each
+ * binds the sentinels independently; read and filter behavior is write-path-independent and covered once under
+ * {@code CreateTraces}. The physical-write tests read the raw columns back to prove the R2DBC driver serializes a
+ * bound {@code Double.NaN} to ClickHouse {@code nan} on write — the link the cutover hinges on, since a stray
+ * {@code NULL} write is rejected by a non-nullable column yet reads back indistinguishably from the sentinel.</p>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class TraceSentinelIntegrationTest {
+
+    private static final String API_KEY = "apiKey-" + UUID.randomUUID();
+    private static final String WORKSPACE_NAME = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+    private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+    private static final String USER = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
+
+    private final RedisContainer redisContainer = RedisContainerUtils.newRedisContainer();
+    private final MySQLContainer mysqlContainer = MySQLContainerUtils.newMySQLContainer();
+    private final GenericContainer<?> zookeeperContainer = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer clickHouseContainer = ClickHouseContainerUtils
+            .newClickHouseContainer(zookeeperContainer);
+
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(redisContainer, mysqlContainer, clickHouseContainer, zookeeperContainer)
+                .join();
+        wireMock = WireMockUtils.startWireMock();
+        var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(
+                clickHouseContainer, DATABASE_NAME);
+        MigrationUtils.runMysqlDbMigration(mysqlContainer);
+        MigrationUtils.runClickhouseDbMigration(clickHouseContainer);
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(mysqlContainer.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .redisUrl(redisContainer.getRedisURI())
+                        .runtimeInfo(wireMock.runtimeInfo())
+                        .customConfigs(List.of(
+                                new CustomConfig("databaseAnalyticsDataModel.traceColumnsNonNullable", "true")))
+                        .build());
+    }
+
+    private TraceResourceClient traceResourceClient;
+    private ConnectionFactory clickHouseConnectionFactory;
+
+    @BeforeAll
+    void beforeAll(ClientSupport clientSupport) {
+        var baseUrl = TestUtils.getBaseUrl(clientSupport);
+        ClientSupportUtils.config(clientSupport);
+        mockTargetWorkspace(wireMock.server(), API_KEY, WORKSPACE_NAME, WORKSPACE_ID, USER);
+        traceResourceClient = new TraceResourceClient(clientSupport, baseUrl);
+        clickHouseConnectionFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(
+                clickHouseContainer, DATABASE_NAME).build();
+    }
+
+    @AfterAll
+    void afterAll() {
+        wireMock.server().stop();
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class CreateTraces {
+
+        @Test
+        void absentEndTimeAndTtftRoundTripAsNull() {
+            var trace = newTraceBuilder()
+                    .endTime(null)
+                    .ttft(null)
+                    .build();
+            var id = traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
+
+            var actualTrace = traceResourceClient.getById(id, WORKSPACE_NAME, API_KEY);
+
+            // Field-by-field, not assertTraces: that helper also asserts the derived duration, but the materialized
+            // duration column is not yet guarded against an epoch end_time (that guard ships with the cutover DDL), so
+            // an absent end_time yields a negative duration instead of null. end_time/ttft are the sentinels under test.
+            assertThat(actualTrace.endTime()).isNull();
+            assertThat(actualTrace.ttft()).isNull();
+        }
+
+        @Test
+        void presentEndTimeAndTtftRoundTripUnchanged() {
+            var startTime = Instant.now().minusSeconds(1);
+            var expectedTrace = newTraceBuilder()
+                    .startTime(startTime)
+                    .endTime(startTime.plusSeconds(1))
+                    .build();
+            var id = traceResourceClient.createTrace(expectedTrace, API_KEY, WORKSPACE_NAME);
+
+            var actualTrace = traceResourceClient.getById(id, WORKSPACE_NAME, API_KEY);
+
+            assertTraces(List.of(actualTrace), List.of(expectedTrace), USER);
+        }
+
+        @Test
+        void absentSentinelsArePhysicallyWritten() {
+            var trace = newTraceBuilder()
+                    .endTime(null)
+                    .ttft(null)
+                    .duration(null)
+                    .build();
+            var id = traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
+
+            var expectedCounts = StoredSentinelCounts.builder()
+                    .nanTtftCount(1L)
+                    .epochEndTimeCount(1L)
+                    .build();
+            var actualCounts = queryStoredSentinelCounts(id);
+
+            assertThat(actualCounts).isEqualTo(expectedCounts);
+        }
+
+        Stream<Arguments> sentinelFilterExcludesAbsentTrace() {
+            return Stream.of(
+                    arguments(TraceField.END_TIME, Operator.LESS_THAN,
+                            Instant.now().plus(1, ChronoUnit.DAYS).toString()),
+                    arguments(TraceField.TTFT, Operator.GREATER_THAN, "1"),
+                    arguments(TraceField.DURATION, Operator.GREATER_THAN, "1"));
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource
+        void sentinelFilterExcludesAbsentTrace(TraceField field, Operator operator, String value) {
+            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var startTime = Instant.now().minusSeconds(1);
+            var presentTrace = newTraceBuilder()
+                    .projectName(projectName)
+                    .startTime(startTime)
+                    .endTime(startTime.plusSeconds(1))
+                    .ttft(5.0d)
+                    .build();
+            var absentTrace = newTraceBuilder()
+                    .projectName(projectName)
+                    .startTime(Instant.now())
+                    .endTime(null)
+                    .ttft(null)
+                    .duration(null)
+                    .build();
+            traceResourceClient.createTrace(presentTrace, API_KEY, WORKSPACE_NAME);
+            traceResourceClient.createTrace(absentTrace, API_KEY, WORKSPACE_NAME);
+
+            var filters = TraceFilter.builder()
+                    .field(field)
+                    .operator(operator).value(value)
+                    .build();
+            var page = traceResourceClient.getTraces(
+                    projectName, null, API_KEY, WORKSPACE_NAME, List.of(filters), List.of(), 10, Map.of());
+
+            assertTraces(page.content(), List.of(presentTrace), List.of(absentTrace), USER);
+        }
+
+        @Test
+        void sortByEndTimeAscendingOrdersAbsentTraceLast() {
+            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var startTime = Instant.now().minusSeconds(1);
+            var presentTrace = newTraceBuilder()
+                    .projectName(projectName)
+                    .startTime(startTime)
+                    .endTime(startTime.plusSeconds(1))
+                    .build();
+            var absentTrace = newTraceBuilder()
+                    .projectName(projectName)
+                    .endTime(null)
+                    .build();
+            traceResourceClient.createTrace(presentTrace, API_KEY, WORKSPACE_NAME);
+            traceResourceClient.createTrace(absentTrace, API_KEY, WORKSPACE_NAME);
+            var sortingField = SortingField.builder()
+                    .field(SortableFields.END_TIME)
+                    .direction(Direction.ASC)
+                    .build();
+
+            var page = traceResourceClient.getTraces(
+                    projectName, null, API_KEY, WORKSPACE_NAME, List.of(), List.of(sortingField), 10, Map.of());
+
+            // The sort maps end_time through nullIf(end_time, epoch), so the absent trace sorts as NULL (last),
+            // preserving Nullable-era ordering — not as the 1970 epoch, which would sort first ascending. Ids, not a
+            // full assertTraces: the absent trace's not-yet-epoch-guarded duration is a negative pre-cutover artifact.
+            var actualOrder = page.content().stream().map(Trace::id).toList();
+            assertThat(actualOrder).containsExactly(presentTrace.id(), absentTrace.id());
+        }
+    }
+
+    @Nested
+    class BatchCreateTraces {
+
+        @Test
+        void absentEndTimeAndTtftRoundTripAsNull() {
+            var trace = newTraceBuilder()
+                    .endTime(null)
+                    .ttft(null)
+                    .build();
+            traceResourceClient.batchCreateTraces(List.of(trace), API_KEY, WORKSPACE_NAME);
+
+            var actualTrace = traceResourceClient.getById(trace.id(), WORKSPACE_NAME, API_KEY);
+
+            assertThat(actualTrace.endTime()).isNull();
+            assertThat(actualTrace.ttft()).isNull();
+        }
+
+        @Test
+        void sentinelsArePhysicallyWrittenPerRow() {
+            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var startTime = Instant.now().minusSeconds(1);
+            var presentTrace = newTraceBuilder()
+                    .projectName(projectName)
+                    .startTime(startTime)
+                    .endTime(startTime.plusSeconds(1))
+                    .ttft(5.0d)
+                    .build();
+            var absentTrace = newTraceBuilder()
+                    .projectName(projectName)
+                    .endTime(null)
+                    .ttft(null)
+                    .duration(null)
+                    .build();
+            traceResourceClient.batchCreateTraces(List.of(presentTrace, absentTrace), API_KEY, WORKSPACE_NAME);
+
+            // Per-row indexed binding (end_time0, end_time1, ...): only the absent row must carry the sentinels.
+            var expectedAbsentCounts = StoredSentinelCounts.builder()
+                    .nanTtftCount(1L)
+                    .epochEndTimeCount(1L)
+                    .build();
+            var expectedPresentCounts = StoredSentinelCounts.builder()
+                    .nanTtftCount(0L)
+                    .epochEndTimeCount(0L)
+                    .build();
+            var actualAbsentCounts = queryStoredSentinelCounts(absentTrace.id());
+            var actualPresentCounts = queryStoredSentinelCounts(presentTrace.id());
+
+            assertThat(actualAbsentCounts).isEqualTo(expectedAbsentCounts);
+            assertThat(actualPresentCounts).isEqualTo(expectedPresentCounts);
+        }
+    }
+
+    @Nested
+    class UpdateTraces {
+
+        @Test
+        void updateOmittingEndTimeAndTtftKeepsStoredValues() {
+            var startTime = Instant.now().minusSeconds(1);
+            var expectedTrace = newTraceBuilder()
+                    .startTime(startTime)
+                    .endTime(startTime.plusSeconds(1))
+                    .ttft(5.0d)
+                    .build();
+            var id = traceResourceClient.createTrace(expectedTrace, API_KEY, WORKSPACE_NAME);
+            var update = factory.manufacturePojo(TraceUpdate.class).toBuilder()
+                    .projectId(null)
+                    .projectName(expectedTrace.projectName())
+                    .endTime(null)
+                    .ttft(null)
+                    .build();
+
+            traceResourceClient.updateTrace(id, update, API_KEY, WORKSPACE_NAME);
+            var actualTrace = traceResourceClient.getById(id, WORKSPACE_NAME, API_KEY);
+
+            // Under the flag an omitted end_time/ttft binds the epoch/NaN sentinel, so the merge must keep the stored
+            // value rather than overwrite it with the sentinel. Field-by-field since the update merges many fields.
+            assertThat(actualTrace.endTime()).isEqualTo(expectedTrace.endTime());
+            assertThat(actualTrace.ttft()).isEqualTo(expectedTrace.ttft());
+        }
+
+        @Test
+        void updateSettingEndTimeAndTtftPersistsThem() {
+            var trace = newTraceBuilder()
+                    .endTime(null)
+                    .ttft(null)
+                    .build();
+            var id = traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
+            var expectedUpdate = factory.manufacturePojo(TraceUpdate.class).toBuilder()
+                    .projectId(null)
+                    .projectName(trace.projectName())
+                    .endTime(Instant.now())
+                    .ttft(7.0d)
+                    .build();
+
+            traceResourceClient.updateTrace(id, expectedUpdate, API_KEY, WORKSPACE_NAME);
+            var actualTrace = traceResourceClient.getById(id, WORKSPACE_NAME, API_KEY);
+
+            assertThat(actualTrace.endTime()).isEqualTo(expectedUpdate.endTime());
+            assertThat(actualTrace.ttft()).isEqualTo(expectedUpdate.ttft());
+        }
+    }
+
+    @Nested
+    class Threads {
+
+        @Test
+        void absentEndTimeThreadReadsAsNull() {
+            var threadId = UUID.randomUUID().toString();
+            var trace = newTraceBuilder()
+                    .threadId(threadId)
+                    .endTime(null)
+                    .build();
+            var traceId = traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
+            var projectId = traceResourceClient.getById(traceId, WORKSPACE_NAME, API_KEY).projectId();
+
+            var thread = traceResourceClient.getTraceThread(threadId, projectId, API_KEY, WORKSPACE_NAME);
+
+            // A thread's end_time is max(trace end_time); with every trace absent it is the epoch, so the flag-gated
+            // ThreadDAO read must surface null rather than the 1970 sentinel.
+            assertThat(thread.endTime()).isNull();
+        }
+    }
+
+    private Trace.TraceBuilder newTraceBuilder() {
+        return factory.manufacturePojo(Trace.class).toBuilder()
+                .feedbackScores(null)
+                .usage(null)
+                .errorInfo(null);
+    }
+
+    /**
+     * Raw stored-sentinel counts for a trace. {@code countIf} yields {@code UInt64} (marshaled to {@code Long}); a
+     * {@code NaN} ttft / epoch end_time counts 1, whereas a wrongly-written {@code NULL} makes {@code isNaN(...)} /
+     * {@code (end_time = epoch)} evaluate to {@code NULL} and count 0 — which is what distinguishes a physically-written
+     * sentinel from the {@code NULL} the still-{@code Nullable} column would also accept.
+     */
+    private StoredSentinelCounts queryStoredSentinelCounts(UUID traceId) {
+        return queryOne("""
+                SELECT countIf(isNaN(ttft))                                             AS nan_ttft_count,
+                       countIf(end_time = toDateTime64('1970-01-01 00:00:00.000', 9))   AS epoch_end_time_count
+                FROM traces FINAL
+                WHERE workspace_id = '%s' AND id = '%s'
+                """.formatted(WORKSPACE_ID, traceId),
+                row -> StoredSentinelCounts.builder()
+                        .nanTtftCount(row.get("nan_ttft_count", Long.class))
+                        .epochEndTimeCount(row.get("epoch_end_time_count", Long.class))
+                        .build());
+    }
+
+    private <T> T queryOne(String sql, Function<Row, T> mapper) {
+        return Mono.usingWhen(
+                clickHouseConnectionFactory.create(),
+                connection -> Mono.from(connection.createStatement(sql).execute())
+                        .flatMap(result -> Mono.from(result.map((row, ignored) -> mapper.apply(row)))),
+                Connection::close)
+                .block();
+    }
+
+    @Builder(toBuilder = true)
+    private record StoredSentinelCounts(Long nanTtftCount, Long epochEndTimeCount) {
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TraceSentinelIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TraceSentinelIntegrationTest.java
@@ -401,11 +401,13 @@ class TraceSentinelIntegrationTest {
             // Materialize both thread records so they surface in the list endpoint.
             traceResourceClient.getTraceThread(presentThreadId, projectId, API_KEY, WORKSPACE_NAME);
             traceResourceClient.getTraceThread(absentThreadId, projectId, API_KEY, WORKSPACE_NAME);
-            var sortByEndTimeAsc = List.of(
-                    SortingField.builder().field(SortableFields.END_TIME).direction(Direction.ASC).build());
+            var sortingField = SortingField.builder()
+                    .field(SortableFields.END_TIME)
+                    .direction(Direction.ASC)
+                    .build();
 
             var page = traceResourceClient.getTraceThreads(
-                    projectId, projectName, API_KEY, WORKSPACE_NAME, List.of(), sortByEndTimeAsc, Map.of());
+                    projectId, projectName, API_KEY, WORKSPACE_NAME, List.of(), List.of(sortingField), Map.of());
 
             // Thread end_time is max(trace end_time); the all-absent thread's epoch sorts as NULL (last) via
             // nullIf(end_time, epoch), not as 1970 (first) — only the flag-gated sort mapping produces this order.

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TraceSentinelIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TraceSentinelIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.comet.opik.infrastructure;
 
 import com.comet.opik.api.Trace;
+import com.comet.opik.api.TraceThread;
 import com.comet.opik.api.TraceUpdate;
 import com.comet.opik.api.filter.Operator;
 import com.comet.opik.api.filter.TraceField;
@@ -374,6 +375,44 @@ class TraceSentinelIntegrationTest {
             // A thread's end_time is max(trace end_time); with every trace absent it is the epoch, so the flag-gated
             // ThreadDAO read must surface null rather than the 1970 sentinel.
             assertThat(thread.endTime()).isNull();
+        }
+
+        @Test
+        void sortByEndTimeAscendingOrdersAbsentThreadLast() {
+            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var presentThreadId = "thread-" + UUID.randomUUID();
+            var absentThreadId = "thread-" + UUID.randomUUID();
+            var startTime = Instant.now().minusSeconds(1);
+            var presentTrace = newTraceBuilder()
+                    .projectName(projectName)
+                    .threadId(presentThreadId)
+                    .startTime(startTime)
+                    .endTime(startTime.plusSeconds(1))
+                    .build();
+            var absentTrace = newTraceBuilder()
+                    .projectName(projectName)
+                    .threadId(absentThreadId)
+                    .startTime(Instant.now())
+                    .endTime(null)
+                    .build();
+            var presentTraceId = traceResourceClient.createTrace(presentTrace, API_KEY, WORKSPACE_NAME);
+            traceResourceClient.createTrace(absentTrace, API_KEY, WORKSPACE_NAME);
+            var projectId = traceResourceClient.getById(presentTraceId, WORKSPACE_NAME, API_KEY).projectId();
+            // Materialize both thread records so they surface in the list endpoint.
+            traceResourceClient.getTraceThread(presentThreadId, projectId, API_KEY, WORKSPACE_NAME);
+            traceResourceClient.getTraceThread(absentThreadId, projectId, API_KEY, WORKSPACE_NAME);
+            var sortByEndTimeAsc = List.of(
+                    SortingField.builder().field(SortableFields.END_TIME).direction(Direction.ASC).build());
+
+            var page = traceResourceClient.getTraceThreads(
+                    projectId, projectName, API_KEY, WORKSPACE_NAME, List.of(), sortByEndTimeAsc, Map.of());
+
+            // Thread end_time is max(trace end_time); the all-absent thread's epoch sorts as NULL (last) via
+            // nullIf(end_time, epoch), not as 1970 (first) — only the flag-gated sort mapping produces this order.
+            var endTimes = page.content().stream().map(TraceThread::endTime).toList();
+            assertThat(endTimes).hasSize(2);
+            assertThat(endTimes.get(0)).isNotNull();
+            assertThat(endTimes.get(1)).isNull();
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TraceSentinelIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TraceSentinelIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.comet.opik.infrastructure;
 
 import com.comet.opik.api.Trace;
-import com.comet.opik.api.TraceThread;
 import com.comet.opik.api.TraceUpdate;
 import com.comet.opik.api.filter.Operator;
 import com.comet.opik.api.filter.TraceField;
@@ -57,6 +56,7 @@ import java.util.stream.Stream;
 
 import static com.comet.opik.api.resources.utils.AuthTestUtils.mockTargetWorkspace;
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.api.resources.utils.traces.TraceAssertions.assertThreads;
 import static com.comet.opik.api.resources.utils.traces.TraceAssertions.assertTraces;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -397,24 +397,23 @@ class TraceSentinelIntegrationTest {
                     .build();
             var presentTraceId = traceResourceClient.createTrace(presentTrace, API_KEY, WORKSPACE_NAME);
             traceResourceClient.createTrace(absentTrace, API_KEY, WORKSPACE_NAME);
+
             var projectId = traceResourceClient.getById(presentTraceId, WORKSPACE_NAME, API_KEY).projectId();
-            // Materialize both thread records so they surface in the list endpoint.
-            traceResourceClient.getTraceThread(presentThreadId, projectId, API_KEY, WORKSPACE_NAME);
-            traceResourceClient.getTraceThread(absentThreadId, projectId, API_KEY, WORKSPACE_NAME);
+            // Retrieve materializes each thread record (so it surfaces in the list) and gives the expected
+            // sorted order: present first, all-absent (end_time = NULL) last.
+            var expectedPresent = traceResourceClient.getTraceThread(presentThreadId, projectId, API_KEY,
+                    WORKSPACE_NAME);
+            var expectedAbsent = traceResourceClient.getTraceThread(absentThreadId, projectId, API_KEY, WORKSPACE_NAME);
             var sortingField = SortingField.builder()
                     .field(SortableFields.END_TIME)
                     .direction(Direction.ASC)
                     .build();
-
             var page = traceResourceClient.getTraceThreads(
                     projectId, projectName, API_KEY, WORKSPACE_NAME, List.of(), List.of(sortingField), Map.of());
 
-            // Thread end_time is max(trace end_time); the all-absent thread's epoch sorts as NULL (last) via
+            // A thread's end_time is max(trace end_time); the all-absent thread's epoch sorts as NULL (last) via
             // nullIf(end_time, epoch), not as 1970 (first) — only the flag-gated sort mapping produces this order.
-            var endTimes = page.content().stream().map(TraceThread::endTime).toList();
-            assertThat(endTimes).hasSize(2);
-            assertThat(endTimes.get(0)).isNotNull();
-            assertThat(endTimes.get(1)).isNull();
+            assertThreads(List.of(expectedPresent, expectedAbsent), page.content());
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/utils/SentinelTranslationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/utils/SentinelTranslationTest.java
@@ -1,0 +1,124 @@
+package com.comet.opik.utils;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static com.comet.opik.utils.ValidationUtils.CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class SentinelTranslationTest {
+
+    @Nested
+    class Outbound {
+
+        static Stream<Arguments> epochToNull() {
+            var realTime = Instant.now();
+            return Stream.of(
+                    arguments(Instant.EPOCH, null),
+                    arguments(null, null),
+                    arguments(realTime, realTime));
+        }
+
+        @ParameterizedTest(name = "epochToNull({0}) -> {1}")
+        @MethodSource
+        void epochToNull(Instant input, Instant expected) {
+            var actual = SentinelTranslation.epochToNull(input);
+
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        static Stream<Arguments> nanToNull() {
+            var realValue = RandomUtils.secure().randomDouble();
+            return Stream.of(
+                    arguments(Double.NaN, null),
+                    arguments(null, null),
+                    arguments(0.0d, 0.0d),
+                    arguments(realValue, realValue),
+                    arguments(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY),
+                    arguments(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY));
+        }
+
+        @ParameterizedTest(name = "nanToNull({0}) -> {1}")
+        @MethodSource
+        void nanToNull(Double input, Double expected) {
+            var actual = SentinelTranslation.nanToNull(input);
+
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        static Stream<Arguments> emptyUuidToNull() {
+            var realUUID = UUID.randomUUID().toString();
+            return Stream.of(
+                    arguments("  ", null),
+                    arguments(CLICKHOUSE_FIXED_STRING_UUID_FIELD_NULL_VALUE, null),
+                    arguments(null, null),
+                    arguments(realUUID, realUUID));
+        }
+
+        @ParameterizedTest(name = "emptyUuidToNull([{0}]) -> {1}")
+        @MethodSource
+        void emptyUuidToNull(String input, String expected) {
+            var actual = SentinelTranslation.emptyUuidToNull(input);
+
+            assertThat(actual).isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    class Inbound {
+
+        static Stream<Arguments> nullToEpoch() {
+            var realTime = Instant.now();
+            return Stream.of(
+                    arguments(null, Instant.EPOCH),
+                    arguments(realTime, realTime));
+        }
+
+        @ParameterizedTest(name = "nullToEpoch({0}) -> {1}")
+        @MethodSource
+        void nullToEpoch(Instant input, Instant expected) {
+            var actual = SentinelTranslation.nullToEpoch(input);
+
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        static Stream<Arguments> nullToNaN() {
+            var realValue = RandomUtils.secure().randomDouble();
+            return Stream.of(
+                    arguments(null, Double.NaN),
+                    arguments(realValue, realValue));
+        }
+
+        @ParameterizedTest(name = "nullToNaN({0}) -> {1}")
+        @MethodSource
+        void nullToNaN(Double input, Double expected) {
+            var actual = SentinelTranslation.nullToNaN(input);
+
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        static Stream<Arguments> nullToEmptyUuid() {
+            var realUUID = UUID.randomUUID().toString();
+            return Stream.of(
+                    arguments(null, ""),
+                    arguments("  ", ""),
+                    arguments(realUUID, realUUID));
+        }
+
+        @ParameterizedTest(name = "nullToEmptyUuid({0}) -> [{1}]")
+        @MethodSource
+        void nullToEmptyUuid(String input, String expected) {
+            var actual = SentinelTranslation.nullToEmptyUuid(input);
+
+            assertThat(actual).isEqualTo(expected);
+        }
+    }
+}

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -80,6 +80,16 @@ databaseAnalytics:
   #  Description: Timeout for the ClickHouse health check query (e.g. 1s, 500ms, 2 minutes)
   healthCheckTimeout: 1s
 
+# Description: Cutover toggles migrating the trace analytics columns to non-nullable, sentinel-defaulted form.
+databaseAnalyticsDataModel:
+  #  Default: false
+  #  Description: Leave false while the traces table still has Nullable end_time/duration/ttft columns; trace writes
+  #   bind null for absent end_time/ttft. Set true once replaced with sentinel-defaulted
+  #   non-nullable columns so writes bind the sentinels (end_time->epoch, ttft->NaN) instead. Gates reads too, so
+  #   while false a legitimate epoch end time round-trips unchanged instead of reading as null.
+  #   Flip in lockstep with the cutover EXCHANGE.
+  traceColumnsNonNullable: false
+
 # Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the
 #   window, protecting data quality.
 uuidValidation:


### PR DESCRIPTION
## Details

Preparation for the ClickHouse data-model revamp that will drop `Nullable(...)` from the high-volume `traces` analytics columns (`end_time`, `duration`, `ttft`) in favour of collision-free, index-friendly sentinels. This lands the framework and its tests now; the DDL cutover activates it in a later slice. Behavior is unchanged while the columns are still nullable — the new `traceColumnsNonNullable` toggle defaults off.

- `SentinelTranslation`: a single translation point mapping sentinel ↔ API `null` in both directions — epoch ↔ `null` for `DateTime64`, `NaN` ↔ `null` for `Float64`, empty/all-NUL ↔ `null` for `FixedString(36)`.
- `FilterQueryBuilder`: flag-gated sentinel-aware `end_time` (`nullIf(end_time, epoch)`), plus epoch/`NaN` guards on `duration`/`ttft` filters that are provable no-ops while the columns are nullable.
- DAOs (`TraceDAO`, `ThreadDAO`, `KpiCardDAO`, `ProjectMetricsDAO`, and the shared duration expression consumers): bind sentinels on write and translate them back on read under the flag; NaN-safe aggregates (`avg` wrapped with `if(isNaN(...))`, `quantile` relies on native NaN-skipping).
- New `databaseAnalyticsDataModel.traceColumnsNonNullable` config toggle (default `false`), intended to be flipped in lockstep with the cutover EXCHANGE.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-6892

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: assisted — implementation and tests
- Human verification: code review + integration tests on the target ClickHouse image

## Testing

Backend unit and integration tests (integration via Testcontainers on the target ClickHouse image `25.8.16.34`), green locally:

- `SentinelTranslationTest` — sentinel ↔ `null` translation across all branches (null / sentinel / real values, ±infinity pass-through, empty and all-NUL `FixedString(36)` forms).
- `FilterQueryBuilderSentinelTest` — flag-gated `end_time` and unconditional `duration`/`ttft` filter SQL, asserted for both flag states.
- `NaNAwareAggregateIntegrationTest` — ClickHouse `NaN` aggregate semantics (`min`/`max`/`quantile` skip `NaN`; the `<agg>If(NOT isNaN(x))` form restores NULL-skipping for `sum`/`avg`/`count`) and the guarded `duration` materialized formula (emits `NaN` at the epoch sentinel).
- `TraceSentinelIntegrationTest` — flag-ON end-to-end wiring against the still-nullable schema (valid because the sentinels are ordinary nullable values): create / batch / update / thread round-trips, a raw physical-write proof that the R2DBC driver serializes a bound `Double.NaN` to ClickHouse `nan` on write (including per-row binding in a mixed batch), sentinel-aware filter exclusion, and `end_time` sort ordering.

The full backend suite runs in CI. Flag-off behavior (the default) is unchanged and is exercised by the existing trace/thread/metrics suites.

## Documentation

N/A — no user-facing or SDK documentation changes; the data-model revamp design is tracked in the Jira ticket.
