### PR TITLE
[OPIK-7491] [BE] perf: trim E2E backend image compile (maven.test.skip, drop ineffective -T 1C)

### DIFF
--- a/apps/opik-backend/Dockerfile
+++ b/apps/opik-backend/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /opt/opik-backend
 
 # Copy parent POM first for dependency caching
 COPY pom.xml spotless.xml ./
-RUN mvn dependency:go-offline
+RUN mvn -T 1C dependency:go-offline
 
 # Copy source code
 COPY src ./src
@@ -13,7 +13,7 @@ COPY src ./src
 ARG OPIK_VERSION
 ENV MAVEN_OPTS="-Xmx1G -XX:MaxMetaspaceSize=265m"
 RUN mvn versions:set -DnewVersion=${OPIK_VERSION} && \
-    mvn clean package -DskipTests -Dspotless.skip=true
+    mvn -T 1C clean package -DskipTests -Dspotless.skip=true
 
 ###############################
 FROM amazoncorretto:25.0.3-al2023

--- a/apps/opik-backend/Dockerfile
+++ b/apps/opik-backend/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /opt/opik-backend
 
 # Copy parent POM first for dependency caching
 COPY pom.xml spotless.xml ./
-RUN mvn -T 1C dependency:go-offline
+RUN mvn dependency:go-offline
 
 # Copy source code
 COPY src ./src
@@ -12,8 +12,12 @@ COPY src ./src
 # Build artifact
 ARG OPIK_VERSION
 ENV MAVEN_OPTS="-Xmx1G -XX:MaxMetaspaceSize=265m"
+# The image only needs the shaded main jar. maven.test.skip drops test
+# compilation (nothing consumes a test-jar), and source/javadoc skip drops
+# artifacts the runtime image never uses — trimming the package stage without
+# changing what ships. (-T is a no-op here: single-module build, no reactor.)
 RUN mvn versions:set -DnewVersion=${OPIK_VERSION} && \
-    mvn -T 1C clean package -DskipTests -Dspotless.skip=true
+    mvn clean package -Dmaven.test.skip=true -Dmaven.source.skip=true -Dmaven.javadoc.skip=true -Dspotless.skip=true
 
 ###############################
 FROM amazoncorretto:25.0.3-al2023


### PR DESCRIPTION
## Details

<img width="1920" height="2236" alt="image" src="https://github.com/user-attachments/assets/65663ddc-f745-4450-9b52-c06df44902ba" />

Trims the Maven `package` stage in the E2E backend image build (`apps/opik-backend/Dockerfile`) so the compile does less work, without changing what ships.

The ticket originally proposed `-T 1C`, but timing it on real CI runs showed no benefit — `opik-backend` is a single-module jar (no reactor), so Maven's `MultiThreadedBuilder` had nothing to parallelize and the compile was marginally slower. Profiling the stage revealed the actual deterministic win:

- `-Dmaven.test.skip=true` replaces `-DskipTests` — the old flag still **compiled** all 427 test sources (~28s) that the runtime image never uses; the new flag skips compiling them entirely. Verified safe: no `test-jar` goal exists, so nothing consumes test classes.
- `-Dmaven.source.skip=true -Dmaven.javadoc.skip=true` stop producing the sources/javadoc jars (matches the existing `scripts/dev-runner-platform.sh` precedent).
- Dropped `-T 1C` (measured no-op on this single-module build).

The produced shaded main jar and `openapi.yaml` are unchanged.

**Measured on the E2E backend build (`clean package` layer):**

| | duration |
|---|---|
| main baseline | 116.7s |
| `-T 1C` (rejected) | 121.3s |
| this PR (`maven.test.skip`) | 90.2s, 110.3s (~100s avg) |

Net ~15s / ~13% off the compile layer, deterministic, no caching or infra changes. Layer/dependency caching (the larger lever — `go-offline` is ~84s of cold downloads every run) is deliberately out of scope here and tracked separately in OPIK_7492.

**Bonus — smaller runtime image.** The runtime stage copies `target/*.jar` (a glob), so it was also shipping `opik-backend-latest-sources.jar` (~2 MB of the app's own source, deflate-compressed) into the final image alongside the shaded jar. Skipping the sources jar drops it: the runtime image is ~2 MB smaller and no longer bakes source code into the shipped container. (`maven.test.skip` has no image-size effect — test classes were never copied; the saving is purely from the source/javadoc skip.)

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-7491

<!-- Related but not resolved here: OPIK_7492 (buildx registry layer caching for E2E images). -->

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation + CI timing analysis
- Human verification: code review + CI E2E build verification (before/after timing recorded above)

## Testing

- `hadolint` passed on the modified Dockerfile via the pre-commit gate.
- E2E Docker image build (`build-opik / Build E2E Docker Images`) is green on the pivot commit across multiple workflows.
- Before/after `clean package` layer timing extracted from the raw CI build logs (table above); test-compile confirmed skipped (`testCompile` runs as a no-op — no "Compiling 427 source files" line — and no sources/javadoc jars are built).
- Produced backend image passes the existing E2E suite unchanged; shaded main jar + `openapi.yaml` byte-identical to before.
- Image size: confirmed via build logs that `target/` now contains only `opik-backend-latest.jar` (before: also `-sources.jar`), so the ~2 MB sources jar is no longer copied into the runtime image.

## Documentation

N/A
