### PR TITLE
[NA] [BE] Reclassify system_tools/system_tools_deferred into the built_in_tools lane

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendBlockDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendBlockDAO.java
@@ -262,27 +262,17 @@ public class CipxSpendBlockDAO {
             };
         }
 
-        /** Breakdown lane: like {@link #lane} but categories with no breakdown rows map to '' (excluded). */
+        /**
+         * Breakdown lane: like {@link #lane} but categories with no breakdown rows map to '' (excluded).
+         * Delegates to {@link #lane} for the shared dispatch table and only overrides the two
+         * intentional differences, so the two tables can't drift apart on a future category addition.
+         */
         private static String bdLane(String category, String toolServer) {
-            return switch (category) {
-                case "tool_io" -> toolServer.isEmpty() ? "built_in_tools" : "mcp_servers";
-                case "system_tools", "system_tools_deferred" -> "built_in_tools";
-                case "user_prompts" -> "user_prompts";
-                case "prior_assistant" -> "prior_assistant";
-                case "mcp_tools_active" -> "mcp_servers";
-                case "skills_menu", "skills_loaded" -> "skills";
-                case "custom_agents" -> "custom_agents";
-                case "memory" -> "memory";
-                case "file_attachments" -> "file_attachments";
-                case "system_prompt", "env_info" -> "static_overhead";
-                case "auto_classifier", "agent_overhead" -> "static_overhead";
-                case "thinking" -> "thinking";
-                case "assistant_text" -> "assistant_text";
-                case "built_in_tool_calls" -> "built_in_tool_calls";
-                case "mcp_tool_calls" -> "mcp_tool_calls";
-                case "skill_invocations" -> "skill_invocations";
-                default -> "";
-            };
+            if (category.equals("mcp_tools_deferred") || category.equals("mcp_server_instructions")) {
+                return "";
+            }
+            String baseLane = lane(category, toolServer);
+            return baseLane.equals("unattributed") ? "" : baseLane;
         }
 
         /** Breakdown row key; which raw field names the row depends on the category. */

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendBlockDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendBlockDAO.java
@@ -243,6 +243,7 @@ public class CipxSpendBlockDAO {
         private static String lane(String category, String toolServer) {
             return switch (category) {
                 case "tool_io" -> toolServer.isEmpty() ? "built_in_tools" : "mcp_servers";
+                case "system_tools", "system_tools_deferred" -> "built_in_tools";
                 case "user_prompts" -> "user_prompts";
                 case "prior_assistant" -> "prior_assistant";
                 case "mcp_tools_active", "mcp_tools_deferred", "mcp_server_instructions" -> "mcp_servers";
@@ -250,7 +251,7 @@ public class CipxSpendBlockDAO {
                 case "custom_agents" -> "custom_agents";
                 case "memory" -> "memory";
                 case "file_attachments" -> "file_attachments";
-                case "system_prompt", "env_info", "system_tools", "system_tools_deferred" -> "static_overhead";
+                case "system_prompt", "env_info" -> "static_overhead";
                 case "auto_classifier", "agent_overhead" -> "static_overhead";
                 case "thinking" -> "thinking";
                 case "assistant_text" -> "assistant_text";
@@ -265,6 +266,7 @@ public class CipxSpendBlockDAO {
         private static String bdLane(String category, String toolServer) {
             return switch (category) {
                 case "tool_io" -> toolServer.isEmpty() ? "built_in_tools" : "mcp_servers";
+                case "system_tools", "system_tools_deferred" -> "built_in_tools";
                 case "user_prompts" -> "user_prompts";
                 case "prior_assistant" -> "prior_assistant";
                 case "mcp_tools_active" -> "mcp_servers";
@@ -272,7 +274,7 @@ public class CipxSpendBlockDAO {
                 case "custom_agents" -> "custom_agents";
                 case "memory" -> "memory";
                 case "file_attachments" -> "file_attachments";
-                case "system_prompt", "env_info", "system_tools", "system_tools_deferred" -> "static_overhead";
+                case "system_prompt", "env_info" -> "static_overhead";
                 case "auto_classifier", "agent_overhead" -> "static_overhead";
                 case "thinking" -> "thinking";
                 case "assistant_text" -> "assistant_text";
@@ -293,11 +295,10 @@ public class CipxSpendBlockDAO {
                         "skill_invocations" ->
                     resource;
                 case "tool_io" -> toolServer.isEmpty() ? toolName : toolServer;
+                case "system_tools", "system_tools_deferred" -> toolName.isEmpty() ? "(unattributed)" : toolName;
                 case "prior_assistant" -> kind;
                 case "mcp_tools_active", "mcp_tool_calls" -> toolServer;
-                case "system_prompt", "env_info", "system_tools", "system_tools_deferred", "auto_classifier",
-                        "agent_overhead" ->
-                    category;
+                case "system_prompt", "env_info", "auto_classifier", "agent_overhead" -> category;
                 case "thinking" -> "thinking";
                 case "assistant_text" -> "assistant_text";
                 case "built_in_tool_calls" -> toolName;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
@@ -291,7 +291,7 @@ class CostIntelligenceIngestionTest {
 
                 // schema block for a named tool: reclassified out of static_overhead, keyed by
                 // tool_name instead of the bare category string (mirrors tool_io's own labeling).
-                var bash = rows.get(0);
+                var bash = rows.getFirst();
                 assertThat(bash.category()).isEqualTo("system_tools");
                 assertThat(bash.lane()).isEqualTo("built_in_tools");
                 assertThat(bash.bdLane()).isEqualTo("built_in_tools");
@@ -315,7 +315,7 @@ class CostIntelligenceIngestionTest {
                 assertThat(systemPrompt.label()).isEqualTo("system_prompt");
                 assertThat(systemPrompt.isDefinition()).isEqualTo(1);
 
-                var envInfo = rows.get(3);
+                var envInfo = rows.getLast();
                 assertThat(envInfo.category()).isEqualTo("env_info");
                 assertThat(envInfo.lane()).isEqualTo("static_overhead");
                 assertThat(envInfo.bdLane()).isEqualTo("static_overhead");

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
@@ -274,7 +274,7 @@ class CostIntelligenceIngestionTest {
         }
 
         @Test
-        @DisplayName("system_tools/system_tools_deferred land in the built_in_tools lane, keyed by tool_name")
+        @DisplayName("system_tools/system_tools_deferred land in built_in_tools; system_prompt/env_info stay in static_overhead")
         void systemToolsLandInBuiltInToolsLane() {
             var ws = newWorkspace();
             String projectName = "cipx-" + UUID.randomUUID();
@@ -287,7 +287,7 @@ class CostIntelligenceIngestionTest {
 
             await().atMost(30, SECONDS).untilAsserted(() -> {
                 var rows = getCipxBlocks(span.id(), ws.workspaceId());
-                assertThat(rows).hasSize(2);
+                assertThat(rows).hasSize(4);
 
                 // schema block for a named tool: reclassified out of static_overhead, keyed by
                 // tool_name instead of the bare category string (mirrors tool_io's own labeling).
@@ -305,6 +305,22 @@ class CostIntelligenceIngestionTest {
                 assertThat(deferred.bdLane()).isEqualTo("built_in_tools");
                 assertThat(deferred.label()).isEqualTo("(unattributed)");
                 assertThat(deferred.isDefinition()).isEqualTo(1);
+
+                // Regression guard: the other static_overhead categories (untouched by this
+                // change, but sharing the same dispatch table) still map correctly.
+                var systemPrompt = rows.get(2);
+                assertThat(systemPrompt.category()).isEqualTo("system_prompt");
+                assertThat(systemPrompt.lane()).isEqualTo("static_overhead");
+                assertThat(systemPrompt.bdLane()).isEqualTo("static_overhead");
+                assertThat(systemPrompt.label()).isEqualTo("system_prompt");
+                assertThat(systemPrompt.isDefinition()).isEqualTo(1);
+
+                var envInfo = rows.get(3);
+                assertThat(envInfo.category()).isEqualTo("env_info");
+                assertThat(envInfo.lane()).isEqualTo("static_overhead");
+                assertThat(envInfo.bdLane()).isEqualTo("static_overhead");
+                assertThat(envInfo.label()).isEqualTo("env_info");
+                assertThat(envInfo.isDefinition()).isEqualTo(1);
             });
         }
 
@@ -565,7 +581,9 @@ class CostIntelligenceIngestionTest {
                             },
                             "blocks": [
                               {"category":"system_tools","side":"input","cache_status":"read","parent_category":"context","chars":150,"tool_name":"Bash","tool_server":"","tool_use_id":"","resource":"","kind":"text"},
-                              {"category":"system_tools_deferred","side":"input","cache_status":"read","parent_category":"context","chars":50,"tool_name":"","tool_server":"","tool_use_id":"","resource":"","kind":"text"}
+                              {"category":"system_tools_deferred","side":"input","cache_status":"read","parent_category":"context","chars":50,"tool_name":"","tool_server":"","tool_use_id":"","resource":"","kind":"text"},
+                              {"category":"system_prompt","side":"input","cache_status":"read","parent_category":"context","chars":40,"tool_name":"","tool_server":"","tool_use_id":"","resource":"","kind":"text"},
+                              {"category":"env_info","side":"input","cache_status":"read","parent_category":"context","chars":30,"tool_name":"","tool_server":"","tool_use_id":"","resource":"","kind":"text"}
                             ]
                           }
                         }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
@@ -273,6 +273,41 @@ class CostIntelligenceIngestionTest {
             });
         }
 
+        @Test
+        @DisplayName("system_tools/system_tools_deferred land in the built_in_tools lane, keyed by tool_name")
+        void systemToolsLandInBuiltInToolsLane() {
+            var ws = newWorkspace();
+            String projectName = "cipx-" + UUID.randomUUID();
+
+            var span = factory.manufacturePojo(Span.class).toBuilder()
+                    .projectName(projectName)
+                    .metadata(systemToolsCipxMetadata("claude-sonnet-4-6", 200))
+                    .build();
+            spanResourceClient.createSpan(span, ws.apiKey(), ws.workspaceName());
+
+            await().atMost(30, SECONDS).untilAsserted(() -> {
+                var rows = getCipxBlocks(span.id(), ws.workspaceId());
+                assertThat(rows).hasSize(2);
+
+                // schema block for a named tool: reclassified out of static_overhead, keyed by
+                // tool_name instead of the bare category string (mirrors tool_io's own labeling).
+                var bash = rows.get(0);
+                assertThat(bash.category()).isEqualTo("system_tools");
+                assertThat(bash.lane()).isEqualTo("built_in_tools");
+                assertThat(bash.bdLane()).isEqualTo("built_in_tools");
+                assertThat(bash.label()).isEqualTo("Bash");
+                assertThat(bash.isDefinition()).isEqualTo(1);
+
+                // deferred-tools reminder: one multi-tool text block, no single tool_name.
+                var deferred = rows.get(1);
+                assertThat(deferred.category()).isEqualTo("system_tools_deferred");
+                assertThat(deferred.lane()).isEqualTo("built_in_tools");
+                assertThat(deferred.bdLane()).isEqualTo("built_in_tools");
+                assertThat(deferred.label()).isEqualTo("(unattributed)");
+                assertThat(deferred.isDefinition()).isEqualTo(1);
+            });
+        }
+
         @DisplayName("write blocks inherit the span's cache TTL (1h vs 5m)")
         @ParameterizedTest
         @CsvSource({
@@ -506,6 +541,36 @@ class CostIntelligenceIngestionTest {
                         }
                         """
                         .formatted(model, lump == 0 ? 50 : lump, cacheCreation5m, cacheCreation1h));
+    }
+
+    private static JsonNode systemToolsCipxMetadata(String model, long cacheRead) {
+        return JsonUtils.getJsonNodeFromString(
+                """
+                        {
+                          "cipx": {
+                            "call": {
+                              "model": "%s",
+                              "usage": {
+                                "input_tokens": 0,
+                                "cache_read_input_tokens": %d,
+                                "cache_creation_input_tokens": 0,
+                                "output_tokens": 0
+                              },
+                              "config": {
+                                "effort": "high",
+                                "thinking_type": "adaptive",
+                                "max_tokens": 64000,
+                                "context_management": "clear_thinking_20251015"
+                              }
+                            },
+                            "blocks": [
+                              {"category":"system_tools","side":"input","cache_status":"read","parent_category":"context","chars":150,"tool_name":"Bash","tool_server":"","tool_use_id":"","resource":"","kind":"text"},
+                              {"category":"system_tools_deferred","side":"input","cache_status":"read","parent_category":"context","chars":50,"tool_name":"","tool_server":"","tool_use_id":"","resource":"","kind":"text"}
+                            ]
+                          }
+                        }
+                        """
+                        .formatted(model, cacheRead));
     }
 
     private static JsonNode traceCipxMetadata(String userUuid, String email, String displayName, String repository,


### PR DESCRIPTION
## Details
Built-in tool schema (definition) cost — `system_tools`/`system_tools_deferred` — was tagged `bd_lane='static_overhead'` at ingestion, so it showed up under "Static overhead" in the AI-Spend breakdown instead of "Built-in tools". MCP's equivalent (`mcp_tools_active`) already shares `bd_lane='mcp_servers'` with its usage rows (`tool_io`), needing zero special-case reporting code downstream. This mirrors that: `lane()`/`bdLane()` now route these two categories to `built_in_tools`, and `label()` keys them by `tool_name` (falling back to `"(unattributed)"` for the blank-tool_name deferred-tools reminder block) instead of the bare category string — same as `tool_io`. `isDefinition()` is unchanged (both categories stay `1`).

Also dedupes `lane()`/`bdLane()`'s near-identical category dispatch tables per review feedback: `bdLane()` now delegates to `lane()` and only overrides the two intentional differences (`mcp_tools_deferred`/`mcp_server_instructions` excluded from the breakdown; `"unattributed"` collapses to `""`), so a future category addition can't update one table and forget the other.

Companion PRs: `ai-cost-backend` (comet-ml/ai-cost-backend#33) removes the now-redundant display-only overlay that this made obsolete; `opik-plugin-ai-spend` (comet-ml/opik-plugin-ai-spend#42) updates the matching lane description text.

Note: this only affects newly-ingested rows going forward. Existing `cipx_spend_blocks` rows keep their historical `bd_lane='static_overhead'` tag (no backfill included in this change).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Sonnet 5
- Scope: full implementation (ingestion reclassification, test coverage, dedup refactor) plus responses to automated review feedback
- Human verification: diff reviewed and CI results checked; not exercised against a live opik-backend deployment

## Testing
- `CostIntelligenceIngestionTest.systemToolsLandInBuiltInToolsLane` covers a named-tool schema block, the blank-tool_name deferred-tools reminder block, and (regression guard) that `system_prompt`/`env_info` still resolve to `static_overhead` after the dispatch-table dedup.
- No local Gradle/Docker access from this environment to run the suite directly; this PR's own CI run (Backend Tests: Unit Tests + all 16 Integration Groups) passed.

## Documentation
No documentation changes needed — this is an internal cost-attribution fix with no user-facing API/behavior change beyond which AI-Spend card the cost appears under.