### PR TITLE
[OPIK-7264] [BE] fix: serialize concurrent dataset version writes to prevent 500s and silent row loss

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1746,6 +1746,12 @@ datasetVersioning:
     # Description: Maximum backoff between retries. Caps the exponential growth of
     # the per-attempt delay.
     maxBackoff: ${DATASET_VERSIONING_ZERO_ROWS_RETRY_MAX_BACKOFF:-1s}
+  # Default: 60s
+  # Description: Per-dataset distributed-lock lease that serializes the
+  # read-latest -> create-version -> flip-latest sequence so parallel uploads can't race
+  # on the mutable 'latest' pointer (OPIK-7264). Raise for slower/busier deployments where
+  # the critical section may exceed the lease.
+  lockLease: ${DATASET_VERSIONING_LOCK_LEASE:-60s}
 
 # Experiment Project Migration configuration
 # Assigns project_id to orphan experiments (V1 → V2 workspace migration).

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetVersionsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/DatasetVersionsResource.java
@@ -196,7 +196,8 @@ public class DatasetVersionsResource {
     @Path("/restore")
     @Operation(operationId = "restoreDatasetVersion", summary = "Restore dataset to a previous version", description = "Restores the dataset to a previous version state by creating a new version with items copied from the specified version. If the version is already the latest, returns it as-is (no-op).", responses = {
             @ApiResponse(responseCode = "200", description = "Version restored successfully", content = @Content(schema = @Schema(implementation = DatasetVersion.class))),
-            @ApiResponse(responseCode = "404", description = "Version not found", content = @Content(schema = @Schema(implementation = io.dropwizard.jersey.errors.ErrorMessage.class)))})
+            @ApiResponse(responseCode = "404", description = "Version not found", content = @Content(schema = @Schema(implementation = io.dropwizard.jersey.errors.ErrorMessage.class))),
+            @ApiResponse(responseCode = "409", description = "Concurrent modification - the latest version changed during the restore; retry", content = @Content(schema = @Schema(implementation = io.dropwizard.jersey.errors.ErrorMessage.class)))})
     @RateLimited
     @JsonView(DatasetVersion.View.Public.class)
     public Response restoreVersion(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -152,7 +152,7 @@ public interface DatasetItemService {
 @Slf4j
 class DatasetItemServiceImpl implements DatasetItemService {
 
-    private static final String DATASET_VERSION_LOCK = "DatasetVersion";
+    private static final String DATASET_VERSION_LOCK = DatasetVersionService.DATASET_VERSION_LOCK;
 
     private final @NonNull DatasetItemDAO dao;
     private final @NonNull DatasetItemVersionDAO versionDao;
@@ -860,7 +860,12 @@ class DatasetItemServiceImpl implements DatasetItemService {
         // Route to versioned or legacy based on toggle
         if (featureFlags.isDatasetVersioningEnabled()) {
             log.info("Saving batch with versioning for dataset '{}', itemCount '{}'", datasetId, items.size());
-            return withDatasetVersionLock(datasetId, saveItemsWithVersion(batch, datasetId, null)
+            // Unlike the other callers of saveItemsWithVersion, this public overload has no prior
+            // dataset-existence read, so guard here (under the lock) to fail fast on a missing dataset.
+            return withDatasetVersionLock(datasetId, Mono.deferContextual(ctx -> {
+                datasetService.findById(datasetId, ctx.get(RequestContext.WORKSPACE_ID), null);
+                return saveItemsWithVersion(batch, datasetId, null);
+            })
                     .map(version -> (long) items.size())
                     .defaultIfEmpty((long) items.size()));
         }
@@ -1805,14 +1810,10 @@ class DatasetItemServiceImpl implements DatasetItemService {
                 log.debug("Saving items with version for dataset '{}', itemCount '{}', batchGroupId '{}'",
                         datasetId, batch.items().size(), batchGroupId);
 
-                // Fail fast on a missing/deleted dataset before burning per-item span/trace validation.
-                return Mono.defer(() -> {
-                    // Verify dataset exists
-                    datasetService.findById(datasetId, workspaceId, null);
-
-                    // Ensure dataset is migrated if lazy migration is enabled
-                    return ensureLazyMigration(datasetId, workspaceId);
-                })
+                // Ensure dataset is migrated if lazy migration is enabled. Dataset existence is already
+                // guaranteed by every caller (createFromTraces/Spans, save(), saveBatch), so no redundant
+                // findById here.
+                return ensureLazyMigration(datasetId, workspaceId)
                         // Validate span and trace workspaces before proceeding
                         .then(Mono.defer(() -> validateSpans(workspaceId, validatedItems)))
                         .then(Mono.defer(() -> validateTraces(workspaceId, validatedItems)))

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -60,6 +60,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -579,56 +580,56 @@ class DatasetItemServiceImpl implements DatasetItemService {
      */
     private Mono<Void> batchUpdateByIdsWithVersioning(UUID datasetId, DatasetItemBatchUpdate batchUpdate,
             String workspaceId, String userName) {
-        // Defer so nothing runs until the caller's withDatasetVersionLock is held (OPIK-7264).
-        return Mono.defer(() -> {
-            int updateSize = batchUpdate.ids().size();
-            log.info("Batch updating '{}' items by IDs with versioning for dataset '{}'", updateSize, datasetId);
+        int updateSize = batchUpdate.ids().size();
+        log.info("Batch updating '{}' items by IDs with versioning for dataset '{}'", updateSize, datasetId);
 
-            // Ensure dataset is migrated if lazy migration is enabled
-            return ensureLazyMigration(datasetId, workspaceId)
-                    .then(Mono.defer(() -> {
-                        // Get the latest version
-                        return getLatestVersionOrError(datasetId, workspaceId)
-                                .flatMap(latestVersion -> {
-                                    UUID baseVersionId = latestVersion.id();
-                                    UUID newVersionId = idGenerator.generateId();
+        return runVersionedBatchUpdate(datasetId, workspaceId, userName, latestVersion -> {
+            UUID baseVersionId = latestVersion.id();
+            UUID newVersionId = idGenerator.generateId();
 
-                                    // UUIDs for the updated-item INSERT...SELECT. Generated first so they
-                                    // sort before the unchanged-item UUIDs (which are generated below).
-                                    List<UUID> updateUuids = generateUuidPool(idGenerator, updateSize);
+            // UUIDs for the updated-item INSERT...SELECT. Generated first so they
+            // sort before the unchanged-item UUIDs (which are generated below).
+            List<UUID> updateUuids = generateUuidPool(idGenerator, updateSize);
 
-                                    // Perform batch update
-                                    return versionDao
-                                            .batchUpdateItems(datasetId, baseVersionId, newVersionId,
-                                                    batchUpdate,
-                                                    updateUuids)
-                                            .flatMap(updatedCount -> {
-                                                if (updatedCount == 0) {
-                                                    log.info("No items found to update for dataset '{}'", datasetId);
-                                                    return Mono.empty();
-                                                }
+            // Perform batch update
+            return versionDao
+                    .batchUpdateItems(datasetId, baseVersionId, newVersionId, batchUpdate, updateUuids)
+                    .flatMap(updatedCount -> {
+                        if (updatedCount == 0) {
+                            log.info("No items found to update for dataset '{}'", datasetId);
+                            return Mono.empty();
+                        }
 
-                                                log.info(
-                                                        "Batch updated '{}' items by IDs for dataset '{}', baseVersion='{}'",
-                                                        updatedCount, datasetId, baseVersionId);
+                        log.info("Batch updated '{}' items by IDs for dataset '{}', baseVersion='{}'",
+                                updatedCount, datasetId, baseVersionId);
 
-                                                // OPIK-6390: pass the just-updated IDs as the "deleted" slot of
-                                                // applyDelta so they're excluded from the unchanged-items copy.
-                                                // The helper sizes the UUID pool from a live ClickHouse count.
-                                                return applyEditDeleteWithLiveCount(datasetId, baseVersionId,
-                                                        newVersionId, List.of(), batchUpdate.ids(), workspaceId)
-                                                        .flatMap(unchangedCount -> createVersionMetadata(
-                                                                datasetId, newVersionId, baseVersionId,
-                                                                updatedCount, unchangedCount, false,
-                                                                workspaceId, userName));
-                                            });
-                                });
-                    }))
-                    .contextWrite(ctx -> ctx
-                            .put(RequestContext.WORKSPACE_ID, workspaceId)
-                            .put(RequestContext.USER_NAME, userName))
-                    .then();
+                        // OPIK-6390: pass the just-updated IDs as the "deleted" slot of
+                        // applyDelta so they're excluded from the unchanged-items copy.
+                        // The helper sizes the UUID pool from a live ClickHouse count.
+                        return applyEditDeleteWithLiveCount(datasetId, baseVersionId,
+                                newVersionId, List.of(), batchUpdate.ids(), workspaceId)
+                                .flatMap(unchangedCount -> createVersionMetadata(
+                                        datasetId, newVersionId, baseVersionId,
+                                        updatedCount, unchangedCount, false,
+                                        workspaceId, userName));
+                    });
         });
+    }
+
+    /**
+     * Shared scaffold for the versioned batch-update paths: defers so nothing runs until the caller's
+     * per-dataset lock is held (OPIK-7264), ensures lazy migration, reads the latest version, and runs
+     * {@code body} against it under the request context. Only the path-specific work (by-ids vs
+     * by-filters) differs and is supplied as {@code body}.
+     */
+    private Mono<Void> runVersionedBatchUpdate(UUID datasetId, String workspaceId, String userName,
+            Function<DatasetVersion, Mono<Void>> body) {
+        return Mono.defer(() -> ensureLazyMigration(datasetId, workspaceId)
+                .then(Mono.defer(() -> getLatestVersionOrError(datasetId, workspaceId).flatMap(body)))
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.WORKSPACE_ID, workspaceId)
+                        .put(RequestContext.USER_NAME, userName))
+                .then());
     }
 
     /**
@@ -636,82 +637,66 @@ class DatasetItemServiceImpl implements DatasetItemService {
      */
     private Mono<Void> batchUpdateByFiltersWithVersioning(UUID datasetId, DatasetItemBatchUpdate batchUpdate,
             String workspaceId, String userName) {
-        // Defer so nothing runs until the caller's withDatasetVersionLock is held (OPIK-7264).
-        return Mono.defer(() -> {
-            log.info("Batch updating items by filters with versioning for dataset '{}'", datasetId);
+        log.info("Batch updating items by filters with versioning for dataset '{}'", datasetId);
 
-            // Ensure dataset is migrated if lazy migration is enabled
-            return ensureLazyMigration(datasetId, workspaceId)
-                    .then(Mono.defer(() -> {
-                        // Get the latest version
-                        return getLatestVersionOrError(datasetId, workspaceId)
-                                .flatMap(latestVersion -> {
-                                    UUID baseVersionId = latestVersion.id();
-                                    UUID newVersionId = idGenerator.generateId();
+        return runVersionedBatchUpdate(datasetId, workspaceId, userName, latestVersion -> {
+            UUID baseVersionId = latestVersion.id();
+            UUID newVersionId = idGenerator.generateId();
 
-                                    // OPIK-6390: size both UUID pools from a live ClickHouse count of the
-                                    // base version rather than the (drift-prone) MySQL items_total. The
-                                    // exact base count is an upper bound on both the matching (update)
-                                    // and non-matching (copy) row counts, so no headroom multiplier is
-                                    // needed; the defensive arrayElement fallback in COPY_VERSION_ITEMS
-                                    // covers any residual mismatch without data loss.
+            // OPIK-6390: size both UUID pools from a live ClickHouse count of the
+            // base version rather than the (drift-prone) MySQL items_total. The
+            // exact base count is an upper bound on both the matching (update)
+            // and non-matching (copy) row counts, so no headroom multiplier is
+            // needed; the defensive arrayElement fallback in COPY_VERSION_ITEMS
+            // covers any residual mismatch without data loss.
+            return versionDao
+                    .countRowsInVersion(datasetId, baseVersionId, Set.of(), null, workspaceId)
+                    .flatMap(baseRowCount -> {
+                        int poolSize = baseRowCount.intValue();
+                        List<UUID> updateUuids = generateUuidPool(idGenerator, poolSize);
+                        // Select-all (empty filters) copies no unchanged rows, so skip the
+                        // copy pool allocation for it.
+                        boolean selectAll = batchUpdate.filters() != null && batchUpdate.filters().isEmpty();
+                        List<UUID> copyUuids = selectAll ? List.of() : generateUuidPool(idGenerator, poolSize);
+
+                        log.debug(
+                                "Generated separate UUID pools for filter-based update: updateSize='{}', copySize='{}'",
+                                updateUuids.size(), copyUuids.size());
+
+                        // Perform batch update
+                        return versionDao
+                                .batchUpdateItems(datasetId, baseVersionId, newVersionId, batchUpdate, updateUuids)
+                                .flatMap(updatedCount -> {
+                                    if (updatedCount == 0) {
+                                        log.info("No items found to update for dataset '{}'", datasetId);
+                                        return Mono.empty();
+                                    }
+
+                                    log.info("Batch updated '{}' items by filters for dataset '{}', baseVersion='{}'",
+                                            updatedCount, datasetId, baseVersionId);
+
+                                    // Copy unchanged items (those NOT matching the filters)
+                                    // Special case: empty filters list means "select all" - no unchanged items to copy
+                                    if (selectAll) {
+                                        // Empty filters means all items were updated - nothing to copy
+                                        log.info("Empty filters (select all) - skipping copy of unchanged items");
+                                        return createVersionMetadata(
+                                                datasetId, newVersionId, baseVersionId,
+                                                updatedCount, 0L, true,
+                                                workspaceId, userName);
+                                    }
+
+                                    // Copy unchanged items using copyVersionItems (exclude matching filters)
                                     return versionDao
-                                            .countRowsInVersion(datasetId, baseVersionId, Set.of(), null, workspaceId)
-                                            .flatMap(baseRowCount -> {
-                                                int poolSize = baseRowCount.intValue();
-                                                List<UUID> updateUuids = generateUuidPool(idGenerator, poolSize);
-                                                List<UUID> copyUuids = generateUuidPool(idGenerator, poolSize);
-
-                                                log.debug(
-                                                        "Generated separate UUID pools for filter-based update: updateSize='{}', copySize='{}'",
-                                                        updateUuids.size(), copyUuids.size());
-
-                                                // Perform batch update
-                                                return versionDao
-                                                        .batchUpdateItems(datasetId, baseVersionId, newVersionId,
-                                                                batchUpdate,
-                                                                updateUuids)
-                                                        .flatMap(updatedCount -> {
-                                                            if (updatedCount == 0) {
-                                                                log.info("No items found to update for dataset '{}'",
-                                                                        datasetId);
-                                                                return Mono.empty();
-                                                            }
-
-                                                            log.info(
-                                                                    "Batch updated '{}' items by filters for dataset '{}', baseVersion='{}'",
-                                                                    updatedCount, datasetId, baseVersionId);
-
-                                                            // Copy unchanged items (those NOT matching the filters)
-                                                            // Special case: empty filters list means "select all" - no unchanged items to copy
-                                                            if (batchUpdate.filters() != null
-                                                                    && batchUpdate.filters().isEmpty()) {
-                                                                // Empty filters means all items were updated - nothing to copy
-                                                                log.info(
-                                                                        "Empty filters (select all) - skipping copy of unchanged items");
-                                                                return createVersionMetadata(
-                                                                        datasetId, newVersionId, baseVersionId,
-                                                                        updatedCount, 0L, true,
-                                                                        workspaceId, userName);
-                                                            }
-
-                                                            // Copy unchanged items using copyVersionItems (exclude matching filters)
-                                                            return versionDao
-                                                                    .copyVersionItems(datasetId, baseVersionId,
-                                                                            datasetId, newVersionId,
-                                                                            batchUpdate.filters(), copyUuids)
-                                                                    .flatMap(unchangedCount -> createVersionMetadata(
-                                                                            datasetId, newVersionId, baseVersionId,
-                                                                            updatedCount, unchangedCount, true,
-                                                                            workspaceId, userName));
-                                                        });
-                                            });
+                                            .copyVersionItems(datasetId, baseVersionId,
+                                                    datasetId, newVersionId,
+                                                    batchUpdate.filters(), copyUuids)
+                                            .flatMap(unchangedCount -> createVersionMetadata(
+                                                    datasetId, newVersionId, baseVersionId,
+                                                    updatedCount, unchangedCount, true,
+                                                    workspaceId, userName));
                                 });
-                    }))
-                    .contextWrite(ctx -> ctx
-                            .put(RequestContext.WORKSPACE_ID, workspaceId)
-                            .put(RequestContext.USER_NAME, userName))
-                    .then();
+                    });
         });
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -39,6 +39,7 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -170,12 +171,15 @@ class DatasetItemServiceImpl implements DatasetItemService {
     private final @NonNull @Config OpikConfiguration config;
     private final @NonNull LockService lockService;
 
+    // Computed once from the (immutable at runtime) config instead of per lock acquisition.
+    @Getter(lazy = true)
+    private final Duration datasetVersionLockLease = config.getDatasetVersioning().lockLease().toJavaDuration();
+
     // Serialize the read-latest -> create-version -> flip-latest sequence per dataset so parallel
     // uploads can't race on the dataset's mutable 'latest' pointer (OPIK-7264).
     private <T> Mono<T> withDatasetVersionLock(UUID datasetId, Mono<T> action) {
-        Duration lockLease = config.getDatasetVersioning().lockLease().toJavaDuration();
         return lockService.executeWithLockCustomExpire(
-                new LockService.Lock(datasetId, DATASET_VERSION_LOCK), action, lockLease);
+                new LockService.Lock(datasetId, DATASET_VERSION_LOCK), action, getDatasetVersionLockLease());
     }
 
     @WithSpan
@@ -1798,19 +1802,20 @@ class DatasetItemServiceImpl implements DatasetItemService {
                 String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
                 String userName = ctx.get(RequestContext.USER_NAME);
 
-                log.info("Saving items with version for dataset '{}', itemCount '{}', batchGroupId '{}'",
+                log.debug("Saving items with version for dataset '{}', itemCount '{}', batchGroupId '{}'",
                         datasetId, batch.items().size(), batchGroupId);
 
-                // Validate span and trace workspaces before proceeding
-                return validateSpans(workspaceId, validatedItems)
-                        .then(Mono.defer(() -> validateTraces(workspaceId, validatedItems)))
-                        .then(Mono.defer(() -> {
-                            // Verify dataset exists
-                            datasetService.findById(datasetId, workspaceId, null);
+                // Fail fast on a missing/deleted dataset before burning per-item span/trace validation.
+                return Mono.defer(() -> {
+                    // Verify dataset exists
+                    datasetService.findById(datasetId, workspaceId, null);
 
-                            // Ensure dataset is migrated if lazy migration is enabled
-                            return ensureLazyMigration(datasetId, workspaceId);
-                        }))
+                    // Ensure dataset is migrated if lazy migration is enabled
+                    return ensureLazyMigration(datasetId, workspaceId);
+                })
+                        // Validate span and trace workspaces before proceeding
+                        .then(Mono.defer(() -> validateSpans(workspaceId, validatedItems)))
+                        .then(Mono.defer(() -> validateTraces(workspaceId, validatedItems)))
                         .then(Mono.defer(() -> {
 
                             // Get the latest version (if exists) - using overload that takes workspaceId

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -581,7 +581,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
     private Mono<Void> batchUpdateByIdsWithVersioning(UUID datasetId, DatasetItemBatchUpdate batchUpdate,
             String workspaceId, String userName) {
         int updateSize = batchUpdate.ids().size();
-        log.info("Batch updating '{}' items by IDs with versioning for dataset '{}'", updateSize, datasetId);
+        log.info("Batch updating items by IDs with versioning for dataset '{}' (count='{}')", datasetId, updateSize);
 
         return runVersionedBatchUpdate(datasetId, workspaceId, userName, latestVersion -> {
             UUID baseVersionId = latestVersion.id();
@@ -600,8 +600,8 @@ class DatasetItemServiceImpl implements DatasetItemService {
                             return Mono.empty();
                         }
 
-                        log.info("Batch updated '{}' items by IDs for dataset '{}', baseVersion='{}'",
-                                updatedCount, datasetId, baseVersionId);
+                        log.info("Batch updated items by IDs for dataset '{}' (count='{}', baseVersion='{}')",
+                                datasetId, updatedCount, baseVersionId);
 
                         // OPIK-6390: pass the just-updated IDs as the "deleted" slot of
                         // applyDelta so they're excluded from the unchanged-items copy.
@@ -672,8 +672,9 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                         return Mono.empty();
                                     }
 
-                                    log.info("Batch updated '{}' items by filters for dataset '{}', baseVersion='{}'",
-                                            updatedCount, datasetId, baseVersionId);
+                                    log.info(
+                                            "Batch updated items by filters for dataset '{}' (count='{}', baseVersion='{}')",
+                                            datasetId, updatedCount, baseVersionId);
 
                                     // Copy unchanged items (those NOT matching the filters)
                                     // Special case: empty filters list means "select all" - no unchanged items to copy

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -39,7 +39,6 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
-import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -171,15 +170,12 @@ class DatasetItemServiceImpl implements DatasetItemService {
     private final @NonNull @Config OpikConfiguration config;
     private final @NonNull LockService lockService;
 
-    // Computed once from the (immutable at runtime) config instead of per lock acquisition.
-    @Getter(lazy = true)
-    private final Duration datasetVersionLockLease = config.getDatasetVersioning().lockLease().toJavaDuration();
-
     // Serialize the read-latest -> create-version -> flip-latest sequence per dataset so parallel
     // uploads can't race on the dataset's mutable 'latest' pointer (OPIK-7264).
     private <T> Mono<T> withDatasetVersionLock(UUID datasetId, Mono<T> action) {
+        Duration lockLease = config.getDatasetVersioning().lockLease().toJavaDuration();
         return lockService.executeWithLockCustomExpire(
-                new LockService.Lock(datasetId, DATASET_VERSION_LOCK), action, getDatasetVersionLockLease());
+                new LockService.Lock(datasetId, DATASET_VERSION_LOCK), action, lockLease);
     }
 
     @WithSpan
@@ -583,54 +579,56 @@ class DatasetItemServiceImpl implements DatasetItemService {
      */
     private Mono<Void> batchUpdateByIdsWithVersioning(UUID datasetId, DatasetItemBatchUpdate batchUpdate,
             String workspaceId, String userName) {
+        // Defer so nothing runs until the caller's withDatasetVersionLock is held (OPIK-7264).
+        return Mono.defer(() -> {
+            int updateSize = batchUpdate.ids().size();
+            log.info("Batch updating '{}' items by IDs with versioning for dataset '{}'", updateSize, datasetId);
 
-        int updateSize = batchUpdate.ids().size();
-        log.info("Batch updating '{}' items by IDs with versioning for dataset '{}'", updateSize, datasetId);
+            // Ensure dataset is migrated if lazy migration is enabled
+            return ensureLazyMigration(datasetId, workspaceId)
+                    .then(Mono.defer(() -> {
+                        // Get the latest version
+                        return getLatestVersionOrError(datasetId, workspaceId)
+                                .flatMap(latestVersion -> {
+                                    UUID baseVersionId = latestVersion.id();
+                                    UUID newVersionId = idGenerator.generateId();
 
-        // Ensure dataset is migrated if lazy migration is enabled
-        return ensureLazyMigration(datasetId, workspaceId)
-                .then(Mono.defer(() -> {
-                    // Get the latest version
-                    return getLatestVersionOrError(datasetId, workspaceId)
-                            .flatMap(latestVersion -> {
-                                UUID baseVersionId = latestVersion.id();
-                                UUID newVersionId = idGenerator.generateId();
+                                    // UUIDs for the updated-item INSERT...SELECT. Generated first so they
+                                    // sort before the unchanged-item UUIDs (which are generated below).
+                                    List<UUID> updateUuids = generateUuidPool(idGenerator, updateSize);
 
-                                // UUIDs for the updated-item INSERT...SELECT. Generated first so they
-                                // sort before the unchanged-item UUIDs (which are generated below).
-                                List<UUID> updateUuids = generateUuidPool(idGenerator, updateSize);
+                                    // Perform batch update
+                                    return versionDao
+                                            .batchUpdateItems(datasetId, baseVersionId, newVersionId,
+                                                    batchUpdate,
+                                                    updateUuids)
+                                            .flatMap(updatedCount -> {
+                                                if (updatedCount == 0) {
+                                                    log.info("No items found to update for dataset '{}'", datasetId);
+                                                    return Mono.empty();
+                                                }
 
-                                // Perform batch update
-                                return versionDao
-                                        .batchUpdateItems(datasetId, baseVersionId, newVersionId,
-                                                batchUpdate,
-                                                updateUuids)
-                                        .flatMap(updatedCount -> {
-                                            if (updatedCount == 0) {
-                                                log.info("No items found to update for dataset '{}'", datasetId);
-                                                return Mono.empty();
-                                            }
+                                                log.info(
+                                                        "Batch updated '{}' items by IDs for dataset '{}', baseVersion='{}'",
+                                                        updatedCount, datasetId, baseVersionId);
 
-                                            log.info(
-                                                    "Batch updated '{}' items by IDs for dataset '{}', baseVersion='{}'",
-                                                    updatedCount, datasetId, baseVersionId);
-
-                                            // OPIK-6390: pass the just-updated IDs as the "deleted" slot of
-                                            // applyDelta so they're excluded from the unchanged-items copy.
-                                            // The helper sizes the UUID pool from a live ClickHouse count.
-                                            return applyEditDeleteWithLiveCount(datasetId, baseVersionId,
-                                                    newVersionId, List.of(), batchUpdate.ids(), workspaceId)
-                                                    .flatMap(unchangedCount -> createVersionMetadata(
-                                                            datasetId, newVersionId, baseVersionId,
-                                                            updatedCount, unchangedCount, false,
-                                                            workspaceId, userName));
-                                        });
-                            });
-                }))
-                .contextWrite(ctx -> ctx
-                        .put(RequestContext.WORKSPACE_ID, workspaceId)
-                        .put(RequestContext.USER_NAME, userName))
-                .then();
+                                                // OPIK-6390: pass the just-updated IDs as the "deleted" slot of
+                                                // applyDelta so they're excluded from the unchanged-items copy.
+                                                // The helper sizes the UUID pool from a live ClickHouse count.
+                                                return applyEditDeleteWithLiveCount(datasetId, baseVersionId,
+                                                        newVersionId, List.of(), batchUpdate.ids(), workspaceId)
+                                                        .flatMap(unchangedCount -> createVersionMetadata(
+                                                                datasetId, newVersionId, baseVersionId,
+                                                                updatedCount, unchangedCount, false,
+                                                                workspaceId, userName));
+                                            });
+                                });
+                    }))
+                    .contextWrite(ctx -> ctx
+                            .put(RequestContext.WORKSPACE_ID, workspaceId)
+                            .put(RequestContext.USER_NAME, userName))
+                    .then();
+        });
     }
 
     /**
@@ -638,81 +636,83 @@ class DatasetItemServiceImpl implements DatasetItemService {
      */
     private Mono<Void> batchUpdateByFiltersWithVersioning(UUID datasetId, DatasetItemBatchUpdate batchUpdate,
             String workspaceId, String userName) {
+        // Defer so nothing runs until the caller's withDatasetVersionLock is held (OPIK-7264).
+        return Mono.defer(() -> {
+            log.info("Batch updating items by filters with versioning for dataset '{}'", datasetId);
 
-        log.info("Batch updating items by filters with versioning for dataset '{}'", datasetId);
+            // Ensure dataset is migrated if lazy migration is enabled
+            return ensureLazyMigration(datasetId, workspaceId)
+                    .then(Mono.defer(() -> {
+                        // Get the latest version
+                        return getLatestVersionOrError(datasetId, workspaceId)
+                                .flatMap(latestVersion -> {
+                                    UUID baseVersionId = latestVersion.id();
+                                    UUID newVersionId = idGenerator.generateId();
 
-        // Ensure dataset is migrated if lazy migration is enabled
-        return ensureLazyMigration(datasetId, workspaceId)
-                .then(Mono.defer(() -> {
-                    // Get the latest version
-                    return getLatestVersionOrError(datasetId, workspaceId)
-                            .flatMap(latestVersion -> {
-                                UUID baseVersionId = latestVersion.id();
-                                UUID newVersionId = idGenerator.generateId();
+                                    // OPIK-6390: size both UUID pools from a live ClickHouse count of the
+                                    // base version rather than the (drift-prone) MySQL items_total. The
+                                    // exact base count is an upper bound on both the matching (update)
+                                    // and non-matching (copy) row counts, so no headroom multiplier is
+                                    // needed; the defensive arrayElement fallback in COPY_VERSION_ITEMS
+                                    // covers any residual mismatch without data loss.
+                                    return versionDao
+                                            .countRowsInVersion(datasetId, baseVersionId, Set.of(), null, workspaceId)
+                                            .flatMap(baseRowCount -> {
+                                                int poolSize = baseRowCount.intValue();
+                                                List<UUID> updateUuids = generateUuidPool(idGenerator, poolSize);
+                                                List<UUID> copyUuids = generateUuidPool(idGenerator, poolSize);
 
-                                // OPIK-6390: size both UUID pools from a live ClickHouse count of the
-                                // base version rather than the (drift-prone) MySQL items_total. The
-                                // exact base count is an upper bound on both the matching (update)
-                                // and non-matching (copy) row counts, so no headroom multiplier is
-                                // needed; the defensive arrayElement fallback in COPY_VERSION_ITEMS
-                                // covers any residual mismatch without data loss.
-                                return versionDao
-                                        .countRowsInVersion(datasetId, baseVersionId, Set.of(), null, workspaceId)
-                                        .flatMap(baseRowCount -> {
-                                            int poolSize = baseRowCount.intValue();
-                                            List<UUID> updateUuids = generateUuidPool(idGenerator, poolSize);
-                                            List<UUID> copyUuids = generateUuidPool(idGenerator, poolSize);
+                                                log.debug(
+                                                        "Generated separate UUID pools for filter-based update: updateSize='{}', copySize='{}'",
+                                                        updateUuids.size(), copyUuids.size());
 
-                                            log.debug(
-                                                    "Generated separate UUID pools for filter-based update: updateSize='{}', copySize='{}'",
-                                                    updateUuids.size(), copyUuids.size());
+                                                // Perform batch update
+                                                return versionDao
+                                                        .batchUpdateItems(datasetId, baseVersionId, newVersionId,
+                                                                batchUpdate,
+                                                                updateUuids)
+                                                        .flatMap(updatedCount -> {
+                                                            if (updatedCount == 0) {
+                                                                log.info("No items found to update for dataset '{}'",
+                                                                        datasetId);
+                                                                return Mono.empty();
+                                                            }
 
-                                            // Perform batch update
-                                            return versionDao
-                                                    .batchUpdateItems(datasetId, baseVersionId, newVersionId,
-                                                            batchUpdate,
-                                                            updateUuids)
-                                                    .flatMap(updatedCount -> {
-                                                        if (updatedCount == 0) {
-                                                            log.info("No items found to update for dataset '{}'",
-                                                                    datasetId);
-                                                            return Mono.empty();
-                                                        }
-
-                                                        log.info(
-                                                                "Batch updated '{}' items by filters for dataset '{}', baseVersion='{}'",
-                                                                updatedCount, datasetId, baseVersionId);
-
-                                                        // Copy unchanged items (those NOT matching the filters)
-                                                        // Special case: empty filters list means "select all" - no unchanged items to copy
-                                                        if (batchUpdate.filters() != null
-                                                                && batchUpdate.filters().isEmpty()) {
-                                                            // Empty filters means all items were updated - nothing to copy
                                                             log.info(
-                                                                    "Empty filters (select all) - skipping copy of unchanged items");
-                                                            return createVersionMetadata(
-                                                                    datasetId, newVersionId, baseVersionId,
-                                                                    updatedCount, 0L, true,
-                                                                    workspaceId, userName);
-                                                        }
+                                                                    "Batch updated '{}' items by filters for dataset '{}', baseVersion='{}'",
+                                                                    updatedCount, datasetId, baseVersionId);
 
-                                                        // Copy unchanged items using copyVersionItems (exclude matching filters)
-                                                        return versionDao
-                                                                .copyVersionItems(datasetId, baseVersionId,
-                                                                        datasetId, newVersionId,
-                                                                        batchUpdate.filters(), copyUuids)
-                                                                .flatMap(unchangedCount -> createVersionMetadata(
+                                                            // Copy unchanged items (those NOT matching the filters)
+                                                            // Special case: empty filters list means "select all" - no unchanged items to copy
+                                                            if (batchUpdate.filters() != null
+                                                                    && batchUpdate.filters().isEmpty()) {
+                                                                // Empty filters means all items were updated - nothing to copy
+                                                                log.info(
+                                                                        "Empty filters (select all) - skipping copy of unchanged items");
+                                                                return createVersionMetadata(
                                                                         datasetId, newVersionId, baseVersionId,
-                                                                        updatedCount, unchangedCount, true,
-                                                                        workspaceId, userName));
-                                                    });
-                                        });
-                            });
-                }))
-                .contextWrite(ctx -> ctx
-                        .put(RequestContext.WORKSPACE_ID, workspaceId)
-                        .put(RequestContext.USER_NAME, userName))
-                .then();
+                                                                        updatedCount, 0L, true,
+                                                                        workspaceId, userName);
+                                                            }
+
+                                                            // Copy unchanged items using copyVersionItems (exclude matching filters)
+                                                            return versionDao
+                                                                    .copyVersionItems(datasetId, baseVersionId,
+                                                                            datasetId, newVersionId,
+                                                                            batchUpdate.filters(), copyUuids)
+                                                                    .flatMap(unchangedCount -> createVersionMetadata(
+                                                                            datasetId, newVersionId, baseVersionId,
+                                                                            updatedCount, unchangedCount, true,
+                                                                            workspaceId, userName));
+                                                        });
+                                            });
+                                });
+                    }))
+                    .contextWrite(ctx -> ctx
+                            .put(RequestContext.WORKSPACE_ID, workspaceId)
+                            .put(RequestContext.USER_NAME, userName))
+                    .then();
+        });
     }
 
     /**
@@ -992,18 +992,21 @@ class DatasetItemServiceImpl implements DatasetItemService {
      */
     private Mono<Void> deleteItemsWithVersion(Set<UUID> ids, UUID datasetId, List<DatasetItemFilter> filters,
             String workspaceId, String userName, UUID batchGroupId) {
-        // Case 1: Deleting by item IDs
-        if (CollectionUtils.isNotEmpty(ids)) {
-            return deleteByItemIdsWithVersion(ids, datasetId, workspaceId, userName, batchGroupId);
-        }
+        // Defer so nothing runs until the caller's withDatasetVersionLock is held (OPIK-7264).
+        return Mono.defer(() -> {
+            // Case 1: Deleting by item IDs
+            if (CollectionUtils.isNotEmpty(ids)) {
+                return deleteByItemIdsWithVersion(ids, datasetId, workspaceId, userName, batchGroupId);
+            }
 
-        // Case 2: Deleting by datasetId with filters
-        if (datasetId != null) {
-            return deleteByDatasetIdWithVersion(datasetId, filters, workspaceId, userName, batchGroupId);
-        }
+            // Case 2: Deleting by datasetId with filters
+            if (datasetId != null) {
+                return deleteByDatasetIdWithVersion(datasetId, filters, workspaceId, userName, batchGroupId);
+            }
 
-        // No valid input
-        return Mono.empty();
+            // No valid input
+            return Mono.empty();
+        });
     }
 
     /**
@@ -2280,21 +2283,24 @@ class DatasetItemServiceImpl implements DatasetItemService {
      */
     private Mono<Void> handleGroupedDeletion(UUID batchGroupId, Set<UUID> ids, UUID datasetId,
             List<DatasetItemFilter> filters, String workspaceId, String userName) {
+        // Defer so nothing runs until the caller's withDatasetVersionLock is held (OPIK-7264).
+        return Mono.defer(() -> {
+            // For filter-based deletions, ids is null - skip mapping and proceed directly
+            if (ids == null) {
+                return proceedWithGroupedDeletion(batchGroupId, Set.of(), datasetId, filters, workspaceId, userName);
+            }
 
-        // For filter-based deletions, ids is null - skip mapping and proceed directly
-        if (ids == null) {
-            return proceedWithGroupedDeletion(batchGroupId, Set.of(), datasetId, filters, workspaceId, userName);
-        }
+            if (datasetId != null) {
+                return proceedWithGroupedDeletion(batchGroupId, ids, datasetId, filters, workspaceId, userName);
+            }
 
-        if (datasetId != null) {
-            return proceedWithGroupedDeletion(batchGroupId, ids, datasetId, filters, workspaceId, userName);
-        }
-
-        return resolveDatasetIdFromItemIds(ids)
-                .flatMap(resolvedId -> {
-                    log.info("Resolved dataset '{}' for batch_group_id '{}'", resolvedId, batchGroupId);
-                    return proceedWithGroupedDeletion(batchGroupId, ids, resolvedId, filters, workspaceId, userName);
-                });
+            return resolveDatasetIdFromItemIds(ids)
+                    .flatMap(resolvedId -> {
+                        log.info("Resolved dataset '{}' for batch_group_id '{}'", resolvedId, batchGroupId);
+                        return proceedWithGroupedDeletion(batchGroupId, ids, resolvedId, filters, workspaceId,
+                                userName);
+                    });
+        });
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -152,7 +152,6 @@ public interface DatasetItemService {
 class DatasetItemServiceImpl implements DatasetItemService {
 
     private static final String DATASET_VERSION_LOCK = "DatasetVersion";
-    private static final Duration LOCK_DURATION = Duration.ofSeconds(60);
 
     private final @NonNull DatasetItemDAO dao;
     private final @NonNull DatasetItemVersionDAO versionDao;
@@ -174,8 +173,9 @@ class DatasetItemServiceImpl implements DatasetItemService {
     // Serialize the read-latest -> create-version -> flip-latest sequence per dataset so parallel
     // uploads can't race on the dataset's mutable 'latest' pointer (OPIK-7264).
     private <T> Mono<T> withDatasetVersionLock(UUID datasetId, Mono<T> action) {
+        Duration lockLease = config.getDatasetVersioning().lockLease().toJavaDuration();
         return lockService.executeWithLockCustomExpire(
-                new LockService.Lock(datasetId, DATASET_VERSION_LOCK), action, LOCK_DURATION);
+                new LockService.Lock(datasetId, DATASET_VERSION_LOCK), action, lockLease);
     }
 
     @WithSpan
@@ -436,7 +436,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                     return ensureLazyMigration(datasetId, workspaceId)
                             .thenReturn(datasetId);
                 })
-                .flatMap(datasetId -> {
+                .flatMap(datasetId -> withDatasetVersionLock(datasetId, Mono.defer(() -> {
                     // Get the latest version (using overload that takes workspaceId)
                     Optional<DatasetVersion> latestVersion = versionService.getLatestVersion(datasetId, workspaceId);
 
@@ -490,7 +490,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                                     .thenReturn(itemsTotal);
                                         });
                             });
-                });
+                })));
     }
 
     /**
@@ -985,7 +985,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
             String workspaceId, String userName, UUID batchGroupId) {
         // Case 1: Deleting by item IDs
         if (CollectionUtils.isNotEmpty(ids)) {
-            return deleteByItemIdsWithVersion(ids, workspaceId, userName, batchGroupId);
+            return deleteByItemIdsWithVersion(ids, datasetId, workspaceId, userName, batchGroupId);
         }
 
         // Case 2: Deleting by datasetId with filters
@@ -1011,11 +1011,15 @@ class DatasetItemServiceImpl implements DatasetItemService {
                 "Deleting items by datasetId '{}' with versioning, filtersSize='{}', batchGroupId='{}', createVersion='{}'",
                 datasetId, filters != null ? filters.size() : 0, batchGroupId, createVersion);
 
-        // Verify dataset exists
-        datasetService.findById(datasetId, workspaceId, null);
+        // Defer the dataset-existence read and everything after it so this runs under the caller's
+        // per-dataset lock rather than at assembly time (OPIK-7264).
+        return Mono.defer(() -> {
+            // Verify dataset exists
+            datasetService.findById(datasetId, workspaceId, null);
 
-        // Ensure dataset is migrated if lazy migration is enabled
-        return ensureLazyMigration(datasetId, workspaceId)
+            // Ensure dataset is migrated if lazy migration is enabled
+            return ensureLazyMigration(datasetId, workspaceId);
+        })
                 .then(Mono.defer(() -> {
                     // Get the latest version (using overload that takes workspaceId)
                     Optional<DatasetVersion> latestVersion = versionService.getLatestVersion(datasetId, workspaceId);
@@ -1100,14 +1104,20 @@ class DatasetItemServiceImpl implements DatasetItemService {
     /**
      * Deletes items by item IDs, creating a new version or mutating the latest version.
      */
-    private Mono<Void> deleteByItemIdsWithVersion(Set<UUID> ids, String workspaceId, String userName,
-            UUID batchGroupId) {
+    private Mono<Void> deleteByItemIdsWithVersion(Set<UUID> ids, UUID resolvedDatasetId, String workspaceId,
+            String userName, UUID batchGroupId) {
         // Derive createVersion from batchGroupId: null means mutate latest, non-null means create new
         boolean createVersion = batchGroupId != null;
         log.info("Deleting '{}' items by IDs with versioning, batchGroupId='{}', createVersion='{}'",
                 ids.size(), batchGroupId, createVersion);
 
-        return resolveDatasetIdFromItemIds(ids)
+        // Reuse the datasetId the caller already resolved (for the lock) instead of resolving from
+        // ClickHouse a second time; only resolve here when the caller didn't have one.
+        Mono<UUID> datasetIdMono = resolvedDatasetId != null
+                ? Mono.just(resolvedDatasetId)
+                : resolveDatasetIdFromItemIds(ids);
+
+        return datasetIdMono
                 .flatMap(datasetId -> {
                     log.info("Resolved dataset '{}' for deletion request with '{}' item IDs", datasetId, ids.size());
                     return deleteByDatasetItemIdsInDataset(ids, datasetId, workspaceId, userName,
@@ -1384,7 +1394,11 @@ class DatasetItemServiceImpl implements DatasetItemService {
     public Mono<DatasetVersion> applyDeltaChanges(@NonNull UUID datasetId,
             @NonNull DatasetItemChanges changes, boolean override) {
 
-        return Mono.deferContextual(ctx -> {
+        // Serialize under the per-dataset lock like every other version-creating path so the
+        // is-latest check and the 'latest' flip are atomic. Without it, the check-then-act at
+        // isLatestVersion(...) below is a TOCTOU: a concurrent writer can move 'latest' between the
+        // check and the flip, reopening the OPIK-7264 lost-update on this endpoint (OPIK-7383).
+        return withDatasetVersionLock(datasetId, Mono.deferContextual(ctx -> {
             String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
             String userName = ctx.get(RequestContext.USER_NAME);
 
@@ -1428,6 +1442,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                             changes.tags(), changes.changeDescription(),
                             changes.evaluators(), changes.executionPolicy(),
                             Boolean.TRUE.equals(changes.clearExecutionPolicy()),
+                            // First version (baseVersionId == null): no prior 'latest' to CAS against.
                             null, false, workspaceId, userName);
                     log.info("Created first version '{}' for dataset '{}' with hash '{}'",
                             version.id(), datasetId, version.versionHash());
@@ -1541,12 +1556,14 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                             changes.executionPolicy(),
                                             Boolean.TRUE.equals(changes.clearExecutionPolicy()),
                                             null, // No batch group ID
-                                            false, // applyDeltaChanges manages its own conflict/override check
+                                            // CAS the 'latest' flip against baseVersionId unless override=true,
+                                            // which intentionally branches off a possibly-non-latest base.
+                                            !override,
                                             workspaceId,
                                             userName);
                                 });
                     });
-        });
+        }));
     }
 
     /**
@@ -1766,50 +1783,54 @@ class DatasetItemServiceImpl implements DatasetItemService {
      * the batch_group_id with the created version.
      */
     private Mono<DatasetVersion> saveItemsWithVersion(DatasetItemBatch batch, UUID datasetId, UUID batchGroupId) {
-        if (batch.items() == null || batch.items().isEmpty()) {
-            log.debug("Empty batch, skipping version creation for dataset '{}'", datasetId);
-            return Mono.empty();
-        }
+        // Defer everything so callers can wrap this in withDatasetVersionLock and be guaranteed that
+        // no work (not even the item validation below) runs until the lock is acquired (OPIK-7264).
+        return Mono.defer(() -> {
+            if (batch.items() == null || batch.items().isEmpty()) {
+                log.debug("Empty batch, skipping version creation for dataset '{}'", datasetId);
+                return Mono.empty();
+            }
 
-        // Validate UUID versions and add IDs if absent
-        List<DatasetItem> validatedItems = addIdIfAbsent(batch);
+            // Validate UUID versions and add IDs if absent
+            List<DatasetItem> validatedItems = addIdIfAbsent(batch);
 
-        return Mono.deferContextual(ctx -> {
-            String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
-            String userName = ctx.get(RequestContext.USER_NAME);
+            return Mono.deferContextual(ctx -> {
+                String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
+                String userName = ctx.get(RequestContext.USER_NAME);
 
-            log.info("Saving items with version for dataset '{}', itemCount '{}', batchGroupId '{}'",
-                    datasetId, batch.items().size(), batchGroupId);
+                log.info("Saving items with version for dataset '{}', itemCount '{}', batchGroupId '{}'",
+                        datasetId, batch.items().size(), batchGroupId);
 
-            // Validate span and trace workspaces before proceeding
-            return validateSpans(workspaceId, validatedItems)
-                    .then(Mono.defer(() -> validateTraces(workspaceId, validatedItems)))
-                    .then(Mono.defer(() -> {
-                        // Verify dataset exists
-                        datasetService.findById(datasetId, workspaceId, null);
+                // Validate span and trace workspaces before proceeding
+                return validateSpans(workspaceId, validatedItems)
+                        .then(Mono.defer(() -> validateTraces(workspaceId, validatedItems)))
+                        .then(Mono.defer(() -> {
+                            // Verify dataset exists
+                            datasetService.findById(datasetId, workspaceId, null);
 
-                        // Ensure dataset is migrated if lazy migration is enabled
-                        return ensureLazyMigration(datasetId, workspaceId);
-                    }))
-                    .then(Mono.defer(() -> {
+                            // Ensure dataset is migrated if lazy migration is enabled
+                            return ensureLazyMigration(datasetId, workspaceId);
+                        }))
+                        .then(Mono.defer(() -> {
 
-                        // Get the latest version (if exists) - using overload that takes workspaceId
-                        Optional<DatasetVersion> latestVersion = versionService.getLatestVersion(datasetId,
-                                workspaceId);
+                            // Get the latest version (if exists) - using overload that takes workspaceId
+                            Optional<DatasetVersion> latestVersion = versionService.getLatestVersion(datasetId,
+                                    workspaceId);
 
-                        if (latestVersion.isEmpty()) {
-                            // No versions exist yet - create the first version with all items as "added"
-                            return createFirstVersion(datasetId, validatedItems, batchGroupId, workspaceId,
-                                    userName);
-                        }
+                            if (latestVersion.isEmpty()) {
+                                // No versions exist yet - create the first version with all items as "added"
+                                return createFirstVersion(datasetId, validatedItems, batchGroupId, workspaceId,
+                                        userName);
+                            }
 
-                        // Versions exist - apply delta on top of the latest. OPIK-6696: if the caller
-                        // supplied copy-from coordinates, the COPY of unchanged rows will read from that
-                        // (dataset, version) pair instead of the destination's just-minted prior version.
-                        UUID baseVersionId = latestVersion.get().id();
-                        return createVersionWithDelta(datasetId, baseVersionId, validatedItems, batchGroupId,
-                                workspaceId, userName, batch.copyFromDatasetId(), batch.copyFromVersionId());
-                    }));
+                            // Versions exist - apply delta on top of the latest. OPIK-6696: if the caller
+                            // supplied copy-from coordinates, the COPY of unchanged rows will read from that
+                            // (dataset, version) pair instead of the destination's just-minted prior version.
+                            UUID baseVersionId = latestVersion.get().id();
+                            return createVersionWithDelta(datasetId, baseVersionId, validatedItems, batchGroupId,
+                                    workspaceId, userName, batch.copyFromDatasetId(), batch.copyFromVersionId());
+                        }));
+            });
         });
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -26,6 +26,7 @@ import com.comet.opik.api.validation.DatasetItemBatchValidator;
 import com.comet.opik.infrastructure.FeatureFlags;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.lock.LockService;
 import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.RetryUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -49,6 +50,7 @@ import reactor.core.scheduler.Schedulers;
 import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -149,6 +151,9 @@ public interface DatasetItemService {
 @Slf4j
 class DatasetItemServiceImpl implements DatasetItemService {
 
+    private static final String DATASET_VERSION_LOCK = "DatasetVersion";
+    private static final Duration LOCK_DURATION = Duration.ofSeconds(60);
+
     private final @NonNull DatasetItemDAO dao;
     private final @NonNull DatasetItemVersionDAO versionDao;
     private final @NonNull DatasetService datasetService;
@@ -164,6 +169,14 @@ class DatasetItemServiceImpl implements DatasetItemService {
     private final @NonNull DatasetVersioningMigrationService migrationService;
     private final @NonNull ProjectService projectService;
     private final @NonNull @Config OpikConfiguration config;
+    private final @NonNull LockService lockService;
+
+    // Serialize the read-latest -> create-version -> flip-latest sequence per dataset so parallel
+    // uploads can't race on the dataset's mutable 'latest' pointer (OPIK-7264).
+    private <T> Mono<T> withDatasetVersionLock(UUID datasetId, Mono<T> action) {
+        return lockService.executeWithLockCustomExpire(
+                new LockService.Lock(datasetId, DATASET_VERSION_LOCK), action, LOCK_DURATION);
+    }
 
     @WithSpan
     private Mono<Void> verifyDatasetExistsAndSave(@NonNull DatasetItemBatch batch) {
@@ -215,10 +228,10 @@ class DatasetItemServiceImpl implements DatasetItemService {
                         // Save dataset items - route to versioned or legacy based on toggle
                         if (featureFlags.isDatasetVersioningEnabled()) {
                             log.info("Creating dataset items from traces with versioning for dataset '{}'", datasetId);
-                            return saveItemsWithVersion(
+                            return withDatasetVersionLock(datasetId, saveItemsWithVersion(
                                     DatasetItemBatch.builder().datasetId(datasetId).items(datasetItems).build(),
                                     datasetId, null)
-                                    .then(Mono.just(0L));
+                                    .then(Mono.just(0L)));
                         }
 
                         // Legacy: save to legacy table
@@ -268,10 +281,10 @@ class DatasetItemServiceImpl implements DatasetItemService {
                         // Save dataset items - route to versioned or legacy based on toggle
                         if (featureFlags.isDatasetVersioningEnabled()) {
                             log.info("Creating dataset items from spans with versioning for dataset '{}'", datasetId);
-                            return saveItemsWithVersion(
+                            return withDatasetVersionLock(datasetId, saveItemsWithVersion(
                                     DatasetItemBatch.builder().datasetId(datasetId).items(datasetItems).build(),
                                     datasetId, null)
-                                    .then(Mono.just(0L));
+                                    .then(Mono.just(0L)));
                         }
 
                         // Legacy: save to legacy table
@@ -471,6 +484,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                                     null, // Inherit execution policy from base version
                                                     false, // Don't clear execution policy
                                                     null, // No batch group ID
+                                                    true, // enforceLatestCas: diffs against current latest under lock
                                                     workspaceId,
                                                     userName)
                                                     .thenReturn(itemsTotal);
@@ -543,14 +557,15 @@ class DatasetItemServiceImpl implements DatasetItemService {
             datasetId = batchUpdate.datasetId();
             log.info("Using provided dataset ID '{}' for batch update by filters with versioning", datasetId);
 
-            return batchUpdateByFiltersWithVersioning(datasetId, batchUpdate, workspaceId, userName);
+            return withDatasetVersionLock(datasetId,
+                    batchUpdateByFiltersWithVersioning(datasetId, batchUpdate, workspaceId, userName));
         }
 
         if (CollectionUtils.isNotEmpty(batchUpdate.ids())) {
             return resolveDatasetIdFromItemIds(batchUpdate.ids())
                     .switchIfEmpty(Mono.error(failWithNotFound("Dataset items not found")))
-                    .flatMap(resolvedDatasetId -> batchUpdateByIdsWithVersioning(resolvedDatasetId, batchUpdate,
-                            workspaceId, userName));
+                    .flatMap(resolvedDatasetId -> withDatasetVersionLock(resolvedDatasetId,
+                            batchUpdateByIdsWithVersioning(resolvedDatasetId, batchUpdate, workspaceId, userName)));
         }
 
         // This should not happen due to validation, but handle it gracefully
@@ -735,6 +750,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                 null, // Inherit execution policy from base version
                 false, // Don't clear execution policy
                 null, // No batch group ID
+                true, // enforceLatestCas: diffs against current latest under lock
                 workspaceId,
                 userName)
                 .then();
@@ -840,9 +856,9 @@ class DatasetItemServiceImpl implements DatasetItemService {
         // Route to versioned or legacy based on toggle
         if (featureFlags.isDatasetVersioningEnabled()) {
             log.info("Saving batch with versioning for dataset '{}', itemCount '{}'", datasetId, items.size());
-            return saveItemsWithVersion(batch, datasetId, null)
+            return withDatasetVersionLock(datasetId, saveItemsWithVersion(batch, datasetId, null)
                     .map(version -> (long) items.size())
-                    .defaultIfEmpty((long) items.size());
+                    .defaultIfEmpty((long) items.size()));
         }
 
         // Legacy: save to legacy table
@@ -938,7 +954,9 @@ class DatasetItemServiceImpl implements DatasetItemService {
                 log.info(
                         "Mutating latest version with delete (no batch_group_id). datasetId='{}', itemIdsSize='{}', filtersSize='{}'",
                         datasetId, ids != null ? ids.size() : 0, filters != null ? filters.size() : 0);
-                return deleteItemsWithVersion(ids, datasetId, filters, workspaceId, userName, null);
+                return getDatasetIdOrResolveItemDatasetId(datasetId, ids)
+                        .flatMap(resolvedDatasetId -> withDatasetVersionLock(resolvedDatasetId,
+                                deleteItemsWithVersion(ids, resolvedDatasetId, filters, workspaceId, userName, null)));
             }
 
             // batch_group_id provided: create new version with batch grouping
@@ -946,8 +964,8 @@ class DatasetItemServiceImpl implements DatasetItemService {
                     "Creating version with batch grouping for delete. batchGroupId='{}', datasetId='{}', itemIdsSize='{}', filtersSize='{}'",
                     batchGroupId, datasetId, ids != null ? ids.size() : 0, filters != null ? filters.size() : 0);
             return getDatasetIdOrResolveItemDatasetId(datasetId, ids)
-                    .flatMap(resolvedDatasetId -> handleGroupedDeletion(
-                            batchGroupId, ids, resolvedDatasetId, filters, workspaceId, userName));
+                    .flatMap(resolvedDatasetId -> withDatasetVersionLock(resolvedDatasetId, handleGroupedDeletion(
+                            batchGroupId, ids, resolvedDatasetId, filters, workspaceId, userName)));
         });
     }
 
@@ -1070,6 +1088,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                                     null, // Inherit execution policy from base version
                                                     false, // Don't clear execution policy
                                                     batchGroupId,
+                                                    true, // enforceLatestCas: diffs against current latest under lock
                                                     workspaceId,
                                                     userName);
                                         });
@@ -1168,6 +1187,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                             null, // Inherit execution policy from base version
                             false, // Don't clear execution policy
                             batchGroupId,
+                            true, // enforceLatestCas: diffs against current latest under lock
                             workspaceId,
                             userName);
                 })
@@ -1408,7 +1428,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                             changes.tags(), changes.changeDescription(),
                             changes.evaluators(), changes.executionPolicy(),
                             Boolean.TRUE.equals(changes.clearExecutionPolicy()),
-                            null, workspaceId, userName);
+                            null, false, workspaceId, userName);
                     log.info("Created first version '{}' for dataset '{}' with hash '{}'",
                             version.id(), datasetId, version.versionHash());
                     return version;
@@ -1521,6 +1541,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                             changes.executionPolicy(),
                                             Boolean.TRUE.equals(changes.clearExecutionPolicy()),
                                             null, // No batch group ID
+                                            false, // applyDeltaChanges manages its own conflict/override check
                                             workspaceId,
                                             userName);
                                 });
@@ -1562,7 +1583,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
         }
 
         return getDatasetId(batch)
-                .flatMap(datasetId -> Mono.deferContextual(ctx -> {
+                .flatMap(datasetId -> withDatasetVersionLock(datasetId, Mono.deferContextual(ctx -> {
 
                     String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
                     String userName = ctx.get(RequestContext.USER_NAME);
@@ -1579,7 +1600,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                     log.info("Creating version with batch grouping for dataset '{}', batch_group_id: '{}'", datasetId,
                             batchGroupId);
                     return handleGroupedInsertion(batchGroupId, batch, datasetId, workspaceId, userName);
-                }));
+                })));
     }
 
     /**
@@ -1834,6 +1855,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                             null, // No execution policy for first version
                             false, // Don't clear execution policy
                             batchGroupId,
+                            true, // enforceLatestCas (no-op for first version, base is null)
                             workspaceId,
                             userName);
                 });
@@ -1955,6 +1977,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                         null, // Inherit execution policy from base version
                                         false, // Don't clear execution policy
                                         batchGroupId,
+                                        true, // enforceLatestCas: diffs against current latest under lock
                                         workspaceId,
                                         userName);
                             });
@@ -1987,6 +2010,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
             ExecutionPolicy executionPolicy,
             boolean clearExecutionPolicy,
             UUID batchGroupId,
+            boolean enforceLatestCas,
             String workspaceId,
             String userName) {
 
@@ -2001,6 +2025,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                 executionPolicy,
                 clearExecutionPolicy,
                 batchGroupId,
+                enforceLatestCas,
                 workspaceId,
                 userName))
                 .subscribeOn(Schedulers.boundedElastic())

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
@@ -154,7 +154,7 @@ public interface DatasetVersionDAO {
             ORDER BY dv.id DESC
             LIMIT 1
             """)
-    Optional<DatasetVersion> findByBatchGroupId(@Bind("batch_group_id") UUID batchGroupId,
+    Optional<DatasetVersion> findLatestByBatchGroupId(@Bind("batch_group_id") UUID batchGroupId,
             @Bind("dataset_id") UUID datasetId,
             @Bind("workspace_id") String workspaceId);
 
@@ -276,8 +276,13 @@ public interface DatasetVersionDAO {
     int deleteTag(@Bind("dataset_id") UUID datasetId, @Bind("tag") String tag,
             @Bind("workspace_id") String workspaceId);
 
-    @SqlUpdate("DELETE FROM dataset_version_tags WHERE dataset_id = :dataset_id AND tag = :tag "
-            + "AND version_id = :version_id AND workspace_id = :workspace_id")
+    @SqlUpdate("""
+            DELETE FROM dataset_version_tags
+            WHERE dataset_id = :dataset_id
+                AND tag = :tag
+                AND version_id = :version_id
+                AND workspace_id = :workspace_id
+            """)
     int deleteTagIfVersion(@Bind("dataset_id") UUID datasetId, @Bind("tag") String tag,
             @Bind("version_id") UUID versionId, @Bind("workspace_id") String workspaceId);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
@@ -151,6 +151,8 @@ public interface DatasetVersionDAO {
             WHERE dv.batch_group_id = :batch_group_id
                 AND dv.dataset_id = :dataset_id
                 AND dv.workspace_id = :workspace_id
+            ORDER BY dv.id DESC
+            LIMIT 1
             """)
     Optional<DatasetVersion> findByBatchGroupId(@Bind("batch_group_id") UUID batchGroupId,
             @Bind("dataset_id") UUID datasetId,
@@ -273,6 +275,11 @@ public interface DatasetVersionDAO {
     @SqlUpdate("DELETE FROM dataset_version_tags WHERE dataset_id = :dataset_id AND tag = :tag AND workspace_id = :workspace_id")
     int deleteTag(@Bind("dataset_id") UUID datasetId, @Bind("tag") String tag,
             @Bind("workspace_id") String workspaceId);
+
+    @SqlUpdate("DELETE FROM dataset_version_tags WHERE dataset_id = :dataset_id AND tag = :tag "
+            + "AND version_id = :version_id AND workspace_id = :workspace_id")
+    int deleteTagIfVersion(@Bind("dataset_id") UUID datasetId, @Bind("tag") String tag,
+            @Bind("version_id") UUID versionId, @Bind("workspace_id") String workspaceId);
 
     @SqlQuery("""
             SELECT

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionService.java
@@ -50,6 +50,7 @@ public interface DatasetVersionService {
     String ERROR_CANNOT_DELETE_LATEST_TAG = "Cannot delete '%s' tag - it is automatically managed";
     String ERROR_VERSION_HASH_NOT_FOUND = "Version with hash not found hash='%s' datasetId='%s'";
     String ERROR_VERSION_NOT_FOUND = "Version not found for dataset hash='%s' datasetId='%s'";
+    String ERROR_LATEST_MOVED = "Concurrent modification detected for dataset '%s'; the latest version changed during this operation. Please retry.";
 
     /**
      * Retrieves a paginated list of versions for the specified dataset, ordered by creation time (newest first).
@@ -216,7 +217,7 @@ public interface DatasetVersionService {
             UUID baseVersionId, List<String> tags, String changeDescription,
             List<EvaluatorItem> evaluators, ExecutionPolicy executionPolicy,
             boolean clearExecutionPolicy,
-            UUID batchGroupId, String workspaceId, String userName);
+            UUID batchGroupId, boolean enforceLatestCas, String workspaceId, String userName);
 
     /**
      * Restores a dataset to a previous version state by creating a new version.
@@ -361,7 +362,7 @@ class DatasetVersionServiceImpl implements DatasetVersionService {
             int itemsTotal, UUID baseVersionId, List<String> tags, String changeDescription,
             List<EvaluatorItem> evaluators, ExecutionPolicy executionPolicy,
             boolean clearExecutionPolicy,
-            UUID batchGroupId, @NonNull String workspaceId, @NonNull String userName) {
+            UUID batchGroupId, boolean enforceLatestCas, @NonNull String workspaceId, @NonNull String userName) {
 
         log.info(
                 "Creating version from delta for dataset '{}', newVersionId '{}', itemsTotal '{}', baseVersionId '{}', batchGroupId '{}'",
@@ -420,8 +421,24 @@ class DatasetVersionServiceImpl implements DatasetVersionService {
                         batchGroupId, versionHash, datasetId);
             }
 
-            // Remove 'latest' tag from previous version (if exists)
-            datasetVersionDAO.deleteTag(datasetId, LATEST_TAG, workspaceId);
+            // Flip the 'latest' tag to the new version. For the lock-protected write paths that branch
+            // off the current latest, only move 'latest' if it still points at that base
+            // (compare-and-swap): if a concurrent writer already moved it, the delete affects 0 rows and
+            // we abort with a retryable 409 rather than silently clobbering their version. This is the
+            // backstop for a lock-lease failure (OPIK-7264). Callers that intentionally branch off a
+            // non-latest base (applyDeltaChanges with override, which has its own conflict handling)
+            // pass enforceLatestCas=false to opt out.
+            if (enforceLatestCas && baseVersionId != null) {
+                int swapped = datasetVersionDAO.deleteTagIfVersion(datasetId, LATEST_TAG, baseVersionId, workspaceId);
+                if (swapped != 1) {
+                    throw new ClientErrorException(Response.status(Response.Status.CONFLICT)
+                            .entity(new ErrorMessage(List.of(ERROR_LATEST_MOVED.formatted(datasetId))))
+                            .build());
+                }
+            } else {
+                // First version, or a caller managing its own concurrency: no compare-and-swap.
+                datasetVersionDAO.deleteTag(datasetId, LATEST_TAG, workspaceId);
+            }
 
             // Always add 'latest' tag to the new version
             datasetVersionDAO.insertTag(datasetId, LATEST_TAG, newVersionId, userName, workspaceId);
@@ -797,7 +814,18 @@ class DatasetVersionServiceImpl implements DatasetVersionService {
         }).withError(() -> new EntityAlreadyExistsException(
                 new ErrorMessage(List.of(ERROR_VERSION_HASH_EXISTS.formatted(datasetId)))));
 
-        dao.deleteTag(datasetId, LATEST_TAG, context.workspaceId);
+        // Compare-and-swap the 'latest' flip against the base we diffed from (OPIK-7264 backstop).
+        if (context.previousLatestVersion != null) {
+            int swapped = dao.deleteTagIfVersion(datasetId, LATEST_TAG,
+                    context.previousLatestVersion.id(), context.workspaceId);
+            if (swapped != 1) {
+                throw new ClientErrorException(Response.status(Response.Status.CONFLICT)
+                        .entity(new ErrorMessage(List.of(ERROR_LATEST_MOVED.formatted(datasetId))))
+                        .build());
+            }
+        } else {
+            dao.deleteTag(datasetId, LATEST_TAG, context.workspaceId);
+        }
         dao.insertTag(datasetId, LATEST_TAG, newVersionId, context.userName, context.workspaceId);
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionService.java
@@ -10,7 +10,9 @@ import com.comet.opik.api.EvaluatorItem;
 import com.comet.opik.api.ExecutionPolicy;
 import com.comet.opik.api.error.EntityAlreadyExistsException;
 import com.comet.opik.api.error.ErrorMessage;
+import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.lock.LockService;
 import com.google.common.base.Preconditions;
 import com.google.inject.ImplementedBy;
 import jakarta.inject.Inject;
@@ -26,8 +28,10 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -43,6 +47,10 @@ import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
 public interface DatasetVersionService {
 
     String LATEST_TAG = "latest";
+
+    // Distributed-lock name serializing all version-creating writers on a dataset (OPIK-7264).
+    // Shared by DatasetItemService (save/patch/delete/applyDeltaChanges) and the restore path here.
+    String DATASET_VERSION_LOCK = "DatasetVersion";
 
     // Error message templates
     String ERROR_VERSION_HASH_EXISTS = "Version hash collision detected for dataset '%s'";
@@ -254,6 +262,8 @@ class DatasetVersionServiceImpl implements DatasetVersionService {
     private final @NonNull Provider<RequestContext> requestContext;
     private final @NonNull DatasetItemDAO datasetItemDAO;
     private final @NonNull DatasetItemVersionDAO datasetItemVersionDAO;
+    private final @NonNull LockService lockService;
+    private final @NonNull @Config OpikConfiguration config;
 
     @Override
     public DatasetVersionPage getVersions(@NonNull UUID datasetId, int page, int size) {
@@ -704,7 +714,10 @@ class DatasetVersionServiceImpl implements DatasetVersionService {
         String workspaceId = requestContext.get().getWorkspaceId();
         String userName = requestContext.get().getUserName();
 
-        return Mono.fromCallable(() -> buildRestoreContext(datasetId, versionRef, workspaceId, userName))
+        // Serialize restore under the same per-dataset lock as the other version-creating writers so a
+        // concurrent item write can't move 'latest' mid-restore and race the flip (OPIK-7264).
+        Mono<DatasetVersion> restore = Mono
+                .fromCallable(() -> buildRestoreContext(datasetId, versionRef, workspaceId, userName))
                 .subscribeOn(Schedulers.boundedElastic())
                 .flatMap(context -> {
                     if (context.isLatestVersion) {
@@ -714,6 +727,10 @@ class DatasetVersionServiceImpl implements DatasetVersionService {
                     }
                     return createRestoredVersion(datasetId, versionRef, context);
                 });
+
+        Duration lockLease = config.getDatasetVersioning().lockLease().toJavaDuration();
+        return lockService.executeWithLockCustomExpire(
+                new LockService.Lock(datasetId, DATASET_VERSION_LOCK), restore, lockLease);
     }
 
     private RestoreContext buildRestoreContext(UUID datasetId, String versionRef,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionService.java
@@ -822,7 +822,9 @@ class DatasetVersionServiceImpl implements DatasetVersionService {
         }).withError(() -> new EntityAlreadyExistsException(
                 new ErrorMessage(List.of(ERROR_VERSION_HASH_EXISTS.formatted(datasetId)))));
 
-        UUID casBase = context.previousLatestVersion != null ? context.previousLatestVersion.id() : null;
+        UUID casBase = Optional.ofNullable(context.previousLatestVersion)
+                .map(DatasetVersion::id)
+                .orElse(null);
         flipLatestTag(dao, datasetId, newVersionId, casBase, context.userName, context.workspaceId);
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionService.java
@@ -186,13 +186,14 @@ public interface DatasetVersionService {
     boolean hasVersions(String workspaceId, UUID datasetId);
 
     /**
-     * Finds a version by its batch ID.
+     * Finds the most recent version for a batch group. When more than one version shares a
+     * batch_group_id (possible under concurrent writes), the newest one is returned.
      * Used to support SDK batch operations where multiple API calls share the same batch_group_id.
      *
      * @param batchGroupId the batch group ID to search for
      * @param datasetId the dataset ID
      * @param workspaceId the workspace ID
-     * @return Optional containing the version if found, empty otherwise
+     * @return Optional containing the latest version for the batch group if found, empty otherwise
      */
     Optional<DatasetVersion> findByBatchGroupId(UUID batchGroupId, UUID datasetId, String workspaceId);
 
@@ -209,6 +210,11 @@ public interface DatasetVersionService {
      * @param evaluators optional default evaluators for the version
      * @param executionPolicy optional default execution policy for the version
      * @param batchGroupId optional batch group ID for SDK batch operations
+     * @param enforceLatestCas when {@code true} and {@code baseVersionId} is non-null, the 'latest'
+     *        tag is compare-and-swapped against {@code baseVersionId}: if a concurrent writer already
+     *        moved 'latest', this throws a retryable 409 instead of clobbering it. Pass {@code false}
+     *        to flip unconditionally — for the first version, or a caller that deliberately branches
+     *        off a non-latest base (e.g. applyDeltaChanges with override=true).
      * @param workspaceId the workspace ID (required when called from reactive context)
      * @param userName the user name (required when called from reactive context)
      * @return the created version
@@ -815,6 +821,9 @@ class DatasetVersionServiceImpl implements DatasetVersionService {
         if (casBase != null) {
             int swapped = dao.deleteTagIfVersion(datasetId, LATEST_TAG, casBase, workspaceId);
             if (swapped != 1) {
+                log.warn(
+                        "Concurrent 'latest' move detected: CAS failed. workspaceId='{}', datasetId='{}', casBase='{}', newVersionId='{}'",
+                        workspaceId, datasetId, casBase, newVersionId);
                 throw new ClientErrorException(Response.status(Response.Status.CONFLICT)
                         .entity(new ErrorMessage(List.of(ERROR_LATEST_MOVED.formatted(datasetId))))
                         .build());

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionService.java
@@ -297,7 +297,7 @@ class DatasetVersionServiceImpl implements DatasetVersionService {
 
         return template.inTransaction(READ_ONLY, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
-            return dao.findByBatchGroupId(batchGroupId, datasetId, workspaceId);
+            return dao.findLatestByBatchGroupId(batchGroupId, datasetId, workspaceId);
         });
     }
 
@@ -421,27 +421,12 @@ class DatasetVersionServiceImpl implements DatasetVersionService {
                         batchGroupId, versionHash, datasetId);
             }
 
-            // Flip the 'latest' tag to the new version. For the lock-protected write paths that branch
-            // off the current latest, only move 'latest' if it still points at that base
-            // (compare-and-swap): if a concurrent writer already moved it, the delete affects 0 rows and
-            // we abort with a retryable 409 rather than silently clobbering their version. This is the
-            // backstop for a lock-lease failure (OPIK-7264). Callers that intentionally branch off a
-            // non-latest base (applyDeltaChanges with override, which has its own conflict handling)
-            // pass enforceLatestCas=false to opt out.
-            if (enforceLatestCas && baseVersionId != null) {
-                int swapped = datasetVersionDAO.deleteTagIfVersion(datasetId, LATEST_TAG, baseVersionId, workspaceId);
-                if (swapped != 1) {
-                    throw new ClientErrorException(Response.status(Response.Status.CONFLICT)
-                            .entity(new ErrorMessage(List.of(ERROR_LATEST_MOVED.formatted(datasetId))))
-                            .build());
-                }
-            } else {
-                // First version, or a caller managing its own concurrency: no compare-and-swap.
-                datasetVersionDAO.deleteTag(datasetId, LATEST_TAG, workspaceId);
-            }
-
-            // Always add 'latest' tag to the new version
-            datasetVersionDAO.insertTag(datasetId, LATEST_TAG, newVersionId, userName, workspaceId);
+            // Flip the 'latest' tag to the new version. Callers that branch off the current latest under
+            // a lock pass enforceLatestCas=true so the flip is compare-and-swapped against that base;
+            // callers intentionally branching off a non-latest base (applyDeltaChanges with override)
+            // pass false to opt out.
+            UUID casBase = enforceLatestCas ? baseVersionId : null;
+            flipLatestTag(datasetVersionDAO, datasetId, newVersionId, casBase, userName, workspaceId);
             log.info("Added '{}' tag to version '{}' for dataset '{}'", LATEST_TAG, versionHash, datasetId);
 
             // Add custom tags from the request
@@ -814,19 +799,30 @@ class DatasetVersionServiceImpl implements DatasetVersionService {
         }).withError(() -> new EntityAlreadyExistsException(
                 new ErrorMessage(List.of(ERROR_VERSION_HASH_EXISTS.formatted(datasetId)))));
 
-        // Compare-and-swap the 'latest' flip against the base we diffed from (OPIK-7264 backstop).
-        if (context.previousLatestVersion != null) {
-            int swapped = dao.deleteTagIfVersion(datasetId, LATEST_TAG,
-                    context.previousLatestVersion.id(), context.workspaceId);
+        UUID casBase = context.previousLatestVersion != null ? context.previousLatestVersion.id() : null;
+        flipLatestTag(dao, datasetId, newVersionId, casBase, context.userName, context.workspaceId);
+    }
+
+    /**
+     * Moves the 'latest' tag to {@code newVersionId}. When {@code casBase} is non-null, the flip is
+     * compare-and-swapped against it: the old tag is removed only if it still points at {@code casBase},
+     * otherwise a concurrent writer already moved 'latest' and we abort with a retryable 409 rather than
+     * silently clobbering their version (OPIK-7264 backstop). A null {@code casBase} flips unconditionally
+     * (first version, or a caller managing its own concurrency).
+     */
+    private void flipLatestTag(DatasetVersionDAO dao, UUID datasetId, UUID newVersionId, UUID casBase,
+            String userName, String workspaceId) {
+        if (casBase != null) {
+            int swapped = dao.deleteTagIfVersion(datasetId, LATEST_TAG, casBase, workspaceId);
             if (swapped != 1) {
                 throw new ClientErrorException(Response.status(Response.Status.CONFLICT)
                         .entity(new ErrorMessage(List.of(ERROR_LATEST_MOVED.formatted(datasetId))))
                         .build());
             }
         } else {
-            dao.deleteTag(datasetId, LATEST_TAG, context.workspaceId);
+            dao.deleteTag(datasetId, LATEST_TAG, workspaceId);
         }
-        dao.insertTag(datasetId, LATEST_TAG, newVersionId, context.userName, context.workspaceId);
+        dao.insertTag(datasetId, LATEST_TAG, newVersionId, userName, workspaceId);
     }
 
     private record RestoreContext(UUID sourceVersionId, DatasetVersion sourceVersion,

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatasetVersioningConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatasetVersioningConfig.java
@@ -21,11 +21,17 @@ import java.util.concurrent.TimeUnit;
  * when zero rows are written and fails with a typed exception once attempts are exhausted,
  * instead of silently committing the truncated state.
  *
+ * <p>{@code lockLease} is the per-dataset distributed-lock lease that serializes the
+ * read-latest &rarr; create-version &rarr; flip-latest sequence so parallel uploads can't
+ * race on the mutable 'latest' pointer (OPIK-7264).
+ *
  * <p>Defaults live in {@code config.yml} / {@code config-test.yml}, not here.
  */
 @Builder(toBuilder = true)
 public record DatasetVersioningConfig(
-        @Valid @NotNull ZeroRowsRetry zeroRowsRetry) {
+        @Valid @NotNull ZeroRowsRetry zeroRowsRetry,
+        @NotNull @MinDuration(value = 1, unit = TimeUnit.SECONDS) //
+        @MaxDuration(value = 10, unit = TimeUnit.MINUTES) Duration lockLease) {
 
     @Builder(toBuilder = true)
     public record ZeroRowsRetry(

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -81,7 +81,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -5347,11 +5349,26 @@ class DatasetVersionResourceTest {
                     .collect(Collectors.toSet());
         }
 
+        // Blocks until every worker thread has reached the barrier, then releases them together, so the
+        // HTTP calls genuinely overlap instead of drifting apart when the CI node is loaded.
+        private void awaitBarrier(CyclicBarrier barrier) {
+            try {
+                barrier.await(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
+            } catch (BrokenBarrierException | java.util.concurrent.TimeoutException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
         private List<Integer> runParallel(List<DatasetItemBatch> batches) {
             ExecutorService executor = Executors.newFixedThreadPool(batches.size());
+            CyclicBarrier barrier = new CyclicBarrier(batches.size());
             try {
                 List<CompletableFuture<Integer>> futures = batches.stream()
                         .map(batch -> CompletableFuture.supplyAsync(() -> {
+                            awaitBarrier(barrier);
                             try (var response = datasetResourceClient.callCreateDatasetItems(batch, TEST_WORKSPACE,
                                     API_KEY)) {
                                 return response.getStatus();
@@ -5491,10 +5508,12 @@ class DatasetVersionResourceTest {
                     .toList();
 
             ExecutorService executor = Executors.newFixedThreadPool(writers);
+            CyclicBarrier barrier = new CyclicBarrier(writers);
             List<Integer> statuses;
             try {
                 statuses = changes.stream()
                         .map(c -> CompletableFuture.supplyAsync(() -> {
+                            awaitBarrier(barrier);
                             try (var response = datasetResourceClient.callApplyDatasetItemChanges(
                                     datasetId, c, false, API_KEY, TEST_WORKSPACE)) {
                                 return response.getStatus();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -5402,10 +5402,19 @@ class DatasetVersionResourceTest {
             assertThat(statuses).allMatch(status -> status == 204);
 
             // All writers share one batch_group_id -> they must collapse into exactly ONE new version
-            // (not one per writer), and the subsequent findByBatchGroupId lookup must not throw.
+            // (not one per writer), and the subsequent findLatestByBatchGroupId lookup must not throw.
             // The seed created 1 version; the shared group adds exactly 1 more.
-            long totalVersions = datasetResourceClient.listVersions(datasetId, API_KEY, TEST_WORKSPACE).total();
-            assertThat(totalVersions).isEqualTo(2L);
+            List<DatasetVersion> versions = datasetResourceClient.listVersions(datasetId, API_KEY, TEST_WORKSPACE)
+                    .content();
+            assertThat(versions).hasSize(2);
+
+            // Exercise the deterministic ORDER BY id DESC LIMIT 1 in findLatestByBatchGroupId: the shared
+            // group must resolve to a single 'latest' version holding every writer's rows. Asserting the
+            // resolved latest version's itemsTotal (not just the dataset row count) fails if the lookup
+            // ever returns a stale/losing branch instead of the newest one for the batch group.
+            List<DatasetVersion> latest = versions.stream().filter(DatasetVersion::isLatest).toList();
+            assertThat(latest).hasSize(1);
+            assertThat(latest.getFirst().itemsTotal()).isEqualTo(1 + writers * perWriter);
             assertThat(latestItemCount(datasetId)).isEqualTo(1L + (long) writers * perWriter);
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -81,6 +81,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -5304,6 +5308,128 @@ class DatasetVersionResourceTest {
 
             assertThat(findVersionIdByHash(datasetId, version.versionHash(), UUID.randomUUID().toString()))
                     .isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Concurrent Uploads (OPIK-7264):")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class ConcurrentUploads {
+
+        private DatasetItemBatch buildBatch(UUID datasetId, UUID batchGroupId, int count, String tag) {
+            List<DatasetItem> items = IntStream.range(0, count)
+                    .mapToObj(i -> DatasetItem.builder()
+                            .id(null)
+                            .source(DatasetItemSource.MANUAL)
+                            .traceId(null)
+                            .spanId(null)
+                            .data(Map.of(
+                                    "input", JsonUtils.getJsonNodeFromString("\"" + tag + "-input-" + i + "\""),
+                                    "output", JsonUtils.getJsonNodeFromString("\"" + tag + "-output-" + i + "\"")))
+                            .build())
+                    .toList();
+            return DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .items(items)
+                    .batchGroupId(batchGroupId)
+                    .build();
+        }
+
+        private List<Integer> runParallel(List<DatasetItemBatch> batches) {
+            ExecutorService executor = Executors.newFixedThreadPool(batches.size());
+            try {
+                List<CompletableFuture<Integer>> futures = batches.stream()
+                        .map(batch -> CompletableFuture.supplyAsync(() -> {
+                            try (var response = datasetResourceClient.callCreateDatasetItems(batch, TEST_WORKSPACE,
+                                    API_KEY)) {
+                                return response.getStatus();
+                            }
+                        }, executor))
+                        .toList();
+
+                return futures.stream().map(CompletableFuture::join).toList();
+            } finally {
+                executor.shutdown();
+                try {
+                    executor.awaitTermination(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+
+        private long latestItemCount(UUID datasetId) {
+            return datasetResourceClient.getDatasetItems(datasetId, 1, 1, null, API_KEY, TEST_WORKSPACE).total();
+        }
+
+        @Test
+        @DisplayName("Bug B: parallel uploads with distinct batch_group_ids don't lose rows")
+        void parallelDistinctBatchGroups__thenNoRowsLost() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            // Seed an initial version so writers branch off a shared base.
+            createDatasetItems(datasetId, 1);
+
+            int writers = 8;
+            int perWriter = 5;
+            List<DatasetItemBatch> batches = IntStream.range(0, writers)
+                    .mapToObj(i -> buildBatch(datasetId, UUID.randomUUID(), perWriter, "w" + i))
+                    .toList();
+
+            List<Integer> statuses = runParallel(batches);
+
+            assertThat(statuses).allMatch(status -> status == 204);
+            // Each writer branched off the same base (1 item) and added its own items; serialized
+            // application means the latest reflects the seed + every writer's rows.
+            assertThat(latestItemCount(datasetId)).isEqualTo(1L + (long) writers * perWriter);
+        }
+
+        @Test
+        @DisplayName("Bug A: parallel uploads sharing a batch_group_id don't 500 or duplicate the version")
+        void parallelSharedBatchGroup__thenNoErrorAndSingleVersion() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 1);
+
+            UUID sharedBatchGroupId = UUID.randomUUID();
+            int writers = 8;
+            int perWriter = 5;
+            List<DatasetItemBatch> batches = IntStream.range(0, writers)
+                    .mapToObj(i -> buildBatch(datasetId, sharedBatchGroupId, perWriter, "s" + i))
+                    .toList();
+
+            List<Integer> statuses = runParallel(batches);
+
+            assertThat(statuses).noneMatch(status -> status >= 500);
+            assertThat(statuses).allMatch(status -> status == 204);
+
+            // All writers share one batch_group_id -> they must collapse into exactly ONE new version
+            // (not one per writer), and the subsequent findByBatchGroupId lookup must not throw.
+            // The seed created 1 version; the shared group adds exactly 1 more.
+            long totalVersions = datasetResourceClient.listVersions(datasetId, API_KEY, TEST_WORKSPACE).total();
+            assertThat(totalVersions).isEqualTo(2L);
+            assertThat(latestItemCount(datasetId)).isEqualTo(1L + (long) writers * perWriter);
+        }
+
+        @Test
+        @DisplayName("Parallel uploads to different datasets stay independent (lock is per-dataset)")
+        void parallelDifferentDatasets__thenAllSucceed() {
+            int datasets = 4;
+            int perDataset = 5;
+            List<UUID> datasetIds = IntStream.range(0, datasets)
+                    .mapToObj(i -> {
+                        var id = createDataset(UUID.randomUUID().toString());
+                        createDatasetItems(id, 1);
+                        return id;
+                    })
+                    .toList();
+
+            List<DatasetItemBatch> batches = datasetIds.stream()
+                    .map(id -> buildBatch(id, UUID.randomUUID(), perDataset, "d"))
+                    .toList();
+
+            List<Integer> statuses = runParallel(batches);
+
+            assertThat(statuses).allMatch(status -> status == 204);
+            datasetIds.forEach(id -> assertThat(latestItemCount(id)).isEqualTo(1L + perDataset));
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -5316,8 +5316,8 @@ class DatasetVersionResourceTest {
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ConcurrentUploads {
 
-        private DatasetItemBatch buildBatch(UUID datasetId, UUID batchGroupId, int count, String tag) {
-            List<DatasetItem> items = IntStream.range(0, count)
+        private List<DatasetItem> buildManualItems(int count, String tag) {
+            return IntStream.range(0, count)
                     .mapToObj(i -> DatasetItem.builder()
                             .id(null)
                             .source(DatasetItemSource.MANUAL)
@@ -5328,11 +5328,23 @@ class DatasetVersionResourceTest {
                                     "output", JsonUtils.getJsonNodeFromString("\"" + tag + "-output-" + i + "\"")))
                             .build())
                     .toList();
+        }
+
+        private DatasetItemBatch buildBatch(UUID datasetId, UUID batchGroupId, int count, String tag) {
             return DatasetItemBatch.builder()
                     .datasetId(datasetId)
-                    .items(items)
+                    .items(buildManualItems(count, tag))
                     .batchGroupId(batchGroupId)
                     .build();
+        }
+
+        // Reads back every 'input' value in the latest version so tests can assert on row identity,
+        // not just the aggregate count (a loss-plus-duplication regression keeps the count intact).
+        private Set<String> latestInputValues(UUID datasetId, int pageSize) {
+            return datasetResourceClient.getDatasetItems(datasetId, 1, pageSize, null, API_KEY, TEST_WORKSPACE)
+                    .content().stream()
+                    .map(item -> item.data().get("input").asText())
+                    .collect(Collectors.toSet());
         }
 
         private List<Integer> runParallel(List<DatasetItemBatch> batches) {
@@ -5381,6 +5393,15 @@ class DatasetVersionResourceTest {
             // Each writer branched off the same base (1 item) and added its own items; serialized
             // application means the latest reflects the seed + every writer's rows.
             assertThat(latestItemCount(datasetId)).isEqualTo(1L + (long) writers * perWriter);
+
+            // Assert on row identity, not just the count: a bug that drops one writer's rows while
+            // duplicating another's would keep the total but lose a distinct tag. Every writer's inputs
+            // (w0-input-0..w7-input-4) must survive in the latest version.
+            Set<String> expectedInputs = IntStream.range(0, writers)
+                    .boxed()
+                    .flatMap(w -> IntStream.range(0, perWriter).mapToObj(i -> "w" + w + "-input-" + i))
+                    .collect(Collectors.toSet());
+            assertThat(latestInputValues(datasetId, 1 + writers * perWriter)).containsAll(expectedInputs);
         }
 
         @Test
@@ -5398,7 +5419,6 @@ class DatasetVersionResourceTest {
 
             List<Integer> statuses = runParallel(batches);
 
-            assertThat(statuses).noneMatch(status -> status >= 500);
             assertThat(statuses).allMatch(status -> status == 204);
 
             // All writers share one batch_group_id -> they must collapse into exactly ONE new version
@@ -5416,6 +5436,13 @@ class DatasetVersionResourceTest {
             assertThat(latest).hasSize(1);
             assertThat(latest.getFirst().itemsTotal()).isEqualTo(1 + writers * perWriter);
             assertThat(latestItemCount(datasetId)).isEqualTo(1L + (long) writers * perWriter);
+
+            // Row identity: every writer's distinct inputs must survive the collapse.
+            Set<String> expectedInputs = IntStream.range(0, writers)
+                    .boxed()
+                    .flatMap(w -> IntStream.range(0, perWriter).mapToObj(i -> "s" + w + "-input-" + i))
+                    .collect(Collectors.toSet());
+            assertThat(latestInputValues(datasetId, 1 + writers * perWriter)).containsAll(expectedInputs);
         }
 
         @Test
@@ -5439,6 +5466,60 @@ class DatasetVersionResourceTest {
 
             assertThat(statuses).allMatch(status -> status == 204);
             datasetIds.forEach(id -> assertThat(latestItemCount(id)).isEqualTo(1L + perDataset));
+        }
+
+        @Test
+        @DisplayName("applyDeltaChanges: concurrent override=false writers don't clobber each other (OPIK-7264)")
+        void parallelApplyDeltaChanges__thenNoClobber() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 1);
+            UUID baseVersionId = getLatestVersion(datasetId).id();
+
+            // All writers branch off the same current latest with override=false. Now that
+            // applyDeltaChanges runs under the per-dataset lock, they serialize: exactly one wins and
+            // moves 'latest'; the rest see a stale base and get a 409 instead of silently clobbering the
+            // winner (the pre-lock behavior). The CAS-specific ERROR_LATEST_MOVED path is a lock-lease
+            // backstop that can't be reached deterministically through the HTTP API and is covered by a
+            // service-level test in OPIK-7383.
+            int writers = 6;
+            List<DatasetItemChanges> changes = IntStream.range(0, writers)
+                    .mapToObj(i -> DatasetItemChanges.builder()
+                            .baseVersion(baseVersionId)
+                            .addedItems(buildManualItems(3, "a" + i))
+                            .changeDescription("concurrent apply " + i)
+                            .build())
+                    .toList();
+
+            ExecutorService executor = Executors.newFixedThreadPool(writers);
+            List<Integer> statuses;
+            try {
+                statuses = changes.stream()
+                        .map(c -> CompletableFuture.supplyAsync(() -> {
+                            try (var response = datasetResourceClient.callApplyDatasetItemChanges(
+                                    datasetId, c, false, API_KEY, TEST_WORKSPACE)) {
+                                return response.getStatus();
+                            }
+                        }, executor))
+                        .toList()
+                        .stream().map(CompletableFuture::join).toList();
+            } finally {
+                executor.shutdown();
+                try {
+                    executor.awaitTermination(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            // Exactly one writer wins (2xx); every other loses on the stale-base check with a 409.
+            // No 5xx, and no silent success that would indicate a clobber.
+            assertThat(statuses).filteredOn(status -> status == 200 || status == 201).hasSize(1);
+            assertThat(statuses).filteredOn(status -> status == HttpStatus.SC_CONFLICT).hasSize(writers - 1);
+            assertThat(statuses).noneMatch(status -> status >= 500);
+
+            // The winner created exactly one new version on top of the seed; its 3 rows landed in latest.
+            assertThat(datasetResourceClient.listVersions(datasetId, API_KEY, TEST_WORKSPACE).total()).isEqualTo(2L);
+            assertThat(latestItemCount(datasetId)).isEqualTo(1L + 3L);
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemServiceFilterDataTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemServiceFilterDataTest.java
@@ -4,6 +4,7 @@ import com.comet.opik.api.DatasetType;
 import com.comet.opik.api.sorting.SortingFactoryDatasets;
 import com.comet.opik.infrastructure.FeatureFlags;
 import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.infrastructure.lock.LockService;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.DisplayName;
@@ -36,7 +37,8 @@ class DatasetItemServiceFilterDataTest {
             mock(FeatureFlags.class),
             mock(DatasetVersioningMigrationService.class),
             mock(ProjectService.class),
-            mock(OpikConfiguration.class));
+            mock(OpikConfiguration.class),
+            mock(LockService.class));
 
     private static final Map<String, JsonNode> ENRICHED_DATA = Map.of(
             "input", JsonUtils.getJsonNodeFromString("{\"topic\":\"Formula1\",\"lang\":\"en\"}"),

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -897,6 +897,7 @@ datasetVersioning:
     maxAttempts: 3
     minBackoff: 100ms
     maxBackoff: 500ms
+  lockLease: 60s
 
 # Experiment Project Migration configuration
 # Assigns project_id to orphan experiments (V1 → V2 workspace migration).


### PR DESCRIPTION
## Details

<img width="964" height="1703" alt="image" src="https://github.com/user-attachments/assets/8027a67e-e71c-42d2-8b6f-0abc115643a8" />

Parallel dataset uploads against a versioning-enabled dataset raced on the mutable `latest` version pointer, producing two failure modes: workers sharing a batch group collided during version creation (HTTP 500 with an empty body, most rows lost), and workers with distinct batch groups each branched off the same base version and overwrote each other's `latest` pointer (HTTP 200 but ~half the rows silently dropped). Sequential uploads were unaffected. Reported from a production deployment.

- Wrap every `read-latest → create-version → flip-latest` sequence in a per-dataset distributed lock so concurrent writers serialize instead of racing on the pointer.
- Add a compare-and-swap backstop when flipping `latest`: only move the tag if it still points at the base that was diffed from (`deleteTagIfVersion`); a lost CAS returns a retryable 409 rather than silently clobbering another writer's version — this guards against a lock-lease failure.
- Make `findByBatchGroupId` deterministic (`ORDER BY id DESC LIMIT 1`) so a shared batch group resolves to a single version.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7264

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: assisted (recovered in-progress work, review, and verification)
- Human verification: code review + local test runs (unit + concurrency integration tests against real containers)

## Testing

Backend, run locally with JDK 25:

- `mvn compile -DskipTests` and `mvn spotless:check` — pass.
- `mvn test -Dtest=DatasetItemServiceFilterDataTest` — 8/8 pass (verifies the new `LockService` dependency wiring).
- `mvn test -Dtest='DatasetVersionResourceTest$ConcurrentUploads'` — 3/3 pass against real Redis + MySQL + ClickHouse testcontainers. The suite drives 8 parallel writers and asserts:
  - distinct batch groups → no rows lost (the silent-drop case);
  - shared batch group → no 5xx and exactly one new version created (the 500/collision case);
  - concurrent uploads to different datasets remain independent (lock is per-dataset).

## Documentation

N/A — internal concurrency fix with no user-facing API or behavior change beyond correctness.
