### PR TITLE
[OPIK-7160] [BE] fix: fail loudly on unresolvable metric reference key

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/studio/metrics.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/metrics.py
@@ -86,6 +86,58 @@ def _resolve_reference(dataset_item: dict, reference_key: str, default=""):
         logger.warning(f"JSONPath parse error for '{reference_key}': {e}, falling back to dict lookup")
         return dataset_item.get(reference_key, default)
 
+
+def _validate_reference_key_resolves(
+    metric_type: str,
+    reference_key: str,
+    dataset_items_provider: Optional[Callable[[], List[Dict[str, Any]]]],
+) -> None:
+    """Fail loudly when a reference key resolves against no dataset item.
+
+    A reference_key that matches no field (a typo, a field absent from the
+    dataset, or a JSONPath that matches nothing) is the silent-failure this
+    guards against: reference-based metrics would otherwise score every item
+    0, the optimizer would beat nothing and return the seed prompt, and the
+    run would report "completed" with no sign anything was misconfigured
+    (OPIK-7160). Raising here surfaces the misconfiguration as a failed run
+    with an actionable message and keeps that failure distinguishable from a
+    legitimate "no improvement over baseline" run (OPIK-7038).
+
+    Only a *total* mismatch (zero items resolve) raises — sparse data where
+    some items lack the key is handled per-item at scoring time.
+
+    Args:
+        metric_type: Metric identifier, used in the error message.
+        reference_key: The configured reference key (field name or JSONPath).
+        dataset_items_provider: Zero-arg callable returning dataset items.
+            When ``None`` (e.g. validation contexts without a dataset), the
+            check is skipped rather than guessing.
+
+    Raises:
+        InvalidMetricError: If no dataset item resolves the reference key.
+    """
+    if dataset_items_provider is None:
+        return
+
+    items = list(dataset_items_provider())
+    if not items:
+        # An empty dataset is reported separately (EmptyDatasetError); there is
+        # nothing to validate the reference key against here.
+        return
+
+    if any(_resolve_reference(item, reference_key, None) is not None for item in items):
+        return
+
+    available_fields = sorted({key for item in items[:20] for key in item.keys()})
+    raise InvalidMetricError(
+        metric_type,
+        f"reference_key '{reference_key}' did not resolve against any of the "
+        f"{len(items)} dataset items. Available fields: "
+        f"{', '.join(available_fields) or '(none)'}. Set the reference key to a "
+        f"dataset field (or a JSONPath that matches one).",
+    )
+
+
 # Environment variable to control execution strategy (same as evaluator.py)
 EXECUTION_STRATEGY = os.getenv("PYTHON_CODE_EXECUTOR_STRATEGY", "process")
 
@@ -230,17 +282,30 @@ def _build_equals_metric(params: Dict[str, Any], model: str, **kwargs) -> Callab
     
     case_sensitive = params.get("case_sensitive", DEFAULT_CASE_SENSITIVE)
     reference_key = params.get("reference_key", DEFAULT_REFERENCE_KEY)
+    _validate_reference_key_resolves(
+        "equals", reference_key, kwargs.get("dataset_items_provider")
+    )
     equals_metric = Equals(case_sensitive=case_sensitive)
-    
+
     def metric_fn(dataset_item, llm_output):
-        reference = _resolve_reference(dataset_item, reference_key, "")
+        reference = _resolve_reference(dataset_item, reference_key, None)
+        if reference is None:
+            logger.warning(
+                f"equals: missing reference value for key '{reference_key}' "
+                f"on a dataset item; scoring 0"
+            )
+            return ScoreResult(
+                value=0.0,
+                name="equals",
+                reason=f"Missing reference value for key '{reference_key}'",
+            )
         result = equals_metric.score(reference=reference, output=llm_output)
-        
+
         if result.value == 1.0:
             reason = "Exact match: output equals reference"
         else:
             reason = "No match: output does not equal reference"
-        
+
         return ScoreResult(value=result.value, name=result.name, reason=reason)
     
     metric_fn.__name__ = "equals"
@@ -266,12 +331,25 @@ def _build_levenshtein_metric(params: Dict[str, Any], model: str, **kwargs) -> C
     
     case_sensitive = params.get("case_sensitive", DEFAULT_CASE_SENSITIVE)
     reference_key = params.get("reference_key", DEFAULT_REFERENCE_KEY)
+    _validate_reference_key_resolves(
+        "levenshtein_ratio", reference_key, kwargs.get("dataset_items_provider")
+    )
     levenshtein_metric = LevenshteinRatio(case_sensitive=case_sensitive)
-    
+
     def metric_fn(dataset_item, llm_output):
-        reference = _resolve_reference(dataset_item, reference_key, "")
+        reference = _resolve_reference(dataset_item, reference_key, None)
+        if reference is None:
+            logger.warning(
+                f"levenshtein_ratio: missing reference value for key "
+                f"'{reference_key}' on a dataset item; scoring 0"
+            )
+            return ScoreResult(
+                value=0.0,
+                name="levenshtein_ratio",
+                reason=f"Missing reference value for key '{reference_key}'",
+            )
         result = levenshtein_metric.score(reference=reference, output=llm_output)
-        
+
         reason = f"Similarity: {result.value * 100:.0f}%"
         return ScoreResult(value=result.value, name=result.name, reason=reason)
     
