### PR TITLE
[OPIK-7322] fix: parse OpenAI error model before OpenRouter in getErrorObject

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/LlmProviderLangChainMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/LlmProviderLangChainMapper.java
@@ -241,14 +241,22 @@ public interface LlmProviderLangChainMapper {
         return t.getMessage() != null && t.getMessage().contains("{");
     }
 
+    /**
+     * Every caller is an OpenAI-compatible provider, whose error payload carries a String
+     * {@code code} (e.g. {@code "rate_limit_exceeded"}). {@link OpenRouterErrorMessage} types
+     * {@code code} as {@code Integer}, so attempting it first made Jackson throw
+     * {@code InvalidFormatException} (wrapped as {@code UncheckedIOException}) on every such error,
+     * logging a full WARN stack before the OpenAI fallback recovered. Attempt the OpenAI model
+     * first so the common path parses on the first try; keep OpenRouter as a defensive fallback.
+     */
     default Optional<ErrorMessage> getErrorObject(@NonNull Throwable throwable, @NonNull Logger log) {
 
-        Optional<ErrorMessage> errorMessage = getErrorMessage(throwable, log, OpenRouterErrorMessage.class);
+        Optional<ErrorMessage> errorMessage = getErrorMessage(throwable, log, OpenAiErrorMessage.class);
 
         if (errorMessage.isPresent()) {
             return errorMessage;
         }
 
-        return getErrorMessage(throwable, log, OpenAiErrorMessage.class);
+        return getErrorMessage(throwable, log, OpenRouterErrorMessage.class);
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/LlmProviderLangChainMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/LlmProviderLangChainMapperTest.java
@@ -1,0 +1,56 @@
+package com.comet.opik.infrastructure.llm;
+
+import io.dropwizard.jersey.errors.ErrorMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LlmProviderLangChainMapperTest {
+
+    private static final Logger log = LoggerFactory.getLogger(LlmProviderLangChainMapperTest.class);
+
+    private final LlmProviderLangChainMapper mapper = LlmProviderLangChainMapper.INSTANCE;
+
+    static Stream<Arguments> openAiStringCodeErrors() {
+        return Stream.of(
+                Arguments.of("rate_limit_exceeded", 429),
+                Arguments.of("insufficient_quota", 402),
+                Arguments.of("invalid_api_key", 401));
+    }
+
+    @ParameterizedTest
+    @MethodSource("openAiStringCodeErrors")
+    @DisplayName("OpenAI-format error with a String code resolves to the right status without a failed parse")
+    void getErrorObjectResolvesOpenAiStringCodeError(String code, int expectedStatus) {
+        var body = """
+                {"error":{"message":"boom","type":"some_type","code":"%s"}}""".formatted(code);
+        var throwable = new RuntimeException("io.dropwizard client error: " + body);
+
+        Optional<ErrorMessage> result = mapper.getErrorObject(throwable, log);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getCode()).isEqualTo(expectedStatus);
+        assertThat(result.get().getMessage()).isEqualTo("boom");
+    }
+
+    @DisplayName("no error object is returned when the throwable carries no JSON payload")
+    @ParameterizedTest
+    @MethodSource("noJsonThrowables")
+    void getErrorObjectReturnsEmptyWhenNoJson(Throwable throwable) {
+        assertThat(mapper.getErrorObject(throwable, log)).isEmpty();
+    }
+
+    static Stream<Arguments> noJsonThrowables() {
+        return Stream.of(
+                Arguments.of(new RuntimeException("connection reset")),
+                Arguments.of(new RuntimeException((String) null)));
+    }
+}


### PR DESCRIPTION
## Details

`LlmProviderLangChainMapper.getErrorObject` attempted to parse a provider error payload as `OpenRouterErrorMessage` first, whose `code` field is typed `Integer`. Every caller is an OpenAI-compatible provider (`FreeModelLlmProvider`, `LlmProviderOpenAi`, `LlmProviderOpenAiResponses`), whose errors carry a String `code` (e.g. `"rate_limit_exceeded"`), so the first attempt always threw `InvalidFormatException` (wrapped `UncheckedIOException`), logging a full WARN stack before the OpenAI fallback recovered. This flips the order to parse the OpenAI model first, keeping OpenRouter as a defensive fallback — the common path now parses on the first try with no thrown/caught exception and no WARN noise.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7322

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Reorder in `LlmProviderLangChainMapper.getErrorObject` (+ javadoc) and a new `LlmProviderLangChainMapperTest`.
- Human verification: Diff reviewed; the new unit test run locally (see Testing); author to confirm CI.

## Testing

- `cd apps/opik-backend && mvn -o test -Dtest=LlmProviderLangChainMapperTest` — `Tests run: 5, Failures: 0, Errors: 0`.
- New test asserts OpenAI-format errors with a String `code` (`rate_limit_exceeded` → 429, `insufficient_quota` → 402, `invalid_api_key` → 401) resolve to the right status, and that a payload-less throwable yields an empty result. With the fix these parse on the first attempt (no "failed to parse" WARN); the only WARNs emitted are from the deliberate no-payload cases.

## Documentation
