### PR TITLE
[OPIK-6425] Include error code in explain errored/retried BI events

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/explain/ExplainPopover.tsx
+++ b/apps/opik-frontend/src/plugins/comet/explain/ExplainPopover.tsx
@@ -114,7 +114,10 @@ const ExplainPopover = ({ target, onContinue }: Props) => {
             variant="tableLink"
             className={`mt-2 ${linkClass}`}
             onClick={() => {
-              trackEvent(OpikEvent.EXPLAIN_RETRIED, { kind: target.kind });
+              trackEvent(OpikEvent.EXPLAIN_RETRIED, {
+                kind: target.kind,
+                code: entry?.code ?? "unknown",
+              });
               retry(target);
             }}
           >

--- a/apps/opik-frontend/src/plugins/comet/explain/explainStore.test.ts
+++ b/apps/opik-frontend/src/plugins/comet/explain/explainStore.test.ts
@@ -424,6 +424,7 @@ describe("explainStore", () => {
     expect(trackEvent).toHaveBeenCalledWith(OpikEvent.EXPLAIN_ERRORED, {
       kind: "trace.error",
       code: "timeout",
+      message: expect.stringMatching(/too long/i),
     });
     expect(emit).toHaveBeenCalledWith("explain:cancel", { explainId });
     // Route retired, so a late chunk that finally arrives is ignored.
@@ -485,6 +486,7 @@ describe("explainStore", () => {
     expect(trackEvent).toHaveBeenCalledWith(OpikEvent.EXPLAIN_ERRORED, {
       kind: "trace.error",
       code: "unavailable",
+      message: expect.stringMatching(/unavailable/i),
     });
     expect(entry.error).not.toBe("raw upstream text"); // friendly copy wins
     expect(entry.error).toMatch(/unavailable/i);
@@ -584,5 +586,12 @@ describe("explainStore", () => {
     expect(entry.phase).toBe("error");
     expect(typeof entry.error).toBe("string");
     expect(entry.error).toBe("boom"); // falls through to the raw message
+    // The raw upstream text also reaches telemetry — the diagnostic detail
+    // for codes with no friendly copy.
+    expect(trackEvent).toHaveBeenCalledWith(OpikEvent.EXPLAIN_ERRORED, {
+      kind: "trace.error",
+      code: "constructor",
+      message: "boom",
+    });
   });
 });

--- a/apps/opik-frontend/src/plugins/comet/explain/explainStore.test.ts
+++ b/apps/opik-frontend/src/plugins/comet/explain/explainStore.test.ts
@@ -6,6 +6,13 @@ import useExplainStore, {
   handleConsoleEvent,
 } from "./explainStore";
 import { ExplainKind, ExplainTarget } from "@/types/assistant-sidebar";
+import { OpikEvent, trackEvent } from "@/lib/analytics/tracking";
+
+vi.mock("@/lib/analytics/tracking", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/analytics/tracking")>();
+  return { ...actual, trackEvent: vi.fn() };
+});
 
 const target = (
   entityId: string,
@@ -414,6 +421,10 @@ describe("explainStore", () => {
     const entry = useExplainStore.getState().entries[key("e1")];
     expect(entry.phase).toBe("error");
     expect(entry.code).toBe("timeout");
+    expect(trackEvent).toHaveBeenCalledWith(OpikEvent.EXPLAIN_ERRORED, {
+      kind: "trace.error",
+      code: "timeout",
+    });
     expect(emit).toHaveBeenCalledWith("explain:cancel", { explainId });
     // Route retired, so a late chunk that finally arrives is ignored.
     expect(useExplainStore.getState().routes[explainId]).toBeUndefined();
@@ -471,6 +482,10 @@ describe("explainStore", () => {
     const entry = useExplainStore.getState().entries[key("e1")];
     expect(entry.phase).toBe("error");
     expect(entry.code).toBe("unavailable");
+    expect(trackEvent).toHaveBeenCalledWith(OpikEvent.EXPLAIN_ERRORED, {
+      kind: "trace.error",
+      code: "unavailable",
+    });
     expect(entry.error).not.toBe("raw upstream text"); // friendly copy wins
     expect(entry.error).toMatch(/unavailable/i);
   });

--- a/apps/opik-frontend/src/plugins/comet/explain/explainStore.ts
+++ b/apps/opik-frontend/src/plugins/comet/explain/explainStore.ts
@@ -264,7 +264,10 @@ const useExplainStore = create<ExplainState>((set, get) => {
   ) => {
     const entry = cellOf(get(), explainId);
     if (!entry) return;
-    trackEvent(OpikEvent.EXPLAIN_ERRORED, { kind: entry.kind });
+    trackEvent(OpikEvent.EXPLAIN_ERRORED, {
+      kind: entry.kind,
+      code: code ?? "unknown",
+    });
     mutate((c) =>
       patchStream(
         c,

--- a/apps/opik-frontend/src/plugins/comet/explain/explainStore.ts
+++ b/apps/opik-frontend/src/plugins/comet/explain/explainStore.ts
@@ -264,9 +264,13 @@ const useExplainStore = create<ExplainState>((set, get) => {
   ) => {
     const entry = cellOf(get(), explainId);
     if (!entry) return;
+    // `message` is the resolved display copy: for known codes it's the static
+    // ERROR_COPY line, for unknown codes it's the raw upstream error — the
+    // diagnostic detail dashboards need. Truncated: upstream text is unbounded.
     trackEvent(OpikEvent.EXPLAIN_ERRORED, {
       kind: entry.kind,
       code: code ?? "unknown",
+      message: message.slice(0, 300),
     });
     mutate((c) =>
       patchStream(


### PR DESCRIPTION
## Details

`opik_explain_errored` fired with only the cell `kind`, while `failCell()` already had the error `code` and message in hand — so the ~30% error rate since the Jul 1 launch can't be split into timeout vs unavailable vs rate_limited vs upstream failures in dashboards, each of which has a different owner.

- `opik_explain_errored` now carries `code` (`timeout` | `unavailable` | `rate_limited` | `waking` | free-form console code | `"unknown"`) and `message` — static ERROR_COPY text for known codes, the raw upstream error text for unknown ones (the diagnostic detail), truncated to 300 chars.
- `opik_explain_retried` now carries the `code` of the error the user is retrying from, so recovery behavior can be broken down by failure type.
- No new event names; Segment adds the `code`/`message` columns to the existing warehouse tables on first receipt.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6425

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Fable 5
- Scope: event payload change in `explainStore.ts` / `ExplainPopover.tsx` and the new payload assertions in `explainStore.test.ts`
- Human verification: test suite and typecheck run locally; diff reviewed before push

## Testing

- `npx vitest run src/plugins/comet/explain/` — 5 files, 52 tests pass, incl. 3 new payload assertions (watchdog timeout, structured console error, raw-message fallthrough for unknown codes)
- `npm run typecheck` — clean
- Not run: full frontend suite / e2e (change is confined to analytics payloads; no UI or behavior change)

## Documentation

None needed — analytics-only change. The Metabase "Opik Explain - Outcome per click" card will split the errored band by `code` once this ships, with `message` as the drill-down for unknowns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)