### PR TITLE
[NA] [QA] fix: match project breadcrumb by text after project-menu redesign

### DIFF
--- a/tests_end_to_end/e2e/pom/logs.page.ts
+++ b/tests_end_to_end/e2e/pom/logs.page.ts
@@ -101,9 +101,15 @@ export class LogsPage {
     });
   }
 
-  /** Breadcrumb link for the current project, shown when navigated to /logs. */
+  /**
+   * The current project's item in the breadcrumb, shown when navigated to /logs.
+   * Matched by text rather than role: older UIs render it as a link, newer ones
+   * (project menu redesign) as a dropdown button — the name is present in both.
+   */
   breadcrumbProjectLink(projectName: string): Locator {
-    return this.page.getByRole('navigation', { name: 'breadcrumb' }).getByRole('link', { name: projectName });
+    return this.page
+      .getByRole('navigation', { name: 'breadcrumb' })
+      .getByText(projectName, { exact: true });
   }
 
   get traceRows(): Locator {


### PR DESCRIPTION
## Details

The project menu redesign (OPIK_7125 / #7386) converted the breadcrumb project item from a `<Link>` (role `link`) into a dropdown `<button>` Popover trigger (`ProjectBreadcrumbSelector`). `LogsPage.breadcrumbProjectLink` still matched on `getByRole('link', …)`, so it no longer resolved and `trace-explore-smoke.spec.ts:48` (\"Trace panel renders … project breadcrumb\") failed on post-merge. This retargets the locator to match the project name **by text within the breadcrumb nav**, which resolves against both the old link and the new button rendering — keeping the test green across older deployments and current main.

- Root cause confirmed via TestOps history: 929 consecutive passes, then the first failure on the exact post-merge run that built #7386.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK_7125 (breadcrumb project-menu redesign — related, not resolved here)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (debugging-e2e-tests + writing-e2e-tests skills)
- Model(s): Claude Opus 4.8
- Scope: Diagnosis of the failing E2E test and the one-line POM selector fix
- Human verification: Local run of the affected spec (2 passed) against the local OSS stack; root cause cross-checked against the #7386 diff and TestOps launch history

## Testing

Ran the affected spec locally from `tests_end_to_end/e2e/` against the local OSS stack (`http://localhost:5173`):

\`\`\`
npx playwright test tests/trace-explore/trace-explore-smoke.spec.ts --reporter=list
\`\`\`

Result:

\`\`\`
✓ trace-explore-smoke.spec.ts:5  Logs view shows seeded traces with correct count and ordering (10.4s)
✓ trace-explore-smoke.spec.ts:48 Trace panel renders … project breadcrumb (14.4s)
2 passed (33.7s)
\`\`\`

- The local stack serves the pre-redesign frontend (breadcrumb still a `link`), so this run verifies the fix against the **old** rendering.
- The **new** button rendering is covered by structure: in `ProjectBreadcrumbSelector` the project name appears exactly once, in a `<span>` inside the button, within the `<nav aria-label=\"breadcrumb\">`, so the text match is unambiguous.

## Documentation

N/A — test-infrastructure fix only.