### PR TITLE
[OPIK-7332] [HELM][DOCS] fix: two-phase HA guidance for multi-replica ClickHouse installs

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/scaling.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/scaling.mdx
@@ -128,6 +128,18 @@ Memory-optimized instances are recommended, with a minimum 4:1 memory-to-CPU rat
 
 Always scale vertically before adding more replicas for efficiency.
 
+#### Fresh multi-replica installs: migrate first, then scale
+
+A brand-new install running directly on **2 or more ClickHouse replicas** cannot complete its analytics migrations. Opik's earliest migrations aren't cluster-aware, so on a fresh multi-replica cluster they only reach one replica; later migrations then fail with errors such as `UNKNOWN_TABLE` or `UNKNOWN_DATABASE` (a table or the `opik` database missing on one replica), and `opik-backend` never becomes ready. Install High-Availability deployments in two phases:
+
+1. Install with `clickhouse.replicasCount: 1`.
+2. Wait until `opik-backend` is `Ready` — all migrations are then applied on the single replica.
+3. Raise `clickhouse.replicasCount` (e.g. to `2`) and upgrade. The ClickHouse operator provisions the new replica and copies the fully-migrated schema to it.
+
+<Callout intent="info">
+This only affects **fresh** installs. Single-replica installs and upgrades of already-migrated multi-replica clusters are unaffected — cluster-aware migrations use `ON CLUSTER '{cluster}'`, so once the base schema is present on all replicas it stays consistent automatically. See [Troubleshooting](/self-host/troubleshooting) if you hit this on a fresh multi-replica install.
+</Callout>
+
 ### CPU & Memory Guidance
 
 Target 10–20% CPU utilization, with safe spikes up to 40–50%.

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/scaling.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/scaling.mdx
@@ -132,9 +132,17 @@ Always scale vertically before adding more replicas for efficiency.
 
 A brand-new install running directly on **2 or more ClickHouse replicas** cannot complete its analytics migrations. Opik's earliest migrations aren't cluster-aware, so on a fresh multi-replica cluster they only reach one replica; later migrations then fail with errors such as `UNKNOWN_TABLE` or `UNKNOWN_DATABASE` (a table or the `opik` database missing on one replica), and `opik-backend` never becomes ready. Install High-Availability deployments in two phases:
 
-1. Install with `clickhouse.replicasCount: 1`.
-2. Wait until `opik-backend` is `Ready` — all migrations are then applied on the single replica.
-3. Raise `clickhouse.replicasCount` (e.g. to `2`) and upgrade. The ClickHouse operator provisions the new replica and copies the fully-migrated schema to it.
+<Steps>
+  <Step>
+    Install with `clickhouse.replicasCount: 1`.
+  </Step>
+  <Step>
+    Wait until `opik-backend` is `Ready` — all migrations are then applied on the single replica.
+  </Step>
+  <Step>
+    Raise `clickhouse.replicasCount` (e.g. to `2`) and upgrade. The ClickHouse operator provisions the new replica and copies the fully-migrated schema to it.
+  </Step>
+</Steps>
 
 <Callout intent="info">
 This only affects **fresh** installs. Single-replica installs and upgrades of already-migrated multi-replica clusters are unaffected — cluster-aware migrations use `ON CLUSTER '{cluster}'`, so once the base schema is present on all replicas it stays consistent automatically. See [Troubleshooting](/self-host/troubleshooting) if you hit this on a fresh multi-replica install.

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
@@ -79,6 +79,43 @@ You should see a row with the macro name and value.
 
 After restarting ClickHouse, retry the backend deployment or migration. The backend should automatically retry after ClickHouse is ready.
 
