### PR TITLE
[NA] feat(fe): tokenize hardcoded hex colors + ban arbitrary hex in lint

### DIFF
--- a/apps/opik-frontend/.eslintrc
+++ b/apps/opik-frontend/.eslintrc
@@ -56,6 +56,17 @@
         ]
       }
     ],
-    "tailwindcss/no-contradicting-classname": "error"
+    "tailwindcss/no-contradicting-classname": "error",
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "Literal[value=/-\\[#[0-9a-fA-F]/]",
+        "message": "Don't hardcode a hex color in a Tailwind class (e.g. bg-[#7C3AED]). Use a design token: an existing semantic color (bg-destructive, text-muted-slate, …) or add one to main.scss + tailwind.config.ts. See .agents/skills/frontend-design-fidelity."
+      },
+      {
+        "selector": "TemplateElement[value.raw=/-\\[#[0-9a-fA-F]/]",
+        "message": "Don't hardcode a hex color in a Tailwind class. Use a design token. See .agents/skills/frontend-design-fidelity."
+      }
+    ]
   }
 }

--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -99,6 +99,26 @@
     --chart-gray-light: #ebf2f5;
     --chart-gray-dark: #45575f;
 
+    /* Agent Insights — severity + issue-callout palette. Tokenized from
+       previously hardcoded hex; values preserved 1:1. Pending design
+       ratification (names/values), see OPIK design-token cleanup. */
+    --severity-critical: #dc2626;
+    --severity-high: #f43f5e;
+    --severity-medium: #f59e0b;
+    --severity-low: #94a3b8;
+    --insight-error: #f14668;
+    --insight-error-surface: #f146681a;
+    --insight-warning: #fb923c;
+    --insight-warning-surface: #fb923c1a;
+    --insight-accent: #a78bfa;
+    --insight-accent-surface: #c4b5fd1a;
+    --insight-info: #89deff;
+    --insight-info-surface: #89deff1a;
+    /* Assertion pass indicator — no dark override (preserves current behavior) */
+    --assertion-indicator: #89deff;
+    /* Dataset version type icon — interim color per OPIK-6845 */
+    --dataset-version-accent: #6bdf93;
+
     /* Optimization Studio icon accents (per-algorithm / per-metric) */
     --optimizer-icon-gepa: #12a594;
     --optimizer-icon-hierarchical: #6e56cf;
@@ -459,6 +479,11 @@
     --accent-magenta: #be48ea;
     --accent-red: #df5a40;
     --accent-indigo: #5356f1;
+
+    /* Agent Insights — dark overrides. Only --insight-info had an explicit
+       dark variant in the original hardcoded markup; the rest inherit :root
+       (which matches their prior no-dark-variant behavior). */
+    --insight-info: #1e3a47;
 
     /* Template icon colors - Dark Mode */
     --template-icon-metrics: #5899da;

--- a/apps/opik-frontend/src/plugins/comet/OllieLoader.tsx
+++ b/apps/opik-frontend/src/plugins/comet/OllieLoader.tsx
@@ -54,7 +54,7 @@ export function OllieLoader({
             className={cn(
               "text-center font-code text-foreground",
               variant === "page"
-                ? "text-[16px] leading-5"
+                ? "text-base leading-5"
                 : "text-[13px] leading-4",
             )}
           >

--- a/apps/opik-frontend/src/v1/pages-shared/experiments/TestSuiteExperiment/AssertionsBreakdownTooltip.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/experiments/TestSuiteExperiment/AssertionsBreakdownTooltip.tsx
@@ -47,7 +47,7 @@ export const AssertionsBreakdownTooltip: React.FC<
             }}
           >
             <div className="flex items-center gap-1.5 px-2 pb-0.5 pt-1">
-              <div className="flex size-4 items-center justify-center rounded bg-[#89DEFF]">
+              <div className="flex size-4 items-center justify-center rounded bg-assertion-indicator">
                 <CheckCheck className="size-3 text-foreground" />
               </div>
               <span className="comet-body-xs-accented text-foreground">
