### PR TITLE
[NA] [DOCS] [SDK] Render empty integration reference pages & fix docstring build errors

### DIFF
--- a/apps/opik-documentation/python-sdk-docs/source/conf.py
+++ b/apps/opik-documentation/python-sdk-docs/source/conf.py
@@ -46,6 +46,37 @@ autodoc_default_options = {
     "show-inheritance": True,
 }
 
+# Mock the heavy third-party integration libraries. autodoc only imports the
+# opik.integrations.* wrappers to read their signatures/docstrings; it does not
+# need the real SDKs, several of which fail to import in the docs environment
+# (e.g. google-genai / litellm raise PydanticSchemaGenerationError at import).
+# Without this, every integration reference page renders empty. Do NOT list
+# libraries the opik core imports (pydantic, httpx), only integration-only deps.
+autodoc_mock_imports = [
+    "agents",
+    "aisuite",
+    "anthropic",
+    "boto3",
+    "botocore",
+    "crewai",
+    "crewai_tools",
+    "dspy",
+    "google",
+    "groq",
+    "guardrails",
+    "harbor",
+    "haystack",
+    "langchain",
+    "langchain_core",
+    "langgraph",
+    "litellm",
+    "llama_index",
+    "mistralai",
+    "openai",
+    "pyagentspec",
+    "sagemaker",
+]
+
 # -- Options for Markdown files ----------------------------------------------
 #
 

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -164,9 +164,10 @@ def evaluate(
         scoring_functions: List of scorer functions to be executed during evaluation.
             Each scorer function includes a scoring method that accepts predefined
             arguments supplied by the evaluation engine:
-                • dataset_item — a dictionary containing the dataset item content,
-                • task_outputs — a dictionary containing the LLM task output.
-                • task_span - the data collected during the LLM task execution [optional].
+
+            - dataset_item — a dictionary containing the dataset item content,
+            - task_outputs — a dictionary containing the LLM task output.
+            - task_span - the data collected during the LLM task execution [optional].
 
         verbose: an integer value that controls evaluation output logs such as summary and tqdm progress bar.
             0 - no outputs, 1 - outputs are enabled (default), 2 - outputs are enabled and detailed statistics
@@ -783,9 +784,10 @@ def evaluate_experiment(
         scoring_functions: List of scorer functions to be executed during evaluation.
             Each scorer function includes a scoring method that accepts predefined
             arguments supplied by the evaluation engine:
-                • dataset_item — a dictionary containing the dataset item content,
-                • task_outputs — a dictionary containing the LLM task output.
-                • task_span - the data collected during the LLM task execution [optional].
+
+            - dataset_item — a dictionary containing the dataset item content,
+            - task_outputs — a dictionary containing the LLM task output.
+            - task_span - the data collected during the LLM task execution [optional].
 
         scoring_threads: amount of thread workers to run scoring metrics.
 
@@ -1003,9 +1005,10 @@ def evaluate_prompt(
         scoring_functions: List of scorer functions to be executed during evaluation.
             Each scorer function includes a scoring method that accepts predefined
             arguments supplied by the evaluation engine:
-                • dataset_item — a dictionary containing the dataset item content,
-                • task_outputs — a dictionary containing the LLM task output.
-                • task_span - the data collected during the LLM task execution [optional].
+
+            - dataset_item — a dictionary containing the dataset item content,
+            - task_outputs — a dictionary containing the LLM task output.
+            - task_span - the data collected during the LLM task execution [optional].
 
         experiment_name_prefix: The prefix to be added to automatically generated experiment names to make them unique
             but grouped under the same prefix. For example, if you set `experiment_name_prefix="my-experiment"`,
@@ -1254,9 +1257,10 @@ def evaluate_optimization_trial(
         scoring_functions: List of scorer functions to be executed during evaluation.
             Each scorer function includes a scoring method that accepts predefined
             arguments supplied by the evaluation engine:
-                • dataset_item — a dictionary containing the dataset item content,
-                • task_outputs — a dictionary containing the LLM task output.
-                • task_span - the data collected during the LLM task execution [optional].
+
+            - dataset_item — a dictionary containing the dataset item content,
+            - task_outputs — a dictionary containing the LLM task output.
+            - task_span - the data collected during the LLM task execution [optional].
 
         experiment_name_prefix: The prefix to be added to automatically generated experiment names to make them unique
                     but grouped under the same prefix. For example, if you set `experiment_name_prefix="my-experiment"`,
@@ -1619,8 +1623,9 @@ def evaluate_on_dict_items(
 
         scoring_functions: List of scorer functions to be executed during evaluation.
             Each scorer function accepts predefined arguments:
-                • dataset_item — a dictionary containing the dataset item content,
-                • task_outputs — a dictionary containing the LLM task output.
+
+            - dataset_item — a dictionary containing the dataset item content,
+            - task_outputs — a dictionary containing the LLM task output.
 
         project_name: The name of the project for logging traces.
 

--- a/sdks/python/src/opik/integrations/openai/opik_tracker.py
+++ b/sdks/python/src/opik/integrations/openai/opik_tracker.py
@@ -33,6 +33,7 @@ def track_openai(
     executes normally but no span/trace is sent.
 
     Tracks calls to:
+
     * `openai_client.chat.completions.create()`, including support for stream=True mode.
     * `openai_client.beta.chat.completions.parse()`
     * `openai_client.beta.chat.completions.stream()`


### PR DESCRIPTION
## Details

Follow-up to #7558. Two docs-build problems that #7558 didn't cover, surfaced by the `Deploy Opik Python SDK docs` build:

- **Integration reference pages deployed empty.** Sphinx autodoc imports each `opik.integrations.*` module to document it, and several crash on import in the docs environment (their third-party SDKs — google-genai, litellm, etc. — raise `PydanticSchemaGenerationError`). Every integration page rendered with **0 signature blocks** (vs 81 on `Opik.html`). Added `autodoc_mock_imports` so autodoc documents the opik wrappers without importing the real SDKs — recovers openai / anthropic / crewai / dspy / guardrails / llama_index / haystack / bedrock / genai.
- **`ERROR: Unexpected indentation`** (docutils) in the `evaluate` / `evaluate_experiment` / `evaluate_prompt` docstrings (`evaluator.py`) and `track_openai` (openai integration): bullet sub-lists placed directly under a line ending in `:`, with no blank line and a non-RST `•` marker. Reformatted to valid `-` lists.

Known follow-ups (not in this PR): the `adk` and `langchain` integration pages still fail autodoc for unrelated reasons — opik's own `google.adk.__version__` version check defeats the mock, and `langchain` fails inside a `langchain_core` import.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues
- N/A — docs-build fixes surfaced by the deploy build; no ticket.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: diagnosis of the empty integration pages and docstring build errors, the fixes in this PR, and local verification.
- Human verification: author to review the diff and the CI docs build before merge.

## Testing

- Built the Python SDK reference locally on top of current `main`:
  `cd apps/opik-documentation/python-sdk-docs && pip install -r requirements.txt && pip install -e ../../../sdks/python && sphinx-build -b html source build/html`.
  Result: build succeeds with **0 ERRORs** (was 3 × `Unexpected indentation`) and warnings **26 → 17**; the previously-empty integration pages now render (e.g. `track_openai`, `OpikCallback`, `track_crewai` show signature blocks).
- CI builds on Python 3.12 vs local 3.14, so the remaining `adk` / `langchain` imports are best confirmed on this PR's CI run.
- Not run: E2E / Docker suites — docs-config plus docstring/comment-only changes, no runtime code change.

## Documentation

This PR is the documentation-build fix.
