### PR TITLE
[OPIK-7086] [QA] test(e2e): add Optimization Studio E2E coverage

### DIFF
--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -1,9 +1,15 @@
+import { gunzipSync } from 'node:zlib';
 import { Opik } from 'opik';
 import { loadEnvConfig } from '../../config/env.config';
 import {
   pollTraceForFeedbackScore,
   type PollFeedbackScoreOpts,
 } from './poll-feedback-score';
+import {
+  pollOptimizationStatus,
+  type OptimizationStatus,
+  type PollOptimizationStatusOpts,
+} from './poll-optimization-status';
 
 export type BackendClient = ReturnType<typeof makeBackendClient>;
 
@@ -60,6 +66,22 @@ export interface AutomationRuleRef {
   projectIds: string[];
 }
 
+export interface OptimizationRef {
+  id: string;
+  name: string;
+  status: OptimizationStatus;
+  objectiveName: string | null;
+  datasetName: string | null;
+  numTrials: number;
+  /**
+   * Baseline/best objective scores. NOTE: a healthy run can legitimately score
+   * 0 (a weak model won't emit exact-match labels), so tests assert these are
+   * present and in [0,1] — never that the run "improved".
+   */
+  baselineObjectiveScore: number | null;
+  bestObjectiveScore: number | null;
+}
+
 /** Backend discriminator for Dataset vs Test Suite (shared DB table). */
 const TEST_SUITE_TYPE = 'evaluation_suite';
 
@@ -70,6 +92,27 @@ export function makeBackendClient(apiKey: string | null = null) {
     workspaceName: env.workspace,
     apiUrl: env.apiBaseUrl,
   });
+
+  // Hoisted so the poll helpers (free functions) can call it without depending
+  // on the not-yet-constructed return object.
+  const localGetOptimization = async (id: string): Promise<OptimizationRef | null> => {
+    try {
+      const o = await opik.api.optimizations.getOptimizationById(id);
+      return {
+        id: String(o.id),
+        name: o.name ?? '',
+        status: String(o.status) as OptimizationStatus,
+        objectiveName: o.objectiveName ?? null,
+        datasetName: o.datasetName ?? null,
+        numTrials: Number(o.numTrials ?? 0),
+        baselineObjectiveScore: o.baselineObjectiveScore ?? null,
+        bestObjectiveScore: o.bestObjectiveScore ?? null,
+      };
+    } catch (err) {
+      if (isNotFoundError(err)) return null;
+      throw err;
+    }
+  };
 
   // Hoisted so pollTraceForFeedbackScore (a free function) can call it without
   // depending on the not-yet-constructed return object.
@@ -289,6 +332,56 @@ export function makeBackendClient(apiKey: string | null = null) {
       } catch (err) {
         if (isNotFoundError(err)) return;
         throw err;
+      }
+    },
+
+    getOptimization: localGetOptimization,
+
+    async pollOptimizationStatus(
+      optimizationId: string,
+      target: OptimizationStatus,
+      opts: PollOptimizationStatusOpts = {},
+    ): Promise<OptimizationRef> {
+      return pollOptimizationStatus(localGetOptimization, optimizationId, target, opts);
+    },
+
+    async deleteOptimization(id: string): Promise<void> {
+      try {
+        await opik.api.optimizations.deleteOptimizationsById({ ids: [id] });
+      } catch (err) {
+        if (isNotFoundError(err)) return;
+        throw err;
+      }
+    },
+
+    /**
+     * Fetch the studio run's logs. The backend returns a presigned URL to a
+     * gzipped log object (the optimizer subprocess stdout); this resolves it and
+     * gunzips the content.
+     *
+     * `urlReachable` distinguishes two very different outcomes so tests can
+     * assert precisely:
+     *  - the backend must always return a `url` (it produced logs) — absence is
+     *    a real failure the caller should assert on;
+     *  - the object-store host may be unreachable *from the test runner* — on a
+     *    local MinIO install the presigned URL uses the internal `minio:9000`
+     *    hostname, resolvable only inside the compose network. That's an
+     *    environment artifact, not a Studio defect, so the fetch failing is
+     *    reported (urlReachable=false) rather than thrown.
+     */
+    async getOptimizationLogs(
+      id: string,
+    ): Promise<{ url: string | null; urlReachable: boolean; content: string | null }> {
+      const meta = await opik.api.optimizations.getStudioOptimizationLogs(id);
+      const url = meta.url ?? null;
+      if (!url) return { url: null, urlReachable: false, content: null };
+      try {
+        const res = await fetch(url);
+        if (!res.ok) return { url, urlReachable: false, content: null };
+        const content = gunzipSync(Buffer.from(await res.arrayBuffer())).toString('utf8');
+        return { url, urlReachable: true, content };
+      } catch {
+        return { url, urlReachable: false, content: null };
       }
     },
   };

