### PR TITLE
[OPIK-7327] frontend nginx: recycle upstream keepalive connections to re-spread ingestion

### DIFF
--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -371,6 +371,8 @@ Call opik api on http://localhost:5173/api
 | component.frontend.ingress.tls.enabled | bool | `false` |  |
 | component.frontend.ingress.tls.hosts | list | `[]` |  |
 | component.frontend.ingress.tls.secretName | string | `""` |  |
+| component.frontend.keepaliveRequests | int | `100` |  |
+| component.frontend.keepaliveTimeout | string | `"60s"` |  |
 | component.frontend.maps | list | `[]` |  |
 | component.frontend.metrics.enabled | bool | `false` |  |
 | component.frontend.podDisruptionBudget.enabled | bool | `false` |  |

--- a/deployment/helm_chart/opik/templates/configmap-frontend-nginx.yaml
+++ b/deployment/helm_chart/opik/templates/configmap-frontend-nginx.yaml
@@ -36,6 +36,13 @@ data:
     upstream backend {
       server {{ include "opik.name" $ }}-backend:{{ (.Values.component.backend.service.ports | first).port }};
       keepalive 16;
+      # Recycle upstream keepalive connections so they re-spread across backend pods. An L4
+      # ClusterIP pins each connection to one pod for its lifetime, so without frequent
+      # recycling a few pods absorb ingestion while the rest idle (HPA scales on the average
+      # and never reacts). Default keepalive_requests is 1000 -- too coarse to rebalance under
+      # sustained ingestion with few frontend replicas.
+      keepalive_requests 100;
+      keepalive_timeout 60s;
     }
     upstream swagger {
       server {{ include "opik.name" $ }}-backend:{{ (index .Values.component.backend.service.ports 1).port }};

--- a/deployment/helm_chart/opik/templates/configmap-frontend-nginx.yaml
+++ b/deployment/helm_chart/opik/templates/configmap-frontend-nginx.yaml
@@ -40,9 +40,9 @@ data:
       # ClusterIP pins each connection to one pod for its lifetime, so without frequent
       # recycling a few pods absorb ingestion while the rest idle (HPA scales on the average
       # and never reacts). Default keepalive_requests is 1000 -- too coarse to rebalance under
-      # sustained ingestion with few frontend replicas.
-      keepalive_requests 100;
-      keepalive_timeout 60s;
+      # sustained ingestion with few frontend replicas. Tunable via component.frontend.*.
+      keepalive_requests {{ .Values.component.frontend.keepaliveRequests | default 100 }};
+      keepalive_timeout {{ .Values.component.frontend.keepaliveTimeout | default "60s" }};
     }
     upstream swagger {
       server {{ include "opik.name" $ }}-backend:{{ (index .Values.component.backend.service.ports 1).port }};

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -464,6 +464,13 @@ component:
     maps: []
     # use internal aws resolvr on vpc
     awsResolver: false
+    # nginx -> opik-backend upstream keepalive connection recycling (OPIK-7327).
+    # Recycling re-spreads long-lived keepalive connections across backend pods; without it a
+    # few pods absorb ingestion while the rest idle and HPA (average CPU) never scales out.
+    # Tune low enough to rebalance under sustained load, but not so low that connection reuse
+    # races on non-idempotent POSTs (keep >= ~50; nginx's own default is 1000).
+    keepaliveRequests: 100    # max requests per upstream keepalive connection before recycle (count)
+    keepaliveTimeout: 60s     # idle timeout for upstream keepalive connections (duration, e.g. 30s/60s)
     # Enable HSTS header (only enable when running behind HTTPS termination)
     # DEPRECATED: Use extraServerHeaders instead for more flexibility
     hstsEnabled: false


### PR DESCRIPTION
## Details
opik-frontend nginx proxies all `/api` traffic to opik-backend over an HTTP/1.1 keepalive pool against the backend Service ClusterIP. Because kube-proxy pins each connection to one pod for its lifetime and the pool is never recycled often enough, ingestion concentrates on a few backend pods while the rest stay near-idle (observed ~100x CPU/memory skew). HPA scales on average CPU, so the low mean never triggers scale-out and the hot pods saturate/OOM first. This sets an explicit, low `keepalive_requests` (plus `keepalive_timeout`) on the `backend` upstream so connections recycle frequently and re-spread across pods.

- nginx's default upstream `keepalive_requests` is 1000 — too coarse to rebalance under sustained ingestion with only a couple of frontend replicas; 100 rotates ~10x more often.
- Reconnect cost is a bare intra-cluster TCP handshake (no TLS on this hop), so churn is cheap.
- Mitigation only: it evens out the time-averaged distribution; instantaneous concurrency is still bounded by connection count. A headless Service + `resolver` + `least_conn` (per-pod L7 balancing) is the more complete follow-up if load testing shows this is insufficient.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7327

<!-- Related but not resolved here: OPIK_6968 (acquire-waiter heap leak — pinned hot pods hit heap limits first). -->

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: investigated the skew, built a local reproduction of the keepalive-over-L4 pinning, and drafted this nginx template change + PR description. All values reviewed by a human.
- Human verification: reviewed the rendered configmap and the local reproduction results; sustained-load validation in staging pending before rollout.

## Testing
- **Render check** — confirmed the chart renders and emits the directives:
  `helm template opik deployment/helm_chart/opik | grep -A4 'upstream backend'`
  → `keepalive 16; keepalive_requests 100; keepalive_timeout 60s;`

- **Mechanism + distribution** — local reproduction with real nginx: an nginx `stream`/L4 proxy stands in for the backend Service ClusterIP (per-connection sticky, like kube-proxy), in front of 8 backend pods, driven by one persistent keepalive client (400 requests):

  | upstream config | backends served |
  |---|---|
  | `keepalive 16;` (before) | **1 / 8** — all traffic pinned to one pod, 7 idle |
  | `keepalive 16; keepalive_requests 50;` | **8 / 8** — even (~50 each) |

  Confirms the pin and that recycling re-spreads load.

- **Safety / in-flight impact** — swept `keepalive_requests` under sustained high concurrency (fortio `-c 16 -keepalive`, ~38k qps) to confirm recycling never drops in-flight requests. Recycling closes a connection only after the current response completes, so realistic values are clean; only a pathologically low value races on reuse:

  | keepalive_requests | requests | Code 200 | errors |
  |---|---|---|---|
  | 5 (too aggressive) | 146,635 | 96.3% | **3.7% (5,496× 502)** |
  | 50 | 556,765 | **100.0%** | 0 |
  | **100 (this PR)** | 568,516 | **100.0%** | 0 |
  | 1000 (nginx default) | 556,724 | 100.0% | 0 |

  Chose **100**: recycles frequently enough to rebalance, with a ~2× margin above the ~50 floor where it stays error-free. Note ingestion is POST (non-idempotent), so nginx won't auto-retry a reuse race — which is why the value is kept comfortably above that floor. (fortio counts are from a single-worker local sandbox; they show relative error behavior across values, not prod throughput.)

- **Rollout** — no in-flight impact expected: roll `opik-frontend` one replica at a time (graceful drain) or via nginx SIGHUP reload (old workers finish active requests first).

- **Not run** — end-to-end at production-scale ingestion. Recommend a staged load test in staging and confirming per-pod `http_server_active_requests` for `opik-backend` flattens after rollout.

## Documentation
No documentation changes — internal Helm/nginx configuration only.
