### PR TITLE
[OPIK-7233] [BE] chore: skip Spotless in the opik-backend Docker build

### DIFF
--- a/apps/opik-backend/Dockerfile
+++ b/apps/opik-backend/Dockerfile
@@ -13,7 +13,7 @@ COPY src ./src
 ARG OPIK_VERSION
 ENV MAVEN_OPTS="-Xmx1G -XX:MaxMetaspaceSize=265m"
 RUN mvn versions:set -DnewVersion=${OPIK_VERSION} && \
-    mvn clean package -DskipTests
+    mvn clean package -DskipTests -Dspotless.skip=true
 
 ###############################
 FROM amazoncorretto:25.0.3-al2023


### PR DESCRIPTION
## Details

<img width="639" height="877" alt="image" src="https://github.com/user-attachments/assets/c21751b7-adc1-4e7d-9f85-34379fab3704" />

The opik-backend Docker/E2E image build ran `mvn clean package`, which triggered `spotless:apply` and pulled the Eclipse JDT formatter from the Eclipse P2 update site (`download.eclipse.org`) at build time. Spotless is the only P2 consumer in the build — everything else resolves from Maven Central — so a P2 outage on 2026-07-04 (HTTP 500) blocked the "Build E2E Docker Images" job even though no code had changed.

This passes `-Dspotless.skip=true` to the Docker `mvn` call so the image build only compiles and packages. The `spotless.skip` property is native to the plugin, so it short-circuits before the JDT formatter is provisioned — no `download.eclipse.org` fetch happens. Formatting stays enforced on every PR by the Code Quality workflow's pre-commit `spotless` hook (unchanged). Local `mvn` and the pre-commit hook still run Spotless — the skip is scoped to the Docker build only. This aligns the backend with the FE and Python pipelines, which already build images compile/package-only and keep linting/formatting as a separate PR gate. The compiled `.jar` is byte-identical whether or not Spotless runs.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-7233

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: code review + local verification that `spotless.skip=true` short-circuits before contacting download.eclipse.org

## Testing

- Verified `mvn spotless:check -Dspotless.skip=true` on `apps/opik-backend` prints `Spotless check skipped` → `BUILD SUCCESS` with no `download.eclipse.org` fetch, confirming the goal short-circuits before formatter provisioning.
- Confirmed the change is Dockerfile-only (no `.java` touched): the pre-commit hook reports "No Java files changed. Skipping Spotless."
- Verified the existing PR formatting gate is untouched — the Code Quality workflow's pre-commit `spotless` hook (`scripts/precommit-spotless.sh`, on changed `apps/opik-backend/**/*.java`) is unchanged and still gates PRs.
- Confirmed the release/image path builds from post-merge `main` via the same Dockerfile (`.github/workflows/build_apps.yml` → `build_and_push_docker.yaml`), so no release path bypasses PR CI.

## Documentation

N/A
