### PR TITLE
[OPIK-7462] [FE] fix: build Recent Activity links via router params to survive basepath strip

### DIFF
--- a/apps/opik-frontend/src/v2/pages/ProjectHomePage/RecentActivitySection.test.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectHomePage/RecentActivitySection.test.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { ActivityType, RecentActivityItem } from "@/types/recent-activity";
+import RecentActivitySection from "./RecentActivitySection";
+
+let mockItems: RecentActivityItem[] = [];
+
+vi.mock("@/api/projects/useRecentActivity", () => ({
+  default: () => ({ data: { content: mockItems }, isPending: false }),
+}));
+
+const PROJECT_ID = "019e3a68-9e79-70a8-adb8-0e04294f9d73";
+
+// Minimal route tree mirroring the real project-scoped leaves the activity
+// links target. `basepath` is "/opik" on cloud and "/" on OSS/self-hosted.
+async function renderAt(workspaceName: string, basepath = "/opik") {
+  const rootRoute = createRootRoute({ component: Outlet });
+  const wsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/$workspaceName",
+    component: Outlet,
+  });
+  const projectsRoute = createRoute({
+    getParentRoute: () => wsRoute,
+    path: "/projects",
+    component: Outlet,
+  });
+  const projectRoute = createRoute({
+    getParentRoute: () => projectsRoute,
+    path: "/$projectId",
+    component: Outlet,
+  });
+  const homeRoute = createRoute({
+    getParentRoute: () => projectRoute,
+    path: "/home",
+    component: RecentActivitySection,
+  });
+  const leaf = (path: string) =>
+    createRoute({
+      getParentRoute: () => projectRoute,
+      path,
+      component: () => null,
+    });
+
+  const routeTree = rootRoute.addChildren([
+    wsRoute.addChildren([
+      projectsRoute.addChildren([
+        projectRoute.addChildren([
+          homeRoute,
+          leaf("/logs"),
+          leaf("/optimizations/$optimizationId"),
+          leaf("/experiments/$datasetId/compare"),
+          leaf("/datasets/$datasetId/items"),
+          leaf("/test-suites/$suiteId/items"),
+          leaf("/prompts/$promptId"),
+          leaf("/alerts/$alertId"),
+        ]),
+      ]),
+    ]),
+  ]);
+
+  const prefix = basepath === "/" ? "" : basepath;
+  const router = createRouter({
+    routeTree,
+    basepath,
+    history: createMemoryHistory({
+      initialEntries: [
+        `${prefix}/${workspaceName}/projects/${PROJECT_ID}/home`,
+      ],
+    }),
+  });
+
+  await router.load();
+  render(<RouterProvider router={router} />);
+}
+
+const hrefByText = (text: string) =>
+  screen.getByText(text).closest("a")!.getAttribute("href");
+
+const ALL_ACTIVITY_ITEMS: RecentActivityItem[] = [
+  {
+    type: ActivityType.TRACE_DAILY,
+    id: "t-1",
+    name: "traces",
+    created_at: "2026-07-23T10:00:00Z",
+  },
+  {
+    type: ActivityType.OPTIMIZATION,
+    id: "opt-1",
+    name: "My optimization",
+    created_at: "2026-07-23T10:00:00Z",
+  },
+  {
+    type: ActivityType.EXPERIMENT,
+    id: "exp-1",
+    name: "My experiment",
+    created_at: "2026-07-23T10:00:00Z",
+    resource_id: "dataset-1",
+  },
+  {
+    type: ActivityType.DATASET_VERSION,
+    id: "ds-1",
+    name: "My dataset",
+    created_at: "2026-07-23T10:00:00Z",
+  },
+  {
+    type: ActivityType.TEST_SUITE_VERSION,
+    id: "ts-1",
+    name: "My suite",
+    created_at: "2026-07-23T10:00:00Z",
+  },
+  {
+    type: ActivityType.PROMPT_VERSION,
+    id: "pr-1",
+    name: "My prompt",
+    created_at: "2026-07-23T10:00:00Z",
+  },
+  {
+    type: ActivityType.ALERT_EVENT,
+    id: "al-1",
+    name: "My alert",
+    created_at: "2026-07-23T10:00:00Z",
+  },
+];
+
+function expectAllHrefs(workspaceName: string, prefix = "/opik") {
+  const base = `${prefix}/${workspaceName}/projects/${PROJECT_ID}`;
+
+  expect(hrefByText("traces")).toBe(`${base}/logs?logsType=traces`);
+  expect(hrefByText("My optimization")).toBe(`${base}/optimizations/opt-1`);
+  expect(hrefByText("My experiment")).toBe(
+    `${base}/experiments/dataset-1/compare?experiments=%5B%22exp-1%22%5D`,
+  );
+  expect(hrefByText("My dataset")).toBe(`${base}/datasets/ds-1/items`);
+  expect(hrefByText("My suite")).toBe(`${base}/test-suites/ts-1/items`);
+  expect(hrefByText("My prompt")).toBe(`${base}/prompts/pr-1`);
+  expect(hrefByText("My alert")).toBe(`${base}/alerts/al-1`);
+}
+
+// Cloud deployments (.env.comet) serve the app under basepath "/opik".
+describe("RecentActivitySection link construction — cloud (basepath /opik)", () => {
+  beforeEach(() => {
+    mockItems = [];
+  });
+
+  // Regression: a workspace whose name starts with "opik" collided with the
+  // "/opik" basepath. TanStack's removeBasepath does an unbounded
+  // pathname.replace(basepath, ""), so a string-concatenated
+  // to="/opik-testing/..." was mangled to "/opik/-testing/...".
+  it("does not mangle a workspace name that starts with the basepath", async () => {
+    mockItems = ALL_ACTIVITY_ITEMS;
+    await renderAt("opik-testing", "/opik");
+
+    expect(hrefByText("My experiment")).not.toContain("/opik/-testing");
+    expectAllHrefs("opik-testing", "/opik");
+  });
+
+  // A workspace name that does not collide with the basepath must be unaffected
+  // by the fix.
+  it("builds correct hrefs for a normal workspace name", async () => {
+    mockItems = ALL_ACTIVITY_ITEMS;
+    await renderAt("andreicc", "/opik");
+
+    expectAllHrefs("andreicc", "/opik");
+  });
+});
+
+// OSS / self-hosted / local deployments (.env.production, .env.development)
+// serve the app under basepath "/". There is no "/opik" prefix, so the links
+// must resolve to "/{workspace}/projects/...".
+describe("RecentActivitySection link construction — OSS/self-hosted (basepath /)", () => {
+  beforeEach(() => {
+    mockItems = [];
+  });
+
+  it("builds correct hrefs for a normal workspace name", async () => {
+    mockItems = ALL_ACTIVITY_ITEMS;
+    await renderAt("default", "/");
+
+    expectAllHrefs("default", "");
+  });
+
+  // A workspace literally named "opik" is only a hazard when a "/opik" basepath
+  // is stripped; on OSS (basepath "/") nothing is stripped, so it must resolve
+  // cleanly to "/opik/projects/...".
+  it("builds correct hrefs for a workspace named 'opik'", async () => {
+    mockItems = ALL_ACTIVITY_ITEMS;
+    await renderAt("opik", "/");
+
+    expectAllHrefs("opik", "");
+  });
+});

