### PR TITLE
[OPIK-7307] [BE] feat: add id_week predicate to SpanDAO read paths

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
@@ -200,6 +200,8 @@ class KpiCardDAOImpl implements KpiCardDAO {
                     FROM spans FINAL
                     WHERE workspace_id = :workspace_id AND project_id = :project_id
                       AND id >= :uuid_from_time AND id \\<= :uuid_to_time
+                      AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))
+                      AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))
                       AND trace_id IN (SELECT id FROM traces_filtered)
                     GROUP BY trace_id
                 )
@@ -313,6 +315,8 @@ class KpiCardDAOImpl implements KpiCardDAO {
                     AND workspace_id = :workspace_id
                     AND id >= :uuid_from_time
                     AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))
                     <if(span_filters)> AND <span_filters> <endif>
                     <if(span_feedback_scores_filters)>
                     AND id in (
@@ -504,6 +508,8 @@ class KpiCardDAOImpl implements KpiCardDAO {
                     FROM spans FINAL
                     WHERE workspace_id = :workspace_id AND project_id = :project_id
                       AND id >= :uuid_from_time AND id \\<= :uuid_to_time
+                      AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))
+                      AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))
                 ) s
                 JOIN traces_final tr ON s.trace_id = tr.id
                 GROUP BY tr.thread_id

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
@@ -550,8 +550,10 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                     WHERE project_id = :project_id
                     AND workspace_id = :workspace_id
                     AND trace_id IN (SELECT id FROM traces_filtered)
-                    <if(uuid_from_time)> AND id >= :uuid_from_time<endif>
-                    <if(uuid_to_time)> AND id \\<= :uuid_to_time<endif>
+                    <if(uuid_from_time)> AND id >= :uuid_from_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                    <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
                 ) s ON s.trace_id = t.id
             )
             SELECT <bucket> AS bucket,
@@ -580,8 +582,10 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                     WHERE project_id = :project_id
                     AND workspace_id = :workspace_id
                     AND trace_id IN (SELECT id FROM traces_filtered)
-                    <if(uuid_from_time)> AND id >= :uuid_from_time<endif>
-                    <if(uuid_to_time)> AND id \\<= :uuid_to_time<endif>
+                    <if(uuid_from_time)> AND id >= :uuid_from_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                    <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
                 ) s ON s.trace_id = t.id
             )
             SELECT <bucket> AS bucket,
@@ -607,8 +611,10 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                     WHERE project_id = :project_id
                     AND workspace_id = :workspace_id
                     AND trace_id IN (SELECT id FROM traces_filtered)
-                    <if(uuid_from_time)> AND id >= :uuid_from_time<endif>
-                    <if(uuid_to_time)> AND id \\<= :uuid_to_time<endif>
+                    <if(uuid_from_time)> AND id >= :uuid_from_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                    <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
                 ) s ON s.trace_id = t.id
                 ARRAY JOIN mapKeys(usage) AS name, mapValues(usage) AS value
                 WHERE value > 0
@@ -641,8 +647,10 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                     WHERE project_id = :project_id
                     AND workspace_id = :workspace_id
                     AND trace_id IN (SELECT id FROM traces_filtered)
-                    <if(uuid_from_time)> AND id >= :uuid_from_time<endif>
-                    <if(uuid_to_time)> AND id \\<= :uuid_to_time<endif>
+                    <if(uuid_from_time)> AND id >= :uuid_from_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                    <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
                 ) s ON s.trace_id = t.id
                 ARRAY JOIN mapKeys(usage) AS name, mapValues(usage) AS value
                 WHERE value > 0
@@ -1155,8 +1163,10 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                     FROM spans final
                     WHERE project_id = :project_id
                     AND workspace_id = :workspace_id
