### PR TITLE
[NA] [SDK] test: un-skip langchain Groq usage-logging test

### DIFF
--- a/sdks/python/tests/library_integration/langchain/test_langchain_groq.py
+++ b/sdks/python/tests/library_integration/langchain/test_langchain_groq.py
@@ -15,7 +15,6 @@ from ...testlib import (
 )
 
 
-@pytest.mark.skip(reason="Until resolve groq credentials issue in CI")
 @pytest.mark.parametrize(
     "streaming",
     [False, True],


### PR DESCRIPTION
## Details

`test_langchain__openai_llm_is_used__token_usage_is_logged__happy_flow` in `test_langchain_groq.py` has been skipped since 2026-04-14 (`Until resolve groq credentials issue in CI`). That issue is now resolved (confirmed via a real API call in a separate PR's CI run), so this un-skips it.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Sonnet 5
- Scope: Single-line change (remove skip decorator), directed by the author after confirming the underlying Groq credentials/billing issue was resolved.
- Human verification: Author to confirm CI passes against the real Groq API before merging out of draft.

## Testing

- Ran locally without `GROQ_API_KEY` — fails loudly via `ensure_groq_configured` as expected (same as before un-skipping; can't validate against the real API without the CI secret).
- `pre-commit run --files sdks/python/tests/library_integration/langchain/test_langchain_groq.py` — ruff, ruff-format, mypy all pass.
- CI (`lib-langchain-tests.yml`) already injects `GROQ_API_KEY` from repo secrets — dispatching to confirm the real-API call now succeeds.

## Documentation

No documentation changes required.