### PR TITLE
[OPIK-7396] [BE] fix: tolerate >1 emitted row in TraceDAO.findById (get-by-id 500)

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -3451,11 +3451,18 @@ class TraceDAOImpl implements TraceDAO {
     @WithSpan
     public Mono<Trace> findById(@NonNull UUID id, @NonNull Connection connection) {
         // A single id can map to more than one emitted Trace when the assembled query fans out
-        // over its join CTEs (e.g. un-merged/duplicated rows). Take the first emission rather than
+        // over its join CTEs (e.g. un-merged/duplicated rows). Take the first row rather than
         // singleOrEmpty(), which throws IndexOutOfBoundsException ("Source emitted more than one
-        // item") and surfaces as a 500 on GET by id. next() preserves the empty case (-> 404).
+        // item") and surfaces as a 500 on GET by id. The empty case is preserved (-> 404).
+        // Log when it happens so the underlying duplication/fan-out stays visible.
         return findByIds(List.of(id), connection)
-                .next();
+                .collectList()
+                .flatMap(traces -> {
+                    if (traces.size() > 1) {
+                        log.warn("Trace id '{}' resolved to '{}' rows; returning the first", id, traces.size());
+                    }
+                    return traces.isEmpty() ? Mono.empty() : Mono.just(traces.get(0));
+                });
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -3457,12 +3457,13 @@ class TraceDAOImpl implements TraceDAO {
         // Log when it happens so the underlying duplication/fan-out stays visible.
         return findByIds(List.of(id), connection)
                 .collectList()
-                .flatMap(traces -> {
+                .flatMap(traces -> Mono.deferContextual(ctx -> {
                     if (traces.size() > 1) {
-                        log.warn("Trace id '{}' resolved to '{}' rows; returning the first", id, traces.size());
+                        log.warn("Trace id '{}' in workspace '{}' resolved to '{}' rows; returning the first",
+                                id, ctx.getOrDefault(RequestContext.WORKSPACE_ID, "unknown"), traces.size());
                     }
-                    return traces.isEmpty() ? Mono.empty() : Mono.just(traces.get(0));
-                });
+                    return traces.isEmpty() ? Mono.<Trace>empty() : Mono.just(traces.get(0));
+                }));
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -468,6 +468,11 @@ class TraceDAOImpl implements TraceDAO {
      * Key format: {@code author} + optional {@code _queueId} + optional {@code _spanId} (ensures uniqueness across
      * queues/spans). Value tuple: (value, reason, category_name, source, last_updated_at, span_type, span_id,
      * source_queue_id, author).
+     *
+     * <p>experiments_agg collapses to a single canonical row per trace_id (the most recent experiment,
+     * by UUIDv7-ordered id) so the trace-by-id LEFT JOIN cannot fan a trace that belongs to multiple
+     * experiments into multiple rows — which surfaced as an IndexOutOfBoundsException 500 on GET by id
+     * and non-deterministic experiment metadata (OPIK-7396).
      */
     private static final String SELECT_BY_IDS = """
             WITH target_spans AS (
@@ -678,7 +683,7 @@ class TraceDAOImpl implements TraceDAO {
                 AND trace_id IN :ids
                 GROUP BY trace_id
             ), experiments_agg AS (
-                SELECT DISTINCT
+                SELECT
                     ei.trace_id,
                     if(div.id != '', div.dataset_item_id, ei.dataset_item_id) AS experiment_dataset_item_id,
                     e.id AS experiment_id,
@@ -706,6 +711,8 @@ class TraceDAOImpl implements TraceDAO {
                     ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
                     LIMIT 1 BY id
                 ) e ON ei.experiment_id = e.id
+                ORDER BY trace_id, experiment_id DESC
+                LIMIT 1 BY trace_id
             )
             SELECT
                 t.*,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -3450,20 +3450,25 @@ class TraceDAOImpl implements TraceDAO {
     @Override
     @WithSpan
     public Mono<Trace> findById(@NonNull UUID id, @NonNull Connection connection) {
-        // A single id can map to more than one emitted Trace when the assembled query fans out
-        // over its join CTEs (e.g. un-merged/duplicated rows). Take the first row rather than
-        // singleOrEmpty(), which throws IndexOutOfBoundsException ("Source emitted more than one
-        // item") and surfaces as a 500 on GET by id. The empty case is preserved (-> 404).
-        // Log when it happens so the underlying duplication/fan-out stays visible.
         return findByIds(List.of(id), connection)
                 .collectList()
-                .flatMap(traces -> Mono.deferContextual(ctx -> {
-                    if (traces.size() > 1) {
-                        log.warn("Trace id '{}' in workspace '{}' resolved to '{}' rows; returning the first",
-                                id, ctx.getOrDefault(RequestContext.WORKSPACE_ID, "unknown"), traces.size());
-                    }
-                    return traces.isEmpty() ? Mono.<Trace>empty() : Mono.just(traces.get(0));
-                }));
+                .flatMap(traces -> Mono.deferContextual(ctx -> Mono.justOrEmpty(
+                        firstOrLogFanOut(traces, id, ctx.getOrDefault(RequestContext.WORKSPACE_ID, "unknown")))));
+    }
+
+    /**
+     * Reduce the rows returned for a single trace id to at most one {@link Trace}. A get-by-id
+     * query can fan out to more than one row over its join CTEs (e.g. un-merged/duplicated rows);
+     * returning the first row avoids the {@code IndexOutOfBoundsException} ("Source emitted more
+     * than one item") that a strict single-item reducer throws, which surfaces as a 500. The empty
+     * case is preserved (-> 404). A fan-out is logged so the underlying duplication stays visible.
+     */
+    static Optional<Trace> firstOrLogFanOut(@NonNull List<Trace> traces, UUID id, String workspaceId) {
+        if (traces.size() > 1) {
+            log.warn("Trace id '{}' in workspace '{}' resolved to '{}' rows; returning the first",
+                    id, workspaceId, traces.size());
+        }
+        return traces.stream().findFirst();
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -33,6 +33,7 @@ import com.comet.opik.utils.TruncationUtils;
 import com.comet.opik.utils.template.TemplateUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.inject.ImplementedBy;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -3470,10 +3471,11 @@ class TraceDAOImpl implements TraceDAO {
      * than one item") that a strict single-item reducer throws, which surfaces as a 500. The empty
      * case is preserved (-> 404). A fan-out is logged so the underlying duplication stays visible.
      */
+    @VisibleForTesting
     static Optional<Trace> firstOrLogFanOut(@NonNull List<Trace> traces, UUID id, String workspaceId) {
         if (traces.size() > 1) {
-            log.warn("Trace id '{}' in workspace '{}' resolved to '{}' rows; returning the first",
-                    id, workspaceId, traces.size());
+            log.warn("Trace get-by-id resolved to multiple rows; returning the first. workspaceId '{}', traceId '{}'",
+                    workspaceId, id);
         }
         return traces.stream().findFirst();
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -3450,8 +3450,12 @@ class TraceDAOImpl implements TraceDAO {
     @Override
     @WithSpan
     public Mono<Trace> findById(@NonNull UUID id, @NonNull Connection connection) {
+        // A single id can map to more than one emitted Trace when the assembled query fans out
+        // over its join CTEs (e.g. un-merged/duplicated rows). Take the first emission rather than
+        // singleOrEmpty(), which throws IndexOutOfBoundsException ("Source emitted more than one
+        // item") and surfaces as a 500 on GET by id. next() preserves the empty case (-> 404).
         return findByIds(List.of(id), connection)
-                .singleOrEmpty();
+                .next();
     }
 
     @Override

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceDAOImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceDAOImplTest.java
@@ -1,0 +1,37 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.Trace;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("TraceDAOImpl get-by-id reducer")
+class TraceDAOImplTest {
+
+    @Test
+    void firstOrLogFanOut__whenNoRows__returnsEmpty() {
+        assertThat(TraceDAOImpl.firstOrLogFanOut(List.of(), UUID.randomUUID(), "ws")).isEmpty();
+    }
+
+    @Test
+    void firstOrLogFanOut__whenSingleRow__returnsIt() {
+        var id = UUID.randomUUID();
+        var trace = Trace.builder().id(id).build();
+
+        assertThat(TraceDAOImpl.firstOrLogFanOut(List.of(trace), id, "ws")).containsSame(trace);
+    }
+
+    @Test
+    void firstOrLogFanOut__whenMoreThanOneRow__returnsFirstWithoutThrowing() {
+        var id = UUID.randomUUID();
+        var first = Trace.builder().id(id).build();
+        var second = Trace.builder().id(id).build();
+
+        // Must not throw IndexOutOfBoundsException ("Source emitted more than one item").
+        assertThat(TraceDAOImpl.firstOrLogFanOut(List.of(first, second), id, "ws")).containsSame(first);
+    }
+}


### PR DESCRIPTION
## Details

`GET /v1/private/traces/{id}` intermittently returned 500 with `IndexOutOfBoundsException: "Source emitted more than one item"`, and — once the reducer was made lenient — could return a non-deterministic `experiment` field. Root cause: in `SELECT_BY_IDS`, the outer `LEFT JOIN experiments_agg eaag ON eaag.trace_id = t.id` had no per-trace dedup, so a trace that belongs to N experiments fanned out into N rows (differing `experiment_id/name/dataset_id`).

- **Fix at the source:** `experiments_agg` now collapses to a single canonical row per `trace_id` — the most recent experiment (`ORDER BY trace_id, experiment_id DESC` + `LIMIT 1 BY trace_id`, ids are UUIDv7 / time-ordered). The trace-by-id join therefore returns exactly one row. This also stops batch `getByIds` returning duplicate rows for multi-experiment traces. `Trace.experiment` is a single field, so collapsing loses nothing at the API level.
- **Defense in depth:** `findById` reduces via `collectList()` + first and logs a WARN (trace id + workspace) if a fan-out ever reappears, so a future regression degrades to a log + one row instead of a 500.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7396

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Production diagnosis, the query-level collapse in `SELECT_BY_IDS`, the defensive reducer, and the unit test.
- Human verification: Author reviewed the diff, confirmed the query change against the fan-out analysis, and confirmed the test run below.

## Testing

- `mvn -o test-compile` + `spotless:apply` clean.
- Unit test `TraceDAOImplTest` on the reducer (no DB): no rows → empty; single → that; >1 → first, no `IndexOutOfBoundsException`. `Tests run: 3, Failures: 0`.
- The query-level collapse is DB-backed; a regression test (a trace in ≥2 experiments → `GET /{id}` returns 200 with a deterministic experiment) belongs in the traces integration suite (CI). Flagged on the ticket.

## Documentation

No documentation changes — internal reliability/correctness fix; no API shape change (`Trace.experiment` remains a single value).
