### PR TITLE
[OPIK-7385] [GHA] chore: migrate CI Python tooling from pip/setup-python to uv

### DIFF
--- a/.github/actions/install_opik_and_run_e2e_lib_integration_tests/action.yml
+++ b/.github/actions/install_opik_and_run_e2e_lib_integration_tests/action.yml
@@ -26,8 +26,8 @@ runs:
         
         echo "Installing test dependencies"
         cd ./tests
-        uv pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
-        uv pip install --no-cache-dir --disable-pip-version-check -r e2e_library_integration/${{ inputs.library_name }}/requirements.txt
+        uv pip install -r test_requirements.txt
+        uv pip install -r e2e_library_integration/${{ inputs.library_name }}/requirements.txt
         uv pip list
         
         echo "Running tests"

--- a/.github/workflows/build_and_publish_sdk.yaml
+++ b/.github/workflows/build_and_publish_sdk.yaml
@@ -50,7 +50,7 @@ jobs:
             fetch-tags: true
 
         - name: Set up Python 3.10
-          uses: actions/setup-python@v5
+          uses: astral-sh/setup-uv@v8.3.2
           with:
                 python-version: "3.10"
 

--- a/.github/workflows/build_and_publish_sdk.yaml
+++ b/.github/workflows/build_and_publish_sdk.yaml
@@ -50,7 +50,7 @@ jobs:
             fetch-tags: true
 
         - name: Set up Python 3.10
-          uses: astral-sh/setup-uv@v8.3.2
+          uses: actions/setup-python@v5
           with:
                 python-version: "3.10"
 

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -157,7 +157,7 @@ jobs:
         working-directory: sdks/typescript
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Cache pre-commit environments
         uses: actions/cache@v4

--- a/.github/workflows/deploy_python_sdk_docs.yml
+++ b/.github/workflows/deploy_python_sdk_docs.yml
@@ -33,7 +33,7 @@ jobs:
           show-progress: false
       
       - name: Setup uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Build Python SDK docs
         run: |

--- a/.github/workflows/documentation_cookbook_tests.yml
+++ b/.github/workflows/documentation_cookbook_tests.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
       - name: Install dependencies
         run: |
           uv pip install --system -U ipython nbconvert

--- a/.github/workflows/documentation_cookbook_tests.yml
+++ b/.github/workflows/documentation_cookbook_tests.yml
@@ -37,27 +37,16 @@ jobs:
       OPIK_SENTRY_ENABLE: False
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
-      - name: pip cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ matrix.os }}-${{ matrix.python-version }}-pip
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-pip
+          enable-cache: true
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -U ipython nbconvert
+          uv pip install --system -U ipython nbconvert
       - name: Install opik from source files (optional)
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.install_opik == 'true' }}
-        run: pip install sdks/python
+        run: uv pip install --system sdks/python
       - name: Prepare env variables
         run: |
           directory=$(dirname -- "${NOTEBOOK_TO_TEST}")

--- a/.github/workflows/documentation_cookbook_tests.yml
+++ b/.github/workflows/documentation_cookbook_tests.yml
@@ -37,10 +37,10 @@ jobs:
       OPIK_SENTRY_ENABLE: False
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.3.2
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          enable-cache: true
+          cache: 'pip'
       - name: Install dependencies
         run: |
           uv pip install --system -U ipython nbconvert

--- a/.github/workflows/documentation_cookbook_tests.yml
+++ b/.github/workflows/documentation_cookbook_tests.yml
@@ -40,7 +40,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
       - name: Set up uv
         uses: astral-sh/setup-uv@v8.3.2
       - name: Install dependencies

--- a/.github/workflows/e2e_tests_post_merge_v2.yml
+++ b/.github/workflows/e2e_tests_post_merge_v2.yml
@@ -91,13 +91,10 @@ jobs:
           cache: 'npm'
           cache-dependency-path: tests_end_to_end/e2e/package-lock.json
 
-      - name: "🐍 Setup Python"
-        uses: actions/setup-python@v5
+      - name: "🐍 Setup uv & Python"
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: '3.12'
-
-      - name: "⚡ Setup uv"
-        uses: astral-sh/setup-uv@v5
 
       - name: "📚 Install E2E test dependencies"
         working-directory: tests_end_to_end/e2e

--- a/.github/workflows/end2end_suites_v2.yml
+++ b/.github/workflows/end2end_suites_v2.yml
@@ -62,13 +62,10 @@ jobs:
           cache: 'npm'
           cache-dependency-path: tests_end_to_end/e2e/package-lock.json
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - name: Setup uv & Python
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: '3.12'
-
-      - name: Setup uv
-        uses: astral-sh/setup-uv@v5
 
       - name: Install E2E test dependencies
         working-directory: ${{ github.workspace }}/tests_end_to_end/e2e

--- a/.github/workflows/guardrails_e2e_tests.yml
+++ b/.github/workflows/guardrails_e2e_tests.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/guardrails_e2e_tests.yml
+++ b/.github/workflows/guardrails_e2e_tests.yml
@@ -74,6 +74,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Run latest Opik server with guardrails
         env:
           OPIK_USAGE_REPORT_ENABLED: false

--- a/.github/workflows/guardrails_e2e_tests.yml
+++ b/.github/workflows/guardrails_e2e_tests.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
@@ -96,13 +96,13 @@ jobs:
       - name: Install opik SDK
         run: |
           cd ${{ github.workspace }}/sdks/python
-          pip install .
+          uv pip install --system .
 
       - name: Install test requirements
         run: |
           cd ${{ github.workspace }}/sdks/python
-          pip install -r tests/test_requirements.txt
-          pip list
+          uv pip install --system -r tests/test_requirements.txt
+          uv pip list --system
 
       - name: Run guardrails E2E tests
         run: |

--- a/.github/workflows/guardrails_unit_tests.yml
+++ b/.github/workflows/guardrails_unit_tests.yml
@@ -40,7 +40,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-          cache: 'pip'
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v8.3.2

