### PR TITLE
[NA] [SDK] [GHA] fix: floor google-adk so resolves cannot land on the 0.0.1 stub

### DIFF
--- a/.github/workflows/lib-adk-legacy-1-3-0-tests.yml
+++ b/.github/workflows/lib-adk-legacy-1-3-0-tests.yml
@@ -64,6 +64,12 @@ jobs:
           cd ./tests
           uv pip install --system -r library_integration/adk/requirements_legacy_adk_1_3_0.txt
 
+      - name: Verify ADK is importable
+        # A resolver backtrack can install the dependency-free google-adk 0.0.1
+        # stub, which succeeds silently and only fails much later during test
+        # collection. Fail here instead, with the resolved version in the log.
+        run: python -c "import importlib.metadata as m, google.adk; print('google-adk', m.version('google-adk'))"
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:

--- a/.github/workflows/lib-adk-tests.yml
+++ b/.github/workflows/lib-adk-tests.yml
@@ -64,6 +64,12 @@ jobs:
           cd ./tests
           uv pip install --system -r library_integration/adk/requirements.txt
 
+      - name: Verify ADK is importable
+        # A resolver backtrack can install the dependency-free google-adk 0.0.1
+        # stub, which succeeds silently and only fails much later during test
+        # collection. Fail here instead, with the resolved version in the log.
+        run: python -c "import importlib.metadata as m, google.adk; print('google-adk', m.version('google-adk'))"
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:

--- a/sdks/python/tests/library_integration/adk/requirements.txt
+++ b/sdks/python/tests/library_integration/adk/requirements.txt
@@ -1,4 +1,7 @@
-google-adk
+# Floored for the same reason as requirements_legacy_adk_1_3_0.txt: an unbounded
+# spec lets a resolver backtrack all the way to the 0.0.1 stub. 1.3.0 is also the
+# boundary that keeps this suite disjoint from the legacy one.
+google-adk>=1.3.0
 python-multipart; python_version < "3.10"
 opentelemetry-api
 opentelemetry-sdk

--- a/sdks/python/tests/library_integration/adk/requirements_legacy_adk_1_3_0.txt
+++ b/sdks/python/tests/library_integration/adk/requirements_legacy_adk_1_3_0.txt
@@ -1,2 +1,6 @@
-google-adk<1.3.0
+# The floor is load-bearing: google-adk 0.0.1 is a dependency-free "hello world"
+# stub, so it is the one release that satisfies any resolve. Without a floor a
+# backtrack silently installs it and the suite fails later with a confusing
+# "No module named 'google'". 1.2.1 is the newest release below 1.3.0.
+google-adk>=1.2.1,<1.3.0
 python-multipart; python_version < "3.10"


### PR DESCRIPTION
## Details

`adk_legacy_1_3_0_tests` has been failing with `ModuleNotFoundError: No module named 'google'` because `google-adk<1.3.0` had no lower bound, and `google-adk==0.0.1` is a 5.5 KB "hello world" placeholder on PyPI: it ships `agent_kit/` (not `google/adk/`), declares **zero dependencies**, and sets `Requires-Python: >=3.8`. That combination makes it the one release that satisfies *any* resolve, so whenever the resolver backtracks it lands there, installs cleanly, and the failure only surfaces ~30s later during pytest collection. This accounts for **15 of the last 17** `adk_legacy_1_3_0_tests` failures.

- Floors both ADK requirements files so the stub is unreachable: `google-adk>=1.2.1,<1.3.0` (legacy) and `google-adk>=1.3.0` (current). 1.2.1 is the newest release below 1.3.0 and is what every passing legacy run already resolved, so default resolution is unchanged.
- Adds a `Verify ADK is importable` step to both workflows after the install. A bad resolve now fails at the install step with the resolved version in the log, instead of as a confusing import error during collection.

Scope note: this fixes the `No module named 'google'` class of failure only. The `adk_tests` failures are a **different root cause** and are not addressed here — all 15 sampled were Vertex AI `429 RESOURCE_EXHAUSTED` against the shared `opik-sdk-tests` GCP project (2 also hit `MALFORMED_FUNCTION_CALL`, i.e. nondeterministic model output). That needs a quota/retry decision, not a dependency fix; the matrix was already trimmed to 3.10+3.14 for the same reason. Related but separate: `setup-uv` reports "Could not determine uv version ... Falling back to latest", so uv silently moves under CI (0.11.32 on the failing run) — pinning it is a repo-wide change and deliberately out of scope here.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Classified all 32 recent ADK job failures by root error, identified the 0.0.1 stub, reproduced the bad resolution deterministically, and authored the fix.
- Human verification: Author reviewed the classification and the reproduction before the fix was applied.

## Testing

Reproduced the bad resolution deterministically, then confirmed the fix closes it. `uv pip compile` against the real requirements files, `--python-version 3.10 --python-platform x86_64-unknown-linux-gnu` (matching the failing CI leg), using **uv 0.11.32** — the exact version the failing run installed:

| resolution | `google-adk<1.3.0` (before) | `google-adk>=1.2.1,<1.3.0` (after) |
|---|---|---|
| `highest` (default) | 1.2.1 | 1.2.1 |
| `lowest-direct` | **0.0.1** | 1.2.1 |

`lowest-direct` reproduces exactly what CI hit (`Resolved 1 package` → `+ google-adk==0.0.1`); after the change the stub is unreachable in both modes. Same check on the current-ADK file: `highest` → 2.5.0 (unchanged), `lowest-direct` → 1.3.0 (was 0.0.1).

Verified the guard command behaves correctly in both directions:
- against a real install (`google-adk 1.2.1`): prints `google-adk 1.2.1`, exit 0
- against `google-adk==0.0.1`: raises `ModuleNotFoundError: No module named 'google'`, exit 1 — the same error CI produced, now surfaced at the install step

End-to-end: built a Python 3.10 env replicating the workflow's three sequential installs and ran `pytest --collect-only` on `sdks/python/tests/library_integration/adk/` — **49 tests collected**, i.e. the step that was throwing now succeeds.

Not run: the ADK suite itself. It makes live Vertex AI calls and needs `GCP_CREDENTIALS_JSON`, which is not available locally — CI will exercise it on this PR.

`uvx pre-commit run --files` on all four changed files: passed, including `⚙️ actionlint`.

## Documentation

No documentation changes needed — CI/test dependency pins with no user-facing surface. The rationale for the floor is captured as comments in both requirements files so the bound is not "simplified" away later.
