### PR TITLE
[BE] fix: register deepseek as a canonical provider so DeepSeek model prices load

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -41,7 +41,8 @@ public class CostService {
             Map.entry("microsoft", "azure"),
             Map.entry("azure", "azure"),
             Map.entry("mistral", "mistral"),
-            Map.entry("xai", "xai"));
+            Map.entry("xai", "xai"),
+            Map.entry("deepseek", "deepseek"));
 
     // Online evaluation (and OTel ingestion) resolve models to LlmProvider serialized values whose names
     // differ from the canonical price-table vocabulary. Normalize those to the single canonical provider
@@ -63,6 +64,7 @@ public class CostService {
                     "openai", SpanCostCalculator::textGenerationWithCacheCostOpenAI,
                     "azure", SpanCostCalculator::textGenerationWithCacheCostOpenAI,
                     "xai", SpanCostCalculator::textGenerationWithCacheCostOpenAI,
+                    "deepseek", SpanCostCalculator::textGenerationWithCacheCostOpenAI,
                     "bedrock", SpanCostCalculator::textGenerationWithCacheCostBedrock,
                     "bedrock_converse", SpanCostCalculator::textGenerationWithCacheCostBedrock,
                     "vertex_ai-language-models", SpanCostCalculator::textGenerationWithCacheCostGoogle,

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -623,6 +623,45 @@ class CostServiceTest {
     }
 
     /**
+     * Covers both branches of registering {@code deepseek} as a canonical provider so that the 12
+     * deepseek-tagged entries in {@code model_prices_and_context_window.json} (the
+     * {@code deepseek-chat} / {@code deepseek-reasoner} / {@code deepseek/deepseek-v3} /
+     * {@code deepseek/deepseek-v4-*} families) are no longer silently dropped at load time:
+     * <ul>
+     *   <li>DeepSeek model with no cache rates falls through to {@link SpanCostCalculator#textGenerationCost}.</li>
+     *   <li>DeepSeek model with cache rates routes through
+     *       {@link SpanCostCalculator#textGenerationWithCacheCostOpenAI} — DeepSeek's cost calculator
+     *       in LiteLLM ({@code litellm/llms/deepseek/cost_calculator.py}) delegates to
+     *       {@code generic_cost_per_token}, so its usage payload follows the same OpenAI shape
+     *       (cached tokens flattened under {@code prompt_tokens_details.cached_tokens}).</li>
+     * </ul>
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideDeepseekProviderCases")
+    void calculateCostHandlesDeepseekModels(String description, String model, Map<String, Integer> usage,
+            String expectedCost) {
+        BigDecimal cost = CostService.calculateCost(model, "deepseek", usage, null);
+
+        assertThat(cost).isEqualByComparingTo(expectedCost);
+    }
+
+    private static Stream<Arguments> provideDeepseekProviderCases() {
+        // deepseek/deepseek-coder: input 1.4e-7, output 2.8e-7 (no cache rates) -> textGenerationCost
+        // 1000 * 1.4e-7 + 200 * 2.8e-7 = 0.00014 + 0.000056 = 0.000196
+        // deepseek/deepseek-chat: input 2.8e-7, output 4.2e-7, cache_read 2.8e-8 -> textGenerationWithCacheCostOpenAI
+        // non-cached input = 1000 - 300 = 700
+        // 700 * 2.8e-7 + 200 * 4.2e-7 + 300 * 2.8e-8 = 0.000196 + 0.000084 + 0.0000084 = 0.0002884
+        return Stream.of(
+                Arguments.of("plain text-generation route", "deepseek/deepseek-coder",
+                        Map.of("prompt_tokens", 1000, "completion_tokens", 200), "0.000196"),
+                Arguments.of("cache-aware route via OpenAI calc", "deepseek/deepseek-chat",
+                        Map.of("original_usage.prompt_tokens", 1000,
+                                "original_usage.completion_tokens", 200,
+                                "original_usage.prompt_tokens_details.cached_tokens", 300),
+                        "0.0002884"));
+    }
+
+    /**
      * Test for issue #5130: Bedrock model names carry a version-pin suffix like
      * "anthropic.claude-opus-4-6-v1:0" while the pricing database stores the base name
      * "anthropic.claude-opus-4-6-v1". Stripping the ":N" pin lets these price correctly.


### PR DESCRIPTION
## Details

Following the pattern of #7262 (which registered `azure`), #7432 (perplexity) and #7433 (xai) — `deepseek` is not currently in `PROVIDERS_MAPPING`, so all 12 entries in `model_prices_and_context_window.json` tagged with `litellm_provider: "deepseek"` silently drop at load time. Every one publishes non-zero input+output rates: `deepseek-chat`, `deepseek-reasoner`, `deepseek-v4-flash`, `deepseek-v4-pro`, plus the `deepseek/deepseek-coder`, `deepseek/deepseek-r1`, `deepseek/deepseek-v3`, `deepseek/deepseek-v3.2` variants.

9 of the 12 also publish `cache_read_input_token_cost`. DeepSeek's cost calculator in LiteLLM (`litellm/llms/deepseek/cost_calculator.py`) is a one-liner that delegates directly to `generic_cost_per_token` — the same helper OpenAI/xAI use — so DeepSeek's usage payload follows the same OpenAI shape (`prompt_tokens_details.cached_tokens` flattened under `original_usage.*`). Route it through the existing `SpanCostCalculator::textGenerationWithCacheCostOpenAI` calculator; no new cache-calc method needed, just a mirror of the `openai` / `azure` / `xai` entries in `PROVIDERS_CACHE_COST_CALCULATOR`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (CLI)
- Model(s): Claude Opus 4.7
- Scope: scouted the reachable DeepSeek model count (12, 9 with cache_read), inspected LiteLLM's DeepSeek cost calc to confirm it delegates to generic_cost_per_token, drafted the two-line plumbing change following the #7262 / #7433 pattern, and wrote the parameterized branch-coverage test
- Human verification: ran the test suite locally; cross-checked expected dollar values against rates in model_prices_and_context_window.json

## Testing

Local verification on JDK 25 + Maven 3.9.9. Result: **102/102 green** (2 new parameterized cases under `calculateCostHandlesDeepseekModels`, style matching #7262).

Scenarios covered:

1. **Plain text-generation route** — `deepseek/deepseek-coder` (input `1.4e-7`, output `2.8e-7`, no cache rates). With `prompt_tokens=1000, completion_tokens=200`, expected `0.000196` (`1000 * 1.4e-7 + 200 * 2.8e-7`).
2. **Cache-aware route via OpenAI calc** — `deepseek/deepseek-chat` (input `2.8e-7`, output `4.2e-7`, `cache_read 2.8e-8`). With `original_usage.prompt_tokens=1000, original_usage.completion_tokens=200, original_usage.prompt_tokens_details.cached_tokens=300`, expected `0.0002884` (non-cached input `700 * 2.8e-7 + 200 * 4.2e-7 + 300 * 2.8e-8`).

## Documentation

No docs change. Behavior change is invisible to end users beyond accurate (non-zero) cost numbers for DeepSeek traces on 12 previously-dropped models.
