### PR TITLE
[OPIK-7402] [BE] Add audit (shadow / log-only) mode to UUIDv7 ingestion validation

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -145,6 +145,13 @@ uuidValidation:
   #  Description: Operational kill-switch. When false, ids are not checked against the window (the
   #   window is still validated to be a sane value).
   enabled: ${UUID_VALIDATION_ENABLED:-false}
+  #  Default: false
+  #  Description: Audit (shadow / log-only) mode. Only takes effect when enabled is true. When true,
+  #   out-of-window ids are counted (opik.ingestion.uuid_v7.rejected, tagged by workspace) and logged
+  #   but NOT rejected, so offenders surface without breaking ingestion. When false, out-of-window ids
+  #   are rejected with HTTP 400. Effective mode: enabled=false -> disabled; enabled=true & auditOnly=true
+  #   -> audit; enabled=true & auditOnly=false -> reject.
+  auditOnly: ${UUID_VALIDATION_AUDIT_ONLY:-false}
   #  Default: 24h
   #  Description: Validation window (between 12h and 45d). Writes whose `id` is a UUIDv7 with an
   #   embedded timestamp more than this far in the past or future are rejected.

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/error/InvalidUUIDExceptionMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/error/InvalidUUIDExceptionMapper.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api.error;
 
+import com.comet.opik.infrastructure.metrics.UuidValidationMetrics;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
@@ -22,7 +23,8 @@ import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 
 /**
  * Maps {@link InvalidUUIDException} to HTTP 400 and records the reject-rate metric.
- * Tags each rejection with the matched route.
+ * Tags each rejection with the matched route and {@code mode=reject} (see {@link UuidValidationMetrics}
+ * for the shared {@code opik.ingestion.uuid_v7.rejected} counter contract).
  *
  * <p>{@link ResourceInfo} is request-scoped, so it is obtained lazily through a {@link Provider}
  * (injecting it directly would fail to construct this singleton outside a request). The lookup resolves
@@ -50,8 +52,11 @@ public class InvalidUUIDExceptionMapper implements ExceptionMapper<InvalidUUIDEx
         var httpRoute = getHttpRoute();
         log.info("Rejected ingestion id, httpRoute: '{}', reason: '{}', error message: '{}'",
                 httpRoute, exception.getReason().getValue(), exception.getMessage());
-        REJECTED_COUNTER.add(1,
-                Attributes.of(HTTP_ROUTE_KEY, httpRoute, REASON_KEY, exception.getReason().getValue()));
+        REJECTED_COUNTER.add(1, Attributes.builder()
+                .put(UuidValidationMetrics.MODE_KEY, UuidValidationMetrics.MODE_REJECT)
+                .put(HTTP_ROUTE_KEY, httpRoute)
+                .put(REASON_KEY, exception.getReason().getValue())
+                .build());
         // Force JSON: ingestion endpoints negotiate other content types (e.g. the OTel endpoint uses protobuf),
         // which have no writer for the error entity — without this the 400 fails to serialize and surfaces as a 500
         return Response.status(BAD_REQUEST)

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/error/InvalidUUIDExceptionMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/error/InvalidUUIDExceptionMapper.java
@@ -2,10 +2,6 @@ package com.comet.opik.api.error;
 
 import com.comet.opik.infrastructure.metrics.UuidValidationMetrics;
 import io.dropwizard.jersey.errors.ErrorMessage;
-import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.LongCounter;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.ws.rs.Path;
@@ -22,9 +18,10 @@ import java.lang.reflect.Method;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 
 /**
- * Maps {@link InvalidUUIDException} to HTTP 400 and records the reject-rate metric.
- * Tags each rejection with the matched route and {@code mode=reject} (see {@link UuidValidationMetrics}
- * for the shared {@code opik.ingestion.uuid_v7.rejected} counter contract).
+ * Maps {@link InvalidUUIDException} to HTTP 400 and records the reject-rate metric, tagged with the
+ * matched route and {@code mode=reject}. The counter itself lives in {@link UuidValidationMetrics}
+ * (the central owner of {@code opik.ingestion.uuid_v7.rejected}); this mapper only supplies the route
+ * and delegates.
  *
  * <p>{@link ResourceInfo} is request-scoped, so it is obtained lazily through a {@link Provider}
  * (injecting it directly would fail to construct this singleton outside a request). The lookup resolves
@@ -34,29 +31,17 @@ import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 public class InvalidUUIDExceptionMapper implements ExceptionMapper<InvalidUUIDException> {
 
-    private static final String METRIC_NAMESPACE = "opik.ingestion";
     private static final String UNKNOWN_ROUTE = "unknown";
 
-    private static final AttributeKey<String> HTTP_ROUTE_KEY = AttributeKey.stringKey("http_route");
-    private static final AttributeKey<String> REASON_KEY = AttributeKey.stringKey("reason");
-
-    private static final LongCounter REJECTED_COUNTER = GlobalOpenTelemetry.get().getMeter(METRIC_NAMESPACE)
-            .counterBuilder("%s.uuid_v7.rejected".formatted(METRIC_NAMESPACE))
-            .setDescription("Number of writes rejected because the id failed UUIDv7 ingestion validation")
-            .build();
-
     private final Provider<ResourceInfo> resourceInfo;
+    private final UuidValidationMetrics uuidValidationMetrics;
 
     @Override
     public Response toResponse(@NonNull InvalidUUIDException exception) {
         var httpRoute = getHttpRoute();
         log.info("Rejected ingestion id, httpRoute: '{}', reason: '{}', error message: '{}'",
                 httpRoute, exception.getReason().getValue(), exception.getMessage());
-        REJECTED_COUNTER.add(1, Attributes.builder()
-                .put(UuidValidationMetrics.MODE_KEY, UuidValidationMetrics.MODE_REJECT)
-                .put(HTTP_ROUTE_KEY, httpRoute)
-                .put(REASON_KEY, exception.getReason().getValue())
-                .build());
+        uuidValidationMetrics.recordReject(exception.getReason().getValue(), httpRoute);
         // Force JSON: ingestion endpoints negotiate other content types (e.g. the OTel endpoint uses protobuf),
         // which have no writer for the error entity — without this the 400 fails to serialize and surfaces as a 500
         return Response.status(BAD_REQUEST)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/IdGenerator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/IdGenerator.java
@@ -111,16 +111,19 @@ class IdGeneratorImpl implements IdGenerator {
     }
 
     @Override
-
-    public void validateIdForUpdate(@NonNull UUID id, String resource, String workspaceId) {
+    public void validateIdNotInFuture(@NonNull UUID id, String resource) {
         IdGenerator.validateVersion(id, resource);
-        uuidV7TimestampValidator.validateNotInFuture(id, resource, workspaceId);
+        // Referenced/foreign ids are validated where the request-scoped workspace is not threaded
+        // (e.g. the synchronous fail-fast batch pass), so the audit metric falls back to UNKNOWN here;
+        // the batch's own ids still carry the workspace via validateId.
+        uuidV7TimestampValidator.validateNotInFuture(id, resource, ErrorMetricsResolver.UNKNOWN);
     }
 
     @Override
-    public Mono<UUID> validateIdForUpdateAsync(@NonNull UUID id, String resource) {
+    public Mono<UUID> validateIdNotInFutureAsync(@NonNull UUID id, String resource) {
         return Mono.deferContextual(ctx -> Mono.fromCallable(() -> {
-            validateIdNotInFuture(id, resource, workspaceId(ctx));
+            IdGenerator.validateVersion(id, resource);
+            uuidV7TimestampValidator.validateNotInFuture(id, resource, workspaceId(ctx));
             return id;
         }));
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/IdGenerator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/IdGenerator.java
@@ -2,7 +2,9 @@ package com.comet.opik.domain;
 
 import com.comet.opik.api.error.InvalidUUIDException;
 import com.comet.opik.api.error.InvalidUUIDException.Reason;
+import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.db.UuidV7TimestampValidator;
+import com.comet.opik.infrastructure.metrics.ErrorMetricsResolver;
 import com.fasterxml.uuid.Generators;
 import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 import com.google.inject.ImplementedBy;
@@ -11,6 +13,7 @@ import jakarta.inject.Singleton;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
+import reactor.util.context.ContextView;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -27,9 +30,11 @@ public interface IdGenerator {
     /**
      * Validates an ingested {@code id}: it must be a version 7 UUID ({@link #validateVersion(UUID, String)})
      * whose embedded timestamp is within the configured ingestion window.
-     * Rejects with HTTP 400. Encapsulates both data-quality checks behind one call.
+     * Rejects with HTTP 400 (or, in audit mode, counts + logs without rejecting). Encapsulates both
+     * data-quality checks behind one call. {@code workspaceId} tags the audit metric so offenders are
+     * attributable per workspace; pass {@link ErrorMetricsResolver#UNKNOWN} when it is not available.
      */
