### PR TITLE
[OPIK-6882] [BE] [CI] feat: align TestContainers ClickHouse config and migration check with distributed layer

### DIFF
--- a/.github/workflows/clickhouse_migration_cluster_check.yml
+++ b/.github/workflows/clickhouse_migration_cluster_check.yml
@@ -92,7 +92,7 @@ jobs:
             echo "💡 What this means:"
             echo "   - DDL operations without ON CLUSTER clause will only execute on a single node"
             echo "   - This can cause inconsistencies in distributed ClickHouse deployments"
-            echo "   - All CREATE, DROP, ALTER, and RENAME statements must include ON CLUSTER '{cluster}'"
+            echo "   - All CREATE, DROP, ALTER, RENAME, and EXCHANGE statements must include ON CLUSTER '{cluster}'"
             echo
             echo "🔧 How to fix:"
             echo "   1. Add 'ON CLUSTER '\"'\"'{cluster}'\"'\"'' to all DDL statements in your migration files"

--- a/apps/opik-backend/src/test/resources/clickhouse.xml
+++ b/apps/opik-backend/src/test/resources/clickhouse.xml
@@ -18,7 +18,11 @@
 
     <zookeeper_path>/clickhouse</zookeeper_path>
     <zookeeper_session_timeout_ms>30000</zookeeper_session_timeout_ms>
-    
+
+    <distributed_ddl>
+        <path>/clickhouse/task_queue/ddl</path>
+    </distributed_ddl>
+
     <remote_servers>
         <cluster>
         <shard>

--- a/apps/opik-backend/src/test/resources/users.xml
+++ b/apps/opik-backend/src/test/resources/users.xml
@@ -18,6 +18,14 @@
              so fresh installs need this enabled to replay the migration chain. -->
         <default>
             <enable_time_time64_type>1</enable_time_time64_type>
+            <!-- Distributed-layer settings the Hyperscale slices (OPIK-6874) depend on. All three
+                 are no-ops on the current single-shard schema, but tests must run with them active
+                 so the Slice 2 Distributed/_local table shape is exercised under the same profile
+                 as production (rolled out via OPIK-6881). Note: ClickHouse only reads <profiles>
+                 from users.d, not config.d, hence they live here rather than in clickhouse.xml. -->
+            <optimize_skip_unused_shards>1</optimize_skip_unused_shards>
+            <do_not_merge_across_partitions_select_final>1</do_not_merge_across_partitions_select_final>
+            <distributed_product_mode>local</distributed_product_mode>
         </default>
         <comet_llm_readonly_freeform_sql_profile>
             <readonly>1</readonly>

--- a/scripts/check_clickhouse_migrations_cluster.sh
+++ b/scripts/check_clickhouse_migrations_cluster.sh
@@ -22,7 +22,10 @@ EXIT_CODE=0
 
 # DDL patterns that require ON CLUSTER clause
 # Reference: https://clickhouse.com/docs/sql-reference/distributed-ddl
-DDL_COMMANDS_REGEX="(CREATE|DROP|ALTER|RENAME)"
+# EXCHANGE covers the Distributed-layer cutover shape (EXCHANGE TABLES foo_local AND foo_shadow_local)
+# used from Hyperscale Slice 2 onward. The check is table-name agnostic: both _local shadow tables
+# and their unsuffixed Distributed wrappers are validated the same way.
+DDL_COMMANDS_REGEX="(CREATE|DROP|ALTER|RENAME|EXCHANGE)"
 # Combined pattern for detecting DDL statements that need ON CLUSTER
 DDL_DETECTION_REGEX="^\s*${DDL_COMMANDS_REGEX}\s+"
 # Exact pattern for ON CLUSTER clause validation (project-specific)
@@ -205,7 +208,7 @@ main() {
         echo -e "   🎉 ${GREEN}All DDL operations include proper ON CLUSTER clause${NC}"
     else
         echo -e "   ❌ ${RED}Found $total_errors file(s) with missing ON CLUSTER clauses${NC}"
-        echo -e "   🛠️  ${YELLOW}Please add 'ON CLUSTER '\"'\"'{cluster}'\"'\"'' to all CREATE, DROP, ALTER, and RENAME statements${NC}"
+        echo -e "   🛠️  ${YELLOW}Please add 'ON CLUSTER '\"'\"'{cluster}'\"'\"'' to all CREATE, DROP, ALTER, RENAME, and EXCHANGE statements${NC}"
         echo
         echo -e "${YELLOW}📖 Reference: https://clickhouse.com/docs/sql-reference/distributed-ddl${NC}"
         echo -e "${YELLOW}🔧 Example: CREATE TABLE my_table ON CLUSTER '{cluster}' (...);${NC}"


### PR DESCRIPTION
## Details

Brings the TestContainers ClickHouse environment and the CI migration-check script in line with the Distributed-layer shape that Hyperscale Slice 2 (epic OPIK_6874) will assume. All settings are no-ops on the current single-shard schema, so tests exercise the same profile production runs with (rolled out via OPIK_6881).

- `apps/opik-backend/src/test/resources/clickhouse.xml`: add the `<distributed_ddl>` block (`/clickhouse/task_queue/ddl`), mirroring `deployment/docker-compose/clickhouse_config/additional_config.xml`. Existing macros block unchanged.
- `apps/opik-backend/src/test/resources/users.xml`: add `optimize_skip_unused_shards=1`, `do_not_merge_across_partitions_select_final=1`, `distributed_product_mode=local` to the `default` settings profile. Note this deviates from the ticket's literal wording (clickhouse.xml): ClickHouse only reads `<profiles>` from users configuration (`users.d/`), so placing them in `config.d/` would be silently ignored. A comment in the file documents this.
- `scripts/check_clickhouse_migrations_cluster.sh`: the ON CLUSTER check is already table-name-agnostic — both `_local` shadow tables and unsuffixed Distributed wrappers validate identically with no false positives. The actual gap for the Slice 2 shape was `EXCHANGE TABLES … ON CLUSTER` (the cutover DDL) being silently skipped by the `(CREATE|DROP|ALTER|RENAME)` regex; `EXCHANGE` is now detected and required to carry `ON CLUSTER '{cluster}'`.
- `.github/workflows/clickhouse_migration_cluster_check.yml`: failure-message text updated to mention EXCHANGE.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6882

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Fable 5
  - Scope: full implementation
  - Human verification: code review + verification of test results and live container settings

## Testing

Ran against the updated test config (local, process mode):

- `mvn test -Dtest="IsAliveE2ETest,ProjectMetricsResourceTest"` — passed. `IsAliveE2ETest` boots the full app and replays all 97 ClickHouse migrations under the new config; `ProjectMetricsResourceTest` (~400 tests) exercises `FINAL`-heavy read paths, the ones `do_not_merge_across_partitions_select_final=1` affects.
- `mvn test -Dtest="ExperimentProjectMigrationJobTest"` — passed (version-deduplicated reads over `experiments`).
- Verified directly in the live test container that all three settings are active in `system.settings` and that the `distributed_ddl` queue path exists in ZooKeeper.
- CI script: identical results vs `main` across all existing migrations (zero new failures; the 24 legacy files failing a full-directory run fail identically before and after — CI only validates added/modified files). A Slice-2-shaped fixture (`traces_local` + Distributed wrapper + `EXCHANGE … ON CLUSTER`) passes; an `EXCHANGE` without `ON CLUSTER` correctly fails with exit 1.
- `mvn spotless:check` — passed.
- Not run: full BE test suite locally (multi-hour); covered by CI on this PR.

## Documentation

N/A
