### PR TITLE
[OPIK-7499] [BE] fix: build parseable JSONPaths for dictionary filter keys

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -1423,7 +1423,7 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                                     .doFinally(signalType -> endSegment(segmentContent))
                                     .flatMap(DatasetItemResultMapper::mapItem)
                                     .collectList()
-                                    .onErrorResume(e -> handleSqlError(e, List.of()))
+                                    .onErrorResume(e -> ErrorUtils.handleMalformedJsonPath(e, List.of()))
                                     .flatMap(
                                             items -> Mono
                                                     .just(new DatasetItemPage(items, page, items.size(), total, columns,
@@ -1459,7 +1459,7 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
             return Flux.from(statement.execute())
                     .flatMap(DatasetItemResultMapper::mapCount)
                     .reduce(0L, Long::sum)
-                    .onErrorResume(e -> handleSqlError(e, 0L))
+                    .onErrorResume(e -> ErrorUtils.handleMalformedJsonPath(e, 0L))
                     .doFinally(signalType -> endSegment(segment));
         }));
     }
@@ -1477,14 +1477,6 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                     .flatMap(result -> DatasetItemResultMapper.mapColumns(result, "data"));
         }))
                 .doFinally(signalType -> endSegment(segment));
-    }
-
-    private <T> Mono<T> handleSqlError(Throwable e, T defaultValue) {
-        // A user-supplied malformed JSON path is rejected by ClickHouse; treat it as an empty result.
-        if (ErrorUtils.isMalformedJsonPath(e)) {
-            return Mono.just(defaultValue);
-        }
-        return Mono.error(e);
     }
 
     @WithSpan

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -2758,7 +2758,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                                 .doFinally(signalType -> endSegment(segment))
                                 .flatMap(DatasetItemResultMapper::mapItem)
                                 .collectList()
-                                .onErrorResume(e -> handleSqlError(e, List.of()))
+                                .onErrorResume(e -> ErrorUtils.handleMalformedJsonPath(e, List.of()))
                                 .map(items -> new DatasetItemPage(items, page, items.size(), total, columns,
                                         sortingFactory.getSortableFields()));
                     });
@@ -2883,7 +2883,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                                     .doFinally(signalType -> endSegment(segment))
                                     .flatMap(DatasetItemResultMapper::mapItem)
                                     .collectList()
-                                    .onErrorResume(e -> handleSqlError(e, List.of()))
+                                    .onErrorResume(e -> ErrorUtils.handleMalformedJsonPath(e, List.of()))
                                     .zipWith(getCountWithExperimentFilters(criteria, versionId,
                                             targetProjectIds, hasAggregated, hasRaw))
                                     .zipWith(getColumns(criteria.datasetId(), versionId))
@@ -2900,14 +2900,6 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                         });
                     });
         });
-    }
-
-    private <T> Mono<T> handleSqlError(Throwable e, T defaultValue) {
-        // A user-supplied malformed JSON path is rejected by ClickHouse; treat it as an empty result.
-        if (ErrorUtils.isMalformedJsonPath(e)) {
-            return Mono.just(defaultValue);
-        }
-        return Mono.error(e);
     }
 
     /**
@@ -3050,7 +3042,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                         .doFinally(signalType -> endSegment(segment))
                         .flatMap(result -> result.map((row, meta) -> row.get("count", Long.class)))
                         .reduce(0L, Long::sum)
-                        .onErrorResume(e -> handleSqlError(e, 0L));
+                        .onErrorResume(e -> ErrorUtils.handleMalformedJsonPath(e, 0L));
             });
         });
     }
@@ -3074,7 +3066,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     .doFinally(signalType -> endSegment(segment))
                     .flatMap(result -> result.map((row, meta) -> row.get("count", Long.class)))
                     .reduce(0L, Long::sum)
-                    .onErrorResume(e -> handleSqlError(e, 0L));
+                    .onErrorResume(e -> ErrorUtils.handleMalformedJsonPath(e, 0L));
         });
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/GroupingQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/GroupingQueryBuilder.java
@@ -1,6 +1,7 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.grouping.GroupBy;
+import com.comet.opik.domain.filter.JsonPathUtils;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.BadRequestException;
 import lombok.NonNull;
@@ -10,8 +11,6 @@ import org.stringtemplate.v4.ST;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
-import static com.comet.opik.domain.filter.FilterQueryBuilder.JSONPATH_ROOT;
 
 @Singleton
 @Slf4j
@@ -60,21 +59,8 @@ public class GroupingQueryBuilder {
 
     private String getKeyAndValidate(GroupBy group) {
 
-        String key = getKey(group);
+        String key = JsonPathUtils.toRootedJsonPath(group.key());
         return isValidJsonPath(key) ? key : DUMMY_JSON_KEY;
-    }
-
-    private String getKey(GroupBy group) {
-
-        if (group.key().startsWith(JSONPATH_ROOT)) {
-            return group.key();
-        }
-
-        if (group.key().startsWith("[") || group.key().startsWith(".")) {
-            return "%s%s".formatted(JSONPATH_ROOT, group.key());
-        }
-
-        return "%s.%s".formatted(JSONPATH_ROOT, group.key());
     }
 
     static boolean isValidJsonPath(String path) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -21,6 +21,7 @@ import com.comet.opik.domain.workspaces.WorkspacesService;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.utils.ClickHouseDateTimeFormat;
+import com.comet.opik.utils.ErrorUtils;
 import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.TruncationUtils;
 import com.comet.opik.utils.UsageUtils;
@@ -2533,7 +2534,9 @@ public class SpanDAO {
     @WithSpan
     public Mono<SpanPage> find(int page, int size, @NonNull SpanSearchCriteria spanSearchCriteria) {
         log.info("Finding span by '{}'", spanSearchCriteria);
-        return countTotal(spanSearchCriteria).flatMap(total -> find(page, size, spanSearchCriteria, total));
+        return countTotal(spanSearchCriteria).flatMap(total -> find(page, size, spanSearchCriteria, total))
+                .onErrorResume(e -> ErrorUtils.handleMalformedJsonPath(e,
+                        SpanPage.empty(page, sortingFactory.getSortableFields())));
     }
 
     @WithSpan
@@ -2588,7 +2591,8 @@ public class SpanDAO {
                 .buffer(limit > 100 ? limit / 2 : limit)
                 .concatWith(Mono.just(List.of()))
                 .filter(CollectionUtils::isNotEmpty)
-                .flatMap(Flux::fromIterable);
+                .flatMap(Flux::fromIterable)
+                .onErrorResume(ErrorUtils::isMalformedJsonPath, e -> Flux.empty());
     }
 
     private BigDecimal calculateCost(Span span) {
@@ -2969,7 +2973,8 @@ public class SpanDAO {
                             .singleOrEmpty();
 
                     return StatsMerger.zipAndMerge(spansMono, feedbackMono);
-                }));
+                }))
+                .onErrorResume(e -> ErrorUtils.handleMalformedJsonPath(e, ProjectStats.empty()));
     }
 
     @SuppressWarnings("unchecked")

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -28,6 +28,7 @@ import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.utils.ClickHouseDateTimeFormat;
+import com.comet.opik.utils.ErrorUtils;
 import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.TruncationUtils;
 import com.comet.opik.utils.template.TemplateUtils;
@@ -3740,7 +3741,9 @@ class TraceDAOImpl implements TraceDAO {
                         .flatMapMany(result1 -> mapToDto(result1, traceSearchCriteria.exclude()))
                         .collectList()
                         .map(traces -> new TracePage(page, traces.size(), total, traces,
-                                sortingFactory.getSortableFields())));
+                                sortingFactory.getSortableFields())))
+                .onErrorResume(e -> ErrorUtils.handleMalformedJsonPath(e,
+                        TracePage.empty(page, sortingFactory.getSortableFields())));
     }
 
     @Override
@@ -4289,7 +4292,8 @@ class TraceDAOImpl implements TraceDAO {
                     });
 
                     return StatsMerger.zipAndMerge(tracesSpansMono, feedbackMono);
-                }));
+                }))
+                .onErrorResume(e -> ErrorUtils.handleMalformedJsonPath(e, ProjectStats.empty()));
     }
 
     /**
@@ -4660,7 +4664,8 @@ class TraceDAOImpl implements TraceDAO {
                 .flatMap(result -> mapToDto(result, Set.of()))
                 .buffer(limit > 100 ? limit / 2 : limit)
                 .concatWith(Mono.just(List.of()))
-                .flatMap(Flux::fromIterable);
+                .flatMap(Flux::fromIterable)
+                .onErrorResume(ErrorUtils::isMalformedJsonPath, e -> Flux.empty());
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -1363,11 +1363,25 @@ public class FilterQueryBuilder {
         return "%s.\"%s\"".formatted(JSONPATH_ROOT, jsonKey);
     }
 
+    /**
+     * Resolves the key bound as {@code :filterKey} for a filter.
+     * <p>
+     * The analytics DB path is delegated to {@link JsonPathUtils#toAnalyticsDbJsonPath(String)} so that
+     * a key holding characters unquoted dot notation cannot express resolves normally instead of
+     * aborting the query. The state DB path is unchanged.
+     */
     private static String getKey(Filter filter) {
 
-        if (filter.key().startsWith(JSONPATH_ROOT)
-                || (filter.field().getType() != FieldType.DICTIONARY
-                        && filter.field().getType() != FieldType.DICTIONARY_STATE_DB)) {
+        if (filter.field().getType() != FieldType.DICTIONARY
+                && filter.field().getType() != FieldType.DICTIONARY_STATE_DB) {
+            return filter.key();
+        }
+
+        if (filter.field().getType() == FieldType.DICTIONARY) {
+            return JsonPathUtils.toAnalyticsDbJsonPath(filter.key());
+        }
+
+        if (filter.key().startsWith(JSONPATH_ROOT)) {
             return filter.key();
         }
 
@@ -1375,11 +1389,7 @@ public class FilterQueryBuilder {
             return "%s%s".formatted(JSONPATH_ROOT, filter.key());
         }
 
-        if (filter.field().getType() == FieldType.DICTIONARY_STATE_DB) {
-            return getSQLJsonPath(filter.key());
-        }
-
-        return "%s.%s".formatted(JSONPATH_ROOT, filter.key());
+        return getSQLJsonPath(filter.key());
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/JsonPathUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/JsonPathUtils.java
@@ -1,0 +1,204 @@
+package com.comet.opik.domain.filter;
+
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.comet.opik.domain.filter.FilterQueryBuilder.JSONPATH_ROOT;
+
+/**
+ * Builds the JSONPath expressions used to address dynamic dictionary fields (typically
+ * {@code metadata}) when querying the analytics DB.
+ * <p>
+ * ClickHouse parses the JSONPath argument of {@code JSON_VALUE} while it analyses the query, before
+ * execution starts. An expression it cannot parse therefore aborts the whole statement with
+ * {@code BAD_ARGUMENTS: Unable to parse JSONPath} rather than yielding no rows, and there is no
+ * runtime option that can soften it. The {@code RETURNING ... NULL ON ERROR} clause used elsewhere in
+ * {@link FilterQueryBuilder} for the state DB is MySQL-only syntax and ClickHouse rejects it outright.
+ * The path therefore has to be settled while it is being built.
+ * <p>
+ * Unquoted dot notation only accepts {@code [A-Za-z0-9_]} in a key, so a key holding any other
+ * character — a hyphen being by far the most common — cannot be expressed that way. Bracket notation
+ * accepts arbitrary characters once quoted and is used for those keys.
+ */
+@UtilityClass
+public class JsonPathUtils {
+
+    private static final Pattern DOT_NOTATION_SEGMENT = Pattern.compile("[A-Za-z0-9_]+");
+
+    /**
+     * A subscript that carries path meaning rather than being part of a key: an array index, a
+     * wildcard, or a quoted key. ClickHouse accepts either quote style, so both are recognised —
+     * treating {@code a["version"].b} as a literal key would resolve a different value than it does
+     * today.
+     */
+    private static final Pattern PATH_SUBSCRIPT = Pattern
+            .compile("\\[(?:\\d+|\\*|'(?:[^'\\\\]|\\\\.)*'|\"(?:[^\"\\\\]|\\\\.)*\")]");
+
+    private static final String PATH_SEPARATOR = ".";
+
+    /**
+     * Sentinel for "not inside a quoted segment" while scanning; otherwise the delimiter that opened
+     * the segment, so a bracket quoted with the other style is not miscounted.
+     */
+    private static final char NOT_QUOTED = 0;
+
+    /**
+     * Resolves a dictionary filter key into a JSONPath for the analytics DB.
+     * <p>
+     * A key that already carries JSONPath syntax was authored by the caller, so it is assembled
+     * exactly as before and only screened for damage. It is deliberately not matched against an
+     * allowlist of accepted shapes: ClickHouse accepts constructs such as wildcard indices
+     * ({@code version[*]}) that no such list here has enumerated, and rejecting them would silently
+     * break filters that work today.
+     * <p>
+     * Everything else is quoted segment by segment into bracket notation, which can express any
+     * character and therefore always parses. Two kinds of key land there:
+     * <ul>
+     * <li>a plain key using characters dot notation does not support, such as a hyphen. Quoting lets
+     * it resolve normally.</li>
+     * <li>an authored expression that is malformed. Quoting turns it into a literal key no document
+     * carries, so it matches nothing.</li>
+     * </ul>
+     * In both cases the query runs instead of aborting.
+     * <p>
+     * A plain key whose every segment is expressible in dot notation keeps producing the exact path it
+     * produced before, and the dot keeps its meaning as the segment separator throughout.
+     *
+     * @param key dictionary key, e.g. {@code environment} or {@code hidden_params.retry-count}
+     * @return the JSONPath, e.g. {@code $.environment} or {@code $['hidden_params']['retry-count']}
+     */
+    public static String toAnalyticsDbJsonPath(@NonNull String key) {
+        var segments = key.split("\\.", -1);
+
+        if (isPathExpression(key)) {
+            var path = toRootedJsonPath(key);
+
+            return isStructurallySound(path) ? path : toBracketNotation(segments);
+        }
+
+        return isExpressibleInDotNotation(segments)
+                ? toRootedJsonPath(key)
+                : toBracketNotation(segments);
+    }
+
+    private static boolean isPathExpression(String key) {
+        if (isRooted(key) || key.startsWith("[") || key.startsWith(PATH_SEPARATOR)) {
+            return true;
+        }
+
+        return hasSubscript(key) && everySubscriptCarriesPathMeaning(key);
+    }
+
+    /**
+     * A leading {@code $} only roots an expression when what follows continues the path: nothing at
+     * all, a separator, or a subscript. A key such as {@code $schema} or {@code $ref} merely begins
+     * with the character and is an ordinary key, so it is quoted rather than handed to ClickHouse as
+     * an expression it cannot parse.
+     */
+    private static boolean isRooted(String key) {
+        if (!key.startsWith(JSONPATH_ROOT)) {
+            return false;
+        }
+
+        var afterRoot = key.substring(JSONPATH_ROOT.length());
+
+        return afterRoot.isEmpty() || afterRoot.startsWith(PATH_SEPARATOR) || afterRoot.startsWith("[");
+    }
+
+    private static boolean hasSubscript(String key) {
+        return key.indexOf('[') >= 0 || key.indexOf(']') >= 0;
+    }
+
+    /**
+     * Distinguishes {@code version[*]}, where the brackets subscript the key, from
+     * {@code feature[beta]}, where they are part of the key itself. A bracket only means subscript if
+     * its content is an index, a wildcard or a quoted key; anything else leaves the whole thing a
+     * literal key, which is then quoted rather than handed to ClickHouse as path syntax.
+     */
+    private static boolean everySubscriptCarriesPathMeaning(String key) {
+        return !hasSubscript(PATH_SUBSCRIPT.matcher(key).replaceAll(""));
+    }
+
+    /**
+     * Screens an authored expression for damage that no JSONPath can survive: unbalanced brackets, an
+     * unterminated quote, or a trailing separator with nothing after it.
+     * <p>
+     * This only ever rejects expressions that cannot parse under any grammar, so a working filter
+     * cannot be turned into an empty one. It is not a completeness check — an expression that is
+     * well-formed here may still be rejected by ClickHouse.
+     */
+    private static boolean isStructurallySound(String path) {
+        if (path.endsWith(PATH_SEPARATOR)) {
+            return false;
+        }
+
+        var depth = 0;
+        var openQuote = NOT_QUOTED;
+
+        for (var i = 0; i < path.length(); i++) {
+            var current = path.charAt(i);
+
+            if (openQuote != NOT_QUOTED) {
+                if (current == '\\') {
+                    i++;
+                } else if (current == openQuote) {
+                    openQuote = NOT_QUOTED;
+                }
+                continue;
+            }
+
+            switch (current) {
+                case '\'', '"' -> openQuote = current;
+                case '[' -> depth++;
+                case ']' -> depth--;
+                default -> {
+                }
+            }
+
+            if (depth < 0) {
+                return false;
+            }
+        }
+
+        return depth == 0 && openQuote == NOT_QUOTED;
+    }
+
+    private static boolean isExpressibleInDotNotation(String[] segments) {
+        return Arrays.stream(segments).allMatch(segment -> DOT_NOTATION_SEGMENT.matcher(segment).matches());
+    }
+
+    /**
+     * Prefixes a key with the root so it reads as a path, e.g. {@code .a} and {@code a} both become
+     * {@code $.a}. Whatever syntax the key already carries — subscripts, wildcards, quoted segments —
+     * is left exactly as written; only the root is supplied. Shared with
+     * {@link com.comet.opik.domain.GroupingQueryBuilder} so the two agree on what a rooted path is.
+     */
+    public static String toRootedJsonPath(@NonNull String key) {
+        if (key.startsWith(JSONPATH_ROOT)) {
+            return key;
+        }
+
+        if (key.startsWith("[") || key.startsWith(PATH_SEPARATOR)) {
+            return "%s%s".formatted(JSONPATH_ROOT, key);
+        }
+
+        return "%s%s%s".formatted(JSONPATH_ROOT, PATH_SEPARATOR, key);
+    }
+
+    /**
+     * Renders {@code a.b-c} as {@code $['a']['b-c']}.
+     */
+    private static String toBracketNotation(String[] segments) {
+        return Arrays.stream(segments)
+                .map(JsonPathUtils::quoteSegment)
+                .collect(Collectors.joining("", JSONPATH_ROOT, ""));
+    }
+
+    private static String quoteSegment(String segment) {
+        return "['%s']".formatted(segment.replace("\\", "\\\\").replace("'", "\\'"));
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/ErrorUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/ErrorUtils.java
@@ -5,6 +5,7 @@ import jakarta.ws.rs.NotFoundException;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
@@ -23,6 +24,23 @@ public class ErrorUtils {
         return e instanceof ClickHouseException && e.getMessage() != null
                 && e.getMessage().contains("Unable to parse JSONPath")
                 && e.getMessage().contains("BAD_ARGUMENTS");
+    }
+
+    /**
+     * Recovers a read whose filter carried a JSON path ClickHouse could not parse, yielding
+     * {@code defaultValue} rather than surfacing a 500. ClickHouse rejects such a path while it
+     * analyses the query, so the failure arrives before any row is read and says nothing about the
+     * data; an empty result is the honest answer. Every other error is propagated untouched.
+     * <p>
+     * Filter keys are built to be parseable in the first place, so this only catches an expression a
+     * caller authored that survives construction but the server still refuses.
+     */
+    public static <T> Mono<T> handleMalformedJsonPath(@NonNull Throwable e, @NonNull T defaultValue) {
+        if (isMalformedJsonPath(e)) {
+            log.info("Filter used a JSON path ClickHouse cannot parse, returning an empty result");
+            return Mono.just(defaultValue);
+        }
+        return Mono.error(e);
     }
 
     public static NotFoundException failWithNotFound(@NonNull String entity, @NonNull String id) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindSpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindSpansResourceTest.java
@@ -2218,6 +2218,102 @@ class FindSpansResourceTest {
         }
 
         @ParameterizedTest
+        @ValueSource(strings = {"$..test", "$[abc]", "$.key with space", "[", "]", "[..]"})
+        @DisplayName("a malformed or non-matching metadata path returns empty stats rather than failing")
+        void whenFilterMetadataPathIsMalformedOrNonMatching__thenReturnEmptyStats(String key) {
+
+            String workspaceName = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var projectName = generator.generate().toString();
+            var spans = PodamFactoryUtils.manufacturePojoList(podamFactory, Span.class)
+                    .stream()
+                    .map(span -> span.toBuilder()
+                            .projectId(null)
+                            .projectName(projectName)
+                            .metadata(JsonUtils.getJsonNodeFromString("{\"model\":\"gpt-4\"}"))
+                            .feedbackScores(null)
+                            .totalEstimatedCost(null)
+                            .build())
+                    .toList();
+
+            spanResourceClient.batchCreateSpans(spans, apiKey, workspaceName);
+
+            var filters = List.of(SpanFilter.builder()
+                    .field(SpanField.METADATA)
+                    .operator(Operator.EQUAL)
+                    .key(key)
+                    .value("gpt-4")
+                    .build());
+
+            var actualStats = spanResourceClient.getSpansStats(projectName, null, filters, apiKey, workspaceName,
+                    Map.of());
+
+            assertThat(actualStats.stats()).isEmpty();
+
+            // The list endpoint recovers on a different path than stats, so assert it separately
+            var actualPage = spanResourceClient.findSpans(workspaceName, apiKey, projectName, null, 1, 10, null, null,
+                    filters, null, null);
+
+            assertThat(actualPage.content()).isEmpty();
+            assertThat(actualPage.total()).isZero();
+        }
+
+        @ParameterizedTest
+        @MethodSource("getFilterTestArguments")
+        void whenFilterMetadataKeyHasSpecialCharacters__thenReturnSpansFiltered(String endpoint,
+                SpanPageTestAssertion testAssertion) {
+
+            String workspaceName = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var projectName = generator.generate().toString();
+            var spans = PodamFactoryUtils.manufacturePojoList(podamFactory, Span.class)
+                    .stream()
+                    .map(span -> span.toBuilder()
+                            .projectId(null)
+                            .projectName(projectName)
+                            .metadata(JsonUtils.getJsonNodeFromString(
+                                    "{\"hidden_params\":{\"additional_headers\":{\"x-litellm-attempted-retries\":\"0\"}}}"))
+                            .feedbackScores(null)
+                            .totalEstimatedCost(null)
+                            .build())
+                    .collect(toCollection(ArrayList::new));
+            spans.set(0, spans.getFirst().toBuilder()
+                    .metadata(JsonUtils.getJsonNodeFromString(
+                            "{\"hidden_params\":{\"additional_headers\":{\"x-litellm-attempted-retries\":\"3\"}}}"))
+                    .build());
+
+            spanResourceClient.batchCreateSpans(spans, apiKey, workspaceName);
+
+            var expectedSpans = List.of(spans.getFirst());
+            var unexpectedSpans = List.of(podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .projectId(null)
+                    .build());
+
+            spanResourceClient.batchCreateSpans(unexpectedSpans, apiKey, workspaceName);
+
+            var filters = List.of(SpanFilter.builder()
+                    .field(SpanField.METADATA)
+                    .operator(Operator.EQUAL)
+                    .key("hidden_params.additional_headers.x-litellm-attempted-retries")
+                    .value("3")
+                    .build());
+
+            var values = testAssertion.transformTestParams(spans, expectedSpans, unexpectedSpans);
+
+            testAssertion.runTestAndAssert(projectName, null, apiKey, workspaceName, values.expected(),
+                    values.unexpected(),
+                    values.all(), filters, Map.of());
+        }
+
+        @ParameterizedTest
         @MethodSource("getFilterTestArguments")
         void whenFilterMetadataEqualNumber__thenReturnSpansFiltered(String endpoint,
                 SpanPageTestAssertion testAssertion) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/GetTracesByProjectResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/GetTracesByProjectResourceTest.java
@@ -1919,6 +1919,39 @@ class GetTracesByProjectResourceTest {
         }
 
         @ParameterizedTest
+        @ValueSource(strings = {"$..test", "$[abc]", "$.key with space", "[", "]", "[..]"})
+        @DisplayName("a malformed or non-matching metadata path returns an empty page rather than failing")
+        void whenFilterMetadataPathIsMalformedOrNonMatching__thenReturnEmptyPage(String key) {
+            var workspaceName = RandomStringUtils.randomAlphanumeric(10);
+            var workspaceId = UUID.randomUUID().toString();
+            var apiKey = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var projectName = RandomStringUtils.randomAlphanumeric(10);
+            var traces = PodamFactoryUtils.manufacturePojoList(factory, Trace.class)
+                    .stream()
+                    .map(trace -> setCommonTraceDefaults(trace.toBuilder())
+                            .projectName(projectName)
+                            .metadata(JsonUtils.getJsonNodeFromString("{\"model\":\"gpt-4\"}"))
+                            .build())
+                    .toList();
+            traces.forEach(trace -> create(trace, apiKey, workspaceName));
+
+            var filters = List.of(TraceFilter.builder()
+                    .field(TraceField.METADATA)
+                    .operator(Operator.EQUAL)
+                    .key(key)
+                    .value("gpt-4")
+                    .build());
+
+            var actualPage = traceResourceClient.getTraces(projectName, null, apiKey, workspaceName, filters, null,
+                    traces.size(), Map.of());
+
+            assertThat(actualPage.content()).isEmpty();
+            assertThat(actualPage.total()).isZero();
+        }
+
+        @ParameterizedTest
         @MethodSource("equalAndNotEqualFilters")
         void whenFilterMetadataEqualString__thenReturnTracesFiltered(String endpoint,
                 Operator operator,

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/filter/JsonPathUtilsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/filter/JsonPathUtilsTest.java
@@ -1,0 +1,157 @@
+package com.comet.opik.domain.filter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static com.comet.opik.domain.filter.JsonPathUtils.toAnalyticsDbJsonPath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("JsonPathUtils")
+class JsonPathUtilsTest {
+
+    @Nested
+    @DisplayName("Keys expressible in dot notation")
+    class DotNotationPreserved {
+
+        static Stream<Arguments> plainKeysAreUnchanged() {
+            return Stream.of(
+                    Arguments.of("environment", "$.environment"),
+                    Arguments.of("key_name", "$.key_name"),
+                    Arguments.of("a.b.c", "$.a.b.c"),
+                    Arguments.of("model2", "$.model2"));
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        @DisplayName("keep producing the exact same path")
+        void plainKeysAreUnchanged(String key, String expected) {
+            assertThat(toAnalyticsDbJsonPath(key)).isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("Keys already carrying JSONPath syntax")
+    class PathExpressionsUntouched {
+
+        static Stream<Arguments> pathExpressionsArePassedThrough() {
+            return Stream.of(
+                    Arguments.of("$.a.b", "$.a.b"),
+                    Arguments.of("$[1].version", "$[1].version"),
+                    Arguments.of("$['already-bracketed']", "$['already-bracketed']"),
+                    Arguments.of(".version[1]", "$.version[1]"),
+                    Arguments.of("[0].model", "$[0].model"),
+                    Arguments.of("version[*]", "$.version[*]"),
+                    Arguments.of("a.b[0].c", "$.a.b[0].c"),
+                    Arguments.of("a[\"version\"].b", "$.a[\"version\"].b"),
+                    Arguments.of("a['version'].b", "$.a['version'].b"),
+                    Arguments.of("a[\"x]b\"].c", "$.a[\"x]b\"].c"),
+                    Arguments.of("a['x]b'].c", "$.a['x]b'].c"),
+                    Arguments.of("a[\"x[b\"].c", "$.a[\"x[b\"].c"));
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        @DisplayName("are assembled exactly as before, never rewritten")
+        void pathExpressionsArePassedThrough(String key, String expected) {
+            assertThat(toAnalyticsDbJsonPath(key)).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("a wildcard index is preserved rather than quoted into a literal key")
+        void wildcardIndexIsPreserved() {
+            assertThat(toAnalyticsDbJsonPath("version[*]"))
+                    .isEqualTo("$.version[*]")
+                    .isNotEqualTo("$['version[*]']");
+        }
+
+        @Test
+        @DisplayName("the bare root is still a path")
+        void bareRootIsAPath() {
+            assertThat(toAnalyticsDbJsonPath("$")).isEqualTo("$");
+        }
+    }
+
+    @Nested
+    @DisplayName("Keys dot notation cannot express")
+    class BracketNotationFallback {
+
+        static Stream<Arguments> fallBackToBracketNotation() {
+            return Stream.of(
+                    Arguments.of("a-b", "$['a-b']"),
+                    Arguments.of("x-litellm-attempted-retries", "$['x-litellm-attempted-retries']"),
+                    Arguments.of("hidden_params.additional_headers.x-litellm-attempted-retries",
+                            "$['hidden_params']['additional_headers']['x-litellm-attempted-retries']"),
+                    Arguments.of("key with space", "$['key with space']"),
+                    Arguments.of("ключ", "$['ключ']"),
+                    Arguments.of("a..b", "$['a']['']['b']"),
+                    Arguments.of("trailing.", "$['trailing']['']"),
+                    Arguments.of("feature[beta]", "$['feature[beta]']"),
+                    Arguments.of("a]b", "$['a]b']"),
+                    Arguments.of("$schema", "$['$schema']"),
+                    Arguments.of("$ref", "$['$ref']"),
+                    Arguments.of("$foo", "$['$foo']"));
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        @DisplayName("fall back to bracket notation, splitting on dots as before")
+        void fallBackToBracketNotation(String key, String expected) {
+            assertThat(toAnalyticsDbJsonPath(key)).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("single quotes in a key are escaped rather than terminating the segment")
+        void singleQuotesAreEscaped() {
+            assertThat(toAnalyticsDbJsonPath("e'f")).isEqualTo("$['e\\'f']");
+        }
+
+        @Test
+        @DisplayName("backslashes in a key are escaped")
+        void backslashesAreEscaped() {
+            assertThat(toAnalyticsDbJsonPath("a\\b")).isEqualTo("$['a\\\\b']");
+        }
+    }
+
+    @Nested
+    @DisplayName("Authored expressions that cannot parse under any grammar")
+    class DamagedExpressionsMatchNothing {
+
+        static Stream<Arguments> areQuotedIntoALiteralKey() {
+            return Stream.of(
+                    Arguments.of("$['unterminated", "$['$[\\'unterminated']"),
+                    Arguments.of("$[0", "$['$[0']"),
+                    Arguments.of("$.a]", "$['$']['a]']"),
+                    Arguments.of("$.", "$['$']['']"));
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        @DisplayName("become a literal key, so the query runs and returns nothing instead of aborting")
+        void areQuotedIntoALiteralKey(String key, String expected) {
+            assertThat(toAnalyticsDbJsonPath(key)).isEqualTo(expected);
+        }
+
+        static Stream<Arguments> wellFormedExpressionsSurvive() {
+            return Stream.of(
+                    Arguments.of("version[*]", "$.version[*]"),
+                    Arguments.of("$[1].version", "$[1].version"),
+                    Arguments.of(".version[1]", "$.version[1]"),
+                    Arguments.of("$.key[0]['another_key']", "$.key[0]['another_key']"),
+                    Arguments.of("$.input['key1'][12]['key2']", "$.input['key1'][12]['key2']"),
+                    Arguments.of("$['it\\'s quoted']", "$['it\\'s quoted']"));
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        @DisplayName("well-formed expressions keep their exact text, including shapes no allowlist enumerates")
+        void wellFormedExpressionsSurvive(String key, String expected) {
+            assertThat(toAnalyticsDbJsonPath(key)).isEqualTo(expected);
+        }
+    }
+}


### PR DESCRIPTION
## Details

Filtering a dictionary field (typically `metadata`) on a key containing characters outside `[A-Za-z0-9_]` — a hyphen being by far the most common — built an invalid ClickHouse JSONPath and failed the request with a 500. Keys of this shape are routinely produced by LLM proxy integrations that record response headers into span metadata, so the filter is reachable straight from the UI. It is not endpoint-specific: any query binding a dictionary filter key is affected, and a single page load can break several at once.

Three properties of ClickHouse constrain the fix, all verified against 25.8.16:

- It parses the JSONPath argument of `JSON_VALUE` while it *analyses* the query. An unparseable expression aborts the statement with `BAD_ARGUMENTS: Unable to parse JSONPath` instead of yielding no rows.
- `JSON_VALUE` requires that argument to be **constant** — `materialize()` is rejected even for a valid path — so the expression cannot be deferred to runtime and must be correct by construction.
- `RETURNING ... NULL ON ERROR`, already used on the `DICTIONARY_STATE_DB` branch, is MySQL-only syntax; ClickHouse rejects it with `Code: 62`.

The fix therefore has two halves, covering disjoint cases.

### 1. Build a path that always parses

In the new `JsonPathUtils.toAnalyticsDbJsonPath`:

- A plain key whose every segment is expressible in dot notation produces the **exact path it produced before**, byte for byte.
- Anything else is quoted segment by segment into **bracket notation** (`$['a']['b-c']`), which can express any character and therefore always parses. The dot keeps its meaning as the segment separator, so nested access reads as it does today; single quotes and backslashes are escaped.
- An expression the caller **authored** is assembled exactly as before and passed through untouched.
- Brackets count as path syntax only when their content is an index, a wildcard or a quoted key, so `version[*]` stays a subscript while a literal key such as `feature[beta]` is quoted.
- A leading `$` roots an expression only when what follows continues the path, so ordinary JSON keys such as `$schema` and `$ref` are quoted instead of aborting the query.
- An authored expression too damaged to parse under any grammar becomes a literal key no document carries, so the query runs and matches nothing.

### 2. Recover the cases construction cannot reach

An authored path can survive construction and still be refused by the server (`$[abc]`). Nothing built at construction time can prevent that, so the recovery introduced for dataset items in OPIK-264 now guards the span and trace reads too. Its two duplicated private copies are replaced by a single `ErrorUtils.handleMalformedJsonPath`, shared by all four DAOs:

| DAO | before | now |
|---|---|---|
| `DatasetItemDAO` | private copy | `ErrorUtils` |
| `DatasetItemVersionDAO` | private copy | `ErrorUtils` |
| `SpanDAO.getStats` / `.find` | unprotected | `ErrorUtils` |
| `TraceDAO.getStats` / `.find` | unprotected | `ErrorUtils` |

Defaults follow the existing convention — `ProjectStats.empty()`, `SpanPage.empty(...)`, `TracePage.empty(...)`.

Both halves are needed. Construction makes a real key such as `x-litellm-attempted-retries` return the *correct rows*; the handler alone would only have made it return empty, which is not a working filter. The handler in turn covers what construction provably cannot. Together they mean no dictionary filter key can produce a 500 on these endpoints.

### On not validating authored expressions

An earlier revision validated authored paths against the allowlist regex in `GroupingQueryBuilder` and fell back to a non-matching key when they failed. That was wrong and CI caught it: the regex has no rule for wildcard indices, so `version[*]` — a working filter covered by `DatasetsResourceTest` — was quoted into a literal key and silently returned nothing.

The lesson is that the regex under-approximates what ClickHouse accepts and must not gate expressions a caller wrote. The structural screen used instead rejects only damage no grammar can survive, so it cannot turn a working filter into an empty one. It is deliberately not a completeness check; anything that slips past it is caught by the handler above.

For the same reason `com.jayway.jsonpath`, already a dependency, is not used as the oracle: its grammar is not ClickHouse's. It *accepts* `$.a-b`, the exact path that produces this bug, and its `getPath()` leaves embedded quotes unescaped.

### Out of scope

`getSQLJsonPath` (the MySQL branch) quotes the whole key, so a nested key `a.b.c` is read as one literal key containing dots and silently returns empty, and a key containing `"` produces a malformed path. Same defect class on a path that is not currently erroring; left for a follow-up and noted on the ticket. The state DB branch is untouched here.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-7499

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Investigation of the failure mode, `JsonPathUtils`, the `getKey` delegation, the `ErrorUtils` extraction and DAO wiring, and the new tests.
- Human verification: Every ClickHouse behaviour claimed here was reproduced by the author against a live instance — before the fix, after it, and again after each review round, including the wildcard-index regression an earlier revision introduced. The diff and test expectations were reviewed line by line.

## Testing

Unit tests, from `apps/opik-backend`:

```
mvn -o surefire:test -Dtest='JsonPathUtilsTest,GroupingQueryBuilderTest,FilterQueryBuilder*Test' -DfailIfNoSpecifiedTests=false
# Tests run: 63, Failures: 0, Errors: 0, Skipped: 0
```

`GroupingQueryBuilderTest` is unchanged and still passes.

**`JsonPathUtilsTest`** covers: plain keys producing an unchanged path; authored expressions assembled exactly as before (`$.a.b`, `$[1].version`, `.version[1]`, `[0].model`, `a.b[0].c`, and `version[*]` as an explicit regression test); bracket-notation fallback including the nested hyphenated case, spaces, non-ASCII, empty segments, `feature[beta]`, `a]b`, `$schema`, `$ref`; quote and backslash escaping; and damaged expressions becoming literal keys.

**Integration tests** added to `FindSpansResourceTest`:

- `whenFilterMetadataKeyHasSpecialCharacters__thenReturnSpansFiltered` — persists spans whose metadata is `{"hidden_params":{"additional_headers":{"x-litellm-attempted-retries":"..."}}}`, filters on the full hyphenated key, and asserts the returned entities. Runs through the existing `getFilterTestArguments` matrix, so it covers every span endpoint. This is the production shape that produced the 500 and exercises `getKey`, the parameter binding and `JSON_VALUE` end to end.
- `whenFilterMetadataJsonPathIsMalformed__thenReturnEmptyStats` — reuses the inputs from the existing `findInvalidJsonPaths` (`$..test`, `$[abc]`, `$.key with space`, `[`, `]`, `[..]`) and asserts `/spans/stats` returns empty stats rather than failing.

**Verified against ClickHouse 25.8.16:**

| path | result |
|---|---|
| `$.a.b.retry-count` (generated before) | `Code: 36 BAD_ARGUMENTS` |
| `$schema`, `$ref` (generated before) | `Code: 36 BAD_ARGUMENTS` |
| `$['a-b']`, `$['key with space']`, `$['feature[beta]']`, `$['$schema']` | resolve |
| `$['hidden_params']['additional_headers']['x-litellm-attempted-retries']` | resolves |
| `$.version[*]` (unchanged from `main`) | resolves |
| damaged paths quoted as literal keys | empty, no error |

**Differential check** over a 38-key corpus — every dictionary key used in the test suite, the grouping test corpus and adversarial inputs — confirms all 21 path-syntax and dot-safe keys resolve byte-identically to `main`; every difference is either the special-character fix or a key that previously errored.

**Injection review.** The generated path is never rendered into SQL: it is bound on all three transports (R2DBC `bind`, v2 client `{filterKeyN:String}`, JDBI `@BindMap`), and `filterKey` is never `@Define`d — only the generated SQL *fragment* is, and that carries placeholders rather than values. Breakout payloads (close-literal, stacked statement, `UNION ALL`, backslash-escape abuse) were all rejected as `Code: 36`, i.e. parsed as data; the server's own echo shows quotes escaped to `\'` and the payload confined inside the literal.

Not run locally: the resource-level integration tests, which need the full harness — they run in CI.

## Documentation

No documentation change. The fix restores the documented behaviour of metadata filtering for keys that previously errored; no API or filter syntax changes.
