### PR TITLE
[OPIK-7249] [BE][FE] fix: cheap existence probe for Logs empty state

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -578,6 +578,32 @@ rateLimit:
       userFacingBucketName: get_trace_stats
       # Description: Rate limit error message
       errorMessage: "You have exceeded the rate limit for this operation. Please try again later."
+    tracesExist:
+      # Default: 30
+      # Description: how many tracesExist empty-state probes are allowed per workspace in the specified time bucket
+      limit: ${RATE_LIMIT_TRACES_EXIST_EVENTS_PER_WORKSPACE_LIMIT:-30}
+      # Default: 60
+      # Description: Time bucket size in seconds
+      durationInSeconds: ${RATE_LIMIT_WORKSPACE_EVENTS_DURATION_IN_SEC:-60}
+      # Description: Header name to use for rate limiting
+      headerName: Traces-Exist
+      # Description: User facing bucket name
+      userFacingBucketName: traces_exist
+      # Description: Rate limit error message
+      errorMessage: "You have exceeded the rate limit for this operation. Please try again later."
+    spansExist:
+      # Default: 30
+      # Description: how many spansExist empty-state probes are allowed per workspace in the specified time bucket
+      limit: ${RATE_LIMIT_SPANS_EXIST_EVENTS_PER_WORKSPACE_LIMIT:-30}
+      # Default: 60
+      # Description: Time bucket size in seconds
+      durationInSeconds: ${RATE_LIMIT_WORKSPACE_EVENTS_DURATION_IN_SEC:-60}
+      # Description: Header name to use for rate limiting
+      headerName: Spans-Exist
+      # Description: User facing bucket name
+      userFacingBucketName: spans_exist
+      # Description: Rate limit error message
+      errorMessage: "You have exceeded the rate limit for this operation. Please try again later."
     mcpOAuthRegister:
       # Default: 20
       # Description: Max dynamic client registrations (RFC 7591) accepted per source IP in the specified time bucket

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ExistenceResponse.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ExistenceResponse.java
@@ -1,0 +1,14 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ExistenceResponse(
+        @Schema(description = "Whether the project has at least one matching entity for the given scope") boolean exists) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
@@ -5,6 +5,7 @@ import com.comet.opik.api.BatchDelete;
 import com.comet.opik.api.Comment;
 import com.comet.opik.api.CreateCommentResponse;
 import com.comet.opik.api.DeleteFeedbackScore;
+import com.comet.opik.api.ExistenceResponse;
 import com.comet.opik.api.FeedbackDefinition;
 import com.comet.opik.api.FeedbackScore;
 import com.comet.opik.api.FeedbackScoreBatchContainer;
@@ -399,6 +400,36 @@ public class SpansResource {
                 projectStats.stats().size(), workspaceId);
 
         return Response.ok(projectStats).build();
