### PR TITLE
[OPIK-7136] [DOCS] [GHA] fix: repair docs broken links and re-verify transient 429/500 in link check

### DIFF
--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -13,8 +13,9 @@ concurrency:
 jobs:
     run:
         runs-on: ubuntu-latest
-        # Recent runs hug the old 15-min ceiling (13.5–14.6 min); the external re-verify
-        # curls added below need headroom so they can't tip a run into a spurious timeout.
+        # Recent runs hug the old 15-min ceiling (13.5–14.6 min). Re-verify now runs in
+        # parallel (bounded to ~one round-trip), so the crawl dominates; 20 gives headroom
+        # while the step logs reveal the true crawl-only duration.
         timeout-minutes: 20
         permissions: write-all
         steps:
@@ -74,6 +75,12 @@ jobs:
                   exit 0
                 fi
 
+                # Progress to the step log (not the PR comment) so a slow run is diagnosable:
+                # show that the crawl finished and the status breakdown it produced.
+                echo "Crawl complete: $(jq '.links | length' linkinator_results.json) links checked."
+                echo "Status breakdown:"
+                jq -r '.links | group_by(.status) | map("  \(.[0].status // "none"): \(length)") | .[]' linkinator_results.json
+
                 # `↳ on page` strips the ephemeral preview host, leaving a stable,
                 # greppable doc path. Append one report entry for a status-0 url whose
                 # recheck label is computed by the caller.
@@ -95,59 +102,119 @@ jobs:
                   | "❌ Broken link: \(.url) (\(.status))\n   ↳ on page: \((.parent // "") | sub("^" + $origin; ""))"
                 ' linkinator_results.json)
 
-                # SSRF guard for re-verify: a PR author controls the links being fetched, so
-                # before curling an external host we require http(s) and reject any host that
-                # resolves into a private/loopback/link-local/metadata range. Exits 0 (safe)
-                # or 1 (blocked). Preview-origin URLs skip this — they are ours by construction.
-                cat > ssrf_guard.py <<'PY'
-                import ipaddress, socket, sys
+                # Re-verify transient links concurrently while preserving an SSRF guard.
+                # A PR author controls these links, so before fetching any URL we require
+                # http(s) and reject hosts that resolve into private/loopback/link-local/
+                # metadata ranges. curl -L would follow a 30x to an arbitrary host WITHOUT
+                # re-checking, so a public URL could bounce to a private/metadata address and
+                # be fetched unguarded — instead this follows redirects manually in waves:
+                # guard every URL, fetch a whole wave in parallel with a single `curl -Z`
+                # (one process, no -L), then guard each Location before the next wave. Real
+                # hosts still resolve (many links legitimately 30x, e.g. http→https or
+                # sdk.vercel.ai→ai-sdk.dev); a redirect into a blocked range is unreachable.
+                # Prints one "<url>\t<label>" line per still-broken url (reachable ones print
+                # nothing). Parallelism keeps the whole phase to ~one round-trip even for a
+                # large 429/500 storm, instead of serializing curls into the job timeout.
+                cat > reverify.py <<'PY'
+                import ipaddress, socket, subprocess, sys
                 from urllib.parse import urlparse
-                url = sys.argv[1]
-                p = urlparse(url)
-                if p.scheme not in ("http", "https") or not p.hostname:
-                    sys.exit(1)
-                try:
-                    infos = socket.getaddrinfo(p.hostname, p.port or (443 if p.scheme == "https" else 80))
-                except socket.gaierror:
-                    sys.exit(1)  # unresolvable — treat as unsafe, report as broken
-                for info in infos:
-                    ip = ipaddress.ip_address(info[4][0])
-                    if (ip.is_private or ip.is_loopback or ip.is_link_local
-                            or ip.is_multicast or ip.is_reserved or ip.is_unspecified):
-                        sys.exit(1)
-                sys.exit(0)
+
+                MAX_REDIRECTS = 5
+                PARALLEL_MAX = 20
+                TIMEOUT = 8
+                MAX_REVERIFY = 200  # sanity cap; overflow reported broken (fail loud)
+
+                def is_safe(url):
+                    p = urlparse(url)
+                    if p.scheme not in ("http", "https") or not p.hostname:
+                        return False
+                    try:
+                        infos = socket.getaddrinfo(p.hostname, p.port or (443 if p.scheme == "https" else 80))
+                    except socket.gaierror:
+                        return False
+                    for info in infos:
+                        ip = ipaddress.ip_address(info[4][0])
+                        if (ip.is_private or ip.is_loopback or ip.is_link_local
+                                or ip.is_multicast or ip.is_reserved or ip.is_unspecified):
+                            return False
+                    return True
+
+                def fetch_all(urls):
+                    cfg = []
+                    for u in urls:
+                        cfg.append('url = "%s"' % u)
+                        cfg.append('output = "/dev/null"')
+                    proc = subprocess.run(
+                        ["curl", "-s", "-Z", "--parallel-max", str(PARALLEL_MAX),
+                         "--max-time", str(TIMEOUT),
+                         "-w", "%{url}\t%{http_code}\t%{redirect_url}\n", "-K", "-"],
+                        input="\n".join(cfg), capture_output=True, text=True,
+                    )
+                    out = {}
+                    for line in proc.stdout.splitlines():
+                        parts = line.split("\t")
+                        if len(parts) == 3:
+                            out[parts[0]] = (parts[1], parts[2])
+                    return out
+
+                candidates = list(dict.fromkeys(a for a in sys.argv[1:] if a))
+                broken = {}
+                for u in candidates[MAX_REVERIFY:]:
+                    broken[u] = "not re-verified, over cap of %d" % MAX_REVERIFY
+                pending = candidates[:MAX_REVERIFY]
+                origin = {u: u for u in pending}
+                for _hop in range(MAX_REDIRECTS + 1):
+                    if not pending:
+                        break
+                    safe, blocked = [], []
+                    for u in pending:
+                        (safe if is_safe(u) else blocked).append(u)
+                    for u in blocked:
+                        broken[origin[u]] = "blocked by SSRF guard or unresolvable"
+                    if not safe:
+                        pending = []
+                        break
+                    results = fetch_all(safe)
+                    nxt = []
+                    for u in safe:
+                        code, redirect = results.get(u, ("000", ""))
+                        orig = origin[u]
+                        if code.startswith("2"):
+                            continue
+                        if code.startswith("3"):
+                            if not redirect:
+                                broken[orig] = "recheck %s (no location)" % code
+                            else:
+                                origin[redirect] = orig
+                                nxt.append(redirect)
+                        else:
+                            broken[orig] = "recheck %s" % (code or "000")
+                    pending = nxt
+                for u in pending:
+                    broken[origin.get(u, u)] = "recheck too many redirects"
+                for url, label in broken.items():
+                    print("%s\t%s" % (url, label))
                 PY
 
                 # Status 0 ("crawl gave up"), 429 (HuggingFace throttling linkinator's burst)
                 # and 500 (Fern preview erroring under crawl load) are all transient false