--- a/.github/workflows/guardrails_unit_tests.yml
+++ b/.github/workflows/guardrails_unit_tests.yml
@@ -37,10 +37,10 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Python 3.10
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-          enable-cache: true
+          cache: 'pip'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/guardrails_unit_tests.yml
+++ b/.github/workflows/guardrails_unit_tests.yml
@@ -37,15 +37,14 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: '3.10'
-          cache: 'pip'
+          enable-cache: true
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt -r tests/test_requirements.txt
+          uv pip install --system -r requirements.txt -r tests/test_requirements.txt
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/guardrails_unit_tests.yml
+++ b/.github/workflows/guardrails_unit_tests.yml
@@ -42,6 +42,9 @@ jobs:
           python-version: '3.10'
           cache: 'pip'
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install dependencies
         run: |
           uv pip install --system -r requirements.txt -r tests/test_requirements.txt

--- a/.github/workflows/installation_tests.yml
+++ b/.github/workflows/installation_tests.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Python
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
 
@@ -61,7 +61,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Python
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
@@ -115,7 +115,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Python
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
@@ -169,7 +169,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Python
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
@@ -224,7 +224,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Python
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/installation_tests.yml
+++ b/.github/workflows/installation_tests.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           python-version: 3.12
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install Python dependencies
         run: |
           uv pip install --system -r ${{ github.workspace }}/tests_end_to_end/test_requirements.txt
@@ -64,6 +67,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Install Python dependencies
         run: |
@@ -119,6 +125,9 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install Python dependencies
         run: |
           uv pip install --system -r ${{ github.workspace }}/tests_end_to_end/test_requirements.txt
@@ -172,6 +181,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Install Python dependencies
         run: |
@@ -227,6 +239,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/installation_tests.yml
+++ b/.github/workflows/installation_tests.yml
@@ -19,14 +19,14 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: 3.12
 
       - name: Install Python dependencies
         run: |
-          pip install -r ${{ github.workspace }}/tests_end_to_end/test_requirements.txt
-          pip install opik
+          uv pip install --system -r ${{ github.workspace }}/tests_end_to_end/test_requirements.txt
+          uv pip install --system opik
           playwright install chromium
 
       - name: Install using opik.sh
@@ -61,14 +61,14 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: '3.12'
 
       - name: Install Python dependencies
         run: |
-          pip install -r ${{ github.workspace }}/tests_end_to_end/test_requirements.txt
-          pip install opik
+          uv pip install --system -r ${{ github.workspace }}/tests_end_to_end/test_requirements.txt
+          uv pip install --system opik
           playwright install chromium
 
       - name: Install using docker compose up --detach
@@ -115,14 +115,14 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: '3.12'
 
       - name: Install Python dependencies
         run: |
-          pip install -r ${{ github.workspace }}/tests_end_to_end/test_requirements.txt
-          pip install opik
+          uv pip install --system -r ${{ github.workspace }}/tests_end_to_end/test_requirements.txt
+          uv pip install --system opik
           playwright install chromium
 
       - name: Install with --build flag
@@ -169,14 +169,14 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: '3.12'
 
       - name: Install Python dependencies
         run: |
-          pip install -r ${{ github.workspace }}/tests_end_to_end/test_requirements.txt
-          pip install opik
+          uv pip install --system -r ${{ github.workspace }}/tests_end_to_end/test_requirements.txt
+          uv pip install --system opik
           playwright install chromium
 
       - name: Install with docker compose with specific version set
@@ -224,14 +224,14 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: '3.12'
 
       - name: Install Python dependencies
         run: |
-          pip install -r ${{ github.workspace }}/tests_end_to_end/test_requirements.txt
-          pip install opik
+          uv pip install --system -r ${{ github.workspace }}/tests_end_to_end/test_requirements.txt
+          uv pip install --system opik
           playwright install chromium
 
       - name: Install with docker compose after pulling latest version

--- a/.github/workflows/lib-adk-legacy-1-3-0-tests.yml
+++ b/.github/workflows/lib-adk-legacy-1-3-0-tests.yml
@@ -44,22 +44,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/adk/requirements_legacy_adk_1_3_0.txt
+          uv pip install --system -r library_integration/adk/requirements_legacy_adk_1_3_0.txt
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/lib-adk-legacy-1-3-0-tests.yml
+++ b/.github/workflows/lib-adk-legacy-1-3-0-tests.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-adk-legacy-1-3-0-tests.yml
+++ b/.github/workflows/lib-adk-legacy-1-3-0-tests.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-adk-tests.yml
+++ b/.github/workflows/lib-adk-tests.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-adk-tests.yml
+++ b/.github/workflows/lib-adk-tests.yml
@@ -44,22 +44,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/adk/requirements.txt
+          uv pip install --system -r library_integration/adk/requirements.txt
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/lib-adk-tests.yml
+++ b/.github/workflows/lib-adk-tests.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-aisuite-tests.yml
+++ b/.github/workflows/lib-aisuite-tests.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-aisuite-tests.yml
+++ b/.github/workflows/lib-aisuite-tests.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-aisuite-tests.yml
+++ b/.github/workflows/lib-aisuite-tests.yml
@@ -36,22 +36,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/aisuite/requirements.txt
+          uv pip install --system -r library_integration/aisuite/requirements.txt
 
       - name: Run tests
         run: |

--- a/.github/workflows/lib-anthropic-tests.yml
+++ b/.github/workflows/lib-anthropic-tests.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-anthropic-tests.yml
+++ b/.github/workflows/lib-anthropic-tests.yml
@@ -32,22 +32,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/anthropic/requirements.txt
+          uv pip install --system -r library_integration/anthropic/requirements.txt
 
       - name: Run tests
         run: |

