### PR TITLE
[OPIK-7250] [FE] feat: theme-aware waste-* callout tokens (AI Spend)

### DIFF
--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -281,6 +281,11 @@
     --warning-box-icon-bg: 45 93% 58%;
     --warning-box-icon-text: 32 85% 32%;
 
+    /* Recoverable-waste callout (AI Spend) */
+    --waste-bg: #fee8d7;
+    --waste-border: #fb9341;
+    --waste-text: #000000;
+
     --selection-bar: 237 68% 29%;
     --row-selected: 235 85% 97%;
 
@@ -526,6 +531,11 @@
     --warning-box-text: 48 96% 64%;
     --warning-box-icon-bg: 32 95% 44%;
     --warning-box-icon-text: 45 93% 58%;
+
+    /* Recoverable-waste callout (AI Spend) - Dark Mode */
+    --waste-bg: #fb934126;
+    --waste-border: #fb9341;
+    --waste-text: #fee8d7;
 
     --selection-bar: 237 58% 39%;
     --row-selected: 0 0% 15%;

--- a/apps/opik-frontend/tailwind.config.ts
+++ b/apps/opik-frontend/tailwind.config.ts
@@ -122,6 +122,11 @@ module.exports = {
         "warning-box-icon-bg": "hsl(var(--warning-box-icon-bg))",
         "warning-box-icon-text": "hsl(var(--warning-box-icon-text))",
 
+        /* Recoverable-waste callout colors (AI Spend) */
+        "waste-bg": "var(--waste-bg)",
+        "waste-border": "var(--waste-border)",
+        "waste-text": "var(--waste-text)",
+
         /* Chart colors (Figma Design System) */
         "chart-blue": "var(--chart-blue)",
         "chart-yellow": "var(--chart-yellow)",


### PR DESCRIPTION
## Details

Adds a theme-aware `waste-*` design-token set for the AI-Spend "recoverable waste" callout, so it flips light/dark through the token system instead of hardcoded hex + manual `dark:` overrides. Follow-up to review feedback on `opik-plugin-ai-spend#25`.

- `apps/opik-frontend/src/main.scss` — `--waste-bg` / `--waste-border` / `--waste-text` in both `:root` and `.dark` (light: `#fee8d7` fill, `#fb9341` border, black text; dark: `#fb9341` @ 15% fill, `#fb9341` border, `#fee8d7` text), mirroring the existing `warning-box-*` block.
- `apps/opik-frontend/tailwind.config.ts` — `waste-bg` / `waste-border` / `waste-text` color mappings (`var(--waste-*)`, following the `chart-*` hex-var precedent so the dark fill's alpha survives).
- Consumed by `opik-plugin-ai-spend#30`; **merge this first** — the plugin's `waste-*` classes only resolve once these tokens exist.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-7250

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Added the `waste-*` CSS variables (light + dark) and Tailwind color mappings.
- Human verification: Reviewed the diff; confirmed the classes emit the expected `var(--waste-*)` CSS and flip light/dark; frontend eslint + tsc pass.

## Testing

- `npx tsc --project tsconfig.json --noEmit` — passes.
- `npx eslint src/plugins/ai-spend` — passes (the consuming plugin).
- Tailwind emission probe: `npx tailwindcss -c tailwind.config.ts ...` confirms `bg-waste-bg → background-color: var(--waste-bg)`, `border-waste-border`, `text-waste-text`, `bg-waste-border` all emit.
- Only CSS variables + Tailwind color mappings are added; no runtime logic changed.

## Documentation

No documentation changes — internal design tokens mirroring the existing `warning-box-*` set.