### PR TITLE
[NA] [BE] fix: register fireworks_ai as a canonical provider so Fireworks model prices load

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -43,7 +43,8 @@ public class CostService {
             Map.entry("mistral", "mistral"),
             Map.entry("xai", "xai"),
             Map.entry("deepseek", "deepseek"),
-            Map.entry("perplexity", "perplexity"));
+            Map.entry("perplexity", "perplexity"),
+            Map.entry("fireworks_ai", "fireworks_ai"));
 
     // Online evaluation (and OTel ingestion) resolve models to LlmProvider serialized values whose names
     // differ from the canonical price-table vocabulary. Normalize those to the single canonical provider
@@ -61,16 +62,18 @@ public class CostService {
     private static final String DATE_SUFFIX_PATTERN = "-\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])$";
     private static final String VERSION_SUFFIX_PATTERN = ":\\d+$";
     private static final Map<String, BiFunction<ModelPrice, Map<String, Integer>, BigDecimal>> PROVIDERS_CACHE_COST_CALCULATOR = Map
-            .of("anthropic", SpanCostCalculator::textGenerationWithCacheCostAnthropic,
-                    "openai", SpanCostCalculator::textGenerationWithCacheCostOpenAI,
-                    "azure", SpanCostCalculator::textGenerationWithCacheCostOpenAI,
-                    "xai", SpanCostCalculator::textGenerationWithCacheCostOpenAI,
-                    "deepseek", SpanCostCalculator::textGenerationWithCacheCostOpenAI,
-                    "bedrock", SpanCostCalculator::textGenerationWithCacheCostBedrock,
-                    "bedrock_converse", SpanCostCalculator::textGenerationWithCacheCostBedrock,
-                    "vertex_ai-language-models", SpanCostCalculator::textGenerationWithCacheCostGoogle,
-                    "gemini", SpanCostCalculator::textGenerationWithCacheCostGoogle,
-                    "vertex_ai-anthropic_models", SpanCostCalculator::textGenerationWithCacheCostAnthropic);
+            .ofEntries(
+                    Map.entry("anthropic", SpanCostCalculator::textGenerationWithCacheCostAnthropic),
+                    Map.entry("openai", SpanCostCalculator::textGenerationWithCacheCostOpenAI),
+                    Map.entry("azure", SpanCostCalculator::textGenerationWithCacheCostOpenAI),
+                    Map.entry("xai", SpanCostCalculator::textGenerationWithCacheCostOpenAI),
+                    Map.entry("deepseek", SpanCostCalculator::textGenerationWithCacheCostOpenAI),
+                    Map.entry("fireworks_ai", SpanCostCalculator::textGenerationWithCacheCostOpenAI),
+                    Map.entry("bedrock", SpanCostCalculator::textGenerationWithCacheCostBedrock),
+                    Map.entry("bedrock_converse", SpanCostCalculator::textGenerationWithCacheCostBedrock),
+                    Map.entry("vertex_ai-language-models", SpanCostCalculator::textGenerationWithCacheCostGoogle),
+                    Map.entry("gemini", SpanCostCalculator::textGenerationWithCacheCostGoogle),
+                    Map.entry("vertex_ai-anthropic_models", SpanCostCalculator::textGenerationWithCacheCostAnthropic));
 
     static {
         try {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -690,6 +690,50 @@ class CostServiceTest {
     }
 
     /**
+     * Covers both branches of registering {@code fireworks_ai} as a canonical provider so that the
+     * ~260 non-zero-cost entries in {@code model_prices_and_context_window.json} tagged with
+     * {@code litellm_provider: "fireworks_ai"} (the {@code accounts/fireworks/models/*} catalog) are
+     * no longer silently dropped at load time:
+     * <ul>
+     *   <li>Fireworks model with no cache rates falls through to
+     *       {@link SpanCostCalculator#textGenerationCost}.</li>
+     *   <li>Fireworks model with cache rates routes through
+     *       {@link SpanCostCalculator#textGenerationWithCacheCostOpenAI} — Fireworks' cost calculator
+     *       in LiteLLM ({@code litellm/llms/fireworks_ai/cost_calculator.py}) delegates to
+     *       {@code generic_cost_per_token}, so its usage payload follows the same OpenAI shape
+     *       (cached tokens flattened under {@code prompt_tokens_details.cached_tokens}).</li>
+     * </ul>
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideFireworksProviderCases")
+    void calculateCostHandlesFireworksModels(String description, String model, Map<String, Integer> usage,
+            String expectedCost) {
+        BigDecimal cost = CostService.calculateCost(model, "fireworks_ai", usage, null);
+
+        assertThat(cost).isEqualByComparingTo(expectedCost);
+    }
+
+    private static Stream<Arguments> provideFireworksProviderCases() {
+        // fireworks_ai/accounts/fireworks/models/llama-v3p1-70b-instruct: input 9e-7, output 9e-7
+        // (no cache rates) -> textGenerationCost
+        // 1000 * 9e-7 + 200 * 9e-7 = 0.0009 + 0.00018 = 0.00108
+        // fireworks_ai/accounts/fireworks/models/kimi-k2p5: input 6e-7, output 3e-6, cache_read 1e-7
+        // -> textGenerationWithCacheCostOpenAI
+        // non-cached input = 1000 - 300 = 700
+        // 700 * 6e-7 + 200 * 3e-6 + 300 * 1e-7 = 0.00042 + 0.0006 + 0.00003 = 0.00105
+        return Stream.of(
+                Arguments.of("plain text-generation route",
+                        "fireworks_ai/accounts/fireworks/models/llama-v3p1-70b-instruct",
+                        Map.of("prompt_tokens", 1000, "completion_tokens", 200), "0.00108"),
+                Arguments.of("cache-aware route via OpenAI calc",
+                        "fireworks_ai/accounts/fireworks/models/kimi-k2p5",
+                        Map.of("original_usage.prompt_tokens", 1000,
+                                "original_usage.completion_tokens", 200,
+                                "original_usage.prompt_tokens_details.cached_tokens", 300),
+                        "0.00105"));
+    }
+
+    /**
      * Covers the provider-prefix fallback in {@link CostService#findModelPrice}. Callers that
      * route a model through an aggregator ({@link com.comet.opik.api.resources.v1.events.BudgetGuard}
      * calls {@code CostService.calculateCost} via {@code LlmProviderFactoryImpl.getResolvedModelInfo},


### PR DESCRIPTION
## Details

Fireworks AI's pricing entries are silently dropped by Opik today. `model_prices_and_context_window.json` carries roughly 260 non-zero-cost entries tagged `litellm_provider: "fireworks_ai"` (the `accounts/fireworks/models/*` catalog spanning the llama, qwen, deepseek, glm, kimi and minimax families), and none of them load because `fireworks_ai` is not registered in `PROVIDERS_MAPPING`; `buildModelPrice` returns `null` for any entry whose provider is not in that map, so every Fireworks span ends up with no cost. This follows the exact pattern of the earlier provider-registration fixes for azure (#7262), xai (#7433), deepseek (#7434) and perplexity (#7432).

- Register `fireworks_ai -> fireworks_ai` in `PROVIDERS_MAPPING` so the entries load
- Route `fireworks_ai` through `textGenerationWithCacheCostOpenAI` in `PROVIDERS_CACHE_COST_CALCULATOR`; Fireworks' LiteLLM cost calculator (`litellm/llms/fireworks_ai/cost_calculator.py`) delegates to `generic_cost_per_token`, so its usage payload uses the OpenAI shape (cached tokens under `prompt_tokens_details.cached_tokens`), and the eight cache-priced Fireworks models today (glm-4p7, glm-5p1, kimi-k2p5, minimax-m2p1) get the same cache-read discount OpenAI/Azure/xAI/DeepSeek receive
- `PROVIDERS_CACHE_COST_CALCULATOR` was at the ten-pair ceiling of `Map.of`, so it moves to `Map.ofEntries` to take the eleventh entry

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

No ticket; discovered by scanning `litellm_provider` values in the bundled price map for providers with priced models that are absent from `PROVIDERS_MAPPING`.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: investigation of the drop path, the two-line mapping change, and the parameterized test
- Human verification: model resolution and both cost figures checked against the bundled `model_prices_and_context_window.json` before submission

## Testing

Added a parameterized test (`calculateCostHandlesFireworksModels`) covering both branches:

- `fireworks_ai/accounts/fireworks/models/llama-v3p1-70b-instruct` (input 9e-7, output 9e-7, no cache) routes through `textGenerationCost`; 1000 prompt + 200 completion tokens = 0.00108
- `fireworks_ai/accounts/fireworks/models/kimi-k2p5` (input 6e-7, output 3e-6, cache_read 1e-7) routes through `textGenerationWithCacheCostOpenAI`; with 300 of 1000 prompt tokens cached, 700 * 6e-7 + 200 * 3e-6 + 300 * 1e-7 = 0.00105

Both cases fail against the current code (the models do not resolve without the mapping entry, so cost comes back as zero) and pass with the fix.

## Documentation

No documentation changes needed; provider pricing is driven entirely by the bundled price map and the provider registration in `CostService`.

## Follow-up

The same drop affects several other high-volume OpenAI-compatible inference providers that could be registered the same way if the team wants them: openrouter (~92 priced models), novita (~85), deepinfra (~67), together_ai (~36), databricks (~28) and moonshot (~22). Happy to open follow-ups for any of those; keeping this PR scoped to Fireworks alone.
