### PR TITLE
[OPIK-7457] [BE] fix: persist cipx block content hash; fold agent_overhead into static overhead

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendBlockDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendBlockDAO.java
@@ -81,7 +81,8 @@ public class CipxSpendBlockDAO {
             @NonNull String bdLane,
             @NonNull String label,
             int isDefinition,
-            double alloc) {
+            double alloc,
+            @NonNull String contentSha256) {
 
         /**
          * Derives all rows for one cipx span: one attributed row per non-identity block (keeping the
@@ -190,6 +191,7 @@ public class CipxSpendBlockDAO {
                     .label(label(category, toolServer, toolName, resource, kind, chars))
                     .isDefinition(isDefinition(category))
                     .alloc(alloc)
+                    .contentSha256(block.path("sha256").asText(""))
                     .build();
         }
 
@@ -213,6 +215,7 @@ public class CipxSpendBlockDAO {
                     .label("")
                     .isDefinition(0)
                     .alloc(tokens)
+                    .contentSha256("")
                     .build();
         }
 
@@ -248,7 +251,7 @@ public class CipxSpendBlockDAO {
                 case "memory" -> "memory";
                 case "file_attachments" -> "file_attachments";
                 case "system_prompt", "env_info", "system_tools", "system_tools_deferred" -> "static_overhead";
-                case "auto_classifier" -> "static_overhead";
+                case "auto_classifier", "agent_overhead" -> "static_overhead";
                 case "thinking" -> "thinking";
                 case "assistant_text" -> "assistant_text";
                 case "built_in_tool_calls" -> "built_in_tool_calls";
@@ -270,7 +273,7 @@ public class CipxSpendBlockDAO {
                 case "memory" -> "memory";
                 case "file_attachments" -> "file_attachments";
                 case "system_prompt", "env_info", "system_tools", "system_tools_deferred" -> "static_overhead";
-                case "auto_classifier" -> "static_overhead";
+                case "auto_classifier", "agent_overhead" -> "static_overhead";
                 case "thinking" -> "thinking";
                 case "assistant_text" -> "assistant_text";
                 case "built_in_tool_calls" -> "built_in_tool_calls";
@@ -292,7 +295,8 @@ public class CipxSpendBlockDAO {
                 case "tool_io" -> toolServer.isEmpty() ? toolName : toolServer;
                 case "prior_assistant" -> kind;
                 case "mcp_tools_active", "mcp_tool_calls" -> toolServer;
-                case "system_prompt", "env_info", "system_tools", "system_tools_deferred", "auto_classifier" ->
+                case "system_prompt", "env_info", "system_tools", "system_tools_deferred", "auto_classifier",
+                        "agent_overhead" ->
                     category;
                 case "thinking" -> "thinking";
                 case "assistant_text" -> "assistant_text";
@@ -392,6 +396,7 @@ public class CipxSpendBlockDAO {
         node.put("label", row.label());
         node.put("is_definition", row.isDefinition());
         node.put("alloc", row.alloc());
+        node.put("content_sha256", row.contentSha256());
         node.put("start_time", ClickHouseDateTimeFormat.formatNanos(row.startTime()));
         out.append(node).append('\n');
     }

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000110_add_content_sha256_to_cipx_spend_blocks.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000110_add_content_sha256_to_cipx_spend_blocks.sql
@@ -1,0 +1,14 @@
+--liquibase formatted sql
+--changeset boryst:000110_add_content_sha256_to_cipx_spend_blocks
+--comment: Persist the per-block content hash on cipx_spend_blocks (OPIK-7457)
+
+-- The proxy already emits a per-block sha256 over the raw block content (utf8 for text,
+-- decoded bytes for binary); it was dropped at ingestion. Persisting it gives the breakdown
+-- queries a stable content identity so item counts can be uniqExact(content_sha256) — a
+-- block re-sent (and re-billed) on later turns shares its hash, so replays and turn
+-- fragmentation collapse to one distinct item. Existing rows read the default ''.
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_spend_blocks ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS content_sha256 String DEFAULT '';
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_spend_blocks ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS content_sha256;
+

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000110_add_content_sha256_to_cipx_spend_blocks.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000110_add_content_sha256_to_cipx_spend_blocks.sql
@@ -2,11 +2,6 @@
 --changeset boryst:000110_add_content_sha256_to_cipx_spend_blocks
 --comment: Persist the per-block content hash on cipx_spend_blocks (OPIK-7457)
 
--- The proxy already emits a per-block sha256 over the raw block content (utf8 for text,
--- decoded bytes for binary); it was dropped at ingestion. Persisting it gives the breakdown
--- queries a stable content identity so item counts can be uniqExact(content_sha256) — a
--- block re-sent (and re-billed) on later turns shares its hash, so replays and turn
--- fragmentation collapse to one distinct item. Existing rows read the default ''.
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_spend_blocks ON CLUSTER '{cluster}'
     ADD COLUMN IF NOT EXISTS content_sha256 String DEFAULT '';
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
@@ -171,7 +171,7 @@ class CostIntelligenceIngestionTest {
 
             await().atMost(30, SECONDS).untilAsserted(() -> {
                 var rows = getCipxBlocks(span.id(), ws.workspaceId());
-                assertThat(rows).hasSize(6);
+                assertThat(rows).hasSize(7);
 
                 // idx 0: memory block, cache_read tier; identity_context at raw idx 1 is dropped but
                 // does not shift the following indexes.
@@ -185,6 +185,7 @@ class CostIntelligenceIngestionTest {
                 assertThat(memory.label()).isEqualTo("CLAUDE.md");
                 assertThat(memory.isDefinition()).isEqualTo(1);
                 assertThat(memory.alloc()).isCloseTo(5.0, within(1e-9)); // 120 * 20 / 480
+                assertThat(memory.contentSha256()).isEqualTo("a1b2c3"); // block sha256 persisted verbatim
 
                 var skills = rows.get(1);
                 assertThat(skills.blockIdx()).isEqualTo(2);
@@ -225,8 +226,18 @@ class CostIntelligenceIngestionTest {
                 assertThat(noTier.label()).isEqualTo("Bash");
                 assertThat(noTier.alloc()).isZero();
 
+                // idx 5: agent_overhead (harness-injected user-role text) folds into the
+                // static_overhead lane, so it never counts as a user prompt (OPIK-7457).
+                var agentOverhead = rows.get(4);
+                assertThat(agentOverhead.blockIdx()).isEqualTo(5);
+                assertThat(agentOverhead.category()).isEqualTo("agent_overhead");
+                assertThat(agentOverhead.lane()).isEqualTo("static_overhead");
+                assertThat(agentOverhead.bdLane()).isEqualTo("static_overhead");
+                assertThat(agentOverhead.label()).isEqualTo("agent_overhead");
+                assertThat(agentOverhead.isDefinition()).isZero();
+
                 // residuals: billed tiers with no blocks (input, cache_creation), deterministic idx.
-                var residualInput = rows.get(4);
+                var residualInput = rows.get(5);
                 assertThat(residualInput.blockIdx()).isEqualTo(65531);
                 assertThat(residualInput.src()).isEqualTo("r");
                 assertThat(residualInput.category()).isEmpty();
@@ -238,7 +249,7 @@ class CostIntelligenceIngestionTest {
 
                 // cache_creation residual inherits the span's TTL: the usage split has 1h > 0, so the
                 // write tier is labeled cache_creation_1h (OPIK-7392).
-                var residualCacheCreation = rows.get(5);
+                var residualCacheCreation = rows.get(6);
                 assertThat(residualCacheCreation.blockIdx()).isEqualTo(65533);
                 assertThat(residualCacheCreation.src()).isEqualTo("r");
                 assertThat(residualCacheCreation.tier()).isEqualTo("cache_creation_1h");
@@ -444,11 +455,12 @@ class CostIntelligenceIngestionTest {
                               }
                             },
                             "blocks": [
-                              {"category":"memory","side":"input","cache_status":"read","parent_category":"context","chars":120,"tool_name":"","tool_server":"","tool_use_id":"","resource":"CLAUDE.md","kind":"text"},
+                              {"category":"memory","side":"input","cache_status":"read","parent_category":"context","chars":120,"tool_name":"","tool_server":"","tool_use_id":"","resource":"CLAUDE.md","kind":"text","sha256":"a1b2c3"},
                               {"category":"identity_context","side":"input","cache_status":"none","parent_category":"identity_context","chars":50,"tool_name":"","tool_server":"","tool_use_id":"","resource":"","kind":"text"},
                               {"category":"skills_loaded","side":"input","cache_status":"read","parent_category":"context","chars":360,"tool_name":"","tool_server":"","tool_use_id":"","resource":"dataviz","kind":"text"},
                               {"category":"mcp_tool_calls","side":"output","cache_status":"none","parent_category":"assistant","chars":30,"tool_name":"search","tool_server":"srv","tool_use_id":"tu1","resource":"res","kind":"tool"},
-                              {"category":"tool_io","side":"input","cache_status":"unknown","parent_category":"context","chars":75,"tool_name":"Bash","tool_server":"","tool_use_id":"tu2","resource":"","kind":"tool"}
+                              {"category":"tool_io","side":"input","cache_status":"unknown","parent_category":"context","chars":75,"tool_name":"Bash","tool_server":"","tool_use_id":"tu2","resource":"","kind":"tool"},
+                              {"category":"agent_overhead","side":"input","cache_status":"unknown","parent_category":"context","chars":40,"tool_name":"","tool_server":"","tool_use_id":"","resource":"","kind":"text"}
                             ]
                           }
                         }
@@ -564,6 +576,7 @@ class CostIntelligenceIngestionTest {
                     model,
                     side, cache_status, parent_category, chars,
                     tool_name, tool_server, tool_use_id, resource, kind,
+                    content_sha256,
                     toUnixTimestamp64Milli(start_time) AS start_ms
                 FROM cipx_spend_blocks FINAL
                 WHERE workspace_id = :workspace_id AND span_id = :span_id
@@ -594,6 +607,7 @@ class CostIntelligenceIngestionTest {
                             row.get("tool_use_id", String.class),
                             row.get("resource", String.class),
                             row.get("kind", String.class),
+                            row.get("content_sha256", String.class),
                             row.get("start_ms", Long.class))))
                     .collectList();
         }).block();
@@ -672,7 +686,7 @@ class CostIntelligenceIngestionTest {
     private record CipxBlockRow(Integer blockIdx, String src, String category, String tier, String lane,
             String bdLane, String label, Integer isDefinition, Double alloc, String model, String side,
             String cacheStatus, String parentCategory, Long chars, String toolName, String toolServer,
-            String toolUseId, String resource, String kind, Long startMs) {
+            String toolUseId, String resource, String kind, String contentSha256, Long startMs) {
     }
 
     private record CipxIdentityRow(String projectId, Long startMs, String userUuid, String userEmail,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
@@ -255,6 +255,16 @@ class CostIntelligenceIngestionTest {
                 assertThat(residualCacheCreation.tier()).isEqualTo("cache_creation_1h");
                 assertThat(residualCacheCreation.alloc()).isCloseTo(5.0, within(1e-9));
 
+                // content_sha256 is persisted per row in order: only the memory block
+                // carried a sha256 in the fixture, so every other row must read "" —
+                // guards against a dropped or misordered hash across the batch.
+                assertThat(rows).filteredOn(row -> !row.contentSha256().isEmpty())
+                        .singleElement()
+                        .satisfies(row -> {
+                            assertThat(row.category()).isEqualTo("memory");
+                            assertThat(row.contentSha256()).isEqualTo("a1b2c3");
+                        });
+
                 // model and start_time ride on every block row.
                 assertThat(rows).allSatisfy(row -> {
                     assertThat(row.model()).isEqualTo("claude-sonnet-4-6");


### PR DESCRIPTION
## Details

Persists the per-block content hash the cipx proxy already emits (it was dropped at ingestion) and reclassifies Claude Code's harness-injected user-role text, so AI-Spend can count *distinct user prompts* instead of re-billed block rows. Part of a coordinated fix for OPIK-7457.

- migration `000110`: add `cipx_spend_blocks.content_sha256`
- `CipxSpendBlockDAO`: persist the block `sha256`; map the new `agent_overhead` category into the `static_overhead` lane (mirrors `auto_classifier`)

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7457
- Related (not resolved here): OPIK_7480

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: implementation, tests, and cross-repo analysis
- Human verification: author reviewed the diff, compiles/tests the Java backend, and validated the fix end-to-end via the local cipx proxy → local Opik

## Testing

- Java backend compiled/tested by the author. `CostIntelligenceIngestionTest` extended: asserts the persisted `content_sha256`, and that the `agent_overhead` category maps to the `static_overhead` lane.
- E2E: fresh Claude Code session through the local cipx proxy → local Opik; the "User prompts" count and Home "Total messages" match the number of prompts actually typed (3 → 3, previously 55).

Paired cost-api change that consumes the column: comet-ml/ai-cost-backend.

> [!IMPORTANT]
> Deploy order: this migration (000110) must be deployed **before** the cost-api change, which reads `content_sha256`. The proxy change is independent.

## Documentation

N/A
