### PR TITLE
[OPIK-7016] [BE] feat: extract cipx session_id into cipx_trace_identities

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxTraceIdentityDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxTraceIdentityDAO.java
@@ -46,6 +46,7 @@ public class CipxTraceIdentityDAO {
             @NonNull String userEmail,
             @NonNull String userDisplayName,
             @NonNull String repository,
+            @NonNull String sessionId,
             int schemaVersion) {
 
         public static TraceIdentityRow from(UUID traceId, UUID projectId, JsonNode metadata, Instant startTime) {
@@ -59,6 +60,7 @@ public class CipxTraceIdentityDAO {
                     .userEmail(identity.path("email").asText(""))
                     .userDisplayName(identity.path("display_name").asText(""))
                     .repository(session.path("repository").path("remote").asText(""))
+                    .sessionId(session.path("session_id").asText(""))
                     .schemaVersion(session.path("schema_version").asInt(0))
                     .build();
         }
@@ -70,7 +72,7 @@ public class CipxTraceIdentityDAO {
     private static final String INSERT = """
             INSERT INTO cipx_trace_identities
                 (workspace_id, project_id, trace_id, start_time, user_uuid,
-                 user_email, user_display_name, repository, schema_version)
+                 user_email, user_display_name, repository, session_id, schema_version)
             SETTINGS log_comment = '<log_comment>'
             FORMAT Values
                 <items:{item |
@@ -83,6 +85,7 @@ public class CipxTraceIdentityDAO {
                         :user_email<item.index>,
                         :user_display_name<item.index>,
                         :repository<item.index>,
+                        :session_id<item.index>,
                         :schema_version<item.index>
                     )
                     <if(item.hasNext)>,<endif>
@@ -120,6 +123,7 @@ public class CipxTraceIdentityDAO {
                     .bind("user_email" + i, row.userEmail())
                     .bind("user_display_name" + i, row.userDisplayName())
                     .bind("repository" + i, row.repository())
+                    .bind("session_id" + i, row.sessionId())
                     .bind("schema_version" + i, row.schemaVersion());
         }
 

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000095_add_session_id_to_cipx_trace_identity.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000095_add_session_id_to_cipx_trace_identity.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+--changeset andriid:000095_add_session_id_to_cipx_trace_identity
+--comment: Add session_id (cipx Claude Code session id) to cipx_trace_identities for the personal Sessions metric
+
+-- cipx emits metadata.cipx.session.session_id per trace (one session -> many traces/turns) and
+-- mirrors it onto the opik trace's native thread_id. Extracted here from the same cipx.session
+-- metadata as the other identity columns; distinct session_id per user is the session count.
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_trace_identities ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS session_id String;
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_trace_identities ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS session_id;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000095_add_session_id_to_cipx_trace_identity.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000095_add_session_id_to_cipx_trace_identity.sql
@@ -9,3 +9,4 @@ ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_trace_identities ON CLUSTER '{clu
     ADD COLUMN IF NOT EXISTS session_id String;
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_trace_identities ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS session_id;
+

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
@@ -294,6 +294,7 @@ class CostIntelligenceIngestionTest {
                 assertThat(row.get().userEmail()).isEqualTo("dev@acme.com");
                 assertThat(row.get().userDisplayName()).isEqualTo("Dev User");
                 assertThat(row.get().repository()).isEqualTo("git@github.com:acme/repo.git");
+                assertThat(row.get().sessionId()).isEqualTo("cc-session-abc");
                 assertThat(row.get().schemaVersion()).isEqualTo(3);
                 assertThat(row.get().projectId()).isNotBlank();
                 assertThat(row.get().startMs()).isEqualTo(cipxTrace.startTime().toEpochMilli());
@@ -379,6 +380,7 @@ class CostIntelligenceIngestionTest {
                   "cipx": {
                     "session": {
                       "schema_version": %d,
+                      "session_id": "cc-session-abc",
                       "repository": {"remote": "%s"},
                       "identity": {
                         "user_uuid": "%s",
@@ -438,7 +440,7 @@ class CostIntelligenceIngestionTest {
                 SELECT
                     project_id AS project_id,
                     toUnixTimestamp64Milli(start_time) AS start_ms,
-                    user_uuid, user_email, user_display_name, repository, schema_version
+                    user_uuid, user_email, user_display_name, repository, session_id, schema_version
                 FROM cipx_trace_identities FINAL
                 WHERE workspace_id = :workspace_id AND trace_id = :trace_id
                 """;
@@ -454,6 +456,7 @@ class CostIntelligenceIngestionTest {
                             row.get("user_email", String.class),
                             row.get("user_display_name", String.class),
                             row.get("repository", String.class),
+                            row.get("session_id", String.class),
                             row.get("schema_version", Integer.class)))));
         }).blockOptional();
     }
@@ -478,6 +481,6 @@ class CostIntelligenceIngestionTest {
     }
 
     private record CipxIdentityRow(String projectId, Long startMs, String userUuid, String userEmail,
-            String userDisplayName, String repository, Integer schemaVersion) {
+            String userDisplayName, String repository, String sessionId, Integer schemaVersion) {
     }
 }


### PR DESCRIPTION
## Details

Extracts the cipx session id into the typed `cipx_trace_identities` table so per-user session counts can be read without parsing raw trace metadata. cipx already emits `metadata.cipx.session.session_id` on every trace (one session → many traces/turns) and mirrors it onto the opik trace's native `thread_id`; this adds the typed column and populates it at ingestion, so `COUNT(DISTINCT session_id)` per user yields the number of sessions.

- Migration `000095`: `ALTER TABLE cipx_trace_identities ADD COLUMN IF NOT EXISTS session_id String`.
- `CipxTraceIdentityDAO`: extract `cipx.session.session_id` and include it in the insert.
- Extend `CostIntelligenceIngestionTest` to cover the new column.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7016

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: full implementation
- Human verification: code review + CI backend build/tests

## Testing

- Extended `CostIntelligenceIngestionTest`: the trace fixture now emits `cipx.session.session_id`, and the ingestion assertion verifies `session_id` lands in `cipx_trace_identities`.
- Backend build/tests (`mvn compile` / `mvn test`) to be validated by CI; not run locally in this session.

## Documentation

N/A
