### PR TITLE
[NA] [SDK] fix: evict per-trace state in LangChain OpikTracer after root run finishes

### DIFF
--- a/sdks/python/src/opik/integrations/langchain/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/langchain/opik_tracer.py
@@ -1,5 +1,6 @@
 import logging
 import datetime
+import threading
 from typing import (
     Any,
     Dict,
@@ -171,6 +172,12 @@ class OpikTracer(BaseTracer):
 
         self._externally_created_traces_ids: Set[str] = set()
 
+        self._external_trace_registration_lock = threading.Lock()
+        """Keeps registering an external trace id (and the span referencing it)
+        atomic with respect to _evict_finished_trace_state's check-then-discard,
+        so a finishing root run cannot discard an id another root run is
+        registering concurrently."""
+
         self._skipped_langgraph_root_run_ids: Set[UUID] = set()
         """Set of run IDs for LangGraph root runs where we skip creating the span."""
 
@@ -322,73 +329,51 @@ class OpikTracer(BaseTracer):
         if not self._opik_context_read_only_mode:
             self._opik_context_storage.pop_trace_data(ensure_id=trace_data.id)
 
-    def _resolve_trace_id(self, run_id: UUID) -> Optional[str]:
-        """Return the trace id a finished root run is allowed to evict, if any.
-
-        A run that created its trace (it has an entry in
-        _created_traces_data_map) owns it, so its trace id is returned.
-        Otherwise the run only has spans. If they point at an externally
-        created trace (distributed tracing), the span's trace_id is returned
-        so the local leftovers of that trace can be released. If they point
-        at a trace created by this tracer but owned by another root run that
-        is still in flight, None is returned: only the owning root run may
-        evict that trace's state, when it finishes.
-        """
-        trace_data = self._created_traces_data_map.get(run_id)
-        if trace_data is not None:
-            return trace_data.id
-
-        span_data = self._span_data_map.get(run_id)
-        if (
-            span_data is not None
-            and span_data.trace_id in self._externally_created_traces_ids
-        ):
-            return span_data.trace_id
-
-        return None
-
-    def _evict_finished_trace_state(self, root_run_id: UUID) -> None:
-        """Release a trace's bookkeeping state once its root run finished.
+    def _evict_finished_trace_state(self, run: Run) -> None:
+        """Release a finished root run's bookkeeping state.
 
         Called at the end of the root run's final end/error callback. That
         is the earliest safe point: _persist_run fires before that callback,
         and the end-span processing in between still reads the root run's
-        entries to emit the final span. Eviction is keyed by trace id, so
-        concurrent in-flight traces sharing this tracer are never touched.
-        Without it every trace's state (including full prompt/completion
-        payloads) stays in the maps for the tracer's lifetime.
+        entries to emit the final span. Eviction walks the finished run's
+        own tree (BaseTracer attaches every child run to its parent's
+        child_runs), so other in-flight root runs sharing this tracer, even
+        ones attached to the same externally created trace, are never
+        touched. Without it every trace's state (including full
+        prompt/completion payloads) stays in the maps for the tracer's
+        lifetime.
         """
-        trace_id = self._resolve_trace_id(root_run_id)
-        if trace_id is None:
-            # A parentless run that attached to another in-flight local
-            # trace: the owning root run evicts the shared state when it
-            # finishes, only this run's own entries are released here.
-            self._span_data_map.pop(root_run_id, None)
-            self._skipped_langgraph_root_run_ids.discard(root_run_id)
-            self._langgraph_parent_span_ids.pop(root_run_id, None)
-            return
+        root_span_data = self._span_data_map.get(run.id)
+        external_trace_id: Optional[str] = None
+        if (
+            root_span_data is not None
+            and root_span_data.trace_id in self._externally_created_traces_ids
+        ):
+            external_trace_id = root_span_data.trace_id
 
-        run_ids = {
-            run_id
-            for run_id, span_data in self._span_data_map.items()
-            if span_data.trace_id == trace_id
-        }
-        # Child runs map to the same TraceData object as the root run.
-        run_ids.update(
-            run_id
-            for run_id, trace_data in self._created_traces_data_map.items()
-            if trace_data.id == trace_id
-        )
-        for run_id in run_ids:
-            self._span_data_map.pop(run_id, None)
-            self._created_traces_data_map.pop(run_id, None)
-            self._skipped_langgraph_root_run_ids.discard(run_id)
-            self._langgraph_parent_span_ids.pop(run_id, None)
+        stack = [run]
+        while stack:
+            current = stack.pop()
+            stack.extend(current.child_runs)
+            self._span_data_map.pop(current.id, None)
+            self._created_traces_data_map.pop(current.id, None)
+            self._skipped_langgraph_root_run_ids.discard(current.id)
+            self._langgraph_parent_span_ids.pop(current.id, None)
 
         # _created_traces is deliberately not evicted: created_traces() is
         # documented to accumulate the traces created by this tracer, and
         # Trace objects are lightweight handles without payloads.
-        self._externally_created_traces_ids.discard(trace_id)
+        if external_trace_id is not None:
+            # The lock keeps the check-then-discard atomic with respect to the
+            # registration sites, so an id being registered by another root
+            # run right now cannot be discarded from under it.
+            with self._external_trace_registration_lock:
+                if not any(
+                    span_data.trace_id == external_trace_id
+                    for span_data in list(self._span_data_map.values())
+                ):
+                    # No other in-flight run references the external trace anymore.
+                    self._externally_created_traces_ids.discard(external_trace_id)
 
     def _ensure_no_hanging_opik_tracer_spans(self) -> None:
         root_run_external_parent_span_id = self._root_run_external_parent_span_id.get()
@@ -510,6 +495,18 @@ class OpikTracer(BaseTracer):
         or distributed headers. If a new trace is created, the span is skipped and only the
         trace data is stored in local storage for future reference.
         """
