### PR TITLE
[OPIK-7085] [QA] test: add annotation queue scoring e2e release-gate test

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow.tsx
@@ -374,6 +374,7 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
           onBlur={onReasonBlur}
           disabled={value === ""}
           className="min-h-6 resize-none overflow-hidden py-1 pt-[4px]"
+          data-testid={`annotate-score-reason-${name}`}
           ref={(e) => {
             textAreaRef.current = e;
             updateTextAreaHeight(e, 32);

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -66,6 +66,19 @@ export interface AutomationRuleRef {
   projectIds: string[];
 }
 
+export interface AnnotationQueueReviewerRef {
+  username: string;
+  /** Count of items this reviewer has scored in the queue. */
+  status: number;
+}
+
+export interface AnnotationQueueDetail {
+  id: string;
+  name: string;
+  itemsCount: number;
+  reviewers: AnnotationQueueReviewerRef[];
+}
+
 export interface OptimizationRef {
   id: string;
   name: string;
@@ -348,6 +361,33 @@ export function makeBackendClient(apiKey: string | null = null) {
     async deleteOptimization(id: string): Promise<void> {
       try {
         await opik.api.optimizations.deleteOptimizationsById({ ids: [id] });
+      } catch (err) {
+        if (isNotFoundError(err)) return;
+        throw err;
+      }
+    },
+
+    async getAnnotationQueue(id: string): Promise<AnnotationQueueDetail | null> {
+      try {
+        const q = await opik.api.annotationQueues.getAnnotationQueueById(id);
+        return {
+          id: String(q.id),
+          name: q.name,
+          itemsCount: q.itemsCount ?? 0,
+          reviewers: (q.reviewers ?? []).map((r) => ({
+            username: r.username ?? '',
+            status: r.status ?? 0,
+          })),
+        };
+      } catch (err) {
+        if (isNotFoundError(err)) return null;
+        throw err;
+      }
+    },
+
+    async deleteAnnotationQueue(id: string): Promise<void> {
+      try {
+        await opik.api.annotationQueues.deleteAnnotationQueueBatch({ ids: [id] });
       } catch (err) {
         if (isNotFoundError(err)) return;
         throw err;

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -68,8 +68,7 @@ export interface AutomationRuleRef {
 
 export interface AnnotationQueueReviewerRef {
   username: string;
-  /** Count of items this reviewer has scored in the queue. */
-  status: number;
+  itemsScored: number;
 }
 
 export interface AnnotationQueueDetail {
@@ -376,7 +375,7 @@ export function makeBackendClient(apiKey: string | null = null) {
           itemsCount: q.itemsCount ?? 0,
           reviewers: (q.reviewers ?? []).map((r) => ({
             username: r.username ?? '',
-            status: r.status ?? 0,
+            itemsScored: r.status ?? 0,
           })),
         };
       } catch (err) {

--- a/tests_end_to_end/e2e/core/backend/index.ts
+++ b/tests_end_to_end/e2e/core/backend/index.ts
@@ -10,5 +10,7 @@ export {
   type FeedbackScoreRef,
   type TraceDetail,
   type AutomationRuleRef,
+  type AnnotationQueueDetail,
+  type AnnotationQueueReviewerRef,
 } from './client';
 export { type PollFeedbackScoreOpts } from './poll-feedback-score';

--- a/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
+++ b/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
@@ -122,6 +122,13 @@ export interface PythonSdkClient {
     items_failed: number;
     items_total: number;
   }>;
+  createAnnotationQueue(args: {
+    project_name: string;
+    name: string;
+    trace_ids: string[];
+    feedback_definition_names?: string[];
+    workspace?: string;
+  }): Promise<{ id: string; name: string }>;
 }
 
 export class PythonSdkBridgeError extends Error {
@@ -268,6 +275,9 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
         items_failed: number;
         items_total: number;
       }>('POST', '/test-suites/run', args);
+    },
+    async createAnnotationQueue(args) {
+      return request<{ id: string; name: string }>('POST', '/annotation-queues', args);
     },
   };
 }

--- a/tests_end_to_end/e2e/fixtures/annotation-queue.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/annotation-queue.fixture.ts
@@ -1,0 +1,77 @@
+import { test as baseTest } from './conversation.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+
+export interface AnnotationQueueTraceRef {
+  id: string;
+  name: string;
+}
+
+export interface AnnotationQueueRef {
+  id: string;
+  name: string;
+  projectId: string;
+  projectName: string;
+  feedbackDefinitionName: string;
+  /** Seeded in queue order — traces[2] is left unscored by the spec. */
+  traces: AnnotationQueueTraceRef[];
+}
+
+export interface AnnotationQueueFixtures {
+  annotationQueue: AnnotationQueueRef;
+}
+
+const TRACE_COUNT = 3;
+
+export const test = baseTest.extend<AnnotationQueueFixtures>({
+  annotationQueue: async (
+    { sdkClient, backendClient, project, feedbackDefinition, testNamespace },
+    use,
+    testInfo,
+  ) => {
+    const traces: AnnotationQueueTraceRef[] = [];
+    for (let i = 0; i < TRACE_COUNT; i += 1) {
+      const name = `${testNamespace}-item-${i}`;
+      const created = await sdkClient.python.createTrace({
+        project_name: project.name,
+        name,
+        input: `seed input ${i}`,
+        output: `seed output ${i}`,
+      });
+      traces.push({ id: created.id, name: created.name });
+    }
+
+    const queueName = `${testNamespace}-queue`;
+    const created = await sdkClient.python.createAnnotationQueue({
+      project_name: project.name,
+      name: queueName,
+      trace_ids: traces.map((t) => t.id),
+      feedback_definition_names: [feedbackDefinition.name],
+    });
+
+    const ref: AnnotationQueueRef = {
+      id: created.id,
+      name: created.name,
+      projectId: project.id,
+      projectName: project.name,
+      feedbackDefinitionName: feedbackDefinition.name,
+      traces,
+    };
+    await testInfo.attach('opik.annotationQueue', {
+      body: JSON.stringify(ref, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use(ref);
+
+    /** Annotation queues don't cascade with project deletion — explicit delete required. */
+    if (!shouldLeaveArtifacts(testInfo)) {
+      try {
+        await backendClient.deleteAnnotationQueue(created.id);
+      } catch (err) {
+        console.warn(`[annotationQueue fixture] delete warning for ${queueName}:`, err);
+      }
+    }
+  },
+});
+
+export { expect } from './conversation.fixture';

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-export { test, expect } from './conversation.fixture';
+export { test, expect } from './annotation-queue.fixture';
 export type { ProjectFixtures } from './project.fixture';
 export type { ScratchDir, ScratchDirFixtures } from './scratch-dir.fixture';
 export type {
@@ -34,4 +34,9 @@ export type {
   ConversationTurnRef,
   ConversationFixtures,
 } from './conversation.fixture';
+export type {
+  AnnotationQueueRef,
+  AnnotationQueueTraceRef,
+  AnnotationQueueFixtures,
+} from './annotation-queue.fixture';
 export type { ProjectRef } from '../core/backend';

--- a/tests_end_to_end/e2e/pom/annotation-queue.page.ts
+++ b/tests_end_to_end/e2e/pom/annotation-queue.page.ts
@@ -1,0 +1,38 @@
+import { test, type Page } from '@playwright/test';
+import { loadEnvConfig } from '../config/env.config';
+import { TracePanelPage } from './trace-panel.page';
+
+export class AnnotationQueuePage {
+  constructor(private readonly page: Page) {}
+
+  async goto(projectId: string, queueId: string): Promise<void> {
+    return test.step(`Open annotation queue ${queueId}`, async () => {
+      const env = loadEnvConfig();
+      await this.page.goto(
+        `${env.baseUrl}/${env.workspace}/projects/${projectId}/annotation-queues/${queueId}`,
+      );
+    });
+  }
+
+  async waitForReady(): Promise<void> {
+    return test.step('Wait for annotation queue page ready', async () => {
+      await this.page.getByRole('tab', { name: 'Queue items' }).waitFor({ state: 'visible' });
+    });
+  }
+
+  /**
+   * Open a queue item's trace panel by navigating directly with a `trace` query
+   * param — the same pattern LogsPage uses. Avoids depending on table row
+   * selectors for a table whose row set changes as items are scored.
+   */
+  async openItem(projectId: string, queueId: string, traceId: string): Promise<TracePanelPage> {
+    return test.step(`Open queue item ${traceId}`, async () => {
+      const env = loadEnvConfig();
+      const url = `${env.baseUrl}/${env.workspace}/projects/${projectId}/annotation-queues/${queueId}?trace=${traceId}`;
+      await this.page.goto(url);
+      const panel = new TracePanelPage(this.page, traceId);
+      await panel.waitForFullyLoaded();
+      return panel;
+    });
+  }
+}

--- a/tests_end_to_end/e2e/pom/trace-panel.page.ts
+++ b/tests_end_to_end/e2e/pom/trace-panel.page.ts
@@ -132,6 +132,26 @@ export class TracePanelPage {
   }
 
   /**
+   * The reason textarea for a named annotate score. Disabled until a score is set.
+   * Sits in a grid cell that is a sibling of the score-input cell (the one carrying
+   * the row testid), not a descendant — so it's scoped to the panel root, same as
+   * the score's "Clear score" button.
+   */
+  annotateReasonInput(definitionName: string): Locator {
+    return this.root.getByTestId(`annotate-score-reason-${definitionName}`);
+  }
+
+  /** Set (or change) the reason text in a named annotate score row. Requires a score to be set first. */
+  async setAnnotateReason(definitionName: string, reason: string): Promise<void> {
+    return test.step(`Set ${definitionName} reason to "${reason}"`, async () => {
+      const input = this.annotateReasonInput(definitionName);
+      await input.fill(reason);
+      // The reason input debounces; blur to flush the write.
+      await input.blur();
+    });
+  }
+
+  /**
    * Clear the score in a named annotate score row. The clear button sits in a
    * grid cell that is a sibling of the score-input cell (the one carrying the
    * row testid), not a descendant — so it's scoped to the panel root. With a

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/main.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/main.py
@@ -3,6 +3,7 @@ from fastapi.responses import JSONResponse
 from opik.rest_api.core.api_error import ApiError
 
 from .routes import (
+    annotation_queues,
     datasets,
     experiments,
     feedback_definitions,
@@ -31,3 +32,4 @@ app.include_router(datasets.router)
 app.include_router(experiments.router)
 app.include_router(prompts.router)
 app.include_router(test_suites.router)
+app.include_router(annotation_queues.router)

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/annotation_queues.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/annotation_queues.py
@@ -1,0 +1,67 @@
+import atexit
+
+from fastapi import APIRouter, Header, HTTPException
+
+from ..opik_factory import make_opik_client
+from ..schemas import AnnotationQueueCreate, AnnotationQueueResponse
+
+router = APIRouter(prefix="/annotation-queues", tags=["annotation-queues"])
+
+
+@router.post("", response_model=AnnotationQueueResponse, status_code=201)
+def create_annotation_queue(
+    body: AnnotationQueueCreate,
+    x_opik_api_key: str | None = Header(default=None),
+) -> AnnotationQueueResponse:
+    # Wraps client.create_traces_annotation_queue(...) + queue.add_traces(...),
+    # the same code path opik.TracesAnnotationQueue users invoke. add_traces
+    # takes Trace/TracePublic objects (not bare ids), so each seeded trace is
+    # looked up by id via search_traces before being added. ApiError is
+    # translated to HTTP by the app-wide exception handler.
+    client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
+    try:
+        queue = client.create_traces_annotation_queue(
+            name=body.name,
+            project_name=body.project_name,
+            feedback_definition_names=body.feedback_definition_names,
+        )
+
+        traces = []
+        for trace_id in body.trace_ids:
+            found = client.search_traces(
+                project_name=body.project_name,
+                filter_string=f'id = "{trace_id}"',
+                max_results=1,
+                wait_for_at_least=1,
+            )
+            if not found:
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Trace {trace_id} not visible when adding to annotation queue",
+                )
+            traces.append(found[0])
+
+        queue.add_traces(traces)
+    finally:
+        client.end(flush=False)
+        atexit.unregister(client.end)
+
+    return AnnotationQueueResponse(id=queue.id, name=queue.name)
+
+
+@router.delete("/{queue_id}")
+def delete_annotation_queue(
+    queue_id: str,
+    x_opik_api_key: str | None = Header(default=None),
+) -> dict[str, bool]:
+    # Returns a JSON body (not 204) so the TS client, which parses every
+    # success as JSON, doesn't choke on an empty body.
+    client = make_opik_client(api_key=x_opik_api_key)
+    try:
+        client._rest_client.annotation_queues.delete_annotation_queue_batch(
+            ids=[queue_id]
+        )
+    finally:
+        client.end(flush=False)
+        atexit.unregister(client.end)
+    return {"deleted": True}

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/annotation_queues.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/annotation_queues.py
@@ -13,19 +13,13 @@ def create_annotation_queue(
     body: AnnotationQueueCreate,
     x_opik_api_key: str | None = Header(default=None),
 ) -> AnnotationQueueResponse:
-    # Wraps client.create_traces_annotation_queue(...) + queue.add_traces(...),
-    # the same code path opik.TracesAnnotationQueue users invoke. add_traces
-    # takes Trace/TracePublic objects (not bare ids), so each seeded trace is
-    # looked up by id via search_traces before being added. ApiError is
-    # translated to HTTP by the app-wide exception handler.
+    # add_traces takes Trace/TracePublic objects (not bare ids), so each
+    # seeded trace is looked up by id via search_traces first; the queue is
+    # only created once every trace is confirmed visible, so a lookup
+    # failure doesn't leave an orphan queue behind. ApiError is translated
+    # to HTTP by the app-wide exception handler.
     client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
     try:
-        queue = client.create_traces_annotation_queue(
-            name=body.name,
-            project_name=body.project_name,
-            feedback_definition_names=body.feedback_definition_names,
-        )
-
         traces = []
         for trace_id in body.trace_ids:
             found = client.search_traces(
@@ -41,6 +35,11 @@ def create_annotation_queue(
                 )
             traces.append(found[0])
 
+        queue = client.create_traces_annotation_queue(
+            name=body.name,
+            project_name=body.project_name,
+            feedback_definition_names=body.feedback_definition_names,
+        )
         queue.add_traces(traces)
     finally:
         client.end(flush=False)

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
@@ -230,3 +230,18 @@ class ChatPromptCreate(BaseModel):
 class PromptResponse(BaseModel):
     id: str
     name: str
+
+
+class AnnotationQueueCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    project_name: str
+    name: str
+    trace_ids: list[str]
+    feedback_definition_names: list[str] | None = None
+    workspace: str | None = None
+
+
+class AnnotationQueueResponse(BaseModel):
+    id: str
+    name: str

--- a/tests_end_to_end/e2e/tests/annotation-queues/annotation-queue-scoring.spec.ts
+++ b/tests_end_to_end/e2e/tests/annotation-queues/annotation-queue-scoring.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@e2e/fixtures';
+import { AnnotationQueuePage } from '@e2e/pom/annotation-queue.page';
+
+test.describe('Annotation queue — UI scoring, SDK verify', { tag: ['@t2-cuj', '@annotation-queue'] }, () => {
+  test('Scoring two items and skipping a third reflects on the source traces', async ({
+    annotationQueue,
+    backendClient,
+    page,
+  }) => {
+    const scoreName = annotationQueue.feedbackDefinitionName;
+    const [firstItem, secondItem, skippedItem] = annotationQueue.traces;
+    const queuePage = new AnnotationQueuePage(page);
+
+    await test.step('Open the queue and score the first item', async () => {
+      await queuePage.goto(annotationQueue.projectId, annotationQueue.id);
+      await queuePage.waitForReady();
+      const panel = await queuePage.openItem(
+        annotationQueue.projectId,
+        annotationQueue.id,
+        firstItem.id,
+      );
+      await panel.openAnnotate();
+      await panel.setAnnotateScore(scoreName, 1);
+      // The score write is optimistic client-side — the UI tag updates before the
+      // PUT resolves. Wait for the server to actually confirm it before setting
+      // the reason, otherwise the two PUTs can land out of order and the second
+      // (score-only) request wipes the reason from the first.
+      await backendClient.pollTraceForFeedbackScore(firstItem.id, scoreName);
+      await panel.setAnnotateReason(scoreName, 'Looks correct');
+    });
+
+    await test.step('Open the second item and score it with a different value and reason', async () => {
+      const panel = await queuePage.openItem(
+        annotationQueue.projectId,
+        annotationQueue.id,
+        secondItem.id,
+      );
+      await panel.openAnnotate();
+      await panel.setAnnotateScore(scoreName, 0);
+      await backendClient.pollTraceForFeedbackScore(secondItem.id, scoreName);
+      await panel.setAnnotateReason(scoreName, 'Missed a key detail');
+    });
+
+    await test.step('Verify the first item scored correctly, reason included', async () => {
+      const score = await backendClient.pollTraceForFeedbackScore(firstItem.id, scoreName);
+      expect(score.value).toBe(1);
+      expect(score.reason).toBe('Looks correct');
+    });
+
+    await test.step('Verify the second item scored correctly, reason included', async () => {
+      const score = await backendClient.pollTraceForFeedbackScore(secondItem.id, scoreName);
+      expect(score.value).toBe(0);
+      expect(score.reason).toBe('Missed a key detail');
+    });
+
+    await test.step('Verify the skipped item has no feedback score from this queue', async () => {
+      const trace = await backendClient.getTrace(skippedItem.id);
+      expect(trace?.feedbackScores.find((fs) => fs.name === scoreName)).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Details
Adds a release-gate E2E test for annotation queues: scoring items from the queue UI and verifying the resulting feedback scores (value + reason) land correctly on the source traces, including that a skipped item receives no score. Introduces the supporting fixture, page object, backend client polling helper, and SDK driver endpoint needed to seed and verify annotation queue state, plus a `data-testid` on the annotate reason textarea so the test can target it reliably.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7085

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Sonnet 5
- Scope: full implementation
- Human verification: code review + manual testing

## Testing
- `npx tsc --noEmit` in `tests_end_to_end/e2e` — passes with no errors
- `python3 -m py_compile` on the modified `opik_sdk_driver` files — passes
- New spec: `tests_end_to_end/e2e/tests/annotation-queues/annotation-queue-scoring.spec.ts`, tagged `@t2-cuj`
- Not run: the Playwright test itself was not executed against a live environment in this session

## Documentation
N/A
