### PR TITLE
[OPIK-7344] [SDK] fix: guard empty span-fetch bucket against unbounded full-project read

### DIFF
--- a/sdks/python/src/opik/cli/migrate/datasets/experiments.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/experiments.py
@@ -1493,21 +1493,54 @@ def _bulk_fetch_spans_for_experiment(
             for tid in trace_ids_in_project
             if tid in source_traces_by_id
         }
-        window = _compute_span_time_window(per_project_traces)
-        filter_string: Optional[str] = None
-        if window is not None:
-            from_time, to_time = window
-            # ISO 8601 with explicit ``Z`` UTC suffix matches the BE
-            # filter grammar's date-time literal format (see the
-            # search_spans docstring on ``client.search_spans``:
-            # "use ISO 8601 format, e.g., '2024-01-01T00:00:00Z'").
-            # ``SpanField.END_TIME`` is filterable too but using
-            # ``start_time`` for both bounds keeps the filter AST simple
-            # and lets the BE's primary-key range scan stay tight.
-            filter_string = (
-                f'start_time >= "{_to_iso_z(from_time)}" '
-                f'AND start_time <= "{_to_iso_z(to_time)}"'
+        # Both branches below would otherwise fall through to an
+        # UNBOUNDED, UNFILTERED
+        # ``search_spans(filter_string=None, max_results=sys.maxsize)`` --
+        # a whole-project read that OOMs the client on large projects
+        # (OPIK-7344). Skip + warn + continue instead: destination traces
+        # in this bucket are still copied, just without spans. A bounded
+        # per-trace fallback for the no-timestamp case is deferred to
+        # OPIK-7343 (once span reads are scoped by ``trace_id IN (...)``
+        # the unbounded read is gone structurally).
+        if not per_project_traces:
+            # Every trace this bucket references is absent from the
+            # experiment's fetched traces -- stale/deleted references that
+            # experiment items still carry. There is nothing to fetch.
+            LOGGER.warning(
+                "Skipping span read for project %s: all %d referenced "
+                "trace_id(s) are stale/deleted (absent from the experiment's "
+                "fetched traces). Avoids an unbounded full-project span read.",
+                project_id,
+                len(trace_ids_in_project),
             )
+            continue
+
+        window = _compute_span_time_window(per_project_traces)
+        if window is None:
+            # The bucket's traces exist but none carry a
+            # start/end/last_updated timestamp, so we can't bound the read.
+            LOGGER.warning(
+                "Skipping span read for project %s: %d trace(s) have no "
+                "usable timestamps to bound the read. Destination traces are "
+                "copied without spans. Avoids an unbounded full-project span "
+                "read.",
+                project_id,
+                len(per_project_traces),
+            )
+            continue
+
+        from_time, to_time = window
+        # ISO 8601 with explicit ``Z`` UTC suffix matches the BE
+        # filter grammar's date-time literal format (see the
+        # search_spans docstring on ``client.search_spans``:
+        # "use ISO 8601 format, e.g., '2024-01-01T00:00:00Z'").
+        # ``SpanField.END_TIME`` is filterable too but using
+        # ``start_time`` for both bounds keeps the filter AST simple
+        # and lets the BE's primary-key range scan stay tight.
+        filter_string = (
+            f'start_time >= "{_to_iso_z(from_time)}" '
+            f'AND start_time <= "{_to_iso_z(to_time)}"'
+        )
 
         all_spans = rest_helpers.ensure_rest_api_call_respecting_rate_limit(
             operation_name="search_spans (experiment bulk read)",

--- a/sdks/python/src/opik/cli/migrate/datasets/experiments.py
+++ b/sdks/python/src/opik/cli/migrate/datasets/experiments.py
@@ -57,6 +57,7 @@ import opik.id_helpers as id_helpers_module
 from opik.api_objects import rest_helpers, rest_stream_parser
 from opik.api_objects.experiment import experiment_item, rest_operations
 from opik.rest_api import OpikApi
+from opik.rest_api.core.api_error import ApiError
 from opik.rest_api.types.experiment_item_public import ExperimentItemPublic
 from opik.rest_api.types.experiment_public import ExperimentPublic
 from opik.rest_api.types.span_public import SpanPublic
@@ -986,10 +987,28 @@ def _copy_traces_and_spans(
             len(missing_ids),
         )
         for tid in missing_ids:
-            fetched = rest_helpers.ensure_rest_api_call_respecting_rate_limit(
-                lambda sid=tid: client.get_trace_content(id=sid),
-                operation_name="get_trace_content (fallback)",
-            )
+            try:
+                fetched = rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+                    lambda sid=tid: client.get_trace_content(id=sid),
+                    operation_name="get_trace_content (fallback)",
+                )
+            except ApiError as err:
+                if err.status_code == 404:
+                    # The experiment item references a trace that has since
+                    # been deleted. It's gone -- there is no data to copy --
+                    # so skip it and continue rather than aborting the whole
+                    # migration (OPIK-7344). Leaving it out of
+                    # ``source_traces_by_id`` means the emission loop below
+                    # skips it too.
+                    LOGGER.warning(
+                        "Experiment %s references trace %s which no longer "
+                        "exists (deleted); skipping it. The destination "
+                        "experiment omits this trace.",
+                        source_experiment_id,
+                        tid,
+                    )
+                    continue
+                raise
             source_traces_by_id[tid] = fetched
 
     # Phase 1b: emit destination traces. ``source="experiment"`` matches
@@ -998,7 +1017,13 @@ def _copy_traces_and_spans(
     # compare would flag).
     total_traces = len(new_source_ids)
     for index, source_trace_id in enumerate(new_source_ids, start=1):
-        source_trace = source_traces_by_id[source_trace_id]
+        source_trace = source_traces_by_id.get(source_trace_id)
+        if source_trace is None:
+            # The trace was referenced by an experiment item but couldn't be
+            # fetched (deleted -- see the 404-tolerant fallback above). Skip
+            # emission; downstream span/feedback/comment copy keys off
+            # ``source_to_new_trace`` so the skipped id never surfaces there.
+            continue
         new_trace_id = id_helpers_module.generate_id()
         source_to_new_trace[source_trace_id] = new_trace_id
 
@@ -1021,7 +1046,9 @@ def _copy_traces_and_spans(
             inner_progress.tick(label=f"trace {index}/{total_traces}")
 
     trace_id_remap.update(source_to_new_trace)
-    traces_copied = len(new_source_ids)
+    # Count traces actually emitted, not referenced -- deleted traces skipped
+    # above (404 fallback) never entered ``source_to_new_trace``.
+    traces_copied = len(source_to_new_trace)
 
     # Record the freshly-minted destination trace ids on the checkpoint and
     # flush it to disk BEFORE the BE flush below. Ordering is the whole point:

--- a/sdks/python/tests/unit/cli/test_migrate_dataset_experiments_cascade.py
+++ b/sdks/python/tests/unit/cli/test_migrate_dataset_experiments_cascade.py
@@ -1882,81 +1882,112 @@ class TestCascadeExperiments:
 
 
 class TestBulkFetchSpansGuard:
-    """``_bulk_fetch_spans_for_experiment`` must never issue an unbounded,
-    unfiltered ``search_spans`` from the cascade.
+    """The cascade must never issue an unbounded, unfiltered ``search_spans``
+    -- ``search_spans(filter_string=None, max_results=sys.maxsize)`` -- which
+    reads a whole project and OOMs the client on large projects.
 
-    A project bucket whose traces can't be time-bounded used to fall through
-    to ``search_spans(filter_string=None, max_results=sys.maxsize)`` -- a
-    whole-project read that OOMed the client on large projects. Two ways a
-    bucket becomes unbounded:
-      * empty ``per_project_traces`` -- every referenced trace is stale/
-        deleted (absent from the experiment's fetched traces);
+    A per-project span-fetch bucket becomes unbounded two ways, both driven
+    here through the public ``cascade_experiments`` entrypoint:
+      * empty bucket -- every trace it references is stale/deleted (absent
+        from the experiment's fetched traces);
       * non-empty bucket whose traces carry no start/end/last_updated
         timestamps -- no window to bound the read.
     Both must be skipped with a warning; the invariant is that
     ``search_spans`` is never called with ``filter_string=None``.
     """
 
-    def _call(
+    def _run(
         self,
         *,
-        source_traces_by_id: Dict[str, Any],
-        traces_by_project: Dict[str, set],
+        rest_client: Any,
+        client: Any,
+        item_id_remap: Dict[str, str],
+        capture_log: Any,
     ) -> Any:
-        client = MagicMock()
-
-        def _get_project(id: str) -> Any:
-            # ``name`` is a reserved MagicMock ctor kwarg (sets the repr),
-            # so set the ``.name`` attribute after construction.
-            project = MagicMock()
-            project.name = f"name-for-{id}"
-            return project
-
-        client.get_project = MagicMock(side_effect=_get_project)
-        client.search_spans = MagicMock(return_value=[])
-        expected = {tid for tids in traces_by_project.values() for tid in tids}
-        cascade_module._bulk_fetch_spans_for_experiment(
-            client,
-            source_traces_by_id=source_traces_by_id,
-            traces_by_project=traces_by_project,
-            project_id_to_name_cache={},
-            expected_trace_ids=expected,
-        )
-        return client
-
-    def test_stale_bucket__skipped_without_unbounded_read(self, capture_log) -> None:
-        # A project bucket whose every trace is absent from
-        # ``source_traces_by_id`` (stale/deleted) must be skipped -- NOT
-        # read as an unbounded full-project search.
-        healthy_trace = _Trace(
-            id="live-1",
-            start_time=dt.datetime(2026, 1, 1, 12, 0, 0),
-            end_time=dt.datetime(2026, 1, 1, 12, 5, 0),
-        )
-        source_traces_by_id = {"live-1": healthy_trace}
-        traces_by_project = {
-            "project-live": {"live-1"},
-            "project-stale": {"gone-1", "gone-2"},  # none in source_traces_by_id
-        }
-
         with capture_log.at_level("WARNING"):
-            client = self._call(
-                source_traces_by_id=source_traces_by_id,
-                traces_by_project=traces_by_project,
+            return cascade_experiments(
+                client,
+                rest_client,
+                source_dataset_id="src-dataset-1",
+                target_dataset_name="MyDataset",
+                target_project_name="DestProject",
+                version_remap={"src-v-1": "dest-v-1"},
+                item_id_remap=item_id_remap,
+                audit=_audit(),
             )
 
-        # Exactly one search_spans call -- the healthy bucket. The stale
-        # bucket was skipped.
-        assert client.search_spans.call_count == 1
+    def _assert_no_unbounded_read(self, client: Any) -> None:
         for call in client.search_spans.call_args_list:
-            # The invariant: never an unbounded, unfiltered read.
             assert call.kwargs.get("filter_string") is not None, (
                 "cascade must never call search_spans with filter_string=None"
             )
             assert "start_time" in call.kwargs["filter_string"]
 
+    def test_stale_bucket__skipped_without_unbounded_read(self, capture_log) -> None:
+        # A project bucket whose every trace is stale/deleted (absent from
+        # the fetched traces) must be skipped -- NOT read as an unbounded
+        # full-project search. ``live`` and ``gone`` live in different
+        # projects so ``gone``'s bucket is degenerate on its own.
+        live = _ExperimentItem(
+            id="src-item-live",
+            experiment_id="src-exp-1",
+            trace_id="src-trace-live",
+            dataset_item_id="src-ds-live",
+        )
+        gone = _ExperimentItem(
+            id="src-item-gone",
+            experiment_id="src-exp-1",
+            trace_id="src-trace-gone",
+            dataset_item_id="src-ds-gone",
+        )
+        experiment = _Experiment(id="src-exp-1", dataset_version_id="src-v-1")
+        rest_client = _cascade_rest_client(
+            experiments_by_dataset={"src-dataset-1": [experiment]},
+            items_by_experiment={"experiment": [live, gone]},
+            # Both traces exist so the item stream buckets each into its own
+            # project; ``gone`` is in a distinct project.
+            traces_by_id={
+                "src-trace-live": _Trace(
+                    id="src-trace-live",
+                    project_id="project-live",
+                    start_time=dt.datetime(2026, 1, 1, 12, 0, 0),
+                    end_time=dt.datetime(2026, 1, 1, 12, 5, 0),
+                ),
+                "src-trace-gone": _Trace(
+                    id="src-trace-gone", project_id="project-gone"
+                ),
+            },
+            spans_by_trace={"src-trace-live": [], "src-trace-gone": []},
+        )
+        client = _client_with_recreate_capture(rest_client)
+
+        # Make ``gone`` unfetchable everywhere: absent from the bulk
+        # search_traces AND 404 on the per-trace fallback. Its project
+        # bucket then has an empty per_project_traces at span-fetch time.
+        client.search_traces = MagicMock(
+            return_value=[
+                rest_client._traces_by_id_for_cascade_search["src-trace-live"]
+            ]
+        )
+        client.get_trace_content = MagicMock(
+            side_effect=ApiError(status_code=404, body="not found")
+        )
+
+        self._run(
+            rest_client=rest_client,
+            client=client,
+            item_id_remap={
+                "src-ds-live": "dest-ds-live",
+                "src-ds-gone": "dest-ds-gone",
+            },
+            capture_log=capture_log,
+        )
+
+        # search_spans ran only for the live bucket, always time-bounded.
+        self._assert_no_unbounded_read(client)
+        assert client.search_spans.call_count == 1
         assert any(
-            "project-stale" in rec.message and "stale/deleted" in rec.message
+            "project-gone" in rec.message and "stale/deleted" in rec.message
             for rec in capture_log.records
         ), "expected a warning naming the skipped stale project"
 
@@ -1965,21 +1996,33 @@ class TestBulkFetchSpansGuard:
     ) -> None:
         # A bucket whose traces exist but carry no usable timestamps can't
         # be time-bounded; it must be skipped rather than read unbounded.
-        no_ts_trace = _Trace(id="notime-1")
+        no_ts = _Trace(id="notime-1", project_id="project-notime")
         # ``_Trace`` defaults ``start_time`` to a real datetime; null all
-        # three timestamp fields so ``_compute_span_time_window`` returns
-        # None (the no-window case the guard must catch).
-        no_ts_trace.start_time = None
-        no_ts_trace.end_time = None
-        no_ts_trace.last_updated_at = None
-        source_traces_by_id = {"notime-1": no_ts_trace}
-        traces_by_project = {"project-notime": {"notime-1"}}
+        # three timestamp fields so the span window can't be derived.
+        no_ts.start_time = None
+        no_ts.end_time = None
+        no_ts.last_updated_at = None
+        item = _ExperimentItem(
+            id="src-item-1",
+            experiment_id="src-exp-1",
+            trace_id="notime-1",
+            dataset_item_id="src-ds-1",
+        )
+        experiment = _Experiment(id="src-exp-1", dataset_version_id="src-v-1")
+        rest_client = _cascade_rest_client(
+            experiments_by_dataset={"src-dataset-1": [experiment]},
+            items_by_experiment={"experiment": [item]},
+            traces_by_id={"notime-1": no_ts},
+            spans_by_trace={"notime-1": []},
+        )
+        client = _client_with_recreate_capture(rest_client)
 
-        with capture_log.at_level("WARNING"):
-            client = self._call(
-                source_traces_by_id=source_traces_by_id,
-                traces_by_project=traces_by_project,
-            )
+        self._run(
+            rest_client=rest_client,
+            client=client,
+            item_id_remap={"src-ds-1": "dest-ds-1"},
+            capture_log=capture_log,
+        )
 
         client.search_spans.assert_not_called()
         assert any(
@@ -1987,17 +2030,36 @@ class TestBulkFetchSpansGuard:
             for rec in capture_log.records
         ), "expected a warning naming the skipped no-timestamp project"
 
-    def test_healthy_bucket__reads_with_bounded_filter(self) -> None:
+    def test_healthy_bucket__reads_with_bounded_filter(self, capture_log) -> None:
         # Sanity: a normal bucket still issues one bounded search_spans.
         trace = _Trace(
             id="ok-1",
+            project_id="project-ok",
             start_time=dt.datetime(2026, 1, 1, 12, 0, 0),
             end_time=dt.datetime(2026, 1, 1, 12, 5, 0),
         )
-        client = self._call(
-            source_traces_by_id={"ok-1": trace},
-            traces_by_project={"project-ok": {"ok-1"}},
+        item = _ExperimentItem(
+            id="src-item-1",
+            experiment_id="src-exp-1",
+            trace_id="ok-1",
+            dataset_item_id="src-ds-1",
         )
+        experiment = _Experiment(id="src-exp-1", dataset_version_id="src-v-1")
+        rest_client = _cascade_rest_client(
+            experiments_by_dataset={"src-dataset-1": [experiment]},
+            items_by_experiment={"experiment": [item]},
+            traces_by_id={"ok-1": trace},
+            spans_by_trace={"ok-1": []},
+        )
+        client = _client_with_recreate_capture(rest_client)
+
+        self._run(
+            rest_client=rest_client,
+            client=client,
+            item_id_remap={"src-ds-1": "dest-ds-1"},
+            capture_log=capture_log,
+        )
+
         client.search_spans.assert_called_once()
         kwargs = client.search_spans.call_args.kwargs
         assert kwargs["filter_string"] is not None

--- a/sdks/python/tests/unit/cli/test_migrate_dataset_experiments_cascade.py
+++ b/sdks/python/tests/unit/cli/test_migrate_dataset_experiments_cascade.py
@@ -2062,8 +2062,15 @@ class TestBulkFetchSpansGuard:
 
         client.search_spans.assert_called_once()
         kwargs = client.search_spans.call_args.kwargs
-        assert kwargs["filter_string"] is not None
-        assert "start_time" in kwargs["filter_string"]
+        # Assert the EXACT bounded filter, not just that one exists -- a
+        # regression that corrupts the derived window would still leave a
+        # non-null filter_string containing "start_time". The trace spans
+        # [12:00, 12:05]; _compute_span_time_window pads by the 5-minute
+        # _SPAN_BULK_WINDOW_BUFFER on each side -> [11:55, 12:10].
+        assert kwargs["filter_string"] == (
+            'start_time >= "2026-01-01T11:55:00Z" '
+            'AND start_time <= "2026-01-01T12:10:00Z"'
+        )
         assert kwargs["max_results"] == sys.maxsize
 
 

--- a/sdks/python/tests/unit/cli/test_migrate_dataset_experiments_cascade.py
+++ b/sdks/python/tests/unit/cli/test_migrate_dataset_experiments_cascade.py
@@ -1876,6 +1876,135 @@ class TestCascadeExperiments:
 
 
 # ---------------------------------------------------------------------------
+# Guard against unbounded full-project span reads (OPIK-7344)
+# ---------------------------------------------------------------------------
+
+
+class TestBulkFetchSpansGuard:
+    """``_bulk_fetch_spans_for_experiment`` must never issue an unbounded,
+    unfiltered ``search_spans`` from the cascade.
+
+    A project bucket whose traces can't be time-bounded used to fall through
+    to ``search_spans(filter_string=None, max_results=sys.maxsize)`` -- a
+    whole-project read that OOMed the client on large projects. Two ways a
+    bucket becomes unbounded:
+      * empty ``per_project_traces`` -- every referenced trace is stale/
+        deleted (absent from the experiment's fetched traces);
+      * non-empty bucket whose traces carry no start/end/last_updated
+        timestamps -- no window to bound the read.
+    Both must be skipped with a warning; the invariant is that
+    ``search_spans`` is never called with ``filter_string=None``.
+    """
+
+    def _call(
+        self,
+        *,
+        source_traces_by_id: Dict[str, Any],
+        traces_by_project: Dict[str, set],
+    ) -> Any:
+        client = MagicMock()
+
+        def _get_project(id: str) -> Any:
+            # ``name`` is a reserved MagicMock ctor kwarg (sets the repr),
+            # so set the ``.name`` attribute after construction.
+            project = MagicMock()
+            project.name = f"name-for-{id}"
+            return project
+
+        client.get_project = MagicMock(side_effect=_get_project)
+        client.search_spans = MagicMock(return_value=[])
+        expected = {tid for tids in traces_by_project.values() for tid in tids}
+        cascade_module._bulk_fetch_spans_for_experiment(
+            client,
+            source_traces_by_id=source_traces_by_id,
+            traces_by_project=traces_by_project,
+            project_id_to_name_cache={},
+            expected_trace_ids=expected,
+        )
+        return client
+
+    def test_stale_bucket__skipped_without_unbounded_read(self, capture_log) -> None:
+        # A project bucket whose every trace is absent from
+        # ``source_traces_by_id`` (stale/deleted) must be skipped -- NOT
+        # read as an unbounded full-project search.
+        healthy_trace = _Trace(
+            id="live-1",
+            start_time=dt.datetime(2026, 1, 1, 12, 0, 0),
+            end_time=dt.datetime(2026, 1, 1, 12, 5, 0),
+        )
+        source_traces_by_id = {"live-1": healthy_trace}
+        traces_by_project = {
+            "project-live": {"live-1"},
+            "project-stale": {"gone-1", "gone-2"},  # none in source_traces_by_id
+        }
+
+        with capture_log.at_level("WARNING"):
+            client = self._call(
+                source_traces_by_id=source_traces_by_id,
+                traces_by_project=traces_by_project,
+            )
+
+        # Exactly one search_spans call -- the healthy bucket. The stale
+        # bucket was skipped.
+        assert client.search_spans.call_count == 1
+        for call in client.search_spans.call_args_list:
+            # The invariant: never an unbounded, unfiltered read.
+            assert call.kwargs.get("filter_string") is not None, (
+                "cascade must never call search_spans with filter_string=None"
+            )
+            assert "start_time" in call.kwargs["filter_string"]
+
+        assert any(
+            "project-stale" in rec.message and "stale/deleted" in rec.message
+            for rec in capture_log.records
+        ), "expected a warning naming the skipped stale project"
+
+    def test_no_timestamp_bucket__skipped_without_unbounded_read(
+        self, capture_log
+    ) -> None:
+        # A bucket whose traces exist but carry no usable timestamps can't
+        # be time-bounded; it must be skipped rather than read unbounded.
+        no_ts_trace = _Trace(id="notime-1")
+        # ``_Trace`` defaults ``start_time`` to a real datetime; null all
+        # three timestamp fields so ``_compute_span_time_window`` returns
+        # None (the no-window case the guard must catch).
+        no_ts_trace.start_time = None
+        no_ts_trace.end_time = None
+        no_ts_trace.last_updated_at = None
+        source_traces_by_id = {"notime-1": no_ts_trace}
+        traces_by_project = {"project-notime": {"notime-1"}}
+
+        with capture_log.at_level("WARNING"):
+            client = self._call(
+                source_traces_by_id=source_traces_by_id,
+                traces_by_project=traces_by_project,
+            )
+
+        client.search_spans.assert_not_called()
+        assert any(
+            "project-notime" in rec.message and "no usable timestamps" in rec.message
+            for rec in capture_log.records
+        ), "expected a warning naming the skipped no-timestamp project"
+
+    def test_healthy_bucket__reads_with_bounded_filter(self) -> None:
+        # Sanity: a normal bucket still issues one bounded search_spans.
+        trace = _Trace(
+            id="ok-1",
+            start_time=dt.datetime(2026, 1, 1, 12, 0, 0),
+            end_time=dt.datetime(2026, 1, 1, 12, 5, 0),
+        )
+        client = self._call(
+            source_traces_by_id={"ok-1": trace},
+            traces_by_project={"project-ok": {"ok-1"}},
+        )
+        client.search_spans.assert_called_once()
+        kwargs = client.search_spans.call_args.kwargs
+        assert kwargs["filter_string"] is not None
+        assert "start_time" in kwargs["filter_string"]
+        assert kwargs["max_results"] == sys.maxsize
+
+
+# ---------------------------------------------------------------------------
 # Planner-level test for cascade action placement in the plan
 # ---------------------------------------------------------------------------
 

--- a/sdks/python/tests/unit/cli/test_migrate_dataset_experiments_cascade.py
+++ b/sdks/python/tests/unit/cli/test_migrate_dataset_experiments_cascade.py
@@ -38,6 +38,7 @@ from opik.cli.migrate.datasets.experiments import (
     cascade_experiments,
 )
 from opik.cli.migrate.errors import ExperimentCascadeError
+from opik.rest_api.core.api_error import ApiError
 
 from ._migrate_helpers import (
     _DatasetRow,
@@ -2002,6 +2003,115 @@ class TestBulkFetchSpansGuard:
         assert kwargs["filter_string"] is not None
         assert "start_time" in kwargs["filter_string"]
         assert kwargs["max_results"] == sys.maxsize
+
+
+# ---------------------------------------------------------------------------
+# Tolerate referenced-but-deleted traces in the trace-fetch fallback
+# (OPIK-7344)
+# ---------------------------------------------------------------------------
+
+
+class TestDeletedTraceFallback:
+    """When ``search_traces(experiment_id=)`` misses a trace, the cascade
+    falls back to per-trace ``get_trace_content``. An experiment item can
+    reference a trace that has since been deleted -- the fallback then 404s.
+    That 404 must skip the trace and continue, not abort the migration.
+    """
+
+    def _setup(
+        self,
+        *,
+        deleted_status_code: int,
+    ) -> tuple:
+        # ``good`` is returned by the bulk search_traces; ``gone`` is
+        # referenced by an item but absent from search_traces, forcing the
+        # per-trace get_trace_content fallback -- which raises for it.
+        good = _ExperimentItem(
+            id="src-item-good",
+            experiment_id="src-exp-1",
+            trace_id="src-trace-good",
+            dataset_item_id="src-ds-good",
+        )
+        gone = _ExperimentItem(
+            id="src-item-gone",
+            experiment_id="src-exp-1",
+            trace_id="src-trace-gone",
+            dataset_item_id="src-ds-gone",
+        )
+        experiment = _Experiment(id="src-exp-1", dataset_version_id="src-v-1")
+        # Only the good trace exists in the source; the deleted trace is
+        # absent so search_traces never returns it, triggering the fallback.
+        rest_client = _cascade_rest_client(
+            experiments_by_dataset={"src-dataset-1": [experiment]},
+            items_by_experiment={"experiment": [good, gone]},
+            traces_by_id={"src-trace-good": _Trace(id="src-trace-good")},
+            spans_by_trace={"src-trace-good": []},
+        )
+        # ``stream_experiment_items`` derives project_id from traces_by_id;
+        # the deleted trace is absent there, so its bucket routes to the
+        # fallback project -- fine, it never gets fetched as a trace.
+        client = _client_with_recreate_capture(rest_client)
+
+        # The fallback delegates client.get_trace_content -> rest_client
+        # .traces.get_trace_by_id. Make the deleted id raise, others pass.
+        def _get_trace_by_id(id: str) -> Any:
+            if id == "src-trace-gone":
+                raise ApiError(status_code=deleted_status_code, body="not found")
+            return _Trace(id=id)
+
+        client.get_trace_content = MagicMock(
+            side_effect=lambda id: _get_trace_by_id(id)
+        )
+        return client, rest_client
+
+    def test_deleted_trace__skipped_and_migration_continues(self, capture_log) -> None:
+        client, rest_client = self._setup(deleted_status_code=404)
+
+        with capture_log.at_level("WARNING"):
+            result = cascade_experiments(
+                client,
+                rest_client,
+                source_dataset_id="src-dataset-1",
+                target_dataset_name="MyDataset",
+                target_project_name="DestProject",
+                version_remap={"src-v-1": "dest-v-1"},
+                item_id_remap={
+                    "src-ds-good": "dest-ds-good",
+                    "src-ds-gone": "dest-ds-gone",
+                },
+                audit=_audit(),
+            )
+
+        # The migration completed; only the surviving trace was copied.
+        assert result.experiments_migrated == 1
+        assert result.traces_migrated == 1
+        assert set(result.trace_id_remap.keys()) == {"src-trace-good"}
+        assert "src-trace-gone" not in result.trace_id_remap
+        assert any(
+            "src-trace-gone" in rec.message and "deleted" in rec.message
+            for rec in capture_log.records
+        ), "expected a warning naming the skipped deleted trace"
+
+    def test_non_404_error__propagates(self) -> None:
+        # A real failure (500) must not be swallowed -- only 404 (deleted)
+        # is tolerated.
+        client, rest_client = self._setup(deleted_status_code=500)
+
+        with pytest.raises(ApiError) as exc_info:
+            cascade_experiments(
+                client,
+                rest_client,
+                source_dataset_id="src-dataset-1",
+                target_dataset_name="MyDataset",
+                target_project_name="DestProject",
+                version_remap={"src-v-1": "dest-v-1"},
+                item_id_remap={
+                    "src-ds-good": "dest-ds-good",
+                    "src-ds-gone": "dest-ds-gone",
+                },
+                audit=_audit(),
+            )
+        assert exc_info.value.status_code == 500
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Details

<img width="1139" height="743" alt="image" src="https://github.com/user-attachments/assets/666bd6b4-f2f5-4f8a-932b-26f9c9da6a3c" />

`opik migrate dataset` could hard-fail the client mid-migration in two ways, both because the dataset-experiment cascade didn't tolerate referenced-but-deleted traces. This PR adds two guards under the same "skip the missing trace + warn, never crash" principle.

**1. Unbounded full-project span read (OOM, exit 137).** In `_bulk_fetch_spans_for_experiment`, a per-project span-fetch bucket with no derivable time window fell through to `search_spans(filter_string=None, max_results=sys.maxsize)` — an unbounded, unfiltered whole-project span read that pages every span into memory. A bucket has no time window when its referenced traces are all absent from the experiment's fetched traces (stale/deleted), or when its traces carry no `start_time`/`end_time`/`last_updated_at`. Both cases are now **skipped with a distinct warning**; the unbounded `search_spans` call is structurally unreachable from this loop.

**2. Unhandled 404 in the trace-fetch fallback (migration abort).** When `search_traces(experiment_id=)` misses a trace, `_copy_traces_and_spans` falls back to per-trace `get_trace_content`. An experiment item can reference a trace that has since been deleted; the fallback then raised `ApiError (404)` and aborted the whole run. The 404 is now caught → the trace is skipped with a warning → the migration continues. Non-404 errors still propagate. The trace-emission loop skips ids absent from the fetched set, and the copied-trace count reflects traces actually emitted.

Destination experiments omit only the genuinely-gone traces; everything else migrates. A bounded per-trace fallback for the no-timestamp span case is deferred to OPIK_7343 (span-read scoping).

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7344

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation (guard + unit tests) with human direction on the skip-vs-fallback decision
- Human verification: code review + unit tests run locally

## Testing

- `pre-commit run --files <changed .py files>` — ruff, ruff-format, mypy all pass.
- `python -m pytest tests/unit/cli/test_migrate_dataset_experiments_cascade.py` — 38 passed, including the pre-existing bulk-read tests (no regression).
- Added `TestBulkFetchSpansGuard` (3 cases) exercising `_bulk_fetch_spans_for_experiment` directly:
  - stale bucket → skipped, warning emitted, no unbounded read;
  - no-timestamp bucket → skipped, warning emitted, `search_spans` not called;
  - healthy bucket → still issues one bounded, time-filtered `search_spans`.
  - Each asserts the invariant that `search_spans` is never called with `filter_string=None`.
- Added `TestDeletedTraceFallback` (2 cases):
  - deleted trace (fallback 404) → skipped with a warning, migration completes, only the surviving trace is copied/remapped;
  - non-404 error (500) → propagates, not swallowed.

## Documentation

N/A — internal CLI migration path; no user-facing docs affected.
