### PR TITLE
[NA] [DOCS] fix: auto-trigger Python SDK docs deploy on merge to main

### DIFF
--- a/.github/workflows/deploy_python_sdk_docs.yml
+++ b/.github/workflows/deploy_python_sdk_docs.yml
@@ -1,5 +1,5 @@
 name: Deploy Opik Python SDK docs
-run-name: Deploy Python SDK docs ${{ github.ref_name }} to S3 ${{ inputs.environment }} by @${{ github.actor }}
+run-name: Deploy Python SDK docs ${{ github.ref_name }} to S3 ${{ inputs.environment || 'production' }} by @${{ github.actor }}
 
 on:
   workflow_dispatch:
@@ -11,11 +11,18 @@ on:
           - staging
           - production
           - development
+  push:
+    branches:
+      - main
+    paths:
+      - "sdks/python/**"
+      - "apps/opik-documentation/python-sdk-docs/**"
+
 jobs:
   upload:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.environment || 'production' }}
     permissions:
       id-token: write   # required for OIDC
       contents: read
@@ -23,6 +30,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ vars.AWS_REGION }}
+      ENVIRONMENT: ${{ inputs.environment || 'production' }}
     steps:
       - name: Verify AWS credentials
         run: aws sts get-caller-identity
@@ -44,8 +52,8 @@ jobs:
             uv pip install ../../../sdks/python
             uv run make build
 
-      - name: Upload sdk docs to site.comet.com (${{ inputs.environment }})
+      - name: Upload sdk docs to site.comet.com (${{ env.ENVIRONMENT }})
         run: |
           aws s3 sync apps/opik-documentation/python-sdk-docs/build/html \
-            s3://site.comet.com/${{ inputs.environment }}/docs-opik/python-sdk-reference \
+            s3://site.comet.com/${{ env.ENVIRONMENT }}/docs-opik/python-sdk-reference \
             --follow-symlinks --no-progress --delete --exclude '.git*'


### PR DESCRIPTION
deploy_python_sdk_docs.yml was workflow_dispatch-only, so publishing a production build depended entirely on someone remembering to run it by hand. The last successful production deploy off main was 2025-10-28 — 9 months stale as of this investigation, missing the whole Opik 2.0 project-scoping change and the Test Suite API.

Add a push trigger on main scoped to sdks/python/** and apps/opik-documentation/python-sdk-docs/**, deploying straight to production with no staging gate — mirroring the pattern already used by build_and_publish_sdk.yaml (same trigger, publishes to PyPI) and by documentation_deploy.yml (the Fern docs site, "merge is deploy"). Confirmed via the GitHub API that the production environment has no required-reviewer protection rules, so this won't silently queue pending an approval nobody grants.

workflow_dispatch stays as a manual override for ad-hoc re-deploys or testing against staging/development.