### PR TITLE
[OPIK-7298] [BE] feat: ingest cipx.session.harness into cipx_trace_identities

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxTraceIdentityDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxTraceIdentityDAO.java
@@ -48,6 +48,7 @@ public class CipxTraceIdentityDAO {
             @NonNull String userDisplayName,
             @NonNull String repository,
             @NonNull String sessionId,
+            @NonNull String harness,
             int schemaVersion) {
 
         public static TraceIdentityRow from(UUID traceId, UUID projectId, JsonNode metadata, Instant startTime) {
@@ -62,6 +63,7 @@ public class CipxTraceIdentityDAO {
                     .userDisplayName(identity.path("display_name").asText(""))
                     .repository(session.path("repository").path("remote").asText(""))
                     .sessionId(session.path("session_id").asText(""))
+                    .harness(session.path("harness").asText(""))
                     .schemaVersion(session.path("schema_version").asInt(0))
                     .build();
         }
@@ -72,7 +74,7 @@ public class CipxTraceIdentityDAO {
     private static final String INSERT = """
             INSERT INTO cipx_trace_identities
                 (workspace_id, project_id, trace_id, start_time, user_uuid,
-                 user_email, user_display_name, repository, session_id, schema_version)
+                 user_email, user_display_name, repository, session_id, harness, schema_version)
             SETTINGS log_comment = '<log_comment>'
             FORMAT Values
                 <items:{item |
@@ -86,6 +88,7 @@ public class CipxTraceIdentityDAO {
                         :user_display_name<item.index>,
                         :repository<item.index>,
                         :session_id<item.index>,
+                        :harness<item.index>,
                         :schema_version<item.index>
                     )
                     <if(item.hasNext)>,<endif>
@@ -116,7 +119,7 @@ public class CipxTraceIdentityDAO {
         // Positional binds: the driver resolves named binds with a linear indexOf over the statement's
         // parameter list (quadratic per statement), while bind(int) is a direct array write. Indices
         // follow the placeholders' first-appearance order in the rendered SQL: workspace_id once at 0
-        // (repeats dedup), then 9 parameters per row tuple in template order.
+        // (repeats dedup), then 10 parameters per row tuple in template order.
         statement.bind(0, workspaceId);
         int index = 1;
         for (TraceIdentityRow row : rows) {
@@ -128,6 +131,7 @@ public class CipxTraceIdentityDAO {
                     .bind(index++, row.userDisplayName())
                     .bind(index++, row.repository())
                     .bind(index++, row.sessionId())
+                    .bind(index++, row.harness())
                     .bind(index++, row.schemaVersion());
         }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxTraceIdentityDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxTraceIdentityDAO.java
@@ -54,11 +54,15 @@ public class CipxTraceIdentityDAO {
         public static TraceIdentityRow from(UUID traceId, UUID projectId, JsonNode metadata, Instant startTime) {
             JsonNode session = metadata.path("cipx").path("session");
             JsonNode identity = session.path("identity");
+            String userUuid = identity.path("user_uuid").asText("");
+            if (userUuid.isEmpty()) {
+                userUuid = identity.path("user_id").asText("");
+            }
             return TraceIdentityRow.builder()
                     .traceId(traceId.toString())
                     .projectId(projectId != null ? projectId.toString() : "")
                     .startTime(startTime)
-                    .userUuid(identity.path("user_uuid").asText(""))
+                    .userUuid(userUuid)
                     .userEmail(identity.path("email").asText(""))
                     .userDisplayName(identity.path("display_name").asText(""))
                     .repository(session.path("repository").path("remote").asText(""))

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000101_add_harness_to_cipx_trace_identity.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000101_add_harness_to_cipx_trace_identity.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+--changeset andriid:000101_add_harness_to_cipx_trace_identity
+--comment: Add harness (cipx coding harness: claude_code / codex / ...) to cipx_trace_identities for the composition harness node
+
+-- cipx stamps metadata.cipx.session.harness per trace ("claude_code", "codex", ...); the proxy sets it
+-- from the request's provider. Extracted here from the same cipx.session metadata as the other identity
+-- columns so the AI-spend composition can group spend by harness instead of assuming Claude Code. Legacy
+-- traces predating harness tagging carry '' (read side coalesces '' -> claude_code).
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_trace_identities ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS harness LowCardinality(String);
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_trace_identities ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS harness;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000102_add_harness_to_cipx_trace_identity.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000102_add_harness_to_cipx_trace_identity.sql
@@ -1,5 +1,5 @@
 --liquibase formatted sql
---changeset andriid:000101_add_harness_to_cipx_trace_identity
+--changeset andriid:000102_add_harness_to_cipx_trace_identity
 --comment: Add harness (cipx coding harness: claude_code / codex / ...) to cipx_trace_identities for the composition harness node
 
 -- cipx stamps metadata.cipx.session.harness per trace ("claude_code", "codex", ...); the proxy sets it

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000102_add_harness_to_cipx_trace_identity.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000102_add_harness_to_cipx_trace_identity.sql
@@ -10,3 +10,4 @@ ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_trace_identities ON CLUSTER '{clu
     ADD COLUMN IF NOT EXISTS harness LowCardinality(String);
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_trace_identities ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS harness;
+

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
@@ -257,7 +257,8 @@ class CostIntelligenceIngestionTest {
 
             var cipxTrace = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectName(projectName)
-                    .metadata(traceCipxMetadata(userUuid, email, "Dev User", "git@github.com:acme/repo.git", 3))
+                    .metadata(traceCipxMetadata(userUuid, email, "Dev User", "git@github.com:acme/repo.git", "codex",
+                            3))
                     .build();
             var plainTrace = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectName(projectName)
@@ -274,6 +275,7 @@ class CostIntelligenceIngestionTest {
                 assertThat(row.get().userDisplayName()).isEqualTo("Dev User");
                 assertThat(row.get().repository()).isEqualTo("git@github.com:acme/repo.git");
                 assertThat(row.get().sessionId()).isEqualTo("cc-session-abc");
+                assertThat(row.get().harness()).isEqualTo("codex");
                 assertThat(row.get().schemaVersion()).isEqualTo(3);
                 assertThat(row.get().projectId()).isNotBlank();
                 assertThat(row.get().startMs()).isEqualTo(cipxTrace.startTime().toEpochMilli());
@@ -300,7 +302,7 @@ class CostIntelligenceIngestionTest {
 
             var update = TraceUpdate.builder()
                     .projectName(projectName)
-                    .metadata(traceCipxMetadata(userUuid, email, "Dev User", "repo-a", 2))
+                    .metadata(traceCipxMetadata(userUuid, email, "Dev User", "repo-a", "claude_code", 2))
                     .build();
             traceResourceClient.updateTrace(traceId, update, ws.apiKey(), ws.workspaceName());
 
@@ -328,7 +330,7 @@ class CostIntelligenceIngestionTest {
 
             var trace = factory.manufacturePojo(Trace.class).toBuilder()
                     .projectName(projectName)
-                    .metadata(traceCipxMetadata(userUuid, oldEmail, "Old", "repo-a", 1))
+                    .metadata(traceCipxMetadata(userUuid, oldEmail, "Old", "repo-a", "claude_code", 1))
                     .build();
             var traceId = traceResourceClient.createTrace(trace, ws.apiKey(), ws.workspaceName());
 
@@ -338,7 +340,7 @@ class CostIntelligenceIngestionTest {
             // user_uuid is part of the sorting key, so only a same-user update collapses to one row.
             var update = TraceUpdate.builder()
                     .projectName(projectName)
-                    .metadata(traceCipxMetadata(userUuid, newEmail, "New", "repo-b", 2))
+                    .metadata(traceCipxMetadata(userUuid, newEmail, "New", "repo-b", "claude_code", 2))
                     .build();
             traceResourceClient.updateTrace(traceId, update, ws.apiKey(), ws.workspaceName());
 
@@ -393,13 +395,14 @@ class CostIntelligenceIngestionTest {
     }
 
     private static JsonNode traceCipxMetadata(String userUuid, String email, String displayName, String repository,
-            int schemaVersion) {
+            String harness, int schemaVersion) {
         return JsonUtils.getJsonNodeFromString("""
                 {
                   "cipx": {
                     "session": {
                       "schema_version": %d,
                       "session_id": "cc-session-abc",
+                      "harness": "%s",
                       "repository": {"remote": "%s"},
                       "identity": {
                         "user_uuid": "%s",
@@ -409,7 +412,7 @@ class CostIntelligenceIngestionTest {
                     }
                   }
                 }
-                """.formatted(schemaVersion, repository, userUuid, email, displayName));
+                """.formatted(schemaVersion, harness, repository, userUuid, email, displayName));
     }
 
     private Optional<CipxSpendRow> getCipxSpend(UUID spanId, String workspaceId) {
@@ -488,7 +491,7 @@ class CostIntelligenceIngestionTest {
                 SELECT
                     project_id AS project_id,
                     toUnixTimestamp64Milli(start_time) AS start_ms,
-                    user_uuid, user_email, user_display_name, repository, session_id, schema_version
+                    user_uuid, user_email, user_display_name, repository, session_id, harness, schema_version
                 FROM cipx_trace_identities FINAL
                 WHERE workspace_id = :workspace_id AND trace_id = :trace_id
                 """;
@@ -505,6 +508,7 @@ class CostIntelligenceIngestionTest {
                             row.get("user_display_name", String.class),
                             row.get("repository", String.class),
                             row.get("session_id", String.class),
+                            row.get("harness", String.class),
                             row.get("schema_version", Integer.class)))));
         }).blockOptional();
     }
@@ -543,6 +547,6 @@ class CostIntelligenceIngestionTest {
     }
 
     private record CipxIdentityRow(String projectId, Long startMs, String userUuid, String userEmail,
-            String userDisplayName, String repository, String sessionId, Integer schemaVersion) {
+            String userDisplayName, String repository, String sessionId, String harness, Integer schemaVersion) {
     }
 }


### PR DESCRIPTION
## Details

Extracts the cipx coding harness (`claude_code` / `codex` / …) — which the cipx proxy already stamps on `metadata.cipx.session.harness` — into a new `harness` column on `cipx_trace_identities`. It was dropped at ingestion, so AI-Spend composition assumed everything was Claude Code; persisting it lets the read side group spend by harness (e.g. surface Codex).

- Adds migration `000101` — `ALTER TABLE cipx_trace_identities ADD COLUMN harness LowCardinality(String)`.
- Parses `cipx.session.harness` in `CipxTraceIdentityDAO` and writes it (INSERT column + positional bind); legacy/untagged rows carry `''` (read side coalesces `'' -> claude_code`).
- Ingestion-only change. The cost-api harness node and the FE rendering land in separate OPIK-7298 PRs (cost-api reads only these tables, so **this migration must deploy first**).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7298

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: code review + ingestion integration test + manual verification on the local dev stack

## Testing

- `mvn spotless:check test-compile` — green.
- `CostIntelligenceIngestionTest` — 5/5 pass against a ClickHouse testcontainer: migration `000101` applies and a trace with `cipx.session.harness = "codex"` ingests with `harness='codex'`.
- Manual, local dev stack (dev-runner, process mode): after routing Codex through the local proxy, fresh Codex traffic lands with `harness='codex'` rows in `cipx_trace_identities`, and the per-harness token split reconciles exactly with `cipx_spends` totals (no tokens lost or double-counted).
- Full `mvn test` not run (large infra-heavy suite unrelated to this change); scoped to the ingestion test above.

## Documentation

N/A