### PR TITLE
[OPIK-7192] [BE][FE] refactor: gate Agent Insights behind the Ollie toggle

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -153,7 +153,7 @@ uuidValidation:
 # Description: credentials for the Agent Insights read-only free-form SQL ClickHouse user (restricted user with a
 #   read-only profile + row policies, provisioned by OPIK-6846). Only the user/password live here; the connection
 #   params (protocol/host/port/database) are reused from databaseAnalytics above (same ClickHouse instance). Only used
-#   when the serviceToggles.agentInsightsEnabled toggle is on.
+#   when the serviceToggles.ollieEnabled toggle is on.
 databaseAnalyticsReadOnlyFreeFormSql:
   #  Default: comet_readonly_freeform_sql_user
   #  Description: The read-only username used to connect to the server
@@ -1373,7 +1373,9 @@ serviceToggles:
   # Description: Whether or not Ollama provider is enabled
   ollamaProviderEnabled: ${TOGGLE_OLLAMA_PROVIDER_ENABLED:-"true"}
   # Default: false
-  # Description: Whether or not the Ollie AI assistant integration is enabled.
+  # Description: Whether or not the Ollie AI assistant integration is enabled. Also gates the Agent Insights
+  #   freeform SQL path: the read-only ClickHouse client and the clickhouse-readonly-freeform-sql health check.
+  #   When off, the read-only client is never queried.
   ollieEnabled: ${TOGGLE_OLLIE_ENABLED:-"false"}
   # Default: false
   # Description: Whether the project homepage is enabled. When false, the Ollie page is the default project page.
@@ -1382,10 +1384,6 @@ serviceToggles:
   # Description: Master switch for the agentic-tools path on LLM-as-judge online scoring. When false, the
   #   inline path is used regardless of context size. Threshold lives under onlineScoring.agenticToolsThresholdTokens.
   agenticToolsEnabled: ${TOGGLE_AGENTIC_TOOLS_ENABLED:-"false"}
-  # Default: false
-  # Description: Whether or not the Agent Insights freeform SQL path is enabled. Gates the read-only ClickHouse client
-  #   and the clickhouse-readonly-freeform-sql health check usage. When off, the read-only client is never queried.
-  agentInsightsEnabled: ${TOGGLE_AGENT_INSIGHTS_ENABLED:-"false"}
   # Default: true
   # Description: Whether the online-scoring (LLM-as-judge) evaluation loop is persisted as monitoring traces/spans.
   #   When on, each evaluation produces one trace (source=evaluator) with one llm span per LLM round, so cost and

--- a/apps/opik-backend/provision_agent_insights_readonly_user.sh
+++ b/apps/opik-backend/provision_agent_insights_readonly_user.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Provision the Agent Insights read-only free-form SQL ClickHouse user, settings profile, grants and row policies.
 #
-# Opt-in: only runs when TOGGLE_AGENT_INSIGHTS_ENABLED=true; otherwise it's a no-op so default installs are untouched.
+# Opt-in: only runs when TOGGLE_OLLIE_ENABLED=true; otherwise it's a no-op so default installs are untouched.
 # This is the single local copy of the DDL, shared by docker-compose (backend container, between run_db_migrations.sh
 # and entrypoint.sh) and scripts/dev-runner.sh. It mirrors the prod provisioning owned by OPIK-6846 — keep them in
 # sync. Must run AFTER the analytics migrations (the GRANT/ROW POLICY statements reference the opik tables) and BEFORE
@@ -16,7 +16,7 @@ set -euo pipefail
 # "true"/"True"/"TRUE" to boolean true — a strict `[ "$VAR" != "true" ]` would silently skip
 # provisioning while the backend boots with the feature armed. `tr` rather than bash 4 `${var,,}`
 # keeps this runnable on macOS bash 3.2 for scripts/dev-runner.sh.
