### PR TITLE
[OPIK-7321] fix: union getProjectIds result stream instead of single()

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
@@ -66,6 +66,7 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1603,6 +1604,11 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
      * Distinct project_ids this experiment's items reference; always emits exactly one Set
      * (possibly empty when no traces with project_id are found). See
      * {@link #GET_PROJECT_IDS}.
+     * <p>
+     * The result stream is folded with {@code reduceWith} rather than terminated with
+     * {@code single()}: the R2DBC result publisher can emit more than one element, which makes
+     * {@code single()}/{@code singleOrEmpty()} throw {@code IndexOutOfBoundsException}. Unioning
+     * the emitted sets always yields exactly one Set and is idempotent for the single-row result.
      */
     @Override
     public Mono<Set<UUID>> getProjectIds(UUID experimentId) {
@@ -1619,7 +1625,10 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                             .stream(row.get("project_ids", String[].class))
                             .map(UUID::fromString)
                             .collect(Collectors.toUnmodifiableSet())));
-        }).single());
+        }).reduceWith(() -> new HashSet<UUID>(), (allProjectIds, projectIds) -> {
+            allProjectIds.addAll(projectIds);
+            return allProjectIds;
+        }).map(Set::copyOf));
     }
 
     private Mono<TraceAggregations> getTraceAggregations(UUID experimentId, Set<UUID> projectIds, UUID labelProjectId) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
@@ -1602,17 +1602,13 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
 
     /**
      * Distinct project_ids this experiment's items reference; always emits exactly one Set
-     * (possibly empty when no traces with project_id are found). See
-     * {@link #GET_PROJECT_IDS}.
-     * <p>
-     * The result stream is folded with {@code reduceWith} rather than terminated with
-     * {@code single()}: the R2DBC result publisher can emit more than one element, which makes
-     * {@code single()}/{@code singleOrEmpty()} throw {@code IndexOutOfBoundsException}. Unioning
-     * the emitted sets always yields exactly one Set and is idempotent for the single-row result.
+     * (possibly empty when no traces with project_id are found). See {@link #GET_PROJECT_IDS} and
+     * {@link #unionProjectIdChunks(Flux)}.
      */
     @Override
     public Mono<Set<UUID>> getProjectIds(UUID experimentId) {
-        return asyncTemplate.nonTransaction(connection -> makeFluxContextAware((userName, workspaceId) -> {
+        return asyncTemplate.nonTransaction(connection -> unionProjectIdChunks(makeFluxContextAware((userName,
+                workspaceId) -> {
             var template = getSTWithLogComment(GET_PROJECT_IDS,
                     "getProjectIds", workspaceId, userName, experimentId.toString());
 
@@ -1625,10 +1621,21 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
                             .stream(row.get("project_ids", String[].class))
                             .map(UUID::fromString)
                             .collect(Collectors.toUnmodifiableSet())));
-        }).reduceWith(() -> new HashSet<UUID>(), (allProjectIds, projectIds) -> {
+        })));
+    }
+
+    /**
+     * Folds the project_id chunks emitted by the result stream into a single immutable Set. Using
+     * {@code reduceWith} (rather than {@code single()}/{@code singleOrEmpty()}) is deliberate: the
+     * R2DBC result publisher can emit more than one element, which would make {@code single()}
+     * throw {@code IndexOutOfBoundsException}. Unioning always yields exactly one Set (empty when
+     * the stream is empty) and is idempotent for the normal single-row result.
+     */
+    static Mono<Set<UUID>> unionProjectIdChunks(Flux<Set<UUID>> projectIdChunks) {
+        return projectIdChunks.reduceWith(() -> new HashSet<UUID>(), (allProjectIds, projectIds) -> {
             allProjectIds.addAll(projectIds);
             return allProjectIds;
-        }).map(Set::copyOf));
+        }).map(Set::copyOf);
     }
 
     private Mono<TraceAggregations> getTraceAggregations(UUID experimentId, Set<UUID> projectIds, UUID labelProjectId) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
@@ -42,6 +42,7 @@ import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.inject.ImplementedBy;
 import io.r2dbc.spi.Connection;
@@ -1631,6 +1632,7 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
      * throw {@code IndexOutOfBoundsException}. Unioning always yields exactly one Set (empty when
      * the stream is empty) and is idempotent for the normal single-row result.
      */
+    @VisibleForTesting
     static Mono<Set<UUID>> unionProjectIdChunks(Flux<Set<UUID>> projectIdChunks) {
         return projectIdChunks.reduceWith(() -> new HashSet<UUID>(), (allProjectIds, projectIds) -> {
             allProjectIds.addAll(projectIds);

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAOImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAOImplTest.java
@@ -1,0 +1,46 @@
+package com.comet.opik.domain.experiments.aggregations;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExperimentAggregatesDAOImplTest {
+
+    @Test
+    @DisplayName("multiple emitted chunks are unioned into exactly one Set (single() would throw here)")
+    void unionProjectIdChunksUnionsMultipleChunks() {
+        var a = UUID.randomUUID();
+        var b = UUID.randomUUID();
+        var c = UUID.randomUUID();
+
+        StepVerifier.create(ExperimentAggregatesDAOImpl.unionProjectIdChunks(
+                Flux.just(Set.of(a, b), Set.of(b, c))))
+                .assertNext(projectIds -> assertThat(projectIds).containsExactlyInAnyOrder(a, b, c))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("a single emitted chunk passes through unchanged")
+    void unionProjectIdChunksPassesSingleChunkThrough() {
+        var a = UUID.randomUUID();
+        var b = UUID.randomUUID();
+
+        StepVerifier.create(ExperimentAggregatesDAOImpl.unionProjectIdChunks(Flux.just(Set.of(a, b))))
+                .assertNext(projectIds -> assertThat(projectIds).containsExactlyInAnyOrder(a, b))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("an empty stream still emits exactly one, empty Set")
+    void unionProjectIdChunksEmitsEmptySetForEmptyStream() {
+        StepVerifier.create(ExperimentAggregatesDAOImpl.unionProjectIdChunks(Flux.empty()))
+                .assertNext(projectIds -> assertThat(projectIds).isEmpty())
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
## Details

`ExperimentAggregatesDAO.getProjectIds` terminated its reactive pipeline with `single()`, which throws `IndexOutOfBoundsException` ("Source emitted more than one item") — surfacing as an unmapped HTTP 500 — whenever the R2DBC result stream emits more than one element. The method is documented to "always emit exactly one Set (possibly empty)", so this folds the emitted sets with `reduceWith` instead: it always emits exactly one Set, is idempotent for the normal single-row result, and no longer depends on the stream emitting exactly one element.

- `reduceWith` uses a fresh accumulator per subscription (avoids the shared-mutable-seed pitfall of `reduce(seed, ...)`).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7321

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Root-cause analysis and the one-method fix in `ExperimentAggregatesDAO.getProjectIds` (+ javadoc).
- Human verification: Diff reviewed; `mvn compile` run locally; author to confirm CI (resource tests do not bootstrap locally).

## Testing

- `cd apps/opik-backend && mvn -q compile` — succeeds.
- Full `mvn test` deferred to CI (the resource test harness does not bootstrap cleanly in this local environment).
- Behavior: the pipeline now unions all emitted sets into a single Set, so a multi-element stream no longer throws; the empty-stream case still emits an empty Set.

## Documentation
