### PR TITLE
[OPIK-7110] [BE] fix: stop capping user-mapped variables on the agentic-tools path

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.api.gax.rpc.InvalidArgumentException;
+import com.google.common.annotations.VisibleForTesting;
 import com.jayway.jsonpath.JsonPath;
 import dev.langchain4j.data.message.AudioContent;
 import dev.langchain4j.data.message.ChatMessage;
@@ -352,6 +353,7 @@ public class OnlineScoringEngine {
      * sentinel variables (like {@code spans}). Used by {@link #capReplacements} to decide which
      * keys to leave uncapped.
      */
+    @VisibleForTesting
     static Set<String> userMappedVariableKeys(Map<String, String> variables) {
         var keys = new HashSet<>(variables.keySet());
         keys.removeIf(k -> SENTINEL_VARIABLE_VALUES.contains(variables.get(k)));
@@ -364,6 +366,7 @@ public class OnlineScoringEngine {
      * variables should be uncapped — capping them forces non-deterministic tool drill-down
      * (OPIK-7110).
      */
+    @VisibleForTesting
     static Map<String, String> capReplacements(Map<String, String> replacements,
             int maxReplacementChars, String drillDownHint, Set<String> uncappedKeys) {
         return replacements.entrySet().stream().collect(Collectors.toMap(

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -80,6 +80,9 @@ public class OnlineScoringEngine {
     private static final String TRACE_VARIABLE_NAME = "trace";
     private static final String SPAN_VARIABLE_NAME = "span";
 
+    private static final Set<String> SENTINEL_VARIABLE_VALUES = Set.of(
+            SPANS_VARIABLE_NAME, TRACE_VARIABLE_NAME, SPAN_VARIABLE_NAME);
+
     private static final ObjectMapper OBJECT_MAPPER = JsonUtils.getMapper();
 
     private static final Pattern JSON_BLOCK_PATTERN = Pattern.compile(
@@ -126,11 +129,13 @@ public class OnlineScoringEngine {
 
     /**
      * Variant of {@link #prepareLlmRequest(LlmAsJudgeCode, Trace, StructuredOutputStrategy, PromptType, List)}
-     * that caps each rendered variable substitution at {@code maxReplacementChars}. Values longer
-     * than the cap are replaced with their first {@code maxReplacementChars} chars followed by
-     * {@code drillDownHint}. Used by the test-suite-assertion (tool-enabled) path, so a 50K-token
-     * trace's input/output doesn't get pasted verbatim into the prompt — the agent can pull the
-     * full content via the {@code read} tool when it actually needs it.
+     * that caps sentinel variable substitutions (e.g. {@code {{spans}}}) at {@code maxReplacementChars}
+     * while leaving user-mapped variables (e.g. {@code output}, {@code expected_output}) uncapped.
+     *
+     * <p>User-mapped variables are the scoring data the judge needs to evaluate — capping them forces
+     * the LLM to drill down via tools, which is non-deterministic and produces intermittent
+     * "Insufficient data" failures (OPIK-7110). Sentinel variables are structural context that the
+     * judge can optionally drill into via {@code read}/{@code jq} tools.
      */
     public static ChatRequest prepareLlmRequest(
             @NonNull LlmAsJudgeCode evaluatorCode, Trace trace,
@@ -150,7 +155,9 @@ public class OnlineScoringEngine {
                 evaluatorCode.messages(), promptType, spans);
         injectTraceIntoReplacements(replacements, evaluatorCode.variables(),
                 evaluatorCode.messages(), promptType, traceStructureJson);
-        Map<String, String> capped = capReplacements(replacements, maxReplacementChars, drillDownHint);
+        Set<String> userMappedKeys = userMappedVariableKeys(evaluatorCode.variables());
+        Map<String, String> capped = capReplacements(replacements, maxReplacementChars,
+                drillDownHint, userMappedKeys);
         var renderedMessages = renderMessagesWithReplacements(evaluatorCode.messages(), capped, promptType);
         return buildChatRequest(renderedMessages, evaluatorCode.schema(), structuredOutputStrategy);
     }
@@ -339,11 +346,31 @@ public class OnlineScoringEngine {
         }
     }
 
+    /**
+     * Returns the set of replacement-map keys that correspond to user-mapped variables (trace
+     * sections like {@code output}, {@code input.question}, or literal constants) as opposed to
+     * sentinel variables (like {@code spans}). Used by {@link #capReplacements} to decide which
+     * keys to leave uncapped.
+     */
+    static Set<String> userMappedVariableKeys(Map<String, String> variables) {
+        var keys = new HashSet<>(variables.keySet());
+        keys.removeIf(k -> SENTINEL_VARIABLE_VALUES.contains(variables.get(k)));
+        return keys;
+    }
+
+    /**
+     * Caps replacement values at {@code maxReplacementChars}, skipping keys in
+     * {@code uncappedKeys}. Pass {@code Set.of()} to cap everything. User-mapped scoring
+     * variables should be uncapped — capping them forces non-deterministic tool drill-down
+     * (OPIK-7110).
+     */
     static Map<String, String> capReplacements(Map<String, String> replacements,
-            int maxReplacementChars, String drillDownHint) {
+            int maxReplacementChars, String drillDownHint, Set<String> uncappedKeys) {
         return replacements.entrySet().stream().collect(Collectors.toMap(
                 Map.Entry::getKey,
-                e -> StringTruncator.truncate(e.getValue(), maxReplacementChars, drillDownHint),
+                e -> uncappedKeys.contains(e.getKey())
+                        ? e.getValue()
+                        : StringTruncator.truncate(e.getValue(), maxReplacementChars, drillDownHint),
                 (a, b) -> b,
                 LinkedHashMap::new));
     }
@@ -386,10 +413,9 @@ public class OnlineScoringEngine {
     /**
      * Tool-mode variant of {@link #prepareSpanLlmRequest(AutomationRuleEvaluatorSpanLlmAsJudge.SpanLlmAsJudgeCode, Span, StructuredOutputStrategy)}
      * used by the span scorer's agentic-tools path: injects the pre-built {@code {{span}}} structure
-     * (span id + the span's own attachment {@code file_name}s) and caps each rendered substitution at
-     * {@code maxReplacementChars}, appending {@code drillDownHint} to over-cap values so a huge span
-     * input/output doesn't pre-load context — the agent pulls the rest via {@code read} / {@code jq}.
-     * Span templates always render with {@link PromptType#MUSTACHE} (span rules carry no prompt type).
+     * (span id + the span's own attachment {@code file_name}s) and caps sentinel variable substitutions
+     * (e.g. {@code {{span}}}) at {@code maxReplacementChars} while leaving user-mapped variables
+     * uncapped (OPIK-7110). Span templates always render with {@link PromptType#MUSTACHE}.
      */
     public static ChatRequest prepareSpanLlmRequest(
             @NonNull AutomationRuleEvaluatorSpanLlmAsJudge.SpanLlmAsJudgeCode evaluatorCode,
@@ -399,7 +425,9 @@ public class OnlineScoringEngine {
         Map<String, String> replacements = toReplacements(evaluatorCode.variables(), span);
         injectSpanIntoReplacements(replacements, evaluatorCode.variables(),
                 evaluatorCode.messages(), PromptType.MUSTACHE, spanStructureJson);
-        Map<String, String> capped = capReplacements(replacements, maxReplacementChars, drillDownHint);
+        Set<String> userMappedKeys = userMappedVariableKeys(evaluatorCode.variables());
+        Map<String, String> capped = capReplacements(replacements, maxReplacementChars,
+                drillDownHint, userMappedKeys);
         var renderedMessages = renderMessagesWithReplacements(evaluatorCode.messages(), capped, PromptType.MUSTACHE);
         return buildChatRequest(renderedMessages, evaluatorCode.schema(), structuredOutputStrategy);
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -1,8 +1,10 @@
 package com.comet.opik.api.resources.v1.events;
 
+import com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.attachment.AttachmentInfo;
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.Constants;
 import com.comet.opik.api.events.TraceToScoreLlmAsJudge;
 import com.comet.opik.api.resources.v1.events.tools.CompressionTier;
 import com.comet.opik.api.resources.v1.events.tools.EntityRef;
@@ -33,10 +35,15 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
 import jakarta.inject.Inject;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.redisson.api.RedissonReactiveClient;
 import org.slf4j.Logger;
 import reactor.core.publisher.Mono;
@@ -62,6 +69,12 @@ import static com.comet.opik.infrastructure.log.LogContextAware.wrapWithMdc;
 @Slf4j
 public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<TraceToScoreLlmAsJudge> {
 
+    private static final String ONLINE_SCORING_NAMESPACE = "online_scoring";
+    private static final AttributeKey<String> WORKSPACE_ID_KEY = AttributeKey.stringKey("workspace_id");
+    private static final AttributeKey<String> WORKSPACE_NAME_KEY = AttributeKey.stringKey("workspace_name");
+    private static final AttributeKey<String> PATH_KEY = AttributeKey.stringKey("path");
+    private static final AttributeKey<String> TRIGGER_KEY = AttributeKey.stringKey("trigger");
+
     private final ChatCompletionService aiProxyService;
     private final Logger userFacingLogger;
     private final LlmProviderFactory llmProviderFactory;
@@ -74,6 +87,7 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
     private final ServiceTogglesConfig serviceTogglesConfig;
     private final OnlineEvaluationRecorder onlineEvaluationRecorder;
     private final AttachmentService attachmentService;
+    private final LongCounter routingDecisions;
 
     @Inject
     public OnlineScoringLlmAsJudgeScorer(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
@@ -105,6 +119,10 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.onlineEvaluationRecorder = onlineEvaluationRecorder;
         this.attachmentService = attachmentService;
+        this.routingDecisions = GlobalOpenTelemetry.getMeter(ONLINE_SCORING_NAMESPACE)
+                .counterBuilder("online_scoring_agentic_routing_total")
+                .setDescription("Agentic vs inline routing decisions per evaluation, by trigger and workspace")
+                .build();
     }
 
     /**
@@ -599,7 +617,33 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
             log.debug("Trace '{}' rule references {{trace}}; switching to agentic-tools mode",
                     message.trace().id());
         }
+
+        recordRoutingDecision(message, useTools, experimentIdPath, overSizeThreshold, traceVariablePath);
         return useTools;
+    }
+
+    private void recordRoutingDecision(TraceToScoreLlmAsJudge message, boolean useTools,
+            boolean experimentIdPath, boolean overSizeThreshold, boolean traceVariablePath) {
+        String path = useTools ? "agentic" : "inline";
+        String trigger = "none";
+        if (useTools) {
+            if (experimentIdPath) {
+                trigger = "experiment_id";
+            } else if (overSizeThreshold) {
+                trigger = "size_threshold";
+            } else if (traceVariablePath) {
+                trigger = "trace_variable";
+            } else {
+                trigger = "attachments";
+            }
+        }
+        String wsId = message.workspaceId();
+        String wsName = StringUtils.defaultIfBlank(message.workspaceName(), wsId);
+        routingDecisions.add(1, Attributes.of(
+                PATH_KEY, path,
+                TRIGGER_KEY, trigger,
+                WORKSPACE_ID_KEY, wsId,
+                WORKSPACE_NAME_KEY, wsName));
     }
 
     // Package-private for unit tests.

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineCapReplacementsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineCapReplacementsTest.java
@@ -1,9 +1,11 @@
 package com.comet.opik.api.resources.v1.events;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,7 +17,7 @@ class OnlineScoringEngineCapReplacementsTest {
     void leavesShortValuesUntouched() {
         var input = Map.of("a", "tiny", "b", "also small");
 
-        var out = OnlineScoringEngine.capReplacements(input, 100, HINT);
+        var out = OnlineScoringEngine.capReplacements(input, 100, HINT, Set.of());
 
         assertThat(out.get("a")).isEqualTo("tiny");
         assertThat(out.get("b")).isEqualTo("also small");
@@ -26,7 +28,7 @@ class OnlineScoringEngineCapReplacementsTest {
         var big = "x".repeat(5_000);
         var input = Map.of("input", big);
 
-        var out = OnlineScoringEngine.capReplacements(input, 4_000, HINT);
+        var out = OnlineScoringEngine.capReplacements(input, 4_000, HINT, Set.of());
 
         var truncated = out.get("input");
         assertThat(truncated).startsWith("x".repeat(4_000));
@@ -39,7 +41,7 @@ class OnlineScoringEngineCapReplacementsTest {
         var atCap = "y".repeat(4_000);
         var input = Map.of("input", atCap);
 
-        var out = OnlineScoringEngine.capReplacements(input, 4_000, HINT);
+        var out = OnlineScoringEngine.capReplacements(input, 4_000, HINT, Set.of());
 
         // length == cap → no truncation suffix
         assertThat(out.get("input")).isEqualTo(atCap);
@@ -52,8 +54,98 @@ class OnlineScoringEngineCapReplacementsTest {
         input.put("second", "s");
         input.put("third", "t");
 
-        var out = OnlineScoringEngine.capReplacements(input, 100, HINT);
+        var out = OnlineScoringEngine.capReplacements(input, 100, HINT, Set.of());
 
         assertThat(out.keySet()).containsExactly("first", "second", "third");
+    }
+
+    @Nested
+    class UserMappedVariableKeysTests {
+
+        @Test
+        void traceSectionVariablesAreUserMapped() {
+            var variables = Map.of(
+                    "output", "output",
+                    "expected", "metadata.expected_output",
+                    "question", "input.question");
+
+            var keys = OnlineScoringEngine.userMappedVariableKeys(variables);
+
+            assertThat(keys).containsExactlyInAnyOrder("output", "expected", "question");
+        }
+
+        @Test
+        void allSentinelVariablesAreExcluded() {
+            var variables = Map.of(
+                    "output", "output",
+                    "my_spans", "spans",
+                    "my_trace", "trace",
+                    "my_span", "span");
+
+            var keys = OnlineScoringEngine.userMappedVariableKeys(variables);
+
+            assertThat(keys).containsExactlyInAnyOrder("output");
+        }
+
+        @Test
+        void variableKeyNamedAfterSentinelButMappedToTraceSectionIsUserMapped() {
+            var variables = Map.of("spans", "output");
+
+            var keys = OnlineScoringEngine.userMappedVariableKeys(variables);
+
+            assertThat(keys).containsExactlyInAnyOrder("spans");
+        }
+
+    }
+
+    @Nested
+    class SelectiveCappingTests {
+
+        @Test
+        void userMappedVariablesAreNotCapped() {
+            var bigOutput = "x".repeat(10_000);
+            var replacements = new LinkedHashMap<String, String>();
+            replacements.put("output", bigOutput);
+            replacements.put("expected", "short expected");
+
+            var userKeys = Set.of("output", "expected");
+            var out = OnlineScoringEngine.capReplacements(
+                    replacements, 4_000, HINT, userKeys);
+
+            assertThat(out.get("output")).isEqualTo(bigOutput);
+            assertThat(out.get("expected")).isEqualTo("short expected");
+        }
+
+        @Test
+        void sentinelVariablesAreStillCapped() {
+            var bigSpans = "s".repeat(10_000);
+            var replacements = new LinkedHashMap<String, String>();
+            replacements.put("output", "x".repeat(10_000));
+            replacements.put("spans", bigSpans);
+
+            var userKeys = Set.of("output");
+            var out = OnlineScoringEngine.capReplacements(
+                    replacements, 4_000, HINT, userKeys);
+
+            assertThat(out.get("output")).hasSize(10_000);
+            assertThat(out.get("spans")).startsWith("s".repeat(4_000));
+            assertThat(out.get("spans")).contains("[TRUNCATED");
+        }
+
+        @Test
+        void emptyUserKeysCapEverything() {
+            var replacements = new LinkedHashMap<String, String>();
+            replacements.put("spans", "s".repeat(10_000));
+            replacements.put("trace", "t".repeat(10_000));
+
+            var out = OnlineScoringEngine.capReplacements(
+                    replacements, 4_000, HINT, Set.of());
+
+            assertThat(out.get("spans")).startsWith("s".repeat(4_000));
+            assertThat(out.get("spans")).contains("[TRUNCATED");
+            assertThat(out.get("trace")).startsWith("t".repeat(4_000));
+            assertThat(out.get("trace")).contains("[TRUNCATED");
+        }
+
     }
 }


### PR DESCRIPTION
## Details

On the agentic-tools path, `capReplacements()` was truncating ALL variable substitutions to 4K chars — including user-mapped scoring variables (`output`, `expected_output`). The LLM judge then had to drill down via tools to recover the full values, which was non-deterministic and produced intermittent "Insufficient data" failures for customers with large traces.

- `capReplacements()` now accepts an `uncappedKeys` set: user-mapped variables (trace sections and literals) pass through at full length, while sentinel variables (`spans`, `trace`, `span`) are still capped since the agentic tools are purpose-built to navigate them.
- Both trace-level and span-level capped `prepareLlmRequest` overloads use the new selective capping.
- The old uniform `capReplacements(replacements, max, hint)` is removed; callers pass `Set.of()` for uniform capping.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-7110

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (Opus)
- Model(s): claude-opus-4-6
- Scope: Implementation, tests, PR description
- Human verification: Code reviewed, locally tested with reproduction script confirming fix

## Testing

- `mvn test -f apps/opik-backend/pom.xml -Dtest=\"OnlineScoringEngineCapReplacementsTest,OnlineScoringEngineTest\"` — 108 tests pass, 0 failures
- `mvn spotless:check` — passes
- Local reproduction with `repro_opik_7110.py`: created an LLM-as-judge rule with `output`/`expected_output` variable mappings, logged traces with 240K+ char output (answer buried past the 4K cap mark), confirmed agentic-tools path activates (`Trace context exceeds '50000' tokens; switching to agentic-tools mode`), and verified:
  - **Before fix**: non-deterministic results — some traces scored `answer_present=[0]` (LLM failed to drill down and find the answer)
  - **After fix**: LLM sees full output directly in the prompt, no tool drill-down needed for scoring data

## Documentation

N/A — internal behavioral fix, no API or config changes.