-    void validateId(UUID id, String resource);
+    void validateId(UUID id, String resource, String workspaceId);
 
     Mono<UUID> validateIdAsync(UUID id, String resource);
 
@@ -78,29 +83,38 @@ class IdGeneratorImpl implements IdGenerator {
     }
 
     @Override
-    public void validateId(@NonNull UUID id, String resource) {
+    public void validateId(@NonNull UUID id, String resource, String workspaceId) {
         IdGenerator.validateVersion(id, resource);
-        uuidV7TimestampValidator.validate(id);
+        uuidV7TimestampValidator.validate(id, resource, workspaceId);
     }
 
     @Override
     public Mono<UUID> validateIdAsync(@NonNull UUID id, String resource) {
-        return Mono.fromCallable(() -> {
-            validateId(id, resource);
+        return Mono.deferContextual(ctx -> Mono.fromCallable(() -> {
+            validateId(id, resource, workspaceId(ctx));
             return id;
-        });
+        }));
     }
 
-    private void validateIdForUpdate(UUID id, String resource) {
+    private void validateIdForUpdate(UUID id, String resource, String workspaceId) {
         IdGenerator.validateVersion(id, resource);
-        uuidV7TimestampValidator.validateNotInFuture(id);
+        uuidV7TimestampValidator.validateNotInFuture(id, resource, workspaceId);
     }
 
     @Override
     public Mono<UUID> validateIdForUpdateAsync(@NonNull UUID id, String resource) {
-        return Mono.fromCallable(() -> {
-            validateIdForUpdate(id, resource);
+        return Mono.deferContextual(ctx -> Mono.fromCallable(() -> {
+            validateIdForUpdate(id, resource, workspaceId(ctx));
             return id;
-        });
+        }));
+    }
+
+    /**
+     * Reads the {@code workspace_id} from the reactive context (the async ingestion paths carry it
+     * there, not in a request-scoped thread-local), falling back to {@link ErrorMetricsResolver#UNKNOWN}
+     * so the audit metric always has a value.
+     */
+    private static String workspaceId(ContextView ctx) {
+        return ctx.getOrDefault(RequestContext.WORKSPACE_ID, ErrorMetricsResolver.UNKNOWN);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/IdGenerator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/IdGenerator.java
@@ -28,11 +28,10 @@ public interface IdGenerator {
     UUID getTimeOrderedEpoch(long epochMilli);
 
     /**
-     * Validates an ingested {@code id}: it must be a version 7 UUID ({@link #validateVersion(UUID, String)})
-     * whose embedded timestamp is within the configured ingestion window.
-     * Rejects with HTTP 400 (or, in audit mode, counts + logs without rejecting). Encapsulates both
-     * data-quality checks behind one call. {@code workspaceId} tags the audit metric so offenders are
-     * attributable per workspace; pass {@link ErrorMetricsResolver#UNKNOWN} when it is not available.
+     * Validates an ingested {@code id}: it must be a version 7 UUID
+     * ({@link #validateVersion(UUID, String)}) whose embedded timestamp is within the configured
+     * ingestion window, throwing {@link InvalidUUIDException} otherwise. {@code workspaceId} attributes
+     * the source workspace for observability; pass {@link ErrorMetricsResolver#UNKNOWN} when unavailable.
      */
     void validateId(UUID id, String resource, String workspaceId);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/IdGenerator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/IdGenerator.java
@@ -50,6 +50,13 @@ public interface IdGenerator {
      */
     void validateIdNotInFuture(UUID id, String resource);
 
+    /**
+     * Workspace-attributed overload of {@link #validateIdNotInFuture(UUID, String)}: callers that know the
+     * request workspace pass it so the audit metric is attributed. The 2-arg form defaults to
+     * {@link ErrorMetricsResolver#UNKNOWN} for callers that don't carry a workspace.
+     */
+    void validateIdNotInFuture(UUID id, String resource, String workspaceId);
+
     Mono<UUID> validateIdNotInFutureAsync(UUID id, String resource);
 
     /**
@@ -57,6 +64,9 @@ public interface IdGenerator {
      * {@code projectId} that may be resolved by name instead). No-op when {@code id} is null.
      */
     void validateIdNotInFutureIfPresent(UUID id, String resource);
+
+    /** Workspace-attributed overload of {@link #validateIdNotInFutureIfPresent(UUID, String)}. */
+    void validateIdNotInFutureIfPresent(UUID id, String resource, String workspaceId);
 
     Mono<UUID> validateIdNotInFutureIfPresentAsync(UUID id, String resource);
 
@@ -112,18 +122,20 @@ class IdGeneratorImpl implements IdGenerator {
 
     @Override
     public void validateIdNotInFuture(@NonNull UUID id, String resource) {
+        // Callers that don't carry a workspace (most config-entity references) default to UNKNOWN.
+        validateIdNotInFuture(id, resource, ErrorMetricsResolver.UNKNOWN);
+    }
+
+    @Override
+    public void validateIdNotInFuture(@NonNull UUID id, String resource, String workspaceId) {
         IdGenerator.validateVersion(id, resource);
-        // Referenced/foreign ids are validated where the request-scoped workspace is not threaded
-        // (e.g. the synchronous fail-fast batch pass), so the audit metric falls back to UNKNOWN here;
-        // the batch's own ids still carry the workspace via validateId.
-        uuidV7TimestampValidator.validateNotInFuture(id, resource, ErrorMetricsResolver.UNKNOWN);
+        uuidV7TimestampValidator.validateNotInFuture(id, resource, workspaceId);
     }
 
     @Override
     public Mono<UUID> validateIdNotInFutureAsync(@NonNull UUID id, String resource) {
         return Mono.deferContextual(ctx -> {
-            IdGenerator.validateVersion(id, resource);
-            uuidV7TimestampValidator.validateNotInFuture(id, resource, workspaceId(ctx));
+            validateIdNotInFuture(id, resource, workspaceId(ctx));
             return Mono.just(id);
         });
     }
@@ -141,6 +153,13 @@ class IdGeneratorImpl implements IdGenerator {
     public void validateIdNotInFutureIfPresent(UUID id, String resource) {
         if (id != null) {
             validateIdNotInFuture(id, resource);
+        }
+    }
+
+    @Override
+    public void validateIdNotInFutureIfPresent(UUID id, String resource, String workspaceId) {
+        if (id != null) {
+            validateIdNotInFuture(id, resource, workspaceId);
         }
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/IdGenerator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/IdGenerator.java
@@ -104,10 +104,10 @@ class IdGeneratorImpl implements IdGenerator {
 
     @Override
     public Mono<UUID> validateIdAsync(@NonNull UUID id, String resource) {
-        return Mono.deferContextual(ctx -> Mono.fromCallable(() -> {
+        return Mono.deferContextual(ctx -> {
             validateId(id, resource, workspaceId(ctx));
-            return id;
-        }));
+            return Mono.just(id);
+        });
     }
 
     @Override
@@ -121,11 +121,11 @@ class IdGeneratorImpl implements IdGenerator {
 
     @Override
     public Mono<UUID> validateIdNotInFutureAsync(@NonNull UUID id, String resource) {
-        return Mono.deferContextual(ctx -> Mono.fromCallable(() -> {
+        return Mono.deferContextual(ctx -> {
             IdGenerator.validateVersion(id, resource);
             uuidV7TimestampValidator.validateNotInFuture(id, resource, workspaceId(ctx));
-            return id;
-        }));
+            return Mono.just(id);
+        });
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
@@ -393,7 +393,7 @@ public class SpanService {
                     Mono<List<Span>> resolveProjects = Flux.fromIterable(projectNames)
                             .flatMap(projectService::getOrCreate)
                             .collectList()
-                            .map(projects -> bindSpanToProjectAndId(dedupedSpans, projects));
+                            .map(projects -> bindSpanToProjectAndId(dedupedSpans, projects, workspaceId));
 
                     return resolveProjects
                             .flatMap(this::stripAttachmentsFromSpanBatch)
@@ -438,7 +438,7 @@ public class SpanService {
         return result;
     }
 
-    private List<Span> bindSpanToProjectAndId(List<Span> spans, List<Project> projects) {
+    private List<Span> bindSpanToProjectAndId(List<Span> spans, List<Project> projects, String workspaceId) {
         Map<String, Project> projectPerName = projects.stream()
                 .collect(Collectors.toMap(
                         WorkspaceUtils::stripProjectName,
@@ -459,7 +459,7 @@ public class SpanService {
                     }
 
                     UUID id = span.id() == null ? idGenerator.generateId() : span.id();
-                    idGenerator.validateId(id, SPAN_KEY);
+                    idGenerator.validateId(id, SPAN_KEY, workspaceId);
 
                     return span.toBuilder().id(id).projectId(project.id()).build();
                 })

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
@@ -375,15 +375,6 @@ public class SpanService {
 
         List<Span> dedupedSpans = dedupSpans(batch.spans());
 
-        // Fail fast on invalid ids BEFORE any side effect below (auto-stripped attachment deletion, project
-        // creation), so a rejected batch never mutates state.
-        dedupedSpans.forEach(span -> {
-            if (span.id() != null) {
-                idGenerator.validateId(span.id(), SPAN_KEY);
-            }
-            validateSpanReferences(span.traceId(), span.parentSpanId());
-        });
-
         List<String> projectNames = dedupedSpans
                 .stream()
                 .map(Span::projectName)
@@ -401,7 +392,19 @@ public class SpanService {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
 
-        return attachmentService.deleteAutoStrippedAttachments(SPAN, spanIds)
+        // Fail fast on invalid ids BEFORE any side effect below (auto-stripped attachment deletion, project
+        // creation), so a rejected batch never mutates state. Runs inside deferContextual so the audit
+        // metric can attribute the batch's own ids to the request workspace.
+        return Mono.deferContextual(validationCtx -> {
+            String validationWorkspaceId = validationCtx.get(RequestContext.WORKSPACE_ID);
+            dedupedSpans.forEach(span -> {
+                if (span.id() != null) {
+                    idGenerator.validateId(span.id(), SPAN_KEY, validationWorkspaceId);
+                }
+                validateSpanReferences(span.traceId(), span.parentSpanId());
+            });
+            return attachmentService.deleteAutoStrippedAttachments(SPAN, spanIds);
+        })
                 .then(Mono.deferContextual(ctx -> {
                     String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
                     String workspaceName = ctx.getOrDefault(RequestContext.WORKSPACE_NAME, "");
@@ -410,7 +413,7 @@ public class SpanService {
                     Mono<List<Span>> resolveProjects = Flux.fromIterable(projectNames)
                             .flatMap(projectService::getOrCreate)
                             .collectList()
-                            .map(projects -> bindSpanToProjectAndId(dedupedSpans, projects, workspaceId));
+                            .map(projects -> bindSpanToProjectAndId(dedupedSpans, projects));
 
                     return resolveProjects
                             .flatMap(this::stripAttachmentsFromSpanBatch)
@@ -462,7 +465,7 @@ public class SpanService {
         idGenerator.validateIdNotInFutureIfPresent(parentSpanId, SPAN_PARENT_KEY);
     }
 
-    private List<Span> bindSpanToProjectAndId(List<Span> spans, List<Project> projects, String workspaceId) {
+    private List<Span> bindSpanToProjectAndId(List<Span> spans, List<Project> projects) {
         Map<String, Project> projectPerName = projects.stream()
                 .collect(Collectors.toMap(
                         WorkspaceUtils::stripProjectName,
@@ -482,9 +485,8 @@ public class SpanService {
                         throw new IllegalStateException("Project not found: %s".formatted(span.projectName()));
                     }
 
+                    // Ids are already validated up-front in create(SpanBatch); generated ids are inherently valid.
                     UUID id = span.id() == null ? idGenerator.generateId() : span.id();
-
-                    idGenerator.validateId(id, SPAN_KEY, workspaceId);
 
                     return span.toBuilder().id(id).projectId(project.id()).build();
                 })

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -191,7 +191,18 @@ class TraceServiceImpl implements TraceService {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
 
-        return attachmentService.deleteAutoStrippedAttachments(EntityType.TRACE, traceIds)
+        // Fail fast on invalid ids BEFORE any side effect below (auto-stripped attachment deletion, project
+        // creation), so a rejected batch never mutates state. Runs inside deferContextual so the audit
+        // metric can attribute the batch's own ids to the request workspace.
+        return Mono.deferContextual(validationCtx -> {
+            String validationWorkspaceId = validationCtx.get(RequestContext.WORKSPACE_ID);
+            dedupedTraces.forEach(trace -> {
+                if (trace.id() != null) {
+                    idGenerator.validateId(trace.id(), TRACE_KEY, validationWorkspaceId);
+                }
+            });
+            return attachmentService.deleteAutoStrippedAttachments(EntityType.TRACE, traceIds);
+        })
                 .then(Mono.deferContextual(ctx -> {
                     String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
                     String workspaceName = ctx.getOrDefault(RequestContext.WORKSPACE_NAME, "");
@@ -200,7 +211,7 @@ class TraceServiceImpl implements TraceService {
                     Mono<List<Trace>> resolveProjects = Flux.fromIterable(projectNames)
                             .flatMap(projectService::getOrCreate)
                             .collectList()
-                            .map(projects -> bindTraceToProjectAndId(dedupedTraces, projects, workspaceId))
+                            .map(projects -> bindTraceToProjectAndId(dedupedTraces, projects))
                             .flatMapMany(Flux::fromIterable)
                             .flatMap(trace -> attachmentStripperService.stripAttachments(trace, workspaceId,
                                     userName,
@@ -237,7 +248,7 @@ class TraceServiceImpl implements TraceService {
         return result;
     }
 
-    private List<Trace> bindTraceToProjectAndId(List<Trace> traces, List<Project> projects, String workspaceId) {
+    private List<Trace> bindTraceToProjectAndId(List<Trace> traces, List<Project> projects) {
         Map<String, Project> projectPerName = projects.stream()
                 .collect(Collectors.toMap(
                         WorkspaceUtils::stripProjectName,
@@ -251,8 +262,8 @@ class TraceServiceImpl implements TraceService {
                     String projectName = WorkspaceUtils.getProjectName(trace.projectName());
                     Project project = projectPerName.get(projectName);
 
+                    // Ids are already validated up-front in create(TraceBatch); generated ids are inherently valid.
                     UUID id = trace.id() == null ? idGenerator.generateId() : trace.id();
-                    idGenerator.validateId(id, TRACE_KEY, workspaceId);
 
                     return trace.toBuilder().id(id).projectId(project.id()).projectName(project.name()).build();
                 })

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -200,7 +200,7 @@ class TraceServiceImpl implements TraceService {
                     Mono<List<Trace>> resolveProjects = Flux.fromIterable(projectNames)
                             .flatMap(projectService::getOrCreate)
                             .collectList()
-                            .map(projects -> bindTraceToProjectAndId(dedupedTraces, projects))
+                            .map(projects -> bindTraceToProjectAndId(dedupedTraces, projects, workspaceId))
                             .flatMapMany(Flux::fromIterable)
                             .flatMap(trace -> attachmentStripperService.stripAttachments(trace, workspaceId,
                                     userName,
@@ -237,7 +237,7 @@ class TraceServiceImpl implements TraceService {
         return result;
     }
 
-    private List<Trace> bindTraceToProjectAndId(List<Trace> traces, List<Project> projects) {
+    private List<Trace> bindTraceToProjectAndId(List<Trace> traces, List<Project> projects, String workspaceId) {
         Map<String, Project> projectPerName = projects.stream()
                 .collect(Collectors.toMap(
                         WorkspaceUtils::stripProjectName,
@@ -252,7 +252,7 @@ class TraceServiceImpl implements TraceService {
                     Project project = projectPerName.get(projectName);
 
                     UUID id = trace.id() == null ? idGenerator.generateId() : trace.id();
-                    idGenerator.validateId(id, TRACE_KEY);
+                    idGenerator.validateId(id, TRACE_KEY, workspaceId);
 
                     return trace.toBuilder().id(id).projectId(project.id()).projectName(project.name()).build();
                 })

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/UuidValidationConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/UuidValidationConfig.java
@@ -14,9 +14,17 @@ import java.util.concurrent.TimeUnit;
  * <p>{@code enabled} is an operational kill-switch: when {@code false}, ids are not checked against
  * {@code window}. {@code window} bounds the embedded-timestamp distance from now, so a misbehaving
  * client can't land a row in a far-future partition.
+ *
+ * <p>{@code auditOnly} adds a third, shadow state on top of the {@code enabled} switch. It only takes
+ * effect when {@code enabled} is {@code true}: instead of rejecting out-of-window ids, the validator
+ * records the reject-rate metric (tagged by workspace) and logs, but lets the write through. This
+ * surfaces offending clients in real time without breaking ingestion. The effective mode is:
+ * {@code enabled=false} → disabled (no-op); {@code enabled=true, auditOnly=true} → audit (count + log,
+ * no reject); {@code enabled=true, auditOnly=false} → reject (HTTP 400).
  */
 @Builder(toBuilder = true)
 public record UuidValidationConfig(
         boolean enabled,
+        boolean auditOnly,
         @NotNull @MinDuration(value = 12, unit = TimeUnit.HOURS) @MaxDuration(value = 45, unit = TimeUnit.DAYS) Duration window) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/UuidV7TimestampValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/UuidV7TimestampValidator.java
@@ -4,9 +4,11 @@ import com.comet.opik.api.error.InvalidUUIDException;
 import com.comet.opik.api.error.InvalidUUIDException.Reason;
 import com.comet.opik.domain.retention.RetentionUtils;
 import com.comet.opik.infrastructure.UuidValidationConfig;
+import com.comet.opik.infrastructure.metrics.UuidValidationMetrics;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
@@ -27,40 +29,54 @@ import java.util.UUID;
  * <p>The validation is intentionally version-agnostic on the timestamp bits: it checks the top 48
  * bits regardless of UUID version, because those bits drive partition placement on every write.
  *
- * <p>When {@code enabled} is false the validator is a no-op, acting as an operational kill-switch.
- * Rejections are signaled via {@link InvalidUUIDException}; the reject-rate metric is recorded by its
- * {@link com.comet.opik.api.error.InvalidUUIDExceptionMapper}.
+ * <p>Three modes, derived from {@link UuidValidationConfig}:
+ * <ul>
+ *   <li><b>disabled</b> ({@code enabled=false}): a no-op kill-switch, ids are not checked.</li>
+ *   <li><b>reject</b> ({@code enabled=true, auditOnly=false}): out-of-window ids are rejected via
+ *   {@link InvalidUUIDException} (HTTP 400); the reject-rate metric is recorded by its
+ *   {@link com.comet.opik.api.error.InvalidUUIDExceptionMapper}.</li>
+ *   <li><b>audit</b> ({@code enabled=true, auditOnly=true}): out-of-window ids are counted
+ *   ({@link UuidValidationMetrics}, tagged by workspace) and logged but NOT rejected — the shadow /
+ *   log-only mode that surfaces offenders without breaking ingestion (OPIK-7402).</li>
+ * </ul>
  */
+@Slf4j
 @Singleton
 public class UuidV7TimestampValidator {
 
     private final boolean enabled;
+    private final boolean auditOnly;
     private final Duration window;
+    private final UuidValidationMetrics metrics;
 
     @Inject
-    public UuidV7TimestampValidator(@NonNull @Config("uuidValidation") UuidValidationConfig config) {
+    public UuidV7TimestampValidator(@NonNull @Config("uuidValidation") UuidValidationConfig config,
+            @NonNull UuidValidationMetrics metrics) {
         this.enabled = config.enabled();
+        this.auditOnly = config.auditOnly();
         this.window = config.window().toJavaDuration();
+        this.metrics = metrics;
     }
 
     /**
-     * Throws {@link InvalidUUIDException} (HTTP 400) when the id's embedded timestamp is out of window
-     * (too old or too far in the future). No-op when validation is disabled or the id is acceptable.
-     * Used by the creation path.
+     * Rejects (HTTP 400) an id whose embedded timestamp is out of window (too old or too far in the
+     * future) in reject mode; counts + logs it without rejecting in audit mode; no-op when validation is
+     * disabled or the id is acceptable. Used by the creation path. {@code resource} (trace/span) and
+     * {@code workspaceId} are attached to the audit metric.
      */
-    public void validate(@NonNull UUID id) {
-        evaluate(id).ifPresent(this::reject);
+    public void validate(@NonNull UUID id, @NonNull String resource, String workspaceId) {
+        evaluate(id).ifPresent(rejection -> handle(rejection, resource, workspaceId));
     }
 
     /**
-     * Throws {@link InvalidUUIDException} (HTTP 400) only when the id's embedded timestamp is too far in
-     * the future. Old ids are accepted, so updating a long-lived entity (e.g. created months ago) is
-     * never rejected. Used by the update path.
+     * Like {@link #validate}, but only acts when the embedded timestamp is too far in the future. Old
+     * ids are accepted, so updating a long-lived entity (e.g. created months ago) is never flagged. Used
+     * by the update path.
      */
-    public void validateNotInFuture(@NonNull UUID id) {
+    public void validateNotInFuture(@NonNull UUID id, @NonNull String resource, String workspaceId) {
         evaluate(id)
                 .filter(rejection -> rejection.getLeft() == Reason.TOO_FAR_FUTURE)
-                .ifPresent(this::reject);
+                .ifPresent(rejection -> handle(rejection, resource, workspaceId));
     }
 
     /**
@@ -82,9 +98,20 @@ public class UuidV7TimestampValidator {
         return Optional.empty();
     }
 
-    private void reject(Pair<Reason, Instant> rejection) {
+    /**
+     * In audit mode, records the per-workspace reject-rate metric and logs the would-be rejection, then
+     * lets the write through. Otherwise throws {@link InvalidUUIDException} (HTTP 400).
+     */
+    private void handle(Pair<Reason, Instant> rejection, String resource, String workspaceId) {
         var reason = rejection.getLeft();
         var timestamp = rejection.getRight();
+        if (auditOnly) {
+            metrics.recordAudit(reason.getValue(), resource, workspaceId);
+            log.info(
+                    "UUIDv7 audit: would-reject {} id with embedded timestamp '{}' outside window '{}', reason '{}', workspace '{}'",
+                    resource, timestamp, window, reason.getValue(), workspaceId);
+            return;
+        }
         throw new InvalidUUIDException(reason,
                 "id with timestamp '%s' must be in the allowed ingestion window of '%s' around now, reason '%s'"
                         .formatted(timestamp, window, reason.getValue()));

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/UuidV7TimestampValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/UuidV7TimestampValidator.java
@@ -107,9 +107,11 @@ public class UuidV7TimestampValidator {
         var timestamp = rejection.getRight();
         if (auditOnly) {
             metrics.recordAudit(reason.getValue(), resource, workspaceId);
+            // Keep a fixed, searchable prefix ("UUIDv7 audit: would-reject id ...") and append the
+            // variable fields at the end, so log searches match on the message rather than the values.
             log.info(
-                    "UUIDv7 audit: would-reject {} id with embedded timestamp '{}' outside window '{}', reason '{}', workspace '{}'",
-                    resource, timestamp, window, reason.getValue(), workspaceId);
+                    "UUIDv7 audit: would-reject id, embedded timestamp '{}' outside window '{}', reason '{}', resource '{}', workspace '{}'",
+                    timestamp, window, reason.getValue(), resource, workspaceId);
             return;
         }
         throw new InvalidUUIDException(reason,

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/UuidV7TimestampValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/UuidV7TimestampValidator.java
@@ -64,7 +64,7 @@ public class UuidV7TimestampValidator {
      * disabled or the id is acceptable. Used by the creation path. {@code resource} (trace/span) and
      * {@code workspaceId} are attached to the audit metric.
      */
-    public void validate(@NonNull UUID id, @NonNull String resource, String workspaceId) {
+    public void validate(@NonNull UUID id, String resource, String workspaceId) {
         evaluate(id).ifPresent(rejection -> handle(rejection, resource, workspaceId));
     }
 
@@ -73,7 +73,7 @@ public class UuidV7TimestampValidator {
      * ids are accepted, so updating a long-lived entity (e.g. created months ago) is never flagged. Used
      * by the update path.
      */
-    public void validateNotInFuture(@NonNull UUID id, @NonNull String resource, String workspaceId) {
+    public void validateNotInFuture(@NonNull UUID id, String resource, String workspaceId) {
         evaluate(id)
                 .filter(rejection -> rejection.getLeft() == Reason.TOO_FAR_FUTURE)
                 .ifPresent(rejection -> handle(rejection, resource, workspaceId));

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/metrics/UuidValidationMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/metrics/UuidValidationMetrics.java
@@ -23,9 +23,10 @@ import static com.comet.opik.infrastructure.metrics.ErrorMetricsResolver.WORKSPA
  * <p>
  * It shares the counter name and description with {@link
  * com.comet.opik.api.error.InvalidUUIDExceptionMapper}, which records the same counter on the reject
- * path. The {@code mode} label distinguishes the two: {@code audit} here vs {@code reject} on the
- * enforced path. Only the audit path carries {@code workspace_id}, because the reject path runs in the
- * exception mapper where the request-scoped workspace is not threaded (a Story-2 follow-up).
+ * path. Both paths carry the {@code mode} label ({@link #MODE_AUDIT} here vs {@link #MODE_REJECT} on
+ * the enforced path), so a query can always split audit from reject. Only the audit path carries
+ * {@code workspace_id}: the reject path runs in the exception mapper where the request-scoped workspace
+ * is not threaded (tagging it there is a follow-up), and instead carries {@code http_route}.
  * <p>
  * The {@code workspace_id} label is bounded by the set of clients actually emitting out-of-window ids
  * (a small cohort), so it does not inflate metric cardinality the way an unconditional per-workspace
@@ -38,6 +39,7 @@ public class UuidValidationMetrics {
     private static final String COUNTER_DESCRIPTION = "Number of writes rejected because the id failed UUIDv7 ingestion validation";
 
     public static final String MODE_AUDIT = "audit";
+    public static final String MODE_REJECT = "reject";
 
     public static final AttributeKey<String> MODE_KEY = AttributeKey.stringKey("mode");
     public static final AttributeKey<String> REASON_KEY = AttributeKey.stringKey("reason");

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/metrics/UuidValidationMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/metrics/UuidValidationMetrics.java
@@ -1,0 +1,70 @@
+package com.comet.opik.infrastructure.metrics;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import org.apache.commons.lang3.StringUtils;
+
+import static com.comet.opik.infrastructure.metrics.ErrorMetricsResolver.UNKNOWN;
+import static com.comet.opik.infrastructure.metrics.ErrorMetricsResolver.WORKSPACE_ID_KEY;
+
+/**
+ * Records the {@code opik.ingestion.uuid_v7.rejected} counter for the audit (shadow / log-only) mode
+ * of {@link com.comet.opik.infrastructure.db.UuidV7TimestampValidator}, broken down by {@code
+ * workspace_id}, the failed-check {@code reason} and the {@code resource} (trace/span).
+ * <p>
+ * This is the freshness mechanism for the UUIDv7 re-enablement campaign (OPIK-7402): with the validator
+ * in audit mode, out-of-window ids are counted here per workspace but not rejected, so offending clients
+ * (e.g. the buggy LiteLLM native Opik integration) surface in real time without breaking ingestion.
+ * <p>
+ * It shares the counter name and description with {@link
+ * com.comet.opik.api.error.InvalidUUIDExceptionMapper}, which records the same counter on the reject
+ * path. The {@code mode} label distinguishes the two: {@code audit} here vs {@code reject} on the
+ * enforced path. Only the audit path carries {@code workspace_id}, because the reject path runs in the
+ * exception mapper where the request-scoped workspace is not threaded (a Story-2 follow-up).
+ * <p>
+ * The {@code workspace_id} label is bounded by the set of clients actually emitting out-of-window ids
+ * (a small cohort), so it does not inflate metric cardinality the way an unconditional per-workspace
+ * label would.
+ */
+@Singleton
+public class UuidValidationMetrics {
+
+    private static final String METRIC_NAMESPACE = "opik.ingestion";
+    private static final String COUNTER_DESCRIPTION = "Number of writes rejected because the id failed UUIDv7 ingestion validation";
+
+    public static final String MODE_AUDIT = "audit";
+
+    public static final AttributeKey<String> MODE_KEY = AttributeKey.stringKey("mode");
+    public static final AttributeKey<String> REASON_KEY = AttributeKey.stringKey("reason");
+    public static final AttributeKey<String> RESOURCE_KEY = AttributeKey.stringKey("resource");
+
+    private final LongCounter rejectedCounter;
+
+    public UuidValidationMetrics() {
+        Meter meter = GlobalOpenTelemetry.get().getMeter(METRIC_NAMESPACE);
+        this.rejectedCounter = meter
+                .counterBuilder("%s.uuid_v7.rejected".formatted(METRIC_NAMESPACE))
+                .setDescription(COUNTER_DESCRIPTION)
+                .build();
+    }
+
+    /**
+     * Records one audit-mode detection: an id that would have been rejected (out of window) but was let
+     * through. {@code reason} is the low-cardinality {@link
+     * com.comet.opik.api.error.InvalidUUIDException.Reason} value, {@code resource} the entity kind
+     * (trace/span), {@code workspaceId} the emitting workspace (falls back to {@code unknown}).
+     */
+    public void recordAudit(@NonNull String reason, @NonNull String resource, String workspaceId) {
+        rejectedCounter.add(1, Attributes.builder()
+                .put(MODE_KEY, MODE_AUDIT)
+                .put(REASON_KEY, reason)
+                .put(RESOURCE_KEY, StringUtils.defaultIfBlank(resource, UNKNOWN))
+                .put(WORKSPACE_ID_KEY, StringUtils.defaultIfBlank(workspaceId, UNKNOWN))
+                .build());
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/metrics/UuidValidationMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/metrics/UuidValidationMetrics.java
@@ -3,6 +3,7 @@ package com.comet.opik.infrastructure.metrics;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import jakarta.inject.Singleton;
@@ -63,12 +64,9 @@ public class UuidValidationMetrics {
      * (trace/span), {@code workspaceId} the emitting workspace. All fall back to {@code unknown}.
      */
     public void recordAudit(String reason, String resource, String workspaceId) {
-        rejectedCounter.add(1, Attributes.builder()
-                .put(MODE_KEY, MODE_AUDIT)
-                .put(REASON_KEY, StringUtils.defaultIfBlank(reason, UNKNOWN))
+        record(MODE_AUDIT, reason, Attributes.builder()
                 .put(RESOURCE_KEY, StringUtils.defaultIfBlank(resource, UNKNOWN))
-                .put(WORKSPACE_ID_KEY, StringUtils.defaultIfBlank(workspaceId, UNKNOWN))
-                .build());
+                .put(WORKSPACE_ID_KEY, StringUtils.defaultIfBlank(workspaceId, UNKNOWN)));
     }
 
     /**
@@ -78,10 +76,18 @@ public class UuidValidationMetrics {
      * fall back to {@code unknown}.
      */
     public void recordReject(String reason, String httpRoute) {
-        rejectedCounter.add(1, Attributes.builder()
-                .put(MODE_KEY, MODE_REJECT)
+        record(MODE_REJECT, reason, Attributes.builder()
+                .put(HTTP_ROUTE_KEY, StringUtils.defaultIfBlank(httpRoute, UNKNOWN)));
+    }
+
+    /**
+     * Shared assembly for the {@code opik.ingestion.uuid_v7.rejected} counter: stamps the common
+     * {@code mode} and {@code reason} tags onto the caller's path-specific attributes and increments.
+     */
+    private void record(String mode, String reason, AttributesBuilder attributes) {
+        rejectedCounter.add(1, attributes
+                .put(MODE_KEY, mode)
                 .put(REASON_KEY, StringUtils.defaultIfBlank(reason, UNKNOWN))
-                .put(HTTP_ROUTE_KEY, StringUtils.defaultIfBlank(httpRoute, UNKNOWN))
                 .build());
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/metrics/UuidValidationMetrics.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/metrics/UuidValidationMetrics.java
@@ -6,27 +6,27 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import jakarta.inject.Singleton;
-import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
 
 import static com.comet.opik.infrastructure.metrics.ErrorMetricsResolver.UNKNOWN;
 import static com.comet.opik.infrastructure.metrics.ErrorMetricsResolver.WORKSPACE_ID_KEY;
 
 /**
- * Records the {@code opik.ingestion.uuid_v7.rejected} counter for the audit (shadow / log-only) mode
- * of {@link com.comet.opik.infrastructure.db.UuidV7TimestampValidator}, broken down by {@code
- * workspace_id}, the failed-check {@code reason} and the {@code resource} (trace/span).
+ * Central owner of the {@code opik.ingestion.uuid_v7.rejected} counter — the single place that defines
+ * the instrument and its label vocabulary for both UUIDv7 ingestion-validation paths. The validator
+ * ({@link com.comet.opik.infrastructure.db.UuidV7TimestampValidator}) records the audit (shadow /
+ * log-only) path via {@link #recordAudit}; the exception mapper
+ * ({@link com.comet.opik.api.error.InvalidUUIDExceptionMapper}) delegates the enforced reject path via
+ * {@link #recordReject}.
  * <p>
  * This is the freshness mechanism for the UUIDv7 re-enablement campaign (OPIK-7402): with the validator
  * in audit mode, out-of-window ids are counted here per workspace but not rejected, so offending clients
  * (e.g. the buggy LiteLLM native Opik integration) surface in real time without breaking ingestion.
  * <p>
- * It shares the counter name and description with {@link
- * com.comet.opik.api.error.InvalidUUIDExceptionMapper}, which records the same counter on the reject
- * path. Both paths carry the {@code mode} label ({@link #MODE_AUDIT} here vs {@link #MODE_REJECT} on
- * the enforced path), so a query can always split audit from reject. Only the audit path carries
- * {@code workspace_id}: the reject path runs in the exception mapper where the request-scoped workspace
- * is not threaded (tagging it there is a follow-up), and instead carries {@code http_route}.
+ * Both paths carry the {@code mode} label ({@link #MODE_AUDIT} vs {@link #MODE_REJECT}), so a query can
+ * always split audit from reject. Only the audit path carries {@code workspace_id}: the reject path runs
+ * in the exception mapper where the request-scoped workspace is not threaded (tagging it there is a
+ * follow-up), and instead carries {@code http_route}.
  * <p>
  * The {@code workspace_id} label is bounded by the set of clients actually emitting out-of-window ids
  * (a small cohort), so it does not inflate metric cardinality the way an unconditional per-workspace
@@ -44,6 +44,7 @@ public class UuidValidationMetrics {
     public static final AttributeKey<String> MODE_KEY = AttributeKey.stringKey("mode");
     public static final AttributeKey<String> REASON_KEY = AttributeKey.stringKey("reason");
     public static final AttributeKey<String> RESOURCE_KEY = AttributeKey.stringKey("resource");
+    public static final AttributeKey<String> HTTP_ROUTE_KEY = AttributeKey.stringKey("http_route");
 
     private final LongCounter rejectedCounter;
 
@@ -59,14 +60,28 @@ public class UuidValidationMetrics {
      * Records one audit-mode detection: an id that would have been rejected (out of window) but was let
      * through. {@code reason} is the low-cardinality {@link
      * com.comet.opik.api.error.InvalidUUIDException.Reason} value, {@code resource} the entity kind
-     * (trace/span), {@code workspaceId} the emitting workspace (falls back to {@code unknown}).
+     * (trace/span), {@code workspaceId} the emitting workspace. All fall back to {@code unknown}.
      */
-    public void recordAudit(@NonNull String reason, @NonNull String resource, String workspaceId) {
+    public void recordAudit(String reason, String resource, String workspaceId) {
         rejectedCounter.add(1, Attributes.builder()
                 .put(MODE_KEY, MODE_AUDIT)
-                .put(REASON_KEY, reason)
+                .put(REASON_KEY, StringUtils.defaultIfBlank(reason, UNKNOWN))
                 .put(RESOURCE_KEY, StringUtils.defaultIfBlank(resource, UNKNOWN))
                 .put(WORKSPACE_ID_KEY, StringUtils.defaultIfBlank(workspaceId, UNKNOWN))
+                .build());
+    }
+
+    /**
+     * Records one enforced rejection (HTTP 400), delegated from {@link
+     * com.comet.opik.api.error.InvalidUUIDExceptionMapper}. Tagged by {@code reason} and the matched
+     * {@code http_route}; {@code workspace_id} is intentionally omitted (not threaded on that path). All
+     * fall back to {@code unknown}.
+     */
+    public void recordReject(String reason, String httpRoute) {
+        rejectedCounter.add(1, Attributes.builder()
+                .put(MODE_KEY, MODE_REJECT)
+                .put(REASON_KEY, StringUtils.defaultIfBlank(reason, UNKNOWN))
+                .put(HTTP_ROUTE_KEY, StringUtils.defaultIfBlank(httpRoute, UNKNOWN))
                 .build());
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/IdGeneratorAsyncValidationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/IdGeneratorAsyncValidationTest.java
@@ -1,0 +1,114 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.error.InvalidUUIDException;
+import com.comet.opik.infrastructure.UuidValidationConfig;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.db.TestUuidV7TimestampValidatorFactory;
+import io.dropwizard.util.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import reactor.util.context.Context;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+/**
+ * Covers the reactive validation paths of {@link IdGenerator} (which the sync {@link
+ * UuidV7TimestampValidatorTest} does not): {@code validateIdAsync} / {@code validateIdForUpdateAsync}
+ * resolve {@code workspaceId} from the Reactor context via {@code deferContextual}, falling back to
+ * {@link com.comet.opik.infrastructure.metrics.ErrorMetricsResolver#UNKNOWN} when the context has no
+ * {@link RequestContext#WORKSPACE_ID}. Both cases must preserve the accept/reject behavior.
+ */
+@DisplayName("IdGenerator reactive validation")
+class IdGeneratorAsyncValidationTest {
+
+    private static final String RESOURCE = "trace";
+    private static final Duration WINDOW = Duration.hours(24);
+
+    // Reject mode: enabled=true, auditOnly=false (config-test default).
+    private final IdGenerator rejectGenerator = TestIdGeneratorFactory.create();
+    // Audit mode: enabled=true, auditOnly=true.
+    private final IdGenerator auditGenerator = new IdGeneratorImpl(TestUuidV7TimestampValidatorFactory.create(
+            UuidValidationConfig.builder().enabled(true).auditOnly(true).window(WINDOW).build()));
+
+    private UUID idAt(Instant instant) {
+        return rejectGenerator.getTimeOrderedEpoch(instant.toEpochMilli());
+    }
+
+    private UUID inWindowId() {
+        return idAt(Instant.now());
+    }
+
+    private UUID tooFarFutureId() {
+        return idAt(Instant.now().plus(48, ChronoUnit.HOURS));
+    }
+
+    private static Context withWorkspace() {
+        return Context.of(RequestContext.WORKSPACE_ID, "ws-async");
+    }
+
+    @Test
+    @DisplayName("reject: validateIdAsync passes an in-window id through (workspace in context)")
+    void rejectAsyncAcceptsInWindow() {
+        var id = inWindowId();
+        StepVerifier.create(rejectGenerator.validateIdAsync(id, RESOURCE).contextWrite(withWorkspace()))
+                .expectNext(id)
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("reject: validateIdAsync rejects a too-far-future id (workspace in context)")
+    void rejectAsyncRejectsFuture() {
+        StepVerifier.create(rejectGenerator.validateIdAsync(tooFarFutureId(), RESOURCE).contextWrite(withWorkspace()))
+                .expectError(InvalidUUIDException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("reject: validateIdAsync still rejects when the context has no workspace id")
+    void rejectAsyncRejectsFutureWithoutContext() {
+        StepVerifier.create(rejectGenerator.validateIdAsync(tooFarFutureId(), RESOURCE))
+                .expectError(InvalidUUIDException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("reject: validateIdForUpdateAsync rejects only too-far-future, accepts old ids")
+    void rejectForUpdateAsync() {
+        var oldId = idAt(Instant.now().minus(48, ChronoUnit.HOURS));
+        StepVerifier.create(rejectGenerator.validateIdForUpdateAsync(oldId, RESOURCE).contextWrite(withWorkspace()))
+                .expectNext(oldId)
+                .verifyComplete();
+        StepVerifier
+                .create(rejectGenerator.validateIdForUpdateAsync(tooFarFutureId(), RESOURCE)
+                        .contextWrite(withWorkspace()))
+                .expectError(InvalidUUIDException.class)
+                .verify();
+    }
+
+    @Test
+    @DisplayName("audit: validateIdAsync passes a too-far-future id through, with and without workspace context")
+    void auditAsyncNeverRejects() {
+        var withCtxId = tooFarFutureId();
+        StepVerifier.create(auditGenerator.validateIdAsync(withCtxId, RESOURCE).contextWrite(withWorkspace()))
+                .expectNext(withCtxId)
+                .verifyComplete();
+
+        var noCtxId = tooFarFutureId();
+        StepVerifier.create(auditGenerator.validateIdAsync(noCtxId, RESOURCE))
+                .expectNext(noCtxId)
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("audit: validateIdForUpdateAsync passes a too-far-future id through")
+    void auditForUpdateAsyncNeverRejects() {
+        var id = tooFarFutureId();
+        StepVerifier.create(Mono.defer(() -> auditGenerator.validateIdForUpdateAsync(id, RESOURCE)))
+                .expectNext(id)
+                .verifyComplete();
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/IdGeneratorAsyncValidationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/IdGeneratorAsyncValidationTest.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 
 /**
  * Covers the reactive validation paths of {@link IdGenerator} (which the sync {@link
- * UuidV7TimestampValidatorTest} does not): {@code validateIdAsync} / {@code validateIdForUpdateAsync}
+ * UuidV7TimestampValidatorTest} does not): {@code validateIdAsync} / {@code validateIdNotInFutureAsync}
  * resolve {@code workspaceId} from the Reactor context via {@code deferContextual}, falling back to
  * {@link com.comet.opik.infrastructure.metrics.ErrorMetricsResolver#UNKNOWN} when the context has no
  * {@link RequestContext#WORKSPACE_ID}. Both cases must preserve the accept/reject behavior.
@@ -76,14 +76,14 @@ class IdGeneratorAsyncValidationTest {
     }
 
     @Test
-    @DisplayName("reject: validateIdForUpdateAsync rejects only too-far-future, accepts old ids")
+    @DisplayName("reject: validateIdNotInFutureAsync rejects only too-far-future, accepts old ids")
     void rejectForUpdateAsync() {
         var oldId = idAt(Instant.now().minus(48, ChronoUnit.HOURS));
-        StepVerifier.create(rejectGenerator.validateIdForUpdateAsync(oldId, RESOURCE).contextWrite(withWorkspace()))
+        StepVerifier.create(rejectGenerator.validateIdNotInFutureAsync(oldId, RESOURCE).contextWrite(withWorkspace()))
                 .expectNext(oldId)
                 .verifyComplete();
         StepVerifier
-                .create(rejectGenerator.validateIdForUpdateAsync(tooFarFutureId(), RESOURCE)
+                .create(rejectGenerator.validateIdNotInFutureAsync(tooFarFutureId(), RESOURCE)
                         .contextWrite(withWorkspace()))
                 .expectError(InvalidUUIDException.class)
                 .verify();
@@ -104,10 +104,10 @@ class IdGeneratorAsyncValidationTest {
     }
 
     @Test
-    @DisplayName("audit: validateIdForUpdateAsync passes a too-far-future id through")
+    @DisplayName("audit: validateIdNotInFutureAsync passes a too-far-future id through")
     void auditForUpdateAsyncNeverRejects() {
         var id = tooFarFutureId();
-        StepVerifier.create(Mono.defer(() -> auditGenerator.validateIdForUpdateAsync(id, RESOURCE)))
+        StepVerifier.create(Mono.defer(() -> auditGenerator.validateIdNotInFutureAsync(id, RESOURCE)))
                 .expectNext(id)
                 .verifyComplete();
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/IdGeneratorAsyncValidationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/IdGeneratorAsyncValidationTest.java
@@ -29,13 +29,13 @@ class IdGeneratorAsyncValidationTest {
     private static final Duration WINDOW = Duration.hours(24);
 
     // Reject mode: enabled=true, auditOnly=false (config-test default).
-    private final IdGenerator rejectGenerator = TestIdGeneratorFactory.create();
+    private static final IdGenerator REJECT_GENERATOR = TestIdGeneratorFactory.create();
     // Audit mode: enabled=true, auditOnly=true.
-    private final IdGenerator auditGenerator = new IdGeneratorImpl(TestUuidV7TimestampValidatorFactory.create(
+    private static final IdGenerator AUDIT_GENERATOR = new IdGeneratorImpl(TestUuidV7TimestampValidatorFactory.create(
             UuidValidationConfig.builder().enabled(true).auditOnly(true).window(WINDOW).build()));
 
     private UUID idAt(Instant instant) {
-        return rejectGenerator.getTimeOrderedEpoch(instant.toEpochMilli());
+        return REJECT_GENERATOR.getTimeOrderedEpoch(instant.toEpochMilli());
     }
 
     private UUID inWindowId() {
@@ -54,7 +54,7 @@ class IdGeneratorAsyncValidationTest {
     @DisplayName("reject: validateIdAsync passes an in-window id through (workspace in context)")
     void rejectAsyncAcceptsInWindow() {
         var id = inWindowId();
-        StepVerifier.create(rejectGenerator.validateIdAsync(id, RESOURCE).contextWrite(withWorkspace()))
+        StepVerifier.create(REJECT_GENERATOR.validateIdAsync(id, RESOURCE).contextWrite(withWorkspace()))
                 .expectNext(id)
                 .verifyComplete();
     }
@@ -62,7 +62,7 @@ class IdGeneratorAsyncValidationTest {
     @Test
     @DisplayName("reject: validateIdAsync rejects a too-far-future id (workspace in context)")
     void rejectAsyncRejectsFuture() {
-        StepVerifier.create(rejectGenerator.validateIdAsync(tooFarFutureId(), RESOURCE).contextWrite(withWorkspace()))
+        StepVerifier.create(REJECT_GENERATOR.validateIdAsync(tooFarFutureId(), RESOURCE).contextWrite(withWorkspace()))
                 .expectError(InvalidUUIDException.class)
                 .verify();
     }
@@ -70,7 +70,7 @@ class IdGeneratorAsyncValidationTest {
     @Test
     @DisplayName("reject: validateIdAsync still rejects when the context has no workspace id")
     void rejectAsyncRejectsFutureWithoutContext() {
-        StepVerifier.create(rejectGenerator.validateIdAsync(tooFarFutureId(), RESOURCE))
+        StepVerifier.create(REJECT_GENERATOR.validateIdAsync(tooFarFutureId(), RESOURCE))
                 .expectError(InvalidUUIDException.class)
                 .verify();
     }
@@ -79,11 +79,11 @@ class IdGeneratorAsyncValidationTest {
     @DisplayName("reject: validateIdNotInFutureAsync rejects only too-far-future, accepts old ids")
     void rejectForUpdateAsync() {
         var oldId = idAt(Instant.now().minus(48, ChronoUnit.HOURS));
-        StepVerifier.create(rejectGenerator.validateIdNotInFutureAsync(oldId, RESOURCE).contextWrite(withWorkspace()))
+        StepVerifier.create(REJECT_GENERATOR.validateIdNotInFutureAsync(oldId, RESOURCE).contextWrite(withWorkspace()))
                 .expectNext(oldId)
                 .verifyComplete();
         StepVerifier
-                .create(rejectGenerator.validateIdNotInFutureAsync(tooFarFutureId(), RESOURCE)
+                .create(REJECT_GENERATOR.validateIdNotInFutureAsync(tooFarFutureId(), RESOURCE)
                         .contextWrite(withWorkspace()))
                 .expectError(InvalidUUIDException.class)
                 .verify();
@@ -93,12 +93,12 @@ class IdGeneratorAsyncValidationTest {
     @DisplayName("audit: validateIdAsync passes a too-far-future id through, with and without workspace context")
     void auditAsyncNeverRejects() {
         var withCtxId = tooFarFutureId();
-        StepVerifier.create(auditGenerator.validateIdAsync(withCtxId, RESOURCE).contextWrite(withWorkspace()))
+        StepVerifier.create(AUDIT_GENERATOR.validateIdAsync(withCtxId, RESOURCE).contextWrite(withWorkspace()))
                 .expectNext(withCtxId)
                 .verifyComplete();
 
         var noCtxId = tooFarFutureId();
-        StepVerifier.create(auditGenerator.validateIdAsync(noCtxId, RESOURCE))
+        StepVerifier.create(AUDIT_GENERATOR.validateIdAsync(noCtxId, RESOURCE))
                 .expectNext(noCtxId)
                 .verifyComplete();
     }
@@ -107,7 +107,7 @@ class IdGeneratorAsyncValidationTest {
     @DisplayName("audit: validateIdNotInFutureAsync passes a too-far-future id through")
     void auditForUpdateAsyncNeverRejects() {
         var id = tooFarFutureId();
-        StepVerifier.create(Mono.defer(() -> auditGenerator.validateIdNotInFutureAsync(id, RESOURCE)))
+        StepVerifier.create(Mono.defer(() -> AUDIT_GENERATOR.validateIdNotInFutureAsync(id, RESOURCE)))
                 .expectNext(id)
                 .verifyComplete();
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/TestUuidV7TimestampValidatorFactory.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/TestUuidV7TimestampValidatorFactory.java
@@ -2,6 +2,7 @@ package com.comet.opik.infrastructure.db;
 
 import com.comet.opik.TestConfigUtils;
 import com.comet.opik.infrastructure.UuidValidationConfig;
+import com.comet.opik.infrastructure.metrics.UuidValidationMetrics;
 import lombok.experimental.UtilityClass;
 
 /**
@@ -15,6 +16,14 @@ public class TestUuidV7TimestampValidatorFactory {
     private static final UuidValidationConfig CONFIG = TestConfigUtils.loadConfigTest().getUuidValidation();
 
     public UuidV7TimestampValidator create() {
-        return new UuidV7TimestampValidator(CONFIG);
+        return create(CONFIG);
+    }
+
+    /**
+     * Builds the validator from an explicit config, so tests can exercise the disabled / reject / audit
+     * modes. The audit metric uses the no-op global OpenTelemetry instance under test.
+     */
+    public UuidV7TimestampValidator create(UuidValidationConfig config) {
+        return new UuidV7TimestampValidator(config, new UuidValidationMetrics());
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/UuidV7TimestampValidatorTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/UuidV7TimestampValidatorTest.java
@@ -1,0 +1,124 @@
+package com.comet.opik.infrastructure.db;
+
+import com.comet.opik.api.error.InvalidUUIDException;
+import com.comet.opik.api.error.InvalidUUIDException.Reason;
+import com.comet.opik.domain.IdGenerator;
+import com.comet.opik.domain.TestIdGeneratorFactory;
+import com.comet.opik.infrastructure.UuidValidationConfig;
+import io.dropwizard.util.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("UuidV7TimestampValidator modes")
+class UuidV7TimestampValidatorTest {
+
+    private static final String RESOURCE = "trace";
+    private static final String WORKSPACE_ID = "ws-123";
+    private static final Duration WINDOW = Duration.hours(24);
+
+    private final IdGenerator idGenerator = TestIdGeneratorFactory.create();
+
+    private UUID idAt(Instant instant) {
+        return idGenerator.getTimeOrderedEpoch(instant.toEpochMilli());
+    }
+
+    private UUID inWindowId() {
+        return idAt(Instant.now());
+    }
+
+    private UUID tooFarFutureId() {
+        return idAt(Instant.now().plus(48, ChronoUnit.HOURS));
+    }
+
+    private UUID tooOldId() {
+        return idAt(Instant.now().minus(48, ChronoUnit.HOURS));
+    }
+
+    private UuidV7TimestampValidator validator(boolean enabled, boolean auditOnly) {
+        return TestUuidV7TimestampValidatorFactory.create(UuidValidationConfig.builder()
+                .enabled(enabled)
+                .auditOnly(auditOnly)
+                .window(WINDOW)
+                .build());
+    }
+
+    @Nested
+    @DisplayName("disabled (enabled=false)")
+    class Disabled {
+
+        private final UuidV7TimestampValidator validator = validator(false, false);
+
+        @Test
+        @DisplayName("accepts out-of-window ids on both paths")
+        void acceptsEverything() {
+            assertThatCode(() -> validator.validate(tooFarFutureId(), RESOURCE, WORKSPACE_ID))
+                    .doesNotThrowAnyException();
+            assertThatCode(() -> validator.validate(tooOldId(), RESOURCE, WORKSPACE_ID)).doesNotThrowAnyException();
+            assertThatCode(() -> validator.validateNotInFuture(tooFarFutureId(), RESOURCE, WORKSPACE_ID))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("reject (enabled=true, auditOnly=false)")
+    class Reject {
+
+        private final UuidV7TimestampValidator validator = validator(true, false);
+
+        @Test
+        @DisplayName("validate: accepts in-window, rejects too-old and too-far-future")
+        void validate() {
+            assertThatCode(() -> validator.validate(inWindowId(), RESOURCE, WORKSPACE_ID)).doesNotThrowAnyException();
+            assertThatThrownBy(() -> validator.validate(tooOldId(), RESOURCE, WORKSPACE_ID))
+                    .isInstanceOf(InvalidUUIDException.class)
+                    .extracting(e -> ((InvalidUUIDException) e).getReason()).isEqualTo(Reason.TOO_OLD);
+            assertThatThrownBy(() -> validator.validate(tooFarFutureId(), RESOURCE, WORKSPACE_ID))
+                    .isInstanceOf(InvalidUUIDException.class)
+                    .extracting(e -> ((InvalidUUIDException) e).getReason()).isEqualTo(Reason.TOO_FAR_FUTURE);
+        }
+
+        @Test
+        @DisplayName("validateNotInFuture: accepts too-old, rejects only too-far-future")
+        void validateNotInFuture() {
+            assertThatCode(() -> validator.validateNotInFuture(tooOldId(), RESOURCE, WORKSPACE_ID))
+                    .doesNotThrowAnyException();
+            assertThatThrownBy(() -> validator.validateNotInFuture(tooFarFutureId(), RESOURCE, WORKSPACE_ID))
+                    .isInstanceOf(InvalidUUIDException.class)
+                    .extracting(e -> ((InvalidUUIDException) e).getReason()).isEqualTo(Reason.TOO_FAR_FUTURE);
+        }
+    }
+
+    @Nested
+    @DisplayName("audit (enabled=true, auditOnly=true)")
+    class Audit {
+
+        private final UuidV7TimestampValidator validator = validator(true, true);
+
+        @Test
+        @DisplayName("never rejects, even for out-of-window ids (shadow / log-only)")
+        void neverRejects() {
+            assertThatCode(() -> validator.validate(inWindowId(), RESOURCE, WORKSPACE_ID)).doesNotThrowAnyException();
+            assertThatCode(() -> validator.validate(tooOldId(), RESOURCE, WORKSPACE_ID)).doesNotThrowAnyException();
+            assertThatCode(() -> validator.validate(tooFarFutureId(), RESOURCE, WORKSPACE_ID))
+                    .doesNotThrowAnyException();
+            assertThatCode(() -> validator.validateNotInFuture(tooFarFutureId(), RESOURCE, WORKSPACE_ID))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("tolerates a blank workspace id (falls back to unknown in the metric)")
+        void toleratesBlankWorkspace() {
+            assertThat(validator).isNotNull();
+            assertThatCode(() -> validator.validate(tooFarFutureId(), RESOURCE, "")).doesNotThrowAnyException();
+        }
+    }
+}

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -118,6 +118,10 @@ uuidValidation:
   #  Description: Operational kill-switch. When false, ids are not checked against the window (the
   #   window is still validated to be a sane value).
   enabled: true
+  #  Default: false for tests
+  #  Description: Audit (shadow / log-only) mode. When true, out-of-window ids are counted and logged
+  #   but not rejected. Tests default to false so the validator rejects.
+  auditOnly: false
   #  Default: 24h
   #  Description: Validation window (between 12h and 45d). Writes whose `id` is a UUIDv7 with an
   #   embedded timestamp more than this far in the past or future are rejected.


### PR DESCRIPTION
## Details

Adds a third **audit** (shadow / log-only) state to `uuidValidation`, on top of the existing `enabled` kill-switch. When `enabled=true` and `auditOnly=true`, ids whose embedded UUIDv7 timestamp is out of the window are **counted and logged but not rejected**, so clients emitting them surface in real time without breaking ingestion. This is the freshness mechanism for safely re-enabling rejection later.

- Effective mode: `enabled=false` → disabled (no-op); `enabled=true & auditOnly=true` → audit; `enabled=true & auditOnly=false` → reject (HTTP 400, unchanged).
- Audit mode emits `opik.ingestion.uuid_v7.rejected` (`mode=audit`) tagged by `workspace_id` + `reason` + `resource`, so offenders can be broken down per workspace. It shares the counter/instrument with the reject-path mapper.
- Scope is the window check (the `enabled`-gated one). The always-on NOT_V7 version check is unchanged. `workspace_id` is read from the reactive context on the async paths and threaded through the batch bind on the sync path; `project_id` is not available at this layer and is left as a follow-up. Reject-path workspace tagging is likewise a follow-up.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7402

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8 (1M context)
- Scope: full implementation (config, validator, metrics recorder, call-site plumbing, unit test) and this description, authored under human direction and review.
- Human verification: design decisions (additive `auditOnly` flag, scope limited to the window check, workspace-only tagging) chosen by the author; `mvn test-compile` and the new unit test run and green locally; diff reviewed.

## Testing

- `mvn test-compile` — BUILD SUCCESS (main + tests).
- `mvn surefire:test -Dtest=UuidV7TimestampValidatorTest` — 5 tests, 0 failures. Covers all three modes: disabled (accepts out-of-window ids), reject (accepts in-window; rejects too-old/too-far-future on create, only too-far-future on update), audit (never rejects, tolerates a blank workspace id).
- Not run locally: resource/integration tests (bootstrap is flaky locally) — left to CI.

## Documentation

Config documented inline in `config.yml` / `config-test.yml` (new `auditOnly` key, effective-mode table) and in the `UuidValidationConfig` / `UuidV7TimestampValidator` / `UuidValidationMetrics` javadoc. No user-facing docs change.
