### PR TITLE
[OPIK-7428] [FE] Prevent Google Translate removeChild crash on mobile get-started

### DIFF
--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/WelcomeStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/WelcomeStep.tsx
@@ -94,7 +94,16 @@ const WelcomeStep: React.FC<{ onNext?: () => void }> = ({ onNext }) => {
 
         <div>
           <div className="flex flex-col gap-2 rounded-xl border border-border bg-background px-4 pb-3 pt-4">
-            <div className="min-h-5 text-sm leading-5 text-foreground">
+            {/* translate="no": this node's text is rewritten by JS every few
+                dozen ms. Letting the browser translate it makes Google
+                Translate mutate the DOM (wrapping text nodes in <font>), which
+                then crashes React with "NotFoundError: removeChild". Excluding
+                just this animated demo string fixes it; the rest of the page
+                still translates. */}
+            <div
+              className="min-h-5 text-sm leading-5 text-foreground"
+              translate="no"
+            >
               <TypingText />
             </div>
             <div className="flex items-center justify-between">


### PR DESCRIPTION
## Details

Production console crash on the Opik get-started onboarding (mobile), reported from a Chrome/Android session in a non-English locale:

> `NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`

`MobileOnboarding/WelcomeStep.tsx` renders a JS typewriter (`TypingText`) that rewrites a text node every 30–80 ms. When the browser auto-translates the page, Google Translate rewrites the DOM (wrapping text nodes in `<font>` elements). React's next commit then calls `removeChild` on a node whose parent changed and throws — the continuous animation makes the crash near-certain once translation is active (see [facebook/react#11538](https://github.com/facebook/react/issues/11538)).

**Fix:** mark the animated demo prompt `translate="no"` so the browser excludes it from translation ([Google's recommended handling for JS-updated dynamic content](https://support.google.com/translate/thread/32410356)). Translate no longer mutates that subtree, so React never hits the crash. The typewriter animation is unchanged and the rest of the page still translates; the only trade-off is that this one decorative example prompt is not translated.

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

OPIK-7428

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: root-cause investigation, the one-line `translate="no"` fix, and local reproduction
- Human verification: crash reproduced and fix verified locally (mobile viewport + Chrome translate) before submission

## Testing

- Reproduced the crash locally with a mobile viewport + Chrome page translation, and confirmed it no longer occurs with the fix.
- ESLint clean (`--max-warnings=0`); frontend eslint + typecheck CI checks pass.

## Documentation

No documentation changes needed — the fix is a single `translate="no"` attribute on the animated onboarding prompt.
