### PR TITLE
[OPIK-7253] fix: request identity encoding on all react-service auth calls

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
@@ -221,6 +221,8 @@ class RemoteAuthService implements AuthService {
                 .path("auth-by-username")
                 .request()
                 .accept(MediaType.APPLICATION_JSON)
+                // avoids gzip double-decompression issue, same as in listEligibleWorkspaces
+                .acceptEncoding("identity")
                 .header(OAUTH_USERNAME_HEADER, token.userName())
                 .post(Entity.json(AuthRequest.builder()
                         .workspaceName(token.workspaceName())
@@ -244,6 +246,8 @@ class RemoteAuthService implements AuthService {
                 .path("auth-session")
                 .request()
                 .accept(MediaType.APPLICATION_JSON)
+                // avoids gzip double-decompression issue, same as in listEligibleWorkspaces
+                .acceptEncoding("identity")
                 .cookie(sessionToken)
                 .post(Entity.json(AuthRequest.builder().workspaceName(workspaceName).build()))) {
             var authResponse = verifyResponse(response);
@@ -301,6 +305,8 @@ class RemoteAuthService implements AuthService {
                 .path("auth-session")
                 .request()
                 .accept(MediaType.APPLICATION_JSON)
+                // avoids gzip double-decompression issue, same as in listEligibleWorkspaces
+                .acceptEncoding("identity")
                 .cookie(sessionToken)
                 .post(Entity.json(AuthRequest.builder()
                         .workspaceName(workspaceName)
@@ -339,6 +345,8 @@ class RemoteAuthService implements AuthService {
                     .path("auth")
                     .request()
                     .accept(MediaType.APPLICATION_JSON)
+                    // avoids gzip double-decompression issue, same as in listEligibleWorkspaces
+                    .acceptEncoding("identity")
                     .header(HttpHeaders.AUTHORIZATION,
                             apiKey)
                     .post(Entity.json(AuthRequest.builder()
@@ -419,6 +427,8 @@ class RemoteAuthService implements AuthService {
                 .path("workspace-id")
                 .queryParam("name", workspaceName)
                 .request()
+                // avoids gzip double-decompression issue, same as in listEligibleWorkspaces
+                .acceptEncoding("identity")
                 .get()) {
 
             return getWorkspaceIdFromResponse(response);

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
@@ -1,15 +1,19 @@
 package com.comet.opik.infrastructure.auth;
 
+import com.codahale.metrics.MetricRegistry;
+import com.comet.opik.TestConfigUtils;
 import com.comet.opik.api.OpikVersion;
 import com.comet.opik.api.ReactServiceErrorResponse;
 import com.comet.opik.api.resources.utils.TestHttpClientUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
 import com.comet.opik.domain.mcpoauth.ValidatedToken;
 import com.comet.opik.infrastructure.AuthenticationConfig;
+import com.comet.opik.infrastructure.http.HttpModule;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.client.JerseyClientBuilder;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.core.Cookie;
@@ -35,6 +39,11 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
 import static com.comet.opik.api.ReactServiceErrorResponse.MISSING_API_KEY;
@@ -211,6 +220,72 @@ class RemoteAuthServiceTest {
                         .build()))
                 .isExactlyInstanceOf(expectedExceptionClass)
                 .hasMessage(expectedMessage);
+    }
+
+    @Test
+    void testAuth__whenResponseIsGzipCompressed__thenIdentityEncodingAvoidsClientDoubleDecompression()
+            throws Exception {
+        // Long user name pushes the response body over the server-side gzip minimum entity size,
+        // like production auth responses for users with large quota/workspace payloads
+        var authResponse = podamFactory.manufacturePojo(RemoteAuthService.AuthResponse.class).toBuilder()
+                .user("user-" + "x".repeat(2000))
+                .build();
+        var apiKey = "apiKey-" + UUID.randomUUID();
+        var workspaceName = "workspace-" + UUID.randomUUID();
+        var responseJson = OBJECT_MAPPER.writeValueAsString(authResponse);
+
+        // Reproduces the client-side double-decompression defect: with the production client settings
+        // (gzipEnabled: true, unlike the shared test client which disables it), Dropwizard wires BOTH
+        // Apache HttpClient's automatic content decompression AND Jersey's GZipDecoder. When the remote
+        // (correctly) gzips a large enough response — WireMock auto-gzips here, exactly like a
+        // Dropwizard/Jetty upstream — Apache decompresses the body but the 'Content-Encoding: gzip'
+        // header survives into Jersey, so GZipDecoder gunzips the already-plain stream and readEntity
+        // throws 'ZipException: Not in GZIP format', which escapes the auth filter as a
+        // ProcessingException and surfaces as a 500. Requesting identity encoding keeps the response
+        // uncompressed, so neither layer engages.
+        WIRE_MOCK.server().stubFor(post("/opik/auth").willReturn(okJson(responseJson)));
+
+        var gzipEnabledAuthService = new RemoteAuthService(newGzipEnabledClient(),
+                new AuthenticationConfig.UrlConfig(WIRE_MOCK.server().url("")),
+                () -> requestContext,
+                new NoopCacheService());
+
+        gzipEnabledAuthService.authenticate(
+                getHeadersMock(workspaceName, apiKey), null,
+                ContextInfoHolder.builder()
+                        .uriInfo(createMockUriInfo("/priv/something"))
+                        .method("GET")
+                        .build());
+
+        assertThat(requestContext.getUserName()).isEqualTo(authResponse.user());
+        assertThat(requestContext.getWorkspaceId()).isEqualTo(authResponse.workspaceId());
+        assertThat(requestContext.getWorkspaceName()).isEqualTo(authResponse.workspaceName());
+    }
+
+    /**
+     * Builds a client with the production gzip settings ({@code gzipEnabled: true}, registering
+     * {@code GZipDecoder}). The shared {@link TestHttpClientUtils#client()} runs with
+     * {@code gzipEnabled: false} (see config-test.yml), which silently skips the response-decoding
+     * path under test here.
+     */
+    private jakarta.ws.rs.client.Client newGzipEnabledClient() throws Exception {
+        var jerseyConfig = TestConfigUtils.loadConfigTest().getJerseyClient();
+        jerseyConfig.setGzipEnabled(true);
+        var threadFactory = new ThreadFactory() {
+            private final AtomicLong counter = new AtomicLong();
+
+            @Override
+            public Thread newThread(Runnable runnable) {
+                var thread = new Thread(runnable, "gzip-test-client-" + counter.incrementAndGet());
+                thread.setDaemon(true);
+                return thread;
+            }
+        };
+        var executor = new ThreadPoolExecutor(2, 8, 60L, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(64), threadFactory);
+        return HttpModule.buildClient(
+                new JerseyClientBuilder(new MetricRegistry()).using(executor),
+                jerseyConfig);
     }
 
     @Test


### PR DESCRIPTION
## Details
Auth calls to the react service (`/opik/auth`, `/opik/auth-session`, `/opik/auth-by-username`, `workspaces/workspace-id`) fail with `java.util.zip.ZipException: Not in GZIP format` whenever the response is large enough for the upstream to gzip it (Dropwizard/Jetty upstreams compress responses over the gzip minimum entity size, 256 bytes by default). The upstream compression is **valid** — the failure is **client-side double decompression**: with the default `jerseyClient.gzipEnabled: true`, Dropwizard 5 wires BOTH Apache HttpClient 5's automatic content decompression (`disableContentCompression(!gzipEnabled)`) AND Jersey's `GZipDecoder`. Apache decompresses the body, the `Content-Encoding: gzip` header survives into Jersey, and `GZipDecoder` gunzips the already-plain stream → `ZipException`.

Because the exception is a `ProcessingException` rather than a `ClientErrorException`, it escapes the auth filter's error handling and surfaces to the caller as an HTTP 500 on regular API traffic (e.g. span/trace ingestion). On the API-key path it also fires before the credentials cache is populated (`authenticateUsingApiKey` caches only after `verifyResponse` succeeds), so an affected API key — one whose auth response exceeds the upstream's gzip threshold — fails on **every** request instead of once. This explains why the errors are chronic but affect a subset of keys.

- `listEligibleWorkspaces` already carries the workaround (`.acceptEncoding("identity")`, "avoids gzip double-decompression issue"); this PR applies the identical workaround to the remaining five react-service call sites in `RemoteAuthService`. With identity encoding the upstream never compresses, so neither decompression layer engages.
- Auth responses are small JSON payloads, so skipping gzip has no meaningful bandwidth cost.
- Verified against the live upstream that its gzip is well-formed (raw wire bytes carry the `1f 8b` gzip magic and gunzip cleanly), and that a production-like client (`gzipEnabled: true`) fails to read that same valid response — pinning the defect to the client stack, not the upstream.
- Note: existing tests never caught this because `config-test.yml` sets `jerseyClient.gzipEnabled: false`, so the shared test client runs with both decompression layers off. Any other outbound Jersey-client call reading gzipped responses of 256+ bytes is exposed to the same defect; a follow-up could consider `gzipEnabled: false` in `config.yml` or an upstream Dropwizard fix.

(Replaces #7367, which was auto-closed by a head-branch rename.)

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7253

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Fable 5
- Scope: Investigated the production error (log/stack-trace analysis, live upstream wire probing, Dropwizard client bytecode inspection), authored the change, the regression test, and this PR description.
- Human verification: pending reviewer verification; change mirrors the existing precedent in `listEligibleWorkspaces`.

## Testing
- New regression test `RemoteAuthServiceTest#testAuth__whenResponseIsGzipCompressed__thenIdentityEncodingAvoidsClientDoubleDecompression`: builds a client with production gzip settings (`gzipEnabled: true`) against a WireMock server that auto-gzips large responses — exactly like a Dropwizard/Jetty upstream, no artificial mislabelling.
  - **Without the fix**: fails with `ProcessingException: java.util.zip.ZipException: Not in GZIP format` through `RemoteAuthService.authenticateUsingApiKey` — the exact production stack.
  - **With the fix**: passes.
- `mvn test -Dtest=RemoteAuthServiceTest`: 29/29 pass.
- `mvn compile` and `mvn spotless:check` on `apps/opik-backend`: pass.
- Wire-level verification: raw HTTP probe of a gzipping upstream shows valid gzip bytes (`1f 8b` magic, gunzips cleanly) while the same response read through the production-like Dropwizard client throws the ZipException; the client advertises `Accept-Encoding: gzip, deflate, lz4-framed, ...` (Apache HC5 content-compression) confirming both decompression layers are active.

## Documentation
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)