### PR TITLE
[OPIK-7038] [SDK] fix: deliberate tie policy + canonical no-improvement signal

### DIFF
--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/evolutionary_optimizer/ops/generation_ops.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/evolutionary_optimizer/ops/generation_ops.py
@@ -18,6 +18,7 @@ except Exception as exc:  # pragma: no cover - exercised when DEAP is missing
 from ....core.state import OptimizationContext
 from ....utils import display as display_utils
 from ....utils import rng as rng_utils
+from ....utils.scoring import improves_over
 from .. import reporting
 from . import crossover_ops, mutation_ops, pareto_ops, population_ops, style_ops
 
@@ -410,7 +411,10 @@ def run_generations(
                     )
                     if current_best_ind is not None:
                         updated_best_primary_score = current_best_ind.fitness.values[0]
-                        if updated_best_primary_score > best_primary_score_overall:
+                        # Tie policy (OPIK-7038): strict improvement only.
+                        if improves_over(
+                            updated_best_primary_score, best_primary_score_overall
+                        ):
                             best_primary_score_overall = updated_best_primary_score
                             best_prompts_overall = optimizer._individual_to_prompts(
                                 current_best_ind

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/evolutionary_optimizer/ops/result_ops.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/evolutionary_optimizer/ops/result_ops.py
@@ -16,6 +16,7 @@ from ....core import runtime
 from . import pareto_ops
 from ....core.state import AlgorithmResult, OptimizationContext
 from ....utils.logging import debug_log
+from ....utils.scoring import improves_over
 
 if TYPE_CHECKING:  # pragma: no cover
     from ...evolutionary_optimizer import EvolutionaryOptimizer
@@ -29,6 +30,27 @@ def _require_deap() -> None:
             "DEAP is required for EvolutionaryOptimizer. "
             "Install the optimizer extras that include DEAP."
         ) from _DEAP_IMPORT_ERROR
