### PR TITLE
[OPIK-7346] Fix ThreadDAO.findById multi-emit HTTP 500

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
@@ -12,6 +12,7 @@ import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils;
 import com.comet.opik.utils.TruncationUtils;
 import com.comet.opik.utils.template.TemplateUtils;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.inject.ImplementedBy;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -1483,11 +1484,28 @@ class ThreadDAOImpl implements ThreadDAO {
 
             InstrumentAsyncUtils.Segment segment = startSegment("threads", "Clickhouse", "findThreadById");
 
-            return Mono.from(statement.execute())
-                    .flatMapMany(this::mapThreadToDto)
-                    .singleOrEmpty()
+            return firstThreadOrEmpty(Mono.from(statement.execute())
+                    .flatMapMany(this::mapThreadToDto))
                     .doFinally(signalType -> endSegment(segment));
         }));
+    }
+
+    /**
+     * Collapses the by-id thread stream to the first matching thread, or empty when none is found.
+     * Using {@code reduce} rather than {@code single()}/{@code singleOrEmpty()} is deliberate:
+     * SELECT_TRACES_THREAD_BY_ID can legitimately return more than one row for a single
+     * {@code (workspace_id, project_id, thread_id)}. The trace_threads table's dedup/sort key includes
+     * the internal thread_model_id ({@code id}), so several thread_model_ids may coexist for one
+     * user-facing thread_id; trace_threads_final keeps one row per id ({@code LIMIT 1 BY id}), and the
+     * final {@code LEFT JOIN ... ON (workspace_id, project_id, thread_id)} (not on id) fans the single
+     * aggregated trace row out to one row per thread_model_id. Each row maps to one TraceThread, so
+     * {@code singleOrEmpty()} would throw {@code IndexOutOfBoundsException} ("Source emitted more than
+     * one item") and surface as an unmapped HTTP 500. Folding to the first emission tolerates the
+     * multi-row result while preserving the not-found (empty) contract.
+     */
+    @VisibleForTesting
+    static Mono<TraceThread> firstThreadOrEmpty(Flux<TraceThread> threads) {
+        return threads.reduce((existingThread, ignored) -> existingThread);
     }
 
     @Override

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ThreadDAOImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ThreadDAOImplTest.java
@@ -1,0 +1,40 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.TraceThread;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ThreadDAOImplTest {
+
+    @Test
+    @DisplayName("a multi-element stream collapses to the first thread (singleOrEmpty would throw here)")
+    void firstThreadOrEmptyCollapsesMultipleEmissions() {
+        var first = TraceThread.builder().id("thread-1").build();
+        var second = TraceThread.builder().id("thread-2").build();
+
+        StepVerifier.create(ThreadDAOImpl.firstThreadOrEmpty(Flux.just(first, second)))
+                .assertNext(thread -> assertThat(thread.id()).isEqualTo("thread-1"))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("a single emitted thread passes through unchanged")
+    void firstThreadOrEmptyPassesSingleThreadThrough() {
+        var thread = TraceThread.builder().id("thread-1").build();
+
+        StepVerifier.create(ThreadDAOImpl.firstThreadOrEmpty(Flux.just(thread)))
+                .assertNext(result -> assertThat(result.id()).isEqualTo("thread-1"))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("an empty stream completes empty (preserving the not-found contract)")
+    void firstThreadOrEmptyCompletesEmptyForEmptyStream() {
+        StepVerifier.create(ThreadDAOImpl.firstThreadOrEmpty(Flux.empty()))
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
## Details

`ThreadDAO.findById` used Reactor's `singleOrEmpty()` on the by-id thread stream. Like `single()`, it is backed by `MonoSingle` and throws `IndexOutOfBoundsException` ("Source emitted more than one item") when the source emits more than one element — surfacing as an unmapped HTTP 500 on `GET /v1/private/traces/threads/retrieve`.

The root cause is that `SELECT_TRACES_THREAD_BY_ID` can legitimately return **more than one row** for a single `(workspace_id, project_id, thread_id)`:

- `trace_threads` is a `ReplacingMergeTree` whose dedup/sort key **includes the internal `thread_model_id` (`id`)**, so multiple `thread_model_id`s can coexist for one user-facing `thread_id` — they are distinct rows and all survive dedup.
- The `trace_threads_final` CTE keeps one row **per `id`** (`LIMIT 1 BY id`), not one row per `thread_id`.
- The final `LEFT JOIN` is on `(workspace_id, project_id, thread_id)` — **not on `id`** — so the single aggregated trace row fans out to one row per `thread_model_id`.

Each row maps to exactly one `TraceThread`, so any thread with more than one model id makes `singleOrEmpty()` throw. The read query joins on `thread_id`, so it makes no single-id guarantee — folding is the correct contract.

A small number of threads carry more than one `thread_model_id` as a pre-existing data condition: an earlier id resolution/create path could mint an id that loses the `project_trace_threads (project_id, thread_id)` unique-key race yet still be written to the `trace_threads` table. The canonical id (the unique-key winner) and the extra id then coexist as distinct `trace_threads` rows.

**This divergence is no longer produced on current code and cannot be reproduced through the API.** The current create path converges: on a unique-key conflict the write handler refetches and returns the winning canonical id, so a losing id is never persisted going forward. Forensics on the existing divergent rows confirm they were all minted within a bounded historical window and none have been produced since. However, the already-written rows persist (there is no delete/TTL on `trace_threads`), so the read path must tolerate them regardless — which is exactly what this change does. The fix is therefore a defensive read-side correction for a legitimate multi-row result, not a fix for an actively reproducible write-path bug.

- Replace `singleOrEmpty()` with a multi-emission-tolerant fold (`reduce((existing, ignored) -> existing)`) extracted as a `@VisibleForTesting` helper. Folding to the first emission tolerates the multi-row result while preserving the empty→empty (not-found) contract.
- Same defect class as #7454 (`ExperimentAggregatesDAO.getProjectIds`), applied here to the sibling `findById` call site.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7346

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8
  - Scope: Root-cause analysis, code change, and unit test authored with assistance.
  - Human verification: Reviewed the diff, confirmed the reduce fold preserves the not-found (empty) contract, and ran the unit test locally.

## Testing

- `mvn -o test -Dtest=ThreadDAOImplTest` — 3 passing (`Tests run: 3, Failures: 0, Errors: 0`).
- `mvn -o test-compile` — compiles clean.
- Scenarios validated via StepVerifier: multi-element stream collapses to the first thread (the case that made `singleOrEmpty()` throw), single element passes through unchanged, empty stream stays empty (not-found contract).

> The regression guard is a `StepVerifier` unit test on the extracted `firstThreadOrEmpty` helper rather than an API-level integration test. Because the write path no longer produces the divergent rows (see Details), the multi-row condition cannot be set up through the public API — the deterministic way to exercise it is to feed the helper the multi-element `Flux` directly, which is exactly what the unit test does.

## Documentation

No documentation change required (internal DAO behavior fix).
