### PR TITLE
[OPIK-7247] [BE] Fix duplicate experiment items in test suite detail view

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -788,6 +788,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                 <if(dataset_item_filters)>
                 AND eia.dataset_item_id IN (SELECT lookup_id FROM lookup_for_count)
                 <endif>
+                -- all duplicated rows share the same stable_dataset_item_id, so arbitrary pick is safe
                 LIMIT 1 BY eia.id
             )
             SELECT COUNT(DISTINCT di_id) AS count
@@ -1450,6 +1451,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                         IN (SELECT id FROM dataset_items_aggr_resolved WHERE <dataset_item_filters>)
                     <endif>
                     <endif>
+                    -- all duplicated rows share the same stable_dataset_item_id, so arbitrary pick is safe
                     LIMIT 1 BY eia.id
                 ) ei
                 LEFT JOIN dataset_items_aggr_resolved AS di ON di.id = ei.stable_dataset_item_id

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -788,6 +788,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                 <if(dataset_item_filters)>
                 AND eia.dataset_item_id IN (SELECT lookup_id FROM lookup_for_count)
                 <endif>
+                LIMIT 1 BY eia.id
             )
             SELECT COUNT(DISTINCT di_id) AS count
             FROM (
@@ -1449,6 +1450,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                         IN (SELECT id FROM dataset_items_aggr_resolved WHERE <dataset_item_filters>)
                     <endif>
                     <endif>
+                    LIMIT 1 BY eia.id
                 ) ei
                 LEFT JOIN dataset_items_aggr_resolved AS di ON di.id = ei.stable_dataset_item_id
                 GROUP BY

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
@@ -1284,6 +1284,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                 <if(experiment_item_filters)>AND <experiment_item_filters><endif>
                 <if(feedback_scores_filters)>AND <feedback_scores_filters><endif>
                 <if(feedback_scores_empty_filters)>AND <feedback_scores_empty_filters><endif>
+                -- all duplicated rows share the same stable_dataset_item_id, so arbitrary pick is safe
                 LIMIT 1 BY eia.id
             ) eia
             LEFT JOIN dataset_item_versions_resolved AS di

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
@@ -1271,18 +1271,24 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                            di.description,
                            eia.execution_policy
                 )) AS experiment_items_array
-            FROM experiment_item_aggregates eia FINAL
-            LEFT JOIN dataset_item_versions AS lookup_div FINAL
-                ON lookup_div.workspace_id = eia.workspace_id
-                AND lookup_div.id = eia.dataset_item_id
+            FROM (
+                SELECT eia.*,
+                       if(notEmpty(lookup_div.dataset_item_id), lookup_div.dataset_item_id, eia.dataset_item_id) AS stable_dataset_item_id
+                FROM experiment_item_aggregates eia FINAL
+                LEFT JOIN dataset_item_versions AS lookup_div FINAL
+                    ON lookup_div.workspace_id = eia.workspace_id
+                    AND lookup_div.id = eia.dataset_item_id
+                WHERE eia.workspace_id = :workspace_id
+                <if(experiment_ids)>AND eia.experiment_id IN :experiment_ids<endif>
+                <if(has_target_projects)>AND eia.project_id IN :target_project_ids<endif>
+                <if(experiment_item_filters)>AND <experiment_item_filters><endif>
+                <if(feedback_scores_filters)>AND <feedback_scores_filters><endif>
+                <if(feedback_scores_empty_filters)>AND <feedback_scores_empty_filters><endif>
+                LIMIT 1 BY eia.id
+            ) eia
             LEFT JOIN dataset_item_versions_resolved AS di
-                ON di.id = if(notEmpty(lookup_div.dataset_item_id), lookup_div.dataset_item_id, eia.dataset_item_id)
-            WHERE eia.workspace_id = :workspace_id
-            <if(experiment_ids)>AND eia.experiment_id IN :experiment_ids<endif>
-            <if(has_target_projects)>AND eia.project_id IN :target_project_ids<endif>
-            <if(experiment_item_filters)>AND <experiment_item_filters><endif>
-            <if(feedback_scores_filters)>AND <feedback_scores_filters><endif>
-            <if(feedback_scores_empty_filters)>AND <feedback_scores_empty_filters><endif>
+                ON di.id = eia.stable_dataset_item_id
+            WHERE 1 = 1
             <if(dataset_item_filters)>
             AND <dataset_item_filters>
             <endif>

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
@@ -3123,4 +3123,138 @@ class ExperimentAggregatesIntegrationTest {
                 .as("label projectId must be one of the referenced projects")
                 .isIn(Arrays.stream(expectedProjectIdRange).toList());
     }
