### PR TITLE
[NA] Point cost-api session auth at comet-backend in platform mode

### DIFF
--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -760,8 +760,13 @@ start_cost_api_local() {
         rm -f "$COST_API_PID_FILE"
     fi
 
-    # No Platform locally, so disable auth (pins to the default workspace). Point at
-    # the dev-runner's own ClickHouse + MySQL (host-published ports, opik/opik).
+    # Point cost-api at the dev-runner's ClickHouse + MySQL (host-published
+    # ports, opik/opik). In platform (EM) mode, cost-api targets local comet-backend
+    # (the React service on EM_BACKEND_PORT).
+    # No-op in OSS mode (cost-api keeps its default).
+    if em_stack_enabled; then
+        export PLATFORM_BASE_URL="http://localhost:${EM_BACKEND_PORT}"
+    fi
     (
         cd "$AI_COST_BACKEND_PATH" || exit 1
         AUTH_ENABLED=false \


### PR DESCRIPTION
## Details

In the dev-runner's platform (EM) mode, point **cost-api**'s session-delegation auth at **comet-backend** instead of the Opik backend. Follow-up to the EM/Platform dev-runner integration (already on `main`).

cost-api's `require_workspace` forwards the browser session cookie to `POST {platform_base_url}/opik/auth-session`, but `platform_base_url` defaults to `http://localhost:8080` — the **Opik** backend, which doesn't serve that endpoint (404), so the AI-Spend endpoints 403. comet-backend (the React service) serves `/opik/auth-session` on `EM_BACKEND_PORT` (`:8200`).

- Fix: when `PLATFORM_ENABLED`, `start_cost_api_local` exports `PLATFORM_BASE_URL=http://localhost:${EM_BACKEND_PORT}`. No-op in OSS mode (cost-api keeps its default).
- Exported (not placed in the env prefix) on purpose: bash decides which prefix words are assignments *before* expansion, so an expanded `${..:+name=val}` word is parsed as the command, not an assignment.
- Pairs with `ai-cost-backend` dropping `comet_backend_base_url` (only `platform_base_url` remains).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

N/A — no ticket (NA).

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: diagnosed the cost-api → comet-backend auth-target mismatch and authored the one-line `start_cost_api_local` fix.
- Human verification: restarted cost-api in platform mode and confirmed the targeting live (below).

## Testing

- `bash -n scripts/dev-runner.sh` — pass.
- Restarted cost-api in platform mode (`PLATFORM_ENABLED=true`, EM stack up) and verified:
  - cost-api process env now carries `PLATFORM_BASE_URL=http://localhost:8200`
  - `:8400/cost-api/ping` → 200
  - auth target `:8200/opik/auth-session` → **401** (comet-backend serves it), vs. the old default `:8080/opik/auth-session` → **404**
  - Opik / EM / proxy unaffected (`:9100/`, `/api/auth/test`, `/opik/api/is-alive/ping` all 200)
- Environment: local process mode, macOS; EM stack on the merged dev-runner.

## Documentation

Covered by the inline comment in `start_cost_api_local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
