### PR TITLE
README: drop internal-sounding sourcing footnote from comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,25 +118,12 @@ Opik competes in the **LLM observability / AI agent evaluation** category alongs
 | Capability | Opik | LangSmith | Phoenix | Arize AX | Weights & Biases (Weave) | Langfuse | Braintrust |
 |---|---|---|---|---|---|---|---|
 | Open source | Yes, Apache-2.0 (full platform) | No | Source-available (Elastic License 2.0, not OSI-approved) | No | Open-source SDK/toolkit; self-managed platform requires a commercial license | MIT-licensed core platform; commercial enterprise modules | No |
-| Self-hosted deployment | Yes | Enterprise only | Yes | Enterprise only | Enterprise only for Weave itself* | Yes, core | Enterprise only |
+| Self-hosted deployment | Yes | Enterprise only | Yes | Enterprise only | Enterprise only for Weave itself | Yes, core | Enterprise only |
 | Free tier available (cloud or self-hosted) | Yes, both | Yes, cloud | Yes, self-hosted | Yes, cloud | Yes, cloud | Yes, both | Yes, cloud |
 | Agent / multi-step tracing | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | LLM-as-a-judge evaluation | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | Prompt management | Yes | Yes | Partly | Partly | Partly | Yes | Yes |
-| Framework-agnostic | Yes | Partly, built around LangChain** | Yes | Yes | Yes | Yes | Yes |
-
-_Created by: Opik (Comet), LangSmith (LangChain), Phoenix and Arize AX (Arize AI), Weave (Weights
-& Biases, acquired by CoreWeave in 2025), Langfuse (joined ClickHouse in 2026), Braintrust
-(independent). Every competitor here has some accessible free way to start, cloud or
-self-hosted, but only Opik, Phoenix, and Langfuse's core let you run the whole thing yourself for
-free; the rest gate that specifically to an Enterprise plan, confirmed directly on each vendor's
-own current pricing page. *W&B does have a free, self-hosted "Personal" tier, but per its own
-pricing page it covers classic experiment tracking only (runs, registry, lineage). Weave's LLM
-tracing and evaluation features aren't included, and per W&B's own Weave self-hosting docs,
-running Weave itself outside the cloud still requires a separate commercial license.
-**LangSmith's own docs describe it as framework-agnostic and it does work outside LangChain, but
-its tooling, docs, and integration depth are built around the LangChain ecosystem first; expect
-more setup outside it._
+| Framework-agnostic | Yes | Partly, built around LangChain | Yes | Yes | Yes | Yes | Yes |
 
 **When teams choose Opik:** Opik's full observability, evaluation, and optimization platform is Apache-2.0 licensed and free to self-host. Unlike closed platforms whose self-hosted deployment requires an Enterprise plan, Opik can be deployed without a commercial license, and it's framework-agnostic so it won't lock you into a single agent ecosystem. See the table above for where self-hosting and licensing differ across alternatives.
 


### PR DESCRIPTION
## Summary
- Removes the "Created by" footnote paragraph below the "How Does Opik Compare?" table (added in #7515). It read like the internal fact-checking trail behind the claims ("confirmed directly on each vendor's own current pricing page", "per its own ... docs") rather than reader-facing copy.
- Drops the now-orphaned `*` / `**` markers from the two table cells the footnote was annotating.

## Why this is safe to cut
- **Attribution** is already covered by the sentence above the table ("Opik competes ... alongside LangSmith, Arize (Phoenix and Arize AX), Weights & Biases (Weave), Langfuse, and Braintrust").
- **The W&B/Weave and LangSmith nuances** are already carried by the cell text itself (`Enterprise only for Weave itself`, `Partly, built around LangChain`) — no need for a footnote to further justify them.
- **The payoff line** ("When teams choose Opik: ... free to self-host ... won't lock you into a single agent ecosystem") already lands the positioning point right below, without the footnote setting it up.

Only thing intentionally not carried forward: the two acquisition asides (Weave → CoreWeave, Langfuse → ClickHouse). Happy to fold those into the sentence above the table instead if useful, but they read as trivia rather than something a reader needs to pick a tool.

## Test plan
- [x] Diffed against current `main` — only the footnote paragraph and two asterisk markers change; table content and all other rows untouched.
- [ ] Human review of rendered README on GitHub before merge.