--- a/.github/workflows/lib-anthropic-tests.yml
+++ b/.github/workflows/lib-anthropic-tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-bedrock-tests.yml
+++ b/.github/workflows/lib-bedrock-tests.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-bedrock-tests.yml
+++ b/.github/workflows/lib-bedrock-tests.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-bedrock-tests.yml
+++ b/.github/workflows/lib-bedrock-tests.yml
@@ -34,22 +34,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/bedrock/requirements.txt
+          uv pip install --system -r library_integration/bedrock/requirements.txt
 
       - name: change aws role
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/lib-crewai-v0-tests.yml
+++ b/.github/workflows/lib-crewai-v0-tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-crewai-v0-tests.yml
+++ b/.github/workflows/lib-crewai-v0-tests.yml
@@ -42,22 +42,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/crewai/requirements_v0.txt
+          uv pip install --system -r library_integration/crewai/requirements_v0.txt
 
       - name: Configure AWS credentials for Bedrock
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/lib-crewai-v0-tests.yml
+++ b/.github/workflows/lib-crewai-v0-tests.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-crewai-v1-tests.yml
+++ b/.github/workflows/lib-crewai-v1-tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-crewai-v1-tests.yml
+++ b/.github/workflows/lib-crewai-v1-tests.yml
@@ -42,22 +42,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/crewai/requirements_v1.txt
+          uv pip install --system -r library_integration/crewai/requirements_v1.txt
 
       - name: Configure AWS credentials for Bedrock
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/lib-crewai-v1-tests.yml
+++ b/.github/workflows/lib-crewai-v1-tests.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-dspy-tests.yml
+++ b/.github/workflows/lib-dspy-tests.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-dspy-tests.yml
+++ b/.github/workflows/lib-dspy-tests.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-dspy-tests.yml
+++ b/.github/workflows/lib-dspy-tests.yml
@@ -34,22 +34,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/dspy/requirements.txt
+          uv pip install --system -r library_integration/dspy/requirements.txt
 
       - name: Run tests
         run: |

--- a/.github/workflows/lib-genai-tests.yml
+++ b/.github/workflows/lib-genai-tests.yml
@@ -52,6 +52,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-genai-tests.yml
+++ b/.github/workflows/lib-genai-tests.yml
@@ -48,22 +48,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/genai/requirements.txt
+          uv pip install --system -r library_integration/genai/requirements.txt
 
       - name: Run tests
         run: |

--- a/.github/workflows/lib-genai-tests.yml
+++ b/.github/workflows/lib-genai-tests.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-groq-tests.yml
+++ b/.github/workflows/lib-groq-tests.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-groq-tests.yml
+++ b/.github/workflows/lib-groq-tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-groq-tests.yml
+++ b/.github/workflows/lib-groq-tests.yml
@@ -32,22 +32,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/groq/requirements.txt
+          uv pip install --system -r library_integration/groq/requirements.txt
 
       - name: Run tests
         run: |

--- a/.github/workflows/lib-guardrails-tests.yml
+++ b/.github/workflows/lib-guardrails-tests.yml
@@ -34,22 +34,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib 
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/guardrails/requirements.txt
+          uv pip install --system -r library_integration/guardrails/requirements.txt
 
       - name: Install checks from guardrails hub
         run: |

--- a/.github/workflows/lib-guardrails-tests.yml
+++ b/.github/workflows/lib-guardrails-tests.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-guardrails-tests.yml
+++ b/.github/workflows/lib-guardrails-tests.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-harbor-tests.yml
+++ b/.github/workflows/lib-harbor-tests.yml
@@ -31,22 +31,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/harbor/requirements.txt
+          uv pip install --system -r library_integration/harbor/requirements.txt
 
       - name: Run tests
         run: |

--- a/.github/workflows/lib-harbor-tests.yml
+++ b/.github/workflows/lib-harbor-tests.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-harbor-tests.yml
+++ b/.github/workflows/lib-harbor-tests.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-haystack-tests.yml
+++ b/.github/workflows/lib-haystack-tests.yml
@@ -33,22 +33,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/haystack/requirements.txt
+          uv pip install --system -r library_integration/haystack/requirements.txt
 
       - name: Run tests
         run: |

--- a/.github/workflows/lib-haystack-tests.yml
+++ b/.github/workflows/lib-haystack-tests.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-haystack-tests.yml
+++ b/.github/workflows/lib-haystack-tests.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-langchain-legacy-tests.yml
+++ b/.github/workflows/lib-langchain-legacy-tests.yml
@@ -43,22 +43,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/langchain/legacy_requirements.txt
+          uv pip install --system -r library_integration/langchain/legacy_requirements.txt
 
       - name: change aws role
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/lib-langchain-legacy-tests.yml
+++ b/.github/workflows/lib-langchain-legacy-tests.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-langchain-legacy-tests.yml
+++ b/.github/workflows/lib-langchain-legacy-tests.yml
@@ -47,6 +47,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-langchain-tests.yml
+++ b/.github/workflows/lib-langchain-tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-langchain-tests.yml
+++ b/.github/workflows/lib-langchain-tests.yml
@@ -42,22 +42,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/langchain/requirements.txt
+          uv pip install --system -r library_integration/langchain/requirements.txt
 
       - name: change aws role
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/lib-langchain-tests.yml
+++ b/.github/workflows/lib-langchain-tests.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-litellm-tests.yml
+++ b/.github/workflows/lib-litellm-tests.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-litellm-tests.yml
+++ b/.github/workflows/lib-litellm-tests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-litellm-tests.yml
+++ b/.github/workflows/lib-litellm-tests.yml
@@ -38,22 +38,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/litellm/requirements.txt
+          uv pip install --system -r library_integration/litellm/requirements.txt
 
       - name: Run tests
         run: |

--- a/.github/workflows/lib-llama-index-tests.yml
+++ b/.github/workflows/lib-llama-index-tests.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-llama-index-tests.yml
+++ b/.github/workflows/lib-llama-index-tests.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-llama-index-tests.yml
+++ b/.github/workflows/lib-llama-index-tests.yml
@@ -33,22 +33,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/llama_index/requirements.txt
+          uv pip install --system -r library_integration/llama_index/requirements.txt
 
       - name: Run tests
         run: |

