### PR TITLE
[OPIK-7257] perf(backend): drop unnecessary FINAL from spans lookup in experiment refs query

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
@@ -547,7 +547,7 @@ class ExperimentItemDAO {
             WHERE ei.workspace_id = :workspace_id
             <if(project_id)> AND ei.project_id = :project_id <endif>
             AND ei.trace_id IN (
-                SELECT DISTINCT trace_id FROM spans FINAL
+                SELECT DISTINCT trace_id FROM spans
                 WHERE id IN :span_ids AND workspace_id = :workspace_id
                 <if(project_id)> AND project_id = :project_id <endif>
             )


### PR DESCRIPTION
## Details

`GET_EXPERIMENT_REFS_BY_SPAN_IDS` resolves trace ids through `SELECT DISTINCT trace_id FROM spans FINAL WHERE id IN :span_ids ...`. The FINAL is unnecessary: `trace_id` is immutable for a given span id, and the subquery result feeds an `IN` set, so version duplicates cannot change the outcome. FINAL forces the ReplacingMergeTree merge to read all sorting-key columns, which multiplies the bytes read on what is otherwise a skip-index-pruned id lookup. This query is a top CPU consumer on the production ClickHouse cluster (it fires from the experiment aggregation listener on span batches).

- Removed `FINAL` from the spans subquery only; `experiments FINAL` stays (its `status` filter needs the latest version) and `experiment_items FINAL` stays untouched.

Measured on a production lookup (read-only): bytes read drop ~5× (7.1MB → 1.4MB) with identical results.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7257

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Fable 5
  - Scope: one-line query change, commit and PR text
  - Human verification: pending reviewer; before/after measured read-only against production ClickHouse

## Testing

- `mvn compile` passes; `mvn spotless:apply` produced no further changes
- Verified read-only in production: same result set with and without FINAL for span-id lookups; bytes read 7.1MB → 1.4MB on the sampled call
- `EXPLAIN indexes=1` unchanged pruning: PK + minmax skip index on `spans.id` select the same granules; only the FINAL merge read is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Documentation

No documentation impact — internal one-line query change.
