### PR TITLE
[OPIK-7256] fix(backend): make project size-estimate cache actually engage

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1021,7 +1021,11 @@ cacheManager:
     # Default: {}
     # Description: Dynamically created caches with their respective time to live in seconds
     automationRules: ${CACHE_MANAGER_AUTOMATION_RULES_DURATION:-PT1S}
-    workspace_metadata: ${CACHE_MANAGER_WORKSPACE_METADATA_DURATION:-PT1H}
+    # Default: PT1H
+    # Description: Cache TTL for the per-project size estimate (ScopeMetadata) gating dynamic sorting.
+    # The estimate scans all of the project's spans, so cache misses are expensive by design.
+    # Renamed from the orphaned workspace_metadata entry, which no code referenced.
+    project_metadata: ${CACHE_MANAGER_PROJECT_METADATA_DURATION:-PT1H}
     # Default: PT5M
     # Description: Cache TTL for workspace version determination results, applied per workspace
     # Scope: Per workspace (cache key includes workspace ID)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceMetadataService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceMetadataService.java
@@ -44,8 +44,10 @@ class WorkspaceMetadataServiceImpl implements WorkspaceMetadataService {
                 .flatMap(resolvedProjectId -> getProjectMetadata(workspaceId, resolvedProjectId));
     }
 
+    // Package-private, not private: Guice method interception (which implements @Cacheable) cannot
+    // intercept private methods, so a private modifier silently disables the cache.
     @Cacheable(name = "project_metadata", key = "'-'+ $workspaceId + '-' + $projectId", returnType = ScopeMetadata.class)
