### PR TITLE
chore(dev): cap ClickHouse memory to 55% of RAM in docker-compose

### DIFF
--- a/deployment/docker-compose/clickhouse_config/additional_config.xml
+++ b/deployment/docker-compose/clickhouse_config/additional_config.xml
@@ -4,6 +4,13 @@
          (dev-runner with TOGGLE_AGENT_INSIGHTS_ENABLED=true, or prod via OPIK-6846). No effect otherwise. -->
     <custom_settings_prefixes>SQL_</custom_settings_prefixes>
 
+    <!-- Local-dev memory guard. The Docker VM is small (~8 GiB) and shared with
+         MySQL/Redis/Minio/Zookeeper/python-backend, but ClickHouse defaults to
+         0.9 * RAM (~7.5 GiB) for itself, so any spike OOM-kills the container
+         (exit 137). Cap it to ~55% so a heavy query errors instead of taking the
+         whole server down, leaving headroom for the rest of the stack. -->
+    <max_server_memory_usage_to_ram_ratio>0.55</max_server_memory_usage_to_ram_ratio>
+
     <macros>
         <shard>1</shard>
         <replica>clickhouse</replica>


### PR DESCRIPTION
## What
Adds `max_server_memory_usage_to_ram_ratio = 0.55` to the local docker-compose ClickHouse config.

## Why
The local ClickHouse container shares a small Docker VM (~8 GiB) with MySQL/Redis/Minio/Zookeeper/python-backend, but ClickHouse defaults to reserving `0.9 * RAM` for itself. A query spike then OOM-kills the container (exit 137), taking the local stack down. Capping to ~55% makes a heavy query error out instead, leaving headroom for the rest of the services.

Local-dev only (docker-compose `clickhouse_config`); no effect on prod/Helm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)