### PR TITLE
[NA] Add query_source to cipx_spends for the AI-spend model-switch lever

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendDAO.java
@@ -53,7 +53,8 @@ public class CipxSpendDAO {
             long uInput,
             long uCacheRead,
             long uCacheCreation,
-            long uOutput) {
+            long uOutput,
+            @NonNull String querySource) {
 
         public static SpanRow from(UUID spanId, UUID traceId, UUID projectId, JsonNode metadata, Instant startTime) {
             JsonNode call = metadata.path("cipx").path("call");
@@ -68,6 +69,7 @@ public class CipxSpendDAO {
                     .uCacheRead(usage.path("cache_read_input_tokens").asLong(0))
                     .uCacheCreation(usage.path("cache_creation_input_tokens").asLong(0))
                     .uOutput(usage.path("output_tokens").asLong(0))
+                    .querySource(call.path("query_source").asText(""))
                     .build();
         }
     }
@@ -77,7 +79,7 @@ public class CipxSpendDAO {
     private static final String INSERT = """
             INSERT INTO cipx_spends
                 (workspace_id, project_id, trace_id, span_id, start_time, model,
-                 u_input, u_cache_read, u_cache_creation, u_output)
+                 u_input, u_cache_read, u_cache_creation, u_output, query_source)
             SETTINGS log_comment = '<log_comment>'
             FORMAT Values
                 <items:{item |
@@ -91,7 +93,8 @@ public class CipxSpendDAO {
                         :u_input<item.index>,
                         :u_cache_read<item.index>,
                         :u_cache_creation<item.index>,
-                        :u_output<item.index>
+                        :u_output<item.index>,
+                        :query_source<item.index>
                     )
                     <if(item.hasNext)>,<endif>
                 }>
@@ -120,7 +123,7 @@ public class CipxSpendDAO {
         // Positional binds: the driver resolves named binds with a linear indexOf over the statement's
         // parameter list (quadratic per statement), while bind(int) is a direct array write. Indices
         // follow the placeholders' first-appearance order in the rendered SQL: workspace_id once at 0
-        // (repeats dedup), then 9 parameters per row tuple in template order.
+        // (repeats dedup), then 10 parameters per row tuple in template order.
         statement.bind(0, workspaceId);
         int index = 1;
         for (SpanRow row : rows) {
@@ -132,7 +135,8 @@ public class CipxSpendDAO {
                     .bind(index++, row.uInput())
                     .bind(index++, row.uCacheRead())
                     .bind(index++, row.uCacheCreation())
-                    .bind(index++, row.uOutput());
+                    .bind(index++, row.uOutput())
+                    .bind(index++, row.querySource());
         }
 
         return statement.execute();

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000101_add_query_source_to_cipx_spend.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000101_add_query_source_to_cipx_spend.sql
@@ -10,3 +10,4 @@ ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_spends ON CLUSTER '{cluster}'
     ADD COLUMN IF NOT EXISTS query_source LowCardinality(String) DEFAULT '';
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_spends ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS query_source;
+

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000101_add_query_source_to_cipx_spend.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000101_add_query_source_to_cipx_spend.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+--changeset petrotiurin:000101_add_query_source_to_cipx_spend
+--comment: Add query_source (cipx.call.query_source) to cipx_spends so AI-spend levers can scope to the main conversation loop
+
+-- cipx emits metadata.cipx.call.query_source ('main' for the primary conversation loop, something
+-- else for subagent/auxiliary calls). The "switch default model" savings lever needs to scope to
+-- 'main' only -- subagent calls aren't affected by changing the default model setting -- so this
+-- needs its own typed column rather than being folded into an existing one.
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_spends ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS query_source LowCardinality(String) DEFAULT '';
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_spends ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS query_source;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
@@ -118,7 +118,7 @@ class CostIntelligenceIngestionTest {
 
             var cipxSpan = factory.manufacturePojo(Span.class).toBuilder()
                     .projectName(projectName)
-                    .metadata(spanCipxMetadata("claude-sonnet-4-6", 100, 20, 5, 40))
+                    .metadata(spanCipxMetadata("claude-sonnet-4-6", 100, 20, 5, 40, "main"))
                     .build();
             var plainSpan = factory.manufacturePojo(Span.class).toBuilder()
                     .projectName(projectName)
@@ -135,6 +135,7 @@ class CostIntelligenceIngestionTest {
                 assertThat(row.get().uCacheRead()).isEqualTo(20L);
                 assertThat(row.get().uCacheCreation()).isEqualTo(5L);
                 assertThat(row.get().uOutput()).isEqualTo(40L);
+                assertThat(row.get().querySource()).isEqualTo("main");
                 assertThat(row.get().projectId()).isNotBlank();
                 assertThat(row.get().startMs()).isEqualTo(cipxSpan.startTime().toEpochMilli());
             });
@@ -143,6 +144,25 @@ class CostIntelligenceIngestionTest {
             // listener has already decided this one: it must not have produced a row.
             assertThat(getCipxSpend(plainSpan.id(), ws.workspaceId())).isEmpty();
             assertThat(getCipxBlocks(plainSpan.id(), ws.workspaceId())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("span with no query_source in cipx.call defaults to an empty string, not dropped")
+        void spanWithoutQuerySourceDefaultsToEmpty() {
+            var ws = newWorkspace();
+            String projectName = "cipx-" + UUID.randomUUID();
+
+            var span = factory.manufacturePojo(Span.class).toBuilder()
+                    .projectName(projectName)
+                    .metadata(spanCipxMetadataNoQuerySource("claude-sonnet-4-6", 100, 20, 5, 40))
+                    .build();
+            spanResourceClient.createSpan(span, ws.apiKey(), ws.workspaceName());
+
+            await().atMost(30, SECONDS).untilAsserted(() -> {
+                var row = getCipxSpend(span.id(), ws.workspaceId());
+                assertThat(row).isPresent();
+                assertThat(row.get().querySource()).isEmpty();
+            });
         }
 
         @Test
@@ -156,7 +176,7 @@ class CostIntelligenceIngestionTest {
             // output=40 (one output block absorbs it all).
             var span = factory.manufacturePojo(Span.class).toBuilder()
                     .projectName(projectName)
-                    .metadata(spanCipxMetadata("claude-sonnet-4-6", 100, 20, 5, 40))
+                    .metadata(spanCipxMetadata("claude-sonnet-4-6", 100, 20, 5, 40, "main"))
                     .build();
             spanResourceClient.createSpan(span, ws.apiKey(), ws.workspaceName());
 
@@ -365,13 +385,14 @@ class CostIntelligenceIngestionTest {
     }
 
     private static JsonNode spanCipxMetadata(String model, long input, long cacheRead, long cacheCreation,
-            long output) {
+            long output, String querySource) {
         return JsonUtils.getJsonNodeFromString(
                 """
                         {
                           "cipx": {
                             "call": {
                               "model": "%s",
+                              "query_source": "%s",
                               "usage": {
                                 "input_tokens": %d,
                                 "cache_read_input_tokens": %d,
@@ -386,6 +407,29 @@ class CostIntelligenceIngestionTest {
                               {"category":"mcp_tool_calls","side":"output","cache_status":"none","parent_category":"assistant","chars":30,"tool_name":"search","tool_server":"srv","tool_use_id":"tu1","resource":"res","kind":"tool"},
                               {"category":"tool_io","side":"input","cache_status":"unknown","parent_category":"context","chars":75,"tool_name":"Bash","tool_server":"","tool_use_id":"tu2","resource":"","kind":"tool"}
                             ]
+                          }
+                        }
+                        """
+                        .formatted(model, querySource, input, cacheRead, cacheCreation, output));
+    }
+
+    // No "query_source" key in cipx.call at all -- proves the DAO's asText("") default kicks in
+    // rather than a dropped/broken binding silently losing the whole row.
+    private static JsonNode spanCipxMetadataNoQuerySource(String model, long input, long cacheRead,
+            long cacheCreation, long output) {
+        return JsonUtils.getJsonNodeFromString(
+                """
+                        {
+                          "cipx": {
+                            "call": {
+                              "model": "%s",
+                              "usage": {
+                                "input_tokens": %d,
+                                "cache_read_input_tokens": %d,
+                                "cache_creation_input_tokens": %d,
+                                "output_tokens": %d
+                              }
+                            }
                           }
                         }
                         """
@@ -418,7 +462,8 @@ class CostIntelligenceIngestionTest {
                     project_id AS project_id,
                     toUnixTimestamp64Milli(start_time) AS start_ms,
                     model AS model,
-                    u_input, u_cache_read, u_cache_creation, u_output
+                    u_input, u_cache_read, u_cache_creation, u_output,
+                    query_source AS query_source
                 FROM cipx_spends FINAL
                 WHERE workspace_id = :workspace_id AND span_id = :span_id
                 """;
@@ -434,7 +479,8 @@ class CostIntelligenceIngestionTest {
                             row.get("u_input", Long.class),
                             row.get("u_cache_read", Long.class),
                             row.get("u_cache_creation", Long.class),
-                            row.get("u_output", Long.class)))));
+                            row.get("u_output", Long.class),
+                            row.get("query_source", String.class)))));
         }).blockOptional();
     }
 