-    private Mono<ScopeMetadata> getProjectMetadata(String workspaceId, UUID projectId) {
+    Mono<ScopeMetadata> getProjectMetadata(String workspaceId, UUID projectId) {
         return workspaceMetadataDAO.getProjectMetadata(workspaceId, projectId);
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceMetadataService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/workspaces/WorkspaceMetadataService.java
@@ -44,10 +44,10 @@ class WorkspaceMetadataServiceImpl implements WorkspaceMetadataService {
                 .flatMap(resolvedProjectId -> getProjectMetadata(workspaceId, resolvedProjectId));
     }
 
-    // Package-private, not private: Guice method interception (which implements @Cacheable) cannot
+    // Must not be private: Guice method interception (which implements @Cacheable) cannot
     // intercept private methods, so a private modifier silently disables the cache.
     @Cacheable(name = "project_metadata", key = "'-'+ $workspaceId + '-' + $projectId", returnType = ScopeMetadata.class)
-    Mono<ScopeMetadata> getProjectMetadata(String workspaceId, UUID projectId) {
+    public Mono<ScopeMetadata> getProjectMetadata(String workspaceId, UUID projectId) {
         return workspaceMetadataDAO.getProjectMetadata(workspaceId, projectId);
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/workspaces/WorkspaceMetadataServiceCacheTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/workspaces/WorkspaceMetadataServiceCacheTest.java
@@ -9,8 +9,10 @@ import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppCon
 import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.infrastructure.cache.CacheManager;
 import com.google.inject.AbstractModule;
 import com.redis.testcontainers.RedisContainer;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,13 +23,13 @@ import org.testcontainers.mysql.MySQLContainer;
 import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
-import static com.comet.opik.api.resources.utils.TestUtils.waitForMillis;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -44,8 +46,6 @@ class WorkspaceMetadataServiceCacheTest {
     private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
     private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
     private final ClickHouseContainer CLICKHOUSE = ClickHouseContainerUtils.newClickHouseContainer(ZOOKEEPER_CONTAINER);
-
-    private static final long CACHE_ASYNC_WAIT_MILLIS = 100;
 
     private static final AtomicInteger PROJECT_METADATA_DAO_CALLS = new AtomicInteger();
 
@@ -101,7 +101,8 @@ class WorkspaceMetadataServiceCacheTest {
     }
 
     @Test
-    void getProjectMetadata__repeatedCallsAreServedFromCache(WorkspaceMetadataService service) {
+    void getProjectMetadata__repeatedCallsAreServedFromCache(WorkspaceMetadataService service,
+            CacheManager cacheManager) {
         var impl = (WorkspaceMetadataServiceImpl) service;
         var workspaceId = UUID.randomUUID().toString();
         var projectId = UUID.randomUUID();
@@ -111,8 +112,12 @@ class WorkspaceMetadataServiceCacheTest {
         assertThat(first).isNotNull();
         assertThat(PROJECT_METADATA_DAO_CALLS.get()).isEqualTo(1);
 
-        // wait for the cache put async to complete
-        waitForMillis(CACHE_ASYNC_WAIT_MILLIS);
+        // the cache put is async and its completion signal is dropped, so wait until the entry is
+        // actually readable before asserting the second call is served from the cache
+        var cacheKey = "project_metadata:--%s-%s".formatted(workspaceId, projectId);
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(5))
+                .until(() -> Boolean.TRUE.equals(cacheManager.contains(cacheKey).block()));
 
         // same key: served from cache, the DAO must not be called again
         var second = impl.getProjectMetadata(workspaceId, projectId).block();

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/workspaces/WorkspaceMetadataServiceCacheTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/workspaces/WorkspaceMetadataServiceCacheTest.java
@@ -1,0 +1,129 @@
+package com.comet.opik.domain.workspaces;
+
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.google.inject.AbstractModule;
+import com.redis.testcontainers.RedisContainer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import reactor.core.publisher.Mono;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.api.resources.utils.TestUtils.waitForMillis;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards that the {@code project_metadata} cache on
+ * {@link WorkspaceMetadataServiceImpl#getProjectMetadata(String, UUID)} actually engages: the
+ * method must stay interceptable by Guice (not private) and the cache name must stay configured,
+ * otherwise the expensive per-project size estimate silently runs on every call.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class WorkspaceMetadataServiceCacheTest {
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+    private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE = ClickHouseContainerUtils.newClickHouseContainer(ZOOKEEPER_CONTAINER);
+
+    private static final long CACHE_ASYNC_WAIT_MILLIS = 100;
+
+    private static final AtomicInteger PROJECT_METADATA_DAO_CALLS = new AtomicInteger();
+
+    private static final WorkspaceMetadataDAO COUNTING_DAO = new WorkspaceMetadataDAO() {
+
+        @Override
+        public Mono<ScopeMetadata> getProjectMetadata(String workspaceId, UUID projectId) {
+            PROJECT_METADATA_DAO_CALLS.incrementAndGet();
+            return Mono.just(ScopeMetadata.builder()
+                    .sizeGb(ThreadLocalRandom.current().nextDouble())
+                    .totalTableSizeGb(100)
+                    .percentageOfTable(1)
+                    .limitSizeGb(10)
+                    .build());
+        }
+
+        @Override
+        public Mono<ExperimentScopeMetadata> getExperimentMetadata(String workspaceId, UUID datasetId) {
+            return Mono.just(ExperimentScopeMetadata.builder().build());
+        }
+    };
+
+    @RegisterApp
+    private final TestDropwizardAppExtension APP;
+
+    {
+        Startables.deepStart(MYSQL, CLICKHOUSE, REDIS, ZOOKEEPER_CONTAINER).join();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(
+                CLICKHOUSE, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE);
+
+        APP = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .redisUrl(REDIS.getRedisURI())
+                        .modules(List.of(new AbstractModule() {
+
+                            @Override
+                            protected void configure() {
+                                bind(WorkspaceMetadataDAO.class).toInstance(COUNTING_DAO);
+                            }
+
+                        }))
+                        .customConfigs(
+                                List.of(
+                                        new CustomConfig("cacheManager.enabled", "true"),
+                                        new CustomConfig("cacheManager.caches.project_metadata", "PT30S")))
+                        .build());
+    }
+
+    @Test
+    void getProjectMetadata__repeatedCallsAreServedFromCache(WorkspaceMetadataService service) {
+        var impl = (WorkspaceMetadataServiceImpl) service;
+        var workspaceId = UUID.randomUUID().toString();
+        var projectId = UUID.randomUUID();
+
+        var first = impl.getProjectMetadata(workspaceId, projectId).block();
+
+        assertThat(first).isNotNull();
+        assertThat(PROJECT_METADATA_DAO_CALLS.get()).isEqualTo(1);
+
+        // wait for the cache put async to complete
+        waitForMillis(CACHE_ASYNC_WAIT_MILLIS);
+
+        // same key: served from cache, the DAO must not be called again
+        var second = impl.getProjectMetadata(workspaceId, projectId).block();
+
+        assertThat(second).isEqualTo(first);
+        assertThat(PROJECT_METADATA_DAO_CALLS.get()).isEqualTo(1);
+
+        // different project: cache miss, the DAO is called again
+        var other = impl.getProjectMetadata(workspaceId, UUID.randomUUID()).block();
+
+        assertThat(other).isNotEqualTo(first);
+        assertThat(PROJECT_METADATA_DAO_CALLS.get()).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
## Details

The per-project size estimate (`WorkspaceMetadataDAO.getProjectMetadata` — a 1000-span size sample plus `uniq(id)` over the whole project) is meant to be cached, but the cache never engaged, so the query ran on essentially every traces/spans find/search request and became one of the top read-volume queries on the ClickHouse cluster (~65 executions/min). Two stacked defects:

- `@Cacheable(name = "project_metadata", ...)` sits on a **private** method, and Guice method interception (which implements `@Cacheable`) cannot intercept private methods — the annotation was silently dead. Made the method package-private with a comment explaining why it must not be private.
- The cache name `project_metadata` was absent from `cacheManager.caches`; the config only carried an orphaned `workspace_metadata` entry that no code references (stale name), so even an intercepted call would have used the 1-second `defaultDuration`. Renamed the entry to `project_metadata` (env `CACHE_MANAGER_PROJECT_METADATA_DURATION`, default PT1H, matching the working `experiment_metadata` sibling).

With the cache engaged, per-(workspace, project) executions drop from once per request to once per TTL window.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7256

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Fable 5
  - Scope: visibility fix, config rename, commit and PR text
  - Human verification: pending reviewer; production query-frequency numbers measured read-only from system.query_log

## Testing

- Added `WorkspaceMetadataServiceCacheTest`: boots the app harness with a counting-stub `WorkspaceMetadataDAO` and asserts a repeated `getProjectMetadata` call for the same key is served from the cache (DAO hit exactly once), and a different project misses. The test fails if the method becomes non-interceptable again (e.g. private) or if the `project_metadata` cache name is dropped from configuration.
- `mvn compile` and `mvn test-compile` pass; `mvn spotless:apply` produced no further changes
- Guice interception limitation is documented behavior (private methods are never intercepted); the sibling `experiment_metadata` cache — public method + configured name — demonstrates the working pattern this change aligns with
- Production `system.query_log` (7 days): ~657K executions/week of this query with per-request cardinality, confirming the cache was not engaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Documentation

No user-facing documentation impact. The new env var `CACHE_MANAGER_PROJECT_METADATA_DURATION` (replacing the orphaned `CACHE_MANAGER_WORKSPACE_METADATA_DURATION`) is documented inline in `config.yml`.



**Note on the sample query itself:** we evaluated also reworking the sample CTE's `ORDER BY (sorting key) DESC LIMIT 1000` (it reads the whole project because reverse-order read never engages for this shape), but dropping the ORDER BY would pin the sample to the oldest ~1000 spans instead of the latest, so the estimate would stop tracking current span sizes. Keeping the query as-is; with the cache engaged it runs at most once per TTL per project.