+        # May register an externally created trace id, which must become
+        # observable together with the span data referencing it.
+        with self._external_trace_registration_lock:
+            self._create_root_trace_and_span_impl(
+                run_id=run_id,
+                run_dict=run_dict,
+                allow_duplicating_root_span=allow_duplicating_root_span,
+            )
+
+    def _create_root_trace_and_span_impl(
+        self, run_id: UUID, run_dict: Dict[str, Any], allow_duplicating_root_span: bool
+    ) -> None:
         # This is the first run for the chain.
         root_run_result = self._track_root_run(run_dict, allow_duplicating_root_span)
         if root_run_result.new_trace_data is not None:
@@ -626,6 +623,18 @@ class OpikTracer(BaseTracer):
         Attaches child span directly to a trace by checking trace data or distributed
         headers and creates new span data based on the provided run information.
         """
+        # May register an externally created trace id, which must become
+        # observable together with the span data referencing it.
+        with self._external_trace_registration_lock:
+            self._attach_span_to_local_or_distributed_trace_impl(
+                run_id=run_id,
+                parent_run_id=parent_run_id,
+                run_dict=run_dict,
+            )
+
+    def _attach_span_to_local_or_distributed_trace_impl(
+        self, run_id: UUID, parent_run_id: UUID, run_dict: Dict[str, Any]
+    ) -> None:
         # Check if we have trace data (new trace) or distributed headers
         if parent_run_id in self._created_traces_data_map:
             # LangGraph created a new trace - attach children directly to trace
@@ -776,7 +785,7 @@ class OpikTracer(BaseTracer):
                 )
                 self._opik_context_storage.pop_span_data(ensure_id=span_data.id)
             if run.parent_run_id is None:
-                self._evict_finished_trace_state(run.id)
+                self._evict_finished_trace_state(run)
 
     def _resolve_provider(
         self, run_dict: Dict[str, Any], model: Optional[str]
@@ -819,7 +828,7 @@ class OpikTracer(BaseTracer):
             self._process_end_span_with_error_impl(run)
         finally:
             if run.parent_run_id is None:
-                self._evict_finished_trace_state(run.id)
+                self._evict_finished_trace_state(run)
 
     def _process_end_span_with_error_impl(self, run: Run) -> None:
         # Skip processing if this is a skipped LangGraph root run

--- a/sdks/python/src/opik/integrations/langchain/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/langchain/opik_tracer.py
@@ -322,6 +322,74 @@ class OpikTracer(BaseTracer):
         if not self._opik_context_read_only_mode:
             self._opik_context_storage.pop_trace_data(ensure_id=trace_data.id)
 
+    def _resolve_trace_id(self, run_id: UUID) -> Optional[str]:
+        """Return the trace id a finished root run is allowed to evict, if any.
+
+        A run that created its trace (it has an entry in
+        _created_traces_data_map) owns it, so its trace id is returned.
+        Otherwise the run only has spans. If they point at an externally
+        created trace (distributed tracing), the span's trace_id is returned
+        so the local leftovers of that trace can be released. If they point
+        at a trace created by this tracer but owned by another root run that
+        is still in flight, None is returned: only the owning root run may
+        evict that trace's state, when it finishes.
+        """
+        trace_data = self._created_traces_data_map.get(run_id)
+        if trace_data is not None:
+            return trace_data.id
+
+        span_data = self._span_data_map.get(run_id)
+        if (
+            span_data is not None
+            and span_data.trace_id in self._externally_created_traces_ids
+        ):
+            return span_data.trace_id
+
+        return None
+
+    def _evict_finished_trace_state(self, root_run_id: UUID) -> None:
+        """Release a trace's bookkeeping state once its root run finished.
+
+        Called at the end of the root run's final end/error callback. That
+        is the earliest safe point: _persist_run fires before that callback,
+        and the end-span processing in between still reads the root run's
+        entries to emit the final span. Eviction is keyed by trace id, so
+        concurrent in-flight traces sharing this tracer are never touched.
+        Without it every trace's state (including full prompt/completion
+        payloads) stays in the maps for the tracer's lifetime.
+        """
+        trace_id = self._resolve_trace_id(root_run_id)
+        if trace_id is None:
+            # A parentless run that attached to another in-flight local
+            # trace: the owning root run evicts the shared state when it
+            # finishes, only this run's own entries are released here.
+            self._span_data_map.pop(root_run_id, None)
+            self._skipped_langgraph_root_run_ids.discard(root_run_id)
+            self._langgraph_parent_span_ids.pop(root_run_id, None)
+            return
+
+        run_ids = {
+            run_id
+            for run_id, span_data in self._span_data_map.items()
+            if span_data.trace_id == trace_id
+        }
+        # Child runs map to the same TraceData object as the root run.
+        run_ids.update(
+            run_id
+            for run_id, trace_data in self._created_traces_data_map.items()
+            if trace_data.id == trace_id
+        )
+        for run_id in run_ids:
+            self._span_data_map.pop(run_id, None)
+            self._created_traces_data_map.pop(run_id, None)
+            self._skipped_langgraph_root_run_ids.discard(run_id)
+            self._langgraph_parent_span_ids.pop(run_id, None)
+
+        # _created_traces is deliberately not evicted: created_traces() is
+        # documented to accumulate the traces created by this tracer, and
+        # Trace objects are lightweight handles without payloads.
+        self._externally_created_traces_ids.discard(trace_id)
+
     def _ensure_no_hanging_opik_tracer_spans(self) -> None:
         root_run_external_parent_span_id = self._root_run_external_parent_span_id.get()
         there_were_no_external_spans_before_chain_invocation = (
@@ -707,6 +775,8 @@ class OpikTracer(BaseTracer):
                     span_id=span_data.id
                 )
                 self._opik_context_storage.pop_span_data(ensure_id=span_data.id)
+            if run.parent_run_id is None:
+                self._evict_finished_trace_state(run.id)
 
     def _resolve_provider(
         self, run_dict: Dict[str, Any], model: Optional[str]
@@ -744,6 +814,14 @@ class OpikTracer(BaseTracer):
         return self._skip_error_callback(error_str)
 
     def _process_end_span_with_error(self, run: Run) -> None:
+        # finally runs on early returns and exceptions too, so eviction always happens
+        try:
+            self._process_end_span_with_error_impl(run)
+        finally:
+            if run.parent_run_id is None:
+                self._evict_finished_trace_state(run.id)
+
+    def _process_end_span_with_error_impl(self, run: Run) -> None:
         # Skip processing if this is a skipped LangGraph root run
         if run.id in self._skipped_langgraph_root_run_ids:
             return

--- a/sdks/python/tests/library_integration/langchain/test_opik_tracer.py
+++ b/sdks/python/tests/library_integration/langchain/test_opik_tracer.py
@@ -1,4 +1,5 @@
 import copy
+import threading
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
@@ -570,9 +571,10 @@ def test_is_internal_langgraph_run__markers_and_malformed_inputs(run_dict, expec
 
 # created_traces() is documented to accumulate lightweight Trace handles,
 # so _created_traces is intentionally absent here: only the payload-heavy
-# per-run state must be released once a trace completes.
+# per-run state must be released once a trace completes. Span data eviction
+# is asserted through the public get_current_span_data_for_run accessor
+# (see _assert_no_span_data), so _span_data_map is absent here too.
 _EMPTY_BOOKKEEPING = {
-    "span_data_map": 0,
     "created_traces_data_map": 0,
     "externally_created_traces_ids": 0,
     "skipped_langgraph_root_run_ids": 0,
@@ -582,7 +584,6 @@ _EMPTY_BOOKKEEPING = {
 
 def _bookkeeping_sizes(tracer: OpikTracer) -> Dict[str, int]:
     return {
-        "span_data_map": len(tracer._span_data_map),
         "created_traces_data_map": len(tracer._created_traces_data_map),
         "externally_created_traces_ids": len(tracer._externally_created_traces_ids),
         "skipped_langgraph_root_run_ids": len(tracer._skipped_langgraph_root_run_ids),
@@ -590,14 +591,39 @@ def _bookkeeping_sizes(tracer: OpikTracer) -> Dict[str, int]:
     }
 
 
+class _RunIdCollector(BaseTracer):
+    """Records the run id of every run it sees, so span data eviction can be
+    asserted per run through the public get_current_span_data_for_run."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.run_ids: List[Any] = []
+
+    def _persist_run(self, run: Any) -> None:
+        pass
+
+    def _start_trace(self, run: Any) -> None:
+        super()._start_trace(run)
+        self.run_ids.append(run.id)
+
+
+def _assert_no_span_data(tracer: OpikTracer, run_ids: List[Any]) -> None:
+    assert run_ids, "collector must have seen at least one run"
+    assert all(
+        tracer.get_current_span_data_for_run(run_id) is None for run_id in run_ids
+    )
+
+
 def test_opik_tracer__trace_completes__all_bookkeeping_state_evicted(fake_backend):
     llm = fake.FakeListLLM(responses=["ok"])
     tracer = OpikTracer()