--- a/.github/workflows/lib-metrics-with-llm-judge-tests.yml
+++ b/.github/workflows/lib-metrics-with-llm-judge-tests.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-metrics-with-llm-judge-tests.yml
+++ b/.github/workflows/lib-metrics-with-llm-judge-tests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-metrics-with-llm-judge-tests.yml
+++ b/.github/workflows/lib-metrics-with-llm-judge-tests.yml
@@ -38,23 +38,23 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/metrics_with_llm_judge/requirements.txt
-          pip list
+          uv pip install --system -r library_integration/metrics_with_llm_judge/requirements.txt
+          uv pip list --system
 
       - name: Run tests
         run: |

--- a/.github/workflows/lib-mistral-tests.yml
+++ b/.github/workflows/lib-mistral-tests.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/lib-mistral-tests.yml
+++ b/.github/workflows/lib-mistral-tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-mistral-tests.yml
+++ b/.github/workflows/lib-mistral-tests.yml
@@ -32,22 +32,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/mistral/requirements.txt
+          uv pip install --system -r library_integration/mistral/requirements.txt
 
       - name: Run tests
         run: |

--- a/.github/workflows/lib-openai-tests.yml
+++ b/.github/workflows/lib-openai-tests.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/lib-openai-tests.yml
+++ b/.github/workflows/lib-openai-tests.yml
@@ -44,23 +44,23 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{matrix.python_version}}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test tools
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+          uv pip install --system -r test_requirements.txt
 
       - name: Install lib
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r library_integration/openai/requirements.txt
-          pip list
+          uv pip install --system -r library_integration/openai/requirements.txt
+          uv pip list --system
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/lib-openai-tests.yml
+++ b/.github/workflows/lib-openai-tests.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           python-version: ${{matrix.python_version}}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/load_tests.yml
+++ b/.github/workflows/load_tests.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Run latest Opik server
         env:
           OPIK_USAGE_REPORT_ENABLED: false

--- a/.github/workflows/load_tests.yml
+++ b/.github/workflows/load_tests.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.12"
 
@@ -57,12 +57,12 @@ jobs:
       - name: Install Opik SDK
         run: |
           cd ${{ github.workspace }}/sdks/python
-          pip install .
+          uv pip install --system .
 
       - name: Install Python SDK load-test requirements
         run: |
           cd ${{ github.workspace }}/tests_load/suite/python_sdk
-          pip install -r requirements.txt
+          uv pip install --system -r requirements.txt
 
       - name: Run Python SDK load tests
         # -n 2 + --dist=worksteal runs two scenarios in parallel at a time.

--- a/.github/workflows/load_tests.yml
+++ b/.github/workflows/load_tests.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/opik-optimizer-e2e-tests.yaml
+++ b/.github/workflows/opik-optimizer-e2e-tests.yaml
@@ -77,11 +77,6 @@ jobs:
           uses: actions/setup-python@v5
           with:
             python-version: ${{matrix.python_version}}
-            cache: 'pip'
-            cache-dependency-path: |
-              sdks/opik_optimizer/pyproject.toml
-              sdks/opik_optimizer/setup.py
-              sdks/opik_optimizer/tests/test_requirements.txt
 
         - name: Set up uv
           uses: astral-sh/setup-uv@v8.3.2
@@ -172,11 +167,6 @@ jobs:
           uses: actions/setup-python@v5
           with:
             python-version: "3.12"
-            cache: 'pip'
-            cache-dependency-path: |
-              sdks/opik_optimizer/pyproject.toml
-              sdks/opik_optimizer/setup.py
-              sdks/opik_optimizer/tests/test_requirements.txt
 
         - name: Set up uv
           uses: astral-sh/setup-uv@v8.3.2

--- a/.github/workflows/opik-optimizer-e2e-tests.yaml
+++ b/.github/workflows/opik-optimizer-e2e-tests.yaml
@@ -74,11 +74,11 @@ jobs:
             docker tag "ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG" ghcr.io/comet-ml/opik/opik-guardrails-backend:latest
 
         - name: Setup Python ${{matrix.python_version}}
-          uses: actions/setup-python@v5
+          uses: astral-sh/setup-uv@v8.3.2
           with:
             python-version: ${{matrix.python_version}}
-            cache: 'pip'
-            cache-dependency-path: |
+            enable-cache: true
+            cache-dependency-glob: |
               sdks/opik_optimizer/pyproject.toml
               sdks/opik_optimizer/setup.py
               sdks/opik_optimizer/tests/test_requirements.txt
@@ -123,12 +123,12 @@ jobs:
               litellm-cache-
 
         - name: Install opik_optimizer
-          run: pip install .[dev]
+          run: uv pip install --system .[dev]
 
         - name: Install test requirements
           run: |
             cd ./tests
-            pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+            uv pip install --system -r test_requirements.txt
 
         - name: Run E2E tests
           run: pytest tests/e2e -vv  --junitxml=${{ github.workspace }}/test_results_${{matrix.python_version}}.xml
@@ -166,11 +166,11 @@ jobs:
           uses: actions/checkout@v6
 
         - name: Setup Python 3.12
-          uses: actions/setup-python@v5
+          uses: astral-sh/setup-uv@v8.3.2
           with:
             python-version: "3.12"
-            cache: 'pip'
-            cache-dependency-path: |
+            enable-cache: true
+            cache-dependency-glob: |
               sdks/opik_optimizer/pyproject.toml
               sdks/opik_optimizer/setup.py
               sdks/opik_optimizer/tests/test_requirements.txt
@@ -184,12 +184,12 @@ jobs:
               hf-datasets-
 
         - name: Install opik_optimizer
-          run: pip install .
+          run: uv pip install --system .
 
         - name: Install test requirements
           run: |
             cd ./tests
