### PR TITLE
[issue-7462] [SDK] fix: use direct workspace-scoped URL for experiment link in evaluate()

### DIFF
--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -409,7 +409,8 @@ def __internal_api__run_test_suite__(
         experiment_url = url_helpers.get_experiment_url_by_id(
             experiment_id=experiment_.id,
             dataset_id=suite_dataset.id,
-            url_override=client.config.url_override,
+            base_url=client.config.url_override,
+            workspace=client._workspace,
         )
         report.display_evaluation_in_progress(experiment_url)
 
@@ -604,7 +605,8 @@ def _evaluate_task(
     experiment_url = url_helpers.get_experiment_url_by_id(
         experiment_id=experiment.id,
         dataset_id=dataset.id,
-        url_override=client.config.url_override,
+        base_url=client.config.url_override,
+        workspace=client._workspace,
     )
 
     report.display_experiment_link(experiment_url=experiment_url)
@@ -737,7 +739,8 @@ def _evaluate_test_suite_task(
     experiment_url = url_helpers.get_experiment_url_by_id(
         experiment_id=experiment.id,
         dataset_id=dataset.id,
-        url_override=client.config.url_override,
+        base_url=client.config.url_override,
+        workspace=client._workspace,
     )
 
     evaluation_result_ = evaluation_result.EvaluationResult(
@@ -883,7 +886,8 @@ def evaluate_experiment(
     experiment_url = url_helpers.get_experiment_url_by_id(
         experiment_id=experiment.id,
         dataset_id=dataset_.id,
-        url_override=client.config.url_override,
+        base_url=client.config.url_override,
+        workspace=client._workspace,
     )
 
     report.display_experiment_link(experiment_url=experiment_url)
@@ -1188,7 +1192,8 @@ def evaluate_prompt(
     experiment_url = url_helpers.get_experiment_url_by_id(
         experiment_id=experiment.id,
         dataset_id=dataset.id,
-        url_override=client.config.url_override,
+        base_url=client.config.url_override,
+        workspace=client._workspace,
     )
 
     report.display_experiment_link(experiment_url=experiment_url)

--- a/sdks/python/src/opik/url_helpers.py
+++ b/sdks/python/src/opik/url_helpers.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import urllib.parse
 from typing import Final
 
@@ -28,15 +29,11 @@ def get_ui_url() -> str:
 
 
 def get_experiment_url_by_id(
-    dataset_id: str, experiment_id: str, url_override: str
+    dataset_id: str, experiment_id: str, base_url: str, workspace: str
 ) -> str:
-    encoded_opik_url = base64.b64encode(url_override.encode("utf-8")).decode("utf-8")
-
-    project_path = urllib.parse.quote(
-        f"v1/session/redirect/experiments/?experiment_id={experiment_id}&dataset_id={dataset_id}&path={encoded_opik_url}",
-        safe=ALLOWED_URL_CHARACTERS,
-    )
-    return urllib.parse.urljoin(ensure_ending_slash(url_override), project_path)
+    domain_root = get_base_url(base_url)
+    experiments_param = urllib.parse.quote(json.dumps([experiment_id]))
+    return f"{domain_root}opik/{workspace}/experiments/{dataset_id}/compare?experiments={experiments_param}"
 
 
 def get_project_url_by_workspace(

--- a/sdks/python/tests/unit/test_url_helpers.py
+++ b/sdks/python/tests/unit/test_url_helpers.py
@@ -138,3 +138,47 @@ def test_get_test_suite_url_by_id__returns_direct_project_scoped_url(
         )
         == expected_test_suite_url
     )
+
+
+@pytest.mark.parametrize(
+    ("base_url", "workspace", "dataset_id", "experiment_id", "expected_url"),
+    [
+        (
+            "http://localhost:5173/api",
+            "default",
+            "dataset-abc123",
+            "exp-xyz789",
+            "http://localhost:5173/opik/default/experiments/dataset-abc123/compare?experiments=%5B%22exp-xyz789%22%5D",
+        ),
+        (
+            "http://localhost:5173/api/",
+            "default",
+            "dataset-abc123",
+            "exp-xyz789",
+            "http://localhost:5173/opik/default/experiments/dataset-abc123/compare?experiments=%5B%22exp-xyz789%22%5D",
+        ),
+        (
+            "https://www.comet.com/opik/api",
+            "my-team",
+            "ds-id-001",
+            "exp-id-002",
+            "https://www.comet.com/opik/my-team/experiments/ds-id-001/compare?experiments=%5B%22exp-id-002%22%5D",
+        ),
+    ],
+)
+def test_get_experiment_url_by_id__returns_direct_workspace_scoped_url(
+    base_url: str,
+    workspace: str,
+    dataset_id: str,
+    experiment_id: str,
+    expected_url: str,
+) -> None:
+    assert (
+        url_helpers.get_experiment_url_by_id(
+            base_url=base_url,
+            workspace=workspace,
+            dataset_id=dataset_id,
+            experiment_id=experiment_id,
+        )
+        == expected_url
+    )


### PR DESCRIPTION
## Details

`get_experiment_url_by_id` was generating a session-redirect URL
(`v1/session/redirect/experiments/?experiment_id=...&dataset_id=...`) that
routes through the user's session context. This surfaced the experiment under
the wrong scope in the UI instead of opening the compare view directly.

The fix replaces the session-redirect URL with the direct compare-page URL
pattern used by `get_dataset_url_by_id` and `get_test_suite_url_by_id` (added
in #7467):

```
{domain_root}opik/{workspace}/experiments/{dataset_id}/compare?experiments=["{experiment_id}"]
```

The `workspace` is added as a new parameter (available as `client._workspace`
at all call sites in `evaluator.py`).

## Change checklist
- [x] User facing

## Issues

- Closes #7462
- Supersedes #7463 (same fix, rebased cleanly on current main after #7467 landed)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-sonnet-4-6
- Scope: url_helpers.py (function signature + implementation), evaluator.py (5 call sites), test_url_helpers.py (3 new parametrized cases)
- Human verification: diff reviewed; test cases verified against the URL pattern used by get_dataset_url_by_id

## Testing

New test: `test_get_experiment_url_by_id__returns_direct_workspace_scoped_url`
— 3 parametrized cases (localhost, localhost with trailing slash, cloud URL).

Run with:
```
cd sdks/python
pytest tests/unit/test_url_helpers.py -v
```

## Documentation

No documentation change required — this fixes an internal log/link URL, not a public API.