### PR TITLE
[OPIK-7237] [CI] fix: drop eslint v9-only --no-warn-ignored flag from fe-eslint hook

### DIFF
--- a/scripts/precommit-fe-lint.sh
+++ b/scripts/precommit-fe-lint.sh
@@ -19,10 +19,7 @@ done
 cd "$prefix"
 status=0
 if [ "${#js_files[@]}" -gt 0 ]; then
-	# --no-warn-ignored: a changed file the eslint config ignores would otherwise
-	# emit a "File ignored …" warning — and with --max-warnings=0 that would FAIL
-	# the commit. ESLint still skips ignored files; this just drops the notice.
-	npx eslint --fix --max-warnings=0 --no-warn-ignored "${js_files[@]}" || status=1
+	npx eslint --fix --max-warnings=0 "${js_files[@]}" || status=1
 fi
 if [ "${#style_files[@]}" -gt 0 ]; then
 	npx stylelint --fix "${style_files[@]}" || status=1

--- a/scripts/test_precommit_wrappers.sh
+++ b/scripts/test_precommit_wrappers.sh
@@ -48,7 +48,11 @@ check_empty "no-arg is a no-op"      "$(scripts/precommit-spotless.sh 2>&1)"
 echo "precommit-fe-lint.sh:"
 out=$(scripts/precommit-fe-lint.sh apps/opik-frontend/src/a.tsx apps/opik-frontend/src/b.css 2>&1)
 check "routes .tsx to eslint"          "eslint"          "$out"
-check "eslint uses --no-warn-ignored"  "--no-warn-ignored" "$out"
+check "eslint uses --max-warnings=0"   "--max-warnings=0" "$out"
+# FE pins eslint v8.57.0, which rejects the v9-only --no-warn-ignored flag
+# (OPIK-7237). Assert the wrapper does NOT pass it.
+check_empty "fe eslint omits --no-warn-ignored" \
+	"$(printf '%s' "$out" | grep -o -- '--no-warn-ignored' || true)"
 check "routes .css to stylelint"       "stylelint"       "$out"
 
 echo "precommit-ts-sdk-lint.sh:"


### PR DESCRIPTION
## Details

<img width="782" height="859" alt="image" src="https://github.com/user-attachments/assets/89853f94-1e2a-4c8b-8217-3bc091b15e94" />

The `fe-eslint` pre-commit hook (`scripts/precommit-fe-lint.sh`, introduced by OPIK-6980) passed `--no-warn-ignored`, a flag added in eslint v9. The frontend pins eslint 8.57.0, which rejects the flag with a hard parse error (`Invalid option '--warn-ignored'`) before any file is linted — failing 100% of FE commits locally and the unified Code Quality CI eslint gate (`lint (🌐 eslint — frontend)`).

This drops the flag. It guarded a "File ignored…" warning that cannot fire in this repo: there is no `.eslintignore`, no `ignorePatterns` in `.eslintrc`, and the hook only feeds files under `apps/opik-frontend/src/`. Removing it is a behavioral no-op on eslint v8 and restores green FE commits and CI.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7237

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: code review + manual verification against pinned eslint 8.57.0

## Testing

Verified against the actual pinned eslint 8.57.0 (`apps/opik-frontend/node_modules/.bin/eslint`):

- **Before (with `--no-warn-ignored`):** `eslint --fix --max-warnings=0 --no-warn-ignored src/index.tsx` → `Invalid option '--warn-ignored'` (hard parse error, non-zero exit) — reproduces the reported failure.
- **After (flag dropped):** `eslint --fix --max-warnings=0 src/index.tsx` → lints cleanly, zero output, exit 0.

Also confirmed there is no `.eslintignore` and no `ignorePatterns` in `apps/opik-frontend/.eslintrc`, so the dropped flag was guarding a case that cannot occur. `shellcheck` passes on both changed scripts.

The pre-commit wrapper smoke test (`scripts/test_precommit_wrappers.sh`, run by the `🧪 pre-commit wrapper smoke tests` CI leg) previously pinned `--no-warn-ignored` for the FE hook — locking in the bug. It now asserts the FE hook **omits** the flag while still passing `--max-warnings=0`. The TS SDK assertion is unchanged: that SDK pins eslint 9.39.2, where the flag is valid and genuinely suppresses generated `rest_api/**` ignore warnings. `scripts/test_precommit_wrappers.sh` passes locally.

## Documentation

N/A
