### PR TITLE
[OPIK-7362] [BE] fix: null-safe PythonEvaluatorService response handling

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorService.java
@@ -27,6 +27,7 @@ import static com.comet.opik.domain.evaluators.python.TraceThreadPythonEvaluator
 public class PythonEvaluatorService {
 
     private static final String URL_TEMPLATE = "%s/v1/private/evaluators/python";
+    private static final int MAX_ERROR_MESSAGE_LENGTH = 500;
 
     private final @NonNull RetriableHttpClient client;
     private final @NonNull OpikConfiguration config;
@@ -101,21 +102,25 @@ public class PythonEvaluatorService {
             try {
                 var errorResponse = response.readEntity(PythonEvaluatorErrorResponse.class);
                 if (errorResponse != null && StringUtils.isNotBlank(errorResponse.error())) {
-                    return errorResponse.error();
+                    return StringUtils.truncate(errorResponse.error(), MAX_ERROR_MESSAGE_LENGTH);
                 }
             } catch (RuntimeException parseErrorResponse) {
-                log.warn("Failed to parse error response, falling back to parsing string", parseErrorResponse);
+                // Expected when the body is not the structured error shape; fall back to the raw body.
+                log.debug("Failed to parse structured error response, falling back to parsing string",
+                        parseErrorResponse);
             }
 
             // Fall back to the raw body when the structured error is absent/blank so the backend
             // detail is not lost (e.g. python-backend "can't be evaluated:" with an empty message).
+            // The body is the evaluated user metric's own error, which we want to surface; bound its
+            // length so an oversized payload can't bloat the thrown exception message.
             try {
                 var body = response.readEntity(String.class);
                 if (StringUtils.isNotBlank(body)) {
-                    return body;
+                    return StringUtils.truncate(body, MAX_ERROR_MESSAGE_LENGTH);
                 }
             } catch (RuntimeException parseStringResponse) {
-                log.warn("Failed to parse error string response", parseStringResponse);
+                log.warn("Failed to read error response body", parseStringResponse);
             }
         }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -70,7 +71,19 @@ public class PythonEvaluatorService {
         Response.StatusType statusInfo = response.getStatusInfo();
 
         if (statusInfo.getFamily() == Response.Status.Family.SUCCESSFUL) {
-            return response.readEntity(PythonEvaluatorResponse.class).scores();
+            // Buffer before reading: the response is consumed further down the reactive chain on a
+            // boundedElastic thread, after which the underlying connection can already be recycled and
+            // readEntity would yield null. A null body (or null scores) must surface as a clean error
+            // rather than a NullPointerException.
+            var body = response.hasEntity() && response.bufferEntity()
+                    ? response.readEntity(PythonEvaluatorResponse.class)
+                    : null;
+            if (body == null || body.scores() == null) {
+                throw new InternalServerErrorException(
+                        "Python evaluation returned HTTP %d with an empty or unparseable response body"
+                                .formatted(statusCode));
+            }
+            return body.scores();
         }
 
         String errorMessage = extractErrorMessage(response);
@@ -84,22 +97,29 @@ public class PythonEvaluatorService {
     }
 
     private String extractErrorMessage(Response response) {
-        String errorMessage = "Unknown error during Python evaluation";
-
         if (response.hasEntity() && response.bufferEntity()) {
             try {
-                errorMessage = response.readEntity(PythonEvaluatorErrorResponse.class).error();
+                var errorResponse = response.readEntity(PythonEvaluatorErrorResponse.class);
+                if (errorResponse != null && StringUtils.isNotBlank(errorResponse.error())) {
+                    return errorResponse.error();
+                }
             } catch (RuntimeException parseErrorResponse) {
                 log.warn("Failed to parse error response, falling back to parsing string", parseErrorResponse);
-                try {
-                    errorMessage = response.readEntity(String.class);
-                } catch (RuntimeException parseStringResponse) {
-                    log.warn("Failed to parse error string response", parseStringResponse);
+            }
+
+            // Fall back to the raw body when the structured error is absent/blank so the backend
+            // detail is not lost (e.g. python-backend "can't be evaluated:" with an empty message).
+            try {
+                var body = response.readEntity(String.class);
+                if (StringUtils.isNotBlank(body)) {
+                    return body;
                 }
+            } catch (RuntimeException parseStringResponse) {
+                log.warn("Failed to parse error string response", parseStringResponse);
             }
         }
 
-        return errorMessage;
+        return "Unknown error during Python evaluation";
     }
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorService.java
@@ -81,7 +81,7 @@ public class PythonEvaluatorService {
                     : null;
             if (body == null || body.scores() == null) {
                 throw new InternalServerErrorException(
-                        "Python evaluation returned HTTP %d with an empty or unparseable response body"
+                        "Python evaluation returned HTTP '%s' with an empty or unparseable response body"
                                 .formatted(statusCode));
             }
             return body.scores();
@@ -94,7 +94,7 @@ public class PythonEvaluatorService {
         }
 
         throw new InternalServerErrorException(
-                "Python evaluation failed (HTTP " + statusCode + "): " + errorMessage);
+                "Python evaluation failed (HTTP '%s'): %s".formatted(statusCode, errorMessage));
     }
 
     private String extractErrorMessage(Response response) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
@@ -564,8 +564,8 @@ class PythonEvaluatorServiceTest {
             return Stream.of(
                     // Structured error object deserializes to null -> fall back to the raw body.
                     Arguments.of("null error object", null, "raw backend error body", "raw backend error body"),
-                    // Structured error field is blank (python-backend "can't be evaluated:").
-                    Arguments.of("blank error field", PythonEvaluatorErrorResponse.builder().error("").build(),
+                    // Structured error field is whitespace-only (exercises isNotBlank, not just isEmpty).
+                    Arguments.of("whitespace error field", PythonEvaluatorErrorResponse.builder().error("   ").build(),
                             "The provided 'code' and 'data' fields can't be evaluated: NameError", "NameError"));
         }
 
@@ -597,6 +597,35 @@ class PythonEvaluatorServiceTest {
             assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
                     .isInstanceOf(BadRequestException.class)
                     .hasMessageContaining(expectedSubstring);
+        }
+
+        @Test
+        void evaluate__when400AndErrorBodyExceedsMaxLength__shouldTruncateSurfacedText() {
+            // Given: a raw error body longer than the surfaced-text cap (MAX_ERROR_MESSAGE_LENGTH = 500).
+            var code = "def evaluate(input, output): return 1.0";
+            var data = Map.<String, Object>of("input", "test input", "output", "test output");
+            var overlongBody = "HEAD" + "x".repeat(600);
+
+            setupHttpCallChain();
+
+            Response badRequestResponse = mock(Response.class);
+            when(badRequestResponse.getStatusInfo()).thenReturn(Status.BAD_REQUEST);
+            when(badRequestResponse.getStatus()).thenReturn(400);
+            when(badRequestResponse.hasEntity()).thenReturn(true);
+            when(badRequestResponse.bufferEntity()).thenReturn(true);
+            when(badRequestResponse.readEntity(PythonEvaluatorErrorResponse.class)).thenReturn(null);
+            when(badRequestResponse.readEntity(String.class)).thenReturn(overlongBody);
+
+            doAnswer(invocation -> {
+                InvocationCallback<Response> callback = invocation.getArgument(1);
+                callback.completed(badRequestResponse);
+                return null;
+            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+
+            // When & Then: message keeps the prefix but is capped at 500 characters.
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
+                    .isInstanceOf(BadRequestException.class)
+                    .satisfies(ex -> assertThat(ex.getMessage()).hasSize(500).startsWith("HEADxxx"));
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
@@ -20,7 +20,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.co.jemos.podam.api.PodamFactory;
@@ -28,6 +32,7 @@ import uk.co.jemos.podam.api.PodamFactory;
 import java.net.SocketTimeoutException;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static com.comet.opik.domain.evaluators.python.TraceThreadPythonEvaluatorRequest.ChatMessage;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -515,11 +520,22 @@ class PythonEvaluatorServiceTest {
 
     @Nested
     @DisplayName("Null / Empty Response Handling Tests")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class NullResponseHandlingTests {
 
-        @Test
-        void evaluate__whenSuccessfulButNullBody__shouldThrowInternalServerErrorInsteadOfNpe() {
-            // Given: a 2xx whose entity deserializes to null (connection recycled before the read).
+        Stream<Arguments> emptySuccessBodies() {
+            return Stream.of(
+                    // A 2xx whose entity deserializes to null (connection recycled before the read).
+                    Arguments.of("null body", null),
+                    // A 2xx whose body carries null scores.
+                    Arguments.of("null scores", PythonEvaluatorResponse.builder().scores(null).build()));
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("emptySuccessBodies")
+        void evaluate__whenSuccessfulButEmptyBody__shouldThrowInternalServerErrorInsteadOfNpe(
+                String caseName, PythonEvaluatorResponse body) {
+            // Given
             var code = "def evaluate(input, output): return 1.0";
             var data = Map.<String, Object>of("input", "test input", "output", "test output");
 
@@ -530,7 +546,7 @@ class PythonEvaluatorServiceTest {
             when(okResponse.getStatus()).thenReturn(200);
             when(okResponse.hasEntity()).thenReturn(true);
             when(okResponse.bufferEntity()).thenReturn(true);
-            when(okResponse.readEntity(PythonEvaluatorResponse.class)).thenReturn(null);
+            when(okResponse.readEntity(PythonEvaluatorResponse.class)).thenReturn(body);
 
             doAnswer(invocation -> {
                 InvocationCallback<Response> callback = invocation.getArgument(1);
@@ -544,37 +560,20 @@ class PythonEvaluatorServiceTest {
                     .hasMessageContaining("empty or unparseable response body");
         }
 
-        @Test
-        void evaluate__whenSuccessfulButNullScores__shouldThrowInternalServerError() {
-            // Given: a 2xx whose body has null scores.
-            var code = "def evaluate(input, output): return 1.0";
-            var data = Map.<String, Object>of("input", "test input", "output", "test output");
-            var nullScoresBody = PythonEvaluatorResponse.builder().scores(null).build();
-
-            setupHttpCallChain();
-
-            Response okResponse = mock(Response.class);
-            when(okResponse.getStatusInfo()).thenReturn(Status.OK);
-            when(okResponse.getStatus()).thenReturn(200);
-            when(okResponse.hasEntity()).thenReturn(true);
-            when(okResponse.bufferEntity()).thenReturn(true);
-            when(okResponse.readEntity(PythonEvaluatorResponse.class)).thenReturn(nullScoresBody);
-
-            doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
-                callback.completed(okResponse);
-                return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
-
-            // When & Then
-            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
-                    .isInstanceOf(InternalServerErrorException.class)
-                    .hasMessageContaining("empty or unparseable response body");
+        Stream<Arguments> missingErrorDetailResponses() {
+            return Stream.of(
+                    // Structured error object deserializes to null -> fall back to the raw body.
+                    Arguments.of("null error object", null, "raw backend error body", "raw backend error body"),
+                    // Structured error field is blank (python-backend "can't be evaluated:").
+                    Arguments.of("blank error field", PythonEvaluatorErrorResponse.builder().error("").build(),
+                            "The provided 'code' and 'data' fields can't be evaluated: NameError", "NameError"));
         }
 
-        @Test
-        void evaluate__when400AndErrorObjectIsNull__shouldNotNpeAndFallBackToStringBody() {
-            // Given: a 400 whose structured error object deserializes to null.
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("missingErrorDetailResponses")
+        void evaluate__when400AndMissingErrorDetail__shouldFallBackToStringBody(
+                String caseName, PythonEvaluatorErrorResponse errorObject, String rawBody, String expectedSubstring) {
+            // Given
             var code = "def evaluate(input, output): return 1.0";
             var data = Map.<String, Object>of("input", "test input", "output", "test output");
 
@@ -585,8 +584,8 @@ class PythonEvaluatorServiceTest {
             when(badRequestResponse.getStatus()).thenReturn(400);
             when(badRequestResponse.hasEntity()).thenReturn(true);
             when(badRequestResponse.bufferEntity()).thenReturn(true);
-            when(badRequestResponse.readEntity(PythonEvaluatorErrorResponse.class)).thenReturn(null);
-            when(badRequestResponse.readEntity(String.class)).thenReturn("raw backend error body");
+            when(badRequestResponse.readEntity(PythonEvaluatorErrorResponse.class)).thenReturn(errorObject);
+            when(badRequestResponse.readEntity(String.class)).thenReturn(rawBody);
 
             doAnswer(invocation -> {
                 InvocationCallback<Response> callback = invocation.getArgument(1);
@@ -597,37 +596,7 @@ class PythonEvaluatorServiceTest {
             // When & Then
             assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
                     .isInstanceOf(BadRequestException.class)
-                    .hasMessageContaining("raw backend error body");
-        }
-
-        @Test
-        void evaluate__when400AndErrorFieldIsBlank__shouldFallBackToStringBody() {
-            // Given: a 400 whose structured error field is blank (python-backend "can't be evaluated:").
-            var code = "def evaluate(input, output): return 1.0";
-            var data = Map.<String, Object>of("input", "test input", "output", "test output");
-            var blankError = PythonEvaluatorErrorResponse.builder().error("").build();
-
-            setupHttpCallChain();
-
-            Response badRequestResponse = mock(Response.class);
-            when(badRequestResponse.getStatusInfo()).thenReturn(Status.BAD_REQUEST);
-            when(badRequestResponse.getStatus()).thenReturn(400);
-            when(badRequestResponse.hasEntity()).thenReturn(true);
-            when(badRequestResponse.bufferEntity()).thenReturn(true);
-            when(badRequestResponse.readEntity(PythonEvaluatorErrorResponse.class)).thenReturn(blankError);
-            when(badRequestResponse.readEntity(String.class))
-                    .thenReturn("The provided 'code' and 'data' fields can't be evaluated: NameError");
-
-            doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
-                callback.completed(badRequestResponse);
-                return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
-
-            // When & Then
-            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
-                    .isInstanceOf(BadRequestException.class)
-                    .hasMessageContaining("NameError");
+                    .hasMessageContaining(expectedSubstring);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
@@ -514,7 +514,7 @@ class PythonEvaluatorServiceTest {
             assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
                     .isInstanceOf(InternalServerErrorException.class)
                     .hasMessageContaining(
-                            "Python evaluation failed (HTTP 500): Unknown error during Python evaluation");
+                            "Python evaluation failed (HTTP '500'): Unknown error during Python evaluation");
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
@@ -513,6 +513,124 @@ class PythonEvaluatorServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("Null / Empty Response Handling Tests")
+    class NullResponseHandlingTests {
+
+        @Test
+        void evaluate__whenSuccessfulButNullBody__shouldThrowInternalServerErrorInsteadOfNpe() {
+            // Given: a 2xx whose entity deserializes to null (connection recycled before the read).
+            var code = "def evaluate(input, output): return 1.0";
+            var data = Map.<String, Object>of("input", "test input", "output", "test output");
+
+            setupHttpCallChain();
+
+            Response okResponse = mock(Response.class);
+            when(okResponse.getStatusInfo()).thenReturn(Status.OK);
+            when(okResponse.getStatus()).thenReturn(200);
+            when(okResponse.hasEntity()).thenReturn(true);
+            when(okResponse.bufferEntity()).thenReturn(true);
+            when(okResponse.readEntity(PythonEvaluatorResponse.class)).thenReturn(null);
+
+            doAnswer(invocation -> {
+                InvocationCallback<Response> callback = invocation.getArgument(1);
+                callback.completed(okResponse);
+                return null;
+            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+
+            // When & Then
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
+                    .isInstanceOf(InternalServerErrorException.class)
+                    .hasMessageContaining("empty or unparseable response body");
+        }
+
+        @Test
+        void evaluate__whenSuccessfulButNullScores__shouldThrowInternalServerError() {
+            // Given: a 2xx whose body has null scores.
+            var code = "def evaluate(input, output): return 1.0";
+            var data = Map.<String, Object>of("input", "test input", "output", "test output");
+            var nullScoresBody = PythonEvaluatorResponse.builder().scores(null).build();
+
+            setupHttpCallChain();
+
+            Response okResponse = mock(Response.class);
+            when(okResponse.getStatusInfo()).thenReturn(Status.OK);
+            when(okResponse.getStatus()).thenReturn(200);
+            when(okResponse.hasEntity()).thenReturn(true);
+            when(okResponse.bufferEntity()).thenReturn(true);
+            when(okResponse.readEntity(PythonEvaluatorResponse.class)).thenReturn(nullScoresBody);
+
+            doAnswer(invocation -> {
+                InvocationCallback<Response> callback = invocation.getArgument(1);
+                callback.completed(okResponse);
+                return null;
+            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+
+            // When & Then
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
+                    .isInstanceOf(InternalServerErrorException.class)
+                    .hasMessageContaining("empty or unparseable response body");
+        }
+
+        @Test
+        void evaluate__when400AndErrorObjectIsNull__shouldNotNpeAndFallBackToStringBody() {
+            // Given: a 400 whose structured error object deserializes to null.
+            var code = "def evaluate(input, output): return 1.0";
+            var data = Map.<String, Object>of("input", "test input", "output", "test output");
+
+            setupHttpCallChain();
+
+            Response badRequestResponse = mock(Response.class);
+            when(badRequestResponse.getStatusInfo()).thenReturn(Status.BAD_REQUEST);
+            when(badRequestResponse.getStatus()).thenReturn(400);
+            when(badRequestResponse.hasEntity()).thenReturn(true);
+            when(badRequestResponse.bufferEntity()).thenReturn(true);
+            when(badRequestResponse.readEntity(PythonEvaluatorErrorResponse.class)).thenReturn(null);
+            when(badRequestResponse.readEntity(String.class)).thenReturn("raw backend error body");
+
+            doAnswer(invocation -> {
+                InvocationCallback<Response> callback = invocation.getArgument(1);
+                callback.completed(badRequestResponse);
+                return null;
+            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+
+            // When & Then
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessageContaining("raw backend error body");
+        }
+
+        @Test
+        void evaluate__when400AndErrorFieldIsBlank__shouldFallBackToStringBody() {
+            // Given: a 400 whose structured error field is blank (python-backend "can't be evaluated:").
+            var code = "def evaluate(input, output): return 1.0";
+            var data = Map.<String, Object>of("input", "test input", "output", "test output");
+            var blankError = PythonEvaluatorErrorResponse.builder().error("").build();
+
+            setupHttpCallChain();
+
+            Response badRequestResponse = mock(Response.class);
+            when(badRequestResponse.getStatusInfo()).thenReturn(Status.BAD_REQUEST);
+            when(badRequestResponse.getStatus()).thenReturn(400);
+            when(badRequestResponse.hasEntity()).thenReturn(true);
+            when(badRequestResponse.bufferEntity()).thenReturn(true);
+            when(badRequestResponse.readEntity(PythonEvaluatorErrorResponse.class)).thenReturn(blankError);
+            when(badRequestResponse.readEntity(String.class))
+                    .thenReturn("The provided 'code' and 'data' fields can't be evaluated: NameError");
+
+            doAnswer(invocation -> {
+                InvocationCallback<Response> callback = invocation.getArgument(1);
+                callback.completed(badRequestResponse);
+                return null;
+            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+
+            // When & Then
+            assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessageContaining("NameError");
+        }
+    }
+
     private Response createMockResponse(Status status, Object entity) {
         Response mockResponse = mock(Response.class);
 


### PR DESCRIPTION
## Details

`PythonEvaluatorService.processResponse(...)` dereferenced `readEntity(...)` results directly. When the response entity deserializes to `null` — which can happen because the response is consumed further down the reactive chain on a `boundedElastic` thread, after the underlying connection has been recycled — the success path did `readEntity(...).scores()` and the error path did `readEntity(...).error()`, both throwing a bare `NullPointerException` that surfaced as an opaque HTTP 500 (counted as `opik_errors_count_total{error_type="NullPointerException"}`).

This turned a user-side error (an invalid user-defined Python metric, for which python-backend returns `400 {"error": "..."}`) into a backend 500, and the backend's error text was lost when the structured `error` field was blank.

- Success path: buffer the entity before reading, and null-check both the body and `scores()`; a null/empty body now raises a clear `InternalServerErrorException` instead of an NPE.
- Error path: null-check the parsed error object and fall back to the raw string body when the structured `error` is absent or blank, so the backend detail is preserved.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7362

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Root-cause analysis from production telemetry, the `PythonEvaluatorService` null-safety change, and the added unit tests.
- Human verification: Author reviewed the diff and confirmed the test run below.

## Testing

Unit tests added to `PythonEvaluatorServiceTest` reproduce the failure modes (each would throw NPE on the previous code) and assert clean exceptions instead:
- 2xx with a null body → `InternalServerErrorException`
- 2xx with null `scores` → `InternalServerErrorException`
- 400 with a null error object → `BadRequestException` (falls back to raw body, no NPE)
- 400 with a blank `error` field → `BadRequestException` carrying the raw body

Commands run (from `apps/opik-backend`):
```
mvn -o test-compile
mvn -o surefire:test -Dtest=PythonEvaluatorServiceTest
```
Result: `Tests run: 18, Failures: 0, Errors: 0, Skipped: 0` — 4 new tests plus the 14 existing tests (no regressions).

## Documentation

No documentation changes required — internal error-handling robustness fix with no API or behavior change on the happy path.
