### PR TITLE
[OPIK-6884] [BE] perf: project/trace-id scope dataset-item + optimization enrichment scans

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -349,6 +349,7 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                 <endif>
                 WHERE workspace_id = :workspace_id
                 AND id IN (SELECT trace_id FROM experiment_items WHERE workspace_id = :workspace_id AND experiment_id IN :experimentIds)
+                AND project_id IN (SELECT DISTINCT project_id FROM traces WHERE workspace_id = :workspace_id AND id IN (SELECT trace_id FROM experiment_items WHERE workspace_id = :workspace_id AND experiment_id IN :experimentIds))
                 <if(experiment_item_filters)>
                 AND <experiment_item_filters>
                 <endif>
@@ -850,6 +851,7 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                 AND ei.trace_id IN (
                     SELECT id FROM traces FINAL WHERE workspace_id = :workspace_id
                     AND id IN (SELECT trace_id FROM experiment_items WHERE workspace_id = :workspace_id <if(experiment_ids)> AND experiment_id IN :experiment_ids <endif>)
+                    AND project_id IN (SELECT DISTINCT project_id FROM traces WHERE workspace_id = :workspace_id AND id IN (SELECT trace_id FROM experiment_items WHERE workspace_id = :workspace_id <if(experiment_ids)> AND experiment_id IN :experiment_ids <endif>))
                     AND <experiment_item_filters>
                 )
                 <endif>

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -343,11 +343,12 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
             INNER JOIN (
                 SELECT
                     id
-                FROM traces
+                FROM traces FINAL
                 <if(feedback_scores_empty_filters)>
                     LEFT JOIN fsc ON fsc.entity_id = traces.id
                 <endif>
                 WHERE workspace_id = :workspace_id
+                AND id IN (SELECT trace_id FROM experiment_items WHERE workspace_id = :workspace_id AND experiment_id IN :experimentIds)
                 <if(experiment_item_filters)>
                 AND <experiment_item_filters>
                 <endif>
@@ -368,8 +369,6 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                 <if(feedback_scores_empty_filters)>
                 AND fsc.feedback_scores_count = 0
                 <endif>
-                ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
-                LIMIT 1 BY id
             ) AS tfs ON ei.trace_id = tfs.id
             <endif>
             <if(dataset_item_filters || search_filter)>