@@ -69,7 +69,7 @@ export const AssertionsBreakdownTooltip: React.FC<
             {assertionNames.map((name, aIdx) => (
               <Fragment key={name}>
                 <div className="flex items-start gap-1.5 px-2 py-1">
-                  <div className="mt-[5px] size-[7px] shrink-0 rounded-[1.5px] bg-[#89DEFF]" />
+                  <div className="mt-[5px] size-[7px] shrink-0 rounded-[1.5px] bg-assertion-indicator" />
                   <span className="comet-body-xs whitespace-nowrap text-muted-slate">
                     {name}
                   </span>

--- a/apps/opik-frontend/src/v1/pages-shared/experiments/TestSuiteExperiment/AssertionsListTooltipContent.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/experiments/TestSuiteExperiment/AssertionsListTooltipContent.tsx
@@ -17,7 +17,7 @@ export const AssertionsListTooltipContent: React.FC<
   return (
     <div className="flex w-[250px] flex-col p-2">
       <div className="flex items-center gap-1.5 px-1 pb-0.5 pt-1">
-        <div className="flex size-4 items-center justify-center rounded bg-[#89DEFF]">
+        <div className="flex size-4 items-center justify-center rounded bg-assertion-indicator">
           <CheckCheck className="size-3 text-foreground" />
         </div>
         <span className="comet-body-xs-accented text-foreground">
@@ -28,7 +28,7 @@ export const AssertionsListTooltipContent: React.FC<
       {assertions.map((assertion, index) => (
         <Fragment key={index}>
           <div className="flex items-start gap-1.5 px-2 py-1">
-            <div className="mt-[5px] size-[7px] shrink-0 rounded-[1.5px] bg-[#89DEFF]" />
+            <div className="mt-[5px] size-[7px] shrink-0 rounded-[1.5px] bg-assertion-indicator" />
             <span className="comet-body-xs text-muted-slate">{assertion}</span>
           </div>
           {index < assertions.length - 1 && (

--- a/apps/opik-frontend/src/v2/pages-shared/DatasetVersionSelectBox/DatasetVersionSelectBox.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/DatasetVersionSelectBox/DatasetVersionSelectBox.tsx
@@ -327,7 +327,7 @@ function DatasetVersionSelectBox({
               <SelectValue
                 placeholder={
                   <div className="flex w-full items-center">
-                    <TypeIcon className="mr-2 size-3 text-[#6bdf93]" />
+                    <TypeIcon className="mr-2 size-3 text-dataset-version-accent" />
                     <span className="truncate font-normal">
                       Select {typeLabel}
                     </span>
@@ -336,7 +336,7 @@ function DatasetVersionSelectBox({
               >
                 <div className="flex w-full items-center justify-between gap-1">
                   <div className="flex min-w-0 items-center gap-2">
-                    <TypeIcon className="size-3 shrink-0 text-[#6bdf93]" />
+                    <TypeIcon className="size-3 shrink-0 text-dataset-version-accent" />
                     <span className="min-w-0 truncate">
                       {selectedDataset?.name}
                     </span>

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/TestSuiteExperiment/AssertionsListTooltipContent.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/TestSuiteExperiment/AssertionsListTooltipContent.tsx
@@ -18,7 +18,7 @@ export const AssertionsListTooltipContent: React.FC<
   return (
     <div className="flex w-[250px] flex-col p-2">
       <div className="flex items-center gap-1.5 px-1 pb-0.5 pt-1">
-        <div className="flex size-4 items-center justify-center rounded bg-[#89DEFF]">
+        <div className="flex size-4 items-center justify-center rounded bg-assertion-indicator">
           <CheckCheck className="size-3 text-foreground" />
         </div>
         <span className="comet-body-xs-accented text-foreground">{title}</span>
@@ -27,7 +27,7 @@ export const AssertionsListTooltipContent: React.FC<
       {assertions.map((assertion, index) => (
         <Fragment key={index}>
           <div className="flex items-start gap-1.5 px-2 py-1">
-            <div className="mt-[5px] size-[7px] shrink-0 rounded-[1.5px] bg-[#89DEFF]" />
+            <div className="mt-[5px] size-[7px] shrink-0 rounded-[1.5px] bg-assertion-indicator" />
             <span className="comet-body-xs text-muted-slate">{assertion}</span>
           </div>
           {index < assertions.length - 1 && (

--- a/apps/opik-frontend/src/v2/pages/SignalsPage/IssuesTab/IssuesTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/SignalsPage/IssuesTab/IssuesTab.tsx
@@ -123,7 +123,7 @@ const IconTile: React.FC<{ className?: string; children: React.ReactNode }> = ({
 
 const RunningBar: React.FC = () => (
   <div className="relative h-1.5 w-full overflow-hidden rounded-full bg-muted">
-    <div className="absolute inset-y-0 left-0 w-2/5 animate-progress-indeterminate rounded-full bg-[#A78BFA]" />
+    <div className="absolute inset-y-0 left-0 w-2/5 animate-progress-indeterminate rounded-full bg-insight-accent" />
   </div>
 );
 
@@ -165,8 +165,8 @@ const FailedBanner: React.FC<{
   const { title, description } = getRunFailureCopy(reason);
   const [open, setOpen] = useState(false);
   return (
-    <div className="flex items-start gap-3 border-b border-border bg-[#F146681A] px-4 py-3">
-      <IconTile className="bg-[#F14668]">
+    <div className="flex items-start gap-3 border-b border-border bg-insight-error-surface px-4 py-3">
+      <IconTile className="bg-insight-error">
         <TriangleAlert className="size-4 text-white" />
       </IconTile>
       <div className="flex min-w-0 flex-1 flex-col gap-2">
@@ -206,8 +206,8 @@ const StaleResultsBanner: React.FC<{
   traceCount: number;
   onRun?: () => void;
 }> = ({ days, traceCount, onRun }) => (
-  <div className="flex items-start gap-3 border-b border-border bg-[#FB923C1A] px-4 py-3">
-    <IconTile className="bg-[#FB923C]">
+  <div className="flex items-start gap-3 border-b border-border bg-insight-warning-surface px-4 py-3">
+    <IconTile className="bg-insight-warning">
       <Clock className="size-4 text-white" />
     </IconTile>
     <div className="flex min-w-0 flex-1 flex-col gap-2">
@@ -418,7 +418,7 @@ const IssuesTab: React.FC<IssuesTabProps> = ({
           )}
           {running && (
             <div className="flex items-start gap-3 border-b border-border bg-primary-50 px-4 py-3">
-              <IconTile className="bg-[#A78BFA]">
+              <IconTile className="bg-insight-accent">
                 <Radar className="size-4 text-black dark:text-white" />
               </IconTile>
               <div className="flex min-w-0 flex-1 flex-col gap-2.5">
@@ -449,9 +449,9 @@ const IssuesTab: React.FC<IssuesTabProps> = ({
     if (running) {
       return (
         <ListEmptyState
-          className="bg-[#C4B5FD1A]"
+          className="bg-insight-accent-surface"
           icon={
-            <IconTile className="bg-[#A78BFA]">
+            <IconTile className="bg-insight-accent">
               <Radar className="size-4 text-black dark:text-white" />
             </IconTile>
           }
@@ -467,9 +467,9 @@ const IssuesTab: React.FC<IssuesTabProps> = ({
       const { title, description } = getRunFailureCopy(failedReason);
       return (
         <ListEmptyState
-          className="bg-[#F146681A]"
+          className="bg-insight-error-surface"
           icon={
-            <IconTile className="bg-[#F14668]">
+            <IconTile className="bg-insight-error">
               <TriangleAlert className="size-4 text-white" />
             </IconTile>
           }
@@ -485,7 +485,7 @@ const IssuesTab: React.FC<IssuesTabProps> = ({
     if (showResolved) {
       return (
         <ListEmptyState
-          className="bg-[#89DEFF1A]"
+          className="bg-insight-info-surface"
           icon={
             <IconTile className="bg-[var(--upload-chip-icon-bg)]">
               <Inbox className="size-3.5 text-black dark:text-white" />
@@ -513,7 +513,7 @@ const IssuesTab: React.FC<IssuesTabProps> = ({
       <ListEmptyState
         className="bg-[var(--upload-chip-bg)]"
         icon={
-          <IconTile className="bg-[#89DEFF] dark:bg-[#1E3A47]">
+          <IconTile className="bg-insight-info">
             <PartyPopper className="size-3.5 text-black dark:text-white" />
           </IconTile>
         }

--- a/apps/opik-frontend/src/v2/pages/SignalsPage/helpers.ts
+++ b/apps/opik-frontend/src/v2/pages/SignalsPage/helpers.ts
@@ -9,10 +9,10 @@ export const SEVERITY_LABEL_MAP: Record<AGENT_INSIGHTS_ISSUE_SEVERITY, string> =
   };
 
 export const SEVERITY_DOT_MAP: Record<AGENT_INSIGHTS_ISSUE_SEVERITY, string> = {
-  [AGENT_INSIGHTS_ISSUE_SEVERITY.critical]: "bg-[#DC2626]",
-  [AGENT_INSIGHTS_ISSUE_SEVERITY.high]: "bg-[#F43F5E]",
-  [AGENT_INSIGHTS_ISSUE_SEVERITY.medium]: "bg-[#F59E0B]",
-  [AGENT_INSIGHTS_ISSUE_SEVERITY.low]: "bg-[#94A3B8]",
+  [AGENT_INSIGHTS_ISSUE_SEVERITY.critical]: "bg-severity-critical",
+  [AGENT_INSIGHTS_ISSUE_SEVERITY.high]: "bg-severity-high",
+  [AGENT_INSIGHTS_ISSUE_SEVERITY.medium]: "bg-severity-medium",
+  [AGENT_INSIGHTS_ISSUE_SEVERITY.low]: "bg-severity-low",
 };
 
 // Multi-day issues show the latest day's count (matches the prose) plus the

--- a/apps/opik-frontend/tailwind.config.ts
+++ b/apps/opik-frontend/tailwind.config.ts
@@ -148,6 +148,22 @@ module.exports = {
         "accent-red": "var(--accent-red)",
         "accent-indigo": "var(--accent-indigo)",
 
+        /* Agent Insights — severity + issue-callout palette (see main.scss) */
+        "severity-critical": "var(--severity-critical)",
+        "severity-high": "var(--severity-high)",
+        "severity-medium": "var(--severity-medium)",
+        "severity-low": "var(--severity-low)",
+        "insight-error": "var(--insight-error)",
+        "insight-error-surface": "var(--insight-error-surface)",
+        "insight-warning": "var(--insight-warning)",
+        "insight-warning-surface": "var(--insight-warning-surface)",
+        "insight-accent": "var(--insight-accent)",
+        "insight-accent-surface": "var(--insight-accent-surface)",
+        "insight-info": "var(--insight-info)",
+        "insight-info-surface": "var(--insight-info-surface)",
+        "assertion-indicator": "var(--assertion-indicator)",
+        "dataset-version-accent": "var(--dataset-version-accent)",
+
         /* Template icon colors */
         "template-icon-metrics": "var(--template-icon-metrics)",
         "template-icon-performance": "var(--template-icon-performance)",


### PR DESCRIPTION
## Details

Replaces the **25 hardcoded hex colors** in the frontend with named design tokens (`main.scss` + `tailwind.config.ts`), and adds an **ESLint rule** (`no-restricted-syntax`) that blocks new arbitrary hex colors in Tailwind classes (e.g. `bg-[#7C3AED]`) as an error. Also converts the one exact typography match `text-[16px]` → `text-base`.

Tokenized **in place**: values preserved 1:1 and per-site dark-mode behavior preserved (only `--insight-info` had an explicit dark variant `#1E3A47`; the rest inherit `:root`, matching their prior no-dark markup). No visual change intended. New tokens: `--severity-{critical,high,medium,low}`, `--insight-{error,warning,accent,info}` (+ `*-surface` 10% variants), `--assertion-indicator`, `--dataset-version-accent` (interim green per OPIK_6845).

Color mapping (for design sign-off): `#DC2626/#F43F5E/#F59E0B/#94A3B8` → `bg-severity-*`; `#F14668`(+`1A`) → `insight-error`(+surface); `#FB923C`(+`1A`) → `insight-warning`; `#A78BFA`/`#C4B5FD1A` → `insight-accent`; `#89DEFF`(+dark `#1E3A47`,+`1A`) → `insight-info`; assertions `#89DEFF` → `assertion-indicator`; `#6bdf93` → `dataset-version-accent`. Names/values open to change (e.g. `insight-error` could reuse `destructive`, same `#f14668`).

Typography (deferred): the remaining 41 arbitrary font-sizes use 8 sub-scale sizes (8–13px) with no matching `comet-*` class — a design consolidation decision (bump to 12px risks dense-layout regressions; blessing tokens bloats the scale), so the font-size rule lands in a follow-up.

`src/plugins/ai-spend` is a gitignored symlink to a separate repo (absent in CI) — its own arbitrary colors are out of scope here.

## Change checklist
- [ ] User facing (no visual change intended — values preserved 1:1)
- [ ] Documentation update

## Issues
- N/A — no ticket (`[NA]`). Related: OPIK_6845 (interim green).

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: enumerated + mapped the 25 hex colors, added tokens (+ dark), swapped usages, added the lint rule
- Human verification: values verified preserved 1:1 in built CSS; lint/typecheck/build pass; visual QA recommended before merge

## Testing

- `npx eslint src --max-warnings=0` (excl. the ai-spend symlink) — pass (rule active, 0 arbitrary hex colors remain)
- `npm run typecheck` — pass
- `npm run build` — pass; confirmed generated CSS contains the token utility classes and `:root`/`.dark` vars, with `--insight-info` = `#89deff` (light) / `#1e3a47` (dark)
- Visual QA still recommended on Agent Insights / Signals + test-suite assertion tooltips (no change expected since values are preserved).

## Documentation

No docs change. Token names pending design ratification.