### PR TITLE
[OPIK-7293] [GHA] feat: auto-label PRs by size + surface size in Slack review commands

### DIFF
--- a/.agents/commands/comet/generate-code-review-slack-command.md
+++ b/.agents/commands/comet/generate-code-review-slack-command.md
@@ -85,6 +85,12 @@ This workflow will:
   - If found, store the status (e.g., "Baz approved: ✅" or "Baz status: pending")
   - If not found or unavailable, skip this field (it's optional)
 
+- **Extract PR size**:
+  - The `📏 Auto Label PR Size` workflow applies one size label to every PR. Read the PR labels and look for a `size/*` label: `🔵 size/XS`, `🟢 size/S`, `🟡 size/M`, `🟠 size/L`, or `🔴 size/XL`.
+  - Store the bucket as `{emoji} {BUCKET}` (e.g. `🟠 L`) — just the bucket, no line counts.
+  - If no size label is present yet (the workflow may not have run), derive the bucket from the PR's changed lines (`additions + deletions`, ignoring lockfiles/generated clients): XS < 20, S 20–100, M 101–300, L 301–600, XL > 600 — and still store only `{emoji} {BUCKET}`.
+  - GitHub is the source of truth; the size at message-publish time is good enough (PRs rarely change bucket after review starts).
+
 - **Extract test environment link from PR description and comments**:
   - First, search PR comments for test environment deployment messages (look for "Test environment is now available!" or similar)
   - When fetching PR comments via `gh api`, **always** use `--paginate` to ensure all results are fetched:
@@ -153,6 +159,7 @@ This workflow will:
   
   :jira_epic: jira link: {{Jira_URL}}
   :github: pr link: {{PR_link}}
+  :straight_ruler: pr size: {{pr_size}}
   :test_tube: test env link: {{test_env}}
   {{baz_approved_status_if_available}}
   :react: fe summary (optional): {{description_in_one_line}}
@@ -166,6 +173,7 @@ This workflow will:
   - **User customization**: If user provided customization text in Step 4, include it after the greeting (before the structured fields)
   - **Jira link**: Include full Jira URL with ticket (e.g., `https://comet-ml.atlassian.net/browse/OPIK-1234`)
   - **PR link**: Include GitHub PR URL
+  - **PR size**: Include the size bucket extracted in Step 3 (e.g., `🟠 L`). Always included — size is always available from GitHub.
   - **Test env link**: Include test environment URL
   - **Baz approved status**: Only include if extracted from PR status checks (optional field)
   - **Component summaries**: Only include optional fields that were provided (skip empty ones)
@@ -178,6 +186,7 @@ This workflow will:
   
   :jira_epic: jira link: https://comet-ml.atlassian.net/browse/OPIK-1234
   :github: pr link: https://github.com/comet-ml/opik/pull/1234
+  :straight_ruler: pr size: 🟠 L
   :test_tube: test env link: https://test.opik.com
   :react: fe summary (optional): Added new metrics dashboard UI
   :java: be summary (optional): Implemented metrics aggregation endpoint
@@ -281,6 +290,7 @@ cursor generate-code-review-slack-command
 # 1. Find PR for current branch: https://github.com/comet-ml/opik/pull/1234
 # 2. Extract Jira ticket from PR title: [OPIK-1234] [FE] feat(api): add metrics dashboard
 # 3. Extract test env from PR comments or description: https://pr-1234.dev.comet.com (from PR comments or Testing section)
+#    Extract PR size from the size/* label (or additions+deletions): 🟠 L
 # 4. Extract summaries from PR description:
 #    - FE: Added new metrics dashboard UI (from Details section)
 #    - BE: Implemented metrics aggregation endpoint (from Details section)
@@ -308,6 +318,7 @@ cursor generate-code-review-slack-command
 # 
 # :jira_epic: jira link: https://comet-ml.atlassian.net/browse/OPIK-1234
 # :github: pr link: https://github.com/comet-ml/opik/pull/1234
+# :straight_ruler: pr size: 🟠 L
 # :test_tube: test env link: https://test.opik.com
 # :react: fe summary (optional): Added new metrics dashboard UI
 # :java: be summary (optional): Implemented metrics aggregation endpoint

--- a/.agents/commands/comet/generate-code-review-slack-command.md
+++ b/.agents/commands/comet/generate-code-review-slack-command.md
@@ -85,11 +85,7 @@ This workflow will:
   - If found, store the status (e.g., "Baz approved: ✅" or "Baz status: pending")
   - If not found or unavailable, skip this field (it's optional)
 
-- **Extract PR size**:
-  - The `📏 Auto Label PR Size` workflow applies one size label to every PR. Read the PR labels and look for a `size/*` label: `🔵 size/XS`, `🟢 size/S`, `🟡 size/M`, `🟠 size/L`, or `🔴 size/XL`.
-  - Store the bucket as `{emoji} {BUCKET}` (e.g. `🟠 L`) — just the bucket, no line counts.
-  - If no size label is present yet (the workflow may not have run), derive the bucket from the PR's changed lines (`additions + deletions`, ignoring lockfiles/generated clients): XS < 20, S 20–100, M 101–300, L 301–600, XL > 600 — and still store only `{emoji} {BUCKET}`.
-  - GitHub is the source of truth; the size at message-publish time is good enough (PRs rarely change bucket after review starts).
+- **Extract PR size**: Follow the shared steps in `.agents/docs/PR_SIZE_EXTRACTION.md` (read the `size/*` label; fall back to changed lines using the workflow's own ignore list + thresholds). Store the bucket as `{emoji} {BUCKET}` (e.g. `🟠 L`).
 
 - **Extract test environment link from PR description and comments**:
   - First, search PR comments for test environment deployment messages (look for "Test environment is now available!" or similar)

--- a/.agents/commands/comet/send-code-review-slack.md
+++ b/.agents/commands/comet/send-code-review-slack.md
@@ -96,11 +96,7 @@ This workflow will:
   - If found, store the status (e.g., "Baz approved: ✅" or "Baz status: pending")
   - If not found or unavailable, skip this field (it\'s optional)
 
-- **Extract PR size**:
-  - The `📏 Auto Label PR Size` workflow applies one size label to every PR. Read the PR labels and look for a `size/*` label: `🔵 size/XS`, `🟢 size/S`, `🟡 size/M`, `🟠 size/L`, or `🔴 size/XL`.
-  - Store the bucket as `{emoji} {BUCKET}` (e.g. `🟠 L`) — just the bucket, no line counts.
-  - If no size label is present yet (the workflow may not have run), derive the bucket from the PR\'s changed lines (`additions + deletions`, ignoring lockfiles/generated clients): XS < 20, S 20–100, M 101–300, L 301–600, XL > 600 — and still store only `{emoji} {BUCKET}`.
-  - GitHub is the source of truth; the size at message-publish time is good enough (PRs rarely change bucket after review starts).
+- **Extract PR size**: Follow the shared steps in `.agents/docs/PR_SIZE_EXTRACTION.md` (read the `size/*` label; fall back to changed lines using the workflow's own ignore list + thresholds). Store the bucket as `{emoji} {BUCKET}` (e.g. `🟠 L`).
 
 - **Extract test environment link from PR description and comments**:
   - First, search PR comments for test environment deployment messages (look for "Test environment is now available!" or similar)

--- a/.agents/commands/comet/send-code-review-slack.md
+++ b/.agents/commands/comet/send-code-review-slack.md
@@ -96,6 +96,12 @@ This workflow will:
   - If found, store the status (e.g., "Baz approved: ✅" or "Baz status: pending")
   - If not found or unavailable, skip this field (it\'s optional)
 
+- **Extract PR size**:
+  - The `📏 Auto Label PR Size` workflow applies one size label to every PR. Read the PR labels and look for a `size/*` label: `🔵 size/XS`, `🟢 size/S`, `🟡 size/M`, `🟠 size/L`, or `🔴 size/XL`.
+  - Store the bucket as `{emoji} {BUCKET}` (e.g. `🟠 L`) — just the bucket, no line counts.
+  - If no size label is present yet (the workflow may not have run), derive the bucket from the PR\'s changed lines (`additions + deletions`, ignoring lockfiles/generated clients): XS < 20, S 20–100, M 101–300, L 301–600, XL > 600 — and still store only `{emoji} {BUCKET}`.
+  - GitHub is the source of truth; the size at message-publish time is good enough (PRs rarely change bucket after review starts).
+
 - **Extract test environment link from PR description and comments**:
   - First, search PR comments for test environment deployment messages (look for "Test environment is now available!" or similar)
   - When fetching PR comments via `gh api`, **always** use `--paginate` to ensure all results are fetched:
@@ -164,6 +170,7 @@ This workflow will:
   
   :jira_epic: jira link: {{Jira_URL}}
   :github: pr link: {{PR_link}}
+  :straight_ruler: pr size: {{pr_size}}
   :test_tube: test env link: {{test_env}}
   {{baz_approved_status_if_available}}
   :react: fe summary (optional): {{description_in_one_line}}
@@ -177,6 +184,7 @@ This workflow will:
   - **User customization**: If user provided customization text in Step 4, include it after the greeting (before the structured fields)
   - **Jira link**: Include full Jira URL with ticket (e.g., `https://comet-ml.atlassian.net/browse/OPIK-1234`)
   - **PR link**: Include GitHub PR URL
+  - **PR size**: Include the size bucket extracted in Step 3 (e.g., `🟠 L`). Always included — size is always available from GitHub.
   - **Test env link**: Include test environment URL
   - **Baz approved status**: Only include if extracted from PR status checks (optional field)
   - **Component summaries**: Only include optional fields that were provided (skip empty ones)
@@ -190,6 +198,7 @@ This workflow will:
   
   :jira_epic: jira link: https://comet-ml.atlassian.net/browse/OPIK-1234
   :github: pr link: https://github.com/comet-ml/opik/pull/1234
+  :straight_ruler: pr size: 🟠 L
   :test_tube: test env link: https://test.opik.com
   :react: fe summary (optional): Added new metrics dashboard UI
   :java: be summary (optional): Implemented metrics aggregation endpoint
@@ -349,6 +358,7 @@ cursor send-code-review-slack
 # 1. Find PR for current branch: https://github.com/comet-ml/opik/pull/1234
 # 2. Extract Jira ticket from PR title: [OPIK-1234] [BE] feat(api): add metrics dashboard
 # 3. Extract test env from PR comments or description: https://pr-1234.dev.comet.com (from PR comments or Testing section)
+#    Extract PR size from the size/* label (or additions+deletions): 🟠 L
 # 4. Extract summaries from PR description:
 #    - FE: Added new metrics dashboard UI (from Details section)
 #    - BE: Implemented metrics aggregation endpoint (from Details section)
@@ -364,6 +374,7 @@ cursor send-code-review-slack
 # Message sent:
 # :jira_epic: jira link: https://comet-ml.atlassian.net/browse/OPIK-1234
 # :github: pr link: https://github.com/comet-ml/opik/pull/1234
+# :straight_ruler: pr size: 🟠 L
 # :test_tube: test env link: https://test.opik.com
 # :react: fe summary (optional): Added new metrics dashboard UI
 # :java: be summary (optional): Implemented metrics aggregation endpoint

--- a/.agents/docs/PR_SIZE_EXTRACTION.md
+++ b/.agents/docs/PR_SIZE_EXTRACTION.md
@@ -1,0 +1,36 @@
+# Extract PR size (shared)
+
+Shared logic for the code-review Slack commands (`send-code-review-slack`,
+`generate-code-review-slack-command`) to derive the PR-size field. Kept in one
+place so the two commands can't drift.
+
+## How to extract
+
+1. The `📏 Auto Label PR Size` workflow (`.github/workflows/pr-size-labeler.yml`)
+   applies exactly one size label to every PR. Read the PR labels and look for a
+   `size/*` label: `🔵 size/XS`, `🟢 size/S`, `🟡 size/M`, `🟠 size/L`, or
+   `🔴 size/XL`.
+2. Store the bucket as `{emoji} {BUCKET}` (e.g. `🟠 L`) — just the bucket, no
+   line counts.
+3. **Fallback** (only if no `size/*` label is present yet — the workflow may not
+   have run): derive the bucket from the PR's changed lines
+   (`additions + deletions`), applying **the same ignore list and thresholds as
+   the workflow** so the fallback can't land in a different bucket than the
+   labeler. The workflow (`.github/workflows/pr-size-labeler.yml`) is the single
+   source of truth for both:
+   - **Ignore list** — read `IGNORE_GLOBS` in the workflow (lockfiles, generated
+     REST clients under `sdks/*/src/opik/rest_api/**`, and snapshot/image files).
+     Do not re-list the globs here; they would drift.
+   - **Thresholds** — read `BUCKETS` in the workflow: XS `< 20`, S `20–100`,
+     M `101–300`, L `301–600`, XL `> 600`.
+   Store the result as `{emoji} {BUCKET}`.
+4. GitHub is the source of truth; the size at message-publish time is good enough
+   (PRs rarely change bucket after review starts).
+
+## Message field
+
+Include a size line in the message template, bucket only (no `+/-` counts):
+
+```
+:straight_ruler: pr size: {{pr_size}}
+```

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,0 +1,138 @@
+name: 📏 Auto Label PR Size
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  size-labeler:
+    name: Label PR by size
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Compute size and apply label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const prNumber = pr.number;
+
+            // Cool -> hot ramp (blue = smallest, red = largest). Traffic-light color lives
+            // on the GitHub label; the emoji makes size obvious at a glance in the label list.
+            // maxSize is the inclusive upper bound of changed LOC (additions + deletions) for
+            // the bucket; the last entry (null) catches everything above it.
+            const BUCKETS = [
+              { name: "🔵 size/XS", color: "1d76db", maxSize: 19 },
+              { name: "🟢 size/S", color: "0e8a16", maxSize: 100 },
+              { name: "🟡 size/M", color: "fbca04", maxSize: 300 },
+              { name: "🟠 size/L", color: "d93f0b", maxSize: 600 },
+              { name: "🔴 size/XL", color: "b60205", maxSize: null },
+            ];
+            const MANAGED_LABELS = BUCKETS.map((b) => b.name);
+
+            // Lockfiles and generated clients dwarf the human-reviewed diff, so exclude them
+            // from the count — otherwise a lockfile bump mislabels a tiny PR as XL.
+            const IGNORE_GLOBS = [
+              "**/package-lock.json",
+              "**/yarn.lock",
+              "**/pnpm-lock.yaml",
+              "**/poetry.lock",
+              "**/uv.lock",
+              "sdks/python/src/opik/rest_api/**",
+              "sdks/typescript/src/opik/rest_api/**",
+              "**/*.snap",
+              "**/*.svg",
+              "**/*.png",
+            ];
+            const globToRegExp = (glob) => {
+              let re = "";
+              for (let i = 0; i < glob.length; i++) {
+                if (glob.startsWith("**/", i)) { re += "(?:[^/]+/)*"; i += 2; continue; }
+                if (glob.startsWith("**", i)) { re += ".*"; i += 1; continue; }
+                const c = glob[i];
+                if (c === "*") { re += "[^/]*"; continue; }
+                if (".+^${}()|[]\\".includes(c)) { re += "\\" + c; continue; }
+                re += c;
+              }
+              return new RegExp("^" + re + "$");
+            };
+            const ignoreRes = IGNORE_GLOBS.map(globToRegExp);
+            const isIgnored = (path) => ignoreRes.some((re) => re.test(path));
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
+
+            const total = files
+              .filter((f) => !isIgnored(f.filename))
+              .reduce((sum, f) => sum + f.additions + f.deletions, 0);
+
+            const bucket =
+              BUCKETS.find((b) => b.maxSize !== null && total <= b.maxSize) ||
+              BUCKETS[BUCKETS.length - 1];
+            core.info(`PR #${prNumber}: ${total} changed LOC (excluding ignored files) -> ${bucket.name}`);
+
+            // Keep the label's color/emoji authoritative regardless of how it was first created.
+            try {
+              const { data: existing } = await github.rest.issues.getLabel({
+                owner,
+                repo,
+                name: bucket.name,
+              });
+              if (existing.color !== bucket.color) {
+                await github.rest.issues.updateLabel({
+                  owner,
+                  repo,
+                  name: bucket.name,
+                  color: bucket.color,
+                });
+              }
+            } catch (err) {
+              if (err.status !== 404) throw err;
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: bucket.name,
+                color: bucket.color,
+              });
+            }
+
+            const current = pr.labels.map((l) => l.name);
+
+            for (const stale of current.filter(
+              (name) => MANAGED_LABELS.includes(name) && name !== bucket.name
+            )) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  name: stale,
+                });
+              } catch (err) {
+                if (err.status !== 404) throw err;
+              }
+            }
+
+            if (!current.includes(bucket.name)) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: [bucket.name],
+              });
+            }

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -3,11 +3,6 @@ name: 📏 Auto Label PR Size
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
-  # TEMP(OPIK-7293): prove the labeler on its own introducing PR. pull_request_target
-  # runs the base-branch copy (main), which lacks this file, so it can't run here yet.
-  # Same-repo PR => pull_request still gets a write token. REVERT before merge.
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
 
 
 concurrency:

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -3,6 +3,11 @@ name: 📏 Auto Label PR Size
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
+  # TEMP(OPIK-7293): prove the labeler on its own introducing PR. pull_request_target
+  # runs the base-branch copy (main), which lacks this file, so it can't run here yet.
+  # Same-repo PR => pull_request still gets a write token. REVERT before merge.
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
 
 
 concurrency:

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -28,16 +28,19 @@ jobs:
             const pr = context.payload.pull_request;
             const prNumber = pr.number;
 
