### PR TITLE
[OPIK-7274] [BE] fix: make Ollie report stale timeout configurable and add pipeline metrics

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/OllieDailyReportJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/OllieDailyReportJob.java
@@ -6,12 +6,15 @@ import com.comet.opik.infrastructure.lock.LockService;
 import io.dropwizard.jobs.Job;
 import io.dropwizard.jobs.annotations.On;
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.JobExecutionContext;
 import reactor.core.publisher.Mono;
@@ -31,10 +34,13 @@ public class OllieDailyReportJob extends Job {
     private static final int WINDOW_MINUTES = 10;
     private static final Lock JOB_LOCK = new Lock("daily_report_job:lock");
 
+    private static final AttributeKey<String> WORKSPACE_ID_KEY = AttributeKey.stringKey("workspace_id");
+    private static final AttributeKey<String> WORKSPACE_NAME_KEY = AttributeKey.stringKey("workspace_name");
+    private static final AttributeKey<String> ERROR_TYPE_KEY = AttributeKey.stringKey("error_type");
+
     private final ReportService reportService;
     private final LockService lockService;
 
-    private final LongCounter reportsTriggeredCounter;
     private final LongCounter triggerErrorCounter;
 
     @Inject
@@ -45,11 +51,6 @@ public class OllieDailyReportJob extends Job {
         this.lockService = lockService;
 
         Meter meter = GlobalOpenTelemetry.get().getMeter("opik.daily_report");
-
-        this.reportsTriggeredCounter = meter
-                .counterBuilder("opik.daily_report.triggered")
-                .setDescription("Number of reports triggered for generation")
-                .build();
 
         this.triggerErrorCounter = meter
                 .counterBuilder("opik.daily_report.trigger_error")
@@ -97,22 +98,16 @@ public class OllieDailyReportJob extends Job {
         List<ReportPreference> prefs = reportService.findEnabledPreferencesInTimeWindow(windowStart, windowEnd);
         log.info("Found {} projects scheduled in window [{}, {})", prefs.size(), windowStart, windowEnd);
 
-        int triggered = 0;
-        int errors = 0;
         for (var pref : prefs) {
             try {
-                var reportId = reportService.createAndTriggerReport(pref.workspaceId(), pref.workspaceName(),
-                        pref.projectId());
-                if (reportId != null) {
-                    triggered++;
-                }
+                reportService.createAndTriggerReport(pref.workspaceId(), pref.workspaceName(), pref.projectId());
             } catch (Exception e) {
                 log.error("Failed to trigger report for project '{}'", pref.projectId(), e);
-                errors++;
+                triggerErrorCounter.add(1, Attributes.of(
+                        WORKSPACE_ID_KEY, pref.workspaceId(),
+                        WORKSPACE_NAME_KEY, StringUtils.defaultIfBlank(pref.workspaceName(), pref.workspaceId()),
+                        ERROR_TYPE_KEY, e.getClass().getSimpleName()));
             }
         }
-
-        reportsTriggeredCounter.add(triggered);
-        triggerErrorCounter.add(errors);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/OllieDailyReportJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/OllieDailyReportJob.java
@@ -5,10 +5,12 @@ import com.comet.opik.domain.ReportService;
 import com.comet.opik.infrastructure.lock.LockService;
 import io.dropwizard.jobs.Job;
 import io.dropwizard.jobs.annotations.On;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.JobExecutionContext;
@@ -20,22 +22,40 @@ import java.util.List;
 
 import static com.comet.opik.infrastructure.lock.LockService.Lock;
 
-/**
- * Runs every 10 minutes and triggers report generation for projects
- * whose schedule_time falls within the previous 10-minute window.
- */
 @Slf4j
 @Singleton
 @DisallowConcurrentExecution
 @On(value = "0 0/10 * * * ?", timeZone = "UTC")
-@RequiredArgsConstructor(onConstructor_ = @Inject)
 public class OllieDailyReportJob extends Job {
 
     private static final int WINDOW_MINUTES = 10;
     private static final Lock JOB_LOCK = new Lock("daily_report_job:lock");
 
-    private final @NonNull ReportService reportService;
-    private final @NonNull LockService lockService;
+    private final ReportService reportService;
+    private final LockService lockService;
+
+    private final LongCounter reportsTriggeredCounter;
+    private final LongCounter triggerErrorCounter;
+
+    @Inject
+    public OllieDailyReportJob(
+            @NonNull ReportService reportService,
+            @NonNull LockService lockService) {
+        this.reportService = reportService;
+        this.lockService = lockService;
+
+        Meter meter = GlobalOpenTelemetry.get().getMeter("opik.daily_report");
+
+        this.reportsTriggeredCounter = meter
+                .counterBuilder("opik.daily_report.triggered")
+                .setDescription("Number of reports triggered for generation")
+                .build();
+
+        this.triggerErrorCounter = meter
+                .counterBuilder("opik.daily_report.trigger_error")
+                .setDescription("Number of report trigger failures")
+                .build();
+    }
 
     record TimeWindow(String start, String end) {
     }
@@ -77,12 +97,22 @@ public class OllieDailyReportJob extends Job {
         List<ReportPreference> prefs = reportService.findEnabledPreferencesInTimeWindow(windowStart, windowEnd);
         log.info("Found {} projects scheduled in window [{}, {})", prefs.size(), windowStart, windowEnd);
 
+        int triggered = 0;
+        int errors = 0;
         for (var pref : prefs) {
             try {
-                reportService.createAndTriggerReport(pref.workspaceId(), pref.workspaceName(), pref.projectId());
+                var reportId = reportService.createAndTriggerReport(pref.workspaceId(), pref.workspaceName(),
+                        pref.projectId());
+                if (reportId != null) {
+                    triggered++;
+                }
             } catch (Exception e) {
                 log.error("Failed to trigger report for project '{}'", pref.projectId(), e);
+                errors++;
             }
         }
+
+        reportsTriggeredCounter.add(triggered);
+        triggerErrorCounter.add(errors);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/StaleReportCleanupJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/StaleReportCleanupJob.java
@@ -5,6 +5,8 @@ import com.comet.opik.infrastructure.lock.LockService;
 import io.dropwizard.jobs.Job;
 import io.dropwizard.jobs.annotations.Every;
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import jakarta.inject.Inject;
@@ -26,6 +28,9 @@ import static com.comet.opik.infrastructure.lock.LockService.Lock;
 public class StaleReportCleanupJob extends Job {
 
     private static final Lock JOB_LOCK = new Lock("stale_report_cleanup:lock");
+
+    private static final AttributeKey<String> WORKSPACE_ID_KEY = AttributeKey.stringKey("workspace_id");
+    private static final AttributeKey<String> WORKSPACE_NAME_KEY = AttributeKey.stringKey("workspace_name");
 
     private final ReportService reportService;
     private final LockService lockService;
@@ -51,13 +56,10 @@ public class StaleReportCleanupJob extends Job {
     public void doJob(JobExecutionContext context) {
         lockService.bestEffortLock(
                 JOB_LOCK,
-                Mono.fromRunnable(() -> {
-                    int swept = reportService.failStaleReports();
-                    log.info("Stale report cleanup swept {} reports", swept);
-                    if (swept > 0) {
-                        staleReportsCounter.add(swept);
-                    }
-                }),
+                Mono.fromRunnable(() -> reportService.failStaleReports()
+                        .forEach((workspaceId, count) -> staleReportsCounter.add(count, Attributes.of(
+                                WORKSPACE_ID_KEY, workspaceId,
+                                WORKSPACE_NAME_KEY, workspaceId)))),
                 Mono.defer(() -> {
                     log.debug("Could not acquire lock for stale report cleanup, another instance is running");
                     return Mono.empty();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/StaleReportCleanupJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/StaleReportCleanupJob.java
@@ -4,10 +4,12 @@ import com.comet.opik.domain.ReportService;
 import com.comet.opik.infrastructure.lock.LockService;
 import io.dropwizard.jobs.Job;
 import io.dropwizard.jobs.annotations.Every;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.JobExecutionContext;
@@ -21,19 +23,41 @@ import static com.comet.opik.infrastructure.lock.LockService.Lock;
 @Singleton
 @DisallowConcurrentExecution
 @Every("15min")
-@RequiredArgsConstructor(onConstructor_ = @Inject)
 public class StaleReportCleanupJob extends Job {
 
     private static final Lock JOB_LOCK = new Lock("stale_report_cleanup:lock");
 
-    private final @NonNull ReportService reportService;
-    private final @NonNull LockService lockService;
+    private final ReportService reportService;
+    private final LockService lockService;
+
+    private final LongCounter staleReportsCounter;
+
+    @Inject
+    public StaleReportCleanupJob(
+            @NonNull ReportService reportService,
+            @NonNull LockService lockService) {
+        this.reportService = reportService;
+        this.lockService = lockService;
+
+        Meter meter = GlobalOpenTelemetry.get().getMeter("opik.daily_report");
+
+        this.staleReportsCounter = meter
+                .counterBuilder("opik.daily_report.stale_swept")
+                .setDescription("Number of stale reports marked as failed")
+                .build();
+    }
 
     @Override
     public void doJob(JobExecutionContext context) {
         lockService.bestEffortLock(
                 JOB_LOCK,
-                Mono.fromRunnable(reportService::failStaleReports),
+                Mono.fromRunnable(() -> {
+                    int swept = reportService.failStaleReports();
+                    log.info("Stale report cleanup swept {} reports", swept);
+                    if (swept > 0) {
+                        staleReportsCounter.add(swept);
+                    }
+                }),
                 Mono.defer(() -> {
                     log.debug("Could not acquire lock for stale report cleanup, another instance is running");
                     return Mono.empty();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OllieReportDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OllieReportDAO.java
@@ -12,6 +12,7 @@ import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -65,9 +66,15 @@ interface OllieReportDAO {
     long countByProjectId(@Bind("workspaceId") String workspaceId,
             @Bind("projectId") UUID projectId);
 
+    @SqlQuery("""
+            SELECT created_at FROM ollie_reports
+            WHERE id = :id AND workspace_id = :workspaceId
+            """)
+    Instant getCreatedAt(@Bind("id") UUID id, @Bind("workspaceId") String workspaceId);
+
     @SqlUpdate("""
             UPDATE ollie_reports SET status = 'failed'
-            WHERE status = 'pending' AND created_at < DATE_SUB(NOW(), INTERVAL 10 MINUTE)
+            WHERE status = 'pending' AND created_at < DATE_SUB(NOW(), INTERVAL 30 MINUTE)
             """)
     int failStaleReports();
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OllieReportDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OllieReportDAO.java
@@ -72,9 +72,15 @@ interface OllieReportDAO {
             """)
     Instant getCreatedAt(@Bind("id") UUID id, @Bind("workspaceId") String workspaceId);
 
+    @SqlQuery("""
+            SELECT workspace_id FROM ollie_reports
+            WHERE status = 'pending' AND created_at < DATE_SUB(NOW(), INTERVAL :staleMinutes MINUTE)
+            """)
+    List<String> findStalePendingWorkspaceIds(@Bind("staleMinutes") int staleMinutes);
+
     @SqlUpdate("""
             UPDATE ollie_reports SET status = 'failed'
-            WHERE status = 'pending' AND created_at < DATE_SUB(NOW(), INTERVAL 30 MINUTE)
+            WHERE status = 'pending' AND created_at < DATE_SUB(NOW(), INTERVAL :staleMinutes MINUTE)
             """)
-    int failStaleReports();
+    int failStaleReports(@Bind("staleMinutes") int staleMinutes);
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ReportService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ReportService.java
@@ -5,34 +5,83 @@ import com.comet.opik.api.OllieReport.ReportStatus;
 import com.comet.opik.api.ReportPreference;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.Meter;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.NotFoundException;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 @Singleton
-@RequiredArgsConstructor(onConstructor_ = @Inject)
 @Slf4j
 public class ReportService {
 
-    private final @NonNull TransactionTemplate transactionTemplate;
-    private final @NonNull IdGenerator idGenerator;
-    private final @NonNull Provider<RequestContext> requestContext;
-    private final @NonNull OrchestratorClient orchestratorClient;
-    private final @NonNull ProjectService projectService;
+    private final TransactionTemplate transactionTemplate;
+    private final IdGenerator idGenerator;
+    private final Provider<RequestContext> requestContext;
+    private final OrchestratorClient orchestratorClient;
+    private final ProjectService projectService;
+
+    private final LongCounter finishedCounter;
+    private final LongHistogram endToEndDuration;
+    private final LongHistogram scheduledToCompletionDuration;
+
+    @Inject
+    public ReportService(
+            @NonNull TransactionTemplate transactionTemplate,
+            @NonNull IdGenerator idGenerator,
+            @NonNull Provider<RequestContext> requestContext,
+            @NonNull OrchestratorClient orchestratorClient,
+            @NonNull ProjectService projectService) {
+        this.transactionTemplate = transactionTemplate;
+        this.idGenerator = idGenerator;
+        this.requestContext = requestContext;
+        this.orchestratorClient = orchestratorClient;
+        this.projectService = projectService;
+
+        Meter meter = GlobalOpenTelemetry.get().getMeter("opik.daily_report");
+
+        this.finishedCounter = meter
+                .counterBuilder("opik.daily_report.finished")
+                .setDescription("Number of reports finalized via the completion callback or trigger failure, "
+                        + "by result (completed / failed / trigger_failed); stale sweeps are counted separately "
+                        + "by opik.daily_report.stale_swept")
+                .build();
+
+        this.endToEndDuration = meter
+                .histogramBuilder("opik.daily_report.end_to_end_duration")
+                .setDescription("Time from report creation to completion callback")
+                .setUnit("ms")
+                .ofLongs()
+                .build();
+
+        this.scheduledToCompletionDuration = meter
+                .histogramBuilder("opik.daily_report.scheduled_to_completion_duration")
+                .setDescription("Time from user-configured schedule time to completion callback")
+                .setUnit("ms")
+                .ofLongs()
+                .build();
+    }
 
     public Mono<UUID> generateReport(@NonNull UUID projectId) {
         var ctx = requestContext.get();
@@ -81,14 +130,19 @@ public class ReportService {
         String workspaceId = requestContext.get().getWorkspaceId();
 
         return Mono.fromCallable(() -> transactionTemplate.inTransaction(WRITE, handle -> {
-            int updated = handle.attach(OllieReportDAO.class)
-                    .update(reportId, workspaceId, projectId, content, sessionId, recommendedActions,
-                            status.getValue());
+            var dao = handle.attach(OllieReportDAO.class);
+
+            int updated = dao.update(reportId, workspaceId, projectId, content, sessionId, recommendedActions,
+                    status.getValue());
             if (updated == 0) {
                 throw new NotFoundException("Report not found or already processed: " + reportId);
             }
-            return null;
-        })).subscribeOn(Schedulers.boundedElastic()).then();
+
+            return dao.getCreatedAt(reportId, workspaceId);
+        }))
+                .doOnNext(createdAt -> recordCompletionMetrics(workspaceId, projectId, status, createdAt))
+                .subscribeOn(Schedulers.boundedElastic())
+                .then();
     }
 
     public Mono<OllieReportPage> getReports(@NonNull UUID projectId, int page, int size) {
@@ -134,26 +188,52 @@ public class ReportService {
                         .findAllEnabledInTimeWindow(windowStart, windowEnd));
     }
 
+    private void recordCompletionMetrics(String workspaceId, UUID projectId, ReportStatus status, Instant createdAt) {
+        try {
+            Instant now = Instant.now();
+            String result = status == ReportStatus.COMPLETED ? "completed" : "failed";
+            Attributes attrs = Attributes.of(stringKey("result"), result);
+
+            finishedCounter.add(1, attrs);
+            endToEndDuration.record(now.toEpochMilli() - createdAt.toEpochMilli(), attrs);
+
+            transactionTemplate.inTransaction(READ_ONLY, handle -> handle.attach(ReportPreferenceDAO.class)
+                    .findByProjectId(workspaceId, projectId))
+                    .map(ReportPreference::scheduleTime)
+                    .ifPresent(scheduleTimeStr -> {
+                        LocalDate reportDate = createdAt.atZone(ZoneOffset.UTC).toLocalDate();
+                        Instant scheduledAt = reportDate.atTime(LocalTime.parse(scheduleTimeStr))
+                                .toInstant(ZoneOffset.UTC);
+                        if (scheduledAt.isAfter(createdAt)) {
+                            scheduledAt = scheduledAt.minusSeconds(86400);
+                        }
+                        scheduledToCompletionDuration.record(now.toEpochMilli() - scheduledAt.toEpochMilli(), attrs);
+                    });
+        } catch (Exception e) {
+            log.warn("Failed to record completion metrics for project '{}'", projectId, e);
+        }
+    }
+
     private void markReportFailed(UUID reportId, String workspaceId, UUID projectId) {
         try {
-            transactionTemplate.inTransaction(WRITE, handle -> {
-                handle.attach(OllieReportDAO.class)
-                        .update(reportId, workspaceId, projectId, null, null, null, ReportStatus.FAILED.getValue());
-                return null;
-            });
-            log.info("Marked report '{}' as failed", reportId);
+            int updated = transactionTemplate.inTransaction(WRITE, handle -> handle.attach(OllieReportDAO.class)
+                    .update(reportId, workspaceId, projectId, null, null, null, ReportStatus.FAILED.getValue()));
+            if (updated > 0) {
+                finishedCounter.add(1, Attributes.of(stringKey("result"), "trigger_failed"));
+                log.info("Marked report '{}' as failed", reportId);
+            }
         } catch (Exception e) {
             log.error("Failed to mark report '{}' as failed", reportId, e);
         }
     }
 
-    public void failStaleReports() {
-        transactionTemplate.inTransaction(WRITE, handle -> {
+    public int failStaleReports() {
+        return transactionTemplate.inTransaction(WRITE, handle -> {
             int failed = handle.attach(OllieReportDAO.class).failStaleReports();
             if (failed > 0) {
                 log.info("Marked {} stale pending reports as failed", failed);
             }
-            return null;
+            return failed;
         });
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ReportService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ReportService.java
@@ -6,6 +6,7 @@ import com.comet.opik.api.ReportPreference;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongHistogram;
@@ -16,6 +17,7 @@ import jakarta.inject.Singleton;
 import jakarta.ws.rs.NotFoundException;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
@@ -25,8 +27,10 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
@@ -36,12 +40,19 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 @Slf4j
 public class ReportService {
 
+    private static final int STALE_THRESHOLD_MINUTES = 30;
+
+    private static final AttributeKey<String> RESULT_KEY = stringKey("result");
+    private static final AttributeKey<String> WORKSPACE_ID_KEY = stringKey("workspace_id");
+    private static final AttributeKey<String> WORKSPACE_NAME_KEY = stringKey("workspace_name");
+
     private final TransactionTemplate transactionTemplate;
     private final IdGenerator idGenerator;
     private final Provider<RequestContext> requestContext;
     private final OrchestratorClient orchestratorClient;
     private final ProjectService projectService;
 
+    private final LongCounter triggeredCounter;
     private final LongCounter finishedCounter;
     private final LongHistogram endToEndDuration;
     private final LongHistogram scheduledToCompletionDuration;
@@ -60,6 +71,11 @@ public class ReportService {
         this.projectService = projectService;
 
         Meter meter = GlobalOpenTelemetry.get().getMeter("opik.daily_report");
+
+        this.triggeredCounter = meter
+                .counterBuilder("opik.daily_report.triggered")
+                .setDescription("Number of reports triggered for generation (scheduled and manual)")
+                .build();
 
         this.finishedCounter = meter
                 .counterBuilder("opik.daily_report.finished")
@@ -119,7 +135,11 @@ public class ReportService {
         orchestratorClient.triggerReportGeneration(
                 reportId.toString(), projectId.toString(), projectName,
                 workspaceName, customPrompt,
-                () -> markReportFailed(reportId, workspaceId, projectId));
+                () -> markReportFailed(reportId, workspaceId, workspaceName, projectId));
+
+        triggeredCounter.add(1, Attributes.of(
+                WORKSPACE_ID_KEY, workspaceId,
+                WORKSPACE_NAME_KEY, StringUtils.defaultIfBlank(workspaceName, workspaceId)));
 
         return reportId;
     }
@@ -127,7 +147,9 @@ public class ReportService {
     public Mono<Void> updateReport(@NonNull UUID projectId, @NonNull UUID reportId,
             @NonNull ReportStatus status, String content, String sessionId,
             JsonNode recommendedActions) {
-        String workspaceId = requestContext.get().getWorkspaceId();
+        var ctx = requestContext.get();
+        String workspaceId = ctx.getWorkspaceId();
+        String workspaceName = ctx.getWorkspaceName();
 
         return Mono.fromCallable(() -> transactionTemplate.inTransaction(WRITE, handle -> {
             var dao = handle.attach(OllieReportDAO.class);
@@ -140,7 +162,8 @@ public class ReportService {
 
             return dao.getCreatedAt(reportId, workspaceId);
         }))
-                .doOnNext(createdAt -> recordCompletionMetrics(workspaceId, projectId, status, createdAt))
+                .doOnNext(createdAt -> recordCompletionMetrics(workspaceId, workspaceName, projectId, status,
+                        createdAt))
                 .subscribeOn(Schedulers.boundedElastic())
                 .then();
     }
@@ -188,11 +211,15 @@ public class ReportService {
                         .findAllEnabledInTimeWindow(windowStart, windowEnd));
     }
 
-    private void recordCompletionMetrics(String workspaceId, UUID projectId, ReportStatus status, Instant createdAt) {
+    private void recordCompletionMetrics(String workspaceId, String workspaceName, UUID projectId,
+            ReportStatus status, Instant createdAt) {
         try {
             Instant now = Instant.now();
             String result = status == ReportStatus.COMPLETED ? "completed" : "failed";
-            Attributes attrs = Attributes.of(stringKey("result"), result);
+            Attributes attrs = Attributes.of(
+                    RESULT_KEY, result,
+                    WORKSPACE_ID_KEY, workspaceId,
+                    WORKSPACE_NAME_KEY, StringUtils.defaultIfBlank(workspaceName, workspaceId));
 
             finishedCounter.add(1, attrs);
             endToEndDuration.record(now.toEpochMilli() - createdAt.toEpochMilli(), attrs);
@@ -214,26 +241,34 @@ public class ReportService {
         }
     }
 
-    private void markReportFailed(UUID reportId, String workspaceId, UUID projectId) {
+    private void markReportFailed(UUID reportId, String workspaceId, String workspaceName, UUID projectId) {
         try {
             int updated = transactionTemplate.inTransaction(WRITE, handle -> handle.attach(OllieReportDAO.class)
                     .update(reportId, workspaceId, projectId, null, null, null, ReportStatus.FAILED.getValue()));
             if (updated > 0) {
-                finishedCounter.add(1, Attributes.of(stringKey("result"), "trigger_failed"));
-                log.info("Marked report '{}' as failed", reportId);
+                finishedCounter.add(1, Attributes.of(
+                        RESULT_KEY, "trigger_failed",
+                        WORKSPACE_ID_KEY, workspaceId,
+                        WORKSPACE_NAME_KEY, StringUtils.defaultIfBlank(workspaceName, workspaceId)));
+                log.info("Marked report as failed reportId='{}' workspaceId='{}' projectId='{}'",
+                        reportId, workspaceId, projectId);
             }
         } catch (Exception e) {
-            log.error("Failed to mark report '{}' as failed", reportId, e);
+            log.error("Failed to mark report as failed reportId='{}' workspaceId='{}' projectId='{}'",
+                    reportId, workspaceId, projectId, e);
         }
     }
 
-    public int failStaleReports() {
+    public Map<String, Long> failStaleReports() {
         return transactionTemplate.inTransaction(WRITE, handle -> {
-            int failed = handle.attach(OllieReportDAO.class).failStaleReports();
+            var dao = handle.attach(OllieReportDAO.class);
+            Map<String, Long> sweptByWorkspace = dao.findStalePendingWorkspaceIds(STALE_THRESHOLD_MINUTES).stream()
+                    .collect(Collectors.groupingBy(id -> id, Collectors.counting()));
+            int failed = dao.failStaleReports(STALE_THRESHOLD_MINUTES);
             if (failed > 0) {
                 log.info("Marked {} stale pending reports as failed", failed);
             }
-            return failed;
+            return sweptByWorkspace;
         });
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ReportService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ReportService.java
@@ -3,6 +3,7 @@ package com.comet.opik.domain;
 import com.comet.opik.api.OllieReport.OllieReportPage;
 import com.comet.opik.api.OllieReport.ReportStatus;
 import com.comet.opik.api.ReportPreference;
+import com.comet.opik.infrastructure.ReportGenerationConfig;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -20,12 +21,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,8 +39,6 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 @Slf4j
 public class ReportService {
 
-    private static final int STALE_THRESHOLD_MINUTES = 30;
-
     private static final AttributeKey<String> RESULT_KEY = stringKey("result");
     private static final AttributeKey<String> WORKSPACE_ID_KEY = stringKey("workspace_id");
     private static final AttributeKey<String> WORKSPACE_NAME_KEY = stringKey("workspace_name");
@@ -51,11 +48,11 @@ public class ReportService {
     private final Provider<RequestContext> requestContext;
     private final OrchestratorClient orchestratorClient;
     private final ProjectService projectService;
+    private final ReportGenerationConfig reportGenerationConfig;
 
     private final LongCounter triggeredCounter;
     private final LongCounter finishedCounter;
     private final LongHistogram endToEndDuration;
-    private final LongHistogram scheduledToCompletionDuration;
 
     @Inject
     public ReportService(
@@ -63,12 +60,14 @@ public class ReportService {
             @NonNull IdGenerator idGenerator,
             @NonNull Provider<RequestContext> requestContext,
             @NonNull OrchestratorClient orchestratorClient,
-            @NonNull ProjectService projectService) {
+            @NonNull ProjectService projectService,
+            @NonNull @Config("reportGeneration") ReportGenerationConfig reportGenerationConfig) {
         this.transactionTemplate = transactionTemplate;
         this.idGenerator = idGenerator;
         this.requestContext = requestContext;
         this.orchestratorClient = orchestratorClient;
         this.projectService = projectService;
+        this.reportGenerationConfig = reportGenerationConfig;
 
         Meter meter = GlobalOpenTelemetry.get().getMeter("opik.daily_report");
 
@@ -87,13 +86,6 @@ public class ReportService {
         this.endToEndDuration = meter
                 .histogramBuilder("opik.daily_report.end_to_end_duration")
                 .setDescription("Time from report creation to completion callback")
-                .setUnit("ms")
-                .ofLongs()
-                .build();
-
-        this.scheduledToCompletionDuration = meter
-                .histogramBuilder("opik.daily_report.scheduled_to_completion_duration")
-                .setDescription("Time from user-configured schedule time to completion callback")
                 .setUnit("ms")
                 .ofLongs()
                 .build();
@@ -162,8 +154,7 @@ public class ReportService {
 
             return dao.getCreatedAt(reportId, workspaceId);
         }))
-                .doOnNext(createdAt -> recordCompletionMetrics(workspaceId, workspaceName, projectId, status,
-                        createdAt))
+                .doOnNext(createdAt -> recordCompletionMetrics(workspaceId, workspaceName, status, createdAt))
                 .subscribeOn(Schedulers.boundedElastic())
                 .then();
     }
@@ -211,34 +202,16 @@ public class ReportService {
                         .findAllEnabledInTimeWindow(windowStart, windowEnd));
     }
 
-    private void recordCompletionMetrics(String workspaceId, String workspaceName, UUID projectId,
-            ReportStatus status, Instant createdAt) {
-        try {
-            Instant now = Instant.now();
-            String result = status == ReportStatus.COMPLETED ? "completed" : "failed";
-            Attributes attrs = Attributes.of(
-                    RESULT_KEY, result,
-                    WORKSPACE_ID_KEY, workspaceId,
-                    WORKSPACE_NAME_KEY, StringUtils.defaultIfBlank(workspaceName, workspaceId));
+    private void recordCompletionMetrics(String workspaceId, String workspaceName, ReportStatus status,
+            Instant createdAt) {
+        String result = status == ReportStatus.COMPLETED ? "completed" : "failed";
+        Attributes attrs = Attributes.of(
+                RESULT_KEY, result,
+                WORKSPACE_ID_KEY, workspaceId,
+                WORKSPACE_NAME_KEY, StringUtils.defaultIfBlank(workspaceName, workspaceId));
 
-            finishedCounter.add(1, attrs);
-            endToEndDuration.record(now.toEpochMilli() - createdAt.toEpochMilli(), attrs);
-
-            transactionTemplate.inTransaction(READ_ONLY, handle -> handle.attach(ReportPreferenceDAO.class)
-                    .findByProjectId(workspaceId, projectId))
-                    .map(ReportPreference::scheduleTime)
-                    .ifPresent(scheduleTimeStr -> {
-                        LocalDate reportDate = createdAt.atZone(ZoneOffset.UTC).toLocalDate();
-                        Instant scheduledAt = reportDate.atTime(LocalTime.parse(scheduleTimeStr))
-                                .toInstant(ZoneOffset.UTC);
-                        if (scheduledAt.isAfter(createdAt)) {
-                            scheduledAt = scheduledAt.minusSeconds(86400);
-                        }
-                        scheduledToCompletionDuration.record(now.toEpochMilli() - scheduledAt.toEpochMilli(), attrs);
-                    });
-        } catch (Exception e) {
-            log.warn("Failed to record completion metrics for project '{}'", projectId, e);
-        }
+        finishedCounter.add(1, attrs);
+        endToEndDuration.record(Instant.now().toEpochMilli() - createdAt.toEpochMilli(), attrs);
     }
 
     private void markReportFailed(UUID reportId, String workspaceId, String workspaceName, UUID projectId) {
@@ -262,9 +235,10 @@ public class ReportService {
     public Map<String, Long> failStaleReports() {
         return transactionTemplate.inTransaction(WRITE, handle -> {
             var dao = handle.attach(OllieReportDAO.class);
-            Map<String, Long> sweptByWorkspace = dao.findStalePendingWorkspaceIds(STALE_THRESHOLD_MINUTES).stream()
+            Map<String, Long> sweptByWorkspace = dao
+                    .findStalePendingWorkspaceIds(reportGenerationConfig.getStaleReportTimeoutMinutes()).stream()
                     .collect(Collectors.groupingBy(id -> id, Collectors.counting()));
-            int failed = dao.failStaleReports(STALE_THRESHOLD_MINUTES);
+            int failed = dao.failStaleReports(reportGenerationConfig.getStaleReportTimeoutMinutes());
             if (failed > 0) {
                 log.info("Marked {} stale pending reports as failed", failed);
             }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ReportGenerationConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ReportGenerationConfig.java
@@ -8,4 +8,7 @@ public class ReportGenerationConfig {
 
     @JsonProperty
     private String url = "";
+
+    @JsonProperty
+    private int staleReportTimeoutMinutes = 10;
 }


### PR DESCRIPTION
## Details

Adds OpenTelemetry metrics to the Ollie daily-report pipeline so failures/latency are observable from opik-backend (context: OPIK-7274, reports failing at a high rate), and makes the stale-report cleanup timeout configurable. Companion per-workspace-pod fix is in comet-backend PR (paired below).

- `opik.daily_report.triggered{workspace_id,workspace_name}` — reports triggered for generation; counted for both the scheduled cron and the manual `/generate` path (via `createAndTriggerReport`), skips excluded.
- `opik.daily_report.trigger_error{workspace_id,workspace_name,error_type}` — scheduled-trigger failures, by exception class.
- `opik.daily_report.finished{result=completed|failed|trigger_failed, workspace_id, workspace_name}` — terminal outcomes via the Ollie callback; the async trigger-failure callback records `trigger_failed`.
- `opik.daily_report.end_to_end_duration{result,...}` — creation→callback latency histogram (origin-agnostic).
- `opik.daily_report.stale_swept{workspace_id,workspace_name}` — pending reports swept as failed by the cleanup job.
- **Configurable stale timeout:** `reportGeneration.staleReportTimeoutMinutes` (default **10**, unchanged behavior; tunable per-env without a redeploy).
- Completion metrics are recorded after the write transaction commits, as a cheap non-blocking side-effect.

Note: an earlier `scheduled_to_completion_duration` histogram was dropped after review — it only added the bounded (<=10m) cron-pickup delay over `end_to_end`, required a blocking callback read + schedule parse, and was skewed by manual triggers; `end_to_end` is the clean latency metric.

A companion Grafana dashboard (`opik-daily-reports.json`) lives in comet-monitoring.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7274

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Metric instrumentation, configurable stale timeout, transaction-safety of the completion path, and review-driven simplification (dropped scheduled_to_completion, configurable timeout). Design/naming iterated with author.
- Human verification: Author reviewed; `mvn compile` passing; spotless clean; code-aware + human review addressed. To be validated in dev before review.

## Testing

- `mvn -o compile` — BUILD SUCCESS; spotless passed.
- Addressed review feedback (indexes confirmed present, timeout made configurable, blocking callback read removed).
- Not yet exercised end-to-end against a live Ollie flow — **deployed to dev to validate metric emission + the fix before it goes up for review** (kept draft until then).

## Documentation
N/A (internal observability; dashboard + README in the comet-monitoring PR).
