### PR TITLE
[NA] [FE] fix: enable Sonnet 5 and Fable 5 in playground and online scoring

### DIFF
--- a/apps/opik-frontend/src/constants/llm.ts
+++ b/apps/opik-frontend/src/constants/llm.ts
@@ -137,6 +137,14 @@ export const ANTHROPIC_MODEL_CAPABILITIES: Partial<
     supportsSamplingParams: false,
     thinkingEffortOptions: ["low", "medium", "high", "xhigh", "max"],
   },
+  [PROVIDER_MODEL_TYPE.CLAUDE_SONNET_5]: {
+    supportsSamplingParams: false,
+    thinkingEffortOptions: ["low", "medium", "high", "xhigh", "max"],
+  },
+  [PROVIDER_MODEL_TYPE.CLAUDE_FABLE_5]: {
+    supportsSamplingParams: false,
+    thinkingEffortOptions: ["low", "medium", "high", "xhigh", "max"],
+  },
   [PROVIDER_MODEL_TYPE.CLAUDE_OPUS_4_6]: {
     thinkingEffortOptions: ["adaptive", "low", "medium", "high", "max"],
   },

--- a/apps/opik-frontend/src/lib/modelUtils.test.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.test.ts
@@ -70,6 +70,15 @@ describe("supportsSamplingParams", () => {
       false,
     );
   });
+
+  it("returns false for Claude Sonnet 5 and Fable 5", () => {
+    expect(supportsSamplingParams(PROVIDER_MODEL_TYPE.CLAUDE_SONNET_5)).toBe(
+      false,
+    );
+    expect(supportsSamplingParams(PROVIDER_MODEL_TYPE.CLAUDE_FABLE_5)).toBe(
+      false,
+    );
+  });
 });
 
 describe("updateProviderConfig — Anthropic", () => {


### PR DESCRIPTION
## Details

Sonnet 5 and Fable 5 failed in the Prompt Playground and Online Scoring with `temperature is deprecated for this model` / `top_p is deprecated for this model` errors. These models (like Opus 4.7/4.8) reject `temperature`/`top_p`, but they were missing from `ANTHROPIC_MODEL_CAPABILITIES`, so `supportsSamplingParams` defaulted to `true` — the UI kept the temperature/top_p sliders visible and the request payload still included those params, producing a 400.

- Added `CLAUDE_SONNET_5` and `CLAUDE_FABLE_5` rows to `ANTHROPIC_MODEL_CAPABILITIES` with `supportsSamplingParams: false` and `thinkingEffortOptions: ["low", "medium", "high", "xhigh", "max"]`, mirroring the existing Opus 4.7/4.8 entries.
- The existing `supportsSamplingParams` gating in `modelUtils.ts` then activates for both models: hides the sliders (`AnthropicModelConfigs`), strips the params from config state on model switch (`updateProviderConfig`), and last-mile-strips them from the request payload (`sanitizeConfigForRequest`, which also covers stale saved prompts).
- No backend change: the Anthropic capability gating is FE-only (the same mechanism that already makes Opus 4.8 work in production).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation (root-cause diagnosis + fix + tests)
- Human verification: code review + local verification (typecheck, lint, unit tests)

## Testing

Local checks run from `apps/opik-frontend`:
- `npm run typecheck` — pass
- `npm run lint` — pass
- `npx vitest run src/lib/modelUtils.test.ts` — 47/47 pass, including a new assertion that `supportsSamplingParams` returns `false` for Sonnet 5 and Fable 5.

Scenarios validated: with the new map rows, `supportsSamplingParams` returns `false` for both models, matching the already-working Opus 4.7/4.8 behavior — sliders hidden, params stripped from state and from the outgoing request.

## Documentation

N/A — no user-facing documentation changes.
