### PR TITLE
[OPIK-7291] [SDK] fix: bound memory in project trace export with chunked flush

### DIFF
--- a/sdks/python/src/opik/cli/exports/project.py
+++ b/sdks/python/src/opik/cli/exports/project.py
@@ -872,27 +872,27 @@ def export_traces(
                             )
                         skipped_count += 1
                         total_processed += 1
-                    else:
-                        # File was deleted after the manifest was written — re-download.
-                        if debug:
-                            debug_print(
-                                f"Trace {trace.id} in manifest but file missing; re-downloading",
-                                debug,
-                            )
-                        already_downloaded.discard(trace.id)
-                        traces_to_fetch[trace.id] = trace
-                        total_processed += 1
-                else:
-                    traces_to_fetch[trace.id] = trace
-                    total_processed += 1
+                        continue
+                    # File was deleted after the manifest was written — re-download.
+                    if debug:
+                        debug_print(
+                            f"Trace {trace.id} in manifest but file missing; re-downloading",
+                            debug,
+                        )
+                    already_downloaded.discard(trace.id)
+
+                traces_to_fetch[trace.id] = trace
+                total_processed += 1
+
+                # Flush the moment the buffer fills — mid-page if necessary — so
+                # peak memory stays bounded to ≈ one chunk of traces + their
+                # spans.  Checking only after a whole page is appended would let
+                # the buffer grow to almost two chunks (a nearly full buffer plus
+                # a freshly appended page).
+                if len(traces_to_fetch) >= chunk_target:
+                    _flush_chunk()
 
             current_page += 1
-
-            # Flush the chunk once enough traces are queued so peak memory stays
-            # bounded (≈ one chunk of traces + their spans) rather than growing
-            # with the whole project.
-            if len(traces_to_fetch) >= chunk_target:
-                _flush_chunk()
 
             # If we got fewer traces than requested, we've reached the end
             if len(traces) < current_page_size:

--- a/sdks/python/src/opik/cli/exports/project.py
+++ b/sdks/python/src/opik/cli/exports/project.py
@@ -522,12 +522,12 @@ def export_traces(
 
         # Fallback cache for the unbounded span scan.  When a chunk's trace ids
         # can't be bounded by a trace_id range filter (e.g. non-UUIDv7 ids), the
-        # backend has to scan every span in the project.  That scan is done once
-        # for the whole export and cached here so subsequent chunks reuse it
-        # instead of re-scanning the entire project on every flush (which would
-        # make a large export O(chunks × full-scan) and time out).
+        # backend has to scan every span in the project.  A *clean* full scan is
+        # cached here once so subsequent chunks reuse it instead of re-scanning
+        # the entire project on every flush (which would make a large export
+        # O(chunks × full-scan) and time out).  A scan that errors out is never
+        # published here — it stays partial and the next chunk retries.
         unbounded_spans_cache: Optional[dict[str, list]] = None
-        unbounded_scan_had_errors = False
 
         def _scan_and_group_spans(
             spans_filter: Optional[str],
@@ -636,7 +636,7 @@ def export_traces(
 
             Returns (spans_by_trace_id, chunk_had_errors).
             """
-            nonlocal unbounded_spans_cache, unbounded_scan_had_errors
+            nonlocal unbounded_spans_cache
 
             spans_by_trace_id: dict[str, list] = {tid: [] for tid in traces_to_fetch}
             chunk_had_errors = False
@@ -659,20 +659,25 @@ def export_traces(
                     return spans_by_trace_id, chunk_had_errors
 
                 # No trace_id range filter could be built (e.g. non-UUIDv7 ids),
-                # so the backend must scan every span in the project. Do that once
-                # for the whole export and cache the grouped result; repeating the
-                # full scan per chunk would make a large export O(chunks × full-scan)
-                # and time out.
-                unbounded_spans_cache = {}
-                unbounded_scan_had_errors = _scan_and_group_spans(
-                    None, unbounded_spans_cache, only_known_ids=False
+                # so the backend must scan every span in the project. Scan into a
+                # local map and only publish it as the shared cache when the scan
+                # completes cleanly, so later chunks reuse a *complete* scan rather
+                # than a partially-populated one poisoned by a transient error.
+                scanned: dict[str, list] = {}
+                scan_had_errors = _scan_and_group_spans(
+                    None, scanned, only_known_ids=False
                 )
+                if scan_had_errors:
+                    # Use the partial result for this chunk (some spans beat none)
+                    # and flag the error, but leave the cache unpublished so the
+                    # next chunk retries the scan instead of reusing partial data.
+                    for tid in spans_by_trace_id:
+                        spans_by_trace_id[tid] = scanned.get(tid, [])
+                    return spans_by_trace_id, True
+                unbounded_spans_cache = scanned
 
-            # Serve this chunk from the cached full scan (built now or by an
-            # earlier chunk). A partial scan (errors) is surfaced on every chunk
-            # it feeds so the manifest is left incomplete and the next run resumes.
-            if unbounded_scan_had_errors:
-                chunk_had_errors = True
+            # Serve this chunk from the cached (clean) full scan — built just now
+            # or by an earlier chunk.
             for tid in spans_by_trace_id:
                 spans_by_trace_id[tid] = unbounded_spans_cache.get(tid, [])
 

--- a/sdks/python/src/opik/cli/exports/project.py
+++ b/sdks/python/src/opik/cli/exports/project.py
@@ -520,29 +520,36 @@ def export_traces(
         # Reset after each flush so it never holds more than one chunk.
         traces_to_fetch: dict[str, Any] = {}
 
-        def _fetch_spans_for_chunk() -> tuple[dict[str, list], bool]:
-            """Fetch and group spans for the buffered chunk's traces.
+        # Fallback cache for the unbounded span scan.  When a chunk's trace ids
+        # can't be bounded by a trace_id range filter (e.g. non-UUIDv7 ids), the
+        # backend has to scan every span in the project.  That scan is done once
+        # for the whole export and cached here so subsequent chunks reuse it
+        # instead of re-scanning the entire project on every flush (which would
+        # make a large export O(chunks × full-scan) and time out).
+        unbounded_spans_cache: Optional[dict[str, list]] = None
+        unbounded_scan_had_errors = False
 
-            Instead of one POST /spans/search per trace (rate-limited to 30
-            req/min), paginate GET /spans bounded to the chunk's trace_id range
-            so the backend prunes by primary key.  Each span carries its
-            trace_id so we group client-side and discard spans for traces
-            outside this chunk.  Returns (spans_by_trace_id, chunk_had_errors).
+        def _scan_and_group_spans(
+            spans_filter: Optional[str],
+            group_into: dict[str, list],
+            only_known_ids: bool,
+        ) -> bool:
+            """Paginate GET /spans and group the results by trace_id into
+            ``group_into``.
+
+            ``spans_filter`` (parsed OQL JSON) optionally bounds the scan by
+            ``trace_id`` range so the backend prunes by primary key.
+
+            When ``only_known_ids`` is True, spans whose ``trace_id`` is not
+            already a key in ``group_into`` are discarded — used for the bounded
+            chunk scan where ``group_into`` is pre-seeded with the chunk's
+            trace_ids (so the range filter only needs to be a superset).  When
+            False, every span is grouped, adding keys as needed — used for the
+            one-shot unbounded full-project scan.
+
+            Returns True if any span page failed after retries (partial spans).
             """
-            spans_by_trace_id: dict[str, list] = {tid: [] for tid in traces_to_fetch}
-            chunk_had_errors = False
-            if not traces_to_fetch:
-                return spans_by_trace_id, chunk_had_errors
-
-            if progress and task is not None:
-                progress.update(task, description="Fetching spans...")
-
-            # Bound the span scan to the chunk's trace_id range so the backend
-            # prunes by primary key. Exactness is still guaranteed by the
-            # membership check (`tid in spans_by_trace_id`) below, so this only
-            # needs to be a superset of the chunk's trace_ids.
-            spans_filter = _spans_trace_id_range_filter(traces_to_fetch.keys())
-
+            had_errors = False
             span_page = 1
             span_consecutive_failures = 0
             while True:
@@ -570,12 +577,12 @@ def export_traces(
                             f"[red]{span_consecutive_failures} consecutive span page failures — "
                             "stopping span fetch. Traces will be exported with partial spans.[/red]"
                         )
-                        chunk_had_errors = True
+                        had_errors = True
                         break
                     console.print(
                         f"[yellow]Error fetching span page {span_page}: {e} — skipping and continuing.[/yellow]"
                     )
-                    chunk_had_errors = True
+                    had_errors = True
                     span_page += 1
                     time.sleep(_PAGE_FETCH_DELAY_SECONDS)
                     continue
@@ -583,11 +590,16 @@ def export_traces(
                 spans = span_result.content or []
                 for span in spans:
                     tid = span.trace_id
-                    if tid and tid in spans_by_trace_id:
-                        spans_by_trace_id[tid].append(span)
+                    if not tid:
+                        continue
+                    if only_known_ids:
+                        if tid in group_into:
+                            group_into[tid].append(span)
+                    else:
+                        group_into.setdefault(tid, []).append(span)
 
                 if debug:
-                    total_relevant = sum(len(v) for v in spans_by_trace_id.values())
+                    total_relevant = sum(len(v) for v in group_into.values())
                     debug_print(
                         f"DEBUG: Span page {span_page}: {len(spans)} spans fetched, "
                         f"{total_relevant} relevant so far",
@@ -595,7 +607,7 @@ def export_traces(
                     )
 
                 if progress and task is not None:
-                    total_relevant = sum(len(v) for v in spans_by_trace_id.values())
+                    total_relevant = sum(len(v) for v in group_into.values())
                     progress.update(
                         task,
                         description=f"Fetching spans... (page {span_page}, {total_relevant} matched)",
@@ -605,6 +617,64 @@ def export_traces(
                     break
 
                 span_page += 1
+
+            return had_errors
+
+        def _fetch_spans_for_chunk() -> tuple[dict[str, list], bool]:
+            """Fetch and group spans for the buffered chunk's traces.
+
+            Instead of one POST /spans/search per trace (rate-limited to 30
+            req/min), paginate GET /spans bounded to the chunk's trace_id range
+            so the backend prunes by primary key.  Each span carries its
+            trace_id so we group client-side and discard spans for traces
+            outside this chunk.
+
+            When the range filter can't be built (e.g. non-UUIDv7 ids) the
+            backend has to scan every span in the project; that unbounded scan is
+            done once and cached (``unbounded_spans_cache``) so later chunks reuse
+            it rather than re-scanning the whole project on every flush.
+
+            Returns (spans_by_trace_id, chunk_had_errors).
+            """
+            nonlocal unbounded_spans_cache, unbounded_scan_had_errors
+
+            spans_by_trace_id: dict[str, list] = {tid: [] for tid in traces_to_fetch}
+            chunk_had_errors = False
+            if not traces_to_fetch:
+                return spans_by_trace_id, chunk_had_errors
+
+            if progress and task is not None:
+                progress.update(task, description="Fetching spans...")
+
+            if unbounded_spans_cache is None:
+                # Bound the span scan to the chunk's trace_id range so the backend
+                # prunes by primary key. Exactness is still guaranteed by the
+                # membership check in _scan_and_group_spans, so this only needs to
+                # be a superset of the chunk's trace_ids.
+                spans_filter = _spans_trace_id_range_filter(traces_to_fetch.keys())
+                if spans_filter is not None:
+                    chunk_had_errors = _scan_and_group_spans(
+                        spans_filter, spans_by_trace_id, only_known_ids=True
+                    )
+                    return spans_by_trace_id, chunk_had_errors
+
+                # No trace_id range filter could be built (e.g. non-UUIDv7 ids),
+                # so the backend must scan every span in the project. Do that once
+                # for the whole export and cache the grouped result; repeating the
+                # full scan per chunk would make a large export O(chunks × full-scan)
+                # and time out.
+                unbounded_spans_cache = {}
+                unbounded_scan_had_errors = _scan_and_group_spans(
+                    None, unbounded_spans_cache, only_known_ids=False
+                )
+
+            # Serve this chunk from the cached full scan (built now or by an
+            # earlier chunk). A partial scan (errors) is surfaced on every chunk
+            # it feeds so the manifest is left incomplete and the next run resumes.
+            if unbounded_scan_had_errors:
+                chunk_had_errors = True
+            for tid in spans_by_trace_id:
+                spans_by_trace_id[tid] = unbounded_spans_cache.get(tid, [])
 
             return spans_by_trace_id, chunk_had_errors
 

--- a/sdks/python/src/opik/cli/exports/project.py
+++ b/sdks/python/src/opik/cli/exports/project.py
@@ -505,11 +505,238 @@ def export_traces(
             progress.add_task("Collecting traces...", total=None) if progress else None
         )
 
-        # ── Phase 1: collect all traces that need downloading ──────────────────
-        # We gather every trace_id → trace object here without touching spans,
-        # so the expensive per-trace POST /spans/search calls are replaced by
-        # a single bulk GET /spans pagination in Phase 2.
-        traces_to_fetch: dict[str, Any] = {}  # trace_id → trace
+        # Peak-memory control: instead of buffering every trace and span in the
+        # project (which OOMs on large projects), process traces in bounded
+        # chunks.  Page through the trace list until `chunk_target` traces need
+        # downloading, then fetch their spans and write them before continuing.
+        # Chunk size tracks page_size so the single --page-size knob stays
+        # meaningful: larger pages mean fewer round-trips but more memory.
+        chunk_target = page_size
+        exported_count = 0
+        # Guards already_downloaded / manifest mutations by the write workers.
+        manifest_lock = threading.Lock()
+
+        # Chunk buffer: trace_id → trace object awaiting span-fetch and write.
+        # Reset after each flush so it never holds more than one chunk.
+        traces_to_fetch: dict[str, Any] = {}
+
+        def _fetch_spans_for_chunk() -> tuple[dict[str, list], bool]:
+            """Fetch and group spans for the buffered chunk's traces.
+
+            Instead of one POST /spans/search per trace (rate-limited to 30
+            req/min), paginate GET /spans bounded to the chunk's trace_id range
+            so the backend prunes by primary key.  Each span carries its
+            trace_id so we group client-side and discard spans for traces
+            outside this chunk.  Returns (spans_by_trace_id, chunk_had_errors).
+            """
+            spans_by_trace_id: dict[str, list] = {tid: [] for tid in traces_to_fetch}
+            chunk_had_errors = False
+            if not traces_to_fetch:
+                return spans_by_trace_id, chunk_had_errors
+
+            if progress and task is not None:
+                progress.update(task, description="Fetching spans...")
+
+            # Bound the span scan to the chunk's trace_id range so the backend
+            # prunes by primary key. Exactness is still guaranteed by the
+            # membership check (`tid in spans_by_trace_id`) below, so this only
+            # needs to be a superset of the chunk's trace_ids.
+            spans_filter = _spans_trace_id_range_filter(traces_to_fetch.keys())
+
+            span_page = 1
+            span_consecutive_failures = 0
+            while True:
+                if debug:
+                    debug_print(f"DEBUG: Fetching span page {span_page}", debug)
+                try:
+                    span_result = _fetch_spans_page(
+                        client, project_name, span_page, page_size, spans_filter
+                    )
+                    span_consecutive_failures = 0
+                except (
+                    ApiError,
+                    httpx.RemoteProtocolError,
+                    httpx.ConnectError,
+                    httpx.TimeoutException,
+                ) as e:
+                    if (
+                        isinstance(e, ApiError)
+                        and e.status_code not in retry_decorator.RETRYABLE_STATUS_CODES
+                    ):
+                        raise
+                    span_consecutive_failures += 1
+                    if span_consecutive_failures >= MAX_CONSECUTIVE_PAGE_FAILURES:
+                        console.print(
+                            f"[red]{span_consecutive_failures} consecutive span page failures — "
+                            "stopping span fetch. Traces will be exported with partial spans.[/red]"
+                        )
+                        chunk_had_errors = True
+                        break
+                    console.print(
+                        f"[yellow]Error fetching span page {span_page}: {e} — skipping and continuing.[/yellow]"
+                    )
+                    chunk_had_errors = True
+                    span_page += 1
+                    time.sleep(_PAGE_FETCH_DELAY_SECONDS)
+                    continue
+
+                spans = span_result.content or []
+                for span in spans:
+                    tid = span.trace_id
+                    if tid and tid in spans_by_trace_id:
+                        spans_by_trace_id[tid].append(span)
+
+                if debug:
+                    total_relevant = sum(len(v) for v in spans_by_trace_id.values())
+                    debug_print(
+                        f"DEBUG: Span page {span_page}: {len(spans)} spans fetched, "
+                        f"{total_relevant} relevant so far",
+                        debug,
+                    )
+
+                if progress and task is not None:
+                    total_relevant = sum(len(v) for v in spans_by_trace_id.values())
+                    progress.update(
+                        task,
+                        description=f"Fetching spans... (page {span_page}, {total_relevant} matched)",
+                    )
+
+                if not spans or len(spans) < page_size:
+                    break
+
+                span_page += 1
+
+            return spans_by_trace_id, chunk_had_errors
+
+        def _write_chunk(spans_by_trace_id: dict[str, list]) -> tuple[int, bool]:
+            """Write the buffered chunk's trace files in parallel.
+
+            Returns ``(exported, chunk_had_errors)``.
+            """
+            if not traces_to_fetch:
+                return 0, False
+
+            if progress and task is not None:
+                progress.update(
+                    task,
+                    description=f"Writing {len(traces_to_fetch)} trace files...",
+                )
+
+            chunk_exported = 0
+            chunk_had_errors = False
+
+            def _process_trace(trace_id: str, trace: Any) -> tuple[bool, bool]:
+                """Fetch attachments and write the trace file for one trace.
+
+                Returns ``(ok, had_error)`` where:
+                - ``ok`` is True when the trace file was written successfully;
+                  the caller increments ``chunk_exported`` only in this case.
+                - ``had_error`` is True when any attachment download failed or
+                  the file write raised; the caller sets ``chunk_had_errors``.
+
+                Side-effects on success: acquires ``manifest_lock``, adds
+                ``trace_id`` to ``already_downloaded``, and calls
+                ``manifest.mark_trace_downloaded`` if a manifest is active.
+                """
+                spans = spans_by_trace_id.get(trace_id, [])
+
+                attachment_metadata: list = []
+                attachment_download_ok = True
+                if att_client is not None:
+                    span_ids = [span.id for span in spans if span.id]
+                    attachment_metadata = _fetch_attachments(
+                        att_client, project_name, trace_id, span_ids
+                    )
+                    for att in attachment_metadata:
+                        if not _download_attachment_file(
+                            att_client,
+                            project_name,
+                            att,
+                            project_dir,
+                            force,
+                        ):
+                            attachment_download_ok = False
+
+                if not attachment_download_ok:
+                    LOGGER.warning(
+                        "Trace %s: one or more attachment downloads failed; "
+                        "writing trace with partial attachments",
+                        trace_id,
+                    )
+
+                trace_data = {
+                    "trace": trace.model_dump(),
+                    "spans": [span.model_dump() for span in spans],
+                    "attachments": attachment_metadata,
+                    "downloaded_at": datetime.now().isoformat(),
+                    "project_name": project_name,
+                }
+                file_path = project_dir / f"trace_{trace_id}.{ext}"
+                try:
+                    if format.lower() == "csv":
+                        write_csv_data(trace_data, file_path, trace_to_csv_rows)
+                        if debug:
+                            debug_print(f"Wrote CSV file: {file_path}", debug)
+                    else:
+                        write_json_data(trace_data, file_path)
+                        if debug:
+                            debug_print(f"Wrote JSON file: {file_path}", debug)
+                    with manifest_lock:
+                        already_downloaded.add(trace_id)
+                        if manifest is not None and attachment_download_ok:
+                            manifest.mark_trace_downloaded(trace_id)
+                    return True, not attachment_download_ok
+                except Exception as write_error:
+                    console.print(
+                        f"[red]Error writing trace {trace_id} to file: {write_error}[/red]"
+                    )
+                    if debug:
+                        import traceback
+
+                        debug_print(f"Traceback: {traceback.format_exc()}", debug)
+                    return False, True
+
+            with ThreadPoolExecutor(max_workers=_PHASE3_MAX_WORKERS) as executor:
+                futures = {
+                    executor.submit(_process_trace, tid, trace): tid
+                    for tid, trace in traces_to_fetch.items()
+                }
+                for future in as_completed(futures):
+                    try:
+                        ok, trace_had_error = future.result()
+                    except Exception as e:
+                        ok, trace_had_error = False, True
+                        console.print(
+                            f"[red]Unexpected error processing trace {futures[future]}: {e}[/red]"
+                        )
+                    # Runs in the calling thread only, so no counter lock needed.
+                    if ok:
+                        chunk_exported += 1
+                    if trace_had_error:
+                        chunk_had_errors = True
+
+            return chunk_exported, chunk_had_errors
+
+        def _flush_chunk() -> None:
+            """Span-fetch and write the buffered chunk, then clear it.
+
+            No-op when the buffer is empty. Accumulates into the outer
+            ``exported_count`` / ``had_errors`` and resets ``traces_to_fetch``.
+            """
+            nonlocal exported_count, had_errors, traces_to_fetch
+            if not traces_to_fetch:
+                return
+            spans_by_trace_id, span_err = _fetch_spans_for_chunk()
+            chunk_exported, write_err = _write_chunk(spans_by_trace_id)
+            exported_count += chunk_exported
+            if span_err or write_err:
+                had_errors = True
+            traces_to_fetch = {}
+
+        # ── Phase 1: page through traces, flushing each bounded chunk ──────────
+        # Buffer only the traces that need downloading; once a chunk fills we
+        # fetch its spans and write it (see _flush_chunk), so we never hold the
+        # whole project in memory at once.
 
         while max_results is None or total_processed < max_results:
             # Calculate how many traces to fetch in this batch
@@ -661,195 +888,18 @@ def export_traces(
 
             current_page += 1
 
+            # Flush the chunk once enough traces are queued so peak memory stays
+            # bounded (≈ one chunk of traces + their spans) rather than growing
+            # with the whole project.
+            if len(traces_to_fetch) >= chunk_target:
+                _flush_chunk()
+
             # If we got fewer traces than requested, we've reached the end
             if len(traces) < current_page_size:
                 break
 
-        # ── Phase 2: fetch all spans for the project in bulk ───────────────────
-        # Instead of one POST /spans/search per trace (rate-limited to 30 req/min),
-        # paginate GET /spans once across the whole project.  Each span carries its
-        # trace_id so we can group client-side and discard spans for already-
-        # downloaded traces.
-        spans_by_trace_id: dict[str, list] = {tid: [] for tid in traces_to_fetch}
-
-        if traces_to_fetch:
-            if progress and task is not None:
-                progress.update(task, description="Fetching spans...")
-
-            # Bound the span scan to the trace_id range of the matched traces so
-            # the backend prunes by primary key instead of paging every span in
-            # the project. Exactness is still guaranteed by the membership check
-            # (`tid in spans_by_trace_id`) below, so this only needs to be a
-            # superset of the matched trace_ids.
-            spans_filter = _spans_trace_id_range_filter(traces_to_fetch.keys())
-
-            span_page = 1
-            span_consecutive_failures = 0
-
-            while True:
-                if debug:
-                    debug_print(f"DEBUG: Fetching span page {span_page}", debug)
-                try:
-                    span_result = _fetch_spans_page(
-                        client, project_name, span_page, page_size, spans_filter
-                    )
-                    span_consecutive_failures = 0
-                except (
-                    ApiError,
-                    httpx.RemoteProtocolError,
-                    httpx.ConnectError,
-                    httpx.TimeoutException,
-                ) as e:
-                    if (
-                        isinstance(e, ApiError)
-                        and e.status_code not in retry_decorator.RETRYABLE_STATUS_CODES
-                    ):
-                        raise
-                    span_consecutive_failures += 1
-                    if span_consecutive_failures >= MAX_CONSECUTIVE_PAGE_FAILURES:
-                        console.print(
-                            f"[red]{span_consecutive_failures} consecutive span page failures — "
-                            "stopping span fetch. Traces will be exported with partial spans.[/red]"
-                        )
-                        had_errors = True
-                        break
-                    console.print(
-                        f"[yellow]Error fetching span page {span_page}: {e} — skipping and continuing.[/yellow]"
-                    )
-                    had_errors = True
-                    span_page += 1
-                    time.sleep(_PAGE_FETCH_DELAY_SECONDS)
-                    continue
-
-                spans = span_result.content or []
-                for span in spans:
-                    tid = span.trace_id
-                    if tid and tid in spans_by_trace_id:
-                        spans_by_trace_id[tid].append(span)
-
-                if debug:
-                    total_relevant = sum(len(v) for v in spans_by_trace_id.values())
-                    debug_print(
-                        f"DEBUG: Span page {span_page}: {len(spans)} spans fetched, "
-                        f"{total_relevant} relevant so far",
-                        debug,
-                    )
-
-                if progress and task is not None:
-                    total_relevant = sum(len(v) for v in spans_by_trace_id.values())
-                    progress.update(
-                        task,
-                        description=f"Fetching spans... (page {span_page}, {total_relevant} matched)",
-                    )
-
-                if not spans or len(spans) < page_size:
-                    break
-
-                span_page += 1
-
-        # ── Phase 3: write trace files (parallel) ─────────────────────────────
-        exported_count = 0
-
-        if traces_to_fetch:
-            if progress and task is not None:
-                progress.update(
-                    task,
-                    description=f"Writing {len(traces_to_fetch)} trace files...",
-                )
-
-            manifest_lock = threading.Lock()
-            counter_lock = threading.Lock()
-
-            def _process_trace(trace_id: str, trace: Any) -> tuple[bool, bool]:
-                """Fetch attachments and write the trace file for one trace.
-
-                Returns ``(ok, had_error)`` where:
-                - ``ok`` is True when the trace file was written successfully;
-                  the caller increments ``exported_count`` only in this case.
-                - ``had_error`` is True when any attachment download failed or
-                  the file write raised; the caller sets the shared
-                  ``had_errors`` flag.
-
-                Side-effects on success: acquires ``manifest_lock``, adds
-                ``trace_id`` to ``already_downloaded``, and calls
-                ``manifest.mark_trace_downloaded`` if a manifest is active.
-                """
-                spans = spans_by_trace_id.get(trace_id, [])
-
-                attachment_metadata: list = []
-                attachment_download_ok = True
-                if att_client is not None:
-                    span_ids = [span.id for span in spans if span.id]
-                    attachment_metadata = _fetch_attachments(
-                        att_client, project_name, trace_id, span_ids
-                    )
-                    for att in attachment_metadata:
-                        if not _download_attachment_file(
-                            att_client,
-                            project_name,
-                            att,
-                            project_dir,
-                            force,
-                        ):
-                            attachment_download_ok = False
-
-                if not attachment_download_ok:
-                    LOGGER.warning(
-                        "Trace %s: one or more attachment downloads failed; "
-                        "writing trace with partial attachments",
-                        trace_id,
-                    )
-
-                trace_data = {
-                    "trace": trace.model_dump(),
-                    "spans": [span.model_dump() for span in spans],
-                    "attachments": attachment_metadata,
-                    "downloaded_at": datetime.now().isoformat(),
-                    "project_name": project_name,
-                }
-                file_path = project_dir / f"trace_{trace_id}.{ext}"
-                try:
-                    if format.lower() == "csv":
-                        write_csv_data(trace_data, file_path, trace_to_csv_rows)
-                        if debug:
-                            debug_print(f"Wrote CSV file: {file_path}", debug)
-                    else:
-                        write_json_data(trace_data, file_path)
-                        if debug:
-                            debug_print(f"Wrote JSON file: {file_path}", debug)
-                    with manifest_lock:
-                        already_downloaded.add(trace_id)
-                        if manifest is not None and attachment_download_ok:
-                            manifest.mark_trace_downloaded(trace_id)
-                    return True, not attachment_download_ok
-                except Exception as write_error:
-                    console.print(
-                        f"[red]Error writing trace {trace_id} to file: {write_error}[/red]"
-                    )
-                    if debug:
-                        import traceback
-
-                        debug_print(f"Traceback: {traceback.format_exc()}", debug)
-                    return False, True
-
-            with ThreadPoolExecutor(max_workers=_PHASE3_MAX_WORKERS) as executor:
-                futures = {
-                    executor.submit(_process_trace, tid, trace): tid
-                    for tid, trace in traces_to_fetch.items()
-                }
-                for future in as_completed(futures):
-                    try:
-                        ok, trace_had_error = future.result()
-                    except Exception as e:
-                        ok, trace_had_error = False, True
-                        console.print(
-                            f"[red]Unexpected error processing trace {futures[future]}: {e}[/red]"
-                        )
-                    with counter_lock:
-                        if ok:
-                            exported_count += 1
-                        if trace_had_error:
-                            had_errors = True
+        # Flush the final (partial) chunk of buffered traces.
+        _flush_chunk()
 
         # Final progress update
         if exported_count == 0 and skipped_count == 0:

--- a/sdks/python/src/opik/cli/exports/project.py
+++ b/sdks/python/src/opik/cli/exports/project.py
@@ -520,32 +520,24 @@ def export_traces(
         # Reset after each flush so it never holds more than one chunk.
         traces_to_fetch: dict[str, Any] = {}
 
-        # Fallback cache for the unbounded span scan.  When a chunk's trace ids
-        # can't be bounded by a trace_id range filter (e.g. non-UUIDv7 ids), the
-        # backend has to scan every span in the project.  A *clean* full scan is
-        # cached here once so subsequent chunks reuse it instead of re-scanning
-        # the entire project on every flush (which would make a large export
-        # O(chunks × full-scan) and time out).  A scan that errors out is never
-        # published here — it stays partial and the next chunk retries.
-        unbounded_spans_cache: Optional[dict[str, list]] = None
-
         def _scan_and_group_spans(
             spans_filter: Optional[str],
             group_into: dict[str, list],
-            only_known_ids: bool,
         ) -> bool:
             """Paginate GET /spans and group the results by trace_id into
             ``group_into``.
 
-            ``spans_filter`` (parsed OQL JSON) optionally bounds the scan by
-            ``trace_id`` range so the backend prunes by primary key.
+            ``group_into`` is pre-seeded with the current chunk's trace_ids;
+            spans whose ``trace_id`` is not already a key are discarded, so the
+            scan only ever retains this chunk's spans.  Peak memory therefore
+            stays bounded to one chunk regardless of how many spans the project
+            holds — even on the unfiltered fallback below where the backend
+            streams back every span.
 
-            When ``only_known_ids`` is True, spans whose ``trace_id`` is not
-            already a key in ``group_into`` are discarded — used for the bounded
-            chunk scan where ``group_into`` is pre-seeded with the chunk's
-            trace_ids (so the range filter only needs to be a superset).  When
-            False, every span is grouped, adding keys as needed — used for the
-            one-shot unbounded full-project scan.
+            ``spans_filter`` (parsed OQL JSON) optionally bounds the scan by
+            ``trace_id`` range so the backend prunes by primary key; the
+            membership check means it only needs to be a superset of the chunk's
+            trace_ids.
 
             Returns True if any span page failed after retries (partial spans).
             """
@@ -592,11 +584,10 @@ def export_traces(
                     tid = span.trace_id
                     if not tid:
                         continue
-                    if only_known_ids:
-                        if tid in group_into:
-                            group_into[tid].append(span)
-                    else:
-                        group_into.setdefault(tid, []).append(span)
+                    # Discard spans for traces outside this chunk (keeps the
+                    # unfiltered fallback scan bounded to one chunk's spans).
+                    if tid in group_into:
+                        group_into[tid].append(span)
 
                 if debug:
                     total_relevant = sum(len(v) for v in group_into.values())
@@ -624,63 +615,35 @@ def export_traces(
             """Fetch and group spans for the buffered chunk's traces.
 
             Instead of one POST /spans/search per trace (rate-limited to 30
-            req/min), paginate GET /spans bounded to the chunk's trace_id range
-            so the backend prunes by primary key.  Each span carries its
-            trace_id so we group client-side and discard spans for traces
-            outside this chunk.
+            req/min), paginate GET /spans and group each span client-side by its
+            trace_id, keeping only the traces in this chunk.
 
-            When the range filter can't be built (e.g. non-UUIDv7 ids) the
-            backend has to scan every span in the project; that unbounded scan is
-            done once and cached (``unbounded_spans_cache``) so later chunks reuse
-            it rather than re-scanning the whole project on every flush.
+            When the chunk's ids are UUIDv7 we bound the scan to their trace_id
+            range so the backend prunes by primary key.  When the range filter
+            can't be built (e.g. non-UUIDv7 ids) the backend has to stream back
+            every span in the project, but ``_scan_and_group_spans`` still
+            discards spans outside this chunk, so peak memory stays bounded to
+            one chunk's spans either way.  (That unfiltered scan runs per chunk
+            rather than once-and-cached: caching the whole-project span set to
+            avoid re-scanning would reintroduce the unbounded peak this chunked
+            export exists to prevent — bounded memory wins over scan count on
+            the rare non-UUIDv7 fallback.)
 
             Returns (spans_by_trace_id, chunk_had_errors).
             """
-            nonlocal unbounded_spans_cache
-
             spans_by_trace_id: dict[str, list] = {tid: [] for tid in traces_to_fetch}
-            chunk_had_errors = False
             if not traces_to_fetch:
-                return spans_by_trace_id, chunk_had_errors
+                return spans_by_trace_id, False
 
             if progress and task is not None:
                 progress.update(task, description="Fetching spans...")
 
-            if unbounded_spans_cache is None:
-                # Bound the span scan to the chunk's trace_id range so the backend
-                # prunes by primary key. Exactness is still guaranteed by the
-                # membership check in _scan_and_group_spans, so this only needs to
-                # be a superset of the chunk's trace_ids.
-                spans_filter = _spans_trace_id_range_filter(traces_to_fetch.keys())
-                if spans_filter is not None:
-                    chunk_had_errors = _scan_and_group_spans(
-                        spans_filter, spans_by_trace_id, only_known_ids=True
-                    )
-                    return spans_by_trace_id, chunk_had_errors
-
-                # No trace_id range filter could be built (e.g. non-UUIDv7 ids),
-                # so the backend must scan every span in the project. Scan into a
-                # local map and only publish it as the shared cache when the scan
-                # completes cleanly, so later chunks reuse a *complete* scan rather
-                # than a partially-populated one poisoned by a transient error.
-                scanned: dict[str, list] = {}
-                scan_had_errors = _scan_and_group_spans(
-                    None, scanned, only_known_ids=False
-                )
-                if scan_had_errors:
-                    # Use the partial result for this chunk (some spans beat none)
-                    # and flag the error, but leave the cache unpublished so the
-                    # next chunk retries the scan instead of reusing partial data.
-                    for tid in spans_by_trace_id:
-                        spans_by_trace_id[tid] = scanned.get(tid, [])
-                    return spans_by_trace_id, True
-                unbounded_spans_cache = scanned
-
-            # Serve this chunk from the cached (clean) full scan — built just now
-            # or by an earlier chunk.
-            for tid in spans_by_trace_id:
-                spans_by_trace_id[tid] = unbounded_spans_cache.get(tid, [])
-
+            # Bound the span scan to the chunk's trace_id range so the backend
+            # prunes by primary key; exactness is still guaranteed by the
+            # membership check in _scan_and_group_spans, so this only needs to be
+            # a superset of the chunk's trace_ids (None ⇒ unfiltered fallback).
+            spans_filter = _spans_trace_id_range_filter(traces_to_fetch.keys())
+            chunk_had_errors = _scan_and_group_spans(spans_filter, spans_by_trace_id)
             return spans_by_trace_id, chunk_had_errors
 
         def _write_chunk(spans_by_trace_id: dict[str, list]) -> tuple[int, bool]:

--- a/sdks/python/tests/unit/cli/test_export_project_rate_limiting.py
+++ b/sdks/python/tests/unit/cli/test_export_project_rate_limiting.py
@@ -83,6 +83,22 @@ def _make_full_page(n=500, offset=0):
     return _make_page([_make_mock_trace(f"bulk-{offset + i}") for i in range(n)])
 
 
+def _uuid7(n: int) -> str:
+    """Deterministic, valid UUIDv7 string for trace index *n*.
+
+    Version nibble is 7 and the variant nibble is RFC-4122 (8), so
+    ``uuid.UUID(...).version == 7`` — this is what makes the exporter build a
+    bounded ``trace_id`` range filter instead of falling back to a full scan.
+    """
+    high = f"{0x0190A1B2C3D4 + n:012x}"
+    return f"{high[:8]}-{high[8:12]}-7000-8000-{n:012x}"
+
+
+def _make_full_page_uuid7(n=500, offset=0):
+    """Like ``_make_full_page`` but with UUIDv7 trace ids (bounded-scan path)."""
+    return _make_page([_make_mock_trace(_uuid7(offset + i)) for i in range(n)])
+
+
 # ---------------------------------------------------------------------------
 # Retry wait behaviour — tested via export_traces (public API)
 # ---------------------------------------------------------------------------
@@ -382,11 +398,13 @@ class TestExportTracesChunking:
         """
         from opik.cli.exports.project import export_traces
 
-        page1 = _make_full_page(2, offset=0)
-        page2 = _make_full_page(2, offset=2)
-        page3 = _make_full_page(2, offset=4)
+        # UUIDv7 ids so each chunk builds a bounded trace_id range filter and
+        # scans spans per chunk (the common, memory-bounded path).
+        page1 = _make_full_page_uuid7(2, offset=0)
+        page2 = _make_full_page_uuid7(2, offset=2)
+        page3 = _make_full_page_uuid7(2, offset=4)
         mock_client = MagicMock()
-        expected_ids = [f"bulk-{i}" for i in range(6)]
+        expected_ids = [_uuid7(i) for i in range(6)]
 
         with tempfile.TemporaryDirectory() as tmp:
             project_dir = Path(tmp)
@@ -445,6 +463,67 @@ class TestExportTracesChunking:
         )
         assert files_on_disk_at_each_span_fetch[0] == 0
         assert files_on_disk_at_each_span_fetch[-1] > 0
+
+    def test_export_traces__non_uuid7_ids__unbounded_span_scan_runs_once(self):
+        """When trace ids aren't UUIDv7 the span scan can't be bounded by a
+        trace_id range, so the backend must scan every span in the project.
+
+        That expensive full scan must run once for the whole export and be
+        cached — not repeated on every chunk.  Per-chunk full scans turn a large
+        export into O(chunks × full-project-scan) and make it far more likely to
+        time out (the regression this guards against).
+        """
+        from opik.cli.exports.project import export_traces
+
+        # Non-UUIDv7 ids ("bulk-N") force the unbounded-scan fallback.
+        page1 = _make_full_page(2, offset=0)
+        page2 = _make_full_page(2, offset=2)
+        page3 = _make_full_page(2, offset=4)
+        mock_client = MagicMock()
+        expected_ids = [f"bulk-{i}" for i in range(6)]
+
+        span_page_requests = []
+
+        def span_fetch_side_effect(*args, **kwargs):
+            # Record every page the spans endpoint is asked for. With caching
+            # this fires only during the single full scan, not once per chunk.
+            span_page_requests.append(kwargs.get("page"))
+            return _make_page([])
+
+        mock_client.rest_client.traces.get_traces_by_project.side_effect = [
+            page1,
+            page2,
+            page3,
+            _make_page([]),
+        ]
+        mock_client.rest_client.spans.get_spans_by_project.side_effect = (
+            span_fetch_side_effect
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            with patch(f"{_MODULE}.time.sleep"):
+                exported, skipped, had_errors = export_traces(
+                    client=mock_client,
+                    project_name="proj",
+                    project_dir=project_dir,
+                    max_results=None,
+                    filter_string=None,
+                    show_progress=False,
+                    page_size=2,
+                )
+
+            assert (exported, skipped, had_errors) == (6, 0, False)
+            written_ids = sorted(
+                p.name[len("trace_") : -len(".json")]
+                for p in project_dir.glob("trace_*.json")
+            )
+            assert written_ids == sorted(expected_ids)
+
+        # Three chunks are flushed, but the unbounded project-wide scan happens
+        # exactly once (a single empty page here) and later chunks reuse the
+        # cache — not one full scan per chunk.
+        assert len(span_page_requests) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/sdks/python/tests/unit/cli/test_export_project_rate_limiting.py
+++ b/sdks/python/tests/unit/cli/test_export_project_rate_limiting.py
@@ -525,6 +525,70 @@ class TestExportTracesChunking:
         # cache — not one full scan per chunk.
         assert len(span_page_requests) == 1
 
+    def test_export_traces__unbounded_scan_errors__cache_not_poisoned_and_retried(self):
+        """A transient failure during the unbounded scan must not poison the
+        cache for the rest of the export.
+
+        The errored scan is left unpublished, so a later chunk retries the scan
+        (and can complete cleanly) instead of every remaining chunk silently
+        reusing a partially-populated result.
+
+        Failure is injected at the private ``_fetch_spans_page`` transport helper
+        (as the sibling span-failure test does): patching the public client
+        boundary would trigger the real 8-attempt retry decorator, making
+        controlled per-page failure injection impractical.
+        """
+        from opik.cli.exports.project import export_traces
+
+        # Non-UUIDv7 ids force the unbounded-scan fallback.
+        page1 = _make_full_page(2, offset=0)
+        page2 = _make_full_page(2, offset=2)
+        page3 = _make_full_page(2, offset=4)
+        mock_client = MagicMock()
+        mock_client.rest_client.traces.get_traces_by_project.side_effect = [
+            page1,
+            page2,
+            page3,
+            _make_page([]),
+        ]
+
+        # One "session" == one _scan_and_group_spans() pagination run, which
+        # always starts at page 1. The first chunk's scan fails every page (so it
+        # aborts after MAX_CONSECUTIVE_PAGE_FAILURES); later scans succeed.
+        scan_sessions = []
+
+        def span_fetch_side_effect(
+            client, project_name, page, page_size, parsed_filter=None
+        ):
+            if page == 1:
+                scan_sessions.append([])
+            scan_sessions[-1].append(page)
+            if len(scan_sessions) == 1:
+                raise ApiError(status_code=503)
+            return _make_page([])
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch(
+                f"{_MODULE}._fetch_spans_page", side_effect=span_fetch_side_effect
+            ):
+                with patch(f"{_MODULE}.time.sleep"):
+                    exported, skipped, had_errors = export_traces(
+                        client=mock_client,
+                        project_name="proj",
+                        project_dir=Path(tmp),
+                        max_results=None,
+                        filter_string=None,
+                        show_progress=False,
+                        page_size=2,
+                    )
+
+        # All traces still written; the failed scan is flagged.
+        assert (exported, skipped) == (6, 0)
+        assert had_errors is True
+        # The failed scan was not cached, so a later chunk retried it (a second
+        # session). That retry succeeded and was cached, so no third session.
+        assert len(scan_sessions) == 2
+
 
 # ---------------------------------------------------------------------------
 # export_traces — inter-page delay

--- a/sdks/python/tests/unit/cli/test_export_project_rate_limiting.py
+++ b/sdks/python/tests/unit/cli/test_export_project_rate_limiting.py
@@ -365,14 +365,20 @@ class TestExportTracesSpanFetchFailures:
 
 class TestExportTracesChunking:
     def test_export_traces__large_project_flushes_in_bounded_chunks(self):
-        """Traces are span-fetched and written incrementally, one bounded chunk
-        at a time, instead of buffering every trace and span before the first
-        write.  This is what keeps peak memory from scaling with the whole
-        project (the previous all-at-once design OOM'd on large projects).
+        """A multi-page export writes traces incrementally, one bounded chunk at
+        a time, instead of buffering every trace and span before the first write.
+        Incremental flushing is what keeps peak memory from scaling with the
+        whole project (the previous all-at-once design OOM'd on large projects).
 
-        With page_size=2 (so chunk_target=2) and three full pages, the flush
-        runs once per page: each chunk's span fetch must see the *prior*
-        chunks' trace files already written to disk.
+        The export is driven purely through the public ``export_traces`` API,
+        mocking only the public REST client boundary
+        (``traces.get_traces_by_project`` / ``spans.get_spans_by_project``) — no
+        private helpers are patched.  Correctness is asserted on the returned
+        tuple and the final ``trace_*.json`` artifacts.  The bounded-chunk
+        property is asserted through robust invariants observed at the public
+        span endpoint (files already on disk when each span fetch fires), not a
+        brittle exact-call-order snapshot: the assertions hold regardless of the
+        exact chunk boundary the implementation picks.
         """
         from opik.cli.exports.project import export_traces
 
@@ -380,43 +386,65 @@ class TestExportTracesChunking:
         page2 = _make_full_page(2, offset=2)
         page3 = _make_full_page(2, offset=4)
         mock_client = MagicMock()
+        expected_ids = [f"bulk-{i}" for i in range(6)]
 
         with tempfile.TemporaryDirectory() as tmp:
             project_dir = Path(tmp)
             files_on_disk_at_each_span_fetch = []
 
             def span_fetch_side_effect(*args, **kwargs):
-                # How many trace files already exist when this chunk's span
-                # fetch begins — proves earlier chunks were flushed to disk.
+                # How many trace files already exist when a span fetch begins.
+                # A growing, sub-total count proves earlier chunks were flushed
+                # to disk before later chunks are processed (incremental), rather
+                # than one all-at-once sweep after buffering everything.
                 files_on_disk_at_each_span_fetch.append(
                     len(list(project_dir.glob("trace_*.json")))
                 )
                 return _make_page([])
 
-            with patch(f"{_MODULE}._fetch_traces_page") as mock_fetch:
-                mock_fetch.side_effect = [page1, page2, page3, _make_page([])]
-                with patch(
-                    f"{_MODULE}._fetch_spans_page",
-                    side_effect=span_fetch_side_effect,
-                ):
-                    with patch(f"{_MODULE}.time.sleep"):
-                        exported, skipped, had_errors = export_traces(
-                            client=mock_client,
-                            project_name="proj",
-                            project_dir=project_dir,
-                            max_results=None,
-                            filter_string=None,
-                            show_progress=False,
-                            page_size=2,
-                        )
+            mock_client.rest_client.traces.get_traces_by_project.side_effect = [
+                page1,
+                page2,
+                page3,
+                _make_page([]),
+            ]
+            mock_client.rest_client.spans.get_spans_by_project.side_effect = (
+                span_fetch_side_effect
+            )
 
-        assert exported == 6
-        assert had_errors is False
-        # One span-fetch session per chunk — three chunks, not one giant sweep.
-        assert len(files_on_disk_at_each_span_fetch) == 3
-        # Incremental: each chunk sees the prior chunks' files already on disk,
-        # so at most one chunk's worth of traces is held in memory at a time.
-        assert files_on_disk_at_each_span_fetch == [0, 2, 4]
+            with patch(f"{_MODULE}.time.sleep"):
+                exported, skipped, had_errors = export_traces(
+                    client=mock_client,
+                    project_name="proj",
+                    project_dir=project_dir,
+                    max_results=None,
+                    filter_string=None,
+                    show_progress=False,
+                    page_size=2,
+                )
+
+            # Public result contract.
+            assert (exported, skipped, had_errors) == (6, 0, False)
+
+            # Final artifacts: exactly the six expected trace files were written.
+            written_ids = sorted(
+                p.name[len("trace_") : -len(".json")]
+                for p in project_dir.glob("trace_*.json")
+            )
+            assert written_ids == sorted(expected_ids)
+
+        # Bounded-chunk invariants (robust to the exact chunk boundary):
+        #  - more than one span-fetch session → work is chunked, not one sweep;
+        #  - counts never decrease → files accumulate as chunks flush;
+        #  - a later fetch sees files already written → earlier chunks were
+        #    flushed to disk before the last chunk was processed, so only ~one
+        #    chunk's worth of traces is held in memory at a time.
+        assert len(files_on_disk_at_each_span_fetch) > 1
+        assert files_on_disk_at_each_span_fetch == sorted(
+            files_on_disk_at_each_span_fetch
+        )
+        assert files_on_disk_at_each_span_fetch[0] == 0
+        assert files_on_disk_at_each_span_fetch[-1] > 0
 
 
 # ---------------------------------------------------------------------------

--- a/sdks/python/tests/unit/cli/test_export_project_rate_limiting.py
+++ b/sdks/python/tests/unit/cli/test_export_project_rate_limiting.py
@@ -464,30 +464,34 @@ class TestExportTracesChunking:
         assert files_on_disk_at_each_span_fetch[0] == 0
         assert files_on_disk_at_each_span_fetch[-1] > 0
 
-    def test_export_traces__non_uuid7_ids__unbounded_span_scan_runs_once(self):
+    def test_export_traces__non_uuid7_ids__span_scan_bounded_per_chunk(self):
         """When trace ids aren't UUIDv7 the span scan can't be bounded by a
-        trace_id range, so the backend must scan every span in the project.
+        trace_id range, so the backend streams back every span in the project.
 
-        That expensive full scan must run once for the whole export and be
-        cached — not repeated on every chunk.  Per-chunk full scans turn a large
-        export into O(chunks × full-project-scan) and make it far more likely to
-        time out (the regression this guards against).
+        Rather than cache that whole-project span set — which would reintroduce
+        the unbounded memory peak this chunked export exists to prevent — each
+        chunk runs its own scan and keeps only its own traces' spans.  Peak
+        memory therefore stays bounded to one chunk regardless of project size;
+        the trade-off is one unfiltered scan per chunk on this rare fallback.
         """
         from opik.cli.exports.project import export_traces
 
-        # Non-UUIDv7 ids ("bulk-N") force the unbounded-scan fallback.
+        # Non-UUIDv7 ids ("bulk-N") force the unfiltered-scan fallback.
         page1 = _make_full_page(2, offset=0)
         page2 = _make_full_page(2, offset=2)
         page3 = _make_full_page(2, offset=4)
         mock_client = MagicMock()
         expected_ids = [f"bulk-{i}" for i in range(6)]
 
-        span_page_requests = []
+        # Each per-chunk scan pages GET /spans starting at page 1; a fresh page-1
+        # request marks a new scan session.
+        scan_sessions = []
 
         def span_fetch_side_effect(*args, **kwargs):
-            # Record every page the spans endpoint is asked for. With caching
-            # this fires only during the single full scan, not once per chunk.
-            span_page_requests.append(kwargs.get("page"))
+            page = kwargs.get("page")
+            if page == 1:
+                scan_sessions.append([])
+            scan_sessions[-1].append(page)
             return _make_page([])
 
         mock_client.rest_client.traces.get_traces_by_project.side_effect = [
@@ -520,74 +524,72 @@ class TestExportTracesChunking:
             )
             assert written_ids == sorted(expected_ids)
 
-        # Three chunks are flushed, but the unbounded project-wide scan happens
-        # exactly once (a single empty page here) and later chunks reuse the
-        # cache — not one full scan per chunk.
-        assert len(span_page_requests) == 1
+        # One unfiltered scan per flushed chunk (3) — not a single cached
+        # whole-project scan — which is what keeps peak memory bounded to a chunk.
+        assert len(scan_sessions) == 3
 
-    def test_export_traces__unbounded_scan_errors__cache_not_poisoned_and_retried(self):
-        """A transient failure during the unbounded scan must not poison the
-        cache for the rest of the export.
+    def test_export_traces__span_scan_error_isolated_to_its_chunk(self):
+        """A transient span-scan failure is confined to the chunk that hit it.
 
-        The errored scan is left unpublished, so a later chunk retries the scan
-        (and can complete cleanly) instead of every remaining chunk silently
-        reusing a partially-populated result.
-
-        Failure is injected at the private ``_fetch_spans_page`` transport helper
-        (as the sibling span-failure test does): patching the public client
-        boundary would trigger the real 8-attempt retry decorator, making
-        controlled per-page failure injection impractical.
+        With per-chunk scanning there is no shared span cache to poison: the
+        failed chunk is exported with partial spans and had_errors is set, while
+        later chunks scan independently and export normally.  The failure is
+        injected at the public REST boundary (``spans.get_spans_by_project``),
+        per the SDK testing guidelines, not at a private transport helper.
         """
         from opik.cli.exports.project import export_traces
 
-        # Non-UUIDv7 ids force the unbounded-scan fallback.
+        # Non-UUIDv7 ids force the unfiltered per-chunk scan fallback.
         page1 = _make_full_page(2, offset=0)
         page2 = _make_full_page(2, offset=2)
         page3 = _make_full_page(2, offset=4)
         mock_client = MagicMock()
-        mock_client.rest_client.traces.get_traces_by_project.side_effect = [
-            page1,
-            page2,
-            page3,
-            _make_page([]),
-        ]
-
-        # One "session" == one _scan_and_group_spans() pagination run, which
-        # always starts at page 1. The first chunk's scan fails every page (so it
-        # aborts after MAX_CONSECUTIVE_PAGE_FAILURES); later scans succeed.
-        scan_sessions = []
-
-        def span_fetch_side_effect(
-            client, project_name, page, page_size, parsed_filter=None
-        ):
-            if page == 1:
-                scan_sessions.append([])
-            scan_sessions[-1].append(page)
-            if len(scan_sessions) == 1:
-                raise ApiError(status_code=503)
-            return _make_page([])
+        expected_ids = [f"bulk-{i}" for i in range(6)]
 
         with tempfile.TemporaryDirectory() as tmp:
-            with patch(
-                f"{_MODULE}._fetch_spans_page", side_effect=span_fetch_side_effect
-            ):
+            project_dir = Path(tmp)
+
+            def get_spans_side_effect(*args, **kwargs):
+                # Fail every span page while the first chunk is being scanned
+                # (nothing flushed yet); once earlier chunks have written their
+                # files, succeed — proving the error didn't leak across chunks.
+                if not any(project_dir.glob("trace_*.json")):
+                    raise ApiError(status_code=503)
+                return _make_page([])
+
+            mock_client.rest_client.traces.get_traces_by_project.side_effect = [
+                page1,
+                page2,
+                page3,
+                _make_page([]),
+            ]
+            mock_client.rest_client.spans.get_spans_by_project.side_effect = (
+                get_spans_side_effect
+            )
+
+            # Neutralise the retry decorator's sleep (public boundary triggers
+            # the real 8-attempt retry) and the inter-page delay.
+            with patch(f"{_MODULE}._fetch_spans_page.retry.sleep"):
                 with patch(f"{_MODULE}.time.sleep"):
                     exported, skipped, had_errors = export_traces(
                         client=mock_client,
                         project_name="proj",
-                        project_dir=Path(tmp),
+                        project_dir=project_dir,
                         max_results=None,
                         filter_string=None,
                         show_progress=False,
                         page_size=2,
                     )
 
-        # All traces still written; the failed scan is flagged.
-        assert (exported, skipped) == (6, 0)
-        assert had_errors is True
-        # The failed scan was not cached, so a later chunk retried it (a second
-        # session). That retry succeeded and was cached, so no third session.
-        assert len(scan_sessions) == 2
+            # The failed chunk still wrote its traces (with partial spans) and the
+            # failure is flagged; later chunks were unaffected, so all 6 landed.
+            assert (exported, skipped) == (6, 0)
+            assert had_errors is True
+            written_ids = sorted(
+                p.name[len("trace_") : -len(".json")]
+                for p in project_dir.glob("trace_*.json")
+            )
+            assert written_ids == sorted(expected_ids)
 
 
 # ---------------------------------------------------------------------------

--- a/sdks/python/tests/unit/cli/test_export_project_rate_limiting.py
+++ b/sdks/python/tests/unit/cli/test_export_project_rate_limiting.py
@@ -359,6 +359,67 @@ class TestExportTracesSpanFetchFailures:
 
 
 # ---------------------------------------------------------------------------
+# export_traces — bounded-chunk (memory) behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestExportTracesChunking:
+    def test_export_traces__large_project_flushes_in_bounded_chunks(self):
+        """Traces are span-fetched and written incrementally, one bounded chunk
+        at a time, instead of buffering every trace and span before the first
+        write.  This is what keeps peak memory from scaling with the whole
+        project (the previous all-at-once design OOM'd on large projects).
+
+        With page_size=2 (so chunk_target=2) and three full pages, the flush
+        runs once per page: each chunk's span fetch must see the *prior*
+        chunks' trace files already written to disk.
+        """
+        from opik.cli.exports.project import export_traces
+
+        page1 = _make_full_page(2, offset=0)
+        page2 = _make_full_page(2, offset=2)
+        page3 = _make_full_page(2, offset=4)
+        mock_client = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            files_on_disk_at_each_span_fetch = []
+
+            def span_fetch_side_effect(*args, **kwargs):
+                # How many trace files already exist when this chunk's span
+                # fetch begins — proves earlier chunks were flushed to disk.
+                files_on_disk_at_each_span_fetch.append(
+                    len(list(project_dir.glob("trace_*.json")))
+                )
+                return _make_page([])
+
+            with patch(f"{_MODULE}._fetch_traces_page") as mock_fetch:
+                mock_fetch.side_effect = [page1, page2, page3, _make_page([])]
+                with patch(
+                    f"{_MODULE}._fetch_spans_page",
+                    side_effect=span_fetch_side_effect,
+                ):
+                    with patch(f"{_MODULE}.time.sleep"):
+                        exported, skipped, had_errors = export_traces(
+                            client=mock_client,
+                            project_name="proj",
+                            project_dir=project_dir,
+                            max_results=None,
+                            filter_string=None,
+                            show_progress=False,
+                            page_size=2,
+                        )
+
+        assert exported == 6
+        assert had_errors is False
+        # One span-fetch session per chunk — three chunks, not one giant sweep.
+        assert len(files_on_disk_at_each_span_fetch) == 3
+        # Incremental: each chunk sees the prior chunks' files already on disk,
+        # so at most one chunk's worth of traces is held in memory at a time.
+        assert files_on_disk_at_each_span_fetch == [0, 2, 4]
+
+
+# ---------------------------------------------------------------------------
 # export_traces — inter-page delay
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Details

`opik export ... all` (and `export ... traces`) OOM'd on large projects because `export_traces()` buffered **every** trace and **every** span in the project in memory before writing a single file (collect-all-traces → collect-all-spans → write-all). This reworks it into a bounded-chunk stream: page through the trace list until `chunk_target` (= `page_size`) traces need downloading, fetch their spans, write them, then discard and continue. Peak memory is now proportional to one chunk instead of the whole project.

- Chunk size tracks `page_size`, so the existing `--page-size` knob now genuinely trades memory against round-trips (no new flag).
- Per-chunk span fetch keeps the `trace_id`-range primary-key pruning: traces come back `id DESC` (UUIDv7 ≈ time order) and spans `trace_id DESC`, so chunks are contiguous and ranges tile with near-zero overlap.
- Each flushed chunk is persisted to the manifest before the next starts, so an interrupted export resumes mid-project instead of losing everything.
- Public contract unchanged: `export_traces()` still returns `(exported, skipped, had_errors)`; callers (`export_single_project`, `export_all`) untouched. Fast-path skip, incremental `created_at` filter, page/span failure handling, attachments, `--force`, and CSV/JSON all preserved.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7291

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8 (1M context)
  - Scope: Refactor of `export_traces()` in `sdks/python/src/opik/cli/exports/project.py` and a new regression test.
  - Human verification: Author reviewed the diff, confirmed the backend sort order that makes per-chunk span pruning efficient, and ran the test/lint/type-check suite below.

## Testing

Run from `sdks/python`:
- `python -m pytest tests/unit/cli/` — 418 passed (includes existing span-fetch/page-failure suites that now exercise the new nested helpers).
- Added `TestExportTracesChunking::test_export_traces__large_project_flushes_in_bounded_chunks` — asserts traces are flushed to disk incrementally (each chunk's span fetch sees prior chunks' files already written: `[0, 2, 4]`), proving only one chunk is held in memory at a time.
- `ruff format` / `ruff check` — clean.
- `python -m mypy src/opik/cli/exports/project.py` — Success, no issues.

Not run: full e2e export suite against a live backend (unit coverage exercises the pagination/flush control flow with mocked clients).

## Documentation

N/A — internal memory/behavior change; the `--page-size` help text already describes the memory/round-trip trade-off that now holds.