+    }
+
+    @GET
+    @Path("/exists")
+    @Operation(operationId = "spansExist", summary = "Check whether a project has spans", description = "Returns whether the project has at least one span matching the given scope. Cheap existence probe (LIMIT 1) used to drive empty-state decisions without scanning or aggregating the whole project.", responses = {
+            @ApiResponse(responseCode = "200", description = "Span existence", content = @Content(schema = @Schema(implementation = ExistenceResponse.class)))
+    })
+    @RateLimited(value = "spansExist:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
+    public Response spansExist(@QueryParam("project_id") UUID projectId,
+            @QueryParam("project_name") String projectName) {
+
+        validateProjectNameAndProjectId(projectName, projectId);
+        var searchCriteria = SpanSearchCriteria.builder()
+                .projectName(projectName)
+                .projectId(projectId)
+                .sortingFields(List.of())
+                .build();
+
+        String workspaceId = requestContext.get().getWorkspaceId();
+
+        log.info("Check spans existence by '{}' on workspaceId '{}'", searchCriteria, workspaceId);
+
+        boolean exists = spanService.existsByProjectId(searchCriteria)
+                .contextWrite(ctx -> setRequestContext(ctx, requestContext))
+                .block();
+
+        log.info("Checked spans existence by '{}', exists '{}' on workspaceId '{}'", searchCriteria, exists,
+                workspaceId);
+
+        return Response.ok(ExistenceResponse.builder().exists(exists).build()).build();
     }
 
     @GET

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/SpansResource.java
@@ -83,6 +83,7 @@ import static com.comet.opik.api.Span.SpanField;
 import static com.comet.opik.api.Span.SpanPage;
 import static com.comet.opik.api.Span.View;
 import static com.comet.opik.utils.AsyncUtils.setRequestContext;
+import static com.comet.opik.utils.ValidationUtils.parseLogsSource;
 import static com.comet.opik.utils.ValidationUtils.validateProjectNameAndProjectId;
 import static com.comet.opik.utils.ValidationUtils.validateTimeRangeParameters;
 
@@ -409,12 +410,14 @@ public class SpansResource {
     })
     @RateLimited(value = "spansExist:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     public Response spansExist(@QueryParam("project_id") UUID projectId,
-            @QueryParam("project_name") String projectName) {
+            @QueryParam("project_name") String projectName,
+            @QueryParam("source") @Schema(description = "Restrict the probe to a single ingestion source (e.g. 'sdk' for the Logs empty state), matching the rendered list's logs-source scope. Omit to probe any source.") String source) {
 
         validateProjectNameAndProjectId(projectName, projectId);
         var searchCriteria = SpanSearchCriteria.builder()
                 .projectName(projectName)
                 .projectId(projectId)
+                .source(parseLogsSource(source))
                 .sortingFields(List.of())
                 .build();
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
@@ -8,6 +8,7 @@ import com.comet.opik.api.CreateCommentResponse;
 import com.comet.opik.api.DeleteFeedbackScore;
 import com.comet.opik.api.DeleteThreadFeedbackScores;
 import com.comet.opik.api.DeleteTraceThreads;
+import com.comet.opik.api.ExistenceResponse;
 import com.comet.opik.api.FeedbackDefinition;
 import com.comet.opik.api.FeedbackScore;
 import com.comet.opik.api.FeedbackScoreBatchContainer;
@@ -439,6 +440,38 @@ public class TracesResource {
                 projectStats.stats().size(), workspaceId);
 
         return Response.ok(projectStats).build();
+    }
+
+    @GET
+    @Path("/exists")
+    @Operation(operationId = "tracesExist", summary = "Check whether a project has traces", description = "Returns whether the project has at least one trace matching the given scope. Cheap existence probe (LIMIT 1) used to drive empty-state decisions without scanning or aggregating the whole project.", responses = {
+            @ApiResponse(responseCode = "200", description = "Trace existence", content = @Content(schema = @Schema(implementation = ExistenceResponse.class)))
+    })
+    @RateLimited(value = "tracesExist:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
+    public Response tracesExist(@QueryParam("project_id") UUID projectId,
+            @QueryParam("project_name") String projectName,
+            @QueryParam("thread_only") @DefaultValue("false") @Schema(description = "When true, only considers traces that belong to a thread (thread_id is set) — used by the Threads empty state.") boolean threadOnly) {
+
+        validateProjectNameAndProjectId(projectName, projectId);
+
+        var searchCriteria = TraceSearchCriteria.builder()
+                .projectName(projectName)
+                .projectId(projectId)
+                .build();
+
+        String workspaceId = requestContext.get().getWorkspaceId();
+
+        log.info("Check traces existence by '{}' (threadOnly={}) on workspaceId '{}'", searchCriteria, threadOnly,
+                workspaceId);
+
+        boolean exists = service.existsByProjectId(searchCriteria, threadOnly)
+                .contextWrite(ctx -> setRequestContext(ctx, requestContext))
+                .block();
+
+        log.info("Checked traces existence by '{}', exists '{}' on workspaceId '{}'", searchCriteria, exists,
+                workspaceId);
+
+        return Response.ok(ExistenceResponse.builder().exists(exists).build()).build();
     }
 
     // Feedback scores

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
@@ -98,6 +98,7 @@ import static com.comet.opik.api.FeedbackScoreBatchContainer.FeedbackScoreBatch;
 import static com.comet.opik.api.FeedbackScoreBatchContainer.FeedbackScoreBatchThread;
 import static com.comet.opik.api.TraceThread.TraceThreadPage;
 import static com.comet.opik.utils.AsyncUtils.setRequestContext;
+import static com.comet.opik.utils.ValidationUtils.parseLogsSource;
 import static com.comet.opik.utils.ValidationUtils.validateProjectNameAndProjectId;
 import static com.comet.opik.utils.ValidationUtils.validateTimeRangeParameters;
 
@@ -450,6 +451,7 @@ public class TracesResource {
     @RateLimited(value = "tracesExist:{workspaceId}", shouldAffectWorkspaceLimit = false, shouldAffectUserGeneralLimit = false)
     public Response tracesExist(@QueryParam("project_id") UUID projectId,
             @QueryParam("project_name") String projectName,
+            @QueryParam("source") @Schema(description = "Restrict the probe to a single ingestion source (e.g. 'sdk' for the Logs empty state), matching the rendered list's logs-source scope. Omit to probe any source.") String source,
             @QueryParam("thread_only") @DefaultValue("false") @Schema(description = "When true, only considers traces that belong to a thread (thread_id is set) — used by the Threads empty state.") boolean threadOnly) {
 
         validateProjectNameAndProjectId(projectName, projectId);
@@ -457,6 +459,7 @@ public class TracesResource {
         var searchCriteria = TraceSearchCriteria.builder()
                 .projectName(projectName)
                 .projectId(projectId)
+                .source(parseLogsSource(source))
                 .build();
 
         String workspaceId = requestContext.get().getWorkspaceId();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -1086,6 +1086,21 @@ public class SpanDAO {
             ;
             """;
 
+    /**
+     * Cheap "does the project have any span?" probe for the Logs empty state. Deliberately minimal — project
+     * scope only — so it is always a primary-key-prunable {@code LIMIT 1}. It intentionally does not support
+     * filters, search, trace_id, type, or time ranges: no consumer needs them, and adding them back would
+     * reintroduce a full-project COUNT fallback.
+     */
+    private static final String EXISTS_BY_PROJECT_ID = """
+            SELECT 1 AS exist
+            FROM spans
+            WHERE workspace_id = :workspace_id
+            AND project_id = :project_id
+            LIMIT 1
+            SETTINGS log_comment = '<log_comment>'
+            """;
+
     private static final String COUNT_BY_PROJECT_ID = """
             <if(feedback_scores_filters || feedback_scores_empty_filters)>
             WITH <if(span_id_prefilter)>span_id_prefilter AS (
@@ -2373,6 +2388,26 @@ public class SpanDAO {
     public Mono<SpanPage> find(int page, int size, @NonNull SpanSearchCriteria spanSearchCriteria) {
         log.info("Finding span by '{}'", spanSearchCriteria);
         return countTotal(spanSearchCriteria).flatMap(total -> find(page, size, spanSearchCriteria, total));
+    }
+
+    @WithSpan
+    public Mono<Boolean> existsByProjectId(@NonNull SpanSearchCriteria spanSearchCriteria) {
+        return Mono.from(connectionFactory.create())
+                .flatMap(connection -> makeMonoContextAware((userName, workspaceId) -> {
+                    var template = getSTWithLogComment(EXISTS_BY_PROJECT_ID, "exists_spans_by_project_id",
+                            workspaceId, userName, "");
+
+                    var statement = connection.createStatement(template.render())
+                            .bind("project_id", spanSearchCriteria.projectId())
+                            .bind("workspace_id", workspaceId);
+
+                    Segment segment = startSegment("spans", "Clickhouse", "existsByProjectId");
+
+                    return Mono.from(statement.execute())
+                            .doFinally(signalType -> endSegment(segment))
+                            .flatMap(result -> Mono.from(result.map((row, metadata) -> true)))
+                            .defaultIfEmpty(false);
+                }));
     }
 
     private Mono<SpanPage> find(int page, int size, SpanSearchCriteria spanSearchCriteria, Long total) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -1097,6 +1097,7 @@ public class SpanDAO {
             FROM spans
             WHERE workspace_id = :workspace_id
             AND project_id = :project_id
+            <if(source)> AND source IN (:source<if(source_legacy)>, :source_legacy<endif>) <endif>
             LIMIT 1
             SETTINGS log_comment = '<log_comment>'
             """;
@@ -2397,9 +2398,25 @@ public class SpanDAO {
                     var template = getSTWithLogComment(EXISTS_BY_PROJECT_ID, "exists_spans_by_project_id",
                             workspaceId, userName, "");
 
+                    var source = spanSearchCriteria.source();
+                    var sourceLegacy = source == null
+                            ? Optional.<String>empty()
+                            : Source.legacyFallbackDbValue(source.getValue());
+                    if (source != null) {
+                        template.add("source", true);
+                        if (sourceLegacy.isPresent()) {
+                            template.add("source_legacy", true);
+                        }
+                    }
+
                     var statement = connection.createStatement(template.render())
                             .bind("project_id", spanSearchCriteria.projectId())
                             .bind("workspace_id", workspaceId);
+
+                    if (source != null) {
+                        statement.bind("source", source.getValue());
+                        sourceLegacy.ifPresent(legacy -> statement.bind("source_legacy", legacy));
+                    }
 
                     Segment segment = startSegment("spans", "Clickhouse", "existsByProjectId");
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanSearchCriteria.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanSearchCriteria.java
@@ -1,5 +1,6 @@
 package com.comet.opik.domain;
 
+import com.comet.opik.api.Source;
 import com.comet.opik.api.filter.Filter;
 import com.comet.opik.api.sorting.SortingField;
 import lombok.Builder;
@@ -14,6 +15,7 @@ import static com.comet.opik.api.Span.SpanField;
 public record SpanSearchCriteria(
         String projectName,
         UUID projectId,
+        Source source,
         UUID traceId,
         SpanType type,
         List<? extends Filter> filters,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
@@ -94,6 +94,13 @@ public class SpanService {
                         }));
     }
 
+    @WithSpan
+    public Mono<Boolean> existsByProjectId(@NonNull SpanSearchCriteria searchCriteria) {
+        return findProjectAndVerifyVisibility(searchCriteria)
+                .flatMap(spanDAO::existsByProjectId)
+                .switchIfEmpty(Mono.just(false));
+    }
+
     private Mono<SpanSearchCriteria> findProjectAndVerifyVisibility(SpanSearchCriteria searchCriteria) {
         return projectService
                 .resolveProjectIdAndVerifyVisibility(searchCriteria.projectId(), searchCriteria.projectName())

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -112,6 +112,9 @@ public interface TraceDAO {
 
     Mono<TracePage> find(int size, int page, TraceSearchCriteria traceSearchCriteria, Connection connection);
 
+    Mono<Boolean> existsByProjectId(TraceSearchCriteria traceSearchCriteria, boolean threadScoped,
+            Connection connection);
+
     Mono<Void> partialInsert(UUID projectId, TraceUpdate traceUpdate, UUID traceId, Connection connection);
 
     Mono<List<WorkspaceAndResourceId>> getTraceWorkspace(Set<UUID> traceIds, Connection connection);
@@ -1477,6 +1480,22 @@ class TraceDAOImpl implements TraceDAO {
             GROUP BY workspace_id, created_by
             SETTINGS log_comment = '<log_comment>'
             ;
+            """;
+
+    /**
+     * Cheap "does the project have any trace?" probe for the Logs empty state. Deliberately minimal —
+     * project scope plus an optional {@code thread_only} clause (thread_id set) — so it is always a
+     * primary-key-prunable {@code LIMIT 1}. It intentionally does not support arbitrary filters, search, or
+     * time ranges: no consumer needs them, and adding them back would reintroduce a full-project COUNT fallback.
+     */
+    private static final String EXISTS_BY_PROJECT_ID = """
+            SELECT 1 AS exist
+            FROM traces
+            WHERE workspace_id = :workspace_id
+            AND project_id = :project_id
+            <if(thread_only)> AND thread_id != '' <endif>
+            LIMIT 1
+            SETTINGS log_comment = '<log_comment>'
             """;
 
     private static final String COUNT_BY_PROJECT_ID = """
@@ -3656,6 +3675,30 @@ class TraceDAOImpl implements TraceDAO {
                         .collectList()
                         .map(traces -> new TracePage(page, traces.size(), total, traces,
                                 sortingFactory.getSortableFields())));
+    }
+
+    @Override
+    @WithSpan
+    public Mono<Boolean> existsByProjectId(@NonNull TraceSearchCriteria traceSearchCriteria, boolean threadScoped,
+            @NonNull Connection connection) {
+        return makeMonoContextAware((userName, workspaceId) -> {
+            var template = getSTWithLogComment(EXISTS_BY_PROJECT_ID, "exists_traces_by_project_id", workspaceId,
+                    userName, "");
+            if (threadScoped) {
+                template.add("thread_only", true);
+            }
+
+            var statement = connection.createStatement(template.render())
+                    .bind("project_id", traceSearchCriteria.projectId())
+                    .bind("workspace_id", workspaceId);
+
+            Segment segment = startSegment("traces", "Clickhouse", "existsByProjectId");
+
+            return Mono.from(statement.execute())
+                    .doFinally(signalType -> endSegment(segment));
+        })
+                .flatMap(result -> Mono.from(result.map((row, metadata) -> true)))
+                .defaultIfEmpty(false);
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -1484,8 +1484,8 @@ class TraceDAOImpl implements TraceDAO {
 
     /**
      * Cheap "does the project have any trace?" probe for the Logs empty state. Deliberately minimal —
-     * project scope plus an optional {@code thread_only} clause (thread_id set) — so it is always a
-     * primary-key-prunable {@code LIMIT 1}. It intentionally does not support arbitrary filters, search, or
+     * project scope only — so it is always a primary-key-prunable {@code LIMIT 1} (traces sort key is
+     * {@code (workspace_id, project_id, id)}). It intentionally does not support arbitrary filters, search, or
      * time ranges: no consumer needs them, and adding them back would reintroduce a full-project COUNT fallback.
      */
     private static final String EXISTS_BY_PROJECT_ID = """
@@ -1493,7 +1493,25 @@ class TraceDAOImpl implements TraceDAO {
             FROM traces
             WHERE workspace_id = :workspace_id
             AND project_id = :project_id
-            <if(thread_only)> AND thread_id != '' <endif>
+            <if(source)> AND source IN (:source<if(source_legacy)>, :source_legacy<endif>) <endif>
+            LIMIT 1
+            SETTINGS log_comment = '<log_comment>'
+            """;
+
+    /**
+     * Thread-scoped variant backing the Threads tab empty state. Probes {@code trace_threads}, not
+     * {@code traces WHERE thread_id != ''}: {@code thread_id} is not in the {@code traces} sort key, and its
+     * only index there is a bloom filter that serves equality, not the {@code != ''} inequality — so that
+     * predicate could not prune and would scan the whole project on exactly the no-threads empty state it
+     * targets. {@code trace_threads} is ordered by {@code (workspace_id, project_id, thread_id, id)}, so project
+     * scope is primary-key-prunable, and it is the same table the Threads list reads (consistent empty state).
+     */
+    private static final String THREADS_EXISTS_BY_PROJECT_ID = """
+            SELECT 1 AS exist
+            FROM trace_threads
+            WHERE workspace_id = :workspace_id
+            AND project_id = :project_id
+            <if(source)> AND source IN (:source<if(source_legacy)>, :source_legacy<endif>) <endif>
             LIMIT 1
             SETTINGS log_comment = '<log_comment>'
             """;
@@ -3682,17 +3700,33 @@ class TraceDAOImpl implements TraceDAO {
     public Mono<Boolean> existsByProjectId(@NonNull TraceSearchCriteria traceSearchCriteria, boolean threadScoped,
             @NonNull Connection connection) {
         return makeMonoContextAware((userName, workspaceId) -> {
-            var template = getSTWithLogComment(EXISTS_BY_PROJECT_ID, "exists_traces_by_project_id", workspaceId,
-                    userName, "");
-            if (threadScoped) {
-                template.add("thread_only", true);
+            var template = getSTWithLogComment(
+                    threadScoped ? THREADS_EXISTS_BY_PROJECT_ID : EXISTS_BY_PROJECT_ID,
+                    threadScoped ? "exists_threads_by_project_id" : "exists_traces_by_project_id",
+                    workspaceId, userName, "");
+
+            var source = traceSearchCriteria.source();
+            var sourceLegacy = source == null
+                    ? Optional.<String>empty()
+                    : Source.legacyFallbackDbValue(source.getValue());
+            if (source != null) {
+                template.add("source", true);
+                if (sourceLegacy.isPresent()) {
+                    template.add("source_legacy", true);
+                }
             }
 
             var statement = connection.createStatement(template.render())
                     .bind("project_id", traceSearchCriteria.projectId())
                     .bind("workspace_id", workspaceId);
 
-            Segment segment = startSegment("traces", "Clickhouse", "existsByProjectId");
+            if (source != null) {
+                statement.bind("source", source.getValue());
+                sourceLegacy.ifPresent(legacy -> statement.bind("source_legacy", legacy));
+            }
+
+            Segment segment = startSegment("traces", "Clickhouse",
+                    threadScoped ? "existsThreadsByProjectId" : "existsByProjectId");
 
             return Mono.from(statement.execute())
                     .doFinally(signalType -> endSegment(segment));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceSearchCriteria.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceSearchCriteria.java
@@ -1,5 +1,6 @@
 package com.comet.opik.domain;
 
+import com.comet.opik.api.Source;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.filter.Filter;
 import com.comet.opik.api.sorting.SortingField;
@@ -13,6 +14,7 @@ import java.util.UUID;
 public record TraceSearchCriteria(
         String projectName,
         UUID projectId,
+        Source source,
         List<? extends Filter> filters,
         List<SortingField> sortingFields,
         UUID lastReceivedId,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -94,6 +94,8 @@ public interface TraceService {
 
     Mono<TracePage> find(int page, int size, TraceSearchCriteria criteria);
 
+    Mono<Boolean> existsByProjectId(TraceSearchCriteria criteria, boolean threadScoped);
+
     Mono<Boolean> validateTraceWorkspace(String workspaceId, Set<UUID> traceIds);
 
     Mono<TraceCountResponse> countTracesPerWorkspace();
@@ -559,6 +561,16 @@ class TraceServiceImpl implements TraceService {
                             return Mono.just(tracePage);
                         }))
                 .switchIfEmpty(Mono.just(TracePage.empty(page, traceSortingFactory.getSortableFields())));
+    }
+
+    @Override
+    @WithSpan
+    public Mono<Boolean> existsByProjectId(@NonNull TraceSearchCriteria criteria, boolean threadScoped) {
+        return findProjectAndVerifyVisibility(criteria)
+                .flatMap(resolvedCriteria -> template
+                        .nonTransaction(
+                                connection -> dao.existsByProjectId(resolvedCriteria, threadScoped, connection)))
+                .switchIfEmpty(Mono.just(false));
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/ValidationUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/ValidationUtils.java
@@ -1,5 +1,6 @@
 package com.comet.opik.utils;
 
+import com.comet.opik.api.Source;
 import jakarta.ws.rs.BadRequestException;
 import org.apache.commons.lang3.StringUtils;
 
@@ -53,6 +54,14 @@ public class ValidationUtils {
         if (StringUtils.isBlank(projectName) && projectId == null) {
             throw new BadRequestException("Either 'project_name' or 'project_id' query params must be provided");
         }
+    }
+
+    public static Source parseLogsSource(String source) {
+        if (StringUtils.isBlank(source)) {
+            return null;
+        }
+        return Source.fromString(source)
+                .orElseThrow(() -> new BadRequestException("Invalid source '%s'".formatted(source)));
     }
 
     public static void validateTimeRangeParameters(Instant startTime, Instant endTime) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/SpanResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/SpanResourceClient.java
@@ -3,6 +3,7 @@ package com.comet.opik.api.resources.utils.resources;
 import com.comet.opik.api.BatchDelete;
 import com.comet.opik.api.Comment;
 import com.comet.opik.api.DeleteFeedbackScore;
+import com.comet.opik.api.ExistenceResponse;
 import com.comet.opik.api.FeedbackScore;
 import com.comet.opik.api.FeedbackScoreBatchContainer;
 import com.comet.opik.api.FeedbackScoreBatchContainer.FeedbackScoreBatch;
@@ -451,6 +452,19 @@ public class SpanResourceClient extends BaseCommentResourceClient {
         }
 
         return null;
+    }
+
+    public boolean existsSpans(String projectName, String apiKey, String workspaceName) {
+        try (var actualResponse = client.target(RESOURCE_PATH.formatted(baseURI))
+                .path("exists")
+                .queryParam("project_name", projectName)
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .get()) {
+            assertThat(actualResponse.getStatus()).isEqualTo(HttpStatus.SC_OK);
+            return actualResponse.readEntity(ExistenceResponse.class).exists();
+        }
     }
 
     public void batchUpdateSpans(SpanBatchUpdate batchUpdate, String apiKey, String workspaceName) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/SpanResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/SpanResourceClient.java
@@ -8,6 +8,7 @@ import com.comet.opik.api.FeedbackScore;
 import com.comet.opik.api.FeedbackScoreBatchContainer;
 import com.comet.opik.api.FeedbackScoreBatchContainer.FeedbackScoreBatch;
 import com.comet.opik.api.ProjectStats;
+import com.comet.opik.api.Source;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.SpanBatch;
 import com.comet.opik.api.SpanBatchUpdate;
@@ -455,9 +456,32 @@ public class SpanResourceClient extends BaseCommentResourceClient {
     }
 
     public boolean existsSpans(String projectName, String apiKey, String workspaceName) {
+        return existsSpans(projectName, null, apiKey, workspaceName);
+    }
+
+    public boolean existsSpans(String projectName, Source source, String apiKey, String workspaceName) {
+        WebTarget webTarget = client.target(RESOURCE_PATH.formatted(baseURI))
+                .path("exists")
+                .queryParam("project_name", projectName);
+
+        if (source != null) {
+            webTarget = webTarget.queryParam("source", source.getValue());
+        }
+
+        try (var actualResponse = webTarget
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .get()) {
+            assertThat(actualResponse.getStatus()).isEqualTo(HttpStatus.SC_OK);
+            return actualResponse.readEntity(ExistenceResponse.class).exists();
+        }
+    }
+
+    public boolean existsSpans(UUID projectId, String apiKey, String workspaceName) {
         try (var actualResponse = client.target(RESOURCE_PATH.formatted(baseURI))
                 .path("exists")
-                .queryParam("project_name", projectName)
+                .queryParam("project_id", projectId)
                 .request()
                 .header(HttpHeaders.AUTHORIZATION, apiKey)
                 .header(WORKSPACE_HEADER, workspaceName)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
@@ -11,6 +11,7 @@ import com.comet.opik.api.FeedbackScore;
 import com.comet.opik.api.FeedbackScoreNames;
 import com.comet.opik.api.Project;
 import com.comet.opik.api.ProjectStats;
+import com.comet.opik.api.Source;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.TraceBatch;
 import com.comet.opik.api.TraceBatchUpdate;
@@ -526,12 +527,21 @@ public class TraceResourceClient extends BaseCommentResourceClient {
     }
 
     public boolean existsTraces(UUID projectId, boolean threadOnly, String apiKey, String workspaceName) {
+        return existsTraces(projectId, threadOnly, null, apiKey, workspaceName);
+    }
+
+    public boolean existsTraces(UUID projectId, boolean threadOnly, Source source, String apiKey,
+            String workspaceName) {
         WebTarget webTarget = client.target(RESOURCE_PATH.formatted(baseURI))
                 .path("exists")
                 .queryParam("project_id", projectId);
 
         if (threadOnly) {
             webTarget = webTarget.queryParam("thread_only", true);
+        }
+
+        if (source != null) {
+            webTarget = webTarget.queryParam("source", source.getValue());
         }
 
         try (var actualResponse = webTarget

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
@@ -6,6 +6,7 @@ import com.comet.opik.api.Comment;
 import com.comet.opik.api.DeleteFeedbackScore;
 import com.comet.opik.api.DeleteThreadFeedbackScores;
 import com.comet.opik.api.DeleteTraceThreads;
+import com.comet.opik.api.ExistenceResponse;
 import com.comet.opik.api.FeedbackScore;
 import com.comet.opik.api.FeedbackScoreNames;
 import com.comet.opik.api.Project;
@@ -522,6 +523,25 @@ public class TraceResourceClient extends BaseCommentResourceClient {
 
         assertThat(actualResponse.getStatus()).isEqualTo(HttpStatus.SC_OK);
         return actualResponse.readEntity(ProjectStats.class);
+    }
+
+    public boolean existsTraces(UUID projectId, boolean threadOnly, String apiKey, String workspaceName) {
+        WebTarget webTarget = client.target(RESOURCE_PATH.formatted(baseURI))
+                .path("exists")
+                .queryParam("project_id", projectId);
+
+        if (threadOnly) {
+            webTarget = webTarget.queryParam("thread_only", true);
+        }
+
+        try (var actualResponse = webTarget
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .get()) {
+            assertThat(actualResponse.getStatus()).isEqualTo(HttpStatus.SC_OK);
+            return actualResponse.readEntity(ExistenceResponse.class).exists();
+        }
     }
 
     public ProjectStats getTraceThreadStats(String projectName, UUID projectId, String apiKey, String workspaceName,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -345,6 +345,37 @@ class SpansResourceTest {
     }
 
     @Nested
+    @DisplayName("Spans existence probe")
+    class SpansExistence {
+
+        @Test
+        @DisplayName("returns true when the project has spans and false when it only has traces")
+        void existsByProject() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var spanProject = "span-exists-" + UUID.randomUUID();
+            var span = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .projectName(spanProject)
+                    .build();
+            spanResourceClient.createSpan(span, apiKey, workspaceName);
+
+            assertThat(spanResourceClient.existsSpans(spanProject, apiKey, workspaceName)).isTrue();
+
+            // A project that has traces but no spans must report no spans (span existence is not trace existence).
+            var traceOnlyProject = "span-empty-" + UUID.randomUUID();
+            var trace = podamFactory.manufacturePojo(Trace.class).toBuilder()
+                    .projectName(traceOnlyProject)
+                    .build();
+            traceResourceClient.createTrace(trace, apiKey, workspaceName);
+
+            assertThat(spanResourceClient.existsSpans(traceOnlyProject, apiKey, workspaceName)).isFalse();
+        }
+    }
+
+    @Nested
     @DisplayName("Required permissions")
     class RequiredPermissionsTest {
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansResourceTest.java
@@ -373,6 +373,53 @@ class SpansResourceTest {
 
             assertThat(spanResourceClient.existsSpans(traceOnlyProject, apiKey, workspaceName)).isFalse();
         }
+
+        @Test
+        @DisplayName("resolves the project by project_id as well as by project_name")
+        void existsByProjectIdParam() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var projectName = "span-id-form-" + UUID.randomUUID();
+            var projectId = projectResourceClient.createProject(projectName, apiKey, workspaceName);
+            var span = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .projectName(projectName)
+                    .build();
+            spanResourceClient.createSpan(span, apiKey, workspaceName);
+
+            assertThat(spanResourceClient.existsSpans(projectId, apiKey, workspaceName)).isTrue();
+        }
+
+        @Test
+        @DisplayName("source scope matches the sdk-logged spans the Logs list shows, incl. legacy unknown")
+        void existsSourceScoped() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            // sdk-sourced project -> present under source=sdk
+            var sdkProject = "span-sdk-" + UUID.randomUUID();
+            spanResourceClient.createSpan(podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .projectName(sdkProject).source(Source.SDK).build(), apiKey, workspaceName);
+
+            // non-sdk (experiment)-only project -> absent under source=sdk, present without the scope
+            var experimentProject = "span-experiment-" + UUID.randomUUID();
+            spanResourceClient.createSpan(podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .projectName(experimentProject).source(Source.EXPERIMENT).build(), apiKey, workspaceName);
+
+            // legacy project (unknown source, predates source tracking) -> counts as sdk via legacy fallback
+            var legacyProject = "span-legacy-" + UUID.randomUUID();
+            spanResourceClient.createSpan(podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .projectName(legacyProject).source(null).build(), apiKey, workspaceName);
+
+            assertThat(spanResourceClient.existsSpans(sdkProject, Source.SDK, apiKey, workspaceName)).isTrue();
+            assertThat(spanResourceClient.existsSpans(experimentProject, Source.SDK, apiKey, workspaceName)).isFalse();
+            assertThat(spanResourceClient.existsSpans(experimentProject, null, apiKey, workspaceName)).isTrue();
+            assertThat(spanResourceClient.existsSpans(legacyProject, Source.SDK, apiKey, workspaceName)).isTrue();
+        }
     }
 
     @Nested

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -340,7 +340,7 @@ class TracesResourceTest {
         }
 
         @Test
-        @DisplayName("thread_only distinguishes projects with threads from trace-only projects")
+        @DisplayName("thread_only distinguishes projects with threads from projects without")
         void existsThreadScoped() {
             String apiKey = UUID.randomUUID().toString();
             String workspaceName = "test-workspace-" + UUID.randomUUID();
@@ -348,12 +348,16 @@ class TracesResourceTest {
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
             var threadProjectName = "thread-project-" + UUID.randomUUID();
+            var threadId = UUID.randomUUID().toString();
             var threadTrace = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectName(threadProjectName)
-                    .threadId(UUID.randomUUID().toString())
+                    .threadId(threadId)
                     .build();
             traceResourceClient.createTrace(threadTrace, apiKey, workspaceName);
             var threadProjectId = getProjectId(threadProjectName, workspaceName, apiKey);
+            // The thread probe reads trace_threads (the same table the Threads list reads); open the
+            // thread so its row exists synchronously rather than waiting on the async aggregation.
+            traceResourceClient.openTraceThread(threadId, threadProjectId, threadProjectName, apiKey, workspaceName);
 
             var traceOnlyProjectName = "trace-only-project-" + UUID.randomUUID();
             var traceOnly = factory.manufacturePojo(Trace.class).toBuilder()
@@ -367,6 +371,45 @@ class TracesResourceTest {
             assertThat(traceResourceClient.existsTraces(traceOnlyProjectId, true, apiKey, workspaceName)).isFalse();
             // A trace-only project still reports base existence.
             assertThat(traceResourceClient.existsTraces(traceOnlyProjectId, false, apiKey, workspaceName)).isTrue();
+        }
+
+        @Test
+        @DisplayName("source scope matches the sdk-logged rows the Logs list shows, incl. legacy unknown")
+        void existsSourceScoped() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            // sdk-sourced project -> present under source=sdk
+            var sdkProjectName = "sdk-project-" + UUID.randomUUID();
+            traceResourceClient.createTrace(factory.manufacturePojo(Trace.class).toBuilder()
+                    .projectName(sdkProjectName).source(Source.SDK).threadId(null)
+                    .usage(null).feedbackScores(null).build(), apiKey, workspaceName);
+            var sdkProjectId = getProjectId(sdkProjectName, workspaceName, apiKey);
+
+            // non-sdk (experiment)-only project -> absent under source=sdk, present without the scope
+            var experimentProjectName = "experiment-project-" + UUID.randomUUID();
+            traceResourceClient.createTrace(factory.manufacturePojo(Trace.class).toBuilder()
+                    .projectName(experimentProjectName).source(Source.EXPERIMENT).threadId(null)
+                    .usage(null).feedbackScores(null).build(), apiKey, workspaceName);
+            var experimentProjectId = getProjectId(experimentProjectName, workspaceName, apiKey);
+
+            // legacy project (unknown source, predates source tracking) -> counts as sdk via legacy fallback
+            var legacyProjectName = "legacy-project-" + UUID.randomUUID();
+            traceResourceClient.createTrace(factory.manufacturePojo(Trace.class).toBuilder()
+                    .projectName(legacyProjectName).source(null).threadId(null)
+                    .usage(null).feedbackScores(null).build(), apiKey, workspaceName);
+            var legacyProjectId = getProjectId(legacyProjectName, workspaceName, apiKey);
+
+            assertThat(traceResourceClient.existsTraces(sdkProjectId, false, Source.SDK, apiKey, workspaceName))
+                    .isTrue();
+            assertThat(traceResourceClient.existsTraces(experimentProjectId, false, Source.SDK, apiKey, workspaceName))
+                    .isFalse();
+            assertThat(traceResourceClient.existsTraces(experimentProjectId, false, null, apiKey, workspaceName))
+                    .isTrue();
+            assertThat(traceResourceClient.existsTraces(legacyProjectId, false, Source.SDK, apiKey, workspaceName))
+                    .isTrue();
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -313,6 +313,64 @@ class TracesResourceTest {
     }
 
     @Nested
+    @DisplayName("Traces existence probe")
+    class TracesExistence {
+
+        @Test
+        @DisplayName("returns true when the project has traces and false for an existing project with none")
+        void existsByProject() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var projectName = "exists-project-" + UUID.randomUUID();
+            var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                    .projectName(projectName)
+                    .build();
+            traceResourceClient.createTrace(trace, apiKey, workspaceName);
+            var projectId = getProjectId(projectName, workspaceName, apiKey);
+
+            assertThat(traceResourceClient.existsTraces(projectId, false, apiKey, workspaceName)).isTrue();
+
+            // A project that exists but has no traces must report false (the empty-state path).
+            var emptyProjectId = projectResourceClient.createProject(
+                    "empty-project-" + UUID.randomUUID(), apiKey, workspaceName);
+            assertThat(traceResourceClient.existsTraces(emptyProjectId, false, apiKey, workspaceName)).isFalse();
+        }
+
+        @Test
+        @DisplayName("thread_only distinguishes projects with threads from trace-only projects")
+        void existsThreadScoped() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var threadProjectName = "thread-project-" + UUID.randomUUID();
+            var threadTrace = factory.manufacturePojo(Trace.class).toBuilder()
+                    .projectName(threadProjectName)
+                    .threadId(UUID.randomUUID().toString())
+                    .build();
+            traceResourceClient.createTrace(threadTrace, apiKey, workspaceName);
+            var threadProjectId = getProjectId(threadProjectName, workspaceName, apiKey);
+
+            var traceOnlyProjectName = "trace-only-project-" + UUID.randomUUID();
+            var traceOnly = factory.manufacturePojo(Trace.class).toBuilder()
+                    .projectName(traceOnlyProjectName)
+                    .threadId(null)
+                    .build();
+            traceResourceClient.createTrace(traceOnly, apiKey, workspaceName);
+            var traceOnlyProjectId = getProjectId(traceOnlyProjectName, workspaceName, apiKey);
+
+            assertThat(traceResourceClient.existsTraces(threadProjectId, true, apiKey, workspaceName)).isTrue();
+            assertThat(traceResourceClient.existsTraces(traceOnlyProjectId, true, apiKey, workspaceName)).isFalse();
+            // A trace-only project still reports base existence.
+            assertThat(traceResourceClient.existsTraces(traceOnlyProjectId, false, apiKey, workspaceName)).isTrue();
+        }
+    }
+
+    @Nested
     @DisplayName("Required permissions")
     class RequiredPermissionsTest {
 

--- a/apps/opik-frontend/src/api/traces/useSpansExist.ts
+++ b/apps/opik-frontend/src/api/traces/useSpansExist.ts
@@ -1,8 +1,10 @@
 import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import api, { QueryConfig, SPANS_KEY, SPANS_REST_ENDPOINT } from "@/api/api";
+import { LOGS_SOURCE } from "@/types/traces";
 
 type UseSpansExistParams = {
   projectId: string;
+  source?: LOGS_SOURCE;
 };
 
 export type UseSpansExistResponse = {
@@ -11,13 +13,13 @@ export type UseSpansExistResponse = {
 
 const getSpansExist = async (
   { signal }: QueryFunctionContext,
-  { projectId }: UseSpansExistParams,
+  { projectId, source }: UseSpansExistParams,
 ) => {
   const { data } = await api.get<UseSpansExistResponse>(
     `${SPANS_REST_ENDPOINT}exists`,
     {
       signal,
-      params: { project_id: projectId },
+      params: { project_id: projectId, ...(source && { source }) },
     },
   );
 

--- a/apps/opik-frontend/src/api/traces/useSpansExist.ts
+++ b/apps/opik-frontend/src/api/traces/useSpansExist.ts
@@ -1,0 +1,36 @@
+import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
+import api, { QueryConfig, SPANS_KEY, SPANS_REST_ENDPOINT } from "@/api/api";
+
+type UseSpansExistParams = {
+  projectId: string;
+};
+
+export type UseSpansExistResponse = {
+  exists: boolean;
+};
+
+const getSpansExist = async (
+  { signal }: QueryFunctionContext,
+  { projectId }: UseSpansExistParams,
+) => {
+  const { data } = await api.get<UseSpansExistResponse>(
+    `${SPANS_REST_ENDPOINT}exists`,
+    {
+      signal,
+      params: { project_id: projectId },
+    },
+  );
+
+  return data;
+};
+
+export default function useSpansExist(
+  params: UseSpansExistParams,
+  options?: QueryConfig<UseSpansExistResponse>,
+) {
+  return useQuery({
+    queryKey: [SPANS_KEY, params, "exists"],
+    queryFn: (context) => getSpansExist(context, params),
+    ...options,
+  });
+}

--- a/apps/opik-frontend/src/api/traces/useTracesExist.ts
+++ b/apps/opik-frontend/src/api/traces/useTracesExist.ts
@@ -1,9 +1,11 @@
 import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import api, { QueryConfig, TRACES_KEY, TRACES_REST_ENDPOINT } from "@/api/api";
+import { LOGS_SOURCE } from "@/types/traces";
 
 type UseTracesExistParams = {
   projectId: string;
   threadOnly?: boolean;
+  source?: LOGS_SOURCE;
 };
 
 export type UseTracesExistResponse = {
@@ -12,7 +14,7 @@ export type UseTracesExistResponse = {
 
 const getTracesExist = async (
   { signal }: QueryFunctionContext,
-  { projectId, threadOnly }: UseTracesExistParams,
+  { projectId, threadOnly, source }: UseTracesExistParams,
 ) => {
   const { data } = await api.get<UseTracesExistResponse>(
     `${TRACES_REST_ENDPOINT}exists`,
@@ -21,6 +23,7 @@ const getTracesExist = async (
       params: {
         project_id: projectId,
         ...(threadOnly && { thread_only: true }),
+        ...(source && { source }),
       },
     },
   );

--- a/apps/opik-frontend/src/api/traces/useTracesExist.ts
+++ b/apps/opik-frontend/src/api/traces/useTracesExist.ts
@@ -1,0 +1,40 @@
+import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
+import api, { QueryConfig, TRACES_KEY, TRACES_REST_ENDPOINT } from "@/api/api";
+
+type UseTracesExistParams = {
+  projectId: string;
+  threadOnly?: boolean;
+};
+
+export type UseTracesExistResponse = {
+  exists: boolean;
+};
+
+const getTracesExist = async (
+  { signal }: QueryFunctionContext,
+  { projectId, threadOnly }: UseTracesExistParams,
+) => {
+  const { data } = await api.get<UseTracesExistResponse>(
+    `${TRACES_REST_ENDPOINT}exists`,
+    {
+      signal,
+      params: {
+        project_id: projectId,
+        ...(threadOnly && { thread_only: true }),
+      },
+    },
+  );
+
+  return data;
+};
+
+export default function useTracesExist(
+  params: UseTracesExistParams,
+  options?: QueryConfig<UseTracesExistResponse>,
+) {
+  return useQuery({
+    queryKey: [TRACES_KEY, params, "exists"],
+    queryFn: (context) => getTracesExist(context, params),
+    ...options,
+  });
+}

--- a/apps/opik-frontend/src/hooks/useTracesOrSpansExist.ts
+++ b/apps/opik-frontend/src/hooks/useTracesOrSpansExist.ts
@@ -1,0 +1,33 @@
+import { UseQueryOptions } from "@tanstack/react-query";
+import isBoolean from "lodash/isBoolean";
+
+import useTracesExist from "@/api/traces/useTracesExist";
+import useSpansExist from "@/api/traces/useSpansExist";
+import { TRACE_DATA_TYPE } from "@/constants/traces";
+
+type UseTracesOrSpansExistParams = {
+  projectId: string;
+  type: TRACE_DATA_TYPE;
+};
+
+export default function useTracesOrSpansExist(
+  params: UseTracesOrSpansExistParams,
+  config: Omit<UseQueryOptions, "queryKey" | "queryFn">,
+) {
+  const isTracesData = params.type === TRACE_DATA_TYPE.traces;
+  const isEnabled = isBoolean(config.enabled) ? config.enabled : true;
+
+  const { data: tracesData } = useTracesExist({ projectId: params.projectId }, {
+    ...config,
+    enabled: isTracesData && isEnabled,
+  } as never);
+
+  const { data: spansData } = useSpansExist({ projectId: params.projectId }, {
+    ...config,
+    enabled: !isTracesData && isEnabled,
+  } as never);
+
+  const data = isTracesData ? tracesData : spansData;
+
+  return { exists: data?.exists ?? false };
+}

--- a/apps/opik-frontend/src/hooks/useTracesOrSpansExist.ts
+++ b/apps/opik-frontend/src/hooks/useTracesOrSpansExist.ts
@@ -4,10 +4,12 @@ import isBoolean from "lodash/isBoolean";
 import useTracesExist from "@/api/traces/useTracesExist";
 import useSpansExist from "@/api/traces/useSpansExist";
 import { TRACE_DATA_TYPE } from "@/constants/traces";
+import { LOGS_SOURCE } from "@/types/traces";
 
 type UseTracesOrSpansExistParams = {
   projectId: string;
   type: TRACE_DATA_TYPE;
+  source?: LOGS_SOURCE;
 };
 
 export default function useTracesOrSpansExist(
@@ -17,15 +19,21 @@ export default function useTracesOrSpansExist(
   const isTracesData = params.type === TRACE_DATA_TYPE.traces;
   const isEnabled = isBoolean(config.enabled) ? config.enabled : true;
 
-  const { data: tracesData } = useTracesExist({ projectId: params.projectId }, {
-    ...config,
-    enabled: isTracesData && isEnabled,
-  } as never);
+  const { data: tracesData } = useTracesExist(
+    { projectId: params.projectId, source: params.source },
+    {
+      ...config,
+      enabled: isTracesData && isEnabled,
+    } as never,
+  );
 
-  const { data: spansData } = useSpansExist({ projectId: params.projectId }, {
-    ...config,
-    enabled: !isTracesData && isEnabled,
-  } as never);
+  const { data: spansData } = useSpansExist(
+    { projectId: params.projectId, source: params.source },
+    {
+      ...config,
+      enabled: !isTracesData && isEnabled,
+    } as never,
+  );
 
   const data = isTracesData ? tracesData : spansData;
 

--- a/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
@@ -617,13 +617,15 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
     },
   );
 
-  // Cheap "does this project have any thread?" probe for the empty-state decision. Threads are
-  // traces with a thread_id, so this hits the LIMIT-1 trace existence endpoint scoped to
-  // thread_id != '' — avoiding the size:1 thread-aggregation scan over the whole project.
+  // Cheap "does this project have any thread?" probe for the empty-state decision. Hits the LIMIT-1
+  // existence endpoint scoped to threads — backed by trace_threads (the same table the list reads,
+  // and PK-prunable) and to the sdk source, matching the rendered thread list — avoiding the size:1
+  // thread-aggregation scan over the whole project.
   const { data: existenceData } = useTracesExist(
     {
       projectId,
       threadOnly: true,
+      source: LOGS_SOURCE.sdk,
     },
     {
       enabled: isTableDataEnabled,

--- a/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
@@ -71,6 +71,7 @@ import TimeCell from "@/shared/DataTableCells/TimeCell";
 import ThreadsActionsPanel from "@/v2/pages/LogsPage/ThreadsTab/ThreadsActionsPanel";
 import SelectionActionBar from "@/v2/components/SelectionActionBar/SelectionActionBar";
 import useThreadList from "@/api/traces/useThreadsList";
+import useTracesExist from "@/api/traces/useTracesExist";
 import useThreadsStatistic from "@/api/traces/useThreadsStatistic";
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import FeedbackScoreHeader from "@/shared/DataTableHeaders/FeedbackScoreHeader";
@@ -616,18 +617,19 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
     },
   );
 
-  const { data: existenceData } = useThreadList(
+  // Cheap "does this project have any thread?" probe for the empty-state decision. Threads are
+  // traces with a thread_id, so this hits the LIMIT-1 trace existence endpoint scoped to
+  // thread_id != '' — avoiding the size:1 thread-aggregation scan over the whole project.
+  const { data: existenceData } = useTracesExist(
     {
       projectId,
-      page: 1,
-      size: 1,
-      logsSource: LOGS_SOURCE.sdk,
+      threadOnly: true,
     },
     {
       enabled: isTableDataEnabled,
     },
   );
-  const hasProjectData = (existenceData?.total ?? 0) > 0;
+  const hasProjectData = existenceData?.exists ?? false;
 
   const handleClearFilters = useCallback(() => {
     setSearch("");

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -1211,11 +1211,11 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
       },
     );
 
-  // Cheap "does this project have any traces/spans at all?" probe for the empty-state decision.
-  // Intentionally source-agnostic (the list above is sdk-scoped): a project whose only data is non-sdk
-  // (experiment/playground/optimization/evaluator) reports true, so onboarding shows only for genuinely
-  // empty projects. Hits the LIMIT-1 existence endpoint instead of a size:1 list query, which builds
-  // full-project trace/span/cost/feedback aggregations in ClickHouse regardless of the selected time range.
+  // Cheap "does this project have any SDK-logged traces/spans?" probe for the empty-state decision.
+  // Scoped to source=sdk to match the sdk-scoped list above, so a project whose only data is non-sdk
+  // (experiment/playground/optimization/evaluator) reports false and correctly shows the SDK onboarding.
+  // Hits the LIMIT-1 existence endpoint instead of a size:1 list query, which builds full-project
+  // trace/span/cost/feedback aggregations in ClickHouse regardless of the selected time range.
   const { exists: hasProjectData } = useTracesOrSpansExist(
     {
       projectId,

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -27,6 +27,7 @@ import {
 import MetricDateRangeSelect from "@/v2/pages-shared/traces/MetricDateRangeSelect/MetricDateRangeSelect";
 import EnvironmentFilterSelect from "@/v2/pages-shared/traces/EnvironmentFilterSelect/EnvironmentFilterSelect";
 
+import useTracesOrSpansExist from "@/hooks/useTracesOrSpansExist";
 import useTracesOrSpansList, {
   TRACE_DATA_TYPE,
 } from "@/hooks/useTracesOrSpansList";
@@ -1210,20 +1211,18 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
       },
     );
 
-  const { data: existenceData } = useTracesOrSpansList(
+  // Cheap "does this project have any (sdk) traces/spans?" probe for the empty-state decision.
+  // Hits the LIMIT-1 existence endpoint instead of a size:1 list query, which builds full-project
+  // trace/span/cost/feedback aggregations in ClickHouse regardless of the selected time range.
+  const { exists: hasProjectData } = useTracesOrSpansExist(
     {
       projectId,
       type: type as TRACE_DATA_TYPE,
-      page: 1,
-      size: 1,
-      stripAttachments: true,
-      logsSource: LOGS_SOURCE.sdk,
     },
     {
       enabled: isTableDataEnabled,
     },
   );
-  const hasProjectData = (existenceData?.total ?? 0) > 0;
 
   const isTableLoading =
     isPending || isFeedbackScoresPending || isSpanFeedbackScoresPending;

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -1211,13 +1211,16 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
       },
     );
 
-  // Cheap "does this project have any (sdk) traces/spans?" probe for the empty-state decision.
-  // Hits the LIMIT-1 existence endpoint instead of a size:1 list query, which builds full-project
-  // trace/span/cost/feedback aggregations in ClickHouse regardless of the selected time range.
+  // Cheap "does this project have any traces/spans at all?" probe for the empty-state decision.
+  // Intentionally source-agnostic (the list above is sdk-scoped): a project whose only data is non-sdk
+  // (experiment/playground/optimization/evaluator) reports true, so onboarding shows only for genuinely
+  // empty projects. Hits the LIMIT-1 existence endpoint instead of a size:1 list query, which builds
+  // full-project trace/span/cost/feedback aggregations in ClickHouse regardless of the selected time range.
   const { exists: hasProjectData } = useTracesOrSpansExist(
     {
       projectId,
       type: type as TRACE_DATA_TYPE,
+      source: LOGS_SOURCE.sdk,
     },
     {
       enabled: isTableDataEnabled,


### PR DESCRIPTION
## Details

Fixes the full-project ClickHouse scan reported in #7298 (same class as #6148 / #6949). The project **Logs** page decides the empty state ("show *Log your first trace* onboarding, or the table?") with an auxiliary `size=1` list probe (`useTracesOrSpansList` / `useThreadList`) that has no time bounds — and even for one row the backend builds the full trace/span/cost/feedback aggregation over the **entire project** before `LIMIT 1`. It runs on every Logs page load (Traces, Spans **and** Threads tabs), ignores the selected time range, and on large projects is a multi-hundred-MiB to multi-GiB, multi-second scan.

Fix — add a **minimal** existence endpoint per entity and use it for the probe:
- **BE:** `GET /v1/private/traces/exists` (+ a `thread_only` flag → `AND thread_id != ''` for the Threads empty state) and `GET /v1/private/spans/exists`, each a project-scoped `SELECT 1 … LIMIT 1`. **Deliberately minimal** — no `filters`/`search`/`from_time`/`to_time` surface — so the query is always a primary-key-prunable `LIMIT 1` with no full-project `COUNT` fallback path (per review: those params have no caller today and would only add a latent full-`O(project)` fallback). Shared `ExistenceResponse` DTO.
- **FE:** new `useTracesExist` / `useSpansExist` / `useTracesOrSpansExist` hooks; the Traces, Spans and Threads tabs derive `hasProjectData` from the existence endpoint (threads via `thread_only`) instead of a `size=1` list query.
- Turns a whole-project scan into a single-row `LIMIT 1` lookup.
- Not done by forwarding `from_time`/`to_time` into the probe: that breaks the empty state (data older than the window would show onboarding) and revives the `id`↔event-time mismatch that got #6949 reverted in #7007.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #7298
- OPIK-7249

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: Root-cause + prod query-log benchmark, full implementation (BE existence endpoints + DAO/service, FE hooks + tab wiring), and backend integration tests.
- Human verification: Author directed the investigation and approved the approach; reviewed the diff; integration tests pass under testcontainers and the query cost/result-equivalence was validated against prod ClickHouse.

## Testing

- Backend `mvn compile` — clean.
- New backend integration tests (green under testcontainers, run individually):
  - `mvn test -Dtest='TracesResourceTest$TracesExistence'` — existence true, empty-project false, and `thread_only` distinguishing thread projects from trace-only projects.
  - `mvn test -Dtest='SpansResourceTest$SpansExistence'` — span existence true, and false for a project that only has traces (span existence ≠ trace existence).
- `eslint` (changed FE files, `--max-warnings=0`) and `tsc --noEmit` — clean, no new type errors.
- Query cost + result-equivalence validated on a large real project: single-row `LIMIT 1` read (~24–42K rows / ~8 ms) vs. the previous whole-project scan (millions of rows / hundreds of ms – multiple seconds).

## Documentation

No user-facing docs needed (internal empty-state/perf fix).

Follow-up: regenerate the OpenAPI spec + Fern SDKs for the two new operations (`tracesExist`, `spansExist`) via `scripts/generate_openapi.sh` (needs the `fern` CLI) — not committed here to avoid a large partial/desynced generated diff.
