### PR TITLE
[issue-7393] [SDK] fix: use direct project-scoped URL for dataset in get_or_create_dataset log

### DIFF
--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -233,7 +233,7 @@ class Opik:
 
     def _display_created_dataset_url(self, dataset_name: str, dataset_id: str) -> None:
         dataset_url = url_helpers.get_dataset_url_by_id(
-            dataset_id, self._config.url_override
+            dataset_id, self._config.url_override, self._workspace
         )
 
         LOGGER.info(f'Created a "{dataset_name}" dataset at {dataset_url}.')

--- a/sdks/python/src/opik/url_helpers.py
+++ b/sdks/python/src/opik/url_helpers.py
@@ -60,14 +60,9 @@ def get_project_url_by_trace_id(trace_id: str, url_override: str) -> str:
     return urllib.parse.urljoin(ensure_ending_slash(url_override), project_path)
 
 
-def get_dataset_url_by_id(dataset_id: str, url_override: str) -> str:
-    encoded_opik_url = base64.b64encode(url_override.encode("utf-8")).decode("utf-8")
-
-    project_path = urllib.parse.quote(
-        f"v1/session/redirect/datasets/?dataset_id={dataset_id}&path={encoded_opik_url}",
-        safe=ALLOWED_URL_CHARACTERS,
-    )
-    return urllib.parse.urljoin(ensure_ending_slash(url_override), project_path)
+def get_dataset_url_by_id(dataset_id: str, base_url: str, workspace: str) -> str:
+    domain_root = get_base_url(base_url)
+    return f"{domain_root}opik/{workspace}/datasets/{dataset_id}/"
 
 
 def get_project_url_by_id(base_url: str, project_id: str, workspace: str) -> str:

--- a/sdks/python/tests/unit/test_url_helpers.py
+++ b/sdks/python/tests/unit/test_url_helpers.py
@@ -55,3 +55,41 @@ def test_get_ui_url__url_override__only_strips_api_suffix(
         lambda: OpikConfig(url_override=url_override),
     )
     assert url_helpers.get_ui_url() == expected_ui_url
+
+
+@pytest.mark.parametrize(
+    ("base_url", "workspace", "dataset_id", "expected_url"),
+    [
+        (
+            "http://localhost:5173/api",
+            "my-workspace",
+            "abc123",
+            "http://localhost:5173/opik/my-workspace/datasets/abc123/",
+        ),
+        (
+            "http://localhost:5173/api/",
+            "my-workspace",
+            "abc123",
+            "http://localhost:5173/opik/my-workspace/datasets/abc123/",
+        ),
+        (
+            "https://www.comet.com/opik/api",
+            "acme",
+            "def456",
+            "https://www.comet.com/opik/acme/datasets/def456/",
+        ),
+        (
+            "https://www.comet.com/opik/api/",
+            "acme",
+            "def456",
+            "https://www.comet.com/opik/acme/datasets/def456/",
+        ),
+    ],
+)
+def test_get_dataset_url_by_id__returns_direct_project_scoped_url(
+    base_url: str, workspace: str, dataset_id: str, expected_url: str
+) -> None:
+    assert (
+        url_helpers.get_dataset_url_by_id(dataset_id, base_url, workspace)
+        == expected_url
+    )


### PR DESCRIPTION
## Details

`get_dataset_url_by_id` was generating a session-redirect URL
(`v1/session/redirect/datasets/?dataset_id=...`) that routes through
the user's session context and surfaces the dataset under "Default Project"
instead of the actual project it belongs to. This meant the URL logged by
`create_dataset` / `get_or_create_dataset` opened the wrong view in the UI.

The fix replaces the session-redirect URL with the same direct URL pattern
used by `get_project_url_by_id`:
`{domain_root}opik/{workspace}/datasets/{dataset_id}/`

The `workspace` is already available on the client as `self._workspace`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #7393

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: url_helpers.py (function rewrite), opik_client.py (call site), test_url_helpers.py (new parametrized test)
- Human verification: diff reviewed; test cases manually verified against the URL pattern used by get_project_url_by_id

## Testing

Existing tests pass (no change to their expectations).

New test added: `test_get_dataset_url_by_id__returns_direct_project_scoped_url`
validates 4 parameter combinations (localhost + comet.com, with and without
trailing slash on the base URL).

Run with:
```
cd sdks/python
pytest tests/unit/test_url_helpers.py -v
```

## Documentation

No documentation change required — this fixes a log message URL, not a
public API.
