### PR TITLE
[NA] [BE][FE] chore: sync provider model definitions

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/AnthropicModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/antropic/AnthropicModelName.java
@@ -20,12 +20,12 @@ public enum AnthropicModelName implements StructuredOutputSupported {
     CLAUDE_OPUS_4("claude-opus-4-20250514"),
     CLAUDE_OPUS_4_5("claude-opus-4-5-20251101"),
     CLAUDE_OPUS_4_6("claude-opus-4-6"),
+    CLAUDE_OPUS_4_7("claude-opus-4-7"),
+    CLAUDE_OPUS_4_8("claude-opus-4-8"),
     CLAUDE_SONNET_4("claude-sonnet-4-20250514"),
     CLAUDE_SONNET_4_5("claude-sonnet-4-5"),
     CLAUDE_SONNET_4_5_20250929("claude-sonnet-4-5-20250929"),
     CLAUDE_SONNET_4_6("claude-sonnet-4-6"),
-    CLAUDE_OPUS_4_7("claude-opus-4-7"),
-    CLAUDE_OPUS_4_8("claude-opus-4-8"),
     CLAUDE_SONNET_5("claude-sonnet-5");
 
     private final String value;

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openrouter/OpenRouterModelName.java
@@ -180,6 +180,7 @@ public enum OpenRouterModelName implements StructuredOutputSupported {
     INCLUSIONAI_LING_2_6_1T_FREE("inclusionai/ling-2.6-1t:free"),
     INCLUSIONAI_LING_2_6_FLASH("inclusionai/ling-2.6-flash"),
     INCLUSIONAI_LING_2_6_FLASH_FREE("inclusionai/ling-2.6-flash:free"),
+    INCLUSIONAI_LING_3_0_FLASH_FREE("inclusionai/ling-3.0-flash:free"),
     INCLUSIONAI_RING_2_6_1T("inclusionai/ring-2.6-1t"),
     INCLUSIONAI_RING_2_6_1T_FREE("inclusionai/ring-2.6-1t:free"),
     INFLECTION_INFLECTION_3_PI("inflection/inflection-3-pi"),

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/vertexai/VertexAIModelName.java
@@ -27,7 +27,8 @@ public enum VertexAIModelName implements StructuredOutputSupported {
     GEMINI_3_FLASH_PREVIEW("vertex_ai/gemini-3-flash-preview", "gemini-3-flash-preview", true),
     GEMINI_3_PRO("vertex_ai/gemini-3-pro-preview", "gemini-3-pro-preview", true),
     GEMINI_3_1_PRO("vertex_ai/gemini-3.1-pro-preview", "gemini-3.1-pro-preview", true),
-    GEMINI_3_5_FLASH("vertex_ai/gemini-3.5-flash", "gemini-3.5-flash", true);
+    GEMINI_3_5_FLASH("vertex_ai/gemini-3.5-flash", "gemini-3.5-flash", true),
+    GEMINI_3_6_FLASH("vertex_ai/gemini-3.6-flash", "gemini-3.6-flash", true);
 
     private static final String WARNING_UNKNOWN_MODEL = "could not find VertexAIModelName with name '{}'";
 

--- a/apps/opik-backend/src/main/resources/llm-models-default.yaml
+++ b/apps/opik-backend/src/main/resources/llm-models-default.yaml
@@ -233,6 +233,10 @@ gemini:
   - id: "nano-banana-pro-preview"
   - id: "text-embedding-004"
 vertex-ai:
+  - id: "gemini-3.6-flash"
+    qualifiedName: "vertex_ai/gemini-3.6-flash"
+    label: "Gemini 3.6 Flash"
+    structuredOutput: true
   - id: "gemini-3.5-flash"
     qualifiedName: "vertex_ai/gemini-3.5-flash"
     label: "Gemini 3.5 Flash"
@@ -633,6 +637,8 @@ openrouter:
     label: "inclusionai/ling-2.6-flash"
   - id: "inclusionai/ling-2.6-flash:free"
     label: "inclusionai/ling-2.6-flash:free"
+  - id: "inclusionai/ling-3.0-flash:free"
+    label: "inclusionai/ling-3.0-flash:free"
   - id: "inclusionai/ring-2.6-1t"
     label: "inclusionai/ring-2.6-1t"
   - id: "inclusionai/ring-2.6-1t:free"

--- a/apps/opik-frontend/src/constants/providerModels.ts
+++ b/apps/opik-frontend/src/constants/providerModels.ts
@@ -804,6 +804,10 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
       label: "inclusionai/ling-2.6-flash:free",
     },
     {
+      value: PROVIDER_MODEL_TYPE.INCLUSIONAI_LING_3_0_FLASH_FREE,
+      label: "inclusionai/ling-3.0-flash:free",
+    },
+    {
       value: PROVIDER_MODEL_TYPE.INCLUSIONAI_RING_2_6_1T,
       label: "inclusionai/ring-2.6-1t",
     },
@@ -2450,6 +2454,10 @@ export const PROVIDER_MODELS: PROVIDER_MODELS_TYPE = {
   ],
 
   [PROVIDER_TYPE.VERTEX_AI]: [
+    {
+      value: PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_6_FLASH,
+      label: "Gemini 3.6 Flash",
+    },
     {
       value: PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_5_FLASH,
       label: "Gemini 3.5 Flash",

--- a/apps/opik-frontend/src/types/providers.ts
+++ b/apps/opik-frontend/src/types/providers.ts
@@ -105,12 +105,12 @@ export enum PROVIDER_MODEL_TYPE {
   CLAUDE_OPUS_4 = "claude-opus-4-20250514",
   CLAUDE_OPUS_4_5 = "claude-opus-4-5-20251101",
   CLAUDE_OPUS_4_6 = "claude-opus-4-6",
+  CLAUDE_OPUS_4_7 = "claude-opus-4-7",
+  CLAUDE_OPUS_4_8 = "claude-opus-4-8",
   CLAUDE_SONNET_4 = "claude-sonnet-4-20250514",
   CLAUDE_SONNET_4_5 = "claude-sonnet-4-5",
   CLAUDE_SONNET_4_5_20250929 = "claude-sonnet-4-5-20250929",
   CLAUDE_SONNET_4_6 = "claude-sonnet-4-6",
-  CLAUDE_OPUS_4_7 = "claude-opus-4-7",
-  CLAUDE_OPUS_4_8 = "claude-opus-4-8",
   CLAUDE_SONNET_5 = "claude-sonnet-5",
 
   //  <---- OpenRouter
@@ -275,6 +275,7 @@ export enum PROVIDER_MODEL_TYPE {
   INCLUSIONAI_LING_2_6_1T_FREE = "inclusionai/ling-2.6-1t:free",
   INCLUSIONAI_LING_2_6_FLASH = "inclusionai/ling-2.6-flash",
   INCLUSIONAI_LING_2_6_FLASH_FREE = "inclusionai/ling-2.6-flash:free",
+  INCLUSIONAI_LING_3_0_FLASH_FREE = "inclusionai/ling-3.0-flash:free",
   INCLUSIONAI_RING_2_6_1T = "inclusionai/ring-2.6-1t",
   INCLUSIONAI_RING_2_6_1T_FREE = "inclusionai/ring-2.6-1t:free",
   INFLECTION_INFLECTION_3_PI = "inflection/inflection-3-pi",
@@ -719,6 +720,7 @@ export enum PROVIDER_MODEL_TYPE {
   VERTEX_AI_GEMINI_3_PRO = "vertex_ai/gemini-3-pro-preview",
   VERTEX_AI_GEMINI_3_1_PRO = "vertex_ai/gemini-3.1-pro-preview",
   VERTEX_AI_GEMINI_3_5_FLASH = "vertex_ai/gemini-3.5-flash",
+  VERTEX_AI_GEMINI_3_6_FLASH = "vertex_ai/gemini-3.6-flash",
 }
 
 export interface ProviderModelsMap {


### PR DESCRIPTION
## Details

Automated sync of LLM provider model definitions from source APIs and prices JSON.

**Sync summary:**
```
## Provider Model Sync

### Openrouter
- Added 1 model(s):
  + inclusionai/ling-3.0-flash:free
- Stale 214 model(s) (not in source, manual review needed):
  ? ai21/jamba-mini-1.7
  ? aion-labs/aion-1.0
  ? aion-labs/aion-1.0-mini
  ? alfredpros/codellama-7b-instruct-solidity
  ? alibaba/tongyi-deepresearch-30b-a3b
  ? alibaba/tongyi-deepresearch-30b-a3b:free
  ? allenai/molmo-2-8b
  ? allenai/olmo-2-0325-32b-instruct
  ? allenai/olmo-3-7b-instruct
  ? allenai/olmo-3-7b-think
  ? allenai/olmo-3.1-32b-instruct
  ? allenai/olmo-3.1-32b-think
  ? alpindale/goliath-120b
  ? anthropic/claude-3.5-haiku
  ? anthropic/claude-3.5-sonnet
  ? anthropic/claude-3.7-sonnet
  ? anthropic/claude-3.7-sonnet:thinking
  ? anthropic/claude-opus-4.6-fast
  ? arcee-ai/afm-4.5b
  ? arcee-ai/coder-large
  ? arcee-ai/maestro-reasoning
  ? arcee-ai/spotlight
  ? arcee-ai/trinity-large-preview
  ? arcee-ai/trinity-large-preview:free
  ? arcee-ai/trinity-large-thinking:free
  ? arcee-ai/trinity-mini
  ? arcee-ai/trinity-mini:free
  ? arliai/qwq-32b-arliai-rpr-v1
  ? arliai/qwq-32b-arliai-rpr-v1:free
  ? baidu/cobuddy:free
  ? baidu/ernie-4.5-21b-a3b
  ? baidu/ernie-4.5-21b-a3b-thinking
  ? baidu/ernie-4.5-300b-a47b
  ? baidu/ernie-4.5-vl-28b-a3b
  ? baidu/qianfan-ocr-fast
  ? baidu/qianfan-ocr-fast:free
  ? cognitivecomputations/dolphin-mistral-24b-venice-edition:free
  ? deepcogito/cogito-v2-preview-deepseek-671b
  ? deepcogito/cogito-v2-preview-llama-109b-moe
  ? deepcogito/cogito-v2-preview-llama-405b
  ? deepcogito/cogito-v2-preview-llama-70b
  ? deepseek/deepseek-chat-v3-0324:free
  ? deepseek/deepseek-prover-v2
  ? deepseek/deepseek-r1-0528-qwen3-8b
  ? deepseek/deepseek-r1-0528-qwen3-8b:free
  ? deepseek/deepseek-r1-0528:free
  ? deepseek/deepseek-r1-distill-llama-70b:free
  ? deepseek/deepseek-r1-distill-qwen-14b
  ? deepseek/deepseek-r1-distill-qwen-32b
  ? deepseek/deepseek-r1:free
  ? deepseek/deepseek-v3.1-terminus:exacto
  ? deepseek/deepseek-v3.2-speciale
  ? deepseek/deepseek-v4-flash:free
  ? eleutherai/llemma_7b
  ? essentialai/rnj-1-instruct
  ? google/gemini-2.0-flash-001
  ? google/gemini-2.0-flash-exp:free
  ? google/gemini-2.0-flash-lite-001
  ? google/gemini-2.5-flash-image-preview
  ? google/gemini-2.5-flash-lite-preview-09-2025
  ? google/gemini-2.5-flash-preview-09-2025
  ? google/gemini-3-pro-preview
  ? google/gemma-2-9b-it
  ? google/gemma-3-12b-it:free
  ? google/gemma-3-27b-it:free
  ? google/gemma-3-4b-it:free
  ? google/gemma-3n-e2b-it:free
  ? google/gemma-3n-e4b-it:free
  ? inception/mercury
  ? inception/mercury-coder
  ? inclusionai/ling-2.6-1t:free
  ? inclusionai/ling-2.6-flash:free
  ? inclusionai/ring-2.6-1t:free
  ? kwaipilot/kat-coder-pro
  ? kwaipilot/kat-coder-pro:free
  ? liquid/lfm-2-24b-a2b
  ? liquid/lfm-2.2-6b
  ? liquid/lfm-2.5-1.2b-instruct:free
  ? liquid/lfm-2.5-1.2b-thinking:free
  ? liquid/lfm2-8b-a1b
  ? meituan/longcat-flash-chat
  ? meituan/longcat-flash-chat:free
  ? meta-llama/llama-3-70b-instruct
  ? meta-llama/llama-3-8b-instruct
  ? meta-llama/llama-3.1-405b
  ? meta-llama/llama-3.1-405b-instruct
  ? meta-llama/llama-3.2-11b-vision-instruct
  ? meta-llama/llama-3.2-3b-instruct:free
  ? meta-llama/llama-3.2-90b-vision-instruct
  ? meta-llama/llama-3.3-70b-instruct:free
  ? meta-llama/llama-guard-2-8b
  ? meta-llama/llama-guard-3-8b
  ? meta-llama/llama-guard-4-12b:free
  ? microsoft/mai-ds-r1
  ? microsoft/mai-ds-r1:free
  ? microsoft/phi-3-medium-128k-instruct
  ? microsoft/phi-3-mini-128k-instruct
  ? microsoft/phi-3.5-mini-128k-instruct
  ? microsoft/phi-4-mini-instruct
  ? microsoft/phi-4-multimodal-instruct
  ? microsoft/phi-4-reasoning-plus
  ? minimax/minimax-m2.5:free
  ? mistralai/codestral-2501
  ? mistralai/devstral-medium
  ? mistralai/devstral-small
  ? mistralai/devstral-small-2505
  ? mistralai/magistral-medium-2506
  ? mistralai/magistral-medium-2506:thinking
  ? mistralai/magistral-small-2506
  ? mistralai/ministral-3b
  ? mistralai/ministral-8b
  ? mistralai/mistral-7b-instruct
  ? mistralai/mistral-7b-instruct-v0.1
  ? mistralai/mistral-7b-instruct-v0.2
  ? mistralai/mistral-7b-instruct-v0.3
  ? mistralai/mistral-7b-instruct:free
  ? mistralai/mistral-large-2411
  ? mistralai/mistral-nemo:free
  ? mistralai/mistral-small
  ? mistralai/mistral-small-24b-instruct-2501:free
  ? mistralai/mistral-small-3.1-24b-instruct:free
  ? mistralai/mistral-small-3.2-24b-instruct:free
  ? mistralai/mistral-small-creative
  ? mistralai/mistral-tiny
  ? mistralai/mixtral-8x7b-instruct
  ? mistralai/pixtral-12b
  ? mistralai/pixtral-large-2411
  ? moonshotai/kimi-dev-72b
  ? moonshotai/kimi-k2-0905:exacto
  ? moonshotai/kimi-k2.6:free
  ? moonshotai/kimi-k2:free
  ? moonshotai/kimi-linear-48b-a3b-instruct
  ? neversleep/llama-3.1-lumimaid-8b
  ? neversleep/noromaid-20b
  ? nex-agi/deepseek-v3.1-nex-n1
  ? nex-agi/nex-n2-pro:free
  ? nousresearch/deephermes-3-mistral-24b-preview
  ? nousresearch/hermes-2-pro-llama-3-8b
  ? nousresearch/hermes-3-llama-3.1-405b:free
  ? nvidia/llama-3.1-nemotron-70b-instruct
  ? nvidia/llama-3.1-nemotron-ultra-253b-v1
  ? nvidia/llama-3.3-nemotron-super-49b-v1.5
  ? nvidia/nemotron-nano-12b-v2-vl
  ? nvidia/nemotron-nano-9b-v2
  ? openai/chatgpt-4o-latest
  ? openai/codex-mini
  ? openai/gpt-4-0314
  ? openai/gpt-4-1106-preview
  ? openai/gpt-4o-audio-preview
  ? openai/gpt-4o:extended
  ? openai/gpt-5.2-chat-latest
  ? openai/gpt-oss-120b:exacto
  ? openai/gpt-oss-120b:free
  ? opengvlab/internvl3-78b
  ? openrouter/elephant-alpha
  ? openrouter/healer-alpha
  ? openrouter/hunter-alpha
  ? openrouter/owl-alpha
  ? perplexity/sonar-reasoning
  ? poolside/laguna-xs.2
  ? poolside/laguna-xs.2:free
  ? prime-intellect/intellect-3
  ? qwen/qwen-2.5-72b-instruct:free
  ? qwen/qwen-2.5-coder-32b-instruct:free
  ? qwen/qwen-2.5-vl-7b-instruct
  ? qwen/qwen-max
  ? qwen/qwen-turbo
  ? qwen/qwen-vl-max
  ? qwen/qwen-vl-plus
  ? qwen/qwen2.5-coder-7b-instruct
  ? qwen/qwen2.5-vl-32b-instruct
  ? qwen/qwen2.5-vl-32b-instruct:free
  ? qwen/qwen3-14b:free
  ? qwen/qwen3-235b-a22b:free
  ? qwen/qwen3-30b-a3b:free
  ? qwen/qwen3-4b:free
  ? qwen/qwen3-coder:exacto
  ? qwen/qwen3-coder:free
  ? qwen/qwen3-next-80b-a3b-instruct:free
  ? qwen/qwen3.6-plus-preview:free
  ? qwen/qwen3.6-plus:free
  ? qwen/qwq-32b
  ? raifle/sorcererlm-8x22b
  ? reka/reka-edge
  ? sao10k/l3-euryale-70b
  ? sao10k/l3.1-70b-hanami-x1
  ? stepfun-ai/step3
  ? stepfun/step-3.5-flash:free
  ? switchpoint/router
  ? tencent/hy3-preview:free
  ? tencent/hy3:free
  ? thedrummer/anubis-70b-v1.1
  ? thudm/glm-4.1v-9b-thinking
  ? tngtech/deepseek-r1t-chimera
  ? tngtech/deepseek-r1t-chimera:free
  ? tngtech/deepseek-r1t2-chimera
  ? tngtech/deepseek-r1t2-chimera:free
  ? x-ai/grok-3
  ? x-ai/grok-3-beta
  ? x-ai/grok-3-mini
  ? x-ai/grok-3-mini-beta
  ? x-ai/grok-4
  ? x-ai/grok-4-fast
  ? x-ai/grok-4.1-fast
  ? x-ai/grok-4.1-fast:free
  ? x-ai/grok-4.20-beta
  ? x-ai/grok-4.20-multi-agent-beta
  ? x-ai/grok-code-fast-1
  ? xiaomi/mimo-v2-flash
  ? xiaomi/mimo-v2-omni
  ? xiaomi/mimo-v2-pro
  ? z-ai/glm-4-32b
  ? z-ai/glm-4.5-air:free
  ? z-ai/glm-4.6:exacto
- Deprecated 1 model(s) (past deprecation_date, excluded from dropdown):
  ✗ google/gemini-2.0-flash-001
- Total models: 557 (dropdown: 556)

### Openai
- Stale 15 model(s) (not in source, manual review needed):
  ? chatgpt-4o-latest
  ? gpt-4-0125-preview
  ? gpt-4-0314
  ? gpt-4-1106-preview
  ? gpt-4-turbo-2024-04-09
  ? gpt-4-turbo-preview
  ? gpt-4o-2024-05-13
  ? gpt-4o-2024-08-06
  ? gpt-4o-2024-11-20
  ? gpt-4o-mini-2024-07-18
  ? o1-2024-12-17
  ? o1-mini
  ? o1-mini-2024-09-12
  ? o1-preview
  ? o1-preview-2024-09-12
- Deprecated 4 model(s) (past deprecation_date, excluded from dropdown):
  ✗ gpt-4-0125-preview
  ✗ gpt-4-0314
  ✗ gpt-4-0613
  ✗ gpt-4-1106-preview
- Total models: 68 (dropdown: 23)

### Anthropic
- Stale 4 model(s) (not in source, manual review needed):
  ? claude-3-7-sonnet-20250219
  ? claude-opus-4-20250514
  ? claude-sonnet-4-20250514
  ? claude-sonnet-4-5
- Deprecated 3 model(s) (past deprecation_date, excluded from dropdown):
  ✗ claude-3-7-sonnet-20250219
  ✗ claude-opus-4-20250514
  ✗ claude-sonnet-4-20250514
- Total models: 14 (dropdown: 10)

### Gemini
- Stale 6 model(s) (not in source, manual review needed):
  ? aqa
  ? gemini-1.0-pro
  ? gemini-1.5-flash-latest
  ? gemini-1.5-pro-latest
  ? gemini-pro-vision
  ? text-embedding-004
- Deprecated 4 model(s) (past deprecation_date, excluded from dropdown):
  ✗ gemini-2.0-flash
  ✗ gemini-2.0-flash-lite
  ✗ gemini-3-pro-preview
  ✗ text-embedding-004
- Total models: 32 (dropdown: 15)

### Vertexai
- Added 1 model(s):
  + vertex_ai/gemini-3.6-flash
- Stale 9 model(s) (not in source, manual review needed):
  ? vertex_ai/gemini-2.0-flash-001
  ? vertex_ai/gemini-2.0-flash-lite-001
  ? vertex_ai/gemini-2.5-flash
  ? vertex_ai/gemini-2.5-flash-lite-preview-06-17
  ? vertex_ai/gemini-2.5-flash-preview-04-17
  ? vertex_ai/gemini-2.5-pro
  ? vertex_ai/gemini-2.5-pro-exp-03-25
  ? vertex_ai/gemini-2.5-pro-preview-03-25
  ? vertex_ai/gemini-2.5-pro-preview-05-06
- Total models: 14 (dropdown: 9)

```

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: GitHub Actions (`sync_provider_models.yml`)
  - Model(s): N/A (scripted automation)
  - Scope: Automated model list sync
  - Human verification: Requires manual review before merge

## Testing

- Script dry-run passed in CI
- Changes are add-only; stale/deprecated models flagged for manual review

## Documentation

N/A