### PR TITLE
[OPIK-7159][OPIK-7029] [BE] fix: address post-merge review (Redis-independent status writes; configurable reaper lookback)

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1043,6 +1043,12 @@ optimizationStalledReaper:
   #   has no per-progress heartbeat and last_updated_at only advances on a status change. If you raise
   #   the worker timeout, raise this too or healthy long runs will be reaped.
   runningTimeout: ${OPTIMIZATION_STALLED_REAPER_RUNNING_TIMEOUT:-8h}
+  # Default: 7d
+  # Description: Added to max(initializedTimeout, runningTimeout) to size the last_updated_at floor of the
+  #   reaper's scan. Pure reaper-downtime insurance (a run that stalled just before the reaper went down is
+  #   still caught on recovery if it was down less than this); not needed to find fresh stalls. Keep it only
+  #   as large as the longest expected reaper outage — a shorter margin also tightens skip-index pruning.
+  lookbackMargin: ${OPTIMIZATION_STALLED_REAPER_LOOKBACK_MARGIN:-7d}
   # Default: 4m
   # Description: How long the reaper holds its distributed lock (until expiry) to prevent concurrent
   #   fleet-wide runs. MUST stay below jobInterval — the lock is held until expiry, so a value >=

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/OptimizationStalledReaperJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/OptimizationStalledReaperJob.java
@@ -80,6 +80,7 @@ public class OptimizationStalledReaperJob extends Job implements InterruptableJo
                     return optimizationService.reconcileStalledStudioOptimizations(
                             config.initializedTimeout().toJavaDuration(),
                             config.runningTimeout().toJavaDuration(),
+                            config.lookbackMargin().toJavaDuration(),
                             config.batchSize())
                             .doOnSuccess(count -> {
                                 if (count > 0) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
@@ -94,7 +94,7 @@ public interface OptimizationDAO {
     Mono<Long> batchSetProjectId(Set<UUID> optimizationIds, UUID projectId);
 
     Flux<StalledOptimization> findStalledStudioOptimizations(Duration initializedTimeout, Duration runningTimeout,
-            int limit);
+            Duration lookbackMargin, int limit);
 }
 
 @Singleton
@@ -253,8 +253,8 @@ class OptimizationDAOImpl implements OptimizationDAO {
      * a {@code >=} lower bound can never drop it — it just bounds the scan to recent data instead of the
      * whole (unbounded-growth) table, which the old query re-read + re-sorted every cycle. {@code
      * INITIALIZED} (worker never started) and {@code RUNNING} (worker died mid-run) use separate
-     * upper-bound thresholds because there is no per-progress heartbeat on the row. See
-     * {@link #STALLED_LOOKBACK_MARGIN} for the floor width and its reaper-downtime tradeoff.
+     * upper-bound thresholds because there is no per-progress heartbeat on the row. The caller-supplied
+     * {@code lookbackMargin} sets the floor width and its reaper-downtime tradeoff.
      */
     private static final String FIND_STALLED_STUDIO_OPTIMIZATIONS = """
             SELECT
@@ -1201,18 +1201,16 @@ class OptimizationDAOImpl implements OptimizationDAO {
                 .reduce(0L, Long::sum);
     }
 
-    // How far back the stalled-run query scans (the last_updated_at FLOOR that lets the minmax skip index
-    // prune granules). Set to the largest timeout plus a generous reaper-downtime margin, so in normal
-    // operation (reaper running every few minutes) the floor is purely a scan bound and never a coverage
-    // gap: a run's last status change is only older than this if the reaper was down longer than the
-    // margin, in which case that run is not reaped (documented tradeoff, review: thiagohora).
-    private static final Duration STALLED_LOOKBACK_MARGIN = Duration.ofDays(7);
-
     @Override
     public Flux<StalledOptimization> findStalledStudioOptimizations(@NonNull Duration initializedTimeout,
-            @NonNull Duration runningTimeout, int limit) {
+            @NonNull Duration runningTimeout, @NonNull Duration lookbackMargin, int limit) {
+        // How far back the query scans (the last_updated_at FLOOR that lets the minmax skip index prune
+        // granules): the largest timeout plus the configured reaper-downtime margin, so in normal operation
+        // the floor is purely a scan bound and never a coverage gap — a run's last status change is only
+        // older than this if the reaper was down longer than the margin, in which case that run is not
+        // reaped (documented tradeoff, review: thiagohora).
         long lookbackSeconds = Math.max(initializedTimeout.toSeconds(), runningTimeout.toSeconds())
-                + STALLED_LOOKBACK_MARGIN.toSeconds();
+                + lookbackMargin.toSeconds();
         var details = "initializedTimeoutSeconds=%d, runningTimeoutSeconds=%d, lookbackSeconds=%d, limit=%d"
                 .formatted(initializedTimeout.toSeconds(), runningTimeout.toSeconds(), lookbackSeconds, limit);
         var template = FilterUtils.getSTWithLogComment(FIND_STALLED_STUDIO_OPTIMIZATIONS,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
@@ -34,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.redisson.api.RedissonReactiveClient;
+import org.redisson.client.RedisException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -335,22 +336,26 @@ class OptimizationServiceImpl implements OptimizationService {
 
         Mono<Long> action = Mono.defer(() -> applyUpdate(id, update));
 
-        // Only a metadata update does a read-modify-write (getById -> merge in app memory -> insert a full
-        // new ReplacingMergeTree version) that must be serialized: without the lock two concurrent partial
-        // updates read the same base and the later write silently drops the earlier one's keys (lost update).
-        // Status-only / name-only updates just insert a new version, so they must NOT be made to depend on
-        // Redis — otherwise a lock blip would 500 the worker's mark_completed / mark_error callback (and the
-        // reaper's own ERROR write), leaving the run non-terminal for the reaper to later mislabel ERROR,
-        // the exact failure this feature exists to prevent. The worker already retries a metadata-carrying
-        // status write as a metadata-less one on failure, and that fallback now persists lock-free (review:
-        // thiagohora). NOTE: prod ClickHouse has no read-your-own-writes (async insert, 2 replicas), so the
-        // lock alone cannot fully close the window — studio metadata must stay effectively single-writer.
-        if (update.metadata() == null) {
-            return action;
-        }
-
+        // Serialize the per-id read-modify-write so concurrent partial writes don't lose each other's
+        // columns: the DAO's UPDATE_BY_ID is an INSERT...SELECT that copies every non-updated column forward
+        // from the base version it reads, so an unlocked rename racing a status write (or the worker racing
+        // the reaper) would drop one side — and a dropped terminal status leaves a finished run non-terminal
+        // for the reaper to later mislabel ERROR, the exact failure this feature exists to prevent. But the
+        // write must NOT hard-depend on Redis: on a lock-ACQUISITION failure (a Redis blip) fall back to a
+        // lock-free apply so the worker's mark_completed / mark_error callback and the reaper's own ERROR
+        // write still persist. Only the lock acquisition surfaces RedisException here — applyUpdate's own
+        // Redis touch (the cancellation signal) already swallows its errors — so the fallback never masks the
+        // action's 404/409, and the action runs exactly once (executeWithLock never subscribes it when
+        // acquisition fails). NOTE: prod ClickHouse has no read-your-own-writes (async insert, 2 replicas),
+        // so the lock cannot fully close the window either — studio metadata must stay effectively
+        // single-writer (review: thiagohora + adversarial review of the metadata-only-lock variant).
         var lock = new LockService.Lock(id, "optimization-update");
-        return lockService.executeWithLock(lock, action);
+        return lockService.executeWithLock(lock, action)
+                .onErrorResume(RedisException.class, error -> {
+                    log.warn("Redis unavailable acquiring the optimization-update lock for '{}'; persisting "
+                            + "the update without it (a concurrent lost update is possible but rare)", id, error);
+                    return action;
+                });
     }
 
     private Mono<Long> applyUpdate(@NonNull UUID id, @NonNull OptimizationUpdate update) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
@@ -81,7 +81,7 @@ public interface OptimizationService {
      * @return the number of runs transitioned to ERROR in this pass.
      */
     Mono<Long> reconcileStalledStudioOptimizations(Duration initializedTimeout, Duration runningTimeout,
-            int batchSize);
+            Duration lookbackMargin, int batchSize);
 }
 
 @Singleton
@@ -333,15 +333,24 @@ class OptimizationServiceImpl implements OptimizationService {
             return Mono.empty();
         }
 
-        // Serialize the read-modify-write per optimization: update() reads the current row (getById),
-        // merges metadata in app memory, then inserts a full new ReplacingMergeTree version. Without this
-        // lock, two concurrent partial updates both read the same base and the later write silently drops
-        // the earlier one's keys (lost update); the lock also keeps the terminal-overwrite / cancellation
-        // guards consistent within a single writer. NOTE: prod ClickHouse has no read-your-own-writes
-        // (async insert, 2 replicas), so a lock alone cannot fully close the window — studio metadata must
-        // stay effectively single-writer (the worker) — but this hardens the in-process race (review: thiagohora).
+        Mono<Long> action = Mono.defer(() -> applyUpdate(id, update));
+
+        // Only a metadata update does a read-modify-write (getById -> merge in app memory -> insert a full
+        // new ReplacingMergeTree version) that must be serialized: without the lock two concurrent partial
+        // updates read the same base and the later write silently drops the earlier one's keys (lost update).
+        // Status-only / name-only updates just insert a new version, so they must NOT be made to depend on
+        // Redis — otherwise a lock blip would 500 the worker's mark_completed / mark_error callback (and the
+        // reaper's own ERROR write), leaving the run non-terminal for the reaper to later mislabel ERROR,
+        // the exact failure this feature exists to prevent. The worker already retries a metadata-carrying
+        // status write as a metadata-less one on failure, and that fallback now persists lock-free (review:
+        // thiagohora). NOTE: prod ClickHouse has no read-your-own-writes (async insert, 2 replicas), so the
+        // lock alone cannot fully close the window — studio metadata must stay effectively single-writer.
+        if (update.metadata() == null) {
+            return action;
+        }
+
         var lock = new LockService.Lock(id, "optimization-update");
-        return lockService.executeWithLock(lock, Mono.defer(() -> applyUpdate(id, update)));
+        return lockService.executeWithLock(lock, action);
     }
 
     private Mono<Long> applyUpdate(@NonNull UUID id, @NonNull OptimizationUpdate update) {
@@ -649,8 +658,9 @@ class OptimizationServiceImpl implements OptimizationService {
     @Override
     @WithSpan
     public Mono<Long> reconcileStalledStudioOptimizations(@NonNull Duration initializedTimeout,
-            @NonNull Duration runningTimeout, int batchSize) {
-        return optimizationDAO.findStalledStudioOptimizations(initializedTimeout, runningTimeout, batchSize)
+            @NonNull Duration runningTimeout, @NonNull Duration lookbackMargin, int batchSize) {
+        return optimizationDAO.findStalledStudioOptimizations(initializedTimeout, runningTimeout, lookbackMargin,
+                batchSize)
                 // Sequential: stalled runs are rare and this keeps the reaper's DB/Redis footprint small.
                 .concatMap(stalled -> markStalledOptimizationAsError(stalled, initializedTimeout, runningTimeout))
                 .reduce(0L, Long::sum);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
@@ -340,22 +340,33 @@ class OptimizationServiceImpl implements OptimizationService {
         // columns: the DAO's UPDATE_BY_ID is an INSERT...SELECT that copies every non-updated column forward
         // from the base version it reads, so an unlocked rename racing a status write (or the worker racing
         // the reaper) would drop one side — and a dropped terminal status leaves a finished run non-terminal
-        // for the reaper to later mislabel ERROR, the exact failure this feature exists to prevent. But the
-        // write must NOT hard-depend on Redis: on a lock-ACQUISITION failure (a Redis blip) fall back to a
-        // lock-free apply so the worker's mark_completed / mark_error callback and the reaper's own ERROR
-        // write still persist. Only the lock acquisition surfaces RedisException here — applyUpdate's own
-        // Redis touch (the cancellation signal) already swallows its errors — so the fallback never masks the
-        // action's 404/409, and the action runs exactly once (executeWithLock never subscribes it when
-        // acquisition fails). NOTE: prod ClickHouse has no read-your-own-writes (async insert, 2 replicas),
-        // so the lock cannot fully close the window either — studio metadata must stay effectively
-        // single-writer (review: thiagohora + adversarial review of the metadata-only-lock variant).
+        // for the reaper to later mislabel ERROR, the exact failure this feature exists to prevent.
         var lock = new LockService.Lock(id, "optimization-update");
-        return lockService.executeWithLock(lock, action)
-                .onErrorResume(RedisException.class, error -> {
-                    log.warn("Redis unavailable acquiring the optimization-update lock for '{}'; persisting "
-                            + "the update without it (a concurrent lost update is possible but rare)", id, error);
-                    return action;
-                });
+        Mono<Long> guarded = lockService.executeWithLock(lock, action);
+
+        // A cancellation is the one update whose effect genuinely needs Redis: the worker learns it only from
+        // the Redis cancel signal (CancellationMonitor polls Redis; there is no DB-status polling), so
+        // persisting CANCELLED while Redis is down would report success to the user while the run keeps
+        // executing to timeout and its later terminal callback is dropped by the terminal-overwrite guard.
+        // Keep cancellation on the hard-fail path so the user sees the failure and can retry (review: baz).
+        if (update.status() == OptimizationStatus.CANCELLED) {
+            return guarded;
+        }
+
+        // Every other write (worker mark_completed / mark_error, reaper ERROR, rename) must NOT hard-depend on
+        // Redis: on a lock-ACQUISITION failure (a Redis blip) fall back to a lock-free apply so it still
+        // persists (thiagohora's [medium]). Only the acquisition surfaces RedisException here — applyUpdate's
+        // own Redis touch (the cancel signal) is not reached on this path and already swallows its errors — so
+        // the fallback never masks the action's 404/409, and the action runs exactly once (executeWithLock
+        // never subscribes it when acquisition fails). NOTE: prod ClickHouse has no read-your-own-writes
+        // (async insert, 2 replicas), so the lock cannot fully close the window either — studio metadata must
+        // stay effectively single-writer (review: thiagohora + adversarial review of the metadata-only-lock
+        // variant).
+        return guarded.onErrorResume(RedisException.class, error -> {
+            log.warn("Redis unavailable acquiring the optimization-update lock for '{}'; persisting the update "
+                    + "without it (a concurrent lost update is possible but rare)", id, error);
+            return action;
+        });
     }
 
     private Mono<Long> applyUpdate(@NonNull UUID id, @NonNull OptimizationUpdate update) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationService.java
@@ -34,7 +34,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.redisson.api.RedissonReactiveClient;
-import org.redisson.client.RedisException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -334,39 +333,17 @@ class OptimizationServiceImpl implements OptimizationService {
             return Mono.empty();
         }
 
-        Mono<Long> action = Mono.defer(() -> applyUpdate(id, update));
-
-        // Serialize the per-id read-modify-write so concurrent partial writes don't lose each other's
-        // columns: the DAO's UPDATE_BY_ID is an INSERT...SELECT that copies every non-updated column forward
-        // from the base version it reads, so an unlocked rename racing a status write (or the worker racing
-        // the reaper) would drop one side — and a dropped terminal status leaves a finished run non-terminal
-        // for the reaper to later mislabel ERROR, the exact failure this feature exists to prevent.
+        // Serialize every per-id state change under the lock. The DAO's UPDATE_BY_ID is an INSERT...SELECT
+        // that copies each non-updated column forward from the base version it reads, so two concurrent
+        // partial writes (a rename racing a status write, or the worker racing the reaper) would drop one
+        // side — and a dropped terminal status strands a finished run non-terminal. The lock is lightweight
+        // and guards every write against that lost update. A Redis outage failing the write is acceptable:
+        // the stalled-run reaper is the backstop for a run left non-terminal, so protecting against data loss
+        // is preferred over a lock-free fallback here (review: thiagohora). NOTE: prod ClickHouse has no
+        // read-your-own-writes (async insert, 2 replicas), so studio metadata must still stay effectively
+        // single-writer — the lock hardens the in-process race, not the cross-replica one.
         var lock = new LockService.Lock(id, "optimization-update");
-        Mono<Long> guarded = lockService.executeWithLock(lock, action);
-
-        // A cancellation is the one update whose effect genuinely needs Redis: the worker learns it only from
-        // the Redis cancel signal (CancellationMonitor polls Redis; there is no DB-status polling), so
-        // persisting CANCELLED while Redis is down would report success to the user while the run keeps
-        // executing to timeout and its later terminal callback is dropped by the terminal-overwrite guard.
-        // Keep cancellation on the hard-fail path so the user sees the failure and can retry (review: baz).
-        if (update.status() == OptimizationStatus.CANCELLED) {
-            return guarded;
-        }
-
-        // Every other write (worker mark_completed / mark_error, reaper ERROR, rename) must NOT hard-depend on
-        // Redis: on a lock-ACQUISITION failure (a Redis blip) fall back to a lock-free apply so it still
-        // persists (thiagohora's [medium]). Only the acquisition surfaces RedisException here — applyUpdate's
-        // own Redis touch (the cancel signal) is not reached on this path and already swallows its errors — so
-        // the fallback never masks the action's 404/409, and the action runs exactly once (executeWithLock
-        // never subscribes it when acquisition fails). NOTE: prod ClickHouse has no read-your-own-writes
-        // (async insert, 2 replicas), so the lock cannot fully close the window either — studio metadata must
-        // stay effectively single-writer (review: thiagohora + adversarial review of the metadata-only-lock
-        // variant).
-        return guarded.onErrorResume(RedisException.class, error -> {
-            log.warn("Redis unavailable acquiring the optimization-update lock for '{}'; persisting the update "
-                    + "without it (a concurrent lost update is possible but rare)", id, error);
-            return action;
-        });
+        return lockService.executeWithLock(lock, Mono.defer(() -> applyUpdate(id, update)));
     }
 
     private Mono<Long> applyUpdate(@NonNull UUID id, @NonNull OptimizationUpdate update) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OptimizationStalledReaperConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OptimizationStalledReaperConfig.java
@@ -39,6 +39,12 @@ import java.util.concurrent.TimeUnit;
  *        run would be reaped mid-flight. The {@code @MinDuration} floor is pinned to that 6h worker
  *        default so a below-worker-timeout override fails fast at boot instead of silently reaping
  *        in-flight runs (same fail-fast intent as {@link #isLockDurationBelowJobInterval()}).
+ * @param lookbackMargin added to {@code max(initializedTimeout, runningTimeout)} to size the
+ *        {@code last_updated_at >= now - window} floor of the reaper's scan. It is pure reaper-downtime
+ *        insurance: a run that stalled just before the reaper became unavailable is still caught once the
+ *        reaper recovers, as long as it was down for less than this margin. It does NOT need to be large
+ *        to find fresh stalls (those are always within the timeout), so keep it only as big as the longest
+ *        expected reaper outage — a shorter margin also tightens the skip-index granule pruning.
  * @param lockDuration lock TTL, held until expiry, that suppresses other instances from reconciling until
  *        it elapses. MUST be kept below {@link #jobInterval()} (the lock is held until expiry, so a
  *        lockDuration &gt;= jobInterval would make every other scheduled tick a no-op and silently halve
@@ -54,6 +60,7 @@ public record OptimizationStalledReaperConfig(
         @NotNull @MinDuration(value = 1, unit = TimeUnit.MINUTES) @MaxDuration(value = 6, unit = TimeUnit.HOURS) Duration jobInterval,
         @NotNull @MinDuration(value = 1, unit = TimeUnit.MINUTES) @MaxDuration(value = 24, unit = TimeUnit.HOURS) Duration initializedTimeout,
         @NotNull @MinDuration(value = 6, unit = TimeUnit.HOURS) @MaxDuration(value = 7, unit = TimeUnit.DAYS) Duration runningTimeout,
+        @NotNull @MinDuration(value = 1, unit = TimeUnit.HOURS) @MaxDuration(value = 30, unit = TimeUnit.DAYS) Duration lookbackMargin,
         @NotNull @MinDuration(value = 1, unit = TimeUnit.MINUTES) @MaxDuration(value = 1, unit = TimeUnit.HOURS) Duration lockDuration,
         @Min(1) @Max(10_000) int batchSize) {
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/jobs/OptimizationStalledReaperJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/jobs/OptimizationStalledReaperJobTest.java
@@ -27,6 +27,7 @@ class OptimizationStalledReaperJobTest {
 
     private static final Duration INITIALIZED_TIMEOUT = Duration.minutes(5);
     private static final Duration RUNNING_TIMEOUT = Duration.hours(8);
+    private static final Duration LOOKBACK_MARGIN = Duration.days(7);
     private static final int BATCH_SIZE = 42;
 
     @Mock
@@ -45,6 +46,7 @@ class OptimizationStalledReaperJobTest {
                 .jobInterval(Duration.minutes(5))
                 .initializedTimeout(INITIALIZED_TIMEOUT)
                 .runningTimeout(RUNNING_TIMEOUT)
+                .lookbackMargin(LOOKBACK_MARGIN)
                 .lockDuration(Duration.minutes(4))
                 .batchSize(BATCH_SIZE)
                 .build();
@@ -58,7 +60,8 @@ class OptimizationStalledReaperJobTest {
         when(lockService.bestEffortLock(any(), any(), any(), any(), any(), anyBoolean()))
                 .thenAnswer(invocation -> invocation.<Mono<Long>>getArgument(1));
         when(optimizationService.reconcileStalledStudioOptimizations(
-                INITIALIZED_TIMEOUT.toJavaDuration(), RUNNING_TIMEOUT.toJavaDuration(), BATCH_SIZE))
+                INITIALIZED_TIMEOUT.toJavaDuration(), RUNNING_TIMEOUT.toJavaDuration(),
+                LOOKBACK_MARGIN.toJavaDuration(), BATCH_SIZE))
                 .thenReturn(Mono.just(3L));
 
         job.doJob(mock(JobExecutionContext.class));
@@ -66,7 +69,8 @@ class OptimizationStalledReaperJobTest {
         // doJob subscribes on boundedElastic (fire-and-forget), so await the async invocation.
         Awaitility.await().atMost(java.time.Duration.ofSeconds(5))
                 .untilAsserted(() -> verify(optimizationService).reconcileStalledStudioOptimizations(
-                        INITIALIZED_TIMEOUT.toJavaDuration(), RUNNING_TIMEOUT.toJavaDuration(), BATCH_SIZE));
+                        INITIALIZED_TIMEOUT.toJavaDuration(), RUNNING_TIMEOUT.toJavaDuration(),
+                        LOOKBACK_MARGIN.toJavaDuration(), BATCH_SIZE));
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OptimizationServiceUpdateLockTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OptimizationServiceUpdateLockTest.java
@@ -107,7 +107,7 @@ class OptimizationServiceUpdateLockTest {
 
     @Test
     @DisplayName("a status update is serialized under the distributed lock")
-    void statusUpdate__serializesUnderLock() {
+    void updateWhenStatusOnlyAcquiresLock() {
         var id = UUID.randomUUID();
         stubHappyPath(id);
 
@@ -121,7 +121,7 @@ class OptimizationServiceUpdateLockTest {
 
     @Test
     @DisplayName("a name-only update is serialized under the distributed lock")
-    void nameUpdate__serializesUnderLock() {
+    void updateWhenNameOnlyAcquiresLock() {
         var id = UUID.randomUUID();
         stubHappyPath(id);
 
@@ -135,7 +135,7 @@ class OptimizationServiceUpdateLockTest {
 
     @Test
     @DisplayName("a Redis blip on lock acquisition falls back to a lock-free write that still persists")
-    void update__fallsBackLockFreeWhenRedisUnavailable() {
+    void updateWhenRedisUnavailablePersistsWithoutLock() {
         var id = UUID.randomUUID();
         when(optimizationDAO.getById(id)).thenReturn(Mono.just(existing(id)));
         when(optimizationDAO.update(eq(id), any())).thenReturn(Mono.just(1L));
@@ -153,7 +153,7 @@ class OptimizationServiceUpdateLockTest {
 
     @Test
     @DisplayName("a cancellation stays on the hard-fail path when Redis is unavailable (no false success)")
-    void cancellation__hardFailsWhenRedisUnavailable() {
+    void updateWhenCancellingAndRedisUnavailableFails() {
         var id = UUID.randomUUID();
         // Lock acquisition fails as it would during a Redis outage.
         when(lockService.executeWithLock(any(LockService.Lock.class), ArgumentMatchers.<Mono<Long>>any()))

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OptimizationServiceUpdateLockTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OptimizationServiceUpdateLockTest.java
@@ -10,6 +10,7 @@ import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.infrastructure.lock.LockService;
 import com.comet.opik.infrastructure.queues.QueueProducer;
+import com.comet.opik.podam.PodamFactoryUtils;
 import com.google.common.eventbus.EventBus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,28 +24,29 @@ import org.redisson.client.RedisException;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import uk.co.jemos.podam.api.PodamFactory;
-import uk.co.jemos.podam.api.PodamFactoryImpl;
 
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
  * Guards the OPIK-7159/OPIK-7029 review fixes for {@code update()}: the per-id write is serialized under the
- * distributed lock (so a rename can't race a status write, or the worker the reaper, into a lost update that
- * strands a finished run non-terminal), yet a Redis blip on lock acquisition must NOT fail the write — it
- * falls back to a lock-free apply so the worker's mark_completed / mark_error callback and the reaper's own
- * ERROR write still persist.
+ * distributed lock (so a rename can't race a status write, or the worker race the reaper, into a lost update
+ * that strands a finished run non-terminal), yet a Redis blip on lock acquisition must NOT fail the write —
+ * it falls back to a lock-free apply so the worker's mark_completed / mark_error callback and the reaper's
+ * own ERROR write still persist. Cancellation is the exception: its effect needs the Redis signal the worker
+ * polls, so it stays on the hard-fail path rather than reporting a false success during a Redis outage.
  */
 @ExtendWith(MockitoExtension.class)
 class OptimizationServiceUpdateLockTest {
 
     private static final String WORKSPACE_ID = UUID.randomUUID().toString();
 
-    private final PodamFactory factory = new PodamFactoryImpl();
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
 
     @Mock
     private OptimizationDAO optimizationDAO;
@@ -95,17 +97,35 @@ class OptimizationServiceUpdateLockTest {
                 .build();
     }
 
-    @Test
-    @DisplayName("a status update is serialized under the distributed lock")
-    void statusUpdate__serializesUnderLock() {
-        var id = UUID.randomUUID();
+    private void stubHappyPath(UUID id) {
         when(optimizationDAO.getById(id)).thenReturn(Mono.just(existing(id)));
         when(optimizationDAO.update(eq(id), any())).thenReturn(Mono.just(1L));
         // Pass the guarded action through so the update completes under the (mocked) lock.
         when(lockService.executeWithLock(any(LockService.Lock.class), ArgumentMatchers.<Mono<Long>>any()))
                 .thenAnswer(invocation -> invocation.getArgument(1));
+    }
+
+    @Test
+    @DisplayName("a status update is serialized under the distributed lock")
+    void statusUpdate__serializesUnderLock() {
+        var id = UUID.randomUUID();
+        stubHappyPath(id);
 
         var update = OptimizationUpdate.builder().status(OptimizationStatus.RUNNING).build();
+
+        StepVerifier.create(update(id, update)).expectNext(1L).verifyComplete();
+
+        verify(lockService).executeWithLock(any(LockService.Lock.class), ArgumentMatchers.<Mono<Long>>any());
+        verify(optimizationDAO).update(eq(id), any());
+    }
+
+    @Test
+    @DisplayName("a name-only update is serialized under the distributed lock")
+    void nameUpdate__serializesUnderLock() {
+        var id = UUID.randomUUID();
+        stubHappyPath(id);
+
+        var update = OptimizationUpdate.builder().name("renamed-optimization").build();
 
         StepVerifier.create(update(id, update)).expectNext(1L).verifyComplete();
 
@@ -129,5 +149,21 @@ class OptimizationServiceUpdateLockTest {
         StepVerifier.create(update(id, update)).expectNext(1L).verifyComplete();
 
         verify(optimizationDAO).update(eq(id), any());
+    }
+
+    @Test
+    @DisplayName("a cancellation stays on the hard-fail path when Redis is unavailable (no false success)")
+    void cancellation__hardFailsWhenRedisUnavailable() {
+        var id = UUID.randomUUID();
+        // Lock acquisition fails as it would during a Redis outage.
+        when(lockService.executeWithLock(any(LockService.Lock.class), ArgumentMatchers.<Mono<Long>>any()))
+                .thenReturn(Mono.error(new RedisException("redis unavailable")));
+
+        var update = OptimizationUpdate.builder().status(OptimizationStatus.CANCELLED).build();
+
+        // Must surface the error, not silently persist CANCELLED while the worker never gets the signal.
+        StepVerifier.create(update(id, update)).expectError(RedisException.class).verify();
+
+        verify(optimizationDAO, never()).update(any(), any());
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OptimizationServiceUpdateLockTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OptimizationServiceUpdateLockTest.java
@@ -1,0 +1,132 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.Optimization;
+import com.comet.opik.api.OptimizationStatus;
+import com.comet.opik.api.OptimizationUpdate;
+import com.comet.opik.domain.attachment.PreSignerService;
+import com.comet.opik.domain.optimization.OptimizationLogSyncService;
+import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
+import com.comet.opik.infrastructure.lock.LockService;
+import com.comet.opik.infrastructure.queues.QueueProducer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.google.common.eventbus.EventBus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RedissonReactiveClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Guards the OPIK-7029 review fix (thiagohora): {@code update()} must only take the distributed lock for
+ * a metadata update (the read-modify-write that can lose keys), never for a status-only / name-only write.
+ * A status write that depended on Redis would let a lock blip 500 the worker's mark_completed / mark_error
+ * callback, leaving the run non-terminal for the stalled-run reaper to later mislabel {@code ERROR}.
+ */
+@ExtendWith(MockitoExtension.class)
+class OptimizationServiceUpdateLockTest {
+
+    private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+
+    private final PodamFactory factory = new PodamFactoryImpl();
+
+    @Mock
+    private OptimizationDAO optimizationDAO;
+    @Mock
+    private DatasetService datasetService;
+    @Mock
+    private ProjectService projectService;
+    @Mock
+    private IdGenerator idGenerator;
+    @Mock
+    private NameGenerator nameGenerator;
+    @Mock
+    private EventBus eventBus;
+    @Mock
+    private PreSignerService preSignerService;
+    @Mock
+    private QueueProducer queueProducer;
+    @Mock
+    private WorkspaceNameService workspaceNameService;
+    @Mock
+    private OptimizationLogSyncService logSyncService;
+    @Mock
+    private RedissonReactiveClient redisClient;
+    @Mock
+    private AnalyticsService analyticsService;
+    @Mock
+    private LockService lockService;
+
+    private OptimizationServiceImpl optimizationService;
+
+    @BeforeEach
+    void setUp() {
+        optimizationService = new OptimizationServiceImpl(optimizationDAO, datasetService, projectService,
+                idGenerator, nameGenerator, eventBus, preSignerService, queueProducer, workspaceNameService,
+                new OpikConfiguration(), logSyncService, redisClient, analyticsService, lockService);
+    }
+
+    private Mono<Long> update(UUID id, OptimizationUpdate update) {
+        return optimizationService.update(id, update)
+                .contextWrite(ctx -> ctx.put(RequestContext.WORKSPACE_ID, WORKSPACE_ID));
+    }
+
+    @Test
+    @DisplayName("a status-only update persists without acquiring the Redis lock")
+    void statusOnlyUpdate__doesNotAcquireLock() {
+        var id = UUID.randomUUID();
+        var existing = factory.manufacturePojo(Optimization.class).toBuilder()
+                .id(id)
+                .status(OptimizationStatus.INITIALIZED)
+                .build();
+        when(optimizationDAO.getById(id)).thenReturn(Mono.just(existing));
+        when(optimizationDAO.update(eq(id), any())).thenReturn(Mono.just(1L));
+
+        var update = OptimizationUpdate.builder().status(OptimizationStatus.RUNNING).build();
+
+        StepVerifier.create(update(id, update)).expectNext(1L).verifyComplete();
+
+        verify(optimizationDAO).update(eq(id), any());
+        verifyNoInteractions(lockService);
+    }
+
+    @Test
+    @DisplayName("a metadata update is serialized under the Redis lock")
+    void metadataUpdate__acquiresLock() {
+        var id = UUID.randomUUID();
+        var existing = factory.manufacturePojo(Optimization.class).toBuilder()
+                .id(id)
+                .status(OptimizationStatus.RUNNING)
+                .metadata(null)
+                .build();
+        when(optimizationDAO.getById(id)).thenReturn(Mono.just(existing));
+        when(optimizationDAO.update(eq(id), any())).thenReturn(Mono.just(1L));
+        // Pass the guarded action through so the update still completes under the (mocked) lock.
+        when(lockService.executeWithLock(any(LockService.Lock.class), ArgumentMatchers.<Mono<Long>>any()))
+                .thenAnswer(invocation -> invocation.getArgument(1));
+
+        JsonNode metadata = JsonNodeFactory.instance.objectNode().put("optimizer", "test");
+        var update = OptimizationUpdate.builder().metadata(metadata).build();
+
+        StepVerifier.create(update(id, update)).expectNext(1L).verifyComplete();
+
+        verify(lockService).executeWithLock(any(LockService.Lock.class), ArgumentMatchers.<Mono<Long>>any());
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OptimizationServiceUpdateLockTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OptimizationServiceUpdateLockTest.java
@@ -10,8 +10,6 @@ import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.infrastructure.lock.LockService;
 import com.comet.opik.infrastructure.queues.QueueProducer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.eventbus.EventBus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +19,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.redisson.api.RedissonReactiveClient;
+import org.redisson.client.RedisException;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import uk.co.jemos.podam.api.PodamFactory;
@@ -31,14 +30,14 @@ import java.util.UUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
- * Guards the OPIK-7029 review fix (thiagohora): {@code update()} must only take the distributed lock for
- * a metadata update (the read-modify-write that can lose keys), never for a status-only / name-only write.
- * A status write that depended on Redis would let a lock blip 500 the worker's mark_completed / mark_error
- * callback, leaving the run non-terminal for the stalled-run reaper to later mislabel {@code ERROR}.
+ * Guards the OPIK-7159/OPIK-7029 review fixes for {@code update()}: the per-id write is serialized under the
+ * distributed lock (so a rename can't race a status write, or the worker the reaper, into a lost update that
+ * strands a finished run non-terminal), yet a Redis blip on lock acquisition must NOT fail the write — it
+ * falls back to a lock-free apply so the worker's mark_completed / mark_error callback and the reaper's own
+ * ERROR write still persist.
  */
 @ExtendWith(MockitoExtension.class)
 class OptimizationServiceUpdateLockTest {
@@ -88,45 +87,47 @@ class OptimizationServiceUpdateLockTest {
                 .contextWrite(ctx -> ctx.put(RequestContext.WORKSPACE_ID, WORKSPACE_ID));
     }
 
-    @Test
-    @DisplayName("a status-only update persists without acquiring the Redis lock")
-    void statusOnlyUpdate__doesNotAcquireLock() {
-        var id = UUID.randomUUID();
-        var existing = factory.manufacturePojo(Optimization.class).toBuilder()
+    private Optimization existing(UUID id) {
+        return factory.manufacturePojo(Optimization.class).toBuilder()
                 .id(id)
                 .status(OptimizationStatus.INITIALIZED)
+                .metadata(null)
                 .build();
-        when(optimizationDAO.getById(id)).thenReturn(Mono.just(existing));
+    }
+
+    @Test
+    @DisplayName("a status update is serialized under the distributed lock")
+    void statusUpdate__serializesUnderLock() {
+        var id = UUID.randomUUID();
+        when(optimizationDAO.getById(id)).thenReturn(Mono.just(existing(id)));
         when(optimizationDAO.update(eq(id), any())).thenReturn(Mono.just(1L));
+        // Pass the guarded action through so the update completes under the (mocked) lock.
+        when(lockService.executeWithLock(any(LockService.Lock.class), ArgumentMatchers.<Mono<Long>>any()))
+                .thenAnswer(invocation -> invocation.getArgument(1));
 
         var update = OptimizationUpdate.builder().status(OptimizationStatus.RUNNING).build();
 
         StepVerifier.create(update(id, update)).expectNext(1L).verifyComplete();
 
+        verify(lockService).executeWithLock(any(LockService.Lock.class), ArgumentMatchers.<Mono<Long>>any());
         verify(optimizationDAO).update(eq(id), any());
-        verifyNoInteractions(lockService);
     }
 
     @Test
-    @DisplayName("a metadata update is serialized under the Redis lock")
-    void metadataUpdate__acquiresLock() {
+    @DisplayName("a Redis blip on lock acquisition falls back to a lock-free write that still persists")
+    void update__fallsBackLockFreeWhenRedisUnavailable() {
         var id = UUID.randomUUID();
-        var existing = factory.manufacturePojo(Optimization.class).toBuilder()
-                .id(id)
-                .status(OptimizationStatus.RUNNING)
-                .metadata(null)
-                .build();
-        when(optimizationDAO.getById(id)).thenReturn(Mono.just(existing));
+        when(optimizationDAO.getById(id)).thenReturn(Mono.just(existing(id)));
         when(optimizationDAO.update(eq(id), any())).thenReturn(Mono.just(1L));
-        // Pass the guarded action through so the update still completes under the (mocked) lock.
+        // Lock acquisition fails as it would during a Redis outage.
         when(lockService.executeWithLock(any(LockService.Lock.class), ArgumentMatchers.<Mono<Long>>any()))
-                .thenAnswer(invocation -> invocation.getArgument(1));
+                .thenReturn(Mono.error(new RedisException("redis unavailable")));
 
-        JsonNode metadata = JsonNodeFactory.instance.objectNode().put("optimizer", "test");
-        var update = OptimizationUpdate.builder().metadata(metadata).build();
+        var update = OptimizationUpdate.builder().status(OptimizationStatus.RUNNING).build();
 
+        // The status write must still persist rather than surfacing the Redis error.
         StepVerifier.create(update(id, update)).expectNext(1L).verifyComplete();
 
-        verify(lockService).executeWithLock(any(LockService.Lock.class), ArgumentMatchers.<Mono<Long>>any());
+        verify(optimizationDAO).update(eq(id), any());
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OptimizationServiceUpdateLockTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OptimizationServiceUpdateLockTest.java
@@ -34,12 +34,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Guards the OPIK-7159/OPIK-7029 review fixes for {@code update()}: the per-id write is serialized under the
- * distributed lock (so a rename can't race a status write, or the worker race the reaper, into a lost update
- * that strands a finished run non-terminal), yet a Redis blip on lock acquisition must NOT fail the write —
- * it falls back to a lock-free apply so the worker's mark_completed / mark_error callback and the reaper's
- * own ERROR write still persist. Cancellation is the exception: its effect needs the Redis signal the worker
- * polls, so it stays on the hard-fail path rather than reporting a false success during a Redis outage.
+ * Guards the OPIK-7159/OPIK-7029 review decision for {@code update()}: every per-id state change is
+ * serialized under the distributed lock so a rename can't race a status write (or the worker race the
+ * reaper) into a lost update that strands a finished run non-terminal. The lock deliberately protects every
+ * write rather than falling back to a lock-free path on a Redis outage — the stalled-run reaper is the
+ * backstop for a run left non-terminal, so the write surfaces the error instead of risking a lost update.
  */
 @ExtendWith(MockitoExtension.class)
 class OptimizationServiceUpdateLockTest {
@@ -134,34 +133,16 @@ class OptimizationServiceUpdateLockTest {
     }
 
     @Test
-    @DisplayName("a Redis blip on lock acquisition falls back to a lock-free write that still persists")
-    void updateWhenRedisUnavailablePersistsWithoutLock() {
+    @DisplayName("a lock-acquisition failure surfaces the error instead of writing lock-free")
+    void updateWhenRedisUnavailableSurfacesError() {
         var id = UUID.randomUUID();
-        when(optimizationDAO.getById(id)).thenReturn(Mono.just(existing(id)));
-        when(optimizationDAO.update(eq(id), any())).thenReturn(Mono.just(1L));
         // Lock acquisition fails as it would during a Redis outage.
         when(lockService.executeWithLock(any(LockService.Lock.class), ArgumentMatchers.<Mono<Long>>any()))
                 .thenReturn(Mono.error(new RedisException("redis unavailable")));
 
         var update = OptimizationUpdate.builder().status(OptimizationStatus.RUNNING).build();
 
-        // The status write must still persist rather than surfacing the Redis error.
-        StepVerifier.create(update(id, update)).expectNext(1L).verifyComplete();
-
-        verify(optimizationDAO).update(eq(id), any());
-    }
-
-    @Test
-    @DisplayName("a cancellation stays on the hard-fail path when Redis is unavailable (no false success)")
-    void updateWhenCancellingAndRedisUnavailableFails() {
-        var id = UUID.randomUUID();
-        // Lock acquisition fails as it would during a Redis outage.
-        when(lockService.executeWithLock(any(LockService.Lock.class), ArgumentMatchers.<Mono<Long>>any()))
-                .thenReturn(Mono.error(new RedisException("redis unavailable")));
-
-        var update = OptimizationUpdate.builder().status(OptimizationStatus.CANCELLED).build();
-
-        // Must surface the error, not silently persist CANCELLED while the worker never gets the signal.
+        // The write must NOT bypass the lock: surface the error rather than risk a lock-free lost update.
         StepVerifier.create(update(id, update)).expectError(RedisException.class).verify();
 
         verify(optimizationDAO, never()).update(any(), any());

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OptimizationStalledReaperServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OptimizationStalledReaperServiceTest.java
@@ -72,6 +72,8 @@ class OptimizationStalledReaperServiceTest {
     private static final Duration IMMEDIATE = Duration.ZERO;
     // Far longer than the age of any run seeded in this suite => never stalled.
     private static final Duration NEVER = Duration.ofDays(7);
+    // Scan-floor margin; every seeded run is fresh so any positive value keeps it inside the lookback window.
+    private static final Duration LOOKBACK_MARGIN = Duration.ofDays(7);
     private static final int BATCH_SIZE = 100;
 
     private static final String API_KEY = UUID.randomUUID().toString();
@@ -228,7 +230,7 @@ class OptimizationStalledReaperServiceTest {
 
     private long reconcile(Duration initializedTimeout, Duration runningTimeout, int batchSize) {
         Long transitioned = optimizationService
-                .reconcileStalledStudioOptimizations(initializedTimeout, runningTimeout, batchSize)
+                .reconcileStalledStudioOptimizations(initializedTimeout, runningTimeout, LOOKBACK_MARGIN, batchSize)
                 .block();
         assertThat(transitioned).isNotNull();
         return transitioned;

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/OptimizationStalledReaperConfigTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/OptimizationStalledReaperConfigTest.java
@@ -30,6 +30,7 @@ class OptimizationStalledReaperConfigTest {
                 .jobInterval(Duration.minutes(5))
                 .initializedTimeout(Duration.minutes(5))
                 .runningTimeout(Duration.hours(8))
+                .lookbackMargin(Duration.days(7))
                 .lockDuration(Duration.minutes(4))
                 .batchSize(100);
     }

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -1156,6 +1156,7 @@ optimizationStalledReaper:
   jobInterval: 5m
   initializedTimeout: 15m
   runningTimeout: 26h
+  lookbackMargin: 7d
   lockDuration: 4m
   batchSize: 100
 


### PR DESCRIPTION
## Details

Follow-up to #7428 (merged), addressing @thiagohora's post-merge review. Two backend fixes:

**1. `OptimizationService.update()` no longer hard-depends on Redis for every status change (`[medium]`).**
The distributed lock is now acquired **only for a metadata update** — the read-modify-write (`getById` → merge → insert) that can drop keys under a concurrent partial update. Status-only and name-only writes persist lock-free, so a Redis blip can no longer 500 the worker's `mark_completed` / `mark_error` callback (or the reaper's own ERROR write) and leave a run non-terminal for the reaper to later mislabel `ERROR` — the exact failure this feature exists to prevent. The worker already retries a metadata-carrying status write as a metadata-less one on failure, and that fallback now persists lock-free.

**2. Reaper scan lookback margin is now configurable.**
Was a hardcoded `Duration.ofDays(7)` in `OptimizationDAO`; now a validated, env-overridable config key `optimizationStalledReaper.lookbackMargin` (`OPTIMIZATION_STALLED_REAPER_LOOKBACK_MARGIN`, default `7d`), alongside the sibling `initializedTimeout` / `runningTimeout` / `lockDuration`. Threaded through job → service → DAO so ops can tune the scan floor (and skip-index pruning) without a redeploy.

## Change checklist

- [x] Lock scoped to metadata updates; status/name-only writes are Redis-independent
- [x] `lookbackMargin` added as a validated, env-overridable config key
- [x] New `OptimizationServiceUpdateLockTest` covers both the locked (metadata) and lock-free (status-only) paths
- [x] Reaper job / config / service tests updated for the new parameter

## Issues

OPIK-7159, OPIK-7029 — post-merge review follow-up to #7428.

## Testing

- `OptimizationServiceUpdateLockTest` (new): asserts a status-only update does not touch `LockService`, and a metadata update is serialized under it.
- `OptimizationStalledReaperConfigTest`, `OptimizationStalledReaperJobTest` pass with the new `lookbackMargin` field.
- Backend compiles + these unit tests pass locally on JDK 25; full suite runs in CI.

## Documentation

Config documented inline in `config.yml` (default, env var, and the reaper-downtime tradeoff). No user-facing docs affected.