-                    <if(uuid_from_time)> AND id >= :uuid_from_time<endif>
-                    <if(uuid_to_time)> AND id \\<= :uuid_to_time<endif>
+                    <if(uuid_from_time)> AND id >= :uuid_from_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                    <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
                 ) s ON s.trace_id = tr.id
             )
             SELECT <bucket> AS bucket,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -819,6 +819,11 @@ public class SpanDAO {
      * immaterial since it is id-bounded and {@code LIMIT 1 BY id}. Field exclusion ({@code exclude_fields}) and
      * truncation are layered on top without dropping the sort key.
      * <p>
+     * Each {@code spans} id-range bound carries a parallel {@code toMonday(id_at)} bound: a strict consequence of the
+     * id-range — and, unlike a {@code created_at} predicate, safe against late-arriving rows since it derives from
+     * {@code id} — that lets the planner prune partitions once {@code spans} is partitioned. The {@code page_wide}
+     * re-read carries the same week bounds via the window it re-reads.
+     * <p>
      * When aggregates are enrichment-only ({@code page_keyed_aggregates}, see
      * {@code shouldPageKeyAggregates}), the feedback-score and comment CTEs are keyed on
      * {@code IN (SELECT arrayJoin((SELECT groupArray(id) FROM page_ids)))} instead of
@@ -832,9 +837,12 @@ public class SpanDAO {
                 SELECT DISTINCT id FROM spans
                 WHERE project_id = :project_id
                 AND workspace_id = :workspace_id
-                <if(last_received_span_id)> AND id \\< :last_received_span_id <endif>
-                <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
-                <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                <if(last_received_span_id)> AND id \\< :last_received_span_id
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:last_received_span_id), 'UTC')) <endif>
+                <if(uuid_from_time)> AND id >= :uuid_from_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                 <if(trace_id)> AND trace_id = :trace_id <endif>
                 <if(type)> AND type = :type <endif>
                 <if(filters)> AND <filters> <endif>
@@ -1007,9 +1015,12 @@ public class SpanDAO {
                 FROM spans s
                 WHERE project_id = :project_id
                 AND workspace_id = :workspace_id
-                <if(last_received_span_id)> AND id \\< :last_received_span_id <endif>
-                <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
-                <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                <if(last_received_span_id)> AND id \\< :last_received_span_id
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:last_received_span_id), 'UTC')) <endif>
+                <if(uuid_from_time)> AND id >= :uuid_from_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                 <if(trace_id)> AND trace_id = :trace_id <endif>
                 <if(type)> AND type = :type <endif>
                 <if(filters)> AND <filters> <endif>
@@ -1055,6 +1066,9 @@ public class SpanDAO {
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
                 AND id IN (SELECT id FROM page_ids)
+                <if(uuid_from_time)> AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                <if(uuid_to_time)> AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
+                <if(last_received_span_id)> AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:last_received_span_id), 'UTC')) <endif>
                 <if(stream)>
                 ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
                 <else>
