### PR TITLE
[SDK] fix: use direct workspace-scoped URL for experiment link in evaluate()

### DIFF
--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -408,7 +408,8 @@ def __internal_api__run_test_suite__(
         experiment_url = url_helpers.get_experiment_url_by_id(
             experiment_id=experiment_.id,
             dataset_id=suite_dataset.id,
-            url_override=client.config.url_override,
+            base_url=client.config.url_override,
+            workspace=client._workspace,
         )
         report.display_evaluation_in_progress(experiment_url)
 
@@ -603,7 +604,8 @@ def _evaluate_task(
     experiment_url = url_helpers.get_experiment_url_by_id(
         experiment_id=experiment.id,
         dataset_id=dataset.id,
-        url_override=client.config.url_override,
+        base_url=client.config.url_override,
+        workspace=client._workspace,
     )
 
     report.display_experiment_link(experiment_url=experiment_url)
@@ -736,7 +738,8 @@ def _evaluate_test_suite_task(
     experiment_url = url_helpers.get_experiment_url_by_id(
         experiment_id=experiment.id,
         dataset_id=dataset.id,
-        url_override=client.config.url_override,
+        base_url=client.config.url_override,
+        workspace=client._workspace,
     )
 
     evaluation_result_ = evaluation_result.EvaluationResult(
@@ -881,7 +884,8 @@ def evaluate_experiment(
     experiment_url = url_helpers.get_experiment_url_by_id(
         experiment_id=experiment.id,
         dataset_id=dataset_.id,
-        url_override=client.config.url_override,
+        base_url=client.config.url_override,
+        workspace=client._workspace,
     )
 
     report.display_experiment_link(experiment_url=experiment_url)
@@ -1185,7 +1189,8 @@ def evaluate_prompt(
     experiment_url = url_helpers.get_experiment_url_by_id(
         experiment_id=experiment.id,
         dataset_id=dataset.id,
-        url_override=client.config.url_override,
+        base_url=client.config.url_override,
+        workspace=client._workspace,
     )
 
     report.display_experiment_link(experiment_url=experiment_url)

--- a/sdks/python/src/opik/url_helpers.py
+++ b/sdks/python/src/opik/url_helpers.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import urllib.parse
 from typing import Final
 
@@ -28,15 +29,11 @@ def get_ui_url() -> str:
 
 
 def get_experiment_url_by_id(
-    dataset_id: str, experiment_id: str, url_override: str
+    dataset_id: str, experiment_id: str, base_url: str, workspace: str
 ) -> str:
-    encoded_opik_url = base64.b64encode(url_override.encode("utf-8")).decode("utf-8")
-
-    project_path = urllib.parse.quote(
-        f"v1/session/redirect/experiments/?experiment_id={experiment_id}&dataset_id={dataset_id}&path={encoded_opik_url}",
-        safe=ALLOWED_URL_CHARACTERS,
-    )
-    return urllib.parse.urljoin(ensure_ending_slash(url_override), project_path)
+    domain_root = get_base_url(base_url)
+    experiments_param = urllib.parse.quote(json.dumps([experiment_id]))
+    return f"{domain_root}opik/{workspace}/experiments/{dataset_id}/compare?experiments={experiments_param}"
 
 
 def get_project_url_by_workspace(

--- a/sdks/python/tests/unit/test_url_helpers.py
+++ b/sdks/python/tests/unit/test_url_helpers.py
@@ -55,3 +55,47 @@ def test_get_ui_url__url_override__only_strips_api_suffix(
         lambda: OpikConfig(url_override=url_override),
     )
     assert url_helpers.get_ui_url() == expected_ui_url
+
+
+@pytest.mark.parametrize(
+    ("base_url", "workspace", "dataset_id", "experiment_id", "expected_url"),
+    [
+        (
+            "http://localhost:5173/api",
+            "default",
+            "dataset-abc123",
+            "exp-xyz789",
+            'http://localhost:5173/opik/default/experiments/dataset-abc123/compare?experiments=%5B%22exp-xyz789%22%5D',
+        ),
+        (
+            "http://localhost:5173/api/",
+            "default",
+            "dataset-abc123",
+            "exp-xyz789",
+            'http://localhost:5173/opik/default/experiments/dataset-abc123/compare?experiments=%5B%22exp-xyz789%22%5D',
+        ),
+        (
+            "https://www.comet.com/opik/api",
+            "my-team",
+            "ds-id-001",
+            "exp-id-002",
+            'https://www.comet.com/opik/my-team/experiments/ds-id-001/compare?experiments=%5B%22exp-id-002%22%5D',
+        ),
+    ],
+)
+def test_get_experiment_url_by_id__returns_direct_workspace_scoped_url(
+    base_url: str,
+    workspace: str,
+    dataset_id: str,
+    experiment_id: str,
+    expected_url: str,
+) -> None:
+    assert (
+        url_helpers.get_experiment_url_by_id(
+            dataset_id=dataset_id,
+            experiment_id=experiment_id,
+            base_url=base_url,
+            workspace=workspace,
+        )
+        == expected_url
+    )


### PR DESCRIPTION
## Summary

Follow-up to #7440 (which fixed `get_dataset_url_by_id`). This PR fixes `get_experiment_url_by_id()` to use the same direct-URL pattern instead of the opaque session-redirect.

**Before:**
```
View your experiment at:
http://localhost:5173/v1/session/redirect/experiments/?experiment_id=abc&dataset_id=xyz&path=aHR0cDovL2xvY2FsaG9zdDo1MTczL2FwaQ==
```

**After:**
```
View your experiment at:
http://localhost:5173/opik/default/experiments/xyz/compare?experiments=%5B%22abc%22%5D
```

## Changes

- `url_helpers.py`: Changed `get_experiment_url_by_id(dataset_id, experiment_id, url_override)` to `get_experiment_url_by_id(dataset_id, experiment_id, base_url, workspace)`. The direct URL mirrors the pattern in `get_project_url_by_id()` and `get_dataset_url_by_id()` (post-#7440). The `experiments` query param is URL-encoded JSON (`%5B%22id%22%5D`) to match TanStack Router's `JsonParam` convention on the Compare Experiments page.
- `evaluator.py`: Updated all 5 call sites to pass `base_url=client.config.url_override, workspace=client._workspace`.
- `test_url_helpers.py`: Added 3 parametrized cases covering localhost, trailing-slash variant, and cloud URL.

## Design decision

`get_experiment_url_by_id` now accepts `workspace` explicitly (like `get_project_url_by_id` and `get_dataset_url_by_id`). For users on the default OSS workspace, `client._workspace` is `"default"`, which is the correct path segment. For Comet cloud users, `client._workspace` holds the actual workspace name. This matches existing conventions in the codebase.

## Test plan

- [ ] `pytest sdks/python/tests/unit/test_url_helpers.py -k test_get_experiment_url_by_id` — all 3 new cases pass
- [ ] Run `evaluate()` against a local opik instance; verify the printed URL opens directly in the browser without a redirect hop

Closes #7462