### PR TITLE
[NA] [SDK] fix: recover agentic LLM judge verdicts from prose-wrapped output

### DIFF
--- a/sdks/python/src/opik/evaluation/suite_evaluators/llm_judge/parsers.py
+++ b/sdks/python/src/opik/evaluation/suite_evaluators/llm_judge/parsers.py
@@ -11,7 +11,7 @@ each assertion produces {"score": <bool/int/float>, "reason": "..."}.
 import copy
 import json
 import logging
-from typing import Any, Dict, List, Type
+from typing import Any, Dict, Iterator, List, Optional, Type
 
 import pydantic
 
@@ -19,6 +19,33 @@ from opik.evaluation.metrics import score_result
 from opik.exceptions import LLMJudgeParseError
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _iter_json_objects(content: str) -> Iterator[Dict[str, Any]]:
+    """Yield every balanced JSON object embedded in ``content``, in order.
+
+    Providers that don't strictly honor ``response_format`` alongside tool
+    calls (Anthropic in particular) return the verdict as prose with the
+    JSON wrapped in a ```json fence, and sometimes emit more than one JSON
+    object — e.g. quoting the agent's output before the verdict. Scanning
+    for each ``{`` and streaming-decoding lets the caller validate every
+    candidate against the schema and keep the one that fits, rather than
+    betting on the first or last brace.
+    """
+    decoder = json.JSONDecoder()
+    index = 0
+    while True:
+        start = content.find("{", index)
+        if start == -1:
+            return
+        try:
+            obj, end = decoder.raw_decode(content, start)
+        except json.JSONDecodeError:
+            index = start + 1
+            continue
+        if isinstance(obj, dict):
+            yield obj
+        index = end
 
 
 def _resolve_refs(schema: Dict[str, Any]) -> Dict[str, Any]:
@@ -120,6 +147,36 @@ class ResponseSchema:
             f"- `{key}`: {assertion}" for key, assertion in self._field_mapping.items()
         )
 
