### PR TITLE
[NA] [SDK] fix: repair the two long-broken weekly video test suites (Veo GA endpoint + AttachmentModel)

### DIFF
--- a/sdks/python/tests/library_integration/genai/test_genai_videos.py
+++ b/sdks/python/tests/library_integration/genai/test_genai_videos.py
@@ -33,7 +33,9 @@ pytestmark = [
     pytest.mark.usefixtures("use_us_central1_for_veo"),
 ]
 
-VIDEO_MODEL = "veo-3.1-fast-generate-preview"
+# GA endpoint. The -preview endpoint this replaced was shut down on 2026-04-02,
+# after which every weekly run 404'd with "Publisher model ... was not found".
+VIDEO_MODEL = "veo-3.1-fast-generate-001"
 
 VIDEO_CONFIG = GenerateVideosConfig(
     duration_seconds=4,

--- a/sdks/python/tests/testlib/models.py
+++ b/sdks/python/tests/testlib/models.py
@@ -37,6 +37,10 @@ class FeedbackScoreModel(models.FeedbackScoreModel):
     pass
 
 
-@dataclasses.dataclass
-class AttachmentModel(models.AttachmentModel):
-    pass
+# Aliased, not subclassed. Attachments reach tests via the parent emulator
+# (BackendEmulatorMessageProcessor takes super().trace_trees), so they are always
+# base ``models.AttachmentModel`` instances. Dataclass __eq__ compares only
+# same-class instances, so a subclass here never matches — and because it fails
+# before field comparison, the ANY_BUT_NONE that tests use for the temp file_path
+# is never consulted.
+AttachmentModel = models.AttachmentModel


### PR DESCRIPTION
## Details

Fixes 5 of the 6 test failures in the weekly Python SDK integration run (`openai_tests` and `genai_tests`). Both were **deterministic and long-standing**, not flakes — they only surface on the Sunday cron because these are `run_expensive_tests` video suites, which is why the same commit `aae4650` passed on the 2026-07-25 daily run and failed on 2026-07-26. **All 15 Sunday runs in the last 100 scheduled runs failed**, going back to 2026-04-19; `genai_tests` failed in every one sampled.

### 1. GenAI (3 tests) — Veo preview endpoint was shut down

`veo-3.1-fast-generate-preview` returned `404 NOT_FOUND: Publisher model ... was not found or your project does not have access to it`. Google removed the Veo video-generation **preview** endpoints on **2026-04-02**, which matches the failure window exactly (first failing Sunday: 2026-04-19).

Migrated to Google's documented replacement, `veo-3.1-fast-generate-001`:
- GA, and the officially recommended migration target for `veo-3.1-fast-generate-preview`
- Available in `us-central1`, which the existing `use_us_central1_for_veo` fixture already pins
- Supports the config these tests use — 4s duration (4/6/8 supported), 720p, and per-request audio toggling
- The clients here already pass `HttpOptions(api_version="v1")`, which sidesteps the v1beta1 routing problem GA Veo calls otherwise hit through `google-genai` ([googleapis/python-genai#2079](https://github.com/googleapis/python-genai/issues/2079), closed as not planned)

Also confirmed there is no newer target: the current family is Veo 3.1 / 3.1 Fast / 3.1 Lite (Lite still public preview); no `veo-3.2` or `-002` endpoint exists.

### 2. OpenAI (2 tests) — cross-class comparison defeated the `ANY_BUT_NONE` matcher

The expected value was a `tests.testlib.models.AttachmentModel`; the actual was an `opik.message_processing.emulation.models.AttachmentModel`. `BackendEmulatorMessageProcessor` subclasses the SDK's `EmulatorMessageProcessor` and returns `super().trace_trees`, so attachments always arrive as base-class instances (built at `emulator_message_processor.py:820`). Dataclass `__eq__` only compares same-class instances, so the comparison failed **before any field was examined** — which is why the `ANY_BUT_NONE` on the temp `file_path` was never honoured, and why the diff read confusingly as `Type ... changed from AttachmentModel to AttachmentModel`.

The subclass was a bare `pass` that added nothing and contradicted this module's own annotations, which already type attachments as `List[models.AttachmentModel]`. It is now aliased rather than subclassed. Only the two video test files reference `AttachmentModel`, so the change is tightly scoped.

### Not fixed here

**LlamaIndex (1 test)** — `openai.BadRequestError: 400 invalid_prompt` on the prompt `"Say pipeline {id} in one word"`, flagged by OpenAI moderation. A provider false positive on benign text; historically ~4 occurrences across ~130 job-runs. Adding a retry would mask a real signal for a low-rate external issue, so I have left it alone.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Classified the weekly-run failures, reproduced the AttachmentModel bug locally, researched the Veo endpoint deprecation, and authored both fixes.
- Human verification: Author reported the failing run, asked for the GenAI cause to be researched, and reviewed the split between the fixable defects and the remaining external one.

## Testing

**AttachmentModel — reproduced the CI failure locally, then confirmed the fix closes it.** Comparing testlib's expected against a base-class actual reproduces the CI message character-for-character:

```
Type of root changed from AttachmentModel to AttachmentModel and value changed from
AttachmentModel(file_path=<ANY_BUT_NONE>, file_name='test_video.mp4', content_type='video/mp4')
to AttachmentModel(file_path='/tmp/tmpd9iphze0.mp4', ...)
```

After the change that comparison passes. Negative control confirms the matcher did not become too loose — a genuine mismatch still fails with `Value of root.file_name changed from "other.mp4" to "test_video.mp4"`.

**Full unit suite** (Python 3.12): `4322 passed, 2 failed, 2 skipped`. The 2 failures (`test_litellm_chat_model_drops_temperature_for_gpt5` and its provider-prefixed variant) are **pre-existing and unrelated** — verified by stashing the change and re-running the full suite on clean `origin/main`, which gives the identical `2 failed, 4322 passed`. Both pass when that file runs in isolation on either revision, so it is order-dependent pollution already on main, not a regression here.

**GenAI** — `pytest --collect-only` on `test_genai_videos.py` collects 4 tests cleanly against `google-genai 2.14.0` with the new model ID.

`uvx pre-commit run --files` on both changed paths: passed (`ruff`, `ruff-format`, whitespace, end-of-files).

**Not verified by this PR's CI, and worth being explicit about:** neither suite runs here. Both are `run_expensive_tests`-gated, and that flag is set only on the Sunday cron — so the next weekly run is the real confirmation. The GenAI fix in particular could not be executed locally: it needs `GCP_CREDENTIALS_JSON` for the `opik-sdk-tests` project and bills real Veo video generation. The model ID, its GA status, region, and parameter support are all confirmed against Google's documentation, but that the project has quota/access for the GA endpoint is an assumption the weekly run will settle. If it still 404s after this, the remaining cause is project-level access rather than a stale endpoint.

## Documentation

No documentation changes needed — test-only changes with no user-facing surface.

Follow-up left out of scope: `FeedbackScoreModel` in `tests/testlib/models.py` is the identical bare-`pass` subclass pattern with the same latent hazard. It works today only because both sides happen to be the subclass (testlib's emulator builds it at `backend_emulator_message_processor.py:136`), while the SDK emulator builds the base class at `local_emulator_message_processor.py:164`. Aliasing it too would be consistent but touches 17 currently-passing usages for no present benefit, so it is better done deliberately on its own.
