### PR TITLE
[NA] [FE] Diagnostics: copy for permission_denied run failure

### DIFF
--- a/apps/opik-frontend/src/v2/pages/SignalsPage/runFailureCopy.ts
+++ b/apps/opik-frontend/src/v2/pages/SignalsPage/runFailureCopy.ts
@@ -29,6 +29,12 @@ export const getRunFailureCopy = (reason?: string): RunFailureCopy => {
         description:
           "The run was never picked up (the service may have been restarting). Try again.",
       };
+    case "permission_denied":
+      return {
+        title: "Diagnostics couldn't access this project",
+        description:
+          "Agent Insights is missing the workspace permission needed to read this project's data. Contact your workspace admin.",
+      };
     case "internal_error":
       return {
         title: "Diagnostics run failed",


### PR DESCRIPTION
## Summary
Adds a `getRunFailureCopy` case for the new **`permission_denied`** `RunFailureCode` emitted by ollie-assist (companion PR: comet-ml/ollie-assist#321).

When an Agent Insights run can't access the project's trace data (the service account is missing the workspace `PROJECT_DATA_VIEW` permission), the run now reports `permission_denied`. Previously this either showed nothing or fell through to the generic "something went wrong" copy. Now the toast/banner explains the real cause:

> **Diagnostics couldn't access this project** — Agent Insights is missing the workspace permission needed to read this project's data. Contact your workspace admin.

## Details
- Single-file change: adds one `case "permission_denied"` to `getRunFailureCopy` in `apps/opik-frontend/src/v2/pages/SignalsPage/runFailureCopy.ts`.
- `getRunFailureCopy(reason?: string)` takes a free string, so there's no TS enum/type to extend; the codes are kept in sync with `ollie-assist`'s `RunFailureCode` (noted in the file's header comment) and the backend `report_failures.reason` (a free `String`).
- Context: a production run failed exactly this way — a blank Diagnostics page with no explanation — because the backend service account lacked workspace access. The ollie-assist PR classifies the failure; this surfaces it to the user.

## Issues
N/A — no JIRA ticket. Companion backend/agent fix: comet-ml/ollie-assist#321.

## Documentation
No documentation changes required — this is internal, user-facing error copy shown in the Diagnostics failure toast/banner.

## Change checklist
- [x] Frontend change only (user-facing copy)
- [x] No API/schema change
- [x] Manually verified the new copy renders via the existing failure toast/banner path
- [ ] Tests: N/A — `getRunFailureCopy` has no existing unit test; change is a static copy case

## Testing
Verified the `permission_denied` branch returns the new title/description; the existing failure-rendering path in `SignalsPage` (`getRunFailureCopy(job.last_failure_reason)` → toast/banner) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)