### PR TITLE
[FE] Support metadata to hide a specified number of messages by default in display (#7594)

### DIFF
--- a/apps/opik-frontend/src/shared/SyntaxHighlighter/hooks/useSyntaxHighlighterHooks.ts
+++ b/apps/opik-frontend/src/shared/SyntaxHighlighter/hooks/useSyntaxHighlighterHooks.ts
@@ -61,36 +61,63 @@ const LLM_MESSAGES_COLLAPSE_THRESHOLD = 10;
 export const useLLMMessagesExpandAll = (
   allMessageIds: string[],
   preserveKey?: string,
+  defaultCollapsedIds?: string[],
 ) => {
   const [initialCount] = useState(allMessageIds.length);
   const defaultExpanded = initialCount <= LLM_MESSAGES_COLLAPSE_THRESHOLD;
 
-  const [localIsAllExpanded, setLocalIsAllExpanded] =
-    useState<boolean>(defaultExpanded);
+  const [initialDefaultCollapsedIds] = useState(defaultCollapsedIds ?? []);
+  const hasDefaultCollapsedOverride = initialDefaultCollapsedIds.length > 0;
 
-  const [preservedIsAllExpanded, setPreservedIsAllExpanded] =
-    useLocalStorageState(
+  // "all expanded" means literally all -- false when an override applies,
+  // even under the threshold, so the toggle button/tooltip stays truthful.
+  const autoDefaultExpanded = defaultExpanded && !hasDefaultCollapsedOverride;
+
+  const [localExplicitIsAllExpanded, setLocalExplicitIsAllExpanded] = useState<
+    boolean | undefined
+  >(undefined);
+
+  // Only an explicit user action (an Expand/Collapse-all click, or manually expanding every
+  // message via the accordion) is ever written here -- deliberately no `defaultValue`. This key
+  // is shared across every trace in the app, not scoped per-trace, and use-local-storage-state
+  // writes back whatever `defaultValue` it's given the moment the key is first read (see its
+  // `getSnapshot` "store default value in localStorage" branch). Passing a per-trace-computed
+  // default there would let whichever trace happens to mount first permanently bake its own
+  // message-count-based default into storage for every other trace afterward -- exactly the bug
+  // that made already-shown-message collapsing silently stop working after any earlier trace
+  // (even a short, unrelated one) had rendered once.
+  const [preservedExplicitIsAllExpanded, setPreservedExplicitIsAllExpanded] =
+    useLocalStorageState<boolean | undefined>(
       preserveKey
         ? `${preserveKey}-llm-expand-all`
         : UNUSED_SYNTAX_HIGHLIGHTER_KEY,
-      { defaultValue: defaultExpanded },
     );
 
-  const [isAllExpanded, setIsAllExpanded] = useMemo(
+  const [explicitIsAllExpanded, setExplicitIsAllExpanded] = useMemo(
     () =>
       preserveKey
-        ? [preservedIsAllExpanded, setPreservedIsAllExpanded]
-        : [localIsAllExpanded, setLocalIsAllExpanded],
+        ? [preservedExplicitIsAllExpanded, setPreservedExplicitIsAllExpanded]
+        : [localExplicitIsAllExpanded, setLocalExplicitIsAllExpanded],
     [
-      localIsAllExpanded,
+      localExplicitIsAllExpanded,
       preserveKey,
-      preservedIsAllExpanded,
-      setPreservedIsAllExpanded,
+      preservedExplicitIsAllExpanded,
+      setPreservedExplicitIsAllExpanded,
     ],
   );
 
-  const [customExpandedIds, setCustomExpandedIds] = useState<Set<string>>(
-    new Set(),
+  // An explicit prior choice (persisted or not) always wins; absent one, fall back to this
+  // trace's own freshly computed default.
+  const isAllExpanded = explicitIsAllExpanded ?? autoDefaultExpanded;
+
+  const [customExpandedIds, setCustomExpandedIds] = useState<Set<string>>(() =>
+    defaultExpanded && hasDefaultCollapsedOverride
+      ? new Set(
+          allMessageIds.filter(
+            (id) => !initialDefaultCollapsedIds.includes(id),
+          ),
+        )
+      : new Set(),
   );
 
   const expandedMessages = useMemo<string[]>(() => {
@@ -102,10 +129,10 @@ export const useLLMMessagesExpandAll = (
 
   const handleToggleAll = useCallback(() => {
     startTransition(() => {
-      setIsAllExpanded(!isAllExpanded);
+      setExplicitIsAllExpanded(!isAllExpanded);
       setCustomExpandedIds(new Set());
     });
-  }, [isAllExpanded, setIsAllExpanded]);
+  }, [isAllExpanded, setExplicitIsAllExpanded]);
 
   const handleValueChange = useCallback(
     (value: string[]) => {
@@ -114,10 +141,10 @@ export const useLLMMessagesExpandAll = (
         allMessageIds.length > 0 &&
         allMessageIds.every((id) => newExpandedSet.has(id));
 
-      setIsAllExpanded(allExpanded);
+      setExplicitIsAllExpanded(allExpanded);
       setCustomExpandedIds(allExpanded ? new Set() : newExpandedSet);
     },
-    [allMessageIds, setIsAllExpanded],
+    [allMessageIds, setExplicitIsAllExpanded],
   );
 
   return {

--- a/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.tsx
@@ -6,7 +6,7 @@ import React, {
   useEffect,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { FoldVertical, UnfoldVertical } from "lucide-react";
+import { ChevronRight, FoldVertical, UnfoldVertical } from "lucide-react";
 import { UnifiedMediaItem } from "@/hooks/useUnifiedMedia";
 import {
   MediaProvider,
@@ -33,7 +33,25 @@ type MessagesTabProps = {
   media: UnifiedMediaItem[];
   isLoading: boolean;
   scrollContainerRef?: React.RefObject<HTMLDivElement>;
+  // Count of leading input messages already presented to the viewer in an earlier span of the
+  // same session (autonomic-opik-export's metadata.already_shown_count, or any exporter
+  // populating the same key) -- hidden by default behind a single disclosure row, independent of
+  // per-message accordion state and the Expand/Collapse-all toggle (see AlreadyShownDisclosure).
+  // Provider-agnostic: every registered format mapper (openai/langchain/anthropic) ids input
+  // messages "input-{index}" by position in the raw input message array, so this maps directly
+  // without needing to know which format matched.
+  unchangedPrefixLength?: number;
 };
+
+type DisplayItem =
+  | { kind: "message"; message: LLMMessageDescriptor }
+  | { kind: "disclosure"; count: number };
+
+const isMessageItem = (
+  item: DisplayItem,
+): item is Extract<DisplayItem, { kind: "message" }> => item.kind === "message";
+
+const ALREADY_SHOWN_DISCLOSURE_ID = "already-shown-disclosure";
 
 function renderBlock(descriptor: LLMBlockDescriptor, key: string) {
   const Component = descriptor.component as React.ComponentType<
@@ -48,21 +66,81 @@ function renderContentBlocks(message: LLMMessageDescriptor) {
   );
 }
 
+const AlreadyShownDisclosure: React.FC<{
+  count: number;
+  onReveal: () => void;
+}> = ({ count, onReveal }) => (
+  <button
+    type="button"
+    onClick={onReveal}
+    className="comet-body-xs-accented flex w-full select-none items-center gap-1 rounded-sm p-1 text-muted-slate transition-colors hover:bg-primary-foreground"
+  >
+    <ChevronRight className="size-3.5 shrink-0 text-light-slate" />
+    {count} earlier message{count === 1 ? "" : "s"} already shown in a previous
+    turn — click to view
+  </button>
+);
+
 const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
   transformedInput,
   transformedOutput,
   media,
   isLoading,
   scrollContainerRef,
+  unchangedPrefixLength,
 }) => {
   const { messages: combinedMessages, usage } = useMemo(
     () => mapAndCombineMessages(transformedInput, transformedOutput),
     [transformedInput, transformedOutput],
   );
 
+  // Ids of the leading input messages already presented to the viewer on an earlier span --
+  // hidden behind a single disclosure row rather than collapsed individually (see
+  // AlreadyShownDisclosure), so neither Expand/Collapse-all nor the persisted expand-state
+  // preference (shared across every trace, see useLLMMessagesExpandAll) can silently reveal or
+  // re-hide them.
+  const alreadyShownIdSet = useMemo(() => {
+    if (!unchangedPrefixLength || unchangedPrefixLength <= 0) return null;
+    const ids = new Set<string>();
+    for (let i = 0; i < unchangedPrefixLength; i += 1) ids.add(`input-${i}`);
+    return ids;
+  }, [unchangedPrefixLength]);
+
+  const [alreadyShownRevealed, setAlreadyShownRevealed] = useState(false);
+
+  const displayItems = useMemo<DisplayItem[]>(() => {
+    if (!alreadyShownIdSet || alreadyShownRevealed) {
+      return combinedMessages.map(
+        (message): DisplayItem => ({ kind: "message", message }),
+      );
+    }
+    const items: DisplayItem[] = [];
+    let disclosureAdded = false;
+    combinedMessages.forEach((message) => {
+      if (alreadyShownIdSet.has(message.id)) {
+        if (!disclosureAdded) {
+          items.push({ kind: "disclosure", count: alreadyShownIdSet.size });
+          disclosureAdded = true;
+        }
+        return;
+      }
+      items.push({ kind: "message", message });
+    });
+    return items;
+  }, [combinedMessages, alreadyShownIdSet, alreadyShownRevealed]);
+
   const allMessageIds = useMemo(
-    () => combinedMessages.map((msg) => msg.id),
-    [combinedMessages],
+    () => displayItems.filter(isMessageItem).map((item) => item.message.id),
+    [displayItems],
+  );
+
+  const defaultCollapsedIds = useMemo(
+    () =>
+      displayItems
+        .filter(isMessageItem)
+        .filter((item) => item.message.role === "system")
+        .map((item) => item.message.id),
+    [displayItems],
   );
 
   const {
@@ -70,7 +148,11 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
     expandedMessages,
     handleToggleAll,
     handleValueChange,
-  } = useLLMMessagesExpandAll(allMessageIds, "messages-tab-combined");
+  } = useLLMMessagesExpandAll(
+    allMessageIds,
+    "messages-tab-combined",
+    defaultCollapsedIds,
+  );
 
   const expandedSet = useMemo(
     () => new Set(expandedMessages),
@@ -87,7 +169,7 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
     [transformedInput, transformedOutput],
   );
 
-  const shouldVirtualize = combinedMessages.length > VIRTUALIZATION_THRESHOLD;
+  const shouldVirtualize = displayItems.length > VIRTUALIZATION_THRESHOLD;
 
   const internalScrollRef = useRef<HTMLDivElement>(null);
   const effectiveScrollRef = scrollContainerRef ?? internalScrollRef;
@@ -100,17 +182,24 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
     }
   }, []);
 
+  const getDisplayItemKey = useCallback(
+    (item: DisplayItem) =>
+      isMessageItem(item) ? item.message.id : ALREADY_SHOWN_DISCLOSURE_ID,
+    [],
+  );
+
   const virtualizer = useVirtualizer({
-    count: combinedMessages.length,
+    count: displayItems.length,
     getScrollElement: () => effectiveScrollRef.current,
     estimateSize: (index) => {
-      const id = combinedMessages[index]?.id;
-      return id && expandedSet.has(id)
+      const item = displayItems[index];
+      if (!item) return ESTIMATED_COLLAPSED_HEIGHT;
+      return isMessageItem(item) && expandedSet.has(item.message.id)
         ? ESTIMATED_EXPANDED_HEIGHT
         : ESTIMATED_COLLAPSED_HEIGHT;
     },
     overscan: VIRTUAL_OVERSCAN,
-    getItemKey: (index) => combinedMessages[index].id,
+    getItemKey: (index) => getDisplayItemKey(displayItems[index]),
     enabled: shouldVirtualize,
     scrollMargin,
   });
@@ -145,8 +234,18 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expandedMessages]);
 
-  const renderMessage = useCallback(
-    (message: LLMMessageDescriptor) => (
+  const renderDisplayItem = useCallback((item: DisplayItem) => {
+    if (!isMessageItem(item)) {
+      return (
+        <AlreadyShownDisclosure
+          key={ALREADY_SHOWN_DISCLOSURE_ID}
+          count={item.count}
+          onReveal={() => setAlreadyShownRevealed(true)}
+        />
+      );
+    }
+    const { message } = item;
+    return (
       <PrettyLLMMessage.Root key={message.id} value={message.id}>
         <PrettyLLMMessage.Header role={message.role} label={message.label} />
         <PrettyLLMMessage.Content>
@@ -158,9 +257,8 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
           )}
         </PrettyLLMMessage.Content>
       </PrettyLLMMessage.Root>
-    ),
-    [],
-  );
+    );
+  }, []);
 
   const expandCollapseButton = (
     <Tooltip>
@@ -215,15 +313,15 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
             }}
           >
             {virtualizer.getVirtualItems().map((virtualRow) => {
-              const message = combinedMessages[virtualRow.index];
+              const item = displayItems[virtualRow.index];
               return (
                 <div
-                  key={message.id}
+                  key={getDisplayItemKey(item)}
                   data-index={virtualRow.index}
                   ref={virtualizer.measureElement}
                   className="w-full pb-1"
                 >
-                  {renderMessage(message)}
+                  {renderDisplayItem(item)}
                 </div>
               );
             })}
