### PR TITLE
[OPIK-6881] Add ClickHouse server profile settings to query parameters

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -85,7 +85,7 @@ databaseAnalytics:
   #   - failover=3
   #   - custom_http_params=max_query_size=100000000
   #  Description: query parameters that will be added to the connection string
-  queryParameters: ${ANALYTICS_DB_QUERY_PARAMETERS:-health_check_interval=2000&compress=1&auto_discovery=true&failover=3&custom_http_params=max_query_size=100000000,async_insert_busy_timeout_max_ms=250,async_insert_busy_timeout_min_ms=100,async_insert=1,wait_for_async_insert=1,async_insert_use_adaptive_busy_timeout=1,async_insert_deduplicate=1,use_skip_indexes_if_final=1}
+  queryParameters: ${ANALYTICS_DB_QUERY_PARAMETERS:-health_check_interval=2000&compress=1&auto_discovery=true&failover=3&custom_http_params=max_query_size=100000000,async_insert_busy_timeout_max_ms=250,async_insert_busy_timeout_min_ms=100,async_insert=1,wait_for_async_insert=1,async_insert_use_adaptive_busy_timeout=1,async_insert_deduplicate=1,use_skip_indexes_if_final=1,optimize_skip_unused_shards=1,do_not_merge_across_partitions_select_final=1,distributed_product_mode=local}
   #  Default: unset (inherits the async_insert_busy_timeout_max_ms=250 carried by queryParameters above)
   #  Description: Optional override (ms) for async_insert_busy_timeout_max_ms in the custom_http_params chain of
   #   queryParameters above; only applied when that setting is already present there, otherwise it is not injected.

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/DatabaseAnalyticsFactoryTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/DatabaseAnalyticsFactoryTest.java
@@ -66,7 +66,10 @@ class DatabaseAnalyticsFactoryTest {
                 + "wait_for_async_insert=1,"
                 + "async_insert_use_adaptive_busy_timeout=1,"
                 + "async_insert_deduplicate=1,"
-                + "use_skip_indexes_if_final=1";
+                + "use_skip_indexes_if_final=1,"
+                + "optimize_skip_unused_shards=1,"
+                + "do_not_merge_across_partitions_select_final=1,"
+                + "distributed_product_mode=local";
 
         ParsedQueryParameters parsed = DatabaseAnalyticsFactory.parseQueryParameters(qp);
 
@@ -75,15 +78,18 @@ class DatabaseAnalyticsFactoryTest {
                 "compress", "1",
                 "auto_discovery", "true",
                 "failover", "3"));
-        assertThat(parsed.serverSettings()).containsExactlyInAnyOrderEntriesOf(Map.of(
-                "max_query_size", "100000000",
-                "async_insert_busy_timeout_max_ms", "250",
-                "async_insert_busy_timeout_min_ms", "100",
-                "async_insert", "1",
-                "wait_for_async_insert", "1",
-                "async_insert_use_adaptive_busy_timeout", "1",
-                "async_insert_deduplicate", "1",
-                "use_skip_indexes_if_final", "1"));
+        assertThat(parsed.serverSettings()).containsExactlyInAnyOrderEntriesOf(Map.ofEntries(
+                Map.entry("max_query_size", "100000000"),
+                Map.entry("async_insert_busy_timeout_max_ms", "250"),
+                Map.entry("async_insert_busy_timeout_min_ms", "100"),
+                Map.entry("async_insert", "1"),
+                Map.entry("wait_for_async_insert", "1"),
+                Map.entry("async_insert_use_adaptive_busy_timeout", "1"),
+                Map.entry("async_insert_deduplicate", "1"),
+                Map.entry("use_skip_indexes_if_final", "1"),
+                Map.entry("optimize_skip_unused_shards", "1"),
+                Map.entry("do_not_merge_across_partitions_select_final", "1"),
+                Map.entry("distributed_product_mode", "local")));
     }
 
     @Test

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -69,7 +69,7 @@ databaseAnalytics:
   #   - failover=3
   #   - custom_http_params=max_query_size=100000000
   #  Description: query parameters that will be added to the connection string
-  queryParameters: health_check_interval=2000&compress=1&auto_discovery=true&failover=3&custom_http_params=max_query_size=100000000,async_insert_busy_timeout_max_ms=60,async_insert_busy_timeout_min_ms=50,async_insert=1,wait_for_async_insert=1,async_insert_use_adaptive_busy_timeout=1,async_insert_deduplicate=1,use_skip_indexes_if_final=1
+  queryParameters: health_check_interval=2000&compress=1&auto_discovery=true&failover=3&custom_http_params=max_query_size=100000000,async_insert_busy_timeout_max_ms=60,async_insert_busy_timeout_min_ms=50,async_insert=1,wait_for_async_insert=1,async_insert_use_adaptive_busy_timeout=1,async_insert_deduplicate=1,use_skip_indexes_if_final=1,optimize_skip_unused_shards=1,do_not_merge_across_partitions_select_final=1,distributed_product_mode=local
   #  Default: unset (inherits the async_insert_busy_timeout_max_ms=60 carried by queryParameters above)
   #  Description: Optional override (ms) for async_insert_busy_timeout_max_ms in the custom_http_params chain of
   #   queryParameters above; only applied when that setting is already present there, otherwise it is not injected.


### PR DESCRIPTION
## Details

Append three ClickHouse server settings to the `databaseAnalytics` `custom_http_params` chain: `optimize_skip_unused_shards=1`, `do_not_merge_across_partitions_select_final=1`, and `distributed_product_mode=local`. All three are no-ops on the current single-partition, single-shard schema — setting them now means they are already in place when partitioning/sharding lands, so no separate rollout step is needed then.

- `config.yml`: append to the `ANALYTICS_DB_QUERY_PARAMETERS` default chain
- `config-test.yml`: mirror in the TestContainers config so tests pick up the settings
- `DatabaseAnalyticsFactoryTest`: extend the full-chain parse assertion (switched to `Map.ofEntries` — now >10 entries)
- No Helm overlay, Docker Compose file, or environment overrides `ANALYTICS_DB_QUERY_PARAMETERS`, so every deployment inherits this `config.yml` default; no overlay changes required

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6881

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: config chain edits, test update, and repo-wide scan confirming no overlay overrides the env var
- Human verification: pending author review

## Testing

- `mvn -o test -Dtest=DatabaseAnalyticsFactoryTest` → 7 tests pass, BUILD SUCCESS
- `mvn -o test-compile` on `opik-backend` succeeds
- Verified the parser routes each `custom_http_params` entry to `builder.serverSetting(k, v)`, so `distributed_product_mode=local` (string value) is applied like the rest
- Environment: local process mode (offline Maven)

Post-deploy the settings can be confirmed via `SELECT * FROM system.settings WHERE name IN ('optimize_skip_unused_shards','do_not_merge_across_partitions_select_final','distributed_product_mode')`.

## Documentation

No documentation changes — internal ClickHouse connection setting; not user facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)