### PR TITLE
[OPIK-7319] Optimize getTraceKpiCards: drop trace_costs LEFT JOIN

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
@@ -55,6 +55,12 @@ class KpiCardDAOImpl implements KpiCardDAO {
     private final @NonNull InstantToUUIDMapper instantToUUIDMapper;
     private final @NonNull OpikConfiguration configuration;
 
+    /**
+     * trace_costs buckets the TOTAL_COST KPI into current/previous periods keyed on trace_id (a
+     * UUIDv7 matching the trace id used for the count/error/duration split) and is CROSS JOINed as a
+     * single row, avoiding the per-trace LEFT JOIN whose hash build dominated peak memory on large
+     * projects. Identical results; the trace_id IN (traces_filtered) semijoin is retained. OPIK-7319.
+     */
     private static final String GET_TRACE_KPI_CARDS = """
             WITH feedback_scores_deduped AS (
                 SELECT workspace_id,
@@ -186,12 +192,17 @@ class KpiCardDAOImpl implements KpiCardDAO {
                     <endif>
                 ) AS t
             ), trace_costs AS (
-                SELECT trace_id, sum(total_estimated_cost) AS cost
-                FROM spans FINAL
-                WHERE workspace_id = :workspace_id AND project_id = :project_id
-                  AND id >= :uuid_from_time AND id \\<= :uuid_to_time
-                  AND trace_id IN (SELECT id FROM traces_filtered)
-                GROUP BY trace_id
+                SELECT
+                    SUMIf(cost, trace_id >= :id_current_start AND trace_id \\<= :id_end) AS current_total_cost,
+                    SUMIf(cost, trace_id >= :id_prior_start AND trace_id \\< :id_current_start) AS previous_total_cost
+                FROM (
+                    SELECT trace_id, sum(total_estimated_cost) AS cost
+                    FROM spans FINAL
+                    WHERE workspace_id = :workspace_id AND project_id = :project_id
+                      AND id >= :uuid_from_time AND id \\<= :uuid_to_time
+                      AND trace_id IN (SELECT id FROM traces_filtered)
+                    GROUP BY trace_id
+                )
             )
             SELECT
                 COUNTIf(tf.id >= :id_current_start AND tf.id \\<= :id_end) AS current_count,
@@ -206,10 +217,10 @@ class KpiCardDAOImpl implements KpiCardDAO {
                     / COUNTIf(tf.id >= :id_prior_start AND tf.id \\< :id_current_start)) AS previous_error_rate,
                 AVGIf(tf.duration, tf.id >= :id_current_start AND tf.id \\<= :id_end) AS current_avg_duration,
                 AVGIf(tf.duration, tf.id >= :id_prior_start AND tf.id \\< :id_current_start) AS previous_avg_duration,
-                SUMIf(tc.cost, tf.id >= :id_current_start AND tf.id \\<= :id_end) AS current_total_cost,
-                SUMIf(tc.cost, tf.id >= :id_prior_start AND tf.id \\< :id_current_start) AS previous_total_cost
+                any(tc.current_total_cost) AS current_total_cost,
+                any(tc.previous_total_cost) AS previous_total_cost
             FROM traces_filtered tf
-            LEFT JOIN trace_costs tc ON tf.id = tc.trace_id
+            CROSS JOIN trace_costs tc
             SETTINGS log_comment = '<log_comment>';
             """;
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/KpiCardsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/KpiCardsResourceTest.java
@@ -191,6 +191,52 @@ class KpiCardsResourceTest {
         }
     }
 
