### PR TITLE
[SDK] fix(url): keep the path prefix in the user-permissions URL

### DIFF
--- a/sdks/python/src/opik/url_helpers.py
+++ b/sdks/python/src/opik/url_helpers.py
@@ -112,4 +112,6 @@ def is_aws_presigned_url(url: str) -> bool:
 
 
 def get_user_permissions_url(url_override: str) -> str:
-    return urllib.parse.urljoin(url_override, "v1/private/workspace-permissions")
+    return urllib.parse.urljoin(
+        ensure_ending_slash(url_override), "v1/private/workspace-permissions"
+    )

--- a/sdks/python/tests/unit/test_url_helpers.py
+++ b/sdks/python/tests/unit/test_url_helpers.py
@@ -35,6 +35,35 @@ def test_get_is_alive_ping_url__base_url__returns_expected_ping_url(
 
 
 @pytest.mark.parametrize(
+    ("url_override", "expected_permissions_url"),
+    [
+        (
+            "http://localhost:5173/api",
+            "http://localhost:5173/api/v1/private/workspace-permissions",
+        ),
+        (
+            "http://localhost:5173/api/",
+            "http://localhost:5173/api/v1/private/workspace-permissions",
+        ),
+        (
+            "https://www.comet.com/opik/api",
+            "https://www.comet.com/opik/api/v1/private/workspace-permissions",
+        ),
+        (
+            "https://www.comet.com/opik/api/",
+            "https://www.comet.com/opik/api/v1/private/workspace-permissions",
+        ),
+    ],
+)
+def test_get_user_permissions_url__url_override__keeps_path_prefix(
+    url_override: str, expected_permissions_url: str
+) -> None:
+    assert (
+        url_helpers.get_user_permissions_url(url_override) == expected_permissions_url
+    )
+
+
+@pytest.mark.parametrize(
     ("url_override", "expected_ui_url"),
     [
         # Shipped defaults must keep working.


### PR DESCRIPTION
## Details

`get_user_permissions_url` doesn't wrap its base in `ensure_ending_slash`, so `urljoin` treats the slash-less final segment as a *file* and replaces it — dropping the `/api` prefix:

```python
>>> get_user_permissions_url("http://localhost:5173/api")
'http://localhost:5173/v1/private/workspace-permissions'      # /api gone
>>> get_user_permissions_url("https://www.comet.com/opik/api")
'https://www.comet.com/opik/v1/private/workspace-permissions' # /opik/api -> /opik
```

Every sibling helper in this module already does wrap its base — `get_is_alive_ping_url` (:105), `get_experiment_url_by_id` (:39), `get_project_url_by_trace_id` (:60). This one is the lone outlier:

```python
>>> get_is_alive_ping_url("http://localhost:5173/api")
'http://localhost:5173/api/is-alive/ping'                     # correct
```

The no-trailing-slash form isn't an edge case — it's the documented way to configure this, and what this repo's own tests use (`tests/conftest.py:229` sets `OPIK_URL_OVERRIDE=http://localhost:5173/api`). The in-code defaults `OPIK_URL_CLOUD`/`OPIK_URL_LOCAL` (`config.py:29-30`) do carry a trailing slash, which is why the shipped default masks this — it only bites users who set `url_override` themselves.

Impact is diagnostic-path only: `opik healthcheck` → `check_user_permissions.run()` → `list_user_permissions()` → this helper, so the request 404s and the healthcheck reports `Failed to fetch user permissions: HTTP error 404`, pointing the user at their server or credentials rather than at this. No data loss.

## Change checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Issues

No existing issue — happy to open one if the team prefers that order for small SDK fixes.

## Testing

Added `test_get_user_permissions_url__url_override__keeps_path_prefix`, parametrized over both slash forms of both the local and cloud URLs — matching how the sibling `test_get_is_alive_ping_url__base_url__returns_expected_ping_url` right above it already pins that contract for its own helper.

Verified it fails first: the two no-trailing-slash cases fail before the fix while the two trailing-slash cases pass, which is exactly the shape of the bug. All 17 pass after.

`tests/unit/test_url_helpers.py` 17 passed; `tests/unit/{message_processing,rate_limit,anonymizer}` 471 passed alongside it. (One timing test, `test_streamer__flush__attachment_uploads__timeout[0.5]`, flaked under parallel load — it passes on its own both with and without this change; I checked rather than assumed.) `ruff check` and `ruff format --check` clean.

## Documentation

None needed — this restores the documented behaviour.

<!-- AI-WATERMARK-START -->
AI-WATERMARK: yes
Tools: Claude Code
Model(s): Claude Opus 4.8
Scope: Bug located with AI assistance and the fix drafted with it. I reproduced the dropped prefix myself against all four URL forms, read the sibling helpers to confirm this one is the outlier, verified the no-slash form is what the repo's own conftest uses, and ran the tests and the flake check above myself.
<!-- AI-WATERMARK-END -->
