### PR TITLE
[NA] [CI] chore: remove Notion MCP from project mcp config

### DIFF
--- a/.agents/mcp.json
+++ b/.agents/mcp.json
@@ -37,11 +37,6 @@
         "args": ["mcp-atlassian"],
         "envFile": "${workspaceFolder}/.env.local"
       },
-      "Notion": {
-        "command": "npx",
-        "args": ["-y", "mcp-remote", "https://mcp.notion.com/mcp"],
-        "env": {}
-      },
       "Sentry": {
         "command": "npx",
         "args": ["-y", "@sentry/mcp-server@latest"],


### PR DESCRIPTION
## Details

Removes the Notion MCP server entry from `.agents/mcp.json`. The entry is no longer needed, so it is dropped from the source config and regenerated with `make claude`, which removes it from the synced `.claude/` files and the generated `.mcp.json`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: manual review

## Testing

Ran `make claude` to regenerate `.claude/` and `.mcp.json`, then verified no `notion` references remain in either `.agents/mcp.json` or the generated `.mcp.json`.

## Documentation

N/A
