### PR TITLE
[OPIK-6905] [BE] feat: cluster + cold_s3 disk ClickHouse health checks

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -95,6 +95,16 @@ databaseAnalytics:
   #  Default: 1s
   #  Description: Timeout for the ClickHouse health check query (e.g. 1s, 500ms, 2 minutes)
   healthCheckTimeout: ${ANALYTICS_DB_HEALTH_CHECK_TIMEOUT:-1s}
+  #  Default: false
+  #  Description: Gates the 'clickhouse-cluster' health check, which fails readiness when the Distributed cluster
+  #   definition ('cluster') isn't visible from the node. Leave false for single-shard / non-Distributed deployments;
+  #   turn true only for the Distributed (Hyperscale) topology.
+  clusterHealthCheckEnabled: ${ANALYTICS_DB_CLUSTER_HEALTH_CHECK_ENABLED:-false}
+  #  Default: false
+  #  Description: Gates the 'clickhouse-cold-storage-disk' health check, which fails readiness when the 'cold_s3'
+  #   tiered-storage disk isn't reachable from the node. Leave false for deployments without tier storage (OSS Docker);
+  #   turn true only once the S3 disk is activated.
+  coldStorageDiskHealthCheckEnabled: ${ANALYTICS_DB_COLD_STORAGE_DISK_HEALTH_CHECK_ENABLED:-false}
 
 # Description: Cutover toggles migrating the trace analytics columns to non-nullable, sentinel-defaulted form.
 databaseAnalyticsDataModel:
@@ -176,6 +186,17 @@ health:
     # the whole backend out of readiness/traffic.
     - name: clickhouse-readonly-freeform-sql
       critical: false
