### PR TITLE
[OPIK-7016] [FE] fix: align Cost Intelligence navigation with entitlements

### DIFF
--- a/apps/opik-frontend/src/contexts/AiSpendContext.tsx
+++ b/apps/opik-frontend/src/contexts/AiSpendContext.tsx
@@ -3,6 +3,7 @@ import React, { createContext, useContext, ReactNode } from "react";
 export type AiSpendContextValue = {
   isPending: boolean;
   hasAccess: boolean;
+  isOrganizationAdmin?: boolean;
   spendWorkspaceName?: string;
   isSpendWorkspaceActive?: boolean;
   organizationName?: string;
@@ -12,6 +13,7 @@ export type AiSpendContextValue = {
 const DEFAULT_VALUE: AiSpendContextValue = {
   isPending: false,
   hasAccess: false,
+  isOrganizationAdmin: false,
   goToCostIntelligence: () => {},
 };
 

--- a/apps/opik-frontend/src/plugins/comet/LayoutProvider.tsx
+++ b/apps/opik-frontend/src/plugins/comet/LayoutProvider.tsx
@@ -13,6 +13,7 @@ const AiSpendProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const {
     isPending,
     hasAccess,
+    isOrganizationAdmin,
     spendWorkspaceName,
     isSpendWorkspaceActive,
     organization,
@@ -43,7 +44,7 @@ const AiSpendProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
       setPreviousWorkspaceName(activeWorkspaceName);
     }
     navigate({
-      to: "/$workspaceName/ai-spend/home",
+      to: "/$workspaceName/ai-spend",
       params: { workspaceName: spendWorkspaceName },
     });
   }, [
@@ -58,6 +59,7 @@ const AiSpendProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
     () => ({
       isPending,
       hasAccess,
+      isOrganizationAdmin,
       spendWorkspaceName,
       isSpendWorkspaceActive,
       organizationName: organization?.name,
@@ -66,6 +68,7 @@ const AiSpendProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
     [
       isPending,
       hasAccess,
+      isOrganizationAdmin,
       spendWorkspaceName,
       isSpendWorkspaceActive,
       organization?.name,

--- a/apps/opik-frontend/src/plugins/comet/useAiSpendManager.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAiSpendManager.ts
@@ -46,7 +46,6 @@ const useAiSpendManager = () => {
     hasAccess:
       Boolean(spendWorkspace) &&
       Boolean(organization?.costIntelligenceEnabled) &&
-      isOrganizationAdmin &&
       workspaceVersion === "v2",
   };
 };

--- a/apps/opik-frontend/src/plugins/development/LayoutProvider.tsx
+++ b/apps/opik-frontend/src/plugins/development/LayoutProvider.tsx
@@ -19,6 +19,7 @@ const AiSpendProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
     () => ({
       isPending: false,
       hasAccess: true,
+      isOrganizationAdmin: true,
       spendWorkspaceName: "default",
       organizationName: "local",
       isSpendWorkspaceActive: true,

--- a/apps/opik-frontend/src/v2/layout/SideBar/MenuItem/SidebarMenuItem.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/MenuItem/SidebarMenuItem.tsx
@@ -18,7 +18,7 @@ export type MenuItem = {
   path?: string;
   type: MENU_ITEM_TYPE;
   icon: React.ComponentType<{ className?: string }>;
-  label: string;
+  label: string | React.ReactElement;
   disabled?: boolean;
   muted?: boolean;
   exact?: boolean;


### PR DESCRIPTION
## Details

Aligns the Cost Intelligence navigation with organization entitlements instead of organization-admin role. Previously the Cost Intelligence menu entry and AI-Spend workspace navigation were gated on `isOrganizationAdmin`, so non-admin members of a Cost-Intelligence-enabled workspace could not reach it. This relaxes the gate to the entitlement (v2 + Cost-Intelligence-enabled org) and propagates the admin flag through context for downstream, role-aware UI.

- Remove the `isOrganizationAdmin` restriction from the access gate in `useAiSpendManager`.
- Propagate `isOrganizationAdmin` through `AiSpendContext` and the layout providers so pages can adapt per role.
- Drop the unnecessary `/home` suffix from the AI-Spend workspace navigation path.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7016

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: assisted
- Human verification: code review + manual testing on an internal test environment with both admin and non-admin users

## Testing

Verified on an internal test environment with both an admin and a non-admin user: the Cost Intelligence menu entry and workspace navigation now appear for non-admin members of a Cost-Intelligence-enabled (v2) workspace, while remaining hidden where the entitlement is absent. Admin behavior is unchanged.

## Documentation

N/A
