### PR TITLE
[NA] [DOCS] fix: point changelog canonical URLs at the changelog index

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-07-13.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-07-13.mdx
@@ -1,5 +1,5 @@
 ---
-canonical-url: https://www.comet.com/docs/opik/changelog/2026-07-13
+canonical-url: https://www.comet.com/docs/opik/changelog
 ---
 
 ## Per-Evaluation Spend Budget for LLM-as-Judge Evaluators

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-07-20.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-07-20.mdx
@@ -1,5 +1,5 @@
 ---
-canonical-url: https://www.comet.com/docs/opik/changelog/2026-07-20
+canonical-url: https://www.comet.com/docs/opik/changelog
 ---
 
 ## Redesigned Optimization Run Overview


### PR DESCRIPTION
## Details

The `2026-07-13` and `2026-07-20` changelog entries set `canonical-url` to a per-date path (`/docs/opik/changelog/<date>`), but both of those URLs 404. Fern renders changelog entries into the changelog section declared by `- changelog: ../docs/changelog` with `slug: changelog`, so individual entries do not get standalone per-date pages. The other **59 of 61** entries all point at `/docs/opik/changelog`; this makes these two match.

This is the cause of the `Docs - Preview link` broken-link failure that has been firing on every docs-touching PR — the same two links appear in the link-check comment on #7599, #7602, and #7608.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Traced the broken links reported by the docs link checker to the deviating `canonical-url` frontmatter and corrected it.
- Human verification: Author identified the canonical URLs as the likely cause and directed the fix.

## Testing

Verified the URLs directly with `curl -o /dev/null -w "%{http_code}" -L`:

| URL | Before | After |
|---|---|---|
| `/docs/opik/changelog/2026-07-13` (old canonical) | **404** | no longer referenced |
| `/docs/opik/changelog/2026-07-20` (old canonical) | **404** | no longer referenced |
| `/docs/opik/changelog` (new canonical) | 200 | **200** |

Confirmed consistency and that the same bug does not exist elsewhere:
- `grep -h "canonical-url" docs/changelog/*.mdx | sort | uniq -c` → **61 entries, all one value** (`https://www.comet.com/docs/opik/changelog`); was 59 + the two deviations
- Repo-wide `grep -rn 'canonical-url:.*changelog/20'` across `apps/opik-documentation` → no remaining matches
- The only other changelog canonical in the repo, `/docs/opik/development/optimization-runs/changelog`, is a real page and returns **200** — unaffected

`uvx pre-commit run --files` on both changed paths: no hooks matched (frontmatter-only change to `.mdx`), so nothing to report.

The authoritative check is `Docs - Preview link` on this PR, which crawls the built preview; it should now report no broken links.

## Documentation

This change *is* the documentation fix. No further docs updates needed.

Out of scope, but worth flagging separately: `docs-v2/changelog/` (the `latest` docs version) stops at **2026-07-06**, while `docs/changelog/` (v1) has entries through **2026-07-20**. So the current docs are missing the 2026-07-13 and 2026-07-20 changelog entries entirely. That is a content gap rather than a link bug, and writing those two entries is an editorial call — this PR only stops the canonical URLs from 404ing.
