### PR TITLE
[OPIK-7094] [QA] test: cover experiment comparison view

### DIFF
--- a/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
+++ b/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
@@ -69,6 +69,30 @@ export interface PythonSdkClient {
       score_value: number;
     }>;
   }>;
+  compareSeed(args: {
+    project_name: string;
+    dataset_name: string;
+    items: Array<{ input: string; expected_output: string }>;
+    experiments: Array<{ experiment_name: string; task_outputs: string[] }>;
+    dataset_description?: string;
+    workspace?: string;
+  }): Promise<{
+    dataset_id: string;
+    dataset_name: string;
+    item_count: number;
+    experiments: Array<{
+      experiment_id: string;
+      experiment_name: string;
+      scores: Array<{
+        dataset_item_id: string;
+        input: string;
+        expected_output: string;
+        task_output: string;
+        score_name: string;
+        score_value: number;
+      }>;
+    }>;
+  }>;
   createTextPrompt(args: {
     name: string;
     prompt: string;
@@ -225,6 +249,25 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
     },
     async createDataset(args) {
       return request<{ id: string; name: string }>('POST', '/datasets', args);
+    },
+    async compareSeed(args) {
+      return request<{
+        dataset_id: string;
+        dataset_name: string;
+        item_count: number;
+        experiments: Array<{
+          experiment_id: string;
+          experiment_name: string;
+          scores: Array<{
+            dataset_item_id: string;
+            input: string;
+            expected_output: string;
+            task_output: string;
+            score_name: string;
+            score_value: number;
+          }>;
+        }>;
+      }>('POST', '/experiments/compare-seed', args);
     },
     async createTextPrompt(args) {
       return request<{ id: string; name: string }>('POST', '/prompts/text', args);

--- a/tests_end_to_end/e2e/fixtures/comparison-experiment.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/comparison-experiment.fixture.ts
@@ -1,0 +1,134 @@
+import { test as baseTest } from './experiment.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+
+export interface ComparisonItemSeed {
+  input: string;
+  expected_output: string;
+}
+
+export interface ComparisonExperimentRef {
+  experimentId: string;
+  experimentName: string;
+  /** Score keyed by shared dataset item id. */
+  scoresByItemId: Record<string, number>;
+  /** Evaluation-task output keyed by shared dataset item id. */
+  outputsByItemId: Record<string, string>;
+  /** Mean of this experiment's per-item scores. */
+  aggregateScore: number;
+}
+
+export interface ComparisonRef {
+  datasetId: string;
+  datasetName: string;
+  projectName: string;
+  items: ComparisonItemSeed[];
+  /** Dataset item ids, aligned by index with `items` (shared across both experiments). */
+  itemIds: string[];
+  evaluator: { name: string };
+  experiments: ComparisonExperimentRef[];
+}
+
+export interface ComparisonFixtures {
+  comparison: ComparisonRef;
+}
+
+/**
+ * Three shared dataset items scored by two experiments. The seed is tuned so a
+ * comparison test can see everything that matters, all at once:
+ *   item      expA out  expB out   expA  expB
+ *   q1 -> A     A         A         pass  pass   (agree)
+ *   q2 -> B     B         WRONG     pass  fail   (disagree)
+ *   q3 -> C     C         WRONG     pass  fail   (disagree)
+ *   aggregate mean:                 1.00  0.33
+ * Properties this buys:
+ *  - the two experiments DISAGREE per item (q2, q3) — side-by-side is meaningful;
+ *  - their AGGREGATES differ (1.00 vs 0.33) — the Feedback scores tab is meaningful;
+ *  - q1 is the UNIQUE highest-aggregate item (2 vs 1) — score-sort has a stable top.
+ */
+const SEED_ITEMS: ComparisonItemSeed[] = [
+  { input: 'q1', expected_output: 'A' },
+  { input: 'q2', expected_output: 'B' },
+  { input: 'q3', expected_output: 'C' },
+];
+
+const EXPERIMENT_A_OUTPUTS = ['A', 'B', 'C'];
+const EXPERIMENT_B_OUTPUTS = ['A', 'WRONG', 'WRONG'];
+
+export const test = baseTest.extend<ComparisonFixtures>({
+  comparison: async ({ sdkClient, backendClient, project, testNamespace }, use, testInfo) => {
+    const datasetName = `${testNamespace}-cmp-ds`;
+    const experimentNameA = `${testNamespace}-cmp-expA`;
+    const experimentNameB = `${testNamespace}-cmp-expB`;
+
+    const seeded = await sdkClient.python.compareSeed({
+      project_name: project.name,
+      dataset_name: datasetName,
+      items: SEED_ITEMS,
+      experiments: [
+        { experiment_name: experimentNameA, task_outputs: EXPERIMENT_A_OUTPUTS },
+        { experiment_name: experimentNameB, task_outputs: EXPERIMENT_B_OUTPUTS },
+      ],
+    });
+
+    // itemId per seed input, so tests can address a shared item by its input.
+    const itemIdByInput: Record<string, string> = {};
+    for (const s of seeded.experiments[0].scores) {
+      itemIdByInput[s.input] = s.dataset_item_id;
+    }
+
+    // The bridge doesn't echo task_output on the dataset item, so map each
+    // experiment's per-item output from the seed arrays (aligned to SEED_ITEMS).
+    const outputsBySeedIndex = [EXPERIMENT_A_OUTPUTS, EXPERIMENT_B_OUTPUTS];
+
+    const experiments: ComparisonExperimentRef[] = seeded.experiments.map((exp, expIndex) => {
+      const scoresByItemId = Object.fromEntries(exp.scores.map((s) => [s.dataset_item_id, s.score_value]));
+      const outputsByItemId: Record<string, string> = {};
+      SEED_ITEMS.forEach((item, i) => {
+        outputsByItemId[itemIdByInput[item.input]] = outputsBySeedIndex[expIndex][i];
+      });
+      const scoreValues = Object.values(scoresByItemId);
+      const aggregateScore = scoreValues.reduce((a, b) => a + b, 0) / scoreValues.length;
+      return {
+        experimentId: exp.experiment_id,
+        experimentName: exp.experiment_name,
+        scoresByItemId,
+        outputsByItemId,
+        aggregateScore,
+      };
+    });
+
+    const ref: ComparisonRef = {
+      datasetId: seeded.dataset_id,
+      datasetName,
+      projectName: project.name,
+      items: SEED_ITEMS,
+      itemIds: SEED_ITEMS.map((item) => itemIdByInput[item.input]),
+      evaluator: { name: 'equals_metric' },
+      experiments,
+    };
+
+    await testInfo.attach('opik.comparison', {
+      body: JSON.stringify(ref, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use(ref);
+
+    if (!shouldLeaveArtifacts(testInfo)) {
+      for (const exp of experiments) {
+        try {
+          await backendClient.deleteExperiment(exp.experimentId);
+        } catch (err) {
+          console.warn(`[comparison fixture] delete experiment warning for ${exp.experimentName}:`, err);
+        }
+      }
+      try {
+        await backendClient.deleteDataset(seeded.dataset_id);
+      } catch (err) {
+        console.warn(`[comparison fixture] delete dataset warning for ${datasetName}:`, err);
+      }
+    }
+  },
+});
+
+export { expect } from './experiment.fixture';

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -16,6 +16,12 @@ export type {
   ExperimentItemScore,
 } from './experiment.fixture';
 export type {
+  ComparisonRef,
+  ComparisonFixtures,
+  ComparisonItemSeed,
+  ComparisonExperimentRef,
+} from './comparison-experiment.fixture';
+export type {
   TestSuiteRef,
   TestSuiteFixtures,
   TestSuiteItemSeed,

--- a/tests_end_to_end/e2e/fixtures/test-suite.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/test-suite.fixture.ts
@@ -1,4 +1,4 @@
-import { test as baseTest } from './experiment.fixture';
+import { test as baseTest } from './comparison-experiment.fixture';
 import { shouldLeaveArtifacts } from '../core/artifacts';
 
 export interface TestSuiteItemSeed {

--- a/tests_end_to_end/e2e/pom/compare-experiments.page.ts
+++ b/tests_end_to_end/e2e/pom/compare-experiments.page.ts
@@ -1,0 +1,234 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { loadEnvConfig } from '../config/env.config';
+
+/**
+ * The compare view lives at /experiments/{datasetId}/compare?experiments=[...]
+ * and renders the SAME page in single- and multi-experiment mode. This POM
+ * targets multi-experiment (comparison) mode: two experiments over one dataset.
+ *
+ * In comparison mode the table is one row per DATASET ITEM. Each cell is
+ * vertically split into one band per experiment, ordered by the position of
+ * the experiment id in the `experiments` query array — so band index 0 is the
+ * first id passed to `goto`, index 1 the second, etc.
+ */
+export class CompareExperimentsPage {
+  constructor(
+    private readonly page: Page,
+    private readonly projectId: string,
+    private readonly datasetId: string,
+    private readonly experimentIds: string[],
+  ) {}
+
+  private compareUrl(tab: 'items' | 'config' | 'scores'): string {
+    const env = loadEnvConfig();
+    const experiments = encodeURIComponent(JSON.stringify(this.experimentIds));
+    return `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/experiments/${this.datasetId}/compare?experiments=${experiments}&tab=${tab}`;
+  }
+
+  async gotoResults(): Promise<void> {
+    await test.step('open the compare Results tab', async () => {
+      await this.page.goto(this.compareUrl('items'));
+    });
+  }
+
+  async gotoConfiguration(): Promise<void> {
+    await test.step('open the compare Configuration tab', async () => {
+      await this.page.goto(this.compareUrl('config'));
+    });
+  }
+
+  async gotoFeedbackScores(): Promise<void> {
+    await test.step('open the compare Feedback scores tab', async () => {
+      await this.page.goto(this.compareUrl('scores'));
+    });
+  }
+
+  async waitForResultsReady(): Promise<void> {
+    await test.step('wait for the Results grid to render', async () => {
+      await this.compareHeading.waitFor({ state: 'visible' });
+      await this.itemRows.first().waitFor({ state: 'visible' });
+    });
+  }
+
+  async countItemRows(): Promise<number> {
+    return this.itemRows.count();
+  }
+
+  async expectCompareModeHeader(experimentCount: number): Promise<void> {
+    await test.step(`header reads "Compare (${experimentCount})"`, async () => {
+      await expect(this.compareHeading).toHaveText(`Compare (${experimentCount})`);
+    });
+  }
+
+  async expectExperimentNamesInSummary(names: string[]): Promise<void> {
+    await test.step('both experiment names appear in the compare summary', async () => {
+      const summary = this.compareSummary;
+      await expect(summary, 'compare summary row').toBeVisible();
+      for (const name of names) {
+        await expect(
+          summary.getByText(name, { exact: true }),
+          `experiment "${name}" named in the compare summary`,
+        ).toBeVisible();
+      }
+    });
+  }
+
+  /**
+   * The per-experiment score for one shared dataset item. `experimentIndex` is
+   * the position of the experiment in the array passed to the constructor,
+   * which is the order the split bands render in.
+   */
+  async readItemScore(datasetItemId: string, experimentIndex: number, metricName: string): Promise<number> {
+    return test.step(`read score for item ${datasetItemId} / experiment #${experimentIndex}`, async () => {
+      const band = this.splitBand(datasetItemId, experimentIndex, `feedback_scores_${metricName}`);
+      await expect(band, `score band for item ${datasetItemId} experiment #${experimentIndex}`).toBeVisible();
+      const text = ((await band.textContent()) ?? '').trim();
+      const value = parseFloat(text);
+      if (Number.isNaN(value)) {
+        throw new Error(
+          `CompareExperimentsPage.readItemScore: could not parse "${text}" for item ${datasetItemId} experiment #${experimentIndex}`,
+        );
+      }
+      return value;
+    });
+  }
+
+  /** The per-experiment evaluation-task output for one shared dataset item. */
+  async readItemOutput(datasetItemId: string, experimentIndex: number): Promise<string> {
+    return test.step(`read output for item ${datasetItemId} / experiment #${experimentIndex}`, async () => {
+      const band = this.splitBand(datasetItemId, experimentIndex, 'output_output');
+      await expect(band, `output band for item ${datasetItemId} experiment #${experimentIndex}`).toBeVisible();
+      return ((await band.textContent()) ?? '').trim();
+    });
+  }
+
+  /** The aggregate (mean) score for one experiment on the Feedback scores tab. */
+  async readAggregateScore(experimentId: string): Promise<number> {
+    return test.step(`read aggregate score for experiment ${experimentId}`, async () => {
+      const cell = this.page.locator(`td[data-cell-id="0_${experimentId}"]`);
+      await expect(cell, `aggregate score cell for experiment ${experimentId}`).toBeVisible();
+      const value = parseFloat(((await cell.textContent()) ?? '').trim());
+      if (Number.isNaN(value)) {
+        throw new Error(`CompareExperimentsPage.readAggregateScore: could not parse a number for ${experimentId}`);
+      }
+      return value;
+    });
+  }
+
+  async searchItems(term: string): Promise<void> {
+    await test.step(`search the grid for "${term}"`, async () => {
+      const url = new URL(this.page.url());
+      url.searchParams.set('search', term);
+      await this.page.goto(url.toString());
+      // Wait for the grid to settle on the filtered result: either matching
+      // rows, or the explicit no-data row — not the mid-reload empty table.
+      await this.page
+        .locator('tbody tr[data-row-id], tbody tr[data-testid="no-data-row"]')
+        .first()
+        .waitFor({ state: 'visible' });
+    });
+  }
+
+  async openRowPanel(datasetItemId: string): Promise<void> {
+    await test.step(`open the detail panel for item ${datasetItemId}`, async () => {
+      const url = new URL(this.page.url());
+      url.searchParams.set('row', datasetItemId);
+      await this.page.goto(url.toString());
+      // The panel's Close control only exists once the slide-over is mounted.
+      await this.page.getByRole('button', { name: 'Close' }).waitFor({ state: 'visible' });
+    });
+  }
+
+  /**
+   * In the row-detail panel each compared experiment is its own section headed
+   * by an h2 with the experiment name; assert both the output and score there.
+   */
+  async expectPanelExperimentResult(
+    experimentName: string,
+    expected: { output: string; score: number; metricName: string },
+  ): Promise<void> {
+    await test.step(`panel shows ${experimentName}'s output and score`, async () => {
+      const section = this.panelExperimentSection(experimentName);
+      await expect(section, `panel section for ${experimentName}`).toBeVisible();
+      await expect(section, `${experimentName} output in panel`).toContainText(expected.output);
+      const scoreRow = section.locator('tr', { hasText: expected.metricName });
+      await expect(scoreRow, `${experimentName} ${expected.metricName} score row`)
+        .toContainText(String(expected.score));
+    });
+  }
+
+  async expectExperimentColumnsInConfiguration(experiments: { id: string; name: string }[]): Promise<void> {
+    await test.step('each experiment is a named column on the Configuration tab', async () => {
+      for (const exp of experiments) {
+        await expect(
+          this.configHeader(exp.id),
+          `configuration column header for experiment ${exp.id}`,
+        ).toContainText(exp.name);
+      }
+    });
+  }
+
+  /**
+   * The score column header is a sticky, overlay-covered element that a direct
+   * click can't reliably hit; the grid instead reads sort state from the
+   * `sorting` query param (the same the header click writes). Driving sort via
+   * the URL exercises the real server-side sort path deterministically and
+   * still asserts on the rendered row order.
+   */
+  async sortByScoreDescending(metricName: string): Promise<void> {
+    await test.step(`sort the grid by "${metricName}" descending`, async () => {
+      const url = new URL(this.page.url());
+      url.searchParams.set(
+        'sorting',
+        JSON.stringify([{ id: `feedback_scores_${metricName}`, desc: true }]),
+      );
+      await this.page.goto(url.toString());
+      await this.itemRows.first().waitFor({ state: 'visible' });
+    });
+  }
+
+  /** Dataset-item ids in current row order, top to bottom. */
+  async itemRowOrder(): Promise<string[]> {
+    return test.step('read the current row order', async () => {
+      const ids = await this.itemRows.evaluateAll((rows) =>
+        rows.map((r) => r.getAttribute('data-row-id') ?? ''),
+      );
+      return ids;
+    });
+  }
+
+  private get compareHeading(): Locator {
+    return this.page.getByRole('heading', { level: 1 });
+  }
+
+  /** The "Baseline of X compared against Y" summary row (compare mode only). */
+  private get compareSummary(): Locator {
+    return this.page.locator('div').filter({ hasText: /^Baseline of/ }).last();
+  }
+
+  private get itemRows(): Locator {
+    return this.page.locator('tbody tr[data-row-id]');
+  }
+
+  /**
+   * A per-experiment band inside a vertically-split grid cell. `columnId` is the
+   * table column id (e.g. `feedback_scores_equals_metric`, `output_output`);
+   * `experimentIndex` is the experiment's position in the `experiments` query
+   * array, which is the order the bands render in.
+   */
+  private splitBand(datasetItemId: string, experimentIndex: number, columnId: string): Locator {
+    const cell = this.page.locator(`td[data-cell-id="${datasetItemId}_${columnId}"]`);
+    return cell.locator(`div[data-virtual-row-id="${datasetItemId}-${experimentIndex}"]`);
+  }
+
+  private configHeader(experimentId: string): Locator {
+    return this.page.locator(`th[data-header-id="${experimentId}"]`);
+  }
+
+  /** A compared experiment's section in the row-detail panel, keyed by its h2 name. */
+  private panelExperimentSection(experimentName: string): Locator {
+    return this.page
+      .getByRole('heading', { level: 2, name: experimentName })
+      .locator('xpath=ancestor::*[.//table][1]');
+  }
+}

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/experiments.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/experiments.py
@@ -7,6 +7,9 @@ from opik.evaluation.metrics import Equals
 
 from ..opik_factory import make_opik_client
 from ..schemas import (
+    CompareExperimentResult,
+    ExperimentCompareSeedRequest,
+    ExperimentCompareSeedResponse,
     ExperimentEvaluateRequest,
     ExperimentEvaluateResponse,
     ExperimentItemScore,
@@ -16,6 +19,26 @@ router = APIRouter(prefix="/experiments", tags=["experiments"])
 
 
 _SCORE_METRIC_NAME = "equals_metric"
+
+
+def _collect_scores(result) -> list[ExperimentItemScore]:
+    scores: list[ExperimentItemScore] = []
+    for tr in result.test_results:
+        for sr in tr.score_results:
+            if sr.name != _SCORE_METRIC_NAME:
+                continue
+            item_content = tr.test_case.dataset_item_content or {}
+            scores.append(
+                ExperimentItemScore(
+                    dataset_item_id=str(tr.test_case.dataset_item_id),
+                    input=str(item_content.get("input", "")),
+                    expected_output=str(item_content.get("expected_output", "")),
+                    task_output=str(item_content.get("task_output", "")),
+                    score_name=sr.name,
+                    score_value=float(sr.value),
+                )
+            )
+    return scores
 
 
 @router.post("/evaluate", response_model=ExperimentEvaluateResponse, status_code=201)
@@ -59,22 +82,7 @@ def evaluate_experiment(
         client.end(flush=True)
         atexit.unregister(client.end)
 
-    scores: list[ExperimentItemScore] = []
-    for tr in result.test_results:
-        for sr in tr.score_results:
-            if sr.name != _SCORE_METRIC_NAME:
-                continue
-            item_content = tr.test_case.dataset_item_content or {}
-            scores.append(
-                ExperimentItemScore(
-                    dataset_item_id=str(tr.test_case.dataset_item_id),
-                    input=str(item_content.get("input", "")),
-                    expected_output=str(item_content.get("expected_output", "")),
-                    task_output=str(item_content.get("task_output", "")),
-                    score_name=sr.name,
-                    score_value=float(sr.value),
-                )
-            )
+    scores = _collect_scores(result)
 
     return ExperimentEvaluateResponse(
         experiment_id=str(result.experiment_id),
@@ -83,4 +91,77 @@ def evaluate_experiment(
         item_count=len(body.items),
         scored_item_count=len(result.test_results),
         scores=scores,
+    )
+
+
+@router.post(
+    "/compare-seed",
+    response_model=ExperimentCompareSeedResponse,
+    status_code=201,
+)
+def compare_seed(
+    body: ExperimentCompareSeedRequest,
+    x_opik_api_key: str | None = Header(default=None),
+) -> ExperimentCompareSeedResponse:
+    """Seed one dataset and run N experiments over its *shared* items.
+
+    Unlike /evaluate, task_output is NOT stored on the dataset item. The items
+    carry only input + expected_output, so every experiment runs against the
+    same dataset-item ids (same content hash). Each experiment supplies its own
+    task_outputs (aligned by index with body.items), so the Equals scores can
+    diverge per experiment while the compare view still aligns rows by item.
+    """
+    if any(len(exp.task_outputs) != len(body.items) for exp in body.experiments):
+        raise ValueError("each experiment's task_outputs must align 1:1 with items")
+
+    client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
+    opik.set_global_client(client, context_wise=True)
+    try:
+        dataset = client.create_dataset(
+            name=body.dataset_name,
+            description=body.dataset_description,
+            project_name=body.project_name,
+        )
+        dataset.insert([item.model_dump() for item in body.items])
+
+        results: list[CompareExperimentResult] = []
+        for exp in body.experiments:
+            # Map input -> task_output for this experiment. The task receives a
+            # dataset item (input + expected_output) and echoes the mapped
+            # output, so scoring is Equals(mapped_output, expected_output).
+            output_by_input = {
+                item.input: task_output
+                for item, task_output in zip(body.items, exp.task_outputs)
+            }
+
+            def _task(item: dict, _map=output_by_input) -> dict:
+                return {"output": _map[item["input"]]}
+
+            result = evaluate(
+                dataset=dataset,
+                task=_task,
+                scoring_metrics=[Equals(case_sensitive=False)],
+                experiment_name=exp.experiment_name,
+                project_name=body.project_name,
+                task_threads=1,
+                verbose=0,
+                scoring_key_mapping={"reference": "expected_output"},
+            )
+            results.append(
+                CompareExperimentResult(
+                    experiment_id=str(result.experiment_id),
+                    experiment_name=result.experiment_name or exp.experiment_name,
+                    scores=_collect_scores(result),
+                )
+            )
+        dataset_id = str(dataset.id)
+    finally:
+        client.end(flush=True)
+        atexit.unregister(client.end)
+
+    return ExperimentCompareSeedResponse(
+        dataset_id=dataset_id,
+        dataset_name=body.dataset_name,
+        item_count=len(body.items),
+        experiments=results,
     )

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
@@ -147,6 +147,48 @@ class ExperimentEvaluateResponse(BaseModel):
     scores: list[ExperimentItemScore]
 
 
+class CompareDatasetItemSeed(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    input: str
+    expected_output: str
+
+
+class CompareExperimentSeed(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    experiment_name: str
+    # Per-experiment task outputs, aligned by index with the shared dataset
+    # items. Keeping task_output off the dataset item is what lets two
+    # experiments share the same items (same content hash) yet score
+    # differently under Equals(output, expected_output).
+    task_outputs: list[str]
+
+
+class ExperimentCompareSeedRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    project_name: str
+    dataset_name: str
+    items: list[CompareDatasetItemSeed]
+    experiments: list[CompareExperimentSeed]
+    dataset_description: str | None = None
+    workspace: str | None = None
+
+
+class CompareExperimentResult(BaseModel):
+    experiment_id: str
+    experiment_name: str
+    scores: list[ExperimentItemScore]
+
+
+class ExperimentCompareSeedResponse(BaseModel):
+    dataset_id: str
+    dataset_name: str
+    item_count: int
+    experiments: list[CompareExperimentResult]
+
+
 class TestSuiteItemSeed(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/tests_end_to_end/e2e/tests/experiments/experiments-compare.spec.ts
+++ b/tests_end_to_end/e2e/tests/experiments/experiments-compare.spec.ts
@@ -1,0 +1,162 @@
+import { test, expect } from '@e2e/fixtures';
+import { CompareExperimentsPage } from '@e2e/pom/compare-experiments.page';
+
+test.describe('Experiments comparison — CUJ', { tag: ['@t2-cuj', '@experiments'] }, () => {
+  test('two SDK-seeded experiments compare side by side with divergent per-item scores and outputs', async ({
+    comparison,
+    project,
+    page,
+  }) => {
+    const [expA, expB] = comparison.experiments;
+    const compare = new CompareExperimentsPage(page, project.id, comparison.datasetId, [
+      expA.experimentId,
+      expB.experimentId,
+    ]);
+
+    await test.step('Open the compare view in comparison mode', async () => {
+      await compare.gotoResults();
+      await compare.waitForResultsReady();
+      await compare.expectCompareModeHeader(2);
+    });
+
+    await test.step('Both seeded experiments are named in the comparison summary', async () => {
+      await compare.expectExperimentNamesInSummary([expA.experimentName, expB.experimentName]);
+    });
+
+    await test.step('One row per shared dataset item', async () => {
+      expect(await compare.countItemRows()).toBe(comparison.items.length);
+    });
+
+    await test.step('Per-item scores match the seeded values for each experiment (closed loop)', async () => {
+      for (const itemId of comparison.itemIds) {
+        const uiA = await compare.readItemScore(itemId, 0, comparison.evaluator.name);
+        const uiB = await compare.readItemScore(itemId, 1, comparison.evaluator.name);
+        expect(uiA, `experiment A score for item ${itemId}`).toBeCloseTo(expA.scoresByItemId[itemId], 5);
+        expect(uiB, `experiment B score for item ${itemId}`).toBeCloseTo(expB.scoresByItemId[itemId], 5);
+      }
+    });
+
+    await test.step('Per-item evaluation-task outputs match the seeded values for each experiment', async () => {
+      for (const itemId of comparison.itemIds) {
+        expect(await compare.readItemOutput(itemId, 0), `experiment A output for item ${itemId}`)
+          .toBe(expA.outputsByItemId[itemId]);
+        expect(await compare.readItemOutput(itemId, 1), `experiment B output for item ${itemId}`)
+          .toBe(expB.outputsByItemId[itemId]);
+      }
+    });
+
+    await test.step('The two experiments disagree on at least one item (comparison is meaningful)', async () => {
+      const disagreements = comparison.itemIds.filter(
+        (id) => expA.scoresByItemId[id] !== expB.scoresByItemId[id],
+      );
+      expect(disagreements.length, 'items where the experiments scored differently').toBeGreaterThan(0);
+    });
+
+    await test.step('Configuration tab lists each experiment as its own named column', async () => {
+      await compare.gotoConfiguration();
+      await compare.expectExperimentColumnsInConfiguration([
+        { id: expA.experimentId, name: expA.experimentName },
+        { id: expB.experimentId, name: expB.experimentName },
+      ]);
+    });
+  });
+
+  test('the grid can be sorted by score and searched by item', async ({ comparison, project, page }) => {
+    const [expA, expB] = comparison.experiments;
+    const compare = new CompareExperimentsPage(page, project.id, comparison.datasetId, [
+      expA.experimentId,
+      expB.experimentId,
+    ]);
+
+    await test.step('Open the compare view', async () => {
+      await compare.gotoResults();
+      await compare.waitForResultsReady();
+    });
+
+    await test.step('Sorting by score descending puts the highest-aggregate item first', async () => {
+      await compare.sortByScoreDescending(comparison.evaluator.name);
+
+      // Per-item aggregate = sum of both experiments' scores. The unique top
+      // item is the one where both experiments pass.
+      const aggregate = (itemId: string) =>
+        expA.scoresByItemId[itemId] + expB.scoresByItemId[itemId];
+      const expectedTop = [...comparison.itemIds].sort((a, b) => aggregate(b) - aggregate(a))[0];
+
+      const order = await compare.itemRowOrder();
+      expect(order[0], 'top row after sorting by score descending').toBe(expectedTop);
+    });
+
+    await test.step('Searching for one item narrows the grid to just that item', async () => {
+      const target = comparison.items[0];
+      const targetId = comparison.itemIds[0];
+      await compare.searchItems(target.input);
+      expect(await compare.countItemRows(), `rows after searching "${target.input}"`).toBe(1);
+      expect((await compare.itemRowOrder())[0], 'the single matching row').toBe(targetId);
+    });
+  });
+
+  test('feedback scores tab shows each experiment aggregate, and they differ', async ({
+    comparison,
+    project,
+    page,
+  }) => {
+    const [expA, expB] = comparison.experiments;
+    const compare = new CompareExperimentsPage(page, project.id, comparison.datasetId, [
+      expA.experimentId,
+      expB.experimentId,
+    ]);
+
+    await test.step('Open the Feedback scores tab', async () => {
+      await compare.gotoFeedbackScores();
+    });
+
+    await test.step('Each experiment aggregate matches the seeded mean', async () => {
+      expect(await compare.readAggregateScore(expA.experimentId), 'experiment A aggregate')
+        .toBeCloseTo(expA.aggregateScore, 1);
+      expect(await compare.readAggregateScore(expB.experimentId), 'experiment B aggregate')
+        .toBeCloseTo(expB.aggregateScore, 1);
+    });
+
+    await test.step('The aggregates differ (the comparison distinguishes the experiments)', async () => {
+      expect(expA.aggregateScore, 'seed sanity: aggregates differ')
+        .not.toBeCloseTo(expB.aggregateScore, 1);
+    });
+  });
+
+  test('the row detail panel shows both experiments side by side for one item', async ({
+    comparison,
+    project,
+    page,
+  }) => {
+    const [expA, expB] = comparison.experiments;
+    const compare = new CompareExperimentsPage(page, project.id, comparison.datasetId, [
+      expA.experimentId,
+      expB.experimentId,
+    ]);
+
+    // Pick an item where the two experiments disagree, so the panel visibly
+    // contrasts them rather than showing two identical results.
+    const itemId = comparison.itemIds.find(
+      (id) => expA.scoresByItemId[id] !== expB.scoresByItemId[id],
+    )!;
+
+    await test.step('Open the compare view and the item detail panel', async () => {
+      await compare.gotoResults();
+      await compare.waitForResultsReady();
+      await compare.openRowPanel(itemId);
+    });
+
+    await test.step('The panel shows each experiment output and score', async () => {
+      await compare.expectPanelExperimentResult(expA.experimentName, {
+        output: expA.outputsByItemId[itemId],
+        score: expA.scoresByItemId[itemId],
+        metricName: comparison.evaluator.name,
+      });
+      await compare.expectPanelExperimentResult(expB.experimentName, {
+        output: expB.outputsByItemId[itemId],
+        score: expB.scoresByItemId[itemId],
+        metricName: comparison.evaluator.name,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Details

Adds E2E coverage for the experiment **comparison** view (`/experiments/{datasetId}/compare` in multi-experiment mode, `CompareExperimentsPage`) — the gap called out in OPIK-7094, where only single-experiment detail was covered. The suite seeds two experiments over one shared dataset with intentionally divergent per-item outcomes and asserts the feature side by side: the results grid, aggregate scores, grid controls, and the per-item drill-in.

- New `POST /experiments/compare-seed` bridge route keeps `task_output` off the dataset item, so both experiments run over the **same** dataset-item ids (content-hash dedup would otherwise split them) while scoring differently — which is what makes a comparison meaningful.
- New `comparison-experiment` fixture + `compare-experiments` POM + a 4-test spec (`@t2-cuj @experiments`).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7094

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Feature analysis, live-UI selector discovery, bridge route + fixture + POM + spec authoring, local test runs.
- Human verification: Author reviewed all code; tests run locally green + stable across repeated serial and parallel runs; selectors verified against the running UI.

## Testing

Local OSS stack (`localhost:5173`, workspace `default`, `OPIK_DEPLOYMENT=oss`). The Playwright `webServer` directive auto-spawns the `opik-sdk-driver` bridge.

Command:
```
npx playwright test tests/experiments/experiments-compare.spec.ts --reporter=list
```

Result: **4 passed**, stable across repeated serial (`--workers=1`) and parallel (`--workers=2`) runs (~18–26s).

Scenarios validated:
- Results tab: `Compare (2)` header, both experiment names in the summary, one row per shared dataset item, per-experiment/per-item **scores** and **outputs** matched to seeded values (closed loop), a genuine per-item disagreement, and each experiment as a Configuration-tab column.
- Grid controls: sort by score (highest-aggregate item first) and search narrowing the grid to a single item.
- Feedback scores tab: each experiment's aggregate matches its seeded mean, and the two aggregates differ (1.00 vs 0.33).
- Row detail panel: opening a disagreement item shows each experiment's output + score side by side.

Also verified: `tsc --noEmit` clean; teardown leaves no orphaned projects/datasets/experiments.

Not run: broader suites (out of scope — this PR adds one spec family). No frontend changes, so no FE build/lint needed.

## Documentation

No documentation changes — internal E2E test coverage only.
