### PR TITLE
[NA] [GHA] ci: trim genai/adk test matrix to reduce Vertex AI 429s

### DIFF
--- a/.github/workflows/lib-adk-tests.yml
+++ b/.github/workflows/lib-adk-tests.yml
@@ -29,12 +29,15 @@ jobs:
 
     strategy:
       fail-fast: true
-      # Throttle concurrent matrix jobs so we keep full Python coverage
-      # without re-multiplying live Vertex AI calls into 429 RESOURCE_EXHAUSTED
-      # against the shared opik-sdk-tests GCP project.
+      # This suite makes live Vertex AI calls against the shared
+      # opik-sdk-tests GCP project (shared with the GenAI suite). Running the
+      # full 3.10-3.14 matrix re-multiplied those calls into 429
+      # RESOURCE_EXHAUSTED, so we run only the oldest and newest supported
+      # Python versions — enough to catch version-specific breakage at a
+      # fraction of the request volume — and keep the concurrency cap.
       max-parallel: 2
       matrix:
-        python_version: ${{ fromJSON(vars.PYTHON_VERSIONS) }}
+        python_version: ["3.10", "3.14"]
 
     steps:
       - name: Check out code

--- a/.github/workflows/lib-genai-tests.yml
+++ b/.github/workflows/lib-genai-tests.yml
@@ -33,13 +33,15 @@ jobs:
 
     strategy:
       fail-fast: true
-      # Throttle concurrent matrix jobs so we keep full Python coverage
-      # without re-multiplying live Vertex AI calls into 429 RESOURCE_EXHAUSTED
-      # against the shared opik-sdk-tests GCP project (shared with the ADK
-      # suite, so any uncapped suite re-multiplies their contention too).
+      # This suite makes live Vertex AI calls against the shared
+      # opik-sdk-tests GCP project (shared with the ADK suite). Running the
+      # full 3.10-3.14 matrix re-multiplied those calls into 429
+      # RESOURCE_EXHAUSTED, so we run only the oldest and newest supported
+      # Python versions — enough to catch version-specific breakage at a
+      # fraction of the request volume — and keep the concurrency cap.
       max-parallel: 2
       matrix:
-        python_version: ${{ fromJSON(vars.PYTHON_VERSIONS) }}
+        python_version: ["3.10", "3.14"]
 
     steps:
       - name: Check out code


### PR DESCRIPTION
## Details

The GenAI and ADK integration suites make live Vertex AI calls against the shared `opik-sdk-tests` GCP project. Expanding the full 3.10–3.14 matrix (five jobs per suite, and the two suites run concurrently) re-multiplied those live calls and tripped `429 RESOURCE_EXHAUSTED` on the shared project's quota — surfacing as flaky failures unrelated to the code under test.

- `lib-genai-tests.yml` / `lib-adk-tests.yml`: run only the oldest and newest supported Python versions (`3.10`, `3.14`) instead of the full `vars.PYTHON_VERSIONS` list.
- Cuts sustained live-request volume ~60% while still exercising the compat endpoints where version-specific breakage would show. The existing `max-parallel: 2` concurrency cap is kept.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- N/A — CI flakiness mitigation (Vertex AI 429 quota); no tracking ticket.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: full implementation
- Human verification: reviewed diff; CI is the real validation

## Testing

- `python -c "import yaml; ..."` on both workflow files → they parse and resolve `python_version` to `['3.10', '3.14']`.
- Behavioral validation is CI itself: the `genai` and `adk` lanes now schedule 2 jobs each instead of 5.

Not applicable: no library code changed, so no unit/integration tests were run locally.

## Documentation

N/A — CI-only change, no user-facing or API surface.
