### PR TITLE
[OPIK-7438] [BE] fix: gate sampling params for Anthropic adaptive-thinking models on the playground/inference path

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/AnthropicClientGenerator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/AnthropicClientGenerator.java
@@ -109,7 +109,7 @@ public class AnthropicClientGenerator implements LlmProviderClientGenerator<Anth
             budgetTokens = budgetNode.asInt();
         }
 
-        return new ThinkingParams(type != null && !"disabled".equals(type), type, budgetTokens);
+        return new ThinkingParams(type != null && !"disabled".equalsIgnoreCase(type), type, budgetTokens);
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/LlmProviderAnthropicMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/LlmProviderAnthropicMapper.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @Mapper
@@ -57,13 +58,52 @@ interface LlmProviderAnthropicMapper {
 
     @Mapping(expression = "java(request.model())", target = "model")
     @Mapping(expression = "java(Boolean.TRUE.equals(request.stream()))", target = "stream")
-    @Mapping(expression = "java(request.temperature())", target = "temperature")
-    @Mapping(expression = "java(request.temperature() != null ? null : request.topP())", target = "topP")
+    @Mapping(source = "request", target = "temperature", qualifiedByName = "resolveTemperature")
+    @Mapping(source = "request", target = "topP", qualifiedByName = "resolveTopP")
     @Mapping(expression = "java(request.stop())", target = "stopSequences")
     @Mapping(source = "request", target = "maxTokens", qualifiedByName = "resolveMaxTokens")
     @Mapping(source = "request", target = "messages", qualifiedByName = "mapToMessages")
     @Mapping(source = "request", target = "system", qualifiedByName = "mapToSystemMessages")
     AnthropicCreateMessageRequest toCreateMessageRequest(@NonNull ChatCompletionRequest request);
+
+    @Named("resolveTemperature")
+    default Double resolveTemperature(@NonNull ChatCompletionRequest request) {
+        return samplingParamsAllowed(request) ? request.temperature() : null;
+    }
+
+    @Named("resolveTopP")
+    default Double resolveTopP(@NonNull ChatCompletionRequest request) {
+        if (!samplingParamsAllowed(request)) {
+            return null;
+        }
+        // Anthropic recommends against sending temperature and top_p together; temperature wins when both are set.
+        return request.temperature() != null ? null : request.topP();
+    }
+
+    /**
+     * Anthropic rejects sampling params (temperature/top_p) with a 400 for adaptive-thinking models
+     * (claude-sonnet-5, claude-opus-4-7/4-8) and whenever extended thinking is enabled for the request.
+     * Gate them server-side so API-created requests — which bypass the FE sanitizer from OPIK-6244 — don't
+     * fail. Mirrors the judge-path logic in {@code AnthropicClientGenerator}.
+     */
+    private boolean samplingParamsAllowed(ChatCompletionRequest request) {
+        return AnthropicModelName.supportsSamplingParams(request.model()) && !thinkingEnabled(request);
+    }
+
+    /**
+     * Extended thinking counts as enabled only when the request's {@code custom_parameters.thinking.type} is an
+     * explicit, non-blank value other than {@code "disabled"} — so {@code "enabled"}, {@code "adaptive"}, and any
+     * future type gate sampling params off, while a missing/blank type (or absent block) leaves them untouched.
+     */
+    private boolean thinkingEnabled(ChatCompletionRequest request) {
+        if (request.customParameters() == null
+                || !(request.customParameters().get("thinking") instanceof Map<?, ?> thinking)) {
+            return false;
+        }
+        return thinking.get("type") instanceof String type
+                && StringUtils.isNotBlank(type)
+                && !"disabled".equals(type);
+    }
 
     @Named("resolveMaxTokens")
     default Integer resolveMaxTokens(@NonNull ChatCompletionRequest request) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/LlmProviderAnthropicMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/LlmProviderAnthropicMapper.java
@@ -102,7 +102,7 @@ interface LlmProviderAnthropicMapper {
         }
         return thinking.get("type") instanceof String type
                 && StringUtils.isNotBlank(type)
-                && !"disabled".equals(type);
+                && !"disabled".equalsIgnoreCase(type);
     }
 
     @Named("resolveMaxTokens")

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/antropic/AnthropicMappersTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/antropic/AnthropicMappersTest.java
@@ -9,16 +9,19 @@ import dev.langchain4j.model.openai.internal.chat.ChatCompletionChoice;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionRequest;
 import dev.langchain4j.model.openai.internal.chat.Role;
 import dev.langchain4j.model.openai.internal.shared.Usage;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import uk.co.jemos.podam.api.PodamFactory;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -129,6 +132,101 @@ public class AnthropicMappersTest {
                     Arguments.of(Boolean.TRUE, true),
                     Arguments.of(Boolean.FALSE, false),
                     Arguments.of(null, false));
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DisplayName("Sampling params gating")
+    class SamplingParamsGating {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"claude-sonnet-5", "claude-opus-4-8"})
+        void dropsTemperatureAndTopPForAdaptiveThinkingModels(String model) {
+            var request = ChatCompletionRequest.builder()
+                    .model(model)
+                    .addUserMessage("hi")
+                    .temperature(0.7)
+                    .topP(0.9)
+                    .build();
+
+            var actual = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
+
+            assertThat(actual.temperature).isNull();
+            assertThat(actual.topP).isNull();
+        }
+
+        @Test
+        void forwardsTemperatureForModelsThatSupportSamplingParams() {
+            var request = ChatCompletionRequest.builder()
+                    .model("claude-3-7-sonnet-20250219")
+                    .addUserMessage("hi")
+                    .temperature(0.7)
+                    .build();
+
+            var actual = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
+
+            assertThat(actual.temperature).isEqualTo(0.7);
+        }
+
+        @Test
+        void forwardsTopPWhenTemperatureAbsentOnSamplingCapableModel() {
+            var request = ChatCompletionRequest.builder()
+                    .model("claude-3-7-sonnet-20250219")
+                    .addUserMessage("hi")
+                    .topP(0.9)
+                    .build();
+
+            var actual = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
+
+            assertThat(actual.temperature).isNull();
+            assertThat(actual.topP).isEqualTo(0.9);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"enabled", "adaptive", "some-future-mode"})
+        void dropsSamplingParamsWhenThinkingEnabledOnSamplingCapableModel(String thinkingType) {
+            var request = ChatCompletionRequest.builder()
+                    .model("claude-3-7-sonnet-20250219")
+                    .addUserMessage("hi")
+                    .temperature(0.7)
+                    .topP(0.9)
+                    .customParameters(Map.of("thinking", Map.of("type", thinkingType, "budget_tokens", 1024)))
+                    .build();
+
+            var actual = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
+
+            assertThat(actual.temperature).isNull();
+            assertThat(actual.topP).isNull();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"disabled", "", " "})
+        void forwardsTemperatureWhenThinkingDisabledOrBlankOnSamplingCapableModel(String thinkingType) {
+            var request = ChatCompletionRequest.builder()
+                    .model("claude-3-7-sonnet-20250219")
+                    .addUserMessage("hi")
+                    .temperature(0.7)
+                    .customParameters(Map.of("thinking", Map.of("type", thinkingType)))
+                    .build();
+
+            var actual = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
+
+            assertThat(actual.temperature).isEqualTo(0.7);
+        }
+
+        @Test
+        void forwardsTemperatureWhenThinkingBlockAbsentOnSamplingCapableModel() {
+            var request = ChatCompletionRequest.builder()
+                    .model("claude-3-7-sonnet-20250219")
+                    .addUserMessage("hi")
+                    .temperature(0.7)
+                    .customParameters(Map.of("max_tokens", 2048))
+                    .build();
+
+            var actual = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
+
+            assertThat(actual.temperature).isEqualTo(0.7);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/antropic/AnthropicMappersTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/antropic/AnthropicMappersTest.java
@@ -141,7 +141,7 @@ public class AnthropicMappersTest {
     class SamplingParamsGating {
 
         @ParameterizedTest
-        @ValueSource(strings = {"claude-sonnet-5", "claude-opus-4-8"})
+        @ValueSource(strings = {"claude-sonnet-5", "claude-opus-4-7", "claude-opus-4-8"})
         void dropsTemperatureAndTopPForAdaptiveThinkingModels(String model) {
             var request = ChatCompletionRequest.builder()
                     .model(model)
@@ -181,6 +181,21 @@ public class AnthropicMappersTest {
 
             assertThat(actual.temperature).isNull();
             assertThat(actual.topP).isEqualTo(0.9);
+        }
+
+        @Test
+        void temperatureWinsOverTopPWhenBothSetOnSamplingCapableModel() {
+            var request = ChatCompletionRequest.builder()
+                    .model("claude-3-7-sonnet-20250219")
+                    .addUserMessage("hi")
+                    .temperature(0.7)
+                    .topP(0.9)
+                    .build();
+
+            var actual = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
+
+            assertThat(actual.temperature).isEqualTo(0.7);
+            assertThat(actual.topP).isNull();
         }
 
         @ParameterizedTest

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/antropic/AnthropicMappersTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/antropic/AnthropicMappersTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import uk.co.jemos.podam.api.PodamFactory;
 
@@ -140,108 +139,64 @@ public class AnthropicMappersTest {
     @DisplayName("Sampling params gating")
     class SamplingParamsGating {
 
-        @ParameterizedTest
-        @ValueSource(strings = {"claude-sonnet-5", "claude-opus-4-7", "claude-opus-4-8"})
-        void dropsTemperatureAndTopPForAdaptiveThinkingModels(String model) {
-            var request = ChatCompletionRequest.builder()
-                    .model(model)
-                    .addUserMessage("hi")
-                    .temperature(0.7)
-                    .topP(0.9)
-                    .build();
-
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("samplingGatingCases")
+        void gatesSamplingParams(String description, ChatCompletionRequest request, Double expectedTemperature,
+                Double expectedTopP) {
             var actual = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
 
-            assertThat(actual.temperature).isNull();
-            assertThat(actual.topP).isNull();
+            assertThat(actual.getTemperature()).isEqualTo(expectedTemperature);
+            assertThat(actual.getTopP()).isEqualTo(expectedTopP);
         }
 
-        @Test
-        void forwardsTemperatureForModelsThatSupportSamplingParams() {
-            var request = ChatCompletionRequest.builder()
-                    .model("claude-3-7-sonnet-20250219")
-                    .addUserMessage("hi")
-                    .temperature(0.7)
-                    .build();
-
-            var actual = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
-
-            assertThat(actual.temperature).isEqualTo(0.7);
+        Stream<Arguments> samplingGatingCases() {
+            return Stream.of(
+                    // Adaptive-thinking models drop both sampling params regardless of what was requested.
+                    adaptiveDropsBoth("claude-sonnet-5"),
+                    adaptiveDropsBoth("claude-opus-4-7"),
+                    adaptiveDropsBoth("claude-opus-4-8"),
+                    // Sampling-capable model: params forwarded, with temperature winning over top_p.
+                    Arguments.of("sampling-capable forwards temperature",
+                            samplingCapable().temperature(0.7).build(), 0.7, null),
+                    Arguments.of("sampling-capable forwards top_p when temperature absent",
+                            samplingCapable().topP(0.9).build(), null, 0.9),
+                    Arguments.of("sampling-capable drops top_p when temperature also set",
+                            samplingCapable().temperature(0.7).topP(0.9).build(), 0.7, null),
+                    // Thinking enabled (any non-blank type other than "disabled", case-insensitive) drops both.
+                    thinkingDropsBoth("enabled"),
+                    thinkingDropsBoth("ENABLED"),
+                    thinkingDropsBoth("adaptive"),
+                    thinkingDropsBoth("some-future-mode"),
+                    // Thinking disabled / blank / absent leaves sampling params untouched.
+                    thinkingForwards("thinking disabled forwards", Map.of("thinking", Map.of("type", "disabled"))),
+                    thinkingForwards("thinking DISABLED (case-insensitive) forwards",
+                            Map.of("thinking", Map.of("type", "DISABLED"))),
+                    thinkingForwards("thinking blank type forwards", Map.of("thinking", Map.of("type", " "))),
+                    thinkingForwards("thinking block absent forwards", Map.of("max_tokens", 2048)));
         }
 
-        @Test
-        void forwardsTopPWhenTemperatureAbsentOnSamplingCapableModel() {
-            var request = ChatCompletionRequest.builder()
-                    .model("claude-3-7-sonnet-20250219")
-                    .addUserMessage("hi")
-                    .topP(0.9)
-                    .build();
-
-            var actual = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
-
-            assertThat(actual.temperature).isNull();
-            assertThat(actual.topP).isEqualTo(0.9);
+        private Arguments adaptiveDropsBoth(String model) {
+            return Arguments.of("adaptive model %s drops both".formatted(model),
+                    ChatCompletionRequest.builder().model(model).addUserMessage("hi")
+                            .temperature(0.7).topP(0.9).build(),
+                    null, null);
         }
 
-        @Test
-        void temperatureWinsOverTopPWhenBothSetOnSamplingCapableModel() {
-            var request = ChatCompletionRequest.builder()
-                    .model("claude-3-7-sonnet-20250219")
-                    .addUserMessage("hi")
-                    .temperature(0.7)
-                    .topP(0.9)
-                    .build();
-
-            var actual = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
-
-            assertThat(actual.temperature).isEqualTo(0.7);
-            assertThat(actual.topP).isNull();
+        private Arguments thinkingDropsBoth(String thinkingType) {
+            return Arguments.of("thinking type '%s' drops both".formatted(thinkingType),
+                    samplingCapable().temperature(0.7).topP(0.9)
+                            .customParameters(Map.of("thinking", Map.of("type", thinkingType, "budget_tokens", 1024)))
+                            .build(),
+                    null, null);
         }
 
-        @ParameterizedTest
-        @ValueSource(strings = {"enabled", "adaptive", "some-future-mode"})
-        void dropsSamplingParamsWhenThinkingEnabledOnSamplingCapableModel(String thinkingType) {
-            var request = ChatCompletionRequest.builder()
-                    .model("claude-3-7-sonnet-20250219")
-                    .addUserMessage("hi")
-                    .temperature(0.7)
-                    .topP(0.9)
-                    .customParameters(Map.of("thinking", Map.of("type", thinkingType, "budget_tokens", 1024)))
-                    .build();
-
-            var actual = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
-
-            assertThat(actual.temperature).isNull();
-            assertThat(actual.topP).isNull();
+        private Arguments thinkingForwards(String description, Map<String, Object> customParameters) {
+            return Arguments.of(description,
+                    samplingCapable().temperature(0.7).customParameters(customParameters).build(), 0.7, null);
         }
 
-        @ParameterizedTest
-        @ValueSource(strings = {"disabled", "", " "})
-        void forwardsTemperatureWhenThinkingDisabledOrBlankOnSamplingCapableModel(String thinkingType) {
-            var request = ChatCompletionRequest.builder()
-                    .model("claude-3-7-sonnet-20250219")
-                    .addUserMessage("hi")
-                    .temperature(0.7)
-                    .customParameters(Map.of("thinking", Map.of("type", thinkingType)))
-                    .build();
-
-            var actual = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
-
-            assertThat(actual.temperature).isEqualTo(0.7);
-        }
-
-        @Test
-        void forwardsTemperatureWhenThinkingBlockAbsentOnSamplingCapableModel() {
-            var request = ChatCompletionRequest.builder()
-                    .model("claude-3-7-sonnet-20250219")
-                    .addUserMessage("hi")
-                    .temperature(0.7)
-                    .customParameters(Map.of("max_tokens", 2048))
-                    .build();
-
-            var actual = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
-
-            assertThat(actual.temperature).isEqualTo(0.7);
+        private ChatCompletionRequest.Builder samplingCapable() {
+            return ChatCompletionRequest.builder().model("claude-3-7-sonnet-20250219").addUserMessage("hi");
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/antropic/AnthropicMappersTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/antropic/AnthropicMappersTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import uk.co.jemos.podam.api.PodamFactory;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -145,8 +146,16 @@ public class AnthropicMappersTest {
                 Double expectedTopP) {
             var actual = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
 
+            // The gate only affects temperature/top_p; assert the full payload so a collateral change to any
+            // other mapped field is caught too. The expected payload is the mapping of the same request with the
+            // sampling params forced to what the gate should produce.
+            var expected = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
+            expected.setTemperature(expectedTemperature);
+            expected.setTopP(expectedTopP);
+
             assertThat(actual.getTemperature()).isEqualTo(expectedTemperature);
             assertThat(actual.getTopP()).isEqualTo(expectedTopP);
+            assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
         }
 
         Stream<Arguments> samplingGatingCases() {
@@ -167,11 +176,12 @@ public class AnthropicMappersTest {
                     thinkingDropsBoth("ENABLED"),
                     thinkingDropsBoth("adaptive"),
                     thinkingDropsBoth("some-future-mode"),
-                    // Thinking disabled / blank / absent leaves sampling params untouched.
+                    // Thinking disabled / blank / null / absent leaves sampling params untouched.
                     thinkingForwards("thinking disabled forwards", Map.of("thinking", Map.of("type", "disabled"))),
                     thinkingForwards("thinking DISABLED (case-insensitive) forwards",
                             Map.of("thinking", Map.of("type", "DISABLED"))),
                     thinkingForwards("thinking blank type forwards", Map.of("thinking", Map.of("type", " "))),
+                    thinkingForwards("thinking null type forwards", nullThinkingTypeParameters()),
                     thinkingForwards("thinking block absent forwards", Map.of("max_tokens", 2048)));
         }
 
@@ -197,6 +207,13 @@ public class AnthropicMappersTest {
 
         private ChatCompletionRequest.Builder samplingCapable() {
             return ChatCompletionRequest.builder().model("claude-3-7-sonnet-20250219").addUserMessage("hi");
+        }
+
+        // Map.of rejects null values, so build the explicit null-type thinking block with a nested HashMap.
+        private Map<String, Object> nullThinkingTypeParameters() {
+            var thinking = new HashMap<String, Object>();
+            thinking.put("type", null);
+            return Map.of("thinking", thinking);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/antropic/AnthropicMappersTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/antropic/AnthropicMappersTest.java
@@ -3,6 +3,9 @@ package com.comet.opik.infrastructure.llm.antropic;
 import com.comet.opik.podam.PodamFactoryUtils;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageRequest;
 import dev.langchain4j.model.anthropic.internal.api.AnthropicCreateMessageResponse;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicMessage;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicRole;
+import dev.langchain4j.model.anthropic.internal.api.AnthropicTextContent;
 import dev.langchain4j.model.anthropic.internal.client.AnthropicClient;
 import dev.langchain4j.model.openai.internal.chat.AssistantMessage;
 import dev.langchain4j.model.openai.internal.chat.ChatCompletionChoice;
@@ -146,15 +149,23 @@ public class AnthropicMappersTest {
                 Double expectedTopP) {
             var actual = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
 
-            // The gate only affects temperature/top_p; assert the full payload so a collateral change to any
-            // other mapped field is caught too. The expected payload is the mapping of the same request with the
-            // sampling params forced to what the gate should produce.
-            var expected = LlmProviderAnthropicMapper.INSTANCE.toCreateMessageRequest(request);
-            expected.setTemperature(expectedTemperature);
-            expected.setTopP(expectedTopP);
+            // Build the expected payload independently of the mapper (not by re-calling it), so a regression in
+            // any collateral field — model, messages, max_tokens, etc. — can't hide by changing actual and
+            // expected identically. Every case uses the same fixture: one "hi" user message, no system, no
+            // explicit max_tokens (defaults to 4096) and no stream/stop. Only temperature/top_p vary per the gate.
+            var expected = AnthropicCreateMessageRequest.builder()
+                    .model(request.model())
+                    .stream(false)
+                    .temperature(expectedTemperature)
+                    .topP(expectedTopP)
+                    .maxTokens(LlmProviderAnthropicMapper.DEFAULT_MAX_COMPLETION_TOKENS)
+                    .messages(List.of(AnthropicMessage.builder()
+                            .role(AnthropicRole.USER)
+                            .content(List.of(new AnthropicTextContent("hi")))
+                            .build()))
+                    .system(List.of())
+                    .build();
 
-            assertThat(actual.getTemperature()).isEqualTo(expectedTemperature);
-            assertThat(actual.getTopP()).isEqualTo(expectedTopP);
             assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
         }
 


### PR DESCRIPTION
## Details

<img width="806" height="830" alt="image" src="https://github.com/user-attachments/assets/1566b870-ea61-4e02-ac39-f4222f10aa44" />

<img width="836" height="840" alt="image" src="https://github.com/user-attachments/assets/40bb8dc9-5654-464b-8886-f746a4d07e72" />

<img width="837" height="740" alt="image" src="https://github.com/user-attachments/assets/986ee994-60af-4dbe-bc64-9bdc4c84dbf8" />

Follow-up to PR #7531 (online-rules judge path). That PR gated `temperature` server-side for Anthropic adaptive-thinking models (`claude-sonnet-5`, `claude-opus-4-7/4-8`) on the **judge** path, but deliberately left the sibling **playground / online-inference / proxy** path out of scope.

`LlmProviderAnthropicMapper.toCreateMessageRequest` still forwarded `temperature` / `top_p` unconditionally, so those models `400` with `temperature is deprecated for this model` for **API-created** requests — which bypass the FE sanitizer added in OPIK-6244.

Changes (backend-only, `infrastructure/llm/antropic`):
- Convert the `temperature` / `top_p` MapStruct mappings to `@Named` resolvers that gate on `AnthropicModelName.supportsSamplingParams(request.model())` **and** whenever extended thinking is enabled per-request via `custom_parameters.thinking.type` (any non-blank type other than `disabled`), mirroring the judge-path logic in `AnthropicClientGenerator`.
- `top_p` is now also dropped when gated (previously it could leak once `temperature` was suppressed).
- `top_k` is **not** sent on this path (`ChatCompletionRequest` has no `top_k`), so there is nothing to gate — no dead code added.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves [OPIK-7438](https://comet-ml.atlassian.net/browse/OPIK-7438)
- Follow-up to #7531 (GitHub issue #7526)

## Testing

- New nested `SamplingParamsGating` cases in `AnthropicMappersTest` (11): adaptive models drop temperature+top_p; sampling-capable models forward them; thinking-enabled (`enabled`/`adaptive`/future) drops them; `disabled`/blank/absent thinking forwards them.
- Existing `AnthropicMappersTest` (7) unaffected — Podam random models default to sampling-supported.
- `mvn clean test-compile` clean on Corretto 25; `AnthropicMappersTest` (18) + `AnthropicClientGeneratorTest` (32) all green; `spotless:apply` clean.

## Documentation

No user-facing docs change required.

[OPIK-7438]: https://comet-ml.atlassian.net/browse/OPIK-7438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