-                # positives — each returns 2xx/3xx when fetched on its own. Re-check each once
-                # and keep it only if still unreachable. Capped at 50 re-verifies so a 500-storm
-                # can't serialize hundreds of curls into the job timeout; the overflow is
-                # reported as broken (fail loud) rather than silently skipped.
-                MAX_REVERIFY=50
-                count=0
-                while IFS= read -r url; do
-                  [ -z "$url" ] && continue
-                  count=$((count + 1))
-                  if [ "$count" -gt "$MAX_REVERIFY" ]; then
-                    report_timeout "$url" "not re-verified, over cap of $MAX_REVERIFY"
-                    continue
-                  fi
-                  case "$url" in
-                    "$PREVIEW_ORIGIN"/*|"$PREVIEW_ORIGIN") ;;   # ours — no SSRF check needed
-                    *)
-                      if ! python3 ssrf_guard.py "$url" 2>/dev/null; then
-                        report_timeout "$url" "blocked by SSRF guard or unresolvable"
-                        continue
-                      fi
-                      ;;
-                  esac
-                  code=$(curl -s -L -o /dev/null -w "%{http_code}" --max-time 20 "$url" 2>/dev/null)
-                  { [ -n "$code" ] && [ "$code" -ge 200 ] && [ "$code" -lt 400 ]; } && continue
-                  report_timeout "$url" "recheck ${code:-000}"
-                done <<< "$(jq -r '[.links[] | select(.status == 0 or .status == 429 or .status == 500) | .url] | unique | .[]' linkinator_results.json)"
+                # positives — each returns 2xx/3xx when fetched on its own.
+                REVERIFY_URLS=$(jq -r '[.links[] | select(.status == 0 or .status == 429 or .status == 500) | .url] | unique | .[]' linkinator_results.json)
+                total_reverify=$(printf '%s\n' "$REVERIFY_URLS" | grep -c . || true)
+                echo "Re-verifying $total_reverify transient (0/429/500) link(s) in parallel..."
+                still_broken=0
+                if [ "$total_reverify" -gt 0 ]; then
+                  # xargs feeds all urls as args; reverify.py fetches them concurrently.
+                  while IFS=$'\t' read -r url label; do
+                    [ -z "$url" ] && continue
+                    echo "  broken: $url -> $label"
+                    report_timeout "$url" "$label"
+                    still_broken=$((still_broken + 1))
+                  done < <(printf '%s\n' "$REVERIFY_URLS" | xargs python3 reverify.py)
+                fi
+                echo "Re-verify done: $still_broken of $total_reverify still broken."
 
-                rm -f ssrf_guard.py
+                rm -f reverify.py
 
                 if [ -n "$BROKEN_LINKS" ]; then
                   {

--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -44,35 +44,46 @@ jobs:
               run: |
                 echo -e "\n\n" >> preview_url.txt
 
-                # linkinator's own retry flags handle the transient failures we used to see:
-                #   --retry        honors Retry-After on 429s (HuggingFace throttling the burst)
-                #   --retry-errors retries 5xx and network/"unknown" responses (Fern erroring
-                #                  under crawl load, dropped-socket crashes), with backoff+jitter
-                # so we no longer re-verify links ourselves. --concurrency 25 keeps the burst
-                # small enough to avoid saturating the preview CDN in the first place.
-                npx linkinator ${{ steps.generate-docs.outputs.URL }} \
-                  --recurse \
-                  --concurrency 25 \
-                  --retry \
-                  --retry-errors \
-                  --retry-errors-count 3 \
-                  --retry-errors-jitter 2000 \
-                  --skip "search\/v2\/key" \
-                  --skip "https://ai.google.dev/gemini-api" \
-                  --skip "https://ai.google.dev/aistudio" \
-                  --skip "chat.comet.com" \
-                  --skip "http://localhost" \
-                  --skip "http://localhost:5173" \
-                  --skip "googletagmanager.com" \
-                  --skip "insights/script.js" \
-                  --format json > linkinator_results.json 2>/dev/null || true
+                # --retry/--retry-errors handle per-link transience (429 Retry-After, 5xx and
+                # network/"unknown" responses) with backoff+jitter, so we don't re-verify links
+                # ourselves. But they can't rescue a crawl that CRASHES: linkinator emits an
+                # unhandled 'error' event on a dropped socket ("SocketError: other side closed"),
+                # which throws and kills the process with no JSON written — there is no per-link
+                # result left to retry. So we also retry the whole crawl once, and send stderr to
+                # the step log (NOT /dev/null) so a crash is diagnosable. --concurrency 25 keeps
+                # the burst small enough to make the crash rare in the first place.
+                crawl() {
+                  npx linkinator ${{ steps.generate-docs.outputs.URL }} \
+                    --recurse \
+                    --concurrency 25 \
+                    --retry \
+                    --retry-errors \
+                    --retry-errors-count 3 \
+                    --retry-errors-jitter 2000 \
+                    --skip "search\/v2\/key" \
+                    --skip "https://ai.google.dev/gemini-api" \
+                    --skip "https://ai.google.dev/aistudio" \
+                    --skip "chat.comet.com" \
+                    --skip "http://localhost" \
+                    --skip "http://localhost:5173" \
+                    --skip "googletagmanager.com" \
+                    --skip "insights/script.js" \
+                    --format json > linkinator_results.json || true
+                }
+                json_ok() { jq -e 'type == "object" and (.links | type == "array")' linkinator_results.json > /dev/null 2>&1; }
+
+                crawl
+                if ! json_ok; then
+                  echo "Crawl produced no valid JSON (likely a dropped-socket crash); retrying once..."
+                  crawl
+                fi
 
                 PREVIEW_ORIGIN=$(echo "${{ steps.generate-docs.outputs.URL }}" | grep -oE '^https?://[^/]+')
 
                 # linkinator exits non-zero both when it finds broken links and when it
                 # crashes mid-crawl (e.g. unhandled ECONNRESET), so trust the output, not
                 # the exit code: invalid/missing JSON means the crawl didn't complete.
-                if ! jq -e 'type == "object" and (.links | type == "array")' linkinator_results.json > /dev/null 2>&1; then
+                if ! json_ok; then
                   {
                     echo "⚠️ The link check did not complete (likely a crawl crash or timeout). Please re-run this check."
                     echo ""

--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -47,22 +47,29 @@ jobs:
                 echo -e "\n\n" >> preview_url.txt
 
                 # linkinator@7.x crashes the whole Node process on ANY unhandled stream 'error'
-                # event — a CloudFront keep-alive socket reaped mid-read (ECONNRESET) or a
-                # request abort both throw and kill the crawl with no JSON written. There is no
-                # flag that fixes this (it's a bug in the tool), and every knob that adds socket
-                # churn makes it worse: --concurrency > 25 crashes reliably; --timeout turns each
-                # timeout into a crashing abort; --retry-errors hammers failing links until the
-                # crawl hangs. So: crawl at 25 (empirically the only survivable concurrency),
-                # keep only --retry (safe, bounded 429/Retry-After handling), skip the big
-                # off-preview trees we don't own, send stderr to the step log (NOT /dev/null) so
-                # a crash is diagnosable, and simply retry the whole crawl until it yields valid
-                # JSON. The crash is a random per-socket event, so a fresh attempt usually
-                # succeeds; timeout-minutes above budgets for a second ~17-min run.
+                # event — a CloudFront keep-alive socket reaped mid-read ("other side closed").
+                # It's a listener leak in the tool (MaxListenersExceededWarning on [Fetch]): the
+                # crash probability grows with the number of requests, so our ~4k-page crawl
+                # (docs publish TWO version trees, latest + v1) crashes on the CI runner every
+                # time — verified: no successful run in weeks. No flag or concurrency fixes it
+                # (--concurrency >25 crashes faster, 5 is too slow to finish, --timeout/--retry-errors
+                # make it worse), and --format json writes nothing until the very end, so a crash
+                # discards ALL findings — the check then silently reports zero broken links.
+                #
+                # So we DON'T rely on the crawl completing. We stream linkinator's per-link output
+                # (--verbosity INFO, one "[STATUS] url" line per link) to a log as it goes, let it
+                # crash if it must (|| true), and parse whatever it emitted BEFORE dying. Every link
+                # checked up to the crash point is still reported — partial results beat none. We
+                # retry to extend coverage, keeping the union of links seen across attempts.
+                # Trade-off vs JSON: the stream omits the "on page" parent, so reports name the
+                # broken url without the linking page. Acceptable to stop losing real findings.
+                : > crawl_lines.txt
                 crawl() {
                   npx linkinator ${{ steps.generate-docs.outputs.URL }} \
                     --recurse \
                     --concurrency 25 \
                     --retry \
+                    --verbosity INFO \
                     --skip "search\/v2\/key" \
                     --skip "https://ai.google.dev/gemini-api" \
                     --skip "https://ai.google.dev/aistudio" \
@@ -75,29 +82,37 @@ jobs:
                     --skip "files.buildwithfern.com" \
                     --skip "github.com" \
                     --skip "raw.githubusercontent.com" \
-                    --format json > linkinator_results.json || true
+                    2>&1 | grep -E '^\[[A-Z0-9]+\] https?://' >> crawl_lines.txt || true
                 }
-                json_ok() { jq -e 'type == "object" and (.links | type == "array")' linkinator_results.json > /dev/null 2>&1; }
 
                 MAX_CRAWL_ATTEMPTS=2
                 for attempt in $(seq 1 "$MAX_CRAWL_ATTEMPTS"); do
                   echo "Crawl attempt $attempt/$MAX_CRAWL_ATTEMPTS..."
                   crawl
-                  if json_ok; then
-                    echo "Crawl attempt $attempt produced valid JSON."
-                    break
-                  fi
-                  echo "Crawl attempt $attempt produced no valid JSON (likely an unhandled-socket-error crash)."
+                  echo "  attempt $attempt: $(wc -l < crawl_lines.txt) cumulative link lines captured."
                 done
 
-                PREVIEW_ORIGIN=$(echo "${{ steps.generate-docs.outputs.URL }}" | grep -oE '^https?://[^/]+')
+                # A crash can cut the final line mid-url (file won't end in a newline). Drop that
+                # truncated last line so a partial "[404] https://half-a-ur" can't become a bogus
+                # broken link: if the file lacks a trailing newline, delete its last line first.
+                # Then normalize to "STATUS<tab>url" (only fully-formed "[STATUS] url" lines match).
+                # POSIX sed/sort/grep, no gawk extension.
+                if [ -s crawl_lines.txt ] && [ -n "$(tail -c1 crawl_lines.txt)" ]; then
+                  sed '$d' crawl_lines.txt > crawl_lines.trimmed && mv crawl_lines.trimmed crawl_lines.txt
+                fi
+                sed -nE 's/^\[([A-Z0-9]+)\] (https?:\/\/[^ ]+).*/\1\t\2/p' crawl_lines.txt | sort -u > crawl_norm.tsv
 
