### PR TITLE
[NA] [FE] feat: add Copy dataset ID action to datasets list row menu

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetRowActionsCell/DatasetRowActionsCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/DatasetRowActionsCell/DatasetRowActionsCell.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useRef, useState } from "react";
 import { CellContext } from "@tanstack/react-table";
-import { Download, MoreHorizontal, Pencil, Trash } from "lucide-react";
+import copy from "clipboard-copy";
+import { Copy, Download, MoreHorizontal, Pencil, Trash } from "lucide-react";
 
 import { Button } from "@/ui/button";
 import {
@@ -126,6 +127,15 @@ export const createDatasetRowActionsCell = ({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-52">
+            <DropdownMenuItem
+              onClick={() => {
+                toast({ description: `Copied ${entityName} ID to clipboard` });
+                copy(dataset.id);
+              }}
+            >
+              <Copy className="mr-2 size-4" />
+              Copy {entityName} ID
+            </DropdownMenuItem>
             {canEditDatasets && (
               <DropdownMenuItem
                 onClick={() => {
@@ -146,10 +156,7 @@ export const createDatasetRowActionsCell = ({
                 Download
               </DropdownMenuItem>
             )}
-            {canDeleteDatasets &&
-              (canEditDatasets || isDatasetExportEnabled) && (
-                <DropdownMenuSeparator />
-              )}
+            {canDeleteDatasets && <DropdownMenuSeparator />}
             {canDeleteDatasets && (
               <DropdownMenuItem
                 onClick={() => {

--- a/tests_end_to_end/e2e/tests/_release-gate/copy-dataset-id.spec.ts
+++ b/tests_end_to_end/e2e/tests/_release-gate/copy-dataset-id.spec.ts
@@ -1,0 +1,53 @@
+// Copy-dataset-ID row action — the datasets list row menu gains a "Copy dataset ID"
+// item that puts the dataset id on the clipboard and confirms with a toast.
+import { test, expect } from '@e2e/fixtures';
+import { DatasetsPage } from '@e2e/pom/datasets.page';
+
+test.describe(
+  'Copy dataset ID — datasets list row action',
+  { tag: ['@release-gate', '@release-gate:2.1.33', '@datasets'] },
+  () => {
+    test('row menu copies the dataset ID to the clipboard and confirms with a toast', async ({
+      dataset,
+      project,
+      page,
+    }) => {
+      await test.step('Grant clipboard access for the assertion', async () => {
+        await page
+          .context()
+          .grantPermissions(['clipboard-read', 'clipboard-write']);
+      });
+
+      const datasets = new DatasetsPage(page);
+
+      await test.step('Open the datasets list and find the seeded dataset row', async () => {
+        await datasets.goto(project.id);
+        await datasets.waitForReady();
+        await expect(datasets.datasetRow(dataset.name)).toBeVisible();
+      });
+
+      await test.step('Copy the dataset ID from the row actions menu', async () => {
+        await datasets
+          .datasetRow(dataset.name)
+          .getByRole('button', { name: 'Actions menu' })
+          .click();
+        await page.getByRole('menuitem', { name: 'Copy dataset ID' }).click();
+      });
+
+      await test.step('The toast confirms and the clipboard holds the dataset ID', async () => {
+        // exact: the toast text also appears in Radix's aria-live announcement span
+        // ("Notification Copied dataset ID to clipboard"), which trips strict mode.
+        await expect(
+          page.getByText('Copied dataset ID to clipboard', { exact: true }),
+        ).toBeVisible();
+        const clipboard = await page.evaluate(() =>
+          navigator.clipboard.readText(),
+        );
+        expect(clipboard).toBe(dataset.id);
+      });
+
+      // Not covered here: the same action on the Test Suites surface
+      // (rowActionsEntityName "test suite") — equivalent surface, see the plan.
+    });
+  },
+);


### PR DESCRIPTION
## Details

Adds a "Copy dataset ID" item to the datasets list row actions menu (clipboard + confirmation toast), mirroring the trace panel's existing "Copy trace ID" idiom. The shared row-actions cell serves both Datasets and Test Suites, so Test Suites gets "Copy test suite ID" for free.

This PR is also the live demo of the dev-driven testing workflow (OPIK_7167 initiative — related, not resolved here): its happy-path `@release-gate` spec (`tests_end_to_end/e2e/tests/_release-gate/copy-dataset-id.spec.ts`, stamped `@release-gate:2.1.33`) was generated by the `/explore-feature` skill from the uncommitted local diff — pre-PR — and ships inside this PR, as the workflow intends.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- NA (UI nicety; no ticket yet — will be linked when created)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Fable 5
- Scope: full implementation (feature + skill-generated release-gate spec), human-directed
- Human verification: scope gate confirmed by the author; spec run green locally against a from-main stack

## Testing

- `cd tests_end_to_end/e2e && OPIK_BASE_URL=http://localhost:5174 OPIK_DEPLOYMENT=oss npm run test:release-gate` → `1 passed (6.7s)` (seeded dataset → row menu → Copy dataset ID → toast asserted + clipboard readback equals the dataset id).
- FE `npm run typecheck` and eslint on the changed file: clean.
- Not run: full E2E tiers (unaffected — the new spec carries only `@release-gate`, which is excluded from `@t1/@t2/@t3`).

## Documentation

- N/A (UI nicety; behavior is discoverable in the row menu).
