### PR TITLE
[OPIK-7287] DB management tool in ai-cost-backend

### DIFF
--- a/scripts/dev-runner-platform.sh
+++ b/scripts/dev-runner-platform.sh
@@ -228,10 +228,31 @@ build_platform_backend() {
 # ReactWebappServerApplication self-migrates its schema on startup, so it only
 # needs the DB + accounts to exist (mirrors comet-mini's init_sql). Runs as the
 # opik root user (root/opik) against the dev-runner MySQL.
+#
+# Prefers a host-installed `mysql` client (connecting to the host-mapped
+# 127.0.0.1:${MYSQL_PORT}); when none is on PATH it falls back to the client
+# shipped inside the dev MySQL container via `docker exec`, so no local MySQL
+# install is required. The container is this worktree's docker-compose `mysql`
+# service, named `${RESOURCE_PREFIX}-mysql-1` (RESOURCE_PREFIX ==
+# COMPOSE_PROJECT_NAME); inside it we connect over the internal 127.0.0.1:3306.
 provision_platform_backend_mysql() {
-    require_command mysql
-    log_info "Provisioning EM 'logger' database + users on Opik MySQL (localhost:${MYSQL_PORT})..."
-    if mysql -h 127.0.0.1 -P "${MYSQL_PORT}" -u root -popik --connect-timeout=10 <<'SQL'
+    # Build the argv that pipes the SQL below into a mysql client. Prefer the
+    # host client; otherwise exec into the dev MySQL container.
+    local -a mysql_cmd
+    if command -v mysql &>/dev/null; then
+        log_info "Provisioning EM 'logger' database + users on Opik MySQL (host client, localhost:${MYSQL_PORT})..."
+        mysql_cmd=(mysql -h 127.0.0.1 -P "${MYSQL_PORT}" -u root -popik --connect-timeout=10)
+    else
+        require_command docker
+        local mysql_container="${RESOURCE_PREFIX}-mysql-1"
+        if ! docker ps --format '{{.Names}}' | grep -qx "$mysql_container"; then
+            log_error "No host 'mysql' client found and dev MySQL container '$mysql_container' is not running; cannot provision EM 'logger' database"
+            return 1
+        fi
+        log_info "Provisioning EM 'logger' database + users on Opik MySQL (container ${mysql_container})..."
+        mysql_cmd=(docker exec -i "$mysql_container" mysql -h 127.0.0.1 -u root -popik --connect-timeout=10)
+    fi
+    if "${mysql_cmd[@]}" <<'SQL'
 CREATE DATABASE IF NOT EXISTS `logger` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 -- comet-backend's Liquibase creates TRIGGERs/functions; Opik's MySQL has binlog
 -- on and the 'user' account isn't SUPER, so allow non-super creators (what

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -157,7 +157,7 @@ find_jar_files() {
     while IFS= read -r -d '' jar; do
         jar_files+=("$jar")
     done < <(find target -maxdepth 1 -type f -name 'opik-backend-*.jar' ! -name '*original*' ! -name '*sources*' ! -name '*javadoc*' -print0)
-    
+
     if [ "${#jar_files[@]}" -eq 0 ]; then
         return 1  # No JAR files found
     elif [ "${#jar_files[@]}" -eq 1 ]; then
@@ -168,13 +168,13 @@ find_jar_files() {
         for jar in "${jar_files[@]}"; do
             log_warning "  - $jar"
         done
-        
+
         # Sort JAR files by version (assuming semantic versioning in filename)
         JAR_FILE=$(printf '%s\n' "${jar_files[@]}" | sort -V | tail -n 1)
         log_warning "Automatically selected JAR with highest version: $JAR_FILE"
         log_warning "To use a different JAR, clean up target/ directory and rebuild"
     fi
-    
+
     return 0  # JAR file found and selected
 }
 
@@ -182,10 +182,10 @@ find_jar_files() {
 # Args: $1 = mode (--infra or --local-be or etc.)
 start_docker_services() {
     local mode="$1"
-    
+
     log_info "Starting Docker services..."
     cd "$PROJECT_ROOT" || { log_error "Project root directory not found"; exit 1; }
-    
+
     if ./opik.sh "$mode"; then
         log_success "Docker services started successfully"
     else
@@ -198,10 +198,10 @@ start_docker_services() {
 # Args: $1 = mode (--infra or --local-be or etc.)
 stop_docker_services() {
     local mode="$1"
-    
+
     log_info "Stopping Docker services..."
     cd "$PROJECT_ROOT" || { log_error "Project root directory not found"; exit 1; }
-    
+
     if ./opik.sh "$mode" --stop; then
         log_success "Docker services stopped"
     else
@@ -213,7 +213,7 @@ stop_docker_services() {
 # Args: $1 = mode (--infra or --local-be or etc.)
 verify_docker_services() {
     local mode="$1"
-    
+
     cd "$PROJECT_ROOT" || { log_error "Project root directory not found"; exit 1; }
     ./opik.sh "$mode" --verify >/dev/null 2>&1
     return $?
@@ -782,8 +782,10 @@ start_cost_api_local() {
         AUTH_ENABLED="$cost_api_auth" \
         CLICKHOUSE_HOST=localhost CLICKHOUSE_PORT="$CLICKHOUSE_HTTP_PORT" \
         CLICKHOUSE_DATABASE=opik CLICKHOUSE_USER=opik CLICKHOUSE_PASSWORD=opik \
-        MYSQL_HOST=localhost MYSQL_PORT="$MYSQL_PORT" \
-        MYSQL_DATABASE=opik MYSQL_USER=opik MYSQL_PASSWORD=opik \
+        OPIK_DB_HOST=localhost OPIK_DB_PORT="$MYSQL_PORT" \
+        OPIK_DB_NAME=opik OPIK_DB_USERNAME=opik OPIK_DB_PASSWORD=opik \
+        AI_COST_DB_HOST=localhost AI_COST_DB_PORT="$MYSQL_PORT" \
+        AI_COST_DB_NAME=opik AI_COST_DB_USERNAME=opik AI_COST_DB_PASSWORD=opik \
         PORT="$AI_COST_BACKEND_PORT" \
         nohup uv run uvicorn cost_api.main:app --host 0.0.0.0 --port "$AI_COST_BACKEND_PORT" \
             > "$COST_API_LOG_FILE" 2>&1 &
@@ -1089,7 +1091,7 @@ stop_backend() {
                 fi
                 sleep 1
             done
-            
+
             # Force kill if still running
             if kill -0 "$BACKEND_PID" 2>/dev/null; then
                 log_warning "Force killing backend..."
@@ -1123,7 +1125,7 @@ stop_frontend() {
                 fi
                 sleep 1
             done
-            
+
             # Force kill if still running (kill main process and find children)
             if kill -0 "$FRONTEND_PID" 2>/dev/null; then
                 log_warning "Force killing frontend..."
@@ -1151,13 +1153,13 @@ stop_frontend() {
     # Clean up any orphaned processes by looking for processes with our frontend directory path
     # This is safe and compatible across Unix systems
     ORPHANED_PIDS=$(pgrep -f "$FRONTEND_DIR" 2>/dev/null || true)
-    
+
     if [ -n "$ORPHANED_PIDS" ]; then
         for PID in $ORPHANED_PIDS; do
             if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
                 # Get process info to verify it's actually our frontend process
                 PROCESS_INFO=$(ps -p "$PID" -o comm,args --no-headers 2>/dev/null || true)
-                
+
                 # Only kill if it's an npm/node/vite process AND contains our directory path
                 if [[ "$PROCESS_INFO" =~ (npm|node|vite) ]] && [[ "$PROCESS_INFO" =~ $FRONTEND_DIR ]]; then
                     log_warning "Cleaning up orphaned process: PID $PID - $PROCESS_INFO"
@@ -1250,7 +1252,7 @@ show_access_information() {
 
 create_demo_data() {
     local mode="$1"
-    
+
     log_info "Creating demo data..."
     cd "$PROJECT_ROOT" || { log_error "Project root directory not found"; return 1; }
 
@@ -1454,7 +1456,7 @@ restart_services() {
 # Function for quick restart (only rebuild backend, keep infrastructure running)
 quick_restart_services() {
     log_info "=== Quick Restart (Backend Only) ==="
-    
+
     # Check if infrastructure is running, start it if not
     log_info "Step 1/7: Checking Docker infrastructure..."
     if verify_local_be_fe; then
@@ -1465,7 +1467,7 @@ quick_restart_services() {
         log_info "Running DB migrations..."
         run_db_migrations
     fi
-    
+
     log_info "Step 2/8: Stopping frontend..."
     stop_frontend
     log_info "Step 3/8: Stopping backend..."
@@ -1490,9 +1492,9 @@ quick_restart_services() {
     local package_json="$FRONTEND_DIR/package.json"
     local package_lock="$FRONTEND_DIR/package-lock.json"
     local node_modules="$FRONTEND_DIR/node_modules"
-    
+
     local needs_install=false
-    
+
     if [ ! -d "$node_modules" ]; then
         log_info "node_modules not found, will install dependencies"
         needs_install=true
@@ -1505,7 +1507,7 @@ quick_restart_services() {
     else
         log_info "Frontend dependencies are up to date, skipping npm install"
     fi
-    
+
     if [ "$needs_install" = true ]; then
         build_frontend
     fi


### PR DESCRIPTION
## Details
Updated environment variables names in the `dev-runner.sh` to properly address used databases.

Changes:
- `scripts/dev-runner.sh`: renamed `MYSQL_*` env vars to environment-specific `OPIK_DB_*` and `AI_COST_DB_*` prefixes for the cost-api process
- `scripts/dev-runner-platform.sh`: added a docker-container fallback for the `mysql` client in `provision_platform_backend_mysql()` — when no host `mysql` binary is on PATH, the function execs into the running dev MySQL container instead of hard-failing

**Rebase note**: the second commit originally modified `dev-runner-em.sh`. PR #7456 renamed that file to `dev-runner-platform.sh` and renamed the provisioning function from `provision_em_backend_mysql` to `provision_platform_backend_mysql`. The PR was rebased onto main and the conflict resolved by applying the docker-fallback logic under the new function name.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7287

<!--
Jira linking: tickets this PR RESOLVES keep the hyphen (OPIK-1234) here and anywhere — they link in Jira's Development panel, which is wanted. A PR may resolve more than one ticket; list each resolved key.
Tickets RELATED but NOT resolved here (escalations, references to older tickets) must NOT link: in the sections above/below and in commit messages, write them with an underscore (OPIK_7000) and paste no Jira URL (the URL contains the hyphenated key and links anyway). See CONTRIBUTING.md.
-->


## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
Manual testing

## Documentation
NA