@@ -533,7 +579,7 @@ class CostIntelligenceIngestionTest {
     }
 
     private record CipxSpendRow(String projectId, Long startMs, String model, Long uInput, Long uCacheRead,
-            Long uCacheCreation, Long uOutput) {
+            Long uCacheCreation, Long uOutput, String querySource) {
     }
 
     private record CipxBlockRow(Integer blockIdx, String src, String category, String tier, String lane,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
@@ -21,6 +21,7 @@ import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.redis.testcontainers.RedisContainer;
+import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -472,15 +473,16 @@ class CostIntelligenceIngestionTest {
                     .bind("workspace_id", workspaceId)
                     .bind("span_id", spanId.toString());
             return Mono.from(statement.execute())
-                    .flatMap(result -> Mono.from(result.map((row, meta) -> new CipxSpendRow(
-                            row.get("project_id", String.class),
-                            row.get("start_ms", Long.class),
-                            row.get("model", String.class),
-                            row.get("u_input", Long.class),
-                            row.get("u_cache_read", Long.class),
-                            row.get("u_cache_creation", Long.class),
-                            row.get("u_output", Long.class),
-                            row.get("query_source", String.class)))));
+                    .flatMap(result -> Mono.from(result.map((row, meta) -> CipxSpendRow.builder()
+                            .projectId(row.get("project_id", String.class))
+                            .startMs(row.get("start_ms", Long.class))
+                            .model(row.get("model", String.class))
+                            .uInput(row.get("u_input", Long.class))
+                            .uCacheRead(row.get("u_cache_read", Long.class))
+                            .uCacheCreation(row.get("u_cache_creation", Long.class))
+                            .uOutput(row.get("u_output", Long.class))
+                            .querySource(row.get("query_source", String.class))
+                            .build())));
         }).blockOptional();
     }
 
