### PR TITLE
docs: add TokenLab OpenAI-compatible tracing example

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/overview.mdx
@@ -109,6 +109,7 @@ Connect your AI coding assistant directly to your Opik workspace with the MCP se
   <Card title="Qianfan" href="/integrations/qianfan" />
   <Card title="Predibase" href="/integrations/predibase" />
   <Card title="Together AI" href="/integrations/together-ai" />
+  <Card title="TokenLab" href="/integrations/tokenlab" />
   <Card title="WatsonX" href="/integrations/watsonx" />
   <Card title="xAI Grok" href="/integrations/xai-grok" />
 </CardGroup>

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/tokenlab.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/tokenlab.mdx
@@ -1,0 +1,93 @@
+---
+description: Track TokenLab model calls with Opik through the OpenAI-compatible API.
+headline: TokenLab
+og:description: Configure Opik tracing for TokenLab using the OpenAI-compatible base URL.
+og:site_name: Opik Documentation
+og:title: Integrate TokenLab with Opik
+title: Observability for TokenLab with Opik
+---
+
+TokenLab provides an OpenAI-compatible API at `https://api.tokenlab.sh/v1`. Opik can trace TokenLab calls by wrapping the OpenAI Python SDK client with the existing `track_openai` integration — no additional runtime code is required.
+
+## Install the dependencies
+
+Install Opik and the OpenAI SDK:
+
+```bash
+pip install opik openai
+```
+
+Configure Opik for your deployment:
+
+```bash
+opik configure
+```
+
+Set your TokenLab API key:
+
+```bash
+export TOKENLAB_API_KEY="<TOKENLAB_API_KEY>"
+```
+
+## Track TokenLab calls
+
+Wrap the OpenAI client with `track_openai` and point it at the TokenLab base URL:
+
+```python
+import os
+
+from openai import OpenAI
+from opik.integrations.openai import track_openai
+
+client = OpenAI(
+    api_key=os.environ["TOKENLAB_API_KEY"],
+    base_url="https://api.tokenlab.sh/v1",
+)
+client = track_openai(client, project_name="tokenlab-demo")
+
+response = client.chat.completions.create(
+    model="<MODEL_ID>",
+    messages=[{"role": "user", "content": "Explain observability in one sentence."}],
+)
+
+print(response.choices[0].message.content)
+```
+
+## Discover available models
+
+TokenLab exposes its model list through the standard OpenAI models endpoint. You can retrieve available model IDs before running tracked calls:
+
+```python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["TOKENLAB_API_KEY"],
+    base_url="https://api.tokenlab.sh/v1",
+)
+
+models = client.models.list()
+for model in models.data:
+    print(model.id)
+```
+
+Alternatively, query the endpoint directly:
+
+```bash
+curl https://api.tokenlab.sh/v1/models \
+  -H "Authorization: Bearer $TOKENLAB_API_KEY"
+```
+
+For the full list of supported models and pricing, see the [TokenLab documentation](https://docs.tokenlab.sh/).
+
+## What gets traced
+
+The `track_openai` wrapper records the full request and response for each call, including:
+
+- Prompt and completion content
+- Token usage (prompt, completion, total)
+- Model identifier
+- Latency
+
+All traces appear in your Opik project dashboard under the project name passed to `track_openai`.

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/tokenlab.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/tokenlab.mdx
@@ -1,0 +1,93 @@
+---
+description: Track TokenLab model calls with Opik through the OpenAI-compatible API.
+headline: TokenLab
+og:description: Configure Opik tracing for TokenLab using the OpenAI-compatible base URL.
+og:site_name: Opik Documentation
+og:title: Integrate TokenLab with Opik
+title: Observability for TokenLab with Opik
+---
+
+TokenLab provides an OpenAI-compatible API at `https://api.tokenlab.sh/v1`. Opik can trace TokenLab calls by wrapping the OpenAI Python SDK client with the existing `track_openai` integration — no additional runtime code is required.
+
+## Install the dependencies
+
+Install Opik and the OpenAI SDK:
+
+```bash
+pip install opik openai
+```
+
+Configure Opik for your deployment:
+
+```bash
+opik configure
+```
+
+Set your TokenLab API key:
+
+```bash
+export TOKENLAB_API_KEY="<TOKENLAB_API_KEY>"
+```
+
+## Track TokenLab calls
+
+Wrap the OpenAI client with `track_openai` and point it at the TokenLab base URL:
+
+```python
+import os
+
+from openai import OpenAI
+from opik.integrations.openai import track_openai
+
+client = OpenAI(
+    api_key=os.environ["TOKENLAB_API_KEY"],
+    base_url="https://api.tokenlab.sh/v1",
+)
+client = track_openai(client, project_name="tokenlab-demo", provider="tokenlab")
+
+response = client.chat.completions.create(
+    model="<MODEL_ID>",
+    messages=[{"role": "user", "content": "Explain observability in one sentence."}],
+)
+
+print(response.choices[0].message.content)
+```
+
+## Discover available models
+
+TokenLab exposes its model list through the standard OpenAI models endpoint. You can retrieve available model IDs before running tracked calls:
+
+```python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["TOKENLAB_API_KEY"],
+    base_url="https://api.tokenlab.sh/v1",
+)
+
+models = client.models.list()
+for model in models.data:
+    print(model.id)
+```
+
+Alternatively, query the endpoint directly:
+
+```bash
+curl https://api.tokenlab.sh/v1/models \
+  -H "Authorization: Bearer $TOKENLAB_API_KEY"
+```
+
+For the full list of supported models and pricing, see the [TokenLab documentation](https://docs.tokenlab.sh/).
+
+## What gets traced
+
+The `track_openai` wrapper instruments chat and completion calls — specifically `chat.completions.create`, `completions.create`, and their streaming variants. For each traced call, Opik records:
+
+- Prompt and completion content
+- Token usage (prompt, completion, total)
+- Model identifier
+- Latency
+
+Utility calls such as `client.models.list()` are not traced. All traces appear in your Opik project dashboard under the project name passed to `track_openai`.

--- a/apps/opik-documentation/documentation/fern/versions/latest.yml
+++ b/apps/opik-documentation/documentation/fern/versions/latest.yml
@@ -770,6 +770,9 @@ navigation:
               - page: Together AI
                 path: ../docs-v2/integrations/together-ai.mdx
                 slug: together-ai
+              - page: TokenLab
+                path: ../docs-v2/integrations/tokenlab.mdx
+                slug: tokenlab
               - page: WatsonX
                 path: ../docs-v2/integrations/watsonx.mdx
                 slug: watsonx


### PR DESCRIPTION
## Details

Adds a documentation page for tracing [TokenLab](https://docs.tokenlab.sh/) calls through the existing `track_openai` integration. TokenLab exposes an OpenAI-compatible API at `https://api.tokenlab.sh/v1`, so no new integration code is required — users configure the OpenAI client with the TokenLab base URL and API key.

The page covers:
- Client setup and `opik configure`
- A complete tracing example using `track_openai`
- Model discovery via `client.models.list()` and the REST endpoint
- What gets recorded in Opik traces

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #7420
- OPIK_7420

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Sonnet 4.6
- Scope: documentation only — new .mdx page and two-line nav entries
- Human verification: yes

## Testing

Docs-only change. Verified:
- `tokenlab.mdx` follows the same structure as `minimax.mdx` (the pattern PR for OpenAI-compatible providers)
- Card added to `overview.mdx` in alphabetical order between Together AI and WatsonX
- Nav entry added to `latest.yml` in the same position

No runtime code changed. No tests required.

## Documentation

New page: `apps/opik-documentation/documentation/fern/docs-v2/integrations/tokenlab.mdx`