-            pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+            uv pip install --system -r test_requirements.txt
 
         - name: Run dataset integration check
           run: pytest -n auto --dist loadfile tests/integration/datasets/test_dataset_sources.py -vv

--- a/.github/workflows/opik-optimizer-e2e-tests.yaml
+++ b/.github/workflows/opik-optimizer-e2e-tests.yaml
@@ -83,6 +83,9 @@ jobs:
               sdks/opik_optimizer/setup.py
               sdks/opik_optimizer/tests/test_requirements.txt
 
+        - name: Set up uv
+          uses: astral-sh/setup-uv@v8.3.2
+
         - name: Run latest Opik server
           env:
             OPIK_USAGE_REPORT_ENABLED: false
@@ -174,6 +177,9 @@ jobs:
               sdks/opik_optimizer/pyproject.toml
               sdks/opik_optimizer/setup.py
               sdks/opik_optimizer/tests/test_requirements.txt
+
+        - name: Set up uv
+          uses: astral-sh/setup-uv@v8.3.2
 
         - name: Cache HuggingFace datasets
           uses: actions/cache@v4

--- a/.github/workflows/opik-optimizer-e2e-tests.yaml
+++ b/.github/workflows/opik-optimizer-e2e-tests.yaml
@@ -74,11 +74,11 @@ jobs:
             docker tag "ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG" ghcr.io/comet-ml/opik/opik-guardrails-backend:latest
 
         - name: Setup Python ${{matrix.python_version}}
-          uses: astral-sh/setup-uv@v8.3.2
+          uses: actions/setup-python@v5
           with:
             python-version: ${{matrix.python_version}}
-            enable-cache: true
-            cache-dependency-glob: |
+            cache: 'pip'
+            cache-dependency-path: |
               sdks/opik_optimizer/pyproject.toml
               sdks/opik_optimizer/setup.py
               sdks/opik_optimizer/tests/test_requirements.txt
@@ -166,11 +166,11 @@ jobs:
           uses: actions/checkout@v6
 
         - name: Setup Python 3.12
-          uses: astral-sh/setup-uv@v8.3.2
+          uses: actions/setup-python@v5
           with:
             python-version: "3.12"
-            enable-cache: true
-            cache-dependency-glob: |
+            cache: 'pip'
+            cache-dependency-path: |
               sdks/opik_optimizer/pyproject.toml
               sdks/opik_optimizer/setup.py
               sdks/opik_optimizer/tests/test_requirements.txt

--- a/.github/workflows/opik-optimizer-publish.yml
+++ b/.github/workflows/opik-optimizer-publish.yml
@@ -20,7 +20,7 @@ jobs:
           uses: actions/checkout@v6
 
         - name: Set up Python 3.9
-          uses: astral-sh/setup-uv@v8.3.2
+          uses: actions/setup-python@v5
           with:
                 python-version: 3.9
 

--- a/.github/workflows/opik-optimizer-publish.yml
+++ b/.github/workflows/opik-optimizer-publish.yml
@@ -20,7 +20,7 @@ jobs:
           uses: actions/checkout@v6
 
         - name: Set up Python 3.9
-          uses: actions/setup-python@v5
+          uses: astral-sh/setup-uv@v8.3.2
           with:
                 python-version: 3.9
 

--- a/.github/workflows/opik-optimizer-unit-tests.yaml
+++ b/.github/workflows/opik-optimizer-unit-tests.yaml
@@ -45,11 +45,11 @@ jobs:
           uses: actions/checkout@v6
             
         - name: Setup Python ${{matrix.python_version}}
-          uses: astral-sh/setup-uv@v8.3.2
+          uses: actions/setup-python@v5
           with:
             python-version: ${{matrix.python_version}}
-            enable-cache: true
-            cache-dependency-glob: |
+            cache: 'pip'
+            cache-dependency-path: |
               sdks/opik_optimizer/pyproject.toml
               sdks/opik_optimizer/setup.py
               sdks/opik_optimizer/tests/test_requirements.txt

--- a/.github/workflows/opik-optimizer-unit-tests.yaml
+++ b/.github/workflows/opik-optimizer-unit-tests.yaml
@@ -48,11 +48,6 @@ jobs:
           uses: actions/setup-python@v5
           with:
             python-version: ${{matrix.python_version}}
-            cache: 'pip'
-            cache-dependency-path: |
-              sdks/opik_optimizer/pyproject.toml
-              sdks/opik_optimizer/setup.py
-              sdks/opik_optimizer/tests/test_requirements.txt
 
         - name: Set up uv
           uses: astral-sh/setup-uv@v8.3.2

--- a/.github/workflows/opik-optimizer-unit-tests.yaml
+++ b/.github/workflows/opik-optimizer-unit-tests.yaml
@@ -45,11 +45,11 @@ jobs:
           uses: actions/checkout@v6
             
         - name: Setup Python ${{matrix.python_version}}
-          uses: actions/setup-python@v5
+          uses: astral-sh/setup-uv@v8.3.2
           with:
             python-version: ${{matrix.python_version}}
-            cache: 'pip'
-            cache-dependency-path: |
+            enable-cache: true
+            cache-dependency-glob: |
               sdks/opik_optimizer/pyproject.toml
               sdks/opik_optimizer/setup.py
               sdks/opik_optimizer/tests/test_requirements.txt
@@ -71,12 +71,12 @@ jobs:
               litellm-cache-
 
         - name: Install opik_optimizer
-          run: pip install .
+          run: uv pip install --system .
         
         - name: Install test requirements
           run: |
             cd ./tests
-            pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt
+            uv pip install --system -r test_requirements.txt
   
         - name: Run unit tests
           run: pytest -n auto --dist loadfile tests/unit -vv --junitxml=${{ github.workspace }}/test_results_${{matrix.python_version}}.xml

--- a/.github/workflows/opik-optimizer-unit-tests.yaml
+++ b/.github/workflows/opik-optimizer-unit-tests.yaml
@@ -54,6 +54,9 @@ jobs:
               sdks/opik_optimizer/setup.py
               sdks/opik_optimizer/tests/test_requirements.txt
 
