### PR TITLE
[OPIK-7386] [CI] chore: migrate Python Dockerfiles from pip to uv

### DIFF
--- a/apps/opik-guardrails-backend/Dockerfile
+++ b/apps/opik-guardrails-backend/Dockerfile
@@ -22,14 +22,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN ln -sf /usr/bin/python3.10 /usr/bin/python && \
     ln -sf /usr/bin/python3.10 /usr/bin/python3
 
+# uv is a drop-in faster pip whose resolver already handles the pinned
+# torch/transformers/hf_xet wheels, so the pip>=24 bootstrap is no longer needed.
+# The binary (pinned, from the official distroless image) is installed system-wide,
+# used for the one install below, then removed so it doesn't linger in the image.
+COPY --from=ghcr.io/astral-sh/uv:0.11.29 /uv /usr/local/bin/uv
+
 WORKDIR /opt/opik-guardrails-backend
 
 COPY requirements.txt .
-# Ubuntu 22.04 ships pip ~22; the pinned torch/transformers/hf_xet wheels need a
-# newer resolver. Float pip forward from a >=24 floor (no rot — it's a lower
-# bound, not a frozen version); dependency versions themselves are in requirements.txt.
-RUN pip install --no-cache-dir -U "pip>=24.0" && \
-    pip install --no-cache-dir --disable-pip-version-check -r requirements.txt
+RUN uv pip install --python /usr/bin/python3.10 --no-cache -r requirements.txt && \
+    rm -f /usr/local/bin/uv
 
 COPY entrypoint.sh .
 RUN chmod u+x entrypoint.sh

--- a/apps/opik-python-backend/Dockerfile
+++ b/apps/opik-python-backend/Dockerfile
@@ -12,13 +12,17 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3018
 RUN apk add --no-cache python3 py3-pip build-base python3-dev musl-dev gcc libffi-dev rust cargo
 
+# uv is a drop-in faster pip; the binary is copied from the official distroless
+# image (pinned) and used only in this builder stage — it never reaches runtime.
+COPY --from=ghcr.io/astral-sh/uv:0.11.29 /uv /usr/local/bin/uv
+
 WORKDIR /opt/opik-python-backend
 
 # Install deps into a venv that we copy whole into the runtime stage.
 COPY requirements.txt .
 RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
-RUN pip install --no-cache-dir -r requirements.txt
+RUN uv pip install --python /opt/venv/bin/python --no-cache -r requirements.txt
 
 # Bytecode-only deps (-o 2, -b = fastest layout); strip source/stubs + package
 # managers. src/ keeps its .py; *.dist-info kept for importlib.metadata.

--- a/apps/opik-sandbox-executor-python/Dockerfile
+++ b/apps/opik-sandbox-executor-python/Dockerfile
@@ -4,21 +4,25 @@
 #######################################################################
 FROM python:3.12.13-slim AS builder
 
+# uv is a drop-in faster pip; the binary is copied from the official distroless
+# image (pinned) and used only in this builder stage — it never reaches runtime.
+COPY --from=ghcr.io/astral-sh/uv:0.11.29 /uv /usr/local/bin/uv
+
 WORKDIR /build
 
 # Install deps first so editing scoring_runner.py doesn't bust this cache layer.
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN uv pip install --system --no-cache -r requirements.txt
 
 # Compile to bytecode (-o 2 strips asserts/docstrings, -b = fastest legacy
 # layout), drop source/stubs, and remove package managers from the sandbox.
+# uv installs no pip; the rm below removes the base image's bundled pip/setuptools/wheel.
 # *.dist-info is kept: litellm/opik/tiktoken read it via importlib.metadata.
 RUN set -eux; \
     PYTHONNODEBUGRANGES=1 python -m compileall -o 2 -b /usr/local/lib/python3.12/site-packages; \
     find /usr/local/lib/python3.12/site-packages -name '*.py' -delete; \
     find /usr/local/lib/python3.12/site-packages -type d -name '__pycache__' -prune -exec rm -rf {} +; \
     find /usr/local/lib/python3.12/site-packages -name '*.pyi' -delete; \
-    pip uninstall -y pip setuptools wheel ensurepip || true; \
     rm -rf /usr/local/lib/python3.12/site-packages/pip* \
            /usr/local/lib/python3.12/site-packages/setuptools* \
            /usr/local/lib/python3.12/site-packages/wheel* \


### PR DESCRIPTION
## Details

<img width="1920" height="3370" alt="image" src="https://github.com/user-attachments/assets/c7682788-95af-4439-ac5e-bf7ac8b4b8fa" />

