### PR TITLE
fix(metrics): score ChrF against each reference for multiple references

### DIFF
--- a/sdks/python/src/opik/evaluation/metrics/heuristics/chrf.py
+++ b/sdks/python/src/opik/evaluation/metrics/heuristics/chrf.py
@@ -85,11 +85,11 @@ class ChrF(BaseMetric):
                     " `pip install nltk` or provide `chrf_fn`."
                 )
 
-            def _compute(candidate: Sequence[str], references: Sequence[str]) -> float:
+            def _score_single(candidate: Sequence[str], reference: str) -> float:
                 try:
                     return float(
                         nltk_chrf_score.sentence_chrf(
-                            references,
+                            reference,
                             candidate,
                             max_len=self._char_order,
                             beta=self._beta,
@@ -98,7 +98,14 @@ class ChrF(BaseMetric):
                     )
                 except TypeError:
                     # Older NLTK versions expose the helper with fewer keyword arguments.
-                    return float(nltk_chrf_score.sentence_chrf(references, candidate))
+                    return float(nltk_chrf_score.sentence_chrf(reference, candidate))
+
+            def _compute(candidate: Sequence[str], references: Sequence[str]) -> float:
+                # NLTK's ``sentence_chrf`` supports only a single reference; passing
+                # a list of references makes it misinterpret the input and return a
+                # wrong score. For multiple references, score against each one and
+                # take the best match (standard multi-reference chrF semantics).
+                return max(_score_single(candidate, ref) for ref in references)
 
             self._chrf_fn = _compute
 

--- a/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
+++ b/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
@@ -525,6 +525,33 @@ def test_chrf_metric__char_order_and_ignore_whitespace_vary__change_score():
     assert order_1 != order_6
 
 
+def test_chrf_metric__multiple_references__scores_against_best_match():
+    # NLTK's sentence_chrf accepts only a single reference; passing the list of
+    # references straight through made it misinterpret the input and return a
+    # wrong score, even when the candidate exactly matched one reference. A
+    # candidate identical to any reference must score 1.0 (best-match semantics).
+    pytest.importorskip("nltk")
+
+    metric = ChrF(track=False)
+
+    match_second = metric.score(
+        output="hello world",
+        reference=["completely different text here", "hello world"],
+    ).value
+    match_first = metric.score(
+        output="hello world",
+        reference=["hello world", "completely different text here"],
+    ).value
+
+    assert match_second == pytest.approx(1.0)
+    assert match_first == pytest.approx(1.0)
+
+    # A perfect match against one reference must not score below matching that
+    # reference alone (the pre-fix bug returned a middling value here).
+    single = metric.score(output="hello world", reference="hello world").value
+    assert match_second == pytest.approx(single)
+
+
 def test_spearman_ranking_metric():
     metric = SpearmanRanking(track=False)
     result = metric.score(output=["b", "a", "c"], reference=["a", "b", "c"])


### PR DESCRIPTION
## Details

`ChrF.score` accepts `reference: Union[str, Sequence[str]]` and builds a list of references, so multiple references are a documented, type-hinted feature. But the default NLTK backend passed that whole list straight to `nltk.translate.chrf_score.sentence_chrf(references, candidate)`, whose `reference` argument is a **single** reference string — not a list. NLTK misinterprets the list and returns a wrong score: a candidate identical to one of the references scored ~0.26 instead of 1.0 (even lower than scoring against that reference alone).

This scores the candidate against each reference separately and takes the best match — standard multi-reference chrF semantics (as in sacrebleu / HuggingFace `evaluate`). Single-reference scoring is unchanged, and the custom `chrf_fn` injection contract is preserved (it still receives the full references list).

- Before: `ChrF().score(output="hello world", reference=["completely different text here", "hello world"]).value` → `0.2552`
- After: → `1.0`

Verified against the real installed code before/after. Added `test_chrf_metric__multiple_references__scores_against_best_match` (the existing ChrF tests only covered single-reference and the custom-`chrf_fn` path, so the real multi-reference NLTK path was untested) — red before the fix, green after. Full ChrF test set: 3 passed. `ruff check` + `ruff format`: clean.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
<!-- No pre-existing issue was found for this bug; happy to open one if the team prefers issue-first. -->

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude (Anthropic)
- Scope: Bug found via an AI-assisted review pass over `sdks/python/src/opik/evaluation/metrics/`; the fix and regression test were AI-drafted and then independently reproduced and verified (red-before/green-after against the real installed code, ruff clean) before submitting.