+        - name: Set up uv
+          uses: astral-sh/setup-uv@v8.3.2
+
         - name: Cache HuggingFace datasets
           uses: actions/cache@v4
           with:

--- a/.github/workflows/python_backend_e2e_tests.yml
+++ b/.github/workflows/python_backend_e2e_tests.yml
@@ -52,6 +52,9 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Run Opik server
         env:
           OPIK_USAGE_REPORT_ENABLED: false

--- a/.github/workflows/python_backend_e2e_tests.yml
+++ b/.github/workflows/python_backend_e2e_tests.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python 3.12
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/python_backend_e2e_tests.yml
+++ b/.github/workflows/python_backend_e2e_tests.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python 3.12
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: '3.12'
 
@@ -71,8 +71,8 @@ jobs:
       - name: Install opik-python-backend
         run: |
           cd ${{ github.workspace }}/apps/opik-python-backend
-          pip install -r requirements.txt -r tests/test_requirements.txt
-          pip install .
+          uv pip install --system -r requirements.txt -r tests/test_requirements.txt
+          uv pip install --system .
 
       - name: Run Python BE E2E tests
         run: |

--- a/.github/workflows/python_backend_tests.yml
+++ b/.github/workflows/python_backend_tests.yml
@@ -36,16 +36,15 @@ jobs:
           fetch-depth: 1
       
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: '3.12'
-          cache: 'pip'
+          enable-cache: true
       
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt -r tests/test_requirements.txt
-          pip install .
+          uv pip install --system -r requirements.txt -r tests/test_requirements.txt
+          uv pip install --system .
       
       - name: Run unit tests
         env:

--- a/.github/workflows/python_backend_tests.yml
+++ b/.github/workflows/python_backend_tests.yml
@@ -36,10 +36,10 @@ jobs:
           fetch-depth: 1
       
       - name: Set up Python 3.12
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          enable-cache: true
+          cache: 'pip'
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/python_backend_tests.yml
+++ b/.github/workflows/python_backend_tests.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/python_backend_tests.yml
+++ b/.github/workflows/python_backend_tests.yml
@@ -39,7 +39,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: 'pip'
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v8.3.2

--- a/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
@@ -87,7 +87,7 @@ jobs:
             docker tag "ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG" ghcr.io/comet-ml/opik/opik-guardrails-backend:latest
 
         - name: Setup Python ${{matrix.python_version}}
-          uses: astral-sh/setup-uv@v8.3.2
+          uses: actions/setup-python@v5
           with:
             python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
@@ -87,7 +87,7 @@ jobs:
             docker tag "ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG" ghcr.io/comet-ml/opik/opik-guardrails-backend:latest
 
         - name: Setup Python ${{matrix.python_version}}
-          uses: actions/setup-python@v5
+          uses: astral-sh/setup-uv@v8.3.2
           with:
             python-version: ${{matrix.python_version}}
 
@@ -118,13 +118,13 @@ jobs:
         - name: Install opik SDK
           run: |
             cd ${{ github.workspace }}/sdks/python
-            pip install .
+            uv pip install --system .
 
         - name: Install test requirements
           run: |
             cd ${{ github.workspace }}/sdks/python
-            pip install -r tests/test_requirements.txt
-            pip list
+            uv pip install --system -r tests/test_requirements.txt
+            uv pip list --system
 
         - name: Run compatibility v1 tests
           run: |

--- a/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
@@ -91,6 +91,9 @@ jobs:
           with:
             python-version: ${{matrix.python_version}}
 
+        - name: Set up uv
+          uses: astral-sh/setup-uv@v8.3.2
+
         - name: Run latest Opik server
           env:
             OPIK_USAGE_REPORT_ENABLED: false

--- a/.github/workflows/python_sdk_e2e_tests.yml
+++ b/.github/workflows/python_sdk_e2e_tests.yml
@@ -87,7 +87,7 @@ jobs:
             docker tag "ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG" ghcr.io/comet-ml/opik/opik-guardrails-backend:latest
 
         - name: Setup Python ${{matrix.python_version}}
-          uses: actions/setup-python@v5
+          uses: astral-sh/setup-uv@v8.3.2
           with:
             python-version: ${{matrix.python_version}}
 
@@ -117,7 +117,7 @@ jobs:
         - name: Install opik SDK
           run: |
             cd ${{ github.workspace }}/sdks/python
-            pip install .
+            uv pip install --system .
 
         - name: Run smoke tests
           run: |
@@ -127,8 +127,8 @@ jobs:
         - name: Install test requirements
           run: |
             cd ${{ github.workspace }}/sdks/python
-            pip install -r tests/test_requirements.txt
-            pip list
+            uv pip install --system -r tests/test_requirements.txt
+            uv pip list --system
 
         - name: Run tests
           # -n 3 + --dist=loadfile distributes whole test files across three

--- a/.github/workflows/python_sdk_e2e_tests.yml
+++ b/.github/workflows/python_sdk_e2e_tests.yml
@@ -87,7 +87,7 @@ jobs:
             docker tag "ghcr.io/comet-ml/opik/opik-guardrails-backend:$TAG" ghcr.io/comet-ml/opik/opik-guardrails-backend:latest
 
         - name: Setup Python ${{matrix.python_version}}
-          uses: astral-sh/setup-uv@v8.3.2
+          uses: actions/setup-python@v5
           with:
             python-version: ${{matrix.python_version}}
 

--- a/.github/workflows/python_sdk_e2e_tests.yml
+++ b/.github/workflows/python_sdk_e2e_tests.yml
@@ -91,6 +91,9 @@ jobs:
           with:
             python-version: ${{matrix.python_version}}
 
+        - name: Set up uv
+          uses: astral-sh/setup-uv@v8.3.2
+
         - name: Run latest Opik server
           env:
             OPIK_USAGE_REPORT_ENABLED: false

