### PR TITLE
[NA] [FE] Add strict Cost-intelligence rounding mode to formatNumberInK

### DIFF
--- a/apps/opik-frontend/src/lib/utils.test.ts
+++ b/apps/opik-frontend/src/lib/utils.test.ts
@@ -4,6 +4,7 @@ import {
   isStringMarkdown,
   removeUndefinedKeys,
   isLooseEqual,
+  formatNumberInK,
 } from "./utils";
 
 describe("isStringMarkdown", () => {
@@ -407,5 +408,51 @@ describe("getSelectAllCheckedState", () => {
 
   it("returns true when selectedCount exceeds totalCount", () => {
     expect(getSelectAllCheckedState(7, 5)).toBe(true);
+  });
+});
+
+describe("formatNumberInK", () => {
+  it("keeps existing (non-strict) behavior: no forced trailing zero", () => {
+    expect(formatNumberInK(7000000)).toBe("7M");
+    expect(formatNumberInK(6900)).toBe("6.9K");
+    expect(formatNumberInK(842)).toBe("842");
+  });
+
+  describe("strict (Cost-intelligence rounding rules)", () => {
+    const strict = (v: number) => formatNumberInK(v, 1, { strict: true });
+
+    it("shows values below 1,000 as raw integers, rounded half up", () => {
+      expect(strict(0)).toBe("0");
+      expect(strict(842)).toBe("842");
+      expect(strict(842.4)).toBe("842");
+      expect(strict(842.5)).toBe("843");
+      expect(strict(999)).toBe("999");
+    });
+
+    it("abbreviates K/M/B with the right suffix", () => {
+      expect(strict(6900)).toBe("6.9K");
+      expect(strict(7_200_000)).toBe("7.2M");
+      expect(strict(549_800_000_000)).toBe("549.8B");
+    });
+
+    it("always keeps one decimal, including a trailing .0", () => {
+      expect(strict(1000)).toBe("1.0K");
+      expect(strict(7_000_000)).toBe("7.0M");
+      expect(strict(1_600_000_000)).toBe("1.6B");
+    });
+
+    it("rounds half up to one decimal", () => {
+      expect(strict(1250)).toBe("1.3K");
+      expect(strict(2651)).toBe("2.7K");
+    });
+
+    it("carries over to the next unit instead of showing 1000.0", () => {
+      expect(strict(999_950)).toBe("1.0M");
+      expect(strict(999_950_000)).toBe("1.0B");
+    });
+
+    it("preserves the sign for negative values", () => {
+      expect(strict(-6900)).toBe("-6.9K");
+    });
   });
 });

--- a/apps/opik-frontend/src/lib/utils.ts
+++ b/apps/opik-frontend/src/lib/utils.ts
@@ -246,13 +246,37 @@ export const truncateMiddle = (text: string, maxLength: number): string => {
   return `${text.slice(0, left)}…${text.slice(-right)}`;
 };
 
-export const formatNumberInK = (value: number, precision = 1): string => {
+export const formatNumberInK = (
+  value: number,
+  precision = 1,
+  { strict = false }: { strict?: boolean } = {},
+): string => {
   const ranges = [
     { threshold: 1000000000000, suffix: "T", divider: 1000000000000 },
     { threshold: 1000000000, suffix: "B", divider: 1000000000 },
     { threshold: 1000000, suffix: "M", divider: 1000000 },
     { threshold: 1000, suffix: "K", divider: 1000 },
   ];
+
+  // Strict mode applies the Cost-intelligence rounding rules: always `precision`
+  // decimals on suffixed values (trailing zeros kept, e.g. 7.0M), an integer
+  // with no decimals below 1000, round-half-up, carry-over to the next unit when
+  // rounding hits 1000 (999,950 -> 1.0M), and a leading sign on negatives.
+  if (strict) {
+    const sign = value < 0 ? "-" : "";
+    const magnitude = Math.abs(value);
+    if (magnitude < 1000) return `${sign}${Math.round(magnitude)}`;
+    const factor = 10 ** precision;
+    const scale = (index: number): number =>
+      Math.round((magnitude / ranges[index].divider) * factor) / factor;
+    let index = ranges.findIndex((r) => magnitude >= r.divider);
+    let scaled = scale(index);
+    if (scaled >= 1000 && index > 0) {
+      index -= 1;
+      scaled = scale(index);
+    }
+    return `${sign}${scaled.toFixed(precision)}${ranges[index].suffix}`;
+  }
 
   const formatValue = (num: number): string =>
     isInteger(num) ? num.toString() : num.toFixed(precision);


### PR DESCRIPTION
## Details

Adds an opt-in `strict` option to `formatNumberInK` (`src/lib/utils.ts`) that applies the Cost-intelligence rounding rules: always `precision` decimals on suffixed values with trailing zeros kept (`7.0M`), an integer with no decimals below 1000 (`843`), round-half-up, carry-over to the next unit when rounding hits 1000 (`999,950 → 1.0M`), and a leading sign on negatives (`-6.9K`). Default behavior is unchanged (`strict` defaults to `false`), so existing callers are unaffected. This lets the AI-Spend plugin's summary reuse the shared helper instead of maintaining a second, divergent K/M/B implementation (per review feedback on the ai-spend PR).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- N/A — no ticket; small shared-helper enhancement supporting the AI-Spend billing-split work.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: implementation of the `strict` option + unit tests
- Human verification: reviewed the diff; ran the test suite and lint/type checks locally (below)

## Testing

- `npx vitest run src/lib/utils.test.ts` — 60 passed (regression case for existing non-strict behavior + full strict-mode coverage: thresholds, trailing `.0`, half-up, both carry-over cases, sign).
- `npx tsc --noEmit -p tsconfig.json` — clean.
- `npx eslint src/lib/utils.ts src/lib/utils.test.ts` — clean.

## Documentation

No docs change — internal utility; behavior documented via a code comment on the `strict` branch and the unit tests.