### PR TITLE
[NA] [FE] Wire up "View billing" link in Diagnostics settings

### DIFF
--- a/apps/opik-frontend/src/v2/pages/SignalsPage/DiagnosticsSettingsDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/SignalsPage/DiagnosticsSettingsDialog.tsx
@@ -12,6 +12,7 @@ import { Separator } from "@/ui/separator";
 import { AGENT_INSIGHTS_JOB_STATUS } from "@/types/signals";
 import useUpdateAgentInsightsJobMutation from "@/api/signals/useUpdateAgentInsightsJobMutation";
 import { OpikEvent, trackEvent } from "@/lib/analytics/tracking";
+import usePluginsStore from "@/store/PluginsStore";
 
 type DiagnosticsSettingsDialogProps = {
   open: boolean;
@@ -28,6 +29,7 @@ const DiagnosticsSettingsDialog: React.FC<DiagnosticsSettingsDialogProps> = ({
 }) => {
   const [on, setOn] = useState(enabled);
   const updateMutation = useUpdateAgentInsightsJobMutation();
+  const BillingLink = usePluginsStore((state) => state.BillingLink);
 
   useEffect(() => {
     if (open) setOn(enabled);
@@ -78,14 +80,7 @@ const DiagnosticsSettingsDialog: React.FC<DiagnosticsSettingsDialogProps> = ({
         <div className="flex flex-col gap-1 py-2">
           <span className="comet-body-s-accented text-foreground">Billing</span>
           <span className="comet-body-s text-muted-slate">
-            Runs on your Ollie tokens.{" "}
-            {/* TODO: wire to the Ollie/Comet billing page */}
-            <button
-              type="button"
-              className="text-foreground underline underline-offset-2 hover:text-primary"
-            >
-              View billing
-            </button>
+            Runs on your Ollie tokens. {BillingLink && <BillingLink />}
           </span>
         </div>
 


### PR DESCRIPTION
## Details

The **View billing** control in the Diagnostics settings dialog was a placeholder `<button>` with no `onClick` handler (left as a `// TODO: wire to the Ollie/Comet billing page`), so clicking it did nothing.

This wires it to the existing `BillingLink` plugin component — the same one already used by the DailyBriefing settings dialog for the identical "Runs on your Ollie tokens" line. `BillingLink` builds a URL to the workspace's Ollie credits page (`organizations/{organizationId}/ollie-credits`) and opens it in a new tab.

Before/after (`DiagnosticsSettingsDialog.tsx`):
- Pulls `BillingLink` from the plugins store.
- Replaces the dead `<button>View billing</button>` with `Runs on your Ollie tokens. {BillingLink && <BillingLink />}`.

## Change checklist

- [x] Frontend-only change; mirrors an already-shipped pattern (DailyBriefing settings dialog).
- [x] `BillingLink` renders `null` when there is no `organizationId` (OSS/local), so no dead/incorrect link appears outside the Comet-hosted context.
- [x] eslint passes on the changed file.

## Issues

N/A

## Testing

- Ran eslint on the changed file — clean.
- Verified the wiring matches the working `BillingLink` usage in `v2/pages/ProjectHomePage/DailyBriefing/SettingsDialog.tsx`.
- Manual: in the Comet-hosted context, "View billing" now opens the Ollie credits page in a new tab; in OSS/local (no org) the link is hidden.

## Documentation

No documentation changes needed — internal UI wiring fix, no user-facing behavior change beyond the link now functioning.