### PR TITLE
[NA] [QA] fix: poll Threads count in thread-logging smoke to fix flake

### DIFF
--- a/tests_end_to_end/e2e/pom/logs.page.ts
+++ b/tests_end_to_end/e2e/pom/logs.page.ts
@@ -117,10 +117,17 @@ export class LogsPage {
     return this.page.getByRole('radio', { name: 'Threads' });
   }
 
-  /** Wait for the Threads table to have rendered at least one row. */
-  async waitForThreadsReady(): Promise<void> {
+  /**
+   * Wait for the Threads table to be ready. When a threadId is given, wait for
+   * that specific row — threads are eventually consistent, so gating on "any
+   * row" can pass before the seeded thread has been aggregated into the list.
+   */
+  async waitForThreadsReady(threadId?: string): Promise<void> {
     return test.step('Wait for Threads table ready', async () => {
-      await this.page.locator('tr[data-row-id]').first().waitFor({ state: 'visible' });
+      const target = threadId
+        ? this.threadRow(threadId)
+        : this.page.locator('tr[data-row-id]').first();
+      await target.waitFor({ state: 'visible' });
     });
   }
 

--- a/tests_end_to_end/e2e/tests/trace-explore/thread-logging-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/thread-logging-smoke.spec.ts
@@ -10,12 +10,19 @@ test.describe('Thread logging — smoke', { tag: ['@t1-smoke', '@trace-explore']
 
     await test.step('Open Logs Threads view', async () => {
       await logs.gotoThreads(conversation.projectId);
-      await logs.waitForThreadsReady();
+      await logs.waitForThreadsReady(conversation.threadId);
     });
 
     await test.step('Verify a single thread is present', async () => {
       await expect(logs.threadsTab).toBeChecked();
-      expect(await logs.countThreads()).toBe(1);
+      // The Threads count card is eventually consistent — poll rather than
+      // reading it once, so a slow-propagating deploy doesn't fail the assertion.
+      await expect
+        .poll(async () => logs.countThreads(), {
+          timeout: 15_000,
+          intervals: [500, 1000, 2000],
+        })
+        .toBe(1);
       await expect(logs.threadRow(conversation.threadId)).toBeVisible();
     });
 
@@ -40,7 +47,7 @@ test.describe('Thread logging — smoke', { tag: ['@t1-smoke', '@trace-explore']
 
     const panel = await test.step('Open the thread detail panel', async () => {
       await logs.gotoThreads(conversation.projectId);
-      await logs.waitForThreadsReady();
+      await logs.waitForThreadsReady(conversation.threadId);
       const panel = await logs.openThreadById(conversation.threadId);
       await panel.waitForFullyLoaded();
       return panel;


### PR DESCRIPTION
## Details

`trace-explore/thread-logging-smoke.spec.ts:5` ("Threads view groups a multi-turn conversation…") flaked on staging launch [82061](https://comet.testops.cloud/launch/82061/tree/367064): it read the eventually-consistent Threads count card once and asserted `=== 1`, but on a slow-propagating deploy the card still read `0` (all 3 retries failed, Expected 1 / Received 0) — after 20 consecutive passes across prod/staging/local. This is a timing flake, not a regression.
- Poll `countThreads()` until it reaches `1` (15s budget) instead of a one-shot read.
- `waitForThreadsReady(threadId?)` now waits for the seeded thread row rather than any first row, so the readiness gate tolerates thread-aggregation lag; both tests pass their `conversation.threadId`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): claude-opus-4-8
  - Scope: Diagnosed the failure via TestOps history + CI logs; wrote the poll/POM change.
  - Human verification: Author reviewed the diff and diagnosis; end-to-end run against a live env still pending (see Testing).

## Testing

- `npx tsc --noEmit -p tsconfig.json` — clean (from `tests_end_to_end/e2e`).
- `npx playwright test tests/trace-explore/thread-logging-smoke.spec.ts --list` — both tests collect.
- Not run end-to-end against a live environment: needs CI login secrets for staging or a full local Opik stack. The change is a timing-only hardening (poll instead of one-shot read; readiness gate on the seeded row) — no selector or assertion-semantics change, and the fixture/POM logic is otherwise unchanged.
- Diagnosis basis: the test has 20/20 prior passes (173 recorded results) across prod/staging/local; the sibling test using the same `conversation` fixture passed in the same run; the failing assertion reads the eventually-consistent `metrics-card-count-value` card.

Note (no action here): the launch also showed this result as IN PROGRESS in TestOps despite 3 FAILED retries — a separate ingestion glitch where the result-finalizing job-run errored with `build server is not configured for job`, leaving the parent unclosed. Recoverable (re-run clears it), unrelated to this test, flagged to the TestOps/allurectl owners.

## Documentation

N/A — no user-facing or docs change (internal E2E test hardening).