### PR TITLE
[OPIK-7093] [QA] test: add direct E2E coverage for the Dataset Items page

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetItemsActionsPanel.tsx
@@ -181,6 +181,7 @@ const DatasetItemsActionsPanel: React.FunctionComponent<
             size="icon-sm"
             onClick={deleteDatasetItemsHandler}
             disabled={disabled}
+            data-testid="dataset-items-bulk-delete-button"
           >
             <Trash />
           </Button>

--- a/tests_end_to_end/e2e/pom/dataset-items.page.ts
+++ b/tests_end_to_end/e2e/pom/dataset-items.page.ts
@@ -61,6 +61,67 @@ export class DatasetItemsPage {
     });
   }
 
+  /** Clicking a row opens the editor side-panel (URL gains ?row=<id>). */
+  async openItemEditor(index: number): Promise<void> {
+    return test.step(`Open editor for item at index ${index}`, async () => {
+      const row = this.itemRow(index);
+      await row.waitFor({ state: 'visible' });
+      await row.getByRole('cell').nth(1).click();
+      await this.editItemPanel.waitFor({ state: 'visible' });
+      await this.editItemPanel.getByRole('region').first().waitFor({ state: 'visible' });
+    });
+  }
+
+  /**
+   * Edits a single field in the open editor. The editor autosaves: changing a
+   * field stages an "edited" draft (Draft badge appears), it does not persist
+   * on its own — commitDraft() turns the draft into a new version.
+   */
+  async editItemField(field: string, value: string): Promise<void> {
+    return test.step(`Edit field "${field}"`, async () => {
+      await this.editItemPanel
+        .getByRole('region', { name: field })
+        .getByPlaceholder('Enter text for this field…')
+        .fill(value);
+      await this.draftBadge().waitFor({ state: 'visible' });
+    });
+  }
+
+  async closeItemEditor(): Promise<void> {
+    return test.step('Close editor side-panel', async () => {
+      await this.editItemPanel.getByRole('button', { name: 'Close' }).click();
+    });
+  }
+
+  async selectRow(index: number): Promise<void> {
+    return test.step(`Select row at index ${index}`, async () => {
+      await this.itemRow(index).getByRole('checkbox', { name: 'Select row' }).click();
+    });
+  }
+
+  /**
+   * Bulk-deletes the currently selected rows. For an explicit selection this
+   * stages a draft (no confirmation dialog) — commitDraft() persists it.
+   */
+  async bulkDeleteSelected(): Promise<void> {
+    return test.step('Bulk-delete selected rows', async () => {
+      await this.page.getByTestId('dataset-items-bulk-delete-button').click();
+      await this.draftBadge().waitFor({ state: 'visible' });
+    });
+  }
+
+  async search(term: string): Promise<void> {
+    return test.step(`Search items for "${term}"`, async () => {
+      await this.page.getByTestId('search-input').fill(term);
+    });
+  }
+
+  async clearSearch(): Promise<void> {
+    return test.step('Clear item search', async () => {
+      await this.page.getByTestId('search-input').fill('');
+    });
+  }
+
   async fillAddItemPanel(fields: Record<string, string>): Promise<void> {
     return test.step('Fill add-item panel', async () => {
       for (const [column, value] of Object.entries(fields)) {
@@ -143,6 +204,10 @@ export class DatasetItemsPage {
 
   get addItemPanel(): Locator {
     return this.page.getByTestId('dataset-item-panel');
+  }
+
+  get editItemPanel(): Locator {
+    return this.page.getByTestId('dataset-item-editor');
   }
 
   private get itemsTableBody(): Locator {

--- a/tests_end_to_end/e2e/tests/datasets/dataset-items.spec.ts
+++ b/tests_end_to_end/e2e/tests/datasets/dataset-items.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@e2e/fixtures';
+import { DatasetsPage } from '@e2e/pom/datasets.page';
+
+test.describe('Dataset items — direct coverage', { tag: ['@datasets'] }, () => {
+  /** Items toolbar collapses to icon-only (no accessible name) below ~850px container width. */
+  test.use({ viewport: { width: 1600, height: 900 } });
+
+  test('Editing an item field commits as a new version and round-trips to the SDK', {
+    tag: ['@t2-cuj'],
+  }, async ({
+    dataset,
+    project,
+    backendClient,
+    page,
+  }) => {
+    const editedInput = 'edited via items page';
+
+    const items = await test.step('Open the dataset items page', async () => {
+      const datasets = new DatasetsPage(page);
+      await datasets.goto(project.id);
+      await datasets.waitForReady();
+      const itemsPage = await datasets.openDatasetByName(dataset.name);
+      await itemsPage.waitForReady();
+      expect(await itemsPage.countItems()).toBe(3);
+      return itemsPage;
+    });
+
+    await test.step('Edit an item field (stages a draft) and commit as a new version', async () => {
+      await items.openItemEditor(0);
+      await items.editItemField('input', editedInput);
+      await items.closeItemEditor();
+      await items.commitDraft();
+      await expect(items.versionLabel(2)).toBeVisible();
+      expect(await items.countItems()).toBe(3);
+    });
+
+    await test.step('Verify the edit persisted via the SDK', async () => {
+      const persisted = await backendClient.getDatasetItems(dataset.id);
+      expect(persisted).toHaveLength(3);
+      const inputs = persisted.map((i) => i.data.input);
+      expect(inputs).toContain(editedInput);
+    });
+  });
+
+  test(
+    'Bulk-deleting selected items commits as a new version and round-trips to the SDK',
+    { tag: ['@t3-nightly'] },
+    async ({ dataset, project, backendClient, page }) => {
+      const items = await test.step('Open the dataset items page', async () => {
+        const datasets = new DatasetsPage(page);
+        await datasets.goto(project.id);
+        await datasets.waitForReady();
+        const itemsPage = await datasets.openDatasetByName(dataset.name);
+        await itemsPage.waitForReady();
+        expect(await itemsPage.countItems()).toBe(3);
+        return itemsPage;
+      });
+
+      await test.step('Select two rows, bulk-delete (stages a draft), and commit', async () => {
+        await items.selectRow(0);
+        await items.selectRow(1);
+        await items.bulkDeleteSelected();
+        expect(await items.countItems()).toBe(1);
+        await items.commitDraft();
+        await expect(items.versionLabel(2)).toBeVisible();
+        expect(await items.countItems()).toBe(1);
+      });
+
+      await test.step('Verify only one item remains via the SDK', async () => {
+        const remaining = await backendClient.getDatasetItems(dataset.id);
+        expect(remaining).toHaveLength(1);
+      });
+    },
+  );
+
+  test(
+    'Searching filters the items table to matching rows',
+    { tag: ['@t3-nightly'] },
+    async ({ dataset, project, page }) => {
+      const items = await test.step('Open the dataset items page', async () => {
+        const datasets = new DatasetsPage(page);
+        await datasets.goto(project.id);
+        await datasets.waitForReady();
+        const itemsPage = await datasets.openDatasetByName(dataset.name);
+        await itemsPage.waitForReady();
+        expect(await itemsPage.countItems()).toBe(3);
+        return itemsPage;
+      });
+
+      await test.step('Search narrows the table to the matching row', async () => {
+        await items.search('seed input 2');
+        await expect.poll(() => items.countItems()).toBe(1);
+      });
+
+      await test.step('Clearing the search restores all rows', async () => {
+        await items.clearSearch();
+        await expect.poll(() => items.countItems()).toBe(3);
+      });
+    },
+  );
+});


### PR DESCRIPTION
## Details

Adds a dataset-items E2E spec (`tests_end_to_end/e2e/tests/datasets/dataset-items.spec.ts`) that directly exercises item-level flows the existing CRUD smoke only touched indirectly. Three flows: editing an item field (commits as a new version, verified via SDK round-trip), bulk-selecting + deleting items (commit + round-trip), and search filtering the items table.

- Extends `pom/dataset-items.page.ts` with `openItemEditor` / `editItemField` / `selectRow` / `bulkDeleteSelected` / `search` methods, reusing the existing draft `commitDraft`/`countItems`/`versionLabel` helpers.
- Adds `data-testid="dataset-items-bulk-delete-button"` to the icon-only bulk-delete button (no stable accessible name otherwise).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7093

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Explored the SDK/FE/live UI, wrote the POM methods + spec, added the FE test-id.
- Human verification: Ran the suite locally against a fresh build of latest main; reviewed all diffs.

## Testing

Built the frontend image from latest `main` (with the new test-id) and recreated the local OSS container, then ran the spec against it:

```
cd tests_end_to_end/e2e
WORKERS=2 npx playwright test tests/datasets/dataset-items.spec.ts --reporter=list
# 3 passed (edit @t2-cuj, bulk-delete @t3-nightly, search @t3-nightly)
```

- Verified tier filtering: `--grep "@t1-smoke|@t2-cuj"` selects only the edit test; the t3 grep selects all three.
- Regression: re-ran `tests/datasets/dataset-crud-smoke.spec.ts` (shared POM) — 2 passed.
- Environment: local OSS Docker stack (`http://localhost:5173`), frontend rebuilt from source; bridge auto-spawned by the Playwright `webServer` directive.

## Documentation