### PR TITLE
[OPIK-6889] [BE] feat: add deletion_events_local audit log migration

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000096_create_deletion_events_local.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000096_create_deletion_events_local.sql
@@ -1,0 +1,24 @@
+--liquibase formatted sql
+--changeset andrescrz:000096_create_deletion_events_local
+--comment: Append-only audit log of deletions, used to replay them across table migrations
+
+-- A lightweight DELETE does not change a row's version column, so deletes issued while a table
+-- is being copied into a new layout are invisible to the version-based delta step and would
+-- reappear in the copy. This log records each delete so the copy step can replay the ids against
+-- the destination. Append-only and read per-shard, hence MergeTree rather than Distributed. No
+-- surrogate id: rows are keyed and replayed on (source_table, event_time, deleted_id).
+CREATE TABLE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME}.deletion_events_local ON CLUSTER '{cluster}'
+(
+    event_time        DateTime64(6, 'UTC')        DEFAULT now64(6),
+    source_table      LowCardinality(String),
+    workspace_id      String,
+    project_id        String,                     -- empty for workspace-scoped source tables
+    deleted_id        String,                     -- source row identifier; not a UUID for every source table
+    deletion_reason   LowCardinality(String)
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/${ANALYTICS_DB_DATABASE_NAME}/deletion_events_local', '{replica}')
+PARTITION BY toYYYYMM(event_time)
+ORDER BY (source_table, event_time, deleted_id)
+TTL toDateTime(event_time + INTERVAL 2 YEAR);
+
+--rollback DROP TABLE IF EXISTS ${ANALYTICS_DB_DATABASE_NAME}.deletion_events_local ON CLUSTER '{cluster}';

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000096_create_deletion_events_local.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000096_create_deletion_events_local.sql
@@ -22,3 +22,4 @@ ORDER BY (source_table, event_time, deleted_id)
 TTL toDateTime(event_time + INTERVAL 2 YEAR);
 
 --rollback DROP TABLE IF EXISTS ${ANALYTICS_DB_DATABASE_NAME}.deletion_events_local ON CLUSTER '{cluster}';
+

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/DeletionEventsLocalTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/DeletionEventsLocalTest.java
@@ -1,0 +1,144 @@
+package com.comet.opik.infrastructure;
+
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.podam.PodamFactoryUtils;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.Result;
+import lombok.Builder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.lifecycle.Startables;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DeletionEventsLocalTest {
+
+    private static final String[] DELETION_EVENTS_IGNORED_FIELDS = {"eventTime"};
+
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
+
+    private final Network network = Network.newNetwork();
+
+    private GenericContainer<?> zooKeeperContainer;
+    private ClickHouseContainer clickHouseContainer;
+
+    private ConnectionFactory connectionFactory;
+
+    @BeforeAll
+    void beforeAll() {
+        zooKeeperContainer = ClickHouseContainerUtils.newZookeeperContainer(false, network);
+        clickHouseContainer = ClickHouseContainerUtils.newClickHouseContainer(false, network, zooKeeperContainer);
+        Startables.deepStart(zooKeeperContainer, clickHouseContainer).join();
+        MigrationUtils.runClickhouseDbMigration(clickHouseContainer);
+        connectionFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(clickHouseContainer, DATABASE_NAME)
+                .build();
+    }
+
+    @AfterAll
+    void afterAll() {
+        if (clickHouseContainer != null && clickHouseContainer.isRunning()) {
+            clickHouseContainer.stop();
+        }
+        if (zooKeeperContainer != null && zooKeeperContainer.isRunning()) {
+            zooKeeperContainer.stop();
+        }
+        network.close();
+    }
+
+    @Test
+    void insertAndSelectDeletionEvent() {
+        var expectedDeletionEvent = podamFactory.manufacturePojo(DeletionEvent.class);
+        insert(expectedDeletionEvent);
+
+        var actualDeletionEvents = findByWorkspaceId(expectedDeletionEvent.workspaceId());
+
+        assertThat(actualDeletionEvents).hasSize(1);
+        var actualDeletionEvent = actualDeletionEvents.getFirst();
+        assertDeletionEvent(actualDeletionEvent, expectedDeletionEvent);
+    }
+
+    /**
+     * Omitted event_time so it exercises the column default, matching the delete-path write.
+     */
+    private void insert(DeletionEvent event) {
+        var sql = """
+                INSERT INTO deletion_events_local
+                    (source_table, workspace_id, project_id, deleted_id, deletion_reason)
+                VALUES (:sourceTable, :workspaceId, :projectId, :deletedId, :deletionReason)
+                """;
+        Mono.usingWhen(
+                connectionFactory.create(),
+                connection -> Flux.from(connection.createStatement(sql)
+                        .bind("sourceTable", event.sourceTable())
+                        .bind("workspaceId", event.workspaceId())
+                        .bind("projectId", event.projectId())
+                        .bind("deletedId", event.deletedId())
+                        .bind("deletionReason", event.deletionReason())
+                        .execute())
+                        .flatMap(Result::getRowsUpdated)
+                        .then(),
+                Connection::close)
+                .block();
+    }
+
+    private List<DeletionEvent> findByWorkspaceId(String workspaceId) {
+        var sql = """
+                SELECT event_time, source_table, workspace_id, project_id, deleted_id, deletion_reason
+                FROM deletion_events_local
+                WHERE workspace_id = :workspaceId
+                """;
+        return Mono.usingWhen(
+                connectionFactory.create(),
+                connection -> Flux.from(connection.createStatement(sql)
+                        .bind("workspaceId", workspaceId)
+                        .execute())
+                        .flatMap(result -> result.map((row, _) -> DeletionEvent.builder()
+                                .eventTime(row.get("event_time", Instant.class))
+                                .sourceTable(row.get("source_table", String.class))
+                                .workspaceId(row.get("workspace_id", String.class))
+                                .projectId(row.get("project_id", UUID.class))
+                                .deletedId(row.get("deleted_id", String.class))
+                                .deletionReason(row.get("deletion_reason", String.class))
+                                .build()))
+                        .collectList(),
+                Connection::close)
+                .block();
+    }
+
+    private void assertDeletionEvent(DeletionEvent actualDeletionEvent, DeletionEvent expectedDeletionEvent) {
+        assertThat(actualDeletionEvent)
+                .usingRecursiveComparison()
+                .ignoringFields(DELETION_EVENTS_IGNORED_FIELDS)
+                .isEqualTo(expectedDeletionEvent);
+        assertThat(actualDeletionEvent.eventTime())
+                .isCloseTo(expectedDeletionEvent.eventTime(), within(1, ChronoUnit.SECONDS));
+    }
+
+    @Builder(toBuilder = true)
+    private record DeletionEvent(
+            Instant eventTime,
+            String sourceTable,
+            String workspaceId,
+            UUID projectId,
+            String deletedId,
+            String deletionReason) {
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/DeletionEventsLocalTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/DeletionEventsLocalTest.java
@@ -82,16 +82,16 @@ class DeletionEventsLocalTest {
         var sql = """
                 INSERT INTO deletion_events_local
                     (source_table, workspace_id, project_id, deleted_id, deletion_reason)
-                VALUES (:sourceTable, :workspaceId, :projectId, :deletedId, :deletionReason)
+                VALUES (:source_table, :workspace_id, :project_id, :deleted_id, :deletion_reason)
                 """;
         Mono.usingWhen(
                 connectionFactory.create(),
                 connection -> Flux.from(connection.createStatement(sql)
-                        .bind("sourceTable", event.sourceTable())
-                        .bind("workspaceId", event.workspaceId())
-                        .bind("projectId", event.projectId())
-                        .bind("deletedId", event.deletedId())
-                        .bind("deletionReason", event.deletionReason())
+                        .bind("source_table", event.sourceTable())
+                        .bind("workspace_id", event.workspaceId())
+                        .bind("project_id", event.projectId())
+                        .bind("deleted_id", event.deletedId())
+                        .bind("deletion_reason", event.deletionReason())
                         .execute())
                         .flatMap(Result::getRowsUpdated)
                         .then(),
@@ -103,12 +103,12 @@ class DeletionEventsLocalTest {
         var sql = """
                 SELECT event_time, source_table, workspace_id, project_id, deleted_id, deletion_reason
                 FROM deletion_events_local
-                WHERE workspace_id = :workspaceId
+                WHERE workspace_id = :workspace_id
                 """;
         return Mono.usingWhen(
                 connectionFactory.create(),
                 connection -> Flux.from(connection.createStatement(sql)
-                        .bind("workspaceId", workspaceId)
+                        .bind("workspace_id", workspaceId)
                         .execute())
                         .flatMap(result -> result.map((row, _) -> DeletionEvent.builder()
                                 .eventTime(row.get("event_time", Instant.class))
@@ -128,8 +128,11 @@ class DeletionEventsLocalTest {
                 .usingRecursiveComparison()
                 .ignoringFields(DELETION_EVENTS_IGNORED_FIELDS)
                 .isEqualTo(expectedDeletionEvent);
+        // insert() omits event_time, so ClickHouse stamps it at insert time — moments after Podam
+        // generated the expected value — leaving the two within a few millis
+        // using 2 seconds which large enough to avoid flakiness
         assertThat(actualDeletionEvent.eventTime())
-                .isCloseTo(expectedDeletionEvent.eventTime(), within(1, ChronoUnit.SECONDS));
+                .isCloseTo(expectedDeletionEvent.eventTime(), within(2, ChronoUnit.SECONDS));
     }
 
     @Builder(toBuilder = true)


### PR DESCRIPTION
## Details

Adds Liquibase migration creating `deletion_events_local`, an append-only ClickHouse audit log of deletions used to replay them when a table is copied into a new layout during a migration. A lightweight DELETE does not change a row's version column, so deletes issued while a table is being copied are invisible to the version-based delta step and would otherwise reappear in the copy; this log records each delete so the copy step can replay the ids against the destination.

- `ReplicatedMergeTree` (not Distributed) — append-only and read per-shard during replay.
- No surrogate id — rows are keyed and replayed on `(source_table, event_time, deleted_id)`.
- `project_id` / `deleted_id` are `String`: `project_id` is empty for workspace-scoped source tables, and `deleted_id` is not a UUID for every source table (some are keyed by a composite tuple rather than an id).
- `event_time` is `DateTime64(6)` server-stamped from the column default; 2-year TTL bounds growth while outlasting any single migration.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-6889

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: full implementation
- Human verification: code review + local test run

## Testing

- `cd apps/opik-backend && mvn test -Dtest=DeletionEventsLocalTest` — R2DBC round-trip against a TestContainers ClickHouse + ZooKeeper cluster: inserts a deletion event (omitting `event_time` to exercise the column default, matching the delete-path write) and asserts the full object round-trips via recursive comparison.
- The migration is additionally exercised on a fresh cluster by every ClickHouse-backed integration test, since the Liquibase `includeAll` changelog applies it during TestContainers setup.

## Documentation

N/A
