### PR TITLE
[OPIK-7255] perf(backend): bound the per-project pending-closure thread scan

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ClosingTraceThreadSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ClosingTraceThreadSubscriber.java
@@ -46,7 +46,7 @@ public class ClosingTraceThreadSubscriber extends BaseRedisSubscriber<ProjectWit
 
         return traceThreadService
                 .processProjectWithTraceThreadsPendingClosure(message.projectId(), now,
-                        defaultTimeoutToMarkThreadAsInactive)
+                        defaultTimeoutToMarkThreadAsInactive, config.getColdStartLookback().toJavaDuration())
                 .contextWrite(context -> context.put(USER_NAME, DEFAULT_USER)
                         .put(WORKSPACE_ID, message.workspaceId()));
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadDAO.java
@@ -585,19 +585,20 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
     @Override
     public Flux<List<TraceThreadModel>> streamPendingClosureThreads(@NonNull UUID projectId,
             @NonNull Instant lastUpdatedAt, @NonNull Instant lookbackBound) {
-        return asyncTemplate.stream(connection -> {
+        return asyncTemplate.stream(connection -> makeFluxContextAware((userName, workspaceId) -> {
 
             var template = getSTWithLogComment(GET_RECENT_CLOSED_THREADS_PER_PROJECT,
-                    "stream_pending_closure_threads", "", "", "");
+                    "stream_pending_closure_threads", workspaceId, userName, projectId);
             var statement = connection.createStatement(template.render())
+                    .bind("workspace_id", workspaceId)
                     .bind("project_id", projectId)
                     .bind("last_updated_at", lastUpdatedAt.truncatedTo(ChronoUnit.MICROS).toString())
                     .bind("lookback_bound", lookbackBound.truncatedTo(ChronoUnit.MICROS).toString())
                     .bind("status", TraceThreadStatus.ACTIVE.getValue());
 
-            return makeFluxContextAware(bindWorkspaceIdToFlux(statement))
+            return Flux.from(statement.execute())
                     .flatMap(result -> result.map((row, rowMetadata) -> TraceThreadMapper.INSTANCE.mapFromRow(row)));
-        }).buffer(1000);
+        })).buffer(1000);
     }
 
     private void bindTemplateParam(TraceThreadCriteria criteria, ST template) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadDAO.java
@@ -69,7 +69,8 @@ public interface TraceThreadDAO {
 
     Mono<Void> updateThread(UUID threadModelId, UUID projectId, TraceThreadUpdate threadUpdate);
 
-    Flux<List<TraceThreadModel>> streamPendingClosureThreads(UUID projectId, Instant lastUpdatedAt);
+    Flux<List<TraceThreadModel>> streamPendingClosureThreads(UUID projectId, Instant lastUpdatedAt,
+            Instant lookbackBound);
 
     Mono<Void> bulkUpdate(@NonNull List<UUID> ids, @NonNull TraceThreadUpdate update, boolean mergeTags);
 }
@@ -275,14 +276,49 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
             ;
             """;
 
+    /**
+     * Uses the same aggregation form as {@link #FIND_PENDING_CLOSURE_THREADS_SQL} instead of FINAL:
+     * without a lower bound on {@code last_updated_at} (not part of the sorting key), FINAL has to
+     * merge-read every version row of the project on every call, which dominates read volume on hot
+     * projects. The {@code :lookback_bound} pre-dedup filter is safe for the same monotonicity
+     * reason documented there, and lets the minmax skip index on {@code last_updated_at} prune
+     * granules. The bound must cover the widest window used by the enqueuing scan (see
+     * {@code TraceThreadService}'s lookback computation), otherwise a thread flagged by the global
+     * scan could be invisible here and be re-enqueued forever.
+     */
     public static final String GET_RECENT_CLOSED_THREADS_PER_PROJECT = """
             SELECT
