### PR TITLE
[OPIK-5094] [BE] fix: propagate opik.tags from OTel root span to trace

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryService.java
@@ -171,6 +171,7 @@ class OpenTelemetryServiceImpl implements OpenTelemetryService {
                             .input(rootSpan.input())
                             .output(rootSpan.output())
                             .metadata(rootSpan.metadata())
+                            .tags(rootSpan.tags())
                             .errorInfo(rootSpan.errorInfo())
                             .source(Source.SDK);
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
@@ -611,6 +611,64 @@ class OpenTelemetryResourceTest {
         }
 
         @Test
+        @DisplayName("test opik.tags on root span propagates to trace in OpenTelemetry")
+        void testRootSpanTagsPropagateToTrace() {
+            String workspaceName = UUID.randomUUID().toString();
+            mockTargetWorkspace(okApikey, workspaceName);
+
+            var otelTraceId = UUID.randomUUID().toString().getBytes();
+            var parentSpanId = UUID.randomUUID().toString().getBytes();
+
+            // Create a root span with opik.tags attribute
+            var rootSpan = Span.newBuilder()
+                    .setName("root span")
+                    .setTraceId(ByteString.copyFrom(otelTraceId))
+                    .setSpanId(ByteString.copyFrom(parentSpanId))
+                    .setStartTimeUnixNano((System.currentTimeMillis() - 1_000) * 1_000_000L)
+                    .setEndTimeUnixNano(System.currentTimeMillis() * 1_000_000L)
+                    .addAttributes(KeyValue.newBuilder()
+                            .setKey("opik.tags")
+                            .setValue(AnyValue.newBuilder()
+                                    .setStringValue("[\"machine-learning\", \"nlp\", \"chatbot\"]"))
+                            .build())
+                    .build();
+
+            // Create a child span
+            var childSpan = Span.newBuilder()
+                    .setName("child span")
+                    .setTraceId(ByteString.copyFrom(otelTraceId))
+                    .setParentSpanId(ByteString.copyFrom(parentSpanId))
+                    .setSpanId(ByteString.copyFrom(UUID.randomUUID().toString().getBytes()))
+                    .setStartTimeUnixNano((System.currentTimeMillis() - 500) * 1_000_000L)
+                    .setEndTimeUnixNano(System.currentTimeMillis() * 1_000_000L)
+                    .build();
+
+            var otelSpans = List.of(rootSpan, childSpan);
+
+            // Calculate expected Opik trace ID
+            var minTimestamp = otelSpans.stream().map(Span::getStartTimeUnixNano).min(Long::compareTo).orElseThrow();
+            var minTimestampMs = Duration.ofNanos(minTimestamp).toMillis();
+            var expectedOpikTraceId = OpenTelemetryMapper.convertOtelIdToUUIDv7(otelTraceId, minTimestampMs);
+
+            // Send the spans
+            sendProtobufTraces(otelSpans, "Test Project", workspaceName, okApikey, true, null);
+
+            // Verify the tags propagated from the root span to the trace
+            Trace trace = traceResourceClient.getById(expectedOpikTraceId, workspaceName, okApikey);
+            assertThat(trace.id()).isEqualTo(expectedOpikTraceId);
+            assertThat(trace.tags()).containsExactlyInAnyOrder("machine-learning", "nlp", "chatbot");
+
+            // Verify the root span retains its tags too
+            var generatedSpanPage = spanResourceClient.getByTraceIdAndProject(expectedOpikTraceId,
+                    "Test Project", workspaceName, okApikey);
+            var rootSpanFromDb = generatedSpanPage.content().stream()
+                    .filter(span -> span.parentSpanId() == null)
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(rootSpanFromDb.tags()).containsExactlyInAnyOrder("machine-learning", "nlp", "chatbot");
+        }
+
+        @Test
         @DisplayName("test token deduplication when parent and child both have usage (PydanticAI/Logfire pattern)")
         void testTokenDeduplicationWhenParentAndChildBothHaveUsage() {
             String workspaceName = UUID.randomUUID().toString();


### PR DESCRIPTION
## Details

<img width="826" height="797" alt="image" src="https://github.com/user-attachments/assets/b1201ee8-931e-4bdf-9c46-bd8a1b55054d" />

OTel users setting `opik.tags` on the root span got the tags applied to the **span** but not the **trace**, so trace-level tag filtering didn't work over the OTel integration.

The `opik.tags` attribute was already parsed and stored on the span (via `GeneralMappingRules` / `OpenTelemetryMapper`). The bug was purely in trace creation: `OpenTelemetryService.doStoreSpans` built the `Trace` from the root span but omitted `.tags(...)`. This adds `.tags(rootSpan.tags())` to the builder.

Scoped to the trace-level fix only. The thread-level tagging ask (raised on the ticket by another team, for Zoox/CUST 6586) is split into a separate follow-up (OPIK 7408) because it needs a new ingestion path that applies tags at lazy thread-materialization time — out of scope for this bug.

## Change checklist

- [x] Bug fix (non-breaking change which fixes an issue)

## Issues

Resolves OPIK-5094. Follow-up: OPIK 7408 (OTel thread-level tags).

## Testing

**Integration test** — added `testRootSpanTagsPropagateToTrace` in `OpenTelemetryResourceTest`: sends an OTel export with `opik.tags` on the root span, asserts the tags land on both the trace and the root span. Verified it **fails without** the one-line fix and **passes with** it. Spotless clean. ✅

**Live staging smoke** — deployed this branch to a test environment (`test-environment` label, image `2.2.1-7537`) and ran a real OTel SDK exporter against it: set `opik.tags` on the root span, then verified via the API that (1) the **trace** carries the tags and (2) **filtering traces by tag returns the trace** — the customer's actual goal. Both passed. ✅

```
[smoke] PASS 1/2: opik.tags propagated from root span to TRACE
[smoke] PASS 2/2: filtering by tag returns the trace
[smoke] ALL GOOD — OPIK-5094 verified end-to-end on the live env
```

## Documentation

No documentation changes — behavior now matches the documented intent of `opik.tags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