+      type: ready
+    # Toggle-gated (databaseAnalytics.clusterHealthCheckEnabled). When the toggle is off the probe reports healthy
+    # without querying ClickHouse, so single-shard / OSS environments are unaffected. When on, a node that can't see
+    # the Distributed cluster definition can't serve distributed queries and must be pulled from rotation.
+    - name: clickhouse-cluster
+      critical: true
+      type: ready
+    # Toggle-gated (databaseAnalytics.coldStorageDiskHealthCheckEnabled). Off by default so deployments without tier
+    # storage are unaffected. When on, a node that can't reach the cold_s3 S3 disk must be pulled from rotation.
+    - name: clickhouse-cold-storage-disk
+      critical: true
       type: ready
     - name: mysql
       critical: true

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatabaseAnalyticsFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatabaseAnalyticsFactory.java
@@ -56,6 +56,19 @@ public class DatabaseAnalyticsFactory {
     // Optional socket timeout, applied in buildClient() only when set (null = library default of 0/no timeout).
     private Duration clientSocketTimeout;
 
+    /**
+     * Gates the {@code clickhouse-cluster} health check. Off for single-shard / non-Distributed
+     * deployments; on only for the Distributed (Hyperscale) topology where the cluster definition
+     * must be visible from every node.
+     */
+    private boolean clusterHealthCheckEnabled;
+
+    /**
+     * Gates the {@code clickhouse-cold-storage-disk} health check. Off for deployments without tier
+     * storage (OSS Docker); on only once the {@code cold_s3} S3 disk is activated.
+     */
+    private boolean coldStorageDiskHealthCheckEnabled;
+
     public ConnectionFactory build() {
         var queryParametersOverrides = getQueryParametersOverrides(queryParameters);
         var options = queryParametersOverrides == null ? "" : "?%s".formatted(queryParametersOverrides);

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/AbstractClickHouseExistenceHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/AbstractClickHouseExistenceHealthCheck.java
@@ -1,0 +1,63 @@
+package com.comet.opik.infrastructure.db;
+
+import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.query.Records;
+import io.dropwizard.util.Duration;
+import lombok.NonNull;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Toggle-gated probe that asserts a single {@code count()} query returns at least one row — used to
+ * verify that a piece of ClickHouse topology (a Distributed cluster definition, a storage disk) is
+ * actually visible from this node.
+ *
+ * <p>Unlike the plain {@code SELECT 1} of {@link AbstractClickHouseHealthCheck}, "the query ran" is
+ * not enough here: {@code SELECT count() FROM system.clusters WHERE cluster = 'cluster'} succeeds and
+ * returns {@code 0} when the cluster is absent. So the probe reads the count and reports unhealthy
+ * when it is zero. It reuses the parent's timeout, {@code max_execution_time} cap and
+ * cancel-on-failure machinery.
+ *
+ * <p>When the feature toggle is off the probe reports healthy without touching ClickHouse, so a
+ * deployment that doesn't have the topology (single-shard / OSS Docker) is never gated by it.
+ */
+abstract class AbstractClickHouseExistenceHealthCheck extends AbstractClickHouseHealthCheck {
+
+    private static final String COUNT_COLUMN = "cnt";
+
+    private final boolean enabled;
+    private final String disabledMessage;
+    private final String existenceQuery;
+    private final String notFoundMessage;
+
+    protected AbstractClickHouseExistenceHealthCheck(@NonNull Client clickHouseClient,
+            @NonNull Duration healthCheckTimeout, String name, boolean enabled, @NonNull String disabledMessage,
+            @NonNull String existenceQuery, @NonNull String notFoundMessage) {
+        super(clickHouseClient, healthCheckTimeout, name);
+        this.enabled = enabled;
+        this.disabledMessage = disabledMessage;
+        this.existenceQuery = existenceQuery;
+        this.notFoundMessage = notFoundMessage;
+    }
+
+    @Override
+    protected Result check() {
+        if (!enabled) {
+            return Result.healthy(disabledMessage);
+        }
+        var queryFuture = clickHouseClient.queryRecords(existenceQuery, newQuerySettings());
+        try (var records = queryFuture.get(healthCheckTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
+            return exists(records) ? Result.healthy() : Result.unhealthy(notFoundMessage);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            return getUnhealthyAndCancelQuery(queryFuture, exception);
+        } catch (Exception exception) {
+            return getUnhealthyAndCancelQuery(queryFuture, exception);
+        }
+    }
+
+    private static boolean exists(Records records) {
+        var iterator = records.iterator();
+        return iterator.hasNext() && iterator.next().getLong(COUNT_COLUMN) > 0L;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/AbstractClickHouseExistenceHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/AbstractClickHouseExistenceHealthCheck.java
@@ -5,8 +5,6 @@ import com.clickhouse.client.api.query.Records;
 import io.dropwizard.util.Duration;
 import lombok.NonNull;
 
-import java.util.concurrent.TimeUnit;
-
 /**
  * Toggle-gated probe that asserts a single {@code count()} query returns at least one row — used to
  * verify that a piece of ClickHouse topology (a Distributed cluster definition, a storage disk) is
@@ -45,15 +43,8 @@ abstract class AbstractClickHouseExistenceHealthCheck extends AbstractClickHouse
         if (!enabled) {
             return Result.healthy(disabledMessage);
         }
-        var queryFuture = clickHouseClient.queryRecords(existenceQuery, newQuerySettings());
-        try (var records = queryFuture.get(healthCheckTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
-            return exists(records) ? Result.healthy() : Result.unhealthy(notFoundMessage);
-        } catch (InterruptedException exception) {
-            Thread.currentThread().interrupt();
-            return getUnhealthyAndCancelQuery(queryFuture, exception);
-        } catch (Exception exception) {
-            return getUnhealthyAndCancelQuery(queryFuture, exception);
-        }
+        return executeProbe(clickHouseClient.queryRecords(existenceQuery, newQuerySettings()),
+                records -> exists(records) ? Result.healthy() : Result.unhealthy(notFoundMessage));
     }
 
     private static boolean exists(Records records) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/AbstractClickHouseHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/AbstractClickHouseHealthCheck.java
@@ -1,7 +1,6 @@
 package com.comet.opik.infrastructure.db;
 
 import com.clickhouse.client.api.Client;
-import com.clickhouse.client.api.query.QueryResponse;
 import com.clickhouse.client.api.query.QuerySettings;
 import com.google.common.base.Preconditions;
 import lombok.Getter;
@@ -35,8 +34,8 @@ abstract class AbstractClickHouseHealthCheck extends NamedHealthCheck {
      */
     private static final String MAX_EXECUTION_TIME = "max_execution_time";
 
-    private final Client clickHouseClient;
-    private final Duration healthCheckTimeout;
+    protected final Client clickHouseClient;
+    protected final Duration healthCheckTimeout;
 
     /**
      * Server-side ceiling aligned with the call-site deadline so ClickHouse aborts a stuck probe
@@ -91,7 +90,7 @@ abstract class AbstractClickHouseHealthCheck extends NamedHealthCheck {
     /**
      * Cancel on failure so the query doesn't keep running server-side.
      */
-    private Result getUnhealthyAndCancelQuery(CompletableFuture<QueryResponse> queryFuture, Exception exception) {
+    protected Result getUnhealthyAndCancelQuery(CompletableFuture<?> queryFuture, Exception exception) {
         queryFuture.cancel(true);
         return Result.unhealthy(exception);
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/AbstractClickHouseHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/AbstractClickHouseHealthCheck.java
@@ -11,6 +11,7 @@ import ru.vyarus.dropwizard.guice.module.installer.feature.health.NamedHealthChe
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 /**
  * Shared probe shape for ClickHouse v2 HTTP health checks: bounded {@code SELECT 1} with a
@@ -20,7 +21,9 @@ import java.util.concurrent.TimeUnit;
  * <p>Subclasses pass their name via the constructor and may override {@link #check()} to
  * short-circuit before delegating to {@code super.check()} (e.g. when a feature toggle disables
  * the underlying capability), or override {@link #newQuerySettings()} when their user runs under
- * a profile that forbids per-query setting changes.
+ * a profile that forbids per-query setting changes. Subclasses running a different query drive it
+ * through {@link #executeProbe(CompletableFuture, Function)} so the timeout, cancellation and
+ * {@code log_comment} handling live in one place.
  */
 abstract class AbstractClickHouseHealthCheck extends NamedHealthCheck {
 
@@ -33,6 +36,9 @@ abstract class AbstractClickHouseHealthCheck extends NamedHealthCheck {
      * prefix and never reaches the server, so it must not be used to impose a server-side cap.
      */
     private static final String MAX_EXECUTION_TIME = "max_execution_time";
+
+    private static final String LOG_COMMENT = "log_comment";
+    private static final String LOG_COMMENT_TEMPLATE = "health_check:%s";
 
     protected final Client clickHouseClient;
     protected final Duration healthCheckTimeout;
@@ -61,9 +67,20 @@ abstract class AbstractClickHouseHealthCheck extends NamedHealthCheck {
 
     @Override
     protected Result check() {
-        var queryFuture = clickHouseClient.query(SELECT_1_QUERY, newQuerySettings());
-        try (var _ = queryFuture.get(healthCheckTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
-            return Result.healthy();
+        return executeProbe(clickHouseClient.query(SELECT_1_QUERY, newQuerySettings()), response -> Result.healthy());
+    }
+
+    /**
+     * Runs a probe query under the shared deadline and cancellation contract: the caller-side
+     * {@code future.get(healthCheckTimeout)} bounds the wait, {@code onResult} maps the (auto-closed)
+     * result to a {@link Result}, and any interrupt/failure cancels the in-flight query so it doesn't
+     * keep running server-side. Subclasses supply the future (via {@link #newQuerySettings()}) and the
+     * result mapping; the flow lives here so timeout and cancellation fixes stay in one place.
+     */
+    protected <T extends AutoCloseable> Result executeProbe(CompletableFuture<T> queryFuture,
+            Function<? super T, Result> onResult) {
+        try (var result = queryFuture.get(healthCheckTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
+            return onResult.apply(result);
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
             return getUnhealthyAndCancelQuery(queryFuture, exception);
@@ -75,7 +92,8 @@ abstract class AbstractClickHouseHealthCheck extends NamedHealthCheck {
     /**
      * Per-call probe settings, built fresh each invocation because {@link QuerySettings} is not
      * thread-safe. Default carries the server-side {@code max_execution_time} cap from
-     * {@link #queryMaxExecutionTimeSeconds}; the caller-side {@code future.get(healthCheckTimeout)}
+     * {@link #queryMaxExecutionTimeSeconds} plus a {@code log_comment} tagging the query with this
+     * probe's name in {@code system.query_log}; the caller-side {@code future.get(healthCheckTimeout)}
      * remains the deadline on top.
      *
      * <p>Subclasses whose user runs under a profile that forbids per-query setting changes
@@ -84,7 +102,9 @@ abstract class AbstractClickHouseHealthCheck extends NamedHealthCheck {
      * ClickHouse rejects the probe with a {@code READONLY} error.
      */
     protected QuerySettings newQuerySettings() {
-        return new QuerySettings().serverSetting(MAX_EXECUTION_TIME, String.valueOf(queryMaxExecutionTimeSeconds));
+        return new QuerySettings()
+                .serverSetting(MAX_EXECUTION_TIME, String.valueOf(queryMaxExecutionTimeSeconds))
+                .serverSetting(LOG_COMMENT, LOG_COMMENT_TEMPLATE.formatted(name));
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/ClickHouseClusterHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/ClickHouseClusterHealthCheck.java
@@ -1,0 +1,42 @@
+package com.comet.opik.infrastructure.db;
+
+import com.clickhouse.client.api.Client;
+import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;
+import io.dropwizard.util.Duration;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
+
+import static com.comet.opik.infrastructure.db.DatabaseAnalyticsModule.CLICKHOUSE_HEALTH_CHECK_TIMEOUT;
+
+/**
+ * Verifies that the Distributed cluster definition is visible from this node via the v2 HTTP client.
+ *
+ * <p>Gated by {@code databaseAnalytics.clusterHealthCheckEnabled}: single-shard / non-Distributed
+ * deployments (OSS Docker, existing single-node environments) leave it off and are unaffected. Only
+ * the Hyperscale Distributed deployment turns it on, where a node that can't see the cluster can't
+ * serve distributed queries and must be pulled from readiness.
+ */
+@Singleton
+public class ClickHouseClusterHealthCheck extends AbstractClickHouseExistenceHealthCheck {
+
+    private static final String NAME = "clickhouse-cluster";
+
+    // The cluster name set in both the Helm CHI and the docker-compose macros.
+    private static final String CLUSTER_NAME = "cluster";
+    private static final String EXISTENCE_QUERY = "SELECT count() AS cnt FROM system.clusters WHERE cluster = '%s'"
+            .formatted(CLUSTER_NAME);
+    private static final String DISABLED_MESSAGE = "Distributed cluster health check disabled";
+    private static final String NOT_FOUND_MESSAGE = "ClickHouse cluster '%s' is not visible from this node"
+            .formatted(CLUSTER_NAME);
+
+    @Inject
+    public ClickHouseClusterHealthCheck(@NonNull Client clickHouseClient,
+            @NonNull @Named(CLICKHOUSE_HEALTH_CHECK_TIMEOUT) Duration healthCheckTimeout,
+            @NonNull @Config("databaseAnalytics") DatabaseAnalyticsFactory databaseAnalytics) {
+        super(clickHouseClient, healthCheckTimeout, NAME, databaseAnalytics.isClusterHealthCheckEnabled(),
+                DISABLED_MESSAGE, EXISTENCE_QUERY, NOT_FOUND_MESSAGE);
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/ClickHouseColdStorageDiskHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/ClickHouseColdStorageDiskHealthCheck.java
@@ -1,0 +1,41 @@
+package com.comet.opik.infrastructure.db;
+
+import com.clickhouse.client.api.Client;
+import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;
+import io.dropwizard.util.Duration;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
+
+import static com.comet.opik.infrastructure.db.DatabaseAnalyticsModule.CLICKHOUSE_HEALTH_CHECK_TIMEOUT;
+
+/**
+ * Verifies that the {@code cold_s3} tiered-storage disk is reachable from this node via the v2 HTTP
+ * client.
+ *
+ * <p>Gated by {@code databaseAnalytics.coldStorageDiskHealthCheckEnabled}: deployments without tier
+ * storage (OSS Docker) leave it off and are unaffected. Only environments with tiered storage
+ * activated turn it on, where a node that can't reach the S3 disk must be pulled from readiness.
+ */
+@Singleton
+public class ClickHouseColdStorageDiskHealthCheck extends AbstractClickHouseExistenceHealthCheck {
+
+    private static final String NAME = "clickhouse-cold-storage-disk";
+
+    private static final String COLD_DISK_NAME = "cold_s3";
+    private static final String EXISTENCE_QUERY = "SELECT count() AS cnt FROM system.disks WHERE name = '%s'"
+            .formatted(COLD_DISK_NAME);
+    private static final String DISABLED_MESSAGE = "Cold storage disk health check disabled";
+    private static final String NOT_FOUND_MESSAGE = "ClickHouse disk '%s' is not reachable from this node"
+            .formatted(COLD_DISK_NAME);
+
+    @Inject
+    public ClickHouseColdStorageDiskHealthCheck(@NonNull Client clickHouseClient,
+            @NonNull @Named(CLICKHOUSE_HEALTH_CHECK_TIMEOUT) Duration healthCheckTimeout,
+            @NonNull @Config("databaseAnalytics") DatabaseAnalyticsFactory databaseAnalytics) {
+        super(clickHouseClient, healthCheckTimeout, NAME, databaseAnalytics.isColdStorageDiskHealthCheckEnabled(),
+                DISABLED_MESSAGE, EXISTENCE_QUERY, NOT_FOUND_MESSAGE);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/HealthCheckIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/HealthCheckIntegrationTest.java
@@ -103,6 +103,12 @@ class HealthCheckIntegrationTest {
             // freeform-SQL issue never gates overall readiness.
             var clickhouseFreeformSqlResponse = HealthCheckResponse.builder()
                     .name("clickhouse-readonly-freeform-sql").healthy(true).critical(false).type(READY).build();
+            // Toggle off in config-test (databaseAnalytics.clusterHealthCheckEnabled / coldStorageDiskHealthCheckEnabled)
+            // → healthy without touching ClickHouse. Critical when enabled, so listed critical here.
+            var clickhouseClusterResponse = HealthCheckResponse.builder()
+                    .name("clickhouse-cluster").healthy(true).critical(true).type(READY).build();
+            var clickhouseColdStorageDiskResponse = HealthCheckResponse.builder()
+                    .name("clickhouse-cold-storage-disk").healthy(true).critical(true).type(READY).build();
             var mysqlResponse = HealthCheckResponse.builder()
                     .name("mysql").healthy(true).critical(true).type(READY).build();
             var redisResponse = HealthCheckResponse.builder()
@@ -118,6 +124,8 @@ class HealthCheckIntegrationTest {
             var all = List.of(
                     clickHouseResponse,
                     clickhouseFreeformSqlResponse,
+                    clickhouseClusterResponse,
+                    clickhouseColdStorageDiskResponse,
                     mysqlResponse,
                     redisResponse,
                     dbResponse,
@@ -128,6 +136,8 @@ class HealthCheckIntegrationTest {
                     arguments("mysql", List.of(mysqlResponse)),
                     arguments("redis", List.of(redisResponse)),
                     arguments("clickhouse-readonly-freeform-sql", List.of(clickhouseFreeformSqlResponse)),
+                    arguments("clickhouse-cluster", List.of(clickhouseClusterResponse)),
+                    arguments("clickhouse-cold-storage-disk", List.of(clickhouseColdStorageDiskResponse)),
                     arguments("shared_http_client", List.of(sharedHttpClientResponse)),
                     arguments("all", all));
         }
@@ -179,6 +189,54 @@ class HealthCheckIntegrationTest {
         }
     }
 
+    /**
+     * Both existence toggles on, so each probe runs its real {@code count()} query against the test
+     * ClickHouse — exercising the end-to-end SQL path the unit tests mock out. The container's {@code
+     * clickhouse.xml} defines a {@code cluster} remote_server (mirroring the deploy macros), so the
+     * cluster probe finds it and reports healthy; there is no {@code cold_s3} disk, so that probe
+     * reports unhealthy. Both are {@code critical: true}, so the per-check endpoint may return a
+     * non-OK status while still carrying the JSON body.
+     */
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @ExtendWith(DropwizardAppExtensionProvider.class)
+    class ExistenceChecksEnabled {
+
+        @RegisterApp
+        private final TestDropwizardAppExtension app = newApp(List.of(
+                new CustomConfig("databaseAnalytics.clusterHealthCheckEnabled", "true"),
+                new CustomConfig("databaseAnalytics.coldStorageDiskHealthCheckEnabled", "true")));
+
+        private ClientSupport client;
+        private String baseURI;
+
+        @BeforeAll
+        void setUpAll(ClientSupport client) {
+            this.client = client;
+            this.baseURI = TestUtils.getBaseUrl(client);
+            ClientSupportUtils.config(client);
+        }
+
+        private Stream<Arguments> healthCheckRunsAgainstClickHouse() {
+            // Cluster 'cluster' is defined in the test container's clickhouse.xml → present → healthy.
+            // Disk 'cold_s3' is not configured on the test container → absent → unhealthy.
+            return Stream.of(
+                    arguments("clickhouse-cluster", true),
+                    arguments("clickhouse-cold-storage-disk", false));
+        }
+
+        @ParameterizedTest(name = "healthCheckRunsAgainstClickHouse - {0} -> healthy={1}")
+        @MethodSource
+        void healthCheckRunsAgainstClickHouse(String name, boolean healthy) {
+            var expected = HealthCheckResponse.builder()
+                    .name(name).healthy(healthy).critical(true).type(READY).build();
+
+            Awaitility.await()
+                    .atMost(5, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertResponse(readHealthCheck(client, baseURI, name), List.of(expected)));
+        }
+    }
+
     @Builder
     private record HealthCheckResponse(String name, boolean healthy, boolean critical, String type) {
     }
@@ -206,6 +264,18 @@ class HealthCheckIntegrationTest {
                 .request()
                 .get()) {
             assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+            return response.readEntity(HEALTH_CHECK_LIST_GENERIC_TYPE);
+        }
+    }
+
+    /**
+     * Reads the health check body without asserting the HTTP status: an unhealthy {@code critical}
+     * check makes the endpoint return a non-OK status while still carrying the JSON results.
+     */
+    private List<HealthCheckResponse> readHealthCheck(ClientSupport client, String baseURI, String name) {
+        try (var response = client.target("%s/health-check?name=%s".formatted(baseURI, name))
+                .request()
+                .get()) {
             return response.readEntity(HEALTH_CHECK_LIST_GENERIC_TYPE);
         }
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/ClickHouseExistenceHealthCheckTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/ClickHouseExistenceHealthCheckTest.java
@@ -41,6 +41,8 @@ class ClickHouseExistenceHealthCheckTest {
     private static final int HEALTH_CHECK_TIMEOUT_SECONDS = 1;
     private static final Duration HEALTH_CHECK_TIMEOUT = Duration.seconds(HEALTH_CHECK_TIMEOUT_SECONDS);
     private static final String CLICKHOUSE_SETTING_MAX_EXECUTION_TIME = "clickhouse_setting_max_execution_time";
+    private static final String CLICKHOUSE_SETTING_LOG_COMMENT = "clickhouse_setting_log_comment";
+    private static final String LOG_COMMENT_PREFIX = "health_check:";
 
     private final Client clickHouseClient = mock(Client.class);
 
@@ -88,7 +90,7 @@ class ClickHouseExistenceHealthCheckTest {
     void check__whenEnabledAndResourcePresent__thenHealthy(String name, String query, String notFoundMessage,
             String disabledMessage, BiFunction<Client, Boolean, AbstractClickHouseExistenceHealthCheck> factory) {
         var records = records(1L);
-        when(clickHouseClient.queryRecords(eq(query), argThat(maxExecutionTimeServerSetting())))
+        when(clickHouseClient.queryRecords(eq(query), argThat(probeServerSettings())))
                 .thenReturn(CompletableFuture.completedFuture(records));
 
         var actualResult = factory.apply(clickHouseClient, true).execute();
@@ -101,7 +103,7 @@ class ClickHouseExistenceHealthCheckTest {
     void check__whenEnabledAndCountIsZero__thenUnhealthy(String name, String query, String notFoundMessage,
             String disabledMessage, BiFunction<Client, Boolean, AbstractClickHouseExistenceHealthCheck> factory) {
         var records = records(0L);
-        when(clickHouseClient.queryRecords(eq(query), argThat(maxExecutionTimeServerSetting())))
+        when(clickHouseClient.queryRecords(eq(query), argThat(probeServerSettings())))
                 .thenReturn(CompletableFuture.completedFuture(records));
 
         var actualResult = factory.apply(clickHouseClient, true).execute();
@@ -115,7 +117,7 @@ class ClickHouseExistenceHealthCheckTest {
             String disabledMessage, BiFunction<Client, Boolean, AbstractClickHouseExistenceHealthCheck> factory) {
         var records = mock(Records.class);
         when(records.iterator()).thenReturn(Collections.emptyIterator());
-        when(clickHouseClient.queryRecords(eq(query), argThat(maxExecutionTimeServerSetting())))
+        when(clickHouseClient.queryRecords(eq(query), argThat(probeServerSettings())))
                 .thenReturn(CompletableFuture.completedFuture(records));
 
         var actualResult = factory.apply(clickHouseClient, true).execute();
@@ -133,7 +135,7 @@ class ClickHouseExistenceHealthCheckTest {
         var failingFuture = mock(CompletableFuture.class);
         when(failingFuture.get(HEALTH_CHECK_TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS))
                 .thenThrow(executionException);
-        when(clickHouseClient.queryRecords(eq(query), argThat(maxExecutionTimeServerSetting())))
+        when(clickHouseClient.queryRecords(eq(query), argThat(probeServerSettings())))
                 .thenReturn(failingFuture);
 
         var actualResult = factory.apply(clickHouseClient, true).execute();
@@ -151,7 +153,7 @@ class ClickHouseExistenceHealthCheckTest {
         var failingFuture = mock(CompletableFuture.class);
         when(failingFuture.get(HEALTH_CHECK_TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS))
                 .thenThrow(interruptedException);
-        when(clickHouseClient.queryRecords(eq(query), argThat(maxExecutionTimeServerSetting())))
+        when(clickHouseClient.queryRecords(eq(query), argThat(probeServerSettings())))
                 .thenReturn(failingFuture);
 
         var actualResult = factory.apply(clickHouseClient, true).execute();
@@ -175,9 +177,14 @@ class ClickHouseExistenceHealthCheckTest {
         return databaseAnalytics;
     }
 
-    private ArgumentMatcher<QuerySettings> maxExecutionTimeServerSetting() {
-        return settings -> String.valueOf(HEALTH_CHECK_TIMEOUT_SECONDS)
-                .equals(settings.getAllSettings().get(CLICKHOUSE_SETTING_MAX_EXECUTION_TIME));
+    private ArgumentMatcher<QuerySettings> probeServerSettings() {
+        return settings -> {
+            var allSettings = settings.getAllSettings();
+            var logComment = allSettings.get(CLICKHOUSE_SETTING_LOG_COMMENT);
+            return String.valueOf(HEALTH_CHECK_TIMEOUT_SECONDS)
+                    .equals(allSettings.get(CLICKHOUSE_SETTING_MAX_EXECUTION_TIME))
+                    && logComment instanceof String value && value.startsWith(LOG_COMMENT_PREFIX);
+        };
     }
 
     private void assertResult(HealthCheck.Result actual, HealthCheck.Result expected) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/ClickHouseExistenceHealthCheckTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/ClickHouseExistenceHealthCheckTest.java
@@ -1,0 +1,199 @@
+package com.comet.opik.infrastructure.db;
+
+import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.query.GenericRecord;
+import com.clickhouse.client.api.query.QuerySettings;
+import com.clickhouse.client.api.query.Records;
+import com.codahale.metrics.health.HealthCheck;
+import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;
+import io.dropwizard.util.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentMatcher;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Behaviour of the toggle-gated existence probes ({@link ClickHouseClusterHealthCheck},
+ * {@link ClickHouseColdStorageDiskHealthCheck}): both share {@link AbstractClickHouseExistenceHealthCheck},
+ * differing only in query, name and messages, so they are exercised with the same parameterized cases.
+ */
+class ClickHouseExistenceHealthCheckTest {
+
+    private static final int HEALTH_CHECK_TIMEOUT_SECONDS = 1;
+    private static final Duration HEALTH_CHECK_TIMEOUT = Duration.seconds(HEALTH_CHECK_TIMEOUT_SECONDS);
+    private static final String CLICKHOUSE_SETTING_MAX_EXECUTION_TIME = "clickhouse_setting_max_execution_time";
+
+    private final Client clickHouseClient = mock(Client.class);
+
+    @AfterEach
+    void afterEach() {
+        // The interrupt-path test leaves the thread's interrupt flag set; clear so it doesn't leak
+        // into subsequent tests on the same JUnit worker thread.
+        Thread.interrupted();
+    }
+
+    private static Stream<Arguments> checks() {
+        return Stream.of(
+                arguments("clickhouse-cluster",
+                        "SELECT count() AS cnt FROM system.clusters WHERE cluster = 'cluster'",
+                        "ClickHouse cluster 'cluster' is not visible from this node",
+                        "Distributed cluster health check disabled",
+                        (BiFunction<Client, Boolean, AbstractClickHouseExistenceHealthCheck>) (client,
+                                enabled) -> new ClickHouseClusterHealthCheck(client, HEALTH_CHECK_TIMEOUT,
+                                        factory(databaseAnalytics -> databaseAnalytics
+                                                .setClusterHealthCheckEnabled(enabled)))),
+                arguments("clickhouse-cold-storage-disk",
+                        "SELECT count() AS cnt FROM system.disks WHERE name = 'cold_s3'",
+                        "ClickHouse disk 'cold_s3' is not reachable from this node",
+                        "Cold storage disk health check disabled",
+                        (BiFunction<Client, Boolean, AbstractClickHouseExistenceHealthCheck>) (client,
+                                enabled) -> new ClickHouseColdStorageDiskHealthCheck(client, HEALTH_CHECK_TIMEOUT,
+                                        factory(databaseAnalytics -> databaseAnalytics
+                                                .setColdStorageDiskHealthCheckEnabled(enabled)))));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("checks")
+    void check__whenDisabled__thenHealthyWithoutTouchingClient(String name, String query, String notFoundMessage,
+            String disabledMessage, BiFunction<Client, Boolean, AbstractClickHouseExistenceHealthCheck> factory) {
+        var healthCheck = factory.apply(clickHouseClient, false);
+
+        var actualResult = healthCheck.execute();
+
+        assertResult(actualResult, HealthCheck.Result.healthy(disabledMessage));
+        verifyNoInteractions(clickHouseClient);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("checks")
+    void check__whenEnabledAndResourcePresent__thenHealthy(String name, String query, String notFoundMessage,
+            String disabledMessage, BiFunction<Client, Boolean, AbstractClickHouseExistenceHealthCheck> factory) {
+        var records = records(1L);
+        when(clickHouseClient.queryRecords(eq(query), argThat(maxExecutionTimeServerSetting())))
+                .thenReturn(CompletableFuture.completedFuture(records));
+
+        var actualResult = factory.apply(clickHouseClient, true).execute();
+
+        assertResult(actualResult, HealthCheck.Result.healthy());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("checks")
+    void check__whenEnabledAndCountIsZero__thenUnhealthy(String name, String query, String notFoundMessage,
+            String disabledMessage, BiFunction<Client, Boolean, AbstractClickHouseExistenceHealthCheck> factory) {
+        var records = records(0L);
+        when(clickHouseClient.queryRecords(eq(query), argThat(maxExecutionTimeServerSetting())))
+                .thenReturn(CompletableFuture.completedFuture(records));
+
+        var actualResult = factory.apply(clickHouseClient, true).execute();
+
+        assertResult(actualResult, HealthCheck.Result.unhealthy(notFoundMessage));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("checks")
+    void check__whenEnabledAndNoRows__thenUnhealthy(String name, String query, String notFoundMessage,
+            String disabledMessage, BiFunction<Client, Boolean, AbstractClickHouseExistenceHealthCheck> factory) {
+        var records = mock(Records.class);
+        when(records.iterator()).thenReturn(Collections.emptyIterator());
+        when(clickHouseClient.queryRecords(eq(query), argThat(maxExecutionTimeServerSetting())))
+                .thenReturn(CompletableFuture.completedFuture(records));
+
+        var actualResult = factory.apply(clickHouseClient, true).execute();
+
+        assertResult(actualResult, HealthCheck.Result.unhealthy(notFoundMessage));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("checks")
+    void check__whenEnabledAndQueryFails__thenUnhealthyAndCancelsQuery(String name, String query,
+            String notFoundMessage, String disabledMessage,
+            BiFunction<Client, Boolean, AbstractClickHouseExistenceHealthCheck> factory) throws Exception {
+        var causeException = new RuntimeException("ClickHouse unavailable");
+        var executionException = new ExecutionException(causeException);
+        var failingFuture = mock(CompletableFuture.class);
+        when(failingFuture.get(HEALTH_CHECK_TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS))
+                .thenThrow(executionException);
+        when(clickHouseClient.queryRecords(eq(query), argThat(maxExecutionTimeServerSetting())))
+                .thenReturn(failingFuture);
+
+        var actualResult = factory.apply(clickHouseClient, true).execute();
+
+        assertResult(actualResult, HealthCheck.Result.unhealthy(executionException));
+        verify(failingFuture).cancel(true);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("checks")
+    void check__whenEnabledAndInterrupted__thenUnhealthyAndRestoresInterruptFlag(String name, String query,
+            String notFoundMessage, String disabledMessage,
+            BiFunction<Client, Boolean, AbstractClickHouseExistenceHealthCheck> factory) throws Exception {
+        var interruptedException = new InterruptedException("Interrupted call unavailable");
+        var failingFuture = mock(CompletableFuture.class);
+        when(failingFuture.get(HEALTH_CHECK_TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS))
+                .thenThrow(interruptedException);
+        when(clickHouseClient.queryRecords(eq(query), argThat(maxExecutionTimeServerSetting())))
+                .thenReturn(failingFuture);
+
+        var actualResult = factory.apply(clickHouseClient, true).execute();
+
+        assertResult(actualResult, HealthCheck.Result.unhealthy(interruptedException));
+        verify(failingFuture).cancel(true);
+        assertThat(Thread.interrupted()).isTrue();
+    }
+
+    private Records records(long count) {
+        var record = mock(GenericRecord.class);
+        when(record.getLong("cnt")).thenReturn(count);
+        var records = mock(Records.class);
+        when(records.iterator()).thenReturn(List.of(record).iterator());
+        return records;
+    }
+
+    private static DatabaseAnalyticsFactory factory(Consumer<DatabaseAnalyticsFactory> customizer) {
+        var databaseAnalytics = new DatabaseAnalyticsFactory();
+        customizer.accept(databaseAnalytics);
+        return databaseAnalytics;
+    }
+
+    private ArgumentMatcher<QuerySettings> maxExecutionTimeServerSetting() {
+        return settings -> String.valueOf(HEALTH_CHECK_TIMEOUT_SECONDS)
+                .equals(settings.getAllSettings().get(CLICKHOUSE_SETTING_MAX_EXECUTION_TIME));
+    }
+
+    private void assertResult(HealthCheck.Result actual, HealthCheck.Result expected) {
+        assertThat(actual.isHealthy()).isEqualTo(expected.isHealthy());
+        assertThat(actual.getMessage()).isEqualTo(expected.getMessage());
+        assertError(actual.getError(), expected.getError());
+    }
+
+    private void assertError(Throwable actual, Throwable expected) {
+        if (expected == null) {
+            assertThat(actual).isNull();
+            return;
+        }
+        assertThat(actual)
+                .isExactlyInstanceOf(expected.getClass())
+                .hasMessage(expected.getMessage())
+                .hasCause(expected.getCause() == null ? null : expected.getCause());
+    }
+}

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -165,6 +165,16 @@ health:
       type: ready
       initialState: false
       schedule: { initialDelay: 0ms, checkInterval: 100ms, downtimeInterval: 100ms, failureAttempts: 1, successAttempts: 1 }
+    - name: clickhouse-cluster
+      critical: true
+      type: ready
+      initialState: false
+      schedule: { initialDelay: 0ms, checkInterval: 100ms, downtimeInterval: 100ms, failureAttempts: 1, successAttempts: 1 }
+    - name: clickhouse-cold-storage-disk
+      critical: true
+      type: ready
+      initialState: false
+      schedule: { initialDelay: 0ms, checkInterval: 100ms, downtimeInterval: 100ms, failureAttempts: 1, successAttempts: 1 }
     - name: mysql
       critical: true
       type: ready


### PR DESCRIPTION
## Details

Adds two toggle-gated ClickHouse readiness probes so the app catches the failure modes the Hyperscale infrastructure introduces. Both default OFF, so single-shard / OSS Docker deployments are unaffected until the relevant flag is flipped at its rollout milestone.

- **`clickhouse-cluster`** (Stage 1) — fails readiness when the Distributed cluster definition (`cluster`) isn't visible from the node (`system.clusters`).
- **`clickhouse-cold-storage-disk`** (Stage 2) — fails readiness when the `cold_s3` tiered-storage disk isn't reachable (`system.disks`).
- A `count()` query succeeds returning `0` when the resource is absent, so the shared base reads the count and reports unhealthy when it is zero — reusing the existing timeout / `max_execution_time` cap / cancel-on-failure machinery of `AbstractClickHouseHealthCheck`.
- Gated by new `databaseAnalytics` flags `clusterHealthCheckEnabled` / `coldStorageDiskHealthCheckEnabled` (env `ANALYTICS_DB_CLUSTER_HEALTH_CHECK_ENABLED` / `ANALYTICS_DB_COLD_STORAGE_DISK_HEALTH_CHECK_ENABLED`); registered `critical: true, type: ready`.

Note: the ticket references `ClickHouseHealthyCheck.java`, which was refactored since it was written; this builds on the current `AbstractClickHouseHealthCheck` + per-probe subclass structure (auto-discovered via guicey).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6905

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Full implementation (new health checks + config wiring + unit and integration tests) under human direction and review.
- Human verification: Design decisions (criticality, scope, flag placement) chosen by author; all tests run and reviewed locally.

## Testing

Local process mode, macOS.

- `mvn test -Dtest="ClickHouseExistenceHealthCheckTest"` — 12 unit cases (parameterized over both checks): disabled, resource-present (healthy), count=0 / no-rows (unhealthy), query-failure and interrupt (unhealthy + cancel).
- `mvn test -Dtest="AbstractClickHouseHealthCheckTest"` — existing probe tests still green after the base refactor.
- `mvn test -Dtest="HealthCheckIntegrationTest"` — 11 cases. Default config: both new checks auto-register and report healthy (toggle off) without touching ClickHouse. New `ExistenceChecksEnabled` flips both toggles and runs the real SQL against the test container: cluster found → healthy (the container's `clickhouse.xml` defines the `cluster` remote_server, mirroring the deploy macros), `cold_s3` absent → unhealthy.
- `mvn spotless:check` — clean.

## Documentation

No user-facing docs required; internal config keys documented inline in `config.yml`.
