### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -11624,6 +11624,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/LlmAsJudgeOutputSchema"
+        max_cost_usd:
+          type: number
     LlmAsJudgeMessage:
       required:
       - role
@@ -11839,6 +11841,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/LlmAsJudgeOutputSchema"
+        max_cost_usd:
+          type: number
     TraceThreadUserDefinedMetricPythonCode:
       required:
       - metric
@@ -12059,6 +12063,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/LlmAsJudgeOutputSchema_Write"
+        max_cost_usd:
+          type: number
     LlmAsJudgeMessageContent_Write:
       required:
       - type
@@ -12259,6 +12265,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/LlmAsJudgeOutputSchema_Write"
+        max_cost_usd:
+          type: number
     TraceThreadUserDefinedMetricPythonCode_Write:
       required:
       - metric
@@ -12519,6 +12527,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/LlmAsJudgeOutputSchema_Public"
+        max_cost_usd:
+          type: number
     LlmAsJudgeMessageContent_Public:
       required:
       - type
@@ -12734,6 +12744,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/LlmAsJudgeOutputSchema_Public"
+        max_cost_usd:
+          type: number
     TraceThreadUserDefinedMetricPythonCode_Public:
       required:
       - metric

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -11624,6 +11624,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/LlmAsJudgeOutputSchema"
+        max_cost_usd:
+          type: number
     LlmAsJudgeMessage:
       required:
       - role
@@ -11839,6 +11841,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/LlmAsJudgeOutputSchema"
+        max_cost_usd:
+          type: number
     TraceThreadUserDefinedMetricPythonCode:
       required:
       - metric
@@ -12059,6 +12063,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/LlmAsJudgeOutputSchema_Write"
+        max_cost_usd:
+          type: number
     LlmAsJudgeMessageContent_Write:
       required:
       - type
@@ -12259,6 +12265,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/LlmAsJudgeOutputSchema_Write"
+        max_cost_usd:
+          type: number
     TraceThreadUserDefinedMetricPythonCode_Write:
       required:
       - metric
@@ -12519,6 +12527,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/LlmAsJudgeOutputSchema_Public"
+        max_cost_usd:
+          type: number
     LlmAsJudgeMessageContent_Public:
       required:
       - type
@@ -12734,6 +12744,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/LlmAsJudgeOutputSchema_Public"
+        max_cost_usd:
+          type: number
     TraceThreadUserDefinedMetricPythonCode_Public:
       required:
       - metric

--- a/sdks/python/src/opik/rest_api/types/llm_as_judge_code.py
+++ b/sdks/python/src/opik/rest_api/types/llm_as_judge_code.py
@@ -16,6 +16,7 @@ class LlmAsJudgeCode(UniversalBaseModel):
     messages: typing.List[LlmAsJudgeMessage]
     variables: typing.Dict[str, str]
     schema_: typing_extensions.Annotated[typing.List[LlmAsJudgeOutputSchema], FieldMetadata(alias="schema")]
+    max_cost_usd: typing.Optional[float] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/llm_as_judge_code_public.py
+++ b/sdks/python/src/opik/rest_api/types/llm_as_judge_code_public.py
@@ -16,6 +16,7 @@ class LlmAsJudgeCodePublic(UniversalBaseModel):
     messages: typing.List[LlmAsJudgeMessagePublic]
     variables: typing.Dict[str, str]
     schema_: typing_extensions.Annotated[typing.List[LlmAsJudgeOutputSchemaPublic], FieldMetadata(alias="schema")]
+    max_cost_usd: typing.Optional[float] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/llm_as_judge_code_write.py
+++ b/sdks/python/src/opik/rest_api/types/llm_as_judge_code_write.py
@@ -16,6 +16,7 @@ class LlmAsJudgeCodeWrite(UniversalBaseModel):
     messages: typing.List[LlmAsJudgeMessageWrite]
     variables: typing.Dict[str, str]
     schema_: typing_extensions.Annotated[typing.List[LlmAsJudgeOutputSchemaWrite], FieldMetadata(alias="schema")]
+    max_cost_usd: typing.Optional[float] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/trace_thread_llm_as_judge_code.py
+++ b/sdks/python/src/opik/rest_api/types/trace_thread_llm_as_judge_code.py
@@ -15,6 +15,7 @@ class TraceThreadLlmAsJudgeCode(UniversalBaseModel):
     model: LlmAsJudgeModelParameters
     messages: typing.List[LlmAsJudgeMessage]
     schema_: typing_extensions.Annotated[typing.List[LlmAsJudgeOutputSchema], FieldMetadata(alias="schema")]