--- a/apps/opik-frontend/src/v2/pages/ProjectHomePage/RecentActivitySection.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectHomePage/RecentActivitySection.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from "@tanstack/react-router";
+import { Link, LinkProps, useParams } from "@tanstack/react-router";
 import {
   FlaskConical,
   Database,
@@ -17,11 +17,18 @@ import { Skeleton } from "@/ui/skeleton";
 import useRecentActivity from "@/api/projects/useRecentActivity";
 import { ActivityType, RecentActivityItem } from "@/types/recent-activity";
 
+type LinkParams = { workspaceName: string; projectId: string };
+
+// The workspace and project are passed as router params rather than
+// concatenated into `to`. TanStack strips the router basepath from `to` with an
+// unbounded `pathname.replace(basepath, "")` (no boundary), so a literal
+// `to: "/opik-testing/..."` under basepath `/opik` gets mangled to
+// `/opik/-testing/...`. Deferring substitution to params runs after the strip.
 type ActivityConfigEntry = {
   label: string | ((item: RecentActivityItem) => string);
   icon: LucideIcon;
   color: string;
-  getLink: (item: RecentActivityItem, base: string) => string;
+  getLink: (item: RecentActivityItem, params: LinkParams) => LinkProps;
 };
 
 const ACTIVITY_CONFIG: Record<ActivityType, ActivityConfigEntry> = {
@@ -32,44 +39,66 @@ const ACTIVITY_CONFIG: Record<ActivityType, ActivityConfigEntry> = {
       )}`,
     icon: ListTree,
     color: "text-chart-teal",
-    getLink: (_item, base) => `${base}/logs?logsType=traces`,
+    getLink: (_item, params) => ({
+      to: "/$workspaceName/projects/$projectId/logs",
+      params,
+      search: { logsType: "traces" },
+    }),
   },
   [ActivityType.OPTIMIZATION]: {
     label: "Optimization run created",
     icon: Sparkles,
     color: "text-chart-burgundy",
-    getLink: (item, base) => `${base}/optimizations/${item.id}`,
+    getLink: (item, params) => ({
+      to: "/$workspaceName/projects/$projectId/optimizations/$optimizationId",
+      params: { ...params, optimizationId: item.id },
+    }),
   },
   [ActivityType.EXPERIMENT]: {
     label: "Experiment created",
     icon: FlaskConical,
     color: "text-chart-green",
-    getLink: (item, base) =>
-      `${base}/experiments/${item.resource_id}/compare?experiments=["${item.id}"]`,
+    getLink: (item, params) => ({
+      to: "/$workspaceName/projects/$projectId/experiments/$datasetId/compare",
+      params: { ...params, datasetId: item.resource_id },
+      search: { experiments: [item.id] },
+    }),
   },
   [ActivityType.DATASET_VERSION]: {
     label: "Dataset updated",
     icon: Database,
     color: "text-chart-purple",
-    getLink: (item, base) => `${base}/datasets/${item.id}/items`,
+    getLink: (item, params) => ({
+      to: "/$workspaceName/projects/$projectId/datasets/$datasetId/items",
+      params: { ...params, datasetId: item.id },
+    }),
   },
   [ActivityType.TEST_SUITE_VERSION]: {
     label: "Test suite updated",
     icon: ListChecks,
     color: "text-chart-purple",
-    getLink: (item, base) => `${base}/test-suites/${item.id}/items`,
+    getLink: (item, params) => ({
+      to: "/$workspaceName/projects/$projectId/test-suites/$suiteId/items",
+      params: { ...params, suiteId: item.id },
+    }),
   },
   [ActivityType.PROMPT_VERSION]: {
     label: "Prompt created",
     icon: FileTerminal,
     color: "text-chart-blue",
-    getLink: (item, base) => `${base}/prompts/${item.id}`,
+    getLink: (item, params) => ({
+      to: "/$workspaceName/projects/$projectId/prompts/$promptId",
+      params: { ...params, promptId: item.id },
+    }),
   },
   [ActivityType.ALERT_EVENT]: {
     label: "Alert triggered",
     icon: AlertTriangle,
     color: "text-chart-red",
-    getLink: (item, base) => `${base}/alerts/${item.id}`,
+    getLink: (item, params) => ({
+      to: "/$workspaceName/projects/$projectId/alerts/$alertId",
+      params: { ...params, alertId: item.id },
+    }),
   },
 };
 
@@ -81,11 +110,10 @@ function ActivityItem({ item }: { item: RecentActivityItem }) {
 
   const config = ACTIVITY_CONFIG[item.type];
   const Icon = config.icon;
-  const base = `/${workspaceName}/projects/${projectId}`;
 
   return (
     <Link
-      to={config.getLink(item, base)}
+      {...config.getLink(item, { workspaceName, projectId })}
       className="group flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left hover:border-primary hover:bg-primary/5"
     >
       <Icon className={`size-4 shrink-0 ${config.color}`} />


### PR DESCRIPTION
## Details

On cloud (basepath `/opik`), the Project Home "Recent activity" links broke for workspaces whose name starts with `opik` (e.g. `opik-testing`, `opik-demo`) — clicking an item navigated to `/opik/-testing/projects/...` instead of `/opik/opik-testing/projects/...`. The links were built by string-concatenating the workspace name into `to`, and TanStack Router strips the basepath with an unbounded `pathname.replace(basepath, "")`, so `/opik-testing/...` lost its `/opik` prefix. This passes the workspace/project as route params (`$workspaceName`/`$projectId`) instead, so substitution runs after the basepath strip — the idiom already used everywhere else in v2.

- Only manifested on cloud (`/opik`) with an `opik*` workspace; OSS/self-hosted/local (basepath `/`) were never affected and stay correct.
- The Experiment link's `experiments` query param is now passed via `search` and percent-encodes to the same value the compare page's `JsonParam` reader expects.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7462

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: Root-cause investigation, the fix, and the regression tests were authored with Claude Code; reviewed by the author.
- Human verification: Diff and test assertions reviewed by the author; failing-then-passing test confirmed manually against the pre-fix code.

## Testing

Frontend unit tests (`apps/opik-frontend`), run with `npx vitest run`:

- `src/v2/pages/ProjectHomePage/RecentActivitySection.test.tsx` — new. Renders the section inside a real TanStack router at each basepath and asserts the produced `href` for every activity type.
  - **cloud (basepath `/opik`)**: `opik-testing` → `/opik/opik-testing/projects/...` and explicitly NOT the mangled `/opik/-testing/...` (this case fails on the current `main` code); `andreicc` unchanged.
  - **OSS/self-hosted (basepath `/`)**: `default` → `/default/projects/...`; a workspace literally named `opik` → `/opik/projects/...`.
- Verified the test reproduces the bug: reverting to the string-concatenation version makes it fail with `/opik/-testing/projects/019e3a68-.../...` (byte-for-byte the reported URL); the fix makes all 4 cases pass.
- `npx vitest run` on the neighboring router-heavy suites (`V1CompatRedirect`, `TracesTabRedirect`) — still green (28 tests).
- `npx tsc --noEmit` (only a pre-existing, unrelated `@codemirror/legacy-modes` type-decl error), `npx eslint` and `npx prettier --check` on the changed files — clean.

Environment: local, frontend unit tests only. Not run: full E2E suite (unit coverage exercises the exact link-formation logic at both basepaths).

## Documentation

No documentation changes — internal bug fix with no user-facing API or behavior change beyond the corrected link.