@@ -1109,8 +1123,10 @@ public class SpanDAO {
                 FROM spans
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
-                <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
-                <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                <if(uuid_from_time)> AND id >= :uuid_from_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                 <if(trace_id)> AND trace_id = :trace_id <endif>
                 <if(type)> AND type = :type <endif>
                 <if(filters)> AND <filters> <endif>
@@ -1192,8 +1208,10 @@ public class SpanDAO {
                 <endif>
                 WHERE project_id = :project_id
                 AND workspace_id = :workspace_id
-                <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
-                <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                <if(uuid_from_time)> AND id >= :uuid_from_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                 <if(trace_id)> AND trace_id = :trace_id <endif>
                 <if(type)> AND type = :type <endif>
                 <if(filters)> AND <filters> <endif>
@@ -1411,8 +1429,10 @@ public class SpanDAO {
                 <endif>
                 WHERE project_id = :project_id
                 AND workspace_id = :workspace_id
-                <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
-                <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                <if(uuid_from_time)> AND id >= :uuid_from_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                 <if(trace_id)> AND trace_id = :trace_id <endif>
                 <if(type)> AND type = :type <endif>
                 <if(filters)> AND <filters> <endif>
@@ -1553,8 +1573,10 @@ public class SpanDAO {
                 <endif>
                 WHERE project_id = :project_id
                 AND workspace_id = :workspace_id
-                <if(uuid_from_time)> AND id >= :uuid_from_time <endif>
-                <if(uuid_to_time)> AND id \\<= :uuid_to_time <endif>
+                <if(uuid_from_time)> AND id >= :uuid_from_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
                 <if(trace_id)> AND trace_id = :trace_id <endif>
                 <if(type)> AND type = :type <endif>
                 <if(filters)> AND <filters> <endif>

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanMetricsQueries.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanMetricsQueries.java
@@ -5,6 +5,10 @@ package com.comet.opik.domain;
  * filters) is identical for per-project ({@link ProjectMetricsDAO}) and workspace-level ({@link WorkspaceMetricsDAO})
  * aggregation; the only difference is the project predicate, which is injected via {@link #spanFilteredPrefix(String)}
  * so both DAOs stay in sync when the CTE changes.
+ * <p>
+ * Each {@code id}-range bound on the {@code spans} scan carries a parallel {@code toMonday(id_at)} bound: a strict
+ * consequence of the id-range that scans the same rows but engages weekly-partition pruning once {@code spans} is
+ * partitioned, which the planner can't infer through {@code UUIDv7ToDateTime}.
  */
 final class SpanMetricsQueries {
 
@@ -118,8 +122,10 @@ final class SpanMetricsQueries {
                     <endif>
                     WHERE workspace_id = :workspace_id
                     AND %s
-                    <if(uuid_from_time)> AND id >= :uuid_from_time<endif>
-                    <if(uuid_to_time)> AND id \\<= :uuid_to_time<endif>
+                    <if(uuid_from_time)> AND id >= :uuid_from_time
+                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                    <if(uuid_to_time)> AND id \\<= :uuid_to_time
+                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
                     <if(span_filters)> AND <span_filters> <endif>
                     <if(span_feedback_scores_filters)>
                     AND id in (

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
@@ -106,6 +106,8 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
             WHERE workspace_id = :workspace_id
                 <if(project_ids)> AND project_id IN :project_ids <endif>
                 AND id BETWEEN :id_prior_start AND :id_end
+                AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:id_prior_start), 'UTC'))
+                AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'))
                 AND start_time BETWEEN parseDateTime64BestEffort(:timestamp_prior_start, 9) AND parseDateTime64BestEffort(:timestamp_end, 9);
             """;
 
@@ -190,6 +192,8 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
                 WHERE workspace_id = :workspace_id
                   AND project_id IN :project_ids
                   AND id BETWEEN :id_start AND :id_end
+                  AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:id_start), 'UTC'))
+                  AND toMonday(id_at) <= toMonday(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'))
                   AND start_time BETWEEN parseDateTime64BestEffort(:timestamp_start, 9) AND parseDateTime64BestEffort(:timestamp_end, 9)
                 GROUP BY project_id, bucket
                 ORDER BY project_id, bucket
@@ -214,6 +218,8 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
                 FROM spans final
                 WHERE workspace_id = :workspace_id
                   AND id BETWEEN :id_start AND :id_end
+                  AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:id_start), 'UTC'))
+                  AND toMonday(id_at) <= toMonday(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'))
                   AND start_time BETWEEN parseDateTime64BestEffort(:timestamp_start, 9) AND parseDateTime64BestEffort(:timestamp_end, 9)
                 GROUP BY bucket
                 ORDER BY bucket

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindSpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindSpansResourceTest.java
@@ -4262,6 +4262,66 @@ class FindSpansResourceTest {
         }
 
         @Test
+        @DisplayName("OPIK-7307: time-windowed + sorted + excluded list paginates byte-for-byte, exercising page_wide id_week bounds")
+        void whenTimeWindowSortExcludeAcrossPages__thenEachPageMatchesFullPageAndReference() {
+            // Companion to the OPIK-6747 pagination test above, but the page is bounded by a UUID creation-time
+            // window (from_time/to_time) instead of a filter. This is the path that renders the toMonday(id_at) week
+            // bounds added to span_id_prefilter / spans_deduped and the page_wide re-read: because the window brackets
+            // every created span, the bounds are a strict no-op, so each page must still match its sorted,
+            // output-excluded slice byte-for-byte (full row content, not just ids).
+            var workspaceName = RandomStringUtils.secure().nextAlphanumeric(10);
+            var workspaceId = UUID.randomUUID().toString();
+            var apiKey = UUID.randomUUID().toString();
+
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var projectName = RandomStringUtils.secure().nextAlphanumeric(10);
+            int total = 12; // > page size -> multiple pages
+            int pageSize = 5;
+
+            // Strictly increasing span-id timestamps so the id-range window and the input sort are both deterministic.
+            Instant base = Instant.now().minus(Duration.ofHours(1));
+            var spans = IntStream.range(0, total)
+                    .mapToObj(i -> podamFactory.manufacturePojo(Span.class).toBuilder()
+                            .id(idGenerator.generateId(base.plus(Duration.ofSeconds(i))))
+                            .projectId(null)
+                            .parentSpanId(null)
+                            .projectName(projectName)
+                            .feedbackScores(null)
+                            .comments(null)
+                            .usage(Map.of("total_tokens", RandomUtils.secure().randomInt()))
+                            .input(JsonUtils.getJsonNodeFromString("{\"q\":\"%03d\"}".formatted(i)))
+                            .output(JsonUtils.getJsonNodeFromString("{\"o\":\"%03d\"}".formatted(i)))
+                            .build())
+                    .collect(Collectors.toCollection(ArrayList::new));
+            spanResourceClient.batchCreateSpans(spans, apiKey, workspaceName);
+
+            // Window brackets every created span so the id_week bounds cannot drop a row.
+            var fromTime = base.minus(Duration.ofSeconds(1)).toString();
+            var toTime = base.plus(Duration.ofSeconds(total)).toString();
+
+            var sorting = List.of(SortingField.builder().field(SortableFields.INPUT).direction(Direction.ASC).build());
+            var exclude = List.of(Span.SpanField.OUTPUT);
+
+            // Independent reference: every span (projectName nulled by the API), sorted by input ASC, output excluded.
+            Comparator<Span> byInput = Comparator.comparing(s -> s.input().toString());
+            var reference = spans.stream()
+                    .map(s -> s.toBuilder().projectName(null).build())
+                    .sorted(byInput)
+                    .map(s -> SpanAssertions.EXCLUDE_FUNCTIONS.get(Span.SpanField.OUTPUT).apply(s))
+                    .toList();
+
+            int pages = (total + pageSize - 1) / pageSize;
+            for (int p = 1; p <= pages; p++) {
+                var slice = reference.subList((p - 1) * pageSize, Math.min(p * pageSize, total));
+                var actualPage = spanResourceClient.findSpans(workspaceName, apiKey, projectName, null,
+                        p, pageSize, null, null, List.of(), sorting, exclude, fromTime, toTime);
+                SpanAssertions.assertPage(actualPage, p, slice.size(), total);
+                SpanAssertions.assertSpan(actualPage.content(), slice, List.of(), USER);
+            }
+        }
+
+        @Test
         void whenSortingByInvalidField__thenIgnoreAndReturnSuccess() {
             var workspaceName = RandomStringUtils.secure().nextAlphanumeric(10);
             var workspaceId = UUID.randomUUID().toString();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindSpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindSpansResourceTest.java
@@ -4312,6 +4312,8 @@ class FindSpansResourceTest {
                     .toList();
 
             int pages = (total + pageSize - 1) / pageSize;
+            // Guard against a silent pass: the loop must actually iterate over multiple pages.
+            assertThat(pages).isGreaterThan(1);
             for (int p = 1; p <= pages; p++) {
                 var slice = reference.subList((p - 1) * pageSize, Math.min(p * pageSize, total));
                 var actualPage = spanResourceClient.findSpans(workspaceName, apiKey, projectName, null,


### PR DESCRIPTION
## Details

Engages weekly-partition pruning on user-facing `spans`-table **read** scans by adding a `toMonday(id_at)` ("id_week") predicate alongside each existing span-`id` bound. The planner cannot infer monotonicity through `UUIDv7ToDateTime(toUUID(id))`, so the bound must be explicit (Decision 16.1 #15). It is a strict consequence of the id-range — never drops a row the id-range wouldn't — and, unlike a `created_at` predicate, safe against late-arriving rows since it derives from `id`. A no-op pre-cutover; once `spans` is `PARTITION BY toMonday(id_at)` it prunes to the partitions in range (most impactful on cold-tier reads, and disproportionately important for the 14 TB `spans` table carrying the cost/spend aggregations).

Spans counterpart of the traces work in **OPIK-6895** (#7235). **Stacked on #7471 (OPIK-7306)**, which ships the `id_at`-on-`spans` migration (`000103`) this predicate targets — review/merge that first.

### Qualifying spans-table scans (predicate mirrors each id bound)
- **`SpanDAO`** — `SELECT_BY_PROJECT_ID` (`span_id_prefilter`, `spans_deduped`, and the `page_wide` window re-read), `COUNT_BY_PROJECT_ID` (prefilter + final scan), `SELECT_SPANS_STATS`, `SELECT_SPAN_FEEDBACK_SCORES_STATS`
- **`SpanMetricsQueries.spans_filtered`** — shared by `ProjectMetricsDAO` + `WorkspaceMetricsDAO` span metrics
- **`ProjectMetricsDAO`** — `GET_COST`(`_WITH_BREAKDOWN`), `GET_TOKEN_USAGE`(`_WITH_BREAKDOWN`), `GET_THREAD_COST`
- **`KpiCardDAO`** — `trace_costs`, `spans_filtered`, `thread_costs`
- **`WorkspaceMetricsDAO`** — `GET_COSTS_SUMMARY`, `GET_COSTS_DAILY`(`_BY_PROJECT`)

Operator mapping mirrors each bound: `id >=` → `toMonday(id_at) >=`; `id <=` / `id <` → `toMonday(id_at) <=`; `id BETWEEN` → both bounds. Windowed `id IN (page_ids)` re-reads carry the window's week bounds. StringTemplate vs raw-SQL `<`-escaping handled per query (e.g. `GET_COSTS_DAILY*` bind raw SQL → plain `<=`; the `newST`-rendered queries → `\<=`).

### Excluded paths (documented — no safe id_week derivation)
- **By-id lookups**: `getById` / `getOnlySpanDataById` / `getPartialById` / `getByIds`, the insert/update conflict reads, `DELETE_BY_IDS`, `BULK_UPDATE`.
- **Trace / experiment-linkage scans** (key on `trace_id` / experiment, not span time/id-range): `getByTraceIds`, `getSpanIdsForTraces`, and span scans in `TraceDAO` / `ThreadDAO` / `DatasetItem*DAO` / `Experiment*DAO` / `OptimizationDAO` / `FeedbackScoreDAO` / `WorkspaceMetadataDAO`. `ProjectMetricsDAO.GET_TOTAL_COST` keys on a `trace_id` range only (a plain mirror would narrow the set — a `created_at`-like hazard), so it is excluded here.
- **`created_at`-windowed** daily BI counters (`SPAN_COUNT_BY_WORKSPACE_ID`, `SPAN_DAILY_*`).
- **No id/time bound to mirror**: `EXISTS_BY_PROJECT_ID`, `GET_PROJECT_TOKEN_USAGE_NAMES`.
- Retention paths (`deleteForRetention*` / `countForRetention`) are handled in #7471; `ESTIMATE_VELOCITY_FOR_RETENTION` stays with the retention work.
- **`AiSpendQueryBuilder`** (a named candidate in the ticket) was removed in #7326 — the AI-spend read endpoints moved to their own `cipx_spends` table — so it no longer scans `spans`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves OPIK-7307

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: The five `spans`-scanning read DAOs listed above; SQL-only changes (no Java logic touched).
- Human verification: Author reviewed the diff; `mvn compile` / `test-compile` green.

## Testing

Semantic no-op — every modified query is already exercised with the predicate rendered by pre-existing integration tests (audited rather than duplicated, as in #7235):
- Span list / search / count time-filtering (boundary + exclusion): `FindSpansResourceTest`, `SpansResourceTest`.
- Span stats: `SpansResourceTest` (`getSpansStats`).
- Span metrics (duration / cost / token usage, incl. breakdown): `ProjectMetricsResourceTest`, `ProjectMetricsWithBreakdownResourceTest`.
- KPI cards (SPANS entity type, incl. thread cost): `KpiCardsResourceTest`.
- Workspace cost summary / daily / span token usage: `WorkspacesResourceTest`.

`mvn -o compile` and `mvn -o test-compile` succeed. `EXPLAIN PARTITIONS` validation is deferred to post-cutover staging per the AC (`spans` is not partitioned yet).

## Documentation

N/A — internal read-path pruning change, no user-facing surface.