+
+
+def reconcile_winner_with_baseline(
+    *,
+    final_best_prompts: dict[str, Any],
+    final_primary_score: float,
+    seed_prompts: dict[str, Any],
+    baseline_score: float,
+) -> tuple[dict[str, Any], float]:
+    """Keep-original-on-tie reconciliation (OPIK-7038).
+
+    The HOF/Pareto selection in ``build_algorithm_result`` is not reconciled
+    against the baseline, so it can surface a candidate that did not STRICTLY
+    beat the seed. If the evolved winner did not beat the baseline, return the
+    seed prompt at the baseline score, so the user-facing winner obeys the tie
+    policy and stays consistent with the score-derived ``reused_baseline`` flag.
+    ``baseline_score`` is ``context.baseline_score`` (same scale as fitness).
+    """
+    if not improves_over(final_primary_score, baseline_score):
+        return seed_prompts, baseline_score
+    return final_best_prompts, final_primary_score
 
 
 def build_algorithm_result(
@@ -149,6 +171,15 @@ def build_algorithm_result(
     metadata.update(final_details)
     if all_final_tools:
         metadata["final_tools"] = all_final_tools
+
+    # Tie policy (OPIK-7038): gate the user-facing winner against the baseline.
+    # The best explored candidate remains visible under metadata["final_prompts"].
+    final_best_prompts, final_primary_score = reconcile_winner_with_baseline(
+        final_best_prompts=final_best_prompts,
+        final_primary_score=final_primary_score,
+        seed_prompts=optimizable_prompts,
+        baseline_score=initial_primary_score,
+    )
 
     history_entries = optimizer.get_history_entries()
     if not history_entries:

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/few_shot_bayesian_optimizer/few_shot_bayesian_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/few_shot_bayesian_optimizer/few_shot_bayesian_optimizer.py
@@ -37,6 +37,7 @@ from ...utils.prompt_library import PromptOverrides
 from ...utils.logging import debug_log
 from ...constants import normalize_eval_threads
 from ...utils.prompt_roles import apply_role_constraints, count_disallowed_role_updates
+from ...utils.scoring import improves_over
 from ...utils.multimodal import preserve_multimodal_message_structure
 from . import types
 from . import prompts as few_shot_prompts
@@ -787,8 +788,9 @@ class FewShotBayesianOptimizer(base_optimizer.BaseOptimizer):
             "demo_examples", []
         )
 
-        if best_score <= baseline_score:
-            # Optimization didn't improve, return original prompts without placeholder
+        if not improves_over(best_score, baseline_score):
+            # Tie policy (OPIK-7038): keep the seed unless a candidate STRICTLY
+            # beats the baseline. Return original prompts without placeholder.
             best_score = baseline_score
             best_prompts = original_prompts
         else:

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/adapter.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/adapter.py
@@ -15,6 +15,7 @@ from ...base_optimizer import _OPTIMIZER_VERSION
 from ...core import evaluation as task_evaluator
 from ...utils.toolcalling.core import metadata as tool_metadata
 from ...utils.toolcalling.core import segment_updates
+from ...utils.scoring import improves_over
 from ...core import runtime
 from ...api_objects import chat_prompt
 from ...api_objects.types import MetricFunction
@@ -370,7 +371,7 @@ class OpikGEPAAdapter(GEPAAdapter[OpikDataInst, dict[str, Any], dict[str, Any]])
                     score = float(metric_result.score)  # type: ignore[arg-type]
                 else:
                     score = float(metric_result)  # type: ignore[arg-type]
-                if score > best_score:
+                if improves_over(score, best_score):
                     best_score = score
                     best_output = candidate
 

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/ops/candidate_ops.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/ops/candidate_ops.py
@@ -5,14 +5,12 @@ from __future__ import annotations
 from typing import Any
 
 from ....utils.candidate import unique_ordered_by_key
+from ....utils.scoring import improves_over
 from ....api_objects.types import rebuild_content_with_new_text
 from ....utils.toolcalling.core import segment_updates
 
 TOOL_COMPONENT_PREFIX = segment_updates.TOOL_COMPONENT_PREFIX
 TOOL_PARAM_COMPONENT_PREFIX = segment_updates.TOOL_PARAM_COMPONENT_PREFIX
-
-
-# TODO: Promote to a shared optimizer candidate helper once GEPA selection is generalized.
 
 
 def build_seed_candidate(
@@ -93,7 +91,9 @@ def select_best_candidate_index(
 
         best_idx = max(range(len(rescored)), key=_tie_break)
         best_score = rescored[best_idx]
-        if best_score <= initial_score:
+        # Tie policy (OPIK-7038): keep the seed unless a candidate STRICTLY beats
+        # the baseline. A tie returns the -1 sentinel -> caller falls back to seed.
+        if not improves_over(best_score, initial_score):
             return -1, float(initial_score)
         return best_idx, best_score
 

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/ops/result_ops.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/ops/result_ops.py
@@ -99,6 +99,9 @@ def build_algorithm_result(
         "dataset_item_ids": [item.get("id") for item in train_items],
     }
     if best_matches_seed:
+        # Legacy GEPA-only key. The canonical, algorithm-agnostic signal is
+        # OptimizationResult.details["reused_baseline"], set in
+        # core.runtime.build_final_result (OPIK-7038). Kept for back-compat.
         metadata["final_evaluation_reused_baseline"] = True
     if experiment_config:
         metadata["experiment"] = experiment_config

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/hierarchical_reflective_optimizer/hierarchical_reflective_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/hierarchical_reflective_optimizer/hierarchical_reflective_optimizer.py
@@ -17,6 +17,7 @@ from ...utils.prompt_library import PromptOverrides
 from ...utils.prompt_roles import apply_role_constraints, count_disallowed_role_updates
 from ...utils.toolcalling.ops import toolcalling as toolcalling_utils
 from ...utils.toolcalling.core import segment_updates
+from ...utils.scoring import improves_over
 
 from .rootcause_ops import HierarchicalRootCauseAnalyzer
 from .types import (
@@ -557,7 +558,8 @@ class HierarchicalReflectiveOptimizer(BaseOptimizer):
                 post_extras=None,
                 post_metrics=None,
             )
-            if improved_score > best_score_local:
+            # Tie policy (OPIK-7038): strict improvement only.
+            if improves_over(improved_score, best_score_local):
                 best_score_local = improved_score
                 best_prompt_bundle = improved_chat_prompts
                 best_result = improved_experiment_result
@@ -702,9 +704,7 @@ class HierarchicalReflectiveOptimizer(BaseOptimizer):
 
         # finish_reason, stopped_early, stop_reason are handled by base class
         # Align with context in case trial accounting updated current_best_score.
-        if context.current_best_score is not None and (
-            best_score is None or context.current_best_score > best_score
-        ):
+        if best_score is None or improves_over(context.current_best_score, best_score):
             best_score = context.current_best_score
         history_entries = self.get_history_entries()
         for entry in history_entries:

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/hierarchical_reflective_optimizer/hierarchical_reflective_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/hierarchical_reflective_optimizer/hierarchical_reflective_optimizer.py
@@ -704,7 +704,9 @@ class HierarchicalReflectiveOptimizer(BaseOptimizer):
 
         # finish_reason, stopped_early, stop_reason are handled by base class
         # Align with context in case trial accounting updated current_best_score.
-        if best_score is None or improves_over(context.current_best_score, best_score):
+        if context.current_best_score is not None and (
+            best_score is None or improves_over(context.current_best_score, best_score)
+        ):
             best_score = context.current_best_score
         history_entries = self.get_history_entries()
         for entry in history_entries:

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/meta_prompt_optimizer/meta_prompt_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/meta_prompt_optimizer/meta_prompt_optimizer.py
@@ -9,6 +9,7 @@ from ... import constants
 from ...api_objects.types import MetricFunction
 from ...utils import throttle as _throttle
 from ...utils.logging import debug_log
+from ...utils.scoring import improves_over
 from collections.abc import Sequence
 from .ops.halloffame_ops import PromptHallOfFame, add_best_candidate_to_hof
 from ...core.results import OptimizationRound
@@ -426,7 +427,8 @@ class MetaPromptOptimizer(BaseOptimizer):
                     improvement=improvement,
                 )
 
-                if best_cand_score_avg > best_score:
+                # Tie policy (OPIK-7038): strict improvement only.
+                if improves_over(best_cand_score_avg, best_score):
                     best_score = best_cand_score_avg
                     best_prompts = best_candidate_this_round
 

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/meta_prompt_optimizer/ops/evaluation_ops.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/meta_prompt_optimizer/ops/evaluation_ops.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 
 from ....api_objects import chat_prompt
 from ....utils import display as display_utils
+from ....utils.scoring import improves_over
 from .. import reporting
 from . import result_ops
 
@@ -78,7 +79,7 @@ def score_candidate_prompts(
                 context.extra_params.pop("suppress_evaluation_progress", None)
             reporter.set_final_score(current_round_best_score, prompt_score)
 
-        if prompt_score > current_round_best_score:
+        if improves_over(prompt_score, current_round_best_score):
             current_round_best_score = prompt_score
 
         prompt_scores.append((candidate, prompt_score))

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/parameter_optimizer/ops/optuna_ops.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/parameter_optimizer/ops/optuna_ops.py
@@ -21,6 +21,7 @@ from ....core import runtime
 from ....core.state import OptimizationContext
 from ....utils import display as display_utils
 from ....utils.logging import debug_log, _sanitize_debug_value
+from ....utils.scoring import improves_over
 from .search_ops import ParameterSearchSpace
 from .sensitivity_ops import sensitivity_analysis
 from .. import reporting
@@ -302,12 +303,14 @@ def select_best_trial(
     best_trial = max(completed_trials, key=lambda t: t.value)  # type: ignore[arg-type]
     if best_trial.value is not None:
         best_value = float(best_trial.value)
-        if best_value > best_score:
+        # OPIK-7038: strict tie policy. Only adopt a trial that STRICTLY beats
+        # the incumbent (routed through the shared ``improves_over`` helper). A
+        # tie keeps the incumbent — on the first call that incumbent is the
+        # baseline (empty ``best_parameters`` + baseline model kwargs), so a
+        # tied trial no longer leaks its parameters into the returned payload
+        # while the ``reused_baseline`` flag still reports "kept the original".
+        if improves_over(best_value, best_score):
             best_score = best_value
-            best_parameters = best_trial.user_attrs.get("parameters", {})
-            best_model_kwargs = best_trial.user_attrs.get("model_kwargs", {})
-            best_model = best_trial.user_attrs.get("model", best_model)
-        elif best_value == best_score and not best_parameters:
             best_parameters = best_trial.user_attrs.get("parameters", {})
             best_model_kwargs = best_trial.user_attrs.get("model_kwargs", {})
             best_model = best_trial.user_attrs.get("model", best_model)

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/parameter_optimizer/parameter_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/parameter_optimizer/parameter_optimizer.py
@@ -21,6 +21,7 @@ from ...api_objects.types import MetricFunction
 from ...utils import display as display_utils
 from ...utils.optuna_runtime import configure_optuna_logging
 from ...utils.logging import debug_log
+from ...utils.scoring import improves_over
 from .types import ParameterType
 from .ops.optuna_ops import (
     build_optuna_objective,
@@ -757,6 +758,10 @@ class ParameterOptimizer(BaseOptimizer):
             "trials_completed": len(completed_trials),
             "stopped_early": len(completed_trials) < total_trials,
             "stop_reason": None,
+            # OPIK-7038: this optimizer builds its result directly (it bypasses
+            # runtime.build_final_result), so set the flag here too for parity.
+            "reused_baseline": baseline_score is not None
+            and not improves_over(best_score, baseline_score),
             "selection_meta": {
                 "sampler": sampler.__class__.__name__ if sampler else None,
                 "pruner": type(study.pruner).__name__ if study.pruner else None,

--- a/sdks/opik_optimizer/src/opik_optimizer/base_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/base_optimizer.py
@@ -46,6 +46,7 @@ from .core.state import (
     prepare_experiment_config,
 )
 from .utils.logging import debug_log
+from .utils.scoring import improves_over
 from .utils.prompt_library import PromptLibrary, PromptOverrides
 from .utils.candidate_selection import select_candidate
 from .utils import rng as rng_utils
@@ -802,7 +803,9 @@ class BaseOptimizer(ABC):
     ) -> None:
         """Common evaluation-complete logic (shared by legacy/new hooks)."""
         context.trials_completed += 1
-        if prev_best_score is None or score > prev_best_score:
+        # Tie policy (OPIK-7038): only a STRICT improvement replaces the running
+        # best; a tie keeps the incumbent (seeded from the baseline).
+        if prev_best_score is None or improves_over(score, prev_best_score):
             context.current_best_score = score
             context.current_best_prompt = prompts
         runtime.evaluation_progress(

--- a/sdks/opik_optimizer/src/opik_optimizer/core/runtime.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/core/runtime.py
@@ -20,6 +20,7 @@ from ..api_objects.types import MetricFunction
 from ..core.results import OptimizationResult, OptimizationRound
 from ..core.state import AlgorithmResult, OptimizationContext
 from ..utils.logging import debug_log
+from ..utils.scoring import improves_over
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..base_optimizer import BaseOptimizer
@@ -104,8 +105,34 @@ def select_result_prompts(
     return best_prompts, initial_prompts
 
 
+def _apply_reused_baseline(
+    details: dict[str, Any],
+    best_score: float | None,
+    baseline_score: float | None,
+) -> None:
+    """Set the ``reused_baseline`` flag on ``details``.
+
+    OPIK-7038: True when no trial STRICTLY beat the baseline score (a tie keeps
+    the seed). A ``None`` baseline means we can't claim to have reused it, so the
+    flag defaults to False. This is an SDK result signal carried in ``details``
+    (alongside ``finish_reason``/``stopped_early``); surfacing it to the backend
+    and UI is separate plumbing. It is derived from the same tie policy the
+    optimizers apply, so it matches keep-original-on-tie. NOTE: it is score-
+    derived — for it to be a reliable "the seed prompt was returned" signal, the
+    optimizer must return the seed when it does not beat the baseline (GEPA,
+    few-shot, and — as of this change — evolutionary do).
+    """
+    details["reused_baseline"] = baseline_score is not None and not improves_over(
+        best_score, baseline_score
+    )
+
+
 def build_early_result(**kwargs: Any) -> OptimizationResult:
     score = kwargs["score"]
+    details = kwargs["details"]
+    # Early/baseline-only result: the returned prompt IS the baseline, so this is
+    # by definition a reused baseline (no improving trial was produced).
+    _apply_reused_baseline(details, score, score)
     return OptimizationResult(
         optimizer=kwargs["optimizer_name"],
         prompt=kwargs["prompt"],
@@ -154,6 +181,10 @@ def build_final_result(
 
     details.update(optimizer_metadata)
     details.update(algorithm_result.metadata)
+
+    # Canonical, algorithm-agnostic "kept the original prompt" signal (OPIK-7038).
+    # Set last so it is authoritative over any per-optimizer metadata.
+    _apply_reused_baseline(details, algorithm_result.best_score, context.baseline_score)
 
     history_entries = _coerce_history_entries(algorithm_result.history)
     if not history_entries:

--- a/sdks/opik_optimizer/src/opik_optimizer/utils/scoring.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/utils/scoring.py
@@ -1,0 +1,30 @@
+"""
+Score-comparison utilities shared across optimizers.
+
+This is the shared helper for the "does this candidate beat the baseline / the
+running best?" decision. Routing baseline/winner comparisons through it keeps the
+tie policy explicit in one place. Note: not every inline score comparison in the
+codebase is migrated here (some remain intentionally, e.g. convergence-threshold
+and display-only comparisons), so this is the canonical helper for the tie
+policy, not a claim that no `>`/`<=` exists elsewhere.
+"""
+
+from __future__ import annotations
+
+
+def improves_over(score: float | None, baseline: float | None) -> bool:
+    """Return True only if ``score`` STRICTLY beats ``baseline`` (higher is better).
+
+    Tie policy (OPIK-7038): an exact tie does NOT beat the baseline, so the
+    original/seed prompt is kept. A candidate that merely matches the baseline
+    score is not considered an improvement.
+
+    ``None`` on either side means "no comparable value" and yields ``False`` (a
+    missing score never counts as an improvement). ``NaN`` also yields ``False``
+    (``NaN > x`` is ``False``); callers that replaced a raw ``score <= baseline``
+    check with ``not improves_over(...)`` therefore fall back to the seed on a
+    ``NaN``/``None`` score instead of crashing or picking it as a winner.
+    """
+    if score is None or baseline is None:
+        return False
+    return score > baseline

--- a/sdks/opik_optimizer/tests/unit/algorithms/evolutionary_optimizer/test_result_baseline_reconciliation.py
+++ b/sdks/opik_optimizer/tests/unit/algorithms/evolutionary_optimizer/test_result_baseline_reconciliation.py
@@ -1,0 +1,49 @@
+"""OPIK-7038: evolutionary winner must be reconciled against the baseline.
+
+The HOF/Pareto selection can surface a candidate that did not strictly beat the
+seed; `reconcile_winner_with_baseline` falls back to the seed on a tie / no
+improvement so the returned prompt matches keep-original-on-tie.
+"""
+
+# mypy: disable-error-code=no-untyped-def
+
+from opik_optimizer.algorithms.evolutionary_optimizer.ops.result_ops import (
+    reconcile_winner_with_baseline,
+)
+
+
+SEED = {"main": "seed-prompt"}
+CANDIDATE = {"main": "evolved-prompt"}
+
+
+def test_strict_improvement_keeps_candidate() -> None:
+    prompts, score = reconcile_winner_with_baseline(
+        final_best_prompts=CANDIDATE,
+        final_primary_score=0.82,
+        seed_prompts=SEED,
+        baseline_score=0.70,
+    )
+    assert prompts is CANDIDATE
+    assert score == 0.82
+
+
+def test_tie_falls_back_to_seed() -> None:
+    prompts, score = reconcile_winner_with_baseline(
+        final_best_prompts=CANDIDATE,
+        final_primary_score=0.70,
+        seed_prompts=SEED,
+        baseline_score=0.70,
+    )
+    assert prompts is SEED
+    assert score == 0.70
+
+
+def test_below_baseline_falls_back_to_seed() -> None:
+    prompts, score = reconcile_winner_with_baseline(
+        final_best_prompts=CANDIDATE,
+        final_primary_score=0.55,
+        seed_prompts=SEED,
+        baseline_score=0.70,
+    )
+    assert prompts is SEED
+    assert score == 0.70

--- a/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_candidate_selection_baseline.py
+++ b/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_candidate_selection_baseline.py
@@ -1,0 +1,38 @@
+"""OPIK-7038: tie policy in GEPA's select_best_candidate_index.
+
+A candidate must STRICTLY beat the baseline to win; a tie returns the -1
+sentinel so the caller falls back to the seed prompt.
+"""
+
+# mypy: disable-error-code=no-untyped-def
+
+import pytest
+
+from opik_optimizer.algorithms.gepa_optimizer.ops import candidate_ops
+
+
+def _indexed(n: int):
+    return [(i, {}) for i in range(n)]
+
+
+@pytest.mark.parametrize(
+    "rescored,initial_score,expected",
+    [
+        ([0.70, 0.82, 0.88], 0.70, (2, 0.88)),  # clear winner
+        ([0.70, 0.70, 0.70], 0.70, (-1, 0.70)),  # all tie baseline -> seed
+        ([0.65, 0.60], 0.70, (-1, 0.70)),  # none beat baseline -> seed
+        ([0.70, 0.70001, 0.70], 0.70, (1, 0.70001)),  # barely beats
+        ([0.88, 0.88], 0.88, (-1, 0.88)),  # tie at the top score -> seed
+    ],
+)
+def test_select_best_candidate_index_tie_policy(
+    rescored, initial_score, expected
+) -> None:
+    result = candidate_ops.select_best_candidate_index(
+        rescored=rescored,
+        filtered_val_scores=list(rescored),
+        filtered_indexed_candidates=_indexed(len(rescored)),
+        initial_score=initial_score,
+        gepa_result=None,
+    )
+    assert result == expected

--- a/sdks/opik_optimizer/tests/unit/algorithms/parameter_optimizer/test_select_best_trial.py
+++ b/sdks/opik_optimizer/tests/unit/algorithms/parameter_optimizer/test_select_best_trial.py
@@ -1,0 +1,120 @@
+"""OPIK-7038: ``select_best_trial`` must follow the strict tie policy so the
+returned payload can never disagree with the ``reused_baseline`` flag."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import optuna
+from optuna.trial import TrialState
+
+from opik_optimizer.algorithms.parameter_optimizer.ops.optuna_ops import (
+    select_best_trial,
+)
+
+
+def _trial(value: float, user_attrs: dict[str, Any]) -> optuna.trial.FrozenTrial:
+    """Build a real completed ``FrozenTrial`` — ``select_best_trial`` reads its
+    ``.value`` and ``.user_attrs``."""
+    return optuna.trial.create_trial(
+        state=TrialState.COMPLETE,
+        value=value,
+        user_attrs=user_attrs,
+    )
+
+
+def _baseline() -> tuple[float, dict[str, Any], dict[str, Any], dict[str, str]]:
+    # Incumbent as initialized by the optimizer before any trial is adopted:
+    # empty parameters, baseline model kwargs/model.
+    return (
+        0.5,
+        {},
+        {"p": {"temperature": 0.0}},
+        {"p": "gpt-4o"},
+    )
+
+
+def test_select_best_trial__no_completed_trials__keeps_incumbent() -> None:
+    incumbent = _baseline()
+    assert (
+        select_best_trial(
+            completed_trials=[],
+            best_score=incumbent[0],
+            best_parameters=incumbent[1],
+            best_model_kwargs=incumbent[2],
+            best_model=incumbent[3],
+        )
+        == incumbent
+    )
+
+
+def test_select_best_trial__trial_strictly_beats_incumbent__adopts_trial() -> None:
+    incumbent = _baseline()
+    trial = _trial(
+        value=0.9,
+        user_attrs={
+            "parameters": {"temperature": 0.7},
+            "model_kwargs": {"p": {"temperature": 0.7}},
+            "model": {"p": "gpt-4o"},
+        },
+    )
+
+    score, parameters, model_kwargs, _ = select_best_trial(
+        completed_trials=[trial],
+        best_score=incumbent[0],
+        best_parameters=incumbent[1],
+        best_model_kwargs=incumbent[2],
+        best_model=incumbent[3],
+    )
+
+    assert score == 0.9
+    assert parameters == {"temperature": 0.7}
+    assert model_kwargs == {"p": {"temperature": 0.7}}
+
+
+def test_select_best_trial__trial_ties_incumbent__keeps_baseline_no_param_leak() -> (
+    None
+):
+    """A tie must NOT leak the trial's parameters into the payload, otherwise
+    ``optimized_parameters`` would contradict ``reused_baseline=True``."""
+    incumbent = _baseline()
+    tied_trial = _trial(
+        value=0.5,  # exactly equal to the baseline score
+        user_attrs={
+            "parameters": {"temperature": 0.7},
+            "model_kwargs": {"p": {"temperature": 0.7}},
+            "model": {"p": "gpt-4o"},
+        },
+    )
+
+    score, parameters, model_kwargs, model = select_best_trial(
+        completed_trials=[tied_trial],
+        best_score=incumbent[0],
+        best_parameters=incumbent[1],
+        best_model_kwargs=incumbent[2],
+        best_model=incumbent[3],
+    )
+
+    assert score == 0.5
+    assert parameters == {}
+    assert model_kwargs == {"p": {"temperature": 0.0}}
+    assert model == {"p": "gpt-4o"}
+
+
+def test_select_best_trial__trial_worse_than_incumbent__keeps_incumbent() -> None:
+    incumbent = _baseline()
+    worse_trial = _trial(
+        value=0.1,
+        user_attrs={"parameters": {"temperature": 0.7}},
+    )
+
+    assert (
+        select_best_trial(
+            completed_trials=[worse_trial],
+            best_score=incumbent[0],
+            best_parameters=incumbent[1],
+            best_model_kwargs=incumbent[2],
+            best_model=incumbent[3],
+        )
+        == incumbent
+    )

--- a/sdks/opik_optimizer/tests/unit/core/test_base_optimizer_finalize.py
+++ b/sdks/opik_optimizer/tests/unit/core/test_base_optimizer_finalize.py
@@ -179,3 +179,76 @@ class TestBuildFinalResultStoppedEarly:
         assert result.details["stop_reason"] == expected_reason
         if finish_reason == "max_trials":
             assert result.details["finish_reason"] == expected_reason
+
+
+class TestBuildFinalResultReusedBaseline:
+    """OPIK-7038: canonical reused_baseline flag in _build_final_result."""
+
+    @pytest.fixture
+    def optimizer(self) -> ConcreteOptimizer:
+        return ConcreteOptimizer(model="gpt-4")
+
+    def _make_context(
+        self, simple_chat_prompt: ChatPrompt, baseline_score: float | None
+    ) -> OptimizationContext:
+        dataset = make_mock_dataset(dataset_id="ds-123")
+        metric = MagicMock(__name__="test_metric")
+        return make_optimization_context(
+            simple_chat_prompt,
+            dataset=dataset,
+            metric=metric,
+            optimization_id="opt-123",
+            baseline_score=baseline_score,
+        )
+
+    @pytest.mark.parametrize(
+        "best_score,baseline_score,expected",
+        [
+            (0.80, 0.50, False),  # strict improvement -> not reused
+            (0.50, 0.50, True),  # exact tie -> original kept
+            (0.30, 0.50, True),  # below baseline -> original kept
+            (0.50, None, False),  # no baseline -> can't claim reuse
+        ],
+    )
+    def test_reused_baseline_flag(
+        self,
+        optimizer: ConcreteOptimizer,
+        simple_chat_prompt: ChatPrompt,
+        best_score: float,
+        baseline_score: float | None,
+        expected: bool,
+    ) -> None:
+        from opik_optimizer.core.state import AlgorithmResult
+
+        context = self._make_context(simple_chat_prompt, baseline_score)
+        algorithm_result = AlgorithmResult(
+            best_prompts={"main": simple_chat_prompt},
+            best_score=best_score,
+            history=[],
+            metadata={},
+        )
+
+        result = optimizer._build_final_result(algorithm_result, context)
+
+        assert result.details["reused_baseline"] is expected
+
+    def test_reused_baseline_overrides_optimizer_metadata(
+        self,
+        optimizer: ConcreteOptimizer,
+        simple_chat_prompt: ChatPrompt,
+    ) -> None:
+        """The canonical flag must win over any per-optimizer metadata key
+        (it is applied AFTER details.update(algorithm_result.metadata))."""
+        from opik_optimizer.core.state import AlgorithmResult
+
+        context = self._make_context(simple_chat_prompt, baseline_score=0.50)
+        algorithm_result = AlgorithmResult(
+            best_prompts={"main": simple_chat_prompt},
+            best_score=0.80,  # strict improvement -> canonical flag is False
+            history=[],
+            metadata={"reused_baseline": True},  # stale/wrong per-optimizer value
+        )
+
+        result = optimizer._build_final_result(algorithm_result, context)
+
+        assert result.details["reused_baseline"] is False

--- a/sdks/opik_optimizer/tests/unit/core/test_base_optimizer_framework_trial_hooks.py
+++ b/sdks/opik_optimizer/tests/unit/core/test_base_optimizer_framework_trial_hooks.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from opik_optimizer.api_objects import chat_prompt
+from opik_optimizer.core import runtime
 from opik_optimizer.core.state import OptimizationContext
 from tests.unit.fixtures.base_optimizer_test_helpers import ConcreteOptimizer
 from tests.unit.test_helpers import make_mock_dataset, make_optimization_context
@@ -130,3 +131,33 @@ def test_post_trial_not_called_by_evaluate(
 
     optimizer.evaluate(context, {"main": simple_chat_prompt})
     assert optimizer.post_trial_called is False
+
+
+def test_handle_trial_end_keeps_incumbent_on_tie(
+    monkeypatch: pytest.MonkeyPatch, simple_chat_prompt
+) -> None:
+    """OPIK-7038: a tie must NOT replace the running-best (seeded from baseline);
+    only a strict improvement does."""
+    optimizer = ConcreteOptimizer(model="gpt-4")
+    context = make_optimization_context(
+        simple_chat_prompt,
+        dataset=make_mock_dataset(),
+        metric=MagicMock(),
+        max_trials=5,
+    )
+    monkeypatch.setattr(runtime, "evaluation_progress", lambda **kwargs: None)
+
+    incumbent = {"main": simple_chat_prompt}
+    context.current_best_score = 0.70
+    context.current_best_prompt = incumbent
+    challenger = {"main": simple_chat_prompt}
+
+    # Tie -> incumbent kept.
+    optimizer._handle_trial_end(context, challenger, 0.70, prev_best_score=0.70)
+    assert context.current_best_prompt is incumbent
+    assert context.current_best_score == 0.70
+
+    # Strict improvement -> challenger wins.
+    optimizer._handle_trial_end(context, challenger, 0.85, prev_best_score=0.70)
+    assert context.current_best_prompt is challenger
+    assert context.current_best_score == 0.85

--- a/sdks/opik_optimizer/tests/unit/core/test_base_optimizer_validation.py
+++ b/sdks/opik_optimizer/tests/unit/core/test_base_optimizer_validation.py
@@ -180,6 +180,9 @@ class TestSkipAndResultHelpers:
         assert result.initial_score == 0.75
         assert result.history == []
         assert result.details["stopped_early"] is True
+        # OPIK-7038: an early/baseline-only result IS the baseline, so the flag
+        # must be True (this covers the perfect-score early-stop path).
+        assert result.details["reused_baseline"] is True
 
 
 class TestMetricRequiredFields:

--- a/sdks/opik_optimizer/tests/unit/utils/test_scoring.py
+++ b/sdks/opik_optimizer/tests/unit/utils/test_scoring.py
@@ -1,0 +1,24 @@
+"""Unit tests for the shared score-comparison helper (OPIK-7038)."""
+
+# mypy: disable-error-code=no-untyped-def
+
+import pytest
+
+from opik_optimizer.utils.scoring import improves_over
+
+
+@pytest.mark.parametrize(
+    "score,baseline,expected",
+    [
+        (0.80, 0.70, True),  # strictly better
+        (0.70, 0.70, False),  # exact tie -> keep original
+        (0.60, 0.70, False),  # worse
+        (0.0, 0.0, False),  # tie at zero
+        (1e-9, 0.0, True),  # tiny strict improvement
+        (None, 0.70, False),  # missing candidate score
+        (0.70, None, False),  # missing baseline
+        (None, None, False),  # both missing
+    ],
+)
+def test_improves_over(score, baseline, expected) -> None:
+    assert improves_over(score, baseline) is expected


### PR DESCRIPTION
## Details

Optimization Studio sometimes surfaced the original (seed) prompt instead of the best-scoring trial: both optimizers only replaced the baseline when a candidate *strictly* beat it, so a tie was discarded in favour of the original, and the fallback was silent. This PR keeps the tie policy (keep-original-on-tie) but makes it deliberate, centralized, and tested, and adds a consistent no-improvement signal. SDK-only; the FE/backend surfacing is a follow-up. Pairs with #7364 (OPIK_7160), which makes silent metric misconfig fail loudly and should land first.

- `utils/scoring.improves_over(score, baseline)` — single tie-policy helper (strict `>`, `None`/`NaN`-safe); routed the winner-vs-baseline / running-best comparisons through it across GEPA, few-shot Bayesian, evolutionary, hierarchical-reflective, meta-prompt, and the base optimizer (behavior-preserving).
- Canonical `details["reused_baseline"]` flag set on every result path — `build_final_result`, `build_early_result` (perfect-score early-stop), and the parameter optimizer's direct result — so "kept the original" is no longer silent or GEPA-only. GEPA's legacy `final_evaluation_reused_baseline` key is retained for back-compat.
- Evolutionary `reconcile_winner_with_baseline` returns the seed + baseline score when the HOF/Pareto winner did not beat the baseline, so the returned prompt and the flag can't disagree.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-7038

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: Implementation, tests, and PR description for the SDK tie-policy centralization and `reused_baseline` signal.
- Human verification: Author reviewed the diff; a multi-perspective adversarial review (correctness/equivalence, completeness, test coverage, design) was run before finalizing; full unit suite + ruff + mypy run locally and passing.

## Testing

- Env: local, `sdks/opik_optimizer` editable install in its `.venv`.
- `python -m pytest tests/unit/algorithms tests/unit/core tests/unit/utils` → **696 passed** (+4 new).
- Targeted suites: `test_scoring.py` (strict/tie/worse/None/epsilon), GEPA `test_candidate_selection_baseline.py` (the ticket's deterministic repro table), base `_handle_trial_end` keeps incumbent on a tie, `reused_baseline` on the final + early/perfect-score paths + precedence over per-optimizer metadata, evolutionary `reconcile_winner_with_baseline`.
- `ruff check` and `ruff format --check` clean on changed files; `mypy` clean on changed files (one pre-existing unrelated error in `parameter_optimizer` baseline eval).
- Not run: no full live end-to-end optimizer run (validated at SDK unit level and via the deterministic repro).

## Documentation

N/A — SDK-internal result signal in `details`; no public documentation affected. Surfacing it in the UI is a tracked follow-up.
