### PR TITLE
[OPIK-7328] [FE] fix: keep picked value in metadata filter key autocomplete

### DIFF
--- a/apps/opik-frontend/src/shared/filter-chips/chips/QueryBuilderChip/cells/AutocompleteCell.tsx
+++ b/apps/opik-frontend/src/shared/filter-chips/chips/QueryBuilderChip/cells/AutocompleteCell.tsx
@@ -61,6 +61,7 @@ export const AutocompleteCell: React.FC<AutocompleteCellProps> = ({
   const [draft, setDraft] = useState(value);
   const [focused, setFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const pickedRef = useRef(false);
   const { items, isLoading } = options;
 
   useEffect(() => {
@@ -88,6 +89,7 @@ export const AutocompleteCell: React.FC<AutocompleteCellProps> = ({
 
   const pick = useCallback(
     (item: string) => {
+      pickedRef.current = true;
       setDraft(item);
       commit(item);
       onPick?.(item);
@@ -121,6 +123,12 @@ export const AutocompleteCell: React.FC<AutocompleteCellProps> = ({
             onFocus={() => setFocused(true)}
             onBlur={() => {
               setFocused(false);
+              // A pick already committed the selected value; skip re-committing the
+              // stale draft this blur closure still holds (setDraft hasn't flushed).
+              if (pickedRef.current) {
+                pickedRef.current = false;
+                return;
+              }
               commit(draft);
             }}
             onKeyDown={handleKeyDown}


### PR DESCRIPTION
## Details

Fixes the metadata filter on the logs page where picking a key from the autocomplete dropdown didn't stick — the typed characters stayed instead of the selected value. The key field (`AutocompleteCell`) commits its value both on blur and on pick; selecting an item ran `setDraft(item)` + `commit(item)` and then blurred the input, which synchronously fired the blur handler while `draft` still held the previously typed text (`setDraft` hadn't flushed yet). That blur re-committed the stale text over the just-picked value.

- Track a `pickedRef` flag so the blur triggered by a pick skips its commit, leaving the picked value in place.
- Normal commit-on-blur is preserved for when the user types and clicks away without selecting.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7328

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: code review + manual testing in the local app

## Testing

- Manually reproduced on the logs page: typed a few characters in a metadata filter key, selected an item from the dropdown, and confirmed the picked value is now retained (previously the typed text remained). Verified the plain type-then-click-away path still commits the typed value.
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npx vitest run src/shared/filter-chips/` — 147 passed

## Documentation

N/A — no user-facing documentation changes.
