### PR TITLE
[NA] [FE] fix: strip deprecated sampling params for Claude Opus 5

### DIFF
--- a/apps/opik-frontend/src/constants/llm.ts
+++ b/apps/opik-frontend/src/constants/llm.ts
@@ -158,6 +158,10 @@ export const ANTHROPIC_MODEL_CAPABILITIES: Partial<
     }
   >
 > = {
+  [PROVIDER_MODEL_TYPE.CLAUDE_OPUS_5]: {
+    supportsSamplingParams: false,
+    thinkingEffortOptions: ["low", "medium", "high", "xhigh", "max"],
+  },
   [PROVIDER_MODEL_TYPE.CLAUDE_OPUS_4_8]: {
     supportsSamplingParams: false,
     thinkingEffortOptions: ["low", "medium", "high", "xhigh", "max"],

--- a/apps/opik-frontend/src/lib/modelUtils.test.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.test.ts
@@ -79,6 +79,12 @@ describe("supportsSamplingParams", () => {
       false,
     );
   });
+
+  it("returns false for Claude Opus 5", () => {
+    expect(supportsSamplingParams(PROVIDER_MODEL_TYPE.CLAUDE_OPUS_5)).toBe(
+      false,
+    );
+  });
 });
 
 describe("updateProviderConfig — Anthropic", () => {


### PR DESCRIPTION
## Details

Selecting Claude Opus 5 in the Playground failed with `top_p is deprecated for this model` — the Claude API rejects `temperature`/`top_p` on `claude-opus-5`. Adds the missing `ANTHROPIC_MODEL_CAPABILITIES` row (`supportsSamplingParams: false` + the `low`–`max` thinking effort ladder), which drives the existing plumbing: the sliders are hidden in the model config UI, stale values are stripped on model switch, and the request payload is sanitized — same treatment as Opus 4.8/4.7, Sonnet 5 and Fable 5.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- N/A

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Fable 5
- Scope: capability map row in `constants/llm.ts` + unit test
- Human verification: reviewed diff, tests and typecheck run locally

## Testing

- `npx vitest run src/lib/modelUtils.test.ts` — 48 tests pass, including a new `supportsSamplingParams` case for Claude Opus 5
- `npx tsc --noEmit` — clean
- Not run: manual Playground round-trip against the live provider (change is identical in shape to the existing Opus 4.8/4.7/Sonnet 5/Fable 5 rows exercised daily)

## Documentation

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)