+### Fresh Multi-Replica Install Migration Failures
+
+#### Problem Description
+
+A brand-new Opik install on a ClickHouse cluster with **2 or more replicas** cannot complete its analytics migrations. The backend never starts (CrashLoopBackOff), and the migration step fails with errors such as:
+
+```
+Code: 60. DB::Exception: Could not find table: <table_name>. (UNKNOWN_TABLE)
+Code: 81. DB::Exception: Database opik does not exist. (UNKNOWN_DATABASE)
+```
+
+**Symptoms:**
+
+- Fresh install only (no existing data); backend in CrashLoopBackOff
+- Migration errors reference a table or the `opik` database that is missing on one replica
+- One replica holds the `opik` database and tables while another has few or none
+
+#### Cause
+
+Opik's earliest analytics migrations predate cluster-aware DDL — they do not use `ON CLUSTER '{cluster}'` — so they create the `opik` database and base tables on a single replica only. Later, cluster-aware migrations fan out to every replica and fail on the one that never received that base schema. The ClickHouse operator only copies schema to a replica when it **joins** the cluster (a scale-up), not during a migration.
+
+#### Resolution
+
+Install High-Availability deployments in two phases so the schema exists before the extra replicas join:
+
+1. Install (or reset to) `clickhouse.replicasCount: 1`.
+2. Wait until `opik-backend` is `Ready` — all migrations are applied on the single replica.
+3. Raise `clickhouse.replicasCount` (e.g. to `2`) and upgrade. The operator provisions the new replica and copies the fully-migrated schema to it.
+
+<Callout intent="info">
+Single-replica installs and upgrades of already-migrated multi-replica clusters are unaffected. Cluster-aware migrations use `ON CLUSTER '{cluster}'`, so once the base schema is present on all replicas, later migrations stay consistent automatically.
+</Callout>
+
+<Callout intent="warning">
+If a fresh multi-replica migration was already attempted, dropped ClickHouse tables can leave stale ZooKeeper paths under `/clickhouse/tables/...`, which cause `REPLICA_ALREADY_EXISTS` on a retry. Clean those up (see [ClickHouse Zookeeper Metadata Loss](#clickhouse-zookeeper-metadata-loss)) before re-running the two-phase flow.
+</Callout>
+
 ### ClickHouse Zookeeper Metadata Loss
 
 #### Problem Description

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
@@ -90,6 +90,8 @@ Code: 60. DB::Exception: Could not find table: <table_name>. (UNKNOWN_TABLE)
 Code: 81. DB::Exception: Database opik does not exist. (UNKNOWN_DATABASE)
 ```
 
+_`opik` is the default analytics database name (`ANALYTICS_DB_DATABASE_NAME`); substitute your own if you overrode it._
+
 **Symptoms:**
 
 - Fresh install only (no existing data); backend in CrashLoopBackOff
@@ -121,7 +123,7 @@ Single-replica installs and upgrades of already-migrated multi-replica clusters 
 </Callout>
 
 <Callout intent="warning">
-If a fresh multi-replica migration was already attempted, dropped ClickHouse tables can leave stale ZooKeeper paths under `/clickhouse/tables/...`, which cause `REPLICA_ALREADY_EXISTS` on a retry. Clean those up (see [ClickHouse Zookeeper Metadata Loss](#clickhouse-zookeeper-metadata-loss)) before re-running the two-phase flow.
+If a fresh multi-replica attempt was torn down, the dropped tables can leave orphaned `/clickhouse/tables/...` ZooKeeper paths that cause `REPLICA_ALREADY_EXISTS` on a retry. Since a fresh install has no data to preserve, recovery only needs those orphaned paths cleared before re-running — the full replica-restore rebuild in [ClickHouse Zookeeper Metadata Loss](#clickhouse-zookeeper-metadata-loss) is for recovering existing data and isn't needed here.
 </Callout>
 
 ### ClickHouse Zookeeper Metadata Loss

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
@@ -104,9 +104,17 @@ Opik's earliest analytics migrations predate cluster-aware DDL — they do not u
 
 Install High-Availability deployments in two phases so the schema exists before the extra replicas join:
 
-1. Install (or reset to) `clickhouse.replicasCount: 1`.
-2. Wait until `opik-backend` is `Ready` — all migrations are applied on the single replica.
-3. Raise `clickhouse.replicasCount` (e.g. to `2`) and upgrade. The operator provisions the new replica and copies the fully-migrated schema to it.
+<Steps>
+  <Step>
+    Install (or reset to) `clickhouse.replicasCount: 1`.
+  </Step>
+  <Step>
+    Wait until `opik-backend` is `Ready` — all migrations are applied on the single replica.
+  </Step>
+  <Step>
+    Raise `clickhouse.replicasCount` (e.g. to `2`) and upgrade. The operator provisions the new replica and copies the fully-migrated schema to it.
+  </Step>
+</Steps>
 
 <Callout intent="info">
 Single-replica installs and upgrades of already-migrated multi-replica clusters are unaffected. Cluster-aware migrations use `ON CLUSTER '{cluster}'`, so once the base schema is present on all replicas, later migrations stay consistent automatically.

--- a/apps/opik-documentation/documentation/fern/docs/self-host/scaling.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/scaling.mdx
@@ -133,9 +133,17 @@ Always scale vertically before adding more replicas for efficiency.
 
 A brand-new install running directly on **2 or more ClickHouse replicas** cannot complete its analytics migrations. Opik's earliest migrations aren't cluster-aware, so on a fresh multi-replica cluster they only reach one replica; later migrations then fail with errors such as `UNKNOWN_TABLE` or `UNKNOWN_DATABASE` (a table or the `opik` database missing on one replica), and `opik-backend` never becomes ready. Install High-Availability deployments in two phases:
 
-1. Install with `clickhouse.replicasCount: 1`.
-2. Wait until `opik-backend` is `Ready` — all migrations are then applied on the single replica.
-3. Raise `clickhouse.replicasCount` (e.g. to `2`) and upgrade. The ClickHouse operator provisions the new replica and copies the fully-migrated schema to it.
+<Steps>
+  <Step>
+    Install with `clickhouse.replicasCount: 1`.
+  </Step>
+  <Step>
+    Wait until `opik-backend` is `Ready` — all migrations are then applied on the single replica.
+  </Step>
+  <Step>
+    Raise `clickhouse.replicasCount` (e.g. to `2`) and upgrade. The ClickHouse operator provisions the new replica and copies the fully-migrated schema to it.
+  </Step>
+</Steps>
 
 <Callout intent="info">
 This only affects **fresh** installs. Single-replica installs and upgrades of already-migrated multi-replica clusters are unaffected — cluster-aware migrations use `ON CLUSTER '{cluster}'`, so once the base schema is present on all replicas it stays consistent automatically. See [Troubleshooting](/v1/self-host/troubleshooting) if you hit this on a fresh multi-replica install.

--- a/apps/opik-documentation/documentation/fern/docs/self-host/scaling.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/scaling.mdx
@@ -129,6 +129,18 @@ Memory-optimized instances are recommended, with a minimum 4:1 memory-to-CPU rat
 
 Always scale vertically before adding more replicas for efficiency.
 
+#### Fresh multi-replica installs: migrate first, then scale
+
+A brand-new install running directly on **2 or more ClickHouse replicas** cannot complete its analytics migrations. Opik's earliest migrations aren't cluster-aware, so on a fresh multi-replica cluster they only reach one replica; later migrations then fail with errors such as `UNKNOWN_TABLE` or `UNKNOWN_DATABASE` (a table or the `opik` database missing on one replica), and `opik-backend` never becomes ready. Install High-Availability deployments in two phases:
+
+1. Install with `clickhouse.replicasCount: 1`.
+2. Wait until `opik-backend` is `Ready` — all migrations are then applied on the single replica.
+3. Raise `clickhouse.replicasCount` (e.g. to `2`) and upgrade. The ClickHouse operator provisions the new replica and copies the fully-migrated schema to it.
+
+<Callout intent="info">
+This only affects **fresh** installs. Single-replica installs and upgrades of already-migrated multi-replica clusters are unaffected — cluster-aware migrations use `ON CLUSTER '{cluster}'`, so once the base schema is present on all replicas it stays consistent automatically. See [Troubleshooting](/v1/self-host/troubleshooting) if you hit this on a fresh multi-replica install.
+</Callout>
+
 ### CPU & Memory Guidance
 
 Target 10–20% CPU utilization, with safe spikes up to 40–50%.

--- a/apps/opik-documentation/documentation/fern/docs/self-host/troubleshooting.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/troubleshooting.mdx
@@ -91,6 +91,8 @@ Code: 60. DB::Exception: Could not find table: <table_name>. (UNKNOWN_TABLE)
 Code: 81. DB::Exception: Database opik does not exist. (UNKNOWN_DATABASE)
 ```
 
+_`opik` is the default analytics database name (`ANALYTICS_DB_DATABASE_NAME`); substitute your own if you overrode it._
+
 **Symptoms:**
 
 - Fresh install only (no existing data); backend in CrashLoopBackOff
@@ -122,7 +124,7 @@ Single-replica installs and upgrades of already-migrated multi-replica clusters 
 </Callout>
 
 <Callout intent="warning">
-If a fresh multi-replica migration was already attempted, dropped ClickHouse tables can leave stale ZooKeeper paths under `/clickhouse/tables/...`, which cause `REPLICA_ALREADY_EXISTS` on a retry. Clean those up (see [ClickHouse Zookeeper Metadata Loss](#clickhouse-zookeeper-metadata-loss)) before re-running the two-phase flow.
+If a fresh multi-replica attempt was torn down, the dropped tables can leave orphaned `/clickhouse/tables/...` ZooKeeper paths that cause `REPLICA_ALREADY_EXISTS` on a retry. Since a fresh install has no data to preserve, recovery only needs those orphaned paths cleared before re-running — the full replica-restore rebuild in [ClickHouse Zookeeper Metadata Loss](#clickhouse-zookeeper-metadata-loss) is for recovering existing data and isn't needed here.
 </Callout>
 
 ### ClickHouse Zookeeper Metadata Loss

--- a/apps/opik-documentation/documentation/fern/docs/self-host/troubleshooting.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/troubleshooting.mdx
@@ -105,9 +105,17 @@ Opik's earliest analytics migrations predate cluster-aware DDL — they do not u
 
 Install High-Availability deployments in two phases so the schema exists before the extra replicas join:
 
-1. Install (or reset to) `clickhouse.replicasCount: 1`.
-2. Wait until `opik-backend` is `Ready` — all migrations are applied on the single replica.
-3. Raise `clickhouse.replicasCount` (e.g. to `2`) and upgrade. The operator provisions the new replica and copies the fully-migrated schema to it.
+<Steps>
+  <Step>
+    Install (or reset to) `clickhouse.replicasCount: 1`.
+  </Step>
+  <Step>
+    Wait until `opik-backend` is `Ready` — all migrations are applied on the single replica.
+  </Step>
+  <Step>
+    Raise `clickhouse.replicasCount` (e.g. to `2`) and upgrade. The operator provisions the new replica and copies the fully-migrated schema to it.
+  </Step>
+</Steps>
 
 <Callout intent="info">
 Single-replica installs and upgrades of already-migrated multi-replica clusters are unaffected. Cluster-aware migrations use `ON CLUSTER '{cluster}'`, so once the base schema is present on all replicas, later migrations stay consistent automatically.

--- a/apps/opik-documentation/documentation/fern/docs/self-host/troubleshooting.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/troubleshooting.mdx
@@ -80,6 +80,43 @@ You should see a row with the macro name and value.
 
 After restarting ClickHouse, retry the backend deployment or migration. The backend should automatically retry after ClickHouse is ready.
 
+### Fresh Multi-Replica Install Migration Failures
+
+#### Problem Description
+
+A brand-new Opik install on a ClickHouse cluster with **2 or more replicas** cannot complete its analytics migrations. The backend never starts (CrashLoopBackOff), and the migration step fails with errors such as:
+
+```
+Code: 60. DB::Exception: Could not find table: <table_name>. (UNKNOWN_TABLE)
+Code: 81. DB::Exception: Database opik does not exist. (UNKNOWN_DATABASE)
+```
+
+**Symptoms:**
+
+- Fresh install only (no existing data); backend in CrashLoopBackOff
+- Migration errors reference a table or the `opik` database that is missing on one replica
+- One replica holds the `opik` database and tables while another has few or none
+
+#### Cause
+
+Opik's earliest analytics migrations predate cluster-aware DDL — they do not use `ON CLUSTER '{cluster}'` — so they create the `opik` database and base tables on a single replica only. Later, cluster-aware migrations fan out to every replica and fail on the one that never received that base schema. The ClickHouse operator only copies schema to a replica when it **joins** the cluster (a scale-up), not during a migration.
+
+#### Resolution
+
+Install High-Availability deployments in two phases so the schema exists before the extra replicas join:
+
+1. Install (or reset to) `clickhouse.replicasCount: 1`.
+2. Wait until `opik-backend` is `Ready` — all migrations are applied on the single replica.
+3. Raise `clickhouse.replicasCount` (e.g. to `2`) and upgrade. The operator provisions the new replica and copies the fully-migrated schema to it.
+
+<Callout intent="info">
+Single-replica installs and upgrades of already-migrated multi-replica clusters are unaffected. Cluster-aware migrations use `ON CLUSTER '{cluster}'`, so once the base schema is present on all replicas, later migrations stay consistent automatically.
+</Callout>
+
+<Callout intent="warning">
+If a fresh multi-replica migration was already attempted, dropped ClickHouse tables can leave stale ZooKeeper paths under `/clickhouse/tables/...`, which cause `REPLICA_ALREADY_EXISTS` on a retry. Clean those up (see [ClickHouse Zookeeper Metadata Loss](#clickhouse-zookeeper-metadata-loss)) before re-running the two-phase flow.
+</Callout>
+
 ### ClickHouse Zookeeper Metadata Loss
 
 #### Problem Description

--- a/deployment/helm_chart/opik/templates/NOTES.txt
+++ b/deployment/helm_chart/opik/templates/NOTES.txt
@@ -6,3 +6,23 @@ To learn more about the release, try:
 
   $ helm status -n {{ .Release.Namespace }} {{ .Release.Name }}
   $ helm -n {{ .Release.Namespace }}  get all {{ .Release.Name }}
+{{- if and .Values.clickhouse.enabled (gt (int (.Values.clickhouse.replicasCount | default 1)) 1) }}
+
+────────────────────────────────────────────────────────────────────────────
+[!] ClickHouse is configured with {{ .Values.clickhouse.replicasCount }} replicas.
+
+    For a FRESH install, Opik's analytics migrations must run against a SINGLE
+    ClickHouse replica first. Installing directly on a multi-replica cluster
+    prevents the migrations from completing (the earliest migrations are not
+    cluster-aware and only reach one replica), so opik-backend never becomes Ready.
+
+    Recommended two-phase install for High Availability:
+      1. Install with clickhouse.replicasCount: 1
+      2. Wait until opik-backend is Ready (all migrations applied)
+      3. Set clickhouse.replicasCount: {{ .Values.clickhouse.replicasCount }} and upgrade — the ClickHouse
+         operator copies the schema to the new replicas.
+
+    Already-migrated multi-replica clusters are unaffected; ignore this on upgrades.
+    Docs: https://www.comet.com/docs/opik/self-host/scaling#replication-strategy
+────────────────────────────────────────────────────────────────────────────
+{{- end }}

--- a/deployment/helm_chart/opik/tests/clickhouse_migration_test.yaml
+++ b/deployment/helm_chart/opik/tests/clickhouse_migration_test.yaml
@@ -1,0 +1,33 @@
+suite: clickhouse multi-replica migration NOTES reminder
+
+# When ClickHouse runs >= 2 replicas, NOTES.txt reminds operators to use the two-phase
+# HA install flow (migrate at 1 replica, then scale up), since a fresh multi-replica
+# install cannot complete its migrations (OPIK-7332).
+
+templates:
+  - templates/NOTES.txt
+
+tests:
+  - it: NOTES omits the multi-replica migration banner for the single-replica default
+    asserts:
+      - notMatchRegexRaw:
+          pattern: "two-phase install"
+
+  - it: NOTES shows the two-phase migration banner when ClickHouse runs multiple replicas
+    set:
+      clickhouse.replicasCount: 2
+    asserts:
+      - matchRegexRaw:
+          pattern: "ClickHouse is configured with 2 replicas"
+      - matchRegexRaw:
+          pattern: "two-phase install for High Availability"
+      - matchRegexRaw:
+          pattern: "clickhouse\\.replicasCount: 1"
+
+  - it: NOTES omits the banner when ClickHouse is disabled even with multiple replicas
+    set:
+      clickhouse.enabled: false
+      clickhouse.replicasCount: 2
+    asserts:
+      - notMatchRegexRaw:
+          pattern: "two-phase install"

--- a/deployment/helm_chart/opik/tests/clickhouse_migration_test.yaml
+++ b/deployment/helm_chart/opik/tests/clickhouse_migration_test.yaml
@@ -8,7 +8,14 @@ templates:
   - templates/NOTES.txt
 
 tests:
-  - it: NOTES omits the multi-replica migration banner for the single-replica default
+  - it: NOTES omits the multi-replica migration banner for the default replica count
+    asserts:
+      - notMatchRegexRaw:
+          pattern: "two-phase install"
+
+  - it: NOTES omits the banner at an explicit single replica
+    set:
+      clickhouse.replicasCount: 1
     asserts:
       - notMatchRegexRaw:
           pattern: "two-phase install"

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -684,6 +684,10 @@ altinity-clickhouse-operator:
 clickhouse:
   enabled: true
   shardsCount: 1
+  # For a FRESH High-Availability install, use the two-phase flow: install with replicasCount 1, let
+  # opik-backend finish all migrations, THEN raise replicasCount and upgrade so the ClickHouse operator
+  # clones the schema to the new replicas. Installing directly on >= 2 replicas prevents the analytics
+  # migrations from completing on a fresh cluster. See the self-host/scaling docs.
   replicasCount: 1
   image: altinity/clickhouse-server:26.3.16.10001.altinitystable
   storage: 50Gi


### PR DESCRIPTION
## Details

Fresh Opik installs on a multi-replica ClickHouse cluster cannot complete the analytics migrations: the earliest migrations aren't cluster-aware, so on a fresh multi-replica cluster they only reach one replica and later migrations fail (e.g. `UNKNOWN_TABLE` / `UNKNOWN_DATABASE`), leaving `opik-backend` unable to start. The existing migrations are immutable, so this change documents and signposts the supported **two-phase High-Availability install** (migrate against a single replica, then scale up so the ClickHouse operator clones the schema to the new replicas) instead of altering migration behavior. Related to the open-source multi-replica migration reports (GitHub issue #7090; not fully resolved here).

- Add a `NOTES.txt` reminder, printed only when `clickhouse.replicasCount >= 2`, pointing to the two-phase flow.
- Document the two-phase install in self-host **Scaling** (Replication Strategy) and add a **Troubleshooting** entry for the failure (both docs versions).
- Add neutral guidance on `clickhouse.replicasCount` in `values.yaml`; keep the migration connection on the load-balanced ClickHouse service and the OSS default at a single replica (no behavior change).
- Add a helm-unittest suite covering the NOTES banner.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7332

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation (analysis, Helm chart + docs changes, tests)
- Human verification: code review + local Helm lint/unittest/dry-run

## Testing

- `helm unittest .` (in `deployment/helm_chart/opik`) → 40/40 pass, including the new NOTES suite: banner present at `replicasCount >= 2`, absent at `1`, and absent when ClickHouse is disabled.
- `helm lint .` → 0 failures.
- `helm install --dry-run` at `replicasCount` 1 and 2 → banner renders only for `>= 2` and interpolates the configured target count.
- `helm-docs` (chart's pinned version) → no README drift, so the docs-sync check passes.
- Fern docs: verified MDX brace-safety, heading nesting, and anchor/link targets across both docs versions.
- No application code changed; CI runs the full quality suite.

## Documentation

- `self-host/scaling`: two-phase HA install guidance under Replication Strategy (both docs versions).
- `self-host/troubleshooting`: "Fresh Multi-Replica Install Migration Failures" entry with symptoms, cause, and resolution (both docs versions).
- `values.yaml`: guidance comment on `clickhouse.replicasCount`.