--- a/tests_end_to_end/e2e/core/backend/poll-optimization-status.ts
+++ b/tests_end_to_end/e2e/core/backend/poll-optimization-status.ts
@@ -1,0 +1,52 @@
+import type { OptimizationRef } from './client';
+
+export type OptimizationStatus =
+  | 'initialized'
+  | 'running'
+  | 'completed'
+  | 'cancelled'
+  | 'error';
+
+const TERMINAL_STATUSES: OptimizationStatus[] = ['completed', 'cancelled', 'error'];
+
+export interface PollOptimizationStatusOpts {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
+/**
+ * Poll an optimization's REST view until it reaches `target`, or throw. A studio
+ * run enqueues an RQ job that the python-backend worker executes asynchronously,
+ * so the status walks initialized → running → completed out of band from the UI.
+ * Reaching a terminal status other than `target` (error/cancelled) fails fast
+ * rather than waiting out the whole timeout.
+ */
+export async function pollOptimizationStatus(
+  getOptimization: (id: string) => Promise<OptimizationRef | null>,
+  optimizationId: string,
+  target: OptimizationStatus,
+  opts: PollOptimizationStatusOpts = {},
+): Promise<OptimizationRef> {
+  const timeoutMs = opts.timeoutMs ?? 240_000;
+  const pollIntervalMs = opts.pollIntervalMs ?? 3_000;
+  const start = Date.now();
+  let last: OptimizationRef | null = null;
+
+  while (Date.now() - start < timeoutMs) {
+    last = await getOptimization(optimizationId);
+    if (last?.status === target) return last;
+    if (last && TERMINAL_STATUSES.includes(last.status) && last.status !== target) {
+      throw new Error(
+        `optimization ${optimizationId} reached terminal status "${last.status}" ` +
+          `while waiting for "${target}"`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+
+  const elapsed = Date.now() - start;
+  throw new Error(
+    `pollOptimizationStatus timed out after ${elapsed}ms waiting for status "${target}" ` +
+      `on optimization ${optimizationId}. Last status: ${last?.status ?? '<not found>'}`,
+  );
+}

--- a/tests_end_to_end/e2e/package.json
+++ b/tests_end_to_end/e2e/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "playwright test --pass-with-no-tests",
     "test:t1": "playwright test --grep @t1-smoke",
+    "test:t1-stsaas": "playwright test --grep \"@t1-smoke|@t1-stsaas\"",
     "test:t2": "playwright test --grep \"@t1-smoke|@t2-cuj\"",
     "test:t3": "playwright test --grep \"@t1-smoke|@t2-cuj|@t3-nightly\"",
     "test:release-gate": "playwright test --grep @release-gate",

--- a/tests_end_to_end/e2e/pom/optimization-studio.page.ts
+++ b/tests_end_to_end/e2e/pom/optimization-studio.page.ts
@@ -1,0 +1,224 @@
+import type { Page, Locator } from '@playwright/test';
+import { test, expect } from '@playwright/test';
+import { loadEnvConfig } from '../config/env.config';
+
+export type OptimizerName = 'GEPA optimizer' | 'Hierarchical Reflective';
+
+export interface StudioRunConfig {
+  /** Name of a dataset already associated with the project (shown in the picker). */
+  datasetName: string;
+  /** User-message prompt content; keep the dataset variable, e.g. `{{text}}`. */
+  prompt: string;
+  /** Model display name as shown in the picker (e.g. "Claude Haiku 4.5"). */
+  modelDisplayName: string;
+  /** Equals-metric reference key — the dataset field holding the gold label. */
+  referenceKey: string;
+  /** Optional optimizer; defaults to the form's GEPA. */
+  optimizer?: OptimizerName;
+}
+
+/**
+ * Drives the v2 Optimization Studio: the new-run form
+ * (`/projects/{id}/optimizations/new`) and the read side of the run-detail page
+ * (`/projects/{id}/optimizations/{optimizationId}`), including the Trials tab
+ * and the Best-trial-configuration panel.
+ *
+ * Only the shared LLM message editor carries data-testids; everything else is
+ * addressed by role/label/text because this POM must run against the deployed
+ * image as it renders, without adding product testids. Selectors are kept
+ * tolerant of version drift where the UI has renamed things (e.g. the dataset
+ * picker is "Select item source" on newer builds, "Select a dataset" on 2.1.x).
+ */
+export class OptimizationStudioPage {
+  constructor(
+    private readonly page: Page,
+    private readonly projectId: string,
+  ) {}
+
+  async gotoNew(): Promise<void> {
+    return test.step('Open the Optimization Studio new-run page', async () => {
+      const env = loadEnvConfig();
+      await this.page.goto(
+        `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/optimizations/new`,
+      );
+      await this.page.getByRole('heading', { name: 'Optimize a prompt' }).waitFor();
+    });
+  }
+
+  /** Assert the form's core sections render with the expected defaults. */
+  async assertFormRenders(opts: { optimizer?: string; metric?: string } = {}): Promise<void> {
+    return test.step('Assert the studio form renders its sections', async () => {
+      await expect(this.promptEditor()).toBeVisible();
+      await expect(this.modelCombobox()).toBeVisible();
+      await expect(this.datasetPickerButton()).toBeVisible();
+      await expect(
+        this.page.locator('[role="combobox"]', { hasText: opts.optimizer ?? 'GEPA optimizer' }),
+      ).toBeVisible();
+      await expect(this.page.getByRole('combobox', { name: 'Metric' })).toContainText(
+        opts.metric ?? 'Equals',
+      );
+      await expect(this.optimizeButton()).toBeDisabled();
+    });
+  }
+
+  async selectDataset(name: string): Promise<void> {
+    return test.step(`Select dataset "${name}"`, async () => {
+      await this.datasetPickerButton().click();
+      await this.page.getByTestId('search-input').fill(name);
+      await this.page.getByRole('dialog').getByText(name, { exact: true }).click();
+      await expect(this.page.getByRole('button', { name })).toBeVisible();
+    });
+  }
+
+  async setUserPrompt(content: string): Promise<void> {
+    return test.step('Type the user-message prompt', async () => {
+      const editor = this.promptEditor();
+      await editor.click();
+      await editor.fill(content);
+      await expect(editor).toContainText(content);
+    });
+  }
+
+  async selectModel(displayName: string): Promise<void> {
+    return test.step(`Select model "${displayName}"`, async () => {
+      const search = this.page.getByRole('textbox', { name: 'Search model' });
+      // The trigger occasionally swallows the first click as a hover, so retry
+      // until the search box (i.e. the open popover) actually appears.
+      await expect(async () => {
+        await this.modelCombobox().click();
+        await expect(search).toBeVisible({ timeout: 2_000 });
+      }).toPass({ timeout: 15_000 });
+      await search.fill(displayName);
+      await this.page.getByRole('option', { name: displayName }).click();
+      await expect(this.modelCombobox()).toContainText(displayName);
+    });
+  }
+
+  async selectOptimizer(optimizer: OptimizerName): Promise<void> {
+    return test.step(`Select optimizer "${optimizer}"`, async () => {
+      const combo = this.page
+        .locator('[role="combobox"]')
+        .filter({ hasText: /GEPA optimizer|Hierarchical Reflective/ });
+      await combo.click();
+      await this.page.getByRole('option', { name: optimizer }).click();
+      await expect(combo).toContainText(optimizer);
+    });
+  }
+
+  async setReferenceKey(key: string): Promise<void> {
+    return test.step(`Set Equals reference key to "${key}"`, async () => {
+      await this.page.locator('input#reference_key').fill(key);
+    });
+  }
+
+  /** Click "Optimize prompt" and return the created optimization's id from the URL. */
+  async startOptimization(): Promise<string> {
+    return test.step('Start the optimization run', async () => {
+      await expect(this.optimizeButton()).toBeEnabled();
+      await this.optimizeButton().click();
+      await this.page.waitForURL(/\/optimizations\/[0-9a-f-]+$/);
+      const match = this.page.url().match(/\/optimizations\/([0-9a-f-]+)$/);
+      if (!match) {
+        throw new Error(`Could not extract optimization id from URL: ${this.page.url()}`);
+      }
+      return match[1];
+    });
+  }
+
+  /** Configure and launch a run in one call; returns the optimization id. */
+  async configureAndStart(config: StudioRunConfig): Promise<string> {
+    return test.step('Configure and start an optimization run', async () => {
+      await this.selectDataset(config.datasetName);
+      await this.setUserPrompt(config.prompt);
+      await this.selectModel(config.modelDisplayName);
+      if (config.optimizer && config.optimizer !== 'GEPA optimizer') {
+        await this.selectOptimizer(config.optimizer);
+      }
+      await this.setReferenceKey(config.referenceKey);
+      return this.startOptimization();
+    });
+  }
+
+  async gotoDetail(optimizationId: string): Promise<void> {
+    return test.step('Open the optimization detail page', async () => {
+      const env = loadEnvConfig();
+      await this.page.goto(
+        `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/optimizations/${optimizationId}`,
+      );
+    });
+  }
+
+  /** Wait for the detail header status tag to read the given status (case-insensitive). */
+  async expectStatus(
+    status: 'completed' | 'running' | 'error',
+    opts: { timeout?: number } = {},
+  ): Promise<void> {
+    return test.step(`Expect detail-page status "${status}"`, async () => {
+      await expect(
+        this.page.getByText(new RegExp(`^${status}$`, 'i')).first(),
+        `optimization detail should show status "${status}"`,
+      ).toBeVisible({ timeout: opts.timeout ?? 15_000 });
+    });
+  }
+
+  /** Open the Trials tab and wait for its table to render. */
+  async openTrialsTab(): Promise<void> {
+    return test.step('Open the Trials tab', async () => {
+      await this.page.getByRole('tab', { name: 'Trials' }).click();
+      await this.trialsTable().waitFor({ state: 'visible' });
+    });
+  }
+
+  async trialRowCount(): Promise<number> {
+    return test.step('Count trial rows', async () => {
+      return this.trialsTable().locator('tbody tr').count();
+    });
+  }
+
+  /** Assert at least one trial row carries the "Best" status tag. */
+  async expectBestTrial(): Promise<void> {
+    return test.step('Expect a Best trial row', async () => {
+      await expect(
+        this.trialsTable().getByText('Best', { exact: true }).first(),
+      ).toBeVisible();
+    });
+  }
+
+  /** Assert the Best-trial-configuration panel shows the given algorithm + metric. */
+  async expectBestTrialConfig(opts: { algorithm: string; metric: string }): Promise<void> {
+    return test.step('Assert Best-trial configuration panel', async () => {
+      const overview = this.page.getByRole('tabpanel');
+      await expect(overview).toContainText(opts.algorithm);
+      await expect(overview).toContainText(opts.metric);
+    });
+  }
+
+  private promptEditor(): Locator {
+    return this.page.locator('[data-testid="playground-message-editor"] .cm-content');
+  }
+
+  private optimizeButton(): Locator {
+    return this.page.getByRole('button', { name: 'Optimize prompt' });
+  }
+
+  /**
+   * The dataset/source picker button. Newer builds label it "Select item
+   * source"; 2.1.x labels it "Select a dataset". Match either, or the button
+   * that has become the selected dataset name.
+   */
+  private datasetPickerButton(): Locator {
+    return this.page.getByRole('button', { name: /Select item source|Select a dataset/ });
+  }
+
+  private modelCombobox(): Locator {
+    // The model picker is the only combobox on the form that renders a provider
+    // name; the others show "GEPA optimizer" / "Equals".
+    return this.page
+      .locator('[role="combobox"]')
+      .filter({ hasText: /Anthropic|OpenAI|Gemini|openrouter|free|gpt-|claude|GPT|Claude/i });
+  }
+
+  private trialsTable(): Locator {
+    return this.page.locator('main table');
+  }
+}

--- a/tests_end_to_end/e2e/tests/optimization-studio/optimization-studio.spec.ts
+++ b/tests_end_to_end/e2e/tests/optimization-studio/optimization-studio.spec.ts
@@ -1,0 +1,219 @@
+import { test, expect } from '@e2e/fixtures';
+import { OptimizationStudioPage } from '@e2e/pom/optimization-studio.page';
+import { ensureModelAvailable } from '@e2e/pom/model-availability';
+
+/**
+ * Sentiment-classification seed: `text` is the prompt variable, `label` is the
+ * Equals-metric reference key. Deterministic Equals metric (no LLM judge) keeps
+ * the run fast and stable. NOTE: the objective score can legitimately be 0 on a
+ * healthy run (a weak model won't emit exact-match labels), so tests assert the
+ * run is *healthy and complete*, never that it *improved*.
+ */
+const SENTIMENT_ITEMS = [
+  { text: 'I absolutely loved this movie, it was fantastic!', label: 'positive' },
+  { text: 'Terrible film, a complete waste of time.', label: 'negative' },
+  { text: 'Best cinematic experience I have had all year.', label: 'positive' },
+  { text: 'Boring and poorly acted, I walked out.', label: 'negative' },
+];
+
+const PROMPT = 'Classify the sentiment of this movie review as exactly "positive" or "negative": {{text}}';
+
+type SdkClient = Parameters<Parameters<typeof test>[2]>[0]['sdkClient'];
+
+function seedSentimentDataset(sdkClient: SdkClient, projectName: string, name: string) {
+  return sdkClient.python.createDataset({
+    project_name: projectName,
+    name,
+    description: 'sentiment classification for optimization studio smoke',
+    items: SENTIMENT_ITEMS as unknown as Array<Record<string, unknown>>,
+  });
+}
+
+test.describe('Optimization Studio — core', { tag: ['@t2-cuj', '@t1-stsaas', '@optimization-studio'] }, () => {
+  test('the new-run form renders its sections and enables Optimize only once valid', async ({
+    project,
+    sdkClient,
+    backendClient,
+    testNamespace,
+    page,
+  }) => {
+    // A form-only test still needs a project-associated dataset for the picker.
+    const dataset = await test.step('Seed a dataset for the picker', async () =>
+      seedSentimentDataset(sdkClient, project.name, `${testNamespace}-form-ds`));
+
+    const studio = new OptimizationStudioPage(page, project.id);
+    await studio.gotoNew();
+
+    await test.step('Form renders with GEPA + Equals defaults and Optimize disabled', async () => {
+      await studio.assertFormRenders();
+    });
+
+    await test.step('Optimize enables once dataset + prompt + reference key are set', async () => {
+      await studio.selectDataset(dataset.name);
+      await studio.setUserPrompt(PROMPT);
+      await studio.setReferenceKey('label');
+      await expect(page.getByRole('button', { name: 'Optimize prompt' })).toBeEnabled();
+    });
+
+    await test.step('Cleanup', async () => {
+      await backendClient.deleteDataset(dataset.id);
+    });
+  });
+
+  test('launches a GEPA + Equals run from the studio UI and it completes end-to-end', async ({
+    project,
+    sdkClient,
+    backendClient,
+    testNamespace,
+    envConfig,
+    page,
+  }) => {
+    test.setTimeout(300_000);
+
+    const modelDisplayName = await test.step(
+      'Ensure an LLM provider is available',
+      async () => ensureModelAvailable(page),
+    );
+
+    const datasetName = `${testNamespace}-sentiment`;
+    const dataset = await test.step('Seed a sentiment dataset associated with the project', async () =>
+      seedSentimentDataset(sdkClient, project.name, datasetName));
+
+    const studio = new OptimizationStudioPage(page, project.id);
+
+    const optimizationId = await test.step('Configure and start the run in the studio', async () => {
+      await studio.gotoNew();
+      await studio.assertFormRenders();
+      return studio.configureAndStart({
+        datasetName,
+        prompt: PROMPT,
+        modelDisplayName,
+        referenceKey: 'label',
+      });
+    });
+
+    const completed = await test.step('Wait for the run to reach completed (backend poll)', async () =>
+      backendClient.pollOptimizationStatus(optimizationId, 'completed', { timeoutMs: 240_000 }));
+
+    await test.step('Assert the completed run is healthy (structural, not improvement)', async () => {
+      expect(completed.status).toBe('completed');
+      expect(completed.objectiveName).toBe('equals');
+      expect(completed.datasetName).toBe(datasetName);
+      expect(completed.numTrials, 'the optimizer ran at least one trial').toBeGreaterThanOrEqual(1);
+      // Scores are produced and in range — NOT that best > baseline (a healthy
+      // run can score 0 with a weak model).
+      for (const s of [completed.baselineObjectiveScore, completed.bestObjectiveScore]) {
+        expect(s, 'objective score present').not.toBeNull();
+        expect(s as number).toBeGreaterThanOrEqual(0);
+        expect(s as number).toBeLessThanOrEqual(1);
+      }
+    });
+
+    await test.step('Confirm the UI detail page reflects a healthy completed run', async () => {
+      await studio.gotoDetail(optimizationId);
+      await studio.expectStatus('completed');
+      await studio.expectBestTrialConfig({ algorithm: 'GEPA optimizer', metric: 'Equals' });
+      await studio.openTrialsTab();
+      expect(await studio.trialRowCount(), 'at least one trial row').toBeGreaterThanOrEqual(1);
+      await studio.expectBestTrial();
+    });
+
+    await test.step('Studio logs are downloadable and show the optimizer ran', async () => {
+      const logs = await backendClient.getOptimizationLogs(optimizationId);
+      // The backend must always produce a logs URL for a completed run.
+      expect(logs.url, 'backend returned a presigned logs URL').toBeTruthy();
+
+      // On local OSS the presigned URL uses the internal `minio:9000` host, which
+      // is genuinely unreachable from a runner outside the compose network — no
+      // deployment config can change that from here, so we can't enforce the
+      // download locally. On EVERY OTHER target (cloud / self-hosted / stsaas)
+      // the presign host MUST be reachable and the log content MUST download —
+      // if it doesn't, the deployment's object-store config is wrong and the
+      // in-app logs viewer would be broken for users, so we FAIL, not skip.
+      if (envConfig.deployment === 'oss') {
+        if (!logs.urlReachable) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[optimization-studio] local OSS: logs URL not reachable from the runner ` +
+              `(${logs.url}) — expected for MinIO's internal host; content check skipped.`,
+          );
+        }
+        return;
+      }
+
+      expect(
+        logs.urlReachable,
+        `logs presigned URL must be reachable on a ${envConfig.deployment} deployment — ` +
+          `if this fails, the object-store presign host (${logs.url}) is not client-reachable ` +
+          `and the in-app logs viewer will be broken; the Studio object-store config needs fixing`,
+      ).toBe(true);
+      expect(logs.content, 'logs content downloaded').toBeTruthy();
+      expect(logs.content!.length, 'logs are non-empty').toBeGreaterThan(0);
+      // Lenient markers: the optimizer subprocess ran end-to-end and reported
+      // success — without coupling to the exact log format.
+      expect(
+        /Opik Optimizer SDK/i.test(logs.content!) || /"success":\s*true/.test(logs.content!),
+        'logs contain the optimizer banner or a success marker',
+      ).toBe(true);
+    });
+
+    await test.step('Cleanup: delete the optimization and dataset', async () => {
+      await backendClient.deleteOptimization(optimizationId);
+      await backendClient.deleteDataset(dataset.id);
+    });
+  });
+});
+
+test.describe('Optimization Studio — variant', { tag: ['@t2-cuj', '@t1-stsaas', '@optimization-studio'] }, () => {
+  test('launches a Hierarchical Reflective + Equals run and it completes end-to-end', async ({
+    project,
+    sdkClient,
+    backendClient,
+    testNamespace,
+    page,
+  }) => {
+    test.setTimeout(360_000);
+
+    const modelDisplayName = await test.step(
+      'Ensure an LLM provider is available',
+      async () => ensureModelAvailable(page),
+    );
+
+    const datasetName = `${testNamespace}-hr-sentiment`;
+    const dataset = await test.step('Seed a sentiment dataset', async () =>
+      seedSentimentDataset(sdkClient, project.name, datasetName));
+
+    const studio = new OptimizationStudioPage(page, project.id);
+
+    const optimizationId = await test.step('Configure and start a Hierarchical Reflective run', async () => {
+      await studio.gotoNew();
+      return studio.configureAndStart({
+        datasetName,
+        prompt: PROMPT,
+        modelDisplayName,
+        referenceKey: 'label',
+        optimizer: 'Hierarchical Reflective',
+      });
+    });
+
+    const completed = await test.step('Wait for the run to reach completed', async () =>
+      backendClient.pollOptimizationStatus(optimizationId, 'completed', { timeoutMs: 300_000 }));
+
+    await test.step('Assert the completed run is healthy', async () => {
+      expect(completed.status).toBe('completed');
+      expect(completed.objectiveName).toBe('equals');
+      expect(completed.numTrials).toBeGreaterThanOrEqual(1);
+    });
+
+    await test.step('Confirm the UI shows Hierarchical Reflective completed', async () => {
+      await studio.gotoDetail(optimizationId);
+      await studio.expectStatus('completed');
+      await studio.expectBestTrialConfig({ algorithm: 'Hierarchical Reflective', metric: 'Equals' });
+    });
+
+    await test.step('Cleanup', async () => {
+      await backendClient.deleteOptimization(optimizationId);
+      await backendClient.deleteDataset(dataset.id);
+    });
+  });
+});


### PR DESCRIPTION
## Details

Adds end-to-end coverage for **Optimization Studio** (v2): three Playwright tests that drive the studio UI to launch real optimization runs and assert they complete healthily, plus supporting POM / backend-client / tier wiring.

- **Form renders + validation gating** (no LLM run): sections render (prompt, model, dataset picker, GEPA + Equals defaults) and Optimize is disabled until valid.
- **GEPA + Equals launch, deep**: configure + launch via UI → poll to `completed` → structural health (`num_trials ≥ 1`, `objective_name`, baseline/best scores present & in `[0,1]` — never "improved") → detail-page Trials tab (Best row) + Best-trial-config panel → studio **logs** read-path (presigned URL + gunzip).
- **Hierarchical Reflective variant**: same flow, second optimizer.
- Tagged `@t2-cuj` + `@t1-stsaas` (kept out of plain `@t1-smoke`); adds a `test:t1-stsaas` script so customer/stsaas regression runs can include the studio checks (companion: comet-automation-tests#273).
- Fragility handled in assertions: score-0 is healthy (assert range, not improvement); studio-logs presigned URL is client-reachable only on real object stores, so the log-content check is enforced on non-oss and skipped-with-warning on local MinIO; selectors tolerate the "Select item source" vs "Select a dataset" rename.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7086

<!-- comet-backend#5616 (studio gateway-auth fix) is related but resolved elsewhere, referenced as OPIK_7267 to avoid mis-linking. -->

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Authored the POM, spec, backend-client methods, poller, and tier/script wiring; explored the live UI on staging/local; iterated to green.
  - Human verification: Developer reviewed the diff and directed the coverage design, tiering, and the deployment-gated logs enforcement; studio run path independently confirmed working end-to-end on self-hosted-eks.

## Testing

Suite: `tests_end_to_end/e2e/`.

- `npx tsc --noEmit` — clean.
- `pre-commit run --files <changed>` — clean.
- Tag/tier wiring verified with `--list`: `@t1-smoke` excludes the studio tests; `test:t1-stsaas` (`@t1-smoke|@t1-stsaas`) and `test:t2` include all three.
- The three tests were run green locally against a local OSS instance during development (form + GEPA-deep + HR variant), and the flows were verified manually on Comet staging. The studio launch→completed path was also confirmed end-to-end on self-hosted-eks after the platform fix (comet-backend#5616) deployed.
- Command to run locally: `OPIK_DEPLOYMENT=oss OPIK_BASE_URL=http://localhost:5173 OPIK_WORKSPACE=default npm run test:t1-stsaas` (requires an LLM provider key in env; `ensureModelAvailable` skips cleanly without one).
- Not re-run after the final file rebuild: the working files were re-created from the verified versions (identical, tsc-clean) but the local OSS stack was down at commit time, so the post-rebuild full-suite run is pending a running stack. The stsaas logs-content assertion is only exercised on a non-oss target (staging/stsaas), not local OSS.

## Documentation

No documentation changes — internal E2E test infrastructure.