### PR TITLE
[OPIK-7448] [BE] test: MySQL query plan-shape gate (EXPLAIN regression guard)

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/CapturingSqlLogger.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/CapturingSqlLogger.java
@@ -1,0 +1,88 @@
+package com.comet.opik.api.resources.utils.planshape;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.statement.SqlLogger;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * JDBI {@link SqlLogger} that captures the {@code EXPLAIN FORMAT=JSON} plan of every {@code SELECT} rendered while it is
+ * installed, keyed by the rendered SQL. It reuses JDBI's own {@link Argument} binding machinery to re-apply the exact
+ * parameters onto the EXPLAIN prepared statement on the same live connection, so no value extraction or re-binding
+ * guesswork is needed. Non-SELECT statements are ignored.
+ *
+ * <p>This is the shared MySQL capture foundation for the query plan-shape gate (OPIK-7448). The plan JSON it collects is
+ * consumed by {@link MySqlPlanShapeAsserter}. Deduplicating by rendered SQL keeps the captured set bounded even when a
+ * query runs many times across a test.
+ */
+@Slf4j
+public class CapturingSqlLogger implements SqlLogger {
+
+    private final Map<String, String> plansByRenderedSql = new ConcurrentHashMap<>();
+
+    @Override
+    public void logAfterExecution(StatementContext context) {
+        var renderedSql = context.getRenderedSql();
+        if (renderedSql == null || !isSelect(renderedSql)) {
+            return;
+        }
+
+        plansByRenderedSql.computeIfAbsent(renderedSql, sql -> explain(context));
+    }
+
+    private String explain(StatementContext context) {
+        var parsedSql = context.getParsedSql();
+        var jdbcSql = parsedSql.getSql();
+        var parameterNames = parsedSql.getParameters().getParameterNames();
+        var binding = context.getBinding();
+
+        try (PreparedStatement explainStatement = context.getConnection()
+                .prepareStatement("EXPLAIN FORMAT=JSON " + jdbcSql)) {
+
+            for (int i = 0; i < parameterNames.size(); i++) {
+                int position = i;
+                String parameterName = parameterNames.get(i);
+                Argument argument = binding.findForName(parameterName, context)
+                        .or(() -> binding.findForPosition(position))
+                        .orElseThrow(() -> new IllegalStateException(
+                                "No bound argument for parameter '%s' in: %s".formatted(parameterName, jdbcSql)));
+                // JDBC positions are 1-based; JDBI Arguments apply themselves onto the target statement.
+                argument.apply(position + 1, explainStatement, context);
+            }
+
+            try (ResultSet resultSet = explainStatement.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getString(1);
+                }
+                return null;
+            }
+        } catch (Exception e) {
+            // A query the gate cannot EXPLAIN (e.g. references a session TEMPORARY TABLE that only exists mid-flight)
+            // must not fail the capturing test run; it is simply left uncaptured and the asserter never sees it.
+            log.debug("Skipping EXPLAIN for query [{}]: {}", jdbcSql, e.getMessage());
+            return null;
+        }
+    }
+
+    private static boolean isSelect(String sql) {
+        return sql.stripLeading().toLowerCase(Locale.ROOT).startsWith("select");
+    }
+
+    /**
+     * @return an immutable snapshot of captured plans, keyed by rendered SQL. Entries whose EXPLAIN failed hold a
+     *         {@code null} plan and are filtered by the asserter.
+     */
+    public Map<String, String> capturedPlans() {
+        return Map.copyOf(plansByRenderedSql);
+    }
+
+    public void clear() {
+        plansByRenderedSql.clear();
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/CapturingSqlLogger.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/CapturingSqlLogger.java
@@ -7,8 +7,10 @@ import org.jdbi.v3.core.statement.StatementContext;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Statement;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -17,14 +19,29 @@ import java.util.concurrent.ConcurrentHashMap;
  * parameters onto the EXPLAIN prepared statement on the same live connection, so no value extraction or re-binding
  * guesswork is needed. Non-SELECT statements are ignored.
  *
- * <p>This is the shared MySQL capture foundation for the query plan-shape gate (OPIK-7448). The plan JSON it collects is
- * consumed by {@link MySqlPlanShapeAsserter}. Deduplicating by rendered SQL keeps the captured set bounded even when a
- * query runs many times across a test.
+ * <p>EXPLAIN is requested in JSON <b>format version 2</b> ({@code explain_json_format_version = 2}): version 1 puts the
+ * table <i>alias</i> in {@code table_name} (so a base-table match like {@code prompts} silently misses {@code FROM
+ * prompts AS p}), while version 2 reports the base table name and a uniform {@code operation}/{@code access_type}
+ * vocabulary for both materialization and full scans. {@link MySqlPlanShapeAsserter} depends on the v2 shape.</p>
+ *
+ * <p>This is the shared MySQL capture foundation for the query plan-shape gate (OPIK-7448). Deduplicating by rendered
+ * SQL keeps the captured set bounded even when a query runs many times. A SELECT whose EXPLAIN throws is recorded in
+ * {@link CapturedQueries#failedSql()} rather than silently dropped, so the gate can surface queries it could not vet
+ * instead of treating them as clean.</p>
  */
 @Slf4j
 public class CapturingSqlLogger implements SqlLogger {
 
     private final Map<String, String> plansByRenderedSql = new ConcurrentHashMap<>();
+    private final Set<String> failedSql = ConcurrentHashMap.newKeySet();
+
+    /**
+     * @param plansByRenderedSql successfully-captured {@code EXPLAIN FORMAT=JSON} plans, keyed by rendered SQL.
+     * @param failedSql          rendered SELECTs whose EXPLAIN threw — captured but un-vetted, surfaced so they can't
+     *                           pass the gate by omission.
+     */
+    public record CapturedQueries(Map<String, String> plansByRenderedSql, Set<String> failedSql) {
+    }
 
     @Override
     public void logAfterExecution(StatementContext context) {
@@ -32,41 +49,61 @@ public class CapturingSqlLogger implements SqlLogger {
         if (renderedSql == null || !isSelect(renderedSql)) {
             return;
         }
+        if (plansByRenderedSql.containsKey(renderedSql) || failedSql.contains(renderedSql)) {
+            return;
+        }
 
-        plansByRenderedSql.computeIfAbsent(renderedSql, sql -> explain(context));
+        var plan = explain(context, renderedSql);
+        if (plan != null) {
+            plansByRenderedSql.put(renderedSql, plan);
+        }
     }
 
-    private String explain(StatementContext context) {
+    private String explain(StatementContext context, String renderedSql) {
         var parsedSql = context.getParsedSql();
         var jdbcSql = parsedSql.getSql();
         var parameterNames = parsedSql.getParameters().getParameterNames();
         var binding = context.getBinding();
 
-        try (PreparedStatement explainStatement = context.getConnection()
-                .prepareStatement("EXPLAIN FORMAT=JSON " + jdbcSql)) {
+        try {
+            forceV2ExplainFormat(context);
 
-            for (int i = 0; i < parameterNames.size(); i++) {
-                int position = i;
-                String parameterName = parameterNames.get(i);
-                Argument argument = binding.findForName(parameterName, context)
-                        .or(() -> binding.findForPosition(position))
-                        .orElseThrow(() -> new IllegalStateException(
-                                "No bound argument for parameter '%s' in: %s".formatted(parameterName, jdbcSql)));
-                // JDBC positions are 1-based; JDBI Arguments apply themselves onto the target statement.
-                argument.apply(position + 1, explainStatement, context);
-            }
+            try (PreparedStatement explainStatement = context.getConnection()
+                    .prepareStatement("EXPLAIN FORMAT=JSON " + jdbcSql)) {
 
-            try (ResultSet resultSet = explainStatement.executeQuery()) {
-                if (resultSet.next()) {
-                    return resultSet.getString(1);
+                for (int i = 0; i < parameterNames.size(); i++) {
+                    int position = i;
+                    String parameterName = parameterNames.get(i);
+                    Argument argument = binding.findForName(parameterName, context)
+                            .or(() -> binding.findForPosition(position))
+                            .orElseThrow(() -> new IllegalStateException(
+                                    "No bound argument for parameter '%s' in: %s".formatted(parameterName, jdbcSql)));
+                    // JDBC positions are 1-based; JDBI Arguments apply themselves onto the target statement.
+                    argument.apply(position + 1, explainStatement, context);
                 }
-                return null;
+
+                try (ResultSet resultSet = explainStatement.executeQuery()) {
+                    if (resultSet.next()) {
+                        return resultSet.getString(1);
+                    }
+                    failedSql.add(renderedSql);
+                    return null;
+                }
             }
         } catch (Exception e) {
-            // A query the gate cannot EXPLAIN (e.g. references a session TEMPORARY TABLE that only exists mid-flight)
-            // must not fail the capturing test run; it is simply left uncaptured and the asserter never sees it.
-            log.debug("Skipping EXPLAIN for query [{}]: {}", jdbcSql, e.getMessage());
+            // A query the gate cannot EXPLAIN (e.g. one referencing a session TEMPORARY TABLE that only exists
+            // mid-flight) is recorded as failed rather than dropped, so the gate can report it instead of passing it
+            // by omission.
+            log.debug("EXPLAIN failed for query [{}]: {}", jdbcSql, e.getMessage());
+            failedSql.add(renderedSql);
             return null;
+        }
+    }
+
+    // v2 puts the base table name in table_name (v1 uses the alias) — required for the full-scan check to match.
+    private void forceV2ExplainFormat(StatementContext context) throws Exception {
+        try (Statement statement = context.getConnection().createStatement()) {
+            statement.execute("SET explain_json_format_version = 2");
         }
     }
 
@@ -74,15 +111,12 @@ public class CapturingSqlLogger implements SqlLogger {
         return sql.stripLeading().toLowerCase(Locale.ROOT).startsWith("select");
     }
 
-    /**
-     * @return an immutable snapshot of captured plans, keyed by rendered SQL. Entries whose EXPLAIN failed hold a
-     *         {@code null} plan and are filtered by the asserter.
-     */
-    public Map<String, String> capturedPlans() {
-        return Map.copyOf(plansByRenderedSql);
+    public CapturedQueries captured() {
+        return new CapturedQueries(Map.copyOf(plansByRenderedSql), Set.copyOf(failedSql));
     }
 
     public void clear() {
         plansByRenderedSql.clear();
+        failedSql.clear();
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/CapturingSqlLogger.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/CapturingSqlLogger.java
@@ -46,7 +46,7 @@ public class CapturingSqlLogger implements SqlLogger {
     @Override
     public void logAfterExecution(StatementContext context) {
         var renderedSql = context.getRenderedSql();
-        if (renderedSql == null || !isSelect(renderedSql)) {
+        if (renderedSql == null || !isReadQuery(renderedSql)) {
             return;
         }
         if (plansByRenderedSql.containsKey(renderedSql) || failedSql.contains(renderedSql)) {
@@ -107,8 +107,12 @@ public class CapturingSqlLogger implements SqlLogger {
         }
     }
 
-    private static boolean isSelect(String sql) {
-        return sql.stripLeading().toLowerCase(Locale.ROOT).startsWith("select");
+    // Read paths the gate vets: plain SELECTs and CTE reads (WITH ... SELECT). Matching only "select" would skip the
+    // CTE class entirely — exactly the multi-reference-CTE shape (OPIK-7198) the gate exists to catch. No WITH-prefixed
+    // @SqlUpdate writes exist in the backend, and MySQL EXPLAINs WITH ... SELECT the same as a plain SELECT.
+    private static boolean isReadQuery(String sql) {
+        var normalized = sql.stripLeading().toLowerCase(Locale.ROOT);
+        return normalized.startsWith("select") || normalized.startsWith("with");
     }
 
     public CapturedQueries captured() {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/CapturingSqlLogger.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/CapturingSqlLogger.java
@@ -109,7 +109,7 @@ public class CapturingSqlLogger implements SqlLogger {
 
     // Read paths the gate vets: plain SELECTs and CTE reads (WITH ... SELECT). Matching only "select" would skip the
     // CTE class entirely — exactly the multi-reference-CTE shape (OPIK-7198) the gate exists to catch. No WITH-prefixed
-    // @SqlUpdate writes exist in the backend, and MySQL EXPLAINs WITH ... SELECT the same as a plain SELECT.
+    // @SqlUpdate writes exist in the backend, and MySQL EXPLAIN handles WITH ... SELECT the same as a plain SELECT.
     private static boolean isReadQuery(String sql) {
         var normalized = sql.stripLeading().toLowerCase(Locale.ROOT);
         return normalized.startsWith("select") || normalized.startsWith("with");

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/CapturingSqlLogger.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/CapturingSqlLogger.java
@@ -13,6 +13,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * JDBI {@link SqlLogger} that captures the {@code EXPLAIN FORMAT=JSON} plan of every read query rendered while it is
@@ -35,6 +36,7 @@ public class CapturingSqlLogger implements SqlLogger {
 
     private final Map<String, String> plansByRenderedSql = new ConcurrentHashMap<>();
     private final Set<String> failedSql = ConcurrentHashMap.newKeySet();
+    private final AtomicLong readsObserved = new AtomicLong();
 
     /**
      * Result of a capture session.
@@ -57,6 +59,11 @@ public class CapturingSqlLogger implements SqlLogger {
         if (!isReadQuery(renderedSql)) {
             return;
         }
+
+        // Counted before the dedup check so it reflects every read query actually executed, not just the ones that were
+        // new. Callers use it to tell "this code path ran no MySQL read" apart from "it ran one already captured".
+        readsObserved.incrementAndGet();
+
         if (plansByRenderedSql.containsKey(renderedSql) || failedSql.contains(renderedSql)) {
             return;
         }
@@ -136,8 +143,19 @@ public class CapturingSqlLogger implements SqlLogger {
         return new CapturedQueries(Map.copyOf(plansByRenderedSql), Set.copyOf(failedSql));
     }
 
+    /**
+     * Total read queries seen since construction, counted before deduplication. Unlike
+     * {@link CapturedQueries#plansByRenderedSql()}, this grows for every read query executed even when its SQL was
+     * already captured, so it is order-independent: a code path that legitimately re-runs SQL an earlier path already
+     * captured still moves this counter.
+     */
+    public long readsObserved() {
+        return readsObserved.get();
+    }
+
     public void clear() {
         plansByRenderedSql.clear();
         failedSql.clear();
+        readsObserved.set(0);
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/CapturingSqlLogger.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/CapturingSqlLogger.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api.resources.utils.planshape;
 
+import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.statement.SqlLogger;
@@ -14,10 +15,10 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * JDBI {@link SqlLogger} that captures the {@code EXPLAIN FORMAT=JSON} plan of every {@code SELECT} rendered while it is
+ * JDBI {@link SqlLogger} that captures the {@code EXPLAIN FORMAT=JSON} plan of every read query rendered while it is
  * installed, keyed by the rendered SQL. It reuses JDBI's own {@link Argument} binding machinery to re-apply the exact
  * parameters onto the EXPLAIN prepared statement on the same live connection, so no value extraction or re-binding
- * guesswork is needed. Non-SELECT statements are ignored.
+ * guesswork is needed. Non-read statements are ignored.
  *
  * <p>EXPLAIN is requested in JSON <b>format version 2</b> ({@code explain_json_format_version = 2}): version 1 puts the
  * table <i>alias</i> in {@code table_name} (so a base-table match like {@code prompts} silently misses {@code FROM
@@ -25,8 +26,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * vocabulary for both materialization and full scans. {@link MySqlPlanShapeAsserter} depends on the v2 shape.</p>
  *
  * <p>This is the shared MySQL capture foundation for the query plan-shape gate (OPIK-7448). Deduplicating by rendered
- * SQL keeps the captured set bounded even when a query runs many times. A SELECT whose EXPLAIN throws is recorded in
- * {@link CapturedQueries#failedSql()} rather than silently dropped, so the gate can surface queries it could not vet
+ * SQL keeps the captured set bounded even when a query runs many times. A read query whose EXPLAIN throws is recorded
+ * in {@link CapturedQueries#failedSql()} rather than silently dropped, so the gate can surface queries it could not vet
  * instead of treating them as clean.</p>
  */
 @Slf4j
@@ -36,17 +37,24 @@ public class CapturingSqlLogger implements SqlLogger {
     private final Set<String> failedSql = ConcurrentHashMap.newKeySet();
 
     /**
+     * Result of a capture session.
+     *
      * @param plansByRenderedSql successfully-captured {@code EXPLAIN FORMAT=JSON} plans, keyed by rendered SQL.
-     * @param failedSql          rendered SELECTs whose EXPLAIN threw — captured but un-vetted, surfaced so they can't
-     *                           pass the gate by omission.
+     * @param failedSql          rendered read queries whose EXPLAIN threw — captured but un-vetted, surfaced so they
+     *                           can't pass the gate by omission.
      */
+    @Builder(toBuilder = true)
     public record CapturedQueries(Map<String, String> plansByRenderedSql, Set<String> failedSql) {
     }
 
     @Override
     public void logAfterExecution(StatementContext context) {
+        if (context == null) {
+            return;
+        }
+
         var renderedSql = context.getRenderedSql();
-        if (renderedSql == null || !isReadQuery(renderedSql)) {
+        if (!isReadQuery(renderedSql)) {
             return;
         }
         if (plansByRenderedSql.containsKey(renderedSql) || failedSql.contains(renderedSql)) {
@@ -69,7 +77,7 @@ public class CapturingSqlLogger implements SqlLogger {
             forceV2ExplainFormat(context);
 
             try (PreparedStatement explainStatement = context.getConnection()
-                    .prepareStatement("EXPLAIN FORMAT=JSON " + jdbcSql)) {
+                    .prepareStatement("EXPLAIN FORMAT=JSON %s".formatted(jdbcSql))) {
 
                 for (int i = 0; i < parameterNames.size(); i++) {
                     int position = i;
@@ -77,7 +85,7 @@ public class CapturingSqlLogger implements SqlLogger {
                     Argument argument = binding.findForName(parameterName, context)
                             .or(() -> binding.findForPosition(position))
                             .orElseThrow(() -> new IllegalStateException(
-                                    "No bound argument for parameter '%s' in: %s".formatted(parameterName, jdbcSql)));
+                                    "No bound argument for parameter '%s' in: '%s'".formatted(parameterName, jdbcSql)));
                     // JDBC positions are 1-based; JDBI Arguments apply themselves onto the target statement.
                     argument.apply(position + 1, explainStatement, context);
                 }
@@ -90,27 +98,36 @@ public class CapturingSqlLogger implements SqlLogger {
                     return null;
                 }
             }
-        } catch (Exception e) {
+        } catch (Exception exception) {
             // A query the gate cannot EXPLAIN (e.g. one referencing a session TEMPORARY TABLE that only exists
-            // mid-flight) is recorded as failed rather than dropped, so the gate can report it instead of passing it
-            // by omission.
-            log.debug("EXPLAIN failed for query [{}]: {}", jdbcSql, e.getMessage());
+            // mid-flight) is recorded as failed rather than dropped, so the gate can report it instead of passing it by
+            // omission. Warn because an un-vetted query is a gap in coverage, not routine noise.
+            log.warn("EXPLAIN failed for query '{}'", jdbcSql, exception);
             failedSql.add(renderedSql);
             return null;
         }
     }
 
-    // v2 puts the base table name in table_name (v1 uses the alias) — required for the full-scan check to match.
+    /**
+     * Pins the connection to EXPLAIN JSON format version 2, whose {@code table_name} is the base table name; version 1
+     * reports the alias, which would make the full-scan check silently miss aliased tables.
+     */
     private void forceV2ExplainFormat(StatementContext context) throws Exception {
         try (Statement statement = context.getConnection().createStatement()) {
             statement.execute("SET explain_json_format_version = 2");
         }
     }
 
-    // Read paths the gate vets: plain SELECTs and CTE reads (WITH ... SELECT). Matching only "select" would skip the
-    // CTE class entirely — exactly the multi-reference-CTE shape (OPIK-7198) the gate exists to catch. No WITH-prefixed
-    // @SqlUpdate writes exist in the backend, and MySQL EXPLAIN handles WITH ... SELECT the same as a plain SELECT.
+    /**
+     * Read paths the gate vets: plain {@code SELECT}s and CTE reads ({@code WITH ... SELECT}). Matching only
+     * {@code select} would skip the CTE class entirely — exactly the multi-reference-CTE shape (OPIK-7198) the gate
+     * exists to catch. No {@code WITH}-prefixed {@code @SqlUpdate} writes exist in the backend, and MySQL EXPLAIN
+     * handles {@code WITH ... SELECT} the same as a plain {@code SELECT}.
+     */
     private static boolean isReadQuery(String sql) {
+        if (sql == null) {
+            return false;
+        }
         var normalized = sql.stripLeading().toLowerCase(Locale.ROOT);
         return normalized.startsWith("select") || normalized.startsWith("with");
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/MySqlPlanShapeAsserter.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/MySqlPlanShapeAsserter.java
@@ -1,0 +1,82 @@
+package com.comet.opik.api.resources.utils.planshape;
+
+import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Inspects a MySQL {@code EXPLAIN FORMAT=JSON} plan for the query-shape regressions the gate guards against
+ * (OPIK-7448):
+ *
+ * <ul>
+ *   <li><b>Materialized / temporary-table nodes</b> — the OPIK-7198 class. Multi-reference CTEs and derived tables that
+ *       MySQL materializes into an internal {@code #sql...} temporary table saturate the TempTable pool under load and
+ *       fail non-deterministically. The JSON surfaces these as {@code materialized_from_subquery} nodes or a
+ *       {@code using_temporary_table} flag.</li>
+ *   <li><b>Full table scans</b> ({@code access_type = ALL}) on tables that grow with tenant data — a latency cliff at
+ *       scale.</li>
+ * </ul>
+ *
+ * The walk is recursive because EXPLAIN nests {@code query_block} / {@code nested_loop} / {@code table} /
+ * {@code materialized_from_subquery} arbitrarily deep.
+ */
+public class MySqlPlanShapeAsserter {
+
+    private static final String MATERIALIZED_FROM_SUBQUERY = "materialized_from_subquery";
+    private static final String USING_TEMPORARY_TABLE = "using_temporary_table";
+    private static final String TABLE = "table";
+    private static final String TABLE_NAME = "table_name";
+    private static final String ACCESS_TYPE = "access_type";
+    private static final String FULL_SCAN = "ALL";
+
+    private final Set<String> fullScanSensitiveTables;
+
+    public MySqlPlanShapeAsserter(@NonNull Set<String> fullScanSensitiveTables) {
+        this.fullScanSensitiveTables = fullScanSensitiveTables;
+    }
+
+    public List<PlanShapeViolation> findViolations(@NonNull String renderedSql, @NonNull String explainJson) {
+        var violations = new ArrayList<PlanShapeViolation>();
+        walk(JsonUtils.getJsonNodeFromString(explainJson), renderedSql, violations);
+        return violations;
+    }
+
+    private void walk(JsonNode node, String renderedSql, List<PlanShapeViolation> violations) {
+        if (node == null) {
+            return;
+        }
+
+        if (node.isObject()) {
+            if (node.has(MATERIALIZED_FROM_SUBQUERY)) {
+                violations.add(new PlanShapeViolation(renderedSql, PlanShapeViolation.Type.MATERIALIZED_SUBQUERY,
+                        "Plan materializes a subquery into an internal temporary table (OPIK-7198 class)."));
+            }
+            if (node.path(USING_TEMPORARY_TABLE).asBoolean(false)) {
+                violations.add(new PlanShapeViolation(renderedSql, PlanShapeViolation.Type.TEMPORARY_TABLE,
+                        "Plan uses an internal temporary table (OPIK-7198 class)."));
+            }
+
+            var tableNode = node.get(TABLE);
+            if (tableNode != null && tableNode.isObject()) {
+                checkTableAccess(tableNode, renderedSql, violations);
+            }
+
+            node.fields().forEachRemaining(entry -> walk(entry.getValue(), renderedSql, violations));
+        } else if (node.isArray()) {
+            node.forEach(child -> walk(child, renderedSql, violations));
+        }
+    }
+
+    private void checkTableAccess(JsonNode tableNode, String renderedSql, List<PlanShapeViolation> violations) {
+        var accessType = tableNode.path(ACCESS_TYPE).asText(null);
+        var tableName = tableNode.path(TABLE_NAME).asText(null);
+        if (FULL_SCAN.equals(accessType) && tableName != null && fullScanSensitiveTables.contains(tableName)) {
+            violations.add(new PlanShapeViolation(renderedSql, PlanShapeViolation.Type.FULL_TABLE_SCAN,
+                    "Full table scan (access_type=ALL) on tenant-growing table '%s'.".formatted(tableName)));
+        }
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/MySqlPlanShapeAsserter.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/MySqlPlanShapeAsserter.java
@@ -9,29 +9,27 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Inspects a MySQL {@code EXPLAIN FORMAT=JSON} plan for the query-shape regressions the gate guards against
- * (OPIK-7448):
+ * Inspects a MySQL {@code EXPLAIN FORMAT=JSON} plan (JSON <b>format version 2</b>, produced by
+ * {@link CapturingSqlLogger}) for the query-shape regressions the gate guards against (OPIK-7448):
  *
  * <ul>
  *   <li><b>Materialized / temporary-table nodes</b> — the OPIK-7198 class. Multi-reference CTEs and derived tables that
- *       MySQL materializes into an internal {@code #sql...} temporary table saturate the TempTable pool under load and
- *       fail non-deterministically. The JSON surfaces these as {@code materialized_from_subquery} nodes or a
- *       {@code using_temporary_table} flag.</li>
- *   <li><b>Full table scans</b> ({@code access_type = ALL}) on tables that grow with tenant data — a latency cliff at
- *       scale.</li>
+ *       MySQL materializes into an internal temporary table saturate the TempTable pool under load and fail
+ *       non-deterministically. In v2 these appear as a node with {@code access_type = "materialize"}.</li>
+ *   <li><b>Full table scans</b> on tables that grow with tenant data — a latency cliff at scale. In v2 a base-table
+ *       scan is {@code access_type = "table"} (an indexed read is {@code "index"}), and {@code table_name} is the base
+ *       table name (v1 reported the alias here, which is why the gate pins v2).</li>
  * </ul>
  *
- * The walk is recursive because EXPLAIN nests {@code query_block} / {@code nested_loop} / {@code table} /
- * {@code materialized_from_subquery} arbitrarily deep.
+ * The walk is recursive because the v2 plan nests {@code inputs} / nested operations arbitrarily deep.
  */
 public class MySqlPlanShapeAsserter {
 
-    private static final String MATERIALIZED_FROM_SUBQUERY = "materialized_from_subquery";
-    private static final String USING_TEMPORARY_TABLE = "using_temporary_table";
-    private static final String TABLE = "table";
-    private static final String TABLE_NAME = "table_name";
+    private static final String OPERATION = "operation";
     private static final String ACCESS_TYPE = "access_type";
-    private static final String FULL_SCAN = "ALL";
+    private static final String TABLE_NAME = "table_name";
+    private static final String ACCESS_MATERIALIZE = "materialize";
+    private static final String ACCESS_TABLE_SCAN = "table";
 
     private final Set<String> fullScanSensitiveTables;
 
@@ -51,32 +49,30 @@ public class MySqlPlanShapeAsserter {
         }
 
         if (node.isObject()) {
-            if (node.has(MATERIALIZED_FROM_SUBQUERY)) {
-                violations.add(new PlanShapeViolation(renderedSql, PlanShapeViolation.Type.MATERIALIZED_SUBQUERY,
-                        "Plan materializes a subquery into an internal temporary table (OPIK-7198 class)."));
-            }
-            if (node.path(USING_TEMPORARY_TABLE).asBoolean(false)) {
-                violations.add(new PlanShapeViolation(renderedSql, PlanShapeViolation.Type.TEMPORARY_TABLE,
-                        "Plan uses an internal temporary table (OPIK-7198 class)."));
-            }
+            var accessType = node.path(ACCESS_TYPE).asText(null);
 
-            var tableNode = node.get(TABLE);
-            if (tableNode != null && tableNode.isObject()) {
-                checkTableAccess(tableNode, renderedSql, violations);
+            if (ACCESS_MATERIALIZE.equals(accessType)) {
+                violations.add(PlanShapeViolation.builder()
+                        .renderedSql(renderedSql)
+                        .type(PlanShapeViolation.Type.MATERIALIZED_SUBQUERY)
+                        .detail("Plan materializes a subquery into an internal temporary table (OPIK-7198 class): "
+                                + node.path(OPERATION).asText("materialize"))
+                        .build());
+            } else if (ACCESS_TABLE_SCAN.equals(accessType)) {
+                var tableName = node.path(TABLE_NAME).asText(null);
+                if (tableName != null && fullScanSensitiveTables.contains(tableName)) {
+                    violations.add(PlanShapeViolation.builder()
+                            .renderedSql(renderedSql)
+                            .type(PlanShapeViolation.Type.FULL_TABLE_SCAN)
+                            .detail("Full table scan on tenant-growing table '%s': %s".formatted(
+                                    tableName, node.path(OPERATION).asText("table scan")))
+                            .build());
+                }
             }
 
             node.fields().forEachRemaining(entry -> walk(entry.getValue(), renderedSql, violations));
         } else if (node.isArray()) {
             node.forEach(child -> walk(child, renderedSql, violations));
-        }
-    }
-
-    private void checkTableAccess(JsonNode tableNode, String renderedSql, List<PlanShapeViolation> violations) {
-        var accessType = tableNode.path(ACCESS_TYPE).asText(null);
-        var tableName = tableNode.path(TABLE_NAME).asText(null);
-        if (FULL_SCAN.equals(accessType) && tableName != null && fullScanSensitiveTables.contains(tableName)) {
-            violations.add(new PlanShapeViolation(renderedSql, PlanShapeViolation.Type.FULL_TABLE_SCAN,
-                    "Full table scan (access_type=ALL) on tenant-growing table '%s'.".formatted(tableName)));
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/MySqlPlanShapeAsserter.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/MySqlPlanShapeAsserter.java
@@ -2,7 +2,7 @@ package com.comet.opik.api.resources.utils.planshape;
 
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
-import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,8 +21,10 @@ import java.util.Set;
  *       table name (v1 reported the alias here, which is why the gate pins v2).</li>
  * </ul>
  *
- * The walk is recursive because the v2 plan nests {@code inputs} / nested operations arbitrarily deep.
+ * The walk is recursive because the v2 plan nests {@code inputs} / nested operations arbitrarily deep. EXPLAIN
+ * documents are shallow (a handful of levels), so stack depth is not a concern here.
  */
+@RequiredArgsConstructor
 public class MySqlPlanShapeAsserter {
 
     private static final String OPERATION = "operation";
@@ -33,11 +35,7 @@ public class MySqlPlanShapeAsserter {
 
     private final Set<String> fullScanSensitiveTables;
 
-    public MySqlPlanShapeAsserter(@NonNull Set<String> fullScanSensitiveTables) {
-        this.fullScanSensitiveTables = fullScanSensitiveTables;
-    }
-
-    public List<PlanShapeViolation> findViolations(@NonNull String renderedSql, @NonNull String explainJson) {
+    public List<PlanShapeViolation> findViolations(String renderedSql, String explainJson) {
         var violations = new ArrayList<PlanShapeViolation>();
         walk(JsonUtils.getJsonNodeFromString(explainJson), renderedSql, violations);
         return violations;
@@ -55,8 +53,8 @@ public class MySqlPlanShapeAsserter {
                 violations.add(PlanShapeViolation.builder()
                         .renderedSql(renderedSql)
                         .type(PlanShapeViolation.Type.MATERIALIZED_SUBQUERY)
-                        .detail("Plan materializes a subquery into an internal temporary table (OPIK-7198 class): "
-                                + node.path(OPERATION).asText("materialize"))
+                        .detail("Plan materializes a subquery into an internal temporary table (OPIK-7198 class): '%s'"
+                                .formatted(node.path(OPERATION).asText("materialize")))
                         .build());
             } else if (ACCESS_TABLE_SCAN.equals(accessType)) {
                 var tableName = node.path(TABLE_NAME).asText(null);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/PlanShapeBaseline.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/PlanShapeBaseline.java
@@ -2,6 +2,7 @@ package com.comet.opik.api.resources.utils.planshape;
 
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.Builder;
 import lombok.NonNull;
 
 import java.io.InputStream;
@@ -18,6 +19,7 @@ import java.util.stream.Collectors;
  */
 public class PlanShapeBaseline {
 
+    @Builder(toBuilder = true)
     public record Entry(@NonNull String fingerprint, String note) {
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/PlanShapeBaseline.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/PlanShapeBaseline.java
@@ -1,0 +1,54 @@
+package com.comet.opik.api.resources.utils.planshape;
+
+import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.NonNull;
+
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The checked-in allowlist of plan-shape violations that already exist in the codebase. The gate blocks only on
+ * <b>net-new</b> violations vs. this baseline (see {@link #netNew(List)}); the allowlist is ratcheted down as legacy
+ * offenders are fixed. Each entry is a {@link PlanShapeViolation#fingerprint()} plus a human note explaining why it is
+ * tolerated / which ticket tracks its removal.
+ */
+public class PlanShapeBaseline {
+
+    public record Entry(@NonNull String fingerprint, String note) {
+    }
+
+    private final Set<String> allowedFingerprints;
+
+    private PlanShapeBaseline(Set<String> allowedFingerprints) {
+        this.allowedFingerprints = allowedFingerprints;
+    }
+
+    public static PlanShapeBaseline loadFromClasspath(@NonNull String resourcePath) {
+        try (InputStream is = PlanShapeBaseline.class.getClassLoader().getResourceAsStream(resourcePath)) {
+            if (is == null) {
+                throw new IllegalStateException("Plan-shape baseline resource not found: " + resourcePath);
+            }
+            List<Entry> entries = JsonUtils.getMapper().readValue(is, new TypeReference<>() {
+            });
+            return new PlanShapeBaseline(entries.stream().map(Entry::fingerprint).collect(Collectors.toSet()));
+        } catch (UncheckedIOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new UncheckedIOException("Failed to load plan-shape baseline: " + resourcePath,
+                    new java.io.IOException(e));
+        }
+    }
+
+    /**
+     * @return the violations that are not present in the baseline — i.e. the ones that must fail the build.
+     */
+    public List<PlanShapeViolation> netNew(@NonNull List<PlanShapeViolation> violations) {
+        return violations.stream()
+                .filter(violation -> !allowedFingerprints.contains(violation.fingerprint()))
+                .toList();
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/PlanShapeBaseline.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/PlanShapeBaseline.java
@@ -35,13 +35,10 @@ public class PlanShapeBaseline {
             if (is == null) {
                 throw new IllegalStateException("Plan-shape baseline resource not found: '%s'".formatted(resourcePath));
             }
-            List<Entry> entries = JsonUtils.getMapper().readValue(is, ENTRIES_TYPE);
+            List<Entry> entries = JsonUtils.readValue(is, ENTRIES_TYPE);
             return new PlanShapeBaseline(entries.stream().map(Entry::fingerprint).collect(Collectors.toSet()));
-        } catch (UncheckedIOException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new UncheckedIOException(new IOException(
-                    "Failed to load plan-shape baseline: '%s'".formatted(resourcePath), e));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/PlanShapeBaseline.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/PlanShapeBaseline.java
@@ -3,8 +3,9 @@ package com.comet.opik.api.resources.utils.planshape;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.Builder;
-import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.List;
@@ -17,38 +18,37 @@ import java.util.stream.Collectors;
  * offenders are fixed. Each entry is a {@link PlanShapeViolation#fingerprint()} plus a human note explaining why it is
  * tolerated / which ticket tracks its removal.
  */
+@RequiredArgsConstructor
 public class PlanShapeBaseline {
 
+    private static final TypeReference<List<Entry>> ENTRIES_TYPE = new TypeReference<>() {
+    };
+
     @Builder(toBuilder = true)
-    public record Entry(@NonNull String fingerprint, String note) {
+    public record Entry(String fingerprint, String note) {
     }
 
     private final Set<String> allowedFingerprints;
 
-    private PlanShapeBaseline(Set<String> allowedFingerprints) {
-        this.allowedFingerprints = allowedFingerprints;
-    }
-
-    public static PlanShapeBaseline loadFromClasspath(@NonNull String resourcePath) {
+    public static PlanShapeBaseline loadFromClasspath(String resourcePath) {
         try (InputStream is = PlanShapeBaseline.class.getClassLoader().getResourceAsStream(resourcePath)) {
             if (is == null) {
-                throw new IllegalStateException("Plan-shape baseline resource not found: " + resourcePath);
+                throw new IllegalStateException("Plan-shape baseline resource not found: '%s'".formatted(resourcePath));
             }
-            List<Entry> entries = JsonUtils.getMapper().readValue(is, new TypeReference<>() {
-            });
+            List<Entry> entries = JsonUtils.getMapper().readValue(is, ENTRIES_TYPE);
             return new PlanShapeBaseline(entries.stream().map(Entry::fingerprint).collect(Collectors.toSet()));
         } catch (UncheckedIOException e) {
             throw e;
         } catch (Exception e) {
-            throw new UncheckedIOException("Failed to load plan-shape baseline: " + resourcePath,
-                    new java.io.IOException(e));
+            throw new UncheckedIOException(new IOException(
+                    "Failed to load plan-shape baseline: '%s'".formatted(resourcePath), e));
         }
     }
 
     /**
-     * @return the violations that are not present in the baseline — i.e. the ones that must fail the build.
+     * Returns the violations that are not present in the baseline — i.e. the ones that must fail the build.
      */
-    public List<PlanShapeViolation> netNew(@NonNull List<PlanShapeViolation> violations) {
+    public List<PlanShapeViolation> netNew(List<PlanShapeViolation> violations) {
         return violations.stream()
                 .filter(violation -> !allowedFingerprints.contains(violation.fingerprint()))
                 .toList();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/PlanShapeViolation.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/PlanShapeViolation.java
@@ -1,0 +1,34 @@
+package com.comet.opik.api.resources.utils.planshape;
+
+import lombok.NonNull;
+
+import java.util.Locale;
+
+/**
+ * A single plan-shape regression found in a captured query. The {@link #fingerprint()} is the stable identity used to
+ * match a violation against the checked-in baseline: it normalizes the SQL (collapse whitespace, strip literals) so
+ * that run-to-run parameter differences (random UUIDs, timestamps) do not change identity, while a genuinely new or
+ * structurally-changed query does.
+ */
+public record PlanShapeViolation(@NonNull String renderedSql, @NonNull Type type, @NonNull String detail) {
+
+    public enum Type {
+        MATERIALIZED_SUBQUERY,
+        TEMPORARY_TABLE,
+        FULL_TABLE_SCAN
+    }
+
+    public String fingerprint() {
+        return type.name() + " :: " + normalize(renderedSql);
+    }
+
+    private static String normalize(String sql) {
+        return sql
+                // string / number literals -> placeholder so bound values do not perturb identity
+                .replaceAll("'(?:[^']|'')*'", "?")
+                .replaceAll("\\b\\d+\\b", "?")
+                .replaceAll("\\s+", " ")
+                .strip()
+                .toLowerCase(Locale.ROOT);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/PlanShapeViolation.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/PlanShapeViolation.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api.resources.utils.planshape;
 
+import lombok.Builder;
 import lombok.NonNull;
 
 import java.util.Locale;
@@ -10,11 +11,11 @@ import java.util.Locale;
  * that run-to-run parameter differences (random UUIDs, timestamps) do not change identity, while a genuinely new or
  * structurally-changed query does.
  */
+@Builder(toBuilder = true)
 public record PlanShapeViolation(@NonNull String renderedSql, @NonNull Type type, @NonNull String detail) {
 
     public enum Type {
         MATERIALIZED_SUBQUERY,
-        TEMPORARY_TABLE,
         FULL_TABLE_SCAN
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/PlanShapeViolation.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/planshape/PlanShapeViolation.java
@@ -1,7 +1,6 @@
 package com.comet.opik.api.resources.utils.planshape;
 
 import lombok.Builder;
-import lombok.NonNull;
 
 import java.util.Locale;
 
@@ -12,7 +11,7 @@ import java.util.Locale;
  * structurally-changed query does.
  */
 @Builder(toBuilder = true)
-public record PlanShapeViolation(@NonNull String renderedSql, @NonNull Type type, @NonNull String detail) {
+public record PlanShapeViolation(String renderedSql, Type type, String detail) {
 
     public enum Type {
         MATERIALIZED_SUBQUERY,
@@ -20,7 +19,7 @@ public record PlanShapeViolation(@NonNull String renderedSql, @NonNull Type type
     }
 
     public String fingerprint() {
-        return type.name() + " :: " + normalize(renderedSql);
+        return "%s :: %s".formatted(type.name(), normalize(renderedSql));
     }
 
     private static String normalize(String sql) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MySqlQueryPlanGateTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MySqlQueryPlanGateTest.java
@@ -102,15 +102,20 @@ class MySqlQueryPlanGateTest {
     void mySqlReadPathsHaveNoPlanShapeRegressions() {
         READ_PATHS.forEach(this::getPage);
 
-        var asserter = new MySqlPlanShapeAsserter(FULL_SCAN_SENSITIVE_TABLES);
-        var violations = capturingSqlLogger.capturedPlans().entrySet().stream()
-                .filter(entry -> entry.getValue() != null)
-                .flatMap(entry -> asserter.findViolations(entry.getKey(), entry.getValue()).stream())
-                .toList();
+        var captured = capturingSqlLogger.captured();
 
-        assertThat(capturingSqlLogger.capturedPlans())
+        assertThat(captured.plansByRenderedSql())
                 .as("the gate must capture SELECTs; an empty capture means the read paths did not exercise MySQL")
                 .isNotEmpty();
+
+        assertThat(captured.failedSql())
+                .as("every captured SELECT must be EXPLAIN-able; an un-vetted query would pass the gate by omission")
+                .isEmpty();
+
+        var asserter = new MySqlPlanShapeAsserter(FULL_SCAN_SENSITIVE_TABLES);
+        var violations = captured.plansByRenderedSql().entrySet().stream()
+                .flatMap(entry -> asserter.findViolations(entry.getKey(), entry.getValue()).stream())
+                .toList();
 
         var netNew = PlanShapeBaseline.loadFromClasspath(BASELINE_RESOURCE).netNew(violations);
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MySqlQueryPlanGateTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MySqlQueryPlanGateTest.java
@@ -1,0 +1,147 @@
+package com.comet.opik.api.resources.v1.priv;
+
+import com.comet.opik.api.resources.utils.AuthTestUtils;
+import com.comet.opik.api.resources.utils.ClientSupportUtils;
+import com.comet.opik.api.resources.utils.TestContainersSetup;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.planshape.CapturingSqlLogger;
+import com.comet.opik.api.resources.utils.planshape.MySqlPlanShapeAsserter;
+import com.comet.opik.api.resources.utils.planshape.PlanShapeBaseline;
+import com.comet.opik.api.resources.utils.planshape.PlanShapeViolation;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.SqlStatements;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_HEADER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Plan-shape regression gate for the MySQL read paths (OPIK-7448, slice 1).
+ *
+ * <p>Result identity is already covered by the resource tests; this gate covers plan <b>shape</b>. It installs a
+ * {@link CapturingSqlLogger} on the app's {@link Jdbi}, drives the real MySQL-backed read endpoints through the REST
+ * API (so it captures exactly the SQL production renders), then runs {@code EXPLAIN FORMAT=JSON} over every captured
+ * {@code SELECT} and fails on any plan that materializes a subquery / uses an internal temporary table (the OPIK-7198
+ * {@code SQLSyntaxErrorException: Table '#sql...' doesn't exist} class) or full-scans a tenant-growing table.</p>
+ *
+ * <p>The read paths are exercised against empty tables: MySQL plans a query the same way regardless of row count, so
+ * the plan shape the gate inspects is identical to production's. Enforcement is <b>net-new only</b> vs. the checked-in
+ * {@code planshape/mysql-baseline.json} allowlist, which is ratcheted down as legacy offenders are fixed. A follow-up
+ * will move capture into the shared test wiring so every resource test contributes queries passively.</p>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("🐬 MySQL Query Plan Gate")
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class MySqlQueryPlanGateTest {
+
+    private static final String BASELINE_RESOURCE = "planshape/mysql-baseline.json";
+
+    // MySQL tables that grow with tenant data — a full scan here is a latency cliff at scale. The high-volume analytics
+    // tables (traces, spans, dataset_items) live in ClickHouse and are out of scope for the MySQL gate.
+    private static final Set<String> FULL_SCAN_SENSITIVE_TABLES = Set.of(
+            "datasets", "experiments", "prompts", "prompt_versions", "feedback_definitions", "projects");
+
+    // MySQL-backed list endpoints. Each renders the SELECT of a DAO the gate must vet.
+    private static final List<String> READ_PATHS = List.of(
+            "/v1/private/datasets",
+            "/v1/private/prompts",
+            "/v1/private/projects",
+            "/v1/private/feedback-definitions",
+            "/v1/private/automations/evaluators");
+
+    private static final String API_KEY = UUID.randomUUID().toString();
+    private static final String USER = UUID.randomUUID().toString();
+    private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+    private static final String TEST_WORKSPACE = UUID.randomUUID().toString();
+
+    private final TestContainersSetup setup = new TestContainersSetup();
+
+    @RegisterApp
+    private final TestDropwizardAppExtension APP = setup.APP;
+
+    private final CapturingSqlLogger capturingSqlLogger = new CapturingSqlLogger();
+
+    private ClientSupport client;
+    private String baseURI;
+
+    @BeforeAll
+    void setUpAll(ClientSupport client, Jdbi jdbi) {
+        this.client = client;
+        this.baseURI = TestUtils.getBaseUrl(client);
+
+        ClientSupportUtils.config(client);
+        AuthTestUtils.mockTargetWorkspace(setup.wireMock.server(), API_KEY, TEST_WORKSPACE, WORKSPACE_ID, USER);
+
+        // The SqlLogger fires for every statement executed through any handle obtained from this Jdbi.
+        jdbi.getConfig(SqlStatements.class).setSqlLogger(capturingSqlLogger);
+    }
+
+    @AfterAll
+    void tearDownAll() {
+        setup.wireMock.server().stop();
+    }
+
+    @Test
+    @DisplayName("🐬 no MySQL read path introduces a materialized/temporary-table plan or a tenant-table full scan")
+    void mySqlReadPathsHaveNoPlanShapeRegressions() {
+        READ_PATHS.forEach(this::getPage);
+
+        var asserter = new MySqlPlanShapeAsserter(FULL_SCAN_SENSITIVE_TABLES);
+        var violations = capturingSqlLogger.capturedPlans().entrySet().stream()
+                .filter(entry -> entry.getValue() != null)
+                .flatMap(entry -> asserter.findViolations(entry.getKey(), entry.getValue()).stream())
+                .toList();
+
+        assertThat(capturingSqlLogger.capturedPlans())
+                .as("the gate must capture SELECTs; an empty capture means the read paths did not exercise MySQL")
+                .isNotEmpty();
+
+        var netNew = PlanShapeBaseline.loadFromClasspath(BASELINE_RESOURCE).netNew(violations);
+
+        assertThat(netNew)
+                .withFailMessage(() -> renderFailure(netNew))
+                .isEmpty();
+    }
+
+    private void getPage(String path) {
+        try (var response = client.target(baseURI + path)
+                .queryParam("page", 1)
+                .queryParam("size", 100)
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .header(HttpHeaders.AUTHORIZATION, API_KEY)
+                .header(WORKSPACE_HEADER, TEST_WORKSPACE)
+                .get()) {
+
+            assertThat(response.getStatus())
+                    .as("read endpoint %s must return 200 so its query is actually rendered", path)
+                    .isEqualTo(200);
+        }
+    }
+
+    private static String renderFailure(List<PlanShapeViolation> netNew) {
+        return netNew.stream()
+                .map(v -> "%n  [%s] %s%n    fingerprint: %s%n    sql: %s".formatted(
+                        v.type(), v.detail(), v.fingerprint(), v.renderedSql()))
+                .collect(Collectors.joining("",
+                        "🐬 Net-new MySQL plan-shape violations (add to planshape/mysql-baseline.json only with a "
+                                + "tracking ticket, or fix the query):",
+                        ""));
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MySqlQueryPlanGateTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MySqlQueryPlanGateTest.java
@@ -56,7 +56,8 @@ class MySqlQueryPlanGateTest {
     // tables: the analytics tables (traces, spans, dataset_items, experiments) live in ClickHouse and are out of scope
     // for the MySQL gate.
     private static final Set<String> FULL_SCAN_SENSITIVE_TABLES = Set.of(
-            "datasets", "prompts", "prompt_versions", "feedback_definitions", "projects");
+            "datasets", "prompts", "prompt_versions", "feedback_definitions", "projects",
+            "automation_rules", "automation_rule_evaluators", "automation_rule_projects");
 
     // MySQL-backed list endpoints. Each renders the SELECT of a DAO the gate must vet.
     private static final List<String> READ_PATHS = List.of(
@@ -71,6 +72,12 @@ class MySqlQueryPlanGateTest {
     private static final String WORKSPACE_ID = UUID.randomUUID().toString();
     private static final String TEST_WORKSPACE = UUID.randomUUID().toString();
 
+    /**
+     * Shared container + app bootstrap: starts Redis/MySQL/ClickHouse/Zookeeper, runs the migrations and builds the
+     * Dropwizard app. The gate needs a booted app backed by a real MySQL to install the {@link CapturingSqlLogger} on
+     * the app's {@link Jdbi} and to run {@code EXPLAIN} on the live connection, so it reuses the same fixture as the
+     * resource ITs rather than duplicating the container wiring inline.
+     */
     private final TestContainersSetup setup = new TestContainersSetup();
 
     @RegisterApp
@@ -101,13 +108,9 @@ class MySqlQueryPlanGateTest {
     @Test
     @DisplayName("🐬 no MySQL read path introduces a materialized/temporary-table plan or a tenant-table full scan")
     void mySqlReadPathsHaveNoPlanShapeRegressions() {
-        READ_PATHS.forEach(this::getPage);
+        READ_PATHS.forEach(this::getPageAndAssertItWasVetted);
 
         var captured = capturingSqlLogger.captured();
-
-        assertThat(captured.plansByRenderedSql())
-                .as("the gate must capture SELECTs; an empty capture means the read paths did not exercise MySQL")
-                .isNotEmpty();
 
         assertThat(captured.failedSql())
                 .as("every captured SELECT must be EXPLAIN-able; an un-vetted query would pass the gate by omission")
@@ -123,6 +126,24 @@ class MySqlQueryPlanGateTest {
         assertThat(netNew)
                 .withFailMessage(() -> renderFailure(netNew))
                 .isEmpty();
+    }
+
+    /**
+     * Drives one read path and asserts it contributed at least one <b>new</b> captured SELECT, so every endpoint is
+     * vetted independently: a global non-empty check alone would stay green if a single route stopped hitting MySQL
+     * while the others still captured queries. Growth is asserted rather than clearing the capture between paths
+     * because {@link CapturingSqlLogger} deduplicates by rendered SQL — clearing would re-capture the queries shared
+     * across endpoints and inflate the vetted set, and a per-path non-empty check on a cleared capture would fail on
+     * correct code whenever two routes render the same SQL.
+     */
+    private void getPageAndAssertItWasVetted(String path) {
+        int capturedBefore = capturingSqlLogger.captured().plansByRenderedSql().size();
+
+        getPage(path);
+
+        assertThat(capturingSqlLogger.captured().plansByRenderedSql().size())
+                .as("read endpoint %s must contribute at least one new MySQL SELECT to the gate", path)
+                .isGreaterThan(capturedBefore);
     }
 
     private void getPage(String path) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MySqlQueryPlanGateTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MySqlQueryPlanGateTest.java
@@ -129,21 +129,21 @@ class MySqlQueryPlanGateTest {
     }
 
     /**
-     * Drives one read path and asserts it contributed at least one <b>new</b> captured SELECT, so every endpoint is
-     * vetted independently: a global non-empty check alone would stay green if a single route stopped hitting MySQL
-     * while the others still captured queries. Growth is asserted rather than clearing the capture between paths
-     * because {@link CapturingSqlLogger} deduplicates by rendered SQL — clearing would re-capture the queries shared
-     * across endpoints and inflate the vetted set, and a per-path non-empty check on a cleared capture would fail on
-     * correct code whenever two routes render the same SQL.
+     * Drives one read path and asserts it executed at least one MySQL read, so every endpoint is vetted independently:
+     * a global check alone would stay green if a single route stopped hitting MySQL while the others still captured
+     * queries. Asserts on {@link CapturingSqlLogger#readsObserved()} rather than on the size of the captured plan set,
+     * because the latter deduplicates by rendered SQL: a route whose SELECT an earlier route already captured adds no
+     * entry, so a growth check there would fail on correct code depending on the order the paths run in. The plan of
+     * such a shared SELECT is still vetted — it was captured once, by whichever route reached it first.
      */
     private void getPageAndAssertItWasVetted(String path) {
-        int capturedBefore = capturingSqlLogger.captured().plansByRenderedSql().size();
+        long readsBefore = capturingSqlLogger.readsObserved();
 
         getPage(path);
 
-        assertThat(capturingSqlLogger.captured().plansByRenderedSql().size())
-                .as("read endpoint %s must contribute at least one new MySQL SELECT to the gate", path)
-                .isGreaterThan(capturedBefore);
+        assertThat(capturingSqlLogger.readsObserved())
+                .as("read endpoint %s must execute at least one MySQL read for the gate to vet", path)
+                .isGreaterThan(readsBefore);
     }
 
     private void getPage(String path) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MySqlQueryPlanGateTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/MySqlQueryPlanGateTest.java
@@ -52,10 +52,11 @@ class MySqlQueryPlanGateTest {
 
     private static final String BASELINE_RESOURCE = "planshape/mysql-baseline.json";
 
-    // MySQL tables that grow with tenant data — a full scan here is a latency cliff at scale. The high-volume analytics
-    // tables (traces, spans, dataset_items) live in ClickHouse and are out of scope for the MySQL gate.
+    // MySQL tables that grow with tenant data — a full scan here is a latency cliff at scale. All entries must be MySQL
+    // tables: the analytics tables (traces, spans, dataset_items, experiments) live in ClickHouse and are out of scope
+    // for the MySQL gate.
     private static final Set<String> FULL_SCAN_SENSITIVE_TABLES = Set.of(
-            "datasets", "experiments", "prompts", "prompt_versions", "feedback_definitions", "projects");
+            "datasets", "prompts", "prompt_versions", "feedback_definitions", "projects");
 
     // MySQL-backed list endpoints. Each renders the SELECT of a DAO the gate must vet.
     private static final List<String> READ_PATHS = List.of(
@@ -142,8 +143,8 @@ class MySqlQueryPlanGateTest {
 
     private static String renderFailure(List<PlanShapeViolation> netNew) {
         return netNew.stream()
-                .map(v -> "%n  [%s] %s%n    fingerprint: %s%n    sql: %s".formatted(
-                        v.type(), v.detail(), v.fingerprint(), v.renderedSql()))
+                .map(violation -> "%n  [%s] %s%n    fingerprint: %s%n    sql: %s".formatted(
+                        violation.type(), violation.detail(), violation.fingerprint(), violation.renderedSql()))
                 .collect(Collectors.joining("",
                         "🐬 Net-new MySQL plan-shape violations (add to planshape/mysql-baseline.json only with a "
                                 + "tracking ticket, or fix the query):",

--- a/apps/opik-backend/src/test/resources/planshape/mysql-baseline.json
+++ b/apps/opik-backend/src/test/resources/planshape/mysql-baseline.json
@@ -1,0 +1,18 @@
+[
+  {
+    "fingerprint": "MATERIALIZED_SUBQUERY :: select * from ( select p.*, ( select count(pv.id) from prompt_versions pv where pv.workspace_id = p.workspace_id and pv.prompt_id = p.id and pv.version_type = ? ) as version_count from prompts as p where workspace_id = :workspace_id ) as prompt_full order by id desc limit :limit offset :offset",
+    "note": "PromptDAO.getPrompts wraps the prompt list in a derived table that MySQL materializes. Pre-existing; tracked for ratchet-down by OPIK-7450."
+  },
+  {
+    "fingerprint": "TEMPORARY_TABLE :: select * from ( select p.*, ( select count(pv.id) from prompt_versions pv where pv.workspace_id = p.workspace_id and pv.prompt_id = p.id and pv.version_type = ? ) as version_count from prompts as p where workspace_id = :workspace_id ) as prompt_full order by id desc limit :limit offset :offset",
+    "note": "Same PromptDAO.getPrompts derived table, surfaced as an internal temporary table. Pre-existing; tracked by OPIK-7450."
+  },
+  {
+    "fingerprint": "MATERIALIZED_SUBQUERY :: select count(id) from ( select p.*, ( select count(pv.id) from prompt_versions pv where pv.workspace_id = p.workspace_id and pv.prompt_id = p.id and pv.version_type = ? ) as version_count from prompts as p where workspace_id = :workspace_id ) as prompt_full",
+    "note": "PromptDAO.count over the same derived table. Pre-existing; tracked by OPIK-7450."
+  },
+  {
+    "fingerprint": "TEMPORARY_TABLE :: select count(id) from ( select p.*, ( select count(pv.id) from prompt_versions pv where pv.workspace_id = p.workspace_id and pv.prompt_id = p.id and pv.version_type = ? ) as version_count from prompts as p where workspace_id = :workspace_id ) as prompt_full",
+    "note": "Same PromptDAO.count derived table, surfaced as an internal temporary table. Pre-existing; tracked by OPIK-7450."
+  }
+]

--- a/apps/opik-backend/src/test/resources/planshape/mysql-baseline.json
+++ b/apps/opik-backend/src/test/resources/planshape/mysql-baseline.json
@@ -4,15 +4,7 @@
     "note": "PromptDAO.getPrompts wraps the prompt list in a derived table that MySQL materializes. Pre-existing; tracked for ratchet-down by OPIK-7450."
   },
   {
-    "fingerprint": "TEMPORARY_TABLE :: select * from ( select p.*, ( select count(pv.id) from prompt_versions pv where pv.workspace_id = p.workspace_id and pv.prompt_id = p.id and pv.version_type = ? ) as version_count from prompts as p where workspace_id = :workspace_id ) as prompt_full order by id desc limit :limit offset :offset",
-    "note": "Same PromptDAO.getPrompts derived table, surfaced as an internal temporary table. Pre-existing; tracked by OPIK-7450."
-  },
-  {
     "fingerprint": "MATERIALIZED_SUBQUERY :: select count(id) from ( select p.*, ( select count(pv.id) from prompt_versions pv where pv.workspace_id = p.workspace_id and pv.prompt_id = p.id and pv.version_type = ? ) as version_count from prompts as p where workspace_id = :workspace_id ) as prompt_full",
-    "note": "PromptDAO.count over the same derived table. Pre-existing; tracked by OPIK-7450."
-  },
-  {
-    "fingerprint": "TEMPORARY_TABLE :: select count(id) from ( select p.*, ( select count(pv.id) from prompt_versions pv where pv.workspace_id = p.workspace_id and pv.prompt_id = p.id and pv.version_type = ? ) as version_count from prompts as p where workspace_id = :workspace_id ) as prompt_full",
-    "note": "Same PromptDAO.count derived table, surfaced as an internal temporary table. Pre-existing; tracked by OPIK-7450."
+    "note": "PromptDAO.count over the same derived table. Pre-existing; tracked for ratchet-down by OPIK-7450."
   }
 ]


### PR DESCRIPTION
## Details

<img width="934" height="1666" alt="image" src="https://github.com/user-attachments/assets/5832c9c8-7917-491c-a04a-615d64fa76a4" />

Adds a **query plan-shape regression gate** for the MySQL read paths (slice 1 of OPIK-7448). Result identity is already covered by the resource tests; this gate covers plan **shape** — the dimension a functional test can't assert.

A JDBI `SqlLogger` captures every rendered `SELECT` exercised by the MySQL-backed read endpoints and runs `EXPLAIN FORMAT=JSON` on the **same live connection**, re-applying the exact bindings via JDBI's own `Argument` machinery (no value-extraction guesswork). EXPLAIN is requested in **JSON format version 2** (`explain_json_format_version=2`): v1 reports the table *alias* in `table_name` (so a base-table match silently misses `FROM prompts AS p`), while v2 reports the base table name and a uniform `operation`/`access_type` vocabulary. The resulting plan is inspected for:

- **Materialized subquery / internal temporary table** (`access_type="materialize"`) — the OPIK-7198 / 7197 / 6735 class (`SQLSyntaxErrorException: Table '#sql...' doesn't exist` under TempTable-pool saturation), which is non-deterministic and load-dependent, so a functional test can't reproduce it.
- **Full table scan** (`access_type="table"` on a base table; indexed reads are `"index"`) on tenant-growing tables — a latency cliff at scale.

Enforcement is **net-new only** vs. a checked-in baseline allowlist (`planshape/mysql-baseline.json`) that ratchets down as legacy offenders are fixed. A SELECT whose EXPLAIN fails is recorded in a `failedSql` set and asserted empty, so an un-vetted query can't pass the gate by omission.

**The gate already earned its keep:** on the current tree it detected that `PromptDAO`'s list/count wraps a derived table MySQL materializes — the same mechanism as OPIK-7198. Those 2 fingerprints are baselined and tracked for ratchet-down under **OPIK-7450**.

Test-scope only — **no production code changes**, and the capture is installed on the injected `Jdbi` inside a single dedicated test, so there's zero blast radius on other tests.

### New files
- `CapturingSqlLogger` — SqlLogger that EXPLAINs each captured SELECT under v2 format; records failures separately (reusable by the planned full-suite slice).
- `MySqlPlanShapeAsserter` — recursive v2 EXPLAIN-JSON walk detecting materialize + full-scan.
- `PlanShapeViolation` — `@Builder` record with a stable SQL fingerprint (literals → `?`) so run-to-run UUIDs don't perturb identity.
- `PlanShapeBaseline` — loads the allowlist, computes net-new.
- `MySqlQueryPlanGateTest` 🐬 — drives the read endpoints and asserts no net-new violations and no un-vetted queries.
- `planshape/mysql-baseline.json` — seeded with the 2 pre-existing PromptDAO fingerprints.

## Change checklist
- [x] Tests added (the gate itself is the test)
- [x] `spotless` passing
- [x] No production code changed
- [ ] Docs — n/a (internal test infra)

## Issues
- Closes the MySQL portion of **OPIK-7448**.
- Absorbs **OPIK-7198** as the first concrete MySQL assertion.
- Ratchet-down follow-up: **OPIK-7450** (PromptDAO derived-table materialization).
- Coverage follow-up: **OPIK-7452** (exercise non-default SQL branches).
- CI wiring + sticky PR comment follow-up: **OPIK-7451** (advisory-first).

**Deliberately deferred to follow-ups** (scope agreed as slice 1 = MySQL):
- Full-suite passive capture (move the `SqlLogger` into shared test wiring so every resource test contributes queries).
- ClickHouse gate (`EXPLAIN indexes=1, json=1` partition-pruning assertions).
- Dedicated CI "Query Plan Gate" required check with the broad path filter (OPIK-7451).

## Testing
`mvn test -Dtest=MySqlQueryPlanGateTest` → green (1/1). Verified the gate **fails** on net-new violations by running with an empty baseline (surfaced the PromptDAO fingerprints), then confirmed green after baselining. The v2 alias fix and full-scan/materialize detection were verified directly against `mysql:8.4.2`.

## Documentation
No user-facing docs. Rationale and the ratchet-down contract live in the class Javadoc and the baseline notes.
