### PR TITLE
[OPIK-7154] [BE] test: tolerate cross-store microsecond rounding in last-trace assertions

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -1400,12 +1400,12 @@ class ProjectsResourceTest {
             assertThat(actualEntity.content().stream().map(Project::id).toList())
                     .isEqualTo(List.of(id3, id2, id));
 
-            assertThat(actualEntity.content().get(0).lastUpdatedTraceAt())
-                    .isEqualTo(expectedProject3.lastUpdatedTraceAt());
-            assertThat(actualEntity.content().get(1).lastUpdatedTraceAt())
-                    .isEqualTo(expectedProject2.lastUpdatedTraceAt());
-            assertThat(actualEntity.content().get(2).lastUpdatedTraceAt())
-                    .isEqualTo(expectedProject.lastUpdatedTraceAt());
+            assertLastUpdatedTraceAtEquals(actualEntity.content().get(0).lastUpdatedTraceAt(),
+                    expectedProject3.lastUpdatedTraceAt());
+            assertLastUpdatedTraceAtEquals(actualEntity.content().get(1).lastUpdatedTraceAt(),
+                    expectedProject2.lastUpdatedTraceAt());
+            assertLastUpdatedTraceAtEquals(actualEntity.content().get(2).lastUpdatedTraceAt(),
+                    expectedProject.lastUpdatedTraceAt());
 
             assertAllProjectsHavePersistedLastTraceAt(workspaceId, List.of(expectedProject, expectedProject2,
                     expectedProject3));
@@ -1714,11 +1714,12 @@ class ProjectsResourceTest {
             assertThat(actualEntity.content().stream().map(Project::id).toList())
                     .isEqualTo(List.of(id3, id2, id1));
 
-            // project3 and project2 carry explicit client timestamps, so the recorded marker matches exactly.
-            assertThat(actualEntity.content().get(0).lastUpdatedTraceAt())
-                    .isEqualTo(expectedProject3.lastUpdatedTraceAt());
-            assertThat(actualEntity.content().get(1).lastUpdatedTraceAt())
-                    .isEqualTo(expectedProject2.lastUpdatedTraceAt());
+            // project3 and project2 carry explicit client timestamps, so the recorded marker matches the stored value
+            // (within the micro-level rounding difference between MySQL and ClickHouse storage).
+            assertLastUpdatedTraceAtEquals(actualEntity.content().get(0).lastUpdatedTraceAt(),
+                    expectedProject3.lastUpdatedTraceAt());
+            assertLastUpdatedTraceAtEquals(actualEntity.content().get(1).lastUpdatedTraceAt(),
+                    expectedProject2.lastUpdatedTraceAt());
             // project1 left lastUpdatedAt null, so its marker is the event publish time: at or after the stored
             // value and not in the future.
             assertThat(actualEntity.content().get(2).lastUpdatedTraceAt())
@@ -2424,9 +2425,23 @@ class ProjectsResourceTest {
         assertThat(actualEntity.lastUpdatedBy()).isEqualTo(USER);
         assertThat(actualEntity.createdBy()).isEqualTo(USER);
 
-        assertThat(actualEntity.lastUpdatedTraceAt()).isEqualTo(project.lastUpdatedTraceAt());
+        assertLastUpdatedTraceAtEquals(actualEntity.lastUpdatedTraceAt(), project.lastUpdatedTraceAt());
         assertThat(actualEntity.createdAt()).isAfter(project.createdAt());
         assertThat(actualEntity.lastUpdatedAt()).isAfter(project.createdAt());
+    }
+
+    /**
+     * last_updated_trace_at is persisted to MySQL (rounds sub-microsecond nanos to micros) while the trace's
+     * last_updated_at is stored in ClickHouse (truncates to micros), so the two representations of the same instant
+     * can differ by up to one microsecond. Compare with the same micro tolerance used for the persisted-marker
+     * assertions. Handles null (projects without traces) explicitly since the comparator dereferences the values.
+     */
+    private void assertLastUpdatedTraceAtEquals(Instant actual, Instant expected) {
+        if (expected == null) {
+            assertThat(actual).isNull();
+        } else {
+            assertThat(actual).usingComparator(TestComparators::compareMicroNanoTime).isEqualTo(expected);
+        }
     }
 
     private void requestAndAssertLastTraceSorting(String workspaceName, String apiKey, List<Project> allProjects,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -137,6 +137,7 @@ import static java.util.stream.Collectors.averagingDouble;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -2431,16 +2432,15 @@ class ProjectsResourceTest {
     }
 
     /**
-     * last_updated_trace_at is persisted to MySQL (rounds sub-microsecond nanos to micros) while the trace's
-     * last_updated_at is stored in ClickHouse (truncates to micros), so the two representations of the same instant
-     * can differ by up to one microsecond. Compare with the same micro tolerance used for the persisted-marker
-     * assertions. Handles null (projects without traces) explicitly since the comparator dereferences the values.
+     * Compares a project's last_updated_trace_at marker with a one-microsecond tolerance: MySQL rounds it to micros
+     * while the source ClickHouse trace timestamp is truncated, so the same instant can differ by up to a microsecond.
+     * Null (projects without traces) is handled separately.
      */
     private void assertLastUpdatedTraceAtEquals(Instant actual, Instant expected) {
         if (expected == null) {
             assertThat(actual).isNull();
         } else {
-            assertThat(actual).usingComparator(TestComparators::compareMicroNanoTime).isEqualTo(expected);
+            assertThat(actual).isCloseTo(expected, within(1, ChronoUnit.MICROS));
         }
     }
 


### PR DESCRIPTION
## Details

Fixes flaky `ProjectsResourceTest` assertions that landed with #7288. `projects.last_updated_trace_at` is persisted to MySQL (`TIMESTAMP(6)`, which **rounds** sub-microsecond nanoseconds to micros) while a trace's `last_updated_at` is stored in ClickHouse (`formatMicros`, which **truncates**), so the two representations of the same instant can differ by up to one microsecond. The page-level exact `isEqualTo` assertions passed on microsecond-precision macOS but flaked (~50%) on nanosecond-precision Linux CI.

- Compare the marker with the same micro tolerance already used by the persisted-marker assertions (`TestComparators.compareMicroNanoTime`), via a shared null-safe `assertLastUpdatedTraceAtEquals` helper (covers the two find-projects tests and the get-project assertion).
- Test-only change; production behavior is unchanged — the marker is a coarse "last active" sort key where sub-second differences are expected and accepted.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7154 (follow-up: fixes flaky tests introduced by #7288)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: root-cause analysis + fix
- Human verification: reviewed; affected tests run locally

## Testing

- Ran the affected tests locally: `ProjectsResourceTest$FindProject#getProjects__whenProjectsHasTraces__thenReturnProjectWithLastUpdatedTraceAt`, `getProjects__whenProjectsHasTracesBatch__thenReturnProjectWithLastUpdatedTraceAt`, and `ProjectsResourceTest$GetProject` — all pass (5 tests) via Testcontainers (ClickHouse + MySQL).
- The flake only manifests on nanosecond-precision clocks (Linux CI); macOS local runs are microsecond-precision and pass regardless. The fix mirrors the tolerance of the already-stable persisted-marker assertions, so CI should be green.

## Documentation

N/A — test-only change.
