### PR TITLE
[NA] [QA] fix: resolve test-suite id before closing bridge client

### DIFF
--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/test_suites.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/test_suites.py
@@ -43,11 +43,14 @@ def create_test_suite(
         )
         if body.items:
             suite.insert([item.model_dump(exclude_none=True) for item in body.items])
+        # suite.id is a lazy cached_property that fetches from the backend on
+        # first read; resolve it while the client is still open, before end().
+        suite_id, suite_name = str(suite.id), suite.name
     finally:
         client.end(flush=True)
         atexit.unregister(client.end)
 
-    return TestSuiteResponse(id=str(suite.id), name=suite.name)
+    return TestSuiteResponse(id=suite_id, name=suite_name)
 
 
 @router.post(


### PR DESCRIPTION
## Details

The `opik-sdk-driver` E2E bridge route for `POST /test-suites` read `suite.id` **after** its `finally` block had already called `client.end(flush=True)`, closing the underlying httpx client. `TestSuite.id` delegates to `Dataset.id`, which is a lazy `@functools.cached_property` that fetches the dataset from the backend on first access — so the deferred fetch fired against a closed client and raised `RuntimeError: Cannot send a request, as the client has been closed`. That surfaced as a bare `500 Internal Server Error` and broke the `SDK-seeded suite renders …` test-suites smoke on both prod and local E2E builds.

- Resolve `suite.id` and `suite.name` inside the `try` block, while the client is still open, then return the pre-resolved values — mirroring what the `insert-items` route already does.
- No backend or main-SDK change: the failure never reached a backend endpoint; the client was closed before the request went out. The floating bridge pin (`opik>=2.0.0` → `opik==2.1.14`) exposed a latent ordering bug in the bridge route.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA — E2E test-infrastructure fix, no ticket.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation (diagnosis + one-line fix)
- Human verification: reproduced the 500 locally against a freshly-built main, applied the fix, re-verified 201 + zero tracebacks; code review

## Testing

Reproduced and verified against a locally-built `main` (dev-runner, backend + FE from source) with the bridge on `opik==2.1.14` (matching CI):

- Before the fix: `POST /test-suites` with the fixture payload (3 items, 2 global assertions, `runs_per_item=1`, `pass_threshold=1`) → `500 Internal Server Error`; bridge traceback ended in `RuntimeError: Cannot send a request, as the client has been closed` at `create_test_suite` reading `suite.id`.
- After the fix: same request → `201` with a valid suite id; bridge log shows zero tracebacks.
- Sanity: `uv run python -c "from opik_sdk_driver.routes import test_suites"` imports and parses cleanly. CI runs no linter/type-checker on this service (it only `uv sync`s and runs it).

## Documentation

N/A — no user-facing or documentation changes.
