### PR TITLE
[OPIK-7076] [BE] Fix query timeouts with feedback score filters by enabling prefilter CTE

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -1104,7 +1104,18 @@ public class SpanDAO {
 
     private static final String COUNT_BY_PROJECT_ID = """
             <if(feedback_scores_filters || feedback_scores_empty_filters)>
-            WITH feedback_scores_deduped AS (
+            WITH <if(span_id_prefilter)>span_id_prefilter AS (
+                SELECT DISTINCT id
+                FROM spans
+                WHERE workspace_id = :workspace_id
+                AND project_id = :project_id
+                <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
+                <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                <if(trace_id)> AND trace_id = :trace_id <endif>
+                <if(type)> AND type = :type <endif>
+                <if(filters)> AND <filters> <endif>
+                <if(search_text)> AND <search_text> <endif>
+            ), <endif>feedback_scores_deduped AS (
                 SELECT workspace_id,
                        project_id,
                        entity_id,
@@ -1124,8 +1135,11 @@ public class SpanDAO {
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
                       AND project_id = :project_id
+                      <if(span_id_prefilter)> AND entity_id IN (SELECT id FROM span_id_prefilter)
+                      <else>
                       <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
                       <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                      <endif>
                     UNION ALL
                     SELECT workspace_id,
                            project_id,
@@ -1138,8 +1152,11 @@ public class SpanDAO {
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
                       AND project_id = :project_id
+                      <if(span_id_prefilter)> AND entity_id IN (SELECT id FROM span_id_prefilter)
+                      <else>
                       <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
                       <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                      <endif>
                 )
                 ORDER BY last_updated_at DESC
                 LIMIT 1 BY workspace_id, project_id, entity_id, name, author
@@ -2582,6 +2599,10 @@ public class SpanDAO {
             var template = newFindTemplate(COUNT_BY_PROJECT_ID, spanSearchCriteria, "count_spans_by_project_id",
                     workspaceId, userName);
 
+            if (shouldUseSpanIdPrefilter(spanSearchCriteria, template)) {
+                template.add("span_id_prefilter", true);
+            }
+
             var statement = connection.createStatement(template.render())
                     .bind("project_id", spanSearchCriteria.projectId())
                     .bind("workspace_id", workspaceId);
@@ -2634,16 +2655,18 @@ public class SpanDAO {
      * uuidFromTime/uuidToTime are excluded because the if/else fallback applies them directly
      * to feedback_scores; lastReceivedSpanId is excluded because it's a pagination cursor,
      * not a semantic filter.
+     *
+     * <p>Feedback score filters use separate template variables ({@code feedback_scores_filters})
+     * and are NOT injected into {@code <filters>}, so the prefilter CTE is safe to use
+     * alongside them (OPIK-7076).
      */
     private boolean shouldUseSpanIdPrefilter(SpanSearchCriteria criteria, ST template) {
-        boolean hasFeedbackScoreFilters = hasFeedbackScoreFilters(template);
-
         boolean hasNarrowingFilters = criteria.traceId() != null
                 || criteria.type() != null
                 || criteria.searchText() != null
                 || template.getAttribute("filters") != null;
 
-        return !hasFeedbackScoreFilters && hasNarrowingFilters;
+        return hasNarrowingFilters;
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -1480,7 +1480,18 @@ class TraceDAOImpl implements TraceDAO {
             """;
 
     private static final String COUNT_BY_PROJECT_ID = """
-            WITH feedback_scores_deduped AS (
+            WITH <if(trace_id_prefilter)>trace_id_prefilter AS (
+                SELECT DISTINCT id
+                FROM traces
+                WHERE workspace_id = :workspace_id
+                AND project_id = :project_id
+                <if(uuid_from_time)> AND id >= :uuid_from_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
+                <if(filters)> AND <filters> <endif>
+                <if(search_text)> AND <search_text> <endif>
+            ), <endif>feedback_scores_deduped AS (
                 SELECT workspace_id,
                        project_id,
                        entity_id,
@@ -1500,8 +1511,11 @@ class TraceDAOImpl implements TraceDAO {
                     WHERE entity_type = 'trace'
                       AND workspace_id = :workspace_id
                       AND project_id = :project_id
+                      <if(trace_id_prefilter)> AND entity_id IN (SELECT id FROM trace_id_prefilter)
+                      <else>
                       <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
                       <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                      <endif>
                     UNION ALL
                     SELECT workspace_id,
                            project_id,
@@ -1516,8 +1530,11 @@ class TraceDAOImpl implements TraceDAO {
                        AND workspace_id = :workspace_id
                        AND project_id = :project_id
                        <if(annotation_queue_id)>AND source_queue_id = :annotation_queue_id<endif>
+                       <if(trace_id_prefilter)> AND entity_id IN (SELECT id FROM trace_id_prefilter)
+                       <else>
                        <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
                        <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                       <endif>
                 )
                 ORDER BY last_updated_at DESC
                 LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
@@ -1542,8 +1559,11 @@ class TraceDAOImpl implements TraceDAO {
                     WHERE entity_type = 'trace'
                     AND workspace_id = :workspace_id
                     AND project_id = :project_id
+                    <if(trace_id_prefilter)> AND entity_id IN (SELECT id FROM trace_id_prefilter)
+                    <else>
                     <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
                     <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+                    <endif>
                     ORDER BY (workspace_id, project_id, entity_type, entity_id, id) DESC, last_updated_at DESC
                     LIMIT 1 BY entity_id, id
                 )
@@ -1558,8 +1578,11 @@ class TraceDAOImpl implements TraceDAO {
                     WHERE aq.scope = 'trace'
                       AND workspace_id = :workspace_id
                       AND project_id = :project_id
+                      <if(trace_id_prefilter)> AND aqi.item_id IN (SELECT id FROM trace_id_prefilter)
+                      <else>
                       <if(uuid_from_time)> AND aqi.item_id >= :uuid_from_time <endif>
                       <if(uuid_to_time)> AND aqi.item_id \\<= :uuid_to_time <endif>
+                      <endif>
                  ) AS annotation_queue_ids_with_trace_id
                  GROUP BY trace_id
             ), target_spans AS (
@@ -1567,8 +1590,11 @@ class TraceDAOImpl implements TraceDAO {
                 FROM spans
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
+                <if(trace_id_prefilter)>AND trace_id IN (SELECT id FROM trace_id_prefilter)
+                <else>
                 <if(uuid_from_time)>AND trace_id >= :uuid_from_time<endif>
                 <if(uuid_to_time)>AND trace_id \\<= :uuid_to_time<endif>
+                <endif>
             ),
             span_feedback_scores_deduped AS (
                 SELECT workspace_id,
@@ -3694,15 +3720,19 @@ class TraceDAOImpl implements TraceDAO {
      * <p>Guardrails filters inject {@code gagg.guardrails_result} into the {@code <filters>}
      * template variable, which references the guardrails_agg CTE alias. Since the prefilter
      * CTE only queries the traces table, these references would fail. Guard against them.
+     *
+     * <p>Feedback score filters use separate template variables ({@code feedback_scores_filters},
+     * {@code span_feedback_scores_filters}) and are NOT injected into {@code <filters>}, so
+     * the prefilter CTE is safe to use alongside them. Enabling it dramatically reduces
+     * feedback score scan volume when trace-column filters are also present (OPIK-7076).
      */
     private boolean shouldUseTraceIdPrefilter(TraceSearchCriteria criteria, ST template) {
-        boolean hasCteDependentFilters = hasFeedbackScoreFilters(template)
-                || template.getAttribute("guardrails_filters") != null;
+        boolean hasGuardrailsInFilters = template.getAttribute("guardrails_filters") != null;
 
         boolean hasNarrowingFilters = criteria.searchText() != null
                 || template.getAttribute("filters") != null;
 
-        return !hasCteDependentFilters && hasNarrowingFilters;
+        return !hasGuardrailsInFilters && hasNarrowingFilters;
     }
 
     /**
@@ -3899,6 +3929,10 @@ class TraceDAOImpl implements TraceDAO {
             var template = newTraceThreadFindTemplate(
                     COUNT_BY_PROJECT_ID, traceSearchCriteria, TRACE_SEARCH_CLAUSE, traceColumnsNonNullable());
             template.add("log_comment", logComment);
+
+            if (shouldUseTraceIdPrefilter(traceSearchCriteria, template)) {
+                template.add("trace_id_prefilter", true);
+            }
 
             var statement = connection.createStatement(template.render())
                     .bind("project_id", traceSearchCriteria.projectId())


### PR DESCRIPTION
## Details

Fixes query timeouts and high latency when users apply 2+ filters including feedback score filters on trace/span listing pages.

**Root cause**: The `trace_id_prefilter` / `span_id_prefilter` CTEs — which narrow downstream feedback score scans by first finding matching trace/span IDs using the primary key — were disabled whenever feedback score filters were present. This was an overly cautious guard introduced in PR #5928 for a guardrails-specific bug (guardrails filter SQL references a CTE alias that doesn't exist in the prefilter CTE). Feedback score filters use separate template variables and never interfere with the prefilter.

**Fix**:
- **TraceDAO**: Remove feedback score exclusion from `shouldUseTraceIdPrefilter()`, keep guardrails guard. Add prefilter CTE to `COUNT_BY_PROJECT_ID` with `IN` predicates for feedback_scores, guardrails, annotation_queues, and target_spans. Activate prefilter in `countTotal()`.
- **SpanDAO**: Same fix for `shouldUseSpanIdPrefilter()`. Add prefilter CTE to `COUNT_BY_PROJECT_ID` inside the feedback score `WITH` block. Activate prefilter in `countTotal()`.

**Measured results** (50K traces, 240K feedback scores, filters: name + tags + feedback score):

| Query | Before | After | Speedup |
|-------|--------|-------|---------|
| Trace listing | 1.3–1.8s | 370–700ms | 2–4x |
| Trace count | 634–725ms | 57–167ms | 4–12x |
| Span listing | 250–344ms | 88–120ms | ~3x |
| Span count | 52–257ms | 21–56ms | 3–5x |

Improvement scales with dataset size and filter selectivity — larger projects with more selective filters will see proportionally bigger gains.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues
- OPIK-7076

## Testing
- Verified prefilter activates (`has_prefilter=1` in ClickHouse `system.query_log`) when trace/span-column filters are combined with feedback score filters
- Verified prefilter does NOT activate when only feedback score filters are present (no narrowing filters) — correct behavior
- Verified prefilter does NOT activate when guardrails filters are present — preserved existing guard
- Compared `read_rows`, `read_bytes`, and `query_duration_ms` before/after via `system.query_log`
- Verified result correctness: same number of results and same traces returned with and without prefilter

## Documentation
N/A — no user-facing API changes, internal query optimization only.