-                # linkinator exits non-zero both when it finds broken links and when it
-                # crashes mid-crawl (e.g. unhandled ECONNRESET), so trust the output, not
-                # the exit code: invalid/missing JSON means the crawl didn't complete.
-                if ! json_ok; then
+                CHECKED_TOTAL=$(cut -f2 crawl_norm.tsv | sort -u | wc -l | tr -d ' ')
+                echo "Crawl reached $CHECKED_TOTAL unique link(s) across $MAX_CRAWL_ATTEMPTS attempt(s)."
+                echo "Status breakdown (per sighting):"
+                cut -f1 crawl_norm.tsv | sort | uniq -c | sed 's/^/  /'
+
+                # Fail loud (never silent) if the crawl barely started — a near-empty capture
+                # means the run is not trustworthy and a human should re-run, NOT a green pass.
+                MIN_LINKS=200
+                if [ "$CHECKED_TOTAL" -lt "$MIN_LINKS" ]; then
                   {
-                    echo "⚠️ The link check did not complete (likely a crawl crash or timeout). Please re-run this check."
+                    echo "⚠️ The link check did not complete (crawl reached only $CHECKED_TOTAL links, expected ≥ $MIN_LINKS). Please re-run this check."
                     echo ""
                     echo "---"
                     echo "📌 Results for commit ${{ github.sha }}"
@@ -106,33 +121,29 @@ jobs:
                   exit 0
                 fi
 
-                # Progress to the step log (not the PR comment) so a slow run is diagnosable:
-                # show that the crawl finished and the status breakdown it produced.
-                echo "Crawl complete: $(jq '.links | length' linkinator_results.json) links checked."
-                echo "Status breakdown:"
-                jq -r '.links | group_by(.status) | map("  \(.[0].status // "none"): \(length)") | .[]' linkinator_results.json
+                # A url is broken only if it NEVER returned OK across all its sightings (a link seen
+                # 200 once is fine even if a later retry blipped). "Good" = 2xx/3xx/SKP. 403 = auth
+                # wall (ignored). status 0 = gave up → re-verified below (same class as the crash).
+                # Everything else (4xx/5xx) that has no good sighting is a real broken link.
+                awk -F'\t' '$1 ~ /^(2|3)/ || $1=="SKP" {print $2}' crawl_norm.tsv | sort -u > good_urls.txt
+                BROKEN_LINKS=""
+                seen_broken=""
 
-                # Real HTTP errors, deduped by url — one broken sidebar link otherwise
-                # multiplies into hundreds of lines and overflows GitHub's 65,536-char
-                # comment limit. 403s are auth walls (not broken), so they are excluded.
-                # status 0 means linkinator gave up on a link mid-crawl (a reaped socket, the
-                # same failure class as the crash) rather than a real 4xx/5xx — these routinely
-                # return 200 when fetched on their own, so they are excluded here and re-verified
-                # below, reported only if still unreachable.
-                BROKEN_LINKS=$(jq -r --arg origin "$PREVIEW_ORIGIN" '
-                  [.links[] | select(.state != "OK" and .status != 403 and .status != 0)]
-                  | group_by(.url) | map(.[0]) | .[]
-                  | "❌ Broken link: \(.url) (\(.status))\n   ↳ on page: \((.parent // "") | sub("^" + $origin; ""))"
-                ' linkinator_results.json)
-
-                # `↳ on page` strips the ephemeral preview host, leaving a stable, greppable
-                # doc path. Append one report entry for a re-verified url that is still broken.
+                # `on page` is unavailable in stream mode; report the broken url and its status.
                 report_broken() {
-                  local url=$1 label=$2 parent
-                  parent=$(jq -r --arg u "$url" --arg origin "$PREVIEW_ORIGIN" \
-                    '(first(.links[] | select(.url == $u)).parent // "") | sub("^" + $origin; "")' linkinator_results.json)
-                  BROKEN_LINKS=$(printf '%s\n❌ Broken link: %s (%s)\n   ↳ on page: %s' "$BROKEN_LINKS" "$url" "$label" "$parent")
+                  local url=$1 label=$2
+                  BROKEN_LINKS=$(printf '%s\n❌ Broken link: %s (%s)' "$BROKEN_LINKS" "$url" "$label")
                 }
+
+                # Real broken links: status is not 2xx/3xx/SKP/403/0, and the url never had a good
+                # sighting. One line per url (dedup on the url, first bad status wins).
+                while IFS=$'\t' read -r st url; do
+                  case "$st" in 2*|3*|SKP|403|0) continue ;; esac
+                  grep -qxF "$url" good_urls.txt && continue
+                  case "$seen_broken" in *"|$url|"*) continue ;; esac
+                  seen_broken="$seen_broken|$url|"
+                  report_broken "$url" "$st"
+                done < crawl_norm.tsv
 
                 # SSRF guard: a PR author controls the doc links, so before curling one we
                 # require http(s) and reject any host resolving into a private/loopback/
@@ -160,7 +171,10 @@ jobs:
                 # timeout). curl -L follows redirects, but the SSRF guard runs on the initial
                 # url; a link that resolves 2xx/3xx on its own was never really broken.
                 MAX_REVERIFY=25
-                REVERIFY_URLS=$(jq -r '[.links[] | select(.status == 0) | .url] | unique | .[]' linkinator_results.json)
+                # status-0 give-ups with no good sighting; these are the crawl's own transient
+                # false positives (routinely 200 on a direct fetch), re-verified below.
+                REVERIFY_URLS=$(awk -F'\t' '$1=="0"{print $2}' crawl_norm.tsv | sort -u \
+                  | grep -vxF -f good_urls.txt || true)
                 total_reverify=$(printf '%s\n' "$REVERIFY_URLS" | grep -c . || true)
                 echo "Re-verifying $total_reverify status-0 give-up link(s), cap $MAX_REVERIFY..."
                 count=0
@@ -213,7 +227,7 @@ jobs:
                   echo "No broken links found" >> preview_url.txt
                 fi
 
-                rm -f linkinator_results.json
+                rm -f crawl_lines.txt crawl_norm.tsv good_urls.txt
 
                 {
                   echo ""

--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -13,11 +13,10 @@ concurrency:
 jobs:
     run:
         runs-on: ubuntu-latest
-        # A single crawl at --concurrency 25 takes ~17 min (the docs publish two version
-        # trees, latest + v1, ~4k pages total; 25 is the only concurrency the crawl survives
-        # — see the crawl comment below). linkinator crashes on any unhandled socket error,
-        # so we retry the whole crawl until it yields valid JSON; 30 min leaves room for a
-        # second attempt after a first-attempt crash.
+        # linkinator crashes ~8 min into the crawl (unhandled socket error; see the crawl
+        # comment below) after reaching ~4k unique links — we parse that partial output rather
+        # than needing a clean finish. 30 min leaves ample room for the crash, the conditional
+        # re-crawl on an unusually early crash, and the status-0 re-verify.
         timeout-minutes: 30
         permissions: write-all
         steps:
@@ -85,19 +84,23 @@ jobs:
                     2>&1 | grep -E '^\[[A-Z0-9]+\] https?://' >> crawl_lines.txt || true
                 }
 
-                # Each crawl crashes at a random point, so a 2nd pass reaches links the 1st never
-                # got to before dying — the union covers more. The per-attempt unique-count log
-                # below quantifies how much attempt 2 actually adds, to decide if it's worth its
-                # ~8 min (tune MAX_CRAWL_ATTEMPTS from that data).
-                MAX_CRAWL_ATTEMPTS=2
-                prev_unique=0
-                for attempt in $(seq 1 "$MAX_CRAWL_ATTEMPTS"); do
-                  echo "Crawl attempt $attempt/$MAX_CRAWL_ATTEMPTS..."
+                # The crawl crashes at a roughly DETERMINISTIC point (where the listener leak
+                # trips), not a random one — measured: attempt 1 reached 3976 unique urls, a full
+                # 2nd pass added +0 new. So a blind retry just wastes ~8 min re-walking the same
+                # pages. Run once; only re-crawl if attempt 1 reached suspiciously few links (an
+                # unusually early crash), where a fresh pass might get further. Common case: one
+                # ~8-min crawl, well inside the timeout.
+                RECRAWL_THRESHOLD=1000
+                unique_urls() { grep -oE '^\[[A-Z0-9]+\] https?://[^ ]+' crawl_lines.txt | awk '{print $2}' | sort -u | wc -l | tr -d ' '; }
+                echo "Crawl attempt 1..."
+                crawl
+                u1=$(unique_urls)
+                echo "  attempt 1: $(wc -l < crawl_lines.txt) lines, $u1 unique urls."
+                if [ "$u1" -lt "$RECRAWL_THRESHOLD" ]; then
+                  echo "  attempt 1 reached only $u1 (< $RECRAWL_THRESHOLD) — likely an early crash; re-crawling once to extend coverage..."
                   crawl
-                  cum_unique=$(grep -oE '^\[[A-Z0-9]+\] https?://[^ ]+' crawl_lines.txt | awk '{print $2}' | sort -u | wc -l | tr -d ' ')
-                  echo "  attempt $attempt: $(wc -l < crawl_lines.txt) cumulative lines, $cum_unique cumulative unique urls (+$((cum_unique - prev_unique)) new this attempt)."
-                  prev_unique=$cum_unique
-                done
+                  echo "  after attempt 2: $(wc -l < crawl_lines.txt) lines, $(unique_urls) unique urls."
+                fi
 
                 # A crash can cut the final line mid-url (file won't end in a newline). Drop that
                 # truncated last line so a partial "[404] https://half-a-ur" can't become a bogus
@@ -110,7 +113,7 @@ jobs:
                 sed -nE 's/^\[([A-Z0-9]+)\] (https?:\/\/[^ ]+).*/\1\t\2/p' crawl_lines.txt | sort -u > crawl_norm.tsv
 
                 CHECKED_TOTAL=$(cut -f2 crawl_norm.tsv | sort -u | wc -l | tr -d ' ')
