### PR TITLE
[NA] [BE] feat: ingest cipx subscription usage windows into cipx_trace_identities

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxTraceIdentityDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxTraceIdentityDAO.java
@@ -61,7 +61,11 @@ public class CipxTraceIdentityDAO {
             int filesAdded,
             int filesDeleted,
             int linesAdded,
-            int linesDeleted) {
+            int linesDeleted,
+            double fiveHourUtilization,
+            @NonNull String fiveHourResetsAt,
+            double sevenDayUtilization,
+            @NonNull String sevenDayResetsAt) {
 
         public static TraceIdentityRow from(UUID traceId, UUID projectId, JsonNode metadata, Instant startTime) {
             JsonNode session = metadata.path("cipx").path("session");
@@ -71,6 +75,10 @@ public class CipxTraceIdentityDAO {
             if (userUuid.isEmpty()) {
                 userUuid = identity.path("user_id").asText("");
             }
+            // Rolling rate-limit windows are nested objects (five_hour/seven_day) — the only nested
+            // identity fields. Absent objects yield utilization 0 and resets_at "" via path() defaults.
+            JsonNode fiveHour = identity.path("five_hour");
+            JsonNode sevenDay = identity.path("seven_day");
             return TraceIdentityRow.builder()
                     .traceId(traceId.toString())
                     .projectId(projectId != null ? projectId.toString() : "")
@@ -94,6 +102,10 @@ public class CipxTraceIdentityDAO {
                     .filesDeleted(repository.path("files_deleted").asInt(0))
                     .linesAdded(repository.path("lines_added").asInt(0))
                     .linesDeleted(repository.path("lines_deleted").asInt(0))
+                    .fiveHourUtilization(fiveHour.path("utilization").asDouble(0))
+                    .fiveHourResetsAt(fiveHour.path("resets_at").asText(""))
+                    .sevenDayUtilization(sevenDay.path("utilization").asDouble(0))
+                    .sevenDayResetsAt(sevenDay.path("resets_at").asText(""))
                     .build();
         }
     }
@@ -106,7 +118,8 @@ public class CipxTraceIdentityDAO {
                  user_email, user_display_name, repository, session_id, harness, schema_version,
                  billing_mode, plan, plan_usage_status,
                  branch, head_sha_start, head_sha_end, dirty, commits_in_trace,
-                 files_added, files_deleted, lines_added, lines_deleted)
+                 files_added, files_deleted, lines_added, lines_deleted,
+                 five_hour_utilization, five_hour_resets_at, seven_day_utilization, seven_day_resets_at)
             SETTINGS log_comment = '<log_comment>'
             FORMAT Values
                 <items:{item |
@@ -133,7 +146,11 @@ public class CipxTraceIdentityDAO {
                         :files_added<item.index>,
                         :files_deleted<item.index>,
                         :lines_added<item.index>,
-                        :lines_deleted<item.index>
+                        :lines_deleted<item.index>,
+                        :five_hour_utilization<item.index>,
+                        :five_hour_resets_at<item.index>,
+                        :seven_day_utilization<item.index>,
+                        :seven_day_resets_at<item.index>
                     )
                     <if(item.hasNext)>,<endif>
                 }>
@@ -163,7 +180,7 @@ public class CipxTraceIdentityDAO {
         // Positional binds: the driver resolves named binds with a linear indexOf over the statement's
         // parameter list (quadratic per statement), while bind(int) is a direct array write. Indices
         // follow the placeholders' first-appearance order in the rendered SQL: workspace_id once at 0
-        // (repeats dedup), then 22 parameters per row tuple in template order.
+        // (repeats dedup), then 26 parameters per row tuple in template order.
         statement.bind(0, workspaceId);
         int index = 1;
         for (TraceIdentityRow row : rows) {
@@ -188,7 +205,11 @@ public class CipxTraceIdentityDAO {
                     .bind(index++, row.filesAdded())
                     .bind(index++, row.filesDeleted())
                     .bind(index++, row.linesAdded())
-                    .bind(index++, row.linesDeleted());
+                    .bind(index++, row.linesDeleted())
+                    .bind(index++, row.fiveHourUtilization())
+                    .bind(index++, row.fiveHourResetsAt())
+                    .bind(index++, row.sevenDayUtilization())
+                    .bind(index++, row.sevenDayResetsAt());
         }
 
         return statement.execute();

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000111_add_usage_windows_to_cipx_trace_identities.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000111_add_usage_windows_to_cipx_trace_identities.sql
@@ -1,0 +1,19 @@
+--liquibase formatted sql
+--changeset aadereiko:000111_add_usage_windows_to_cipx_trace_identities
+--comment: Add rolling usage-window columns to cipx_trace_identities (Anthropic 5h/7d utilization + reset, for the Spend & Activity limits meter)
+
+-- The proxy now captures the raw rolling rate-limit windows from /api/oauth/usage (previously it kept
+-- only the reduced within/over status). Each window carries utilization (percent-of-limit consumed,
+-- 0-100) and resets_at (ISO-8601 timestamp when the window rolls over). Identity is trace-level, so
+-- these land alongside plan / billing_mode / plan_usage_status (000104). Additive columns with
+-- defaults; existing rows read the default. resets_at is stored as the raw ISO-8601 String (the UI
+-- renders a countdown from it; we never do date math on it in ClickHouse — row recency uses
+-- start_time). An absent window (api pricing, gateway-scrubbed, or unfetched) leaves utilization 0 and
+-- resets_at ''.
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_trace_identities ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS five_hour_utilization  Float64 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS five_hour_resets_at     String  DEFAULT '',
+    ADD COLUMN IF NOT EXISTS seven_day_utilization  Float64 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS seven_day_resets_at     String  DEFAULT '';
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_trace_identities ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS five_hour_utilization, DROP COLUMN IF EXISTS five_hour_resets_at, DROP COLUMN IF EXISTS seven_day_utilization, DROP COLUMN IF EXISTS seven_day_resets_at;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000113_add_usage_windows_to_cipx_trace_identities.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000113_add_usage_windows_to_cipx_trace_identities.sql
@@ -1,5 +1,5 @@
 --liquibase formatted sql
---changeset aadereiko:000111_add_usage_windows_to_cipx_trace_identities
+--changeset aadereiko:000113_add_usage_windows_to_cipx_trace_identities
 --comment: Add rolling usage-window columns to cipx_trace_identities (Anthropic 5h/7d utilization + reset, for the Spend & Activity limits meter)
 
 -- The proxy now captures the raw rolling rate-limit windows from /api/oauth/usage (previously it kept

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
@@ -352,6 +352,11 @@ class CostIntelligenceIngestionTest {
                 assertThat(row.get().filesDeleted()).isEqualTo(1);
                 assertThat(row.get().linesAdded()).isEqualTo(40);
                 assertThat(row.get().linesDeleted()).isEqualTo(5);
+                // rolling usage windows (nested five_hour/seven_day objects)
+                assertThat(row.get().fiveHourUtilization()).isEqualTo(88.5);
+                assertThat(row.get().fiveHourResetsAt()).isEqualTo("2026-07-23T18:00:00Z");
+                assertThat(row.get().sevenDayUtilization()).isEqualTo(42.0);
+                assertThat(row.get().sevenDayResetsAt()).isEqualTo("2026-07-28T00:00:00Z");
 
                 assertThat(getUserMappings(email)).containsExactly(userUuid);
             });
@@ -535,7 +540,9 @@ class CostIntelligenceIngestionTest {
                         "display_name": "%s",
                         "billing_mode": "subscription",
                         "plan": "max",
-                        "plan_usage_status": "within"
+                        "plan_usage_status": "within",
+                        "five_hour": {"utilization": 88.5, "resets_at": "2026-07-23T18:00:00Z"},
+                        "seven_day": {"utilization": 42, "resets_at": "2026-07-28T00:00:00Z"}
                       }
                     }
                   }
@@ -631,7 +638,8 @@ class CostIntelligenceIngestionTest {
                     user_uuid, user_email, user_display_name, repository, session_id, harness, schema_version,
                     billing_mode, plan, plan_usage_status,
                     branch, head_sha_start, head_sha_end, dirty, commits_in_trace,
-                    files_added, files_deleted, lines_added, lines_deleted
+                    files_added, files_deleted, lines_added, lines_deleted,
+                    five_hour_utilization, five_hour_resets_at, seven_day_utilization, seven_day_resets_at
                 FROM cipx_trace_identities FINAL
                 WHERE workspace_id = :workspace_id AND trace_id = :trace_id
                 """;
@@ -661,7 +669,11 @@ class CostIntelligenceIngestionTest {
                             row.get("files_added", Integer.class),
                             row.get("files_deleted", Integer.class),
                             row.get("lines_added", Integer.class),
-                            row.get("lines_deleted", Integer.class)))));
+                            row.get("lines_deleted", Integer.class),
+                            row.get("five_hour_utilization", Double.class),
+                            row.get("five_hour_resets_at", String.class),
+                            row.get("seven_day_utilization", Double.class),
+                            row.get("seven_day_resets_at", String.class)))));
         }).blockOptional();
     }
 
@@ -703,6 +715,8 @@ class CostIntelligenceIngestionTest {
             String userDisplayName, String repository, String sessionId, String harness, Integer schemaVersion,
             String billingMode, String plan, String planUsageStatus,
             String branch, String headShaStart, String headShaEnd, Boolean dirty, Integer commitsInTrace,
-            Integer filesAdded, Integer filesDeleted, Integer linesAdded, Integer linesDeleted) {
+            Integer filesAdded, Integer filesDeleted, Integer linesAdded, Integer linesDeleted,
+            Double fiveHourUtilization, String fiveHourResetsAt, Double sevenDayUtilization,
+            String sevenDayResetsAt) {
     }
 }


### PR DESCRIPTION
## What

Persist Anthropic's rolling **5h / 7d** rate-limit windows (`utilization` + `resets_at`) that the cipx proxy now emits on `cipx.session.identity` (comet-ml/cost-intelligence-proxy-internal#46).

- **Migration `000110`** — four additive columns on `cipx_trace_identities`: `five_hour_utilization`/`seven_day_utilization` (`Float64`), `five_hour_resets_at`/`seven_day_resets_at` (`String`). `resets_at` is stored as the raw ISO-8601 string (the UI renders a countdown; no ClickHouse date math, and row recency uses `start_time`).
- **`CipxTraceIdentityDAO`** — parses the nested `five_hour`/`seven_day` objects (the first nested identity fields) and binds the 4 columns alongside the existing ones.

Merged cleanly on top of `main`'s recent git-delta columns (OPIK-7345); the DAO now binds 26 params/row.

## Deploy order

Deploy **after** the proxy PR (so real data flows) and **before** the cost-api `me/limits` PR (comet-ml/ai-cost-backend#41), which reads these columns. Liquibase applies the additive migration at boot; safe during a rolling deploy (old instances just don't write the columns).

## Tests

`CostIntelligenceIngestionTest` (real ClickHouse via testcontainers) extended for the new windows — **8 tests pass, BUILD SUCCESS**. The fixture carries both the git-repository block and the `five_hour`/`seven_day` objects; assertions verify both round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)