### PR TITLE
[OPIK-7235] [INFRA] fix: make hooks uses pre-commit install -f to avoid migration-mode chaining

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,11 @@ hooks:
 		echo "         git config --global --unset core.hooksPath  # if it was set globally"; \
 		exit 1; \
 	fi
-	@pre-commit install
+	@# -f: install only pre-commit's hook, never chain a pre-existing one in
+	@# "migration mode" (a stale chained hook breaks commits). See OPIK-7235.
+	@pre-commit install -f
+	@# Clear any legacy hook a prior non-force install left behind.
+	@rm -f "$$(git rev-parse --git-path hooks)/pre-commit.legacy"
 	@echo "pre-commit hook installed."
 
 # Uninstall the pre-commit framework hook.


### PR DESCRIPTION
## Details

<img width="830" height="686" alt="image" src="https://github.com/user-attachments/assets/585ac974-1633-4111-ade5-f9f5305c11f3" />

Follow-up to OPIK 6980 (#7165). That PR replaced the hand-written `.hooks/pre-commit` bash hook with the pre-commit framework, but the `make hooks` recipe ran plain `pre-commit install`.

For any contributor who still had the **old** `.git/hooks/pre-commit` installed (everyone who ran the pre-6980 `make hooks`), pre-commit detects the existing hook and installs in **migration mode**:

```
Running in migration mode with existing hooks at .git/hooks/pre-commit.legacy
```

It moves the old hook to `pre-commit.legacy` and **chains** to it on every commit. The legacy hook calls scripts 6980 deleted (`scripts/run-precommit-changed-files.sh`, `dev-runner.sh`), so it now **errors on commit** — and re-running `make hooks` doesn't fix it (still no `-f`).

Fix: the `hooks:` recipe now runs `pre-commit install -f` (skips migration mode; a no-op overwrite on a clean clone) and `rm -f` any leftover `pre-commit.legacy` (idempotent — no error when absent).

## Change checklist
- [x] User facing (developer-facing tooling)
- [x] Documentation update

## Issues

- OPIK-7235

## Testing

- Reproduced migration mode locally against an existing old hook; confirmed the chained legacy hook errors on commit.
- With the fix: `make hooks` installs cleanly, **no migration-mode message**, no `.legacy` left behind.
- Verified from **inside a git worktree**: `pre-commit install -f` targets the shared common hooks dir correctly; `rm -f "$(git rev-parse --git-path hooks)/pre-commit.legacy"` resolves to `<main>/.git/hooks` and is a safe no-op when the file is absent.
- Confirmed the new hook does **no** `git add` — the cross-worktree auto-staging bug the old `git -C "$REPO_ROOT" add -u` guard protected against cannot recur.

## Documentation

- Recipe carries an inline comment explaining `-f` and the migration-mode failure it prevents. CONTRIBUTING.md already notes the hook is shared across worktrees / installed once per clone; no doc change needed.