### PR TITLE
[OPIK-7281] Fix outbound gzip response double-decompression

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/http/ContentEncodingReconcilingResponseFilter.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/http/ContentEncodingReconcilingResponseFilter.java
@@ -4,6 +4,7 @@ import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientResponseContext;
 import jakarta.ws.rs.client.ClientResponseFilter;
 import jakarta.ws.rs.core.HttpHeaders;
+import lombok.NonNull;
 
 import java.util.Locale;
 import java.util.Set;
@@ -32,11 +33,11 @@ public class ContentEncodingReconcilingResponseFilter implements ClientResponseF
     private static final Set<String> TRANSPARENTLY_DECODED = Set.of("gzip", "x-gzip", "deflate");
 
     @Override
-    public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) {
+    public void filter(ClientRequestContext requestContext, @NonNull ClientResponseContext responseContext) {
         String contentEncoding = responseContext.getHeaderString(HttpHeaders.CONTENT_ENCODING);
 
         if (contentEncoding != null
-                && TRANSPARENTLY_DECODED.contains(contentEncoding.trim().toLowerCase(Locale.ROOT))) {
+                && TRANSPARENTLY_DECODED.contains(contentEncoding.strip().toLowerCase(Locale.ROOT))) {
             var headers = responseContext.getHeaders();
             headers.remove(HttpHeaders.CONTENT_ENCODING);
             headers.remove(HttpHeaders.CONTENT_LENGTH);

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/http/ContentEncodingReconcilingResponseFilter.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/http/ContentEncodingReconcilingResponseFilter.java
@@ -1,0 +1,45 @@
+package com.comet.opik.infrastructure.http;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientResponseContext;
+import jakarta.ws.rs.client.ClientResponseFilter;
+import jakarta.ws.rs.core.HttpHeaders;
+
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Reconciles response headers after Apache HttpClient 5 has already decompressed the body, so that
+ * Jersey's {@code GZipDecoder} does not decompress it a second time.
+ *
+ * <p>When {@code jerseyClient.gzipEnabled} is {@code true}, Dropwizard wires BOTH Apache HttpClient's
+ * transparent content decompression (advertises {@code Accept-Encoding} and decodes the entity) AND
+ * Jersey's {@code GZipDecoder} reader interceptor. {@code DropwizardApacheConnector} copies the raw
+ * HTTP/1.1 response headers — including {@code Content-Encoding: gzip} — into the Jersey response while
+ * handing over the entity stream that HttpClient has already decoded. {@code GZipDecoder} then sees the
+ * stale {@code Content-Encoding} header and wraps the already-plain stream in a {@code GZIPInputStream},
+ * so {@code readEntity} throws {@code java.util.zip.ZipException: Not in GZIP format}.
+ *
+ * <p>This filter runs before entity reading and drops the {@code Content-Encoding} (and now-incorrect
+ * {@code Content-Length}) header for the encodings HttpClient decodes transparently, leaving a single,
+ * correct decode. {@code Accept-Encoding: gzip} is still sent on the wire, so compression is preserved.
+ * It is only registered when gzip is enabled (see {@link HttpModule#buildClient}), which is exactly when
+ * HttpClient performs the transparent decode.
+ */
+public class ContentEncodingReconcilingResponseFilter implements ClientResponseFilter {
+
+    // Content codings that Apache HttpClient 5's ContentCompressionExec decodes transparently by default.
+    private static final Set<String> TRANSPARENTLY_DECODED = Set.of("gzip", "x-gzip", "deflate");
+
+    @Override
+    public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) {
+        String contentEncoding = responseContext.getHeaderString(HttpHeaders.CONTENT_ENCODING);
+
+        if (contentEncoding != null
+                && TRANSPARENTLY_DECODED.contains(contentEncoding.trim().toLowerCase(Locale.ROOT))) {
+            var headers = responseContext.getHeaders();
+            headers.remove(HttpHeaders.CONTENT_ENCODING);
+            headers.remove(HttpHeaders.CONTENT_LENGTH);
+        }
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/http/HttpModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/http/HttpModule.java
@@ -37,6 +37,14 @@ public class HttpModule extends DropwizardAwareModule<OpikConfiguration> {
      */
     @VisibleForTesting
     public static Client buildClient(JerseyClientBuilder builder, JerseyClientConfiguration config) {
+        if (config.isGzipEnabled()) {
+            // With gzip enabled, Dropwizard leaves Apache HttpClient's transparent content decompression
+            // ON and also registers Jersey's GZipDecoder. HttpClient decodes the entity but the stale
+            // 'Content-Encoding: gzip' header survives into the Jersey response, so GZipDecoder gunzips the
+            // already-plain stream and readEntity throws 'ZipException: Not in GZIP format'. Reconciling the
+            // header once HttpClient has decoded keeps exactly one decode while still advertising gzip.
+            builder.withProvider(new ContentEncodingReconcilingResponseFilter());
+        }
         return builder
                 .using(config)
                 .using(Jackson.newObjectMapper())

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/HttpModuleGzipDecompressionTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/HttpModuleGzipDecompressionTest.java
@@ -1,0 +1,103 @@
+package com.comet.opik.infrastructure.http;
+
+import com.codahale.metrics.MetricRegistry;
+import com.comet.opik.TestConfigUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import io.dropwizard.client.JerseyClientBuilder;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the client-side gzip double-decompression defect.
+ *
+ * <p>Runs with production gzip settings ({@code gzipEnabled: true}), which the shared
+ * {@code config-test.yml} disables — so the existing suite never exercises the response-decoding path.
+ * With gzip enabled, Dropwizard wires both Apache HttpClient's transparent decompression and Jersey's
+ * {@code GZipDecoder}; without the reconciling filter registered by {@link HttpModule#buildClient}, the
+ * stale {@code Content-Encoding: gzip} header triggers a second decode and {@code readEntity} throws
+ * {@code java.util.zip.ZipException: Not in GZIP format}.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HttpModuleGzipDecompressionTest {
+
+    private static final WireMockUtils.WireMockRuntime WIRE_MOCK = WireMockUtils.startWireMock();
+
+    private Client gzipEnabledClient;
+
+    @BeforeAll
+    void setUpAll() throws Exception {
+        WIRE_MOCK.server().start();
+        gzipEnabledClient = newGzipEnabledClient();
+    }
+
+    @AfterAll
+    void tearDownAll() {
+        WIRE_MOCK.server().stop();
+        gzipEnabledClient.close();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        WIRE_MOCK.server().resetAll();
+    }
+
+    @Test
+    void readEntity__whenResponseIsGzipCompressed__thenSharedClientDecodesExactlyOnce() {
+        // A body large enough that the upstream gzips it, like a real Dropwizard/Jetty upstream over its
+        // minimum entity size. With gzipEnabled: true both HttpClient and Jersey's GZipDecoder are active;
+        // the reconciling filter drops the stale Content-Encoding header so only HttpClient decodes.
+        var largeBody = "{\"payload\":\"" + "x".repeat(4000) + "\"}";
+        WIRE_MOCK.server().stubFor(get(urlPathEqualTo("/models")).willReturn(okJson(largeBody)));
+
+        try (Response response = gzipEnabledClient.target(WIRE_MOCK.server().url("/models"))
+                .request(MediaType.APPLICATION_JSON)
+                .get()) {
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(response.readEntity(String.class)).isEqualTo(largeBody);
+        }
+    }
+
+    /**
+     * Builds a client through {@link HttpModule#buildClient} with production gzip settings
+     * ({@code gzipEnabled: true}), so it registers {@code GZipDecoder} and the reconciling filter.
+     */
+    private Client newGzipEnabledClient() {
+        var jerseyConfig = TestConfigUtils.loadConfigTest().getJerseyClient();
+        jerseyConfig.setGzipEnabled(true);
+
+        ThreadFactory threadFactory = new ThreadFactory() {
+            private final AtomicLong counter = new AtomicLong();
+
+            @Override
+            public Thread newThread(Runnable runnable) {
+                var thread = new Thread(runnable, "gzip-decompress-test-client-" + counter.incrementAndGet());
+                thread.setDaemon(true);
+                return thread;
+            }
+        };
+        var executor = new ThreadPoolExecutor(2, 8, 60L, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(64), threadFactory);
+
+        return HttpModule.buildClient(
+                new JerseyClientBuilder(new MetricRegistry()).using(executor),
+                jerseyConfig);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/HttpModuleGzipDecompressionTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/http/HttpModuleGzipDecompressionTest.java
@@ -2,9 +2,10 @@ package com.comet.opik.infrastructure.http;
 
 import com.codahale.metrics.MetricRegistry;
 import com.comet.opik.TestConfigUtils;
-import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.github.tomakehurst.wiremock.WireMockServer;
 import io.dropwizard.client.JerseyClientBuilder;
 import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.AfterAll;
@@ -13,15 +14,21 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.zip.GZIPOutputStream;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -37,42 +44,62 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class HttpModuleGzipDecompressionTest {
 
-    private static final WireMockUtils.WireMockRuntime WIRE_MOCK = WireMockUtils.startWireMock();
+    // gzip disabled so WireMock serves the explicitly gzipped body verbatim rather than re-encoding it —
+    // the response-side gzip is asserted by the stub, not left to WireMock's auto-gzip default.
+    private final WireMockServer wireMockServer = new WireMockServer(
+            wireMockConfig().dynamicPort().dynamicHttpsPort().gzipDisabled(true));
 
     private Client gzipEnabledClient;
 
     @BeforeAll
-    void setUpAll() throws Exception {
-        WIRE_MOCK.server().start();
+    void setUpAll() {
+        wireMockServer.start();
         gzipEnabledClient = newGzipEnabledClient();
     }
 
     @AfterAll
     void tearDownAll() {
-        WIRE_MOCK.server().stop();
+        wireMockServer.stop();
         gzipEnabledClient.close();
     }
 
     @BeforeEach
     void beforeEach() {
-        WIRE_MOCK.server().resetAll();
+        wireMockServer.resetAll();
     }
 
     @Test
     void readEntity__whenResponseIsGzipCompressed__thenSharedClientDecodesExactlyOnce() {
-        // A body large enough that the upstream gzips it, like a real Dropwizard/Jetty upstream over its
-        // minimum entity size. With gzipEnabled: true both HttpClient and Jersey's GZipDecoder are active;
-        // the reconciling filter drops the stale Content-Encoding header so only HttpClient decodes.
-        var largeBody = "{\"payload\":\"" + "x".repeat(4000) + "\"}";
-        WIRE_MOCK.server().stubFor(get(urlPathEqualTo("/models")).willReturn(okJson(largeBody)));
+        var body = "{\"payload\":\"" + "x".repeat(4000) + "\"}";
 
-        try (Response response = gzipEnabledClient.target(WIRE_MOCK.server().url("/models"))
+        // Simulate a real upstream that gzips its response: gzipped bytes + Content-Encoding: gzip.
+        // With gzipEnabled: true, Apache HttpClient transparently decodes the entity, but the stale
+        // Content-Encoding header survives into the Jersey response; without the reconciling filter,
+        // GZipDecoder decodes the already-plain stream a second time and readEntity throws
+        // 'ZipException: Not in GZIP format'. The filter drops the stale header, leaving a single decode.
+        wireMockServer.stubFor(get(urlPathEqualTo("/models")).willReturn(aResponse()
+                .withStatus(200)
+                .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .withHeader(HttpHeaders.CONTENT_ENCODING, "gzip")
+                .withBody(gzip(body))));
+
+        try (Response response = gzipEnabledClient.target(wireMockServer.url("/models"))
                 .request(MediaType.APPLICATION_JSON)
                 .get()) {
 
             assertThat(response.getStatus()).isEqualTo(200);
-            assertThat(response.readEntity(String.class)).isEqualTo(largeBody);
+            assertThat(response.readEntity(String.class)).isEqualTo(body);
         }
+    }
+
+    private static byte[] gzip(String value) {
+        var baos = new ByteArrayOutputStream();
+        try (var gzipStream = new GZIPOutputStream(baos)) {
+            gzipStream.write(value.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return baos.toByteArray();
     }
 
     /**


### PR DESCRIPTION
## Details

Fixes recurring `java.util.zip.ZipException: Not in GZIP format` on the shared outbound HTTP client. With `jerseyClient.gzipEnabled: true` (production default), Dropwizard wires **both** Apache HttpClient's transparent content decompression **and** Jersey's `GZipDecoder`. HttpClient decodes the body, but the stale `Content-Encoding: gzip` header survives into the Jersey response, so `GZipDecoder` decodes the already-plain stream a second time and `readEntity` throws. This affects any outbound Jersey call reading a gzipped body ≥ the upstream's minimum gzip size without a per-call `.acceptEncoding("identity")` workaround (e.g. `OllamaService.listModels`, whose failure is swallowed into an empty model list).

- Register a `ContentEncodingReconcilingResponseFilter` on the shared client (gated on `gzipEnabled`) that strips the stale `Content-Encoding`/`Content-Length` after HttpClient's transparent decode — leaving exactly one decode while keeping `Accept-Encoding: gzip` on the wire. One systemic fix for every call site, instead of per-call opt-outs.
- Underlying cause is upstream in Dropwizard's `DropwizardApacheConnector` (it copies raw response headers, incl. `Content-Encoding`, alongside the already-decoded entity); to be reported separately.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7281

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Full diff (filter, `HttpModule` wiring, regression test) drafted by Claude from a production-log investigation; root cause pinned via Dropwizard bytecode inspection.
- Human verification: Approach directed and reviewed by the author; regression test verified locally to fail with the exact `ZipException` when the filter is disabled and pass with it enabled.

## Testing

Local, `apps/opik-backend`:
- `mvn -Dtest=HttpModuleGzipDecompressionTest test` — new regression test built with `gzipEnabled: true` (the path `config-test.yml` skips). Verified it reproduces the defect: with the filter disabled it fails with `ProcessingException` caused by `ZipException: Not in GZIP format`; with the filter enabled it passes.
- `mvn -Dtest=RemoteAuthServiceTest test` — 29/29 pass (no regression on the existing gzip-enabled auth path).

## Documentation

No user-facing documentation changes.
