### PR TITLE
[OPIK-6899] [BE] feat: apply real-data-benchmark codec refinements to traces_local_v2

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000107_apply_traces_local_v2_real_data_codec_refinements.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000107_apply_traces_local_v2_real_data_codec_refinements.sql
@@ -1,0 +1,31 @@
+--liquibase formatted sql
+--changeset andrescrz:000107_apply_traces_local_v2_real_data_codec_refinements
+--comment: Refine traces_local_v2 codecs from real-data validation (OPIK-6899), metadata-only on the empty table
+
+-- Per-column codec choices validated on real production traces data (OPIK-6899), superseding the synthetic-slice
+-- estimates in 000106. traces_local_v2 is still empty, so each MODIFY COLUMN is metadata-only; this MUST run before any
+-- backfill, or it degrades into a full re-compress. Two groups:
+--   * end_time, last_updated_at: restore Delta + ZSTD(1) (000106 had dropped Delta). 000106 assumed, from the synthetic
+--     slice, that these are non-monotonic in the (workspace_id, project_id, id) storage order; on real data they are
+--     monotonic enough that Delta is smaller than plain ZSTD(1) (~16% / ~5%). Re-confirm the margin on the full dataset
+--     at the backfill (Delta is never materially worse than plain ZSTD(1), so it is safe to adopt now).
+--   * workspace_id, name, tags, created_by, last_updated_by, thread_id: ZSTD(1) -> ZSTD(3). ClickHouse 26.3 (the LTS
+--     this table is deployed on) regressed ZSTD level 1 on small, repetitive, variable-length String/Array columns,
+--     making ZSTD(1) larger than LZ4 on them; ZSTD(3) is unaffected and smallest on both 25.8 and 26.3, at
+--     codec-level-independent decode (no read penalty).
+-- id/project_id stay ZSTD(1): FixedString UUIDv7, unaffected by the regression and already smallest under ZSTD(1).
+-- Everything else (output_keys; input/output/metadata and their slim/truncated forms; the Delta/T64 numeric codecs;
+-- floats/enums) is unchanged. Columns are ordered as declared in 000101.
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 ON CLUSTER '{cluster}'
+    MODIFY COLUMN IF EXISTS workspace_id      String                 CODEC(ZSTD(3)),
+    MODIFY COLUMN IF EXISTS name              String                 DEFAULT ''       CODEC(ZSTD(3)),
+    MODIFY COLUMN IF EXISTS end_time          DateTime64(6, 'UTC')   DEFAULT toDateTime64('1970-01-01 00:00:00', 6) CODEC(Delta, ZSTD(1)),
+    MODIFY COLUMN IF EXISTS tags              Array(String)          DEFAULT []       CODEC(ZSTD(3)),
+    MODIFY COLUMN IF EXISTS last_updated_at   DateTime64(6, 'UTC')   DEFAULT now64(6) CODEC(Delta, ZSTD(1)),
+    MODIFY COLUMN IF EXISTS created_by        String                 DEFAULT ''       CODEC(ZSTD(3)),
+    MODIFY COLUMN IF EXISTS last_updated_by   String                 DEFAULT ''       CODEC(ZSTD(3)),
+    MODIFY COLUMN IF EXISTS thread_id         String                 DEFAULT ''       CODEC(ZSTD(3));
+
+-- Empty rollback: an in-place codec change is not cleanly reversible, and restoring the superseded 000106 codecs is
+-- never a wanted recovery step (matches 000106).
+--rollback empty

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2BenchmarkTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2BenchmarkTest.java
@@ -96,26 +96,26 @@ class TracesLocalV2BenchmarkTest {
      * The intended codec for every {@code traces_local_v2} column, keyed by column name. This is the canonical record
      * of the per-field decisions the benchmarks below justify; {@link #everyTracesLocalV2ColumnUsesItsIntendedCodec()}
      * asserts the live DDL matches it, column for column. It reflects the codecs the live table ships after migrations
-     * {@code 000101} (create) and {@code 000106} (which applies the six benchmark-driven refinements), so it moves in
-     * lockstep with those migrations — the pin test fails loudly if the DDL and this map ever drift apart.
+     * {@code 000101} (create), {@code 000106} and {@code 000107} (which apply the benchmark-driven refinements), so it
+     * moves in lockstep with those migrations — the pin test fails loudly if the DDL and this map ever drift apart.
      */
     private static final Map<String, ExpectedCodec> TRACES_LOCAL_V2_CODECS = Map.ofEntries(
             Map.entry("id", ExpectedCodec.ZSTD1),
-            Map.entry("workspace_id", ExpectedCodec.ZSTD1),
+            Map.entry("workspace_id", ExpectedCodec.ZSTD3),
             Map.entry("project_id", ExpectedCodec.ZSTD1),
-            Map.entry("name", ExpectedCodec.ZSTD1),
+            Map.entry("name", ExpectedCodec.ZSTD3),
             Map.entry("start_time", ExpectedCodec.DELTA_ZSTD1),
-            Map.entry("end_time", ExpectedCodec.ZSTD1),
+            Map.entry("end_time", ExpectedCodec.DELTA_ZSTD1),
             Map.entry("input", ExpectedCodec.ZSTD3),
             Map.entry("output", ExpectedCodec.ZSTD3),
             Map.entry("metadata", ExpectedCodec.ZSTD3),
-            Map.entry("tags", ExpectedCodec.ZSTD1),
+            Map.entry("tags", ExpectedCodec.ZSTD3),
             Map.entry("created_at", ExpectedCodec.DELTA_ZSTD1),
-            Map.entry("last_updated_at", ExpectedCodec.ZSTD1),
-            Map.entry("created_by", ExpectedCodec.ZSTD1),
-            Map.entry("last_updated_by", ExpectedCodec.ZSTD1),
+            Map.entry("last_updated_at", ExpectedCodec.DELTA_ZSTD1),
+            Map.entry("created_by", ExpectedCodec.ZSTD3),
+            Map.entry("last_updated_by", ExpectedCodec.ZSTD3),
             Map.entry("error_info", ExpectedCodec.ZSTD1),
-            Map.entry("thread_id", ExpectedCodec.ZSTD1),
+            Map.entry("thread_id", ExpectedCodec.ZSTD3),
             Map.entry("visibility_mode", ExpectedCodec.ZSTD1),
             Map.entry("truncation_threshold", ExpectedCodec.ZSTD1),
             Map.entry("input_slim", ExpectedCodec.ZSTD3),
@@ -172,6 +172,7 @@ class TracesLocalV2BenchmarkTest {
                     proj_zstd3        FixedString(36)              CODEC(ZSTD(3)),
                     ws_lz4            String                       CODEC(LZ4),
                     ws_zstd1          String                       CODEC(ZSTD(1)),
+                    ws_zstd3          String                       CODEC(ZSTD(3)),
                     name_lz4          String                       CODEC(LZ4),
                     name_zstd1        String                       CODEC(ZSTD(1)),
                     name_zstd3        String                       CODEC(ZSTD(3)),
@@ -253,6 +254,7 @@ class TracesLocalV2BenchmarkTest {
                         proj_zstd3,
                         ws_lz4,
                         ws_zstd1,
+                        ws_zstd3,
                         name_lz4,
                         name_zstd1,
                         name_zstd3,
@@ -472,6 +474,7 @@ class TracesLocalV2BenchmarkTest {
                     project_id,   -- proj_zstd3
                     workspace_id, -- ws_lz4
                     workspace_id, -- ws_zstd1
+                    workspace_id, -- ws_zstd3
                     name,         -- name_lz4
                     name,         -- name_zstd1
                     name,         -- name_zstd3
@@ -597,30 +600,35 @@ class TracesLocalV2BenchmarkTest {
     }
 
     @Test
-    void clusteredUuidV4WorkspaceIdColumnCompressesBestWithLz4() {
-        long uncompressed = uncompressed("ws_zstd1");
+    void clusteredUuidV4WorkspaceIdColumnShipsZstd3() {
+        long uncompressed = uncompressed("ws_zstd3");
         long lz4 = compressed("ws_lz4");
         long zstd1 = compressed("ws_zstd1");
+        long zstd3 = compressed("ws_zstd3");
 
-        // workspace_id is a UUIDv4 (no timestamp prefix) but clustered in long runs (first sort key), so it also
-        // compresses to a small fraction of its raw size. On CH 26.3 LZ4 wins here: ZSTD(1) on this clustered-UUIDv4
-        // String is ~2x larger than LZ4 (measured ws_lz4 ~4.5k vs ws_zstd1 ~8.7k), a reversal from 25.8 where ZSTD(1)
-        // was far smaller. Require LZ4 to be at least WITHIN_5_PCT smaller than ZSTD(1) — the margin is on the ZSTD(1)
-        // side so the check fails if LZ4 ever stops being the clear winner. It cannot be LowCardinality (ORDER BY prefix).
-        assertThat(lz4).isLessThan(uncompressed);
-        assertThat(lz4).isLessThanOrEqualTo(Math.round(zstd1 / WITHIN_5_PCT));
-        log.info("[OPIK-6899] clustered workspace_id (UUIDv4) compressed bytes | LZ4: {} | ZSTD(1): {}", lz4, zstd1);
+        // workspace_id is a clustered UUIDv4 String (first sort key, long runs), so it compresses to a tiny fraction of
+        // its raw size; it cannot be LowCardinality (ORDER BY prefix). Ships ZSTD(3): on ClickHouse 26.3 ZSTD(1)
+        // regressed on this clustered String (larger than LZ4), while ZSTD(3) is unaffected and smallest, at
+        // level-independent decode. The shipped codec is pinned by everyTracesLocalV2ColumnUsesItsIntendedCodec.
+        assertThat(zstd3).isLessThan(uncompressed);
+        assertThat(zstd3).isLessThanOrEqualTo(lz4);
+        assertThat(zstd3).isLessThanOrEqualTo(zstd1);
+        log.info("[OPIK-6899] clustered workspace_id (UUIDv4) compressed bytes | LZ4: {} | ZSTD(1): {} | ZSTD(3): {}",
+                lz4, zstd1, zstd3);
     }
 
     @Test
-    void traceNameColumnCompressesBestWithZstd1() {
+    void traceNameColumnShipsZstd3() {
         long lz4 = compressed("name_lz4");
         long zstd1 = compressed("name_zstd1");
         long zstd3 = compressed("name_zstd3");
 
-        // The trace name is short medium-cardinality text; ZSTD(1) beats LZ4 and ZSTD(3) adds little.
-        assertThat(zstd1).isLessThan(lz4);
-        assertThat(zstd1).isLessThanOrEqualTo(Math.round(zstd3 * WITHIN_15_PCT));
+        // The trace name is short medium-cardinality text. Ships ZSTD(3): on ClickHouse 26.3 ZSTD(1) regressed on these
+        // repetitive variable-length String columns, while ZSTD(3) is unaffected and smallest, at level-independent
+        // decode. The shipped codec is pinned by everyTracesLocalV2ColumnUsesItsIntendedCodec.
+        assertThat(zstd3).isLessThan(lz4);
+        assertThat(zstd3).isLessThanOrEqualTo(Math.round(zstd1 * WITHIN_5_PCT));
+        log.info("[OPIK-6899] name compressed bytes | LZ4: {} | ZSTD(1): {} | ZSTD(3): {}", lz4, zstd1, zstd3);
     }
 
     @Test
@@ -720,14 +728,18 @@ class TracesLocalV2BenchmarkTest {
     }
 
     @Test
-    void tagsArrayColumnCompressesBestWithZstd1() {
+    void tagsArrayColumnShipsZstd3() {
         long lz4 = compressed("arr_lz4");
         long zstd1 = compressed("arr_zstd1");
         long zstd3 = compressed("arr_zstd3");
 
-        // tags is an Array(String) of low-cardinality values; ZSTD(1) beats LZ4 and ZSTD(3) adds little.
-        assertThat(zstd1).isLessThan(lz4);
-        assertThat(zstd1).isLessThanOrEqualTo(Math.round(zstd3 * WITHIN_15_PCT));
+        // tags is an Array(String) of low-cardinality values. Ships ZSTD(3): it is smallest and, unlike ZSTD(1), is
+        // unaffected by the ClickHouse 26.3 level-1 regression on repetitive columns. The shipped codec is pinned by
+        // everyTracesLocalV2ColumnUsesItsIntendedCodec.
+        assertThat(zstd3).isLessThan(lz4);
+        assertThat(zstd3).isLessThanOrEqualTo(Math.round(zstd1 * WITHIN_5_PCT));
+        log.info("[OPIK-6899] tags Array(String) compressed bytes | LZ4: {} | ZSTD(1): {} | ZSTD(3): {}",
+                lz4, zstd1, zstd3);
     }
 
     @Test
@@ -791,36 +803,37 @@ class TracesLocalV2BenchmarkTest {
     }
 
     @Test
-    void endTimeIsNotMonotonicSoPlainZstd1BeatsDelta() {
+    void endTimeShipsDeltaZstd1FromRealData() {
         long lz4 = compressed("et_lz4");
         long zstd1 = compressed("et_zstd1");
         long deltaZstd1 = compressed("et_delta_zstd1");
 
-        // Unlike start_time/created_at (monotonic in storage order), end_time is start_time + a variable duration and
-        // carries epoch sentinels for unfinished traces, so it is NOT monotonic in storage order: Delta hurts rather
-        // than helps and plain ZSTD(1) is the smallest. The size of the gap depends on the duration distribution and
-        // the epoch fraction.
+        // Ships Delta + ZSTD(1) (restoring 000101, reverting the 000106 plain ZSTD(1)): on real production data end_time
+        // is monotonic enough in storage order that Delta is smaller than plain ZSTD(1). This synthetic slice
+        // deliberately scrambles end_time (start + a wide random duration + epoch sentinels), so plain ZSTD(1) can edge
+        // Delta here; hence only the robust facts are asserted (both ZSTD variants beat LZ4). The shipped codec is
+        // pinned by everyTracesLocalV2ColumnUsesItsIntendedCodec.
         assertThat(zstd1).isLessThan(lz4);
-        assertThat(zstd1).isLessThanOrEqualTo(deltaZstd1);
-        log.info(
-                "[OPIK-6899] end_time (start+duration, ~3% epoch) compressed bytes | LZ4: {} | ZSTD(1): {} | Delta+ZSTD(1): {}",
+        assertThat(deltaZstd1).isLessThan(lz4);
+        log.info("[OPIK-6899] end_time compressed bytes | LZ4: {} | ZSTD(1): {} | Delta+ZSTD(1): {} (ships Delta)",
                 lz4, zstd1, deltaZstd1);
     }
 
     @Test
-    void lastUpdatedAtIsScrambledSoPlainZstd1BeatsDelta() {
+    void lastUpdatedAtShipsDeltaZstd1FromRealData() {
         long lz4 = compressed("lua_lz4");
         long zstd1 = compressed("lua_zstd1");
         long deltaZstd1 = compressed("lua_delta_zstd1");
 
-        // last_updated_at is the ReplacingMergeTree version column = last write time. For created-then-finalized traces
-        // (~70%) it is ~ start + duration, so like end_time it is NOT monotonic in storage order and plain ZSTD(1) beats
-        // Delta. The size of the gap depends on the updated-trace fraction.
+        // last_updated_at is the ReplacingMergeTree version column. Ships Delta + ZSTD(1) (restoring 000101, reverting
+        // the 000106 plain ZSTD(1)): on real production data it is monotonic enough that Delta is smaller than plain
+        // ZSTD(1). This synthetic slice scrambles it (like end_time), so plain ZSTD(1) can edge Delta here; only the
+        // robust facts are asserted (both ZSTD variants beat LZ4). The shipped codec is pinned by
+        // everyTracesLocalV2ColumnUsesItsIntendedCodec.
         assertThat(zstd1).isLessThan(lz4);
-        assertThat(zstd1).isLessThanOrEqualTo(deltaZstd1);
+        assertThat(deltaZstd1).isLessThan(lz4);
         log.info(
-                "[OPIK-6899] last_updated_at (version column, ~70% updated) compressed bytes | LZ4: {} | ZSTD(1): {} | "
-                        + "Delta+ZSTD(1): {}",
+                "[OPIK-6899] last_updated_at compressed bytes | LZ4: {} | ZSTD(1): {} | Delta+ZSTD(1): {} (ships Delta)",
                 lz4, zstd1, deltaZstd1);
     }
 
@@ -854,15 +867,18 @@ class TracesLocalV2BenchmarkTest {
     }
 
     @Test
-    void flexibleThreadIdColumnCompressesBestWithZstd1() {
+    void flexibleThreadIdColumnShipsZstd3() {
         long lz4 = compressed("thread_lz4");
         long zstd1 = compressed("thread_zstd1");
         long zstd3 = compressed("thread_zstd3");
 
-        // thread_id is a free-form identifier — mostly empty, else a UUIDv4 or a short random string — and scattered
-        // (not in the sort key). ZSTD(1) beats LZ4 whatever the exact format; ZSTD(3) adds little. Shipped ZSTD(1) holds.
-        assertThat(zstd1).isLessThan(lz4);
-        assertThat(zstd1).isLessThanOrEqualTo(Math.round(zstd3 * WITHIN_15_PCT));
+        // thread_id is a free-form, high-entropy identifier (mostly empty, else a UUID or short random string), not in
+        // the sort key. Ships ZSTD(3) for consistency with the other variable-length String columns: it is smallest on
+        // 26.3 and ~equal to ZSTD(1) otherwise, at level-independent decode. The shipped codec is pinned by
+        // everyTracesLocalV2ColumnUsesItsIntendedCodec.
+        assertThat(zstd3).isLessThan(lz4);
+        assertThat(zstd3).isLessThanOrEqualTo(Math.round(zstd1 * WITHIN_15_PCT));
+        log.info("[OPIK-6899] thread_id compressed bytes | LZ4: {} | ZSTD(1): {} | ZSTD(3): {}", lz4, zstd1, zstd3);
     }
 
     @Test
@@ -1064,21 +1080,22 @@ class TracesLocalV2BenchmarkTest {
                     duration Float64 MATERIALIZED if(end_time = toDateTime64('1970-01-01 00:00:00', 6) OR start_time = toDateTime64('1970-01-01 00:00:00', 6), toFloat64('nan'), dateDiff('microsecond', start_time, end_time) / 1000.0) CODEC(ZSTD(1)),
                     id_at DateTime('UTC') MATERIALIZED UUIDv7ToDateTime(toUUID(id)) CODEC(Delta, ZSTD(1))
                 """;
-        // NEW traces_local_v2 format = the live table's codecs after migrations 000101 (create) + 000106 (the six
-        // benchmark-driven refinements: end_time / last_updated_at -> ZSTD(1); visibility_mode / source / environment ->
-        // ZSTD(1); output_keys -> ZSTD(3)), matching the pin map above. The refinements are best guesses to re-validate
-        // at the staging cutover; the headline is the deployed format, DateTime64(6), epoch/NaN sentinels, is_deleted.
+        // NEW traces_local_v2 format = the live table's codecs after migrations 000101 (create), 000106 and 000107 (the
+        // benchmark-driven refinements), matching the pin map above: the variable-length String/Array columns
+        // (workspace_id, name, tags, created_by, last_updated_by, thread_id, output_keys) on ZSTD(3); end_time /
+        // last_updated_at on Delta + ZSTD(1); visibility_mode / source / environment on ZSTD(1). The headline is the
+        // deployed format: tuned per-column codecs, DateTime64(6), epoch/NaN sentinels, is_deleted.
         execute(("""
                 CREATE TABLE {db}.full_after
                 (
-                    id FixedString(36) CODEC(ZSTD(1)), workspace_id String CODEC(ZSTD(1)),
-                    project_id FixedString(36) CODEC(ZSTD(1)), name String CODEC(ZSTD(1)),
-                    start_time DateTime64(6, 'UTC') CODEC(Delta, ZSTD(1)), end_time DateTime64(6, 'UTC') CODEC(ZSTD(1)),
+                    id FixedString(36) CODEC(ZSTD(1)), workspace_id String CODEC(ZSTD(3)),
+                    project_id FixedString(36) CODEC(ZSTD(1)), name String CODEC(ZSTD(3)),
+                    start_time DateTime64(6, 'UTC') CODEC(Delta, ZSTD(1)), end_time DateTime64(6, 'UTC') CODEC(Delta, ZSTD(1)),
                     input String CODEC(ZSTD(3)), output String CODEC(ZSTD(3)), metadata String CODEC(ZSTD(3)),
-                    tags Array(String) CODEC(ZSTD(1)),
-                    created_at DateTime64(6, 'UTC') CODEC(Delta, ZSTD(1)), last_updated_at DateTime64(6, 'UTC') CODEC(ZSTD(1)),
-                    created_by String CODEC(ZSTD(1)), last_updated_by String CODEC(ZSTD(1)),
-                    error_info String CODEC(ZSTD(1)), thread_id String CODEC(ZSTD(1)),
+                    tags Array(String) CODEC(ZSTD(3)),
+                    created_at DateTime64(6, 'UTC') CODEC(Delta, ZSTD(1)), last_updated_at DateTime64(6, 'UTC') CODEC(Delta, ZSTD(1)),
+                    created_by String CODEC(ZSTD(3)), last_updated_by String CODEC(ZSTD(3)),
+                    error_info String CODEC(ZSTD(1)), thread_id String CODEC(ZSTD(3)),
                     visibility_mode Enum8('unknown' = 0, 'default' = 1, 'hidden' = 2) CODEC(ZSTD(1)),
                     truncation_threshold UInt64 CODEC(ZSTD(1)), input_slim String CODEC(ZSTD(3)), output_slim String CODEC(ZSTD(3)),
                     ttft Float64 CODEC(ZSTD(1)),


### PR DESCRIPTION
## Details

Re-validate the `traces_local_v2` per-column codecs against a byte-weighted sample of **real** production `traces` data and apply the refinements, superseding the synthetic-slice estimates from #7492 (000106). Migration `000107` is a metadata-only `ALTER` on the still-empty `traces_local_v2`, so it must run before any backfill.

- `end_time` / `last_updated_at`: restore `Delta + ZSTD(1)` (revert 000106's plain `ZSTD(1)`). On real prod data these are monotonic enough in `(workspace_id, project_id, id)` storage order that Delta is smaller; 000106 had assumed otherwise from the scrambled synthetic slice.
- `workspace_id`, `name`, `tags`, `created_by`, `last_updated_by`, `thread_id`: `ZSTD(1)` -> `ZSTD(3)`. ClickHouse 26.3 LTS (the deployed version, #7493) regressed ZSTD level-1 on small, repetitive, variable-length String/Array columns, making `ZSTD(1)` larger than LZ4 on them; `ZSTD(3)` is unaffected and smallest on both 25.8 and 26.3, at codec-level-independent decode (no read penalty).
- `id` / `project_id` stay `ZSTD(1)`: FixedString UUIDv7, immune to the regression and already smallest under `ZSTD(1)`.
- `TracesLocalV2BenchmarkTest` updated to match: the codec pin map (drift guard), the per-column assertions, and the whole-row before/after DDL.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6899

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Benchmark methodology, real-production-data extraction, migration `000107`, and the benchmark-test updates were authored and iterated with AI assistance.
- Human verification: Reviewed by @andrescrz. Codecs validated against a real prod-data sample and the OPIK-6899 investigation; `TracesLocalV2BenchmarkTest` run locally (29/29) against the altinity 26.3 LTS testcontainer.

## Testing

- `mvn -Dtest=TracesLocalV2BenchmarkTest test` (opik-backend) — 29/29 green against the altinity ClickHouse 26.3 LTS + ZooKeeper testcontainers; covers the codec drift-guard pin map, per-column codec bake-offs, and the whole-row before/after storage check.
- Migration `000107` is metadata-only on the empty `traces_local_v2` (verified against 000101's column types/defaults so only the codec changes); full migration + table suite exercised by `TracesLocalV2TableTest` / `TracesLocalV2PartitioningTest` in CI.
- Final comment-only commit not re-run locally; covered by CI.

## Documentation

N/A — internal ClickHouse schema/codec change, no user-facing or SDK surface.
