### PR TITLE
[OPIK-7377] [DOCS] docs: add data export best practices and read rate limits

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/faq.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/faq.mdx
@@ -143,15 +143,23 @@ Opik.
 Additionally, there's another data ingestion limit of `5,000` events/minute per workspace and per
 user.
 
-Finally, there's a rate limit of `250` requests/minute per user for the `Get span by id` endpoint:
+There's a rate limit of `250` requests/minute per user for the `Get span by id` endpoint:
 `GET /api/v1/private/spans/:id`.
+
+Finally, the search and listing endpoints used to read/export traces and spans are limited to `30`
+requests/minute per workspace, each with its own bucket: `search_traces` and `search_spans` (used by
+the SDK `Opik.search_traces` / `Opik.search_spans` methods), and the paginated `GET /traces` and
+`GET /spans` endpoints. This is the limit you are most likely to hit when exporting data at scale;
+see [Exporting at scale](/tracing/advanced/export-data#exporting-at-scale) for how to stay within it.
 
 <Note>
 The Python SDK has implemented some logic to slow down the logging to avoid data loss when
 encountering rate limits. You will see the message: `OPIK: Ingestion rate limited, retrying in 55 seconds, remaining queue size: 1, ...`.
 
-If you are using other logging methods, you will need to implement your own "backoff and retry"
-strategy
+The SDK also automatically backs off and retries on the read/search endpoints, so the
+`Opik.search_traces`, `Opik.search_spans`, and `Opik.search_threads` methods respect these limits
+for you. If you are using other methods, you will need to implement your own "backoff and retry"
+strategy.
 
 </Note>
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/export_data.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/export_data.mdx
@@ -118,13 +118,48 @@ client.search_traces(filter_string='tags contains "production"')
 
 The full list of supported columns per entity type is documented below.
 
+### Exporting at scale
+
+Read operations are rate limited per workspace. The search and listing endpoints used for export — `search_traces` and `search_spans` (and the underlying `GET /traces` and `GET /spans` endpoints) — are capped at `30` requests per minute per workspace. Exceeding a limit returns `429 Too Many Requests` with a `RateLimit-Reset` header telling you how long to wait. See the [rate-limit FAQ](/faq#are-there-are-rate-limits-on-opik-cloud) for the full list.
+
+That budget is small, so how you fetch matters:
+
+- **Fetch in bulk, not item-by-item.** A single `search_spans` call streams up to 2,000 rows per underlying request, auto-paginates, and backs off on `429`, so one call can return thousands of spans without ever erroring. Avoid making one request per trace.
+- **Filter on the server** with `filter_string` (e.g. a time window) so you only transfer the data you need.
+- **Go easy on concurrency.** Limits are shared per workspace, so parallel requests compete for the same budget and hit `429` sooner without finishing faster.
+
+```python title="✅ Do: fetch in bulk, join on the client"
+from collections import defaultdict
+
+traces = client.search_traces(project_name="Default project", max_results=1000000)
+
+# One call for all the spans, then group them by trace_id in memory.
+spans = client.search_spans(project_name="Default project", max_results=1000000)
+spans_by_trace = defaultdict(list)
+for span in spans:
+    spans_by_trace[str(span.trace_id)].append(span)
+```
+
+```python title="❌ Don't: one request per trace"
+traces = client.search_traces(project_name="Default project", max_results=1000000)
+
+# A request per trace: slow, and quickly hits the read rate limit.
+spans_by_trace = {}
+for trace in traces:
+    spans_by_trace[trace.id] = client.search_spans(
+        project_name="Default project", trace_id=trace.id
+    )
+```
+
 ## REST API
 
 Use the [`/traces`](/reference/rest-api/traces/get-traces-by-project) and [`/spans`](/reference/rest-api/spans/get-spans-by-project) endpoints to export data. Both endpoints are paginated.
 
 <Warning>
   The REST API `filter` parameter has limited flexibility as it was designed for use with the Opik UI.
-  For complex queries, use the SDK instead.
+  For complex queries, use the SDK instead. These endpoints are also rate limited and do not back off
+  on their own — for large exports, prefer the SDK (see [Exporting at scale](#exporting-at-scale)) or
+  implement your own retry on `429` that honors the `RateLimit-Reset` header.
 </Warning>
 
 ## UI


### PR DESCRIPTION
## Details

Adds data-export best practices to the docs so users can pull traces and spans at scale without hitting read rate limits. Read/search endpoints are capped at 30 req/min per workspace, and the most common failure mode is fetching one request per trace, which quickly triggers `429`s and drops data.

- New **Exporting at scale** section in the export-data page: prefer the SDK `search_*` methods (they stream up to 2,000 rows/request, auto-paginate, and back off on `429`), fetch in bulk and group by `trace_id` client-side instead of per-trace requests, filter server-side, and keep concurrency modest — with a ✅ Do / ❌ Don't example.
- REST-API section now warns that those endpoints don't back off on their own.
- Rate-limit FAQ now documents the 30 req/min per-workspace read/search limit and notes the SDK respects it automatically.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves # <!-- NA -->
- OPIK-7377

<!-- Related but not resolved here: OPIK_7075 (customer 429 escalation that motivated this doc). -->

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Authored the documentation changes; all technical claims (SDK streaming/backoff behavior, 30 req/min read limits) verified against the Python SDK source and `apps/opik-backend/config.yml`.
- Human verification: Reviewed and iterated with the author (content trimmed, generalized, and restructured per feedback); rate-limit numbers confirmed against backend config.

## Testing

Docs-only change; no runtime code.

- Ran `pre-commit` on both changed files (markdownlint / prettier / codespell) — clean.
- Verified internal links resolve to real anchors (`/faq#are-there-are-rate-limits-on-opik-cloud`, `/tracing/advanced/export-data#exporting-at-scale`) and that the doc lives in the live `docs-v2/` tree (not the noindexed v1 `docs/`).

## Documentation

This PR *is* the documentation change:

- `docs-v2/observability/export_data.mdx` — new "Exporting at scale" section + REST warning.
- `docs-v2/faq.mdx` — read/search rate-limit entry + SDK auto-backoff note.
