### PR TITLE
[OPIK-7437] [FE] feat: mobile onboarding swipe navigation and bigger CTAs

### DIFF
--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/ConnectStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/ConnectStep.tsx
@@ -17,8 +17,13 @@ import useSendOnboardingEmailMutation from "@/hooks/useSendOnboardingEmailMutati
 import { trackEvent, OpikEvent } from "@/lib/analytics/tracking";
 import { ConnectIllustration } from "./illustrations";
 
+// Form state (email, emailSent) is owned by the parent: step panels remount
+// to replay their entrance animations, and lifted state survives the remount.
 interface ConnectStepProps {
-  userEmail?: string;
+  email: string;
+  onEmailChange: (value: string) => void;
+  emailSent: boolean;
+  onEmailSentChange: (sent: boolean) => void;
 }
 
 const emailSchema = z.string().email();
@@ -44,10 +49,13 @@ const BenefitCard: React.FC<{
   </div>
 );
 
-const ConnectStep: React.FC<ConnectStepProps> = ({ userEmail = "" }) => {
+const ConnectStep: React.FC<ConnectStepProps> = ({
+  email,
+  onEmailChange,
+  emailSent,
+  onEmailSentChange,
+}) => {
   const { mutate, isPending, isAvailable } = useSendOnboardingEmailMutation();
-  const [email, setEmail] = useState(userEmail);
-  const [emailSent, setEmailSent] = useState(false);
   const [flyRect, setFlyRect] = useState<{
     top: number;
     left: number;
@@ -70,7 +78,7 @@ const ConnectStep: React.FC<ConnectStepProps> = ({ userEmail = "" }) => {
             height: rect.height,
           });
         }
-        setEmailSent(true);
+        onEmailSentChange(true);
       },
     });
   };
@@ -139,8 +147,8 @@ const ConnectStep: React.FC<ConnectStepProps> = ({ userEmail = "" }) => {
               placeholder="your@email.com"
               value={email}
               onChange={(e) => {
-                setEmail(e.target.value);
-                if (emailSent) setEmailSent(false);
+                onEmailChange(e.target.value);
+                if (emailSent) onEmailSentChange(false);
               }}
               dimension="sm"
               autoComplete="email"

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/ConnectStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/ConnectStep.tsx
@@ -149,7 +149,7 @@ const ConnectStep: React.FC<ConnectStepProps> = ({ userEmail = "" }) => {
             />
 
             <Button
-              size="sm"
+              size="lg"
               type="submit"
               disabled={!isValidEmail(email) || emailSent || isPending}
               className="gap-1.5"
@@ -186,7 +186,7 @@ const ConnectStep: React.FC<ConnectStepProps> = ({ userEmail = "" }) => {
             <div className="h-px flex-1 bg-border" />
           </div>
 
-          <Button variant="outline" size="sm" asChild>
+          <Button variant="outline" size="lg" asChild>
             <a
               href={buildDocsUrl("/quickstart")}
               target="_blank"
@@ -194,13 +194,13 @@ const ConnectStep: React.FC<ConnectStepProps> = ({ userEmail = "" }) => {
               className="gap-1.5"
             >
               Open docs
-              <ArrowUpRight className="size-3.5" />
+              <ArrowUpRight className="size-4" />
             </a>
           </Button>
         </div>
       ) : (
         <Button
-          size="sm"
+          size="lg"
           className="slide-fade-right gap-1.5 [animation-delay:200ms]"
           asChild
         >
@@ -210,7 +210,7 @@ const ConnectStep: React.FC<ConnectStepProps> = ({ userEmail = "" }) => {
             rel="noopener noreferrer"
           >
             Quickstart guide
-            <ArrowUpRight className="size-3.5" />
+            <ArrowUpRight className="size-4" />
           </a>
         </Button>
       )}

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboarding.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboarding.tsx
@@ -32,6 +32,23 @@ const MobileOnboarding: React.FC = () => {
     { defaultValue: false },
   );
 
+  // ConnectStep form state lives here so it survives the panel remounts that
+  // replay step entrance animations.
+  const [connectEmail, setConnectEmail] = useState(userEmail);
+  const [connectEmailSent, setConnectEmailSent] = useState(false);
+  const emailTouchedRef = useRef(false);
+  useEffect(() => {
+    // The store may resolve the user's email after mount; prefill only while
+    // the user hasn't typed anything themselves.
+    if (!emailTouchedRef.current) {
+      setConnectEmail(userEmail);
+    }
+  }, [userEmail]);
+  const handleConnectEmailChange = useCallback((value: string) => {
+    emailTouchedRef.current = true;
+    setConnectEmail(value);
+  }, []);
+
   const stepRef = useRef(1);
   const completedRef = useRef(completed);
 
@@ -116,7 +133,12 @@ const MobileOnboarding: React.FC = () => {
       <WelcomeStep onNext={handleNext} active={step === 1} />
       <TraceStep onNext={handleNext} />
       <IssuesStep />
-      <ConnectStep userEmail={userEmail} />
+      <ConnectStep
+        email={connectEmail}
+        onEmailChange={handleConnectEmailChange}
+        emailSent={connectEmailSent}
+        onEmailSentChange={setConnectEmailSent}
+      />
     </MobileOnboardingShell>
   );
 };

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboarding.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboarding.tsx
@@ -91,6 +91,12 @@ const MobileOnboarding: React.FC = () => {
     }
   }, [step]);
 
+  // Swipe navigation: the shell reports the step the user scrolled to.
+  const handleStepChange = useCallback((next: number) => {
+    stepRef.current = next;
+    setStep(next);
+  }, []);
+
   if (completed) {
     return <Navigate to="/$workspaceName/home" params={{ workspaceName }} />;
   }
@@ -103,13 +109,14 @@ const MobileOnboarding: React.FC = () => {
       totalSteps={STEP_CONFIG.length}
       onBack={step > 1 ? handleBack : undefined}
       onNext={handleNext}
+      onStepChange={handleStepChange}
       nextLabel={config.nextLabel}
       nextVariant={config.nextVariant}
     >
-      {step === 1 && <WelcomeStep onNext={handleNext} />}
-      {step === 2 && <TraceStep onNext={handleNext} />}
-      {step === 3 && <IssuesStep />}
-      {step === 4 && <ConnectStep userEmail={userEmail} />}
+      <WelcomeStep onNext={handleNext} />
+      <TraceStep onNext={handleNext} />
+      <IssuesStep />
+      <ConnectStep userEmail={userEmail} />
     </MobileOnboardingShell>
   );
 };

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboarding.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboarding.tsx
@@ -33,21 +33,12 @@ const MobileOnboarding: React.FC = () => {
   );
 
   // ConnectStep form state lives here so it survives the panel remounts that
-  // replay step entrance animations.
-  const [connectEmail, setConnectEmail] = useState(userEmail);
+  // replay step entrance animations. Only what the user typed is stored
+  // (null = untouched); the effective value falls back to the store's email,
+  // which may resolve after mount.
+  const [typedEmail, setTypedEmail] = useState<string | null>(null);
   const [connectEmailSent, setConnectEmailSent] = useState(false);