-                workspace_id, project_id, thread_id, id, status, created_by, last_updated_by, created_at, last_updated_at, tags, sampling_per_rule, source, environment
-            FROM trace_threads final
-            WHERE workspace_id = :workspace_id
-            AND project_id = :project_id
-            AND status = :status
-            AND last_updated_at < parseDateTime64BestEffort(:last_updated_at, 6)
+                workspace_id, project_id, thread_id, id,
+                latest_status AS status,
+                latest_created_by AS created_by,
+                latest_last_updated_by AS last_updated_by,
+                first_created_at AS created_at,
+                latest_updated_at AS last_updated_at,
+                latest_tags AS tags,
+                latest_sampling_per_rule AS sampling_per_rule,
+                latest_source AS source,
+                latest_environment AS environment
+            FROM (
+                SELECT
+                    workspace_id, project_id, thread_id, id,
+                    argMax(status, last_updated_at)            AS latest_status,
+                    argMax(created_by, last_updated_at)        AS latest_created_by,
+                    argMax(last_updated_by, last_updated_at)   AS latest_last_updated_by,
+                    min(created_at)                            AS first_created_at,
+                    max(last_updated_at)                       AS latest_updated_at,
+                    argMax(tags, last_updated_at)              AS latest_tags,
+                    argMax(sampling_per_rule, last_updated_at) AS latest_sampling_per_rule,
+                    argMax(source, last_updated_at)            AS latest_source,
+                    argMax(environment, last_updated_at)       AS latest_environment
+                FROM trace_threads
+                WHERE workspace_id = :workspace_id
+                AND project_id = :project_id
+                AND last_updated_at > parseDateTime64BestEffort(:lookback_bound, 6)
+                GROUP BY workspace_id, project_id, thread_id, id
+            )
+            WHERE latest_status = :status
+            AND latest_updated_at \\< parseDateTime64BestEffort(:last_updated_at, 6)
+            SETTINGS log_comment = '<log_comment>'
             ;
             """;
 
@@ -548,12 +584,15 @@ class TraceThreadDAOImpl implements TraceThreadDAO {
 
     @Override
     public Flux<List<TraceThreadModel>> streamPendingClosureThreads(@NonNull UUID projectId,
-            @NonNull Instant lastUpdatedAt) {
+            @NonNull Instant lastUpdatedAt, @NonNull Instant lookbackBound) {
         return asyncTemplate.stream(connection -> {
 
-            var statement = connection.createStatement(GET_RECENT_CLOSED_THREADS_PER_PROJECT)
+            var template = getSTWithLogComment(GET_RECENT_CLOSED_THREADS_PER_PROJECT,
+                    "stream_pending_closure_threads", "", "", "");
+            var statement = connection.createStatement(template.render())
                     .bind("project_id", projectId)
                     .bind("last_updated_at", lastUpdatedAt.truncatedTo(ChronoUnit.MICROS).toString())
+                    .bind("lookback_bound", lookbackBound.truncatedTo(ChronoUnit.MICROS).toString())
                     .bind("status", TraceThreadStatus.ACTIVE.getValue());
 
             return makeFluxContextAware(bindWorkspaceIdToFlux(statement))

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
@@ -56,7 +56,7 @@ public interface TraceThreadService {
             int limit);
 
     Mono<Void> processProjectWithTraceThreadsPendingClosure(UUID projectId, Instant now,
-            Duration defaultTimeoutToMarkThreadAsInactive);
+            Duration defaultTimeoutToMarkThreadAsInactive, Duration minLookback);
 
     Mono<Boolean> addToPendingQueue(UUID projectId);
 
@@ -277,7 +277,14 @@ class TraceThreadServiceImpl implements TraceThreadService {
     public Flux<ProjectWithPendingClosureTraceThreads> getProjectsWithPendingClosureThreads(
             @NonNull Instant now, @NonNull Duration defaultTimeoutToMarkThreadAsInactive,
             Duration minLookback, int limit) {
-        return getMaxTimeoutMarkThreadAsInactive(defaultTimeoutToMarkThreadAsInactive)
+        return getPendingClosureLookbackBound(now, defaultTimeoutToMarkThreadAsInactive, minLookback)
+                .flatMapMany(cachedMaxInactivePeriod -> traceThreadDAO
+                        .findProjectsWithPendingClosureThreads(now, defaultTimeoutToMarkThreadAsInactive,
+                                cachedMaxInactivePeriod, limit));
+    }
+
+    private Mono<Instant> getPendingClosureLookbackBound(Instant now, Duration defaultTimeout, Duration minLookback) {
+        return getMaxTimeoutMarkThreadAsInactive(defaultTimeout)
                 .map(maxTimeout -> {
                     // max(coalesce(maxTimeout, defaultTimeout) + 1h, 1 day)
                     // Floor at 1 day: cheap enough (minmax index keeps it fast) and covers
@@ -291,10 +298,7 @@ class TraceThreadServiceImpl implements TraceThreadService {
                         lookbackPeriod = minLookback;
                     }
                     return now.minus(lookbackPeriod);
-                })
-                .flatMapMany(cachedMaxInactivePeriod -> traceThreadDAO
-                        .findProjectsWithPendingClosureThreads(now, defaultTimeoutToMarkThreadAsInactive,
-                                cachedMaxInactivePeriod, limit));
+                });
     }
 
     private Mono<Duration> getMaxTimeoutMarkThreadAsInactive(Duration defaultTimeout) {
@@ -311,20 +315,26 @@ class TraceThreadServiceImpl implements TraceThreadService {
 
     @Override
     public Mono<Void> processProjectWithTraceThreadsPendingClosure(@NonNull UUID projectId,
-            @NonNull Instant now, @NonNull Duration defaultTimeoutToMarkThreadAsInactive) {
+            @NonNull Instant now, @NonNull Duration defaultTimeoutToMarkThreadAsInactive, Duration minLookback) {
         return Mono.deferContextual(
-                contextView -> closeThreadWith(projectId, now, defaultTimeoutToMarkThreadAsInactive,
+                contextView -> closeThreadWith(projectId, now, defaultTimeoutToMarkThreadAsInactive, minLookback,
                         contextView))
                 .then();
     }
 
     private Mono<Long> closeThreadWith(UUID projectId, Instant now, Duration defaultTimeoutToMarkThreadAsInactive,
-            ContextView ctx) {
+            Duration minLookback, ContextView ctx) {
 
         String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
 
+        // The lookback bound must be at least as wide as any window the enqueuing scan
+        // (getProjectsWithPendingClosureThreads) may have used, so minLookback here should be the
+        // cold-start lookback: a thread visible to the enqueuer but outside this window would be
+        // re-enqueued on every job run and never closed.
         return getWorkspaceTimeout(now, defaultTimeoutToMarkThreadAsInactive)
-                .flatMapMany(lastUpdatedAt -> traceThreadDAO.streamPendingClosureThreads(projectId, lastUpdatedAt))
+                .zipWith(getPendingClosureLookbackBound(now, defaultTimeoutToMarkThreadAsInactive, minLookback))
+                .flatMapMany(bounds -> traceThreadDAO.streamPendingClosureThreads(projectId, bounds.getT1(),
+                        bounds.getT2()))
                 .flatMap(threads -> {
 
                     if (threads.isEmpty()) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadService.java
@@ -330,11 +330,17 @@ class TraceThreadServiceImpl implements TraceThreadService {
         // The lookback bound must be at least as wide as any window the enqueuing scan
         // (getProjectsWithPendingClosureThreads) may have used, so minLookback here should be the
         // cold-start lookback: a thread visible to the enqueuer but outside this window would be
-        // re-enqueued on every job run and never closed.
+        // re-enqueued on every job run and never closed. Both scans read the same Redis-backed
+        // cached max timeout, so their windows stay consistent; the clamp below additionally
+        // guarantees a well-formed window (lookback before cutoff) even if that cached value lags
+        // a workspace timeout increase for up to its TTL.
         return getWorkspaceTimeout(now, defaultTimeoutToMarkThreadAsInactive)
                 .zipWith(getPendingClosureLookbackBound(now, defaultTimeoutToMarkThreadAsInactive, minLookback))
-                .flatMapMany(bounds -> traceThreadDAO.streamPendingClosureThreads(projectId, bounds.getT1(),
-                        bounds.getT2()))
+                .flatMapMany(bounds -> {
+                    Instant lastUpdatedAt = bounds.getT1();
+                    Instant lookbackBound = bounds.getT2().isBefore(lastUpdatedAt) ? bounds.getT2() : lastUpdatedAt;
+                    return traceThreadDAO.streamPendingClosureThreads(projectId, lastUpdatedAt, lookbackBound);
+                })
                 .flatMap(threads -> {
 
                     if (threads.isEmpty()) {


### PR DESCRIPTION
## Details

The per-project pending-closure query (`GET_RECENT_CLOSED_THREADS_PER_PROJECT`) ran `trace_threads FINAL` filtered only by workspace/project plus predicates (`status`, `last_updated_at < cutoff`) that no index can serve, so every closure event merge-read every version row of the project. On hot projects this is one of the largest read-volume queries on the ClickHouse cluster, and most fires return zero rows.

- Rewritten to the same aggregation form already used (and documented) by `FIND_PENDING_CLOSURE_THREADS_SQL`: `argMax`/`max` per thread key instead of FINAL, with a `last_updated_at > :lookback_bound` pre-dedup filter that the minmax skip index can prune on. The pre-filter is safe for the monotonicity reason documented on that query.
- The lookback bound reuses the enqueuing scan's lookback computation (extracted to `getPendingClosureLookbackBound`), widened by the cold-start lookback so the per-project window always covers the widest window the enqueuer may have used — otherwise a flagged thread could be invisible here and re-enqueued forever.
- Added a `log_comment` (`stream_pending_closure_threads`) for query attribution in `system.query_log`.

Verified against production data: both forms evaluated in a single statement over a project with live pending-closure threads returned identical results (same ids, zero field mismatches across all columns). Read volume on the hottest project dropped ~4.5× with the default 7d cold-start bound (~20× with a 1d bound); the no-op case (nothing to close) drops the same way.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7255

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Fable 5
  - Scope: query rewrite, lookback plumbing, commit and PR text
  - Human verification: pending reviewer; query equivalence and read-volume numbers validated live against production ClickHouse (read-only)

## Testing

- `mvn compile` and `mvn test-compile` pass; `mvn spotless:apply` produced no further changes
- Query equivalence proven live on production data: single-statement comparison of old (FINAL) vs new (bounded aggregate) form on a project with pending threads — identical row sets and field values
- `EXPLAIN indexes=1` confirms the minmax `last_updated_at` skip index prunes granules only with the new lower bound (old shape: 232→229 granules, i.e. no pruning; new shape prunes to a fraction and shrinks further as the bound tightens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Documentation

No user-facing documentation impact — internal ClickHouse query optimization. The query's design rationale is captured in the javadoc on `GET_RECENT_CLOSED_THREADS_PER_PROJECT`.
