### PR TITLE
[OPIK-7384] [DOCS] docs: add Hermes integration page

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/hermes.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/hermes.mdx
@@ -1,0 +1,67 @@
+---
+description: Install and configure the opik-hermes plugin to export LLM, tool, and
+  agent traces to Opik.
+headline: Hermes | Opik Documentation
+og:description: Connect Hermes to Opik with the opik-hermes plugin.
+og:site_name: Opik Documentation
+og:title: Hermes Integration - Opik
+title: Observability for Hermes with Opik
+---
+
+[Hermes](https://github.com/NousResearch/hermes-agent) can send trace data to Opik through the plugin package [`opik-hermes`](https://github.com/comet-ml/opik-hermes).
+
+This integration captures:
+
+- A root trace per agent turn, organized by Hermes `session_id`
+- LLM spans (`type=llm`): messages, assistant output, model/provider, token usage, and USD cost
+- Tool spans (`type=tool`): tool arguments and results
+
+## Prerequisites
+
+- The [Hermes](https://github.com/NousResearch/hermes-agent) agent framework installed.
+- Opik project/workspace details (for cloud or enterprise deployments).
+
+## Setup
+
+<Steps>
+  <Step title="1. Install the plugin">
+    ```bash
+    pip install opik-hermes
+    ```
+
+    Installing the package automatically registers the plugin with Hermes.
+  </Step>
+  <Step title="2. Enable the plugin">
+    Add `opik` to the enabled plugins in `~/.hermes/config.yaml`:
+
+    ```yaml
+    plugins:
+      enabled: [opik]
+    ```
+  </Step>
+  <Step title="3. Configure Opik credentials">
+    Set the Opik environment variables in `~/.hermes/.env`.
+
+    For a local open-source Opik deployment:
+
+    ```bash
+    OPIK_URL_OVERRIDE=http://localhost:5173/api
+    OPIK_PROJECT_NAME=hermes
+    ```
+
+    For Comet-hosted Opik:
+
+    ```bash
+    OPIK_API_KEY=your-api-key
+    OPIK_WORKSPACE=your-workspace
+    ```
+  </Step>
+</Steps>
+
+## Validate setup
+
+Run a Hermes chat session and verify traces appear in the configured Opik project dashboard.
+
+## Next step
+
+For OTEL-native pipelines, see [OpenTelemetry integration](/integrations/opentelemetry).

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/overview.mdx
@@ -194,6 +194,7 @@ Connect your AI coding assistant directly to your Opik workspace with the MCP se
   <Card title="Cursor" href="/integrations/cursor" />
   <Card title="Dify" href="/integrations/dify" />
   <Card title="Flowise" href="/integrations/flowise" />
+  <Card title="Hermes" href="/integrations/hermes" />
   <Card title="Langflow" href="/integrations/langflow" />
   <Card title="n8n" href="/integrations/n8n" />
   <Card title="OpenClaw" href="/integrations/openclaw" />

--- a/apps/opik-documentation/documentation/fern/docs.yml
+++ b/apps/opik-documentation/documentation/fern/docs.yml
@@ -220,6 +220,9 @@ redirects:
   - source: "/docs/opik/tracing/integrations/flowise"
     destination: "/docs/opik/integrations/flowise"
     permanent: true
+  - source: "/docs/opik/tracing/integrations/hermes"
+    destination: "/docs/opik/integrations/hermes"
+    permanent: true
   - source: "/docs/opik/tracing/integrations/gemini"
     destination: "/docs/opik/integrations/gemini"
     permanent: true

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/hermes.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/hermes.mdx
@@ -1,0 +1,68 @@
+---
+description: Install and configure the opik-hermes plugin to export LLM, tool, and
+  agent traces to Opik.
+headline: Hermes | Opik Documentation
+og:description: Connect Hermes to Opik with the opik-hermes plugin.
+og:site_name: Opik Documentation
+og:title: Hermes Integration - Opik
+title: Observability for Hermes with Opik
+canonical-url: https://www.comet.com/docs/opik/integrations/hermes
+---
+
+[Hermes](https://github.com/NousResearch/hermes-agent) can send trace data to Opik through the plugin package [`opik-hermes`](https://github.com/comet-ml/opik-hermes).
+
+This integration captures:
+
+- A root trace per agent turn, organized by Hermes `session_id`
+- LLM spans (`type=llm`): messages, assistant output, model/provider, token usage, and USD cost
+- Tool spans (`type=tool`): tool arguments and results
+
+## Prerequisites
+
+- The [Hermes](https://github.com/NousResearch/hermes-agent) agent framework installed.
+- Opik project/workspace details (for cloud or enterprise deployments).
+
+## Setup
+
+<Steps>
+  <Step title="1. Install the plugin">
+    ```bash
+    pip install opik-hermes
+    ```
+
+    Installing the package automatically registers the plugin with Hermes.
+  </Step>
+  <Step title="2. Enable the plugin">
+    Add `opik` to the enabled plugins in `~/.hermes/config.yaml`:
+
+    ```yaml
+    plugins:
+      enabled: [opik]
+    ```
+  </Step>
+  <Step title="3. Configure Opik credentials">
+    Set the Opik environment variables in `~/.hermes/.env`.
+
+    For a local open-source Opik deployment:
+
+    ```bash
+    OPIK_URL_OVERRIDE=http://localhost:5173/api
+    OPIK_PROJECT_NAME=hermes
+    ```
+
+    For Comet-hosted Opik:
+
+    ```bash
+    OPIK_API_KEY=your-api-key
+    OPIK_WORKSPACE=your-workspace
+    ```
+  </Step>
+</Steps>
+
+## Validate setup
+
+Run a Hermes chat session and verify traces appear in the configured Opik project dashboard.
+
+## Next step
+
+For OTEL-native pipelines, see [OpenTelemetry integration](/v1/integrations/opentelemetry).

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/overview.mdx
@@ -185,6 +185,7 @@ Opik helps you easily log, visualize, and evaluate everything from raw LLM calls
   <Card title="Cursor" href="/v1/integrations/cursor" />
   <Card title="Dify" href="/v1/integrations/dify" />
   <Card title="Flowise" href="/v1/integrations/flowise" />
+  <Card title="Hermes" href="/v1/integrations/hermes" />
   <Card title="Langflow" href="/v1/integrations/langflow" />
   <Card title="n8n" href="/v1/integrations/n8n" />
   <Card title="OpenClaw" href="/v1/integrations/openclaw" />

--- a/apps/opik-documentation/documentation/fern/versions/latest.yml
+++ b/apps/opik-documentation/documentation/fern/versions/latest.yml
@@ -855,6 +855,9 @@ navigation:
           - page: Flowise
             path: ../docs-v2/integrations/flowise.mdx
             slug: flowise
+          - page: Hermes
+            path: ../docs-v2/integrations/hermes.mdx
+            slug: hermes
           - page: Langflow
             path: ../docs-v2/integrations/langflow.mdx
             slug: langflow

--- a/apps/opik-documentation/documentation/fern/versions/v1.yml
+++ b/apps/opik-documentation/documentation/fern/versions/v1.yml
@@ -664,6 +664,9 @@ navigation:
           - page: Flowise
             path: ../docs/tracing/integrations/flowise.mdx
             slug: flowise
+          - page: Hermes
+            path: ../docs/tracing/integrations/hermes.mdx
+            slug: hermes
           - page: Langflow
             path: ../docs/tracing/integrations/langflow.mdx
             slug: langflow


### PR DESCRIPTION
## Details

<img width="1920" height="1960" alt="image" src="https://github.com/user-attachments/assets/343493f5-f8b5-41f2-b89b-5c760add448c" />

Adds a No-Code documentation page for the `opik-hermes` plugin, which auto-instruments the [Hermes](https://github.com/NousResearch/hermes-agent) agent framework and exports traces to Opik. The plugin shipped under OPIK_7015 but had no docs presence, which matters for users who reach for docs over the UI, and for GEO/SEO and agent discoverability. The page covers install (`pip install opik-hermes`), enabling it in `~/.hermes/config.yaml`, Opik env-var config, and the traced data (root trace per turn, LLM spans, tool spans). Wired into both doc trees (v1 + v2): new page, overview No-Code card, version nav, and a `docs.yml` redirect. Placed alphabetically after Flowise.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7384
- Escalation for OPIK_7015 (plugin already shipped there; not resolved by this PR)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: `fern check` (0 errors) + code review

## Testing

- Ran `fern check` in `apps/opik-documentation/documentation` → **0 errors** (4 pre-existing warnings unrelated to this change: FDR network 403, accent-color contrast ratios, PostHog host).
- Verified the new page appears in both nav trees (`versions/latest.yml` for v2, `versions/v1.yml` for v1) and both overview No-Code card lists, positioned after Flowise.
- Confirmed the `docs.yml` redirect mirrors the existing Flowise/OpenClaw pattern.
- No application code changed; backend/frontend/SDK quality gates are N/A for this docs-only change.

## Documentation

This PR is itself the documentation change — it adds the Hermes integration page to the public Opik docs.