-  const emailTouchedRef = useRef(false);
-  useEffect(() => {
-    // The store may resolve the user's email after mount; prefill only while
-    // the user hasn't typed anything themselves.
-    if (!emailTouchedRef.current) {
-      setConnectEmail(userEmail);
-    }
-  }, [userEmail]);
-  const handleConnectEmailChange = useCallback((value: string) => {
-    emailTouchedRef.current = true;
-    setConnectEmail(value);
-  }, []);
+  const connectEmail = typedEmail ?? userEmail ?? "";
 
   const stepRef = useRef(1);
   const completedRef = useRef(completed);
@@ -135,7 +126,7 @@ const MobileOnboarding: React.FC = () => {
       <IssuesStep />
       <ConnectStep
         email={connectEmail}
-        onEmailChange={handleConnectEmailChange}
+        onEmailChange={setTypedEmail}
         emailSent={connectEmailSent}
         onEmailSentChange={setConnectEmailSent}
       />

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboarding.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboarding.tsx
@@ -113,7 +113,7 @@ const MobileOnboarding: React.FC = () => {
       nextLabel={config.nextLabel}
       nextVariant={config.nextVariant}
     >
-      <WelcomeStep onNext={handleNext} />
+      <WelcomeStep onNext={handleNext} active={step === 1} />
       <TraceStep onNext={handleNext} />
       <IssuesStep />
       <ConnectStep userEmail={userEmail} />

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboardingShell.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboardingShell.tsx
@@ -155,7 +155,16 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
         className="flex min-h-0 flex-1 snap-x snap-mandatory overflow-x-auto overflow-y-hidden overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
         {React.Children.map(children, (panel, i) => (
-          <div className="w-full shrink-0 snap-center snap-always overflow-y-auto overflow-x-hidden px-5 py-3">
+          <div
+            // Offscreen panels are inert: removed from the tab order, the
+            // accessibility tree and pointer events, so keyboard/screen-reader
+            // users can't reach controls of steps they're not on. Set
+            // imperatively — React 18 has no boolean `inert` prop support.
+            ref={(node) => {
+              if (node) node.inert = i + 1 !== step;
+            }}
+            className="w-full shrink-0 snap-center snap-always overflow-y-auto overflow-x-hidden px-5 py-3"
+          >
             <div
               key={panelAnim[i]?.seq ?? 0}
               className={`flex flex-col gap-3 ${

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboardingShell.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboardingShell.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import Logo from "@/shared/Logo/Logo";
 import { Button } from "@/ui/button";
@@ -8,20 +8,106 @@ interface MobileOnboardingShellProps {
   totalSteps: number;
   onBack?: () => void;
   onNext: () => void;
+  /** Called when the user swipes to another step. */
+  onStepChange: (step: number) => void;
   nextLabel: string;
   nextVariant?: "default" | "outline";
+  /** One panel per step; all stay mounted so swiping is native scrolling. */
   children: React.ReactNode;
 }
+
+const clampStep = (value: number, totalSteps: number) =>
+  Math.min(totalSteps, Math.max(1, value));
 
 const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
   step,
   totalSteps,
   onBack,
   onNext,
+  onStepChange,
   nextLabel,
   nextVariant = "default",
   children,
 }) => {
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  // Set when a step change came from the user's own swipe — the scroller is
+  // already at (or snapping to) the right place, so don't scroll it again.
+  const fromScroll = useRef(false);
+  // While a button-driven smooth scroll is in flight, scroll events must not
+  // sync state (early frames still round to the old step and would flip the
+  // progress bar back and forth). Holds the target position until reached.
+  const targetLeft = useRef<number | null>(null);
+
+  // Per-panel animation state. On every step change (swipe or buttons) the
+  // outgoing panel's content remounts wrapped in `onboarding-anim-reverse`,
+  // replaying its staggered slide-fade entrance BACKWARDS (elements cascade
+  // out), while the incoming panel remounts normally and staggers in.
+  const prevStep = useRef(step);
+  const [panelAnim, setPanelAnim] = useState<
+    { seq: number; mode: "in" | "out" }[]
+  >(() => Array.from({ length: totalSteps }, () => ({ seq: 0, mode: "in" })));
+
+  // On step change: run the out/in animations and, for button navigation,
+  // scroll the panel into view. Single effect so the fromScroll flag is read
+  // and consumed in one place.
+  useEffect(() => {
+    if (prevStep.current === step) return;
+    const from = prevStep.current;
+    prevStep.current = step;
+
+    setPanelAnim((arr) =>
+      arr.map((p, i) =>
+        i === step - 1
+          ? { seq: p.seq + 1, mode: "in" }
+          : i === from - 1
+            ? { seq: p.seq + 1, mode: "out" }
+            : p,
+      ),
+    );
+
+    const el = scrollerRef.current;
+    if (!el) return;
+    if (fromScroll.current) {
+      // User swiped — the scroller is already there; just the animations.
+      fromScroll.current = false;
+      return;
+    }
+    const left = (step - 1) * el.clientWidth;
+    if (Math.abs(el.scrollLeft - left) < 2) return;
+    const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)")
+      .matches;
+    targetLeft.current = left;
+    el.scrollTo({ left, behavior: reduceMotion ? "auto" : "smooth" });
+  }, [step]);
+
+  // Swiping is plain native horizontal scrolling with snap points; we only
+  // observe it to keep the step state (progress bar, labels) in sync.
+  const handleScroll = () => {
+    const el = scrollerRef.current;
+    if (!el || !el.clientWidth) return;
+
+    if (targetLeft.current !== null) {
+      // Programmatic scroll in flight — just watch for arrival.
+      if (Math.abs(el.scrollLeft - targetLeft.current) < 2) {
+        targetLeft.current = null;
+      }
+    } else {
+      const index = clampStep(
+        Math.round(el.scrollLeft / el.clientWidth) + 1,
+        totalSteps,
+      );
+      if (index !== step) {
+        fromScroll.current = true;
+        onStepChange(index);
+      }
+    }
+  };
+
+  // A touch interrupting a button-driven scroll returns control to the user.
+  const handleUserScrollStart = () => {
+    targetLeft.current = null;
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-background">
       <div className="flex flex-col gap-3 px-5 pb-2 pt-5">
@@ -48,30 +134,46 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-5 py-3">
-        <div className="flex flex-col gap-3">{children}</div>
+      <div
+        ref={scrollerRef}
+        onScroll={handleScroll}
+        onTouchStart={handleUserScrollStart}
+        className="flex min-h-0 flex-1 snap-x snap-mandatory overflow-x-auto overflow-y-hidden overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        {React.Children.map(children, (panel, i) => (
+          <div className="w-full shrink-0 snap-center snap-always overflow-y-auto overflow-x-hidden px-5 py-3">
+            <div
+              key={panelAnim[i]?.seq ?? 0}
+              className={`flex flex-col gap-3 ${
+                panelAnim[i]?.mode === "out" ? "onboarding-anim-reverse" : ""
+              }`}
+            >
+              {panel}
+            </div>
+          </div>
+        ))}
       </div>
 
       <div className="flex items-center gap-2 p-5">
         {onBack && (
           <Button
             variant="outline"
-            size="sm"
+            size="lg"
             onClick={onBack}
-            className="w-20 gap-1.5"
+            className="w-24 gap-1.5"
           >
-            <ArrowLeft className="size-3.5" />
+            <ArrowLeft className="size-4" />
             Back
           </Button>
         )}
         <Button
           variant={nextVariant}
-          size="sm"
+          size="lg"
           onClick={onNext}
           className="flex-1 gap-1.5"
         >
           {nextLabel}
-          <ArrowRight className="size-3.5" />
+          <ArrowRight className="size-4" />
         </Button>
       </div>
     </div>

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboardingShell.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboardingShell.tsx
@@ -19,9 +19,12 @@ interface MobileOnboardingShellProps {
 const clampStep = (value: number, totalSteps: number) =>
   Math.min(totalSteps, Math.max(1, value));
 
-// Longest stagger (525ms delay + 200ms duration) rounded up — after this the
-// outgoing panel's reverse cascade is done and it can be restored.
-const OUT_ANIMATION_TOTAL_MS = 800;
+// The outgoing panel is restored once its reverse cascade finishes, detected
+// via animationend debounce (which adapts to whatever delays the steps use).
+// The fallback cap only fires when no animation events arrive at all (e.g.
+// prefers-reduced-motion disables the animations, leaving content visible).
+const OUT_RESET_DEBOUNCE_MS = 300;
+const OUT_RESET_FALLBACK_MS = 2500;
 
 /** Derives the 1-indexed step the scroller is currently closest to. */
 const stepFromScroll = (el: HTMLElement, totalSteps: number) =>
@@ -35,8 +38,8 @@ const stepFromScroll = (el: HTMLElement, totalSteps: number) =>
 const scrollPanelIntoView = (el: HTMLElement, step: number): number | null => {
   const left = (step - 1) * el.clientWidth;
   if (Math.abs(el.scrollLeft - left) < 2) return null;
-  const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)")
-    .matches;
+  const reduceMotion =
+    window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
   el.scrollTo({ left, behavior: reduceMotion ? "auto" : "smooth" });
   return left;
 };
@@ -84,24 +87,25 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
           ? { seq: p.seq + 1, mode: "in" }
           : i === from - 1
             ? { seq: p.seq + 1, mode: "out" }
-            : p,
+            : p.mode === "out"
+              ? // A rapid earlier navigation may have cancelled this panel's
+                // pending restore — bring any straggler back now (offscreen,
+                // so the forward replay is invisible).
+                { seq: p.seq + 1, mode: "in" }
+              : p,
       ),
     );
 
     // The reversed cascade parks the departed panel at its hidden first
-    // frame (fill-mode: both). Once it finishes, restore the panel to its
-    // settled visible state — the forward replay happens offscreen — so
-    // peeking back at it mid-swipe never reveals a blank page.
-    // (Cleared on any subsequent step change, so firing implies the departed
-    // panel is still not the current one.)
+    // frame (fill-mode: both). Once it finishes — detected by animationend
+    // debounce below, with this timer as a no-events fallback — restore the
+    // panel to its settled visible state so peeking back at it mid-swipe
+    // never reveals a blank page.
     clearTimeout(outResetTimer.current);
-    outResetTimer.current = setTimeout(() => {
-      setPanelAnim((arr) =>
-        arr.map((p, i) =>
-          i === from - 1 ? { seq: p.seq + 1, mode: "in" } : p,
-        ),
-      );
-    }, OUT_ANIMATION_TOTAL_MS);
+    outResetTimer.current = setTimeout(
+      () => restoreOutPanel(from - 1),
+      OUT_RESET_FALLBACK_MS,
+    );
 
     const el = scrollerRef.current;
     if (!el) return;
@@ -114,6 +118,28 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
   }, [step]);
 
   useEffect(() => () => clearTimeout(outResetTimer.current), []);
+
+  // Restores a departed panel to its settled visible state after its reverse
+  // cascade. Guarded on mode so a late timer can't remount an active panel.
+  const restoreOutPanel = (panelIndex: number) => {
+    setPanelAnim((arr) =>
+      arr.map((p, i) =>
+        i === panelIndex && p.mode === "out"
+          ? { seq: p.seq + 1, mode: "in" }
+          : p,
+      ),
+    );
+  };
+
+  // Each animationend from the outgoing panel pushes the debounce forward;
+  // when the events stop, the cascade is done and the panel can be restored.
+  const handlePanelAnimationEnd = (panelIndex: number) => {
+    clearTimeout(outResetTimer.current);
+    outResetTimer.current = setTimeout(
+      () => restoreOutPanel(panelIndex),
+      OUT_RESET_DEBOUNCE_MS,
+    );
+  };
 
   // Swiping is plain native horizontal scrolling with snap points; we only
   // observe it to keep the step state (progress bar, labels) in sync.
@@ -182,9 +208,26 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
             // accessibility tree and pointer events, so keyboard/screen-reader
             // users can't reach controls of steps they're not on. Set
             // imperatively — React 18 has no boolean `inert` prop support.
+            // Browsers without inert fall back to aria-hidden plus disabled
+            // pointer events (tab order can't be fully fixed without inert).
             ref={(node) => {
-              if (node) node.inert = i + 1 !== step;
+              if (!node) return;
+              const inactive = i + 1 !== step;
+              if ("inert" in node) {
+                node.inert = inactive;
+              } else if (inactive) {
+                (node as HTMLElement).setAttribute("aria-hidden", "true");
+                (node as HTMLElement).style.pointerEvents = "none";
+              } else {
+                (node as HTMLElement).removeAttribute("aria-hidden");
+                (node as HTMLElement).style.pointerEvents = "";
+              }
             }}
+            onAnimationEnd={
+              panelAnim[i]?.mode === "out"
+                ? () => handlePanelAnimationEnd(i)
+                : undefined
+            }
             className="w-full shrink-0 snap-center snap-always overflow-y-auto overflow-x-hidden px-5 py-3"
           >
             <div

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboardingShell.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboardingShell.tsx
@@ -19,6 +19,10 @@ interface MobileOnboardingShellProps {
 const clampStep = (value: number, totalSteps: number) =>
   Math.min(totalSteps, Math.max(1, value));
 
+// Longest stagger (525ms delay + 200ms duration) rounded up — after this the
+// outgoing panel's reverse cascade is done and it can be restored.
+const OUT_ANIMATION_TOTAL_MS = 800;
+
 /** Derives the 1-indexed step the scroller is currently closest to. */
 const stepFromScroll = (el: HTMLElement, totalSteps: number) =>
   clampStep(Math.round(el.scrollLeft / el.clientWidth) + 1, totalSteps);
@@ -61,6 +65,7 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
   // replaying its staggered slide-fade entrance BACKWARDS (elements cascade
   // out), while the incoming panel remounts normally and staggers in.
   const prevStep = useRef(step);
+  const outResetTimer = useRef<ReturnType<typeof setTimeout>>();
   const [panelAnim, setPanelAnim] = useState<
     { seq: number; mode: "in" | "out" }[]
   >(() => Array.from({ length: totalSteps }, () => ({ seq: 0, mode: "in" })));
@@ -83,6 +88,21 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
       ),
     );
 
+    // The reversed cascade parks the departed panel at its hidden first
+    // frame (fill-mode: both). Once it finishes, restore the panel to its
+    // settled visible state — the forward replay happens offscreen — so
+    // peeking back at it mid-swipe never reveals a blank page.
+    // (Cleared on any subsequent step change, so firing implies the departed
+    // panel is still not the current one.)
+    clearTimeout(outResetTimer.current);
+    outResetTimer.current = setTimeout(() => {
+      setPanelAnim((arr) =>
+        arr.map((p, i) =>
+          i === from - 1 ? { seq: p.seq + 1, mode: "in" } : p,
+        ),
+      );
+    }, OUT_ANIMATION_TOTAL_MS);
+
     const el = scrollerRef.current;
     if (!el) return;
     if (fromScroll.current) {
@@ -92,6 +112,8 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
     }
     targetLeft.current = scrollPanelIntoView(el, step);
   }, [step]);
+
+  useEffect(() => () => clearTimeout(outResetTimer.current), []);
 
   // Swiping is plain native horizontal scrolling with snap points; we only
   // observe it to keep the step state (progress bar, labels) in sync.

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboardingShell.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboardingShell.tsx
@@ -19,6 +19,28 @@ interface MobileOnboardingShellProps {
 const clampStep = (value: number, totalSteps: number) =>
   Math.min(totalSteps, Math.max(1, value));
 
+interface PanelAnim {
+  /** Remount counter — bumping it replays the panel's entrance animation. */
+  seq: number;
+  mode: "in" | "out";
+}
+
+/** Panel animation state for a step change: the incoming panel replays its
+ * entrance, the outgoing one plays it in reverse, and any straggler still
+ * marked "out" (a rapid earlier navigation cancelled its pending restore)
+ * is brought back — offscreen, so its forward replay is invisible. */
+const panelAnimForStepChange = (
+  arr: PanelAnim[],
+  incomingIndex: number,
+  outgoingIndex: number,
+): PanelAnim[] =>
+  arr.map((p, i) => {
+    if (i === incomingIndex) return { seq: p.seq + 1, mode: "in" };
+    if (i === outgoingIndex) return { seq: p.seq + 1, mode: "out" };
+    if (p.mode === "out") return { seq: p.seq + 1, mode: "in" };
+    return p;
+  });
+
 // The outgoing panel is restored once its reverse cascade finishes, detected
 // via animationend debounce (which adapts to whatever delays the steps use).
 // The fallback cap only fires when no animation events arrive at all (e.g.
@@ -69,9 +91,9 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
   // out), while the incoming panel remounts normally and staggers in.
   const prevStep = useRef(step);
   const outResetTimer = useRef<ReturnType<typeof setTimeout>>();
-  const [panelAnim, setPanelAnim] = useState<
-    { seq: number; mode: "in" | "out" }[]
-  >(() => Array.from({ length: totalSteps }, () => ({ seq: 0, mode: "in" })));
+  const [panelAnim, setPanelAnim] = useState<PanelAnim[]>(() =>
+    Array.from({ length: totalSteps }, () => ({ seq: 0, mode: "in" })),
+  );
 
   // On step change: run the out/in animations and, for button navigation,
   // scroll the panel into view. Single effect so the fromScroll flag is read
@@ -81,20 +103,7 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
     const from = prevStep.current;
     prevStep.current = step;
 
-    setPanelAnim((arr) =>
-      arr.map((p, i) =>
-        i === step - 1
-          ? { seq: p.seq + 1, mode: "in" }
-          : i === from - 1
-            ? { seq: p.seq + 1, mode: "out" }
-            : p.mode === "out"
-              ? // A rapid earlier navigation may have cancelled this panel's
-                // pending restore — bring any straggler back now (offscreen,
-                // so the forward replay is invisible).
-                { seq: p.seq + 1, mode: "in" }
-              : p,
-      ),
-    );
+    setPanelAnim((arr) => panelAnimForStepChange(arr, step - 1, from - 1));
 
     // The reversed cascade parks the departed panel at its hidden first
     // frame (fill-mode: both). Once it finishes — detected by animationend

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboardingShell.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboardingShell.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useRef, useState } from "react";
+import React from "react";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import Logo from "@/shared/Logo/Logo";
 import { Button } from "@/ui/button";
+import { useSwipeableSteps } from "./useSwipeableSteps";
 
 interface MobileOnboardingShellProps {
   step: number;
@@ -16,56 +17,6 @@ interface MobileOnboardingShellProps {
   children: React.ReactNode;
 }
 
-const clampStep = (value: number, totalSteps: number) =>
-  Math.min(totalSteps, Math.max(1, value));
-
-interface PanelAnim {
-  /** Remount counter — bumping it replays the panel's entrance animation. */
-  seq: number;
-  mode: "in" | "out";
-}
-
-/** Panel animation state for a step change: the incoming panel replays its
- * entrance, the outgoing one plays it in reverse, and any straggler still
- * marked "out" (a rapid earlier navigation cancelled its pending restore)
- * is brought back — offscreen, so its forward replay is invisible. */
-const panelAnimForStepChange = (
-  arr: PanelAnim[],
-  incomingIndex: number,
-  outgoingIndex: number,
-): PanelAnim[] =>
-  arr.map((p, i) => {
-    if (i === incomingIndex) return { seq: p.seq + 1, mode: "in" };
-    if (i === outgoingIndex) return { seq: p.seq + 1, mode: "out" };
-    if (p.mode === "out") return { seq: p.seq + 1, mode: "in" };
-    return p;
-  });
-
-// The outgoing panel is restored once its reverse cascade finishes, detected
-// via animationend debounce (which adapts to whatever delays the steps use).
-// The fallback cap only fires when no animation events arrive at all (e.g.
-// prefers-reduced-motion disables the animations, leaving content visible).
-const OUT_RESET_DEBOUNCE_MS = 300;
-const OUT_RESET_FALLBACK_MS = 2500;
-
-/** Derives the 1-indexed step the scroller is currently closest to. */
-const stepFromScroll = (el: HTMLElement, totalSteps: number) =>
-  clampStep(Math.round(el.scrollLeft / el.clientWidth) + 1, totalSteps);
-
-/**
- * Smooth-scrolls the panel for `step` into view (instant under
- * prefers-reduced-motion). Returns the target scrollLeft, or null when the
- * scroller is already there.
- */
-const scrollPanelIntoView = (el: HTMLElement, step: number): number | null => {
-  const left = (step - 1) * el.clientWidth;
-  if (Math.abs(el.scrollLeft - left) < 2) return null;
-  const reduceMotion =
-    window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
-  el.scrollTo({ left, behavior: reduceMotion ? "auto" : "smooth" });
-  return left;
-};
-
 const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
   step,
   totalSteps,
@@ -76,106 +27,11 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
   nextVariant = "default",
   children,
 }) => {
-  const scrollerRef = useRef<HTMLDivElement>(null);
-  // Set when a step change came from the user's own swipe — the scroller is
-  // already at (or snapping to) the right place, so don't scroll it again.
-  const fromScroll = useRef(false);
-  // While a button-driven smooth scroll is in flight, scroll events must not
-  // sync state (early frames still round to the old step and would flip the
-  // progress bar back and forth). Holds the target position until reached.
-  const targetLeft = useRef<number | null>(null);
-
-  // Per-panel animation state. On every step change (swipe or buttons) the
-  // outgoing panel's content remounts in `comet-onboarding-anim-reverse`,
-  // replaying its staggered slide-fade entrance BACKWARDS (elements cascade
-  // out), while the incoming panel remounts normally and staggers in.
-  const prevStep = useRef(step);
-  const outResetTimer = useRef<ReturnType<typeof setTimeout>>();
-  const [panelAnim, setPanelAnim] = useState<PanelAnim[]>(() =>
-    Array.from({ length: totalSteps }, () => ({ seq: 0, mode: "in" })),
-  );
-
-  // On step change: run the out/in animations and, for button navigation,
-  // scroll the panel into view. Single effect so the fromScroll flag is read
-  // and consumed in one place.
-  useEffect(() => {
-    if (prevStep.current === step) return;
-    const from = prevStep.current;
-    prevStep.current = step;
-
-    setPanelAnim((arr) => panelAnimForStepChange(arr, step - 1, from - 1));
-
-    // The reversed cascade parks the departed panel at its hidden first
-    // frame (fill-mode: both). Once it finishes — detected by animationend
-    // debounce below, with this timer as a no-events fallback — restore the
-    // panel to its settled visible state so peeking back at it mid-swipe
-    // never reveals a blank page.
-    clearTimeout(outResetTimer.current);
-    outResetTimer.current = setTimeout(
-      () => restoreOutPanel(from - 1),
-      OUT_RESET_FALLBACK_MS,
-    );
-
-    const el = scrollerRef.current;
-    if (!el) return;
-    if (fromScroll.current) {
-      // User swiped — the scroller is already there; just the animations.
-      fromScroll.current = false;
-      return;
-    }
-    targetLeft.current = scrollPanelIntoView(el, step);
-  }, [step]);
-
-  useEffect(() => () => clearTimeout(outResetTimer.current), []);
-
-  // Restores a departed panel to its settled visible state after its reverse
-  // cascade. Guarded on mode so a late timer can't remount an active panel.
-  const restoreOutPanel = (panelIndex: number) => {
-    setPanelAnim((arr) =>
-      arr.map((p, i) =>
-        i === panelIndex && p.mode === "out"
-          ? { seq: p.seq + 1, mode: "in" }
-          : p,
-      ),
-    );
-  };
-
-  // Each animationend from the outgoing panel pushes the debounce forward;
-  // when the events stop, the cascade is done and the panel can be restored.
-  const handlePanelAnimationEnd = (panelIndex: number) => {
-    clearTimeout(outResetTimer.current);
-    outResetTimer.current = setTimeout(
-      () => restoreOutPanel(panelIndex),
-      OUT_RESET_DEBOUNCE_MS,
-    );
-  };
-
-  // Swiping is plain native horizontal scrolling with snap points; we only
-  // observe it to keep the step state (progress bar, labels) in sync.
-  const handleScroll = () => {
-    const el = scrollerRef.current;
-    if (!el || !el.clientWidth) return;
-
-    if (targetLeft.current !== null) {
-      // Programmatic scroll in flight — just watch for arrival.
-      if (Math.abs(el.scrollLeft - targetLeft.current) < 2) {
-        targetLeft.current = null;
-      }
-    } else {
-      const index = stepFromScroll(el, totalSteps);
-      if (index !== step) {
-        fromScroll.current = true;
-        onStepChange(index);
-      }
-    }
-  };
-
-  // Any user interaction (touch, trackpad/wheel, pointer) interrupting a
-  // button-driven scroll returns control to the user immediately, so step
-  // syncing is never left suppressed by an unreached target position.
-  const handleUserScrollStart = () => {
-    targetLeft.current = null;
-  };
+  const { scrollerProps, getPanelProps, getContentProps } = useSwipeableSteps({
+    step,
+    totalSteps,
+    onStepChange,
+  });
 
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-background">
@@ -204,53 +60,27 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
       </div>
 
       <div
-        ref={scrollerRef}
-        onScroll={handleScroll}
-        onTouchStart={handleUserScrollStart}
-        onWheel={handleUserScrollStart}
-        onPointerDown={handleUserScrollStart}
+        {...scrollerProps}
         className="flex min-h-0 flex-1 snap-x snap-mandatory overflow-x-auto overflow-y-hidden overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
-        {React.Children.map(children, (panel, i) => (
-          <div
-            // Offscreen panels are inert: removed from the tab order, the
-            // accessibility tree and pointer events, so keyboard/screen-reader
-            // users can't reach controls of steps they're not on. Set
-            // imperatively — React 18 has no boolean `inert` prop support.
-            // Browsers without inert fall back to aria-hidden plus disabled
-            // pointer events (tab order can't be fully fixed without inert).
-            ref={(node) => {
-              if (!node) return;
-              const inactive = i + 1 !== step;
-              if ("inert" in node) {
-                node.inert = inactive;
-              } else if (inactive) {
-                (node as HTMLElement).setAttribute("aria-hidden", "true");
-                (node as HTMLElement).style.pointerEvents = "none";
-              } else {
-                (node as HTMLElement).removeAttribute("aria-hidden");
-                (node as HTMLElement).style.pointerEvents = "";
-              }
-            }}
-            onAnimationEnd={
-              panelAnim[i]?.mode === "out"
-                ? () => handlePanelAnimationEnd(i)
-                : undefined
-            }
-            className="w-full shrink-0 snap-center snap-always overflow-y-auto overflow-x-hidden px-5 py-3"
-          >
+        {React.Children.map(children, (panel, i) => {
+          const { key, reversed } = getContentProps(i);
+          return (
             <div
-              key={panelAnim[i]?.seq ?? 0}
-              className={`flex flex-col gap-3 ${
-                panelAnim[i]?.mode === "out"
-                  ? "comet-onboarding-anim-reverse"
-                  : ""
-              }`}
+              {...getPanelProps(i)}
+              className="w-full shrink-0 snap-center snap-always overflow-y-auto overflow-x-hidden px-5 py-3"
             >
-              {panel}
+              <div
+                key={key}
+                className={`flex flex-col gap-3 ${
+                  reversed ? "comet-onboarding-anim-reverse" : ""
+                }`}
+              >
+                {panel}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       <div className="flex items-center gap-2 p-5">

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboardingShell.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/MobileOnboardingShell.tsx
@@ -19,6 +19,24 @@ interface MobileOnboardingShellProps {
 const clampStep = (value: number, totalSteps: number) =>
   Math.min(totalSteps, Math.max(1, value));
 
+/** Derives the 1-indexed step the scroller is currently closest to. */
+const stepFromScroll = (el: HTMLElement, totalSteps: number) =>
+  clampStep(Math.round(el.scrollLeft / el.clientWidth) + 1, totalSteps);
+
+/**
+ * Smooth-scrolls the panel for `step` into view (instant under
+ * prefers-reduced-motion). Returns the target scrollLeft, or null when the
+ * scroller is already there.
+ */
+const scrollPanelIntoView = (el: HTMLElement, step: number): number | null => {
+  const left = (step - 1) * el.clientWidth;
+  if (Math.abs(el.scrollLeft - left) < 2) return null;
+  const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)")
+    .matches;
+  el.scrollTo({ left, behavior: reduceMotion ? "auto" : "smooth" });
+  return left;
+};
+
 const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
   step,
   totalSteps,
@@ -39,7 +57,7 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
   const targetLeft = useRef<number | null>(null);
 
   // Per-panel animation state. On every step change (swipe or buttons) the
-  // outgoing panel's content remounts wrapped in `onboarding-anim-reverse`,
+  // outgoing panel's content remounts in `comet-onboarding-anim-reverse`,
   // replaying its staggered slide-fade entrance BACKWARDS (elements cascade
   // out), while the incoming panel remounts normally and staggers in.
   const prevStep = useRef(step);
@@ -72,12 +90,7 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
       fromScroll.current = false;
       return;
     }
-    const left = (step - 1) * el.clientWidth;
-    if (Math.abs(el.scrollLeft - left) < 2) return;
-    const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)")
-      .matches;
-    targetLeft.current = left;
-    el.scrollTo({ left, behavior: reduceMotion ? "auto" : "smooth" });
+    targetLeft.current = scrollPanelIntoView(el, step);
   }, [step]);
 
   // Swiping is plain native horizontal scrolling with snap points; we only
@@ -92,10 +105,7 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
         targetLeft.current = null;
       }
     } else {
-      const index = clampStep(
-        Math.round(el.scrollLeft / el.clientWidth) + 1,
-        totalSteps,
-      );
+      const index = stepFromScroll(el, totalSteps);
       if (index !== step) {
         fromScroll.current = true;
         onStepChange(index);
@@ -103,7 +113,9 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
     }
   };
 
-  // A touch interrupting a button-driven scroll returns control to the user.
+  // Any user interaction (touch, trackpad/wheel, pointer) interrupting a
+  // button-driven scroll returns control to the user immediately, so step
+  // syncing is never left suppressed by an unreached target position.
   const handleUserScrollStart = () => {
     targetLeft.current = null;
   };
@@ -138,6 +150,8 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
         ref={scrollerRef}
         onScroll={handleScroll}
         onTouchStart={handleUserScrollStart}
+        onWheel={handleUserScrollStart}
+        onPointerDown={handleUserScrollStart}
         className="flex min-h-0 flex-1 snap-x snap-mandatory overflow-x-auto overflow-y-hidden overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
         {React.Children.map(children, (panel, i) => (
@@ -145,7 +159,9 @@ const MobileOnboardingShell: React.FC<MobileOnboardingShellProps> = ({
             <div
               key={panelAnim[i]?.seq ?? 0}
               className={`flex flex-col gap-3 ${
-                panelAnim[i]?.mode === "out" ? "onboarding-anim-reverse" : ""
+                panelAnim[i]?.mode === "out"
+                  ? "comet-onboarding-anim-reverse"
+                  : ""
               }`}
             >
               {panel}

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/WelcomeStep.test.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/WelcomeStep.test.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import WelcomeStep from "./WelcomeStep";
+
+vi.mock("./illustrations", () => ({
+  WelcomeIllustration: () => <div data-testid="illustration" />,
+}));
+
+const TYPING_START_DELAY = 500;
+const TYPE_SPEED = 80;
+
+let documentHidden = false;
+
+const setDocumentHidden = (hidden: boolean) => {
+  documentHidden = hidden;
+  act(() => {
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+};
+
+const typedText = (container: HTMLElement) =>
+  container.querySelector('[translate="no"]')?.textContent ?? "";
+
+describe("WelcomeStep TypingText timer lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    documentHidden = false;
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => documentHidden,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("types one character per tick after the start delay", () => {
+    const { container } = render(<WelcomeStep />);
+
+    act(() => {
+      vi.advanceTimersByTime(TYPING_START_DELAY);
+    });
+    expect(typedText(container)).toBe("W");
+
+    act(() => {
+      vi.advanceTimersByTime(TYPE_SPEED * 2);
+    });
+    expect(typedText(container)).toBe("Wha");
+  });
+
+  it("does not run the typing loop while the step is inactive", () => {
+    const { container } = render(<WelcomeStep active={false} />);
+
+    act(() => {
+      vi.advanceTimersByTime(TYPING_START_DELAY + TYPE_SPEED * 10);
+    });
+    expect(typedText(container)).toBe("");
+  });
+
+  it("stops typing when the step becomes inactive", () => {
+    const { container, rerender } = render(<WelcomeStep active />);
+
+    act(() => {
+      vi.advanceTimersByTime(TYPING_START_DELAY + TYPE_SPEED * 2);
+    });
+    expect(typedText(container)).toBe("Wha");
+
+    rerender(<WelcomeStep active={false} />);
+    act(() => {
+      vi.advanceTimersByTime(TYPE_SPEED * 10);
+    });
+    // Paused — no further progress while offscreen.
+    expect(typedText(container)).toBe("Wha");
+  });
+
+  it("keeps a single tick chain when visibility toggles during the start delay", () => {
+    const { container } = render(<WelcomeStep />);
+
+    // Hide and re-show before the initial start timer (500ms) has fired. The
+    // visibility handler starts the loop immediately; the pending start timer
+    // must be cancelled or a second concurrent chain doubles the speed.
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    setDocumentHidden(true);
+    setDocumentHidden(false);
+
+    expect(typedText(container)).toBe("W");
+
+    // 400ms spans the moment the stale start timer would have fired (t=500ms).
+    // A single healthy chain types exactly 5 more characters (80ms each).
+    act(() => {
+      vi.advanceTimersByTime(TYPE_SPEED * 5);
+    });
+    expect(typedText(container)).toBe("What i");
+  });
+
+  it("pauses while the document is hidden and resumes cleanly", () => {
+    const { container } = render(<WelcomeStep />);
+
+    act(() => {
+      vi.advanceTimersByTime(TYPING_START_DELAY + TYPE_SPEED * 2);
+    });
+    expect(typedText(container)).toBe("Wha");
+
+    setDocumentHidden(true);
+    act(() => {
+      vi.advanceTimersByTime(TYPE_SPEED * 10);
+    });
+    // No progress while hidden.
+    expect(typedText(container)).toBe("Wha");
+
+    setDocumentHidden(false);
+    // Resume types the next character immediately, then one per tick.
+    expect(typedText(container)).toBe("What");
+    act(() => {
+      vi.advanceTimersByTime(TYPE_SPEED);
+    });
+    expect(typedText(container)).toBe("What ");
+  });
+});

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/WelcomeStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/WelcomeStep.tsx
@@ -112,11 +112,11 @@ const WelcomeStep: React.FC<{ onNext?: () => void }> = ({ onNext }) => {
                 <Mic className="size-3.5 text-light-slate" />
                 <Button
                   variant="ghost"
-                  size="icon-xs"
+                  size="icon"
                   onClick={onNext}
-                  className="size-6 rounded-full bg-foreground hover:bg-foreground"
+                  className="size-9 rounded-full bg-foreground hover:bg-foreground"
                 >
-                  <ArrowUp className="size-3 text-background" />
+                  <ArrowUp className="size-4 text-background" />
                 </Button>
               </div>
             </div>

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/WelcomeStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/WelcomeStep.tsx
@@ -10,10 +10,14 @@ const PAUSE_AFTER_TYPE = 2500;
 const PAUSE_AFTER_DELETE = 500;
 const TYPING_START_DELAY = 500;
 
-const TypingText: React.FC = () => {
+const TypingText: React.FC<{ active: boolean }> = ({ active }) => {
   const [text, setText] = useState("");
 
   useEffect(() => {
+    // Pause the timer loop entirely while the step is offscreen (the user
+    // swiped to another panel) — no work runs for invisible content.
+    if (!active) return;
+    setText("");
     let timer: ReturnType<typeof setTimeout>;
     let pos = 0;
     let deleting = false;
@@ -57,7 +61,7 @@ const TypingText: React.FC = () => {
       clearTimeout(timer);
       document.removeEventListener("visibilitychange", handleVisibility);
     };
-  }, []);
+  }, [active]);
 
   return (
     <>
@@ -67,7 +71,10 @@ const TypingText: React.FC = () => {
   );
 };
 
-const WelcomeStep: React.FC<{ onNext?: () => void }> = ({ onNext }) => {
+const WelcomeStep: React.FC<{ onNext?: () => void; active?: boolean }> = ({
+  onNext,
+  active = true,
+}) => {
   return (
     <>
       <div className="slide-fade-left">
@@ -104,7 +111,7 @@ const WelcomeStep: React.FC<{ onNext?: () => void }> = ({ onNext }) => {
               className="min-h-5 text-sm leading-5 text-foreground"
               translate="no"
             >
-              <TypingText />
+              <TypingText active={active} />
             </div>
             <div className="flex items-center justify-between">
               <Plus className="size-3.5 text-light-slate" />

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/WelcomeStep.tsx
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/WelcomeStep.tsx
@@ -49,7 +49,12 @@ const TypingText: React.FC<{ active: boolean }> = ({ active }) => {
     const handleVisibility = () => {
       if (document.hidden) {
         clearTimeout(timer);
+        clearTimeout(startTimer);
       } else {
+        // Clear both timers before restarting so a pending start timer can't
+        // spawn a second concurrent tick chain.
+        clearTimeout(timer);
+        clearTimeout(startTimer);
         tick();
       }
     };

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/animations.css
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/animations.css
@@ -162,6 +162,16 @@
   }
 }
 
+/* Wrapping a step's content in this class replays its staggered entrance
+   animations backwards — elements cascade out (visible → hidden) — used for
+   the outgoing panel when navigating between onboarding steps. */
+.onboarding-anim-reverse .onboarding-fade-in,
+.onboarding-anim-reverse .slide-fade-subtle,
+.onboarding-anim-reverse .slide-fade-left,
+.onboarding-anim-reverse .slide-fade-right {
+  animation-direction: reverse;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .onboarding-fade-in,
   .slide-fade-subtle,

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/animations.css
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/animations.css
@@ -165,10 +165,10 @@
 /* Wrapping a step's content in this class replays its staggered entrance
    animations backwards — elements cascade out (visible → hidden) — used for
    the outgoing panel when navigating between onboarding steps. */
-.onboarding-anim-reverse .onboarding-fade-in,
-.onboarding-anim-reverse .slide-fade-subtle,
-.onboarding-anim-reverse .slide-fade-left,
-.onboarding-anim-reverse .slide-fade-right {
+.comet-onboarding-anim-reverse .onboarding-fade-in,
+.comet-onboarding-anim-reverse .slide-fade-subtle,
+.comet-onboarding-anim-reverse .slide-fade-left,
+.comet-onboarding-anim-reverse .slide-fade-right {
   animation-direction: reverse;
 }
 

--- a/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/useSwipeableSteps.ts
+++ b/apps/opik-frontend/src/v2/pages/GetStartedPage/MobileOnboarding/useSwipeableSteps.ts
@@ -1,0 +1,214 @@
+import { useEffect, useRef, useState } from "react";
+
+interface UseSwipeableStepsParams {
+  /** 1-indexed current step. */
+  step: number;
+  totalSteps: number;
+  /** Called when the user swipes/scrolls to another step. */
+  onStepChange: (step: number) => void;
+}
+
+interface PanelAnim {
+  /** Remount counter — bumping it replays the panel's entrance animation. */
+  seq: number;
+  mode: "in" | "out";
+}
+
+// The outgoing panel is restored once its reverse cascade finishes, detected
+// via animationend debounce (which adapts to whatever delays the steps use).
+// The fallback cap only fires when no animation events arrive at all (e.g.
+// prefers-reduced-motion disables the animations, leaving content visible).
+const OUT_RESET_DEBOUNCE_MS = 300;
+const OUT_RESET_FALLBACK_MS = 2500;
+
+const clampStep = (value: number, totalSteps: number) =>
+  Math.min(totalSteps, Math.max(1, value));
+
+/** Derives the 1-indexed step the scroller is currently closest to. */
+const stepFromScroll = (el: HTMLElement, totalSteps: number) =>
+  clampStep(Math.round(el.scrollLeft / el.clientWidth) + 1, totalSteps);
+
+/**
+ * Smooth-scrolls the panel for `step` into view (instant under
+ * prefers-reduced-motion). Returns the target scrollLeft, or null when the
+ * scroller is already there.
+ */
+const scrollPanelIntoView = (el: HTMLElement, step: number): number | null => {
+  const left = (step - 1) * el.clientWidth;
+  if (Math.abs(el.scrollLeft - left) < 2) return null;
+  const reduceMotion =
+    window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
+  el.scrollTo({ left, behavior: reduceMotion ? "auto" : "smooth" });
+  return left;
+};
+
+/** Panel animation state for a step change: the incoming panel replays its
+ * entrance, the outgoing one plays it in reverse, and any straggler still
+ * marked "out" (a rapid earlier navigation cancelled its pending restore)
+ * is brought back — offscreen, so its forward replay is invisible. */
+const panelAnimForStepChange = (
+  arr: PanelAnim[],
+  incomingIndex: number,
+  outgoingIndex: number,
+): PanelAnim[] =>
+  arr.map((p, i) => {
+    if (i === incomingIndex) return { seq: p.seq + 1, mode: "in" };
+    if (i === outgoingIndex) return { seq: p.seq + 1, mode: "out" };
+    if (p.mode === "out") return { seq: p.seq + 1, mode: "in" };
+    return p;
+  });
+
+/** Marks a panel inert while inactive: removed from the tab order, the
+ * accessibility tree and pointer events, so keyboard/screen-reader users
+ * can't reach controls of steps they're not on. Set imperatively — React 18
+ * has no boolean `inert` prop support. Browsers without inert fall back to
+ * aria-hidden plus disabled pointer events. */
+const applyPanelInert = (node: HTMLElement, inactive: boolean) => {
+  if ("inert" in node) {
+    node.inert = inactive;
+  } else if (inactive) {
+    (node as HTMLElement).setAttribute("aria-hidden", "true");
+    (node as HTMLElement).style.pointerEvents = "none";
+  } else {
+    (node as HTMLElement).removeAttribute("aria-hidden");
+    (node as HTMLElement).style.pointerEvents = "";
+  }
+};
+
+/**
+ * Drives swipeable onboarding steps over a native CSS scroll-snap container:
+ * syncs the step state with user swipes, scrolls button-driven step changes
+ * into view (without stepper flicker), replays the staggered entrance
+ * animations (forward for the incoming panel, reversed for the outgoing one)
+ * and keeps offscreen panels inert.
+ *
+ * The component only spreads the returned props onto the scroller, each
+ * panel wrapper and each panel's content element.
+ */
+export const useSwipeableSteps = ({
+  step,
+  totalSteps,
+  onStepChange,
+}: UseSwipeableStepsParams) => {
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  // Set when a step change came from the user's own swipe — the scroller is
+  // already at (or snapping to) the right place, so don't scroll it again.
+  const fromScroll = useRef(false);
+  // While a button-driven smooth scroll is in flight, scroll events must not
+  // sync state (early frames still round to the old step and would flip the
+  // progress bar back and forth). Holds the target position until reached.
+  const targetLeft = useRef<number | null>(null);
+
+  const prevStep = useRef(step);
+  const outResetTimer = useRef<ReturnType<typeof setTimeout>>();
+  const [panelAnim, setPanelAnim] = useState<PanelAnim[]>(() =>
+    Array.from({ length: totalSteps }, () => ({ seq: 0, mode: "in" })),
+  );
+
+  // On step change: run the out/in animations and, for button navigation,
+  // scroll the panel into view. Single effect so the fromScroll flag is read
+  // and consumed in one place.
+  useEffect(() => {
+    if (prevStep.current === step) return;
+    const from = prevStep.current;
+    prevStep.current = step;
+
+    setPanelAnim((arr) => panelAnimForStepChange(arr, step - 1, from - 1));
+
+    // The reversed cascade parks the departed panel at its hidden first
+    // frame (fill-mode: both). Once it finishes — detected by animationend
+    // debounce below, with this timer as a no-events fallback — restore the
+    // panel to its settled visible state so peeking back at it mid-swipe
+    // never reveals a blank page.
+    clearTimeout(outResetTimer.current);
+    outResetTimer.current = setTimeout(
+      () => restoreOutPanel(from - 1),
+      OUT_RESET_FALLBACK_MS,
+    );
+
+    const el = scrollerRef.current;
+    if (!el) return;
+    if (fromScroll.current) {
+      // User swiped — the scroller is already there; just the animations.
+      fromScroll.current = false;
+      return;
+    }
+    targetLeft.current = scrollPanelIntoView(el, step);
+  }, [step]);
+
+  useEffect(() => () => clearTimeout(outResetTimer.current), []);
+
+  // Restores a departed panel to its settled visible state after its reverse
+  // cascade. Guarded on mode so a late timer can't remount an active panel.
+  const restoreOutPanel = (panelIndex: number) => {
+    setPanelAnim((arr) =>
+      arr.map((p, i) =>
+        i === panelIndex && p.mode === "out"
+          ? { seq: p.seq + 1, mode: "in" }
+          : p,
+      ),
+    );
+  };
+
+  // Each animationend from the outgoing panel pushes the debounce forward;
+  // when the events stop, the cascade is done and the panel can be restored.
+  const handlePanelAnimationEnd = (panelIndex: number) => {
+    clearTimeout(outResetTimer.current);
+    outResetTimer.current = setTimeout(
+      () => restoreOutPanel(panelIndex),
+      OUT_RESET_DEBOUNCE_MS,
+    );
+  };
+
+  // Swiping is plain native horizontal scrolling with snap points; we only
+  // observe it to keep the step state (progress bar, labels) in sync.
+  const handleScroll = () => {
+    const el = scrollerRef.current;
+    if (!el || !el.clientWidth) return;
+
+    if (targetLeft.current !== null) {
+      // Programmatic scroll in flight — just watch for arrival.
+      if (Math.abs(el.scrollLeft - targetLeft.current) < 2) {
+        targetLeft.current = null;
+      }
+    } else {
+      const index = stepFromScroll(el, totalSteps);
+      if (index !== step) {
+        fromScroll.current = true;
+        onStepChange(index);
+      }
+    }
+  };
+
+  // Any user interaction (touch, trackpad/wheel, pointer) interrupting a
+  // button-driven scroll returns control to the user immediately, so step
+  // syncing is never left suppressed by an unreached target position.
+  const handleUserScrollStart = () => {
+    targetLeft.current = null;
+  };
+
+  const scrollerProps = {
+    ref: scrollerRef,
+    onScroll: handleScroll,
+    onTouchStart: handleUserScrollStart,
+    onWheel: handleUserScrollStart,
+    onPointerDown: handleUserScrollStart,
+  };
+
+  const getPanelProps = (index: number) => ({
+    ref: (node: HTMLDivElement | null) => {
+      if (node) applyPanelInert(node, index + 1 !== step);
+    },
+    onAnimationEnd:
+      panelAnim[index]?.mode === "out"
+        ? () => handlePanelAnimationEnd(index)
+        : undefined,
+  });
+
+  const getContentProps = (index: number) => ({
+    key: panelAnim[index]?.seq ?? 0,
+    reversed: panelAnim[index]?.mode === "out",
+  });
+
+  return { scrollerProps, getPanelProps, getContentProps };
+};


### PR DESCRIPTION
## Details

Implements the two mobile-onboarding improvements from OPIK-7437: swiping between steps and bigger CTA hit areas.

- Step panels live in a **native CSS scroll-snap container** (`snap-x snap-mandatory` + `snap-center` panels) — finger-tracking, momentum and snapping are handled by the browser; no gesture library or custom drag code.
- JS only syncs state: `onScroll` derives the current step from `scrollLeft` (progress bar/labels update live), Back/Next buttons drive `scrollTo({ behavior: "smooth" })` (respects `prefers-reduced-motion`).
- While a button-driven smooth scroll is in flight, scroll events don't sync state — prevents the stepper flickering between old/new step. Any user interaction (touch/wheel/pointer) mid-flight returns control immediately.
- On step change the outgoing panel replays its staggered slide-fade entrance **in reverse** (elements cascade out) while the incoming panel staggers in — reuses the existing keyframes via `animation-direction: reverse` under a `comet-onboarding-anim-reverse` wrapper.
- `overscroll-x-contain` keeps the browser's edge back-gesture from swallowing right-swipes; swiping can't skip past the last step (completing stays an explicit button tap).
- WelcomeStep's typing demo pauses its timer loop while its panel is offscreen.
- CTAs bumped from `size="sm"` (32px) to `size="lg"` (44px hit area); WelcomeStep round send button 24px → 36px.

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-7437

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: implementation, review fixes, and PR description; design direction and acceptance by the author
- Human verification: manually exercised on a local run against dev; author verified swipe behavior on device

## Testing

- `npx tsc --noEmit`, `npx eslint --max-warnings=0`, `npx stylelint` — clean.
- `vitest run src/v2/pages/GetStartedPage` — 14/14 pass (Node 20).
- Manually exercised against dev (`vite --mode comet.local`) with the phone media query forced: swipe forward/back starting from header/content/footer areas, button navigation both directions, no stepper flicker during button-driven scroll, forward-swipe blocked on the last step, reverse/forward stagger animations on step change.
- Worth a quick real-device pass (iOS Safari edge-swipe) on the preview build.

## Documentation

No documentation changes — UI-only behavior change inside the mobile onboarding flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)