### PR TITLE
[NA] [DOCS] fix: add missing TestSuite/TestSuiteResult pages to Pytho…

### DIFF
--- a/apps/opik-documentation/python-sdk-docs/source/Objects/TestSuiteResult.rst
+++ b/apps/opik-documentation/python-sdk-docs/source/Objects/TestSuiteResult.rst
@@ -1,0 +1,5 @@
+TestSuiteResult
+===============
+
+.. autoclass:: opik.TestSuiteResult
+    :members:

--- a/apps/opik-documentation/python-sdk-docs/source/evaluation/TestSuite.rst
+++ b/apps/opik-documentation/python-sdk-docs/source/evaluation/TestSuite.rst
@@ -1,0 +1,6 @@
+TestSuite
+=========
+
+.. autoclass:: opik.TestSuite
+    :members:
+    :special-members: __init__

--- a/apps/opik-documentation/python-sdk-docs/source/index.rst
+++ b/apps/opik-documentation/python-sdk-docs/source/index.rst
@@ -196,6 +196,7 @@ You can learn more about the `opik` python SDK in the following sections:
    :maxdepth: 1
    
    evaluation/Dataset
+   evaluation/TestSuite
    evaluation/evaluate
    evaluation/evaluate_prompt
    evaluation/evaluate_experiment
@@ -257,6 +258,7 @@ You can learn more about the `opik` python SDK in the following sections:
    Objects/ExperimentItemReferences.rst
    Objects/EvaluationResult.rst
    Objects/TestResult.rst
+   Objects/TestSuiteResult.rst
    Objects/Prompt.rst
    Objects/ChatPrompt.rst
    Objects/ScoreResult.rst


### PR DESCRIPTION
…n SDK reference

opik.TestSuite and opik.TestSuiteResult have been public top-level exports since the Test Suite API shipped in 2.0 (opik/__init__.py), but neither had a reference page or toctree entry, unlike Dataset/Experiment which each get one. This gap exists independently of the SDK reference site's staleness — it would persist even after a fresh rebuild.

## Details
<!--
REPLACE ME WITH:
Short 2-3 lines single paragraph explaining whats changed and the motivation (why).
If you need to have changes explained in detail include single line dot point(s).
-->

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

<!--
Jira linking: tickets this PR RESOLVES keep the hyphen (OPIK-1234) here and anywhere — they link in Jira's Development panel, which is wanted. A PR may resolve more than one ticket; list each resolved key.
Tickets RELATED but NOT resolved here (escalations, references to older tickets) must NOT link: in the sections above/below and in commit messages, write them with an underscore (OPIK_7000) and paste no Jira URL (the URL contains the hyphenated key and links anyway). See CONTRIBUTING.md.
-->


## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
<!--
REPLACE ME WITH:

How you tested

Include:
- Exact commands run (for example: `mvn test`, `npm run lint && npm run test`, `pytest ...`)
- Scenarios validated (happy path, edge cases, regressions)
- Environment/context used (local process mode vs Docker, OS/browser when relevant)
- Any tests not run, with reason
- Relevant logs/artifacts links if available

Video evidence:
- External contributors: include a short recording for all contributions where possible.
- Internal contributors: include a short recording for complex changes where possible.
-->

## Documentation
