### PR TITLE
[NA] dev-runner: mount ai-spend FE plugin, EM→Platform rename, --platform-enabled flag

### DIFF
--- a/.agents/skills/local-dev/SKILL.md
+++ b/.agents/skills/local-dev/SKILL.md
@@ -36,7 +36,7 @@ PLATFORM_ENABLED=true ./scripts/dev-runner.sh --restart   # then also --start/--
 #                 http://localhost:9100/opik   (Opik, comet mode)
 ```
 
-Env vars (`COMET_BACKEND_PATH`, `COMET_REACT_PATH`, `EM_JAVA_HOME`, `EM_*_PORT`)
+Env vars (`COMET_BACKEND_PATH`, `COMET_REACT_PATH`, `PLATFORM_JAVA_HOME`, `PLATFORM_*_PORT`)
 and `--platform-build` are documented in `./scripts/dev-runner.sh --help`.
 
 ## URLs

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,7 +84,7 @@ backend, and frontend services for development workflows.
 
 **EM / Platform Mode** (Opik-team only — opt-in via `PLATFORM_ENABLED=true`):
 
-Runs the Comet EM/Platform stack (`comet-backend` + `comet-react`, auto-detected sibling checkouts) alongside Opik behind a single-origin proxy, with Opik in comet mode. Off by default; Standard/BE-only dev is unaffected. See `--help` for env vars (`COMET_BACKEND_PATH`, `COMET_REACT_PATH`, `EM_JAVA_HOME`, `EM_*_PORT`).
+Runs the Comet EM/Platform stack (`comet-backend` + `comet-react`, auto-detected sibling checkouts) alongside Opik behind a single-origin proxy, with Opik in comet mode. Off by default; Standard/BE-only dev is unaffected. See `--help` for env vars (`COMET_BACKEND_PATH`, `COMET_REACT_PATH`, `PLATFORM_JAVA_HOME`, `PLATFORM_*_PORT`).
 
 | Command | Description |
 |---------|-------------|

--- a/scripts/dev-runner-platform.sh
+++ b/scripts/dev-runner-platform.sh
@@ -5,7 +5,7 @@
 # This file is SOURCED by dev-runner.sh (not executed) to keep the core script
 # focused on the Opik dev flow. It defines the EM_* variables, sibling-repo
 # auto-detection, and every em_*/*_em_* function. dev-runner.sh only calls a
-# handful of hooks (start_em_stack/stop_em_stack/em_print_status/…), all gated
+# handful of hooks (start_platform_stack/stop_platform_stack/platform_print_status/…), all gated
 # on PLATFORM_ENABLED=true, so with the flag unset this is inert.
 #
 # Relies on helpers/vars defined in dev-runner.sh before it is sourced:
@@ -25,27 +25,27 @@
 # second webpack dev server, so it stays off unless PLATFORM_ENABLED=true.
 PLATFORM_ENABLED="${PLATFORM_ENABLED:-false}"
 # Ports offset per worktree, clear of Opik's 8080/8081/5173/5174.
-EM_BACKEND_PORT="${EM_BACKEND_PORT:-$((8200 + PORT_OFFSET))}"
-EM_BACKEND_ADMIN_PORT="${EM_BACKEND_ADMIN_PORT:-$((8201 + PORT_OFFSET))}"
-EM_FRONTEND_PORT="${EM_FRONTEND_PORT:-$((8300 + PORT_OFFSET))}"
-EM_BACKEND_PID_FILE="/tmp/${RESOURCE_PREFIX}-em-backend.pid"
-EM_BACKEND_LOG_FILE="/tmp/${RESOURCE_PREFIX}-em-backend.log"
+PLATFORM_BACKEND_PORT="${PLATFORM_BACKEND_PORT:-$((8200 + PORT_OFFSET))}"
+PLATFORM_BACKEND_ADMIN_PORT="${PLATFORM_BACKEND_ADMIN_PORT:-$((8201 + PORT_OFFSET))}"
+PLATFORM_FRONTEND_PORT="${PLATFORM_FRONTEND_PORT:-$((8300 + PORT_OFFSET))}"
+PLATFORM_BACKEND_PID_FILE="/tmp/${RESOURCE_PREFIX}-em-backend.pid"
+PLATFORM_BACKEND_LOG_FILE="/tmp/${RESOURCE_PREFIX}-em-backend.log"
 # Sidecar so --stop can find the repo even without COMET_BACKEND_PATH in scope.
-EM_BACKEND_REPO_PATH_FILE="/tmp/${RESOURCE_PREFIX}-em-backend.repo"
+PLATFORM_BACKEND_REPO_PATH_FILE="/tmp/${RESOURCE_PREFIX}-em-backend.repo"
 # Generated Dropwizard config (patched copy of the module's test-config.yml).
-EM_BACKEND_CONFIG_FILE="/tmp/${RESOURCE_PREFIX}-em-backend-config.yml"
-EM_FRONTEND_PID_FILE="/tmp/${RESOURCE_PREFIX}-em-frontend.pid"
-EM_FRONTEND_LOG_FILE="/tmp/${RESOURCE_PREFIX}-em-frontend.log"
-EM_FRONTEND_REPO_PATH_FILE="/tmp/${RESOURCE_PREFIX}-em-frontend.repo"
+PLATFORM_BACKEND_CONFIG_FILE="/tmp/${RESOURCE_PREFIX}-em-backend-config.yml"
+PLATFORM_FRONTEND_PID_FILE="/tmp/${RESOURCE_PREFIX}-em-frontend.pid"
+PLATFORM_FRONTEND_LOG_FILE="/tmp/${RESOURCE_PREFIX}-em-frontend.log"
+PLATFORM_FRONTEND_REPO_PATH_FILE="/tmp/${RESOURCE_PREFIX}-em-frontend.repo"
 # Backup of the developer's hand-maintained comet-react public/config.js, so
 # --stop can restore it after dev-runner points the FE at the EM backend.
-EM_FRONTEND_CONFIG_BAK_FILE="/tmp/${RESOURCE_PREFIX}-em-frontend-config.js.bak"
+PLATFORM_FRONTEND_CONFIG_BAK_FILE="/tmp/${RESOURCE_PREFIX}-em-frontend-config.js.bak"
 # Single-origin reverse proxy (nginx container) fronting EM + Opik. Comet mode's
 # URLs are all relative (/, /api, /opik, /opik/api), so the whole integrated UI
 # must be served from ONE origin — this is the URL you open in the browser.
-EM_PROXY_PORT="${EM_PROXY_PORT:-$((9100 + PORT_OFFSET))}"
-EM_PROXY_CONTAINER="${RESOURCE_PREFIX}-em-proxy"
-EM_PROXY_CONF="/tmp/${RESOURCE_PREFIX}-em-proxy.conf"
+PLATFORM_PROXY_PORT="${PLATFORM_PROXY_PORT:-$((9100 + PORT_OFFSET))}"
+PLATFORM_PROXY_CONTAINER="${RESOURCE_PREFIX}-em-proxy"
+PLATFORM_PROXY_CONF="/tmp/${RESOURCE_PREFIX}-em-proxy.conf"
 
 # ---- Sibling-repo auto-detection ----
 # Auto-detect sibling comet-backend / comet-react checkouts for the EM stack
@@ -75,13 +75,13 @@ fi
 # gitignored comet-react public/config.js (backed up + restored on --stop).
 
 # Is the EM backend opted in and available?
-em_stack_enabled() {
+platform_stack_enabled() {
     [ "$PLATFORM_ENABLED" = "true" ] && [ -n "${COMET_BACKEND_PATH:-}" ]
 }
 
 # Is the EM frontend (comet-react) also available? Requires the backend gate.
-em_frontend_enabled() {
-    em_stack_enabled && [ -n "${COMET_REACT_PATH:-}" ]
+platform_frontend_enabled() {
+    platform_stack_enabled && [ -n "${COMET_REACT_PATH:-}" ]
 }
 
 # Feature (major) version of the JDK at $1 (a JAVA_HOME dir); echoes nothing if
@@ -99,17 +99,17 @@ _java_major_of() {
 # Lombok 1.18.30 (works on 17/21, NOT newer), whereas opik-backend requires JDK
 # 25 — so the two can't share JAVA_HOME, and we must NOT assume the user's
 # default JDK suits comet-backend (most Opik devs default to 25). Resolution:
-# explicit EM_JAVA_HOME wins; else find an installed JDK whose major is one of
-# EM_JAVA_ACCEPTED_MAJORS (default "17 21", tried in order) across macOS
+# explicit PLATFORM_JAVA_HOME wins; else find an installed JDK whose major is one of
+# PLATFORM_JAVA_ACCEPTED_MAJORS (default "17 21", tried in order) across macOS
 # java_home, the ambient JAVA_HOME, SDKMAN, Linux, and Homebrew. Echoes nothing
 # if none is found (callers warn + skip the EM stack).
-em_java_home() {
-    if [ -n "${EM_JAVA_HOME:-}" ]; then
-        echo "$EM_JAVA_HOME"
+platform_java_home() {
+    if [ -n "${PLATFORM_JAVA_HOME:-}" ]; then
+        echo "$PLATFORM_JAVA_HOME"
         return
     fi
     local want cand
-    for want in ${EM_JAVA_ACCEPTED_MAJORS:-17 21}; do
+    for want in ${PLATFORM_JAVA_ACCEPTED_MAJORS:-17 21}; do
         # macOS: any installed JDK of this major, regardless of the default.
         # NB: java_home falls back to the newest JDK for an unavailable version
         # (exit 0), so verify the resolved major actually matches.
@@ -136,8 +136,8 @@ em_java_home() {
     done
 }
 
-em_backend_running() {
-    [ -f "$EM_BACKEND_PID_FILE" ] && kill -0 "$(cat "$EM_BACKEND_PID_FILE")" 2>/dev/null
+platform_backend_running() {
+    [ -f "$PLATFORM_BACKEND_PID_FILE" ] && kill -0 "$(cat "$PLATFORM_BACKEND_PID_FILE")" 2>/dev/null
 }
 
 # Is the EM backend serving? Liveness probe, NOT deep health: /isAlive/ping is
@@ -147,45 +147,45 @@ em_backend_running() {
 # readiness wait would time out. /auth/test returns 200 as soon as the app is
 # serving, independent of feature toggles. Also detects an instance started
 # outside dev-runner (e.g. from IntelliJ) so we reuse it instead of colliding.
-em_backend_healthy() {
+platform_backend_healthy() {
     command -v curl >/dev/null 2>&1 || return 1
-    curl -sf --max-time 2 "http://localhost:${EM_BACKEND_PORT}/auth/test" >/dev/null 2>&1
+    curl -sf --max-time 2 "http://localhost:${PLATFORM_BACKEND_PORT}/auth/test" >/dev/null 2>&1
 }
 
-em_frontend_running() {
-    [ -f "$EM_FRONTEND_PID_FILE" ] && kill -0 "$(cat "$EM_FRONTEND_PID_FILE")" 2>/dev/null
+platform_frontend_running() {
+    [ -f "$PLATFORM_FRONTEND_PID_FILE" ] && kill -0 "$(cat "$PLATFORM_FRONTEND_PID_FILE")" 2>/dev/null
 }
 
-wait_for_em_backend_ready() {
+wait_for_platform_backend_ready() {
     require_command curl
     local pid="${1:-}"
-    log_info "Waiting for EM backend to be ready on port ${EM_BACKEND_PORT}..."
+    log_info "Waiting for EM backend to be ready on port ${PLATFORM_BACKEND_PORT}..."
     # First boot runs schema migrations against the fresh 'logger' DB, so allow
     # a generous window.
     local max_wait=180
     local count=0
     while [ $count -lt $max_wait ]; do
-        if em_backend_healthy; then
+        if platform_backend_healthy; then
             log_success "EM backend is ready and accepting connections"
-            log_info "EM backend API: ${GREEN}http://localhost:${EM_BACKEND_PORT}${NC}"
+            log_info "EM backend API: ${GREEN}http://localhost:${PLATFORM_BACKEND_PORT}${NC}"
             return 0
         fi
         sleep 1
         count=$((count + 1))
         if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
             log_error "EM backend process died while waiting for it to be ready"
-            log_error "Check logs: tail -f $EM_BACKEND_LOG_FILE"
-            rm -f "$EM_BACKEND_PID_FILE"
+            log_error "Check logs: tail -f $PLATFORM_BACKEND_LOG_FILE"
+            rm -f "$PLATFORM_BACKEND_PID_FILE"
             return 1
         fi
     done
     log_error "EM backend failed to become ready after ${max_wait}s"
-    log_error "Check logs: tail -f $EM_BACKEND_LOG_FILE"
+    log_error "Check logs: tail -f $PLATFORM_BACKEND_LOG_FILE"
     return 1
 }
 
 # Locate the shaded react-webapp jar (mirrors find_jar_files for opik-backend).
-find_em_backend_jar() {
+find_platform_backend_jar() {
     local dir="$COMET_BACKEND_PATH/comet-ml-react-webapp/target"
     local jars=()
     while IFS= read -r -d '' j; do
@@ -195,17 +195,17 @@ find_em_backend_jar() {
     if [ "${#jars[@]}" -eq 0 ]; then
         return 1
     fi
-    EM_BACKEND_JAR=$(printf '%s\n' "${jars[@]}" | sort -V | tail -n 1)
+    PLATFORM_BACKEND_JAR=$(printf '%s\n' "${jars[@]}" | sort -V | tail -n 1)
     return 0
 }
 
-build_em_backend() {
+build_platform_backend() {
     require_command mvn
     local em_jh
-    em_jh=$(em_java_home)
+    em_jh=$(platform_java_home)
     if [ -z "$em_jh" ] || [ ! -x "$em_jh/bin/java" ]; then
         log_error "EM stack needs a JDK 17 for comet-backend (opik-backend uses JDK 25; they can't share one)."
-        log_error "Install a JDK 17 or set EM_JAVA_HOME=/path/to/jdk17, then retry."
+        log_error "Install a JDK 17 or set PLATFORM_JAVA_HOME=/path/to/jdk17, then retry."
         return 1
     fi
     log_info "Building comet-backend React webapp with JDK $(_java_major_of "$em_jh") at $em_jh (EM reactor; first run is slow)..."
@@ -213,11 +213,11 @@ build_em_backend() {
          mvn -pl comet-ml-react-webapp -am clean install \
              -T 1C -Dmaven.test.skip=true -Dspotless.skip=true \
              -Dmaven.javadoc.skip=true -Dmaven.source.skip=true ); then
-        if ! find_em_backend_jar; then
+        if ! find_platform_backend_jar; then
             log_error "comet-backend build finished but no react-webapp JAR was found"
             return 1
         fi
-        log_success "comet-backend React webapp built: $EM_BACKEND_JAR"
+        log_success "comet-backend React webapp built: $PLATFORM_BACKEND_JAR"
     else
         log_error "comet-backend build failed"
         return 1
@@ -228,7 +228,7 @@ build_em_backend() {
 # ReactWebappServerApplication self-migrates its schema on startup, so it only
 # needs the DB + accounts to exist (mirrors comet-mini's init_sql). Runs as the
 # opik root user (root/opik) against the dev-runner MySQL.
-provision_em_backend_mysql() {
+provision_platform_backend_mysql() {
     require_command mysql
     log_info "Provisioning EM 'logger' database + users on Opik MySQL (localhost:${MYSQL_PORT})..."
     if mysql -h 127.0.0.1 -P "${MYSQL_PORT}" -u root -popik --connect-timeout=10 <<'SQL'
@@ -257,8 +257,8 @@ SQL
 #   - redisConfig.redisPass is hardcoded 'NA'; Opik's Redis needs 'opik'
 #   - the S3 endpoint port is hardcoded ':9000'; Opik's MinIO API is on
 #     ${MINIO_API_PORT} (the :9000 rewrite is scoped to MINIO_HOST lines)
-# Everything else is env-substituted from start_em_backend_local.
-generate_em_backend_config() {
+# Everything else is env-substituted from start_platform_backend_local.
+generate_platform_backend_config() {
     local src="$COMET_BACKEND_PATH/comet-ml-react-webapp/src/test/resources/test-config.yml"
     if [ ! -f "$src" ]; then
         log_error "EM backend config template not found: $src"
@@ -267,19 +267,19 @@ generate_em_backend_config() {
     sed -E \
         -e 's/redisPass: NA/redisPass: opik/g' \
         -e "/MINIO_HOST/ s/:9000/:${MINIO_API_PORT}/g" \
-        "$src" > "$EM_BACKEND_CONFIG_FILE"
-    log_debug "Generated EM backend config: $EM_BACKEND_CONFIG_FILE"
+        "$src" > "$PLATFORM_BACKEND_CONFIG_FILE"
+    log_debug "Generated EM backend config: $PLATFORM_BACKEND_CONFIG_FILE"
 }
 
-start_em_backend_local() {
-    if ! em_stack_enabled; then
+start_platform_backend_local() {
+    if ! platform_stack_enabled; then
         return 0
     fi
     local em_jh
-    em_jh=$(em_java_home)
+    em_jh=$(platform_java_home)
     if [ -z "$em_jh" ] || [ ! -x "$em_jh/bin/java" ]; then
         log_warning "EM stack needs a JDK 17 for comet-backend (opik uses JDK 25); none found."
-        log_warning "Set EM_JAVA_HOME=/path/to/jdk17 and retry. Skipping EM backend."
+        log_warning "Set PLATFORM_JAVA_HOME=/path/to/jdk17 and retry. Skipping EM backend."
         return 1
     fi
 
@@ -290,27 +290,27 @@ start_em_backend_local() {
     fi
 
     # Reuse a healthy EM backend started outside dev-runner (e.g. IntelliJ).
-    if em_backend_healthy; then
-        log_success "EM backend already healthy on port ${EM_BACKEND_PORT} — reusing existing instance"
+    if platform_backend_healthy; then
+        log_success "EM backend already healthy on port ${PLATFORM_BACKEND_PORT} — reusing existing instance"
         # Clear any stale PID so --stop won't try to kill the reused instance.
-        rm -f "$EM_BACKEND_PID_FILE" "$EM_BACKEND_REPO_PATH_FILE"
+        rm -f "$PLATFORM_BACKEND_PID_FILE" "$PLATFORM_BACKEND_REPO_PATH_FILE"
         return 0
     fi
-    if em_backend_running; then
-        log_warning "EM backend is already running (PID: $(cat "$EM_BACKEND_PID_FILE"))"
+    if platform_backend_running; then
+        log_warning "EM backend is already running (PID: $(cat "$PLATFORM_BACKEND_PID_FILE"))"
         return 0
     fi
-    rm -f "$EM_BACKEND_PID_FILE"
+    rm -f "$PLATFORM_BACKEND_PID_FILE"
 
-    if ! find_em_backend_jar; then
+    if ! find_platform_backend_jar; then
         log_warning "No EM backend JAR found in target/. Building comet-backend automatically..."
-        build_em_backend || { log_warning "Continuing without EM backend"; return 1; }
+        build_platform_backend || { log_warning "Continuing without EM backend"; return 1; }
     fi
 
-    provision_em_backend_mysql || { log_warning "Continuing without EM backend"; return 1; }
-    generate_em_backend_config || return 1
+    provision_platform_backend_mysql || { log_warning "Continuing without EM backend"; return 1; }
+    generate_platform_backend_config || return 1
 
-    log_info "Starting comet-backend ReactWebappServerApplication on port ${EM_BACKEND_PORT}..."
+    log_info "Starting comet-backend ReactWebappServerApplication on port ${PLATFORM_BACKEND_PORT}..."
     (
         cd "$COMET_BACKEND_PATH/comet-ml-react-webapp" || exit 1
         CORS=true \
@@ -324,47 +324,47 @@ start_em_backend_local() {
         PAYMENT_PUBLISHABLE_KEY=pk_test_stub \
         PAYMENT_SECRET_KEY=sk_test_stub \
         REACT_BIND_HOST=0.0.0.0 \
-        REACT_BACKEND_HTTP_PORT="$EM_BACKEND_PORT" \
-        REACT_BACKEND_HTTPS_PORT="$EM_BACKEND_ADMIN_PORT" \
+        REACT_BACKEND_HTTP_PORT="$PLATFORM_BACKEND_PORT" \
+        REACT_BACKEND_HTTPS_PORT="$PLATFORM_BACKEND_ADMIN_PORT" \
         JWT_SAME_SITE=LAX \
         MPM_DRUID_ENABLED=False \
         SMART_API_KEY_ENABLED=False \
-        COMET_REDIRECT_URL_SEGMENT=":$EM_PROXY_PORT" \
+        COMET_REDIRECT_URL_SEGMENT=":$PLATFORM_PROXY_PORT" \
         OPIK_BASE_URL="http://localhost:${BACKEND_PORT}/" \
         COMET_LLM_INTEGRATION=true \
         JAVA_HOME="$em_jh" \
-        nohup "$em_jh/bin/java" -jar "$EM_BACKEND_JAR" server "$EM_BACKEND_CONFIG_FILE" \
-            > "$EM_BACKEND_LOG_FILE" 2>&1 &
-        echo $! > "$EM_BACKEND_PID_FILE"
+        nohup "$em_jh/bin/java" -jar "$PLATFORM_BACKEND_JAR" server "$PLATFORM_BACKEND_CONFIG_FILE" \
+            > "$PLATFORM_BACKEND_LOG_FILE" 2>&1 &
+        echo $! > "$PLATFORM_BACKEND_PID_FILE"
     )
-    printf '%s\n' "$COMET_BACKEND_PATH" > "$EM_BACKEND_REPO_PATH_FILE"
+    printf '%s\n' "$COMET_BACKEND_PATH" > "$PLATFORM_BACKEND_REPO_PATH_FILE"
 
     local pid
-    pid=$(cat "$EM_BACKEND_PID_FILE")
+    pid=$(cat "$PLATFORM_BACKEND_PID_FILE")
     log_debug "EM backend process started with PID: $pid"
 
     sleep 3
     if ! kill -0 "$pid" 2>/dev/null; then
-        log_warning "EM backend failed to start. Check logs: cat $EM_BACKEND_LOG_FILE"
-        rm -f "$EM_BACKEND_PID_FILE"
+        log_warning "EM backend failed to start. Check logs: cat $PLATFORM_BACKEND_LOG_FILE"
+        rm -f "$PLATFORM_BACKEND_PID_FILE"
         return 1
     fi
     log_success "EM backend process started (PID: $pid)"
-    log_info "EM backend logs: tail -f $EM_BACKEND_LOG_FILE"
-    if ! wait_for_em_backend_ready "$pid"; then
+    log_info "EM backend logs: tail -f $PLATFORM_BACKEND_LOG_FILE"
+    if ! wait_for_platform_backend_ready "$pid"; then
         log_warning "EM backend did not become ready in time; continuing"
         return 1
     fi
     return 0
 }
 
-stop_em_backend_local() {
-    if [ ! -f "$EM_BACKEND_PID_FILE" ] && [ ! -f "$EM_BACKEND_REPO_PATH_FILE" ]; then
+stop_platform_backend_local() {
+    if [ ! -f "$PLATFORM_BACKEND_PID_FILE" ] && [ ! -f "$PLATFORM_BACKEND_REPO_PATH_FILE" ]; then
         return 0
     fi
-    if [ -f "$EM_BACKEND_PID_FILE" ]; then
+    if [ -f "$PLATFORM_BACKEND_PID_FILE" ]; then
         local pid
-        pid=$(cat "$EM_BACKEND_PID_FILE")
+        pid=$(cat "$PLATFORM_BACKEND_PID_FILE")
         if kill -0 "$pid" 2>/dev/null; then
             log_info "Stopping EM backend (PID: $pid)..."
             local descendants
@@ -384,24 +384,24 @@ stop_em_backend_local() {
             log_warning "EM backend PID file exists but process is not running (cleaning up stale PID file)"
         fi
     fi
-    rm -f "$EM_BACKEND_PID_FILE" "$EM_BACKEND_REPO_PATH_FILE"
+    rm -f "$PLATFORM_BACKEND_PID_FILE" "$PLATFORM_BACKEND_REPO_PATH_FILE"
     log_success "EM backend stopped"
 }
 
-display_em_backend_process_status() {
-    if [ -f "$EM_BACKEND_PID_FILE" ] && kill -0 "$(cat "$EM_BACKEND_PID_FILE")" 2>/dev/null; then
-        echo -e "EM Backend:  ${GREEN}RUNNING${NC} (PID: $(cat "$EM_BACKEND_PID_FILE"))"
+display_platform_backend_process_status() {
+    if [ -f "$PLATFORM_BACKEND_PID_FILE" ] && kill -0 "$(cat "$PLATFORM_BACKEND_PID_FILE")" 2>/dev/null; then
+        echo -e "EM Backend:  ${GREEN}RUNNING${NC} (PID: $(cat "$PLATFORM_BACKEND_PID_FILE"))"
         return 0
     fi
-    if em_backend_healthy; then
-        echo -e "EM Backend:  ${GREEN}RUNNING${NC} (reused external instance on port ${EM_BACKEND_PORT})"
+    if platform_backend_healthy; then
+        echo -e "EM Backend:  ${GREEN}RUNNING${NC} (reused external instance on port ${PLATFORM_BACKEND_PORT})"
         return 0
     fi
     echo -e "EM Backend:  ${RED}STOPPED${NC}"
     return 1
 }
 
-build_em_frontend() {
+build_platform_frontend() {
     require_command npm
     log_info "Installing comet-react dependencies (npm install)..."
     if ( cd "$COMET_REACT_PATH" && npm install ); then
@@ -416,25 +416,25 @@ build_em_frontend() {
 # (gitignored; this is exactly what `npm run switch-env` rewrites). The existing
 # file is backed up once so --stop can restore the developer's own config.
 # NOTE: no /api suffix — the standalone backend serves Jersey at root ('/').
-generate_em_frontend_config() {
+generate_platform_frontend_config() {
     local cfg="$COMET_REACT_PATH/public/config.js"
-    if [ -f "$cfg" ] && [ ! -f "$EM_FRONTEND_CONFIG_BAK_FILE" ]; then
-        cp "$cfg" "$EM_FRONTEND_CONFIG_BAK_FILE"
-        log_debug "Backed up existing comet-react config.js -> $EM_FRONTEND_CONFIG_BAK_FILE"
+    if [ -f "$cfg" ] && [ ! -f "$PLATFORM_FRONTEND_CONFIG_BAK_FILE" ]; then
+        cp "$cfg" "$PLATFORM_FRONTEND_CONFIG_BAK_FILE"
+        log_debug "Backed up existing comet-react config.js -> $PLATFORM_FRONTEND_CONFIG_BAK_FILE"
     fi
     mkdir -p "$COMET_REACT_PATH/public"
     cat > "$cfg" <<EOF
 // Generated by opik dev-runner (EM stack). Restored from backup on --stop.
-// URLs point at the single-origin EM proxy (:${EM_PROXY_PORT}) so the browser
+// URLs point at the single-origin EM proxy (:${PLATFORM_PROXY_PORT}) so the browser
 // talks to one origin: /api -> comet-backend, /opik -> Opik. LLM_BASE_URL is
 // how comet-react navigates to Opik (LLM_APPLICATION_URL falls back to /opik/).
 var environmentVariablesOverwrite = {
   ENV: 'dev',
   PRODUCTION: false,
   NODE_ENV: 'production',
-  BASE_URL: 'http://localhost:${EM_PROXY_PORT}/api/',
-  ROOT_URL: 'http://localhost:${EM_PROXY_PORT}/',
-  LLM_BASE_URL: 'http://localhost:${EM_PROXY_PORT}/opik/',
+  BASE_URL: 'http://localhost:${PLATFORM_PROXY_PORT}/api/',
+  ROOT_URL: 'http://localhost:${PLATFORM_PROXY_PORT}/',
+  LLM_BASE_URL: 'http://localhost:${PLATFORM_PROXY_PORT}/opik/',
   SHOULD_LOAD_ANALYTICS: false,
   SENTRY_ENVIRONMENT: 'development',
   ON_PREMISE: true
@@ -446,67 +446,67 @@ try {
   /* This is for Mocha only, ignore in any other case */
 }
 EOF
-    log_debug "Generated comet-react config.js -> $cfg (backend :${EM_BACKEND_PORT})"
+    log_debug "Generated comet-react config.js -> $cfg (backend :${PLATFORM_BACKEND_PORT})"
 }
 
-start_em_frontend_local() {
-    if ! em_frontend_enabled; then
-        if em_stack_enabled; then
+start_platform_frontend_local() {
+    if ! platform_frontend_enabled; then
+        if platform_stack_enabled; then
             log_warning "EM stack enabled but COMET_REACT_PATH not found; skipping comet-react frontend"
         fi
         return 0
     fi
     require_command npm
 
-    if em_frontend_running; then
-        log_warning "EM frontend is already running (PID: $(cat "$EM_FRONTEND_PID_FILE"))"
+    if platform_frontend_running; then
+        log_warning "EM frontend is already running (PID: $(cat "$PLATFORM_FRONTEND_PID_FILE"))"
         return 0
     fi
-    rm -f "$EM_FRONTEND_PID_FILE"
+    rm -f "$PLATFORM_FRONTEND_PID_FILE"
 
     if [ ! -d "$COMET_REACT_PATH/node_modules" ]; then
         log_warning "comet-react node_modules missing; installing..."
-        build_em_frontend || { log_warning "Continuing without EM frontend"; return 1; }
+        build_platform_frontend || { log_warning "Continuing without EM frontend"; return 1; }
     fi
 
-    generate_em_frontend_config
+    generate_platform_frontend_config
 
-    log_info "Starting comet-react dev server on port ${EM_FRONTEND_PORT}..."
+    log_info "Starting comet-react dev server on port ${PLATFORM_FRONTEND_PORT}..."
     (
         cd "$COMET_REACT_PATH" || exit 1
-        CI=true REACT_DEV_SERVER_PORT="$EM_FRONTEND_PORT" \
-        ROOT_URL="http://localhost:${EM_PROXY_PORT}/" \
-        BASE_URL="http://localhost:${EM_PROXY_PORT}/api/" \
-        LLM_BASE_URL="http://localhost:${EM_PROXY_PORT}/opik/" \
+        CI=true REACT_DEV_SERVER_PORT="$PLATFORM_FRONTEND_PORT" \
+        ROOT_URL="http://localhost:${PLATFORM_PROXY_PORT}/" \
+        BASE_URL="http://localhost:${PLATFORM_PROXY_PORT}/api/" \
+        LLM_BASE_URL="http://localhost:${PLATFORM_PROXY_PORT}/opik/" \
         ON_PREMISE=true \
-        nohup npm run start > "$EM_FRONTEND_LOG_FILE" 2>&1 &
-        echo $! > "$EM_FRONTEND_PID_FILE"
+        nohup npm run start > "$PLATFORM_FRONTEND_LOG_FILE" 2>&1 &
+        echo $! > "$PLATFORM_FRONTEND_PID_FILE"
     )
-    printf '%s\n' "$COMET_REACT_PATH" > "$EM_FRONTEND_REPO_PATH_FILE"
+    printf '%s\n' "$COMET_REACT_PATH" > "$PLATFORM_FRONTEND_REPO_PATH_FILE"
 
     local pid
-    pid=$(cat "$EM_FRONTEND_PID_FILE")
+    pid=$(cat "$PLATFORM_FRONTEND_PID_FILE")
     log_debug "EM frontend process started with PID: $pid"
 
     sleep 3
     if ! kill -0 "$pid" 2>/dev/null; then
-        log_warning "EM frontend failed to start. Check logs: cat $EM_FRONTEND_LOG_FILE"
-        rm -f "$EM_FRONTEND_PID_FILE"
+        log_warning "EM frontend failed to start. Check logs: cat $PLATFORM_FRONTEND_LOG_FILE"
+        rm -f "$PLATFORM_FRONTEND_PID_FILE"
         return 1
     fi
     log_success "EM frontend process started (PID: $pid)"
-    log_info "EM frontend available at: ${GREEN}http://localhost:${EM_FRONTEND_PORT}${NC} (webpack dev server may take a bit to compile)"
-    log_info "EM frontend logs: tail -f $EM_FRONTEND_LOG_FILE"
+    log_info "EM frontend available at: ${GREEN}http://localhost:${PLATFORM_FRONTEND_PORT}${NC} (webpack dev server may take a bit to compile)"
+    log_info "EM frontend logs: tail -f $PLATFORM_FRONTEND_LOG_FILE"
     return 0
 }
 
-stop_em_frontend_local() {
-    if [ ! -f "$EM_FRONTEND_PID_FILE" ] && [ ! -f "$EM_FRONTEND_REPO_PATH_FILE" ]; then
+stop_platform_frontend_local() {
+    if [ ! -f "$PLATFORM_FRONTEND_PID_FILE" ] && [ ! -f "$PLATFORM_FRONTEND_REPO_PATH_FILE" ]; then
         return 0
     fi
-    if [ -f "$EM_FRONTEND_PID_FILE" ]; then
+    if [ -f "$PLATFORM_FRONTEND_PID_FILE" ]; then
         local pid
-        pid=$(cat "$EM_FRONTEND_PID_FILE")
+        pid=$(cat "$PLATFORM_FRONTEND_PID_FILE")
         if kill -0 "$pid" 2>/dev/null; then
             log_info "Stopping EM frontend (PID: $pid)..."
             local descendants
@@ -529,21 +529,21 @@ stop_em_frontend_local() {
 
     # Restore the developer's original comet-react config.js if we backed it up.
     local cr_repo="${COMET_REACT_PATH:-}"
-    if [ -z "$cr_repo" ] && [ -f "$EM_FRONTEND_REPO_PATH_FILE" ]; then
-        cr_repo=$(cat "$EM_FRONTEND_REPO_PATH_FILE")
+    if [ -z "$cr_repo" ] && [ -f "$PLATFORM_FRONTEND_REPO_PATH_FILE" ]; then
+        cr_repo=$(cat "$PLATFORM_FRONTEND_REPO_PATH_FILE")
     fi
-    if [ -n "$cr_repo" ] && [ -f "$EM_FRONTEND_CONFIG_BAK_FILE" ]; then
-        cp "$EM_FRONTEND_CONFIG_BAK_FILE" "$cr_repo/public/config.js" && rm -f "$EM_FRONTEND_CONFIG_BAK_FILE"
+    if [ -n "$cr_repo" ] && [ -f "$PLATFORM_FRONTEND_CONFIG_BAK_FILE" ]; then
+        cp "$PLATFORM_FRONTEND_CONFIG_BAK_FILE" "$cr_repo/public/config.js" && rm -f "$PLATFORM_FRONTEND_CONFIG_BAK_FILE"
         log_info "Restored comet-react public/config.js from backup"
     fi
 
-    rm -f "$EM_FRONTEND_PID_FILE" "$EM_FRONTEND_REPO_PATH_FILE"
+    rm -f "$PLATFORM_FRONTEND_PID_FILE" "$PLATFORM_FRONTEND_REPO_PATH_FILE"
     log_success "EM frontend stopped"
 }
 
-display_em_frontend_process_status() {
-    if [ -f "$EM_FRONTEND_PID_FILE" ] && kill -0 "$(cat "$EM_FRONTEND_PID_FILE")" 2>/dev/null; then
-        echo -e "EM Frontend: ${GREEN}RUNNING${NC} (PID: $(cat "$EM_FRONTEND_PID_FILE"))"
+display_platform_frontend_process_status() {
+    if [ -f "$PLATFORM_FRONTEND_PID_FILE" ] && kill -0 "$(cat "$PLATFORM_FRONTEND_PID_FILE")" 2>/dev/null; then
+        echo -e "EM Frontend: ${GREEN}RUNNING${NC} (PID: $(cat "$PLATFORM_FRONTEND_PID_FILE"))"
         return 0
     fi
     echo -e "EM Frontend: ${RED}STOPPED${NC}"
@@ -556,8 +556,27 @@ display_em_frontend_process_status() {
 # and /api are matched before /opik and /. Trailing-slash proxy_pass strips the
 # location prefix (so /api/x -> comet-backend /x, /opik/api/x -> opik-backend /x);
 # /opik/ is passed through unchanged (Opik Vite serves under base /opik).
-generate_em_proxy_conf() {
-    cat > "$EM_PROXY_CONF" <<EOF
+generate_platform_proxy_conf() {
+    # When the ai-spend FE plugin is present, its API calls arrive here as
+    # /opik/api/v1/private/ai-spend/* (browser -> this single-origin proxy) and
+    # must reach cost-api (ai-cost-backend), not the Opik backend (which has no
+    # ai-spend routes -> 404). This routing lives in the Platform proxy because
+    # the /opik/... path and the proxy itself are Platform-topology concerns; the vite
+    # proxy handles the OSS-mode /api/... path independently. Gated on the plugin
+    # being linked AND cost-api being configured (cost_api_enabled): if there is
+    # no cost-api to route to, omit the location so requests fall through to the
+    # opik-backend 404 rather than an nginx 502. Not gated on cost_api_healthy —
+    # nginx resolves the upstream per-request, so the route must persist across
+    # cost-api (re)starts, and a 502 from a configured-but-down cost-api is a
+    # clearer signal than a 404. host.docker.internal reaches cost-api on the host.
+    local cost_api_upstream="" cost_api_location=""
+    if [ -L "$AI_SPEND_PLUGIN_LINK" ] && cost_api_enabled; then
+        cost_api_upstream="    upstream em_cost_api { server host.docker.internal:${AI_COST_BACKEND_PORT}; keepalive 32; }"
+        # Longer prefix than /opik/api/ so nginx routes just this subtree here.
+        # /opik/api/v1/private/ai-spend/X -> cost-api /cost-api/v1/private/ai-spend/X
+        cost_api_location="        location /opik/api/v1/private/ai-spend/ { proxy_pass http://em_cost_api/cost-api/v1/private/ai-spend/; }"
+    fi
+    cat > "$PLATFORM_PROXY_CONF" <<EOF
 worker_processes 1;
 events { worker_connections 4096; }
 http {
@@ -570,8 +589,9 @@ http {
     # Keepalive connection pools to each dev server / backend.
     upstream em_opik_be { server host.docker.internal:${BACKEND_PORT}; keepalive 64; }
     upstream em_opik_fe { server host.docker.internal:${FRONTEND_PORT}; keepalive 128; }
-    upstream em_comet_be { server host.docker.internal:${EM_BACKEND_PORT}; keepalive 32; }
-    upstream em_comet_fe { server host.docker.internal:${EM_FRONTEND_PORT}; keepalive 128; }
+    upstream em_comet_be { server host.docker.internal:${PLATFORM_BACKEND_PORT}; keepalive 32; }
+    upstream em_comet_fe { server host.docker.internal:${PLATFORM_FRONTEND_PORT}; keepalive 128; }
+${cost_api_upstream}
 
     server {
         listen 80;
@@ -586,6 +606,7 @@ http {
         proxy_read_timeout 3600s;
         proxy_send_timeout 3600s;
 
+${cost_api_location}
         # Opik backend API (strip /opik/api -> /)
         location /opik/api/ { proxy_pass http://em_opik_be/; }
         # Opik UI — Vite dev server (comet mode, base /opik) + HMR websocket
@@ -597,52 +618,52 @@ http {
     }
 }
 EOF
-    log_debug "Generated EM proxy nginx config: $EM_PROXY_CONF"
+    log_debug "Generated EM proxy nginx config: $PLATFORM_PROXY_CONF"
 }
 
-em_proxy_running() {
+platform_proxy_running() {
     command -v docker >/dev/null 2>&1 || return 1
-    [ -n "$(docker ps -q -f "name=^${EM_PROXY_CONTAINER}$" 2>/dev/null)" ]
+    [ -n "$(docker ps -q -f "name=^${PLATFORM_PROXY_CONTAINER}$" 2>/dev/null)" ]
 }
 
-start_em_proxy() {
-    em_stack_enabled || return 0
+start_platform_proxy() {
+    platform_stack_enabled || return 0
     require_command docker
-    generate_em_proxy_conf
+    generate_platform_proxy_conf
     # Recreate cleanly so config/port changes always take effect.
-    docker rm -f "$EM_PROXY_CONTAINER" >/dev/null 2>&1 || true
-    log_info "Starting EM single-origin proxy (nginx) on port ${EM_PROXY_PORT}..."
-    if docker run -d --name "$EM_PROXY_CONTAINER" \
+    docker rm -f "$PLATFORM_PROXY_CONTAINER" >/dev/null 2>&1 || true
+    log_info "Starting EM single-origin proxy (nginx) on port ${PLATFORM_PROXY_PORT}..."
+    if docker run -d --name "$PLATFORM_PROXY_CONTAINER" \
         --add-host=host.docker.internal:host-gateway \
-        -p "${EM_PROXY_PORT}:80" \
-        -v "${EM_PROXY_CONF}:/etc/nginx/nginx.conf:ro" \
+        -p "${PLATFORM_PROXY_PORT}:80" \
+        -v "${PLATFORM_PROXY_CONF}:/etc/nginx/nginx.conf:ro" \
         nginx:alpine >/dev/null 2>&1; then
         log_success "EM proxy started"
-        log_info "Integrated UI (EM + Opik): ${GREEN}http://localhost:${EM_PROXY_PORT}${NC}"
-        log_info "  Opik under: ${GREEN}http://localhost:${EM_PROXY_PORT}/opik${NC}"
+        log_info "Integrated UI (EM + Opik): ${GREEN}http://localhost:${PLATFORM_PROXY_PORT}${NC}"
+        log_info "  Opik under: ${GREEN}http://localhost:${PLATFORM_PROXY_PORT}/opik${NC}"
     else
-        log_warning "EM proxy failed to start. Check: docker logs ${EM_PROXY_CONTAINER}"
+        log_warning "EM proxy failed to start. Check: docker logs ${PLATFORM_PROXY_CONTAINER}"
         return 1
     fi
 }
 
-stop_em_proxy() {
+stop_platform_proxy() {
     # Cheap gate: the conf only exists once the proxy has been started, so when
     # the EM stack was never used this returns before any docker shell-out —
     # keeping --stop/--restart zero-overhead for plain Opik dev.
-    [ -f "$EM_PROXY_CONF" ] || return 0
+    [ -f "$PLATFORM_PROXY_CONF" ] || return 0
     command -v docker >/dev/null 2>&1 || return 0
-    if [ -n "$(docker ps -aq -f "name=^${EM_PROXY_CONTAINER}$" 2>/dev/null)" ]; then
+    if [ -n "$(docker ps -aq -f "name=^${PLATFORM_PROXY_CONTAINER}$" 2>/dev/null)" ]; then
         log_info "Stopping EM proxy..."
-        docker rm -f "$EM_PROXY_CONTAINER" >/dev/null 2>&1 || true
+        docker rm -f "$PLATFORM_PROXY_CONTAINER" >/dev/null 2>&1 || true
         log_success "EM proxy stopped"
     fi
-    rm -f "$EM_PROXY_CONF"
+    rm -f "$PLATFORM_PROXY_CONF"
 }
 
-display_em_proxy_process_status() {
-    if em_proxy_running; then
-        echo -e "EM Proxy:    ${GREEN}RUNNING${NC} (http://localhost:${EM_PROXY_PORT})"
+display_platform_proxy_process_status() {
+    if platform_proxy_running; then
+        echo -e "EM Proxy:    ${GREEN}RUNNING${NC} (http://localhost:${PLATFORM_PROXY_PORT})"
         return 0
     fi
     echo -e "EM Proxy:    ${RED}STOPPED${NC}"
@@ -650,37 +671,45 @@ display_em_proxy_process_status() {
 }
 
 # Bring the EM pair up / down as a unit. Safe to call unconditionally: the
-# start wrapper is gated on em_stack_enabled, and the stop functions quietly
+# start wrapper is gated on platform_stack_enabled, and the stop functions quietly
 # no-op when there's nothing tracked.
-start_em_stack() {
-    em_stack_enabled || return 0
+start_platform_stack() {
+    platform_stack_enabled || return 0
     log_info "Starting Comet EM stack (comet-backend + comet-react + proxy)..."
-    start_em_backend_local || log_warning "EM backend startup failed; continuing"
-    start_em_frontend_local || log_warning "EM frontend startup failed; continuing"
+    start_platform_backend_local || log_warning "EM backend startup failed; continuing"
+    start_platform_frontend_local || log_warning "EM frontend startup failed; continuing"
     # Proxy last: it fronts opik FE (comet mode) + comet-react + both backends
     # on one origin, which is what comet mode's relative URLs require.
-    start_em_proxy || log_warning "EM proxy startup failed; open services on individual ports"
+    start_platform_proxy || log_warning "EM proxy startup failed; open services on individual ports"
 }
 
-stop_em_stack() {
-    stop_em_proxy
-    stop_em_frontend_local
-    stop_em_backend_local
+stop_platform_stack() {
+    stop_platform_proxy
+    stop_platform_frontend_local
+    stop_platform_backend_local
 }
 
 # ---- Thin hooks called from dev-runner.sh (keep core-script changes minimal) ----
 
 # Extra `npm run start` args to put Opik FE in comet mode (empty unless enabled).
-em_opik_vite_args() {
-    if em_stack_enabled; then printf -- '-- --mode comet'; fi
+platform_opik_vite_args() {
+    if platform_stack_enabled; then printf -- '-- --mode comet'; fi
 }
 
-# Prep the Opik FE env for comet mode: unset VITE_FE_PLUGINS so ACTIVE_PLUGINS
-# falls back to [MODE]=["comet"]. No-op unless the platform stack is enabled.
-em_prepare_opik_comet_env() {
-    em_stack_enabled || return 0
-    unset VITE_FE_PLUGINS
-    log_info "Starting frontend in comet mode (platform-connected, base /opik)"
+# Prep the Opik FE env for comet mode. The comet plugin always runs here; the
+# ai-spend plugin is added only when its sibling checkout is linked (the comet
+# plugin's Cost Intelligence entry point is gated on hasPlugin("ai-spend")).
+# VITE_FE_PLUGINS is set explicitly rather than left to unset -> [MODE] fallback,
+# so the plugin set doesn't depend on vite's --mode resolution and any leaked
+# value from the parent env is overridden. No-op unless the platform stack is enabled.
+platform_prepare_opik_comet_env() {
+    platform_stack_enabled || return 0
+    if [ -L "$AI_SPEND_PLUGIN_LINK" ]; then
+        export VITE_FE_PLUGINS="comet,ai-spend"
+    else
+        export VITE_FE_PLUGINS="comet"
+    fi
+    log_info "Starting frontend in comet mode (platform-connected, base /opik) [VITE_FE_PLUGINS=$VITE_FE_PLUGINS]"
 }
 
 # Prep the Opik BACKEND env for platform auth (M2). With AUTH_ENABLED=true the
@@ -690,10 +719,10 @@ em_prepare_opik_comet_env() {
 # /workspaces/workspace-id. Without this the Opik backend only knows its own
 # `default` workspace and 404s every call scoped to a Comet workspace.
 # No-op unless the platform stack is enabled.
-em_prepare_opik_backend_auth_env() {
-    em_stack_enabled || return 0
+platform_prepare_opik_backend_auth_env() {
+    platform_stack_enabled || return 0
     export AUTH_ENABLED=true
-    export REACT_SERVICE_URL="http://localhost:${EM_BACKEND_PORT}"
+    export REACT_SERVICE_URL="http://localhost:${PLATFORM_BACKEND_PORT}"
     # Skip the onboarding "Almost ready…" demo-loading screen. It polls forever
     # for the "Opik Demo Agent Observability" project, which only gets created by
     # comet-backend's post-signup hook (OPIK_DEMO_PROJECT_CREATION + a reachable
@@ -705,42 +734,43 @@ em_prepare_opik_backend_auth_env() {
 }
 
 # Rebuild the EM backend jar on --restart so comet-backend changes are picked up.
-em_restart_build() {
-    em_stack_enabled || return 0
+platform_restart_build() {
+    platform_stack_enabled || return 0
     log_info "Building Comet EM stack (comet-backend)..."
-    build_em_backend || log_warning "EM backend build failed; will try existing jar on start"
+    build_platform_backend || log_warning "EM backend build failed; will try existing jar on start"
 }
 
 # EM lines for verify_services status output.
-em_print_status() {
-    if em_stack_enabled || [ -f "$EM_BACKEND_PID_FILE" ]; then
-        display_em_backend_process_status || true
+platform_print_status() {
+    if platform_stack_enabled || [ -f "$PLATFORM_BACKEND_PID_FILE" ]; then
+        display_platform_backend_process_status || true
     fi
-    if em_frontend_enabled || [ -f "$EM_FRONTEND_PID_FILE" ]; then
-        display_em_frontend_process_status || true
+    if platform_frontend_enabled || [ -f "$PLATFORM_FRONTEND_PID_FILE" ]; then
+        display_platform_frontend_process_status || true
     fi
-    if em_stack_enabled; then
-        display_em_proxy_process_status || true
-        echo -e "  ${BLUE}Integrated EM + Opik UI: http://localhost:${EM_PROXY_PORT}  (Opik: /opik)${NC}"
+    if platform_stack_enabled; then
+        display_platform_proxy_process_status || true
+        echo -e "  ${BLUE}Integrated EM + Opik UI: http://localhost:${PLATFORM_PROXY_PORT}  (Opik: /opik)${NC}"
     fi
 }
 
 # EM lines for the verify_services / Logs section.
-em_print_logs() {
-    if em_stack_enabled || [ -f "$EM_BACKEND_LOG_FILE" ]; then
-        echo "  EM Backend:       tail -f $EM_BACKEND_LOG_FILE"
+platform_print_logs() {
+    if platform_stack_enabled || [ -f "$PLATFORM_BACKEND_LOG_FILE" ]; then
+        echo "  EM Backend:       tail -f $PLATFORM_BACKEND_LOG_FILE"
     fi
-    if em_frontend_enabled || [ -f "$EM_FRONTEND_LOG_FILE" ]; then
-        echo "  EM Frontend:      tail -f $EM_FRONTEND_LOG_FILE"
+    if platform_frontend_enabled || [ -f "$PLATFORM_FRONTEND_LOG_FILE" ]; then
+        echo "  EM Frontend:      tail -f $PLATFORM_FRONTEND_LOG_FILE"
     fi
-    if em_stack_enabled; then
-        echo "  EM Proxy:         docker logs -f ${EM_PROXY_CONTAINER}"
+    if platform_stack_enabled; then
+        echo "  EM Proxy:         docker logs -f ${PLATFORM_PROXY_CONTAINER}"
     fi
 }
 
 # EM env-var docs for show_usage.
-em_print_usage() {
+platform_print_usage() {
     echo "  PLATFORM_ENABLED=true    - Opik-team only: also run the Comet EM/Platform stack"
+    echo "                          (env-var form of the --platform-enabled flag above)"
     echo "                          (comet-backend ReactWebappServerApplication + comet-react)"
     echo "                          alongside Opik behind a single-origin proxy, reusing Opik's"
     echo "                          dev MySQL/Redis/MinIO — no comet-helm-mini needed. Runs with"
@@ -748,42 +778,42 @@ em_print_usage() {
     echo "                          default. comet-backend/comet-react auto-detected as siblings."
     echo "  COMET_BACKEND_PATH=<p>   - Override comet-backend checkout (default: <opik-root>/../comet-backend)"
     echo "  COMET_REACT_PATH=<p>     - Override comet-react checkout (default: <opik-root>/../comet-react)"
-    echo "  EM_JAVA_HOME=<p>      - JDK for the EM backend. comet-backend needs JDK 17/21 (Lombok"
+    echo "  PLATFORM_JAVA_HOME=<p>      - JDK for the EM backend. comet-backend needs JDK 17/21 (Lombok"
     echo "                          1.18.30) while opik needs JDK 25, so they can't share JAVA_HOME."
     echo "                          If unset, dev-runner auto-detects an installed 17 (then 21) via"
     echo "                          java_home / SDKMAN / Linux / Homebrew, independent of your"
     echo "                          default JDK. EM build + run use this JDK; Opik is unaffected."
-    echo "  EM_JAVA_ACCEPTED_MAJORS=\"17 21\" - Override the accepted EM JDK majors / preference order"
-    echo "  EM_BACKEND_PORT=<n>   - EM backend (ReactWebapp) port (default: 8200 + worktree offset)"
-    echo "  EM_FRONTEND_PORT=<n>  - EM frontend (comet-react) port (default: 8300 + worktree offset)"
-    echo "  EM_PROXY_PORT=<n>     - Single-origin proxy port = the integrated EM+Opik UI URL you"
+    echo "  PLATFORM_JAVA_ACCEPTED_MAJORS=\"17 21\" - Override the accepted EM JDK majors / preference order"
+    echo "  PLATFORM_BACKEND_PORT=<n>   - EM backend (ReactWebapp) port (default: 8200 + worktree offset)"
+    echo "  PLATFORM_FRONTEND_PORT=<n>  - EM frontend (comet-react) port (default: 8300 + worktree offset)"
+    echo "  PLATFORM_PROXY_PORT=<n>     - Single-origin proxy port = the integrated EM+Opik UI URL you"
     echo "                          open (default: 9100 + worktree offset). Opik lives at /opik."
 }
 
 # --platform-build entrypoint.
-em_build() {
-    if ! em_stack_enabled; then
+platform_build() {
+    if ! platform_stack_enabled; then
         log_error "EM stack not enabled. Set PLATFORM_ENABLED=true (and ensure COMET_BACKEND_PATH resolves)."
         return 1
     fi
-    build_em_backend || return 1
-    if em_frontend_enabled; then
-        build_em_frontend || return 1
+    build_platform_backend || return 1
+    if platform_frontend_enabled; then
+        build_platform_frontend || return 1
     fi
 }
 
 # "port:label" lines for check_port_collisions (empty unless platform enabled).
 # EM backend/proxy are skipped when already healthy/running (reuse is expected).
-em_collision_ports() {
-    em_stack_enabled || return 0
-    if ! em_backend_healthy; then
-        echo "$EM_BACKEND_PORT:EM Backend"
-        echo "$EM_BACKEND_ADMIN_PORT:EM Backend Admin"
+platform_collision_ports() {
+    platform_stack_enabled || return 0
+    if ! platform_backend_healthy; then
+        echo "$PLATFORM_BACKEND_PORT:EM Backend"
+        echo "$PLATFORM_BACKEND_ADMIN_PORT:EM Backend Admin"
     fi
-    if em_frontend_enabled; then
-        echo "$EM_FRONTEND_PORT:EM Frontend"
+    if platform_frontend_enabled; then
+        echo "$PLATFORM_FRONTEND_PORT:EM Frontend"
     fi
-    if ! em_proxy_running; then
-        echo "$EM_PROXY_PORT:EM Proxy"
+    if ! platform_proxy_running; then
+        echo "$PLATFORM_PROXY_PORT:EM Proxy"
     fi
 }

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -70,10 +70,10 @@ OLLIE_CONSOLE_PORT="${OLLIE_CONSOLE_PORT:-3333}"
 AI_COST_BACKEND_PORT="${AI_COST_BACKEND_PORT:-$((8400 + PORT_OFFSET))}"
 
 # Comet EM stack (comet-backend + comet-react + single-origin proxy).
-# All EM logic lives in dev-runner-em.sh to keep this script focused; it is inert
+# All EM logic lives in dev-runner-platform.sh to keep this script focused; it is inert
 # unless PLATFORM_ENABLED=true. Sourced here so its EM_* vars and em_* functions
-# are in scope for the thin hooks below (start_em_stack, em_print_status, …).
-source "$SCRIPT_DIR/dev-runner-em.sh"
+# are in scope for the thin hooks below (start_platform_stack, platform_print_status, …).
+source "$SCRIPT_DIR/dev-runner-platform.sh"
 
 # Colors for output
 RED='\033[0;31m'
@@ -746,7 +746,7 @@ start_cost_api_local() {
     # tell whether the running instance has AUTH_ENABLED=true, so a reused
     # OSS-mode instance would fail org-scoped /ai-spend/* requests. Start our own.
     if cost_api_healthy; then
-        if em_stack_enabled; then
+        if platform_stack_enabled; then
             log_warning "cost-api already healthy on port ${AI_COST_BACKEND_PORT}, but EM mode needs AUTH_ENABLED=true — not reusing it (start our own; will warn if the port is taken)"
         else
             log_success "cost-api is already healthy on port ${AI_COST_BACKEND_PORT} — reusing existing instance"
@@ -769,12 +769,12 @@ start_cost_api_local() {
 
     # Point cost-api at the dev-runner's ClickHouse + MySQL (host-published
     # ports, opik/opik). In platform (EM) mode, cost-api targets local comet-backend
-    # (the React service on EM_BACKEND_PORT) and delegates auth to it (cookie /
+    # (the React service on PLATFORM_BACKEND_PORT) and delegates auth to it (cookie /
     # API-key), so org-scoped endpoints resolve the real org. In OSS mode there is
     # no platform to delegate to, so keep auth off and pin to the default workspace.
     local cost_api_auth="false"
-    if em_stack_enabled; then
-        export PLATFORM_BASE_URL="http://localhost:${EM_BACKEND_PORT}"
+    if platform_stack_enabled; then
+        export PLATFORM_BASE_URL="http://localhost:${PLATFORM_BACKEND_PORT}"
         cost_api_auth="true"
     fi
     (
@@ -962,8 +962,9 @@ start_backend() {
 }
 
 # Symlink the sibling private ai-spend plugin's source into the FE plugins
-# folder (gitignored) so it compiles as part of opik. Removes the link when no
-# sibling is present, so toggling the checkout is clean.
+# folder (gitignored) so it compiles as part of opik. Links whenever a sibling
+# checkout is present; removes the link when it is not, so toggling the checkout
+# is clean.
 sync_ai_spend_plugin_link() {
     if [ -n "${AI_SPEND_PLUGIN_PATH:-}" ] && [ -d "${AI_SPEND_PLUGIN_PATH}/src" ]; then
         ln -sfn "${AI_SPEND_PLUGIN_PATH}/src" "$AI_SPEND_PLUGIN_LINK"
@@ -1029,8 +1030,10 @@ start_frontend() {
         log_warning "OLLIE_REPO_PATH is set but ollie healthz is not responding; sidebar disabled"
     fi
 
-    # Link the private ai-spend plugin (if checked out) and activate it
-    # alongside the local development plugin.
+    # Link + activate the private ai-spend plugin whenever a sibling checkout is
+    # present (sync_ai_spend_plugin_link only creates the link then). This sets
+    # the OSS-mode plugin list; comet mode overrides it in
+    # platform_prepare_opik_comet_env below (same present-link condition).
     sync_ai_spend_plugin_link
     if [ -L "$AI_SPEND_PLUGIN_LINK" ]; then
         export VITE_FE_PLUGINS="development,ai-spend"
@@ -1048,11 +1051,11 @@ start_frontend() {
     fi
 
     # Opik FE runs in comet mode when the platform stack is enabled; see
-    # em_prepare_opik_comet_env / em_opik_vite_args in dev-runner-em.sh
-    # (em_opik_vite_args is empty when the platform stack is off).
+    # platform_prepare_opik_comet_env / platform_opik_vite_args in dev-runner-platform.sh
+    # (platform_opik_vite_args is empty when the platform stack is off).
     log_debug "Starting frontend with: npm run start"
-    em_prepare_opik_comet_env
-    CI=true nohup npm run start $(em_opik_vite_args) > "$FRONTEND_LOG_FILE" 2>&1 &
+    platform_prepare_opik_comet_env
+    CI=true nohup npm run start $(platform_opik_vite_args) > "$FRONTEND_LOG_FILE" 2>&1 &
     FRONTEND_PID=$!
     echo "$FRONTEND_PID" > "$FRONTEND_PID_FILE"
 
@@ -1300,7 +1303,7 @@ verify_services() {
     if cost_api_enabled || [ -f "$COST_API_PID_FILE" ]; then
         display_cost_api_process_status || true
     fi
-    em_print_status
+    platform_print_status
 
     # Show access information if all services are running
     if [ "$docker_services_running" = true ] && [ "$backend_running" = true ] && [ "$frontend_running" = true ]; then
@@ -1317,7 +1320,7 @@ verify_services() {
     if cost_api_enabled || [ -f "$COST_API_LOG_FILE" ]; then
         echo "  cost-api Process: tail -f $COST_API_LOG_FILE"
     fi
-    em_print_logs
+    platform_print_logs
 }
 
 # Function to verify BE-only services
@@ -1366,8 +1369,8 @@ start_services() {
     run_db_migrations
     log_info "Step 3/6: Starting backend process..."
     # Platform auth for the Opik backend — full FE+BE flows only (BE-only can't host
-    # the EM stack). Set before start_backend so its JVM inherits it. See dev-runner-em.sh.
-    em_prepare_opik_backend_auth_env
+    # the EM stack). Set before start_backend so its JVM inherits it. See dev-runner-platform.sh.
+    platform_prepare_opik_backend_auth_env
     start_backend
     log_info "Step 4/6: Starting ollie-assist (optional)..."
     start_ollie_local || log_warning "ollie-assist startup failed; continuing without sidebar"
@@ -1376,7 +1379,7 @@ start_services() {
     log_info "Step 6/6: Creating demo data..."
     create_demo_data "--local-be-fe"
     # Comet EM stack (comet-backend + comet-react), gated on PLATFORM_ENABLED.
-    start_em_stack
+    start_platform_stack
     log_success "=== Start Complete ==="
     verify_services
 }
@@ -1387,7 +1390,7 @@ stop_services() {
     log_info "Step 1/4: Stopping frontend..."
     stop_frontend
     # Comet EM stack first — it depends on Opik's infra (MySQL/Redis/MinIO).
-    stop_em_stack
+    stop_platform_stack
     log_info "Step 2/4: Stopping ollie-assist (if running)..."
     stop_ollie_local
     stop_cost_api_local
@@ -1416,7 +1419,7 @@ restart_services() {
     log_info "Step 1/12: Stopping frontend process..."
     stop_frontend
     # Comet EM stack first — it depends on Opik's infra (MySQL/Redis/MinIO).
-    stop_em_stack
+    stop_platform_stack
     log_info "Step 2/12: Stopping ollie-assist (if running)..."
     stop_ollie_local
     stop_cost_api_local
@@ -1430,11 +1433,11 @@ restart_services() {
     build_backend
     log_info "Step 7/12: Building frontend..."
     build_frontend
-    em_restart_build
+    platform_restart_build
     log_info "Step 8/12: Running DB migrations..."
     run_db_migrations
     log_info "Step 9/12: Starting backend process..."
-    em_prepare_opik_backend_auth_env
+    platform_prepare_opik_backend_auth_env
     start_backend
     log_info "Step 10/12: Starting ollie-assist (optional)..."
     start_ollie_local || log_warning "ollie-assist startup failed; continuing without sidebar"
@@ -1443,7 +1446,7 @@ restart_services() {
     log_info "Step 12/12: Creating demo data..."
     create_demo_data "--local-be-fe"
     # Comet EM stack (comet-backend + comet-react), gated on PLATFORM_ENABLED.
-    start_em_stack
+    start_platform_stack
     log_success "=== Restart Complete ==="
     verify_services
 }
@@ -1470,7 +1473,7 @@ quick_restart_services() {
     log_info "Step 4/8: Building backend..."
     build_backend
     log_info "Step 5/8: Starting backend..."
-    em_prepare_opik_backend_auth_env
+    platform_prepare_opik_backend_auth_env
     start_backend
 
     log_info "Step 6/8: Ensuring ollie-assist is running (optional)..."
@@ -1511,7 +1514,7 @@ quick_restart_services() {
     start_frontend
     # Ensure the Comet EM stack is up (gated). Builds the jar only if missing;
     # use --restart or --platform-build to force a comet-backend rebuild.
-    start_em_stack
+    start_platform_stack
     log_success "=== Quick Restart Complete ==="
     verify_services
 }
@@ -1594,6 +1597,9 @@ show_usage() {
     echo "  --lint-be        - Lint backend code"
     echo "  --lint-fe        - Lint frontend code"
     echo "  --debug          - Enable debug mode (meant to be combined with other flags)"
+    echo "  --platform-enabled - Opik-team only: also run the Comet Platform stack (combine"
+    echo "                     with an action, e.g. '--platform-enabled --restart'; alone it"
+    echo "                     implies the default restart). Same as PLATFORM_ENABLED=true."
     echo "  --logs           - Show logs for backend and frontend services"
     echo "  --help           - Show this help message"
     echo ""
@@ -1617,7 +1623,11 @@ show_usage() {
     echo "                          cost-api (uv, auth disabled) against the dev ClickHouse+MySQL"
     echo "                          and serves the AI Spend pages. Opt out: AI_COST_BACKEND_PATH="
     echo "  AI_COST_BACKEND_PORT=<n> - Override cost-api port (default: 8400 + worktree offset)"
-    em_print_usage
+    echo "  AI_SPEND_PLUGIN_PATH=<p> - Opik-team only: path to a local opik-plugin-ai-spend"
+    echo "                          checkout. Auto-detected as a sibling; when present the"
+    echo "                          ai-spend FE plugin (Cost Intelligence pages) is compiled"
+    echo "                          in. Opt out with AI_SPEND_PLUGIN_PATH= (empty string)."
+    platform_print_usage
 }
 
 # Function to handle unknown options
@@ -1686,10 +1696,10 @@ check_port_collisions() {
         ports_to_check+=("$AI_COST_BACKEND_PORT:cost-api")
     fi
 
-    # EM stack ports (empty unless PLATFORM_ENABLED); see em_collision_ports.
+    # EM stack ports (empty unless PLATFORM_ENABLED); see platform_collision_ports.
     while IFS= read -r _em_port; do
         [ -n "$_em_port" ] && ports_to_check+=("$_em_port")
-    done < <(em_collision_ports)
+    done < <(platform_collision_ports)
 
     log_info "Checking for port collisions..."
 
@@ -1730,6 +1740,13 @@ while [[ $# -gt 0 ]]; do
       DEBUG_MODE=true
       shift # Remove --debug from arguments
       ;;
+    --platform-enabled|--platform_enabled)
+      # Modifier flag (like --debug): opt into the Comet Platform stack, then
+      # fall through to whatever action follows (default: restart). Equivalent to
+      # the PLATFORM_ENABLED=true env var; platform_stack_enabled reads this at runtime.
+      PLATFORM_ENABLED=true
+      shift
+      ;;
     *)
       ARGS+=("$1") # Keep other arguments
       shift
@@ -1758,7 +1775,7 @@ case "${1:-}" in
         build_frontend
         ;;
     "--platform-build")
-        em_build || exit 1
+        platform_build || exit 1
         ;;
     "--migrate")
         migrate_services


### PR DESCRIPTION
## Details

Refactor of the local `dev-runner` (Opik-team dev tooling). No functional change to the standard Opik dev flow; the Comet Platform stack stays off by default. Three scopes:

**1. Mount the ai-spend FE plugin in Platform (comet) mode**
- Platform (comet) mode previously `unset VITE_FE_PLUGINS`, dropping the private `ai-spend` plugin. It now activates `comet,ai-spend` when an `opik-plugin-ai-spend` sibling checkout is present (the same auto-detect already used in OSS mode), so the Cost Intelligence pages load.
- Adds the single-origin-proxy nginx route so `/opik/api/v1/private/ai-spend/*` reaches the local `cost-api` (previously hit opik-backend, which has no ai-spend routes → 404). Gated on the plugin being linked **and** cost-api being configured (`cost_api_enabled`); opt out with `AI_SPEND_PLUGIN_PATH=`.

**2. Rename EM → Platform**
- 35 functions renamed (`em_stack_enabled` → `platform_stack_enabled`, …); all `EM_*` env vars → `PLATFORM_*` (e.g. `EM_BACKEND_PORT` → `PLATFORM_BACKEND_PORT`); `scripts/dev-runner-em.sh` → `scripts/dev-runner-platform.sh`.
- Internal `-em-` tmp/container string values left as-is to avoid orphaning running dev instances.

**3. Platform mode as a command-line flag**
- New `--platform-enabled` flag (modifier, like `--debug`): opt into the Platform stack, then fall through to the action (default: restart). `PLATFORM_ENABLED=true` env var still honored.

Built on top of #7415 (cost-api auth in platform mode), already in `main`.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

N/A — internal dev-runner refactor, no Jira ticket.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: authored the dev-runner changes (plugin mounting fix + cost-api route, EM→Platform rename, `--platform-enabled` flag) and this PR text.
- Human verification: diffs reviewed; `bash -n` on both scripts; nginx config render matrix (plugin/cost-api present/absent) and `nginx -t` on the rendered config run locally.

## Testing

Local, macOS (dev-runner is a local dev tool; no product code changed).
- `bash -n scripts/dev-runner.sh scripts/dev-runner-platform.sh` — pass.
- Rendered the generated nginx proxy config across the gating matrix (plugin linked ± cost-api configured): the `/opik/api/v1/private/ai-spend/` location appears only when both hold, absent otherwise; `nginx -t` passes on the rendered config.
- Verified no `EM_*` identifiers / `AI_COST_FE_ENABLED` references remain; `--platform-enabled` parse behavior checked (sets `PLATFORM_ENABLED`, stripped from the action, alone → default restart).
- Not run: a full `--platform-enabled --restart` boot in CI (requires local sibling checkouts + Docker); exercised manually during development.

## Documentation

Updated `scripts/README.md` and `.agents/skills/local-dev/SKILL.md` to reference the renamed `PLATFORM_*` env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)