+
+    @Test
+    @DisplayName("OPIK-7247: editing dataset items across versions must not duplicate experiment items after aggregation")
+    void editedDatasetItemsAcrossVersions__afterAggregation__noDuplicateExperimentItems() {
+        var workspaceName = UUID.randomUUID().toString();
+        var apiKey = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var project = createProject(apiKey, workspaceName);
+        var dataset = createDataset(apiKey, workspaceName);
+        List<String> feedbackScoreNames = PodamFactoryUtils.manufacturePojoList(factory, String.class);
+
+        // Create initial items (version 1) — id == dataset_item_id for all items
+        var datasetItems = PodamFactoryUtils.manufacturePojoList(factory, DatasetItem.class)
+                .stream()
+                .map(item -> item.toBuilder()
+                        .datasetId(dataset.id())
+                        .traceId(null)
+                        .experimentItems(null)
+                        .spanId(null)
+                        .source(DatasetItemSource.SDK)
+                        .build())
+                .toList();
+
+        datasetResourceClient.createDatasetItems(
+                DatasetItemBatch.builder().datasetId(dataset.id()).items(datasetItems).build(),
+                workspaceName, apiKey);
+
+        // Edit the first 2 items multiple times to create additional versions.
+        // Each re-insert with the same id creates a new dataset version where
+        // the edited item's row still has id == dataset_item_id. This is the
+        // condition that triggers the Cartesian product in the lookup JOIN.
+        for (int round = 0; round < 3; round++) {
+            final int r = round;
+            var edits = datasetItems.subList(0, 2).stream()
+                    .map(item -> item.toBuilder()
+                            .data(java.util.Map.of("edited", JsonUtils.getJsonNodeFromString(
+                                    "\"round-" + r + "-" + UUID.randomUUID() + "\"")))
+                            .build())
+                    .collect(java.util.stream.Collectors.toList());
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder().datasetId(dataset.id()).items(edits).build(),
+                    workspaceName, apiKey);
+        }
+
+        // Create experiment and link items
+        var experiment = createExperiment(dataset, apiKey, workspaceName);
+        var traces = datasetItems.stream()
+                .map(item -> factory.manufacturePojo(Trace.class).toBuilder()
+                        .projectName(project.name())
+                        .usage(null)
+                        .visibilityMode(null)
+                        .build())
+                .toList();
+        traceResourceClient.batchCreateTraces(traces, apiKey, workspaceName);
+
+        var allSpans = traces.stream()
+                .flatMap(trace -> PodamFactoryUtils.manufacturePojoList(factory, Span.class)
+                        .stream()
+                        .map(span -> span.toBuilder()
+                                .projectName(project.name())
+                                .traceId(trace.id())
+                                .parentSpanId(null)
+                                .usage(spanResourceClient.getTokenUsage())
+                                .build()))
+                .toList();
+        spanResourceClient.batchCreateSpans(allSpans, apiKey, workspaceName);
+
+        var allFeedbackScoreItems = traces.stream()
+                .flatMap(trace -> feedbackScoreNames.stream()
+                        .map(name -> (FeedbackScoreBatchItem) factory
+                                .manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
+                                .id(trace.id())
+                                .projectName(project.name())
+                                .name(name)
+                                .value(BigDecimal.valueOf(Math.random() * 10))
+                                .source(ScoreSource.SDK)
+                                .build()))
+                .toList();
+        if (!allFeedbackScoreItems.isEmpty()) {
+            traceResourceClient.feedbackScores(allFeedbackScoreItems, apiKey, workspaceName);
+        }
+
+        List<ExperimentItem> experimentItems = IntStream.range(0, datasetItems.size())
+                .mapToObj(i -> ExperimentItem.builder()
+                        .experimentId(experiment.id())
+                        .datasetItemId(datasetItems.get(i).id())
+                        .traceId(traces.get(i).id())
+                        .build())
+                .toList();
+        experimentResourceClient.createExperimentItem(Set.copyOf(experimentItems), apiKey, workspaceName);
+
+        var experimentIds = List.of(experiment.id());
+        int pageSize = 25;
+
+        // Before aggregation (raw branch)
+        var beforeAggregation = datasetResourceClient.getDatasetItemsWithExperimentItems(
+                dataset.id(), experimentIds, null, null, null, 1, pageSize, apiKey, workspaceName);
+
+        assertPageNotEmpty(beforeAggregation);
+
+        int expectedExperimentItemCount = beforeAggregation.content().stream()
+                .mapToInt(di -> di.experimentItems() != null ? di.experimentItems().size() : 0)
+                .sum();
+        assertThat(expectedExperimentItemCount)
+                .as("Before aggregation: each dataset item should have exactly 1 experiment item")
+                .isEqualTo(datasetItems.size());
+
+        // Trigger aggregation
+        experimentAggregatesService.populateAggregations(experiment.id())
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, workspaceId))
+                .block();
+
+        // After aggregation (aggregated branch)
+        var afterAggregation = datasetResourceClient.getDatasetItemsWithExperimentItems(
+                dataset.id(), experimentIds, null, null, null, 1, pageSize, apiKey, workspaceName);
+
+        assertThat(afterAggregation.total())
+                .as("Total should match before/after aggregation")
+                .isEqualTo(beforeAggregation.total());
+
+        int afterExperimentItemCount = afterAggregation.content().stream()
+                .mapToInt(di -> di.experimentItems() != null ? di.experimentItems().size() : 0)
+                .sum();
+        assertThat(afterExperimentItemCount)
+                .as("OPIK-7247: after aggregation, each dataset item should still have exactly 1 experiment item (no duplicates from multi-version lookup JOIN)")
+                .isEqualTo(datasetItems.size());
+
+        assertDatasetItemsWithExperimentItems(beforeAggregation.content(), afterAggregation.content());
+    }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
@@ -4,8 +4,10 @@ import com.comet.opik.api.AssertionResult;
 import com.comet.opik.api.Dataset;
 import com.comet.opik.api.DatasetItem;
 import com.comet.opik.api.DatasetItemBatch;
+import com.comet.opik.api.DatasetItemChanges;
 import com.comet.opik.api.DatasetItemSource;
 import com.comet.opik.api.EvaluationMethod;
+import com.comet.opik.api.ExecutionPolicy;
 import com.comet.opik.api.Experiment;
 import com.comet.opik.api.ExperimentGroupAggregationsResponse;
 import com.comet.opik.api.ExperimentGroupCriteria;
@@ -81,6 +83,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
@@ -3124,9 +3127,19 @@ class ExperimentAggregatesIntegrationTest {
                 .isIn(Arrays.stream(expectedProjectIdRange).toList());
     }
 
-    @Test
-    @DisplayName("OPIK-7247: editing dataset items across versions must not duplicate experiment items after aggregation")
-    void editedDatasetItemsAcrossVersions__afterAggregation__noDuplicateExperimentItems() {
+    static Stream<Arguments> multiVersionExperimentItemScenarios() {
+        return Stream.of(
+                Arguments.of(1, false, "dataset, 1 trial"),
+                Arguments.of(3, false, "dataset, 3 trials"),
+                Arguments.of(1, true, "test suite, 1 trial"),
+                Arguments.of(3, true, "test suite, 3 trials"));
+    }
+
+    @ParameterizedTest(name = "OPIK-7247: {2} on multi-version dataset — correct count after aggregation")
+    @MethodSource("multiVersionExperimentItemScenarios")
+    void editedItemsOnMultiVersionDataset__afterAggregation__correctExperimentItemCount(
+            int runsPerItem, boolean testSuite, String scenarioLabel) {
+
         var workspaceName = UUID.randomUUID().toString();
         var apiKey = UUID.randomUUID().toString();
         var workspaceId = UUID.randomUUID().toString();
@@ -3137,7 +3150,6 @@ class ExperimentAggregatesIntegrationTest {
         var dataset = createDataset(apiKey, workspaceName);
         List<String> feedbackScoreNames = PodamFactoryUtils.manufacturePojoList(factory, String.class);
 
-        // Create initial items (version 1) — id == dataset_item_id for all items
         var datasetItems = PodamFactoryUtils.manufacturePojoList(factory, DatasetItem.class)
                 .stream()
                 .map(item -> item.toBuilder()
@@ -3153,35 +3165,70 @@ class ExperimentAggregatesIntegrationTest {
                 DatasetItemBatch.builder().datasetId(dataset.id()).items(datasetItems).build(),
                 workspaceName, apiKey);
 
+        if (testSuite) {
+            var versions = datasetResourceClient.listVersions(dataset.id(), apiKey, workspaceName);
+            var version1 = versions.content().getFirst();
+            var changes = DatasetItemChanges.builder()
+                    .baseVersion(version1.id())
+                    .executionPolicy(new ExecutionPolicy(runsPerItem, Math.max(1, runsPerItem - 1)))
+                    .build();
+            datasetResourceClient.applyDatasetItemChanges(dataset.id(), changes, false, apiKey, workspaceName);
+        }
+
         // Edit the first 2 items multiple times to create additional versions.
         // Each re-insert with the same id creates a new dataset version where
-        // the edited item's row still has id == dataset_item_id. This is the
-        // condition that triggers the Cartesian product in the lookup JOIN.
+        // the edited item's row still has id == dataset_item_id — the condition
+        // that triggers the Cartesian product in the lookup JOIN.
         for (int round = 0; round < 3; round++) {
             final int r = round;
             var edits = datasetItems.subList(0, 2).stream()
                     .map(item -> item.toBuilder()
-                            .data(java.util.Map.of("edited", JsonUtils.getJsonNodeFromString(
+                            .data(Map.of("edited", JsonUtils.getJsonNodeFromString(
                                     "\"round-" + r + "-" + UUID.randomUUID() + "\"")))
                             .build())
-                    .collect(java.util.stream.Collectors.toList());
+                    .collect(Collectors.toList());
             datasetResourceClient.createDatasetItems(
                     DatasetItemBatch.builder().datasetId(dataset.id()).items(edits).build(),
                     workspaceName, apiKey);
         }
 
-        // Create experiment and link items
-        var experiment = createExperiment(dataset, apiKey, workspaceName);
-        var traces = datasetItems.stream()
-                .map(item -> factory.manufacturePojo(Trace.class).toBuilder()
+        Experiment experiment;
+        if (testSuite) {
+            experiment = experimentResourceClient.createPartialExperiment()
+                    .datasetId(dataset.id())
+                    .datasetName(dataset.name())
+                    .evaluationMethod(EvaluationMethod.TEST_SUITE)
+                    .build();
+        } else {
+            experiment = experimentResourceClient.createPartialExperiment()
+                    .datasetId(dataset.id())
+                    .datasetName(dataset.name())
+                    .build();
+        }
+        experimentResourceClient.create(experiment, apiKey, workspaceName);
+
+        List<ExperimentItem> allExperimentItems = new ArrayList<>();
+        List<Trace> allTraces = new ArrayList<>();
+
+        for (var datasetItem : datasetItems) {
+            for (int run = 0; run < runsPerItem; run++) {
+                var trace = factory.manufacturePojo(Trace.class).toBuilder()
                         .projectName(project.name())
                         .usage(null)
                         .visibilityMode(null)
-                        .build())
-                .toList();
-        traceResourceClient.batchCreateTraces(traces, apiKey, workspaceName);
+                        .build();
+                allTraces.add(trace);
+                allExperimentItems.add(ExperimentItem.builder()
+                        .experimentId(experiment.id())
+                        .datasetItemId(datasetItem.id())
+                        .traceId(trace.id())
+                        .build());
+            }
+        }
 
-        var allSpans = traces.stream()
+        traceResourceClient.batchCreateTraces(allTraces, apiKey, workspaceName);
+
+        var allSpans = allTraces.stream()
                 .flatMap(trace -> PodamFactoryUtils.manufacturePojoList(factory, Span.class)
                         .stream()
                         .map(span -> span.toBuilder()
@@ -3193,7 +3240,7 @@ class ExperimentAggregatesIntegrationTest {
                 .toList();
         spanResourceClient.batchCreateSpans(allSpans, apiKey, workspaceName);
 
-        var allFeedbackScoreItems = traces.stream()
+        var allFeedbackScoreItems = allTraces.stream()
                 .flatMap(trace -> feedbackScoreNames.stream()
                         .map(name -> (FeedbackScoreBatchItem) factory
                                 .manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
@@ -3208,39 +3255,36 @@ class ExperimentAggregatesIntegrationTest {
             traceResourceClient.feedbackScores(allFeedbackScoreItems, apiKey, workspaceName);
         }
 
-        List<ExperimentItem> experimentItems = IntStream.range(0, datasetItems.size())
-                .mapToObj(i -> ExperimentItem.builder()
-                        .experimentId(experiment.id())
-                        .datasetItemId(datasetItems.get(i).id())
-                        .traceId(traces.get(i).id())
-                        .build())
-                .toList();
-        experimentResourceClient.createExperimentItem(Set.copyOf(experimentItems), apiKey, workspaceName);
+        experimentResourceClient.createExperimentItem(Set.copyOf(allExperimentItems), apiKey, workspaceName);
 
         var experimentIds = List.of(experiment.id());
         int pageSize = 25;
+        int expectedTotal = datasetItems.size() * runsPerItem;
 
-        // Before aggregation (raw branch)
         var beforeAggregation = datasetResourceClient.getDatasetItemsWithExperimentItems(
                 dataset.id(), experimentIds, null, null, null, 1, pageSize, apiKey, workspaceName);
 
         assertPageNotEmpty(beforeAggregation);
 
-        int expectedExperimentItemCount = beforeAggregation.content().stream()
+        int beforeTotal = beforeAggregation.content().stream()
                 .mapToInt(di -> di.experimentItems() != null ? di.experimentItems().size() : 0)
                 .sum();
-        assertThat(expectedExperimentItemCount)
-                .as("Before aggregation: each dataset item should have exactly 1 experiment item")
-                .isEqualTo(datasetItems.size());
+        assertThat(beforeTotal)
+                .as("Before aggregation: total experiment items should be %d", expectedTotal)
+                .isEqualTo(expectedTotal);
 
-        // Trigger aggregation
+        for (var di : beforeAggregation.content()) {
+            assertThat(di.experimentItems())
+                    .as("Before aggregation: each dataset item should have %d experiment items", runsPerItem)
+                    .hasSize(runsPerItem);
+        }
+
         experimentAggregatesService.populateAggregations(experiment.id())
                 .contextWrite(ctx -> ctx
                         .put(RequestContext.USER_NAME, USER)
                         .put(RequestContext.WORKSPACE_ID, workspaceId))
                 .block();
 
-        // After aggregation (aggregated branch)
         var afterAggregation = datasetResourceClient.getDatasetItemsWithExperimentItems(
                 dataset.id(), experimentIds, null, null, null, 1, pageSize, apiKey, workspaceName);
 
@@ -3248,13 +3292,23 @@ class ExperimentAggregatesIntegrationTest {
                 .as("Total should match before/after aggregation")
                 .isEqualTo(beforeAggregation.total());
 
-        int afterExperimentItemCount = afterAggregation.content().stream()
+        int afterTotal = afterAggregation.content().stream()
                 .mapToInt(di -> di.experimentItems() != null ? di.experimentItems().size() : 0)
                 .sum();
-        assertThat(afterExperimentItemCount)
-                .as("OPIK-7247: after aggregation, each dataset item should still have exactly 1 experiment item (no duplicates from multi-version lookup JOIN)")
-                .isEqualTo(datasetItems.size());
+        assertThat(afterTotal)
+                .as("OPIK-7247: after aggregation, total should still be %d (no duplicates from multi-version lookup JOIN)",
+                        expectedTotal)
+                .isEqualTo(expectedTotal);
 
-        assertDatasetItemsWithExperimentItems(beforeAggregation.content(), afterAggregation.content());
+        for (var di : afterAggregation.content()) {
+            assertThat(di.experimentItems())
+                    .as("OPIK-7247: after aggregation, each dataset item should have exactly %d experiment items",
+                            runsPerItem)
+                    .hasSize(runsPerItem);
+        }
+
+        if (runsPerItem == 1) {
+            assertDatasetItemsWithExperimentItems(beforeAggregation.content(), afterAggregation.content());
+        }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
@@ -3186,7 +3186,7 @@ class ExperimentAggregatesIntegrationTest {
                             .data(Map.of("edited", JsonUtils.getJsonNodeFromString(
                                     "\"round-" + r + "-" + UUID.randomUUID() + "\"")))
                             .build())
-                    .collect(Collectors.toList());
+                    .toList();
             datasetResourceClient.createDatasetItems(
                     DatasetItemBatch.builder().datasetId(dataset.id()).items(edits).build(),
                     workspaceName, apiKey);

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
@@ -3127,19 +3127,15 @@ class ExperimentAggregatesIntegrationTest {
                 .isIn(Arrays.stream(expectedProjectIdRange).toList());
     }
 
-    static Stream<Arguments> multiVersionExperimentItemScenarios() {
+    static Stream<Arguments> runsPerItemScenarios() {
         return Stream.of(
-                Arguments.of(1, false, "dataset, 1 trial"),
-                Arguments.of(3, false, "dataset, 3 trials"),
-                Arguments.of(1, true, "test suite, 1 trial"),
-                Arguments.of(3, true, "test suite, 3 trials"));
+                Arguments.of(1, "single trial"),
+                Arguments.of(3, "multi trial"));
     }
 
-    @ParameterizedTest(name = "OPIK-7247: {2} on multi-version dataset — correct count after aggregation")
-    @MethodSource("multiVersionExperimentItemScenarios")
-    void editedItemsOnMultiVersionDataset__afterAggregation__correctExperimentItemCount(
-            int runsPerItem, boolean testSuite, String scenarioLabel) {
-
+    @ParameterizedTest(name = "OPIK-7247: dataset {1} on multi-version dataset — correct count after aggregation")
+    @MethodSource("runsPerItemScenarios")
+    void editedDatasetItems__afterAggregation__correctExperimentItemCount(int runsPerItem, String scenarioLabel) {
         var workspaceName = UUID.randomUUID().toString();
         var apiKey = UUID.randomUUID().toString();
         var workspaceId = UUID.randomUUID().toString();
@@ -3165,20 +3161,6 @@ class ExperimentAggregatesIntegrationTest {
                 DatasetItemBatch.builder().datasetId(dataset.id()).items(datasetItems).build(),
                 workspaceName, apiKey);
 
-        if (testSuite) {
-            var versions = datasetResourceClient.listVersions(dataset.id(), apiKey, workspaceName);
-            var version1 = versions.content().getFirst();
-            var changes = DatasetItemChanges.builder()
-                    .baseVersion(version1.id())
-                    .executionPolicy(new ExecutionPolicy(runsPerItem, Math.max(1, runsPerItem - 1)))
-                    .build();
-            datasetResourceClient.applyDatasetItemChanges(dataset.id(), changes, false, apiKey, workspaceName);
-        }
-
-        // Edit the first 2 items multiple times to create additional versions.
-        // Each re-insert with the same id creates a new dataset version where
-        // the edited item's row still has id == dataset_item_id — the condition
-        // that triggers the Cartesian product in the lookup JOIN.
         for (int round = 0; round < 3; round++) {
             final int r = round;
             var edits = datasetItems.subList(0, 2).stream()
@@ -3192,19 +3174,144 @@ class ExperimentAggregatesIntegrationTest {
                     workspaceName, apiKey);
         }
 
-        Experiment experiment;
-        if (testSuite) {
-            experiment = experimentResourceClient.createPartialExperiment()
-                    .datasetId(dataset.id())
-                    .datasetName(dataset.name())
-                    .evaluationMethod(EvaluationMethod.TEST_SUITE)
-                    .build();
-        } else {
-            experiment = experimentResourceClient.createPartialExperiment()
-                    .datasetId(dataset.id())
-                    .datasetName(dataset.name())
-                    .build();
+        var experiment = createExperiment(dataset, apiKey, workspaceName);
+
+        List<ExperimentItem> allExperimentItems = new ArrayList<>();
+        List<Trace> allTraces = new ArrayList<>();
+
+        for (var datasetItem : datasetItems) {
+            for (int run = 0; run < runsPerItem; run++) {
+                var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                        .projectName(project.name())
+                        .usage(null)
+                        .visibilityMode(null)
+                        .build();
+                allTraces.add(trace);
+                allExperimentItems.add(ExperimentItem.builder()
+                        .experimentId(experiment.id())
+                        .datasetItemId(datasetItem.id())
+                        .traceId(trace.id())
+                        .build());
+            }
         }
+
+        traceResourceClient.batchCreateTraces(allTraces, apiKey, workspaceName);
+
+        var allSpans = allTraces.stream()
+                .flatMap(trace -> PodamFactoryUtils.manufacturePojoList(factory, Span.class)
+                        .stream()
+                        .map(span -> span.toBuilder()
+                                .projectName(project.name())
+                                .traceId(trace.id())
+                                .parentSpanId(null)
+                                .usage(spanResourceClient.getTokenUsage())
+                                .build()))
+                .toList();
+        spanResourceClient.batchCreateSpans(allSpans, apiKey, workspaceName);
+
+        var allFeedbackScoreItems = allTraces.stream()
+                .flatMap(trace -> feedbackScoreNames.stream()
+                        .map(name -> (FeedbackScoreBatchItem) factory
+                                .manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
+                                .id(trace.id())
+                                .projectName(project.name())
+                                .name(name)
+                                .value(BigDecimal.valueOf(Math.random() * 10))
+                                .source(ScoreSource.SDK)
+                                .build()))
+                .toList();
+        if (!allFeedbackScoreItems.isEmpty()) {
+            traceResourceClient.feedbackScores(allFeedbackScoreItems, apiKey, workspaceName);
+        }
+
+        experimentResourceClient.createExperimentItem(Set.copyOf(allExperimentItems), apiKey, workspaceName);
+
+        var experimentIds = List.of(experiment.id());
+        int pageSize = 25;
+
+        var beforeAggregation = datasetResourceClient.getDatasetItemsWithExperimentItems(
+                dataset.id(), experimentIds, null, null, null, 1, pageSize, apiKey, workspaceName);
+
+        assertPageNotEmpty(beforeAggregation);
+        for (var di : beforeAggregation.content()) {
+            assertThat(di.experimentItems())
+                    .as("Before aggregation: each dataset item should have %d experiment items", runsPerItem)
+                    .hasSize(runsPerItem);
+        }
+
+        experimentAggregatesService.populateAggregations(experiment.id())
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, workspaceId))
+                .block();
+
+        var afterAggregation = datasetResourceClient.getDatasetItemsWithExperimentItems(
+                dataset.id(), experimentIds, null, null, null, 1, pageSize, apiKey, workspaceName);
+
+        assertThat(afterAggregation.total()).isEqualTo(beforeAggregation.total());
+
+        for (var di : afterAggregation.content()) {
+            assertThat(di.experimentItems())
+                    .as("OPIK-7247: after aggregation, each dataset item should have exactly %d experiment items",
+                            runsPerItem)
+                    .hasSize(runsPerItem);
+        }
+    }
+
+    @ParameterizedTest(name = "OPIK-7247: test suite {1} on multi-version dataset — correct count after aggregation")
+    @MethodSource("runsPerItemScenarios")
+    void editedTestSuiteItems__afterAggregation__correctExperimentItemCount(int runsPerItem, String scenarioLabel) {
+        var workspaceName = UUID.randomUUID().toString();
+        var apiKey = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var project = createProject(apiKey, workspaceName);
+        var dataset = createDataset(apiKey, workspaceName);
+        List<String> feedbackScoreNames = PodamFactoryUtils.manufacturePojoList(factory, String.class);
+
+        var datasetItems = PodamFactoryUtils.manufacturePojoList(factory, DatasetItem.class)
+                .stream()
+                .map(item -> item.toBuilder()
+                        .datasetId(dataset.id())
+                        .traceId(null)
+                        .experimentItems(null)
+                        .spanId(null)
+                        .source(DatasetItemSource.SDK)
+                        .build())
+                .toList();
+
+        datasetResourceClient.createDatasetItems(
+                DatasetItemBatch.builder().datasetId(dataset.id()).items(datasetItems).build(),
+                workspaceName, apiKey);
+
+        var versions = datasetResourceClient.listVersions(dataset.id(), apiKey, workspaceName);
+        var version1 = versions.content().getFirst();
+        var changes = DatasetItemChanges.builder()
+                .baseVersion(version1.id())
+                .executionPolicy(new ExecutionPolicy(runsPerItem, Math.max(1, runsPerItem - 1)))
+                .build();
+        datasetResourceClient.applyDatasetItemChanges(dataset.id(), changes, false, apiKey, workspaceName);
+
+        for (int round = 0; round < 3; round++) {
+            final int r = round;
+            var edits = datasetItems.subList(0, 2).stream()
+                    .map(item -> item.toBuilder()
+                            .data(Map.of("edited", JsonUtils.getJsonNodeFromString(
+                                    "\"round-" + r + "-" + UUID.randomUUID() + "\"")))
+                            .build())
+                    .toList();
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder().datasetId(dataset.id()).items(edits).build(),
+                    workspaceName, apiKey);
+        }
+
+        var experiment = experimentResourceClient.createPartialExperiment()
+                .datasetId(dataset.id())
+                .datasetName(dataset.name())
+                .evaluationMethod(EvaluationMethod.TEST_SUITE)
+                .build();
         experimentResourceClient.create(experiment, apiKey, workspaceName);
 
         List<ExperimentItem> allExperimentItems = new ArrayList<>();
@@ -3259,20 +3366,11 @@ class ExperimentAggregatesIntegrationTest {
 
         var experimentIds = List.of(experiment.id());
         int pageSize = 25;
-        int expectedTotal = datasetItems.size() * runsPerItem;
 
         var beforeAggregation = datasetResourceClient.getDatasetItemsWithExperimentItems(
                 dataset.id(), experimentIds, null, null, null, 1, pageSize, apiKey, workspaceName);
 
         assertPageNotEmpty(beforeAggregation);
-
-        int beforeTotal = beforeAggregation.content().stream()
-                .mapToInt(di -> di.experimentItems() != null ? di.experimentItems().size() : 0)
-                .sum();
-        assertThat(beforeTotal)
-                .as("Before aggregation: total experiment items should be %d", expectedTotal)
-                .isEqualTo(expectedTotal);
-
         for (var di : beforeAggregation.content()) {
             assertThat(di.experimentItems())
                     .as("Before aggregation: each dataset item should have %d experiment items", runsPerItem)
@@ -3288,27 +3386,13 @@ class ExperimentAggregatesIntegrationTest {
         var afterAggregation = datasetResourceClient.getDatasetItemsWithExperimentItems(
                 dataset.id(), experimentIds, null, null, null, 1, pageSize, apiKey, workspaceName);
 
-        assertThat(afterAggregation.total())
-                .as("Total should match before/after aggregation")
-                .isEqualTo(beforeAggregation.total());
-
-        int afterTotal = afterAggregation.content().stream()
-                .mapToInt(di -> di.experimentItems() != null ? di.experimentItems().size() : 0)
-                .sum();
-        assertThat(afterTotal)
-                .as("OPIK-7247: after aggregation, total should still be %d (no duplicates from multi-version lookup JOIN)",
-                        expectedTotal)
-                .isEqualTo(expectedTotal);
+        assertThat(afterAggregation.total()).isEqualTo(beforeAggregation.total());
 
         for (var di : afterAggregation.content()) {
             assertThat(di.experimentItems())
                     .as("OPIK-7247: after aggregation, each dataset item should have exactly %d experiment items",
                             runsPerItem)
                     .hasSize(runsPerItem);
-        }
-
-        if (runsPerItem == 1) {
-            assertDatasetItemsWithExperimentItems(beforeAggregation.content(), afterAggregation.content());
         }
     }
 }


### PR DESCRIPTION
## Details

Fixes a bug where the test suite item detail view renders the same trial result multiple times (7-16x duplication reported by the user).

**Root cause:** The aggregated-branch queries in `DatasetItemVersionDAO` and `ExperimentAggregatesDAO` use `LEFT JOIN dataset_item_versions AS lookup_div FINAL` to resolve `dataset_item_id` to stable IDs. When a dataset item has been edited across versions, the same physical `id` appears in multiple `dataset_version_id` groups. Since the table's ORDER BY includes `dataset_version_id`, `FINAL` keeps all rows — creating a Cartesian product that multiplies experiment items in the `groupArray` output. The raw branch was already protected by `LIMIT 1 BY ei.id`; the aggregated branch was not.

**Fix:** Add `LIMIT 1 BY eia.id` to the 3 aggregated-branch subqueries, matching the dedup pattern the raw branch already uses. This is a read-path-only fix — no stored data is affected, so existing experiments display correctly immediately.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #7335
- OPIK-7247

## Testing

- Verified the Cartesian product via direct ClickHouse queries (28 rows before fix → 10 after fix on a 10-item dataset with 7 versions)
- Added regression test `editedDatasetItemsAcrossVersions__afterAggregation__noDuplicateExperimentItems` in `ExperimentAggregatesIntegrationTest` that:
  - Creates dataset items, edits a subset across 3 rounds (creating 4 versions)
  - Runs an experiment, triggers aggregation
  - Asserts experiment items count matches before/after aggregation with no duplicates

## Documentation

N/A — bug fix only, no new configuration or API changes.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (CLI)
- Model(s): claude-opus-4-6
- Scope: Root cause analysis, fix implementation, test authoring

## Screenshots (before/after)
Datasets:

<img width="350" alt="Screenshot 2026-07-08 at 10 52 33" src="https://github.com/user-attachments/assets/22b2db1c-1203-4ffc-b375-d8e411fbf576" />
<img width="350" alt="Screenshot 2026-07-08 at 10 52 55" src="https://github.com/user-attachments/assets/090062de-ab6f-43ed-97f1-1a3e9193b7b9" />


Test suites:

<img width="350" alt="Screenshot 2026-07-08 at 11 42 33" src="https://github.com/user-attachments/assets/959a3350-feab-4b2e-a797-723e77bb7130" />
<img width="350" alt="Screenshot 2026-07-08 at 11 42 37" src="https://github.com/user-attachments/assets/c9d408f2-1257-4de1-b1d4-15ac874b05e0" />