@@ -241,7 +339,7 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
         onValueChange={handleValueChange}
         className="space-y-1"
       >
-        {combinedMessages.map((message) => renderMessage(message))}
+        {displayItems.map((item) => renderDisplayItem(item))}
       </PrettyLLMMessage.Container>
     );
   }
@@ -254,12 +352,12 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
             LLM messages
           </div>
           <div className="flex flex-1 items-center justify-end gap-2">
-            {combinedMessages.length > 0 && expandCollapseButton}
+            {displayItems.length > 0 && expandCollapseButton}
             {copyButton}
           </div>
         </div>
         <div className="pt-3">
-          {combinedMessages.length > 0 ? (
+          {displayItems.length > 0 ? (
             <>
               {shouldVirtualize
                 ? renderVirtualizedMessages()

--- a/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -82,6 +82,14 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
   );
   const hasSpanAgentGraph =
     Boolean(agentGraphData) && type !== TRACE_TYPE_FOR_TREE;
+
+  const alreadyShownCountRaw = get(
+    data,
+    ["metadata", "already_shown_count"],
+    undefined,
+  );
+  const unchangedPrefixLength =
+    typeof alreadyShownCountRaw === "number" ? alreadyShownCountRaw : undefined;
   const hasPrompts = useMemo(() => {
     const prompts = (data.metadata as Record<string, unknown>)?.opik_prompts;
     return Array.isArray(prompts) && prompts.length > 0;
@@ -352,11 +360,17 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
           {canShowMessagesTab && (
             <TabsContent value="messages">
               <MessagesTab
+                // Not remounted between spans otherwise (TraceDataViewer isn't keyed by the
+                // caller) -- forces the accordion/already-shown-disclosure state in MessagesTab
+                // to reset instead of carrying over stale per-span computed defaults when
+                // navigating between spans without closing the panel.
+                key={data.id}
                 transformedInput={transformedInput}
                 transformedOutput={transformedOutput}
                 media={media}
                 isLoading={isSpanInputOutputLoading}
                 scrollContainerRef={rootScrollRef}
+                unchangedPrefixLength={unchangedPrefixLength}
               />
             </TabsContent>
           )}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.tsx
@@ -6,7 +6,7 @@ import React, {
   useEffect,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { FoldVertical, UnfoldVertical } from "lucide-react";
+import { ChevronRight, FoldVertical, UnfoldVertical } from "lucide-react";
 import { UnifiedMediaItem } from "@/hooks/useUnifiedMedia";
 import {
   MediaProvider,
@@ -34,7 +34,25 @@ type MessagesTabProps = {
   media: UnifiedMediaItem[];
   isLoading: boolean;
   scrollContainerRef?: React.RefObject<HTMLDivElement>;
+  // Count of leading input messages already presented to the viewer in an earlier span of the
+  // same session (autonomic-opik-export's metadata.already_shown_count, or any exporter
+  // populating the same key) -- hidden by default behind a single disclosure row, independent of
+  // per-message accordion state and the Expand/Collapse-all toggle (see AlreadyShownDisclosure).
+  // Provider-agnostic: every registered format mapper (openai/langchain/anthropic) ids input
+  // messages "input-{index}" by position in the raw input message array, so this maps directly
+  // without needing to know which format matched.
+  unchangedPrefixLength?: number;
 };
+
+type DisplayItem =
+  | { kind: "message"; message: LLMMessageDescriptor }
+  | { kind: "disclosure"; count: number };
+
+const isMessageItem = (
+  item: DisplayItem,
+): item is Extract<DisplayItem, { kind: "message" }> => item.kind === "message";
+
+const ALREADY_SHOWN_DISCLOSURE_ID = "already-shown-disclosure";
 
 function renderBlock(descriptor: LLMBlockDescriptor, key: string) {
   const Component = descriptor.component as React.ComponentType<
@@ -49,21 +67,81 @@ function renderContentBlocks(message: LLMMessageDescriptor) {
   );
 }
 
+const AlreadyShownDisclosure: React.FC<{
+  count: number;
+  onReveal: () => void;
+}> = ({ count, onReveal }) => (
+  <button
+    type="button"
+    onClick={onReveal}
+    className="comet-body-xs-accented flex w-full select-none items-center gap-1 rounded-sm p-1 text-muted-slate transition-colors hover:bg-primary-foreground"
+  >
+    <ChevronRight className="size-3.5 shrink-0 text-light-slate" />
+    {count} earlier message{count === 1 ? "" : "s"} already shown in a previous
+    turn — click to view
+  </button>
+);
+
 const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
   transformedInput,
   transformedOutput,
   media,
   isLoading,
   scrollContainerRef,
+  unchangedPrefixLength,
 }) => {
   const { messages: combinedMessages, usage } = useMemo(
     () => mapAndCombineMessages(transformedInput, transformedOutput),
     [transformedInput, transformedOutput],
   );
 
+  // Ids of the leading input messages already presented to the viewer on an earlier span --
+  // hidden behind a single disclosure row rather than collapsed individually (see
+  // AlreadyShownDisclosure), so neither Expand/Collapse-all nor the persisted expand-state
+  // preference (shared across every trace, see useLLMMessagesExpandAll) can silently reveal or
+  // re-hide them.
+  const alreadyShownIdSet = useMemo(() => {
+    if (!unchangedPrefixLength || unchangedPrefixLength <= 0) return null;
+    const ids = new Set<string>();
+    for (let i = 0; i < unchangedPrefixLength; i += 1) ids.add(`input-${i}`);
+    return ids;
+  }, [unchangedPrefixLength]);
+
+  const [alreadyShownRevealed, setAlreadyShownRevealed] = useState(false);
+
+  const displayItems = useMemo<DisplayItem[]>(() => {
+    if (!alreadyShownIdSet || alreadyShownRevealed) {
+      return combinedMessages.map(
+        (message): DisplayItem => ({ kind: "message", message }),
+      );
+    }
+    const items: DisplayItem[] = [];
+    let disclosureAdded = false;
+    combinedMessages.forEach((message) => {
+      if (alreadyShownIdSet.has(message.id)) {
+        if (!disclosureAdded) {
+          items.push({ kind: "disclosure", count: alreadyShownIdSet.size });
+          disclosureAdded = true;
+        }
+        return;
+      }
+      items.push({ kind: "message", message });
+    });
+    return items;
+  }, [combinedMessages, alreadyShownIdSet, alreadyShownRevealed]);
+
   const allMessageIds = useMemo(
-    () => combinedMessages.map((msg) => msg.id),
-    [combinedMessages],
+    () => displayItems.filter(isMessageItem).map((item) => item.message.id),
+    [displayItems],
+  );
+
+  const defaultCollapsedIds = useMemo(
+    () =>
+      displayItems
+        .filter(isMessageItem)
+        .filter((item) => item.message.role === "system")
+        .map((item) => item.message.id),
+    [displayItems],
   );
 
   const {
@@ -71,7 +149,11 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
     expandedMessages,
     handleToggleAll,
     handleValueChange,
-  } = useLLMMessagesExpandAll(allMessageIds, "messages-tab-combined");
+  } = useLLMMessagesExpandAll(
+    allMessageIds,
+    "messages-tab-combined",
+    defaultCollapsedIds,
+  );
 
   const expandedSet = useMemo(
     () => new Set(expandedMessages),
@@ -88,7 +170,7 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
     [transformedInput, transformedOutput],
   );
 
-  const shouldVirtualize = combinedMessages.length > VIRTUALIZATION_THRESHOLD;
+  const shouldVirtualize = displayItems.length > VIRTUALIZATION_THRESHOLD;
 
   const internalScrollRef = useRef<HTMLDivElement>(null);
   const effectiveScrollRef = scrollContainerRef ?? internalScrollRef;
@@ -101,17 +183,24 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
     }
   }, []);
 
+  const getDisplayItemKey = useCallback(
+    (item: DisplayItem) =>
+      isMessageItem(item) ? item.message.id : ALREADY_SHOWN_DISCLOSURE_ID,
+    [],
+  );
+
   const virtualizer = useVirtualizer({
-    count: combinedMessages.length,
+    count: displayItems.length,
     getScrollElement: () => effectiveScrollRef.current,
     estimateSize: (index) => {
-      const id = combinedMessages[index]?.id;
-      return id && expandedSet.has(id)
+      const item = displayItems[index];
+      if (!item) return ESTIMATED_COLLAPSED_HEIGHT;
+      return isMessageItem(item) && expandedSet.has(item.message.id)
         ? ESTIMATED_EXPANDED_HEIGHT
         : ESTIMATED_COLLAPSED_HEIGHT;
     },
     overscan: VIRTUAL_OVERSCAN,
-    getItemKey: (index) => combinedMessages[index].id,
+    getItemKey: (index) => getDisplayItemKey(displayItems[index]),
     enabled: shouldVirtualize,
     scrollMargin,
   });
@@ -146,8 +235,18 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expandedMessages]);
 
-  const renderMessage = useCallback(
-    (message: LLMMessageDescriptor) => (
+  const renderDisplayItem = useCallback((item: DisplayItem) => {
+    if (!isMessageItem(item)) {
+      return (
+        <AlreadyShownDisclosure
+          key={ALREADY_SHOWN_DISCLOSURE_ID}
+          count={item.count}
+          onReveal={() => setAlreadyShownRevealed(true)}
+        />
+      );
+    }
+    const { message } = item;
+    return (
       <PrettyLLMMessage.Root key={message.id} value={message.id}>
         <PrettyLLMMessage.Header role={message.role} label={message.label} />
         <PrettyLLMMessage.Content>
@@ -159,9 +258,8 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
           )}
         </PrettyLLMMessage.Content>
       </PrettyLLMMessage.Root>
-    ),
-    [],
-  );
+    );
+  }, []);
 
   const expandCollapseButton = (
     <Tooltip>
@@ -216,15 +314,15 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
             }}
           >
             {virtualizer.getVirtualItems().map((virtualRow) => {
-              const message = combinedMessages[virtualRow.index];
+              const item = displayItems[virtualRow.index];
               return (
                 <div
-                  key={message.id}
+                  key={getDisplayItemKey(item)}
                   data-index={virtualRow.index}
                   ref={virtualizer.measureElement}
                   className="w-full pb-1"
                 >
-                  {renderMessage(message)}
+                  {renderDisplayItem(item)}
                 </div>
               );
             })}