-            // Cool -> hot ramp (blue = smallest, red = largest). Traffic-light color lives
-            // on the GitHub label; the emoji makes size obvious at a glance in the label list.
+            // Uniform charcoal chip for every size label so the size metadata reads as one
+            // recessive family and doesn't compete with semantic labels (bug, Frontend, …) on
+            // a busy PR list. The cool -> hot ramp lives entirely in the per-bucket emoji
+            // (🔵 smallest -> 🔴 largest), which keeps its crisp shape on a neutral background.
             // maxSize is the inclusive upper bound of changed LOC (additions + deletions) for
             // the bucket; the last entry (null) catches everything above it.
+            const CHIP_COLOR = "2d3139";
             const BUCKETS = [
-              { name: "🔵 size/XS", color: "1d76db", maxSize: 19 },
-              { name: "🟢 size/S", color: "0e8a16", maxSize: 100 },
-              { name: "🟡 size/M", color: "fbca04", maxSize: 300 },
-              { name: "🟠 size/L", color: "d93f0b", maxSize: 600 },
-              { name: "🔴 size/XL", color: "b60205", maxSize: null },
+              { name: "🔵 size/XS", color: CHIP_COLOR, maxSize: 19 },
+              { name: "🟢 size/S", color: CHIP_COLOR, maxSize: 100 },
+              { name: "🟡 size/M", color: CHIP_COLOR, maxSize: 300 },
+              { name: "🟠 size/L", color: CHIP_COLOR, maxSize: 600 },
+              { name: "🔴 size/XL", color: CHIP_COLOR, maxSize: null },
             ];
             const MANAGED_LABELS = BUCKETS.map((b) => b.name);
 