-                echo "Crawl reached $CHECKED_TOTAL unique link(s) across $MAX_CRAWL_ATTEMPTS attempt(s)."
+                echo "Crawl reached $CHECKED_TOTAL unique link(s)."
                 echo "Status breakdown (per sighting):"
                 cut -f1 crawl_norm.tsv | sort | uniq -c | sed 's/^/  /'
 

--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -13,10 +13,12 @@ concurrency:
 jobs:
     run:
         runs-on: ubuntu-latest
-        # The crawl dominates runtime; linkinator's own --retry/--retry-errors add bounded
-        # backoff for transient 429/5xx rather than a separate re-verify phase. 20 gives
-        # headroom over the old 15-min ceiling while the step logs reveal the true duration.
-        timeout-minutes: 20
+        # A single crawl at --concurrency 25 takes ~17 min (the docs publish two version
+        # trees, latest + v1, ~4k pages total; 25 is the only concurrency the crawl survives
+        # — see the crawl comment below). linkinator crashes on any unhandled socket error,
+        # so we retry the whole crawl until it yields valid JSON; 30 min leaves room for a
+        # second attempt after a first-attempt crash.
+        timeout-minutes: 30
         permissions: write-all
         steps:
             - name: Checkout repository
@@ -44,22 +46,23 @@ jobs:
               run: |
                 echo -e "\n\n" >> preview_url.txt
 
-                # --retry/--retry-errors handle per-link transience (429 Retry-After, 5xx and
-                # network/"unknown" responses) with backoff+jitter, so we don't re-verify links
-                # ourselves. But they can't rescue a crawl that CRASHES: linkinator emits an
-                # unhandled 'error' event on a dropped socket ("SocketError: other side closed"),
-                # which throws and kills the process with no JSON written — there is no per-link
-                # result left to retry. So we also retry the whole crawl once, and send stderr to
-                # the step log (NOT /dev/null) so a crash is diagnosable. --concurrency 25 keeps
-                # the burst small enough to make the crash rare in the first place.
+                # linkinator@7.x crashes the whole Node process on ANY unhandled stream 'error'
+                # event — a CloudFront keep-alive socket reaped mid-read (ECONNRESET) or a
+                # request abort both throw and kill the crawl with no JSON written. There is no
+                # flag that fixes this (it's a bug in the tool), and every knob that adds socket
+                # churn makes it worse: --concurrency > 25 crashes reliably; --timeout turns each
+                # timeout into a crashing abort; --retry-errors hammers failing links until the
+                # crawl hangs. So: crawl at 25 (empirically the only survivable concurrency),
+                # keep only --retry (safe, bounded 429/Retry-After handling), skip the big
+                # off-preview trees we don't own, send stderr to the step log (NOT /dev/null) so
+                # a crash is diagnosable, and simply retry the whole crawl until it yields valid
+                # JSON. The crash is a random per-socket event, so a fresh attempt usually
+                # succeeds; timeout-minutes above budgets for a second ~17-min run.
                 crawl() {
                   npx linkinator ${{ steps.generate-docs.outputs.URL }} \
                     --recurse \
                     --concurrency 25 \
                     --retry \
-                    --retry-errors \
-                    --retry-errors-count 3 \
-                    --retry-errors-jitter 2000 \
                     --skip "search\/v2\/key" \
                     --skip "https://ai.google.dev/gemini-api" \
                     --skip "https://ai.google.dev/aistudio" \
@@ -68,15 +71,24 @@ jobs:
                     --skip "http://localhost:5173" \
                     --skip "googletagmanager.com" \
                     --skip "insights/script.js" \
+                    --skip "www.comet.com" \
+                    --skip "files.buildwithfern.com" \
+                    --skip "github.com" \
+                    --skip "raw.githubusercontent.com" \
                     --format json > linkinator_results.json || true
                 }
                 json_ok() { jq -e 'type == "object" and (.links | type == "array")' linkinator_results.json > /dev/null 2>&1; }
 
-                crawl
-                if ! json_ok; then
-                  echo "Crawl produced no valid JSON (likely a dropped-socket crash); retrying once..."
+                MAX_CRAWL_ATTEMPTS=2
+                for attempt in $(seq 1 "$MAX_CRAWL_ATTEMPTS"); do
+                  echo "Crawl attempt $attempt/$MAX_CRAWL_ATTEMPTS..."
                   crawl
-                fi
+                  if json_ok; then
+                    echo "Crawl attempt $attempt produced valid JSON."
+                    break
+                  fi
+                  echo "Crawl attempt $attempt produced no valid JSON (likely an unhandled-socket-error crash)."
+                done
 
                 PREVIEW_ORIGIN=$(echo "${{ steps.generate-docs.outputs.URL }}" | grep -oE '^https?://[^/]+')
 
@@ -103,13 +115,91 @@ jobs:
                 # Real HTTP errors, deduped by url — one broken sidebar link otherwise
                 # multiplies into hundreds of lines and overflows GitHub's 65,536-char
                 # comment limit. 403s are auth walls (not broken), so they are excluded.
