### PR TITLE
[NA] [CI] docs: regenerate Helm chart README to match chart version

### DIFF
--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Comet Opik
 
-![Version: 2.1.8](https://img.shields.io/badge/Version-2.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.8](https://img.shields.io/badge/AppVersion-2.1.8-informational?style=flat-square)
+![Version: 2.1.16](https://img.shields.io/badge/Version-2.1.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.16](https://img.shields.io/badge/AppVersion-2.1.16-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opik)](https://artifacthub.io/packages/search?repo=opik)
 
 # Run Comet Opik with Helm


### PR DESCRIPTION
## Details

<img width="756" height="706" alt="image" src="https://github.com/user-attachments/assets/5adcd12d-9e66-4407-8084-442555d09956" />

The Helm chart README version badge had drifted behind `Chart.yaml`: the README showed `2.1.8` while the chart is at `2.1.16`. Version bumps land on `main` (via release automation) touching `Chart.yaml` but not regenerating the README, so the `helm-docs` lint gate — which runs on **every** PR and validates the README is in sync — fails on all open PRs, not just chart changes.

This regenerates `deployment/helm_chart/opik/README.md` via the `helm-docs` pre-commit hook so the gate goes green again.
- README-only change; the badge line updates `2.1.8` → `2.1.16`. No chart values or templates changed.

Follow-up (separate ticket): close the automation gap so a version bump regenerates the README in the same commit — the existing `update_helm_readme.yaml` bot only triggers on PRs that touch `deployment/helm_chart/opik/**`, so bumps outside that path let the README drift.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: full implementation
- Human verification: reviewed the one-line diff; re-ran the helm-docs hook to confirm the README is in sync

## Testing

- `pre-commit run helm-docs` against the chart on a branch cut from latest `origin/main` — regenerated the README, then re-ran the hook and it reported no changes (in sync).
- Diff is a single line: the version/appVersion badge `2.1.8` → `2.1.16`.

## Documentation

N/A — this regenerates generated documentation; no authored docs changed.
