### PR TITLE
[OPIK-7392] [BE] fix: split cipx cache-creation tokens by TTL (5m vs 1h)

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendBlockDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendBlockDAO.java
@@ -47,7 +47,7 @@ public class CipxSpendBlockDAO {
 
     /** Tier names ordered by the residual block_idx ordinal. The cache_creation entry (ordinal 2) is a
      * placeholder: its written label is the per-span TTL variant (cache_creation_5m / cache_creation_1h),
-     * resolved by {@link BlockRow#tierName}. */
+     * resolved by {@link BlockRow#tierName(int, String)}. */
     private static final String[] TIER_NAMES = {"input", "cache_read", "cache_creation", "output"};
     private static final int RESIDUAL_IDX_BASE = 65531;
     private static final int CACHE_CREATION_TIER = 2;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendBlockDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendBlockDAO.java
@@ -45,9 +45,12 @@ import java.util.UUID;
 @Slf4j
 public class CipxSpendBlockDAO {
 
-    /** Tier names ordered by the residual block_idx ordinal. */
+    /** Tier names ordered by the residual block_idx ordinal. The cache_creation entry (ordinal 2) is a
+     * placeholder: its written label is the per-span TTL variant (cache_creation_5m / cache_creation_1h),
+     * resolved by {@link BlockRow#tierName}. */
     private static final String[] TIER_NAMES = {"input", "cache_read", "cache_creation", "output"};
     private static final int RESIDUAL_IDX_BASE = 65531;
+    private static final int CACHE_CREATION_TIER = 2;
     /** Rows per bulk-insert chunk; caps the JSON payload at ~35MB (~650 bytes/row). */
     private static final int INSERT_CHUNK_SIZE = 50_000;
     private static final String SRC_ATTRIBUTED = "a";
@@ -98,6 +101,15 @@ public class CipxSpendBlockDAO {
                     usage.path("cache_creation_input_tokens").asLong(0),
                     usage.path("output_tokens").asLong(0),
             };
+            // A cipx span is a single LLM call, and Claude Code writes all of a call's cache breakpoints
+            // with one TTL, so every write block on the span inherits the span's TTL. Pick it from the
+            // usage split; when the split is absent (legacy / not reported) fall back to 1h, since CC's
+            // cache writes are overwhelmingly 1h (OPIK-7392).
+            JsonNode cacheCreation = usage.path("cache_creation");
+            String writeTier = cacheCreation.path("ephemeral_5m_input_tokens").asLong(0) > 0
+                    && cacheCreation.path("ephemeral_1h_input_tokens").asLong(0) == 0
+                            ? "cache_creation_5m"
+                            : "cache_creation_1h";
 
             JsonNode blocks = metadata.path("cipx").path("blocks");
             long[] tierChars = new long[TIER_NAMES.length];
@@ -128,19 +140,24 @@ public class CipxSpendBlockDAO {
                     if (isIdentityContext(block)) {
                         continue;
                     }
-                    rows.add(attributed(base, idx, block, tierTokens, tierChars));
+                    rows.add(attributed(base, idx, block, tierTokens, tierChars, writeTier));
                 }
             }
             for (int tier = 0; tier < TIER_NAMES.length; tier++) {
                 if (!tierPresent[tier] && tierTokens[tier] > 0) {
-                    rows.add(residual(base, tier, tierTokens[tier]));
+                    rows.add(residual(base, tier, tierTokens[tier], writeTier));
                 }
             }
             return rows;
         }
 
+        /** cache_creation (ordinal 2) is written as its per-span TTL variant; the rest are fixed. */
+        private static String tierName(int tier, String writeTier) {
+            return tier == CACHE_CREATION_TIER ? writeTier : TIER_NAMES[tier];
+        }
+
         private static BlockRow attributed(BlockRowBuilder base, int idx, JsonNode block, long[] tierTokens,
-                long[] tierChars) {
+                long[] tierChars, String writeTier) {
             String category = block.path("category").asText("");
             String side = block.path("side").asText("");
             String cacheStatus = block.path("cache_status").asText("");
@@ -167,7 +184,7 @@ public class CipxSpendBlockDAO {
                     .toolUseId(block.path("tool_use_id").asText(""))
                     .resource(resource)
                     .kind(kind)
-                    .tier(tier >= 0 ? TIER_NAMES[tier] : "")
+                    .tier(tier >= 0 ? tierName(tier, writeTier) : "")
                     .lane(lane(category, toolServer))
                     .bdLane(bdLane(category, toolServer))
                     .label(label(category, toolServer, toolName, resource, kind, chars))
@@ -176,7 +193,7 @@ public class CipxSpendBlockDAO {
                     .build();
         }
 
-        private static BlockRow residual(BlockRowBuilder base, int tier, long tokens) {
+        private static BlockRow residual(BlockRowBuilder base, int tier, long tokens, String writeTier) {
             return base
                     .blockIdx(RESIDUAL_IDX_BASE + tier)
                     .src(SRC_RESIDUAL)
@@ -190,7 +207,7 @@ public class CipxSpendBlockDAO {
                     .toolUseId("")
                     .resource("")
                     .kind("")
-                    .tier(TIER_NAMES[tier])
+                    .tier(tierName(tier, writeTier))
                     .lane("unattributed")
                     .bdLane("")
                     .label("")

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendDAO.java
@@ -53,6 +53,8 @@ public class CipxSpendDAO {
             long uInput,
             long uCacheRead,
             long uCacheCreation,
+            long uCacheCreation5m,
+            long uCacheCreation1h,
             long uOutput,
             @NonNull String effort,
             @NonNull String thinkingType,
@@ -62,6 +64,7 @@ public class CipxSpendDAO {
         public static SpanRow from(UUID spanId, UUID traceId, UUID projectId, JsonNode metadata, Instant startTime) {
             JsonNode call = metadata.path("cipx").path("call");
             JsonNode usage = call.path("usage");
+            JsonNode cacheCreation = usage.path("cache_creation");
             JsonNode config = call.path("config");
             return SpanRow.builder()
                     .spanId(spanId.toString())
@@ -72,6 +75,8 @@ public class CipxSpendDAO {
                     .uInput(usage.path("input_tokens").asLong(0))
                     .uCacheRead(usage.path("cache_read_input_tokens").asLong(0))
                     .uCacheCreation(usage.path("cache_creation_input_tokens").asLong(0))
+                    .uCacheCreation5m(cacheCreation.path("ephemeral_5m_input_tokens").asLong(0))
+                    .uCacheCreation1h(cacheCreation.path("ephemeral_1h_input_tokens").asLong(0))
                     .uOutput(usage.path("output_tokens").asLong(0))
                     .effort(config.path("effort").asText(""))
                     .thinkingType(config.path("thinking_type").asText(""))
@@ -86,7 +91,7 @@ public class CipxSpendDAO {
     private static final String INSERT = """
             INSERT INTO cipx_spends
                 (workspace_id, project_id, trace_id, span_id, start_time, model,
-                 u_input, u_cache_read, u_cache_creation, u_output,
+                 u_input, u_cache_read, u_cache_creation, u_cache_creation_5m, u_cache_creation_1h, u_output,
                  effort, thinking_type, max_tokens, context_management)
             SETTINGS log_comment = '<log_comment>'
             FORMAT Values
@@ -101,6 +106,8 @@ public class CipxSpendDAO {
                         :u_input<item.index>,
                         :u_cache_read<item.index>,
                         :u_cache_creation<item.index>,
+                        :u_cache_creation_5m<item.index>,
+                        :u_cache_creation_1h<item.index>,
                         :u_output<item.index>,
                         :effort<item.index>,
                         :thinking_type<item.index>,
@@ -134,7 +141,7 @@ public class CipxSpendDAO {
         // Positional binds: the driver resolves named binds with a linear indexOf over the statement's
         // parameter list (quadratic per statement), while bind(int) is a direct array write. Indices
         // follow the placeholders' first-appearance order in the rendered SQL: workspace_id once at 0
-        // (repeats dedup), then 13 parameters per row tuple in template order.
+        // (repeats dedup), then 15 parameters per row tuple in template order.
         statement.bind(0, workspaceId);
         int index = 1;
         for (SpanRow row : rows) {
@@ -146,6 +153,8 @@ public class CipxSpendDAO {
                     .bind(index++, row.uInput())
                     .bind(index++, row.uCacheRead())
                     .bind(index++, row.uCacheCreation())
+                    .bind(index++, row.uCacheCreation5m())
+                    .bind(index++, row.uCacheCreation1h())
                     .bind(index++, row.uOutput())
                     .bind(index++, row.effort())
                     .bind(index++, row.thinkingType())

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000109_add_cache_creation_split_to_cipx_spends.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000109_add_cache_creation_split_to_cipx_spends.sql
@@ -2,13 +2,10 @@
 --changeset boryst:000109_add_cache_creation_split_to_cipx_spends
 --comment: Split cache-creation tokens by TTL on cipx_spends (5m vs 1h, OPIK-7392)
 
--- Anthropic bills cache writes by TTL: 5-minute at 1.25x input, 1-hour at 2x input. Claude Code
--- writes its stable prefix with a 1-hour TTL, so pricing every cache-creation token at the 5m rate
--- understates cost (~18% in practice). The proxy already emits the split on
+-- Split the cache-creation token count by TTL. The proxy emits the split on
 -- cipx.call.usage.cache_creation.{ephemeral_5m_input_tokens, ephemeral_1h_input_tokens}; it was
--- collapsed into the single u_cache_creation lump here. These columns carry it through so pricing can
--- charge the 1h bucket at 2x. u_cache_creation stays the lump total; existing rows read the default 0
--- for the split (priced as 5m via the lump remainder, i.e. unchanged).
+-- collapsed into the single u_cache_creation lump here. u_cache_creation stays the lump total;
+-- existing rows read the default 0 for the new columns.
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_spends ON CLUSTER '{cluster}'
     ADD COLUMN IF NOT EXISTS u_cache_creation_5m Int64 DEFAULT 0,
     ADD COLUMN IF NOT EXISTS u_cache_creation_1h Int64 DEFAULT 0;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000109_add_cache_creation_split_to_cipx_spends.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000109_add_cache_creation_split_to_cipx_spends.sql
@@ -1,0 +1,16 @@
+--liquibase formatted sql
+--changeset boryst:000109_add_cache_creation_split_to_cipx_spends
+--comment: Split cache-creation tokens by TTL on cipx_spends (5m vs 1h, OPIK-7392)
+
+-- Anthropic bills cache writes by TTL: 5-minute at 1.25x input, 1-hour at 2x input. Claude Code
+-- writes its stable prefix with a 1-hour TTL, so pricing every cache-creation token at the 5m rate
+-- understates cost (~18% in practice). The proxy already emits the split on
+-- cipx.call.usage.cache_creation.{ephemeral_5m_input_tokens, ephemeral_1h_input_tokens}; it was
+-- collapsed into the single u_cache_creation lump here. These columns carry it through so pricing can
+-- charge the 1h bucket at 2x. u_cache_creation stays the lump total; existing rows read the default 0
+-- for the split (priced as 5m via the lump remainder, i.e. unchanged).
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_spends ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS u_cache_creation_5m Int64 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS u_cache_creation_1h Int64 DEFAULT 0;
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_spends ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS u_cache_creation_5m, DROP COLUMN IF EXISTS u_cache_creation_1h;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000109_add_cache_creation_split_to_cipx_spends.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000109_add_cache_creation_split_to_cipx_spends.sql
@@ -14,3 +14,4 @@ ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_spends ON CLUSTER '{cluster}'
     ADD COLUMN IF NOT EXISTS u_cache_creation_1h Int64 DEFAULT 0;
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_spends ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS u_cache_creation_5m, DROP COLUMN IF EXISTS u_cache_creation_1h;
+

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.lifecycle.Startables;
@@ -118,7 +120,7 @@ class CostIntelligenceIngestionTest {
 
             var cipxSpan = factory.manufacturePojo(Span.class).toBuilder()
                     .projectName(projectName)
-                    .metadata(spanCipxMetadata("claude-sonnet-4-6", 100, 20, 5, 40))
+                    .metadata(spanCipxMetadata("claude-sonnet-4-6", 100, 20, 5, 2, 3, 40))
                     .build();
             var plainSpan = factory.manufacturePojo(Span.class).toBuilder()
                     .projectName(projectName)
@@ -134,6 +136,8 @@ class CostIntelligenceIngestionTest {
                 assertThat(row.get().uInput()).isEqualTo(100L);
                 assertThat(row.get().uCacheRead()).isEqualTo(20L);
                 assertThat(row.get().uCacheCreation()).isEqualTo(5L);
+                assertThat(row.get().uCacheCreation5m()).isEqualTo(2L);
+                assertThat(row.get().uCacheCreation1h()).isEqualTo(3L);
                 assertThat(row.get().uOutput()).isEqualTo(40L);
                 assertThat(row.get().projectId()).isNotBlank();
                 assertThat(row.get().startMs()).isEqualTo(cipxSpan.startTime().toEpochMilli());
@@ -161,7 +165,7 @@ class CostIntelligenceIngestionTest {
             // output=40 (one output block absorbs it all).
             var span = factory.manufacturePojo(Span.class).toBuilder()
                     .projectName(projectName)
-                    .metadata(spanCipxMetadata("claude-sonnet-4-6", 100, 20, 5, 40))
+                    .metadata(spanCipxMetadata("claude-sonnet-4-6", 100, 20, 5, 2, 3, 40))
                     .build();
             spanResourceClient.createSpan(span, ws.apiKey(), ws.workspaceName());
 
@@ -232,10 +236,12 @@ class CostIntelligenceIngestionTest {
                 assertThat(residualInput.label()).isEmpty();
                 assertThat(residualInput.alloc()).isCloseTo(100.0, within(1e-9));
 
+                // cache_creation residual inherits the span's TTL: the usage split has 1h > 0, so the
+                // write tier is labeled cache_creation_1h (OPIK-7392).
                 var residualCacheCreation = rows.get(5);
                 assertThat(residualCacheCreation.blockIdx()).isEqualTo(65533);
                 assertThat(residualCacheCreation.src()).isEqualTo("r");
-                assertThat(residualCacheCreation.tier()).isEqualTo("cache_creation");
+                assertThat(residualCacheCreation.tier()).isEqualTo("cache_creation_1h");
                 assertThat(residualCacheCreation.alloc()).isCloseTo(5.0, within(1e-9));
 
                 // model and start_time ride on every block row.
@@ -243,6 +249,33 @@ class CostIntelligenceIngestionTest {
                     assertThat(row.model()).isEqualTo("claude-sonnet-4-6");
                     assertThat(row.startMs()).isEqualTo(span.startTime().toEpochMilli());
                 });
+            });
+        }
+
+        @DisplayName("write blocks inherit the span's cache TTL (1h vs 5m)")
+        @ParameterizedTest
+        @CsvSource({
+                "0, 50, cache_creation_1h", // usage split: 1h -> whole span is 1h
+                "50, 0, cache_creation_5m", // usage split: 5m only -> whole span is 5m
+                "0, 0, cache_creation_1h", // no split reported -> fall back to 1h (lump forced to 50)
+        })
+        void writeBlocksInheritSpanCacheTtl(long cacheCreation5m, long cacheCreation1h, String expectedTier) {
+            var ws = newWorkspace();
+            String projectName = "cipx-" + UUID.randomUUID();
+
+            var span = factory.manufacturePojo(Span.class).toBuilder()
+                    .projectName(projectName)
+                    .metadata(spanCipxWriteBlockMetadata("claude-sonnet-4-6", cacheCreation5m, cacheCreation1h))
+                    .build();
+            spanResourceClient.createSpan(span, ws.apiKey(), ws.workspaceName());
+
+            await().atMost(30, SECONDS).untilAsserted(() -> {
+                var rows = getCipxBlocks(span.id(), ws.workspaceId());
+                assertThat(rows).hasSize(1);
+                var writeBlock = rows.getFirst();
+                assertThat(writeBlock.cacheStatus()).isEqualTo("write");
+                assertThat(writeBlock.tier()).isEqualTo(expectedTier);
+                assertThat(writeBlock.alloc()).isCloseTo(50.0, within(1e-9)); // sole write block absorbs the lump
             });
         }
     }
@@ -386,7 +419,7 @@ class CostIntelligenceIngestionTest {
     }
 
     private static JsonNode spanCipxMetadata(String model, long input, long cacheRead, long cacheCreation,
-            long output) {
+            long cacheCreation5m, long cacheCreation1h, long output) {
         return JsonUtils.getJsonNodeFromString(
                 """
                         {
@@ -397,6 +430,10 @@ class CostIntelligenceIngestionTest {
                                 "input_tokens": %d,
                                 "cache_read_input_tokens": %d,
                                 "cache_creation_input_tokens": %d,
+                                "cache_creation": {
+                                  "ephemeral_5m_input_tokens": %d,
+                                  "ephemeral_1h_input_tokens": %d
+                                },
                                 "output_tokens": %d
                               },
                               "config": {
@@ -416,7 +453,37 @@ class CostIntelligenceIngestionTest {
                           }
                         }
                         """
-                        .formatted(model, input, cacheRead, cacheCreation, output));
+                        .formatted(model, input, cacheRead, cacheCreation, cacheCreation5m, cacheCreation1h, output));
+    }
+
+    // A cipx span with a single write block (side=input, cache_status=write), so the whole cache-creation
+    // lump lands on it. The usage split (5m/1h) drives which TTL tier the write block inherits.
+    private static JsonNode spanCipxWriteBlockMetadata(String model, long cacheCreation5m, long cacheCreation1h) {
+        long lump = cacheCreation5m + cacheCreation1h;
+        return JsonUtils.getJsonNodeFromString(
+                """
+                        {
+                          "cipx": {
+                            "call": {
+                              "model": "%s",
+                              "usage": {
+                                "input_tokens": 0,
+                                "cache_read_input_tokens": 0,
+                                "cache_creation_input_tokens": %d,
+                                "cache_creation": {
+                                  "ephemeral_5m_input_tokens": %d,
+                                  "ephemeral_1h_input_tokens": %d
+                                },
+                                "output_tokens": 0
+                              }
+                            },
+                            "blocks": [
+                              {"category":"system_prompt","side":"input","cache_status":"write","parent_category":"context","chars":200,"tool_name":"","tool_server":"","tool_use_id":"","resource":"","kind":"text"}
+                            ]
+                          }
+                        }
+                        """
+                        .formatted(model, lump == 0 ? 50 : lump, cacheCreation5m, cacheCreation1h));
     }
 
     private static JsonNode traceCipxMetadata(String userUuid, String email, String displayName, String repository,
@@ -460,7 +527,7 @@ class CostIntelligenceIngestionTest {
                     project_id AS project_id,
                     toUnixTimestamp64Milli(start_time) AS start_ms,
                     model AS model,
-                    u_input, u_cache_read, u_cache_creation, u_output,
+                    u_input, u_cache_read, u_cache_creation, u_cache_creation_5m, u_cache_creation_1h, u_output,
                     effort, thinking_type, max_tokens, context_management
                 FROM cipx_spends FINAL
                 WHERE workspace_id = :workspace_id AND span_id = :span_id
@@ -477,6 +544,8 @@ class CostIntelligenceIngestionTest {
                             row.get("u_input", Long.class),
                             row.get("u_cache_read", Long.class),
                             row.get("u_cache_creation", Long.class),
+                            row.get("u_cache_creation_5m", Long.class),
+                            row.get("u_cache_creation_1h", Long.class),
                             row.get("u_output", Long.class),
                             row.get("effort", String.class),
                             row.get("thinking_type", String.class),
@@ -596,8 +665,8 @@ class CostIntelligenceIngestionTest {
     }
 
     private record CipxSpendRow(String projectId, Long startMs, String model, Long uInput, Long uCacheRead,
-            Long uCacheCreation, Long uOutput, String effort, String thinkingType,
-            Long maxTokens, String contextManagement) {
+            Long uCacheCreation, Long uCacheCreation5m, Long uCacheCreation1h, Long uOutput, String effort,
+            String thinkingType, Long maxTokens, String contextManagement) {
     }
 
     private record CipxBlockRow(Integer blockIdx, String src, String category, String tier, String lane,


### PR DESCRIPTION
## Details

Persists the 5-minute vs 1-hour cache-creation split so AI-spend can price 1h cache writes at 2× input. Previously `cipx_spends` collapsed the split into a single `u_cache_creation` lump, so cost was computed at the 5m rate (1.25× input) for all cache-creation tokens — a ~18% understatement, since Claude Code writes its cache with a 1-hour TTL (2× input).

- migration `000109`: add `u_cache_creation_5m` / `u_cache_creation_1h` to `cipx_spends`
- `CipxSpendDAO`: parse and persist the split from `usage.cache_creation`
- `CipxSpendBlockDAO`: a cipx span is a single LLM call with one cache TTL, so each write block inherits the span's TTL into its `tier` (`cache_creation_5m` / `cache_creation_1h`); legacy rows keep `cache_creation` and are read as 1h downstream

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7392

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: implementation, tests, and analysis
- Human verification: author reviewed the diff, compiles/tests the Java backend, and validated the fix end-to-end against Claude Code `/usage`

## Testing

- Java backend compiled/tested by the author. `CostIntelligenceIngestionTest` extended with 5m/1h split assertions and a parameterized write-block TTL-inheritance test.
- E2E: fresh Claude Code session through the local cipx proxy → local Opik; `cipx_spends.u_cache_creation_1h` and `cipx_spend_blocks.tier='cache_creation_1h'` populate correctly, and the AI-spend UI total matches `/usage` to the cent.

Paired cost-api change that applies the pricing: comet-ml/ai-cost-backend#36

> [!IMPORTANT]
> Deploy order: this migration (000109) must be deployed **before** the cost-api change, which reads the new columns.

## Documentation

N/A