@@ -849,7 +848,9 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                 <endif>
                 <if(experiment_item_filters)>
                 AND ei.trace_id IN (
-                    SELECT id FROM traces WHERE workspace_id = :workspace_id AND <experiment_item_filters>
+                    SELECT id FROM traces FINAL WHERE workspace_id = :workspace_id
+                    AND id IN (SELECT trace_id FROM experiment_items WHERE workspace_id = :workspace_id <if(experiment_ids)> AND experiment_id IN :experiment_ids <endif>)
+                    AND <experiment_item_filters>
                 )
                 <endif>
             ), feedback_scores_combined AS (

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
@@ -401,6 +401,7 @@ class OptimizationDAOImpl implements OptimizationDAO {
                     FROM traces
                     WHERE workspace_id = :workspace_id
                     AND id IN (SELECT trace_id FROM experiment_items_final)
+                    AND project_id IN (SELECT DISTINCT project_id FROM traces WHERE workspace_id = :workspace_id AND id IN (SELECT trace_id FROM experiment_items_final))
                     ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
                     LIMIT 1 BY workspace_id, project_id, id
                 ) AS t ON ei.trace_id = t.id
@@ -411,6 +412,7 @@ class OptimizationDAOImpl implements OptimizationDAO {
                         FROM spans
                         WHERE workspace_id = :workspace_id
                         AND trace_id IN (SELECT trace_id FROM experiment_items_final)
+                        AND project_id IN (SELECT DISTINCT project_id FROM traces WHERE workspace_id = :workspace_id AND id IN (SELECT trace_id FROM experiment_items_final))
                         ORDER BY (workspace_id, project_id, trace_id, parent_span_id, id) DESC, last_updated_at DESC
                         LIMIT 1 BY workspace_id, project_id, trace_id, parent_span_id, id
                     )


### PR DESCRIPTION
## Details

Closes the one genuine R3 residual code fix from the OPIK-6883 full-scan audit (the rest of R3 is covered by the default-window handling). The `DatasetItemDAO` experiment-item/feedback **filter gates** scanned the whole workspace's `traces` (`workspace_id` only, all projects) to resolve the experiment items' trace ids.

- Bound both gates (the count query and the stats query) by the referenced experiment trace-id set **and its project set**: `AND id IN (SELECT trace_id FROM experiment_items … experiment_id IN :experimentIds) AND project_id IN (SELECT DISTINCT project_id FROM traces WHERE … id IN (…))`. Both are implied by the existing `ei.trace_id = tfs.id` join (results unchanged); together they engage the full `(workspace_id, project_id, id)` primary-key prefix. **Prod `EXPLAIN` (large workspace): the `traces` read drops 98,507 → ~55 granules** (id-set alone: ~1,305; adding `project_id`: ~55).
- Use `traces FINAL` in both gates: `<experiment_item_filters>` can filter **mutable** trace columns (tags/output/etc.), which must be matched against the deduplicated latest version, not stale `ReplacingMergeTree` versions. `FINAL` is affordable here because the id-set bound scopes it to the same ~1,309 granules (same I/O as the prior `LIMIT 1 BY` — prod `EXPLAIN` confirms identical granule count — plus a small bounded merge); the now-redundant `LIMIT 1 BY id` on the count gate is dropped.

**`OptimizationDAO.FIND`** (also flagged, R3/row 12 "no target-project pruning"): its `experiment_durations` CTE enriches optimizations with per-experiment duration/cost by scanning `traces` and `spans` for the experiments' trace ids. Both scans were `workspace_id` + `(trace_)id IN` only — no `project_id` — so the `(workspace_id, project_id, …)` sorting-key prefix couldn't prune. Added `AND project_id IN (SELECT DISTINCT project_id FROM traces WHERE workspace_id = :workspace_id AND id IN (SELECT trace_id FROM experiment_items_final))` to both. A span/trace shares its trace's project, so the resolved set is a superset filter (results unchanged) and it restores the PK-prefix prune. Prod `EXPLAIN`: the `spans` scan drops **4,842 → 163 granules (~30×)**; the `traces` scan is also project-pruned.

(The `optimizations` entity table itself needs no change — it's small, workspace-scoped, not tiered, and `project_id` isn't in its sorting key `(workspace_id, dataset_id, id)`.)

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6884 (partial — rolling story; R1/R2 and Bucket 2/3 items tracked separately on OPIK-6883)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: R3 residual audit, DatasetItemDAO query changes, prod EXPLAIN cost verification, and this PR description.
- Human verification: Author reviewed the query changes and prod EXPLAIN numbers; the cited test was run locally and passes.

## Testing

Local, offline (`-o`), backend Testcontainers (real MySQL/ClickHouse):

- `mvn test -Dtest='DatasetsResourceTest$FindDatasetItemsWithExperimentItems'` — 56 tests, pass (results preserved with the id-set bound + `FINAL`).
- `mvn test -Dtest='OptimizationsResourceTest$GetOptimizerById,OptimizationsResourceTest$FindOptimizations'` — 13 tests, pass (duration/cost/scores unchanged with the project-scoped enrichment scans).
- `mvn spotless:check` / `mvn compile` — clean.

Prod validation (read-only `agentro`, plan-only `EXPLAIN` — no execution/scan; workspace with 5 experiments):

- DatasetItemDAO count-gate `traces` scan: baseline (`workspace_id` only) **98,507 granules** → id-set bound **~1,305** → id-set + `project_id` **~55 granules**; `FINAL` reads the same bounded set (identical I/O to the prior `LIMIT 1 BY`, plus a small bounded merge).
- OptimizationDAO.FIND `spans` scan: **4,842 → 163 granules (~30×)** with the added `project_id IN (…)`; `traces` scan also project-pruned.

## Documentation

No user-facing or SDK changes; internal query-path hardening only.