Migrates the three Python Dockerfiles (`opik-sandbox-executor-python`, `opik-python-backend`, `opik-guardrails-backend`) from `pip install` to `uv pip install`, completing the uv migration that OPIK-7385 started in CI. This is a drop-in, **unpinned** swap: same `requirements.txt`, same PyPI sources, no `uv.lock`, no reproducibility-contract change — just a faster resolver and installer. The pinned `uv 0.11.29` binary is staged from the official distroless image in each build stage and never reaches the runtime images. Existing bytecode slimming, venv layout, and package-manager stripping are left untouched.

- **sandbox-executor**: `uv pip install --system`; the redundant `pip uninstall` line is dropped (the base image's bundled pip/setuptools/wheel is still removed by the existing `rm -rf`).
- **python-backend**: `uv pip install --python /opt/venv/bin/python` targets the existing venv; uv stays in the builder stage, out of the copied venv.
- **guardrails**: the `pip install -U "pip>=24.0"` bootstrap is removed — uv's resolver already handles the pinned torch/transformers/hf_xet wheels natively. The uv binary is removed after install so the single-stage image stays clean.

### Measured (`docker build --no-cache`, base image pre-cached in all runs)

**Dependency-install step** — the honest, stable uv-attributable metric:

| Dockerfile | pip (before) | uv (after) | Speedup |
|---|---|---|---|
| `opik-sandbox-executor-python` | 31.3s | 4.7s | **6.7× (−85%)** |
| `opik-python-backend` | 247.0s | 170.1s | **−31% (−77s)** |
| `opik-guardrails-backend` | 53.6s | 15.1s | **3.6× (−38s)** |

**Total build wall-clock** — faster too, but the delta is smaller than the install saving because a uv-independent step dominates each total:

| Dockerfile | pip (before) | uv (after) | Δ |
|---|---|---|---|
| `opik-sandbox-executor-python` | 54.2s | 38.8s | −28% |
| `opik-python-backend` | 336.3s | 280.9s | −16% |
| `opik-guardrails-backend` | 262.0s | 255.3s | −7s |

**Final image size** — unchanged (same wheels installed):

| Dockerfile | pip | uv | Δ |
|---|---|---|---|
| `opik-sandbox-executor-python` | 85.2 MB | 85.2 MB | ≈ (−34 KB) |
| `opik-python-backend` | 292.7 MB | 292.6 MB | ≈ (−54 KB) |
| `opik-guardrails-backend` | 3874 MB | 3851 MB | −24 MB |

Notes:
- python-backend's install is dominated by native rust/cargo wheel compilation (pydantic-core) that uv can't accelerate.
- guardrails' total is dominated by a ~200s ML-model download (spaCy `en_core_web_lg` + bart-large-mnli, ~2GB) that uv never touches and that swings ±15–20s run-to-run on network conditions — so uv's real −38s install win is mostly masked in the total. That download is the actual build-time target and is a uv-independent fast-follow: OPIK-7391.
- guardrails is −24 MB smaller because dropping the `pip>=24.0` bootstrap removes pip/setuptools/wheel that the old single-stage build left in the final image.
- Single-run (n=1) local measurements; install-step deltas are stable, totals are indicative.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7386

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: full implementation
- Human verification: code review + local Docker builds of all 3 images (before/after, `--no-cache`, base pre-cached), selftest/entrypoint verified, runtime images inspected for leaked pip/uv, image sizes compared

## Testing

Built all three images locally with `docker build --no-cache` on both the pip (baseline) and uv versions:

- All 3 images build successfully (exit 0) on the uv version.
- `opik-sandbox-executor-python`: the baked-in `selftest.sh` (real end-to-end metric scoring) passes in both the builder and runtime stages.
- `opik-guardrails-backend`: uv resolved 66 packages including `torch==2.6.0` and the `hf_xet` extra in 2.37s with **zero conflicts** — no `--index-strategy unsafe-best-match` or added constraint needed.
- Runtime images inspected: uv binary confirmed absent from guardrails, sandbox runtime, and python-backend's `/opt/venv`. (The dangling `/usr/local/bin/pip` shim in the sandbox runtime is pre-existing and non-functional — identical before and after this change.)
- Image sizes compared before/after: unchanged within noise; guardrails −24 MB (see Details).
- `hadolint` passes on all 3 Dockerfiles (via pre-commit).

No `uv.lock` introduced; requirements files and dependency versions unchanged.

## Documentation

N/A — no user-facing or API documentation changes.
