### PR TITLE
[NA] fix(dev-runner): use -DskipTests for EM backend build so comet-mpm-service's test-jar is produced

### DIFF
--- a/scripts/dev-runner-platform.sh
+++ b/scripts/dev-runner-platform.sh
@@ -209,9 +209,11 @@ build_platform_backend() {
         return 1
     fi
     log_info "Building comet-backend React webapp with JDK $(_java_major_of "$em_jh") at $em_jh (EM reactor; first run is slow)..."
+    # -DskipTests (not -Dmaven.test.skip): comet-ml-mpm-webapp needs comet-mpm-service's
+    # test-jar as a reactor dependency, which only gets produced if test sources compile.
     if ( cd "$COMET_BACKEND_PATH" && JAVA_HOME="$em_jh" \
          mvn -pl comet-ml-react-webapp -am clean install \
-             -T 1C -Dmaven.test.skip=true -Dspotless.skip=true \
+             -T 1C -DskipTests -Dspotless.skip=true \
              -Dmaven.javadoc.skip=true -Dmaven.source.skip=true ); then
         if ! find_platform_backend_jar; then
             log_error "comet-backend build finished but no react-webapp JAR was found"


### PR DESCRIPTION
## Details
`platform_restart_build()` builds the EM backend reactor (`comet-ml-react-webapp -am`) with `-Dmaven.test.skip=true`, which skips test compilation as well as execution. `comet-ml-mpm-webapp` (a reactor dependency of `comet-ml-react-webapp`) needs `comet-mpm-service`'s test-jar as a test-scoped dependency, so skipping test compilation means that jar never gets produced/attached and the reactor fails to resolve it — leaving the EM backend permanently `STOPPED` on any fresh `comet-backend` checkout. Swapping to `-DskipTests` still skips running the tests (same speed benefit) but compiles them, so the test-jar goal has classes to package.

- `mvn -pl comet-ml-react-webapp -am clean install -Dmaven.test.skip=true ...` → `BUILD FAILURE`:
  `Could not find artifact com.comet:comet-mpm-service:jar:tests:1.0-SNAPSHOT`

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Sonnet 5
- Scope: root-cause diagnosis (reproduced the build failure, traced it to the missing test-jar), the one-line fix, and this PR description/commit message
- Human verification: directed the investigation, confirmed the fix by rebuilding `comet-mpm-service` and `comet-ml-react-webapp` locally and running `./scripts/dev-runner.sh --restart --platform-enabled` end-to-end (EM backend reached `RUNNING`/ready), reviewing before merge

## Testing
Commands run (in `comet-backend`, JDK 17 via `/usr/libexec/java_home -v 17`):
- `mvn -pl comet-mpm-service -am install -T 1C -DskipTests -Dspotless.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true` → `BUILD SUCCESS`, produced and installed `comet-mpm-service-1.0-SNAPSHOT-tests.jar`
- `mvn -pl comet-ml-react-webapp -am install -T 1C -DskipTests -Dspotless.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true` → `BUILD SUCCESS`
- `./scripts/dev-runner.sh --restart --platform-enabled` (from `opik/`) → EM backend built, started, and reported `RUNNING (PID ...)` / "EM backend is ready and accepting connections"

Scenarios validated:
- Clean `comet-backend` checkout with no prior `target/` build (the original failing case) — confirmed the exact `BUILD FAILURE` before the fix.
- Full `--restart --platform-enabled` flow after the fix, local process mode (not Docker) on macOS.

Not run: comet-backend's own test suite (intentionally skipped by design — this is a local dev-tooling build, not a CI path).

## Documentation
None needed — internal dev script only.