--- a/.github/workflows/python_sdk_unit_tests.yml
+++ b/.github/workflows/python_sdk_unit_tests.yml
@@ -53,7 +53,7 @@ jobs:
         run: echo "$PR_TITLE"
 
       - name: Setup Python ${{ matrix.python_version }}
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
 

--- a/.github/workflows/python_sdk_unit_tests.yml
+++ b/.github/workflows/python_sdk_unit_tests.yml
@@ -53,18 +53,18 @@ jobs:
         run: echo "$PR_TITLE"
 
       - name: Setup Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{ matrix.python_version }}
 
       - name: Install opik
-        run: pip install .
+        run: uv pip install --system .
 
       - name: Install test requirements
         run: |
           cd ./tests
-          pip install --no-cache-dir --disable-pip-version-check -r test_requirements.txt -r ./unit/test_requirements.txt
-          pip list
+          uv pip install --system -r test_requirements.txt -r ./unit/test_requirements.txt
+          uv pip list --system
 
       - name: Running SDK Unit Tests
         # Per-test timeout (thread method dumps all thread stacks via faulthandler)

--- a/.github/workflows/python_sdk_unit_tests.yml
+++ b/.github/workflows/python_sdk_unit_tests.yml
@@ -57,6 +57,9 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install opik
         run: uv pip install --system .
 

--- a/.github/workflows/quickstart_guide_snippets_test.yml
+++ b/.github/workflows/quickstart_guide_snippets_test.yml
@@ -32,7 +32,7 @@ jobs:
                 ref: ${{ github.ref }}
             
             - name: Setup Python
-              uses: astral-sh/setup-uv@v8.3.2
+              uses: actions/setup-python@v5
               with:
                 python-version: 3.12
 

--- a/.github/workflows/quickstart_guide_snippets_test.yml
+++ b/.github/workflows/quickstart_guide_snippets_test.yml
@@ -36,6 +36,9 @@ jobs:
               with:
                 python-version: 3.12
 
+            - name: Set up uv
+              uses: astral-sh/setup-uv@v8.3.2
+
             - name: Install Opik
               run: uv pip install --system opik
 

--- a/.github/workflows/quickstart_guide_snippets_test.yml
+++ b/.github/workflows/quickstart_guide_snippets_test.yml
@@ -32,18 +32,18 @@ jobs:
                 ref: ${{ github.ref }}
             
             - name: Setup Python
-              uses: actions/setup-python@v5
+              uses: astral-sh/setup-uv@v8.3.2
               with:
                 python-version: 3.12
 
             - name: Install Opik
-              run: pip install opik
+              run: uv pip install --system opik
 
             - name: Install Test Dependencies
               run: |
-                pip install -r ${{ github.workspace }}/tests_end_to_end/test_requirements.txt
-                pip install -r ${{ github.workspace }}/tests_end_to_end/integrations_requirements.txt
-                pip install allure-pytest
+                uv pip install --system -r ${{ github.workspace }}/tests_end_to_end/test_requirements.txt
+                uv pip install --system -r ${{ github.workspace }}/tests_end_to_end/integrations_requirements.txt
+                uv pip install --system allure-pytest
                 playwright install
           
             - name: Install allurectl

--- a/.github/workflows/sdk-e2e-library-tests.yaml
+++ b/.github/workflows/sdk-e2e-library-tests.yaml
@@ -100,7 +100,7 @@ jobs:
           docker tag "ghcr.io/comet-ml/opik/opik-python-backend:$TAG" ghcr.io/comet-ml/opik/opik-python-backend:latest
 
       - name: Install uv and set the Python version ${{ matrix.python_version }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{ matrix.python_version }}
 

--- a/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
+++ b/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
@@ -33,10 +33,10 @@ jobs:
         run: npm install -g fern-api@4.71.5
 
       - name: Set up Python
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          enable-cache: true
+          cache: 'pip'
 
       - name: Install Opik Optimizer SDK (for Fern docs)
         run: |

--- a/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
+++ b/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
@@ -33,15 +33,14 @@ jobs:
         run: npm install -g fern-api@4.71.5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: '3.11'
-          cache: 'pip'
+          enable-cache: true
 
       - name: Install Opik Optimizer SDK (for Fern docs)
         run: |
-          python -m pip install --upgrade pip
-          pip install -e sdks/opik_optimizer
+          uv pip install --system -e sdks/opik_optimizer
 
       - name: Set branch name
         run: |

--- a/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
+++ b/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
@@ -38,6 +38,9 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install Opik Optimizer SDK (for Fern docs)
         run: |
           uv pip install --system -e sdks/opik_optimizer

--- a/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
+++ b/.github/workflows/sdks_generate_openapi_spec_and_fern_code.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v8.3.2

--- a/.github/workflows/sync_provider_models.yml
+++ b/.github/workflows/sync_provider_models.yml
@@ -27,12 +27,12 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install requests
+        run: uv pip install --system requests
 
       - name: Set branch name
         run: |

--- a/.github/workflows/sync_provider_models.yml
+++ b/.github/workflows/sync_provider_models.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/sync_provider_models.yml
+++ b/.github/workflows/sync_provider_models.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
+
       - name: Install dependencies
         run: uv pip install --system requests
 

--- a/.github/workflows/test_docs_links.yml
+++ b/.github/workflows/test_docs_links.yml
@@ -33,6 +33,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.3.2
       
       - name: Install pytest and allure
         run: |

--- a/.github/workflows/test_docs_links.yml
+++ b/.github/workflows/test_docs_links.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: '18'
       
       - name: Install Python
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       

--- a/.github/workflows/test_docs_links.yml
+++ b/.github/workflows/test_docs_links.yml
@@ -30,21 +30,21 @@ jobs:
           node-version: '18'
       
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: '3.12'
       
       - name: Install pytest and allure
         run: |
-          pip install pytest allure-pytest
+          uv pip install --system pytest allure-pytest
 
       - name: Install allurectl
         uses: allure-framework/setup-allurectl@v1
 
       - name: Install Test Dependencies
         run: |