-toggle="${TOGGLE_AGENT_INSIGHTS_ENABLED:-false}"
+toggle="${TOGGLE_OLLIE_ENABLED:-false}"
 toggle="${toggle#\"}"
 toggle="${toggle%\"}"
 toggle=$(printf '%s' "$toggle" | tr '[:upper:]' '[:lower:]')

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgentInsightsReportSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgentInsightsReportSubscriber.java
@@ -114,7 +114,7 @@ public class AgentInsightsReportSubscriber extends BaseRedisSubscriber<AgentInsi
     }
 
     private boolean isDisabled() {
-        if (!serviceToggles.isAgentInsightsEnabled()) {
+        if (!serviceToggles.isOllieEnabled()) {
             log.info("Agent Insights is disabled, skipping report subscriber lifecycle operation");
             return true;
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/internal/AnalyticsQueriesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/internal/AnalyticsQueriesResource.java
@@ -37,7 +37,7 @@ import java.util.concurrent.CompletionException;
 /**
  * Internal, authenticated endpoint that runs Ollie-generated read-only SQL against ClickHouse, bounded to the
  * caller's workspace and the requested project. Authentication is required only to derive the bounding
- * {@code workspace_id} ({@code project_id} comes from the body). Gated behind the {@code agentInsightsEnabled}
+ * {@code workspace_id} ({@code project_id} comes from the body). Gated behind the {@code ollieEnabled}
  * toggle: when off it returns {@code 501 Not Implemented} and performs no ClickHouse access.
  *
  * <p>The caller's final query must return exactly one column named {@code result}, produced via
@@ -67,7 +67,7 @@ public class AnalyticsQueriesResource {
     public Response executeQuery(@PathParam("projectId") @NotNull UUID projectId,
             @RequestBody(content = @Content(schema = @Schema(implementation = AnalyticsQueryRequest.class))) @NotNull @Valid AnalyticsQueryRequest request) {
 
-        if (!serviceToggles.isAgentInsightsEnabled()) {
+        if (!serviceToggles.isOllieEnabled()) {
             return Response.status(Response.Status.NOT_IMPLEMENTED).build();
         }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsReportPublisher.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsReportPublisher.java
@@ -49,7 +49,7 @@ public class AgentInsightsReportPublisher {
     public Mono<String> enqueue(@NonNull UUID projectId, @NonNull String workspaceId,
             @NonNull Instant periodStart, @NonNull Instant periodEnd, @NonNull String triggerSource) {
 
-        if (!serviceToggles.isAgentInsightsEnabled()) {
+        if (!serviceToggles.isOllieEnabled()) {
             log.debug("Agent Insights is disabled, ignoring trigger for project '{}'", projectId);
             return Mono.empty();
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
@@ -68,8 +68,6 @@ public class ServiceTogglesConfig {
     @JsonProperty
     @NotNull boolean agenticToolsEnabled;
     @JsonProperty
-    @NotNull boolean agentInsightsEnabled;
-    @JsonProperty
     @NotNull boolean onlineScoringTracingEnabled;
 
     @NotNull Set<@NotBlank String> v2WorkspaceAllowlistIds = Set.of();

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bi/OpikGuiceyLifecycleEventListener.java
@@ -240,7 +240,7 @@ public class OpikGuiceyLifecycleEventListener implements GuiceyLifecycleListener
     private void setAgentInsightsReportJob() {
         var serviceToggles = injector.get().getInstance(OpikConfiguration.class).getServiceToggles();
 
-        if (!serviceToggles.isAgentInsightsEnabled()) {
+        if (!serviceToggles.isOllieEnabled()) {
             log.info("Agent Insights is disabled, skipping report job setup");
             return;
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/ClickHouseReadOnlyFreeFormSqlHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/ClickHouseReadOnlyFreeFormSqlHealthCheck.java
@@ -16,7 +16,7 @@ import static com.comet.opik.infrastructure.db.DatabaseAnalyticsModule.READ_ONLY
 /**
  * Probes the Agent Insights read-only free-form SQL ClickHouse user via the v2 HTTP client.
  *
- * <p>Gated by {@code agentInsightsEnabled}: when the feature is off the probe reports healthy
+ * <p>Gated by {@code ollieEnabled}: when the feature is off the probe reports healthy
  * without querying ClickHouse, so a misconfigured read-only user never gates overall readiness
  * for an environment that doesn't use the feature.
  */
@@ -31,7 +31,7 @@ public class ClickHouseReadOnlyFreeFormSqlHealthCheck extends AbstractClickHouse
             @NonNull @Named(CLICKHOUSE_HEALTH_CHECK_TIMEOUT) Duration healthCheckTimeout,
             @NonNull @Config("serviceToggles") ServiceTogglesConfig serviceToggles) {
         super(readOnlyClient, healthCheckTimeout, "clickhouse-readonly-freeform-sql");
-        this.enabled = serviceToggles.isAgentInsightsEnabled();
+        this.enabled = serviceToggles.isOllieEnabled();
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/DatabaseAnalyticsModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/DatabaseAnalyticsModule.java
@@ -41,7 +41,7 @@ public class DatabaseAnalyticsModule extends DropwizardAwareModule<OpikConfigura
         });
 
         // Read-only client used for Agent Insights freeform SQL. The v2 client connects lazily, so building it is
-        // cheap and never contacts ClickHouse until a query runs; the agentInsightsEnabled toggle gates all usage.
+        // cheap and never contacts ClickHouse until a query runs; the ollieEnabled toggle gates all usage.
         readOnlyFreeFormSqlClickHouseClient = buildReadOnlyFreeFormSqlClient();
         environment().lifecycle().manage(new Managed() {
             @Override

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/internal/AnalyticsQueriesResourceDisabledTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/internal/AnalyticsQueriesResourceDisabledTest.java
@@ -69,7 +69,7 @@ class AnalyticsQueriesResourceDisabledTest {
         MigrationUtils.runMysqlDbMigration(MYSQL);
         MigrationUtils.runClickhouseDbMigration(CLICKHOUSE);
 
-        // agentInsightsEnabled is left at its default (false): the endpoint must return 501.
+        // ollieEnabled is left at its default (false): the endpoint must return 501.
         APP = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
                 TestDropwizardAppExtensionUtils.AppContextConfig.builder()
                         .jdbcUrl(MYSQL.getJdbcUrl())

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/internal/AnalyticsQueriesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/internal/AnalyticsQueriesResourceTest.java
@@ -99,7 +99,7 @@ class AnalyticsQueriesResourceTest {
                         // The read-only free-form SQL user is provisioned globally on the ClickHouse container
                         // (users.xml) and wired by config-test.yml; the test only needs to flip the toggle on.
                         .customConfigs(List.of(
-                                new CustomConfig("serviceToggles.agentInsightsEnabled", "true")))
+                                new CustomConfig("serviceToggles.ollieEnabled", "true")))
                         .build());
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentInsightsJobsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AgentInsightsJobsResourceTest.java
@@ -120,7 +120,7 @@ class AgentInsightsJobsResourceTest {
                 .isMinIO(true)
                 // Enable the Agent Insights feature so the publisher publishes and the subscriber consumes.
                 .customConfigs(List.of(
-                        new TestDropwizardAppExtensionUtils.CustomConfig("serviceToggles.agentInsightsEnabled",
+                        new TestDropwizardAppExtensionUtils.CustomConfig("serviceToggles.ollieEnabled",
                                 "true")))
                 .modules(List.of(new AbstractModule() {
                     @Override

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/HealthCheckIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/HealthCheckIntegrationTest.java
@@ -73,7 +73,7 @@ class HealthCheckIntegrationTest {
     }
 
     /**
-     * Default test-config: {@code serviceToggles.agentInsightsEnabled} off. Covers the standard
+     * Default test-config: {@code serviceToggles.ollieEnabled} off. Covers the standard
      * health check HTTP surface (per-check + aggregate {@code all}). Opik-owned checks
      * (clickhouse, mysql, redis, clickhouse-readonly-freeform-sql) are asserted individually;
      * Dropwizard-provided checks (db, deadlocks) only appear in the aggregate row.
@@ -150,7 +150,7 @@ class HealthCheckIntegrationTest {
     }
 
     /**
-     * {@code serviceToggles.agentInsightsEnabled} on. The production-shape Agent Insights
+     * {@code serviceToggles.ollieEnabled} on. The production-shape Agent Insights
      * read-only user is provisioned globally on the test ClickHouse container (see
      * {@code src/test/resources/users.xml}, mirroring
      * {@code apps/opik-backend/provision_agent_insights_readonly_user.sh}), so the {@code
@@ -167,7 +167,7 @@ class HealthCheckIntegrationTest {
 
         @RegisterApp
         private final TestDropwizardAppExtension app = newApp(List.of(
-                new CustomConfig("serviceToggles.agentInsightsEnabled", "true")));
+                new CustomConfig("serviceToggles.ollieEnabled", "true")));
 
         private ClientSupport client;
         private String baseURI;

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/AbstractClickHouseHealthCheckTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/AbstractClickHouseHealthCheckTest.java
@@ -97,7 +97,7 @@ class AbstractClickHouseHealthCheckTest {
     }
 
     /**
-     * Behaviours specific to the Agent Insights read-only subclass: the {@code agentInsightsEnabled}
+     * Behaviours specific to the Agent Insights read-only subclass: the {@code ollieEnabled}
      * short-circuit and the {@link ClickHouseReadOnlyFreeFormSqlHealthCheck#newQuerySettings()}
      * override that returns {@code null} so the probe carries no per-call settings — the production
      * {@code readonly=1} profile rejects any setting not in its {@code CHANGEABLE_IN_READONLY}
@@ -136,9 +136,9 @@ class AbstractClickHouseHealthCheckTest {
                 .equals(settings.getAllSettings().get(CLICKHOUSE_SETTING_MAX_EXECUTION_TIME));
     }
 
-    private ServiceTogglesConfig toggles(boolean agentInsightsEnabled) {
+    private ServiceTogglesConfig toggles(boolean ollieEnabled) {
         var serviceTogglesConfig = new ServiceTogglesConfig();
-        serviceTogglesConfig.setAgentInsightsEnabled(agentInsightsEnabled);
+        serviceTogglesConfig.setOllieEnabled(ollieEnabled);
         return serviceTogglesConfig;
     }
 

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -126,7 +126,7 @@ uuidValidation:
 # Description: credentials for the Agent Insights read-only free-form SQL user. The connection params are reused
 #   from databaseAnalytics (overridden to the test container). The username/password match the production-shape user
 #   provisioned globally on the test ClickHouse container via src/test/resources/users.xml (mirrors
-#   provision_agent_insights_readonly_user.sh) — so any test enabling serviceToggles.agentInsightsEnabled exercises
+#   provision_agent_insights_readonly_user.sh) — so any test enabling serviceToggles.ollieEnabled exercises
 #   the real readonly=1 profile (max_execution_time pinned, only SQL_workspace_id/SQL_project_id changeable in readonly).
 databaseAnalyticsReadOnlyFreeFormSql:
   username: comet_readonly_freeform_sql_user
@@ -760,7 +760,9 @@ serviceToggles:
   # Description: Whether or not Ollama provider is enabled
   ollamaProviderEnabled: "true"
   # Default: false
-  # Description: Whether or not the Ollie AI assistant integration is enabled.
+  # Description: Whether or not the Ollie AI assistant integration is enabled. Also gates the Agent Insights
+  #   freeform SQL path and the clickhouse-readonly-freeform-sql health check. Tests flip this on when exercising
+  #   the read-only ClickHouse client.
   ollieEnabled: "false"
   # Default: false
   # Description: Master switch for the agentic-tools path on LLM-as-judge online scoring.
@@ -768,10 +770,6 @@ serviceToggles:
   # Default: true
   # Description: Whether the online-scoring (LLM-as-judge) evaluation loop is persisted as monitoring traces.
   onlineScoringTracingEnabled: "true"
-  # Default: false
-  # Description: Whether or not the Agent Insights freeform SQL path is enabled. Tests flip this on when exercising
-  #   the read-only ClickHouse client and the clickhouse-readonly-freeform-sql health check.
-  agentInsightsEnabled: "false"
   # Default: "" (empty, no allowlisted workspaces)
   # Description: Comma-separated list of workspace IDs that should always receive V2 navigation.
   # Valid values: comma-separated workspace IDs (e.g. "ws-id-1,ws-id-2"), or "" (empty, disabled).

--- a/apps/opik-backend/src/test/resources/users.xml
+++ b/apps/opik-backend/src/test/resources/users.xml
@@ -4,7 +4,7 @@
         apps/opik-backend/provision_agent_insights_readonly_user.sh: settings profile, user, the
         per-table SELECT grants and the row policies. Loaded by ClickHouse at startup from
         /etc/clickhouse-server/users.d/. Inert unless a test enables
-        serviceToggles.agentInsightsEnabled and points the freeform-SQL client credentials at
+        serviceToggles.ollieEnabled and points the freeform-SQL client credentials at
         this user (config-test.yml already does).
 
         The opik database is created by the container at startup via the CLICKHOUSE_DB env var

--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -20789,7 +20789,6 @@ components:
           format: int64
     ServiceTogglesConfig:
       required:
-      - agentInsightsEnabled
       - agenticToolsEnabled
       - alertsEnabled
       - anthropicProviderEnabled
@@ -20867,8 +20866,6 @@ components:
         projectHomepageEnabled:
           type: boolean
         agenticToolsEnabled:
-          type: boolean
-        agentInsightsEnabled:
           type: boolean
         onlineScoringTracingEnabled:
           type: boolean

--- a/apps/opik-frontend/src/contexts/feature-toggles-provider.tsx
+++ b/apps/opik-frontend/src/contexts/feature-toggles-provider.tsx
@@ -26,7 +26,6 @@ const DEFAULT_STATE: FeatureToggles = {
   [FeatureToggleKeys.DATASET_EXPORT_ENABLED]: true,
   [FeatureToggleKeys.DEMO_DATA_ENABLED]: true,
   [FeatureToggleKeys.OLLIE_ENABLED]: false,
-  [FeatureToggleKeys.AGENT_INSIGHTS_ENABLED]: false,
   [FeatureToggleKeys.PROJECT_HOMEPAGE_ENABLED]: false,
   [FeatureToggleKeys.COST_INTELLIGENCE_ENABLED]: false,
   [FeatureToggleKeys.SPAN_LLM_AS_JUDGE_ENABLED]: false,

--- a/apps/opik-frontend/src/types/feature-toggles.ts
+++ b/apps/opik-frontend/src/types/feature-toggles.ts
@@ -11,7 +11,6 @@ export enum FeatureToggleKeys {
   DATASET_EXPORT_ENABLED = "dataset_export_enabled",
   DEMO_DATA_ENABLED = "demo_data_enabled",
   OLLIE_ENABLED = "ollie_enabled",
-  AGENT_INSIGHTS_ENABLED = "agent_insights_enabled",
   PROJECT_HOMEPAGE_ENABLED = "project_homepage_enabled",
   SPAN_LLM_AS_JUDGE_ENABLED = "span_llm_as_judge_enabled",
   SPAN_USER_DEFINED_METRIC_PYTHON_ENABLED = "span_user_defined_metric_python_enabled",

--- a/apps/opik-frontend/src/v2/layout/SideBar/SideBarMenuItems.tsx
+++ b/apps/opik-frontend/src/v2/layout/SideBar/SideBarMenuItems.tsx
@@ -19,9 +19,6 @@ const SideBarMenuItems: React.FC<SideBarMenuItemsProps> = ({ expanded }) => {
   const activeProjectId = useActiveProjectId();
   const AssistantSidebar = usePluginsStore((state) => state.AssistantSidebar);
   const ollieEnabled = useIsFeatureEnabled(FeatureToggleKeys.OLLIE_ENABLED);
-  const agentInsightsEnabled = useIsFeatureEnabled(
-    FeatureToggleKeys.AGENT_INSIGHTS_ENABLED,
-  );
   const projectHomepageEnabled = useIsFeatureEnabled(
     FeatureToggleKeys.PROJECT_HOMEPAGE_ENABLED,
   );
@@ -52,7 +49,7 @@ const SideBarMenuItems: React.FC<SideBarMenuItemsProps> = ({ expanded }) => {
     canViewAlerts,
     showHomePage: projectHomepageEnabled,
     showOlliePage: !!AssistantSidebar && ollieEnabled,
-    showDiagnostics: !!AssistantSidebar && ollieEnabled && agentInsightsEnabled,
+    showDiagnostics: !!AssistantSidebar && ollieEnabled,
   });
 
   const renderItems = (items: MenuItem[]) => {

--- a/apps/opik-frontend/src/v2/pages/SignalsPage/SignalsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/SignalsPage/SignalsPage.tsx
@@ -69,9 +69,6 @@ const SignalsPage: React.FC<{ showResolved?: boolean }> = ({
 
   const AssistantSidebar = usePluginsStore((state) => state.AssistantSidebar);
   const ollieEnabled = useIsFeatureEnabled(FeatureToggleKeys.OLLIE_ENABLED);
-  const agentInsightsEnabled = useIsFeatureEnabled(
-    FeatureToggleKeys.AGENT_INSIGHTS_ENABLED,
-  );
 
   // Running / enabling / configuring diagnostics are write actions gated on
   // workspace-settings permission; viewing issues stays open to all.
@@ -199,7 +196,7 @@ const SignalsPage: React.FC<{ showResolved?: boolean }> = ({
   const hasData = (issuesData?.content?.length ?? 0) > 0;
   const isActive = isJobEnabled || isRunning;
 
-  if (!AssistantSidebar || !ollieEnabled || !agentInsightsEnabled) {
+  if (!AssistantSidebar || !ollieEnabled) {
     return (
       <Navigate
         to="/$workspaceName/projects/$projectId/home"

--- a/deployment/docker-compose/clickhouse_config/additional_config.xml
+++ b/deployment/docker-compose/clickhouse_config/additional_config.xml
@@ -1,7 +1,7 @@
 <clickhouse>
     <!-- Permits SQL_-prefixed custom settings (SQL_workspace_id / SQL_project_id) used by the Agent Insights
          read-only user's settings profile and row policies. Inert unless that user/profile is provisioned
-         (dev-runner with TOGGLE_AGENT_INSIGHTS_ENABLED=true, or prod via OPIK-6846). No effect otherwise. -->
+         (dev-runner with TOGGLE_OLLIE_ENABLED=true, or prod via OPIK-6846). No effect otherwise. -->
     <custom_settings_prefixes>SQL_</custom_settings_prefixes>
 
     <macros>

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -168,9 +168,9 @@ services:
       ANALYTICS_DB_DATABASE_NAME: opik
       ANALYTICS_DB_USERNAME: opik
       ANALYTICS_DB_PASS: opik
-      # Agent Insights read-only freeform SQL (default off). When true, the backend provisions the restricted
+      # Ollie / Agent Insights read-only freeform SQL (default off). When true, the backend provisions the restricted
       # read-only user (provision_agent_insights_readonly_user.sh, after migrations) and connects as it.
-      TOGGLE_AGENT_INSIGHTS_ENABLED: ${TOGGLE_AGENT_INSIGHTS_ENABLED:-"false"}
+      TOGGLE_OLLIE_ENABLED: ${TOGGLE_OLLIE_ENABLED:-"false"}
       ANALYTICS_DB_READ_ONLY_FREEFORM_SQL_USER: ${ANALYTICS_DB_READ_ONLY_FREEFORM_SQL_USER:-comet_readonly_freeform_sql_user}
       ANALYTICS_DB_READ_ONLY_FREEFORM_SQL_PASS: ${ANALYTICS_DB_READ_ONLY_FREEFORM_SQL_PASS:-opik}
       JAVA_OPTS: "-Dliquibase.propertySubstitutionEnabled=true -XX:+UseG1GC -XX:MaxRAMPercentage=80.0"

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -16,11 +16,11 @@ ORIGINAL_COMMAND="$0 $@"
 # version_1) before invoking the script.
 export TOGGLE_FORCE_WORKSPACE_VERSION="${TOGGLE_FORCE_WORKSPACE_VERSION:-version_2}"
 
-# Agent Insights read-only freeform SQL is off by default for local dev (the feature is driven by the Ollie agent,
-# which isn't available locally). Set TOGGLE_AGENT_INSIGHTS_ENABLED=true before invoking to opt in: start_backend
+# Ollie / Agent Insights read-only freeform SQL is off by default for local dev (the feature is driven by the Ollie
+# agent, which isn't available locally). Set TOGGLE_OLLIE_ENABLED=true before invoking to opt in: start_backend
 # then provisions the restricted read-only ClickHouse user/profile/policies and the JVM connects with the feature on.
 # Exported here so this single variable controls both the provisioning gate and the JAR-mode backend (config.yml).
-export TOGGLE_AGENT_INSIGHTS_ENABLED="${TOGGLE_AGENT_INSIGHTS_ENABLED:-false}"
+export TOGGLE_OLLIE_ENABLED="${TOGGLE_OLLIE_ENABLED:-false}"
 
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
@@ -901,11 +901,11 @@ start_backend() {
     # read-only ClickHouse user (via the shared script also used by the docker-compose backend container) and export
     # its credentials so the locally-launched backend connects as that user. Default off: behavior unchanged. The
     # script runs against the docker-compose ClickHouse on localhost:${ANALYTICS_DB_PORT} exported just above.
-    if [ "${TOGGLE_AGENT_INSIGHTS_ENABLED}" = "true" ]; then
+    if [ "${TOGGLE_OLLIE_ENABLED}" = "true" ]; then
         export ANALYTICS_DB_READ_ONLY_FREEFORM_SQL_USER="${ANALYTICS_DB_READ_ONLY_FREEFORM_SQL_USER:-comet_readonly_freeform_sql_user}"
         export ANALYTICS_DB_READ_ONLY_FREEFORM_SQL_PASS="${ANALYTICS_DB_READ_ONLY_FREEFORM_SQL_PASS:-opik}"
         bash "$BACKEND_DIR/provision_agent_insights_readonly_user.sh"
-        log_debug "  TOGGLE_AGENT_INSIGHTS_ENABLED=true (read-only CH user: ${ANALYTICS_DB_READ_ONLY_FREEFORM_SQL_USER})"
+        log_debug "  TOGGLE_OLLIE_ENABLED=true (read-only CH user: ${ANALYTICS_DB_READ_ONLY_FREEFORM_SQL_USER})"
     fi
 
     log_debug "Backend configured with:"

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -20789,7 +20789,6 @@ components:
           format: int64
     ServiceTogglesConfig:
       required:
-      - agentInsightsEnabled
       - agenticToolsEnabled
       - alertsEnabled
       - anthropicProviderEnabled
@@ -20867,8 +20866,6 @@ components:
         projectHomepageEnabled:
           type: boolean
         agenticToolsEnabled:
-          type: boolean
-        agentInsightsEnabled:
           type: boolean
         onlineScoringTracingEnabled:
           type: boolean

--- a/sdks/python/src/opik/rest_api/types/service_toggles_config.py
+++ b/sdks/python/src/opik/rest_api/types/service_toggles_config.py
@@ -37,7 +37,6 @@ class ServiceTogglesConfig(UniversalBaseModel):
     ollie_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="ollieEnabled")]
     project_homepage_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="projectHomepageEnabled")]
     agentic_tools_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="agenticToolsEnabled")]
-    agent_insights_enabled: typing_extensions.Annotated[bool, FieldMetadata(alias="agentInsightsEnabled")]
     online_scoring_tracing_enabled: typing_extensions.Annotated[
         bool, FieldMetadata(alias="onlineScoringTracingEnabled")
     ]

--- a/sdks/typescript/src/opik/rest_api/api/types/ServiceTogglesConfig.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/ServiceTogglesConfig.ts
@@ -25,7 +25,6 @@ export interface ServiceTogglesConfig {
     ollieEnabled: boolean;
     projectHomepageEnabled: boolean;
     agenticToolsEnabled: boolean;
-    agentInsightsEnabled: boolean;
     onlineScoringTracingEnabled: boolean;
     v2WorkspaceAllowlistIds: string[];
     v1WorkspaceAllowlistIds: string[];

--- a/sdks/typescript/src/opik/rest_api/serialization/types/ServiceTogglesConfig.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/ServiceTogglesConfig.ts
@@ -32,7 +32,6 @@ export const ServiceTogglesConfig: core.serialization.ObjectSchema<
     ollieEnabled: core.serialization.boolean(),
     projectHomepageEnabled: core.serialization.boolean(),
     agenticToolsEnabled: core.serialization.boolean(),
-    agentInsightsEnabled: core.serialization.boolean(),
     onlineScoringTracingEnabled: core.serialization.boolean(),
     v2WorkspaceAllowlistIds: core.serialization.list(core.serialization.string()),
     v1WorkspaceAllowlistIds: core.serialization.list(core.serialization.string()),
@@ -68,7 +67,6 @@ export declare namespace ServiceTogglesConfig {
         ollieEnabled: boolean;
         projectHomepageEnabled: boolean;
         agenticToolsEnabled: boolean;
-        agentInsightsEnabled: boolean;
         onlineScoringTracingEnabled: boolean;
         v2WorkspaceAllowlistIds: string[];
         v1WorkspaceAllowlistIds: string[];


### PR DESCRIPTION
## Details

Removes the standalone Agent Insights feature toggle from the frontend and backend and gates the feature solely on the existing **Ollie** toggle, so a single switch enables/disables it. Motivation: Agent Insights is only usable when Ollie is available, so two independent toggles added configuration surface with no benefit and let the two features drift out of sync.

- FE: dropped `AGENT_INSIGHTS_ENABLED` from the toggle enum/defaults; the Diagnostics menu item and the Signals/Diagnostics page now gate on `ollieEnabled` only.
- BE: removed `agentInsightsEnabled` from `ServiceTogglesConfig` and repointed every gate site (freeform-SQL endpoint, report publisher/subscriber, cron job setup, readonly-freeform-sql health check) to `isOllieEnabled()`.
- Deployment/dev: `TOGGLE_AGENT_INSIGHTS_ENABLED` → `TOGGLE_OLLIE_ENABLED` in docker-compose, `dev-runner.sh`, the readonly-user provisioning script, and the ClickHouse config comment.
- Regenerated the OpenAPI specs and TypeScript `rest_api` types without the field.

> [!NOTE]
> `ollieEnabled` was previously not read on the backend at all. Enabling Ollie in an environment now also arms the freeform-SQL / ClickHouse read-only path and the report pipeline. That is the intended consolidation, but the two features can no longer be toggled independently.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7192

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Full change — located both toggles, applied the FE/BE/deployment edits, updated generated artifacts, and authored this description.
  - Human verification: Reviewed by @aadereiko; frontend typecheck run locally.

## Testing

- `npx tsc --noEmit` in `apps/opik-frontend` — passes clean (0 errors).
- Repo-wide grep confirms no remaining references to `agentInsightsEnabled` / `TOGGLE_AGENT_INSIGHTS_ENABLED` / `AGENT_INSIGHTS_ENABLED`.
- Backend build/tests not run locally (requires JDK 25 + Maven); CI will exercise the updated `serviceToggles.ollieEnabled`-gated tests (`AnalyticsQueriesResourceTest`, `AnalyticsQueriesResourceDisabledTest`, `AgentInsightsJobsResourceTest`, `HealthCheckIntegrationTest`, `AbstractClickHouseHealthCheckTest`).

## Documentation

No user-facing docs change; the OpenAPI reference is regenerated as part of this PR.
