### PR TITLE
[OPIK-7262] [BE] observability: metrics for project last-updated flush + events consumed by listeners

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/ProjectLastUpdatedFlushJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/ProjectLastUpdatedFlushJob.java
@@ -4,6 +4,11 @@ import com.comet.opik.domain.ProjectLastUpdatedTraceBufferService;
 import com.comet.opik.infrastructure.ProjectLastUpdatedFlushConfig;
 import com.comet.opik.infrastructure.lock.LockService;
 import io.dropwizard.jobs.Job;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongHistogram;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -22,6 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.comet.opik.infrastructure.lock.LockService.Lock;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 /**
  * Schedules the periodic drain of the Redis-buffered {@code projects.last_updated_trace_at} maxima to MySQL.
@@ -38,11 +44,16 @@ public class ProjectLastUpdatedFlushJob extends Job implements InterruptableJob 
 
     private static final Lock FLUSH_LOCK = new Lock("project_last_updated_flush_job:scan_lock");
 
+    private static final AttributeKey<String> RESULT_KEY = stringKey("result");
+
     private final AtomicBoolean interrupted = new AtomicBoolean(false);
     private final AtomicReference<Disposable> subscription = new AtomicReference<>();
     private final ProjectLastUpdatedFlushConfig config;
     private final ProjectLastUpdatedTraceBufferService bufferService;
     private final LockService lockService;
+
+    private final LongCounter runCounter;
+    private final LongHistogram runDuration;
 
     @Inject
     public ProjectLastUpdatedFlushJob(
@@ -52,6 +63,18 @@ public class ProjectLastUpdatedFlushJob extends Job implements InterruptableJob 
         this.config = config;
         this.bufferService = bufferService;
         this.lockService = lockService;
+
+        var meter = GlobalOpenTelemetry.get().getMeter("opik.project_last_updated_flush");
+        this.runCounter = meter
+                .counterBuilder("opik.project_last_updated_flush.run")
+                .setDescription("Project last-updated flush job runs, by result")
+                .build();
+        this.runDuration = meter
+                .histogramBuilder("opik.project_last_updated_flush.duration")
+                .setDescription("Duration of a project last-updated flush job run")
+                .setUnit("ms")
+                .ofLongs()
+                .build();
     }
 
     @Override
@@ -62,18 +85,27 @@ public class ProjectLastUpdatedFlushJob extends Job implements InterruptableJob 
 
         // flush() is blocking (Redis + MySQL); run it off the scheduler thread. The subscription is kept so interrupt()
         // can cancel an in-flight flush, not just the schedule.
+        long startMs = System.currentTimeMillis();
         Disposable disposable = lockService.bestEffortLock(
                 FLUSH_LOCK,
                 Mono.fromCallable(bufferService::flush)
                         .subscribeOn(Schedulers.boundedElastic())
                         .doOnNext(count -> {
+                            runCounter.add(1, Attributes.of(RESULT_KEY, "success"));
+                            runDuration.record(System.currentTimeMillis() - startMs);
                             if (count > 0) {
                                 log.info("Project last-updated flush processed '{}' project markers", count);
                             }
                         })
+                        .doOnError(error -> {
+                            runCounter.add(1, Attributes.of(RESULT_KEY, "error"));
+                            runDuration.record(System.currentTimeMillis() - startMs);
+                        })
                         .then(),
-                Mono.fromRunnable(() -> log.debug(
-                        "Another instance is flushing project last-updated markers, skipping")),
+                Mono.fromRunnable(() -> {
+                    runCounter.add(1, Attributes.of(RESULT_KEY, "skipped_lock"));
+                    log.debug("Another instance is flushing project last-updated markers, skipping");
+                }),
                 config.getJobLockTime().toJavaDuration(),
                 config.getJobLockWaitTime().toJavaDuration(),
                 true)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectLastUpdatedTraceBufferService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectLastUpdatedTraceBufferService.java
@@ -4,6 +4,10 @@ import com.comet.opik.api.ProjectIdLastUpdated;
 import com.comet.opik.infrastructure.ProjectLastUpdatedFlushConfig;
 import com.comet.opik.infrastructure.redis.StringRedisClient;
 import com.google.inject.ImplementedBy;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.Builder;
@@ -19,6 +23,8 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 /**
  * Owns the {@code projects.last_updated_trace_at} buffering: the ingestion-path write that keeps the marker off the
@@ -48,9 +54,15 @@ class ProjectLastUpdatedTraceBufferServiceImpl implements ProjectLastUpdatedTrac
     static final String FLUSHING_SET_KEY = "project:last-updated-trace:flushing";
     private static final String MEMBER_SEPARATOR = ":";
 
+    static final String METER_NAME = "opik.project_last_updated_flush";
+    private static final AttributeKey<String> RESULT_KEY = stringKey("result");
+
     private final ProjectLastUpdatedFlushConfig config;
     private final StringRedisClient redisClient;
     private final ProjectService projectService;
+
+    private final LongCounter bufferedRecords;
+    private final LongCounter flushedMarkers;
 
     @Inject
     public ProjectLastUpdatedTraceBufferServiceImpl(
@@ -60,6 +72,16 @@ class ProjectLastUpdatedTraceBufferServiceImpl implements ProjectLastUpdatedTrac
         this.config = config;
         this.redisClient = redisClient;
         this.projectService = projectService;
+
+        var meter = GlobalOpenTelemetry.get().getMeter(METER_NAME);
+        this.bufferedRecords = meter
+                .counterBuilder("opik.project_last_updated_flush.buffered")
+                .setDescription("Project last-updated markers buffered to Redis on the ingestion path, by result")
+                .build();
+        this.flushedMarkers = meter
+                .counterBuilder("opik.project_last_updated_flush.markers")
+                .setDescription("Project last-updated markers processed by the flush")
+                .build();
     }
 
     @Override
@@ -78,7 +100,9 @@ class ProjectLastUpdatedTraceBufferServiceImpl implements ProjectLastUpdatedTrac
             RScoredSortedSet<String> pending = redisClient.getScoredSortedSet(PENDING_SET_KEY);
             lastUpdatedTraces.forEach(project -> pending.addIfGreater(
                     project.lastUpdatedAt().toEpochMilli(), member(workspaceId, project.id())));
+            bufferedRecords.add(lastUpdatedTraces.size(), Attributes.of(RESULT_KEY, "ok"));
         } catch (RuntimeException e) {
+            bufferedRecords.add(lastUpdatedTraces.size(), Attributes.of(RESULT_KEY, "error"));
             log.warn("Failed to buffer last-updated-trace marker for workspace '{}'", workspaceId, e);
         }
     }
@@ -106,6 +130,9 @@ class ProjectLastUpdatedTraceBufferServiceImpl implements ProjectLastUpdatedTrac
             if (entries.size() < batchSize) {
                 break;
             }
+        }
+        if (written > 0) {
+            flushedMarkers.add(written);
         }
         return written;
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/events/EventInterceptor.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/events/EventInterceptor.java
@@ -23,10 +23,16 @@ class EventInterceptor implements MethodInterceptor {
 
     private static final AttributeKey<String> LISTENER_KEY = stringKey("listener");
 
+    private final LongCounter consumedCounter;
     private final LongCounter errorCounter;
 
     EventInterceptor() {
-        this.errorCounter = GlobalOpenTelemetry.get().getMeter(TRACER_NAME)
+        var meter = GlobalOpenTelemetry.get().getMeter(TRACER_NAME);
+        this.consumedCounter = meter
+                .counterBuilder("opik.event.consumed")
+                .setDescription("Events successfully consumed, by listener")
+                .build();
+        this.errorCounter = meter
                 .counterBuilder("opik.event.error")
                 .setDescription("Event processing errors, by listener and error type")
                 .build();
@@ -56,6 +62,7 @@ class EventInterceptor implements MethodInterceptor {
 
         try (Scope scope = span.makeCurrent()) {
             Object result = methodInvocation.proceed();
+            consumedCounter.add(1, Attributes.of(LISTENER_KEY, listenerName));
             log.info("Event intercepted: {}", event);
             return result;
         } catch (Throwable e) {


### PR DESCRIPTION
## Details

Adds observability for the project last-updated-trace buffering feature (from #7361) and a general "events consumed" metric for all event listeners. No behavior change.

- **Buffer/flush metrics** (meter `opik.project_last_updated_flush`):
  - `.buffered` (counter, `result=ok|error`) — markers buffered to Redis on the ingestion path; surfaces the previously log-only, fail-open Redis write failures.
  - `.markers` (counter) — markers processed per flush.
  - `.run` (counter, `result=success|skipped_lock|error`) and `.duration` (histogram, ms) — flush job cycle outcome and latency.
- **`opik.event.consumed`** (counter, tag `listener`) in `EventInterceptor` — counts every event successfully consumed by a listener, complementing the existing `opik.event.error`.

Follows the existing OTel idiom (`RetentionSlidingWindowJob`, `MetricsAlertJob`).

> Stacked on top of #7361 (base branch = `thiagoh/OPIK-7246-project-marker-redis-flush`); the flush/buffer code it instruments lives there. Rebase to `main` once #7361 merges.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7262

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Implementation of the metrics + tests.
- Human verification: Author reviewed; builds and unit tests pass (see Testing).

## Testing

- `mvn compiler:compile compiler:testCompile` — BUILD SUCCESS.
- `mvn surefire:test` on `ProjectLastUpdatedTraceBufferServiceTest` + `ProjectLastUpdatedFlushJobTest` — 10/10 pass (existing behaviour unaffected by the added metrics).
- Metrics emission itself is not unit-tested (consistent with the sibling metered jobs, which rely on the OTel runtime).

## Documentation

No user-facing docs. Metrics are self-describing via their OTel descriptions.