-          pip install -r ${{ github.workspace }}/tests_end_to_end/test_requirements.txt
-          pip install opik
+          uv pip install --system -r ${{ github.workspace }}/tests_end_to_end/test_requirements.txt
+          uv pip install --system opik
           playwright install chromium
         
       - name: Install linkinator

--- a/tests_end_to_end/integrations_requirements.txt
+++ b/tests_end_to_end/integrations_requirements.txt
@@ -1,0 +1,12 @@
+anthropic
+openai
+boto3
+dspy
+google-genai
+haystack-ai
+langchain
+langgraph
+llama_index
+llama-index-callbacks-opik
+langchain_openai
+ragas

--- a/tests_end_to_end/test_requirements.txt
+++ b/tests_end_to_end/test_requirements.txt
@@ -1,0 +1,5 @@
+pytest
+playwright==1.49.0
+pytest-playwright
+pytest-rerunfailures
+allure-pytest>=2.13.0


### PR DESCRIPTION
## Details

<img width="714" height="921" alt="image" src="https://github.com/user-attachments/assets/96f44ccf-6723-46dd-8e06-60c5adb2e7c3" />

Completes the repo's in-progress migration to uv: every remaining CI workflow (and the e2e-lib composite action) now installs Python dependencies via `uv pip install --system` instead of `pip install`. The motivation is speed and consistency — the dependency-install step is the longest non-test step in the install-heavy SDK/optimizer/integration jobs, and ~5 workflows were already on uv while ~40 were still on pip.

Follows Astral's documented GitHub CI pattern: `actions/setup-python` still provides the (runner-cached, fast) interpreter, and a `setup-uv` step is added alongside it so `uv` is the installer. `setup-uv` alone provides a uv-managed Python that `uv pip install --system` cannot target, so both actions are needed.

- Resolution stays **unpinned** (`uv pip install --system`) — drop-in faster pip, same packages/sources, no `uv.lock`, no reproducibility-contract change.
- All `setup-uv` refs pinned to exact `v8.3.2` — upstream publishes no `v8` moving tag (only exact `v8.x.y`; moving majors stop at `v7`), so `@v8` would fail to resolve at runtime.
- Cleanups: dropped `python -m pip install --upgrade pip` no-ops and pip-only flags (`--no-cache-dir`, `--disable-pip-version-check`); removed the now-inert `cache: 'pip'` from jobs that install via uv (uv uses `~/.cache/uv`); deduped a double `setup-uv` step in the v2 e2e workflows; converted `pip list` → `uv pip list --system`.
- Recreated `tests_end_to_end/{test,integrations}_requirements.txt` — deleted by the E2E-retirement PR but still referenced by three daily-scheduled workflows (`installation_tests`, `quickstart_guide_snippets_test`, `test_docs_links`), which have therefore been failing daily on main independently of this migration.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-7385

Related (not resolved here):
- OPIK_7388 — an e2e litellm test pins a litellm version below opik's declared security floor; surfaced by uv's stricter resolver but pre-exists this migration.
- OPIK_7412 — recreated `integrations_requirements.txt` may be missing deps the quickstart snippets import; pre-existing gap, audit tracked separately.
- OPIK_7422 — the lib integration runner only triggers on `sdks/python/**`, so edits to the integration workflows themselves aren't tested; trigger-coverage fix tracked separately.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: full implementation
- Human verification: code review + local dependency-resolution checks + measured CI timings

## Testing

Static + resolution validation locally, then measured on CI:

- `actionlint` — exit 0 across all workflows and composite actions.
- YAML parse check — all workflow files parse.
- Invariants: 0 `actions/setup-python`-only setups broken, 0 bare `pip install`/`pip list`, 0 inert `cache: 'pip'`, uniform `astral-sh/setup-uv@v8.3.2` pin.
- **Dependency resolution** via `uv pip compile` against every requirements set the workflows install: core SDK, all 20 `lib-*` integrations, optimizer (dev + testreqs), guardrails, load tests, and both recreated `tests_end_to_end` files — all resolve cleanly.

### Measured — per-job dependency-install step (real CI runs, before = `main` pip, after = this PR uv)

| Workflow | before (pip) | after (uv) | install speed-up |
|---|---|---|---|
| `python_sdk_unit_tests` | 46s | 4s (+4s uv) | 11× |
| `python_sdk_e2e_tests` | 38s | 4s (+4s uv) | 9× |
| `python_sdk_compatibility_v1_e2e_tests` | 40s | 5s (+5s uv) | 8× |
| `opik-optimizer-e2e-tests` | 50s | 4s (+4s uv) | 12× |
| `python_backend_tests` | 40s | 8s (+5s uv) | 5× |
| `guardrails_e2e_tests` | 42s | 3s (+5s uv) | 14× |
| `guardrails_unit_tests` | 85s | 27s (+6s uv) | 3× |
| `lib-openai` (matrix) | ~50s | ~6s (+4s uv) | 8× |
| `lib-langchain` (matrix) | ~60s | ~7s (+3s uv) | 8× |
| `lib-bedrock` (matrix) | ~36s | ~6s (+4s uv) | 6× |

Per-job install-step average. `(+Ns uv)` is the one-time `Set up uv` step; even counting it, every job is net faster. **Total-job wall-clock is deliberately not reported as a uv metric** — it's dominated by test time, server spin-up, and matrix size, which vary run-to-run independent of the installer.

The `lib-*` integration matrix (`SDK Library Integration Tests Runner`) is `sdks/python/**`-path-triggered, so it doesn't run on this `.github/`-only PR — its "after" numbers were captured via a manual `workflow_dispatch` on the branch (run `29825434986`, green). The runner-trigger coverage gap this exposes is tracked separately as OPIK_7422. `opik-optimizer-unit-tests` likewise did not re-trigger on the PR.

## Documentation

N/A — CI tooling change only; no user- or developer-facing docs affected.
