### PR TITLE
[OPIK-6884] [BE] refactor: SELECT DISTINCT trace_id in dataset-item filter-gate bounds

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -348,8 +348,8 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                     LEFT JOIN fsc ON fsc.entity_id = traces.id
                 <endif>
                 WHERE workspace_id = :workspace_id
-                AND id IN (SELECT trace_id FROM experiment_items WHERE workspace_id = :workspace_id AND experiment_id IN :experimentIds)
-                AND project_id IN (SELECT DISTINCT project_id FROM traces WHERE workspace_id = :workspace_id AND id IN (SELECT trace_id FROM experiment_items WHERE workspace_id = :workspace_id AND experiment_id IN :experimentIds))
+                AND id IN (SELECT DISTINCT trace_id FROM experiment_items WHERE workspace_id = :workspace_id AND experiment_id IN :experimentIds)
+                AND project_id IN (SELECT DISTINCT project_id FROM traces WHERE workspace_id = :workspace_id AND id IN (SELECT DISTINCT trace_id FROM experiment_items WHERE workspace_id = :workspace_id AND experiment_id IN :experimentIds))
                 <if(experiment_item_filters)>
                 AND <experiment_item_filters>
                 <endif>
@@ -850,8 +850,8 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                 <if(experiment_item_filters)>
                 AND ei.trace_id IN (
                     SELECT id FROM traces FINAL WHERE workspace_id = :workspace_id
-                    AND id IN (SELECT trace_id FROM experiment_items WHERE workspace_id = :workspace_id <if(experiment_ids)> AND experiment_id IN :experiment_ids <endif>)
-                    AND project_id IN (SELECT DISTINCT project_id FROM traces WHERE workspace_id = :workspace_id AND id IN (SELECT trace_id FROM experiment_items WHERE workspace_id = :workspace_id <if(experiment_ids)> AND experiment_id IN :experiment_ids <endif>))
+                    AND id IN (SELECT DISTINCT trace_id FROM experiment_items WHERE workspace_id = :workspace_id <if(experiment_ids)> AND experiment_id IN :experiment_ids <endif>)
+                    AND project_id IN (SELECT DISTINCT project_id FROM traces WHERE workspace_id = :workspace_id AND id IN (SELECT DISTINCT trace_id FROM experiment_items WHERE workspace_id = :workspace_id <if(experiment_ids)> AND experiment_id IN :experiment_ids <endif>))
                     AND <experiment_item_filters>
                 )
                 <endif>


### PR DESCRIPTION
## Details

Follow-up to the merged #7412, addressing @andrescrz's review nit: *"Minor: I believe better with distinct trace_id for both cases. Applies to the changes below as well."*

The `DatasetItemDAO` experiment-item filter gates (count query and stats query) added in #7412 bound the `traces` scan by the experiment trace-id set:

```sql
AND id IN (SELECT trace_id FROM experiment_items WHERE workspace_id = :workspace_id ...)
AND project_id IN (SELECT DISTINCT project_id FROM traces WHERE ... id IN (SELECT trace_id FROM experiment_items ...))
```

`experiment_items` holds one row per (experiment, dataset item), so a trace referenced by multiple items appears multiple times. This changes those four gate subqueries to `SELECT DISTINCT trace_id`, deduplicating the id set before it feeds the `IN (...)` bound (and the nested project-resolution). `DISTINCT` inside an `IN (...)` is result-equivalent — set membership is unchanged — so query results are identical; it only yields a smaller prepared set.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6884 (rolling story; full-scan audit follow-up)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: applied the `DISTINCT trace_id` review suggestion to the four gate subqueries and authored this PR description.
- Human verification: Author reviewed the change; `mvn spotless:check compile` runs clean locally.

## Testing

- `mvn spotless:check compile -DskipTests` (offline) — clean. The change is `DISTINCT` inside existing `IN (...)` subqueries, which is result-equivalent, so the existing `DatasetsResourceTest$FindDatasetItemsWithExperimentItems` coverage (56 tests, green on #7412) continues to apply.

## Documentation

No user-facing or SDK changes; internal query-path hardening only.
