### PR TITLE
[NA] [BE] Bump Dropwizard 5.0.0 -> 5.0.2

### DIFF
--- a/apps/opik-backend/pom.xml
+++ b/apps/opik-backend/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <dropwizard.version>5.0.0</dropwizard.version>
+        <dropwizard.version>5.0.2</dropwizard.version>
         <swagger.version>2.2.33</swagger.version>
         <lombok.version>1.18.46</lombok.version>
         <mysql.version>9.7.0</mysql.version>


### PR DESCRIPTION
## Details

Patch bump of the `io.dropwizard` BOM (`dropwizard.version`) from 5.0.0 to 5.0.2 in `apps/opik-backend`. 5.0.1 and 5.0.2 are dependency-only maintenance releases (Jetty 12.1.9, Jackson 2.21.4, Hibernate 6.6.52, Logback 1.5.33) with no API or behavioral changes, so no code changes were required.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

No ticket — see `[NA]` in the title.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: version property bump in pom.xml + local compile verification
- Human verification: pending reviewer

## Testing

- Exact command run: `mvn -o compile` in `apps/opik-backend` → BUILD SUCCESS with dropwizard 5.0.2 (dependency tree resolves, backend compiles cleanly).
- Scenarios validated: clean compile against the new BOM.
- Environment/context: local, JDK/Maven build (offline).
- Tests not run: full `mvn test` suite — not run for a dependency-only patch bump with no code changes.

## Documentation

No documentation changes required — internal dependency bump with no user-facing or API impact.