### PR TITLE
[OPIK-7183] [FE] fix: land workspace clicks on the Projects tab

### DIFF
--- a/apps/opik-frontend/src/v2/pages/HomePage/HomePage.tsx
+++ b/apps/opik-frontend/src/v2/pages/HomePage/HomePage.tsx
@@ -1,35 +1,19 @@
 import { useEffect } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import {
-  useActiveWorkspaceName,
-  useActiveProjectId,
-  useIsProjectLoading,
-} from "@/store/AppStore";
+import { useActiveWorkspaceName } from "@/store/AppStore";
 import Loader from "@/shared/Loader/Loader";
 
 const HomePage = () => {
   const workspaceName = useActiveWorkspaceName();
-  const activeProjectId = useActiveProjectId();
-  const isLoading = useIsProjectLoading();
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (isLoading) return;
-
-    if (activeProjectId) {
-      navigate({
-        to: "/$workspaceName/projects/$projectId/home",
-        params: { workspaceName, projectId: activeProjectId },
-        replace: true,
-      });
-    } else {
-      navigate({
-        to: "/$workspaceName/projects",
-        params: { workspaceName },
-        replace: true,
-      });
-    }
-  }, [activeProjectId, isLoading, workspaceName, navigate]);
+    navigate({
+      to: "/$workspaceName/projects",
+      params: { workspaceName },
+      replace: true,
+    });
+  }, [workspaceName, navigate]);
 
   return <Loader />;
 };

--- a/apps/opik-frontend/src/v2/router.tsx
+++ b/apps/opik-frontend/src/v2/router.tsx
@@ -154,7 +154,7 @@ const baseRoute = createRoute({
   ),
 });
 
-// ----------- home (redirects to active project traces)
+// ----------- home (redirects to the workspace Projects tab)
 const homeRoute = createRoute({
   path: "/$workspaceName/home",
   getParentRoute: () => workspaceGuardRoute,


### PR DESCRIPTION
## Details

Clicking a workspace dropped the user into their last-visited project instead of the workspace overview. Per the Netflix customer request, a workspace click should always land on the workspace **Projects tab** for a consistent, discoverable entry point.

All workspace-click entry points route through `HomePage` (`/$workspaceName/home`), which branched on the stored last-visited project and redirected into it when present. This PR removes that branch so the workspace home **always** redirects to `/$workspaceName/projects`.

- `HomePage.tsx` — always `navigate({ to: "/$workspaceName/projects" })`; dropped the now-unused `activeProjectId` / `isProjectLoading` reads (also removes a brief loader flicker while the project resolved).
- `router.tsx` — updated the stale route comment.

Last-visited-project state is still tracked (the "Back to <project>" button and sidebar highlighting keep working) — it is simply no longer auto-opened on a workspace click. Flows that intentionally deep-link to a project (`BackToProjectButton`, `ProjectSelector`) bypass `HomePage` and are unaffected.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7183

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation (single-choke-point redirect change) with human direction
- Human verification: manual E2E in the browser (comet mode)

## Testing

Ran the frontend in `--mode comet` against `dev.comet.com` in the `yaroslav-boiko` workspace, with a last-visited project set ("Demo chatbot", confirmed by the "Back to Demo chatbot" link):

- **Direct workspace URL** (`/opik/yaroslav-boiko`) → redirects to the **Projects tab**, not the last-visited project.
- **In-app "Workspace" click from inside the Demo chatbot project** → lands on the **Projects tab**; the "Back to Demo chatbot" link remains, confirming last-visited state is preserved but no longer auto-opened.
- `npm run typecheck` and `eslint` on the changed files — both clean.

## Documentation

N/A — navigation behavior change; no user-facing docs affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)