### PR TITLE
[OPIK-6809] [BE] test: cover trace-without-spans in experiment_items_bulk

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ExperimentsResourceTest.java
@@ -6465,6 +6465,45 @@ class ExperimentsResourceTest {
             assertExperimentItems(actualExperimentItems, expectedItems);
         }
 
+        @Test
+        @DisplayName("when an item has a trace but spans is omitted, then the request succeeds without an NPE")
+        void experimentItemsBulk__whenTraceProvidedButSpansOmitted__thenReturnNoContent() {
+            // given
+            var datasetWithItem = createDatasetWithItem();
+
+            var trace = createTrace();
+            UUID projectId = projectResourceClient.createProject(trace.projectName(), API_KEY, TEST_WORKSPACE);
+            trace = trace.toBuilder()
+                    .projectId(projectId)
+                    .build();
+
+            var feedbackScore = createScore();
+
+            List<ExperimentItem> expectedItems = getExpectedItem(datasetWithItem.item(), trace, feedbackScore, null);
+
+            var experimentName = newExperimentName();
+            var bulkRecord = ExperimentItemBulkRecord.builder()
+                    .datasetItemId(datasetWithItem.item().id())
+                    .trace(trace)
+                    .feedbackScores(List.of(feedbackScore))
+                    .build();
+
+            var bulkUpload = ExperimentItemBulkUpload.builder()
+                    .experimentName(experimentName)
+                    .datasetName(datasetWithItem.datasetName())
+                    .items(List.of(bulkRecord))
+                    .build();
+
+            // when
+            experimentResourceClient.bulkUploadExperimentItem(bulkUpload, API_KEY, TEST_WORKSPACE);
+
+            // then
+            List<ExperimentItem> actualExperimentItems = experimentResourceClient.getExperimentItems(experimentName,
+                    API_KEY, TEST_WORKSPACE);
+
+            assertExperimentItems(actualExperimentItems, expectedItems);
+        }
+
         private List<ExperimentItem> getExpectedItem(DatasetItem datasetItem, Trace trace,
                 FeedbackScore feedbackScore, JsonNode evaluateTaskResult) {
             return List.of(


### PR DESCRIPTION
## Details
Adds regression coverage for the `experiment-items/bulk` endpoint when a
record provides a `trace` but omits `spans`. Previously this combination
could trigger a `NullPointerException` (OPIK-6809). The current
`ExperimentItemBulkValidator` already handles the case null-safely
(`CollectionUtils.isEmpty(spans)`), and this test locks in that behavior so
the endpoint returns success (No Content) instead of a 500.

The new test in `ExperimentsResourceTest` builds a bulk upload with a single
record containing a trace and feedback scores but no spans, performs the bulk
upload, and asserts the persisted experiment items match the expected result.

## Change checklist
<!-- Please check the type of changes made -->
- [ ] User facing
- [ ] Documentation update

## Issues
- OPIK-6809

## Testing
- New test: `experimentItemsBulk__whenTraceProvidedButSpansOmitted__thenReturnNoContent`
  in `ExperimentsResourceTest`, verifying a trace-without-spans bulk record
  succeeds and produces the expected experiment items (no NPE / 500).

## Documentation
N/A
