### PR TITLE
[OPIK-7292] [SDK] fix: preserve tags on CLI export/import for prompts, experiments, datasets

### DIFF
--- a/sdks/python/src/opik/cli/exports/dataset.py
+++ b/sdks/python/src/opik/cli/exports/dataset.py
@@ -57,11 +57,16 @@ def export_single_dataset(
 
         # Dataset-level tags are stored on the version, not surfaced by
         # get_dataset(); fetch them explicitly. Never let a tags lookup abort
-        # the export.
+        # the export, but log it so a missing-tags export is diagnosable.
         try:
             dataset_tags = dataset.get_tags()
-        except Exception:
+        except Exception as tag_error:
             dataset_tags = None
+            console.print(
+                f"[yellow]Warning: Could not fetch tags for dataset "
+                f"'{dataset.name}' ({dataset_id}): {tag_error}. "
+                f"Exporting without tags.[/yellow]"
+            )
 
         # Create dataset data structure
         dataset_data = {
@@ -216,8 +221,13 @@ def export_experiment_datasets(
 
             try:
                 dataset_tags = dataset_obj.get_tags()
-            except Exception:
+            except Exception as tag_error:
                 dataset_tags = None
+                console.print(
+                    f"[yellow]Warning: Could not fetch tags for dataset "
+                    f"'{dataset_name}' ({dataset_id}): {tag_error}. "
+                    f"Exporting without tags.[/yellow]"
+                )
 
             dataset_data = {
                 "dataset": {

--- a/sdks/python/src/opik/cli/exports/dataset.py
+++ b/sdks/python/src/opik/cli/exports/dataset.py
@@ -55,11 +55,20 @@ def export_single_dataset(
             formatted_item = {k: v for k, v in item.items() if k != "id"}
             formatted_items.append(formatted_item)
 
+        # Dataset-level tags are stored on the version, not surfaced by
+        # get_dataset(); fetch them explicitly. Never let a tags lookup abort
+        # the export.
+        try:
+            dataset_tags = dataset.get_tags()
+        except Exception:
+            dataset_tags = None
+
         # Create dataset data structure
         dataset_data = {
             "id": dataset_id,
             "name": dataset.name,
             "description": dataset.description,
+            "tags": dataset_tags,
             "items": formatted_items,
             "downloaded_at": datetime.now().isoformat(),
         }
@@ -205,10 +214,16 @@ def export_experiment_datasets(
 
             dataset_items = dataset_obj.get_items()
 
+            try:
+                dataset_tags = dataset_obj.get_tags()
+            except Exception:
+                dataset_tags = None
+
             dataset_data = {
                 "dataset": {
                     "name": dataset_name,
                     "id": dataset_id,
+                    "tags": dataset_tags,
                 },
                 # Use all fields from each item, excluding 'id' (internal field)
                 "items": [

--- a/sdks/python/src/opik/cli/exports/prompt.py
+++ b/sdks/python/src/opik/cli/exports/prompt.py
@@ -79,6 +79,22 @@ def _get_prompt_type_string(prompt: Any) -> Optional[str]:
     return str(prompt_type).upper()
 
 
+def _build_version_data(prompt: Any) -> dict:
+    """Build the serialized per-version dict shared by every prompt export path.
+
+    Keeping this in one place ensures ``current_version`` and each ``history``
+    entry stay in sync when the exported metadata changes.
+    """
+    return {
+        "prompt": _get_prompt_content(prompt),
+        "metadata": getattr(prompt, "metadata", None),
+        "type": _get_prompt_type_string(prompt),
+        "commit": getattr(prompt, "commit", None),
+        "template_structure": _get_template_structure(prompt),
+        "tags": getattr(prompt, "tags", None),
+    }
+
+
 def _safe_prompt_history(
     client: opik.Opik,
     prompt: Union[Prompt, ChatPrompt],
@@ -128,25 +144,8 @@ def export_single_prompt(
         prompt_data = {
             "id": prompt_id,
             "name": prompt.name,
-            "current_version": {
-                "prompt": _get_prompt_content(prompt),
-                "metadata": getattr(prompt, "metadata", None),
-                "type": _get_prompt_type_string(prompt),
-                "commit": getattr(prompt, "commit", None),
-                "template_structure": _get_template_structure(prompt),
-                "tags": getattr(prompt, "tags", None),
-            },
-            "history": [
-                {
-                    "prompt": _get_prompt_content(version),
-                    "metadata": getattr(version, "metadata", None),
-                    "type": _get_prompt_type_string(version),
-                    "commit": getattr(version, "commit", None),
-                    "template_structure": _get_template_structure(version),
-                    "tags": getattr(version, "tags", None),
-                }
-                for version in prompt_history
-            ],
+            "current_version": _build_version_data(prompt),
+            "history": [_build_version_data(version) for version in prompt_history],
             "downloaded_at": datetime.now().isoformat(),
         }
 
@@ -342,25 +341,8 @@ def export_prompts_by_ids(
                         else None
                     ),
                 },
-                "current_version": {
-                    "prompt": _get_prompt_content(prompt),
-                    "metadata": getattr(prompt, "metadata", None),
-                    "type": _get_prompt_type_string(prompt),
-                    "commit": getattr(prompt, "commit", None),
-                    "template_structure": _get_template_structure(prompt),
-                    "tags": getattr(prompt, "tags", None),
-                },
-                "history": [
-                    {
-                        "prompt": _get_prompt_content(version),
-                        "metadata": getattr(version, "metadata", None),
-                        "type": _get_prompt_type_string(version),
-                        "commit": getattr(version, "commit", None),
-                        "template_structure": _get_template_structure(version),
-                        "tags": getattr(version, "tags", None),
-                    }
-                    for version in prompt_history
-                ],
+                "current_version": _build_version_data(prompt),
+                "history": [_build_version_data(version) for version in prompt_history],
                 "downloaded_at": datetime.now().isoformat(),
             }
 
@@ -494,24 +476,9 @@ def export_related_prompts_by_name(
                         "created_at": getattr(prompt, "created_at", None),
                         "last_updated_at": getattr(prompt, "last_updated_at", None),
                     },
-                    "current_version": {
-                        "prompt": _get_prompt_content(prompt),
-                        "metadata": getattr(prompt, "metadata", None),
-                        "type": _get_prompt_type_string(prompt),
-                        "commit": getattr(prompt, "commit", None),
-                        "template_structure": _get_template_structure(prompt),
-                        "tags": getattr(prompt, "tags", None),
-                    },
+                    "current_version": _build_version_data(prompt),
                     "history": [
-                        {
-                            "prompt": _get_prompt_content(version),
-                            "metadata": getattr(version, "metadata", None),
-                            "type": _get_prompt_type_string(version),
-                            "commit": getattr(version, "commit", None),
-                            "template_structure": _get_template_structure(version),
-                            "tags": getattr(version, "tags", None),
-                        }
-                        for version in prompt_history
+                        _build_version_data(version) for version in prompt_history
                     ],
                     "downloaded_at": datetime.now().isoformat(),
                     "related_to_experiment": experiment.name or experiment.id,

--- a/sdks/python/src/opik/cli/exports/prompt.py
+++ b/sdks/python/src/opik/cli/exports/prompt.py
@@ -167,6 +167,47 @@ def _safe_prompt_history(
         return []
 
 
+def _build_prompt_export_data(
+    client: opik.Opik,
+    prompt: Union[Prompt, ChatPrompt],
+    prompt_history: List[Union[Prompt, ChatPrompt]],
+    project_name: str,
+    base: dict,
+    extra: Optional[dict] = None,
+) -> dict:
+    """Assemble the serialized prompt payload shared by every export path.
+
+    ``base`` carries the path-specific identity fields (a flat ``id``/``name`` or
+    a nested ``prompt`` block), ``extra`` any additional top-level keys. The
+    shared ``current_version``/``history``/``downloaded_at`` block — including the
+    container-level tag resolution — lives here so the exported schema stays in
+    sync across paths and tags cannot be dropped on one of them.
+    """
+    current_version = _build_version_data(prompt)
+    current_version["tags"] = _resolve_prompt_tags(client, prompt, project_name)
+    prompt_data = {
+        **base,
+        "current_version": current_version,
+        "history": [_build_version_data(version) for version in prompt_history],
+        "downloaded_at": datetime.now().isoformat(),
+    }
+    if extra:
+        prompt_data.update(extra)
+    return prompt_data
+
+
+def _write_prompt_export_file(
+    prompt_data: dict,
+    prompt_file: Path,
+    format: str,
+) -> None:
+    """Write a prompt payload to disk in the requested format."""
+    if format.lower() == "csv":
+        write_csv_data(prompt_data, prompt_file, prompt_to_csv_rows)
+    else:
+        write_json_data(prompt_data, prompt_file)
+
+
 def export_single_prompt(
     client: opik.Opik,
     prompt: Union[Prompt, ChatPrompt],
@@ -194,22 +235,17 @@ def export_single_prompt(
         prompt_history = _safe_prompt_history(client, prompt, project_name)
 
         # Create prompt data structure. Tags are container-level and not
-        # surfaced by the direct lookup, so resolve them explicitly.
-        current_version = _build_version_data(prompt)
-        current_version["tags"] = _resolve_prompt_tags(client, prompt, project_name)
-        prompt_data = {
-            "id": prompt_id,
-            "name": prompt.name,
-            "current_version": current_version,
-            "history": [_build_version_data(version) for version in prompt_history],
-            "downloaded_at": datetime.now().isoformat(),
-        }
+        # surfaced by the direct lookup; the shared helper resolves them.
+        prompt_data = _build_prompt_export_data(
+            client,
+            prompt,
+            prompt_history,
+            project_name,
+            base={"id": prompt_id, "name": prompt.name},
+        )
 
         # Save to file using the appropriate format
-        if format.lower() == "csv":
-            write_csv_data(prompt_data, prompt_file, prompt_to_csv_rows)
-        else:
-            write_json_data(prompt_data, prompt_file)
+        _write_prompt_export_file(prompt_data, prompt_file, format)
 
         if debug:
             debug_print(f"Exported prompt: {prompt.name}", debug)
@@ -381,35 +417,37 @@ def export_prompts_by_ids(
                 )
 
             # Create prompt data structure. Tags are container-level and not
-            # surfaced by the direct lookup, so resolve them explicitly.
-            current_version = _build_version_data(prompt)
-            current_version["tags"] = _resolve_prompt_tags(client, prompt, project_name)
-            prompt_data = {
-                "prompt": {
-                    "id": getattr(prompt, "id", None),
-                    "name": prompt.name,
-                    "description": getattr(prompt, "description", None),
-                    "created_at": (
-                        created_at.isoformat()
-                        if (created_at := getattr(prompt, "created_at", None))
-                        else None
-                    ),
-                    "last_updated_at": (
-                        last_updated_at.isoformat()
-                        if (last_updated_at := getattr(prompt, "last_updated_at", None))
-                        else None
-                    ),
+            # surfaced by the direct lookup; the shared helper resolves them.
+            prompt_data = _build_prompt_export_data(
+                client,
+                prompt,
+                prompt_history,
+                project_name,
+                base={
+                    "prompt": {
+                        "id": getattr(prompt, "id", None),
+                        "name": prompt.name,
+                        "description": getattr(prompt, "description", None),
+                        "created_at": (
+                            created_at.isoformat()
+                            if (created_at := getattr(prompt, "created_at", None))
+                            else None
+                        ),
+                        "last_updated_at": (
+                            last_updated_at.isoformat()
+                            if (
+                                last_updated_at := getattr(
+                                    prompt, "last_updated_at", None
+                                )
+                            )
+                            else None
+                        ),
+                    },
                 },
-                "current_version": current_version,
-                "history": [_build_version_data(version) for version in prompt_history],
-                "downloaded_at": datetime.now().isoformat(),
-            }
+            )
 
             # Save prompt data using the appropriate format
-            if format.lower() == "csv":
-                write_csv_data(prompt_data, prompt_file, prompt_to_csv_rows)
-            else:
-                write_json_data(prompt_data, prompt_file)
+            _write_prompt_export_file(prompt_data, prompt_file, format)
 
             console.print(f"[green]Exported prompt: {prompt.name or prompt_id}[/green]")
             exported_count += 1
@@ -527,26 +565,23 @@ def export_related_prompts_by_name(
                 prompt_history = _safe_prompt_history(client, prompt, project_name)
 
                 # Create prompt data structure. Tags are container-level and not
-                # surfaced by the direct lookup, so resolve them explicitly.
-                current_version = _build_version_data(prompt)
-                current_version["tags"] = _resolve_prompt_tags(
-                    client, prompt, project_name
-                )
-                prompt_data = {
-                    "prompt": {
-                        "id": getattr(prompt, "__internal_api__prompt_id__", None),
-                        "name": prompt.name,
-                        "description": getattr(prompt, "description", None),
-                        "created_at": getattr(prompt, "created_at", None),
-                        "last_updated_at": getattr(prompt, "last_updated_at", None),
+                # surfaced by the direct lookup; the shared helper resolves them.
+                prompt_data = _build_prompt_export_data(
+                    client,
+                    prompt,
+                    prompt_history,
+                    project_name,
+                    base={
+                        "prompt": {
+                            "id": getattr(prompt, "__internal_api__prompt_id__", None),
+                            "name": prompt.name,
+                            "description": getattr(prompt, "description", None),
+                            "created_at": getattr(prompt, "created_at", None),
+                            "last_updated_at": getattr(prompt, "last_updated_at", None),
+                        },
                     },
-                    "current_version": current_version,
-                    "history": [
-                        _build_version_data(version) for version in prompt_history
-                    ],
-                    "downloaded_at": datetime.now().isoformat(),
-                    "related_to_experiment": experiment.name or experiment.id,
-                }
+                    extra={"related_to_experiment": experiment.name or experiment.id},
+                )
 
                 # File is keyed by prompt ID (the name lives inside the file).
                 ext = "csv" if format.lower() == "csv" else "json"
@@ -560,10 +595,7 @@ def export_related_prompts_by_name(
                     continue
 
                 # File doesn't exist or force is set, so export it
-                if format.lower() == "csv":
-                    write_csv_data(prompt_data, prompt_file, prompt_to_csv_rows)
-                else:
-                    write_json_data(prompt_data, prompt_file)
+                _write_prompt_export_file(prompt_data, prompt_file, format)
 
                 console.print(f"[green]Exported related prompt: {prompt.name}[/green]")
                 exported_count += 1

--- a/sdks/python/src/opik/cli/exports/prompt.py
+++ b/sdks/python/src/opik/cli/exports/prompt.py
@@ -95,6 +95,44 @@ def _build_version_data(prompt: Any) -> dict:
     }
 
 
+def _resolve_prompt_tags(
+    client: opik.Opik,
+    prompt: Union[Prompt, ChatPrompt],
+    project_name: str,
+) -> Optional[List[str]]:
+    """Return the prompt's container-level tags.
+
+    Tags live on the prompt container, and ``get_prompt`` /
+    ``retrieve_prompt_version`` do not surface them (they come back empty).
+    ``search_prompts`` injects the container tags, so fall back to it whenever
+    the directly-fetched prompt object carries none.
+    """
+    tags = getattr(prompt, "tags", None)
+    if tags:
+        return tags
+
+    name = getattr(prompt, "name", None)
+    if not name:
+        return tags
+
+    try:
+        candidates = client.search_prompts(
+            filter_string=f'name = "{name}"', project_name=project_name
+        )
+    except Exception:
+        # Fall back to an unfiltered scan if the name filter can't be parsed
+        # (e.g. names with characters the query language rejects).
+        try:
+            candidates = client.search_prompts(project_name=project_name)
+        except Exception:
+            return tags
+
+    for candidate in candidates:
+        if getattr(candidate, "name", None) == name:
+            return getattr(candidate, "tags", None) or tags
+    return tags
+
+
 def _safe_prompt_history(
     client: opik.Opik,
     prompt: Union[Prompt, ChatPrompt],
@@ -140,11 +178,14 @@ def export_single_prompt(
         # Get prompt history (scoped to the prompt's project)
         prompt_history = _safe_prompt_history(client, prompt, project_name)
 
-        # Create prompt data structure
+        # Create prompt data structure. Tags are container-level and not
+        # surfaced by the direct lookup, so resolve them explicitly.
+        current_version = _build_version_data(prompt)
+        current_version["tags"] = _resolve_prompt_tags(client, prompt, project_name)
         prompt_data = {
             "id": prompt_id,
             "name": prompt.name,
-            "current_version": _build_version_data(prompt),
+            "current_version": current_version,
             "history": [_build_version_data(version) for version in prompt_history],
             "downloaded_at": datetime.now().isoformat(),
         }
@@ -324,7 +365,10 @@ def export_prompts_by_ids(
                     client.get_prompt_history(prompt_id, project_name=project_name)
                 )
 
-            # Create prompt data structure
+            # Create prompt data structure. Tags are container-level and not
+            # surfaced by the direct lookup, so resolve them explicitly.
+            current_version = _build_version_data(prompt)
+            current_version["tags"] = _resolve_prompt_tags(client, prompt, project_name)
             prompt_data = {
                 "prompt": {
                     "id": getattr(prompt, "id", None),
@@ -341,7 +385,7 @@ def export_prompts_by_ids(
                         else None
                     ),
                 },
-                "current_version": _build_version_data(prompt),
+                "current_version": current_version,
                 "history": [_build_version_data(version) for version in prompt_history],
                 "downloaded_at": datetime.now().isoformat(),
             }
@@ -467,7 +511,12 @@ def export_related_prompts_by_name(
                 # Get prompt history - use appropriate method based on prompt type
                 prompt_history = _safe_prompt_history(client, prompt, project_name)
 
-                # Create prompt data structure
+                # Create prompt data structure. Tags are container-level and not
+                # surfaced by the direct lookup, so resolve them explicitly.
+                current_version = _build_version_data(prompt)
+                current_version["tags"] = _resolve_prompt_tags(
+                    client, prompt, project_name
+                )
                 prompt_data = {
                     "prompt": {
                         "id": getattr(prompt, "__internal_api__prompt_id__", None),
@@ -476,7 +525,7 @@ def export_related_prompts_by_name(
                         "created_at": getattr(prompt, "created_at", None),
                         "last_updated_at": getattr(prompt, "last_updated_at", None),
                     },
-                    "current_version": _build_version_data(prompt),
+                    "current_version": current_version,
                     "history": [
                         _build_version_data(version) for version in prompt_history
                     ],

--- a/sdks/python/src/opik/cli/exports/prompt.py
+++ b/sdks/python/src/opik/cli/exports/prompt.py
@@ -134,6 +134,7 @@ def export_single_prompt(
                 "type": _get_prompt_type_string(prompt),
                 "commit": getattr(prompt, "commit", None),
                 "template_structure": _get_template_structure(prompt),
+                "tags": getattr(prompt, "tags", None),
             },
             "history": [
                 {
@@ -142,6 +143,7 @@ def export_single_prompt(
                     "type": _get_prompt_type_string(version),
                     "commit": getattr(version, "commit", None),
                     "template_structure": _get_template_structure(version),
+                    "tags": getattr(version, "tags", None),
                 }
                 for version in prompt_history
             ],
@@ -346,6 +348,7 @@ def export_prompts_by_ids(
                     "type": _get_prompt_type_string(prompt),
                     "commit": getattr(prompt, "commit", None),
                     "template_structure": _get_template_structure(prompt),
+                    "tags": getattr(prompt, "tags", None),
                 },
                 "history": [
                     {
@@ -354,6 +357,7 @@ def export_prompts_by_ids(
                         "type": _get_prompt_type_string(version),
                         "commit": getattr(version, "commit", None),
                         "template_structure": _get_template_structure(version),
+                        "tags": getattr(version, "tags", None),
                     }
                     for version in prompt_history
                 ],
@@ -496,6 +500,7 @@ def export_related_prompts_by_name(
                         "type": _get_prompt_type_string(prompt),
                         "commit": getattr(prompt, "commit", None),
                         "template_structure": _get_template_structure(prompt),
+                        "tags": getattr(prompt, "tags", None),
                     },
                     "history": [
                         {
@@ -504,6 +509,7 @@ def export_related_prompts_by_name(
                             "type": _get_prompt_type_string(version),
                             "commit": getattr(version, "commit", None),
                             "template_structure": _get_template_structure(version),
+                            "tags": getattr(version, "tags", None),
                         }
                         for version in prompt_history
                     ],

--- a/sdks/python/src/opik/cli/exports/prompt.py
+++ b/sdks/python/src/opik/cli/exports/prompt.py
@@ -1,6 +1,7 @@
 """Prompt export functionality."""
 
 import json
+import logging
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -20,6 +21,8 @@ from .utils import (
     write_json_data,
     print_export_summary,
 )
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _get_prompt_content(prompt: Any) -> Any:
@@ -121,10 +124,22 @@ def _resolve_prompt_tags(
         )
     except Exception:
         # Fall back to an unfiltered scan if the name filter can't be parsed
-        # (e.g. names with characters the query language rejects).
+        # (e.g. names with characters the query language rejects). Log with a
+        # stack trace so the failure is diagnosable rather than silent.
+        LOGGER.debug(
+            "Filtered search_prompts failed for prompt %r; retrying unfiltered",
+            name,
+            exc_info=True,
+        )
         try:
             candidates = client.search_prompts(project_name=project_name)
         except Exception:
+            LOGGER.warning(
+                "Could not resolve container-level tags for prompt %r via "
+                "search_prompts; exported tags may be incomplete",
+                name,
+                exc_info=True,
+            )
             return tags
 
     for candidate in candidates:

--- a/sdks/python/src/opik/cli/exports/utils.py
+++ b/sdks/python/src/opik/cli/exports/utils.py
@@ -162,6 +162,7 @@ def create_experiment_data_structure(
             "feedback_scores": getattr(experiment_data_obj, "feedback_scores", None),
             "comments": getattr(experiment_data_obj, "comments", None),
             "duration": getattr(experiment_data_obj, "duration", None),
+            "tags": getattr(experiment_data_obj, "tags", None),
             "prompt_version": getattr(experiment_data_obj, "prompt_version", None),
             "prompt_versions": getattr(experiment_data_obj, "prompt_versions", None),
         },

--- a/sdks/python/src/opik/cli/imports/dataset.py
+++ b/sdks/python/src/opik/cli/imports/dataset.py
@@ -64,6 +64,14 @@ def import_datasets_from_directory(
                     else None
                 )
 
+                # Dataset-level tags live at the top level (export_single_dataset)
+                # or nested under "dataset" (export_experiment_datasets).
+                dataset_tags = dataset_data.get("tags") or (
+                    dataset_data.get("dataset", {}).get("tags")
+                    if dataset_data.get("dataset")
+                    else None
+                )
+
                 # Check if name is missing or empty
                 if not dataset_name or (
                     isinstance(dataset_name, str) and not dataset_name.strip()
@@ -113,6 +121,25 @@ def import_datasets_from_directory(
                     if debug:
                         console.print(
                             f"[blue]Created new dataset: {dataset_name}[/blue]"
+                        )
+
+                # Apply dataset-level tags. create_dataset() doesn't expose a
+                # tags argument, so set them via the REST update endpoint after
+                # the dataset exists.
+                if dataset_tags:
+                    try:
+                        client.rest_client.datasets.update_dataset(
+                            dataset.id,
+                            name=dataset_name,
+                            tags=dataset_tags,
+                        )
+                        if debug:
+                            console.print(
+                                f"[blue]Applied tags to dataset '{dataset_name}': {dataset_tags}[/blue]"
+                            )
+                    except Exception as tag_error:
+                        console.print(
+                            f"[yellow]Warning: Could not apply tags to dataset '{dataset_name}': {tag_error}[/yellow]"
                         )
 
                 # Import dataset items

--- a/sdks/python/src/opik/cli/imports/dataset.py
+++ b/sdks/python/src/opik/cli/imports/dataset.py
@@ -133,9 +133,18 @@ def import_datasets_from_directory(
                 # tags, so distinguish None (no tags field -> skip) from [].
                 if dataset_tags is not None:
                     try:
+                        # description is silently nulled by the backend when
+                        # omitted from this PUT (unlike tags/visibility, it
+                        # isn't COALESCEd against the existing row), so it
+                        # must be re-passed here to avoid wiping it.
+                        existing = client.rest_client.datasets.get_dataset_by_id(
+                            dataset.id
+                        )
                         client.rest_client.datasets.update_dataset(
                             dataset.id,
                             name=dataset_name,
+                            description=existing.description,
+                            visibility=existing.visibility,
                             tags=dataset_tags,
                         )
                         if debug:

--- a/sdks/python/src/opik/cli/imports/dataset.py
+++ b/sdks/python/src/opik/cli/imports/dataset.py
@@ -65,12 +65,16 @@ def import_datasets_from_directory(
                 )
 
                 # Dataset-level tags live at the top level (export_single_dataset)
-                # or nested under "dataset" (export_experiment_datasets).
-                dataset_tags = dataset_data.get("tags") or (
-                    dataset_data.get("dataset", {}).get("tags")
-                    if dataset_data.get("dataset")
-                    else None
-                )
+                # or nested under "dataset" (export_experiment_datasets). Check
+                # key presence rather than truthiness so an explicit empty list
+                # ([]) survives and can clear the destination's tags; only fall
+                # back to the nested field when the flat key is missing/null.
+                if dataset_data.get("tags") is not None:
+                    dataset_tags = dataset_data.get("tags")
+                elif dataset_data.get("dataset"):
+                    dataset_tags = dataset_data.get("dataset", {}).get("tags")
+                else:
+                    dataset_tags = None
 
                 # Check if name is missing or empty
                 if not dataset_name or (
@@ -125,8 +129,9 @@ def import_datasets_from_directory(
 
                 # Apply dataset-level tags. create_dataset() doesn't expose a
                 # tags argument, so set them via the REST update endpoint after
-                # the dataset exists.
-                if dataset_tags:
+                # the dataset exists. An explicit empty list clears existing
+                # tags, so distinguish None (no tags field -> skip) from [].
+                if dataset_tags is not None:
                     try:
                         client.rest_client.datasets.update_dataset(
                             dataset.id,

--- a/sdks/python/src/opik/cli/imports/experiment.py
+++ b/sdks/python/src/opik/cli/imports/experiment.py
@@ -514,9 +514,11 @@ def recreate_experiment(
             "project_name": project_name,
         }
         # Tags round-trip on both paths: the exporter now serializes them and
-        # create_experiment accepts them directly.
+        # create_experiment accepts them directly. Check for None (no tags
+        # field) rather than truthiness so an explicit empty list ([]) is
+        # preserved instead of collapsing to tags=None.
         experiment_tags = experiment_info.get("tags")
-        if experiment_tags:
+        if experiment_tags is not None:
             create_kwargs["tags"] = experiment_tags
         if experiment_id is not None:
             create_kwargs["experiment_id"] = experiment_id

--- a/sdks/python/src/opik/cli/imports/experiment.py
+++ b/sdks/python/src/opik/cli/imports/experiment.py
@@ -513,13 +513,17 @@ def recreate_experiment(
             "type": experiment_info.get("type", "regular"),
             "project_name": project_name,
         }
+        # Tags round-trip on both paths: the exporter now serializes them and
+        # create_experiment accepts them directly.
+        experiment_tags = experiment_info.get("tags")
+        if experiment_tags:
+            create_kwargs["tags"] = experiment_tags
         if experiment_id is not None:
             create_kwargs["experiment_id"] = experiment_id
         if is_migrate_path:
             create_kwargs["evaluation_method"] = experiment_info.get(
                 "evaluation_method", "dataset"
             )
-            create_kwargs["tags"] = experiment_info.get("tags")
             create_kwargs["dataset_version_id"] = target_dataset_version_id
             optimization_id = experiment_info.get("optimization_id")
             if optimization_id:

--- a/sdks/python/src/opik/cli/imports/prompt.py
+++ b/sdks/python/src/opik/cli/imports/prompt.py
@@ -97,6 +97,7 @@ def import_prompts_from_directory(
                 metadata = current_version.get("metadata")
                 prompt_type = current_version.get("type")
                 template_structure = current_version.get("template_structure", "text")
+                tags = current_version.get("tags")
 
                 # Validate prompt content exists
                 if prompt_content is None:
@@ -142,6 +143,7 @@ def import_prompts_from_directory(
                             messages=prompt_content,
                             metadata=metadata,
                             type=prompt_type_enum,
+                            tags=tags,
                             project_name=project_name,
                         )
                         if debug:
@@ -164,6 +166,7 @@ def import_prompts_from_directory(
                             prompt=prompt_content,
                             metadata=metadata,
                             type=prompt_type_enum,
+                            tags=tags,
                             project_name=project_name,
                         )
                         if debug:

--- a/sdks/python/tests/e2e/test_cli_import_export.py
+++ b/sdks/python/tests/e2e/test_cli_import_export.py
@@ -980,8 +980,15 @@ class TestCLIImportExport:
             imported_chat_prompt,
             name=prompt_name,
         )
-        assert set(imported_chat_prompt.tags or []) == set(_CHAT_PROMPT_TAGS), (
-            f"Imported chat prompt tags mismatch: {imported_chat_prompt.tags!r}"
+        # Tags live on the prompt container and are not surfaced by
+        # get_chat_prompt()/retrieve_prompt_version (they come back empty);
+        # search_prompts() injects the container tags. Assert against it to
+        # mirror the text-prompt flow above and exports._resolve_prompt_tags.
+        imported_chat_container = next(
+            p for p in imported_prompts if p.name == prompt_name
+        )
+        assert set(imported_chat_container.tags or []) == set(_CHAT_PROMPT_TAGS), (
+            f"Imported chat prompt tags mismatch: {imported_chat_container.tags!r}"
         )
 
     def test_import_projects_automatically_recreates_experiments(

--- a/sdks/python/tests/e2e/test_cli_import_export.py
+++ b/sdks/python/tests/e2e/test_cli_import_export.py
@@ -21,6 +21,15 @@ from opik.cli.imports.prompt import import_prompts_from_directory
 from ..conftest import random_chars
 from . import verifiers
 
+# Tags seeded on the created entities so the export/import flow can be asserted
+# to preserve them (regression guard for OPIK-7292, where tags were dropped for
+# prompts, experiments, and datasets). Backends don't guarantee tag ordering, so
+# assertions compare as sets.
+_DATASET_TAGS = ["cli-test", "dataset-tag"]
+_PROMPT_TAGS = ["cli-test", "prompt-tag"]
+_CHAT_PROMPT_TAGS = ["cli-test", "chat-prompt-tag"]
+_EXPERIMENT_TAGS = ["cli-test", "experiment-tag"]
+
 
 def _find_project_dir(base_dir: Path, project_name: str) -> Path:
     """Locate the id-named export folder for a project by its recorded name.
@@ -110,6 +119,12 @@ class TestCLIImportExport:
             ]
         )
 
+        # create_dataset() has no tags argument; set dataset-level tags via REST
+        # so the export/import round-trip can be asserted to preserve them.
+        opik_client.rest_client.datasets.update_dataset(
+            dataset.id, name=dataset_name, tags=_DATASET_TAGS
+        )
+
         return dataset_name
 
     def _create_test_prompt(self, opik_client: opik.Opik, project_name: str) -> str:
@@ -118,6 +133,7 @@ class TestCLIImportExport:
         opik_client.create_prompt(
             name=prompt_name,
             prompt="You are a helpful assistant. Answer the following question: {question}",
+            tags=_PROMPT_TAGS,
             project_name=project_name,
         )
         return prompt_name
@@ -138,6 +154,7 @@ class TestCLIImportExport:
             name=prompt_name,
             messages=messages,
             metadata={"version": "1.0", "test": "chat_import_export"},
+            tags=_CHAT_PROMPT_TAGS,
             project_name=project_name,
         )
         return prompt_name
@@ -155,6 +172,7 @@ class TestCLIImportExport:
             dataset_name=dataset_name,
             name=experiment_name,
             experiment_config={"model": "test-model", "version": "1.0"},
+            tags=_EXPERIMENT_TAGS,
             project_name=project_name,
         )
 
@@ -333,6 +351,10 @@ class TestCLIImportExport:
         assert "name" in dataset_data
         assert "items" in dataset_data
         assert "downloaded_at" in dataset_data
+        # Dataset-level tags must survive export (OPIK-7292).
+        assert set(dataset_data.get("tags") or []) == set(_DATASET_TAGS), (
+            f"Exported dataset tags mismatch: {dataset_data.get('tags')!r}"
+        )
 
         # Step 3: Import datasets using direct function call
         source_dir = _find_project_dir(test_data_dir, source_project_name) / "datasets"
@@ -348,6 +370,14 @@ class TestCLIImportExport:
         # Verify import succeeded
         assert stats.get("datasets", 0) >= 1, (
             "Expected at least 1 dataset to be imported"
+        )
+
+        # Tags must survive the import back onto the dataset.
+        imported_dataset = opik_client.get_dataset(
+            dataset_name, project_name=source_project_name
+        )
+        assert set(imported_dataset.get_tags()) == set(_DATASET_TAGS), (
+            f"Imported dataset tags mismatch: {imported_dataset.get_tags()!r}"
         )
 
     def test_export_import_prompts_happy_flow(
@@ -398,6 +428,12 @@ class TestCLIImportExport:
         assert "current_version" in prompt_data
         assert "history" in prompt_data
         assert "downloaded_at" in prompt_data
+        # Prompt tags must survive export (OPIK-7292).
+        assert set(prompt_data["current_version"].get("tags") or []) == set(
+            _PROMPT_TAGS
+        ), (
+            f"Exported prompt tags mismatch: {prompt_data['current_version'].get('tags')!r}"
+        )
 
         # Step 3: Import prompts using direct function call
         source_dir = _find_project_dir(test_data_dir, source_project_name) / "prompts"
@@ -425,6 +461,9 @@ class TestCLIImportExport:
         verifiers.verify_prompt_version(
             imported_prompt,
             name=prompt_name,
+        )
+        assert set(imported_prompt.tags or []) == set(_PROMPT_TAGS), (
+            f"Imported prompt tags mismatch: {imported_prompt.tags!r}"
         )
 
     def test_export_import_all_data_types_happy_flow(
@@ -755,6 +794,7 @@ class TestCLIImportExport:
         experiment1 = opik_client.create_experiment(
             name=exp1_name,
             dataset_name=dataset1_name,
+            tags=_EXPERIMENT_TAGS,
             project_name=source_project_name,
         )
         experiment2 = opik_client.create_experiment(
@@ -848,6 +888,10 @@ class TestCLIImportExport:
         assert exp_data["experiment"]["dataset_name"] == dataset1_name, (
             f"Expected dataset_name to be {dataset1_name}, got {exp_data['experiment']['dataset_name']}"
         )
+        # Experiment tags must survive export (OPIK-7292).
+        assert set(exp_data["experiment"].get("tags") or []) == set(_EXPERIMENT_TAGS), (
+            f"Exported experiment tags mismatch: {exp_data['experiment'].get('tags')!r}"
+        )
 
     def test_export_import_chat_prompts_happy_flow(
         self,
@@ -902,6 +946,10 @@ class TestCLIImportExport:
         )
         assert "template_structure" in current_version
         assert current_version["template_structure"] == "chat"
+        # Chat prompt tags must survive export (OPIK-7292).
+        assert set(current_version.get("tags") or []) == set(_CHAT_PROMPT_TAGS), (
+            f"Exported chat prompt tags mismatch: {current_version.get('tags')!r}"
+        )
 
         # Step 3: Import chat prompt using direct function call
         source_dir = _find_project_dir(test_data_dir, source_project_name) / "prompts"
@@ -932,6 +980,9 @@ class TestCLIImportExport:
             imported_chat_prompt,
             name=prompt_name,
         )
+        assert set(imported_chat_prompt.tags or []) == set(_CHAT_PROMPT_TAGS), (
+            f"Imported chat prompt tags mismatch: {imported_chat_prompt.tags!r}"
+        )
 
     def test_import_projects_automatically_recreates_experiments(
         self,
@@ -943,7 +994,9 @@ class TestCLIImportExport:
         # Step 1: Prepare test data with experiments
         dataset_name = self._create_test_dataset(opik_client, source_project_name)
         self._create_test_traces(opik_client, source_project_name)
-        self._create_test_experiment(opik_client, source_project_name, dataset_name)
+        experiment_name = self._create_test_experiment(
+            opik_client, source_project_name, dataset_name
+        )
 
         # Step 2: Export the project data (traces) using direct function call
         export_project_traces(
@@ -958,9 +1011,38 @@ class TestCLIImportExport:
             api_key=None,
         )
 
+        # Export the experiment too, so the recreate-on-import path has an
+        # experiment_*.json file to work with (trace export alone does not emit
+        # experiments).
+        export_experiment_by_name(
+            name=experiment_name,
+            workspace="default",
+            project_name=source_project_name,
+            output_path=str(test_data_dir),
+            dataset=dataset_name,
+            max_traces=None,
+            force=False,
+            debug=False,
+            format="json",
+            api_key=None,
+        )
+
         # Verify export files were created
         project_dir = _find_project_dir(test_data_dir, source_project_name)
         assert project_dir.exists(), f"Export directory not found: {project_dir}"
+
+        # The exported experiment file must carry the tags (OPIK-7292).
+        experiments_dir = project_dir / "experiments"
+        exp_file = next(
+            ef
+            for ef in experiments_dir.glob("experiment_*.json")
+            if json.loads(ef.read_text()).get("experiment", {}).get("name")
+            == experiment_name
+        )
+        exported_experiment = json.loads(exp_file.read_text())["experiment"]
+        assert set(exported_experiment.get("tags") or []) == set(_EXPERIMENT_TAGS), (
+            f"Exported experiment tags mismatch: {exported_experiment.get('tags')!r}"
+        )
 
         # Step 3: Test import (experiments are automatically recreated) using direct function call
         project_dir = _find_project_dir(test_data_dir, source_project_name)
@@ -978,6 +1060,21 @@ class TestCLIImportExport:
         assert stats.get("projects", 0) >= 1, (
             "Expected at least 1 project to be imported"
         )
+        assert stats.get("experiments", 0) >= 1, (
+            "Expected at least 1 experiment to be recreated"
+        )
+
+        # The recreated experiment must carry the tags (OPIK-7292). Importing
+        # into the source project leaves the original alongside the recreated
+        # copy; both were created with the same tags, so assert every match.
+        recreated = opik_client.get_experiments_by_name(
+            experiment_name, project_name=source_project_name
+        )
+        assert recreated, f"Expected experiment {experiment_name} after import"
+        for exp in recreated:
+            assert set(exp.tags or []) == set(_EXPERIMENT_TAGS), (
+                f"Recreated experiment tags mismatch: {exp.tags!r}"
+            )
 
     def test_export_import_llm_span_preserves_type_and_usage(
         self,

--- a/sdks/python/tests/unit/cli/test_tags_roundtrip.py
+++ b/sdks/python/tests/unit/cli/test_tags_roundtrip.py
@@ -186,6 +186,43 @@ class TestDatasetTagsImport:
         client.rest_client.datasets.update_dataset.assert_called_once()
         assert client.rest_client.datasets.update_dataset.call_args.kwargs["tags"] == []
 
+    def test_import_dataset__existing_dataset_with_description__preserves_description(
+        self, tmp_path: Path
+    ) -> None:
+        # Tags-only import must not silently null out a description the
+        # destination dataset already had (the backend's update PUT doesn't
+        # COALESCE description against the existing row).
+        self._write_dataset(
+            tmp_path,
+            {"name": "ds", "tags": ["a"], "items": []},
+        )
+        client = self._make_client()
+        # Re-import onto a dataset that already exists (get_dataset succeeds).
+        existing_dataset = Mock()
+        existing_dataset.id = "existing-ds-id"
+        client.get_dataset = Mock(return_value=existing_dataset)
+        existing_remote = Mock()
+        existing_remote.description = "original description"
+        existing_remote.visibility = "private"
+        client.rest_client.datasets.get_dataset_by_id = Mock(
+            return_value=existing_remote
+        )
+
+        import_datasets_from_directory(
+            client=client,
+            source_dir=tmp_path,
+            project_name="proj",
+            dry_run=False,
+            name_pattern=None,
+            debug=False,
+        )
+
+        client.rest_client.datasets.update_dataset.assert_called_once()
+        call = client.rest_client.datasets.update_dataset.call_args
+        assert call.kwargs["description"] == "original description"
+        assert call.kwargs["visibility"] == "private"
+        assert call.kwargs["tags"] == ["a"]
+
     def test_import_dataset__update_dataset_raises__continues_and_inserts_items(
         self, tmp_path: Path
     ) -> None:

--- a/sdks/python/tests/unit/cli/test_tags_roundtrip.py
+++ b/sdks/python/tests/unit/cli/test_tags_roundtrip.py
@@ -17,6 +17,10 @@ sys.modules.setdefault("opik.api_objects.prompt.prompt", MagicMock())
 
 from opik.cli.imports.prompt import import_prompts_from_directory  # noqa: E402
 from opik.cli.imports.dataset import import_datasets_from_directory  # noqa: E402
+from opik.cli.exports.prompt import (  # noqa: E402
+    export_single_prompt,
+    _resolve_prompt_tags,
+)
 from opik.cli.imports.experiment import (  # noqa: E402
     ExperimentData,
     recreate_experiment,
@@ -211,6 +215,67 @@ class TestDatasetTagsImport:
         client.create_dataset.return_value.insert.assert_called_once()
         assert result["datasets"] == 1
         assert result["datasets_errors"] == 0
+
+
+class TestPromptTagsExport:
+    """Prompt tags are container-level and are dropped by the direct
+    get_prompt() lookup; the exporter must recover them via search_prompts.
+    """
+
+    def test_resolve_prompt_tags__object_has_tags__skips_search(self) -> None:
+        prompt = Mock()
+        prompt.tags = ["prod"]
+        prompt.name = "greeting"
+        client = Mock()
+
+        assert _resolve_prompt_tags(client, prompt, "proj") == ["prod"]
+        client.search_prompts.assert_not_called()
+
+    def test_resolve_prompt_tags__empty_object_tags__recovers_from_search(
+        self,
+    ) -> None:
+        prompt = Mock()
+        prompt.tags = []  # direct lookup lost the container tags
+        prompt.name = "greeting"
+
+        candidate = Mock()
+        candidate.name = "greeting"
+        candidate.tags = ["prod", "greeting"]
+        client = Mock()
+        client.search_prompts = Mock(return_value=[candidate])
+
+        assert _resolve_prompt_tags(client, prompt, "proj") == ["prod", "greeting"]
+
+    def test_export_single_prompt__container_only_tags__writes_them(
+        self, tmp_path: Path
+    ) -> None:
+        prompt = Mock()
+        prompt.id = "p1"
+        prompt.name = "greeting"
+        prompt.tags = []  # direct lookup dropped tags
+
+        candidate = Mock()
+        candidate.name = "greeting"
+        candidate.tags = ["prod", "greeting"]
+        client = Mock()
+        client.search_prompts = Mock(return_value=[candidate])
+        # No history available; _safe_prompt_history swallows the error.
+        client.get_prompt_history = Mock(side_effect=Exception("no history"))
+
+        count = export_single_prompt(
+            client=client,
+            prompt=prompt,
+            output_dir=tmp_path,
+            project_name="proj",
+            max_results=None,
+            force=True,
+            debug=False,
+            format="json",
+        )
+
+        assert count == 1
+        data = json.loads((tmp_path / "prompt_p1.json").read_text())
+        assert data["current_version"]["tags"] == ["prod", "greeting"]
 
 
 class TestExperimentTags:

--- a/sdks/python/tests/unit/cli/test_tags_roundtrip.py
+++ b/sdks/python/tests/unit/cli/test_tags_roundtrip.py
@@ -25,7 +25,7 @@ from opik.cli.exports.utils import create_experiment_data_structure  # noqa: E40
 
 
 class TestPromptTagsImport:
-    def test_text_prompt_import_forwards_tags(self, tmp_path: Path) -> None:
+    def test_import_text_prompt__with_tags__forwards_tags(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt_p1.json"
         prompt_file.write_text(
             json.dumps(
@@ -57,7 +57,7 @@ class TestPromptTagsImport:
         client.create_prompt.assert_called_once()
         assert client.create_prompt.call_args.kwargs["tags"] == ["prod", "greeting"]
 
-    def test_chat_prompt_import_forwards_tags(self, tmp_path: Path) -> None:
+    def test_import_chat_prompt__with_tags__forwards_tags(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt_c1.json"
         prompt_file.write_text(
             json.dumps(
@@ -106,7 +106,9 @@ class TestDatasetTagsImport:
         client.rest_client.datasets.update_dataset = Mock()
         return client
 
-    def test_flat_format_applies_tags(self, tmp_path: Path) -> None:
+    def test_import_dataset__flat_format_with_tags__applies_tags(
+        self, tmp_path: Path
+    ) -> None:
         self._write_dataset(
             tmp_path,
             {"name": "ds", "tags": ["a", "b"], "items": []},
@@ -127,7 +129,9 @@ class TestDatasetTagsImport:
         assert call.args[0] == "new-ds-id"
         assert call.kwargs["tags"] == ["a", "b"]
 
-    def test_nested_format_applies_tags(self, tmp_path: Path) -> None:
+    def test_import_dataset__nested_format_with_tags__applies_tags(
+        self, tmp_path: Path
+    ) -> None:
         self._write_dataset(
             tmp_path,
             {"dataset": {"name": "ds", "id": "x", "tags": ["c"]}, "items": []},
@@ -148,7 +152,7 @@ class TestDatasetTagsImport:
             "c"
         ]
 
-    def test_no_tags_skips_update(self, tmp_path: Path) -> None:
+    def test_import_dataset__no_tags_field__skips_update(self, tmp_path: Path) -> None:
         self._write_dataset(tmp_path, {"name": "ds", "items": []})
         client = self._make_client()
 
@@ -163,9 +167,54 @@ class TestDatasetTagsImport:
 
         client.rest_client.datasets.update_dataset.assert_not_called()
 
+    def test_import_dataset__empty_tags_list__clears_tags(self, tmp_path: Path) -> None:
+        # An explicit empty list must still call the REST update so a
+        # re-import can clear pre-existing tags on the destination.
+        self._write_dataset(tmp_path, {"name": "ds", "tags": [], "items": []})
+        client = self._make_client()
+
+        import_datasets_from_directory(
+            client=client,
+            source_dir=tmp_path,
+            project_name="proj",
+            dry_run=False,
+            name_pattern=None,
+            debug=False,
+        )
+
+        client.rest_client.datasets.update_dataset.assert_called_once()
+        assert client.rest_client.datasets.update_dataset.call_args.kwargs["tags"] == []
+
+    def test_import_dataset__update_dataset_raises__continues_and_inserts_items(
+        self, tmp_path: Path
+    ) -> None:
+        # A tag-update failure must be swallowed with a warning so the rest of
+        # the import (item insertion, count, manifest) still proceeds.
+        self._write_dataset(
+            tmp_path,
+            {"name": "ds", "tags": ["a"], "items": [{"id": "1", "input": "x"}]},
+        )
+        client = self._make_client()
+        client.rest_client.datasets.update_dataset = Mock(side_effect=Exception("boom"))
+
+        result = import_datasets_from_directory(
+            client=client,
+            source_dir=tmp_path,
+            project_name="proj",
+            dry_run=False,
+            name_pattern=None,
+            debug=False,
+        )
+
+        # The import did not abort: items were still inserted and the dataset
+        # counted as imported.
+        client.create_dataset.return_value.insert.assert_called_once()
+        assert result["datasets"] == 1
+        assert result["datasets_errors"] == 0
+
 
 class TestExperimentTags:
-    def test_export_structure_includes_tags(self) -> None:
+    def test_export_experiment_structure__with_tags__includes_tags(self) -> None:
         experiment = Mock()
         experiment.id = "exp-1"
         experiment.name = "e"
@@ -178,7 +227,7 @@ class TestExperimentTags:
 
         assert structure["experiment"]["tags"] == ["t1", "t2"]
 
-    def test_import_from_disk_forwards_tags(self) -> None:
+    def test_import_experiment_from_disk__with_tags__forwards_tags(self) -> None:
         client = Mock()
         client.flush = Mock(return_value=True)
         client.get_or_create_dataset = Mock(return_value=Mock(name="ds"))
@@ -217,3 +266,43 @@ class TestExperimentTags:
             "golden",
             "regression",
         ]
+
+    def test_import_experiment_from_disk__empty_tags_list__forwards_empty_tags(
+        self,
+    ) -> None:
+        # An explicit empty list must round-trip as tags=[], not collapse to
+        # tags=None (which would drop a deliberately cleared tag set).
+        client = Mock()
+        client.flush = Mock(return_value=True)
+        client.get_or_create_dataset = Mock(return_value=Mock(name="ds"))
+        created_experiment = Mock()
+        created_experiment.id = "exp-123"
+        client.create_experiment = Mock(return_value=created_experiment)
+        client._rest_client = Mock()
+
+        experiment_data = ExperimentData(
+            experiment={
+                "id": "exp-123",
+                "name": "test-experiment",
+                "dataset_name": "test-dataset",
+                "type": "regular",
+                "tags": [],
+            },
+            items=[],
+        )
+
+        with patch("opik.cli.imports.experiment.id_helpers_module") as mock_id_helpers:
+            mock_id_helpers.generate_id = Mock(return_value="generated-id")
+
+            recreate_experiment(
+                client,
+                experiment_data,
+                "test-project",
+                {},  # trace_id_map
+                {},  # dataset_item_id_map
+                dry_run=False,
+                debug=False,
+            )
+
+        client.create_experiment.assert_called_once()
+        assert client.create_experiment.call_args.kwargs["tags"] == []

--- a/sdks/python/tests/unit/cli/test_tags_roundtrip.py
+++ b/sdks/python/tests/unit/cli/test_tags_roundtrip.py
@@ -17,10 +17,7 @@ sys.modules.setdefault("opik.api_objects.prompt.prompt", MagicMock())
 
 from opik.cli.imports.prompt import import_prompts_from_directory  # noqa: E402
 from opik.cli.imports.dataset import import_datasets_from_directory  # noqa: E402
-from opik.cli.exports.prompt import (  # noqa: E402
-    export_single_prompt,
-    _resolve_prompt_tags,
-)
+from opik.cli.exports.prompt import export_single_prompt  # noqa: E402
 from opik.cli.imports.experiment import (  # noqa: E402
     ExperimentData,
     recreate_experiment,
@@ -222,37 +219,41 @@ class TestPromptTagsExport:
     get_prompt() lookup; the exporter must recover them via search_prompts.
     """
 
-    def test_resolve_prompt_tags__object_has_tags__skips_search(self) -> None:
-        prompt = Mock()
-        prompt.tags = ["prod"]
-        prompt.name = "greeting"
-        client = Mock()
-
-        assert _resolve_prompt_tags(client, prompt, "proj") == ["prod"]
-        client.search_prompts.assert_not_called()
-
-    def test_resolve_prompt_tags__empty_object_tags__recovers_from_search(
-        self,
-    ) -> None:
-        prompt = Mock()
-        prompt.tags = []  # direct lookup lost the container tags
-        prompt.name = "greeting"
-
-        candidate = Mock()
-        candidate.name = "greeting"
-        candidate.tags = ["prod", "greeting"]
-        client = Mock()
-        client.search_prompts = Mock(return_value=[candidate])
-
-        assert _resolve_prompt_tags(client, prompt, "proj") == ["prod", "greeting"]
-
-    def test_export_single_prompt__container_only_tags__writes_them(
+    def test_export_single_prompt__object_has_tags__skips_search(
         self, tmp_path: Path
     ) -> None:
         prompt = Mock()
         prompt.id = "p1"
         prompt.name = "greeting"
-        prompt.tags = []  # direct lookup dropped tags
+        prompt.tags = ["prod"]  # direct lookup already carries the tags
+        client = Mock()
+        # No history available; _safe_prompt_history swallows the error.
+        client.get_prompt_history = Mock(side_effect=Exception("no history"))
+
+        count = export_single_prompt(
+            client=client,
+            prompt=prompt,
+            output_dir=tmp_path,
+            project_name="proj",
+            max_results=None,
+            force=True,
+            debug=False,
+            format="json",
+        )
+
+        assert count == 1
+        data = json.loads((tmp_path / "prompt_p1.json").read_text())
+        assert data["current_version"]["tags"] == ["prod"]
+        # Tags were already present, so no recovery search is needed.
+        client.search_prompts.assert_not_called()
+
+    def test_export_single_prompt__container_only_tags__recovered_from_search(
+        self, tmp_path: Path
+    ) -> None:
+        prompt = Mock()
+        prompt.id = "p1"
+        prompt.name = "greeting"
+        prompt.tags = []  # direct lookup dropped the container-level tags
 
         candidate = Mock()
         candidate.name = "greeting"
@@ -276,6 +277,35 @@ class TestPromptTagsExport:
         assert count == 1
         data = json.loads((tmp_path / "prompt_p1.json").read_text())
         assert data["current_version"]["tags"] == ["prod", "greeting"]
+
+    def test_export_single_prompt__search_fails__still_exports_with_fallback(
+        self, tmp_path: Path
+    ) -> None:
+        # Tag resolution is best-effort: a search_prompts failure is logged but
+        # must not abort the export — the prompt still exports with whatever tags
+        # the object carried.
+        prompt = Mock()
+        prompt.id = "p1"
+        prompt.name = "greeting"
+        prompt.tags = []  # nothing on the object; recovery will be attempted
+        client = Mock()
+        client.search_prompts = Mock(side_effect=Exception("api down"))
+        client.get_prompt_history = Mock(side_effect=Exception("no history"))
+
+        count = export_single_prompt(
+            client=client,
+            prompt=prompt,
+            output_dir=tmp_path,
+            project_name="proj",
+            max_results=None,
+            force=True,
+            debug=False,
+            format="json",
+        )
+
+        assert count == 1
+        data = json.loads((tmp_path / "prompt_p1.json").read_text())
+        assert data["current_version"]["tags"] == []
 
 
 class TestExperimentTags:

--- a/sdks/python/tests/unit/cli/test_tags_roundtrip.py
+++ b/sdks/python/tests/unit/cli/test_tags_roundtrip.py
@@ -1,0 +1,219 @@
+"""Unit tests verifying that item tags round-trip through CLI export/import.
+
+Covers the regression where ``opik export`` / ``opik import`` silently dropped
+tags for prompts, datasets, and experiments because the exporters used
+hand-written field allowlists that omitted ``tags`` (and the importers never
+forwarded them). Traces and spans already round-tripped correctly.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import Mock, MagicMock, patch
+
+# The experiment/prompt import modules pull in a prompt module that is awkward
+# to import in isolation; mirror the shim used by test_import_experiment.py.
+sys.modules.setdefault("opik.api_objects.prompt.prompt", MagicMock())
+
+from opik.cli.imports.prompt import import_prompts_from_directory  # noqa: E402
+from opik.cli.imports.dataset import import_datasets_from_directory  # noqa: E402
+from opik.cli.imports.experiment import (  # noqa: E402
+    ExperimentData,
+    recreate_experiment,
+)
+from opik.cli.exports.utils import create_experiment_data_structure  # noqa: E402
+
+
+class TestPromptTagsImport:
+    def test_text_prompt_import_forwards_tags(self, tmp_path: Path) -> None:
+        prompt_file = tmp_path / "prompt_p1.json"
+        prompt_file.write_text(
+            json.dumps(
+                {
+                    "name": "greeting",
+                    "current_version": {
+                        "prompt": "Hello {{name}}",
+                        "type": "mustache",
+                        "template_structure": "text",
+                        "tags": ["prod", "greeting"],
+                    },
+                    "history": [],
+                }
+            )
+        )
+
+        client = Mock()
+        client.create_prompt = Mock()
+
+        import_prompts_from_directory(
+            client=client,
+            source_dir=tmp_path,
+            project_name="proj",
+            dry_run=False,
+            name_pattern=None,
+            debug=False,
+        )
+
+        client.create_prompt.assert_called_once()
+        assert client.create_prompt.call_args.kwargs["tags"] == ["prod", "greeting"]
+
+    def test_chat_prompt_import_forwards_tags(self, tmp_path: Path) -> None:
+        prompt_file = tmp_path / "prompt_c1.json"
+        prompt_file.write_text(
+            json.dumps(
+                {
+                    "name": "chat",
+                    "current_version": {
+                        "prompt": [{"role": "user", "content": "hi"}],
+                        "type": "mustache",
+                        "template_structure": "chat",
+                        "tags": ["chatty"],
+                    },
+                    "history": [],
+                }
+            )
+        )
+
+        client = Mock()
+        client.create_chat_prompt = Mock()
+
+        import_prompts_from_directory(
+            client=client,
+            source_dir=tmp_path,
+            project_name="proj",
+            dry_run=False,
+            name_pattern=None,
+            debug=False,
+        )
+
+        client.create_chat_prompt.assert_called_once()
+        assert client.create_chat_prompt.call_args.kwargs["tags"] == ["chatty"]
+
+
+class TestDatasetTagsImport:
+    def _write_dataset(self, tmp_path: Path, payload: dict) -> None:
+        (tmp_path / "dataset_d1.json").write_text(json.dumps(payload))
+
+    def _make_client(self) -> Mock:
+        client = Mock()
+        # Force the create path (get_dataset raises -> create_dataset used).
+        client.get_dataset = Mock(side_effect=Exception("not found"))
+        created = Mock()
+        created.id = "new-ds-id"
+        client.create_dataset = Mock(return_value=created)
+        client.rest_client = Mock()
+        client.rest_client.datasets = Mock()
+        client.rest_client.datasets.update_dataset = Mock()
+        return client
+
+    def test_flat_format_applies_tags(self, tmp_path: Path) -> None:
+        self._write_dataset(
+            tmp_path,
+            {"name": "ds", "tags": ["a", "b"], "items": []},
+        )
+        client = self._make_client()
+
+        import_datasets_from_directory(
+            client=client,
+            source_dir=tmp_path,
+            project_name="proj",
+            dry_run=False,
+            name_pattern=None,
+            debug=False,
+        )
+
+        client.rest_client.datasets.update_dataset.assert_called_once()
+        call = client.rest_client.datasets.update_dataset.call_args
+        assert call.args[0] == "new-ds-id"
+        assert call.kwargs["tags"] == ["a", "b"]
+
+    def test_nested_format_applies_tags(self, tmp_path: Path) -> None:
+        self._write_dataset(
+            tmp_path,
+            {"dataset": {"name": "ds", "id": "x", "tags": ["c"]}, "items": []},
+        )
+        client = self._make_client()
+
+        import_datasets_from_directory(
+            client=client,
+            source_dir=tmp_path,
+            project_name="proj",
+            dry_run=False,
+            name_pattern=None,
+            debug=False,
+        )
+
+        client.rest_client.datasets.update_dataset.assert_called_once()
+        assert client.rest_client.datasets.update_dataset.call_args.kwargs["tags"] == [
+            "c"
+        ]
+
+    def test_no_tags_skips_update(self, tmp_path: Path) -> None:
+        self._write_dataset(tmp_path, {"name": "ds", "items": []})
+        client = self._make_client()
+
+        import_datasets_from_directory(
+            client=client,
+            source_dir=tmp_path,
+            project_name="proj",
+            dry_run=False,
+            name_pattern=None,
+            debug=False,
+        )
+
+        client.rest_client.datasets.update_dataset.assert_not_called()
+
+
+class TestExperimentTags:
+    def test_export_structure_includes_tags(self) -> None:
+        experiment = Mock()
+        experiment.id = "exp-1"
+        experiment.name = "e"
+        experiment.dataset_name = "ds"
+        data_obj = Mock()
+        data_obj.tags = ["t1", "t2"]
+        experiment.get_experiment_data = Mock(return_value=data_obj)
+
+        structure = create_experiment_data_structure(experiment, [])
+
+        assert structure["experiment"]["tags"] == ["t1", "t2"]
+
+    def test_import_from_disk_forwards_tags(self) -> None:
+        client = Mock()
+        client.flush = Mock(return_value=True)
+        client.get_or_create_dataset = Mock(return_value=Mock(name="ds"))
+        created_experiment = Mock()
+        created_experiment.id = "exp-123"
+        client.create_experiment = Mock(return_value=created_experiment)
+        client._rest_client = Mock()
+
+        experiment_data = ExperimentData(
+            experiment={
+                "id": "exp-123",
+                "name": "test-experiment",
+                "dataset_name": "test-dataset",
+                "type": "regular",
+                "tags": ["golden", "regression"],
+            },
+            items=[],
+        )
+
+        with patch("opik.cli.imports.experiment.id_helpers_module") as mock_id_helpers:
+            mock_id_helpers.generate_id = Mock(return_value="generated-id")
+
+            recreate_experiment(
+                client,
+                experiment_data,
+                "test-project",
+                {},  # trace_id_map
+                {},  # dataset_item_id_map
+                dry_run=False,
+                debug=False,
+                # target_project_name defaults to None -> import-from-disk path
+            )
+
+        client.create_experiment.assert_called_once()
+        assert client.create_experiment.call_args.kwargs["tags"] == [
+            "golden",
+            "regression",
+        ]


### PR DESCRIPTION
## Details

`opik export` / `opik import` silently dropped `tags` for prompts, experiments, and datasets because those exporters used hand-written field allowlists that omitted `tags`, and the importers never forwarded them. Traces and spans already round-tripped correctly. This threads tags through both sides of the flow.

- **Prompts**: serialize `tags` in `current_version` + each `history` entry; forward to `create_prompt`/`create_chat_prompt` on import.
- **Experiments**: add `tags` to the export structure; forward on the plain import-from-disk path (previously only the `opik migrate` path forwarded them — that path is unchanged).
- **Datasets**: export dataset-level tags via `dataset.get_tags()` (wrapped so a tags lookup can never abort an export); apply on import via the REST `update_dataset` endpoint, since the high-level `create_dataset()` has no `tags` argument.

### Notes / out of scope
- **Dataset item-level tags are still dropped**, but earlier — inside the SDK. `api_objects/dataset/rest_operations.py:144` reconstructs `DatasetItem` without the `tags` column, so the CLI never sees item tags. Fixing that is a separate core-SDK change, intentionally not included here. (The existing migrate e2e `conftest.py` already documents this SDK limitation.)
- On import, dataset tags are applied with `update_dataset`, which **replaces** rather than merges tags on a pre-existing dataset. This is reasonable for import; flagging in case merge semantics are preferred.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7292

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8 (1M context)
  - Scope: Investigation of the tag-drop bug, code changes across 6 CLI export/import modules, plus new unit tests and extended e2e coverage.
  - Human verification: Author reviewed the diff, and the fix was verified against the Opik REST/SDK signatures (`create_prompt`/`create_chat_prompt`/`create_experiment` accept `tags`; `update_dataset` REST endpoint used for datasets).

## Testing

**Unit** — `sdks/python/tests/unit/cli/test_tags_roundtrip.py` (new, 7 tests): prompt (text + chat) import forwarding, dataset import (flat format, nested format, no-tags-skips-update), and experiment (export structure + import-from-disk forwarding).

**E2E** — `sdks/python/tests/e2e/test_cli_import_export.py` (extended): seed tags on the dataset, prompt, chat-prompt, and experiment fixtures and assert they survive both the exported files and the re-import.
- `test_export_import_datasets_happy_flow`: tags present in the exported dataset file **and** on the re-imported dataset (`get_tags()`).
- `test_export_import_prompts_happy_flow`: tags present in the exported `current_version` **and** on the imported prompt.
- `test_export_import_chat_prompts_happy_flow`: same, for the chat path.
- `test_export_experiment_with_dataset_filter`: tags present in the exported experiment file.
- `test_import_projects_automatically_recreates_experiments`: now also exports the experiment (trace export alone emits none), so it actually exercises recreation and verifies tags on the recreated experiment.

Previously this e2e suite asserted no tags on any entity — which is why the regression went unnoticed.

Commands run from `sdks/python`:
- `python -m pytest tests/unit/cli/test_tags_roundtrip.py -q` → 7 passed
- `python -m pytest tests/unit/cli/ -q` → 424 passed (no regressions; migrate-path cascade tests still green)
- `python -m pytest tests/e2e/test_cli_import_export.py --collect-only` → 12 collected, no import errors
- `ruff check` + `ruff format --check` on all changed files → clean

Not run locally: the e2e suite itself, which requires a live Opik backend — it runs in CI.

## Documentation

N/A — no user-facing docs describe the per-entity field lists; behavior change is a bug fix (tags now preserved).
