### PR TITLE
[OPIK-7253] fix: request identity encoding on all react-service auth calls

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
@@ -221,6 +221,8 @@ class RemoteAuthService implements AuthService {
                 .path("auth-by-username")
                 .request()
                 .accept(MediaType.APPLICATION_JSON)
+                // avoids gzip double-decompression issue, same as in listEligibleWorkspaces
+                .acceptEncoding("identity")
                 .header(OAUTH_USERNAME_HEADER, token.userName())
                 .post(Entity.json(AuthRequest.builder()
                         .workspaceName(token.workspaceName())
@@ -244,6 +246,8 @@ class RemoteAuthService implements AuthService {
                 .path("auth-session")
                 .request()
                 .accept(MediaType.APPLICATION_JSON)
+                // avoids gzip double-decompression issue, same as in listEligibleWorkspaces
+                .acceptEncoding("identity")
                 .cookie(sessionToken)
                 .post(Entity.json(AuthRequest.builder().workspaceName(workspaceName).build()))) {
             var authResponse = verifyResponse(response);
@@ -301,6 +305,8 @@ class RemoteAuthService implements AuthService {
                 .path("auth-session")
                 .request()
                 .accept(MediaType.APPLICATION_JSON)
+                // avoids gzip double-decompression issue, same as in listEligibleWorkspaces
+                .acceptEncoding("identity")
                 .cookie(sessionToken)
                 .post(Entity.json(AuthRequest.builder()
                         .workspaceName(workspaceName)
@@ -339,6 +345,8 @@ class RemoteAuthService implements AuthService {
                     .path("auth")
                     .request()
                     .accept(MediaType.APPLICATION_JSON)
+                    // avoids gzip double-decompression issue, same as in listEligibleWorkspaces
+                    .acceptEncoding("identity")
                     .header(HttpHeaders.AUTHORIZATION,
                             apiKey)
                     .post(Entity.json(AuthRequest.builder()
@@ -419,6 +427,8 @@ class RemoteAuthService implements AuthService {
                 .path("workspace-id")
                 .queryParam("name", workspaceName)
                 .request()
+                // avoids gzip double-decompression issue, same as in listEligibleWorkspaces
+                .acceptEncoding("identity")
                 .get()) {
 
             return getWorkspaceIdFromResponse(response);

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
@@ -1,15 +1,19 @@
 package com.comet.opik.infrastructure.auth;
 
+import com.codahale.metrics.MetricRegistry;
+import com.comet.opik.TestConfigUtils;
 import com.comet.opik.api.OpikVersion;
 import com.comet.opik.api.ReactServiceErrorResponse;
 import com.comet.opik.api.resources.utils.TestHttpClientUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
 import com.comet.opik.domain.mcpoauth.ValidatedToken;
 import com.comet.opik.infrastructure.AuthenticationConfig;
+import com.comet.opik.infrastructure.http.HttpModule;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.client.JerseyClientBuilder;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.core.Cookie;
@@ -35,6 +39,11 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
 import static com.comet.opik.api.ReactServiceErrorResponse.MISSING_API_KEY;
@@ -211,6 +220,74 @@ class RemoteAuthServiceTest {
                         .build()))
                 .isExactlyInstanceOf(expectedExceptionClass)
                 .hasMessage(expectedMessage);
+    }
+
+    @Test
+    void testAuth__whenRemoteMislabelsGzipResponses__thenIdentityEncodingAvoidsZipException() throws Exception {
+        var authResponse = podamFactory.manufacturePojo(RemoteAuthService.AuthResponse.class);
+        var apiKey = "apiKey-" + UUID.randomUUID();
+        var workspaceName = "workspace-" + UUID.randomUUID();
+        var responseJson = OBJECT_MAPPER.writeValueAsString(authResponse);
+
+        // Reproduces the mislabelled-gzip incident: unless the client explicitly requests identity
+        // encoding, the remote replies with 'Content-Encoding: gzip' while the body is NOT valid gzip
+        // (double-decompression / mislabelling by an intermediary). With the production client settings
+        // (gzipEnabled: true, unlike the shared test client which disables it), GZipDecoder trusts the
+        // response header and readEntity throws 'ZipException: Not in GZIP format', which escapes the
+        // auth filter as a ProcessingException and surfaces as a 500. Requesting identity encoding
+        // sidesteps the mislabelled responses entirely.
+        WIRE_MOCK.server().stubFor(post("/opik/auth")
+                .atPriority(5)
+                .willReturn(aResponse().withStatus(HttpStatus.SC_OK)
+                        .withHeader("Content-Type", "application/json")
+                        .withHeader(HttpHeaders.CONTENT_ENCODING, "gzip")
+                        .withBody(responseJson)));
+        WIRE_MOCK.server().stubFor(post("/opik/auth")
+                .atPriority(1)
+                .withHeader(HttpHeaders.ACCEPT_ENCODING, equalTo("identity"))
+                .willReturn(okJson(responseJson)));
+
+        var gzipEnabledAuthService = new RemoteAuthService(newGzipEnabledClient(),
+                new AuthenticationConfig.UrlConfig(WIRE_MOCK.server().url("")),
+                () -> requestContext,
+                new NoopCacheService());
+
+        gzipEnabledAuthService.authenticate(
+                getHeadersMock(workspaceName, apiKey), null,
+                ContextInfoHolder.builder()
+                        .uriInfo(createMockUriInfo("/priv/something"))
+                        .method("GET")
+                        .build());
+
+        assertThat(requestContext.getUserName()).isEqualTo(authResponse.user());
+        assertThat(requestContext.getWorkspaceId()).isEqualTo(authResponse.workspaceId());
+        assertThat(requestContext.getWorkspaceName()).isEqualTo(authResponse.workspaceName());
+    }
+
+    /**
+     * Builds a client with the production gzip settings ({@code gzipEnabled: true}, registering
+     * {@code GZipDecoder}). The shared {@link TestHttpClientUtils#client()} runs with
+     * {@code gzipEnabled: false} (see config-test.yml), which silently skips the response-decoding
+     * path under test here.
+     */
+    private jakarta.ws.rs.client.Client newGzipEnabledClient() throws Exception {
+        var jerseyConfig = TestConfigUtils.loadConfigTest().getJerseyClient();
+        jerseyConfig.setGzipEnabled(true);
+        var threadFactory = new ThreadFactory() {
+            private final AtomicLong counter = new AtomicLong();
+
+            @Override
+            public Thread newThread(Runnable runnable) {
+                var thread = new Thread(runnable, "gzip-test-client-" + counter.incrementAndGet());
+                thread.setDaemon(true);
+                return thread;
+            }
+        };
+        var executor = new ThreadPoolExecutor(2, 8, 60L, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(64), threadFactory);
+        return HttpModule.buildClient(
+                new JerseyClientBuilder(new MetricRegistry()).using(executor),
+                jerseyConfig);
     }
 
     @Test


### PR DESCRIPTION
## Details
Auth calls to the react service (`/opik/auth`, `/opik/auth-session`, `/opik/auth-by-username`, `workspaces/workspace-id`) can fail with `java.util.zip.ZipException: Not in GZIP format` while reading a successful (2xx) response whose `Content-Encoding: gzip` header doesn't match the actual body bytes (gzip double-decompression / mislabelled encoding). The exception is a `ProcessingException` rather than a `ClientErrorException`, so it escapes the auth filter's error handling and surfaces to the caller as an HTTP 500 on regular API traffic (e.g. span/trace ingestion). On the API-key path it also fires before the credentials cache is populated (`authenticateUsingApiKey` caches only after `verifyResponse` succeeds), so an affected API key fails on **every** request instead of once.

- `listEligibleWorkspaces` already carries the workaround (`.acceptEncoding("identity")`, "avoids gzip double-decompression issue"); this PR applies the identical workaround to the remaining five react-service call sites in `RemoteAuthService`.
- Auth responses are small JSON payloads, so skipping gzip has no meaningful bandwidth cost.
- Note: existing tests never caught this because `config-test.yml` sets `jerseyClient.gzipEnabled: false` (production default is `true`), so the shared test client never registers `GZipDecoder`. The new regression test builds a production-like client with `gzipEnabled: true`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7253

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Fable 5
- Scope: Investigated the production error (log/stack-trace analysis), authored the change, the regression test, and this PR description.
- Human verification: pending reviewer verification; change mirrors the existing precedent in `listEligibleWorkspaces`.

## Testing
- New regression test `RemoteAuthServiceTest#testAuth__whenRemoteMislabelsGzipResponses__thenIdentityEncodingAvoidsZipException`: builds a client with production gzip settings (`gzipEnabled: true`) and stubs the react service to mislabel responses as `Content-Encoding: gzip` (plain body) unless the client requests identity encoding — mirroring the observed upstream behavior.
  - **Without the fix**: the test fails with `jakarta.ws.rs.ProcessingException: java.util.zip.ZipException: Not in GZIP format` through `RemoteAuthService.authenticateUsingApiKey` — the exact production stack.
  - **With the fix**: passes.
- `mvn test -Dtest=RemoteAuthServiceTest`: 29/29 pass.
- `mvn compile` and `mvn spotless:check` on `apps/opik-backend`: pass.
- Verified in a cloud install that the failing path is `verifyResponse` → `readEntity` on 2xx responses, matching the stack trace, and that error frequency correlates with auth-cache misses.

## Documentation
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)