+    @Test
+    @DisplayName("trace TOTAL_COST sums every span belonging to a trace")
+    void traceCostSumsAllSpansOfTrace() {
+        mockTargetWorkspace();
+        var projectName = RandomStringUtils.secure().nextAlphabetic(10);
+        var projectId = projectResourceClient.createProject(projectName, API_KEY, WORKSPACE_NAME);
+
+        Instant intervalStart = Instant.now();
+        Instant now = Instant.now();
+
+        Trace trace = factory.manufacturePojo(Trace.class).toBuilder()
+                .id(idGenerator.generateId(now))
+                .projectName(projectName)
+                .startTime(now)
+                .endTime(now.plus(DURATION_1, ChronoUnit.MILLIS))
+                .errorInfo(null)
+                .threadId(null)
+                .build();
+
+        List<Span> spans = List.of(COST_1, COST_2, COST_3).stream()
+                .map(cost -> factory.manufacturePojo(Span.class).toBuilder()
+                        .id(idGenerator.generateId(now.plus(1, ChronoUnit.MILLIS)))
+                        .traceId(trace.id())
+                        .projectName(projectName)
+                        .startTime(now)
+                        .endTime(now.plus(50, ChronoUnit.MILLIS))
+                        .totalEstimatedCost(BigDecimal.valueOf(cost))
+                        .errorInfo(null)
+                        .build())
+                .toList();
+
+        traceResourceClient.batchCreateTraces(List.of(trace), API_KEY, WORKSPACE_NAME);
+        spanResourceClient.batchCreateSpans(spans, API_KEY, WORKSPACE_NAME);
+
+        Instant intervalEnd = Instant.now().plus(1, ChronoUnit.MINUTES);
+
+        KpiCardResponse response = projectResourceClient.getKpiCards(projectId, KpiCardRequest.builder()
+                .entityType(EntityType.TRACES)
+                .intervalStart(intervalStart)
+                .intervalEnd(intervalEnd)
+                .build(), API_KEY, WORKSPACE_NAME);
+
+        assertMetric(response, KpiMetricType.COUNT, 1.0, 0.0);
+        assertMetric(response, KpiMetricType.TOTAL_COST, COST_1 + COST_2 + COST_3, 0.0);
+    }
+
     @ParameterizedTest
     @EnumSource(EntityType.class)
     @DisplayName("returns metrics only for current period when no previous data exists")


### PR DESCRIPTION
## Details

`getTraceKpiCards` is the heaviest of the three KPI-card ClickHouse queries. It combined `traces_filtered` (count / error-rate / avg-duration) with `trace_costs` (the `spans FINAL` cost aggregation) via a per-trace `LEFT JOIN trace_costs tc ON tf.id = tc.trace_id`; on large projects `traces_filtered` is millions of rows and that join's hash build dominated peak memory.

Since the current/previous period split is keyed on the trace's UUIDv7 `id` and `spans.trace_id` is that same id, the cost can be pre-bucketed into the two periods inside `trace_costs` and `CROSS JOIN`ed as a single row, eliminating the join. Results are identical and the `trace_id IN (traces_filtered)` semijoin is retained for correctness. The `spans FINAL` scan (the query's dominant IO) is unchanged — this is a memory/latency trim.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7319

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: query rewrite in `KpiCardDAO.GET_TRACE_KPI_CARDS`, live validation and benchmarking against a production ClickHouse replica, commit and PR authoring.
- Human verification: rewrite reviewed; results and benchmark independently reproduced against production before merge.

## Testing

The exact rendered query (no-filter form) was run against a production ClickHouse replica on the highest-cost project over a ~14-day window and compared to the original:

- Output identical: counts, error-rates and total cost match to the cent (`avg_duration` differs only at the 15th decimal — floating-point summation-order noise, non-deterministic between runs of either query).
- 5 runs each: median latency 2971 ms -> 2552 ms (~14% faster); median peak memory 1.54 GiB -> 1.23 GiB (~20% lower and more stable); rows/bytes/marks unchanged.

CI runs `KpiCardsResourceTest` which exercises the templated path (including filter branches). Local resource tests were not run due to a known local-bootstrap harness limitation; relying on CI for the integration suite.

## Documentation

None — internal query optimization, no behavior or API change.
