### PR TITLE
[NA] chore: throwaway perf-baseline env (DO NOT MERGE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,3 +387,5 @@ There are many ways to contribute to Opik:
 - Upvoting [popular feature requests](https://github.com/comet-ml/opik/issues?q=is%3Aissue+is%3Aopen+label%3A%22enhancement%22) to show your support
 
 To learn more about how to contribute to Opik, please see our [contributing guidelines](CONTRIBUTING.md).
+
+<!-- perf-baseline throwaway PR: build a main adhoc env for OPIK-7264 before/after benchmark. Do not merge. -->


### PR DESCRIPTION
## Details
Throwaway PR to build a **main-based adhoc test environment** for the OPIK-7264 dataset-upload perf benchmark — so we can measure the **baseline** (before the OPIK-7264 lock/CAS changes) and compare against the PR's "after" numbers.

**This is one no-op README comment on top of latest `main`. Not for review, not for merge.** It exists only to trigger a `test-environment` adhoc deploy running essentially-main code.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- NA (tooling/testing scaffold for OPIK-7264)

## AI-WATERMARK
AI-WATERMARK: yes
- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: created throwaway baseline env for perf benchmarking
- Human verification: N/A (no-op change)

## Testing
N/A — no code change; used only to spin up a baseline adhoc env.

## Documentation
N/A