@@ -459,6 +537,9 @@ def _build_numerical_similarity_metric(params: Dict[str, Any], model: str, **kwa
     from opik.evaluation.metrics.score_result import ScoreResult
 
     reference_key = params.get("reference_key", DEFAULT_REFERENCE_KEY)
+    _validate_reference_key_resolves(
+        "numerical_similarity", reference_key, kwargs.get("dataset_items_provider")
+    )
 
     # Infer the value range from dataset reference values so the error is
     # normalized relative to the scale (e.g., 0-5).  Falls back to 1.0

--- a/apps/opik-python-backend/src/opik_backend/studio/metrics.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/metrics.py
@@ -68,6 +68,12 @@ def _is_jsonpath(key: str) -> bool:
     return bool(_JSONPATH_PATTERN.search(key))
 
 
+# Sentinel distinguishing "key genuinely absent" from a legitimately resolved
+# value that happens to be None (a present-but-null dataset field). Build-time
+# validation must not treat the latter as a misconfiguration.
+_MISSING = object()
+
+
 def _resolve_reference(dataset_item: dict, reference_key: str, default=""):
     """Resolve a reference value from a dataset item.
 
@@ -87,10 +93,45 @@ def _resolve_reference(dataset_item: dict, reference_key: str, default=""):
         return dataset_item.get(reference_key, default)
 
 
+def _reference_key_resolves(dataset_item: Any, reference_key: str) -> bool:
+    """Whether ``reference_key`` resolves to a value on this item.
+
+    A present-but-null value counts as resolved: null is a data-quality issue,
+    not a key misconfiguration, so it must not abort the run. Only a genuinely
+    absent field (or a JSONPath that matches nothing) is unresolved. Non-dict
+    items (malformed data) resolve nothing rather than raising.
+    """
+    if not isinstance(dataset_item, dict):
+        return False
+    return _resolve_reference(dataset_item, reference_key, _MISSING) is not _MISSING
+
+
+def _available_fields_hint(dataset_items: List[Any]) -> str:
+    """A ', '-joined sample of top-level field names, for error messages."""
+    fields = sorted({
+        key
+        for item in dataset_items[:20]
+        if isinstance(item, dict)
+        for key in item.keys()
+    })
+    return ", ".join(fields) or "(none)"
+
+
+def _reference_key_error(
+    metric_type: str, reference_key: str, dataset_items: List[Any], reason: str
+) -> InvalidMetricError:
+    """Build the actionable error raised when a reference key is unusable."""
+    return InvalidMetricError(
+        metric_type,
+        f"reference_key '{reference_key}' {reason} (checked "
+        f"{len(dataset_items)} dataset items). Available fields: "
+        f"{_available_fields_hint(dataset_items)}. Set the reference key to a "
+        f"dataset field (or a JSONPath that matches one).",
+    )
+
+
 def _validate_reference_key_resolves(
-    metric_type: str,
-    reference_key: str,
-    dataset_items_provider: Optional[Callable[[], List[Dict[str, Any]]]],
+    metric_type: str, reference_key: str, dataset_items: List[Any]
 ) -> None:
     """Fail loudly when a reference key resolves against no dataset item.
 
@@ -104,37 +145,42 @@ def _validate_reference_key_resolves(
     legitimate "no improvement over baseline" run (OPIK-7038).
 
     Only a *total* mismatch (zero items resolve) raises — sparse data where
-    some items lack the key is handled per-item at scoring time.
+    some items lack the key is handled per-item at scoring time. An empty list
+    (no dataset available) skips the check rather than guessing.
 
     Args:
         metric_type: Metric identifier, used in the error message.
         reference_key: The configured reference key (field name or JSONPath).
-        dataset_items_provider: Zero-arg callable returning dataset items.
-            When ``None`` (e.g. validation contexts without a dataset), the
-            check is skipped rather than guessing.
+        dataset_items: Materialized dataset items to validate against.
 
     Raises:
         InvalidMetricError: If no dataset item resolves the reference key.
     """
-    if dataset_items_provider is None:
+    if not dataset_items:
         return
-
-    items = list(dataset_items_provider())
-    if not items:
-        # An empty dataset is reported separately (EmptyDatasetError); there is
-        # nothing to validate the reference key against here.
+    if any(_reference_key_resolves(item, reference_key) for item in dataset_items):
         return
+    raise _reference_key_error(
+        metric_type, reference_key, dataset_items,
+        "did not resolve against any dataset item",
+    )
 
-    if any(_resolve_reference(item, reference_key, None) is not None for item in items):
-        return
 
-    available_fields = sorted({key for item in items[:20] for key in item.keys()})
-    raise InvalidMetricError(
-        metric_type,
-        f"reference_key '{reference_key}' did not resolve against any of the "
-        f"{len(items)} dataset items. Available fields: "
-        f"{', '.join(available_fields) or '(none)'}. Set the reference key to a "
-        f"dataset field (or a JSONPath that matches one).",
+def _missing_reference_result(metric_name: str, reference_key: str) -> "ScoreResult":
+    """Per-item result when a reference is absent/null on a specific item.
+
+    Sparse data is legitimate (the key resolved for other items, so the metric
+    built), but this item can't be scored — surface that instead of silently
+    treating the missing value as an empty-string match.
+    """
+    logger.warning(
+        f"{metric_name}: missing reference value for key '{reference_key}' "
+        f"on a dataset item; scoring 0"
+    )
+    return ScoreResult(
+        value=0.0,
+        name=metric_name,
+        reason=f"Missing reference value for key '{reference_key}'",
     )
 
 
@@ -238,15 +284,21 @@ class MetricFactory:
             metric_params: Parameters for the metric
             model: LLM model identifier (required for LLM-based metrics)
             dataset_items_provider: Optional zero-arg callable that returns
-                dataset items. Only invoked by metrics that need to inspect
-                the data at build time (e.g., numerical_similarity for
-                scale inference), avoiding eager materialization.
-            
+                dataset items. Invoked at build time by metrics that inspect
+                the data: numerical_similarity for scale inference, and all
+                reference-based metrics (equals, levenshtein_ratio,
+                numerical_similarity) to validate that reference_key resolves
+                against the dataset. When None, that validation is skipped.
+                Not invoked by metrics that ignore the dataset at build time
+                (e.g. geval, json_schema_validator, code).
+
         Returns:
             A callable metric function(dataset_item, llm_output) -> ScoreResult
-            
+
         Raises:
-            InvalidMetricError: If metric_type is not registered
+            InvalidMetricError: If metric_type is not registered, or a
+                reference-based metric's reference_key resolves against no
+                dataset item.
         """
         if metric_type not in cls._BUILDERS:
             available = ", ".join(sorted(cls._BUILDERS.keys()))
@@ -282,23 +334,17 @@ def _build_equals_metric(params: Dict[str, Any], model: str, **kwargs) -> Callab
     
     case_sensitive = params.get("case_sensitive", DEFAULT_CASE_SENSITIVE)
     reference_key = params.get("reference_key", DEFAULT_REFERENCE_KEY)
-    _validate_reference_key_resolves(
-        "equals", reference_key, kwargs.get("dataset_items_provider")
-    )
+    dataset_items_provider = kwargs.get("dataset_items_provider")
+    if dataset_items_provider is not None:
+        _validate_reference_key_resolves(
+            "equals", reference_key, list(dataset_items_provider())
+        )
     equals_metric = Equals(case_sensitive=case_sensitive)
 
     def metric_fn(dataset_item, llm_output):
         reference = _resolve_reference(dataset_item, reference_key, None)
         if reference is None:
-            logger.warning(
-                f"equals: missing reference value for key '{reference_key}' "
-                f"on a dataset item; scoring 0"
-            )
-            return ScoreResult(
-                value=0.0,
-                name="equals",
-                reason=f"Missing reference value for key '{reference_key}'",
-            )
+            return _missing_reference_result("equals", reference_key)
         result = equals_metric.score(reference=reference, output=llm_output)
 
         if result.value == 1.0:
@@ -331,23 +377,17 @@ def _build_levenshtein_metric(params: Dict[str, Any], model: str, **kwargs) -> C
     
     case_sensitive = params.get("case_sensitive", DEFAULT_CASE_SENSITIVE)
     reference_key = params.get("reference_key", DEFAULT_REFERENCE_KEY)
-    _validate_reference_key_resolves(
-        "levenshtein_ratio", reference_key, kwargs.get("dataset_items_provider")
-    )
+    dataset_items_provider = kwargs.get("dataset_items_provider")
+    if dataset_items_provider is not None:
+        _validate_reference_key_resolves(
+            "levenshtein_ratio", reference_key, list(dataset_items_provider())
+        )
     levenshtein_metric = LevenshteinRatio(case_sensitive=case_sensitive)
 
     def metric_fn(dataset_item, llm_output):
         reference = _resolve_reference(dataset_item, reference_key, None)
         if reference is None:
-            logger.warning(
-                f"levenshtein_ratio: missing reference value for key "
-                f"'{reference_key}' on a dataset item; scoring 0"
-            )
-            return ScoreResult(
-                value=0.0,
-                name="levenshtein_ratio",
-                reason=f"Missing reference value for key '{reference_key}'",
-            )
+            return _missing_reference_result("levenshtein_ratio", reference_key)
         result = levenshtein_metric.score(reference=reference, output=llm_output)
 
         reason = f"Similarity: {result.value * 100:.0f}%"
@@ -537,32 +577,51 @@ def _build_numerical_similarity_metric(params: Dict[str, Any], model: str, **kwa
     from opik.evaluation.metrics.score_result import ScoreResult
 
     reference_key = params.get("reference_key", DEFAULT_REFERENCE_KEY)
-    _validate_reference_key_resolves(
-        "numerical_similarity", reference_key, kwargs.get("dataset_items_provider")
-    )
 
     # Infer the value range from dataset reference values so the error is
-    # normalized relative to the scale (e.g., 0-5).  Falls back to 1.0
-    # when the range can't be determined.
+    # normalized relative to the scale (e.g., 0-5).  Falls back to 1.0 when the
+    # provider is absent, or the dataset has fewer than 2 distinct numeric
+    # references.  This single pass over the dataset also validates the key:
+    # unlike equals/levenshtein a resolved-but-non-numeric reference is still a
+    # dead metric (every item scores 0), so numerical_similarity fails loudly
+    # when no item yields a numeric value, not merely when the key is absent
+    # (OPIK-7160).
     scale_range = 1.0
     dataset_items_provider = kwargs.get("dataset_items_provider")
-    if dataset_items_provider:
-        ref_values = []
-        for item in dataset_items_provider():
-            raw = _resolve_reference(item, reference_key, None)
-            if raw is not None:
+    if dataset_items_provider is not None:
+        items = list(dataset_items_provider())
+        if items:
+            resolved_any = False
+            ref_values = []
+            for item in items:
+                raw = _resolve_reference(item, reference_key, _MISSING)
+                if raw is _MISSING:
+                    continue
+                resolved_any = True
+                if raw is None:
+                    continue
                 try:
                     ref_values.append(float(raw))
                 except (ValueError, TypeError):
                     pass
-        if len(ref_values) >= 2:
-            inferred = max(ref_values) - min(ref_values)
-            if inferred > 0:
-                scale_range = inferred
-                logger.info(
-                    f"numerical_similarity: inferred scale_range={scale_range} "
-                    f"from {len(ref_values)} reference values"
+            if not resolved_any:
+                raise _reference_key_error(
+                    "numerical_similarity", reference_key, items,
+                    "did not resolve against any dataset item",
                 )
+            if not ref_values:
+                raise _reference_key_error(
+                    "numerical_similarity", reference_key, items,
+                    "resolved but no dataset item held a numeric value",
+                )
+            if len(ref_values) >= 2:
+                inferred = max(ref_values) - min(ref_values)
+                if inferred > 0:
+                    scale_range = inferred
+                    logger.info(
+                        f"numerical_similarity: inferred scale_range={scale_range} "
+                        f"from {len(ref_values)} reference values"
+                    )
 
     def metric_fn(dataset_item, llm_output):
         reference = _resolve_reference(dataset_item, reference_key, None)
@@ -577,11 +636,7 @@ def _build_numerical_similarity_metric(params: Dict[str, Any], model: str, **kwa
             )
 
         if reference is None:
-            return ScoreResult(
-                value=0.0,
-                name="numerical_similarity",
-                reason=f"Missing reference value for key '{reference_key}'"
-            )
+            return _missing_reference_result("numerical_similarity", reference_key)
 
         try:
             reference_val = float(reference)

--- a/apps/opik-python-backend/src/opik_backend/studio/metrics.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/metrics.py
@@ -130,6 +130,35 @@ def _reference_key_error(
     )
 
 
+def _raise_if_malformed_jsonpath(metric_type: str, reference_key: str) -> None:
+    """Raise a clear error when a JSONPath-shaped key has invalid syntax.
+
+    ``_resolve_reference`` deliberately swallows JSONPath parse errors and falls
+    back to a literal dict lookup, so a field literally named e.g. "user@email"
+    (which the ``_is_jsonpath`` heuristic flags because of the '@') still works.
+    That same fallback, however, means a *genuinely malformed* JSONPath resolves
+    against nothing and would otherwise surface as the generic
+    "did not resolve against any dataset item" error, hiding the real cause.
+
+    Callers invoke this only after confirming the key resolved nowhere: a key
+    that does resolve (valid JSONPath, or a literal field with special chars)
+    never reaches here, so this stays purely additive and never rejects a
+    working config. The syntax error is data-independent, so an empty probe is
+    enough to trigger it.
+    """
+    if not _is_jsonpath(reference_key):
+        return
+    try:
+        jsonpath.findall(reference_key, {})
+    except Exception as e:
+        raise InvalidMetricError(
+            metric_type,
+            f"reference_key '{reference_key}' is not a valid JSONPath expression: "
+            f"{e}. Use a plain dataset field name, or a valid JSONPath such as "
+            f"\"$.feedback_scores[?(@.name == 'Useful')].value\".",
+        ) from e
+
+
 def _validate_reference_key_resolves(
     metric_type: str, reference_key: str, dataset_items: List[Any]
 ) -> None:
@@ -160,6 +189,9 @@ def _validate_reference_key_resolves(
         return
     if any(_reference_key_resolves(item, reference_key) for item in dataset_items):
         return
+    # Nothing resolved: a malformed JSONPath is the more specific cause, so
+    # report it before the generic "no field matched" message.
+    _raise_if_malformed_jsonpath(metric_type, reference_key)
     raise _reference_key_error(
         metric_type, reference_key, dataset_items,
         "did not resolve against any dataset item",
@@ -315,86 +347,101 @@ class MetricFactory:
         return metric_fn
 
 
+def _build_reference_metric(
+    metric_type: str,
+    opik_metric: Any,
+    reason_for: Callable[[float], str],
+    params: Dict[str, Any],
+    **kwargs,
+) -> Callable:
+    """Build a reference-based string metric (equals / levenshtein_ratio).
+
+    Both metrics share the same scaffolding — resolve ``reference_key`` from the
+    config, validate it against the dataset at build time, and at scoring time
+    resolve the per-item reference, short-circuit to a missing-reference result
+    when it is absent, then delegate to the underlying opik metric. Only the
+    opik metric instance and the human-readable ``reason`` differ, so those are
+    the parameters; everything else lives here so the two stay in lock-step.
+
+    Args:
+        metric_type: Metric identifier, used for validation errors, the missing
+            reference result, and ``metric_fn.__name__``.
+        opik_metric: A pre-built opik metric exposing ``score(reference, output)``.
+        reason_for: Maps the resulting score value to a human-readable reason.
+        params: Metric parameters (reads ``reference_key``).
+    """
+    reference_key = params.get("reference_key", DEFAULT_REFERENCE_KEY)
+    dataset_items_provider = kwargs.get("dataset_items_provider")
+    if dataset_items_provider is not None:
+        _validate_reference_key_resolves(
+            metric_type, reference_key, list(dataset_items_provider())
+        )
+
+    def metric_fn(dataset_item, llm_output):
+        reference = _resolve_reference(dataset_item, reference_key, None)
+        if reference is None:
+            return _missing_reference_result(metric_type, reference_key)
+        result = opik_metric.score(reference=reference, output=llm_output)
+        return ScoreResult(
+            value=result.value, name=result.name, reason=reason_for(result.value)
+        )
+
+    metric_fn.__name__ = metric_type
+    return metric_fn
+
+
 @MetricFactory.register("equals")
 def _build_equals_metric(params: Dict[str, Any], model: str, **kwargs) -> Callable:
     """Build an Equals metric function.
-    
+
     Compares output with reference from dataset using exact string match.
-    
+
     Args:
         params: Metric parameters
             - case_sensitive (bool): Whether comparison is case-sensitive
             - reference_key (str): Key in dataset item containing reference value
         model: LLM model (not used for this metric)
-        
+
     Returns:
         Metric function
     """
-    from opik.evaluation.metrics.score_result import ScoreResult
-    
     case_sensitive = params.get("case_sensitive", DEFAULT_CASE_SENSITIVE)
-    reference_key = params.get("reference_key", DEFAULT_REFERENCE_KEY)
-    dataset_items_provider = kwargs.get("dataset_items_provider")
-    if dataset_items_provider is not None:
-        _validate_reference_key_resolves(
-            "equals", reference_key, list(dataset_items_provider())
-        )
-    equals_metric = Equals(case_sensitive=case_sensitive)
-
-    def metric_fn(dataset_item, llm_output):
-        reference = _resolve_reference(dataset_item, reference_key, None)
-        if reference is None:
-            return _missing_reference_result("equals", reference_key)
-        result = equals_metric.score(reference=reference, output=llm_output)
-
-        if result.value == 1.0:
-            reason = "Exact match: output equals reference"
-        else:
-            reason = "No match: output does not equal reference"
-
-        return ScoreResult(value=result.value, name=result.name, reason=reason)
-    
-    metric_fn.__name__ = "equals"
-    return metric_fn
+    return _build_reference_metric(
+        "equals",
+        Equals(case_sensitive=case_sensitive),
+        lambda value: (
+            "Exact match: output equals reference"
+            if value == 1.0
+            else "No match: output does not equal reference"
+        ),
+        params,
+        **kwargs,
+    )
 
 
 @MetricFactory.register("levenshtein_ratio")
 def _build_levenshtein_metric(params: Dict[str, Any], model: str, **kwargs) -> Callable:
     """Build a LevenshteinRatio metric function.
-    
+
     Computes string similarity using Levenshtein distance.
-    
+
     Args:
         params: Metric parameters
             - case_sensitive (bool): Whether comparison is case-sensitive
             - reference_key (str): Key in dataset item containing reference value
         model: LLM model (not used for this metric)
-        
+
     Returns:
         Metric function
     """
-    from opik.evaluation.metrics.score_result import ScoreResult
-    
     case_sensitive = params.get("case_sensitive", DEFAULT_CASE_SENSITIVE)
-    reference_key = params.get("reference_key", DEFAULT_REFERENCE_KEY)
-    dataset_items_provider = kwargs.get("dataset_items_provider")
-    if dataset_items_provider is not None:
-        _validate_reference_key_resolves(
-            "levenshtein_ratio", reference_key, list(dataset_items_provider())
-        )
-    levenshtein_metric = LevenshteinRatio(case_sensitive=case_sensitive)
-
-    def metric_fn(dataset_item, llm_output):
-        reference = _resolve_reference(dataset_item, reference_key, None)
-        if reference is None:
-            return _missing_reference_result("levenshtein_ratio", reference_key)
-        result = levenshtein_metric.score(reference=reference, output=llm_output)
-
-        reason = f"Similarity: {result.value * 100:.0f}%"
-        return ScoreResult(value=result.value, name=result.name, reason=reason)
-    
-    metric_fn.__name__ = "levenshtein_ratio"
-    return metric_fn
+    return _build_reference_metric(
+        "levenshtein_ratio",
+        LevenshteinRatio(case_sensitive=case_sensitive),
+        lambda value: f"Similarity: {value * 100:.0f}%",
+        params,
+        **kwargs,
+    )
 
 
 def _interpolate_template(template: str, dataset_item: Dict[str, Any]) -> str:
@@ -605,6 +652,7 @@ def _build_numerical_similarity_metric(params: Dict[str, Any], model: str, **kwa
                 except (ValueError, TypeError):
                     pass
             if not resolved_any:
+                _raise_if_malformed_jsonpath("numerical_similarity", reference_key)
                 raise _reference_key_error(
                     "numerical_similarity", reference_key, items,
                     "did not resolve against any dataset item",

--- a/apps/opik-python-backend/tests/unit/test_metrics_factory.py
+++ b/apps/opik-python-backend/tests/unit/test_metrics_factory.py
@@ -591,6 +591,61 @@ class TestReferenceKeyValidation:
                 dataset_items_provider=lambda: dataset_items,
             )
 
+    def test_build_passes_when_field_present_but_null(self):
+        # A field that exists on every item but holds null is a data-quality
+        # issue, not a key misconfiguration -> the metric must still build
+        # (regression guard: this previously hard-failed the run with a
+        # self-contradictory "did not resolve ... available fields: answer"
+        # message).
+        dataset_items = [{"answer": None}, {"answer": None}]
+        metric_fn = MetricFactory.build(
+            "equals",
+            {"reference_key": "answer"},
+            "model",
+            dataset_items_provider=lambda: dataset_items,
+        )
+        assert callable(metric_fn)
+
+    def test_build_does_not_crash_on_non_dict_items(self):
+        # Malformed dataset items must yield a clean InvalidMetricError, not an
+        # AttributeError from .get()/.keys() on a non-dict.
+        dataset_items = [None, "scalar", 42]
+        with pytest.raises(InvalidMetricError) as exc_info:
+            MetricFactory.build(
+                "equals",
+                {"reference_key": "answer"},
+                "model",
+                dataset_items_provider=lambda: dataset_items,
+            )
+        assert "did not resolve" in str(exc_info.value)
+
+    def test_numerical_similarity_raises_when_references_non_numeric(self):
+        # The key resolves for every item, but to non-numeric text -> every item
+        # would score 0 (silent flat-0). numerical_similarity must fail loudly
+        # (OPIK-7160), unlike equals/levenshtein for which any resolved value is
+        # scoreable.
+        dataset_items = [{"answer": "positive"}, {"answer": "negative"}]
+        with pytest.raises(InvalidMetricError) as exc_info:
+            MetricFactory.build(
+                "numerical_similarity",
+                {"reference_key": "answer"},
+                "model",
+                dataset_items_provider=lambda: dataset_items,
+            )
+        assert "no dataset item held a numeric value" in str(exc_info.value)
+
+    def test_numerical_similarity_builds_with_one_numeric_reference(self):
+        # Sparse numeric data: only some items are numeric. Build succeeds
+        # (there is at least one numeric reference to work with).
+        dataset_items = [{"score": 3}, {"score": "n/a"}]
+        metric_fn = MetricFactory.build(
+            "numerical_similarity",
+            {"reference_key": "score"},
+            "model",
+            dataset_items_provider=lambda: dataset_items,
+        )
+        assert callable(metric_fn)
+
 
 class TestMissingReferencePerItem:
     """Per-item feedback when a reference key is absent on a specific item."""
@@ -609,6 +664,14 @@ class TestMissingReferencePerItem:
         result = metric_fn({"other": "x"}, "x")
         assert result.value == 0.0
         assert "Missing reference value" in result.reason
+
+    def test_present_empty_string_reference_matches_empty_output(self):
+        # A field that is present but holds "" is a real reference value, not a
+        # missing one: empty output should still score a perfect match. Only a
+        # genuinely absent field short-circuits to the missing-reference result.
+        metric_fn = MetricFactory.build("equals", {"reference_key": "answer"}, "model")
+        result = metric_fn({"answer": ""}, "")
+        assert result.value == 1.0
 
 
 class TestNumericalSimilarityMetric:

--- a/apps/opik-python-backend/tests/unit/test_metrics_factory.py
+++ b/apps/opik-python-backend/tests/unit/test_metrics_factory.py
@@ -437,8 +437,13 @@ class TestJsonPathReferenceKey:
         result = metric_fn(dataset_item, "42")
         assert result.value == 1.0
 
-    def test_jsonpath_no_match_returns_default(self):
-        """Test that a JSONPath with no matches returns the default empty string."""
+    def test_jsonpath_no_match_scores_zero_with_reason(self):
+        """A JSONPath that resolves nothing must not silently match empty output.
+
+        Regression guard for OPIK-7160: the old behavior defaulted an
+        unresolvable reference to "" and reported a perfect 1.0 against empty
+        output, hiding the misconfiguration. It now scores 0.0 and explains why.
+        """
         metric_fn = MetricFactory.build(
             "equals",
             {"reference_key": "$.feedback_scores[?(@.name == 'NonExistent')].value"},
@@ -451,10 +456,11 @@ class TestJsonPathReferenceKey:
             ]
         }
         result = metric_fn(dataset_item, "")
-        assert result.value == 1.0
+        assert result.value == 0.0
+        assert "Missing reference value" in result.reason
 
     def test_jsonpath_no_match_against_nonempty_output(self):
-        """Test that a JSONPath with no matches (default='') doesn't match non-empty output."""
+        """A JSONPath with no matches scores 0 against non-empty output."""
         metric_fn = MetricFactory.build(
             "equals",
             {"reference_key": "$.feedback_scores[?(@.name == 'NonExistent')].value"},
@@ -494,6 +500,115 @@ class TestJsonPathReferenceKey:
         assert _is_jsonpath("scores[0].value") is True
         assert _is_jsonpath("$.scores[?(@.name == 'x')].value") is True
         assert _is_jsonpath("items..value") is True
+
+
+class TestReferenceKeyValidation:
+    """Build-time validation that a reference_key resolves against the dataset.
+
+    Guards OPIK-7160: a reference_key matching no dataset field silently scored
+    every item 0, so no candidate could beat the baseline and the optimizer
+    returned the seed prompt while the run reported "completed". Building the
+    metric now fails loudly instead, keeping that failure distinguishable from a
+    legitimate "no improvement over baseline" run (OPIK-7038).
+    """
+
+    def test_equals_build_raises_when_key_resolves_no_item(self):
+        dataset_items = [{"answer": "a"}, {"answer": "b"}]
+        with pytest.raises(InvalidMetricError) as exc_info:
+            MetricFactory.build(
+                "equals",
+                {"reference_key": "label"},  # not a dataset field
+                "model",
+                dataset_items_provider=lambda: dataset_items,
+            )
+        message = str(exc_info.value)
+        assert "label" in message
+        assert "did not resolve" in message
+        # Available fields are surfaced to make the fix obvious.
+        assert "answer" in message
+
+    def test_levenshtein_build_raises_when_key_resolves_no_item(self):
+        dataset_items = [{"answer": "a"}, {"answer": "b"}]
+        with pytest.raises(InvalidMetricError) as exc_info:
+            MetricFactory.build(
+                "levenshtein_ratio",
+                {"reference_key": "typo"},
+                "model",
+                dataset_items_provider=lambda: dataset_items,
+            )
+        assert "did not resolve" in str(exc_info.value)
+
+    def test_numerical_similarity_build_raises_when_key_resolves_no_item(self):
+        dataset_items = [{"score": 1}, {"score": 2}]
+        with pytest.raises(InvalidMetricError) as exc_info:
+            MetricFactory.build(
+                "numerical_similarity",
+                {"reference_key": "value"},
+                "model",
+                dataset_items_provider=lambda: dataset_items,
+            )
+        assert "did not resolve" in str(exc_info.value)
+
+    def test_build_passes_when_key_resolves_for_some_items(self):
+        # Sparse data: the key is present on only one item. Validation passes;
+        # missing items are handled per-item at scoring time.
+        dataset_items = [{"answer": "a"}, {"other": "b"}]
+        metric_fn = MetricFactory.build(
+            "equals",
+            {"reference_key": "answer"},
+            "model",
+            dataset_items_provider=lambda: dataset_items,
+        )
+        assert callable(metric_fn)
+
+    def test_build_skips_validation_without_provider(self):
+        # No dataset available (e.g. config validation) -> do not guess, skip.
+        metric_fn = MetricFactory.build(
+            "equals",
+            {"reference_key": "anything"},
+            "model",
+        )
+        assert callable(metric_fn)
+
+    def test_build_skips_validation_for_empty_dataset(self):
+        metric_fn = MetricFactory.build(
+            "equals",
+            {"reference_key": "anything"},
+            "model",
+            dataset_items_provider=lambda: [],
+        )
+        assert callable(metric_fn)
+
+    def test_equals_jsonpath_build_raises_when_no_item_matches(self):
+        dataset_items = [
+            {"feedback_scores": [{"name": "Useful", "value": 0}]},
+        ]
+        with pytest.raises(InvalidMetricError):
+            MetricFactory.build(
+                "equals",
+                {"reference_key": "$.feedback_scores[?(@.name == 'Missing')].value"},
+                "model",
+                dataset_items_provider=lambda: dataset_items,
+            )
+
+
+class TestMissingReferencePerItem:
+    """Per-item feedback when a reference key is absent on a specific item."""
+
+    def test_equals_missing_reference_scores_zero_with_reason(self):
+        metric_fn = MetricFactory.build("equals", {"reference_key": "answer"}, "model")
+        result = metric_fn({"other": "x"}, "x")
+        assert result.value == 0.0
+        assert "Missing reference value" in result.reason
+        assert "answer" in result.reason
+
+    def test_levenshtein_missing_reference_scores_zero_with_reason(self):
+        metric_fn = MetricFactory.build(
+            "levenshtein_ratio", {"reference_key": "answer"}, "model"
+        )
+        result = metric_fn({"other": "x"}, "x")
+        assert result.value == 0.0
+        assert "Missing reference value" in result.reason
 
 
 class TestNumericalSimilarityMetric:

--- a/apps/opik-python-backend/tests/unit/test_metrics_factory.py
+++ b/apps/opik-python-backend/tests/unit/test_metrics_factory.py
@@ -591,6 +591,34 @@ class TestReferenceKeyValidation:
                 dataset_items_provider=lambda: dataset_items,
             )
 
+    def test_malformed_jsonpath_build_raises_with_syntax_error(self):
+        # A JSONPath-shaped key with invalid syntax that matches no literal field
+        # must fail with a JSONPath-specific message, not the generic
+        # "did not resolve" one (which hides the real cause). The literal
+        # fallback in _resolve_reference otherwise swallows the parse error.
+        dataset_items = [{"answer": "42"}]
+        with pytest.raises(InvalidMetricError) as exc_info:
+            MetricFactory.build(
+                "equals",
+                {"reference_key": "$.foo["},
+                "model",
+                dataset_items_provider=lambda: dataset_items,
+            )
+        assert "not a valid JSONPath expression" in str(exc_info.value)
+
+    def test_numerical_similarity_malformed_jsonpath_build_raises(self):
+        # Same guard on the numerical_similarity validation path, which infers
+        # scale from a separate resolution loop.
+        dataset_items = [{"score": 3}]
+        with pytest.raises(InvalidMetricError) as exc_info:
+            MetricFactory.build(
+                "numerical_similarity",
+                {"reference_key": "$.foo["},
+                "model",
+                dataset_items_provider=lambda: dataset_items,
+            )
+        assert "not a valid JSONPath expression" in str(exc_info.value)
+
     def test_build_passes_when_field_present_but_null(self):
         # A field that exists on every item but holds null is a data-quality
         # issue, not a key misconfiguration -> the metric must still build
@@ -636,7 +664,8 @@ class TestReferenceKeyValidation:
 
     def test_numerical_similarity_builds_with_one_numeric_reference(self):
         # Sparse numeric data: only some items are numeric. Build succeeds
-        # (there is at least one numeric reference to work with).
+        # (there is at least one numeric reference to work with) and the numeric
+        # scoring path is actually live -- not a silent flat-0.
         dataset_items = [{"score": 3}, {"score": "n/a"}]
         metric_fn = MetricFactory.build(
             "numerical_similarity",
@@ -645,6 +674,19 @@ class TestReferenceKeyValidation:
             dataset_items_provider=lambda: dataset_items,
         )
         assert callable(metric_fn)
+        # A single numeric reference means scale_range falls back to 1.0, so an
+        # exact match scores 1.0 -- exercising the similarity math, not just the
+        # constructor.
+        exact = metric_fn({"score": 3}, "3")
+        assert exact.value == 1.0
+        assert exact.name == "numerical_similarity"
+        # A unit-off output is normalized against scale_range=1.0 -> 0.0.
+        off_by_one = metric_fn({"score": 3}, "2")
+        assert off_by_one.value == 0.0
+        # The non-numeric sibling still yields a clean 0 with an explanatory reason.
+        non_numeric = metric_fn({"score": "n/a"}, "3")
+        assert non_numeric.value == 0.0
+        assert "not numeric" in non_numeric.reason
 
 
 class TestMissingReferencePerItem:


### PR DESCRIPTION
## Details

When a metric's `reference_key` didn't match any field in the dataset items, the studio metric silently scored every item 0 — scores went flat, no candidate could beat the baseline, and the run reported "completed" while the optimizer returned the seed/original prompt. This PR makes an unresolvable `reference_key` fail loudly at metric build time and gives per-item feedback for sparse mismatches, so a misconfigured run is visibly distinct from a legitimate no-improvement run (the state OPIK_7038 surfaces as "No improvement over baseline, original prompt kept"). Backend only, behind `OPTIMIZATION_STUDIO_ENABLED` (v2).

- `_validate_reference_key_resolves` raises `InvalidMetricError` (listing the dataset's available fields) when the `reference_key` resolves against zero dataset items; wired into `equals`, `levenshtein_ratio`, and `numerical_similarity`. `optimizer_runner.py` already turns this into a failed-run result, so a typo'd key fails visibly instead of "completing".
- A reference missing on a specific item now scores `0.0` with a `"Missing reference value for key '…'"` reason + warning log, instead of silently defaulting to `""` (matches the existing `numerical_similarity` precedent).
- Only a total mismatch (zero items resolve) raises; sparse data (key present on some items) still runs with per-item feedback. Left `DEFAULT_REFERENCE_KEY = "answer"` as-is — the new build-time guard makes a wrong default fail loudly, and the API/demo path relies on the default.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-7160

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: Backend metric-validation fix, tests, and PR description.
- Human verification: Author reviewed the diff; ran the metric test suite and a deterministic repro against the real `MetricFactory` code path.

## Testing

- `test_metrics_factory.py`: added `TestReferenceKeyValidation` (total mismatch for all 3 metrics, sparse-data pass, no-provider skip, empty-dataset skip, JSONPath no-match) and `TestMissingReferencePerItem`; updated the JSONPath no-match regression to assert the new loud behavior (was asserting the buggy `1.0`).
- Metric suite: **81 passed**. Full `tests/unit/`: **232 passed** (1 pre-existing failure + 2 errors in unrelated `subprocess_logging`/`demo_data_generator` modules, not touched here).
- Ran the real `MetricFactory` code path (same call shape as `optimizer_runner.py`, realistic 6-item sentiment dataset): the repro `reference_key="label"` now yields `Invalid metric: 'equals'. reference_key 'label' did not resolve against any of the 6 dataset items. Available fields: answer, text. …`; the correct key `"answer"` scores correctly; sparse data runs with per-item feedback.
- Not run: no full live optimizer run (live OpenAI via dev gateway + redis-queued subprocess). Verification was deterministic against the production code path, not an end-to-end job.

## Documentation

N/A — backend behavior change (loud failure on misconfiguration); no public documentation affected. The ticket's FE items (`reference_key` validation in `EqualsMetricConfigs.tsx`, and the `getDefaultMetricConfig` wrong-constant fix) are tracked separately and not in this PR.
