### PR TITLE
[OPIK-6686] [BE] fix: scope prompt name uniqueness to project

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000089_update_prompts_unique_constraint.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000089_update_prompts_unique_constraint.sql
@@ -1,8 +1,8 @@
 --liquibase formatted sql
 --changeset boryst:000089_update_prompts_unique_constraint
 
-ALTER TABLE prompts DROP INDEX `prompts_workspace_id_name_uk`;
 ALTER TABLE prompts ADD CONSTRAINT `prompts_workspace_id_project_id_name_uk` UNIQUE (workspace_id, project_id, name);
+ALTER TABLE prompts DROP INDEX `prompts_workspace_id_name_uk`;
 
---rollback ALTER TABLE prompts DROP INDEX `prompts_workspace_id_project_id_name_uk`;
 --rollback ALTER TABLE prompts ADD CONSTRAINT `prompts_workspace_id_name_uk` UNIQUE (workspace_id, name);
+--rollback ALTER TABLE prompts DROP INDEX `prompts_workspace_id_project_id_name_uk`;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000089_update_prompts_unique_constraint.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000089_update_prompts_unique_constraint.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+--changeset boryst:000089_update_prompts_unique_constraint
+
+ALTER TABLE prompts DROP INDEX `prompts_workspace_id_name_uk`;
+ALTER TABLE prompts ADD CONSTRAINT `prompts_workspace_id_project_id_name_uk` UNIQUE (workspace_id, project_id, name);
+
+--rollback ALTER TABLE prompts DROP INDEX `prompts_workspace_id_project_id_name_uk`;
+--rollback ALTER TABLE prompts ADD CONSTRAINT `prompts_workspace_id_name_uk` UNIQUE (workspace_id, name);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -1087,7 +1087,7 @@ class PromptResourceTest {
                     .projectId(null)
                     .build();
 
-            Prompt duplicatedPrompt = buildPrompt().build();
+            Prompt duplicatedPrompt = buildPrompt().projectName("conflict-test-project").build();
             createPrompt(duplicatedPrompt, API_KEY, TEST_WORKSPACE);
 
             return Stream.of(
@@ -1116,6 +1116,22 @@ class PromptResourceTest {
                     Arguments.of(buildPrompt().name("").build(),
                             HttpStatus.SC_UNPROCESSABLE_ENTITY,
                             new ErrorMessage(List.of("name must not be blank")), ErrorMessage.class));
+        }
+
+        @Test
+        @DisplayName("when creating prompts with the same name in different projects, then both succeed")
+        void when__creatingPromptsWithSameNameInDifferentProjects__thenBothSucceed() {
+            String sharedName = UUID.randomUUID().toString();
+
+            var prompt1 = buildPrompt().name(sharedName).projectName("project-alpha").build();
+            var prompt2 = buildPrompt().name(sharedName).projectName("project-beta").build();
+
+            var id1 = createPrompt(prompt1, API_KEY, TEST_WORKSPACE);
+            var id2 = createPrompt(prompt2, API_KEY, TEST_WORKSPACE);
+
+            assertThat(id1).isNotNull();
+            assertThat(id2).isNotNull();
+            assertThat(id1).isNotEqualTo(id2);
         }
     }
 
@@ -1177,11 +1193,13 @@ class PromptResourceTest {
             var prompt = buildPrompt()
                     .lastUpdatedBy(USER)
                     .createdBy(USER)
+                    .projectName("update-conflict-project")
                     .build();
 
             var prompt2 = buildPrompt()
                     .lastUpdatedBy(USER)
                     .createdBy(USER)
+                    .projectName("update-conflict-project")
                     .build();
 
             UUID promptId = createPrompt(prompt, API_KEY, TEST_WORKSPACE);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -1087,7 +1087,7 @@ class PromptResourceTest {
                     .projectId(null)
                     .build();
 
-            Prompt duplicatedPrompt = buildPrompt().projectName("conflict-test-project").build();
+            Prompt duplicatedPrompt = buildPrompt().projectName(factory.manufacturePojo(String.class)).build();
             createPrompt(duplicatedPrompt, API_KEY, TEST_WORKSPACE);
 
             return Stream.of(
@@ -1123,15 +1123,23 @@ class PromptResourceTest {
         void when__creatingPromptsWithSameNameInDifferentProjects__thenBothSucceed() {
             String sharedName = UUID.randomUUID().toString();
 
-            var prompt1 = buildPrompt().name(sharedName).projectName("project-alpha").build();
-            var prompt2 = buildPrompt().name(sharedName).projectName("project-beta").build();
+            var projectId1 = projectResourceClient.createProject(factory.manufacturePojo(String.class), API_KEY,
+                    TEST_WORKSPACE);
+            var projectId2 = projectResourceClient.createProject(factory.manufacturePojo(String.class), API_KEY,
+                    TEST_WORKSPACE);
+
+            var prompt1 = buildPrompt().name(sharedName).lastUpdatedBy(USER).createdBy(USER).versionCount(1L)
+                    .projectId(projectId1).build();
+            var prompt2 = buildPrompt().name(sharedName).lastUpdatedBy(USER).createdBy(USER).versionCount(1L)
+                    .projectId(projectId2).build();
 
             var id1 = createPrompt(prompt1, API_KEY, TEST_WORKSPACE);
             var id2 = createPrompt(prompt2, API_KEY, TEST_WORKSPACE);
 
-            assertThat(id1).isNotNull();
-            assertThat(id2).isNotNull();
             assertThat(id1).isNotEqualTo(id2);
+
+            getPromptAndAssert(id1, prompt1, API_KEY, TEST_WORKSPACE, Set.of());
+            getPromptAndAssert(id2, prompt2, API_KEY, TEST_WORKSPACE, Set.of());
         }
     }
 
@@ -1190,16 +1198,18 @@ class PromptResourceTest {
         @DisplayName("when updating prompt name to an existing one, then return conflict")
         void when__updatingPromptNameToAnExistingOne__thenReturnConflict() {
 
+            String projectName = factory.manufacturePojo(String.class);
+
             var prompt = buildPrompt()
                     .lastUpdatedBy(USER)
                     .createdBy(USER)
-                    .projectName("update-conflict-project")
+                    .projectName(projectName)
                     .build();
 
             var prompt2 = buildPrompt()
                     .lastUpdatedBy(USER)
                     .createdBy(USER)
-                    .projectName("update-conflict-project")
+                    .projectName(projectName)
                     .build();
 
             UUID promptId = createPrompt(prompt, API_KEY, TEST_WORKSPACE);


### PR DESCRIPTION
## Details

Prompt name uniqueness was enforced at the workspace level, so creating a prompt with a name that already existed in a different project failed with `Prompt id or name already exists`. The application already scopes prompt lookups by `project_id`; this change aligns the database constraint with that behavior by replacing the `(workspace_id, name)` unique index with `(workspace_id, project_id, name)`, so names only need to be unique within a project.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6686

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Liquibase migration authoring and test coverage
- Human verification: Author to review and run backend build/tests

## Testing

- Added `PromptResourceTest` case verifying prompts with the same name in different projects both succeed.
- Updated existing conflict tests to pin prompts to a shared project so the intended within-project duplicate conflict is still exercised.
- Backend build and test suite to be run by the author (`mvn compile -DskipTests && mvn test && mvn spotless:check`).

## Documentation

N/A