-                # Transient 429/500/network failures are already retried by linkinator's
-                # --retry/--retry-errors above, so anything still failing here is genuine.
+                # status 0 means linkinator gave up on a link mid-crawl (a reaped socket, the
+                # same failure class as the crash) rather than a real 4xx/5xx — these routinely
+                # return 200 when fetched on their own, so they are excluded here and re-verified
+                # below, reported only if still unreachable.
                 BROKEN_LINKS=$(jq -r --arg origin "$PREVIEW_ORIGIN" '
-                  [.links[] | select(.state != "OK" and .status != 403)]
+                  [.links[] | select(.state != "OK" and .status != 403 and .status != 0)]
                   | group_by(.url) | map(.[0]) | .[]
                   | "❌ Broken link: \(.url) (\(.status))\n   ↳ on page: \((.parent // "") | sub("^" + $origin; ""))"
                 ' linkinator_results.json)
+
+                # `↳ on page` strips the ephemeral preview host, leaving a stable, greppable
+                # doc path. Append one report entry for a re-verified url that is still broken.
+                report_broken() {
+                  local url=$1 label=$2 parent
+                  parent=$(jq -r --arg u "$url" --arg origin "$PREVIEW_ORIGIN" \
+                    '(first(.links[] | select(.url == $u)).parent // "") | sub("^" + $origin; "")' linkinator_results.json)
+                  BROKEN_LINKS=$(printf '%s\n❌ Broken link: %s (%s)\n   ↳ on page: %s' "$BROKEN_LINKS" "$url" "$label" "$parent")
+                }
+
+                # SSRF guard: a PR author controls the doc links, so before curling one we
+                # require http(s) and reject any host resolving into a private/loopback/
+                # link-local/metadata range. Exits 0 (safe) or 1 (blocked/unresolvable).
+                cat > ssrf_guard.py <<'PY'
+                import ipaddress, socket, sys
+                from urllib.parse import urlparse
+                p = urlparse(sys.argv[1])
+                if p.scheme not in ("http", "https") or not p.hostname:
+                    sys.exit(1)
+                try:
+                    infos = socket.getaddrinfo(p.hostname, p.port or (443 if p.scheme == "https" else 80))
+                except socket.gaierror:
+                    sys.exit(1)
+                for info in infos:
+                    ip = ipaddress.ip_address(info[4][0])
+                    if (ip.is_private or ip.is_loopback or ip.is_link_local
+                            or ip.is_multicast or ip.is_reserved or ip.is_unspecified):
+                        sys.exit(1)
+                sys.exit(0)
+                PY
+
+                # Re-verify the status-0 give-ups one at a time (there are only ever a handful;
+                # capped so a pathological run can't serialize hundreds of curls into the job
+                # timeout). curl -L follows redirects, but the SSRF guard runs on the initial
+                # url; a link that resolves 2xx/3xx on its own was never really broken.
+                MAX_REVERIFY=25
+                REVERIFY_URLS=$(jq -r '[.links[] | select(.status == 0) | .url] | unique | .[]' linkinator_results.json)
+                total_reverify=$(printf '%s\n' "$REVERIFY_URLS" | grep -c . || true)
+                echo "Re-verifying $total_reverify status-0 give-up link(s), cap $MAX_REVERIFY..."
+                count=0
+                still_broken=0
+                while IFS= read -r url; do
+                  [ -z "$url" ] && continue
+                  count=$((count + 1))
+                  if [ "$count" -gt "$MAX_REVERIFY" ]; then
+                    echo "  [$count/$total_reverify] $url -> over cap, reporting broken"
+                    report_broken "$url" "not re-verified, over cap of $MAX_REVERIFY"
+                    still_broken=$((still_broken + 1))
+                    continue
+                  fi
+                  if ! python3 ssrf_guard.py "$url" 2>/dev/null; then
+                    echo "  [$count/$total_reverify] $url -> blocked by SSRF guard or unresolvable"
+                    report_broken "$url" "blocked by SSRF guard or unresolvable"
+                    still_broken=$((still_broken + 1))
+                    continue
+                  fi
+                  # The give-ups are transient by definition, and a single curl can itself blip
+                  # (000/timeout), so try up to 3 times and clear on the first 2xx/3xx. Only a
+                  # link that fails all three is reported broken.
+                  code=000
+                  for _try in 1 2 3; do
+                    code=$(curl -sL -o /dev/null -w "%{http_code}" --max-time 15 "$url" 2>/dev/null)
+                    case "$code" in 2*|3*) break ;; esac
+                    sleep 2
+                  done
+                  case "$code" in
+                    2*|3*) echo "  [$count/$total_reverify] $url -> reachable ($code), cleared" ;;
+                    *)
+                      echo "  [$count/$total_reverify] $url -> recheck ${code:-000} (3 attempts)"
+                      report_broken "$url" "recheck ${code:-000}"
+                      still_broken=$((still_broken + 1))
+                      ;;
+                  esac
+                done <<< "$REVERIFY_URLS"
+                echo "Re-verify done: $still_broken of $total_reverify still broken."
+                rm -f ssrf_guard.py
 
                 if [ -n "$BROKEN_LINKS" ]; then
                   {

--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -13,9 +13,9 @@ concurrency:
 jobs:
     run:
         runs-on: ubuntu-latest
-        # Recent runs hug the old 15-min ceiling (13.5–14.6 min). Re-verify now runs in
-        # parallel (bounded to ~one round-trip), so the crawl dominates; 20 gives headroom
-        # while the step logs reveal the true crawl-only duration.
+        # The crawl dominates runtime; linkinator's own --retry/--retry-errors add bounded
+        # backoff for transient 429/5xx rather than a separate re-verify phase. 20 gives
+        # headroom over the old 15-min ceiling while the step logs reveal the true duration.
         timeout-minutes: 20
         permissions: write-all
         steps:
@@ -44,11 +44,19 @@ jobs:
               run: |
                 echo -e "\n\n" >> preview_url.txt
 
-                # --concurrency 500: the preview CDN serves bursts without rate-limiting;
-                # the recurse otherwise brushes the job's timeout.
+                # linkinator's own retry flags handle the transient failures we used to see:
+                #   --retry        honors Retry-After on 429s (HuggingFace throttling the burst)
+                #   --retry-errors retries 5xx and network/"unknown" responses (Fern erroring
+                #                  under crawl load, dropped-socket crashes), with backoff+jitter
+                # so we no longer re-verify links ourselves. --concurrency 25 keeps the burst
+                # small enough to avoid saturating the preview CDN in the first place.
                 npx linkinator ${{ steps.generate-docs.outputs.URL }} \
                   --recurse \
-                  --concurrency 500 \
+                  --concurrency 25 \
+                  --retry \
+                  --retry-errors \
+                  --retry-errors-count 3 \
+                  --retry-errors-jitter 2000 \
                   --skip "search\/v2\/key" \
                   --skip "https://ai.google.dev/gemini-api" \
                   --skip "https://ai.google.dev/aistudio" \
@@ -57,7 +65,7 @@ jobs:
                   --skip "http://localhost:5173" \
                   --skip "googletagmanager.com" \
                   --skip "insights/script.js" \
-                  --format json > linkinator_results.json || true
+                  --format json > linkinator_results.json 2>/dev/null || true
 
                 PREVIEW_ORIGIN=$(echo "${{ steps.generate-docs.outputs.URL }}" | grep -oE '^https?://[^/]+')
 
@@ -81,140 +89,16 @@ jobs:
                 echo "Status breakdown:"
                 jq -r '.links | group_by(.status) | map("  \(.[0].status // "none"): \(length)") | .[]' linkinator_results.json
 
-                # `↳ on page` strips the ephemeral preview host, leaving a stable,
-                # greppable doc path. Append one report entry for a status-0 url whose
-                # recheck label is computed by the caller.
-                report_timeout() {
-                  local url=$1 label=$2 parent
-                  parent=$(jq -r --arg u "$url" --arg origin "$PREVIEW_ORIGIN" \
-                    '(first(.links[] | select(.url == $u)).parent // "") | sub("^" + $origin; "")' linkinator_results.json)
-                  BROKEN_LINKS=$(printf '%s\n❌ Broken link: %s (%s)\n   ↳ on page: %s' "$BROKEN_LINKS" "$url" "$label" "$parent")
-                }
-
                 # Real HTTP errors, deduped by url — one broken sidebar link otherwise
                 # multiplies into hundreds of lines and overflows GitHub's 65,536-char
-                # comment limit. 403s are auth walls (not broken); 0/429/500 are re-verified
-                # below (crawl gave up, HuggingFace rate-limit, Fern-under-load) so they are
-                # excluded here and re-added only if genuinely unreachable.
+                # comment limit. 403s are auth walls (not broken), so they are excluded.
+                # Transient 429/500/network failures are already retried by linkinator's
+                # --retry/--retry-errors above, so anything still failing here is genuine.
                 BROKEN_LINKS=$(jq -r --arg origin "$PREVIEW_ORIGIN" '
-                  [.links[] | select(.state != "OK" and .status != 403 and .status != 0 and .status != 429 and .status != 500)]
+                  [.links[] | select(.state != "OK" and .status != 403)]
                   | group_by(.url) | map(.[0]) | .[]
                   | "❌ Broken link: \(.url) (\(.status))\n   ↳ on page: \((.parent // "") | sub("^" + $origin; ""))"
                 ' linkinator_results.json)
-
-                # Re-verify transient links concurrently while preserving an SSRF guard.
-                # A PR author controls these links, so before fetching any URL we require
-                # http(s) and reject hosts that resolve into private/loopback/link-local/
-                # metadata ranges. curl -L would follow a 30x to an arbitrary host WITHOUT
-                # re-checking, so a public URL could bounce to a private/metadata address and
-                # be fetched unguarded — instead this follows redirects manually in waves:
-                # guard every URL, fetch a whole wave in parallel with a single `curl -Z`
-                # (one process, no -L), then guard each Location before the next wave. Real
-                # hosts still resolve (many links legitimately 30x, e.g. http→https or
-                # sdk.vercel.ai→ai-sdk.dev); a redirect into a blocked range is unreachable.
-                # Prints one "<url>\t<label>" line per still-broken url (reachable ones print
-                # nothing). Parallelism keeps the whole phase to ~one round-trip even for a
-                # large 429/500 storm, instead of serializing curls into the job timeout.
-                cat > reverify.py <<'PY'
-                import ipaddress, socket, subprocess, sys
-                from urllib.parse import urlparse
-
-                MAX_REDIRECTS = 5
-                PARALLEL_MAX = 20
-                TIMEOUT = 8
-                MAX_REVERIFY = 200  # sanity cap; overflow reported broken (fail loud)
-
-                def is_safe(url):
-                    p = urlparse(url)
-                    if p.scheme not in ("http", "https") or not p.hostname:
-                        return False
-                    try:
-                        infos = socket.getaddrinfo(p.hostname, p.port or (443 if p.scheme == "https" else 80))
-                    except socket.gaierror:
-                        return False
-                    for info in infos:
-                        ip = ipaddress.ip_address(info[4][0])
-                        if (ip.is_private or ip.is_loopback or ip.is_link_local
-                                or ip.is_multicast or ip.is_reserved or ip.is_unspecified):
-                            return False
-                    return True
-
-                def fetch_all(urls):
-                    cfg = []
-                    for u in urls:
-                        cfg.append('url = "%s"' % u)
-                        cfg.append('output = "/dev/null"')
-                    proc = subprocess.run(
-                        ["curl", "-s", "-Z", "--parallel-max", str(PARALLEL_MAX),
-                         "--max-time", str(TIMEOUT),
-                         "-w", "%{url}\t%{http_code}\t%{redirect_url}\n", "-K", "-"],
-                        input="\n".join(cfg), capture_output=True, text=True,
-                    )
-                    out = {}
-                    for line in proc.stdout.splitlines():
-                        parts = line.split("\t")
-                        if len(parts) == 3:
-                            out[parts[0]] = (parts[1], parts[2])
-                    return out
-
-                candidates = list(dict.fromkeys(a for a in sys.argv[1:] if a))
-                broken = {}
-                for u in candidates[MAX_REVERIFY:]:
-                    broken[u] = "not re-verified, over cap of %d" % MAX_REVERIFY
-                pending = candidates[:MAX_REVERIFY]
-                origin = {u: u for u in pending}
-                for _hop in range(MAX_REDIRECTS + 1):
-                    if not pending:
-                        break
-                    safe, blocked = [], []
-                    for u in pending:
-                        (safe if is_safe(u) else blocked).append(u)
-                    for u in blocked:
-                        broken[origin[u]] = "blocked by SSRF guard or unresolvable"
-                    if not safe:
-                        pending = []
-                        break
-                    results = fetch_all(safe)
-                    nxt = []
-                    for u in safe:
-                        code, redirect = results.get(u, ("000", ""))
-                        orig = origin[u]
-                        if code.startswith("2"):
-                            continue
-                        if code.startswith("3"):
-                            if not redirect:
-                                broken[orig] = "recheck %s (no location)" % code
-                            else:
-                                origin[redirect] = orig
-                                nxt.append(redirect)
-                        else:
-                            broken[orig] = "recheck %s" % (code or "000")
-                    pending = nxt
-                for u in pending:
-                    broken[origin.get(u, u)] = "recheck too many redirects"
-                for url, label in broken.items():
-                    print("%s\t%s" % (url, label))
-                PY
-
-                # Status 0 ("crawl gave up"), 429 (HuggingFace throttling linkinator's burst)
-                # and 500 (Fern preview erroring under crawl load) are all transient false
-                # positives — each returns 2xx/3xx when fetched on its own.
-                REVERIFY_URLS=$(jq -r '[.links[] | select(.status == 0 or .status == 429 or .status == 500) | .url] | unique | .[]' linkinator_results.json)
-                total_reverify=$(printf '%s\n' "$REVERIFY_URLS" | grep -c . || true)
-                echo "Re-verifying $total_reverify transient (0/429/500) link(s) in parallel..."
-                still_broken=0
-                if [ "$total_reverify" -gt 0 ]; then
-                  # xargs feeds all urls as args; reverify.py fetches them concurrently.
-                  while IFS=$'\t' read -r url label; do
-                    [ -z "$url" ] && continue
-                    echo "  broken: $url -> $label"
-                    report_timeout "$url" "$label"
-                    still_broken=$((still_broken + 1))
-                  done < <(printf '%s\n' "$REVERIFY_URLS" | xargs python3 reverify.py)
-                fi
-                echo "Re-verify done: $still_broken of $total_reverify still broken."
-
-                rm -f reverify.py
 
                 if [ -n "$BROKEN_LINKS" ]; then
                   {

--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -85,11 +85,18 @@ jobs:
                     2>&1 | grep -E '^\[[A-Z0-9]+\] https?://' >> crawl_lines.txt || true
                 }
 
+                # Each crawl crashes at a random point, so a 2nd pass reaches links the 1st never
+                # got to before dying — the union covers more. The per-attempt unique-count log
+                # below quantifies how much attempt 2 actually adds, to decide if it's worth its
+                # ~8 min (tune MAX_CRAWL_ATTEMPTS from that data).
                 MAX_CRAWL_ATTEMPTS=2
+                prev_unique=0
                 for attempt in $(seq 1 "$MAX_CRAWL_ATTEMPTS"); do
                   echo "Crawl attempt $attempt/$MAX_CRAWL_ATTEMPTS..."
                   crawl
-                  echo "  attempt $attempt: $(wc -l < crawl_lines.txt) cumulative link lines captured."
+                  cum_unique=$(grep -oE '^\[[A-Z0-9]+\] https?://[^ ]+' crawl_lines.txt | awk '{print $2}' | sort -u | wc -l | tr -d ' ')
+                  echo "  attempt $attempt: $(wc -l < crawl_lines.txt) cumulative lines, $cum_unique cumulative unique urls (+$((cum_unique - prev_unique)) new this attempt)."
+                  prev_unique=$cum_unique
                 done
 
                 # A crash can cut the final line mid-url (file won't end in a newline). Drop that
@@ -197,9 +204,12 @@ jobs:
                   # The give-ups are transient by definition, and a single curl can itself blip
                   # (000/timeout), so try up to 3 times and clear on the first 2xx/3xx. Only a
                   # link that fails all three is reported broken.
+                  # `|| true`: curl exits non-zero on timeout (28) / connect-fail, and the step
+                  # runs under `bash -e` — an unguarded failure here aborts the whole step before
+                  # the report is written. Tolerate it; an empty code falls through to "broken".
                   code=000
                   for _try in 1 2 3; do
-                    code=$(curl -sL -o /dev/null -w "%{http_code}" --max-time 15 "$url" 2>/dev/null)
+                    code=$(curl -sL -o /dev/null -w "%{http_code}" --max-time 15 "$url" 2>/dev/null || true)
                     case "$code" in 2*|3*) break ;; esac
                     sleep 2
                   done

--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -133,8 +133,11 @@ jobs:
 
                 # A url is broken only if it NEVER returned OK across all its sightings (a link seen
                 # 200 once is fine even if a later retry blipped). "Good" = 2xx/3xx/SKP. 403 = auth
-                # wall (ignored). status 0 = gave up → re-verified below (same class as the crash).
-                # Everything else (4xx/5xx) that has no good sighting is a real broken link.
+                # wall (ignored). Transient-under-crawl-load statuses — 0 (gave up), 429 (rate
+                # limited), and 5xx (Fern/preview erroring under burst; verified: our own preview
+                # pages 500 mid-crawl yet return 200 on a direct fetch) — are NOT reported here;
+                # they go to the SSRF-guarded re-verify below and are kept only if still failing.
+                # Only a 4xx other than 403/429 with no good sighting is an immediate broken link.
                 awk -F'\t' '$1 ~ /^(2|3)/ || $1=="SKP" {print $2}' crawl_norm.tsv | sort -u > good_urls.txt
                 BROKEN_LINKS=""
                 seen_broken=""
@@ -145,10 +148,10 @@ jobs:
                   BROKEN_LINKS=$(printf '%s\n❌ Broken link: %s (%s)' "$BROKEN_LINKS" "$url" "$label")
                 }
 