@@ -242,7 +340,7 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
         onValueChange={handleValueChange}
         className="space-y-1"
       >
-        {combinedMessages.map((message) => renderMessage(message))}
+        {displayItems.map((item) => renderDisplayItem(item))}
       </PrettyLLMMessage.Container>
     );
   }
@@ -253,13 +351,13 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
         title="LLM messages"
         actions={
           <>
-            {combinedMessages.length > 0 && expandCollapseButton}
+            {displayItems.length > 0 && expandCollapseButton}
             {copyButton}
           </>
         }
         bodyClassName="px-2 pb-2 pt-1"
       >
-        {combinedMessages.length > 0 ? (
+        {displayItems.length > 0 ? (
           <>
             {shouldVirtualize
               ? renderVirtualizedMessages()

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.unchangedPrefixLength.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.unchangedPrefixLength.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { TooltipProvider } from "@/ui/tooltip";
+import MessagesTab from "./MessagesTab";
+
+// Provider-agnostic: unchangedPrefixLength hides input-0..input-{N-1} behind a single disclosure
+// row, the id scheme every registered format mapper (openai/langchain/anthropic) already uses
+// for input messages by position in the raw input array. Not specific to Anthropic -- exercised
+// here with a plain OpenAI-shaped payload to keep that separation explicit (see
+// MessagesTab.anthropic.test.tsx for Anthropic-specific rendering behavior; this file tests
+// unrelated, independently-shippable functionality).
+//
+// The hide is deliberately NOT implemented as per-message accordion collapse: MessagesTab
+// hardcodes preserveKey="messages-tab-combined" (not per-trace), so its Expand/Collapse-all
+// state persists to the SAME localStorage key across every trace shown in the app. An earlier
+// version collapsed the already-shown prefix as ordinary accordion items, which meant a stale
+// "expand all" preference left over from any other trace silently defeated the hint. The
+// disclosure row sits outside accordion state entirely so neither Expand/Collapse-all nor a
+// persisted preference from another trace can reveal or re-hide it.
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+const renderMessagesTab = (
+  props: Omit<React.ComponentProps<typeof MessagesTab>, "media" | "isLoading">,
+) =>
+  render(
+    <TooltipProvider>
+      <MessagesTab media={[]} isLoading={false} {...props} />
+    </TooltipProvider>,
+  );
+
+describe("MessagesTab unchangedPrefixLength", () => {
+  const transformedInput = {
+    messages: [
+      { role: "user", content: "First message" },
+      { role: "assistant", content: "Second message" },
+      { role: "user", content: "Third message, genuinely new" },
+    ],
+  };
+  const transformedOutput = {
+    choices: [{ message: { role: "assistant", content: "Reply" }, index: 0 }],
+  };
+
+  it("hides input-0..input-{N-1} behind a disclosure row and leaves the rest visible", () => {
+    renderMessagesTab({
+      transformedInput,
+      transformedOutput,
+      unchangedPrefixLength: 2,
+    });
+
+    expect(screen.queryByText("First message")).not.toBeInTheDocument();
+    expect(screen.queryByText("Second message")).not.toBeInTheDocument();
+    expect(screen.queryAllByText("User")).toHaveLength(1);
+    // The one remaining "Assistant" bubble is the output turn ("Reply"), not the hidden
+    // input-1 message ("Second message") -- confirms the hide is scoped to the input prefix.
+    expect(screen.queryAllByText("Assistant")).toHaveLength(1);
+    expect(
+      screen.getByText(/2 earlier messages already shown/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Third message, genuinely new"),
+    ).toBeInTheDocument();
+  });
+
+  it("reveals the hidden prefix on click, unaffected by Expand/Collapse-all state", () => {
+    renderMessagesTab({
+      transformedInput,
+      transformedOutput,
+      unchangedPrefixLength: 2,
+    });
+
+    fireEvent.click(screen.getByText(/2 earlier messages already shown/));
+
+    expect(
+      screen.queryByText(/earlier messages already shown/),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("First message")).toBeInTheDocument();
+    expect(screen.getByText("Second message")).toBeInTheDocument();
+    expect(
+      screen.getByText("Third message, genuinely new"),
+    ).toBeInTheDocument();
+  });
+
+  it("leaves everything visible and expanded when unchangedPrefixLength is 0 or absent", () => {
+    renderMessagesTab({ transformedInput, transformedOutput });
+
+    expect(
+      screen.queryByText(/earlier messages already shown/),
+    ).not.toBeInTheDocument();
+    const [firstUser] = screen.getAllByText("User");
+    expect(firstUser.closest("[aria-expanded]")).toHaveAttribute(
+      "data-state",
+      "open",
+    );
+    expect(screen.getByText("First message")).toBeInTheDocument();
+  });
+
+  it("degrades gracefully when unchangedPrefixLength exceeds the actual message count", () => {
+    expect(() =>
+      renderMessagesTab({
+        transformedInput,
+        transformedOutput,
+        unchangedPrefixLength: 50,
+      }),
+    ).not.toThrow();
+  });
+
+  it("still hides the prefix even with a stale persisted expand-all preference from another trace", () => {
+    // Regression coverage for the actual bug report: MessagesTab's Expand/Collapse-all
+    // preference is persisted under the SAME localStorage key for every trace in the app. Before
+    // the disclosure row existed, a `true` value left over from any earlier trace (a short one
+    // under the auto-expand threshold, or an explicit "Expand all" click) silently blew the
+    // already-shown prefix back open on every subsequent trace, defeating already_shown_count
+    // entirely. Simulate that stuck preference directly and confirm the hide still holds.
+    localStorage.setItem("messages-tab-combined-llm-expand-all", "true");
+
+    renderMessagesTab({
+      transformedInput,
+      transformedOutput,
+      unchangedPrefixLength: 2,
+    });
+
+    expect(screen.queryByText("First message")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/2 earlier messages already shown/),
+    ).toBeInTheDocument();
+    // The stale "expand all" preference should still apply to the messages that ARE shown.
+    expect(
+      screen.getByText("Third message, genuinely new"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -73,6 +73,14 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
     ["metadata", METADATA_AGENT_GRAPH_KEY],
     null,
   );
+
+  const alreadyShownCountRaw = get(
+    data,
+    ["metadata", "already_shown_count"],
+    undefined,
+  );
+  const unchangedPrefixLength =
+    typeof alreadyShownCountRaw === "number" ? alreadyShownCountRaw : undefined;
   const hasSpanAgentGraph =
     Boolean(agentGraphData) && type !== TRACE_TYPE_FOR_TREE;
 
@@ -308,11 +316,17 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
           {canShowMessagesTab && (
             <TabsContent value="messages">
               <MessagesTab
+                // Not remounted between spans otherwise (TraceDataViewer isn't keyed by the
+                // caller) -- forces the accordion/already-shown-disclosure state in MessagesTab
+                // to reset instead of carrying over stale per-span computed defaults when
+                // navigating between spans without closing the panel.
+                key={data.id}
                 transformedInput={transformedInput}
                 transformedOutput={transformedOutput}
                 media={media}
                 isLoading={isSpanInputOutputLoading}
                 scrollContainerRef={rootScrollRef}
+                unchangedPrefixLength={unchangedPrefixLength}
               />
             </TabsContent>
           )}


### PR DESCRIPTION
## Details

In a long conversation in which new items are appended, collapsing already-seen messages allows a reader to focus only on content added in the current turn.

Using metadata for this allows format-aware work (discarding volatile content like cachepoints, or message fields where a specific default value and a non-present value are semantically identical) to happen at ingestion time rather than being the frontend's responsibility.

## Change checklist
- [X] User facing
- [ ] Documentation update

## Issues

- Resolves #7594

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Sonnet 5.0, Opus 4.7 advising
  - Scope: Close iteration with active/interactive human user proposing (and then talking through consequences of) specifications, reading code, and testing output.
  - Human verification: Yes -- actively using a branch that includes this and other changes (most notably Anthropic rendering support) in practice.

## Testing

All smoketesting done with a docker-compose environment (`./opik.sh --build` on an arm64 MacOS system with Colima for the Docker stack). Browser used for manual testing is Brave 1.92.134 (based on Chromium 150.0.7871.63). Node.js for local / dev-host testing provided by NixOS 26.05.

<details><summary>`make precommit` has been run -- expand the fold for output</summary>

```
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /Users/chaduffy/.cache/pre-commit/patch1784819751-53848.
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/kynan/nbstripout.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/igorshubovych/markdownlint-cli.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/codespell-project/codespell.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for local.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for local.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for local.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/jendrikseipp/vulture.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/rhysd/actionlint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
🐍 trim trailing whitespace — python sdk.............(no files to check)Skipped
- hook id: trailing-whitespace
🐍 fix end of files — python sdk.....................(no files to check)Skipped
- hook id: end-of-file-fixer
🐍 ruff — python sdk.................................(no files to check)Skipped
- hook id: ruff
🐍 ruff-format — python sdk..........................(no files to check)Skipped
- hook id: ruff-format
🐍 mypy — python sdk.................................(no files to check)Skipped
- hook id: mypy
🤖 trim trailing whitespace — optimizer..............(no files to check)Skipped
- hook id: trailing-whitespace
🤖 fix end of files — optimizer......................(no files to check)Skipped
- hook id: end-of-file-fixer
🤖 check yaml — optimizer............................(no files to check)Skipped
- hook id: check-yaml
🤖 check json — optimizer............................(no files to check)Skipped
- hook id: check-json
🤖 check toml — optimizer............................(no files to check)Skipped
- hook id: check-toml
🤖 check for added large files — optimizer...........(no files to check)Skipped
- hook id: check-added-large-files
🔐 detect private key — optimizer....................(no files to check)Skipped
- hook id: detect-private-key
🤖 check for merge conflicts — optimizer.............(no files to check)Skipped
- hook id: check-merge-conflict
🤖 check for case conflicts — optimizer..............(no files to check)Skipped
- hook id: check-case-conflict
🤖 pyupgrade — optimizer.............................(no files to check)Skipped
- hook id: pyupgrade
🤖 ruff — optimizer..................................(no files to check)Skipped
- hook id: ruff
🤖 ruff-format — optimizer...........................(no files to check)Skipped
- hook id: ruff-format
🤖 mypy — optimizer..................................(no files to check)Skipped
- hook id: mypy
📓 nbstripout — optimizer notebooks..................(no files to check)Skipped
- hook id: nbstripout
📝 markdownlint — optimizer..........................(no files to check)Skipped
- hook id: markdownlint
🔤 codespell — optimizer.............................(no files to check)Skipped
- hook id: codespell
📊 radon cc — optimizer..............................(no files to check)Skipped
- hook id: radon-cc
📊 radon raw — optimizer.............................(no files to check)Skipped
- hook id: radon-raw
📊 xenon — optimizer.................................(no files to check)Skipped
- hook id: xenon
📊 lizard — optimizer................................(no files to check)Skipped
- hook id: lizard
🧹 vulture — optimizer...............................(no files to check)Skipped
- hook id: vulture
🛡️ trim trailing whitespace — guardrails.............(no files to check)Skipped
- hook id: trailing-whitespace
🛡️ fix end of files — guardrails.....................(no files to check)Skipped
- hook id: end-of-file-fixer
🛡️ ruff — guardrails.................................(no files to check)Skipped
- hook id: ruff
🛡️ ruff-format — guardrails..........................(no files to check)Skipped
- hook id: ruff-format
🛡️ mypy — guardrails.................................(no files to check)Skipped
- hook id: mypy
⚓ helm-docs.........................................(no files to check)Skipped
- hook id: helm-docs
block non-public FE plugins..........................(no files to check)Skipped
- hook id: no-private-fe-plugins
☕ spotless — java backend...........................(no files to check)Skipped
- hook id: spotless
🧪 pre-commit wrapper smoke tests....................(no files to check)Skipped
- hook id: precommit-wrapper-tests
🌐 eslint — frontend.....................................................Passed
- hook id: fe-eslint
- duration: 19.64s
🌐 typecheck — frontend..................................................
charlesdzero246:opik chaduffy$ cat /tmp/precommit-run.log
warning: Git tree '/Users/chaduffy/dev/opik' is dirty
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /Users/chaduffy/.cache/pre-commit/patch1784819751-53848.
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/kynan/nbstripout.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/igorshubovych/markdownlint-cli.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/codespell-project/codespell.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for local.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for local.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for local.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/jendrikseipp/vulture.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/rhysd/actionlint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
🐍 trim trailing whitespace — python sdk.............(no files to check)Skipped
- hook id: trailing-whitespace
🐍 fix end of files — python sdk.....................(no files to check)Skipped
- hook id: end-of-file-fixer
🐍 ruff — python sdk.................................(no files to check)Skipped
- hook id: ruff
🐍 ruff-format — python sdk..........................(no files to check)Skipped
- hook id: ruff-format
🐍 mypy — python sdk.................................(no files to check)Skipped
- hook id: mypy
🤖 trim trailing whitespace — optimizer..............(no files to check)Skipped
- hook id: trailing-whitespace
🤖 fix end of files — optimizer......................(no files to check)Skipped
- hook id: end-of-file-fixer
🤖 check yaml — optimizer............................(no files to check)Skipped
- hook id: check-yaml
🤖 check json — optimizer............................(no files to check)Skipped
- hook id: check-json
🤖 check toml — optimizer............................(no files to check)Skipped
- hook id: check-toml
🤖 check for added large files — optimizer...........(no files to check)Skipped
- hook id: check-added-large-files
🔐 detect private key — optimizer....................(no files to check)Skipped
- hook id: detect-private-key
🤖 check for merge conflicts — optimizer.............(no files to check)Skipped
- hook id: check-merge-conflict
🤖 check for case conflicts — optimizer..............(no files to check)Skipped
- hook id: check-case-conflict
🤖 pyupgrade — optimizer.............................(no files to check)Skipped
- hook id: pyupgrade
🤖 ruff — optimizer..................................(no files to check)Skipped
- hook id: ruff
🤖 ruff-format — optimizer...........................(no files to check)Skipped
- hook id: ruff-format
🤖 mypy — optimizer..................................(no files to check)Skipped
- hook id: mypy
📓 nbstripout — optimizer notebooks..................(no files to check)Skipped
- hook id: nbstripout
📝 markdownlint — optimizer..........................(no files to check)Skipped
- hook id: markdownlint
🔤 codespell — optimizer.............................(no files to check)Skipped
- hook id: codespell
📊 radon cc — optimizer..............................(no files to check)Skipped
- hook id: radon-cc
📊 radon raw — optimizer.............................(no files to check)Skipped
- hook id: radon-raw
📊 xenon — optimizer.................................(no files to check)Skipped
- hook id: xenon
📊 lizard — optimizer................................(no files to check)Skipped
- hook id: lizard
🧹 vulture — optimizer...............................(no files to check)Skipped
- hook id: vulture
🛡️ trim trailing whitespace — guardrails.............(no files to check)Skipped
- hook id: trailing-whitespace
🛡️ fix end of files — guardrails.....................(no files to check)Skipped
- hook id: end-of-file-fixer
🛡️ ruff — guardrails.................................(no files to check)Skipped
- hook id: ruff
🛡️ ruff-format — guardrails..........................(no files to check)Skipped
- hook id: ruff-format
🛡️ mypy — guardrails.................................(no files to check)Skipped
- hook id: mypy
⚓ helm-docs.........................................(no files to check)Skipped
- hook id: helm-docs
block non-public FE plugins..........................(no files to check)Skipped
- hook id: no-private-fe-plugins
☕ spotless — java backend...........................(no files to check)Skipped
- hook id: spotless
🧪 pre-commit wrapper smoke tests....................(no files to check)Skipped
- hook id: precommit-wrapper-tests
🌐 eslint — frontend.....................................................Passed
- hook id: fe-eslint
- duration: 19.64s
🌐 typecheck — frontend..................................................Passed
- hook id: fe-typecheck
- duration: 17.56s

> opik-frontend@0.0.1 typecheck
> tsc --project tsconfig.json --noEmit

📘 eslint — typescript sdk...........................(no files to check)Skipped
- hook id: ts-sdk-eslint
📘 typecheck — typescript sdk........................(no files to check)Skipped
- hook id: ts-sdk-typecheck
⚙️ actionlint — github workflows.....................(no files to check)Skipped
- hook id: actionlint
🐳 hadolint — dockerfiles............................(no files to check)Skipped
- hook id: hadolint-docker
```

</details>

<details>
<summary>npm run test output (149 files, 2247 tests, all passed)</summary>

```
warning: Git tree '/Users/chaduffy/dev/opik' is dirty
opik-frontend devshell: node v22.23.1, npm 10.9.8 (inFrontendDir <cmd> to run npm scripts)

> opik-frontend@0.0.1 test
> vitest run


 RUN  v3.0.5 /Users/chaduffy/dev/opik/apps/opik-frontend

 ✓ src/shared/JsonTreePopover/jsonTreeUtils.test.ts (54 tests) 7ms
 ✓ src/v2/pages-shared/experiments/OptimizationProgressChart/optimizationChartUtils.test.ts (39 tests) 8ms
 ✓ src/lib/images.test.ts (53 tests) 13ms
 ✓ src/v1/pages-shared/traces/TraceDetailsPanel/TraceTreeViewer/helpers.test.ts (42 tests) 8ms
 ✓ src/v2/pages-shared/traces/TraceDetailsPanel/TraceTreeViewer/helpers.test.ts (42 tests) 10ms
stderr | src/lib/dashboard/migrations.test.ts > migrateDashboardConfig > invalid inputs > should return empty dashboard for non-object config
Dashboard config is not an object

stderr | src/lib/dashboard/migrations.test.ts > migrateDashboardConfig > invalid inputs > should return empty dashboard for undefined config
Dashboard config is not an object

stderr | src/lib/dashboard/migrations.test.ts > migrateDashboardConfig > invalid inputs > should return empty dashboard for string config
Dashboard config is not an object

stderr | src/lib/dashboard/migrations.test.ts > migrateDashboardConfig > invalid inputs > should return empty dashboard for number config
Dashboard config is not an object

 ✓ src/lib/dashboard/migrations.test.ts (31 tests) 8ms
 ✓ src/plugins/comet/explain/explainStore.test.ts (30 tests) 19ms
 ✓ src/lib/traces.test.ts (39 tests) 7ms
 ✓ src/lib/terminalOutput.test.ts (60 tests) 9ms
 ✓ src/lib/modelUtils.test.ts (47 tests) 8ms
 ✓ src/lib/optimizations.test.ts (90 tests) 10ms
 ✓ src/shared/filter-chips/lib/sanitizeFilters.test.ts (35 tests) 8ms
 ✓ src/lib/media.test.ts (42 tests) 9ms
 ✓ src/lib/utils.test.ts (53 tests) 7ms
 ✓ src/hooks/charts/useChartTickDefaultConfig.test.ts (37 tests) 27ms
 ✓ src/v2/pages-shared/experiments/TestSuiteExperiment/PassedCell.test.ts (27 tests) 5ms
 ✓ src/v1/pages/SMEFlowPage/AnnotationView/AnnotationView.test.tsx (17 tests) 133ms
stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Rendering > should render dialog when open
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Rendering > should display correct item count in button
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Rendering > should display totalCount when isAllItemsSelected is true
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Rendering > should only display tags shared by all entities
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Tag Addition via inline input > should show input when clicking + Add tag
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Tag Addition via inline input > should add a new tag on Enter
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Tag Addition via inline input > should revert to button on blur
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

 ✓ src/shared/LinkifyText/LinkifyText.test.tsx (41 tests) 75ms
stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Tag Addition via inline input > should prevent duplicate tags in new tags list
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Tag Length Validation > should enforce maxTagLength via input maxLength attribute
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

 ✓ src/v1/pages-shared/datasets/DatasetExportPanel/DatasetExportPanel.test.tsx (14 tests) 95ms
stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Max Tags Validation > should enforce maxTags limit on submission
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Max Entities Validation > should allow dialog when isAllItemsSelected is true regardless of entities length
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

 ✓ src/v2/pages-shared/datasets/DatasetExportPanel/DatasetExportPanel.test.tsx (14 tests) 91ms
stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Update Operation > should call onUpdate with correct parameters
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Update Operation > should show success toast on successful update
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Update Operation > should reset state after successful update
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Update Operation > should disable update button when no changes
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Tag Removal (strikethrough) > should show removed common tag with strikethrough
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx > ManageTagsDialog > Dialog Close > should reset state when dialog is closed
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

 ✓ src/shared/ManageTagsDialog/ManageTagsDialog.test.tsx (19 tests) 375ms
 ✓ src/lib/annotation-queues.test.ts (35 tests) 5ms
stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should render the test suite dialog when open
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should display enrichment checkboxes when selecting a dataset with traces
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should have all enrichment checkboxes checked by default
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should allow unchecking enrichment options
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should display span enrichment checkboxes when selecting a dataset with spans
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should have all span enrichment checkboxes checked by default
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should allow unchecking span enrichment options
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should list only datasets matching dataset type when adding to a dataset
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should list only test suites when adding to a test suite
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should display search input in dropdown
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should display add test suite option in dropdown
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should show alert when no valid rows are present
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should show alert when only some rows are valid
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should disable dropdown when no valid rows
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should call addTracesToDataset mutation when clicking on dataset with only traces
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should call addSpansToDataset mutation when clicking on dataset with only spans
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should respect unchecked enrichment options when adding traces
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

 ✓ src/v2/pages/SMEFlowPage/useAnnotationPersistence.test.ts (17 tests) 28ms
stderr | src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should respect unchecked enrichment options when adding spans
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

 ✓ src/v2/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx (18 tests) 503ms
 ✓ src/shared/filter-chips/hooks/useFilterChips.test.ts (27 tests) 32ms
 ✓ src/lib/dashboard/layout.test.ts (42 tests) 16ms
stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should render the dialog when open
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should display enrichment checkboxes when only traces are selected
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should have all enrichment checkboxes checked by default
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should allow unchecking enrichment options
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

 ✓ src/v2/pages-shared/dashboards/hooks/useDashboardPersistence.test.ts (11 tests) 41ms
 ✓ src/v1/pages-shared/dashboards/hooks/useDashboardPersistence.test.ts (11 tests) 43ms
stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should display span enrichment checkboxes when only spans are selected
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should have all span enrichment checkboxes checked by default
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should allow unchecking span enrichment options
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should display available datasets
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should display search input
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should display create new test suite button
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should show alert when no valid rows are present
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should show alert when only some rows are valid
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should disable create new test suite button when no valid rows
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should call addTracesToDataset mutation when clicking on dataset with only traces
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should call addSpansToDataset mutation when clicking on dataset with only spans
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should respect unchecked enrichment options when adding traces
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx > AddToDatasetDialog > should respect unchecked enrichment options when adding spans
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

 ✓ src/v1/pages-shared/traces/AddToDatasetDialog/AddToDatasetDialog.test.tsx (17 tests) 356ms
 ✓ src/lib/dashboard/utils.test.ts (41 tests) 15ms
 ✓ src/shared/filter-chips/hooks/useQuickAttributeFilterActions.test.ts (21 tests) 22ms
stderr | src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.test.ts
Warning: Please use the `legacy` build in Node.js environments.

stderr | src/shared/PrettyLLMMessage/llmMessages/providers/langchain/mapper.test.ts
Warning: Please use the `legacy` build in Node.js environments.

 ✓ src/v1/pages-shared/llm/ChatPromptRawView/ChatPromptRawView.test.tsx (35 tests) 5ms
 ✓ src/v2/pages-shared/llm/ChatPromptRawView/ChatPromptRawView.test.tsx (35 tests) 7ms
 ✓ src/v2/pages/GetStartedPage/NewQuickstart.test.tsx (14 tests) 40ms
 ✓ src/shared/PrettyLLMMessage/llmMessages/providers/langchain/mapper.test.ts (30 tests) 7ms
 ✓ src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.test.ts (27 tests) 8ms
 ✓ src/v1/pages-shared/experiments/OptimizationProgressChart/optimizationChartUtils.test.ts (15 tests) 4ms
 ✓ src/v2/pages/OptimizationPage/optimizationOverviewHelpers.test.ts (27 tests) 11ms
 ✓ src/lib/trials.test.ts (21 tests) 13ms
 ✓ src/lib/pythonArgumentsParset.test.ts (23 tests) 6ms
 ✓ src/lib/configuration-renderer.test.ts (24 tests) 5ms
 ✓ src/lib/experiment-metrics.test.ts (14 tests) 4ms
 ✓ src/lib/metadata.test.ts (19 tests) 5ms
 ✓ src/api/playground/useCompletionProxyStreaming.test.ts (16 tests) 4ms
 ✓ src/shared/SyntaxHighlighter/base64Extension.test.ts (9 tests) 24ms
 ✓ src/v2/pages/AlertsPage/AddEditAlertPage/helpers.test.ts (9 tests) 5ms
 ✓ src/shared/WorkspaceVersionResolver/WorkspaceVersionResolver.test.tsx (8 tests) 20ms
stderr | src/api/projects/useFirstTraceReceived.test.ts > useFirstTraceReceived > refetchInterval callback > sets pollExpired and returns false once MAX_POLL_DURATION_MS is exceeded
Warning: An update to TestComponent inside a test was not wrapped in act(...).

When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
    at TestComponent (/Users/chaduffy/dev/opik/apps/opik-frontend/node_modules/@testing-library/react/dist/pure.js:307:5)

 ✓ src/api/projects/useFirstTraceReceived.test.ts (11 tests) 22ms
 ✓ src/v2/redirect/TracesTabRedirect.test.tsx (19 tests) 32ms
 ✓ src/shared/PrettyLLMMessage/llmMessages/providers/langchain/detector.test.ts (23 tests) 4ms
 ✓ src/api/playground/promptLinkage.test.ts (15 tests) 6ms
 ✓ src/shared/filter-chips/chips/TimeChip/TimeChip.logic.test.ts (25 tests) 14ms
 ✓ src/v2/pages/OptimizationsPage/OptimizationsNewPage/useOptimizationsNewFormHandlers.test.tsx (7 tests) 22ms
 ✓ src/shared/CodeDiff/promptComparisonTargets.test.ts (9 tests) 5ms
 ✓ src/v2/pages/OptimizationsPage/OptimizationsNewPage/OptimizationsNewPageContent.test.tsx (7 tests) 39ms
 ✓ src/lib/ls-migrations/001_fix_column_order.test.ts (16 tests) 5ms
 ✓ src/shared/SyntaxHighlighter/quickFilterPaths.test.ts (18 tests) 21ms
 ✓ src/v1/pages/OptimizationPage/sortCandidates.test.ts (13 tests) 12ms
 ✓ src/v2/pages/OptimizationPage/sortCandidates.test.ts (13 tests) 12ms
 ✓ src/v1/pages-shared/datasets/DatasetItemEditor/hooks/useDatasetItemFormHelpers.test.ts (21 tests) 4ms
 ✓ src/v2/pages-shared/datasets/DatasetItemEditor/hooks/useDatasetItemFormHelpers.test.ts (21 tests) 4ms
 ✓ src/v2/pages/LogsPage/TracesSpansTab/explainTargets.test.ts (13 tests) 3ms
 ✓ src/v2/layout/ProjectMenu/resolveProjectSwitchTarget.test.ts (14 tests) 4ms
 ✓ src/shared/OAuthConsentPage/helpers.test.ts (27 tests) 7ms
 ✓ src/v2/pages-shared/agent-configuration/useAgentConfigurationSave.test.ts (20 tests) 4ms
 ✓ src/shared/ColumnsButton/ColumnsButton.test.tsx (10 tests) 3ms
 ✓ src/shared/CodeDiff/promptMessageDiff.test.ts (18 tests) 4ms
 ✓ src/lib/prompt.test.ts (17 tests) 4ms
stderr | src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.unchangedPrefixLength.test.tsx
Warning: Please use the `legacy` build in Node.js environments.

 ✓ src/shared/CodeDiff/PromptComparison.test.tsx (9 tests) 57ms
 ✓ src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.unchangedPrefixLength.test.tsx (5 tests) 93ms
 ✓ src/v2/pages-shared/optimizations/OptimizationConfigForm/schema.test.ts (9 tests) 15ms
 ✓ src/lib/entityReferences.test.ts (14 tests) 3ms
 ✓ src/v2/pages-shared/llm/ManageAIProviderDialog/customProviderConfig.test.ts (15 tests) 4ms
 ✓ src/shared/filter-chips/chips/NumericChip/NumericChip.logic.test.ts (12 tests) 4ms
 ✓ src/v2/pages-shared/traces/ThreadDetailsPanel/ThreadAnnotatePanel.test.tsx (2 tests) 45ms
 ✓ src/v2/pages/PlaygroundPage/PlaygroundOutputs/useTestSuitePromptResults.test.ts (9 tests) 3ms
 ✓ src/lib/remarkCollapsibleHeadings.test.ts (8 tests) 3ms
 ✓ src/v1/pages-shared/traces/MetricDateRangeSelect/utils.test.ts (14 tests) 11ms
 ✓ src/v2/pages-shared/traces/MetricDateRangeSelect/utils.test.ts (14 tests) 12ms
 ✓ src/v2/pages/SMEFlowPage/AnnotationView/AnnotationView.test.tsx (6 tests) 40ms
 ✓ src/shared/DateRangeSelect/utils.test.ts (7 tests) 4ms
 ✓ src/lib/filters.test.ts (9 tests) 6ms
 ✓ src/shared/ResizableSidePanel/ResizableSidePanelArrowNavigation.test.tsx (11 tests) 45ms
 ✓ src/v2/pages/OptimizationPage/TrialSidebar/useTrialSidebarState.test.ts (7 tests) 19ms
 ✓ src/v2/pages/OptimizationPage/optimizationHeaderConfig.test.ts (10 tests) 3ms
 ✓ src/v2/pages-shared/llm/PromptModelSelect/useModelOptions.test.ts (4 tests) 18ms
 ✓ src/v2/pages-shared/automations/AddEditRuleDialog/RuleFilteringSection.test.ts (14 tests) 5ms
stderr | src/v1/pages-shared/datasets/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.test.tsx > AddEditFeedbackDefinitionDialog > Clone mode > should append ' (Copy)' to the name when cloning
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/datasets/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.test.tsx > AddEditFeedbackDefinitionDialog > Clone mode > should preserve all other properties when cloning
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/datasets/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.test.tsx > AddEditFeedbackDefinitionDialog > Edit mode > should not append ' (Copy)' to the name when editing
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v1/pages-shared/datasets/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.test.tsx > AddEditFeedbackDefinitionDialog > Create mode > should have empty name when creating new definition
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

 ✓ src/v1/pages-shared/datasets/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.test.tsx (4 tests) 120ms
 ✓ src/v2/pages/LogsPage/ThreadsTab/explainTargets.test.ts (8 tests) 3ms
 ✓ src/shared/PrettyLLMMessage/llmMessages/providers/openai/detector.test.ts (14 tests) 3ms
 ✓ src/v2/pages-shared/traces/hiddenSpans.test.ts (5 tests) 3ms
stderr | src/v2/pages-shared/datasets/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.test.tsx > AddEditFeedbackDefinitionDialog > Clone mode > should append ' (Copy)' to the name when cloning
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

 ✓ src/v2/pages/OptimizationPage/BestTrialPrompt.test.tsx (5 tests) 37ms
stderr | src/v2/pages-shared/datasets/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.test.tsx > AddEditFeedbackDefinitionDialog > Clone mode > should preserve all other properties when cloning
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/datasets/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.test.tsx > AddEditFeedbackDefinitionDialog > Edit mode > should not append ' (Copy)' to the name when editing
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

stderr | src/v2/pages-shared/datasets/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.test.tsx > AddEditFeedbackDefinitionDialog > Create mode > should have empty name when creating new definition
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

 ✓ src/v2/pages-shared/datasets/AddEditFeedbackDefinitionDialog/AddEditFeedbackDefinitionDialog.test.tsx (4 tests) 110ms
 ✓ src/v2/pages-shared/agent-configuration/fields/blueprintFieldLayout.test.ts (15 tests) 3ms
 ✓ src/v1/pages/SMEFlowPage/ReturnToAnnotationQueueButton.test.tsx (3 tests) 25ms
 ✓ src/v2/pages-shared/agent-configuration/blueprintFieldValidation.test.ts (24 tests) 6ms
stderr | src/lib/file.test.ts > validateCsvFile > should return an error if CSV parsing fails
Error: Parsing error
    at [90m/Users/chaduffy/dev/opik/apps/opik-frontend/[39msrc/lib/file.test.ts:49:43
    at [90mfile:///Users/chaduffy/dev/opik/apps/opik-frontend/[39mnode_modules/[4m@vitest/runner[24m/dist/index.js:174:14
    at [90mfile:///Users/chaduffy/dev/opik/apps/opik-frontend/[39mnode_modules/[4m@vitest/runner[24m/dist/index.js:561:28
    at [90mfile:///Users/chaduffy/dev/opik/apps/opik-frontend/[39mnode_modules/[4m@vitest/runner[24m/dist/index.js:61:24
    at new Promise (<anonymous>)
    at runWithTimeout [90m(file:///Users/chaduffy/dev/opik/apps/opik-frontend/[39mnode_modules/[4m@vitest/runner[24m/dist/index.js:41:12[90m)[39m
    at runTest [90m(file:///Users/chaduffy/dev/opik/apps/opik-frontend/[39mnode_modules/[4m@vitest/runner[24m/dist/index.js:1140:17[90m)[39m
[90m    at processTicksAndRejections (node:internal/process/task_queues:103:5)[39m
    at runSuite [90m(file:///Users/chaduffy/dev/opik/apps/opik-frontend/[39mnode_modules/[4m@vitest/runner[24m/dist/index.js:1294:15[90m)[39m
    at runSuite [90m(file:///Users/chaduffy/dev/opik/apps/opik-frontend/[39mnode_modules/[4m@vitest/runner[24m/dist/index.js:1294:15[90m)[39m

 ✓ src/lib/file.test.ts (8 tests) 33ms
 ✓ src/v2/redirect/V1CompatRedirect.test.tsx (7 tests) 18ms
 ✓ src/v2/pages/OptimizationPage/TrialPromptSection.test.tsx (5 tests) 42ms
 ✓ src/shared/filter-chips/chips/QueryBuilderChip/QueryBuilderChip.logic.test.ts (8 tests) 3ms
 ✓ src/lib/attachments.test.ts (9 tests) 3ms
 ✓ src/plugins/comet/explain/ExplainButton.test.tsx (5 tests) 82ms
 ✓ src/plugins/comet/explain/ExplainPopover.test.tsx (7 tests) 47ms
 ✓ src/lib/ls-migrations/engine.test.ts (7 tests) 5ms
 ✓ src/plugins/comet/assistantBridge.test.ts (6 tests) 4ms
 ✓ src/shared/filter-chips/chips/SingleSelectChip/SingleSelectChip.logic.test.ts (10 tests) 4ms
 ✓ src/v2/pages-shared/TagsAutocomplete/helpers.test.ts (12 tests) 4ms
 ✓ src/v2/pages-shared/traces/MetricDateRangeSelect/useMetricDateRangeWithQueryAndStorage.test.ts (5 tests) 14ms
 ✓ src/v2/pages/OptimizationPage/OptimizationCompareRedirect.test.tsx (4 tests) 12ms
 ✓ src/hooks/useTablePageSize.test.ts (9 tests) 17ms
 ✓ src/v2/pages/OptimizationPage/TrialsRedirect.test.tsx (6 tests) 25ms
 ✓ src/plugins/comet/usePinnedWorkspaces.test.ts (6 tests) 16ms
 ✓ src/v1/pages/OptimizationPage/OptimizationCompareRedirect.test.tsx (4 tests) 12ms
stderr | src/v2/pages/AgentRunnerPage/AgentRunnerContent.test.tsx
Warning: Please use the `legacy` build in Node.js environments.

 ✓ src/plugins/comet/explain/registry.test.ts (3 tests) 3ms
 ✓ src/hooks/usePairingState.test.ts (4 tests) 13ms
 ✓ src/lib/table.test.ts (5 tests) 3ms
 ✓ src/v2/layout/ProjectMenu/usePinnedProjects.test.ts (6 tests) 15ms
 ✓ src/v2/pages-shared/experiments/OptimizationProgressChart/TrialCard.test.tsx (4 tests) 23ms
 ✓ src/v2/pages/SMEFlowPage/ReturnToAnnotationQueueButton.test.tsx (2 tests) 18ms
 ✓ src/v2/pages/OptimizationPage/candidatePrompt.test.ts (4 tests) 2ms
 ✓ src/v2/pages/LogsPage/explain/withExplain.test.tsx (3 tests) 18ms
 ✓ src/v2/pages/OptimizationPage/MetricPopoverContent.test.tsx (4 tests) 22ms
 ✓ src/v1/pages/SMEFlowPage/CompletionView/CompletionView.test.tsx (2 tests) 28ms
 ✓ src/v2/pages/PlaygroundPage/metricSelection.test.ts (10 tests) 4ms
 ✓ src/plugins/comet/explain/useCanExplain.test.tsx (7 tests) 15ms
 ✓ src/v2/pages/SMEFlowPage/CompletionView/CompletionView.test.tsx (2 tests) 31ms
 ✓ src/plugins/comet/useRecentWorkspaces.test.ts (5 tests) 20ms
 ✓ src/shared/filter-chips/chips/BooleanChip/BooleanChip.logic.test.ts (5 tests) 3ms
 ✓ src/lib/scroll.test.ts (4 tests) 2ms
 ✓ src/v2/pages-shared/optimizations/TrialStatusPill.test.tsx (4 tests) 22ms
 ✓ src/v2/pages/OptimizationPage/RunErrorPanel.test.tsx (2 tests) 29ms
 ✓ src/shared/filter-chips/lib/chipsToFilters.test.ts (4 tests) 3ms
 ✓ src/hooks/useLLMProviderModelsData.test.ts (1 test) 9ms
 ✓ src/shared/Autocomplete/Autocomplete.test.tsx (3 tests) 48ms
 ✓ src/lib/date.test.ts (6 tests) 3ms
 ✓ src/v2/pages-shared/optimizations/MetricSettings/metricConfigs/CodeMetricConfigs.test.tsx (2 tests) 21ms
 ✓ src/v2/pages/LogsPage/createExplainTargetBuilder.test.ts (4 tests) 2ms
 ✓ src/lib/landingRoutes.test.ts (7 tests) 3ms
 ✓ src/v2/pages/OptimizationPage/runError.test.ts (4 tests) 2ms
 ✓ src/v1/pages-shared/llm/PromptModelSelect/useModelOptions.test.ts (2 tests) 10ms
 ✓ src/lib/experiments.test.ts (3 tests) 1ms
 ✓ src/lib/playground.test.ts (2 tests) 2ms
 ✓ src/v2/pages/OptimizationPage/TrialSidebar/TrialStatusCard.test.tsx (3 tests) 24ms
 ✓ src/v2/pages-shared/optimizations/modelPillIcon.test.ts (3 tests) 2ms
 ✓ src/v2/pages/OptimizationPage/useOptimizationColumns.test.ts (3 tests) 12ms
 ✓ src/v2/pages-shared/experiments/OptimizationProgressChart/chartConstants.test.ts (4 tests) 2ms
 ✓ src/types/assistant-sidebar.test.ts (1 test) 1ms
 ✓ src/lib/aiSpend.test.ts (2 tests) 2ms
 ✓ src/v2/pages/AgentRunnerPage/AgentRunnerContent.test.tsx (9 tests) 76ms

 Test Files  149 passed (149)
      Tests  2247 passed (2247)
   Start at  10:21:16
   Duration  34.92s (transform 9.03s, setup 42.73s, collect 132.00s, tests 3.92s, environment 85.43s, prepare 14.62s)

```

</details>

Playwright tests have not been run -- I'm not aware of any new flows that the unit tests don't cover, which would thus require browser-based testing.

The real-world data I'm running against is sensitive, so I can't reasonably create a video of the updated frontend in use in that context. A video showing testing of canned/fake data, on the other hand, would be entirely feasible -- let me know if that would be considered essential, and I can see about doing the work to put such a thing together.

## Documentation

Not yet.