### PR TITLE
[OPIK-7267] [BE] fix: normalize Bearer-prefixed API key in remote auth

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
@@ -44,6 +44,7 @@ import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_QUERY_
 class RemoteAuthService implements AuthService {
     private static final String USER_NOT_FOUND = "User not found";
     private static final String NOT_LOGGED_USER = "Please login first";
+    private static final String BEARER_PREFIX = "Bearer ";
 
     // GenericType instances are thread-safe and expensive to build, so reuse a single instance.
     private static final GenericType<List<WorkspaceIdNameResponse>> WORKSPACE_LIST_TYPE = new GenericType<>() {
@@ -319,9 +320,24 @@ class RemoteAuthService implements AuthService {
         }
     }
 
+    /**
+     * Strips a leading {@code Bearer } prefix from the API key. OpenAI-compatible clients — notably
+     * LiteLLM, which Optimization Studio uses to route LLM calls through
+     * {@code /v1/private/chat/completions} — send the key as {@code Authorization: Bearer <key>}. The
+     * react-service does a literal key lookup, so the prefix must be removed or single-tenant deployments
+     * reject the request with "User with provided api key not found!" (OPIK-7267). A real Opik API key
+     * never starts with {@code Bearer }, so stripping it is a safe normalization.
+     */
+    private static String stripBearerPrefix(String apiKey) {
+        return apiKey.regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())
+                ? apiKey.substring(BEARER_PREFIX.length()).strip()
+                : apiKey;
+    }
+
     private void authenticateUsingApiKey(HttpHeaders headers, String workspaceName, String path,
             List<String> requiredPermissions) {
-        var apiKey = Optional.ofNullable(headers.getHeaderString(HttpHeaders.AUTHORIZATION)).orElse("");
+        var apiKey = stripBearerPrefix(
+                Optional.ofNullable(headers.getHeaderString(HttpHeaders.AUTHORIZATION)).orElse(""));
         if (apiKey.isBlank()) {
             log.info("API key not found in headers");
             throw new ClientErrorException(MISSING_API_KEY, Response.Status.UNAUTHORIZED);

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
@@ -149,6 +149,43 @@ class RemoteAuthServiceTest {
     }
 
     @Test
+    void testAuth__whenApiKeyHasBearerPrefix__thenPrefixStrippedAndAuthSucceeds() throws JsonProcessingException {
+        // Reproduces OPIK-7267: Optimization Studio routes its LLM calls through the backend gateway
+        // (/v1/private/chat/completions) via LiteLLM, whose OpenAI-compatible client sends the Opik API
+        // key as "Bearer <key>". Single-tenant (stsaas) react-services do a literal key lookup, so the
+        // "Bearer " prefix makes the lookup fail with "User with provided api key not found!" — even
+        // though the very same key authenticates fine for the SDK's REST calls, which send it raw. The
+        // auth layer must strip the prefix before forwarding to the react-service.
+        var authResponse = podamFactory.manufacturePojo(RemoteAuthService.AuthResponse.class);
+        var apiKey = "apiKey-" + UUID.randomUUID();
+        var workspaceName = "workspace-" + UUID.randomUUID();
+
+        // Model the strict stsaas react-service: the RAW key resolves to a user...
+        WIRE_MOCK.server().stubFor(post("/opik/auth")
+                .withHeader(HttpHeaders.AUTHORIZATION, equalTo(apiKey))
+                .willReturn(okJson(OBJECT_MAPPER.writeValueAsString(authResponse))));
+        // ...but a Bearer-prefixed value is rejected exactly as the ticket reports.
+        WIRE_MOCK.server().stubFor(post("/opik/auth")
+                .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Bearer " + apiKey))
+                .willReturn(aResponse().withStatus(HttpStatus.SC_UNAUTHORIZED)
+                        .withHeader("Content-Type", "application/json")
+                        .withJsonBody(JsonUtils.readTree(new ReactServiceErrorResponse(
+                                "User with provided api key not found!", HttpStatus.SC_UNAUTHORIZED)))));
+
+        remoteAuthService.authenticate(
+                getHeadersMock(workspaceName, "Bearer " + apiKey), null,
+                ContextInfoHolder.builder()
+                        .uriInfo(createMockUriInfo("/priv/chat/completions"))
+                        .method("POST")
+                        .build());
+
+        assertThat(requestContext.getUserName()).isEqualTo(authResponse.user());
+        assertThat(requestContext.getWorkspaceId()).isEqualTo(authResponse.workspaceId());
+        // The credential stored in context is the normalized (raw) key.
+        assertThat(requestContext.getApiKey()).isEqualTo(apiKey);
+    }
+
+    @Test
     void testAuthCacheHit_preservesAllCredentials() throws JsonProcessingException {
         var authResponse = podamFactory.manufacturePojo(RemoteAuthService.AuthResponse.class);
         var apiKey = "apiKey-" + UUID.randomUUID();


### PR DESCRIPTION
## Details

Optimization Studio runs failed immediately on single-tenant deployments with `401 "User with provided api key not found!"`, while OSS and multi-tenant SaaS worked on the same version and model. The optimizer worker routes its LLM calls through the backend gateway (`/v1/private/chat/completions`) via LiteLLM, whose OpenAI-compatible client sends the Opik API key as `Authorization: Bearer <key>`. `RemoteAuthService` forwarded that header verbatim to the auth service, which does a literal key lookup — so the `Bearer ` prefix broke authentication, even though the very same key authenticates fine for the SDK's REST calls (which send it raw, e.g. the dataset load that succeeds earlier in the same run).

- Strip a leading `Bearer ` prefix in `RemoteAuthService.authenticateUsingApiKey`, before the cache lookup and before forwarding to the auth service, so the cache key and the forwarded header both use the raw key.
- A real Opik API key never starts with `Bearer `, so the normalization is safe; it also makes any OpenAI-compatible client hitting the gateway behave consistently across OSS / SaaS / single-tenant.
- The MCP-OAuth path is unaffected (its tokens carry a distinct `opik_mcp_at_` prefix and are handled earlier in `AuthFilter`).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7267

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: full implementation — investigation, fix, and regression test
- Human verification: reproduction and fix verified via the added `RemoteAuthService` test; pending code review

## Testing

- `cd apps/opik-backend && mvn -o test -Dtest=RemoteAuthServiceTest` → 30 passed, 0 failures.
- Reproduction: on the unmodified code the new test `testAuth__whenApiKeyHasBearerPrefix__thenPrefixStrippedAndAuthSucceeds` fails with the exact reported error `jakarta.ws.rs.ClientErrorException: User with provided api key not found!` — the WireMock auth-service stub models the strict single-tenant behavior (the raw key resolves to a user; a `Bearer `-prefixed value is rejected). With the fix, the prefix is stripped and the test passes.
- `cd apps/opik-backend && mvn -o spotless:check` → clean.
- Full backend test suite runs in CI.
- Not run locally: an end-to-end optimizer run against a real single-tenant deployment (requires an auth-enabled backend plus a strict remote auth service). The added test reproduces the failing seam faithfully, using the exact `Authorization` header LiteLLM emits and the exact error string from the report.

## Documentation

N/A — internal auth normalization only; no user-facing, API, or configuration changes.
