### PR TITLE
[NA] [QA] test(e2e): fall through to an offered provider when configuring models

### DIFF
--- a/tests_end_to_end/e2e/pom/configuration.page.ts
+++ b/tests_end_to_end/e2e/pom/configuration.page.ts
@@ -91,9 +91,15 @@ export class ConfigurationPage {
   /**
    * Add a provider's API key via the UI. Idempotent: if the provider is already
    * in the table, no-ops.
+   *
+   * Returns `false` when the deployment doesn't offer this provider in the
+   * add-provider dialog — restricted environments expose only a subset of
+   * providers, and a missing option must fall through to the next candidate
+   * instead of hanging on a click that will never resolve. Returns `true` when
+   * the provider is configured (either already present or added just now).
    */
-  async ensureProviderConfigured(provider: ProviderName, apiKey: string): Promise<void> {
-    if (await this.hasProvider(provider)) return;
+  async ensureProviderConfigured(provider: ProviderName, apiKey: string): Promise<boolean> {
+    if (await this.hasProvider(provider)) return true;
 
     // Two buttons can have the name "Add configuration": the toolbar button
     // (always visible) and an empty-state CTA inside the table's no-data row.
@@ -106,11 +112,27 @@ export class ConfigurationPage {
     const dialog = this.page.getByTestId('add-provider-dialog');
     await dialog.waitFor({ state: 'visible' });
 
+    // Wait for the option grid to populate before deciding a provider is
+    // absent: the dialog turns visible a beat before its options render, so an
+    // immediate presence check would false-negative an offered provider.
+    await dialog.getByTestId('add-provider-dialog-option').first().waitFor({ state: 'visible' });
+
     const providerType = PROVIDER_TYPE_MAP[provider];
     const providerButton = dialog
       .getByTestId('add-provider-dialog-option')
-      .and(this.page.locator(`[data-provider="${providerType}"]`));
-    await providerButton.first().click();
+      .and(this.page.locator(`[data-provider="${providerType}"]`))
+      .first();
+
+    const offered = await providerButton
+      .waitFor({ state: 'visible', timeout: 2_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!offered) {
+      await this.page.keyboard.press('Escape');
+      await dialog.waitFor({ state: 'hidden' });
+      return false;
+    }
+    await providerButton.click();
 
     // Step 2: API key input. The textbox accessible name follows
     // "<Provider> API Key" exactly (verified during Phase 3 discovery).
@@ -125,6 +147,7 @@ export class ConfigurationPage {
         intervals: [500, 1000],
       })
       .toBe(true);
+    return true;
   }
 
   /**

--- a/tests_end_to_end/e2e/pom/configuration.page.ts
+++ b/tests_end_to_end/e2e/pom/configuration.page.ts
@@ -1,5 +1,5 @@
 import type { Page } from '@playwright/test';
-import { expect } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { loadEnvConfig } from '../config/env.config';
 
 /**
@@ -99,55 +99,57 @@ export class ConfigurationPage {
    * the provider is configured (either already present or added just now).
    */
   async ensureProviderConfigured(provider: ProviderName, apiKey: string): Promise<boolean> {
-    if (await this.hasProvider(provider)) return true;
+    return test.step(`ensure provider "${provider}" is configured`, async () => {
+      if (await this.hasProvider(provider)) return true;
 
-    // Two buttons can have the name "Add configuration": the toolbar button
-    // (always visible) and an empty-state CTA inside the table's no-data row.
-    // Scope to the toolbar button — it's always present.
-    const tabpanel = this.page.getByTestId('ai-providers-tabpanel');
-    const toolbarButton = tabpanel
-      .getByRole('button', { name: 'Add configuration', exact: true })
-      .first();
-    await toolbarButton.click();
-    const dialog = this.page.getByTestId('add-provider-dialog');
-    await dialog.waitFor({ state: 'visible' });
+      // Two buttons can have the name "Add configuration": the toolbar button
+      // (always visible) and an empty-state CTA inside the table's no-data row.
+      // Scope to the toolbar button — it's always present.
+      const tabpanel = this.page.getByTestId('ai-providers-tabpanel');
+      const toolbarButton = tabpanel
+        .getByRole('button', { name: 'Add configuration', exact: true })
+        .first();
+      await toolbarButton.click();
+      const dialog = this.page.getByTestId('add-provider-dialog');
+      await dialog.waitFor({ state: 'visible' });
 
-    // Wait for the option grid to populate before deciding a provider is
-    // absent: the dialog turns visible a beat before its options render, so an
-    // immediate presence check would false-negative an offered provider.
-    await dialog.getByTestId('add-provider-dialog-option').first().waitFor({ state: 'visible' });
+      // The provider option this candidate needs may be absent: a deployment
+      // exposes only the providers its feature toggles enable, and the grid
+      // renders nothing for the rest. Probe with a bounded wait so an absent
+      // option (or an entirely empty grid) falls through instead of hanging on
+      // the default 30s timeout.
+      const providerType = PROVIDER_TYPE_MAP[provider];
+      const providerButton = dialog
+        .getByTestId('add-provider-dialog-option')
+        .and(this.page.locator(`[data-provider="${providerType}"]`))
+        .first();
 
-    const providerType = PROVIDER_TYPE_MAP[provider];
-    const providerButton = dialog
-      .getByTestId('add-provider-dialog-option')
-      .and(this.page.locator(`[data-provider="${providerType}"]`))
-      .first();
+      const offered = await providerButton
+        .waitFor({ state: 'visible', timeout: 2_000 })
+        .then(() => true)
+        .catch(() => false);
+      if (!offered) {
+        await this.page.keyboard.press('Escape');
+        await dialog.waitFor({ state: 'hidden' });
+        return false;
+      }
+      await providerButton.click();
 
-    const offered = await providerButton
-      .waitFor({ state: 'visible', timeout: 2_000 })
-      .then(() => true)
-      .catch(() => false);
-    if (!offered) {
-      await this.page.keyboard.press('Escape');
+      // Step 2: API key input. The textbox accessible name follows
+      // "<Provider> API Key" exactly (verified during Phase 3 discovery).
+      await dialog.getByRole('textbox', { name: `${provider} API Key` }).fill(apiKey);
+      await dialog.getByRole('button', { name: 'Add provider', exact: true }).click();
       await dialog.waitFor({ state: 'hidden' });
-      return false;
-    }
-    await providerButton.click();
 
-    // Step 2: API key input. The textbox accessible name follows
-    // "<Provider> API Key" exactly (verified during Phase 3 discovery).
-    await dialog.getByRole('textbox', { name: `${provider} API Key` }).fill(apiKey);
-    await dialog.getByRole('button', { name: 'Add provider', exact: true }).click();
-    await dialog.waitFor({ state: 'hidden' });
-
-    // Wait for the new row to land in the table.
-    await expect
-      .poll(async () => this.hasProvider(provider), {
-        timeout: 15_000,
-        intervals: [500, 1000],
-      })
-      .toBe(true);
-    return true;
+      // Wait for the new row to land in the table.
+      await expect
+        .poll(async () => this.hasProvider(provider), {
+          timeout: 15_000,
+          intervals: [500, 1000],
+        })
+        .toBe(true);
+      return true;
+    });
   }
 
   /**
@@ -155,37 +157,56 @@ export class ConfigurationPage {
    * `ensureProviderConfigured` because Custom providers carry a user-defined
    * provider_name and require URL + Models list fields. Idempotent: if a row
    * matching the same provider_name is already present, no-ops.
+   *
+   * Returns `false` when the deployment doesn't offer the Custom option in the
+   * dialog (its feature toggle is off), mirroring `ensureProviderConfigured` so
+   * the caller can fall through instead of hanging on a missing option. Returns
+   * `true` when the provider is configured (already present or added just now).
    */
-  async ensureCustomProviderConfigured(config: CustomProviderConfig): Promise<void> {
-    if (await this.hasCustomProvider(config.providerName)) return;
+  async ensureCustomProviderConfigured(config: CustomProviderConfig): Promise<boolean> {
+    return test.step(`ensure custom provider "${config.providerName}" is configured`, async () => {
+      if (await this.hasCustomProvider(config.providerName)) return true;
 
-    const tabpanel = this.page.getByTestId('ai-providers-tabpanel');
-    const toolbarButton = tabpanel
-      .getByRole('button', { name: 'Add configuration', exact: true })
-      .first();
-    await toolbarButton.click();
-    const dialog = this.page.getByTestId('add-provider-dialog');
-    await dialog.waitFor({ state: 'visible' });
+      const tabpanel = this.page.getByTestId('ai-providers-tabpanel');
+      const toolbarButton = tabpanel
+        .getByRole('button', { name: 'Add configuration', exact: true })
+        .first();
+      await toolbarButton.click();
+      const dialog = this.page.getByTestId('add-provider-dialog');
+      await dialog.waitFor({ state: 'visible' });
 
-    const providerButton = dialog
-      .getByTestId('add-provider-dialog-option')
-      .and(this.page.locator(`[data-provider="${CUSTOM_PROVIDER_TYPE}"]`));
-    await providerButton.first().click();
+      const providerButton = dialog
+        .getByTestId('add-provider-dialog-option')
+        .and(this.page.locator(`[data-provider="${CUSTOM_PROVIDER_TYPE}"]`))
+        .first();
 
-    await dialog.getByRole('textbox', { name: 'Provider name' }).fill(config.providerName);
-    await dialog.getByRole('textbox', { name: 'URL' }).fill(config.baseUrl);
-    await dialog.getByRole('textbox', { name: 'API key' }).fill(config.apiKey);
-    await dialog.getByRole('textbox', { name: 'Models list' }).fill(config.models);
+      const offered = await providerButton
+        .waitFor({ state: 'visible', timeout: 2_000 })
+        .then(() => true)
+        .catch(() => false);
+      if (!offered) {
+        await this.page.keyboard.press('Escape');
+        await dialog.waitFor({ state: 'hidden' });
+        return false;
+      }
+      await providerButton.click();
 
-    await dialog.getByRole('button', { name: 'Add provider', exact: true }).click();
-    await dialog.waitFor({ state: 'hidden' });
+      await dialog.getByRole('textbox', { name: 'Provider name' }).fill(config.providerName);
+      await dialog.getByRole('textbox', { name: 'URL' }).fill(config.baseUrl);
+      await dialog.getByRole('textbox', { name: 'API key' }).fill(config.apiKey);
+      await dialog.getByRole('textbox', { name: 'Models list' }).fill(config.models);
 
-    await expect
-      .poll(async () => this.hasCustomProvider(config.providerName), {
-        timeout: 15_000,
-        intervals: [500, 1000],
-      })
-      .toBe(true);
+      await dialog.getByRole('button', { name: 'Add provider', exact: true }).click();
+      await dialog.waitFor({ state: 'hidden' });
+
+      await expect
+        .poll(async () => this.hasCustomProvider(config.providerName), {
+          timeout: 15_000,
+          intervals: [500, 1000],
+        })
+        .toBe(true);
+      return true;
+    });
   }
 
   /**

--- a/tests_end_to_end/e2e/pom/model-availability.ts
+++ b/tests_end_to_end/e2e/pom/model-availability.ts
@@ -34,19 +34,21 @@ export async function ensureModelAvailable(page: Page): Promise<string> {
   if (openai && (await cfg.ensureProviderConfigured('OpenAI', openai))) {
     return 'GPT 4o Mini';
   }
-  if (openrouter) {
-    await cfg.ensureCustomProviderConfigured({
+  if (
+    openrouter &&
+    (await cfg.ensureCustomProviderConfigured({
       providerName: 'openrouter',
       baseUrl: 'https://openrouter.ai/api/v1',
       apiKey: openrouter,
       models: 'openai/gpt-4o-mini',
-    });
+    }))
+  ) {
     return 'openai/gpt-4o-mini';
   }
 
   test.skip(
     true,
-    'No configured provider is offered by this deployment (built-ins absent and OPENROUTER_API_KEY not set)',
+    'No configured provider is offered by this deployment (none of Anthropic, OpenAI, or the OpenRouter Custom Provider is available for the keys present)',
   );
   return '';
 }

--- a/tests_end_to_end/e2e/pom/model-availability.ts
+++ b/tests_end_to_end/e2e/pom/model-availability.ts
@@ -1,0 +1,52 @@
+import type { Page } from '@playwright/test';
+import { test } from '@e2e/fixtures';
+import { ConfigurationPage } from '@e2e/pom/configuration.page';
+
+/**
+ * Provision an LLM provider for tests that drive the Playground / LLM-judge UI,
+ * and return the model display name to select.
+ *
+ * Provider selection is driven by BOTH the runner's env keys AND what the target
+ * deployment actually offers. A restricted environment may expose only a subset
+ * of providers (e.g. no Anthropic), so picking a provider purely from env-var
+ * presence — as the older per-spec copies did — would commit to a provider the
+ * deployment can't add and hang on the dialog click. Each built-in candidate is
+ * attempted only when its key is present, and skipped (falling through to the
+ * next) when the deployment doesn't offer it. The OpenRouter Custom Provider is
+ * the final fallback for environments that block the built-ins entirely.
+ */
+export async function ensureModelAvailable(page: Page): Promise<string> {
+  const anthropic = process.env.ANTHROPIC_API_KEY;
+  const openai = process.env.OPENAI_API_KEY;
+  const openrouter = process.env.OPENROUTER_API_KEY;
+
+  if (!anthropic && !openai && !openrouter) {
+    test.skip(true, 'None of ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY is set');
+    return '';
+  }
+
+  const cfg = new ConfigurationPage(page);
+  await cfg.gotoAiProviders();
+
+  if (anthropic && (await cfg.ensureProviderConfigured('Anthropic', anthropic))) {
+    return 'Claude Haiku 4.5';
+  }
+  if (openai && (await cfg.ensureProviderConfigured('OpenAI', openai))) {
+    return 'GPT 4o Mini';
+  }
+  if (openrouter) {
+    await cfg.ensureCustomProviderConfigured({
+      providerName: 'openrouter',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      apiKey: openrouter,
+      models: 'openai/gpt-4o-mini',
+    });
+    return 'openai/gpt-4o-mini';
+  }
+
+  test.skip(
+    true,
+    'No configured provider is offered by this deployment (built-ins absent and OPENROUTER_API_KEY not set)',
+  );
+  return '';
+}

--- a/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-smoke.spec.ts
@@ -1,32 +1,9 @@
 import { test, expect } from '@e2e/fixtures';
 import { OnlineEvaluationPage } from '@e2e/pom/online-evaluation.page';
 import { LogsPage } from '@e2e/pom/logs.page';
-import { ConfigurationPage } from '@e2e/pom/configuration.page';
+import { ensureModelAvailable } from '@e2e/pom/model-availability';
 
 const MODERATION_SCORE_NAME = 'Moderation'; // canned template's schema name
-
-/**
- * Pick an Anthropic-or-OpenAI model from env; provision the matching provider
- * key via the UI if it isn't already configured. Returns the model display
- * name to use with the LLM-as-judge dialog. Mirrors the OPIK-6137 test-suites
- * pattern so the test runs everywhere — local builds, staging, CI, prod.
- */
-async function ensureModelAvailable(page: import('@playwright/test').Page): Promise<string> {
-  const anthropic = process.env.ANTHROPIC_API_KEY;
-  const openai = process.env.OPENAI_API_KEY;
-  if (!anthropic && !openai) {
-    test.skip(true, 'Neither ANTHROPIC_API_KEY nor OPENAI_API_KEY is set');
-    return '';
-  }
-  const cfg = new ConfigurationPage(page);
-  await cfg.gotoAiProviders();
-  if (anthropic) {
-    await cfg.ensureProviderConfigured('Anthropic', anthropic);
-    return 'Claude Haiku 4.5';
-  }
-  await cfg.ensureProviderConfigured('OpenAI', openai!);
-  return 'GPT 4o Mini';
-}
 
 interface ContentTrace {
   id: string;

--- a/tests_end_to_end/e2e/tests/playground/playground-providers.spec.ts
+++ b/tests_end_to_end/e2e/tests/playground/playground-providers.spec.ts
@@ -64,20 +64,27 @@ test.describe('Playground — provider sanity', { tag: ['@provider-sanity', '@pl
       const apiKey = process.env[provider.api_key_env_var];
       test.skip(!apiKey, `${provider.api_key_env_var} not set in this env`);
 
-      await test.step(`Ensure ${provider.provider_name} provider key is configured`, async () => {
-        const cfg = new ConfigurationPage(page);
-        await cfg.gotoAiProviders();
-        if (provider.provider_type === 'custom') {
-          await cfg.ensureCustomProviderConfigured({
-            providerName: provider.provider_name,
-            baseUrl: provider.base_url,
-            apiKey: apiKey!,
-            models: provider.models.map((m) => m.name).join(','),
-          });
-        } else {
-          await cfg.ensureProviderConfigured(provider.provider_name, apiKey!);
-        }
-      });
+      const offered = await test.step(
+        `Ensure ${provider.provider_name} provider key is configured`,
+        async () => {
+          const cfg = new ConfigurationPage(page);
+          await cfg.gotoAiProviders();
+          if (provider.provider_type === 'custom') {
+            return cfg.ensureCustomProviderConfigured({
+              providerName: provider.provider_name,
+              baseUrl: provider.base_url,
+              apiKey: apiKey!,
+              models: provider.models.map((m) => m.name).join(','),
+            });
+          }
+          return cfg.ensureProviderConfigured(provider.provider_name, apiKey!);
+        },
+      );
+
+      // This deployment doesn't offer the provider under test (its feature
+      // toggle is off), so there is no model to run against — skip rather than
+      // fail on a model selection that can never resolve.
+      test.skip(!offered, `${provider.provider_name} is not offered by this deployment`);
 
       await test.step(`Run a simple prompt against ${model.ui_selector} with options ${JSON.stringify(
         model.options ?? {},

--- a/tests_end_to_end/e2e/tests/playground/playground-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/playground/playground-smoke.spec.ts
@@ -1,41 +1,6 @@
 import { test, expect } from '@e2e/fixtures';
 import { PlaygroundPage } from '@e2e/pom/playground.page';
-import { ConfigurationPage } from '@e2e/pom/configuration.page';
-
-/**
- * Pick an Anthropic / OpenAI / OpenRouter model from env; provision the matching
- * provider key via the UI if it isn't already configured. Returns the model
- * display name to use with the playground.
- */
-async function ensureModelAvailable(page: import('@playwright/test').Page): Promise<string> {
-  const anthropic = process.env.ANTHROPIC_API_KEY;
-  const openai = process.env.OPENAI_API_KEY;
-  const openrouter = process.env.OPENROUTER_API_KEY;
-  if (!anthropic && !openai && !openrouter) {
-    test.skip(
-      true,
-      'None of ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY is set',
-    );
-    return ''; // unreachable
-  }
-  const cfg = new ConfigurationPage(page);
-  await cfg.gotoAiProviders();
-  if (anthropic) {
-    await cfg.ensureProviderConfigured('Anthropic', anthropic);
-    return 'Claude Haiku 4.5';
-  }
-  if (openai) {
-    await cfg.ensureProviderConfigured('OpenAI', openai);
-    return 'GPT 4o Mini';
-  }
-  await cfg.ensureCustomProviderConfigured({
-    providerName: 'openrouter',
-    baseUrl: 'https://openrouter.ai/api/v1',
-    apiKey: openrouter!,
-    models: 'openai/gpt-4o-mini',
-  });
-  return 'openai/gpt-4o-mini';
-}
+import { ensureModelAvailable } from '@e2e/pom/model-availability';
 
 /**
  * T1 Playground smoke: run prompts against a seeded dataset → Re-run auto-creates

--- a/tests_end_to_end/e2e/tests/prompts/prompt-playground-traces.spec.ts
+++ b/tests_end_to_end/e2e/tests/prompts/prompt-playground-traces.spec.ts
@@ -2,26 +2,9 @@ import { test, expect } from '../../fixtures/prompt.fixture';
 import { PromptsPage } from '@e2e/pom/prompts.page';
 import { PlaygroundPage } from '@e2e/pom/playground.page';
 import { PlaygroundLogsSidebarPage } from '@e2e/pom/playground-logs-sidebar.page';
-import { ConfigurationPage } from '@e2e/pom/configuration.page';
+import { ensureModelAvailable } from '@e2e/pom/model-availability';
 import type { PromptDetailPage } from '@e2e/pom/prompt-detail.page';
 import type { Locator } from '@playwright/test';
-
-async function ensureModelAvailable(page: import('@playwright/test').Page): Promise<string> {
-  const anthropic = process.env.ANTHROPIC_API_KEY;
-  const openai = process.env.OPENAI_API_KEY;
-  if (!anthropic && !openai) {
-    test.skip(true, 'Neither ANTHROPIC_API_KEY nor OPENAI_API_KEY is set');
-    return '';
-  }
-  const cfg = new ConfigurationPage(page);
-  await cfg.gotoAiProviders();
-  if (anthropic) {
-    await cfg.ensureProviderConfigured('Anthropic', anthropic);
-    return 'Claude Haiku 4.5';
-  }
-  await cfg.ensureProviderConfigured('OpenAI', openai!);
-  return 'GPT 4o Mini';
-}
 
 type PromptVariant = {
   label: string;

--- a/tests_end_to_end/e2e/tests/prompts/prompt-version-playground.spec.ts
+++ b/tests_end_to_end/e2e/tests/prompts/prompt-version-playground.spec.ts
@@ -1,24 +1,7 @@
 import { test, expect } from '../../fixtures/prompt.fixture';
 import { PlaygroundPage } from '@e2e/pom/playground.page';
 import { PlaygroundLogsSidebarPage } from '@e2e/pom/playground-logs-sidebar.page';
-import { ConfigurationPage } from '@e2e/pom/configuration.page';
-
-async function ensureModelAvailable(page: import('@playwright/test').Page): Promise<string> {
-  const anthropic = process.env.ANTHROPIC_API_KEY;
-  const openai = process.env.OPENAI_API_KEY;
-  if (!anthropic && !openai) {
-    test.skip(true, 'Neither ANTHROPIC_API_KEY nor OPENAI_API_KEY is set');
-    return '';
-  }
-  const cfg = new ConfigurationPage(page);
-  await cfg.gotoAiProviders();
-  if (anthropic) {
-    await cfg.ensureProviderConfigured('Anthropic', anthropic);
-    return 'Claude Haiku 4.5';
-  }
-  await cfg.ensureProviderConfigured('OpenAI', openai!);
-  return 'GPT 4o Mini';
-}
+import { ensureModelAvailable } from '@e2e/pom/model-availability';
 
 const PROMPT_VARIANTS = [
   {

--- a/tests_end_to_end/e2e/tests/test-suites/test-suites-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/test-suites/test-suites-smoke.spec.ts
@@ -1,29 +1,7 @@
 import { test, expect } from '@e2e/fixtures';
 import { TestSuitesPage } from '@e2e/pom/test-suites.page';
 import { TestSuiteItemsPage } from '@e2e/pom/test-suite-items.page';
-import { ConfigurationPage } from '@e2e/pom/configuration.page';
-
-/**
- * Pick an Anthropic-or-OpenAI model from env; provision the matching provider key
- * via the UI if it isn't already configured. Returns the model display name to use
- * with the playground.
- */
-async function ensureModelAvailable(page: import('@playwright/test').Page): Promise<string> {
-  const anthropic = process.env.ANTHROPIC_API_KEY;
-  const openai = process.env.OPENAI_API_KEY;
-  if (!anthropic && !openai) {
-    test.skip(true, 'Neither ANTHROPIC_API_KEY nor OPENAI_API_KEY is set');
-    return '';
-  }
-  const cfg = new ConfigurationPage(page);
-  await cfg.gotoAiProviders();
-  if (anthropic) {
-    await cfg.ensureProviderConfigured('Anthropic', anthropic);
-    return 'Claude Haiku 4.5';
-  }
-  await cfg.ensureProviderConfigured('OpenAI', openai!);
-  return 'GPT 4o Mini';
-}
+import { ensureModelAvailable } from '@e2e/pom/model-availability';
 
 test.describe('Test Suites — smoke', { tag: ['@t1-smoke', '@test-suites'] }, () => {
   /**


### PR DESCRIPTION
## Details

The five duplicated `ensureModelAvailable` E2E helpers picked an LLM provider by which API key the **runner** had, then committed to it — so a runner with `ANTHROPIC_API_KEY` always tried Anthropic even against deployments that don't offer it. Restricted environments gate providers off via feature toggles and the add-provider dialog omits ungated options entirely (`ProviderGrid.tsx` renders only what `useProviderOptions` returns), so the click hung 15s and failed the playground / test-suites / online-evaluation t1 smokes.

- `pom/configuration.page.ts`: `ensureProviderConfigured` now returns `boolean` — it probes whether the provider option is actually offered (short 2s wait) and returns `false` (dismissing the dialog) instead of hanging when it is absent, so the caller can fall through.
- `pom/model-availability.ts` (new): one shared `ensureModelAvailable` trying Anthropic → OpenAI → OpenRouter (Custom Provider), attempting each built-in only when its key is present **and** the deployment offers it. Replaces the five per-spec copies.
- The five specs now import the shared helper.

The prior PR #7155 added the OpenRouter fallback to `playground-smoke` only, and keyed it on env-var presence rather than dialog availability — so a runner with `ANTHROPIC_API_KEY` never reached it. This generalizes the fallthrough and applies it everywhere.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-NONE

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-opus-4-8
  - Scope: provider-availability detection in the E2E configuration POM + consolidation of the duplicated ensureModelAvailable helpers (all code Claude-authored, reviewed locally, validated green)
  - Human verification: validated against a local OSS Opik 2.1.13 instance. Full `test:t1` twice = 18 passed / 2 skipped (2 skips are cloud-only Ollie). Fallthrough validated by unsetting the built-in keys to force the OpenRouter Custom Provider path: the 3 affected specs passed and the backend confirmed a `custom-llm`/`openrouter` provider row was provisioned with real completions. `tsc --noEmit` clean.

## Testing

Local OSS Opik 2.1.13 on `http://localhost:5173`, SDK bridge on `:5175`, `WORKERS=2`.

```bash
cd tests_end_to_end/e2e
OPIK_DEPLOYMENT=oss OPIK_BASE_URL=http://localhost:5173 OPIK_WORKSPACE=default \
  OPIK_SDK_DRIVER_URL=http://localhost:5175 WORKERS=2 npm run test:t1
```

- Full `test:t1` ×2 (happy path, Anthropic offered): **18 passed / 2 skipped** each — stable.
- Forced OpenRouter path (built-in keys unset): the 3 affected specs passed; `test-suites` Test A skipped (its own SDK-bridge judge guard, unchanged here).

## Documentation

None.
