### PR TITLE
[NA] [QA] test(e2e): retry model-picker click to fix Playground flake

### DIFF
--- a/tests_end_to_end/e2e/pom/playground.page.ts
+++ b/tests_end_to_end/e2e/pom/playground.page.ts
@@ -468,9 +468,14 @@ export class PlaygroundPage {
   }
 
   private async setModelForVariant(index: number, modelDisplayName: string): Promise<void> {
-    await this.modelPicker(index).click();
     const listbox = this.page.getByRole('listbox');
-    await listbox.waitFor({ state: 'visible' });
+    // The trigger occasionally swallows the first click as a hover (surfacing a
+    // tooltip instead of opening the popover), so retry the click until the
+    // listbox actually opens rather than firing once and waiting.
+    await expect(async () => {
+      await this.modelPicker(index).click();
+      await expect(listbox).toBeVisible({ timeout: 2_000 });
+    }).toPass({ timeout: 15_000 });
     await listbox.getByPlaceholder('Search model').fill(modelDisplayName);
     await listbox.getByRole('option', { name: modelDisplayName, exact: true }).first().click();
   }


### PR DESCRIPTION
## Problem

`PlaygroundPage.setModelForVariant` clicks the model picker once, then waits for the options `listbox` to appear. On higher-latency environments the first click sometimes registers as a **hover** — surfacing the model's tooltip instead of opening the popover — so the listbox never becomes visible and the step times out after 15s.

Observed as a repeated failure (initial attempt + both retries) on the Bayer stsaas regression run (`playground-smoke` → "Run prompts against a dataset auto-creates an experiment"). The failure snapshot showed the trigger `[active]` with a tooltip rendered but no listbox — the click landed but didn't open the popover. The test has a long clean pass streak on every other environment and is flagged flaky in TestOps.

## Fix

Wrap the click in `expect(async () => { … }).toPass()` so it re-clicks the trigger until the listbox actually opens, instead of firing once and waiting. Strictly safer than the original — same selectors, same assertions, just resilient to a click that doesn't register as opening the popover.

```ts
const listbox = this.page.getByRole('listbox');
await expect(async () => {
  await this.modelPicker(index).click();
  await expect(listbox).toBeVisible({ timeout: 2_000 });
}).toPass({ timeout: 15_000 });
```

## Testing

- `tsc --noEmit` clean; `playground-smoke` verified green locally 3× against a 2.1.13 instance.
- The same guard was applied to the Optimization Studio POM's `selectModel` on the `e2e-compat/2.1.13` branch (that POM doesn't exist on `main` yet), which has the identical single-click-then-wait shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)