### PR TITLE
[BE] fix: apply above_128k and above_272k tier pricing in cost calculation

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ModelCostData.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ModelCostData.java
@@ -21,10 +21,14 @@ public record ModelCostData(String litellmProvider,
         // Jackson's SnakeCaseStrategy doesn't insert an underscore between letters and digits,
         // so the camelCase fields below would resolve to keys like "above200k" without an
         // underscore. Pin each tier field to the literal LiteLLM JSON key with @JsonProperty.
+        @JsonProperty("input_cost_per_token_above_128k_tokens") String inputCostPerTokenAbove128kTokens,
+        @JsonProperty("output_cost_per_token_above_128k_tokens") String outputCostPerTokenAbove128kTokens,
         @JsonProperty("input_cost_per_token_above_200k_tokens") String inputCostPerTokenAbove200kTokens,
         @JsonProperty("output_cost_per_token_above_200k_tokens") String outputCostPerTokenAbove200kTokens,
         @JsonProperty("cache_creation_input_token_cost_above_200k_tokens") String cacheCreationInputTokenCostAbove200kTokens,
         @JsonProperty("cache_read_input_token_cost_above_200k_tokens") String cacheReadInputTokenCostAbove200kTokens,
+        @JsonProperty("input_cost_per_token_above_272k_tokens") String inputCostPerTokenAbove272kTokens,
+        @JsonProperty("output_cost_per_token_above_272k_tokens") String outputCostPerTokenAbove272kTokens,
         String mode,
         boolean supportsVision,
         String aliasOf) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -394,9 +394,17 @@ public class CostService {
         BigDecimal outputAudioTokenPrice = Optional.ofNullable(modelCost.outputCostPerAudioToken())
                 .map(BigDecimal::new)
                 .orElse(BigDecimal.ZERO);
-        // Tier rates: above_200k_tokens variants. Models without a tier (most) leave these null
-        // in the LiteLLM JSON; we default to zero and the effective-price helpers on ModelPrice
-        // fall through to the base rate in that case.
+        // Tier rates: above_{128k,200k,272k}_tokens variants. Models without a tier (most) leave
+        // these null in the LiteLLM JSON; we default to zero and the effective-price helpers on
+        // ModelPrice fall through to the base rate in that case. Reachable models today: Gemini
+        // 1.5 Flash at 128k, Gemini 2.5 Pro / Claude Sonnet 4.5 at 200k, GPT-5.4 and GPT-5.5
+        // families (both openai and azure) at 272k.
+        BigDecimal inputPriceAbove128kTokens = Optional.ofNullable(modelCost.inputCostPerTokenAbove128kTokens())
+                .map(BigDecimal::new)
+                .orElse(BigDecimal.ZERO);
+        BigDecimal outputPriceAbove128kTokens = Optional.ofNullable(modelCost.outputCostPerTokenAbove128kTokens())
+                .map(BigDecimal::new)
+                .orElse(BigDecimal.ZERO);
         BigDecimal inputPriceAbove200kTokens = Optional.ofNullable(modelCost.inputCostPerTokenAbove200kTokens())
                 .map(BigDecimal::new)
                 .orElse(BigDecimal.ZERO);
@@ -409,6 +417,12 @@ public class CostService {
                 .orElse(BigDecimal.ZERO);
         BigDecimal cacheReadInputTokenPriceAbove200kTokens = Optional
                 .ofNullable(modelCost.cacheReadInputTokenCostAbove200kTokens())
+                .map(BigDecimal::new)
+                .orElse(BigDecimal.ZERO);
+        BigDecimal inputPriceAbove272kTokens = Optional.ofNullable(modelCost.inputCostPerTokenAbove272kTokens())
+                .map(BigDecimal::new)
+                .orElse(BigDecimal.ZERO);
+        BigDecimal outputPriceAbove272kTokens = Optional.ofNullable(modelCost.outputCostPerTokenAbove272kTokens())
                 .map(BigDecimal::new)
                 .orElse(BigDecimal.ZERO);
         ModelMode mode = ModelMode.fromValue(modelCost.mode());
@@ -427,10 +441,14 @@ public class CostService {
                 .inputAudioTokenPrice(inputAudioTokenPrice)
                 .outputAudioTokenPrice(outputAudioTokenPrice)
                 .calculator(calculator)
+                .inputPriceAbove128kTokens(inputPriceAbove128kTokens)
+                .outputPriceAbove128kTokens(outputPriceAbove128kTokens)
                 .inputPriceAbove200kTokens(inputPriceAbove200kTokens)
                 .outputPriceAbove200kTokens(outputPriceAbove200kTokens)
                 .cacheCreationInputTokenPriceAbove200kTokens(cacheCreationInputTokenPriceAbove200kTokens)
                 .cacheReadInputTokenPriceAbove200kTokens(cacheReadInputTokenPriceAbove200kTokens)
+                .inputPriceAbove272kTokens(inputPriceAbove272kTokens)
+                .outputPriceAbove272kTokens(outputPriceAbove272kTokens)
                 .build();
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/ModelPrice.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/ModelPrice.java
@@ -18,18 +18,29 @@ public record ModelPrice(
         @NonNull BigDecimal inputAudioTokenPrice,
         @NonNull BigDecimal outputAudioTokenPrice,
         @NonNull BiFunction<ModelPrice, Map<String, Integer>, BigDecimal> calculator,
+        @NonNull BigDecimal inputPriceAbove128kTokens,
+        @NonNull BigDecimal outputPriceAbove128kTokens,
         @NonNull BigDecimal inputPriceAbove200kTokens,
         @NonNull BigDecimal outputPriceAbove200kTokens,
         @NonNull BigDecimal cacheCreationInputTokenPriceAbove200kTokens,
-        @NonNull BigDecimal cacheReadInputTokenPriceAbove200kTokens) {
+        @NonNull BigDecimal cacheReadInputTokenPriceAbove200kTokens,
+        @NonNull BigDecimal inputPriceAbove272kTokens,
+        @NonNull BigDecimal outputPriceAbove272kTokens) {
 
     /**
-     * Whole-prompt tier threshold for the {@code *_above_200k_tokens} rates published by
-     * LiteLLM (e.g. Gemini 2.5 Pro, Claude Sonnet 4.5). When the total prompt size strictly
-     * exceeds this, every token in the request is billed at the tier rate (this matches
-     * LiteLLM's {@code _get_token_base_cost} which replaces the base rate wholesale).
+     * Whole-prompt tier thresholds for the {@code *_above_NNNk_tokens} rates published by
+     * LiteLLM: when the total prompt size strictly exceeds one, every token in the request
+     * bills at that tier's rate (matches LiteLLM's {@code _get_token_base_cost}, which
+     * replaces the base rate wholesale). Models today publish at most one applicable
+     * threshold (e.g. Gemini 1.5 Flash at 128k, Gemini 2.5 Pro at 200k, GPT-5.4/5.5 at 272k),
+     * but the effective-price helpers below check descending so that if a model ever
+     * publishes multiple tiers, the highest applicable one wins.
      */
+    public static final int TIER_THRESHOLD_128K = 128_000;
+
     public static final int TIER_THRESHOLD_200K = 200_000;
+
+    public static final int TIER_THRESHOLD_272K = 272_000;
 
     /**
      * Returns a builder pre-populated with zero rates and the no-op {@code defaultCost} calculator.
@@ -47,10 +58,14 @@ public record ModelPrice(
                 .inputAudioTokenPrice(BigDecimal.ZERO)
                 .outputAudioTokenPrice(BigDecimal.ZERO)
                 .calculator(SpanCostCalculator::defaultCost)
+                .inputPriceAbove128kTokens(BigDecimal.ZERO)
+                .outputPriceAbove128kTokens(BigDecimal.ZERO)
                 .inputPriceAbove200kTokens(BigDecimal.ZERO)
                 .outputPriceAbove200kTokens(BigDecimal.ZERO)
                 .cacheCreationInputTokenPriceAbove200kTokens(BigDecimal.ZERO)
-                .cacheReadInputTokenPriceAbove200kTokens(BigDecimal.ZERO);
+                .cacheReadInputTokenPriceAbove200kTokens(BigDecimal.ZERO)
+                .inputPriceAbove272kTokens(BigDecimal.ZERO)
+                .outputPriceAbove272kTokens(BigDecimal.ZERO);
     }
 
     public static ModelPrice empty() {
@@ -58,26 +73,48 @@ public record ModelPrice(
     }
 
     public BigDecimal effectiveInputPrice(int totalPromptTokens) {
-        return useTier(totalPromptTokens, inputPriceAbove200kTokens) ? inputPriceAbove200kTokens : inputPrice;
+        return effectiveTieredPrice(totalPromptTokens, inputPrice,
+                inputPriceAbove128kTokens, inputPriceAbove200kTokens, inputPriceAbove272kTokens);
     }
 
     public BigDecimal effectiveOutputPrice(int totalPromptTokens) {
-        return useTier(totalPromptTokens, outputPriceAbove200kTokens) ? outputPriceAbove200kTokens : outputPrice;
+        return effectiveTieredPrice(totalPromptTokens, outputPrice,
+                outputPriceAbove128kTokens, outputPriceAbove200kTokens, outputPriceAbove272kTokens);
     }
 
     public BigDecimal effectiveCacheCreationInputTokenPrice(int totalPromptTokens) {
-        return useTier(totalPromptTokens, cacheCreationInputTokenPriceAbove200kTokens)
+        return useTier(totalPromptTokens, TIER_THRESHOLD_200K, cacheCreationInputTokenPriceAbove200kTokens)
                 ? cacheCreationInputTokenPriceAbove200kTokens
                 : cacheCreationInputTokenPrice;
     }
 
     public BigDecimal effectiveCacheReadInputTokenPrice(int totalPromptTokens) {
-        return useTier(totalPromptTokens, cacheReadInputTokenPriceAbove200kTokens)
+        return useTier(totalPromptTokens, TIER_THRESHOLD_200K, cacheReadInputTokenPriceAbove200kTokens)
                 ? cacheReadInputTokenPriceAbove200kTokens
                 : cacheReadInputTokenPrice;
     }
 
-    private static boolean useTier(int totalPromptTokens, BigDecimal tierRate) {
-        return totalPromptTokens > TIER_THRESHOLD_200K && tierRate.compareTo(BigDecimal.ZERO) > 0;
+    /**
+     * Shared descending-threshold traversal for input/output tiered rates so both effective-price
+     * accessors stay in lock-step. Highest applicable tier wins (272K, then 200K, then 128K); if
+     * none apply — either because the prompt is below every threshold or because the tier rate is
+     * zero (unpublished) — the base rate is returned.
+     */
+    private static BigDecimal effectiveTieredPrice(int totalPromptTokens, BigDecimal baseRate,
+            BigDecimal above128kRate, BigDecimal above200kRate, BigDecimal above272kRate) {
+        if (useTier(totalPromptTokens, TIER_THRESHOLD_272K, above272kRate)) {
+            return above272kRate;
+        }
+        if (useTier(totalPromptTokens, TIER_THRESHOLD_200K, above200kRate)) {
+            return above200kRate;
+        }
+        if (useTier(totalPromptTokens, TIER_THRESHOLD_128K, above128kRate)) {
+            return above128kRate;
+        }
+        return baseRate;
+    }
+
+    private static boolean useTier(int totalPromptTokens, int threshold, BigDecimal tierRate) {
+        return totalPromptTokens > threshold && tierRate.compareTo(BigDecimal.ZERO) > 0;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/SpanCostCalculator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/SpanCostCalculator.java
@@ -39,9 +39,10 @@ class SpanCostCalculator {
                 ? Math.max(0, completionTokens - audioOutputTokens)
                 : completionTokens;
 
-        return modelPrice.inputPrice().multiply(BigDecimal.valueOf(nonAudioPromptTokens))
+        return modelPrice.effectiveInputPrice(promptTokens).multiply(BigDecimal.valueOf(nonAudioPromptTokens))
                 .add(inputAudioRate.multiply(BigDecimal.valueOf(audioInputTokens)))
-                .add(modelPrice.outputPrice().multiply(BigDecimal.valueOf(nonAudioCompletionTokens)))
+                .add(modelPrice.effectiveOutputPrice(promptTokens)
+                        .multiply(BigDecimal.valueOf(nonAudioCompletionTokens)))
                 .add(outputAudioRate.multiply(BigDecimal.valueOf(audioOutputTokens)));
     }
 
@@ -53,6 +54,9 @@ class SpanCostCalculator {
 
         // Get the input tokens (SDK version below 1.6.0 logged prompt_tokens, while 1.6.0+ logged original_usage.prompt_tokens)
         int inputTokens = usage.getOrDefault("original_usage.prompt_tokens", usage.getOrDefault("prompt_tokens", 0));
+        // Keep the total prompt-token count for tier evaluation: which above_NNNk rate applies is
+        // decided on the whole prompt, not on the post-cache-subtraction remainder.
+        int totalPromptTokens = inputTokens;
 
         // Get the cached read input tokens; fall back to OTel bare key for LiteLLM/OTel spans
         int cachedReadInputTokens = usage.getOrDefault("original_usage.prompt_tokens_details.cached_tokens",
@@ -105,11 +109,12 @@ class SpanCostCalculator {
             outputTokens = Math.max(0, outputTokens - audioOutputTokens);
         }
 
-        return modelPrice.inputPrice().multiply(BigDecimal.valueOf(inputTokens))
+        return modelPrice.effectiveInputPrice(totalPromptTokens).multiply(BigDecimal.valueOf(inputTokens))
                 .add(inputAudioRate.multiply(BigDecimal.valueOf(audioInputTokens)))
-                .add(modelPrice.outputPrice().multiply(BigDecimal.valueOf(outputTokens)))
+                .add(modelPrice.effectiveOutputPrice(totalPromptTokens).multiply(BigDecimal.valueOf(outputTokens)))
                 .add(outputAudioRate.multiply(BigDecimal.valueOf(audioOutputTokens)))
-                .add(modelPrice.cacheReadInputTokenPrice().multiply(BigDecimal.valueOf(cachedReadInputTokens)));
+                .add(modelPrice.effectiveCacheReadInputTokenPrice(totalPromptTokens)
+                        .multiply(BigDecimal.valueOf(cachedReadInputTokens)));
     }
 
     public static BigDecimal textGenerationWithCacheCostAnthropic(@NonNull ModelPrice modelPrice,

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -179,6 +179,68 @@ class CostServiceTest {
                 Arguments.of("above threshold uses tier rate", 300_000, "0.765"));
     }
 
+    /**
+     * Whole-prompt tier semantics for {@code *_above_128k_tokens} rates: once the prompt strictly
+     * exceeds 128K every token bills at the tier rate; exactly at the threshold the base rate
+     * still applies. {@code gemini-1.5-flash} is the reachable model at this threshold (input
+     * 7.5e-8 base, 1.5e-7 above 128k — 2x).
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideGeminiAbove128kTierCases")
+    void calculateCostAppliesAbove128kTierPricingForGemini(String description, int promptTokens,
+            String expectedCost) {
+        Map<String, Integer> usage = Map.of(
+                "prompt_tokens", promptTokens,
+                "completion_tokens", 1_000,
+                "original_usage.prompt_token_count", promptTokens,
+                "original_usage.candidates_token_count", 1_000);
+
+        BigDecimal cost = CostService.calculateCost("gemini/gemini-1.5-flash", "google_ai", usage, null);
+
+        assertThat(cost).isEqualByComparingTo(expectedCost);
+    }
+
+    private static Stream<Arguments> provideGeminiAbove128kTierCases() {
+        // gemini-1.5-flash base: input 7.5e-8 / output 0; above_128k: input 1.5e-7 (output stays 0).
+        return Stream.of(
+                // 128_000 * 7.5e-8 + 1_000 * 0 = 0.0096
+                Arguments.of("at threshold uses base rate", 128_000, "0.0096"),
+                // 200_000 * 1.5e-7 + 1_000 * 0 = 0.030
+                Arguments.of("above threshold uses tier rate", 200_000, "0.030"));
+    }
+
+    /**
+     * Whole-prompt tier semantics for {@code *_above_272k_tokens} rates: once the prompt strictly
+     * exceeds 272K every token bills at the tier rate. Reachable models include the OpenAI GPT-5.4
+     * and GPT-5.5 families (and their Azure-hosted twins). {@code gpt-5.4} publishes cache rates
+     * too, so it routes through {@link SpanCostCalculator#textGenerationWithCacheCostOpenAI} —
+     * confirming that the effective-rate helpers cover the OpenAI cache path, not just the Google
+     * and Anthropic ones.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideGpt54Above272kTierCases")
+    void calculateCostAppliesAbove272kTierPricingForOpenAI(String description, int promptTokens,
+            String expectedCost) {
+        Map<String, Integer> usage = Map.of(
+                "prompt_tokens", promptTokens,
+                "completion_tokens", 1_000,
+                "original_usage.prompt_tokens", promptTokens,
+                "original_usage.completion_tokens", 1_000);
+
+        BigDecimal cost = CostService.calculateCost("gpt-5.4", "openai", usage, null);
+
+        assertThat(cost).isEqualByComparingTo(expectedCost);
+    }
+
+    private static Stream<Arguments> provideGpt54Above272kTierCases() {
+        // gpt-5.4 base: input 2.5e-6 / output 1.5e-5; above_272k: input 5e-6 / output 2.25e-5.
+        return Stream.of(
+                // 272_000 * 2.5e-6 + 1_000 * 1.5e-5 = 0.68 + 0.015 = 0.695
+                Arguments.of("at threshold uses base rate", 272_000, "0.695"),
+                // 300_000 * 5e-6 + 1_000 * 2.25e-5 = 1.5 + 0.0225 = 1.5225
+                Arguments.of("above threshold uses tier rate", 300_000, "1.5225"));
+    }
+
     @Test
     void calculateCostUsesGoogleCacheCalculatorWhenCachePricesConfigured_issue6976() {
         Map<String, Integer> usage = Map.of(


### PR DESCRIPTION
## Details

Follow-up to #7023 (which introduced the whole-prompt `*_above_200k_tokens` tier for Gemini 2.5 Pro / Claude Sonnet 4.5), covering two additional thresholds LiteLLM publishes in `model_prices_and_context_window.json` that Opik currently ignores:

- **`*_above_128k_tokens`** — reachable model today: `gemini/gemini-1.5-flash` (input `7.5e-8` → `1.5e-7` above 128k, 2x).
- **`*_above_272k_tokens`** — reachable models today: the OpenAI `gpt-5.4` / `gpt-5.5` families plus every `-pro` variant (`2.5e-6` → `5e-6` input, `1.5e-5` → `2.25e-5` output, 2x/1.5x). With #7262 registering `azure` as a canonical provider, the Azure-hosted twins (`azure/gpt-5.4`, `azure/gpt-5.5*`) inherit the same rates — 17 flagship models in total whose above-threshold traces have been silently underbilled.

The scope for the tier fields is intentionally limited to `input_cost_per_token` / `output_cost_per_token` at each of the two new thresholds — LiteLLM does not publish `cache_creation_input_token_cost_above_128k_tokens` or `cache_read_input_token_cost_above_272k_tokens`, so cache-side tier handling stays 200k-only. Cache-tier for other thresholds can be picked up if and when models start publishing those fields.

This was pre-approved as a follow-up direction when #7023 landed. Andres, if the scope has drifted from what you expected, happy to split further.

### What changed

- `ModelCostData`: four new `@JsonProperty` fields for `input/output_cost_per_token_above_{128k,272k}_tokens` (Jackson's `SnakeCaseStrategy` doesn't insert underscores between letters and digits, so each tier field is pinned to the literal JSON key — same shape as the 200k fields already there).
- `ModelPrice`: four new tier fields plus two new threshold constants (`TIER_THRESHOLD_128K`, `TIER_THRESHOLD_272K`). `effectiveInputPrice` / `effectiveOutputPrice` walk the thresholds descending (272k → 200k → 128k → base) so if a model ever publishes multiple applicable tiers the highest wins.
- `CostService.buildModelPrice`: symmetric parsing + builder wiring for the four new fields.
- `SpanCostCalculator`: two additional call sites now consult the effective-rate helpers rather than the base rates:
  - `textGenerationCost` was billing plain OpenAI models at `inputPrice()` / `outputPrice()` — never picked up any tier.
  - `textGenerationWithCacheCostOpenAI` had the same problem, plus the cache bucket now consults `effectiveCacheReadInputTokenPrice`. Total prompt-token count is captured before the cached-tokens subtraction so the tier decision is based on the whole prompt, not the post-cache remainder.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (CLI)
- Model(s): Claude Opus 4.7
- Scope: assisted in the LiteLLM JSON scout that identified 128k / 272k as the two thresholds with reachable-model impact (after ruling out 256k and 512k, each with a single unreachable model), drafted the symmetric plumbing following the 200k pattern from #7023, and wrote the parameterized branch-coverage tests
- Human verification: ran the test suite locally; cross-checked the expected dollar values against the prices in `model_prices_and_context_window.json`; verified that `effectiveInputPrice` returns the base rate for every existing model and every existing fixture (no regressions in the 68-case CostServiceTest baseline)

## Testing

Local verification on JDK 25 + Maven 3.9.9:

```
mvn -ntp -f apps/opik-backend/pom.xml \
  -Dtest=CostServiceTest,SpanCostCalculatorTest test
```

Result: **88/88 green** (four new parameterized cases under `calculateCostAppliesAbove128kTierPricingForGemini` and `calculateCostAppliesAbove272kTierPricingForOpenAI`, mirroring the style of the existing `calculateCostAppliesAbove200kTierPricingForGemini_issue6982`).

Scenarios covered:

1. **128k tier, `gemini/gemini-1.5-flash`** (Google canonical, cache-Google calc path)
   - At threshold (`prompt_tokens=128_000`) → base rate: `128_000 × 7.5e-8 + 1_000 × 0 = 0.0096`
   - Above threshold (`prompt_tokens=200_000`) → tier rate: `200_000 × 1.5e-7 + 1_000 × 0 = 0.030`
2. **272k tier, `gpt-5.4`** (OpenAI canonical, cache-OpenAI calc path — cache rate `2.5e-7` triggers routing through `textGenerationWithCacheCostOpenAI` even without cached tokens in the usage payload)
   - At threshold (`prompt_tokens=272_000`) → base rates: `272_000 × 2.5e-6 + 1_000 × 1.5e-5 = 0.695`
   - Above threshold (`prompt_tokens=300_000`) → tier rates: `300_000 × 5e-6 + 1_000 × 2.25e-5 = 1.5225`

The 200k Gemini test from #7023 continues to pass unchanged, confirming the descending-threshold traversal correctly falls through to lower tiers.

## Documentation

No docs change. Behavior change is invisible to end users beyond more accurate cost numbers for above-threshold traces on the 17 affected models.