### PR TITLE
[OPIK-7435] [FE] Fix Google Translate removeChild crash on onboarding email step

### DIFF
--- a/.agents/skills/opik-frontend/SKILL.md
+++ b/.agents/skills/opik-frontend/SKILL.md
@@ -52,6 +52,16 @@ const selectedEntity = useEntityStore(state => state.selectedEntity);
 const { selectedEntity, filters } = useEntityStore();
 ```
 
+### Browser Translation Safety (Google Translate)
+Many users auto-translate the page; the translator wraps text nodes in `<font>` elements, so React throws `NotFoundError: removeChild` when it reconciles a **bare dynamic text node** it re-parented. Wrap dynamic/conditional strings in their own element instead of rendering bare text.
+```typescript
+// ❌ bare dynamic text → crash under translation
+<button>{icon}{label}</button>
+// ✅ wrap it → React swaps a stable element, stays translatable
+<button>{icon}<span>{label}</span></button>
+```
+For timer-driven text (typewriter/counter), also avoid per-tick `setState` — write into a ref'd node's `textContent` (React never reconciles it), or mark a decorative node `translate="no"`. Ref: [facebook/react#11538](https://github.com/facebook/react/issues/11538) (OPIK-7428, OPIK-7435).
+
 ## Layer Architecture
 
 ### Shared layers (used by all versions)

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/ConnectStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/ConnectStep.tsx
@@ -161,11 +161,20 @@ const ConnectStep: React.FC<ConnectStepProps> = ({ userEmail = "" }) => {
               ) : (
                 <Mail className="size-3.5" />
               )}
-              {isPending
-                ? "Sending..."
-                : emailSent
-                  ? "Instructions sent!"
-                  : "Email setup instructions"}
+              {/* Wrap the state-dependent label in a <span> so React swaps a
+                  stable wrapper element instead of a bare text node. Under
+                  browser translation Google Translate re-parents text nodes
+                  into <font> elements; reconciling this label (icon + text swap
+                  on submit) against a re-parented bare text node throws
+                  "NotFoundError: removeChild". The wrapper keeps the label fully
+                  translatable (unlike translate="no"). See facebook/react#11538. */}
+              <span>
+                {isPending
+                  ? "Sending..."
+                  : emailSent
+                    ? "Instructions sent!"
+                    : "Email setup instructions"}
+              </span>
             </Button>
           </form>
 


### PR DESCRIPTION
## Details

Same class of crash as OPIK-7428, on the **final** onboarding step. Submitting the setup email on the mobile get-started onboarding throws:

> `NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`

Reproduces when the browser auto-translates the page (Chrome, non-English locale, mobile viewport).

`MobileOnboarding/ConnectStep.tsx` renders the submit button label as a bare, state-dependent interpolated string (`Email setup instructions` → `Sending...` → `Instructions sent!`) sitting as a text sibling of the button icon. Chrome Translate wraps that text node in a `<font>` element; when the send handler flips state, React reconciles the button (icon swap + label change) against a node Translate re-parented and throws `removeChild`/`insertBefore` `NotFoundError`. Same mechanism as the `WelcomeStep` typewriter fix (see [facebook/react#11538](https://github.com/facebook/react/issues/11538)).

**Fix:** wrap the dynamic label in its own `<span>` — the canonical React + Google Translate fix. React now swaps a stable wrapper element (a direct child of the button) instead of a bare text node Translate re-parented. The label stays fully translatable (no `translate="no"` opt-out).

Also documents this crash class as a rule in `.agents/skills/opik-frontend/SKILL.md` (Critical Gotchas) so new dynamic/animated text wraps interpolated strings in an element — browser translation is common among our users.

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

OPIK-7435

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: root-cause investigation and the one-element `<span>` wrap fix
- Human verification: crash reported and reproduced on the mobile onboarding email step (Chrome translate); reviewer to confirm the fix on the same repro

## Testing

- ESLint clean (`--max-warnings=0`); TypeScript typecheck passes.
- Manual: on a mobile viewport with Chrome page-translation on, advance to the last onboarding step and submit the email — no longer crashes; the label still translates.

## Documentation

Added a rule to `.agents/skills/opik-frontend/SKILL.md` (Critical Gotchas → "Browser Translation Safety") describing the crash class and the wrap-in-element pattern.
