### PR TITLE
fix(BE): scope trace cost/usage aggregation to the resolved project on GET /traces/{id}

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -671,6 +671,7 @@ class TraceDAOImpl implements TraceDAO {
                 FROM span_feedback_scores_grouped
             ), spans_agg AS (
                 SELECT
+                    project_id,
                     trace_id,
                     sumMap(usage) as usage,
                     sum(total_estimated_cost) as total_estimated_cost,
@@ -682,7 +683,13 @@ class TraceDAOImpl implements TraceDAO {
                 WHERE workspace_id = :workspace_id
                 <if(has_target_projects)>AND project_id IN :target_project_ids<endif>
                 AND trace_id IN :ids
-                GROUP BY trace_id
+                -- grouped per (project_id, trace_id): a trace_id may collide across
+                -- projects (e.g. batch-imported data), and target_project_ids can
+                -- legitimately contain more than one project id in that case. Without
+                -- grouping by project_id here, the join below would match every
+                -- colliding project's spans onto a single trace row and sum their
+                -- cost/usage together (see OPIK-7473).
+                GROUP BY project_id, trace_id
             ), experiments_agg AS (
                 SELECT
                     ei.trace_id,
@@ -744,7 +751,7 @@ class TraceDAOImpl implements TraceDAO {
                 ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
                 LIMIT 1 BY id
             ) AS t
-            LEFT JOIN spans_agg s ON t.id = s.trace_id
+            LEFT JOIN spans_agg s ON t.id = s.trace_id AND t.project_id = s.project_id
             LEFT JOIN experiments_agg eaag ON eaag.trace_id = t.id
             LEFT JOIN (
                 SELECT

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -2378,6 +2378,76 @@ class TracesResourceTest {
             var id = generator.generate();
             getAndAssertTraceNotFound(id, API_KEY, TEST_WORKSPACE);
         }
+
+        @Test
+        @DisplayName("when the same trace id exists in two different projects, then cost/usage/span "
+                + "counts of the by-id response are scoped to the trace's own project, not summed across "
+                + "both projects")
+        void getTrace__whenTraceIdCollidesAcrossProjects__thenCostAndUsageAreNotAggregatedAcrossProjects() {
+            // Batch endpoints don't enforce the single-create project/id consistency check, so two
+            // traces sharing the same id can legitimately end up in different projects (e.g. via
+            // deterministic client-side id generation across independent imports). See OPIK-7473.
+            var sharedId = generator.generate();
+            var projectNameA = RandomStringUtils.secure().nextAlphanumeric(10);
+            var projectNameB = RandomStringUtils.secure().nextAlphanumeric(10);
+
+            var traceA = createTrace().toBuilder().id(sharedId).projectName(projectNameA).build();
+            var traceB = createTrace().toBuilder().id(sharedId).projectName(projectNameB).build();
+            traceResourceClient.batchCreateTraces(List.of(traceA), API_KEY, TEST_WORKSPACE);
+            traceResourceClient.batchCreateTraces(List.of(traceB), API_KEY, TEST_WORKSPACE);
+
+            BigDecimal costA = new BigDecimal("0.10");
+            BigDecimal costB = new BigDecimal("0.15");
+            // Span.usage() values are Integer; the trace-level aggregate (Trace.usage()) sums them as Long.
+            Map<String, Integer> spanUsageA = Map.of("prompt_tokens", 3);
+            Map<String, Integer> spanUsageB = Map.of("prompt_tokens", 7);
+            Map<String, Long> traceUsageA = Map.of("prompt_tokens", 3L);
+            Map<String, Long> traceUsageB = Map.of("prompt_tokens", 7L);
+
+            var spanA = factory.manufacturePojo(Span.class).toBuilder()
+                    .projectName(projectNameA)
+                    .traceId(sharedId)
+                    .usage(spanUsageA)
+                    .totalEstimatedCost(costA)
+                    .build();
+            var spanB = factory.manufacturePojo(Span.class).toBuilder()
+                    .projectName(projectNameB)
+                    .traceId(sharedId)
+                    .usage(spanUsageB)
+                    .totalEstimatedCost(costB)
+                    .build();
+            batchCreateSpansAndAssert(List.of(spanA), API_KEY, TEST_WORKSPACE);
+            batchCreateSpansAndAssert(List.of(spanB), API_KEY, TEST_WORKSPACE);
+
+            var projectIdA = getProjectId(projectNameA, TEST_WORKSPACE, API_KEY);
+            var projectIdB = getProjectId(projectNameB, TEST_WORKSPACE, API_KEY);
+
+            var actualTrace = traceResourceClient.getById(sharedId, TEST_WORKSPACE, API_KEY);
+
+            // Whichever project the by-id lookup resolves the trace to, its cost/usage/span count must
+            // match *that project's* single span only. Regardless of which project wins, the buggy
+            // behaviour (summing both projects' spans) is excluded by the "not equal to combined" checks
+            // below, and the "must equal the resolved project's own values" checks pin down correctness.
+            assertThat(actualTrace.projectId()).isIn(projectIdA, projectIdB);
+
+            BigDecimal expectedCost = actualTrace.projectId().equals(projectIdA) ? costA : costB;
+            Map<String, Long> expectedUsage = actualTrace.projectId().equals(projectIdA) ? traceUsageA : traceUsageB;
+
+            assertThat(actualTrace.totalEstimatedCost())
+                    .usingComparator(BigDecimal::compareTo)
+                    .isEqualTo(expectedCost);
+            assertThat(actualTrace.usage()).isEqualTo(expectedUsage);
+            assertThat(actualTrace.spanCount()).isEqualTo(1);
+
+            // The regression this guards against: before the fix, spans_agg grouped only by trace_id
+            // (not project_id) and was joined on trace_id alone, so a colliding trace_id summed cost,
+            // usage and span_count across every project sharing that id.
+            BigDecimal buggyAggregatedCost = costA.add(costB);
+            assertThat(actualTrace.totalEstimatedCost())
+                    .usingComparator(BigDecimal::compareTo)
+                    .isNotEqualTo(buggyAggregatedCost);
+            assertThat(actualTrace.spanCount()).isNotEqualTo(2);
+        }
     }
 
     private Trace createTrace() {


### PR DESCRIPTION
## What

`GET /v1/private/traces/{id}` inflates `total_estimated_cost`, `usage`, `span_count`, `llm_span_count`, `has_tool_spans` and `providers` whenever the same `trace_id` exists in more than one project in the workspace.

This can legitimately happen in practice: the batch `traces`/`spans` endpoints (unlike the single-create endpoint) don't reject a `trace_id` that already exists under a different `project_id`, so deterministic/replayed client-side ID generation across independent imports can end up sharing an id across projects (see the reproducer and discussion on #7473).

## Root cause

`TraceDAO#findByIds` first resolves *every* `project_id` that contains a matching `trace_id` via `getTargetProjectIdsForTraces`, and binds that whole set as `target_project_ids`.

The trace row itself is then correctly narrowed down to a single project (`ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC LIMIT 1 BY id`). But the `spans_agg` CTE only grouped by `trace_id` (not `project_id`), and was `LEFT JOIN`ed onto the trace row using `t.id = s.trace_id` alone — so it summed `total_estimated_cost`/`usage`/span counts across **every** colliding project's spans, and attached that sum to the single resolved trace row, regardless of which project was actually requested.

## Fix

Group `spans_agg` by `(project_id, trace_id)` and join it to the resolved trace row on both `id` **and** `project_id`, so the aggregate always matches the specific project the trace row belongs to.

This is a SQL-only, backward-compatible change — no API or schema changes, and it applies uniformly to both callers of `findByIds` (single `GET /traces/{id}` and the internal batch fetch path), since a `trace_id` collision across projects can affect either.

**Note on why this one was silent:** the codebase already has a defensive `firstOrLogFanOut` in `TraceDAO#findById` for CTEs (comments, feedback scores) that can fan a single trace id out into multiple joined rows across colliding projects — it logs a warning and returns the first row rather than throwing. `spans_agg` doesn't hit that path at all, because it pre-aggregates (`sum`/`sumMap`) down to one row *before* the join, so the cross-project blend happens invisibly inside the aggregate itself rather than as a detectable multi-row fan-out. That's why this surfaced as silently wrong data instead of a logged warning or a 500.

## Testing

Added `TracesResourceTest$GetTrace#getTrace__whenTraceIdCollidesAcrossProjects__thenCostAndUsageAreNotAggregatedAcrossProjects`, which:
- Creates the same trace id in two different projects via the batch trace-create endpoint (mirroring how the collision occurs in practice).
- Creates one span per project with distinct, known `totalEstimatedCost`/`usage` values.
- Calls `GET /traces/{id}` and asserts the response's cost/usage/span_count match *only* the resolved project's own span — not the cross-project sum.

Verified explicitly:
- Against the unfixed query, the test fails with `expected: 0.15 but was: 0.250000000000` (the exact cross-project sum of the two spans' costs) — reproducing the reported bug.
- With the fix, the test passes.
- The existing `TracesResourceTest$GetTrace` (6 tests) and `TracesResourceTest$BatchInsert` (22 tests) suites pass in full with the fix applied.
- `mvn spotless:check` passes.

Fixes #7473

🤖 Generated with [Claude Code](https://claude.com/claude-code)