-                # Real broken links: status is not 2xx/3xx/SKP/403/0, and the url never had a good
-                # sighting. One line per url (dedup on the url, first bad status wins).
+                # Immediate broken links: a hard 4xx (not 403/429, not a 5xx/0 transient) with no
+                # good sighting. One line per url (dedup on the url, first bad status wins).
                 while IFS=$'\t' read -r st url; do
-                  case "$st" in 2*|3*|SKP|403|0) continue ;; esac
+                  case "$st" in 2*|3*|5*|SKP|403|429|0) continue ;; esac
                   grep -qxF "$url" good_urls.txt && continue
                   case "$seen_broken" in *"|$url|"*) continue ;; esac
                   seen_broken="$seen_broken|$url|"
@@ -176,17 +179,18 @@ jobs:
                 sys.exit(0)
                 PY
 
-                # Re-verify the status-0 give-ups one at a time (there are only ever a handful;
-                # capped so a pathological run can't serialize hundreds of curls into the job
-                # timeout). curl -L follows redirects, but the SSRF guard runs on the initial
-                # url; a link that resolves 2xx/3xx on its own was never really broken.
+                # Re-verify the transient-class links one at a time (capped so a pathological run
+                # can't serialize hundreds of curls into the job timeout). curl -L follows
+                # redirects, but the SSRF guard runs on the initial url; a link that resolves
+                # 2xx/3xx on its own was never really broken.
                 MAX_REVERIFY=25
-                # status-0 give-ups with no good sighting; these are the crawl's own transient
-                # false positives (routinely 200 on a direct fetch), re-verified below.
-                REVERIFY_URLS=$(awk -F'\t' '$1=="0"{print $2}' crawl_norm.tsv | sort -u \
+                # Transient statuses with no good sighting — 0 (gave up), 429 (rate limited), 5xx
+                # (Fern/preview erroring under crawl load). These routinely return 200 on a direct
+                # fetch, so re-check before reporting; kept only if still failing.
+                REVERIFY_URLS=$(awk -F'\t' '$1=="0" || $1=="429" || $1 ~ /^5/ {print $2}' crawl_norm.tsv | sort -u \
                   | grep -vxF -f good_urls.txt || true)
                 total_reverify=$(printf '%s\n' "$REVERIFY_URLS" | grep -c . || true)
-                echo "Re-verifying $total_reverify status-0 give-up link(s), cap $MAX_REVERIFY..."
+                echo "Re-verifying $total_reverify transient (0/429/5xx) link(s), cap $MAX_REVERIFY..."
                 count=0
                 still_broken=0
                 while IFS= read -r url; do

--- a/.github/workflows/documentation_preview_link.yml
+++ b/.github/workflows/documentation_preview_link.yml
@@ -13,7 +13,9 @@ concurrency:
 jobs:
     run:
         runs-on: ubuntu-latest
-        timeout-minutes: 15
+        # Recent runs hug the old 15-min ceiling (13.5–14.6 min); the external re-verify
+        # curls added below need headroom so they can't tip a run into a spurious timeout.
+        timeout-minutes: 20
         permissions: write-all
         steps:
             - name: Checkout repository
@@ -42,7 +44,7 @@ jobs:
                 echo -e "\n\n" >> preview_url.txt
 
                 # --concurrency 500: the preview CDN serves bursts without rate-limiting;
-                # the recurse otherwise brushes the job's 15-minute timeout.
+                # the recurse otherwise brushes the job's timeout.
                 npx linkinator ${{ steps.generate-docs.outputs.URL }} \
                   --recurse \
                   --concurrency 500 \
@@ -82,32 +84,70 @@ jobs:
                   BROKEN_LINKS=$(printf '%s\n❌ Broken link: %s (%s)\n   ↳ on page: %s' "$BROKEN_LINKS" "$url" "$label" "$parent")
                 }
 
