### PR TITLE
[OPIK-7336] [DOCS] Document span/trace ingestion size limits + attachments

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/faq.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/faq.mdx
@@ -159,21 +159,15 @@ For questions about rate limits, reach out to us on [Slack](https://chat.comet.c
 
 ### Is there a limit on how large a trace or span can be?
 
-Yes. To keep ingestion fast and reliable, Opik enforces size limits on logged data:
+Yes. Opik caps both the per-field size of `input`/`output` (recent SDKs truncate a larger
+`input`/`output` client-side, replacing it with a truncation marker and logging a warning) and the
+per-request payload size (oversized requests are rejected with `413`/`400`). `metadata` is not
+truncated and embedded base64 media is handled separately as an attachment.
 
-- **Per field (~20 MB):** keep each span/trace `input` and `output` under ~20 MB. Recent Opik SDK
-  versions truncate a larger `input`/`output` client-side before sending - the span is still
-  recorded (with the oversized field replaced by a truncation marker) and a warning is logged.
-  `metadata` is **not** truncated, so keep it small too: it still counts toward the per-request
-  limit below, and an oversized `metadata` causes the whole request to be rejected rather than trimmed.
-- **Per request:** a single ingestion batch is capped at roughly **~50 MB compressed** (on the wire)
-  and **~256 MB uncompressed**. Larger requests are rejected before they're fully processed
-  (`413`, or `400` for an oversized single document).
-
-If you need to keep large content - documents, full retrieval results, images, or audio - log it as
-an [attachment](/tracing/advanced/log_multimodal_traces#size-limits) instead of inline in `input`/`output`.
-Attachments store the full payload and keep your traces lightweight. As a rule of thumb, log the
-top-K results, IDs, or a summary rather than an entire result set or corpus.
+See [**Size limits**](/tracing/advanced/log_multimodal_traces#size-limits) for the exact numbers and
+the full behavior. If you need to keep large content - documents, full retrieval results, images, or
+audio - log it as an [attachment](/tracing/advanced/log_multimodal_traces) instead of inline. As a
+rule of thumb, log the top-K results, IDs, or a summary rather than an entire result set or corpus.
 
 ## Integrations
 
@@ -252,7 +246,8 @@ checking your environment variables (`OPIK_API_KEY`, `OPIK_WORKSPACE`, `OPIK_URL
 
 ### Why am I getting a 413 ("payload too large") error?
 
-Your request exceeded Opik's ingestion size limit - roughly ~50 MB per batch (compressed) or an
+Your request exceeded Opik's ingestion
+[size limit](/tracing/advanced/log_multimodal_traces#size-limits) - the per-request payload cap, or an
 oversized single document. This usually means a span is logging a very large `input`/`output`, such
 as an entire retrieval result set or document inline. To fix it:
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/faq.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/faq.mdx
@@ -162,14 +162,14 @@ For questions about rate limits, reach out to us on [Slack](https://chat.comet.c
 Yes. To keep ingestion fast and reliable, Opik enforces size limits on logged data:
 
 - **Per field (~20 MB):** each span/trace `input`, `output`, and `metadata` should stay under ~20 MB.
-  The Opik SDK automatically truncates a larger field before sending - the span is still recorded
-  (marked truncated) and a warning is logged.
+  Recent Opik SDK versions truncate a larger field client-side before sending - the span is still
+  recorded (with the oversized field replaced by a truncation marker) and a warning is logged.
 - **Per request:** a single ingestion batch is capped at roughly **~50 MB compressed** (on the wire)
   and **~256 MB uncompressed**. Larger requests are rejected before they're fully processed
   (`413`, or `400` for an oversized single document).
 
 If you need to keep large content - documents, full retrieval results, images, or audio - log it as
-an [attachment](/tracing/advanced/log_multimodal_traces) instead of inline in `input`/`output`.
+an [attachment](/tracing/advanced/log_multimodal_traces#size-limits) instead of inline in `input`/`output`.
 Attachments store the full payload and keep your traces lightweight. As a rule of thumb, log the
 top-K results, IDs, or a summary rather than an entire result set or corpus.
 
@@ -256,9 +256,12 @@ as an entire retrieval result set or document inline. To fix it:
 
 - Log only what you need to observe - top-K results, IDs, or a summary - instead of full result sets
   or documents.
-- Move large content to [attachments](/tracing/advanced/log_multimodal_traces) instead of inline
-  `input`/`output`.
-- Upgrade to the latest Opik SDK, which truncates oversized fields client-side automatically.
+- Move large content to [attachments](/tracing/advanced/log_multimodal_traces#size-limits) instead
+  of inline `input`/`output`.
+- Upgrade to the latest Opik SDK, which truncates an oversized span field client-side before sending
+  so individual spans stay within the per-field limit. This addresses oversized single spans; a very
+  large batch (many or large spans in one request) can still be rejected, so reduce the payload or
+  use attachments in that case.
 
 ## How can I diagnose issues with Opik?
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/faq.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/faq.mdx
@@ -161,9 +161,11 @@ For questions about rate limits, reach out to us on [Slack](https://chat.comet.c
 
 Yes. To keep ingestion fast and reliable, Opik enforces size limits on logged data:
 
-- **Per field (~20 MB):** each span/trace `input`, `output`, and `metadata` should stay under ~20 MB.
-  Recent Opik SDK versions truncate a larger field client-side before sending - the span is still
+- **Per field (~20 MB):** keep each span/trace `input` and `output` under ~20 MB. Recent Opik SDK
+  versions truncate a larger `input`/`output` client-side before sending - the span is still
   recorded (with the oversized field replaced by a truncation marker) and a warning is logged.
+  `metadata` is **not** truncated, so keep it small too: it still counts toward the per-request
+  limit below, and an oversized `metadata` causes the whole request to be rejected rather than trimmed.
 - **Per request:** a single ingestion batch is capped at roughly **~50 MB compressed** (on the wire)
   and **~256 MB uncompressed**. Larger requests are rejected before they're fully processed
   (`413`, or `400` for an oversized single document).

--- a/apps/opik-documentation/documentation/fern/docs-v2/faq.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/faq.mdx
@@ -157,6 +157,22 @@ strategy
 
 For questions about rate limits, reach out to us on [Slack](https://chat.comet.com).
 
+### Is there a limit on how large a trace or span can be?
+
+Yes. To keep ingestion fast and reliable, Opik enforces size limits on logged data:
+
+- **Per field (~20 MB):** each span/trace `input`, `output`, and `metadata` should stay under ~20 MB.
+  The Opik SDK automatically truncates a larger field before sending - the span is still recorded
+  (marked truncated) and a warning is logged.
+- **Per request:** a single ingestion batch is capped at roughly **~50 MB compressed** (on the wire)
+  and **~256 MB uncompressed**. Larger requests are rejected before they're fully processed
+  (`413`, or `400` for an oversized single document).
+
+If you need to keep large content - documents, full retrieval results, images, or audio - log it as
+an [attachment](/tracing/advanced/log_multimodal_traces) instead of inline in `input`/`output`.
+Attachments store the full payload and keep your traces lightweight. As a rule of thumb, log the
+top-K results, IDs, or a summary rather than an entire result set or corpus.
+
 ## Integrations
 
 ### What integrations does Opik support?
@@ -231,6 +247,18 @@ You can find your current configuration in the Opik configuration file (`~/.opik
 checking your environment variables (`OPIK_API_KEY`, `OPIK_WORKSPACE`, `OPIK_URL_OVERRIDE`,
 `OPIK_PROJECT_NAME`). For more details on configuration, see our
 [SDK Configuration guide](/tracing/advanced/sdk_configuration).
+
+### Why am I getting a 413 ("payload too large") error?
+
+Your request exceeded Opik's ingestion size limit - roughly ~50 MB per batch (compressed) or an
+oversized single document. This usually means a span is logging a very large `input`/`output`, such
+as an entire retrieval result set or document inline. To fix it:
+
+- Log only what you need to observe - top-K results, IDs, or a summary - instead of full result sets
+  or documents.
+- Move large content to [attachments](/tracing/advanced/log_multimodal_traces) instead of inline
+  `input`/`output`.
+- Upgrade to the latest Opik SDK, which truncates oversized fields client-side automatically.
 
 ## How can I diagnose issues with Opik?
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/faq.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/faq.mdx
@@ -162,7 +162,8 @@ For questions about rate limits, reach out to us on [Slack](https://chat.comet.c
 Yes. Opik caps both the per-field size of `input`/`output` (recent SDKs truncate a larger
 `input`/`output` client-side, replacing it with a truncation marker and logging a warning) and the
 per-request payload size (oversized requests are rejected with `413`/`400`). `metadata` is not
-truncated and embedded base64 media is handled separately as an attachment.
+truncated and embedded base64 content (images, audio, video, PDFs, or JSON) is handled separately as
+an attachment.
 
 See [**Size limits**](/tracing/advanced/log_multimodal_traces#size-limits) for the exact numbers and
 the full behavior. If you need to keep large content - documents, full retrieval results, images, or
@@ -248,17 +249,17 @@ checking your environment variables (`OPIK_API_KEY`, `OPIK_WORKSPACE`, `OPIK_URL
 
 Your request exceeded Opik's ingestion
 [size limit](/tracing/advanced/log_multimodal_traces#size-limits) - the per-request payload cap, or an
-oversized single document. This usually means a span is logging a very large `input`/`output`, such
-as an entire retrieval result set or document inline. To fix it:
+oversized single document. This usually means a span or trace is logging a very large
+`input`/`output`, such as an entire retrieval result set or document inline. To fix it:
 
 - Log only what you need to observe - top-K results, IDs, or a summary - instead of full result sets
   or documents.
 - Move large content to [attachments](/tracing/advanced/log_multimodal_traces#size-limits) instead
   of inline `input`/`output`.
-- Upgrade to the latest Opik SDK, which truncates an oversized span field client-side before sending
-  so individual spans stay within the per-field limit. This addresses oversized single spans; a very
-  large batch (many or large spans in one request) can still be rejected, so reduce the payload or
-  use attachments in that case.
+- Upgrade to the latest Opik SDK, which truncates an oversized `input`/`output` field client-side
+  before sending so individual spans and traces stay within the per-field limit. This addresses
+  oversized single spans and traces; a very large batch (many or large spans/traces in one request)
+  can still be rejected, so reduce the payload or use attachments in that case.
 
 ## How can I diagnose issues with Opik?
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/faq.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/faq.mdx
@@ -161,7 +161,7 @@ For questions about rate limits, reach out to us on [Slack](https://chat.comet.c
 
 Yes. Opik caps both the per-field size of `input`/`output` (recent SDKs truncate a larger
 `input`/`output` client-side, replacing it with a truncation marker and logging a warning) and the
-per-request payload size (oversized requests are rejected with `413`/`400`). `metadata` is not
+per-request payload size (oversized requests are rejected with `413`). `metadata` is not
 truncated and embedded base64 content (images, audio, video, PDFs, or JSON) is handled separately as
 an attachment.
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/log_multimodal_traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/log_multimodal_traces.mdx
@@ -25,8 +25,7 @@ directly in a span/trace `input`, `output`, or `metadata`:
   warning), so individual spans and traces stay within the limit. `metadata` is **not** truncated -
   keep it small too, since it still counts toward the per-request limit below.
 - **Per request:** a single ingestion batch is capped at roughly **~50 MB compressed** and
-  **~256 MB uncompressed**; larger requests are rejected (`413`, or `400` for an oversized single
-  document).
+  **~256 MB uncompressed**; larger requests are rejected with `413`.
 
 **Base64-encoded content is handled separately and is not bound by the two limits above.** When you
 embed a large base64 blob in a field - images, audio, video, PDFs, and other recognized formats such

--- a/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/log_multimodal_traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/log_multimodal_traces.mdx
@@ -16,14 +16,21 @@ and output of your LLM, but also images, videos and audio and any other media.
 
 ## Size limits
 
-To keep ingestion fast and reliable, Opik enforces size limits on logged data:
+To keep ingestion fast and reliable, Opik enforces size limits on **inline** content - what you put
+directly in a span/trace `input`, `output`, or `metadata`:
 
-- **Per field (~20 MB):** each span/trace `input`, `output`, and `metadata` should stay under
-  ~20 MB. The Opik SDK truncates a larger field client-side before sending (marking it and logging
-  a warning), so individual spans stay within the limit.
+- **Per field (~20 MB):** inline, non-media field content should stay under ~20 MB. Recent Opik SDK
+  versions truncate a larger field client-side before sending (replacing it with a truncation marker
+  and logging a warning), so individual spans stay within the limit.
 - **Per request:** a single ingestion batch is capped at roughly **~50 MB compressed** and
   **~256 MB uncompressed**; larger requests are rejected (`413`, or `400` for an oversized single
   document).
+
+**Base64 media is handled separately and is not bound by the two limits above.** When you embed
+base64-encoded media in a field, the SDK automatically extracts anything larger than ~250 KB and
+uploads it as an attachment - a separate upload, not part of the JSON ingestion request - so a
+single embedded media value can be up to **100 MB**. See [Embedded base64 size
+limits](#embedded-base64-size-limits) below.
 
 Attachments are the recommended way to keep large content without hitting these limits: instead of
 embedding a large payload inline in `input`/`output`, log it as an attachment (below). The full
@@ -328,9 +335,9 @@ For base64-encoded content larger than 250KB, Opik automatically extracts and st
 
 When you retrieve your traces or spans later, the attachments are automatically included by default. For faster queries when you don't need the attachment data, use the `strip_attachments=true` parameter.
 
-### Size Limits
+### Embedded base64 size limits
 
-Opik Cloud supports embedded attachments up to **100MB per field**. This limit applies to individual string values in your `input`, `output`, or `metadata` fields.
+Opik Cloud supports embedded attachments up to **100MB per field**. This limit applies to individual base64 string values in your `input`, `output`, or `metadata` fields, and is separate from the [inline field/request limits](#size-limits) above - because base64 media above ~250KB is extracted and uploaded as an attachment rather than sent inline.
 
 <Note>
 Base64 encoding increases file size by about 33%. For example, a 75MB video becomes ~100MB when base64-encoded.

--- a/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/log_multimodal_traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/log_multimodal_traces.mdx
@@ -19,9 +19,10 @@ and output of your LLM, but also images, videos and audio and any other media.
 To keep ingestion fast and reliable, Opik enforces size limits on **inline** content - what you put
 directly in a span/trace `input`, `output`, or `metadata`:
 
-- **Per field (~20 MB):** inline, non-media field content should stay under ~20 MB. Recent Opik SDK
-  versions truncate a larger field client-side before sending (replacing it with a truncation marker
-  and logging a warning), so individual spans stay within the limit.
+- **Per field (~20 MB):** keep inline, non-media `input`/`output` content under ~20 MB. Recent Opik
+  SDK versions truncate a larger `input`/`output` client-side before sending (replacing it with a
+  truncation marker and logging a warning), so individual spans stay within the limit. `metadata` is
+  **not** truncated - keep it small too, since it still counts toward the per-request limit below.
 - **Per request:** a single ingestion batch is capped at roughly **~50 MB compressed** and
   **~256 MB uncompressed**; larger requests are rejected (`413`, or `400` for an oversized single
   document).

--- a/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/log_multimodal_traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/log_multimodal_traces.mdx
@@ -19,19 +19,20 @@ and output of your LLM, but also images, videos and audio and any other media.
 To keep ingestion fast and reliable, Opik enforces size limits on **inline** content - what you put
 directly in a span/trace `input`, `output`, or `metadata`:
 
-- **Per field (~20 MB):** keep inline, non-media `input`/`output` content under ~20 MB. Recent Opik
-  SDK versions truncate a larger `input`/`output` client-side before sending (replacing it with a
-  truncation marker and logging a warning), so individual spans stay within the limit. `metadata` is
-  **not** truncated - keep it small too, since it still counts toward the per-request limit below.
+- **Per field (~20 MB):** keep each inline, non-media `input`/`output` field under ~20 MB - the same
+  cap also applies to `input` and `output` combined. Recent Opik SDK versions truncate an oversized
+  `input`/`output` client-side before sending (replacing it with a truncation marker and logging a
+  warning), so individual spans and traces stay within the limit. `metadata` is **not** truncated -
+  keep it small too, since it still counts toward the per-request limit below.
 - **Per request:** a single ingestion batch is capped at roughly **~50 MB compressed** and
   **~256 MB uncompressed**; larger requests are rejected (`413`, or `400` for an oversized single
   document).
 
-**Base64 media is handled separately and is not bound by the two limits above.** When you embed
-base64-encoded media in a field, the SDK automatically extracts anything larger than ~250 KB and
-uploads it as an attachment - a separate upload, not part of the JSON ingestion request - so a
-single embedded media value can be up to **100 MB**. See [Embedded base64 size
-limits](#embedded-base64-size-limits) below.
+**Base64-encoded content is handled separately and is not bound by the two limits above.** When you
+embed a large base64 blob in a field - images, audio, video, PDFs, and other recognized formats such
+as JSON - the SDK automatically extracts anything larger than ~250 KB and uploads it as an attachment
+- a separate upload, not part of the JSON ingestion request - so a single embedded value can be up to
+**100 MB**. See [Embedded base64 size limits](#embedded-base64-size-limits) below.
 
 Attachments are the recommended way to keep large content without hitting these limits: instead of
 embedding a large payload inline in `input`/`output`, log it as an attachment (below). The full

--- a/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/log_multimodal_traces.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/log_multimodal_traces.mdx
@@ -14,6 +14,22 @@ and output of your LLM, but also images, videos and audio and any other media.
   <img src="/img/tracing/attachments.png" />
 </Frame>
 
+## Size limits
+
+To keep ingestion fast and reliable, Opik enforces size limits on logged data:
+
+- **Per field (~20 MB):** each span/trace `input`, `output`, and `metadata` should stay under
+  ~20 MB. The Opik SDK truncates a larger field client-side before sending (marking it and logging
+  a warning), so individual spans stay within the limit.
+- **Per request:** a single ingestion batch is capped at roughly **~50 MB compressed** and
+  **~256 MB uncompressed**; larger requests are rejected (`413`, or `400` for an oversized single
+  document).
+
+Attachments are the recommended way to keep large content without hitting these limits: instead of
+embedding a large payload inline in `input`/`output`, log it as an attachment (below). The full
+payload is stored via object storage while your traces stay lightweight. As a rule of thumb, log
+summaries, top-K results, or IDs inline and attach anything large.
+
 ## Logging Attachments
 
 In the Python SDK, you can use the `Attachment` type to add files to your traces.


### PR DESCRIPTION
## Details

Adds two FAQ entries documenting the upcoming span/trace **ingestion size limits** and the Attachments alternative, in the Latest docs version (`fern/docs-v2/faq.mdx`):

- **Opik Cloud →** *"Is there a limit on how large a trace or span can be?"* — per-field (~20 MB, SDK truncates), per-request (~50 MB compressed / ~256 MB uncompressed → `413`/`400`), and pointing to **Attachments** for large payloads.
- **Troubleshooting →** *"Why am I getting a 413 (payload too large) error?"*.

Part of the effort to enforce span/trace ingestion size limits and stop the unbounded-payload OOM (read-path OPIK-6999, write-path OPIK-7273).

⚠️ **Draft / merge-with-release:** the `~20 / ~50 / ~256 MB` values must match what the backend (OPIK-7333/7334) and SDK (OPIK-7335) actually ship. Kept as a **draft** to merge *alongside* the enforcement release, not ahead of it.

**Error-code note:** `RequestSizeLimitFilter` returns `413`; `maxDocumentLength` currently returns `400` (Jackson `StreamConstraintsException` → `JsonProcessingExceptionMapper`). Docs say "413/400" until OPIK-7334 normalizes it to `413`.

## Change checklist

- [x] User facing
- [x] Documentation update

## Issues

- OPIK-7336 (parent: OPIK-7312)

## Testing

Docs-only change (no code paths affected). Validate the rendered FAQ locally with `cd apps/opik-documentation/documentation && npm run dev` — there is no automated docs test suite.

## Documentation

This PR **is** the documentation change: two new FAQ entries in `fern/docs-v2/faq.mdx` (Latest docs version). Links use the version-relative slug to the Attachments page (`/tracing/advanced/log_multimodal_traces`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