### PR DESCRIPTION
## Details

<img width="737" height="786" alt="image" src="https://github.com/user-attachments/assets/109f397d-7b29-4524-a1e2-b12ed0d4177a" />

Adds a GitHub Action that labels every PR with one size bucket (XS/S/M/L/XL) the moment it opens or updates, and surfaces that size in the two code-review Slack commands. Motivation: across 200 recently-merged PRs, size was the dominant predictor of time-to-merge (median ~4h for XS → ~43h for XL), yet the repo had no size signal — only path-based labels.

- New `📏 Auto Label PR Size` workflow (`actions/github-script`): paginates the PR's changed files, sums changed lines (`additions + deletions`) excluding lockfiles and generated REST clients, maps to a bucket, and keeps exactly one size label on the PR. All five labels share one neutral charcoal chip (`#2d3139`) so size metadata reads as a single family rather than a five-color rainbow competing with semantic labels; the cool→hot signal lives in the per-bucket emoji: 🔵 `size/XS` (<20) · 🟢 `size/S` (20–100) · 🟡 `size/M` (101–300) · 🟠 `size/L` (301–600) · 🔴 `size/XL` (>600). The workflow creates the labels and self-heals their color on drift.
- Both code-review Slack commands now include a `pr size:` line (bucket only, e.g. `🟠 L`) derived from the size label. The shared extraction steps live in `.agents/docs/PR_SIZE_EXTRACTION.md` (one source of truth for both commands); its fallback defers to the workflow's own ignore list + thresholds so the Slack bucket can't diverge from the applied label.
- Labels only for now — no PR comment. An active XL split-warning nudge was considered and deliberately deferred.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-7293

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8 (1M context)
  - Scope: full implementation
  - Human verification: code review + local validation (actionlint, node --check, bucketing/ignore-list dry-run against fixtures) + live end-to-end run on this PR

## Testing

- `actionlint .github/workflows/pr-size-labeler.yml` — clean (also passes in pre-commit).
- `node --check` on the extracted github-script body — clean.
- Dry-ran the bucketing + ignore-list logic against fixtures (tiny 15-LOC, boundary 19/20/100/101/300/301/600/900, lockfile-heavy, generated-`rest_api`-churn, svg/png) — all buckets correct; the inline glob matcher was validated to agree with `minimatch` on every ignore pattern.
- **Live end-to-end on this PR** (via a temporary `pull_request` trigger, since `pull_request_target` runs the base-branch copy which doesn't exist yet): the workflow ran green in 9s and applied `🟡 size/M` (`#fbca04`) — matching the 165 counted LOC and the offline dry-run. The temporary trigger was reverted before merge.

## Documentation

N/A — internal CI tooling; no user-facing docs. Behavior is documented in the workflow file, `.agents/docs/PR_SIZE_EXTRACTION.md`, and the ticket.

