### PR TITLE
[OPIK-7139] [BE] [FE] BI events for Agent Insights + trigger_source

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgentInsightsReportSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgentInsightsReportSubscriber.java
@@ -71,8 +71,13 @@ public class AgentInsightsReportSubscriber extends BaseRedisSubscriber<AgentInsi
         log.info("Processing Agent Insights report trigger: reportId='{}', project='{}', workspace='{}'",
                 message.reportId(), message.projectId(), message.workspaceId());
 
+        // Default a null (legacy message queued before triggerSource existed) to the scheduled sweep.
+        String triggerSource = message.triggerSource() != null
+                ? message.triggerSource()
+                : AgentInsightsMetrics.SCHEDULED;
+
         return Mono.fromRunnable(() -> reportClient.triggerAgentInsights(message.reportId(), message.projectId(),
-                message.workspaceId(), message.periodStart(), message.periodEnd(), message.triggerSource()))
+                message.workspaceId(), message.periodStart(), message.periodEnd(), triggerSource))
                 .subscribeOn(Schedulers.boundedElastic())
                 .then()
                 .doOnSuccess(unused -> {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgentInsightsReportSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgentInsightsReportSubscriber.java
@@ -72,7 +72,7 @@ public class AgentInsightsReportSubscriber extends BaseRedisSubscriber<AgentInsi
                 message.reportId(), message.projectId(), message.workspaceId());
 
         return Mono.fromRunnable(() -> reportClient.triggerAgentInsights(message.reportId(), message.projectId(),
-                message.workspaceId(), message.periodStart(), message.periodEnd()))
+                message.workspaceId(), message.periodStart(), message.periodEnd(), message.triggerSource()))
                 .subscribeOn(Schedulers.boundedElastic())
                 .then()
                 .doOnSuccess(unused -> {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/AgentInsightsReportJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/AgentInsightsReportJob.java
@@ -103,7 +103,8 @@ public class AgentInsightsReportJob extends Job {
                             .flatMapMany(withTraces -> Flux.fromIterable(jobs)
                                     .filter(job -> withTraces.contains(job.projectId())))
                             .concatMap(job -> reportPublisher
-                                    .enqueue(job.projectId(), job.workspaceId(), periodStart, periodEnd)
+                                    .enqueue(job.projectId(), job.workspaceId(), periodStart, periodEnd,
+                                            AgentInsightsMetrics.SCHEDULED)
                                     .doOnNext(__ -> AgentInsightsMetrics.REPORTS_ENQUEUED.add(1,
                                             AgentInsightsMetrics.ENQUEUE_SCHEDULED_SUCCESS))
                                     .then()

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobService.java
@@ -93,7 +93,8 @@ public class AgentInsightsJobService {
                                 "Agent insights job not found for project: " + projectId)));
 
         Instant periodEnd = Instant.now();
-        reportPublisher.enqueue(job.projectId(), workspaceId, periodEnd.minus(TRIGGER_WINDOW), periodEnd)
+        reportPublisher.enqueue(job.projectId(), workspaceId, periodEnd.minus(TRIGGER_WINDOW), periodEnd,
+                AgentInsightsMetrics.MANUAL)
                 .subscribe(
                         reportId -> {
                             AgentInsightsMetrics.REPORTS_ENQUEUED.add(1, AgentInsightsMetrics.ENQUEUE_MANUAL_SUCCESS);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsReportClient.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsReportClient.java
@@ -15,5 +15,5 @@ import java.util.UUID;
 public interface AgentInsightsReportClient {
 
     void triggerAgentInsights(String reportId, UUID projectId, String workspaceId,
-            Instant periodStart, Instant periodEnd);
+            Instant periodStart, Instant periodEnd, String triggerSource);
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsReportMessage.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsReportMessage.java
@@ -12,6 +12,10 @@ import java.util.UUID;
  * A queued request to generate an Agent Insights report for a (workspace, project) over a time window.
  * Published by {@link AgentInsightsReportPublisher} and consumed by the Agent Insights report subscriber,
  * which performs the actual (bounded) trigger via {@link AgentInsightsReportClient}.
+ *
+ * @param triggerSource "manual" (Run diagnostics) or "scheduled" (daily sweep), carried through to the Ollie
+ *                      trigger. Nullable (not {@code @NonNull}) so a message queued before this field existed
+ *                      still deserializes on a rolling upgrade; the subscriber defaults a null to "scheduled".
  */
 @Builder(toBuilder = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
@@ -21,8 +25,5 @@ public record AgentInsightsReportMessage(
         @NonNull String workspaceId,
         @NonNull Instant periodStart,
         @NonNull Instant periodEnd,
-        // "manual" (Run diagnostics) or "scheduled" (daily sweep), carried through to the Ollie trigger.
-        // Nullable (not @NonNull) so a message queued before this field existed still deserializes on a
-        // rolling upgrade; the subscriber defaults a null to "scheduled".
         String triggerSource) implements RedisSubscriberMessage {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsReportMessage.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsReportMessage.java
@@ -20,5 +20,7 @@ public record AgentInsightsReportMessage(
         @NonNull UUID projectId,
         @NonNull String workspaceId,
         @NonNull Instant periodStart,
-        @NonNull Instant periodEnd) implements RedisSubscriberMessage {
+        @NonNull Instant periodEnd,
+        // "manual" (Run diagnostics) or "scheduled" (daily sweep), carried through to the Ollie trigger.
+        @NonNull String triggerSource) implements RedisSubscriberMessage {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsReportMessage.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsReportMessage.java
@@ -22,5 +22,7 @@ public record AgentInsightsReportMessage(
         @NonNull Instant periodStart,
         @NonNull Instant periodEnd,
         // "manual" (Run diagnostics) or "scheduled" (daily sweep), carried through to the Ollie trigger.
-        @NonNull String triggerSource) implements RedisSubscriberMessage {
+        // Nullable (not @NonNull) so a message queued before this field existed still deserializes on a
+        // rolling upgrade; the subscriber defaults a null to "scheduled".
+        String triggerSource) implements RedisSubscriberMessage {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsReportPublisher.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsReportPublisher.java
@@ -47,7 +47,7 @@ public class AgentInsightsReportPublisher {
      * stream, or completes empty when publishing is disabled.
      */
     public Mono<String> enqueue(@NonNull UUID projectId, @NonNull String workspaceId,
-            @NonNull Instant periodStart, @NonNull Instant periodEnd) {
+            @NonNull Instant periodStart, @NonNull Instant periodEnd, @NonNull String triggerSource) {
 
         if (!serviceToggles.isAgentInsightsEnabled()) {
             log.debug("Agent Insights is disabled, ignoring trigger for project '{}'", projectId);
@@ -61,6 +61,7 @@ public class AgentInsightsReportPublisher {
                 .workspaceId(workspaceId)
                 .periodStart(periodStart)
                 .periodEnd(periodEnd)
+                .triggerSource(triggerSource)
                 .build();
 
         // DEBUG: the daily sweep enqueues one per enabled project, so keep INFO for lifecycle events only.

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsTriggerRequest.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsTriggerRequest.java
@@ -20,5 +20,7 @@ record AgentInsightsTriggerRequest(
         @NonNull UUID projectId,
         @NonNull String workspaceId,
         @NonNull Instant periodStart,
-        @NonNull Instant periodEnd) {
+        @NonNull Instant periodEnd,
+        // "manual" (Run diagnostics) or "scheduled" (daily sweep) — forwarded so Ollie can tag its BI events.
+        @NonNull String triggerSource) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PlatformAgentInsightsReportClient.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PlatformAgentInsightsReportClient.java
@@ -37,7 +37,8 @@ public class PlatformAgentInsightsReportClient implements AgentInsightsReportCli
 
     @Override
     public void triggerAgentInsights(@NonNull String reportId, @NonNull UUID projectId,
-            @NonNull String workspaceId, @NonNull Instant periodStart, @NonNull Instant periodEnd) {
+            @NonNull String workspaceId, @NonNull Instant periodStart, @NonNull Instant periodEnd,
+            @NonNull String triggerSource) {
 
         var payload = AgentInsightsTriggerRequest.builder()
                 .reportType(REPORT_TYPE)
@@ -46,6 +47,7 @@ public class PlatformAgentInsightsReportClient implements AgentInsightsReportCli
                 .workspaceId(workspaceId)
                 .periodStart(periodStart)
                 .periodEnd(periodEnd)
+                .triggerSource(triggerSource)
                 .build();
 
         try (Response response = httpClient.target(config.getTriggerUrl())

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/jobs/AgentInsightsReportJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/jobs/AgentInsightsReportJobTest.java
@@ -67,12 +67,12 @@ class AgentInsightsReportJobTest {
         when(agentInsightsJobService.findAllEnabled()).thenReturn(List.of(withTraces, withoutTraces));
         when(traceService.getProjectsWithTracesInRange(any(), any(), any()))
                 .thenReturn(Mono.just(Set.of(withTraces.projectId())));
-        when(reportPublisher.enqueue(any(), any(), any(), any())).thenReturn(Mono.just("report-id"));
+        when(reportPublisher.enqueue(any(), any(), any(), any(), any())).thenReturn(Mono.just("report-id"));
 
         job().runSweep(PERIOD_START, PERIOD_END).block();
 
-        verify(reportPublisher).enqueue(withTraces.projectId(), workspaceId, PERIOD_START, PERIOD_END);
-        verify(reportPublisher, never()).enqueue(eq(withoutTraces.projectId()), any(), any(), any());
+        verify(reportPublisher).enqueue(withTraces.projectId(), workspaceId, PERIOD_START, PERIOD_END, "scheduled");
+        verify(reportPublisher, never()).enqueue(eq(withoutTraces.projectId()), any(), any(), any(), any());
     }
 
     @Test
@@ -85,14 +85,14 @@ class AgentInsightsReportJobTest {
         when(agentInsightsJobService.findAllEnabled()).thenReturn(List.of(jobA, jobB));
         when(traceService.getProjectsWithTracesInRange(any(), any(), any()))
                 .thenReturn(Mono.just(Set.of(jobA.projectId(), jobB.projectId())));
-        when(reportPublisher.enqueue(any(), any(), any(), any())).thenReturn(Mono.just("report-id"));
+        when(reportPublisher.enqueue(any(), any(), any(), any(), any())).thenReturn(Mono.just("report-id"));
 
         job().runSweep(PERIOD_START, PERIOD_END).block();
 
         // Exactly one trace query for the whole enabled set (no per-workspace loop).
         verify(traceService).getProjectsWithTracesInRange(any(), eq(PERIOD_START), eq(PERIOD_END));
-        verify(reportPublisher).enqueue(jobA.projectId(), workspaceA, PERIOD_START, PERIOD_END);
-        verify(reportPublisher).enqueue(jobB.projectId(), workspaceB, PERIOD_START, PERIOD_END);
+        verify(reportPublisher).enqueue(jobA.projectId(), workspaceA, PERIOD_START, PERIOD_END, "scheduled");
+        verify(reportPublisher).enqueue(jobB.projectId(), workspaceB, PERIOD_START, PERIOD_END, "scheduled");
     }
 
     @Test
@@ -104,13 +104,13 @@ class AgentInsightsReportJobTest {
         when(agentInsightsJobService.findAllEnabled()).thenReturn(List.of(jobA, jobB));
         when(traceService.getProjectsWithTracesInRange(any(), any(), any()))
                 .thenReturn(Mono.just(Set.of(jobA.projectId(), jobB.projectId())));
-        when(reportPublisher.enqueue(eq(jobA.projectId()), any(), any(), any()))
+        when(reportPublisher.enqueue(eq(jobA.projectId()), any(), any(), any(), any()))
                 .thenReturn(Mono.error(new RuntimeException("redis down")));
-        when(reportPublisher.enqueue(eq(jobB.projectId()), any(), any(), any()))
+        when(reportPublisher.enqueue(eq(jobB.projectId()), any(), any(), any(), any()))
                 .thenReturn(Mono.just("report-id"));
 
         job().runSweep(PERIOD_START, PERIOD_END).block();
 
-        verify(reportPublisher).enqueue(jobB.projectId(), workspaceId, PERIOD_START, PERIOD_END);
+        verify(reportPublisher).enqueue(jobB.projectId(), workspaceId, PERIOD_START, PERIOD_END, "scheduled");
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentInsightsJobsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentInsightsJobsResourceTest.java
@@ -75,13 +75,15 @@ class AgentInsightsJobsResourceTest {
     private static final String WORKSPACE_NAME_2 = "workspace" + RandomStringUtils.secure().nextAlphanumeric(36);
     private static final String USER_2 = "user-" + RandomStringUtils.secure().nextAlphanumeric(36);
 
-    private record Trigger(UUID projectId, String workspaceId, Instant periodStart, Instant periodEnd) {
+    private record Trigger(UUID projectId, String workspaceId, Instant periodStart, Instant periodEnd,
+            String triggerSource) {
     }
 
     // Recording client bound in place of the platform default, to capture triggers fired via the queue.
     private static final List<Trigger> TRIGGERS = new CopyOnWriteArrayList<>();
     private static final AgentInsightsReportClient RECORDING_CLIENT = (reportId, projectId, workspaceId,
-            periodStart, periodEnd) -> TRIGGERS.add(new Trigger(projectId, workspaceId, periodStart, periodEnd));
+            periodStart, periodEnd, triggerSource) -> TRIGGERS.add(
+                    new Trigger(projectId, workspaceId, periodStart, periodEnd, triggerSource));
 
     // Full stack: creating projects via the API exercises ClickHouse, so analytics containers are required.
     private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
@@ -299,6 +301,7 @@ class AgentInsightsJobsResourceTest {
         var trigger = TRIGGERS.stream().filter(t -> t.projectId().equals(projectId)).findFirst().orElseThrow();
         assertThat(trigger.workspaceId()).isEqualTo(WORKSPACE_ID);
         assertThat(trigger.periodStart()).isBefore(trigger.periodEnd());
+        assertThat(trigger.triggerSource()).isEqualTo("manual");
     }
 
     // Failures are recorded through the report-failures endpoint (type=agent_insights, project_id=project),
@@ -435,5 +438,7 @@ class AgentInsightsJobsResourceTest {
 
         await().atMost(10, SECONDS).untilAsserted(() -> assertThat(
                 TRIGGERS.stream().filter(t -> t.projectId().equals(projectId)).toList()).hasSize(1));
+        var trigger = TRIGGERS.stream().filter(t -> t.projectId().equals(projectId)).findFirst().orElseThrow();
+        assertThat(trigger.triggerSource()).isEqualTo("scheduled");
     }
 }

--- a/apps/opik-frontend/src/hooks/useDiagnosticsRunState.ts
+++ b/apps/opik-frontend/src/hooks/useDiagnosticsRunState.ts
@@ -91,6 +91,7 @@ const useDiagnosticsRunState = (projectId: string) => {
 
   return {
     isRunning,
+    startedAt: state?.startedAt ?? 0,
     baseline: state?.baseline ?? 0,
     failBaseline: state?.failBaseline ?? 0,
     startRun,

--- a/apps/opik-frontend/src/lib/analytics/tracking.ts
+++ b/apps/opik-frontend/src/lib/analytics/tracking.ts
@@ -23,6 +23,15 @@ export const OpikEvent = {
   EXPLAIN_CONTINUE_CLICKED: "opik_explain_continue_clicked",
   EXPLAIN_RETRIED: "opik_explain_retried",
   QUICK_FILTER_APPLIED: "opik_quick_filter_applied",
+  DIAGNOSTICS_RUN_CLICKED: "opik_diagnostics_run_clicked",
+  DIAGNOSTICS_RUN_COMPLETED: "opik_diagnostics_run_completed",
+  DIAGNOSTICS_RUN_FAILED: "opik_diagnostics_run_failed",
+  DIAGNOSTICS_TRY_AGAIN_CLICKED: "opik_diagnostics_try_again_clicked",
+  DIAGNOSTICS_AUTO_ENABLED: "opik_diagnostics_auto_enabled",
+  DIAGNOSTICS_AUTO_DISABLED: "opik_diagnostics_auto_disabled",
+  DIAGNOSTICS_ISSUE_RESOLVED: "opik_diagnostics_issue_resolved",
+  DIAGNOSTICS_ISSUE_REOPENED: "opik_diagnostics_issue_reopened",
+  DIAGNOSTICS_CONTINUE_WITH_OLLIE: "opik_diagnostics_continue_with_ollie",
 } as const;
 
 type OpikEventValues = (typeof OpikEvent)[keyof typeof OpikEvent];

--- a/apps/opik-frontend/src/v2/pages/SignalsPage/DiagnosticsSettingsDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/SignalsPage/DiagnosticsSettingsDialog.tsx
@@ -11,6 +11,7 @@ import { Switch } from "@/ui/switch";
 import { Separator } from "@/ui/separator";
 import { AGENT_INSIGHTS_JOB_STATUS } from "@/types/signals";
 import useUpdateAgentInsightsJobMutation from "@/api/signals/useUpdateAgentInsightsJobMutation";
+import { OpikEvent, trackEvent } from "@/lib/analytics/tracking";
 
 type DiagnosticsSettingsDialogProps = {
   open: boolean;
@@ -33,6 +34,14 @@ const DiagnosticsSettingsDialog: React.FC<DiagnosticsSettingsDialogProps> = ({
   }, [open, enabled]);
 
   const handleSave = () => {
+    if (on !== enabled) {
+      trackEvent(
+        on
+          ? OpikEvent.DIAGNOSTICS_AUTO_ENABLED
+          : OpikEvent.DIAGNOSTICS_AUTO_DISABLED,
+        { project_id: projectId, source: "settings" },
+      );
+    }
     updateMutation.mutate(
       {
         projectId,

--- a/apps/opik-frontend/src/v2/pages/SignalsPage/IssuesTab/IssueDetail.tsx
+++ b/apps/opik-frontend/src/v2/pages/SignalsPage/IssuesTab/IssueDetail.tsx
@@ -25,6 +25,7 @@ import AffectedTracesSample from "@/v2/pages/SignalsPage/IssuesTab/AffectedTrace
 import { formatOccurrences } from "@/v2/pages/SignalsPage/helpers";
 import useAgentInsightsIssue from "@/api/signals/useAgentInsightsIssue";
 import useUpdateAgentInsightsIssueMutation from "@/api/signals/useUpdateAgentInsightsIssueMutation";
+import { OpikEvent, trackEvent } from "@/lib/analytics/tracking";
 
 type IssueDetailProps = {
   issue: AgentInsightsIssue;
@@ -87,10 +88,21 @@ const IssueDetail: React.FC<IssueDetailProps> = ({
 
   const updateMutation = useUpdateAgentInsightsIssueMutation();
 
-  const setStatus = (status: AGENT_INSIGHTS_ISSUE_STATUS) =>
+  const setStatus = (status: AGENT_INSIGHTS_ISSUE_STATUS) => {
+    trackEvent(
+      status === AGENT_INSIGHTS_ISSUE_STATUS.resolved
+        ? OpikEvent.DIAGNOSTICS_ISSUE_RESOLVED
+        : OpikEvent.DIAGNOSTICS_ISSUE_REOPENED,
+      { project_id: projectId, issue_id: issue.id, severity: issue.severity },
+    );
     updateMutation.mutate({ issueId: issue.id, projectId, status });
+  };
 
   const handleContinueWithOllie = () => {
+    trackEvent(OpikEvent.DIAGNOSTICS_CONTINUE_WITH_OLLIE, {
+      project_id: projectId,
+      issue_id: issue.id,
+    });
     const message = [
       `Help me fix the "${issue.name}" issue detected in this project.`,
       issue.cause ? `Root cause: ${issue.cause}` : null,

--- a/apps/opik-frontend/src/v2/pages/SignalsPage/IssuesTab/IssuesTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/SignalsPage/IssuesTab/IssuesTab.tsx
@@ -41,6 +41,7 @@ import IssueDetail from "@/v2/pages/SignalsPage/IssuesTab/IssueDetail";
 import IssueSeverityBadge from "@/v2/pages/SignalsPage/IssuesTab/IssueSeverityBadge";
 import IssuesSkeleton from "@/v2/pages/SignalsPage/IssuesTab/IssuesSkeleton";
 import { getRunFailureCopy } from "@/v2/pages/SignalsPage/runFailureCopy";
+import { OpikEvent, trackEvent } from "@/lib/analytics/tracking";
 
 const SORT_OPTIONS: { value: string; label: string; sorting: Sorting }[] = [
   {
@@ -305,6 +306,13 @@ const IssuesTab: React.FC<IssuesTabProps> = ({
   const status = showResolved
     ? AGENT_INSIGHTS_ISSUE_STATUS.resolved
     : AGENT_INSIGHTS_ISSUE_STATUS.open;
+  const handleTryAgain = () => {
+    trackEvent(OpikEvent.DIAGNOSTICS_TRY_AGAIN_CLICKED, {
+      project_id: projectId,
+      reason: failedReason,
+    });
+    onRunDiagnostic?.();
+  };
   const [sortValue, setSortValue] = useState<string>(SORT_OPTIONS[0].value);
   const [activeIssueId, setActiveIssueId] = useQueryParam(
     "issue",
@@ -398,7 +406,7 @@ const IssuesTab: React.FC<IssuesTabProps> = ({
             <FailedBanner
               reason={failedReason}
               detail={failedDetail}
-              onRetry={onRunDiagnostic}
+              onRetry={handleTryAgain}
             />
           )}
           {stale && (
@@ -553,7 +561,7 @@ const IssuesTab: React.FC<IssuesTabProps> = ({
             <FailedBanner
               reason={failedReason}
               detail={failedDetail}
-              onRetry={onRunDiagnostic}
+              onRetry={handleTryAgain}
             />
           </div>
         )}

--- a/apps/opik-frontend/src/v2/pages/SignalsPage/SignalsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/SignalsPage/SignalsPage.tsx
@@ -28,6 +28,7 @@ import useUpdateAgentInsightsJobMutation from "@/api/signals/useUpdateAgentInsig
 import useDiagnosticsRunState from "@/hooks/useDiagnosticsRunState";
 import useDiagnosticsSeen from "@/hooks/useDiagnosticsSeen";
 import { getRunFailureCopy } from "@/v2/pages/SignalsPage/runFailureCopy";
+import { OpikEvent, trackEvent } from "@/lib/analytics/tracking";
 import { useToast } from "@/ui/use-toast";
 import SignalsStatsCards from "@/v2/pages/SignalsPage/SignalsStatsCards";
 import IssuesTab from "@/v2/pages/SignalsPage/IssuesTab/IssuesTab";
@@ -112,7 +113,7 @@ const SignalsPage: React.FC<{ showResolved?: boolean }> = ({
   const { toast } = useToast();
   const triggerMutation = useTriggerAgentInsightsJobMutation();
   const updateJobMutation = useUpdateAgentInsightsJobMutation();
-  const { isRunning, baseline, failBaseline, startRun, endRun } =
+  const { isRunning, startedAt, baseline, failBaseline, startRun, endRun } =
     useDiagnosticsRunState(projectId);
   const { markSeen } = useDiagnosticsSeen(projectId);
 
@@ -170,22 +171,30 @@ const SignalsPage: React.FC<{ showResolved?: boolean }> = ({
   useEffect(() => {
     if (!isRunning) return;
     if (maxUpdatedAt(issuesData?.content ?? []) > baseline) {
+      trackEvent(OpikEvent.DIAGNOSTICS_RUN_COMPLETED, {
+        project_id: projectId,
+        duration_ms: startedAt ? Date.now() - startedAt : undefined,
+      });
       endRun();
     }
-  }, [issuesData, isRunning, baseline, endRun]);
+  }, [issuesData, isRunning, baseline, startedAt, projectId, endRun]);
 
   // last_failed_at past the trigger baseline = this run failed: end it and toast once.
   useEffect(() => {
     if (!isRunning) return;
     const failedAt = job?.last_failed_at ? Date.parse(job.last_failed_at) : 0;
     if (failedAt > failBaseline) {
+      trackEvent(OpikEvent.DIAGNOSTICS_RUN_FAILED, {
+        project_id: projectId,
+        reason: job?.last_failure_reason,
+      });
       endRun();
       const { title, description } = getRunFailureCopy(
         job?.last_failure_reason,
       );
       toast({ title, description, variant: "destructive" });
     }
-  }, [job, isRunning, failBaseline, endRun, toast]);
+  }, [job, isRunning, failBaseline, projectId, endRun, toast]);
 
   const hasData = (issuesData?.content?.length ?? 0) > 0;
   const isActive = isJobEnabled || isRunning;
@@ -201,6 +210,11 @@ const SignalsPage: React.FC<{ showResolved?: boolean }> = ({
   }
 
   const handleRunDiagnostic = () => {
+    trackEvent(OpikEvent.DIAGNOSTICS_RUN_CLICKED, {
+      project_id: projectId,
+      source: isJobEnabled || hasData ? "rerun" : "empty_state",
+      is_first_run: !hasData,
+    });
     const baselineNow = maxUpdatedAt(issuesData?.content ?? []);
     const failBaselineNow = job?.last_failed_at
       ? Date.parse(job.last_failed_at)
@@ -212,6 +226,10 @@ const SignalsPage: React.FC<{ showResolved?: boolean }> = ({
   };
 
   const handleTurnOnAuto = () => {
+    trackEvent(OpikEvent.DIAGNOSTICS_AUTO_ENABLED, {
+      project_id: projectId,
+      source: "header",
+    });
     updateJobMutation.mutate({
       projectId,
       status: AGENT_INSIGHTS_JOB_STATUS.enabled,


### PR DESCRIPTION
## Details

Adds product-analytics (BI) instrumentation to Agent Insights / Diagnostics — there was none before (only OTel ops metrics). Two parts in this repo:

**Backend — thread `trigger_source` (manual | scheduled).** Only opik-backend knows whether a run was a *Run diagnostics* click (`triggerNow`) or the daily sweep (`runSweep`), so it originates a `trigger_source` and carries it through the Redis message → report client → platform trigger payload; Ollie tags its generation BI events with it. No BE product-BI events — OTel already covers the trigger. `trigger_source` is nullable end-to-end (a legacy queued message / older BE defaults to `scheduled`).

**Frontend — Segment `trackEvent`.** 9 `opik_diagnostics_*` events across the Signals UI: run clicked (source, is_first_run), run completed (duration_ms), run failed (reason), try-again, auto enabled/disabled (header + settings), issue resolved/reopened, continue-with-Ollie. No-ops when Segment isn't configured.

Companion PRs (all optional-field / no-op, so deploy order is flexible): comet-backend #5605 (pass-through) and ollie-assist #319 (`ollie_insights_run_*` events).

## Change checklist
- [x] User facing (BI only; no UX change)
- [ ] Documentation update

## Issues
- OPIK-7139

## Testing
- BE: `AgentInsightsReportJobTest` (3) + `AgentInsightsJobsResourceTest` (16, asserts manual/scheduled + legacy-null tolerance) green; `spotless:apply`.
- FE: `tsc --noEmit` + eslint clean on changed files.

## Documentation
No user-facing docs change — internal Diagnostics telemetry only.