+    max_cost_usd: typing.Optional[float] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/trace_thread_llm_as_judge_code_public.py
+++ b/sdks/python/src/opik/rest_api/types/trace_thread_llm_as_judge_code_public.py
@@ -15,6 +15,7 @@ class TraceThreadLlmAsJudgeCodePublic(UniversalBaseModel):
     model: LlmAsJudgeModelParametersPublic
     messages: typing.List[LlmAsJudgeMessagePublic]
     schema_: typing_extensions.Annotated[typing.List[LlmAsJudgeOutputSchemaPublic], FieldMetadata(alias="schema")]
+    max_cost_usd: typing.Optional[float] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/python/src/opik/rest_api/types/trace_thread_llm_as_judge_code_write.py
+++ b/sdks/python/src/opik/rest_api/types/trace_thread_llm_as_judge_code_write.py
@@ -15,6 +15,7 @@ class TraceThreadLlmAsJudgeCodeWrite(UniversalBaseModel):
     model: LlmAsJudgeModelParametersWrite
     messages: typing.List[LlmAsJudgeMessageWrite]
     schema_: typing_extensions.Annotated[typing.List[LlmAsJudgeOutputSchemaWrite], FieldMetadata(alias="schema")]
+    max_cost_usd: typing.Optional[float] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/typescript/src/opik/rest_api/api/types/LlmAsJudgeCode.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/LlmAsJudgeCode.ts
@@ -7,4 +7,5 @@ export interface LlmAsJudgeCode {
     messages: OpikApi.LlmAsJudgeMessage[];
     variables: Record<string, string>;
     schema: OpikApi.LlmAsJudgeOutputSchema[];
+    maxCostUsd?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/LlmAsJudgeCodePublic.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/LlmAsJudgeCodePublic.ts
@@ -7,4 +7,5 @@ export interface LlmAsJudgeCodePublic {
     messages: OpikApi.LlmAsJudgeMessagePublic[];
     variables: Record<string, string>;
     schema: OpikApi.LlmAsJudgeOutputSchemaPublic[];
+    maxCostUsd?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/LlmAsJudgeCodeWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/LlmAsJudgeCodeWrite.ts
@@ -7,4 +7,5 @@ export interface LlmAsJudgeCodeWrite {
     messages: OpikApi.LlmAsJudgeMessageWrite[];
     variables: Record<string, string>;
     schema: OpikApi.LlmAsJudgeOutputSchemaWrite[];
+    maxCostUsd?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/TraceThreadLlmAsJudgeCode.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TraceThreadLlmAsJudgeCode.ts
@@ -6,4 +6,5 @@ export interface TraceThreadLlmAsJudgeCode {
     model: OpikApi.LlmAsJudgeModelParameters;
     messages: OpikApi.LlmAsJudgeMessage[];
     schema: OpikApi.LlmAsJudgeOutputSchema[];
+    maxCostUsd?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/TraceThreadLlmAsJudgeCodePublic.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TraceThreadLlmAsJudgeCodePublic.ts
@@ -6,4 +6,5 @@ export interface TraceThreadLlmAsJudgeCodePublic {
     model: OpikApi.LlmAsJudgeModelParametersPublic;
     messages: OpikApi.LlmAsJudgeMessagePublic[];
     schema: OpikApi.LlmAsJudgeOutputSchemaPublic[];
+    maxCostUsd?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/api/types/TraceThreadLlmAsJudgeCodeWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/TraceThreadLlmAsJudgeCodeWrite.ts
@@ -6,4 +6,5 @@ export interface TraceThreadLlmAsJudgeCodeWrite {
     model: OpikApi.LlmAsJudgeModelParametersWrite;
     messages: OpikApi.LlmAsJudgeMessageWrite[];
     schema: OpikApi.LlmAsJudgeOutputSchemaWrite[];
+    maxCostUsd?: number;
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/LlmAsJudgeCode.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/LlmAsJudgeCode.ts
@@ -13,6 +13,7 @@ export const LlmAsJudgeCode: core.serialization.ObjectSchema<serializers.LlmAsJu
         messages: core.serialization.list(LlmAsJudgeMessage),
         variables: core.serialization.record(core.serialization.string(), core.serialization.string()),
         schema: core.serialization.list(LlmAsJudgeOutputSchema),
+        maxCostUsd: core.serialization.property("max_cost_usd", core.serialization.number().optional()),
     });
 
 export declare namespace LlmAsJudgeCode {
@@ -21,5 +22,6 @@ export declare namespace LlmAsJudgeCode {
         messages: LlmAsJudgeMessage.Raw[];
         variables: Record<string, string>;
         schema: LlmAsJudgeOutputSchema.Raw[];
+        max_cost_usd?: number | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/LlmAsJudgeCodePublic.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/LlmAsJudgeCodePublic.ts
@@ -15,6 +15,7 @@ export const LlmAsJudgeCodePublic: core.serialization.ObjectSchema<
     messages: core.serialization.list(LlmAsJudgeMessagePublic),
     variables: core.serialization.record(core.serialization.string(), core.serialization.string()),
     schema: core.serialization.list(LlmAsJudgeOutputSchemaPublic),
+    maxCostUsd: core.serialization.property("max_cost_usd", core.serialization.number().optional()),
 });
 
 export declare namespace LlmAsJudgeCodePublic {
@@ -23,5 +24,6 @@ export declare namespace LlmAsJudgeCodePublic {
         messages: LlmAsJudgeMessagePublic.Raw[];
         variables: Record<string, string>;
         schema: LlmAsJudgeOutputSchemaPublic.Raw[];
+        max_cost_usd?: number | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/LlmAsJudgeCodeWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/LlmAsJudgeCodeWrite.ts
@@ -15,6 +15,7 @@ export const LlmAsJudgeCodeWrite: core.serialization.ObjectSchema<
     messages: core.serialization.list(LlmAsJudgeMessageWrite),
     variables: core.serialization.record(core.serialization.string(), core.serialization.string()),
     schema: core.serialization.list(LlmAsJudgeOutputSchemaWrite),
+    maxCostUsd: core.serialization.property("max_cost_usd", core.serialization.number().optional()),
 });
 
 export declare namespace LlmAsJudgeCodeWrite {
@@ -23,5 +24,6 @@ export declare namespace LlmAsJudgeCodeWrite {
         messages: LlmAsJudgeMessageWrite.Raw[];
         variables: Record<string, string>;
         schema: LlmAsJudgeOutputSchemaWrite.Raw[];
+        max_cost_usd?: number | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TraceThreadLlmAsJudgeCode.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TraceThreadLlmAsJudgeCode.ts
@@ -14,6 +14,7 @@ export const TraceThreadLlmAsJudgeCode: core.serialization.ObjectSchema<
     model: LlmAsJudgeModelParameters,
     messages: core.serialization.list(LlmAsJudgeMessage),
     schema: core.serialization.list(LlmAsJudgeOutputSchema),
+    maxCostUsd: core.serialization.property("max_cost_usd", core.serialization.number().optional()),
 });
 
 export declare namespace TraceThreadLlmAsJudgeCode {
@@ -21,5 +22,6 @@ export declare namespace TraceThreadLlmAsJudgeCode {
         model: LlmAsJudgeModelParameters.Raw;
         messages: LlmAsJudgeMessage.Raw[];
         schema: LlmAsJudgeOutputSchema.Raw[];
+        max_cost_usd?: number | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TraceThreadLlmAsJudgeCodePublic.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TraceThreadLlmAsJudgeCodePublic.ts
@@ -14,6 +14,7 @@ export const TraceThreadLlmAsJudgeCodePublic: core.serialization.ObjectSchema<
     model: LlmAsJudgeModelParametersPublic,
     messages: core.serialization.list(LlmAsJudgeMessagePublic),
     schema: core.serialization.list(LlmAsJudgeOutputSchemaPublic),
+    maxCostUsd: core.serialization.property("max_cost_usd", core.serialization.number().optional()),
 });
 
 export declare namespace TraceThreadLlmAsJudgeCodePublic {
@@ -21,5 +22,6 @@ export declare namespace TraceThreadLlmAsJudgeCodePublic {
         model: LlmAsJudgeModelParametersPublic.Raw;
         messages: LlmAsJudgeMessagePublic.Raw[];
         schema: LlmAsJudgeOutputSchemaPublic.Raw[];
+        max_cost_usd?: number | null;
     }
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/TraceThreadLlmAsJudgeCodeWrite.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/TraceThreadLlmAsJudgeCodeWrite.ts
@@ -14,6 +14,7 @@ export const TraceThreadLlmAsJudgeCodeWrite: core.serialization.ObjectSchema<
     model: LlmAsJudgeModelParametersWrite,
     messages: core.serialization.list(LlmAsJudgeMessageWrite),
     schema: core.serialization.list(LlmAsJudgeOutputSchemaWrite),
+    maxCostUsd: core.serialization.property("max_cost_usd", core.serialization.number().optional()),
 });
 
 export declare namespace TraceThreadLlmAsJudgeCodeWrite {
@@ -21,5 +22,6 @@ export declare namespace TraceThreadLlmAsJudgeCodeWrite {
         model: LlmAsJudgeModelParametersWrite.Raw;
         messages: LlmAsJudgeMessageWrite.Raw[];
         schema: LlmAsJudgeOutputSchemaWrite.Raw[];
+        max_cost_usd?: number | null;
     }
 }


### PR DESCRIPTION
## Details
Automated daily update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate