### PR TITLE
[OPIK-4324] [BE] fix: keep react-service auth errors as client errors when the body is not JSON

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
@@ -45,6 +45,9 @@ class RemoteAuthService implements AuthService {
     private static final String USER_NOT_FOUND = "User not found";
     private static final String NOT_LOGGED_USER = "Please login first";
 
+    // Remote error bodies are arbitrary upstream content, so cap what reaches the logs.
+    private static final int MAX_LOGGED_BODY_LENGTH = 512;
+
     // GenericType instances are thread-safe and expensive to build, so reuse a single instance.
     private static final GenericType<List<WorkspaceIdNameResponse>> WORKSPACE_LIST_TYPE = new GenericType<>() {
     };
@@ -284,13 +287,19 @@ class RemoteAuthService implements AuthService {
         return new InternalServerErrorException("Unexpected error while " + operation);
     }
 
+    /**
+     * Reads the response body for diagnostics only, never to be surfaced to the caller. The result is capped at
+     * {@link #MAX_LOGGED_BODY_LENGTH} characters: a remote error body is arbitrary upstream content (a proxy error page
+     * or a stack trace, not necessarily our own JSON), so it must not be able to flood the logs or carry an unbounded
+     * amount of upstream detail into them.
+     */
     private static String readBodySafely(Response response) {
         try {
             if (!response.hasEntity()) {
                 return "";
             }
             bufferEntitySafely(response);
-            return response.readEntity(String.class);
+            return StringUtils.abbreviate(response.readEntity(String.class), MAX_LOGGED_BODY_LENGTH);
         } catch (RuntimeException e) {
             log.warn("Failed to read remote response body for debugging", e);
             return "";
@@ -499,7 +508,8 @@ class RemoteAuthService implements AuthService {
             return response.readEntity(String.class);
         } else if (response.getStatus() == Response.Status.BAD_REQUEST.getStatusCode()) {
             var message = readErrorMessage(response, MISSING_WORKSPACE);
-            log.error("Workspace not found by name: '{}'", message);
+            // An unknown workspace name is a caller mistake on the public-endpoint fallback path, not a server fault.
+            log.warn("Workspace not found by name: '{}'", message);
             throw new ClientErrorException(message, Response.Status.BAD_REQUEST);
         }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
@@ -295,10 +295,9 @@ class RemoteAuthService implements AuthService {
      */
     private static String readBodySafely(Response response) {
         try {
-            if (!response.hasEntity()) {
+            if (!isEntityReadable(response)) {
                 return "";
             }
-            bufferEntitySafely(response);
             return StringUtils.abbreviate(response.readEntity(String.class), MAX_LOGGED_BODY_LENGTH);
         } catch (RuntimeException e) {
             log.warn("Failed to read remote response body for debugging", e);
@@ -307,15 +306,22 @@ class RemoteAuthService implements AuthService {
     }
 
     /**
-     * Buffers the response entity so it can be read more than once. A client response entity is backed by a single-shot
-     * input stream, so without buffering the first reader consumes it and every later read fails. Buffering is
-     * idempotent, so callers do not need to track whether it already happened.
+     * Guards a {@code readEntity} call: reports whether the response carries an entity and that entity was buffered, so
+     * that it can be read, and read again. A client response entity is backed by a single-shot input stream, so without
+     * buffering the first reader consumes it and every later read fails. Buffering is idempotent — an already buffered
+     * entity reports success — so callers do not need to track whether it already happened.
+     *
+     * @return {@code false} when there is no entity, or when it could not be buffered and is therefore unsafe to read
      */
-    private static void bufferEntitySafely(Response response) {
+    private static boolean isEntityReadable(Response response) {
+        if (!response.hasEntity()) {
+            return false;
+        }
         try {
-            response.bufferEntity();
+            return response.bufferEntity();
         } catch (RuntimeException e) {
             log.warn("Failed to buffer remote response entity, status: '{}'", response.getStatus(), e);
+            return false;
         }
     }
 
@@ -332,17 +338,16 @@ class RemoteAuthService implements AuthService {
      * <p>
      * Only a JSON body is treated as a message intended for the caller. Any other content type is a framework-level
      * response rather than an application error, so it is logged and the caller-facing {@code fallback} is used instead
-     * of leaking the remote framework's wording. The entity is buffered up front so that both the diagnostic logging
-     * here and any later reader of the same response can read it, rather than relying on being the first to consume the
-     * single-shot entity stream.
+     * of leaking the remote framework's wording. Every read is guarded by {@link #isEntityReadable(Response)}, which
+     * also buffers, so that both the diagnostic logging here and any later reader of the same response can read it
+     * rather than relying on being the first to consume the single-shot entity stream.
      *
      * @param fallback message used when the body is absent, not JSON, unreadable or empty
      */
     private static String readErrorMessage(Response response, String fallback) {
-        if (!response.hasEntity()) {
+        if (!isEntityReadable(response)) {
             return fallback;
         }
-        bufferEntitySafely(response);
         var mediaType = response.getMediaType();
         if (mediaType == null || !MediaType.APPLICATION_JSON_TYPE.isCompatible(mediaType)) {
             log.warn("React service replied with a non-JSON error body, status: '{}', contentType: '{}', body: '{}'",

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
@@ -286,10 +286,27 @@ class RemoteAuthService implements AuthService {
 
     private static String readBodySafely(Response response) {
         try {
-            return response.hasEntity() ? response.readEntity(String.class) : "";
+            if (!response.hasEntity()) {
+                return "";
+            }
+            bufferEntitySafely(response);
+            return response.readEntity(String.class);
         } catch (RuntimeException e) {
-            log.warn("Failed to read remote response body for debugging: {}", e.getMessage());
+            log.warn("Failed to read remote response body for debugging", e);
             return "";
+        }
+    }
+
+    /**
+     * Buffers the response entity so it can be read more than once. A client response entity is backed by a single-shot
+     * input stream, so without buffering the first reader consumes it and every later read fails. Buffering is
+     * idempotent, so callers do not need to track whether it already happened.
+     */
+    private static void bufferEntitySafely(Response response) {
+        try {
+            response.bufferEntity();
+        } catch (RuntimeException e) {
+            log.warn("Failed to buffer remote response entity, status: '{}'", response.getStatus(), e);
         }
     }
 
@@ -306,8 +323,9 @@ class RemoteAuthService implements AuthService {
      * <p>
      * Only a JSON body is treated as a message intended for the caller. Any other content type is a framework-level
      * response rather than an application error, so it is logged and the caller-facing {@code fallback} is used instead
-     * of leaking the remote framework's wording. The entity is read at most once, since a client response stream
-     * cannot be consumed twice.
+     * of leaking the remote framework's wording. The entity is buffered up front so that both the diagnostic logging
+     * here and any later reader of the same response can read it, rather than relying on being the first to consume the
+     * single-shot entity stream.
      *
      * @param fallback message used when the body is absent, not JSON, unreadable or empty
      */
@@ -315,18 +333,21 @@ class RemoteAuthService implements AuthService {
         if (!response.hasEntity()) {
             return fallback;
         }
+        bufferEntitySafely(response);
         var mediaType = response.getMediaType();
         if (mediaType == null || !MediaType.APPLICATION_JSON_TYPE.isCompatible(mediaType)) {
-            log.warn("React service replied status {} with non-JSON content type '{}', body: '{}'",
+            log.warn("React service replied with a non-JSON error body, status: '{}', contentType: '{}', body: '{}'",
                     response.getStatus(), mediaType, readBodySafely(response));
             return fallback;
         }
         try {
-            var message = response.readEntity(ReactServiceErrorResponse.class).msg();
-            return StringUtils.isBlank(message) ? fallback : message.strip();
+            var errorResponse = response.readEntity(ReactServiceErrorResponse.class);
+            return errorResponse == null || StringUtils.isBlank(errorResponse.msg())
+                    ? fallback
+                    : errorResponse.msg().strip();
         } catch (RuntimeException e) {
-            log.warn("Failed to read react service error response, status: {}, error: {}",
-                    response.getStatus(), e.getMessage());
+            log.warn("Failed to read react service error response, status: '{}', body: '{}'",
+                    response.getStatus(), readBodySafely(response), e);
             return fallback;
         }
     }
@@ -478,7 +499,7 @@ class RemoteAuthService implements AuthService {
             return response.readEntity(String.class);
         } else if (response.getStatus() == Response.Status.BAD_REQUEST.getStatusCode()) {
             var message = readErrorMessage(response, MISSING_WORKSPACE);
-            log.error("Not found workspace by name : {}", message);
+            log.error("Workspace not found by name: '{}'", message);
             throw new ClientErrorException(message, Response.Status.BAD_REQUEST);
         }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
@@ -293,6 +293,44 @@ class RemoteAuthService implements AuthService {
         }
     }
 
+    /**
+     * Extracts the error message from a non-successful react-service response without assuming the body is JSON.
+     * <p>
+     * The react service does not always answer with a {@link ReactServiceErrorResponse}: endpoints guarded by
+     * Dropwizard's {@code @Auth} filter (for example {@code /opik/auth-session}) reject an expired or invalid session
+     * cookie through the default {@code UnauthorizedHandler}, which replies {@code 401} with a {@code text/plain} body.
+     * Reading such a response as {@link ReactServiceErrorResponse} makes Jersey raise
+     * {@code MessageBodyProviderNotFoundException}, a {@code ProcessingException} that is not a
+     * {@link ClientErrorException} and therefore escapes the auth filter and surfaces as a {@code 500} instead of the
+     * intended client error.
+     * <p>
+     * Only a JSON body is treated as a message intended for the caller. Any other content type is a framework-level
+     * response rather than an application error, so it is logged and the caller-facing {@code fallback} is used instead
+     * of leaking the remote framework's wording. The entity is read at most once, since a client response stream
+     * cannot be consumed twice.
+     *
+     * @param fallback message used when the body is absent, not JSON, unreadable or empty
+     */
+    private static String readErrorMessage(Response response, String fallback) {
+        if (!response.hasEntity()) {
+            return fallback;
+        }
+        var mediaType = response.getMediaType();
+        if (mediaType == null || !MediaType.APPLICATION_JSON_TYPE.isCompatible(mediaType)) {
+            log.warn("React service replied status {} with non-JSON content type '{}', body: '{}'",
+                    response.getStatus(), mediaType, readBodySafely(response));
+            return fallback;
+        }
+        try {
+            var message = response.readEntity(ReactServiceErrorResponse.class).msg();
+            return StringUtils.isBlank(message) ? fallback : message.strip();
+        } catch (RuntimeException e) {
+            log.warn("Failed to read react service error response, status: {}, error: {}",
+                    response.getStatus(), e.getMessage());
+            return fallback;
+        }
+    }
+
     private void authenticateUsingSessionToken(Cookie sessionToken, String workspaceName, String path,
             List<String> requiredPermissions) {
         if (isDefaultWorkspace(workspaceName)) {
@@ -371,15 +409,15 @@ class RemoteAuthService implements AuthService {
             }
             return authResponse;
         } else if (response.getStatus() == Response.Status.UNAUTHORIZED.getStatusCode()) {
-            var errorResponse = response.readEntity(ReactServiceErrorResponse.class);
-            throw new ClientErrorException(errorResponse.msg(), Response.Status.UNAUTHORIZED);
+            throw new ClientErrorException(readErrorMessage(response, NOT_LOGGED_USER),
+                    Response.Status.UNAUTHORIZED);
         } else if (response.getStatus() == Response.Status.FORBIDDEN.getStatusCode()) {
             // EM never returns FORBIDDEN as of now
             throw new ClientErrorException(
                     NOT_ALLOWED_TO_ACCESS_WORKSPACE, Response.Status.FORBIDDEN);
         } else if (response.getStatus() == Response.Status.BAD_REQUEST.getStatusCode()) {
-            var errorResponse = response.readEntity(ReactServiceErrorResponse.class);
-            throw new ClientErrorException(errorResponse.msg(), Response.Status.BAD_REQUEST);
+            throw new ClientErrorException(readErrorMessage(response, MISSING_WORKSPACE),
+                    Response.Status.BAD_REQUEST);
         }
         throw unexpectedRemoteError("authenticating user", response);
     }
@@ -439,9 +477,9 @@ class RemoteAuthService implements AuthService {
         if (response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL) {
             return response.readEntity(String.class);
         } else if (response.getStatus() == Response.Status.BAD_REQUEST.getStatusCode()) {
-            var errorResponse = response.readEntity(ReactServiceErrorResponse.class);
-            log.error("Not found workspace by name : {}", errorResponse.msg());
-            throw new ClientErrorException(errorResponse.msg(), Response.Status.BAD_REQUEST);
+            var message = readErrorMessage(response, MISSING_WORKSPACE);
+            log.error("Not found workspace by name : {}", message);
+            throw new ClientErrorException(message, Response.Status.BAD_REQUEST);
         }
 
         throw unexpectedRemoteError("getting workspace id", response);

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -326,6 +327,21 @@ class RemoteAuthService implements AuthService {
     }
 
     /**
+     * Reports whether the body should be read as JSON, matching what the registered Jackson provider actually parses
+     * rather than only the exact {@code application/json} type. A structured suffix ({@code application/problem+json})
+     * and a non-{@code application} type ({@code text/json}) both deserialize fine, so gating on
+     * {@code APPLICATION_JSON_TYPE.isCompatible} would discard a perfectly good remote message. A wildcard or absent
+     * type tells us nothing about the body and is not treated as JSON.
+     */
+    private static boolean isJson(MediaType mediaType) {
+        if (mediaType == null || MediaType.MEDIA_TYPE_WILDCARD.equals(mediaType.getSubtype())) {
+            return false;
+        }
+        var subtype = mediaType.getSubtype().toLowerCase(Locale.ROOT);
+        return "json".equals(subtype) || subtype.endsWith("+json");
+    }
+
+    /**
      * Extracts the error message from a non-successful react-service response without assuming the body is JSON.
      * <p>
      * The react service does not always answer with a {@link ReactServiceErrorResponse}: endpoints guarded by
@@ -349,7 +365,7 @@ class RemoteAuthService implements AuthService {
             return fallback;
         }
         var mediaType = response.getMediaType();
-        if (mediaType == null || !MediaType.APPLICATION_JSON_TYPE.isCompatible(mediaType)) {
+        if (!isJson(mediaType)) {
             log.warn("React service replied with a non-JSON error body, status: '{}', contentType: '{}', body: '{}'",
                     response.getStatus(), mediaType, readBodySafely(response));
             return fallback;

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
@@ -331,13 +331,17 @@ class RemoteAuthService implements AuthService {
      * rather than only the exact {@code application/json} type. A structured suffix ({@code application/problem+json})
      * and a non-{@code application} type ({@code text/json}) both deserialize fine, so gating on
      * {@code APPLICATION_JSON_TYPE.isCompatible} would discard a perfectly good remote message. A wildcard or absent
-     * type tells us nothing about the body and is not treated as JSON.
+     * type tells us nothing about the body and is not treated as JSON — including a wildcard carrying the suffix
+     * ({@code application/*+json}), which is not a legal response content type in the first place.
      */
     private static boolean isJson(MediaType mediaType) {
-        if (mediaType == null || MediaType.MEDIA_TYPE_WILDCARD.equals(mediaType.getSubtype())) {
+        if (mediaType == null) {
             return false;
         }
         var subtype = mediaType.getSubtype().toLowerCase(Locale.ROOT);
+        if (subtype.contains(MediaType.MEDIA_TYPE_WILDCARD)) {
+            return false;
+        }
         return "json".equals(subtype) || subtype.endsWith("+json");
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
@@ -75,6 +75,7 @@ class RemoteAuthServiceTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String NOT_LOGGED_USER = "Please login first";
     private static final String DROPWIZARD_UNAUTHORIZED_BODY = "Credentials are required to access this resource.";
+    private static final String REMOTE_ERROR_MESSAGE = "remote error message";
 
     private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
 
@@ -510,6 +511,68 @@ class RemoteAuthServiceTest {
                 arguments(HttpStatus.SC_UNAUTHORIZED, "{\"msg\":\"   \"}", NOT_LOGGED_USER),
                 arguments(HttpStatus.SC_UNAUTHORIZED, "{}", NOT_LOGGED_USER),
                 arguments(HttpStatus.SC_BAD_REQUEST, "not json at all", MISSING_WORKSPACE));
+    }
+
+    static Stream<Arguments> errorBodyContentTypeArgs() {
+        return Stream.of(
+                arguments("application/json", REMOTE_ERROR_MESSAGE),
+                arguments("application/json;charset=utf-8", REMOTE_ERROR_MESSAGE),
+                // Jackson parses a structured +json suffix and a non-application type just as happily, so gating on
+                // APPLICATION_JSON_TYPE.isCompatible would discard a remote message these used to surface
+                arguments("application/problem+json", REMOTE_ERROR_MESSAGE),
+                arguments("text/json", REMOTE_ERROR_MESSAGE),
+                // these say nothing about the body, so the caller-facing fallback is used instead
+                arguments("application/octet-stream", NOT_LOGGED_USER),
+                arguments("text/plain", NOT_LOGGED_USER),
+                arguments("*/*", NOT_LOGGED_USER));
+    }
+
+    /**
+     * Pins which content types are still read as JSON. Anything the Jackson provider can deserialize must keep
+     * surfacing the remote {@code msg()}, exactly as it did before this class started gating on the content type;
+     * everything else resolves to the caller-facing fallback instead of a server error.
+     */
+    @ParameterizedTest
+    @MethodSource("errorBodyContentTypeArgs")
+    void testSessionAuth__whenRemoteRepliesUnauthorized__thenOnlyJsonContentTypesSurfaceRemoteMessage(
+            String contentType, String expectedMessage) {
+        var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        var sessionTokenValue = "session-" + UUID.randomUUID();
+        WIRE_MOCK.server().stubFor(post("/opik/auth-session")
+                .willReturn(aResponse().withStatus(HttpStatus.SC_UNAUTHORIZED)
+                        .withHeader("Content-Type", contentType)
+                        .withBody("{\"msg\":\"%s\",\"code\":401}".formatted(REMOTE_ERROR_MESSAGE))));
+
+        assertThatThrownBy(() -> remoteAuthService.authenticate(
+                getHeadersMock(workspaceName, ""),
+                sessionCookie(sessionTokenValue),
+                ContextInfoHolder.builder()
+                        .uriInfo(createMockUriInfo("/priv/something"))
+                        .method("GET")
+                        .build()))
+                .isExactlyInstanceOf(ClientErrorException.class)
+                .hasMessage(expectedMessage)
+                .satisfies(throwable -> assertThat(((ClientErrorException) throwable).getResponse().getStatus())
+                        .isEqualTo(HttpStatus.SC_UNAUTHORIZED));
+    }
+
+    @Test
+    void testSessionAuth__whenRemoteRepliesUnauthorizedWithoutContentType__thenFallbackMessage() {
+        var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        var sessionTokenValue = "session-" + UUID.randomUUID();
+        WIRE_MOCK.server().stubFor(post("/opik/auth-session")
+                .willReturn(aResponse().withStatus(HttpStatus.SC_UNAUTHORIZED)
+                        .withBody("{\"msg\":\"%s\",\"code\":401}".formatted(REMOTE_ERROR_MESSAGE))));
+
+        assertThatThrownBy(() -> remoteAuthService.authenticate(
+                getHeadersMock(workspaceName, ""),
+                sessionCookie(sessionTokenValue),
+                ContextInfoHolder.builder()
+                        .uriInfo(createMockUriInfo("/priv/something"))
+                        .method("GET")
+                        .build()))
+                .isExactlyInstanceOf(ClientErrorException.class)
+                .hasMessage(NOT_LOGGED_USER);
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
@@ -428,7 +428,7 @@ class RemoteAuthServiceTest {
 
     @ParameterizedTest
     @MethodSource("nonJsonErrorBodyArgs")
-    void testSessionAuth__whenRemoteErrorBodyIsNotJson__thenClientErrorInsteadOfServerError(
+    void sessionAuth__whenRemoteErrorBodyIsNotJson__thenClientErrorInsteadOfServerError(
             int remoteAuthStatusCode, String contentType, String body, String expectedMessage) {
         var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
         var sessionTokenValue = "session-" + UUID.randomUUID();
@@ -452,7 +452,7 @@ class RemoteAuthServiceTest {
 
     @ParameterizedTest
     @MethodSource("nonJsonErrorBodyArgs")
-    void testAuth__whenRemoteErrorBodyIsNotJson__thenClientErrorInsteadOfServerError(
+    void auth__whenRemoteErrorBodyIsNotJson__thenClientErrorInsteadOfServerError(
             int remoteAuthStatusCode, String contentType, String body, String expectedMessage) {
         var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
         var apiKey = "apiKey-" + UUID.randomUUID();
@@ -481,7 +481,7 @@ class RemoteAuthServiceTest {
      */
     @ParameterizedTest
     @MethodSource("malformedJsonErrorBodyArgs")
-    void testSessionAuth__whenRemoteErrorBodyIsMalformedJson__thenClientErrorAndBodyReReadForDiagnostics(
+    void sessionAuth__whenRemoteErrorBodyIsMalformedJson__thenClientErrorAndBodyReReadForDiagnostics(
             int remoteAuthStatusCode, String body, String expectedMessage) {
         var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
         var sessionTokenValue = "session-" + UUID.randomUUID();
@@ -538,7 +538,7 @@ class RemoteAuthServiceTest {
      */
     @ParameterizedTest
     @MethodSource("errorBodyContentTypeArgs")
-    void testSessionAuth__whenRemoteRepliesUnauthorized__thenJsonSubtypesSurfaceRemoteMessage(
+    void sessionAuth__whenRemoteRepliesUnauthorized__thenJsonSubtypesSurfaceRemoteMessage(
             String contentType, String expectedMessage) {
         var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
         var sessionTokenValue = "session-" + UUID.randomUUID();
@@ -561,7 +561,7 @@ class RemoteAuthServiceTest {
     }
 
     @Test
-    void testSessionAuth__whenRemoteRepliesUnauthorizedWithoutContentType__thenFallbackMessage() {
+    void sessionAuth__whenRemoteRepliesUnauthorizedWithoutContentType__thenFallbackMessage() {
         var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
         var sessionTokenValue = "session-" + UUID.randomUUID();
         WIRE_MOCK.server().stubFor(post("/opik/auth-session")

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
@@ -74,6 +74,7 @@ class RemoteAuthServiceTest {
     private static final WireMockUtils.WireMockRuntime WIRE_MOCK = WireMockUtils.startWireMock();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String NOT_LOGGED_USER = "Please login first";
+    private static final String DROPWIZARD_UNAUTHORIZED_BODY = "Credentials are required to access this resource.";
 
     private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
 
@@ -411,6 +412,62 @@ class RemoteAuthServiceTest {
                         .build()))
                 .isExactlyInstanceOf(expectedExceptionClass)
                 .hasMessage(expectedMessage);
+    }
+
+    static Stream<Arguments> nonJsonErrorBodyArgs() {
+        return Stream.of(
+                // Dropwizard's default UnauthorizedHandler, used by the @Auth filter guarding /opik/auth-session
+                arguments(HttpStatus.SC_UNAUTHORIZED, "text/plain", DROPWIZARD_UNAUTHORIZED_BODY, NOT_LOGGED_USER),
+                arguments(HttpStatus.SC_UNAUTHORIZED, "text/html", "<html><body>401</body></html>", NOT_LOGGED_USER),
+                arguments(HttpStatus.SC_UNAUTHORIZED, "text/plain", "", NOT_LOGGED_USER),
+                arguments(HttpStatus.SC_BAD_REQUEST, "text/plain", "Bad Request", MISSING_WORKSPACE));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonJsonErrorBodyArgs")
+    void testSessionAuth__whenRemoteErrorBodyIsNotJson__thenClientErrorInsteadOfServerError(
+            int remoteAuthStatusCode, String contentType, String body, String expectedMessage) {
+        var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        var sessionTokenValue = "session-" + UUID.randomUUID();
+        WIRE_MOCK.server().stubFor(post("/opik/auth-session")
+                .willReturn(aResponse().withStatus(remoteAuthStatusCode)
+                        .withHeader("Content-Type", contentType)
+                        .withBody(body)));
+
+        assertThatThrownBy(() -> remoteAuthService.authenticate(
+                getHeadersMock(workspaceName, ""),
+                sessionCookie(sessionTokenValue),
+                ContextInfoHolder.builder()
+                        .uriInfo(createMockUriInfo("/priv/something"))
+                        .method("GET")
+                        .build()))
+                .isExactlyInstanceOf(ClientErrorException.class)
+                .hasMessage(expectedMessage)
+                .satisfies(throwable -> assertThat(((ClientErrorException) throwable).getResponse().getStatus())
+                        .isEqualTo(remoteAuthStatusCode));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonJsonErrorBodyArgs")
+    void testAuth__whenRemoteErrorBodyIsNotJson__thenClientErrorInsteadOfServerError(
+            int remoteAuthStatusCode, String contentType, String body, String expectedMessage) {
+        var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        var apiKey = "apiKey-" + UUID.randomUUID();
+        WIRE_MOCK.server().stubFor(post("/opik/auth")
+                .willReturn(aResponse().withStatus(remoteAuthStatusCode)
+                        .withHeader("Content-Type", contentType)
+                        .withBody(body)));
+
+        assertThatThrownBy(() -> remoteAuthService.authenticate(
+                getHeadersMock(workspaceName, apiKey), null,
+                ContextInfoHolder.builder()
+                        .uriInfo(createMockUriInfo("/priv/something"))
+                        .method("GET")
+                        .build()))
+                .isExactlyInstanceOf(ClientErrorException.class)
+                .hasMessage(expectedMessage)
+                .satisfies(throwable -> assertThat(((ClientErrorException) throwable).getResponse().getStatus())
+                        .isEqualTo(remoteAuthStatusCode));
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
@@ -524,17 +524,21 @@ class RemoteAuthServiceTest {
                 // these say nothing about the body, so the caller-facing fallback is used instead
                 arguments("application/octet-stream", NOT_LOGGED_USER),
                 arguments("text/plain", NOT_LOGGED_USER),
-                arguments("*/*", NOT_LOGGED_USER));
+                arguments("*/*", NOT_LOGGED_USER),
+                // a wildcard is not a legal response content type, so it is not trusted even with the +json suffix
+                arguments("application/*", NOT_LOGGED_USER),
+                arguments("application/*+json", NOT_LOGGED_USER));
     }
 
     /**
-     * Pins which content types are still read as JSON. Anything the Jackson provider can deserialize must keep
-     * surfacing the remote {@code msg()}, exactly as it did before this class started gating on the content type;
-     * everything else resolves to the caller-facing fallback instead of a server error.
+     * Pins which content types are read as JSON: subtype {@code json} or a {@code +json} structured suffix. Anything
+     * the Jackson provider can deserialize must keep surfacing the remote {@code msg()}, exactly as it did before this
+     * class started gating on the content type; everything else resolves to the caller-facing fallback instead of a
+     * server error.
      */
     @ParameterizedTest
     @MethodSource("errorBodyContentTypeArgs")
-    void testSessionAuth__whenRemoteRepliesUnauthorized__thenOnlyJsonContentTypesSurfaceRemoteMessage(
+    void testSessionAuth__whenRemoteRepliesUnauthorized__thenJsonSubtypesSurfaceRemoteMessage(
             String contentType, String expectedMessage) {
         var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
         var sessionTokenValue = "session-" + UUID.randomUUID();

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
@@ -470,6 +470,46 @@ class RemoteAuthServiceTest {
                         .isEqualTo(remoteAuthStatusCode));
     }
 
+    /**
+     * The content type claims JSON but the body is not parseable, so the JSON branch is entered and
+     * {@code readEntity} fails. Pins the client-facing outcome of that recovery path: a client error carrying the
+     * fallback message, never a server error. The path also re-reads the raw body for diagnostics, which is what the
+     * up-front buffering enables; the logged body itself is not asserted here.
+     */
+    @ParameterizedTest
+    @MethodSource("malformedJsonErrorBodyArgs")
+    void testSessionAuth__whenRemoteErrorBodyIsMalformedJson__thenClientErrorAndBodyReReadForDiagnostics(
+            int remoteAuthStatusCode, String body, String expectedMessage) {
+        var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        var sessionTokenValue = "session-" + UUID.randomUUID();
+        WIRE_MOCK.server().stubFor(post("/opik/auth-session")
+                .willReturn(aResponse().withStatus(remoteAuthStatusCode)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(body)));
+
+        assertThatThrownBy(() -> remoteAuthService.authenticate(
+                getHeadersMock(workspaceName, ""),
+                sessionCookie(sessionTokenValue),
+                ContextInfoHolder.builder()
+                        .uriInfo(createMockUriInfo("/priv/something"))
+                        .method("GET")
+                        .build()))
+                .isExactlyInstanceOf(ClientErrorException.class)
+                .hasMessage(expectedMessage)
+                .satisfies(throwable -> assertThat(((ClientErrorException) throwable).getResponse().getStatus())
+                        .isEqualTo(remoteAuthStatusCode));
+    }
+
+    static Stream<Arguments> malformedJsonErrorBodyArgs() {
+        return Stream.of(
+                arguments(HttpStatus.SC_UNAUTHORIZED, "not json at all", NOT_LOGGED_USER),
+                arguments(HttpStatus.SC_UNAUTHORIZED, "{\"msg\":", NOT_LOGGED_USER),
+                // valid JSON, but no usable message for the caller
+                arguments(HttpStatus.SC_UNAUTHORIZED, "{\"msg\":\"   \"}", NOT_LOGGED_USER),
+                arguments(HttpStatus.SC_UNAUTHORIZED, "{}", NOT_LOGGED_USER),
+                arguments(HttpStatus.SC_BAD_REQUEST, "not json at all", MISSING_WORKSPACE));
+    }
+
     @Test
     void testListEligibleWorkspaces__filtersDefaultWorkspaceAndMapsToWorkspaceInfo() throws JsonProcessingException {
         var sessionTokenValue = "session-" + UUID.randomUUID();

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
@@ -420,6 +420,8 @@ class RemoteAuthServiceTest {
                 arguments(HttpStatus.SC_UNAUTHORIZED, "text/plain", DROPWIZARD_UNAUTHORIZED_BODY, NOT_LOGGED_USER),
                 arguments(HttpStatus.SC_UNAUTHORIZED, "text/html", "<html><body>401</body></html>", NOT_LOGGED_USER),
                 arguments(HttpStatus.SC_UNAUTHORIZED, "text/plain", "", NOT_LOGGED_USER),
+                // a proxy error page far larger than the logged-body cap must still resolve to a client error
+                arguments(HttpStatus.SC_UNAUTHORIZED, "text/html", "x".repeat(5_000), NOT_LOGGED_USER),
                 arguments(HttpStatus.SC_BAD_REQUEST, "text/plain", "Bad Request", MISSING_WORKSPACE));
     }
 


### PR DESCRIPTION
## Details

`RemoteAuthService.verifyResponse` read non-successful react-service replies as `ReactServiceErrorResponse` unconditionally. That assumption does not hold for endpoints guarded by Dropwizard's `@Auth` filter (`/opik/auth-session`): an expired or invalid session cookie is rejected by the default `UnauthorizedHandler`, which answers `401` with a `text/plain` body. Reading it as JSON made Jersey raise `MessageBodyProviderNotFoundException` — a `ProcessingException`, not a `ClientErrorException` — so it escaped `AuthFilter` and was mapped by `LoggingExceptionMapper` to a **`500`** instead of the intended `401`. Clients could not tell an expired session from a server fault, so the UI never prompted for re-login and every in-flight request on the page failed at once.

- New `readErrorMessage` helper reads the remote message only when the response body is actually JSON; any other content type is logged (status, content type, raw body) and a caller-facing fallback message is used, so remote framework wording is never surfaced to the client.
- Applied to the `401` and `400` branches of `verifyResponse` and to the `400` branch of `getWorkspaceIdFromResponse`.
- The entity is read at most once, since a client response stream cannot be consumed twice.
- Status codes are unchanged: `401` stays `401`, `400` stays `400`. Behaviour for JSON error bodies is unchanged.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-4324

<!-- Duplicate ticket OPIK_1606 tracks the same defect and is linked in Jira. -->

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Root-cause investigation from production logs, the `readErrorMessage` helper and its call sites, and the new parameterized regression tests.
- Human verification: Author reviewed the diff, confirmed the failure mode against production logs and the upstream Dropwizard `DefaultUnauthorizedHandler` source, and ran the test suite locally both with and without the fix.

## Testing

`mvn -o surefire:test -Dtest='RemoteAuthServiceTest'` in `apps/opik-backend` — **37 tests pass** (29 before, 8 new).

Added `nonJsonErrorBodyArgs` and drove it through both auth paths (`testSessionAuth__whenRemoteErrorBodyIsNotJson__thenClientErrorInsteadOfServerError` and `testAuth__whenRemoteErrorBodyIsNotJson__thenClientErrorInsteadOfServerError`), covering:

| Remote reply | Expected |
|---|---|
| `401` `text/plain` with Dropwizard's exact default body | `ClientErrorException`, status `401`, message `Please login first` |
| `401` `text/html` | `ClientErrorException`, status `401` |
| `401` `text/plain` with an empty body | `ClientErrorException`, status `401` |
| `400` `text/plain` | `ClientErrorException`, status `400`, fallback message |

Regression check: with the production change reverted and only the tests applied, all 8 fail with exactly the reported `MessageBodyProviderNotFoundException: MessageBodyReader not found for media type=text/plain, type=class com.comet.opik.api.ReactServiceErrorResponse` — so the tests are not vacuous. Existing JSON-body coverage (`unauthorizedArgs`, gzip/identity-encoding, cache-hit, workspace-authorization) still passes unchanged.

Not run locally: the full backend suite and the resource-level integration tests, which need the container harness — left to CI.

## Documentation

No documentation change: internal error-handling fix with no API-surface or configuration change.
