### PR TITLE
[OPIK-7397] [BE] fix: ignore null/blank sort field instead of 500 (SortingFactory NPE)

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingFactory.java
@@ -70,12 +70,16 @@ public abstract class SortingFactory {
             sorting = List.of(sorting.get(0));
         }
 
-        // Filter out unsupported fields
+        // Filter out unsupported fields. A null/blank field is treated as unsupported and ignored
+        // (rather than dereferenced): getSortableFields() is an immutable List, whose contains(null)
+        // throws NPE, and isDynamicFieldSupported dereferences the field too.
         List<SortingField> validFields = sorting.stream()
                 .filter(sortField -> {
-                    boolean isValid = isFieldSupported(sortField.field()) || isDynamicFieldSupported(sortField.field());
+                    String field = sortField.field();
+                    boolean isValid = StringUtils.isNotBlank(field)
+                            && (isFieldSupported(field) || isDynamicFieldSupported(field));
                     if (!isValid) {
-                        log.info("Ignoring unsupported sorting field: '{}'", sortField.field());
+                        log.info("Ignoring unsupported sorting field: '{}'", field);
                     }
                     return isValid;
                 })

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingFactory.java
@@ -30,6 +30,12 @@ public abstract class SortingFactory {
             throw new BadRequestException(ERR_INVALID_SORTING_PARAM_TEMPLATE.formatted(queryParam), exception);
         }
 
+        // Drop entries with a null/blank field before any per-field processing. Subclass
+        // processFields hooks (e.g. SortingFactoryDatasets.ensureBindKeyParam) and the validity
+        // check dereference the field, and immutable getSortableFields().contains(null) /
+        // field.startsWith(...) both throw NPE on a null field.
+        sorting = sorting.stream().filter(field -> StringUtils.isNotBlank(field.field())).toList();
+
         // Hook for subclasses to process fields after deserialization
         sorting = processFields(sorting);
 
@@ -70,16 +76,12 @@ public abstract class SortingFactory {
             sorting = List.of(sorting.get(0));
         }
 
-        // Filter out unsupported fields. A null/blank field is treated as unsupported and ignored
-        // (rather than dereferenced): getSortableFields() is an immutable List, whose contains(null)
-        // throws NPE, and isDynamicFieldSupported dereferences the field too.
+        // Filter out unsupported fields
         List<SortingField> validFields = sorting.stream()
                 .filter(sortField -> {
-                    String field = sortField.field();
-                    boolean isValid = StringUtils.isNotBlank(field)
-                            && (isFieldSupported(field) || isDynamicFieldSupported(field));
+                    boolean isValid = isFieldSupported(sortField.field()) || isDynamicFieldSupported(sortField.field());
                     if (!isValid) {
-                        log.info("Ignoring unsupported sorting field: '{}'", field);
+                        log.info("Ignoring unsupported sorting field: '{}'", sortField.field());
                     }
                     return isValid;
                 })

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/sorting/SortingFactoryTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/sorting/SortingFactoryTest.java
@@ -43,4 +43,22 @@ class SortingFactoryTest {
         assertThat(result.get(0).field()).isEqualTo("name");
         assertThat(result.get(0).direction()).isEqualTo(Direction.DESC);
     }
+
+    @Test
+    void newSorting__whenAnEntryHasNullField__keepsTheValidEntry() {
+        var result = factory.newSorting("[{\"field\":\"name\",\"direction\":\"ASC\"},{\"direction\":\"DESC\"}]");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).field()).isEqualTo("name");
+    }
+
+    @Test
+    void newSorting__whenNullFieldOnDatasetsFactory__ignoresItWithoutThrowing() {
+        // Regression: the null field reaches SortingFactoryDatasets.processFields -> ensureBindKeyParam,
+        // which called field.startsWith(...) and NPE'd before the validity filter ran.
+        var datasetsFactory = new SortingFactoryDatasets();
+
+        assertThatCode(() -> datasetsFactory.newSorting("[{\"direction\":\"DESC\"}]")).doesNotThrowAnyException();
+        assertThat(datasetsFactory.newSorting("[{\"direction\":\"DESC\"}]")).isEmpty();
+    }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/sorting/SortingFactoryTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/sorting/SortingFactoryTest.java
@@ -1,0 +1,46 @@
+package com.comet.opik.api.sorting;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@DisplayName("SortingFactory")
+class SortingFactoryTest {
+
+    private final SortingFactory factory = new SortingFactory() {
+        @Override
+        public List<String> getSortableFields() {
+            return List.of("id", "name");
+        }
+    };
+
+    @Test
+    void newSorting__whenFieldIsNull__ignoresItWithoutThrowing() {
+        // field omitted -> null; previously NPE'd via getSortableFields().contains(null) on an immutable List.
+        assertThatCode(() -> factory.newSorting("[{\"direction\":\"DESC\"}]")).doesNotThrowAnyException();
+        assertThat(factory.newSorting("[{\"direction\":\"DESC\"}]")).isEmpty();
+    }
+
+    @Test
+    void newSorting__whenFieldIsBlank__ignoresIt() {
+        assertThat(factory.newSorting("[{\"field\":\"   \",\"direction\":\"ASC\"}]")).isEmpty();
+    }
+
+    @Test
+    void newSorting__whenFieldIsUnsupported__ignoresIt() {
+        assertThat(factory.newSorting("[{\"field\":\"unknown\",\"direction\":\"ASC\"}]")).isEmpty();
+    }
+
+    @Test
+    void newSorting__whenFieldIsSupported__returnsIt() {
+        var result = factory.newSorting("[{\"field\":\"name\",\"direction\":\"DESC\"}]");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).field()).isEqualTo("name");
+        assertThat(result.get(0).direction()).isEqualTo(Direction.DESC);
+    }
+}


### PR DESCRIPTION
## Details

`GET /v1/private/traces` (list traces by project) returns 500 with a `NullPointerException` when the `sorting` query param contains an entry whose `field` is null. `SortingFactory.isFieldSupported` does `getSortableFields().contains(field)`, and `getSortableFields()` returns an immutable `List.of(...)` whose `contains(null)` throws NPE (`isDynamicFieldSupported` would dereference the field too).

- `filterValidFields` now treats a null/blank field as unsupported and ignores it (its documented "graceful degradation" behavior) instead of dereferencing it, so the request proceeds with the remaining valid fields / default sorting. Same class as OPIK-7362 (user input → NPE 500).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7397

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Production diagnosis (stack traced to `TracesResource.getTracesByProject` → `SortingFactory.isFieldSupported`), the null/blank-field guard, and the unit tests.
- Human verification: Author reviewed the diff and confirmed the test run below.

## Testing

- `mvn -o test-compile` + `spotless:apply` clean.
- New unit test `SortingFactoryTest` (pure, no DB harness), exercising `newSorting` via a concrete factory with sortable fields `["id","name"]`:
  - **null field → ignored, no exception** (the fix; previously NPE'd)
  - blank field → ignored
  - unsupported field → ignored
  - supported field → returned with its direction

  `mvn -o surefire:test -Dtest=SortingFactoryTest` → `Tests run: 4, Failures: 0, Errors: 0`.

## Documentation

No documentation changes — internal input-robustness fix, no API/behavior change for valid sorting params.