@@ -578,6 +580,7 @@ class CostIntelligenceIngestionTest {
     private record WorkspaceContext(String apiKey, String workspaceName, String workspaceId) {
     }
 
+    @Builder(toBuilder = true)
     private record CipxSpendRow(String projectId, Long startMs, String model, Long uInput, Long uCacheRead,
             Long uCacheCreation, Long uOutput, String querySource) {
     }


### PR DESCRIPTION
## Details
Re-adds `query_source` as a typed column on `cipx_spends` — dropped when the table moved from `spans.metadata` JSON to typed columns — so the companion ai-cost-backend PR's "switch default model" savings estimate can scope to the main conversation loop only (subagent calls aren't affected by the default-model setting, so including them would overstate the recommendation).

- `cipx.call.query_source` (`'main'` for the primary conversation loop vs. subagent/auxiliary calls) was dropped when `cipx_spends` moved from `spans.metadata` JSON to typed columns (migrations 000093/000094 + `CipxSpendDAO`).
- `000101_add_query_source_to_cipx_spend.sql`: `ALTER TABLE ... ADD COLUMN IF NOT EXISTS query_source LowCardinality(String) DEFAULT ''`. (Renumbered from 000098 -> 000101 and rebased `CipxSpendDAO` after main's own OPIK-7231 refactor (#7392) claimed 000098-000100 moving `blocks` off `cipx_spends` into a new `cipx_spend_blocks` table — that refactor is orthogonal to this column and didn't change `cipx_spends`' per-span row shape.)
- `CipxSpendDAO.SpanRow.from()` now extracts `call.query_source` (defaulting to `""`, same pattern as `model`) and threads it through the `INSERT`.

Companion PR: comet-ml/ai-cost-backend#7 (reads this column; degrades gracefully — `model_main_loop` just comes back empty — until this lands and backfills).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK_7231

<!--
Jira linking: tickets this PR RESOLVES keep the hyphen (OPIK-1234) here and anywhere — they link in Jira's Development panel, which is wanted. A PR may resolve more than one ticket; list each resolved key.
Tickets RELATED but NOT resolved here (escalations, references to older tickets) must NOT link: in the sections above/below and in commit messages, write them with an underscore (OPIK_7000) and paste no Jira URL (the URL contains the hyphenated key and links anyway). See CONTRIBUTING.md.
-->

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Sonnet 5
- Scope: Full implementation (migration + DAO change), rebase, tests, and PR description
- Human verification: Reviewed by petrotiurin

## Testing
- [x] `mvn -o compile -Dmaven.test.skip=true` on `apps/opik-backend` — clean
- [x] `mvn -o test -Dtest=CostIntelligenceIngestionTest` — 6/6 passing, including a new pair of cases asserting `query_source` round-trips: a non-empty value persists through to `cipx_spends`, and a span with the key entirely absent from `cipx.call` defaults to `""` rather than dropping the row
- [x] `./scripts/check_clickhouse_migrations_cluster.sh` on the new migration file — passes (`ON CLUSTER '{cluster}'` present)
- [x] `./scripts/check_backend_migration_conflicts.sh` — `000101` is a unique, available prefix vs. current `origin/main`
- [x] `mvn -o spotless:check` — clean

## Documentation

None needed — internal schema/DAO change with no user-facing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)