+    def _parse_and_validate(self, content: str) -> pydantic.BaseModel:
+        """Return the schema-validated response for ``content``.
+
+        Fast path: the whole string is the JSON object (OpenAI / strict
+        structured output). Fallback: scan every embedded JSON object and
+        return the first that validates against the schema — this recovers
+        the verdict when a provider wraps it in prose or a ```json fence
+        and precedes it with an unrelated object (e.g. a quoted copy of the
+        agent's output). Raises ``JSONDecodeError`` when no object is found
+        and the last ``ValidationError`` when candidates were found but none
+        matched, so ``parse`` reports the failure the same way as before.
+        """
+        try:
+            parsed = json.loads(content)
+            if isinstance(parsed, dict):
+                return self._response_model(**parsed)
+        except (json.JSONDecodeError, pydantic.ValidationError):
+            pass
+
+        last_error: Optional[pydantic.ValidationError] = None
+        for candidate in _iter_json_objects(content):
+            try:
+                return self._response_model(**candidate)
+            except pydantic.ValidationError as validation_error:
+                last_error = validation_error
+
+        if last_error is not None:
+            raise last_error
+        raise json.JSONDecodeError("No JSON object found in model output", content, 0)
+
     def parse(self, content: str) -> List[score_result.ScoreResult]:
         """Parse and validate the LLM model output JSON into ScoreResult objects.
 
@@ -142,8 +199,7 @@ class ResponseSchema:
             )
 
         try:
-            parsed = json.loads(content)
-            validated = self._response_model(**parsed)
+            validated = self._parse_and_validate(content)
 
             results = [
                 score_result.ScoreResult(

--- a/sdks/python/tests/library_integration/metrics_with_llm_judge/agentic/conftest.py
+++ b/sdks/python/tests/library_integration/metrics_with_llm_judge/agentic/conftest.py
@@ -32,11 +32,13 @@ from tests import llm_constants
 #   canonical "doesn't call tools" failure mode (see
 #   `SupportedJudgeProvider.java`), so don't swap it in here without
 #   re-validating tool-use tests by hand.
-# - Anthropic `claude-haiku-4-5` (native `AnthropicChatModel`): the
-#   cheap+fast Claude tier. Sonnet would also work but the per-call
-#   latency hurts CI throughput given the agentic loop's multi-round
-#   nature.
-# - Anthropic `claude-haiku-4-5` *via LiteLLM* (`litellm_anthropic`):
+# - Anthropic `claude-sonnet-4-6` (native `AnthropicChatModel`): the
+#   Claude tier we run the agentic judge against. Haiku is cheaper but
+#   on the agentic path (tools in the request, so `response_format` is
+#   best-effort) it narrates in prose and wraps the verdict in a
+#   ```json fence rather than emitting the bare object the parser
+#   expects; Sonnet follows the structured-output contract reliably.
+# - Anthropic `claude-sonnet-4-6` *via LiteLLM* (`litellm_anthropic`):
 #   identical model string as the native row, but routed through the
 #   LiteLLM adapter by forcing `_should_use_anthropic_native=False`.
 #   This is the only parametrize entry that exercises Anthropic-by-
@@ -51,11 +53,11 @@ from tests import llm_constants
 _JUDGE_MODEL_PARAMS: List[Tuple[str, List[str]]] = [
     (llm_constants.OPENAI_GPT_4O_MINI, ["_skip_unless_openai_configured"]),
     (
-        f"{llm_constants.ANTHROPIC_CLAUDE_HAIKU}",
+        f"{llm_constants.ANTHROPIC_CLAUDE_SONNET}",
         ["_skip_unless_anthropic_configured"],
     ),
     (
-        f"{llm_constants.LITELLM_ANTHROPIC_CLAUDE_HAIKU}",
+        f"{llm_constants.LITELLM_ANTHROPIC_CLAUDE_SONNET}",
         ["_skip_unless_anthropic_configured", "_force_litellm_path"],
     ),
 ]

--- a/sdks/python/tests/unit/evaluation/suite_evaluators/test_llm_judge_parsers.py
+++ b/sdks/python/tests/unit/evaluation/suite_evaluators/test_llm_judge_parsers.py
@@ -325,6 +325,67 @@ class TestResponseSchema:
         assert prop["description"] == long_assertion
         assert len("assertion_1") < 64
 
+    def test_parse__verdict_wrapped_in_prose_and_code_fence__returns_score_results(
+        self,
+    ):
+        """Agentic judge fallback: Anthropic (native + LiteLLM) narrates in
+        prose and wraps the verdict in a ```json fence instead of emitting a
+        bare object. The parser must recover it. Payload mirrors the real
+        `claude-haiku-4-5` output that failed the agentic integration suite.
+        """
+        assertion = "The agent's output mentions Tokyo."
+        schema = llm_judge_parsers.ResponseSchema([assertion])
+        content = (
+            "I'll evaluate the assertion by examining the agent's output.\n\n"
+            "**Assertion 1: The agent's output mentions Tokyo.**\n\n"
+            "Looking at the task output provided:\n"
+            '```json\n{\n  "answer": "The capital of France is Paris."\n}\n```\n\n'
+            "The output does not mention Tokyo.\n\n## Verdict\n\n"
+            '```json\n{\n  "assertion_1": {\n    "score": false,\n'
+            '    "reason": "The output is about Paris, not Tokyo.",\n'
+            '    "confidence": 1.0\n  }\n}\n```'
+        )
+
+        results = schema.parse(content)
+
+        assert len(results) == 1
+        assert results[0].name == assertion
+        assert results[0].value is False
+        assert results[0].reason == "The output is about Paris, not Tokyo."
+        assert results[0].scoring_failed is False
+        assert results[0].metadata == {"confidence": 1.0}
+
+    def test_parse__multiple_json_objects__skips_non_matching_and_uses_verdict(self):
+        """When several JSON objects are present, pick the one that validates
+        against the schema, not merely the first or last brace."""
+        schema = llm_judge_parsers.ResponseSchema(["Response is accurate"])
+        content = (
+            'Quoting the agent first: {"answer": "Paris"}\n'
+            'Then the verdict: {"assertion_1": {"score": true, '
+            '"reason": "correct", "confidence": 0.9}}'
+        )
+
+        results = schema.parse(content)
+
+        assert len(results) == 1
+        assert results[0].value is True
+        assert results[0].reason == "correct"
+        assert results[0].scoring_failed is False
+
+    def test_parse__prose_with_no_valid_verdict__raises_with_failed_results(self):
+        """Prose that contains a JSON object which never matches the schema
+        must still surface as a parse failure (not silently pass)."""
+        schema = llm_judge_parsers.ResponseSchema(["Response is accurate"])
+        content = 'Here is my thinking: {"answer": "Paris"} and nothing else.'
+
+        with pytest.raises(LLMJudgeParseError) as exc_info:
+            schema.parse(content)
+
+        results = exc_info.value.results
+        assert len(results) == 1
+        assert results[0].scoring_failed is True
+        assert results[0].metadata["raw_output"] == content
+
     def test_parse__assertion_with_special_characters__handles_correctly(self):
         assertion = 'Response doesn\'t contain "quotes" or special chars: {}/\\'
         schema = llm_judge_parsers.ResponseSchema([assertion])


### PR DESCRIPTION
## Details

The agentic LLM judge's final turn returns free-form content. OpenAI honors `response_format` strictly, but Anthropic (native and via LiteLLM) treats it as best-effort when tools are in the request — on a *false* verdict `claude-haiku-4-5` narrates in prose and wraps the JSON in a ` ```json ` fence, sometimes preceded by a second JSON object (a quoted copy of the agent output). The parser's bare `json.loads` failed at char 0, so `scoring_failed=True`, and temperature-0 retries reproduced the same prose — failing the agentic evaluation-metrics tests deterministically (`test_false_assertion__fails[anthropic]` and `[litellm_anthropic]`).

- `parsers.py`: scan every embedded JSON object and return the first that validates against the schema — recovers a prose/fenced verdict and skips the quoted agent-output block. The bare-JSON fast path (OpenAI / strict structured output) is unchanged.
- Agentic judge integration tests now run the Anthropic lanes against `claude-sonnet-4-6` instead of `claude-haiku-4-5`; Sonnet follows the structured-output contract reliably (the one-shot suite already used Sonnet).
- Added unit tests for prose+fence payloads and multi-object candidate selection.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- N/A — CI test-stability fix for the agentic evaluation-metrics suite; no tracking ticket.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: full implementation (analysis, fix, tests)
- Human verification: code review + local test run

## Testing

Commands run from `sdks/python` (project venv):

- `python -m pytest tests/unit/evaluation/suite_evaluators/test_llm_judge_parsers.py` → 23 passed (20 existing + 3 new)
- `python -m pytest tests/unit/evaluation/suite_evaluators/` → 213 passed, 2 skipped (no regressions)
- `ruff check`, `ruff format --check`, and `mypy` on the changed files → clean
- Replayed the exact CI raw output (prose + ` ```json ` fence + a quoted agent-output object) through `ResponseSchema.parse` → verdict recovered (`scoring_failed=False`, `value=False`).

Not run locally: the two failing tests are library-integration tests that call real provider models (require `ANTHROPIC_API_KEY`); they are validated by the `evaluation_metrics_tests` CI lane. Both fixes (tolerant parser + Sonnet) independently target that exact failure.

## Documentation

N/A — no user-facing or API changes.