+    collector = _RunIdCollector()
 
     for i in range(10):
-        llm.invoke(f"message {i}", config={"callbacks": [tracer]})
+        llm.invoke(f"message {i}", config={"callbacks": [tracer, collector]})
     tracer.flush()
 
+    _assert_no_span_data(tracer, collector.run_ids)
     assert _bookkeeping_sizes(tracer) == _EMPTY_BOOKKEEPING
     # tracing is unaffected: every trace still reached the backend WITH its
     # root span (evicting before the root run's last callback would silently
@@ -611,10 +637,12 @@ def test_opik_tracer__chained_run_completes__child_span_state_evicted(fake_backe
     prompt = PromptTemplate(input_variables=["title"], template="Title: {title}.")
     chain = prompt | fake.FakeListLLM(responses=["ok"])
     tracer = OpikTracer()
+    collector = _RunIdCollector()
 
-    chain.invoke({"title": "hello"}, config={"callbacks": [tracer]})
+    chain.invoke({"title": "hello"}, config={"callbacks": [tracer, collector]})
     tracer.flush()
 
+    _assert_no_span_data(tracer, collector.run_ids)
     assert _bookkeeping_sizes(tracer) == _EMPTY_BOOKKEEPING
 
 
@@ -624,11 +652,13 @@ def test_opik_tracer__chain_raises__state_evicted_on_error_path(fake_backend):
 
     chain = RunnableLambda(boom)
     tracer = OpikTracer()
+    collector = _RunIdCollector()
 
     with pytest.raises(ValueError, match="boom"):
-        chain.invoke("hello", config={"callbacks": [tracer]})
+        chain.invoke("hello", config={"callbacks": [tracer, collector]})
     tracer.flush()
 
+    _assert_no_span_data(tracer, collector.run_ids)
     assert _bookkeeping_sizes(tracer) == _EMPTY_BOOKKEEPING
 
 
@@ -641,20 +671,157 @@ def test_opik_tracer__concurrent_in_flight_trace__untouched_by_other_trace_finis
     tracer.on_chain_start(
         {"name": "in-flight-chain"}, {"input": "x"}, run_id=in_flight_run_id
     )
+
+    def in_flight_membership() -> Dict[str, bool]:
+        return {
+            "span_data_map": tracer.get_current_span_data_for_run(in_flight_run_id)
+            is not None,
+            "created_traces_data_map": in_flight_run_id
+            in tracer._created_traces_data_map,
+            "skipped_langgraph_root_run_ids": in_flight_run_id
+            in tracer._skipped_langgraph_root_run_ids,
+            "langgraph_parent_span_ids": in_flight_run_id
+            in tracer._langgraph_parent_span_ids,
+        }
+
+    membership_before = in_flight_membership()
+    assert any(membership_before.values()), (
+        "in-flight run must register bookkeeping state"
+    )
     in_flight_entries = {
         name: size for name, size in _bookkeeping_sizes(tracer).items() if size > 0
     }
-    assert in_flight_entries, "in-flight run must register bookkeeping state"
 
     fake.FakeListLLM(responses=["ok"]).invoke(
         "other trace", config={"callbacks": [tracer]}
     )
     tracer.flush()
 
-    # the finished trace is fully evicted; the in-flight one is untouched
+    # the in-flight run's own entries survived, tied to its run id
+    assert in_flight_membership() == membership_before
+    # and the finished trace left nothing behind beyond the in-flight baseline
     assert {
         name: size for name, size in _bookkeeping_sizes(tracer).items() if size > 0
     } == in_flight_entries
+
+
+def test_opik_tracer__get_current_span_data_for_run__cleared_once_trace_completes(
+    fake_backend,
+):
+    tracer = OpikTracer()
+    root_run_id, child_run_id = uuid4(), uuid4()
+    tracer.on_chain_start({"name": "root"}, {"input": "x"}, run_id=root_run_id)
+    tracer.on_chain_start(
+        {"name": "child"},
+        {"input": "y"},
+        run_id=child_run_id,
+        parent_run_id=root_run_id,
+    )
+
+    # queryable while the trace is in flight
+    assert tracer.get_current_span_data_for_run(child_run_id) is not None
+
+    tracer.on_chain_end({"output": "y"}, run_id=child_run_id)
+    tracer.on_chain_end({"output": "x"}, run_id=root_run_id)
+    tracer.flush()
+
+    # once the root run finished, the accessor no longer returns stale data
+    assert tracer.get_current_span_data_for_run(child_run_id) is None
+    assert tracer.get_current_span_data_for_run(root_run_id) is None
+
+
+def test_opik_tracer__shared_external_trace__finishing_root_run_leaves_other_in_flight(
+    fake_backend,
+):
+    external_trace_data = trace_module.TraceData(name="external-trace")
+    context_storage.set_trace_data(external_trace_data)
+    tracer = OpikTracer()
+    first_run_id, second_run_id = uuid4(), uuid4()
+    try:
+        tracer.on_chain_start({"name": "first"}, {"input": "x"}, run_id=first_run_id)
+        tracer.on_chain_start({"name": "second"}, {"input": "y"}, run_id=second_run_id)
+        tracer.on_chain_end({"output": "x"}, run_id=first_run_id)
+
+        # the finished root run released only its own entries: the other
+        # in-flight root run sharing the external trace keeps its span data
+        # and the shared external trace id stays registered
+        assert tracer.get_current_span_data_for_run(second_run_id) is not None
+        assert tracer.get_current_span_data_for_run(first_run_id) is None
+        assert external_trace_data.id in tracer._externally_created_traces_ids
+
+        tracer.on_chain_end({"output": "y"}, run_id=second_run_id)
+        tracer.flush()
+    finally:
+        context_storage.pop_trace_data()
+
+    assert external_trace_data.id not in tracer._externally_created_traces_ids
+    _assert_no_span_data(tracer, [first_run_id, second_run_id])
+    assert _bookkeeping_sizes(tracer) == _EMPTY_BOOKKEEPING
+
+
+def test_opik_tracer__external_id_registration_races_eviction__id_not_discarded_mid_registration(
+    fake_backend,
+):
+    """Deterministic reproduction of the registration/eviction race.
+
+    A root run registers an external trace id BEFORE saving the span that
+    references it. This test pauses a second root run exactly inside that
+    window (id registered, span not yet saved) while the first root run
+    finishes. Without the registration lock, the first run's eviction scans
+    the span map, sees no reference, and discards the id the second run just
+    registered; its _persist_run would then wrongly finalize the external
+    trace. With the lock, eviction waits for the registration to complete
+    and keeps the id.
+    """
+    external_trace_data = trace_module.TraceData(name="external-trace")
+    context_storage.set_trace_data(external_trace_data)
+    tracer = OpikTracer()
+    first_run_id, second_run_id = uuid4(), uuid4()
+
+    registration_entered = threading.Event()
+    resume_registration = threading.Event()
+    original_save = tracer._save_span_trace_data_to_local_maps
+
+    def paused_save(run_id, span_data, trace_data):
+        if run_id == second_run_id:
+            registration_entered.set()
+            assert resume_registration.wait(timeout=5)
+        original_save(run_id=run_id, span_data=span_data, trace_data=trace_data)
+
+    def start_second_root():
+        # a fresh thread has its own context, set the shared external trace
+        context_storage.set_trace_data(external_trace_data)
+        tracer.on_chain_start({"name": "second"}, {"input": "y"}, run_id=second_run_id)
+
+    try:
+        tracer.on_chain_start({"name": "first"}, {"input": "x"}, run_id=first_run_id)
+        tracer._save_span_trace_data_to_local_maps = paused_save
+
+        second_thread = threading.Thread(target=start_second_root)
+        second_thread.start()
+        assert registration_entered.wait(timeout=5)
+
+        # finish the first root while the second is mid-registration; with the
+        # lock this blocks until the registration completes, so release it
+        # shortly after
+        threading.Timer(0.3, resume_registration.set).start()
+        tracer.on_chain_end({"output": "x"}, run_id=first_run_id)
+        second_thread.join(timeout=5)
+        assert not second_thread.is_alive()
+
+        # the id registered mid-eviction survived, and so did the span
+        assert external_trace_data.id in tracer._externally_created_traces_ids
+        assert tracer.get_current_span_data_for_run(second_run_id) is not None
+
+        tracer.on_chain_end({"output": "y"}, run_id=second_run_id)
+        tracer.flush()
+    finally:
+        tracer._save_span_trace_data_to_local_maps = original_save
+        context_storage.pop_trace_data()
+
+    assert external_trace_data.id not in tracer._externally_created_traces_ids
+    _assert_no_span_data(tracer, [first_run_id, second_run_id])
+    assert _bookkeeping_sizes(tracer) == _EMPTY_BOOKKEEPING
 
 
 def test_opik_tracer__externally_created_trace__id_discarded_after_completion(
@@ -663,11 +830,15 @@ def test_opik_tracer__externally_created_trace__id_discarded_after_completion(
     external_trace_data = trace_module.TraceData(name="external-trace")
     context_storage.set_trace_data(external_trace_data)
     tracer = OpikTracer()
+    collector = _RunIdCollector()
     try:
-        fake.FakeListLLM(responses=["ok"]).invoke("hi", config={"callbacks": [tracer]})
+        fake.FakeListLLM(responses=["ok"]).invoke(
+            "hi", config={"callbacks": [tracer, collector]}
+        )
         tracer.flush()
     finally:
         context_storage.pop_trace_data()
 
     assert external_trace_data.id not in tracer._externally_created_traces_ids
+    _assert_no_span_data(tracer, collector.run_ids)
     assert _bookkeeping_sizes(tracer) == _EMPTY_BOOKKEEPING

--- a/sdks/python/tests/library_integration/langchain/test_opik_tracer.py
+++ b/sdks/python/tests/library_integration/langchain/test_opik_tracer.py
@@ -3,12 +3,15 @@ from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 import pytest
+from langchain_core.language_models import fake
+from langchain_core.prompts import PromptTemplate
+from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import tool
 from langchain_core.tracers import BaseTracer
 from langgraph.graph import END, START, StateGraph
 from typing_extensions import TypedDict
 
-from opik import exceptions
+from opik import context_storage, exceptions
 from opik.api_objects import span as span_module, trace as trace_module
 from opik.integrations import langchain
 from opik.integrations.langchain.opik_tracer import OpikTracer
@@ -563,3 +566,108 @@ def test_get_run_metadata__non_dict_opik_value__coerced_then_tagged(
 )
 def test_is_internal_langgraph_run__markers_and_malformed_inputs(run_dict, expected):
     assert run_parse_helpers.is_internal_langgraph_run(run_dict) is expected
+
+
+# created_traces() is documented to accumulate lightweight Trace handles,
+# so _created_traces is intentionally absent here: only the payload-heavy
+# per-run state must be released once a trace completes.
+_EMPTY_BOOKKEEPING = {
+    "span_data_map": 0,
+    "created_traces_data_map": 0,
+    "externally_created_traces_ids": 0,
+    "skipped_langgraph_root_run_ids": 0,
+    "langgraph_parent_span_ids": 0,
+}
+
+
+def _bookkeeping_sizes(tracer: OpikTracer) -> Dict[str, int]:
+    return {
+        "span_data_map": len(tracer._span_data_map),
+        "created_traces_data_map": len(tracer._created_traces_data_map),
+        "externally_created_traces_ids": len(tracer._externally_created_traces_ids),
+        "skipped_langgraph_root_run_ids": len(tracer._skipped_langgraph_root_run_ids),
+        "langgraph_parent_span_ids": len(tracer._langgraph_parent_span_ids),
+    }
+
+
+def test_opik_tracer__trace_completes__all_bookkeeping_state_evicted(fake_backend):
+    llm = fake.FakeListLLM(responses=["ok"])
+    tracer = OpikTracer()
+
+    for i in range(10):
+        llm.invoke(f"message {i}", config={"callbacks": [tracer]})
+    tracer.flush()
+
+    assert _bookkeeping_sizes(tracer) == _EMPTY_BOOKKEEPING
+    # tracing is unaffected: every trace still reached the backend WITH its
+    # root span (evicting before the root run's last callback would silently
+    # drop span emission), and created_traces() still accumulates
+    assert len(fake_backend.trace_trees) == 10
+    assert all(tree.spans for tree in fake_backend.trace_trees)
+    assert len(tracer.created_traces()) == 10
+
+
+def test_opik_tracer__chained_run_completes__child_span_state_evicted(fake_backend):
+    prompt = PromptTemplate(input_variables=["title"], template="Title: {title}.")
+    chain = prompt | fake.FakeListLLM(responses=["ok"])
+    tracer = OpikTracer()
+
+    chain.invoke({"title": "hello"}, config={"callbacks": [tracer]})
+    tracer.flush()
+
+    assert _bookkeeping_sizes(tracer) == _EMPTY_BOOKKEEPING
+
+
+def test_opik_tracer__chain_raises__state_evicted_on_error_path(fake_backend):
+    def boom(_input):
+        raise ValueError("boom")
+
+    chain = RunnableLambda(boom)
+    tracer = OpikTracer()
+
+    with pytest.raises(ValueError, match="boom"):
+        chain.invoke("hello", config={"callbacks": [tracer]})
+    tracer.flush()
+
+    assert _bookkeeping_sizes(tracer) == _EMPTY_BOOKKEEPING
+
+
+def test_opik_tracer__concurrent_in_flight_trace__untouched_by_other_trace_finishing(
+    fake_backend,
+):
+    tracer = OpikTracer()
+    in_flight_run_id = uuid4()
+    # start a root run via the public callback API and never finish it
+    tracer.on_chain_start(
+        {"name": "in-flight-chain"}, {"input": "x"}, run_id=in_flight_run_id
+    )
+    in_flight_entries = {
+        name: size for name, size in _bookkeeping_sizes(tracer).items() if size > 0
+    }
+    assert in_flight_entries, "in-flight run must register bookkeeping state"
+
+    fake.FakeListLLM(responses=["ok"]).invoke(
+        "other trace", config={"callbacks": [tracer]}
+    )
+    tracer.flush()
+
+    # the finished trace is fully evicted; the in-flight one is untouched
+    assert {
+        name: size for name, size in _bookkeeping_sizes(tracer).items() if size > 0
+    } == in_flight_entries
+
+
+def test_opik_tracer__externally_created_trace__id_discarded_after_completion(
+    fake_backend,
+):
+    external_trace_data = trace_module.TraceData(name="external-trace")
+    context_storage.set_trace_data(external_trace_data)
+    tracer = OpikTracer()
+    try:
+        fake.FakeListLLM(responses=["ok"]).invoke("hi", config={"callbacks": [tracer]})
+        tracer.flush()
+    finally:
+        context_storage.pop_trace_data()
+
+    assert external_trace_data.id not in tracer._externally_created_traces_ids
+    assert _bookkeeping_sizes(tracer) == _EMPTY_BOOKKEEPING


### PR DESCRIPTION
## Details

Fixes an unbounded memory leak in the LangChain integration. `OpikTracer` only ever adds to its six per-instance bookkeeping structures (`_span_data_map`, `_created_traces_data_map`, `_created_traces`, `_externally_created_traces_ids`, `_skipped_langgraph_root_run_ids`, `_langgraph_parent_span_ids`), so a tracer built once and reused across requests (the documented pattern) retains every prompt/completion payload for the process lifetime. Full analysis, production numbers and an offline repro are in the linked issue.

The fix releases a trace's state right after its root run's final end/error callback: a `finally` hook in `_process_end_span` and `_process_end_span_with_error` for parentless runs, calling the new `_evict_finished_trace_state`. That is the earliest safe point: langchain calls `_persist_run` before that callback, and the end-span processing still needs the root run's entries to emit the final span. `_persist_run` is untouched.

- Eviction walks the finished root run's own tree (`BaseTracer` attaches every child to its parent's `child_runs`), so it removes exactly that run's entries and never scans the shared maps. Other in-flight root runs on the same tracer, including ones attached to the same externally created (distributed) trace, are untouched. The external trace id is only discarded once no remaining span references it; a narrow lock shared by the id registration sites and that check-then-discard makes the two atomic, so a concurrent root run cannot have the id discarded from under it. Child span starts stay lock-free.
- The hooks sit in `finally`, so the error path cannot leak either.
- Evicting inside `_persist_run` was tried first: it passes the chain-based tests but silently drops root span emission for direct model invocations (measured 10 invocations -> 10 traces, 0 spans). A regression test now asserts spans reach the backend, so that placement fails the suite.
- `_created_traces` is deliberately NOT evicted: `created_traces()` is documented to accumulate, existing tests and docs rely on it, and Trace objects are small handles without payloads. A long-lived tracer still accumulates one small handle per trace; whether to bound that is your design call, happy to help in a follow-up if you want it bounded.

Before/after with the repro from the issue, after 50 invocations:

```
opik 2.1.31:  _span_data_map= 100  _created_traces_data_map= 150  _created_traces=  50  _skipped_langgraph_root_run_ids=  50  _langgraph_parent_span_ids=  50  retained_payload_bytes=13123
this branch:  _span_data_map=   0  _created_traces_data_map=   0  _created_traces=  50  _skipped_langgraph_root_run_ids=   0  _langgraph_parent_span_ids=   0  retained_payload_bytes=0
```

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #7516

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Fable 5
- Scope: root-cause analysis, implementation draft and regression tests; commits authored and reviewed by the contributor
- Human verification: LangChain integration test subset run locally, before/after repro run against PyPI 2.1.31 and this branch, pre-commit hooks on the changed files, emission counts measured under both eviction placements

## Testing

Eight regression tests added to `tests/library_integration/langchain/test_opik_tracer.py`, following the existing `fake_backend` conventions: all payload-carrying state evicted after completion while traces still reach the backend with their spans and `created_traces()` accumulates, chained-run child state evicted, eviction on the error path, a concurrent in-flight trace untouched, a root run finishing on a shared external trace leaving the other in-flight root run's state intact, a deterministic registration/eviction race test (a second root run paused between registering the external id and saving its span while the first root run finishes; verified to fail when the lock is neutralized), the public `get_current_span_data_for_run` accessor returning None once the trace completes instead of stale data, an external trace id discarded.

Run locally (Python 3.10.12, langchain-core 1.4.9, offline):

- `pytest tests/library_integration/langchain/test_opik_tracer.py`: 89 passed
- wider langchain subset (`test_langchain.py`, `test_langgraph.py`, `test_langchain_thread_id.py`, `test_message_converters.py`): 32 passed, 2 failed; the same 2 fail identically on pristine `main` in this environment (no OPENAI_API_KEY, unrelated to this change)
- pre-commit hooks on the changed files (ruff, ruff-format, mypy): pass
- the issue's repro against this branch: all evictable counters stay at 0

## Documentation

No public API or parameter changes, `created_traces()` behavior unchanged. One observable difference: `get_current_span_data_for_run` returns None once the run's trace completed, where it previously kept returning the retained span data; that is the eviction working and is pinned by a regression test.
