### PR TITLE
[OPIK-6993] [BE] Capture Claude Agent SDK / Claude Code content in Opik OTEL traces

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -142,20 +142,24 @@ public class OpenTelemetryMapper {
         ObjectNode output = JsonUtils.createObjectNode();
         ObjectNode metadata = JsonUtils.createObjectNode();
         Set<String> tags = new HashSet<>();
+        // Claude Code spans carry a lot of session/config attributes that aren't input. For that
+        // integration the default bucket for unmapped attributes is metadata (not input), so only
+        // the explicitly promoted content attributes land in input/output/usage.
+        // Decided per span by name (not from the batch-level integrationName below): a single OTLP
+        // batch can mix scopes from more than one integration, so gating this on the batch-wide
+        // value could misroute a non-Claude span or skip routing for a real Claude Code span.
+        boolean isClaudeCode = OpenTelemetryMappingRuleFactory.isClaudeCodeSpan(spanName);
+        ObjectNode defaultBucket = isClaudeCode ? metadata : input;
+
         // Hold model and provider until the attribute loop completes so we can apply
         // post-processing (e.g. Elastic Inference Service routing) that needs both values.
+        // Claude Code is Anthropic-only and never sends a provider attribute, so set it directly.
         String model = null;
-        String provider = null;
+        String provider = isClaudeCode ? "anthropic" : null;
 
         if (StringUtils.isNotBlank(integrationName)) {
             metadata.put("integration", integrationName);
         }
-
-        // Claude Code spans carry a lot of session/config attributes that aren't input. For that
-        // integration the default bucket for unmapped attributes is metadata (not input), so only
-        // the explicitly promoted content attributes land in input/output/usage.
-        boolean isClaudeCode = OpenTelemetryMappingRuleFactory.isClaudeCode(integrationName);
-        ObjectNode defaultBucket = isClaudeCode ? metadata : input;
 
         // Iterate over each attribute key-value pair
         for (KeyValue attribute : attributes) {
@@ -170,10 +174,10 @@ public class OpenTelemetryMapper {
                 continue;
             }
 
-            var ruleOpt = OpenTelemetryMappingRuleFactory.findRule(key, integrationName);
+            var ruleOpt = OpenTelemetryMappingRuleFactory.findRule(key, isClaudeCode);
 
             if (ruleOpt.isEmpty()) {
-                log.debug("No rule found for kv {} -> {}. Using default bucket.", key, attribute.getValue());
+                log.debug("No rule found for kv '{}' -> '{}'. Using default bucket.", key, attribute.getValue());
                 extractToJsonColumn(defaultBucket, key, value);
                 continue;
             }
@@ -301,15 +305,22 @@ public class OpenTelemetryMapper {
      * @param output the output node to populate
      */
     private static void extractToolOutputEvent(List<Span.Event> events, ObjectNode output) {
-        if (CollectionUtils.isEmpty(events)) {
-            return;
-        }
-        events.stream()
-                .filter(event -> TOOL_OUTPUT_EVENT_NAME.equals(event.getName()))
-                .reduce((first, second) -> second)
+        findLastEvent(events, TOOL_OUTPUT_EVENT_NAME)
                 .ifPresent(event -> event.getAttributesList().stream()
                         .filter(attribute -> TOOL_OUTPUT_CONTENT_KEYS.contains(attribute.getKey()))
                         .forEach(attribute -> extractToJsonColumn(output, attribute.getKey(), attribute.getValue())));
+    }
+
+    /**
+     * Finds the last span event with the given name; the last one wins when several exist.
+     */
+    private static Optional<Span.Event> findLastEvent(List<Span.Event> events, String name) {
+        if (CollectionUtils.isEmpty(events)) {
+            return Optional.empty();
+        }
+        return events.stream()
+                .filter(event -> name.equals(event.getName()))
+                .reduce((first, second) -> second);
     }
 
     private static final String EXCEPTION_EVENT_NAME = "exception";
@@ -333,9 +344,7 @@ public class OpenTelemetryMapper {
      * @return the extracted error info, or empty when the span did not fail
      */
     static Optional<ErrorInfo> extractErrorInfo(Span otelSpan) {
-        var exceptionEvent = otelSpan.getEventsList().stream()
-                .filter(event -> EXCEPTION_EVENT_NAME.equals(event.getName()))
-                .reduce((first, second) -> second);
+        var exceptionEvent = findLastEvent(otelSpan.getEventsList(), EXCEPTION_EVENT_NAME);
 
         if (exceptionEvent.isPresent()) {
             var attributes = exceptionEvent.get().getAttributesList();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -135,16 +135,21 @@ public class OpenTelemetryMapper {
             metadata.put("integration", integrationName);
         }
 
+        // Claude Code spans carry a lot of session/config attributes that aren't input. For that
+        // integration the default bucket for unmapped attributes is metadata (not input), so only
+        // the explicitly promoted content attributes land in input/output/usage.
+        boolean isClaudeCode = OpenTelemetryMappingRuleFactory.isClaudeCode(integrationName);
+        ObjectNode defaultBucket = isClaudeCode ? metadata : input;
+
         // Iterate over each attribute key-value pair
         for (KeyValue attribute : attributes) {
             var key = attribute.getKey();
             var value = attribute.getValue();
-            var ruleOpt = OpenTelemetryMappingRuleFactory.findRule(key);
+            var ruleOpt = OpenTelemetryMappingRuleFactory.findRule(key, integrationName);
 
             if (ruleOpt.isEmpty()) {
-                // if it's not explicitly request to drop, we keep it in input
-                log.debug("No rule found for kv {} -> {}. Using for Input.", key, attribute.getValue());
-                extractToJsonColumn(input, key, value);
+                log.debug("No rule found for kv {} -> {}. Using default bucket.", key, attribute.getValue());
+                extractToJsonColumn(defaultBucket, key, value);
                 continue;
             }
 
@@ -207,7 +212,9 @@ public class OpenTelemetryMapper {
         // Claude Code emits the tool result as a `tool.output` span event (Bash carries it on
         // `output`, file tools on `content`). Surface it as the tool span's output instead of
         // leaving it only in metadata.opentelemetry.events.
-        extractToolOutputEvent(events, output);
+        if (isClaudeCode) {
+            extractToolOutputEvent(events, output);
+        }
 
         // Rewrite Elastic Inference Service model/provider into the underlying provider so
         // that cost lookup and provider-based filtering see the real upstream. Records the

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -128,6 +128,13 @@ public class OpenTelemetryMapper {
     private static final String CLAUDE_CODE_LLM_SPAN = "claude_code.llm_request";
     private static final String NEW_CONTEXT_ATTR = "new_context";
 
+    /**
+     * Same as {@link #enrichSpanWithAttributes(SpanBuilder, List, String, List)} but with the OTEL
+     * span name, used for span-name-aware routing (e.g. Claude Code's {@code new_context} maps to
+     * input only on {@code claude_code.llm_request} spans).
+     *
+     * @param spanName the OTEL span name (may be null)
+     */
     public static void enrichSpanWithAttributes(SpanBuilder spanBuilder, List<KeyValue> attributes,
             String integrationName, List<Span.Event> events, String spanName) {
         Map<String, Integer> usage = new HashMap<>();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -104,7 +104,8 @@ public class OpenTelemetryMapper {
                 .endTime(Instant.ofEpochMilli(endTimeMs));
 
         List<Span.Event> events = otelSpan.getEventsList();
-        enrichSpanWithAttributes(spanBuilder, otelSpan.getAttributesList(), integrationName, events);
+        enrichSpanWithAttributes(spanBuilder, otelSpan.getAttributesList(), integrationName, events,
+                otelSpan.getName());
 
         extractErrorInfo(otelSpan).ifPresent(spanBuilder::errorInfo);
 
@@ -121,6 +122,14 @@ public class OpenTelemetryMapper {
      */
     public static void enrichSpanWithAttributes(SpanBuilder spanBuilder, List<KeyValue> attributes,
             String integrationName, List<Span.Event> events) {
+        enrichSpanWithAttributes(spanBuilder, attributes, integrationName, events, null);
+    }
+
+    private static final String CLAUDE_CODE_LLM_SPAN = "claude_code.llm_request";
+    private static final String NEW_CONTEXT_ATTR = "new_context";
+
+    public static void enrichSpanWithAttributes(SpanBuilder spanBuilder, List<KeyValue> attributes,
+            String integrationName, List<Span.Event> events, String spanName) {
         Map<String, Integer> usage = new HashMap<>();
         ObjectNode input = JsonUtils.createObjectNode();
         ObjectNode output = JsonUtils.createObjectNode();
@@ -145,6 +154,17 @@ public class OpenTelemetryMapper {
         for (KeyValue attribute : attributes) {
             var key = attribute.getKey();
             var value = attribute.getValue();
+
+            // Claude Code's `new_context` is the latest message fed to the model on llm_request
+            // spans (the real LLM input); on interaction/tool spans it just repeats the prompt /
+            // tool result, so it's dropped there.
+            if (isClaudeCode && NEW_CONTEXT_ATTR.equals(key)) {
+                if (CLAUDE_CODE_LLM_SPAN.equals(spanName)) {
+                    extractToJsonColumn(input, key, value);
+                }
+                continue;
+            }
+
             var ruleOpt = OpenTelemetryMappingRuleFactory.findRule(key, integrationName);
 
             if (ruleOpt.isEmpty()) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -177,7 +177,7 @@ public class OpenTelemetryMapper {
             var ruleOpt = OpenTelemetryMappingRuleFactory.findRule(key, isClaudeCode);
 
             if (ruleOpt.isEmpty()) {
-                log.debug("No rule found for kv '{}' -> '{}'. Using default bucket.", key, attribute.getValue());
+                log.debug("No rule found for unmapped attribute key '{}'. Using default bucket.", key);
                 extractToJsonColumn(defaultBucket, key, value);
                 continue;
             }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -157,11 +157,9 @@ public class OpenTelemetryMapper {
 
             // Claude Code's `new_context` is the latest message fed to the model on llm_request
             // spans (the real LLM input); on interaction/tool spans it just repeats the prompt /
-            // tool result, so it's dropped there.
+            // tool result, so it's kept in metadata there rather than input.
             if (isClaudeCode && NEW_CONTEXT_ATTR.equals(key)) {
-                if (CLAUDE_CODE_LLM_SPAN.equals(spanName)) {
-                    extractToJsonColumn(input, key, value);
-                }
+                extractToJsonColumn(CLAUDE_CODE_LLM_SPAN.equals(spanName) ? input : metadata, key, value);
                 continue;
             }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -204,6 +204,11 @@ public class OpenTelemetryMapper {
         // Process events and add them to metadata
         processEvents(events, metadata);
 
+        // Claude Code emits the tool result as a `tool.output` span event (Bash carries it on
+        // `output`, file tools on `content`). Surface it as the tool span's output instead of
+        // leaving it only in metadata.opentelemetry.events.
+        extractToolOutputEvent(events, output);
+
         // Rewrite Elastic Inference Service model/provider into the underlying provider so
         // that cost lookup and provider-based filtering see the real upstream. Records the
         // original values in metadata for traceability. Returns the (possibly unchanged) pair.
@@ -250,6 +255,29 @@ public class OpenTelemetryMapper {
         if (!tags.isEmpty()) {
             spanBuilder.tags(tags);
         }
+    }
+
+    private static final String TOOL_OUTPUT_EVENT_NAME = "tool.output";
+    private static final Set<String> TOOL_OUTPUT_CONTENT_KEYS = Set.of("output", "content");
+
+    /**
+     * Maps a Claude Code {@code tool.output} span event into the tool span's output. The event
+     * carries the tool result on {@code output} (Bash) or {@code content} (file tools). The last
+     * event wins if several are present.
+     *
+     * @param events the list of events extracted from the otel payload
+     * @param output the output node to populate
+     */
+    private static void extractToolOutputEvent(List<Span.Event> events, ObjectNode output) {
+        if (CollectionUtils.isEmpty(events)) {
+            return;
+        }
+        events.stream()
+                .filter(event -> TOOL_OUTPUT_EVENT_NAME.equals(event.getName()))
+                .reduce((first, second) -> second)
+                .ifPresent(event -> event.getAttributesList().stream()
+                        .filter(attribute -> TOOL_OUTPUT_CONTENT_KEYS.contains(attribute.getKey()))
+                        .forEach(attribute -> extractToJsonColumn(output, attribute.getKey(), attribute.getValue())));
     }
 
     private static final String EXCEPTION_EVENT_NAME = "exception";

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingRuleFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingRuleFactory.java
@@ -26,10 +26,17 @@ import java.util.stream.Stream;
 public class OpenTelemetryMappingRuleFactory {
 
     /**
-     * Instrumentation scope name Claude Code / Claude Agent SDK spans are tagged with.
-     * Claude Code rules are applied only for this integration (see {@link #findRule(String, String)}).
+     * Instrumentation scope name Claude Code / Claude Agent SDK spans are tagged with. Used only
+     * for the cosmetic {@code metadata.integration} label; which rules apply is decided per span
+     * by {@link #isClaudeCodeSpan(String)} instead (see its javadoc for why).
      */
     public static final String CLAUDE_CODE_INSTRUMENTATION = "com.anthropic.claude_code.tracing";
+
+    /**
+     * Every Claude Code OTEL span name is prefixed with this (e.g. {@code claude_code.llm_request},
+     * {@code claude_code.tool}). See {@link #isClaudeCodeSpan(String)}.
+     */
+    private static final String CLAUDE_CODE_SPAN_PREFIX = "claude_code.";
 
     private static final List<OpenTelemetryMappingRule> ALL_RULES = Stream.of(
             LogfireMappingRules.getRules(),
@@ -61,31 +68,35 @@ public class OpenTelemetryMappingRuleFactory {
     }
 
     /**
-     * Finds the matching rule for the given key, applying integration-specific rules first.
-     * Claude Code rules are scoped so their reclassification (e.g. session.id → thread, tokens →
-     * usage) doesn't affect other integrations. Falls back to the global rules.
+     * Finds the matching rule for the given key, applying Claude Code's rules first when the span
+     * is a Claude Code span. Falls back to the global rules.
      *
      * @param key the attribute key to find a rule for
-     * @param integrationName the detected instrumentation scope name (may be null)
+     * @param isClaudeCode whether the current span is a Claude Code span (see {@link #isClaudeCodeSpan(String)})
      * @return an Optional containing the matching rule, or empty if no rule matches
      */
-    public static Optional<OpenTelemetryMappingRule> findRule(String key, String integrationName) {
-        if (isClaudeCode(integrationName)) {
-            var claudeCodeRule = ClaudeCodeMappingRules.getRules().stream()
-                    .filter(rule -> rule.matches(key))
-                    .findFirst();
-            if (claudeCodeRule.isPresent()) {
-                return claudeCodeRule;
-            }
+    public static Optional<OpenTelemetryMappingRule> findRule(String key, boolean isClaudeCode) {
+        if (!isClaudeCode) {
+            return findRule(key);
         }
-        return findRule(key);
+        return ClaudeCodeMappingRules.findRule(key).or(() -> findRule(key));
     }
 
     /**
-     * Whether the detected integration is Claude Code / Claude Agent SDK.
+     * Whether the given OTEL span name belongs to Claude Code / Claude Agent SDK.
+     * <p>
+     * This is decided per span, by name, rather than from the batch-level detected
+     * {@code integrationName} (see {@code OpenTelemetryService}): an {@code ExportTraceServiceRequest}
+     * can carry spans from more than one {@code ScopeSpans}/integration in the same batch, but
+     * {@code integrationName} is resolved once for the whole batch. Gating Claude-specific routing
+     * (default attribute bucket, provider, tool-output extraction — see
+     * {@code OpenTelemetryMapper#enrichSpanWithAttributes}) on that batch-wide value would either
+     * misroute a differently-scoped span as Claude Code, or skip Claude routing for a genuine
+     * Claude Code span, depending on which scope happened to be seen first. The span name has no
+     * such ambiguity: Claude Code always names its own spans with this prefix.
      */
-    public static boolean isClaudeCode(String integrationName) {
-        return CLAUDE_CODE_INSTRUMENTATION.equalsIgnoreCase(integrationName);
+    public static boolean isClaudeCodeSpan(String spanName) {
+        return spanName != null && spanName.startsWith(CLAUDE_CODE_SPAN_PREFIX);
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingRuleFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingRuleFactory.java
@@ -1,5 +1,6 @@
 package com.comet.opik.domain.mapping;
 
+import com.comet.opik.domain.mapping.otel.ClaudeCodeMappingRules;
 import com.comet.opik.domain.mapping.otel.GenAIMappingRules;
 import com.comet.opik.domain.mapping.otel.GeneralMappingRules;
 import com.comet.opik.domain.mapping.otel.LangFuseMappingRules;
@@ -26,6 +27,7 @@ public class OpenTelemetryMappingRuleFactory {
 
     private static final List<OpenTelemetryMappingRule> ALL_RULES = Stream.of(
             LogfireMappingRules.getRules(),
+            ClaudeCodeMappingRules.getRules(),
             GenAIMappingRules.getRules(),
             OpenInferenceMappingRules.getRules(),
             LiveKitMappingRules.getRules(),

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingRuleFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingRuleFactory.java
@@ -25,9 +25,14 @@ import java.util.stream.Stream;
 @UtilityClass
 public class OpenTelemetryMappingRuleFactory {
 
+    /**
+     * Instrumentation scope name Claude Code / Claude Agent SDK spans are tagged with.
+     * Claude Code rules are applied only for this integration (see {@link #findRule(String, String)}).
+     */
+    public static final String CLAUDE_CODE_INSTRUMENTATION = "com.anthropic.claude_code.tracing";
+
     private static final List<OpenTelemetryMappingRule> ALL_RULES = Stream.of(
             LogfireMappingRules.getRules(),
-            ClaudeCodeMappingRules.getRules(),
             GenAIMappingRules.getRules(),
             OpenInferenceMappingRules.getRules(),
             LiveKitMappingRules.getRules(),
@@ -53,6 +58,34 @@ public class OpenTelemetryMappingRuleFactory {
         return ALL_RULES.stream()
                 .filter(rule -> rule.matches(key))
                 .findFirst();
+    }
+
+    /**
+     * Finds the matching rule for the given key, applying integration-specific rules first.
+     * Claude Code rules are scoped so their reclassification (e.g. session.id → thread, tokens →
+     * usage) doesn't affect other integrations. Falls back to the global rules.
+     *
+     * @param key the attribute key to find a rule for
+     * @param integrationName the detected instrumentation scope name (may be null)
+     * @return an Optional containing the matching rule, or empty if no rule matches
+     */
+    public static Optional<OpenTelemetryMappingRule> findRule(String key, String integrationName) {
+        if (isClaudeCode(integrationName)) {
+            var claudeCodeRule = ClaudeCodeMappingRules.getRules().stream()
+                    .filter(rule -> rule.matches(key))
+                    .findFirst();
+            if (claudeCodeRule.isPresent()) {
+                return claudeCodeRule;
+            }
+        }
+        return findRule(key);
+    }
+
+    /**
+     * Whether the detected integration is Claude Code / Claude Agent SDK.
+     */
+    public static boolean isClaudeCode(String integrationName) {
+        return CLAUDE_CODE_INSTRUMENTATION.equalsIgnoreCase(integrationName);
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingUtils.java
@@ -82,6 +82,12 @@ public class OpenTelemetryMappingUtils {
         }
     }
 
+    // Prefix rules (e.g. `gen_ai.usage.`) carry the usage name in the suffix; exact-match rules
+    // (e.g. Claude Code's `input_tokens`) use the full key.
+    private static String usageKey(OpenTelemetryMappingRule rule, String key) {
+        return rule.isPrefix() ? key.substring(rule.getRule().length()) : key;
+    }
+
     /**
      * Extracts usage-related fields from a given value and adds them to the usage map.
      * The method supports extracting usage from integer values, string values, and JSON objects.
@@ -91,12 +97,6 @@ public class OpenTelemetryMappingUtils {
      * @param key the attribute key associated with the value
      * @param value the value to be processed and extracted
      */
-    // Prefix rules (e.g. `gen_ai.usage.`) carry the usage name in the suffix; exact-match rules
-    // (e.g. Claude Code's `input_tokens`) use the full key.
-    private static String usageKey(OpenTelemetryMappingRule rule, String key) {
-        return rule.isPrefix() ? key.substring(rule.getRule().length()) : key;
-    }
-
     public static void extractUsageField(@NonNull Map<String, Integer> usage, @NonNull OpenTelemetryMappingRule rule,
             @NonNull String key, @NonNull AnyValue value) {
         // usage might appear as single int or string values as well as a JSON object

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingUtils.java
@@ -26,7 +26,11 @@ public class OpenTelemetryMappingUtils {
 
     private static final Map<String, String> USAGE_KEYS_MAPPING = Map.of(
             "input_tokens", "prompt_tokens",
-            "output_tokens", "completion_tokens");
+            "output_tokens", "completion_tokens",
+            // Claude Code emits short cache-token names; normalize to the names the Anthropic
+            // cache-cost path (SpanCostCalculator) recognizes, otherwise cache pricing is skipped.
+            "cache_read_tokens", "cache_read_input_tokens",
+            "cache_creation_tokens", "cache_creation_input_tokens");
 
     /**
      * Extracts a value from an AnyValue object and writes it to a specified JSON field in an ObjectNode.

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/OpenTelemetryMappingUtils.java
@@ -87,11 +87,17 @@ public class OpenTelemetryMappingUtils {
      * @param key the attribute key associated with the value
      * @param value the value to be processed and extracted
      */
+    // Prefix rules (e.g. `gen_ai.usage.`) carry the usage name in the suffix; exact-match rules
+    // (e.g. Claude Code's `input_tokens`) use the full key.
+    private static String usageKey(OpenTelemetryMappingRule rule, String key) {
+        return rule.isPrefix() ? key.substring(rule.getRule().length()) : key;
+    }
+
     public static void extractUsageField(@NonNull Map<String, Integer> usage, @NonNull OpenTelemetryMappingRule rule,
             @NonNull String key, @NonNull AnyValue value) {
         // usage might appear as single int or string values as well as a JSON object
         if (value.hasIntValue()) {
-            var actualKey = key.substring(rule.getRule().length());
+            var actualKey = usageKey(rule, key);
             usage.put(USAGE_KEYS_MAPPING.getOrDefault(actualKey, actualKey), (int) value.getIntValue());
         } else if (value.hasStringValue()) {
             boolean extracted = tryExtractUsageFromString(usage, rule, key, value.getStringValue());
@@ -221,7 +227,7 @@ public class OpenTelemetryMappingUtils {
             String key, String stringValue) {
         try {
             int intValue = Integer.parseInt(stringValue);
-            var actualKey = key.substring(rule.getRule().length());
+            var actualKey = usageKey(rule, key);
             usage.put(USAGE_KEYS_MAPPING.getOrDefault(actualKey, actualKey), intValue);
             return true;
         } catch (NumberFormatException e) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/ClaudeCodeMappingRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/ClaudeCodeMappingRules.java
@@ -24,7 +24,7 @@ import java.util.List;
  * </ul>
  * {@code new_context} is handled span-aware in {@code OpenTelemetryMapper}: it is the latest LLM
  * message on {@code claude_code.llm_request} spans (→ input) and a duplicate of the prompt / tool
- * result elsewhere (dropped).
+ * result elsewhere (→ metadata).
  * The tool result is emitted as a {@code tool.output} span event and mapped to the tool span
  * output directly in {@code OpenTelemetryMapper}.
  */

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/ClaudeCodeMappingRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/ClaudeCodeMappingRules.java
@@ -18,7 +18,8 @@ import java.util.List;
  *     <li>input: {@code user_prompt} (interaction), {@code tool_input} (tool),
  *     {@code model} / {@code system_prompt_preview} (llm; {@code tools} is mapped to input
  *     globally), {@code hook_event} / {@code hook_name} / {@code hook_definitions} (hook)</li>
- *     <li>output: {@code response.model_output} (llm; assistant text)</li>
+ *     <li>output: {@code response.model_output} (assistant text), {@code stop_reason},
+ *     {@code response.has_tool_call} (llm response)</li>
  *     <li>usage: {@code input_tokens} / {@code output_tokens} / {@code cache_*_tokens}</li>
  *     <li>thread: {@code session.id} (groups the interaction turns into one Opik thread)</li>
  * </ul>
@@ -48,8 +49,10 @@ public final class ClaudeCodeMappingRules {
             rule("hook_event", OpenTelemetryMappingRule.Outcome.INPUT),
             rule("hook_name", OpenTelemetryMappingRule.Outcome.INPUT),
             rule("hook_definitions", OpenTelemetryMappingRule.Outcome.INPUT),
-            // --- output ---
+            // --- output: the model's response ---
             rule("response.model_output", OpenTelemetryMappingRule.Outcome.OUTPUT),
+            rule("stop_reason", OpenTelemetryMappingRule.Outcome.OUTPUT),
+            rule("response.has_tool_call", OpenTelemetryMappingRule.Outcome.OUTPUT),
             // --- usage ---
             rule("input_tokens", OpenTelemetryMappingRule.Outcome.USAGE),
             rule("output_tokens", OpenTelemetryMappingRule.Outcome.USAGE),

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/ClaudeCodeMappingRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/ClaudeCodeMappingRules.java
@@ -1,0 +1,55 @@
+package com.comet.opik.domain.mapping.otel;
+
+import com.comet.opik.domain.mapping.OpenTelemetryMappingRule;
+import lombok.experimental.UtilityClass;
+
+import java.util.List;
+
+/**
+ * Mapping rules for Claude Code / Claude Agent SDK spans.
+ * <p>
+ * Claude Code emits its content on span attributes that don't match any generic rule, so without
+ * these they all fall into the input attribute-bag (see {@code OpenTelemetryMapper}). These rules
+ * surface the content as clean span input/output:
+ * <ul>
+ *     <li>{@code user_prompt} on {@code claude_code.interaction} → trace input</li>
+ *     <li>{@code tool_input} on {@code claude_code.tool} → tool span input</li>
+ *     <li>{@code response.model_output} on {@code claude_code.llm_request} → LLM span output
+ *     (assistant text, emitted under the detailed-tracing beta)</li>
+ * </ul>
+ * The tool result is emitted as a {@code tool.output} span event and is mapped to the tool span
+ * output directly in {@code OpenTelemetryMapper}, not here.
+ */
+@UtilityClass
+public final class ClaudeCodeMappingRules {
+
+    public static final String SOURCE = "ClaudeCode";
+
+    private static final List<OpenTelemetryMappingRule> RULES = List.of(
+            OpenTelemetryMappingRule.builder()
+                    .rule("user_prompt").source(SOURCE).outcome(OpenTelemetryMappingRule.Outcome.INPUT).build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("user_prompt_length").source(SOURCE).outcome(OpenTelemetryMappingRule.Outcome.METADATA)
+                    .build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("tool_input").source(SOURCE).outcome(OpenTelemetryMappingRule.Outcome.INPUT).build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("tool_input_truncated").source(SOURCE).outcome(OpenTelemetryMappingRule.Outcome.METADATA)
+                    .build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("tool_input_original_length").source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("response.model_output").source(SOURCE).outcome(OpenTelemetryMappingRule.Outcome.OUTPUT)
+                    .build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("response.model_output_truncated").source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build(),
+            OpenTelemetryMappingRule.builder()
+                    .rule("response.model_output_original_length").source(SOURCE)
+                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build());
+
+    public static List<OpenTelemetryMappingRule> getRules() {
+        return RULES;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/ClaudeCodeMappingRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/ClaudeCodeMappingRules.java
@@ -8,46 +8,43 @@ import java.util.List;
 /**
  * Mapping rules for Claude Code / Claude Agent SDK spans.
  * <p>
- * Claude Code emits its content on span attributes that don't match any generic rule, so without
- * these they all fall into the input attribute-bag (see {@code OpenTelemetryMapper}). These rules
- * surface the content as clean span input/output:
+ * These rules are applied only when the instrumentation scope is
+ * {@code com.anthropic.claude_code.tracing} (see {@code OpenTelemetryMappingRuleFactory} and
+ * {@code OpenTelemetryMapper}). For Claude Code spans the default bucket for unmapped attributes
+ * is metadata (not input), so this list only needs to <em>promote</em> the handful of attributes
+ * that carry real content into input/output/usage/thread; everything else (session/user identity,
+ * durations, prompt hashes, tool ids, hook counters, ...) falls through to metadata automatically.
  * <ul>
- *     <li>{@code user_prompt} on {@code claude_code.interaction} → trace input</li>
- *     <li>{@code tool_input} on {@code claude_code.tool} → tool span input</li>
- *     <li>{@code response.model_output} on {@code claude_code.llm_request} → LLM span output
- *     (assistant text, emitted under the detailed-tracing beta)</li>
+ *     <li>{@code user_prompt} → input (root {@code claude_code.interaction} → trace input)</li>
+ *     <li>{@code tool_input} → input ({@code claude_code.tool})</li>
+ *     <li>{@code response.model_output} → output ({@code claude_code.llm_request}; assistant text)</li>
+ *     <li>{@code input_tokens} / {@code output_tokens} / {@code cache_*_tokens} → usage</li>
+ *     <li>{@code session.id} → thread id (groups the interaction turns into one Opik thread)</li>
+ *     <li>{@code new_context} → dropped (verbatim duplicate of the prompt / tool result)</li>
  * </ul>
- * The tool result is emitted as a {@code tool.output} span event and is mapped to the tool span
- * output directly in {@code OpenTelemetryMapper}, not here.
+ * The tool result is emitted as a {@code tool.output} span event and mapped to the tool span
+ * output directly in {@code OpenTelemetryMapper}.
  */
 @UtilityClass
 public final class ClaudeCodeMappingRules {
 
     public static final String SOURCE = "ClaudeCode";
 
+    private static OpenTelemetryMappingRule rule(String key, OpenTelemetryMappingRule.Outcome outcome) {
+        return OpenTelemetryMappingRule.builder().rule(key).source(SOURCE).outcome(outcome).build();
+    }
+
     private static final List<OpenTelemetryMappingRule> RULES = List.of(
-            OpenTelemetryMappingRule.builder()
-                    .rule("user_prompt").source(SOURCE).outcome(OpenTelemetryMappingRule.Outcome.INPUT).build(),
-            OpenTelemetryMappingRule.builder()
-                    .rule("user_prompt_length").source(SOURCE).outcome(OpenTelemetryMappingRule.Outcome.METADATA)
-                    .build(),
-            OpenTelemetryMappingRule.builder()
-                    .rule("tool_input").source(SOURCE).outcome(OpenTelemetryMappingRule.Outcome.INPUT).build(),
-            OpenTelemetryMappingRule.builder()
-                    .rule("tool_input_truncated").source(SOURCE).outcome(OpenTelemetryMappingRule.Outcome.METADATA)
-                    .build(),
-            OpenTelemetryMappingRule.builder()
-                    .rule("tool_input_original_length").source(SOURCE)
-                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build(),
-            OpenTelemetryMappingRule.builder()
-                    .rule("response.model_output").source(SOURCE).outcome(OpenTelemetryMappingRule.Outcome.OUTPUT)
-                    .build(),
-            OpenTelemetryMappingRule.builder()
-                    .rule("response.model_output_truncated").source(SOURCE)
-                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build(),
-            OpenTelemetryMappingRule.builder()
-                    .rule("response.model_output_original_length").source(SOURCE)
-                    .outcome(OpenTelemetryMappingRule.Outcome.METADATA).build());
+            rule("user_prompt", OpenTelemetryMappingRule.Outcome.INPUT),
+            rule("tool_input", OpenTelemetryMappingRule.Outcome.INPUT),
+            rule("response.model_output", OpenTelemetryMappingRule.Outcome.OUTPUT),
+            rule("input_tokens", OpenTelemetryMappingRule.Outcome.USAGE),
+            rule("output_tokens", OpenTelemetryMappingRule.Outcome.USAGE),
+            rule("cache_read_tokens", OpenTelemetryMappingRule.Outcome.USAGE),
+            rule("cache_creation_tokens", OpenTelemetryMappingRule.Outcome.USAGE),
+            rule("session.id", OpenTelemetryMappingRule.Outcome.THREAD_ID),
+            // Verbatim duplicate of user_prompt (interaction) / the tool.output event (tool, llm).
+            rule("new_context", OpenTelemetryMappingRule.Outcome.DROP));
 
     public static List<OpenTelemetryMappingRule> getRules() {
         return RULES;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/ClaudeCodeMappingRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/ClaudeCodeMappingRules.java
@@ -15,12 +15,13 @@ import java.util.List;
  * that carry real content into input/output/usage/thread; everything else (session/user identity,
  * durations, prompt hashes, tool ids, hook counters, ...) falls through to metadata automatically.
  * <ul>
- *     <li>{@code user_prompt} → input (root {@code claude_code.interaction} → trace input)</li>
- *     <li>{@code tool_input} → input ({@code claude_code.tool})</li>
- *     <li>{@code response.model_output} → output ({@code claude_code.llm_request}; assistant text)</li>
- *     <li>{@code input_tokens} / {@code output_tokens} / {@code cache_*_tokens} → usage</li>
- *     <li>{@code session.id} → thread id (groups the interaction turns into one Opik thread)</li>
- *     <li>{@code new_context} → dropped (verbatim duplicate of the prompt / tool result)</li>
+ *     <li>input: {@code user_prompt} (interaction), {@code tool_input} (tool),
+ *     {@code model} / {@code system_prompt_preview} (llm; {@code tools} is mapped to input
+ *     globally), {@code hook_event} / {@code hook_name} / {@code hook_definitions} (hook)</li>
+ *     <li>output: {@code response.model_output} (llm; assistant text)</li>
+ *     <li>usage: {@code input_tokens} / {@code output_tokens} / {@code cache_*_tokens}</li>
+ *     <li>thread: {@code session.id} (groups the interaction turns into one Opik thread)</li>
+ *     <li>dropped: {@code new_context} (verbatim duplicate of the prompt / tool result)</li>
  * </ul>
  * The tool result is emitted as a {@code tool.output} span event and mapped to the tool span
  * output directly in {@code OpenTelemetryMapper}.
@@ -35,13 +36,24 @@ public final class ClaudeCodeMappingRules {
     }
 
     private static final List<OpenTelemetryMappingRule> RULES = List.of(
-            rule("user_prompt", OpenTelemetryMappingRule.Outcome.INPUT),
-            rule("tool_input", OpenTelemetryMappingRule.Outcome.INPUT),
+            // --- input: the content each operation was invoked with ---
+            rule("user_prompt", OpenTelemetryMappingRule.Outcome.INPUT), // claude_code.interaction
+            rule("tool_input", OpenTelemetryMappingRule.Outcome.INPUT), // claude_code.tool
+            // claude_code.llm_request: the request setup (tools are mapped to input globally)
+            rule("model", OpenTelemetryMappingRule.Outcome.INPUT),
+            rule("system_prompt_preview", OpenTelemetryMappingRule.Outcome.INPUT),
+            // claude_code.hook: which hook fired and its definition
+            rule("hook_event", OpenTelemetryMappingRule.Outcome.INPUT),
+            rule("hook_name", OpenTelemetryMappingRule.Outcome.INPUT),
+            rule("hook_definitions", OpenTelemetryMappingRule.Outcome.INPUT),
+            // --- output ---
             rule("response.model_output", OpenTelemetryMappingRule.Outcome.OUTPUT),
+            // --- usage ---
             rule("input_tokens", OpenTelemetryMappingRule.Outcome.USAGE),
             rule("output_tokens", OpenTelemetryMappingRule.Outcome.USAGE),
             rule("cache_read_tokens", OpenTelemetryMappingRule.Outcome.USAGE),
             rule("cache_creation_tokens", OpenTelemetryMappingRule.Outcome.USAGE),
+            // --- thread grouping ---
             rule("session.id", OpenTelemetryMappingRule.Outcome.THREAD_ID),
             // Verbatim duplicate of user_prompt (interaction) / the tool.output event (tool, llm).
             rule("new_context", OpenTelemetryMappingRule.Outcome.DROP));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/ClaudeCodeMappingRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/ClaudeCodeMappingRules.java
@@ -1,28 +1,38 @@
 package com.comet.opik.domain.mapping.otel;
 
+import com.comet.opik.domain.SpanType;
 import com.comet.opik.domain.mapping.OpenTelemetryMappingRule;
 import lombok.experimental.UtilityClass;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Mapping rules for Claude Code / Claude Agent SDK spans.
  * <p>
- * These rules are applied only when the instrumentation scope is
- * {@code com.anthropic.claude_code.tracing} (see {@code OpenTelemetryMappingRuleFactory} and
- * {@code OpenTelemetryMapper}). For Claude Code spans the default bucket for unmapped attributes
- * is metadata (not input), so this list only needs to <em>promote</em> the handful of attributes
+ * These rules are applied only to spans whose OTEL span name is prefixed {@code claude_code.}
+ * (see {@code OpenTelemetryMappingRuleFactory#isClaudeCodeSpan} and {@code OpenTelemetryMapper});
+ * decided per span rather than from the batch-detected integration name, since a single OTLP batch
+ * can mix scopes from more than one integration. For Claude Code spans the default bucket for
+ * unmapped attributes is metadata (not input), so this list only needs to <em>promote</em> the handful of attributes
  * that carry real content into input/output/usage/thread; everything else (session/user identity,
  * durations, prompt hashes, tool ids, hook counters, ...) falls through to metadata automatically.
  * <ul>
  *     <li>input: {@code user_prompt} (interaction), {@code tool_input} (tool),
- *     {@code model} / {@code system_prompt_preview} (llm; {@code tools} is mapped to input
- *     globally), {@code hook_event} / {@code hook_name} / {@code hook_definitions} (hook)</li>
+ *     {@code system_prompt_preview} (llm; {@code tools} is mapped to input globally),
+ *     {@code hook_event} / {@code hook_name} / {@code hook_definitions} (hook)</li>
+ *     <li>model: {@code model} (llm; sets the span's model field, not input)</li>
  *     <li>output: {@code response.model_output} (assistant text), {@code stop_reason},
  *     {@code response.has_tool_call} (llm response)</li>
  *     <li>usage: {@code input_tokens} / {@code output_tokens} / {@code cache_*_tokens}</li>
  *     <li>thread: {@code session.id} (groups the interaction turns into one Opik thread)</li>
  * </ul>
+ * The provider is always {@code anthropic} for this integration; since no attribute carries it,
+ * {@code OpenTelemetryMapper} sets it directly for Claude Code spans rather than via a rule here.
+ * <p>
  * {@code new_context} is handled span-aware in {@code OpenTelemetryMapper}: it is the latest LLM
  * message on {@code claude_code.llm_request} spans (→ input) and a duplicate of the prompt / tool
  * result elsewhere (→ metadata).
@@ -35,35 +45,50 @@ public final class ClaudeCodeMappingRules {
     public static final String SOURCE = "ClaudeCode";
 
     private static OpenTelemetryMappingRule rule(String key, OpenTelemetryMappingRule.Outcome outcome) {
-        return OpenTelemetryMappingRule.builder().rule(key).source(SOURCE).outcome(outcome).build();
+        return rule(key, outcome, null);
+    }
+
+    private static OpenTelemetryMappingRule rule(String key, OpenTelemetryMappingRule.Outcome outcome,
+            SpanType spanType) {
+        return OpenTelemetryMappingRule.builder().rule(key).source(SOURCE).outcome(outcome).spanType(spanType)
+                .build();
     }
 
     private static final List<OpenTelemetryMappingRule> RULES = List.of(
             // --- input: the content each operation was invoked with ---
             rule("user_prompt", OpenTelemetryMappingRule.Outcome.INPUT), // claude_code.interaction
-            rule("tool_input", OpenTelemetryMappingRule.Outcome.INPUT), // claude_code.tool
+            rule("tool_input", OpenTelemetryMappingRule.Outcome.INPUT, SpanType.tool), // claude_code.tool
             // claude_code.llm_request: the request setup (tools are mapped to input globally)
-            rule("model", OpenTelemetryMappingRule.Outcome.INPUT),
-            rule("system_prompt_preview", OpenTelemetryMappingRule.Outcome.INPUT),
+            rule("model", OpenTelemetryMappingRule.Outcome.MODEL, SpanType.llm),
+            rule("system_prompt_preview", OpenTelemetryMappingRule.Outcome.INPUT, SpanType.llm),
             // claude_code.hook: which hook fired and its definition
             rule("hook_event", OpenTelemetryMappingRule.Outcome.INPUT),
             rule("hook_name", OpenTelemetryMappingRule.Outcome.INPUT),
             rule("hook_definitions", OpenTelemetryMappingRule.Outcome.INPUT),
             // --- output: the model's response ---
-            rule("response.model_output", OpenTelemetryMappingRule.Outcome.OUTPUT),
-            rule("stop_reason", OpenTelemetryMappingRule.Outcome.OUTPUT),
-            rule("response.has_tool_call", OpenTelemetryMappingRule.Outcome.OUTPUT),
+            rule("response.model_output", OpenTelemetryMappingRule.Outcome.OUTPUT, SpanType.llm),
+            rule("stop_reason", OpenTelemetryMappingRule.Outcome.OUTPUT, SpanType.llm),
+            rule("response.has_tool_call", OpenTelemetryMappingRule.Outcome.OUTPUT, SpanType.llm),
             // --- usage ---
-            rule("input_tokens", OpenTelemetryMappingRule.Outcome.USAGE),
-            rule("output_tokens", OpenTelemetryMappingRule.Outcome.USAGE),
-            rule("cache_read_tokens", OpenTelemetryMappingRule.Outcome.USAGE),
-            rule("cache_creation_tokens", OpenTelemetryMappingRule.Outcome.USAGE),
+            rule("input_tokens", OpenTelemetryMappingRule.Outcome.USAGE, SpanType.llm),
+            rule("output_tokens", OpenTelemetryMappingRule.Outcome.USAGE, SpanType.llm),
+            rule("cache_read_tokens", OpenTelemetryMappingRule.Outcome.USAGE, SpanType.llm),
+            rule("cache_creation_tokens", OpenTelemetryMappingRule.Outcome.USAGE, SpanType.llm),
             // --- thread grouping ---
             rule("session.id", OpenTelemetryMappingRule.Outcome.THREAD_ID));
     // `new_context` is handled span-aware in OpenTelemetryMapper: it is the latest LLM message on
     // llm_request spans (→ input) but a duplicate of the prompt / tool result elsewhere (dropped).
 
+    // Every rule above is an exact-match key (no prefix rules), so a Map gives O(1) lookup instead
+    // of scanning the list per attribute.
+    private static final Map<String, OpenTelemetryMappingRule> RULES_BY_KEY = RULES.stream()
+            .collect(Collectors.toMap(OpenTelemetryMappingRule::getRule, Function.identity()));
+
     public static List<OpenTelemetryMappingRule> getRules() {
         return RULES;
+    }
+
+    public static Optional<OpenTelemetryMappingRule> findRule(String key) {
+        return Optional.ofNullable(RULES_BY_KEY.get(key));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/ClaudeCodeMappingRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/ClaudeCodeMappingRules.java
@@ -21,8 +21,10 @@ import java.util.List;
  *     <li>output: {@code response.model_output} (llm; assistant text)</li>
  *     <li>usage: {@code input_tokens} / {@code output_tokens} / {@code cache_*_tokens}</li>
  *     <li>thread: {@code session.id} (groups the interaction turns into one Opik thread)</li>
- *     <li>dropped: {@code new_context} (verbatim duplicate of the prompt / tool result)</li>
  * </ul>
+ * {@code new_context} is handled span-aware in {@code OpenTelemetryMapper}: it is the latest LLM
+ * message on {@code claude_code.llm_request} spans (→ input) and a duplicate of the prompt / tool
+ * result elsewhere (dropped).
  * The tool result is emitted as a {@code tool.output} span event and mapped to the tool span
  * output directly in {@code OpenTelemetryMapper}.
  */
@@ -54,9 +56,9 @@ public final class ClaudeCodeMappingRules {
             rule("cache_read_tokens", OpenTelemetryMappingRule.Outcome.USAGE),
             rule("cache_creation_tokens", OpenTelemetryMappingRule.Outcome.USAGE),
             // --- thread grouping ---
-            rule("session.id", OpenTelemetryMappingRule.Outcome.THREAD_ID),
-            // Verbatim duplicate of user_prompt (interaction) / the tool.output event (tool, llm).
-            rule("new_context", OpenTelemetryMappingRule.Outcome.DROP));
+            rule("session.id", OpenTelemetryMappingRule.Outcome.THREAD_ID));
+    // `new_context` is handled span-aware in OpenTelemetryMapper: it is the latest LLM message on
+    // llm_request spans (→ input) but a duplicate of the prompt / tool result elsewhere (dropped).
 
     public static List<OpenTelemetryMappingRule> getRules() {
         return RULES;

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1701,14 +1701,14 @@ class OpenTelemetryMapperTest {
         }
 
         @Test
-        void newContextIsDroppedOnNonLlmSpans() {
+        void newContextGoesToMetadataOnNonLlmSpans() {
             var span = enrich(List.of(
                     str("user_prompt", "hello"),
                     str("new_context", "[USER PROMPT]\nhello")),
                     null, "claude_code.interaction");
 
             assertThat(span.input().has("new_context")).isFalse();
-            assertThat(span.metadata().has("new_context")).isFalse();
+            assertThat(span.metadata().get("new_context").asText()).contains("hello");
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1652,6 +1652,42 @@ class OpenTelemetryMapperTest {
         }
 
         @Test
+        void hookIdentityMapsToInput() {
+            var span = enrich(List.of(
+                    str("hook_event", "UserPromptSubmit"),
+                    str("hook_name", "UserPromptSubmit"),
+                    str("hook_definitions", "[{\"type\":\"command\"}]"),
+                    intVal("num_hooks", 1),
+                    str("user.id", "user-1")),
+                    null);
+
+            assertThat(span.input().get("hook_event").asText()).isEqualTo("UserPromptSubmit");
+            assertThat(span.input().get("hook_name").asText()).isEqualTo("UserPromptSubmit");
+            assertThat(span.input().has("hook_definitions")).isTrue();
+            // counters and identity stay in metadata
+            assertThat(span.metadata().has("num_hooks")).isTrue();
+            assertThat(span.metadata().get("user.id").asText()).isEqualTo("user-1");
+        }
+
+        @Test
+        void llmRequestSetupMapsToInput() {
+            var span = enrich(List.of(
+                    str("model", "claude-sonnet-4-6"),
+                    str("system_prompt_preview", "You are a Claude agent..."),
+                    str("llm_request.context", "interaction"),
+                    str("query_source", "sdk"),
+                    str("user.id", "user-1")),
+                    null);
+
+            assertThat(span.input().get("model").asText()).isEqualTo("claude-sonnet-4-6");
+            assertThat(span.input().get("system_prompt_preview").asText()).contains("Claude agent");
+            // request classifiers / identity stay in metadata
+            assertThat(span.metadata().get("llm_request.context").asText()).isEqualTo("interaction");
+            assertThat(span.metadata().get("query_source").asText()).isEqualTo("sdk");
+            assertThat(span.metadata().get("user.id").asText()).isEqualTo("user-1");
+        }
+
+        @Test
         void newContextIsDropped() {
             var span = enrich(List.of(
                     str("user_prompt", "hello"),

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1,6 +1,7 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.Span;
+import com.comet.opik.domain.mapping.OpenTelemetryMappingRuleFactory;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.fasterxml.uuid.Generators;
 import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
@@ -1532,7 +1533,7 @@ class OpenTelemetryMapperTest {
     @Nested
     class ClaudeCodeMappingTest {
 
-        private static final String CLAUDE_CODE = "com.anthropic.claude_code.tracing";
+        private static final String CLAUDE_CODE = OpenTelemetryMappingRuleFactory.CLAUDE_CODE_INSTRUMENTATION;
 
         private Span enrich(List<KeyValue> attributes, List<io.opentelemetry.proto.trace.v1.Span.Event> events) {
             return enrich(attributes, events, "claude_code.interaction");
@@ -1574,7 +1575,7 @@ class OpenTelemetryMapperTest {
         void toolInputMapsToInput() {
             var span = enrich(List.of(str("tool_input", "[TOOL INPUT: Bash]\n{\"command\":\"ls\"}")), null);
 
-            assertThat(span.input().get("tool_input").asText()).contains("\"command\":\"ls\"");
+            assertThat(span.input().get("tool_input").asText()).isEqualTo("[TOOL INPUT: Bash]\n{\"command\":\"ls\"}");
         }
 
         @Test
@@ -1707,7 +1708,7 @@ class OpenTelemetryMapperTest {
                     null);
 
             assertThat(span.input().get("model").asText()).isEqualTo("claude-sonnet-4-6");
-            assertThat(span.input().get("system_prompt_preview").asText()).contains("Claude agent");
+            assertThat(span.input().get("system_prompt_preview").asText()).isEqualTo("You are a Claude agent...");
             // request classifiers / identity stay in metadata
             assertThat(span.metadata().get("llm_request.context").asText()).isEqualTo("interaction");
             assertThat(span.metadata().get("query_source").asText()).isEqualTo("sdk");
@@ -1719,7 +1720,7 @@ class OpenTelemetryMapperTest {
             var span = enrich(List.of(str("new_context", "[TOOL RESULT: t1]\nAGENTS.md README.md")),
                     null, "claude_code.llm_request");
 
-            assertThat(span.input().get("new_context").asText()).contains("AGENTS.md README.md");
+            assertThat(span.input().get("new_context").asText()).isEqualTo("[TOOL RESULT: t1]\nAGENTS.md README.md");
         }
 
         @Test
@@ -1730,7 +1731,7 @@ class OpenTelemetryMapperTest {
                     null, "claude_code.interaction");
 
             assertThat(span.input().has("new_context")).isFalse();
-            assertThat(span.metadata().get("new_context").asText()).contains("hello");
+            assertThat(span.metadata().get("new_context").asText()).isEqualTo("[USER PROMPT]\nhello");
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1587,6 +1587,25 @@ class OpenTelemetryMapperTest {
         }
 
         @Test
+        void llmResponseFieldsMapToOutput() {
+            var span = enrich(List.of(
+                    str("response.model_output", "calling a tool"),
+                    str("stop_reason", "tool_use"),
+                    KeyValue.newBuilder().setKey("response.has_tool_call")
+                            .setValue(AnyValue.newBuilder().setBoolValue(true)).build(),
+                    str("request_id", "req_abc"),
+                    intVal("ttft_ms", 1230)),
+                    null, "claude_code.llm_request");
+
+            assertThat(span.output().get("stop_reason").asText()).isEqualTo("tool_use");
+            assertThat(span.output().get("response.has_tool_call").asBoolean()).isTrue();
+            // call identifiers / latency stay in metadata, not output
+            assertThat(span.output().has("request_id")).isFalse();
+            assertThat(span.metadata().get("request_id").asText()).isEqualTo("req_abc");
+            assertThat(span.metadata().get("ttft_ms").asInt()).isEqualTo(1230);
+        }
+
+        @Test
         void modelOutputTruncationSiblingsGoToMetadata() {
             var span = enrich(List.of(
                     str("response.model_output", "partial"),

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1630,12 +1630,15 @@ class OpenTelemetryMapperTest {
             var span = enrich(List.of(
                     intVal("input_tokens", 1234),
                     intVal("output_tokens", 26),
-                    intVal("cache_read_tokens", 100)),
+                    intVal("cache_read_tokens", 100),
+                    intVal("cache_creation_tokens", 50)),
                     null);
 
             assertThat(span.usage().get("prompt_tokens")).isEqualTo(1234);
             assertThat(span.usage().get("completion_tokens")).isEqualTo(26);
-            assertThat(span.usage().get("cache_read_tokens")).isEqualTo(100);
+            // Normalized to the names the Anthropic cache-cost calculator recognizes.
+            assertThat(span.usage().get("cache_read_input_tokens")).isEqualTo(100);
+            assertThat(span.usage().get("cache_creation_input_tokens")).isEqualTo(50);
             assertThat(span.input()).isNull();
             assertThat(span.output()).isNull();
         }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1532,14 +1532,23 @@ class OpenTelemetryMapperTest {
     @Nested
     class ClaudeCodeMappingTest {
 
+        private static final String CLAUDE_CODE = "com.anthropic.claude_code.tracing";
+
         private Span enrich(List<KeyValue> attributes, List<io.opentelemetry.proto.trace.v1.Span.Event> events) {
             var spanBuilder = Span.builder()
                     .id(UUID.randomUUID())
                     .traceId(UUID.randomUUID())
                     .projectId(UUID.randomUUID())
                     .startTime(Instant.now());
-            OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, events);
+            OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, CLAUDE_CODE, events);
             return spanBuilder.build();
+        }
+
+        private KeyValue intVal(String key, long value) {
+            return KeyValue.newBuilder()
+                    .setKey(key)
+                    .setValue(AnyValue.newBuilder().setIntValue(value))
+                    .build();
         }
 
         private KeyValue str(String key, String value) {
@@ -1601,6 +1610,56 @@ class OpenTelemetryMapperTest {
             var span = enrich(List.of(), List.of(event));
 
             assertThat(span.output().get(contentKey).asText()).isEqualTo(value);
+        }
+
+        @Test
+        void sessionIdMapsToThreadId() {
+            var span = enrich(List.of(str("session.id", "session-abc-123")), null);
+
+            assertThat(span.metadata().get("thread_id").asText()).isEqualTo("session-abc-123");
+            assertThat(span.input()).isNull();
+        }
+
+        @Test
+        void tokensMapToUsage() {
+            var span = enrich(List.of(
+                    intVal("input_tokens", 1234),
+                    intVal("output_tokens", 26),
+                    intVal("cache_read_tokens", 100)),
+                    null);
+
+            assertThat(span.usage().get("prompt_tokens")).isEqualTo(1234);
+            assertThat(span.usage().get("completion_tokens")).isEqualTo(26);
+            assertThat(span.usage().get("cache_read_tokens")).isEqualTo(100);
+            assertThat(span.input()).isNull();
+            assertThat(span.output()).isNull();
+        }
+
+        @Test
+        void unmappedAttributesGoToMetadataNotInput() {
+            var span = enrich(List.of(
+                    str("user.id", "user-1"),
+                    str("terminal.type", "ghostty"),
+                    str("span.type", "interaction"),
+                    str("user_prompt", "hello")),
+                    null);
+
+            // Only the promoted content is input; the session/identity noise is metadata.
+            assertThat(span.input().get("user_prompt").asText()).isEqualTo("hello");
+            assertThat(span.input().has("user.id")).isFalse();
+            assertThat(span.metadata().get("user.id").asText()).isEqualTo("user-1");
+            assertThat(span.metadata().get("terminal.type").asText()).isEqualTo("ghostty");
+        }
+
+        @Test
+        void newContextIsDropped() {
+            var span = enrich(List.of(
+                    str("user_prompt", "hello"),
+                    str("new_context", "[USER PROMPT]\nhello")),
+                    null);
+
+            assertThat(span.input().has("new_context")).isFalse();
+            assertThat(span.metadata().has("new_context")).isFalse();
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1535,12 +1535,17 @@ class OpenTelemetryMapperTest {
         private static final String CLAUDE_CODE = "com.anthropic.claude_code.tracing";
 
         private Span enrich(List<KeyValue> attributes, List<io.opentelemetry.proto.trace.v1.Span.Event> events) {
+            return enrich(attributes, events, "claude_code.interaction");
+        }
+
+        private Span enrich(List<KeyValue> attributes, List<io.opentelemetry.proto.trace.v1.Span.Event> events,
+                String spanName) {
             var spanBuilder = Span.builder()
                     .id(UUID.randomUUID())
                     .traceId(UUID.randomUUID())
                     .projectId(UUID.randomUUID())
                     .startTime(Instant.now());
-            OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, CLAUDE_CODE, events);
+            OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, CLAUDE_CODE, events, spanName);
             return spanBuilder.build();
         }
 
@@ -1688,11 +1693,19 @@ class OpenTelemetryMapperTest {
         }
 
         @Test
-        void newContextIsDropped() {
+        void newContextMapsToInputOnLlmRequestSpan() {
+            var span = enrich(List.of(str("new_context", "[TOOL RESULT: t1]\nAGENTS.md README.md")),
+                    null, "claude_code.llm_request");
+
+            assertThat(span.input().get("new_context").asText()).contains("AGENTS.md README.md");
+        }
+
+        @Test
+        void newContextIsDroppedOnNonLlmSpans() {
             var span = enrich(List.of(
                     str("user_prompt", "hello"),
                     str("new_context", "[USER PROMPT]\nhello")),
-                    null);
+                    null, "claude_code.interaction");
 
             assertThat(span.input().has("new_context")).isFalse();
             assertThat(span.metadata().has("new_context")).isFalse();

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1698,7 +1698,7 @@ class OpenTelemetryMapperTest {
         }
 
         @Test
-        void llmRequestSetupMapsToInput() {
+        void llmRequestSetupMapsToModelAndProviderNotInput() {
             var span = enrich(List.of(
                     str("model", "claude-sonnet-4-6"),
                     str("system_prompt_preview", "You are a Claude agent..."),
@@ -1707,12 +1707,31 @@ class OpenTelemetryMapperTest {
                     str("user.id", "user-1")),
                     null);
 
-            assertThat(span.input().get("model").asText()).isEqualTo("claude-sonnet-4-6");
+            // 'model' sets the span's model field (needed for cost calc), not input
+            assertThat(span.model()).isEqualTo("claude-sonnet-4-6");
+            assertThat(span.input().has("model")).isFalse();
             assertThat(span.input().get("system_prompt_preview").asText()).isEqualTo("You are a Claude agent...");
+            // Claude Code is Anthropic-only and never sends a provider attribute
+            assertThat(span.provider()).isEqualTo("anthropic");
+            assertThat(span.type()).isEqualTo(SpanType.llm);
             // request classifiers / identity stay in metadata
             assertThat(span.metadata().get("llm_request.context").asText()).isEqualTo("interaction");
             assertThat(span.metadata().get("query_source").asText()).isEqualTo("sdk");
             assertThat(span.metadata().get("user.id").asText()).isEqualTo("user-1");
+        }
+
+        @Test
+        void toolInputSetsToolSpanType() {
+            var span = enrich(List.of(str("tool_input", "[TOOL INPUT: Bash]\n{\"command\":\"ls\"}")), null);
+
+            assertThat(span.type()).isEqualTo(SpanType.tool);
+        }
+
+        @Test
+        void providerIsAnthropicEvenWithoutModelAttribute() {
+            var span = enrich(List.of(str("user_prompt", "hello")), null);
+
+            assertThat(span.provider()).isEqualTo("anthropic");
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1587,30 +1587,20 @@ class OpenTelemetryMapperTest {
             assertThat(span.metadata().get("response.model_output_original_length").asInt()).isEqualTo(120);
         }
 
-        @Test
-        void toolOutputEventMapsToOutput() {
+        @ParameterizedTest
+        @CsvSource({
+                "output, AGENTS.md README.md",
+                "content, marker: OTEL-REPRO-MARKER-12345"
+        })
+        void toolOutputEventMapsToOutput(String contentKey, String value) {
             var event = io.opentelemetry.proto.trace.v1.Span.Event.newBuilder()
                     .setName("tool.output")
-                    .addAttributes(str("bash_command", "ls"))
-                    .addAttributes(str("output", "AGENTS.md\nREADME.md"))
-                    .build();
-
-            var span = enrich(List.of(str("tool_name", "Bash")), List.of(event));
-
-            assertThat(span.output().get("output").asText()).isEqualTo("AGENTS.md\nREADME.md");
-        }
-
-        @Test
-        void toolOutputEventContentAttributeMapsToOutput() {
-            var event = io.opentelemetry.proto.trace.v1.Span.Event.newBuilder()
-                    .setName("tool.output")
-                    .addAttributes(str("file_path", "/tmp/repro.txt"))
-                    .addAttributes(str("content", "marker: OTEL-REPRO-MARKER-12345"))
+                    .addAttributes(str(contentKey, value))
                     .build();
 
             var span = enrich(List.of(), List.of(event));
 
-            assertThat(span.output().get("content").asText()).isEqualTo("marker: OTEL-REPRO-MARKER-12345");
+            assertThat(span.output().get(contentKey).asText()).isEqualTo(value);
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1528,4 +1528,89 @@ class OpenTelemetryMapperTest {
             assertThat(map(okSpan).errorInfo()).isNull();
         }
     }
+
+    @Nested
+    class ClaudeCodeMappingTest {
+
+        private Span enrich(List<KeyValue> attributes, List<io.opentelemetry.proto.trace.v1.Span.Event> events) {
+            var spanBuilder = Span.builder()
+                    .id(UUID.randomUUID())
+                    .traceId(UUID.randomUUID())
+                    .projectId(UUID.randomUUID())
+                    .startTime(Instant.now());
+            OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, events);
+            return spanBuilder.build();
+        }
+
+        private KeyValue str(String key, String value) {
+            return KeyValue.newBuilder()
+                    .setKey(key)
+                    .setValue(AnyValue.newBuilder().setStringValue(value))
+                    .build();
+        }
+
+        @Test
+        void userPromptMapsToInput() {
+            var span = enrich(List.of(str("user_prompt", "What is the marker?")), null);
+
+            assertThat(span.input().get("user_prompt").asText()).isEqualTo("What is the marker?");
+        }
+
+        @Test
+        void toolInputMapsToInput() {
+            var span = enrich(List.of(str("tool_input", "[TOOL INPUT: Bash]\n{\"command\":\"ls\"}")), null);
+
+            assertThat(span.input().get("tool_input").asText()).contains("\"command\":\"ls\"");
+        }
+
+        @Test
+        void responseModelOutputMapsToOutput() {
+            var span = enrich(List.of(str("response.model_output", "The marker is OTEL-REPRO-MARKER-12345.")), null);
+
+            assertThat(span.output().get("response.model_output").asText())
+                    .isEqualTo("The marker is OTEL-REPRO-MARKER-12345.");
+            assertThat(span.input()).isNull();
+        }
+
+        @Test
+        void modelOutputTruncationSiblingsGoToMetadata() {
+            var span = enrich(List.of(
+                    str("response.model_output", "partial"),
+                    KeyValue.newBuilder().setKey("response.model_output_truncated")
+                            .setValue(AnyValue.newBuilder().setBoolValue(true)).build(),
+                    KeyValue.newBuilder().setKey("response.model_output_original_length")
+                            .setValue(AnyValue.newBuilder().setIntValue(120)).build()),
+                    null);
+
+            assertThat(span.output().has("response.model_output")).isTrue();
+            assertThat(span.metadata().has("response.model_output_truncated")).isTrue();
+            assertThat(span.metadata().get("response.model_output_original_length").asInt()).isEqualTo(120);
+        }
+
+        @Test
+        void toolOutputEventMapsToOutput() {
+            var event = io.opentelemetry.proto.trace.v1.Span.Event.newBuilder()
+                    .setName("tool.output")
+                    .addAttributes(str("bash_command", "ls"))
+                    .addAttributes(str("output", "AGENTS.md\nREADME.md"))
+                    .build();
+
+            var span = enrich(List.of(str("tool_name", "Bash")), List.of(event));
+
+            assertThat(span.output().get("output").asText()).isEqualTo("AGENTS.md\nREADME.md");
+        }
+
+        @Test
+        void toolOutputEventContentAttributeMapsToOutput() {
+            var event = io.opentelemetry.proto.trace.v1.Span.Event.newBuilder()
+                    .setName("tool.output")
+                    .addAttributes(str("file_path", "/tmp/repro.txt"))
+                    .addAttributes(str("content", "marker: OTEL-REPRO-MARKER-12345"))
+                    .build();
+
+            var span = enrich(List.of(), List.of(event));
+
+            assertThat(span.output().get("content").asText()).isEqualTo("marker: OTEL-REPRO-MARKER-12345");
+        }
+    }
 }

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/claude-agent-sdk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/claude-agent-sdk.mdx
@@ -13,8 +13,11 @@ Claude Code telemetry is configured through environment variables.
 
 Use this guide when you want to configure Claude Code's official OpenTelemetry settings and align endpoint/header values with your Opik deployment mode.
 
-<Callout type="warning">
-Claude Code's monitoring docs currently describe OTel <b>metrics</b> and <b>events/logs</b> exporters. Opik tracing views are span-based. Verify your pipeline emits spans if your goal is trace visualization in Opik.
+<Callout type="info">
+Opik ingests OTel <b>trace spans</b>. Claude Code emits spans when you set
+<code>CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1</code> and <code>OTEL_TRACES_EXPORTER=otlp</code>.
+Prompt, tool I/O, and assistant output are <b>redacted by default</b> and are only captured on
+spans once you enable the content flags and the detailed-tracing beta below.
 </Callout>
 
 ## Opik OTLP endpoint modes
@@ -63,42 +66,48 @@ For full endpoint/header details, see [Opik OpenTelemetry overview](/integration
     </Tab>
 </Tabs>
 
-## Claude telemetry configuration (official pattern)
+## Minimal setup for full trace visibility
 
-Intent:
-Enable Claude Code telemetry and route supported OTel signals to your collector/backend.
-
-Applies when:
-You run Claude Code with telemetry enabled via environment variables.
-
-Required fields:
-- `CLAUDE_CODE_ENABLE_TELEMETRY=1`
-- at least one exporter (`OTEL_METRICS_EXPORTER` or `OTEL_LOGS_EXPORTER`)
-
-Optional fields:
-- `OTEL_EXPORTER_OTLP_PROTOCOL`
-- `OTEL_EXPORTER_OTLP_ENDPOINT`
-- `OTEL_EXPORTER_OTLP_HEADERS`
-- per-signal overrides such as `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`
-
-Minimal valid setup:
+This is the minimal set of environment variables that captures the **user prompt, tool
+input/output, and assistant output** as spans in Opik (Opik Cloud shown; swap the endpoint for
+your deployment mode above). Set these before starting your Claude Agent SDK app or `claude`.
 
 ```bash wordWrap
+# 1. Enable Claude Code telemetry and trace-span emission
 export CLAUDE_CODE_ENABLE_TELEMETRY=1
-export OTEL_METRICS_EXPORTER=otlp
-export OTEL_LOGS_EXPORTER=otlp
-export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
-export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
-# Optional if your collector/export path requires auth
-export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <token>"
-claude
+export CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1
+
+# 2. Export traces to Opik
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://www.comet.com/opik/api/v1/private/otel
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=<your-api-key>,Comet-Workspace=<your-workspace>,projectName=<your-project-name>'
+
+# 3. Un-redact content (prompt + tool input/output)
+export OTEL_LOG_USER_PROMPTS=1
+export OTEL_LOG_TOOL_DETAILS=1
+export OTEL_LOG_TOOL_CONTENT=1
+
+# 4. Capture assistant/AI output on spans (detailed-tracing beta)
+export ENABLE_BETA_TRACING_DETAILED=1
+export BETA_TRACING_ENDPOINT=https://www.comet.com/opik/api/v1/private/otel
 ```
+
+### Why each block matters
+
+- **Blocks 1-2** get `claude_code.*` spans into Opik. Without `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1` Claude Code emits only metrics/logs (no spans), and nothing appears in Opik.
+- **Block 3** un-redacts the user prompt and tool input/output, which are redacted by default.
+- **Block 4** is required for **assistant/AI output**. Claude Code only puts response text on spans (`response.model_output`) under the detailed-tracing beta; otherwise it goes to the OTel *logs* signal, which Opik does not ingest. `BETA_TRACING_ENDPOINT` is a standard OTLP base URL — point it at the same Opik endpoint. For the Claude Agent SDK and other non-interactive (`claude -p`) runs, this beta needs no additional server-side enablement.
+
+<Callout type="info">
+`OTEL_LOG_ASSISTANT_RESPONSES=1` also un-redacts response text, but on the OTel logs signal — which Opik has no receiver for. Use block 4 (detailed-tracing beta) to get assistant output into Opik.
+</Callout>
 
 ## Validation
 
-1. Start Claude with telemetry enabled.
-2. Confirm your OTLP backend receives `claude_code.*` metrics/events.
-3. If targeting Opik trace views, verify spans are emitted by your pipeline; metrics/logs alone will not appear as traces.
+1. Start your agent (or `claude`) with the variables above set.
+2. Open the target project in Opik and find the `claude_code.interaction` trace.
+3. Confirm the spans carry content: the user prompt (trace input), `tool_input` / tool output on `claude_code.tool` spans, and `response.model_output` on `claude_code.llm_request` spans.
 
 ## Source references
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/claude-agent-sdk.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/claude-agent-sdk.mdx
@@ -70,7 +70,14 @@ For full endpoint/header details, see [Opik OpenTelemetry overview](/integration
 
 This is the minimal set of environment variables that captures the **user prompt, tool
 input/output, and assistant output** as spans in Opik (Opik Cloud shown; swap the endpoint for
-your deployment mode above). Set these before starting your Claude Agent SDK app or `claude`.
+your deployment mode above). Set these before starting your Claude Agent SDK app, or `claude -p`
+(non-interactive) runs.
+
+<Callout type="warning">
+Assistant output (block 4) relies on the detailed-tracing beta, which is only ungated for the
+Claude Agent SDK and non-interactive `claude -p`. In an **interactive** `claude` session that beta
+is gated, so you will get the user prompt and tool I/O but **not** `response.model_output`.
+</Callout>
 
 ```bash wordWrap
 # 1. Enable Claude Code telemetry and trace-span emission
@@ -97,7 +104,7 @@ export BETA_TRACING_ENDPOINT=https://www.comet.com/opik/api/v1/private/otel
 
 - **Blocks 1-2** get `claude_code.*` spans into Opik. Without `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1` Claude Code emits only metrics/logs (no spans), and nothing appears in Opik.
 - **Block 3** un-redacts the user prompt and tool input/output, which are redacted by default.
-- **Block 4** is required for **assistant/AI output**. Claude Code only puts response text on spans (`response.model_output`) under the detailed-tracing beta; otherwise it goes to the OTel *logs* signal, which Opik does not ingest. `BETA_TRACING_ENDPOINT` is a standard OTLP base URL — point it at the same Opik endpoint. For the Claude Agent SDK and other non-interactive (`claude -p`) runs, this beta needs no additional server-side enablement.
+- **Block 4** is required for **assistant/AI output**. Claude Code only puts response text on spans (`response.model_output`) under the detailed-tracing beta; otherwise it goes to the OTel *logs* signal, which Opik does not ingest. `BETA_TRACING_ENDPOINT` is a standard OTLP base URL — point it at the same Opik endpoint. Its exporter reuses `OTEL_EXPORTER_OTLP_HEADERS` (block 2), so the `Authorization` / `Comet-Workspace` headers Opik Cloud and Enterprise require are sent automatically; no separate header variable is needed. For the Claude Agent SDK and other non-interactive (`claude -p`) runs, this beta needs no additional server-side enablement.
 
 <Callout type="info">
 `OTEL_LOG_ASSISTANT_RESPONSES=1` also un-redacts response text, but on the OTel logs signal — which Opik has no receiver for. Use block 4 (detailed-tracing beta) to get assistant output into Opik.
@@ -105,7 +112,7 @@ export BETA_TRACING_ENDPOINT=https://www.comet.com/opik/api/v1/private/otel
 
 ## Validation
 
-1. Start your agent (or `claude`) with the variables above set.
+1. Start your Claude Agent SDK app (or `claude -p`) with the variables above set.
 2. Open the target project in Opik and find the `claude_code.interaction` trace.
 3. Confirm the spans carry content: the user prompt (trace input), `tool_input` / tool output on `claude_code.tool` spans, and `response.model_output` on `claude_code.llm_request` spans.
 


### PR DESCRIPTION
## Details

Fixes the Autodesk escalation (OPIK-6993): when a Claude Agent SDK / Claude Code agent is traced into Opik over OpenTelemetry, Opik captured only metadata — the user prompt was buried in the input attribute-bag, tool I/O only appeared under `metadata.opentelemetry.events`, and assistant/AI output was missing entirely.

Investigation (via the official Claude Code monitoring docs + the CLI itself) found two things:

1. **AI output is a client-side config gap, not an ingest bug.** Claude Code only emits assistant text on a span (`response.model_output`) under the detailed-tracing beta (`ENABLE_BETA_TRACING_DETAILED=1` + `BETA_TRACING_ENDPOINT`, a plain OTLP base URL you can point at Opik). Otherwise it goes on the OTel *logs* signal, which Opik has no receiver for. For the Agent SDK / non-interactive runs this beta needs no server-side enablement. Once enabled, prompt + tool I/O + AI output all reach Opik's existing `/v1/traces` receiver — no logs receiver needed.

2. **The content then lands in the input attribute-bag** because no mapping rule routes Claude Code's attributes/events to input/output.

This PR does both parts:

- **Docs** (`claude-agent-sdk.mdx`): documents the minimal validated env-var set for full trace visibility, including the detailed-tracing beta required for assistant output, and why `OTEL_LOG_ASSISTANT_RESPONSES` alone is not enough for Opik.
- **Backend mapping** (`ClaudeCodeMappingRules` + `OpenTelemetryMapper`): rules are scoped to the `com.anthropic.claude_code.tracing` integration, and for that integration the default bucket for unmapped attributes is **metadata** (not input). So input/output/usage carry only real content and the session/config attribute-bag no longer floods input:
  - `user_prompt` → input (trace input); `tool_input` → input (tool span)
  - `response.model_output` → output (llm span); `tool.output` span event → tool span output
  - `input_tokens` / `output_tokens` / `cache_*_tokens` → **usage** (were polluting input/output)
  - `session.id` → **thread_id** (groups the interaction turns into one Opik thread)
  - `new_context` → dropped (verbatim duplicate of prompt / tool result)
  - everything else (user/terminal/session ids, durations, prompt hashes, tool ids, hook counters, ...) → **metadata**

## Change checklist

- [x] Backend change (OTEL mapping)
- [x] Documentation update
- [x] Unit tests

## Issues

Resolves [OPIK-6993](https://comet-ml.atlassian.net/browse/OPIK-6993). Escalated from CUST-6311.

## AI-WATERMARK

This PR was developed with assistance from Claude Code.

## Testing

- `OpenTelemetryMapperTest` / `OpenTelemetryMappingUtilsTest` / `OpenTelemetryEventsMapperTest` → **BUILD SUCCESS, 128 tests, 0 failures**. Added `ClaudeCodeMappingTest` covering: user_prompt/tool_input → input, response.model_output → output, `tool.output` event → output (parameterized), `session.id` → thread_id, tokens → usage, unmapped attributes → metadata (not input), `new_context` dropped.
- Client-side config validated end-to-end against a deployed build by running a real Claude Agent SDK agent with telemetry pointed at Opik: `response.model_output` (AI text), `tool_input`, and the `tool.output` event all confirmed present on spans.
- The mapping reorganization is validated by unit tests; end-to-end re-verification against the PR test env (after redeploy of this commit) is the remaining step.

## Documentation

Updated `apps/opik-documentation/documentation/fern/docs-v2/integrations/claude-agent-sdk.mdx` (latest/docs-v2). The v1 page is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OPIK-6993]: https://comet-ml.atlassian.net/browse/OPIK-6993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