-                # Real HTTP errors (excluding 403s), deduped by url — one broken sidebar
-                # link otherwise multiplies into hundreds of lines and overflows GitHub's
-                # 65,536-char comment limit.
+                # Real HTTP errors, deduped by url — one broken sidebar link otherwise
+                # multiplies into hundreds of lines and overflows GitHub's 65,536-char
+                # comment limit. 403s are auth walls (not broken); 0/429/500 are re-verified
+                # below (crawl gave up, HuggingFace rate-limit, Fern-under-load) so they are
+                # excluded here and re-added only if genuinely unreachable.
                 BROKEN_LINKS=$(jq -r --arg origin "$PREVIEW_ORIGIN" '
-                  [.links[] | select(.state != "OK" and .status != 403 and .status != 0)]
+                  [.links[] | select(.state != "OK" and .status != 403 and .status != 0 and .status != 429 and .status != 500)]
                   | group_by(.url) | map(.[0]) | .[]
                   | "❌ Broken link: \(.url) (\(.status))\n   ↳ on page: \((.parent // "") | sub("^" + $origin; ""))"
                 ' linkinator_results.json)
 
-                # Status 0 is "crawl gave up", not an HTTP error — a false positive for
-                # healthy-but-slow pages. Re-check each (only on the preview origin, so a
-                # PR-authored link can't point curl at an arbitrary host) and keep it only
-                # if genuinely unreachable.
+                # SSRF guard for re-verify: a PR author controls the links being fetched, so
+                # before curling an external host we require http(s) and reject any host that
+                # resolves into a private/loopback/link-local/metadata range. Exits 0 (safe)
+                # or 1 (blocked). Preview-origin URLs skip this — they are ours by construction.
+                cat > ssrf_guard.py <<'PY'
+                import ipaddress, socket, sys
+                from urllib.parse import urlparse
+                url = sys.argv[1]
+                p = urlparse(url)
+                if p.scheme not in ("http", "https") or not p.hostname:
+                    sys.exit(1)
+                try:
+                    infos = socket.getaddrinfo(p.hostname, p.port or (443 if p.scheme == "https" else 80))
+                except socket.gaierror:
+                    sys.exit(1)  # unresolvable — treat as unsafe, report as broken
+                for info in infos:
+                    ip = ipaddress.ip_address(info[4][0])
+                    if (ip.is_private or ip.is_loopback or ip.is_link_local
+                            or ip.is_multicast or ip.is_reserved or ip.is_unspecified):
+                        sys.exit(1)
+                sys.exit(0)
+                PY
+
+                # Status 0 ("crawl gave up"), 429 (HuggingFace throttling linkinator's burst)
+                # and 500 (Fern preview erroring under crawl load) are all transient false
+                # positives — each returns 2xx/3xx when fetched on its own. Re-check each once
+                # and keep it only if still unreachable. Capped at 50 re-verifies so a 500-storm
+                # can't serialize hundreds of curls into the job timeout; the overflow is
+                # reported as broken (fail loud) rather than silently skipped.
+                MAX_REVERIFY=50
+                count=0
                 while IFS= read -r url; do
                   [ -z "$url" ] && continue
+                  count=$((count + 1))
+                  if [ "$count" -gt "$MAX_REVERIFY" ]; then
+                    report_timeout "$url" "not re-verified, over cap of $MAX_REVERIFY"
+                    continue
+                  fi
                   case "$url" in
-                    "$PREVIEW_ORIGIN"/*|"$PREVIEW_ORIGIN")
-                      code=$(curl -s -L -o /dev/null -w "%{http_code}" --max-time 20 "$url" 2>/dev/null)
-                      { [ -n "$code" ] && [ "$code" -ge 200 ] && [ "$code" -lt 400 ]; } && continue
-                      report_timeout "$url" "timeout, recheck ${code:-000}"
-                      ;;
+                    "$PREVIEW_ORIGIN"/*|"$PREVIEW_ORIGIN") ;;   # ours — no SSRF check needed
                     *)
-                      report_timeout "$url" "timeout"
+                      if ! python3 ssrf_guard.py "$url" 2>/dev/null; then
+                        report_timeout "$url" "blocked by SSRF guard or unresolvable"
+                        continue
+                      fi
                       ;;
                   esac
-                done <<< "$(jq -r '[.links[] | select(.status == 0) | .url] | unique | .[]' linkinator_results.json)"
+                  code=$(curl -s -L -o /dev/null -w "%{http_code}" --max-time 20 "$url" 2>/dev/null)
+                  { [ -n "$code" ] && [ "$code" -ge 200 ] && [ "$code" -lt 400 ]; } && continue
+                  report_timeout "$url" "recheck ${code:-000}"
+                done <<< "$(jq -r '[.links[] | select(.status == 0 or .status == 429 or .status == 500) | .url] | unique | .[]' linkinator_results.json)"
+
+                rm -f ssrf_guard.py
 
                 if [ -n "$BROKEN_LINKS" ]; then
                   {

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/metrics/g_eval.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/metrics/g_eval.mdx
@@ -378,4 +378,4 @@ const score = await metric.score({ output: payload });
 
 In Python, this functionality relies on LiteLLM. See the [LiteLLM Providers](https://docs.litellm.ai/docs/providers) guide for a full list of supported providers and model identifiers.
 
-In TypeScript, the SDK uses the [Vercel AI SDK](https://sdk.vercel.ai/providers) for model integration. See the [Models documentation](/reference/typescript-sdk/evaluation/models) for configuration details.
+In TypeScript, the SDK uses the [Vercel AI SDK](https://ai-sdk.dev/providers/ai-sdk-providers) for model integration. See the [Models documentation](/reference/typescript-sdk/evaluation/models) for configuration details.

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/vercel-ai-sdk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/vercel-ai-sdk.mdx
@@ -12,7 +12,7 @@ title: Observability for Vercel AI SDK with Opik
 ## Setup
 
 The AI SDK supports tracing via OpenTelemetry. With the `OpikExporter` you can collect these traces in Opik.
-While telemetry is experimental ([docs](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry#enabling-telemetry)), you can enable it by setting `experimental_telemetry` on each request that you want to trace.
+While telemetry is experimental ([docs](https://ai-sdk.dev/docs/ai-sdk-core/telemetry#enabling-telemetry)), you can enable it by setting `experimental_telemetry` on each request that you want to trace.
 
 ```ts
 const result = await generateText({
@@ -214,6 +214,6 @@ OPIK_LOG_LEVEL=DEBUG
 
 ## Source references
 
-- [Vercel AI SDK telemetry](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry)
+- [Vercel AI SDK telemetry](https://ai-sdk.dev/docs/ai-sdk-core/telemetry)
 - [Next.js OpenTelemetry guide](https://nextjs.org/docs/app/building-your-application/optimizing/open-telemetry)
 - [Opik Vercel exporter package](https://www.npmjs.com/package/opik-vercel)

--- a/apps/opik-documentation/documentation/fern/docs-v2/reference/typescript-sdk/evaluation/metrics.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/reference/typescript-sdk/evaluation/metrics.mdx
@@ -895,11 +895,11 @@ const metric2 = new Hallucination({ model: anthropicModel });
 const metric3 = new Hallucination({ model: googleModel });
 ```
 
-See [Vercel AI SDK Provider Documentation](https://sdk.vercel.ai/providers) for provider-specific options:
+See [Vercel AI SDK Provider Documentation](https://ai-sdk.dev/providers/ai-sdk-providers) for provider-specific options:
 
-- [OpenAI Provider Options](https://sdk.vercel.ai/providers/ai-sdk-providers/openai)
-- [Anthropic Provider Options](https://sdk.vercel.ai/providers/ai-sdk-providers/anthropic)
-- [Google Provider Options](https://sdk.vercel.ai/providers/ai-sdk-providers/google-generative-ai)
+- [OpenAI Provider Options](https://ai-sdk.dev/providers/ai-sdk-providers/openai)
+- [Anthropic Provider Options](https://ai-sdk.dev/providers/ai-sdk-providers/anthropic)
+- [Google Provider Options](https://ai-sdk.dev/providers/ai-sdk-providers)
 
 ## See Also
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/reference/typescript-sdk/evaluation/models.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/reference/typescript-sdk/evaluation/models.mdx
@@ -175,7 +175,7 @@ await evaluatePrompt({
 });
 ```
 
-For a complete list of available models, see the [Vercel AI SDK OpenAI provider documentation](https://sdk.vercel.ai/providers/ai-sdk-providers/openai).
+For a complete list of available models, see the [Vercel AI SDK OpenAI provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/openai).
 
 ### Anthropic
 
@@ -199,7 +199,7 @@ await evaluatePrompt({
 });
 ```
 
-For a complete list of available models, see the [Vercel AI SDK Anthropic provider documentation](https://sdk.vercel.ai/providers/ai-sdk-providers/anthropic).
+For a complete list of available models, see the [Vercel AI SDK Anthropic provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/anthropic).
 
 ### Google Gemini
 
@@ -223,7 +223,7 @@ await evaluatePrompt({
 });
 ```
 
-For a complete list of available models, see the [Vercel AI SDK Google provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai#model-capabilities).
+For a complete list of available models, see the [Vercel AI SDK Google provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers).
 
 ## Using Models in Opik
 
@@ -528,4 +528,4 @@ await evaluatePrompt({
 
 - [evaluatePrompt Function](/reference/typescript-sdk/evaluation/evaluate_prompt_function) - Using models with prompt evaluation
 - [Metrics](/reference/typescript-sdk/evaluation/metrics) - Using models with LLM Judge metrics
-- [Vercel AI SDK Documentation](https://sdk.vercel.ai/docs) - Full LanguageModel documentation
+- [Vercel AI SDK Documentation](https://ai-sdk.dev/docs/introduction) - Full LanguageModel documentation

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-06-02.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-06-02.mdx
@@ -1,5 +1,5 @@
 ---
-canonical-url: https://www.comet.com/docs/opik/changelog/2026-06-02
+canonical-url: https://www.comet.com/docs/opik/changelog
 ---
 
 ## Prompt Library Now Available in Opik 2.0

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-06-09.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-06-09.mdx
@@ -1,5 +1,5 @@
 ---
-canonical-url: https://www.comet.com/docs/opik/changelog/2026-06-09
+canonical-url: https://www.comet.com/docs/opik/changelog
 ---
 
 ## Resume Interrupted Evaluations with `evaluate_resume`

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-06-16.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-06-16.mdx
@@ -1,5 +1,5 @@
 ---
-canonical-url: https://www.comet.com/docs/opik/changelog/2026-06-16
+canonical-url: https://www.comet.com/docs/opik/changelog
 ---
 
 ## PydanticAI and Logfire Trace Fidelity Improvements
@@ -17,7 +17,7 @@ The error-surfacing fix is generic and benefits all OTel integrations; the tool 
 
 Setting up Claude Desktop (or any MCP client) to connect to Opik no longer requires manually editing JSON config files. Running `opik configure` now offers an opt-in MCP setup step at the end of the flow. The standalone `opik mcp configure` command runs the same wizard on its own. Both automatically write the Opik MCP server block to your Claude Desktop configuration.
 
-👉 [MCP server documentation](https://www.comet.com/docs/opik/prompt_engineering/mcp-server)
+👉 [MCP server documentation](https://www.comet.com/docs/opik/mcp-server)
 
 ## Bug Fixes & Improvements
 

--- a/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/g_eval.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/evaluation/metrics/g_eval.mdx
@@ -379,4 +379,4 @@ const score = await metric.score({ output: payload });
 
 In Python, this functionality relies on LiteLLM. See the [LiteLLM Providers](https://docs.litellm.ai/docs/providers) guide for a full list of supported providers and model identifiers.
 
-In TypeScript, the SDK uses the [Vercel AI SDK](https://sdk.vercel.ai/providers) for model integration. See the [Models documentation](/reference/typescript-sdk/evaluation/models) for configuration details.
+In TypeScript, the SDK uses the [Vercel AI SDK](https://ai-sdk.dev/providers/ai-sdk-providers) for model integration. See the [Models documentation](/reference/typescript-sdk/evaluation/models) for configuration details.

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/metrics.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/metrics.mdx
@@ -896,11 +896,11 @@ const metric2 = new Hallucination({ model: anthropicModel });
 const metric3 = new Hallucination({ model: googleModel });
 ```
 
-See [Vercel AI SDK Provider Documentation](https://sdk.vercel.ai/providers) for provider-specific options:
+See [Vercel AI SDK Provider Documentation](https://ai-sdk.dev/providers/ai-sdk-providers) for provider-specific options:
 
-- [OpenAI Provider Options](https://sdk.vercel.ai/providers/ai-sdk-providers/openai)
-- [Anthropic Provider Options](https://sdk.vercel.ai/providers/ai-sdk-providers/anthropic)
-- [Google Provider Options](https://sdk.vercel.ai/providers/ai-sdk-providers/google-generative-ai)
+- [OpenAI Provider Options](https://ai-sdk.dev/providers/ai-sdk-providers/openai)
+- [Anthropic Provider Options](https://ai-sdk.dev/providers/ai-sdk-providers/anthropic)
+- [Google Provider Options](https://ai-sdk.dev/providers/ai-sdk-providers)
 
 ## See Also
 

--- a/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/models.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/reference/typescript-sdk/evaluation/models.mdx
@@ -176,7 +176,7 @@ await evaluatePrompt({
 });
 ```
 
-For a complete list of available models, see the [Vercel AI SDK OpenAI provider documentation](https://sdk.vercel.ai/providers/ai-sdk-providers/openai).
+For a complete list of available models, see the [Vercel AI SDK OpenAI provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/openai).
 
 ### Anthropic
 
@@ -200,7 +200,7 @@ await evaluatePrompt({
 });
 ```
 
-For a complete list of available models, see the [Vercel AI SDK Anthropic provider documentation](https://sdk.vercel.ai/providers/ai-sdk-providers/anthropic).
+For a complete list of available models, see the [Vercel AI SDK Anthropic provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/anthropic).
 
 ### Google Gemini
 
@@ -224,7 +224,7 @@ await evaluatePrompt({
 });
 ```
 
-For a complete list of available models, see the [Vercel AI SDK Google provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai#model-capabilities).
+For a complete list of available models, see the [Vercel AI SDK Google provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers).
 
 ## Using Models in Opik
 
@@ -529,4 +529,4 @@ await evaluatePrompt({
 
 - [evaluatePrompt Function](/reference/typescript-sdk/evaluation/evaluate_prompt_function) - Using models with prompt evaluation
 - [Metrics](/reference/typescript-sdk/evaluation/metrics) - Using models with LLM Judge metrics
-- [Vercel AI SDK Documentation](https://sdk.vercel.ai/docs) - Full LanguageModel documentation
+- [Vercel AI SDK Documentation](https://ai-sdk.dev/docs/introduction) - Full LanguageModel documentation

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/vercel-ai-sdk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/vercel-ai-sdk.mdx
@@ -13,7 +13,7 @@ canonical-url: https://www.comet.com/docs/opik/integrations/vercel-ai-sdk
 ## Setup
 
 The AI SDK supports tracing via OpenTelemetry. With the `OpikExporter` you can collect these traces in Opik.
-While telemetry is experimental ([docs](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry#enabling-telemetry)), you can enable it by setting `experimental_telemetry` on each request that you want to trace.
+While telemetry is experimental ([docs](https://ai-sdk.dev/docs/ai-sdk-core/telemetry#enabling-telemetry)), you can enable it by setting `experimental_telemetry` on each request that you want to trace.
 
 ```ts
 const result = await generateText({
@@ -197,6 +197,6 @@ OPIK_LOG_LEVEL=DEBUG
 
 ## Source references
 
-- [Vercel AI SDK telemetry](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry)
+- [Vercel AI SDK telemetry](https://ai-sdk.dev/docs/ai-sdk-core/telemetry)
 - [Next.js OpenTelemetry guide](https://nextjs.org/docs/app/building-your-application/optimizing/open-telemetry)
 - [Opik Vercel exporter package](https://www.npmjs.com/package/opik-vercel)


### PR DESCRIPTION
## Details

The `Docs - Preview link` check goes red for two unrelated reasons: genuine 404s in the docs, and transient crawl artifacts (HuggingFace `429` rate-limiting linkinator's burst, Fern preview `500` under crawl load) that are actually reachable. This PR fixes the real broken links and makes the check ignore the transient noise, so a red run means a real problem.

- **Changelog `canonical-url` (3 entries):** `2026-06-{02,09,16}.mdx` pointed at hyphenated-date URLs that 404; repointed to the bare `https://www.comet.com/docs/opik/changelog` index used by the other 54 entries. (Nested `/YYYY/M/D` paths return 200 but only redirect to that index and are being removed, so the bare index is the correct canonical.)
- **MCP-server link** (`changelog/2026-06-16.mdx`): the `prompt_engineering/mcp-server` path is not published; repointed to the live `https://www.comet.com/docs/opik/mcp-server` page (verified serving real content).
- **ai-sdk.dev links:** the `google-generative-ai` provider slug is fully dead (both the anchored link in `models.mdx` and the plain link in `metrics.mdx`); repointed to the provider index `https://ai-sdk.dev/providers/ai-sdk-providers`. Normalized every `sdk.vercel.ai` reference across the docs to the canonical `ai-sdk.dev` host (the old host only survives on a Vercel redirect).
- **Workflow re-verification:** extended from `status: 0` only to also cover `429`/`500`. The re-verify step now curls external hosts (needed to clear HuggingFace 429s) behind an SSRF guard — `http(s)` only, resolves the host and rejects any private/loopback/link-local/multicast/reserved/metadata address. Re-verify is capped at 50 (overflow reported broken, fail loud) and each curl has `--max-time 20`.
- **Timeout:** raised `timeout-minutes` from 15 to 20 — recent runs hug the old ceiling (13.5–14.6 min) and the added external curls need headroom.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-7136

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: full implementation
- Human verification: link targets browser/curl-verified; SSRF guard and re-verify loop unit-tested against synthetic linkinator output; final green run of the Docs - Preview link check on this PR is the acceptance gate

## Testing

Docs-only + workflow change — no Java/FE/SDK source touched, so language build/test suites do not apply.

- **Link targets:** every new URL curl-verified 200 (bare changelog index, `/docs/opik/mcp-server`, `ai-sdk.dev` provider index / openai / anthropic / docs-introduction / telemetry). Confirmed the dead `google-generative-ai` slug and hyphenated-date changelog URLs 404.
- **SSRF guard:** tested against 11 URLs — public hosts (huggingface.co, ai-sdk.dev) allowed; `localhost`, `127.0.0.1`, `10.x`, `192.168.x`, `169.254.169.254` metadata, GCP metadata hostname, `ftp://`, `file://`, and unresolvable hosts all blocked.
- **Re-verify loop:** run against a mock linkinator JSON — genuine 404 reported; 429/500 dropped when reachable; status-0 unreachable reported; SSRF targets blocked and reported; cap-overflow path exercised.
- **Lint:** `actionlint` clean on the workflow (also runs at commit time); `pre-commit` on changed files clean; YAML and the embedded Python guard compile.
- **Portability:** re-verify loop uses `while read` (not bash-4 `mapfile`) so it runs on the CI shell.
- **Acceptance gate:** the `Docs - Preview link` check on this PR passing (no broken links reported) confirms all fixes end-to-end.

## Documentation

This PR is documentation content fixes plus a tuning change to the docs link-check workflow. No separate docs update required.
