### PR TITLE
[OPIK-7458] [FE] fix: name the real cause when an optimization run shows nothing usable

### DIFF
--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/EmptyRunWarningPanel.test.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/EmptyRunWarningPanel.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import EmptyRunWarningPanel from "./EmptyRunWarningPanel";
+import { EMPTY_RUN_CAUSE } from "./optimizationOverviewHelpers";
+import { Optimization } from "@/types/optimizations";
+
+vi.mock("@/api/optimizations/useOptimizationStudioLogs", () => ({
+  default: () => ({
+    data: {
+      content: "INFO run started\nINFO baseline scored 1.0",
+      url: null,
+      expiresAt: null,
+    },
+    dataUpdatedAt: 0,
+  }),
+}));
+
+const optimization = {
+  id: "opt-1",
+  status: "completed",
+} as unknown as Optimization;
+
+describe("EmptyRunWarningPanel", () => {
+  it("names the optimizer, not the metric, when no candidates were generated", () => {
+    // OPIK-7458: the baseline scored fine, so the panel must not claim the
+    // metric failed on every item.
+    render(
+      <EmptyRunWarningPanel
+        optimization={optimization}
+        cause={EMPTY_RUN_CAUSE.NO_CANDIDATES}
+      />,
+    );
+
+    expect(screen.getByText("No candidates generated")).toBeInTheDocument();
+    expect(screen.queryByText("No usable scores")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/produced no prompt variants to score/),
+    ).toBeInTheDocument();
+    // Nothing is broken, so there is no "run it again" call to action.
+    expect(screen.queryByText(/run it again/)).not.toBeInTheDocument();
+  });
+
+  it("keeps the scoring-failure copy and CTA when nothing scored", () => {
+    render(
+      <EmptyRunWarningPanel
+        optimization={optimization}
+        cause={EMPTY_RUN_CAUSE.SCORING_FAILED}
+      />,
+    );
+
+    expect(screen.getByText("No usable scores")).toBeInTheDocument();
+    expect(screen.getByText(/run it again/)).toBeInTheDocument();
+  });
+
+  it("shows exact scoring-health counts when the backend provided them", () => {
+    render(
+      <EmptyRunWarningPanel
+        optimization={optimization}
+        cause={EMPTY_RUN_CAUSE.SCORING_FAILED}
+        scoringHealth={{ failed_count: 5, total_count: 5 }}
+      />,
+    );
+
+    expect(screen.getByText(/All 5 items failed to score/)).toBeInTheDocument();
+  });
+
+  it("renders nothing when the backend says no item failed", () => {
+    // The client classifier and the item-level counts can legitimately diverge;
+    // the backend wins, so we must not contradict it with a warning.
+    const { container } = render(
+      <EmptyRunWarningPanel
+        optimization={optimization}
+        cause={EMPTY_RUN_CAUSE.SCORING_FAILED}
+        scoringHealth={{ failed_count: 0, total_count: 10 }}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("offers the logs on both causes", () => {
+    const { unmount } = render(
+      <EmptyRunWarningPanel
+        optimization={optimization}
+        cause={EMPTY_RUN_CAUSE.NO_CANDIDATES}
+      />,
+    );
+    expect(screen.getByText("View logs")).toBeInTheDocument();
+    unmount();
+
+    render(
+      <EmptyRunWarningPanel
+        optimization={optimization}
+        cause={EMPTY_RUN_CAUSE.SCORING_FAILED}
+      />,
+    );
+    expect(screen.getByText("View logs")).toBeInTheDocument();
+  });
+});

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/EmptyRunWarningPanel.test.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/EmptyRunWarningPanel.test.tsx
@@ -23,8 +23,6 @@ const optimization = {
 
 describe("EmptyRunWarningPanel", () => {
   it("names the optimizer, not the metric, when no candidates were generated", () => {
-    // OPIK-7458: the baseline scored fine, so the panel must not claim the
-    // metric failed on every item.
     render(
       <EmptyRunWarningPanel
         optimization={optimization}
@@ -37,7 +35,6 @@ describe("EmptyRunWarningPanel", () => {
     expect(
       screen.getByText(/produced no prompt variants to score/),
     ).toBeInTheDocument();
-    // Nothing is broken, so there is no "run it again" call to action.
     expect(screen.queryByText(/run it again/)).not.toBeInTheDocument();
   });
 
@@ -66,8 +63,7 @@ describe("EmptyRunWarningPanel", () => {
   });
 
   it("renders nothing when the backend says no item failed", () => {
-    // The client classifier and the item-level counts can legitimately diverge;
-    // the backend wins, so we must not contradict it with a warning.
+    // The classifier and the item counts can diverge; the backend wins.
     const { container } = render(
       <EmptyRunWarningPanel
         optimization={optimization}

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/EmptyRunWarningPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/EmptyRunWarningPanel.tsx
@@ -1,46 +1,87 @@
 import React, { useMemo, useState } from "react";
-import { TriangleAlert } from "lucide-react";
+import { Info, TriangleAlert } from "lucide-react";
 
 import { Button } from "@/ui/button";
 import { Optimization, OptimizationScoringHealth } from "@/types/optimizations";
 import useOptimizationStudioLogs from "@/api/optimizations/useOptimizationStudioLogs";
 import { convertTerminalOutputToHtml } from "@/lib/terminalOutput";
 import OptimizationLogsFullscreenDialog from "@/v2/pages-shared/optimizations/OptimizationLogs/OptimizationLogsFullscreenDialog";
-import { getEmptyRunWarningMessage } from "./optimizationOverviewHelpers";
+import {
+  EMPTY_RUN_CAUSE,
+  EmptyRunCause,
+  getEmptyRunMessage,
+  getEmptyRunTitle,
+} from "./optimizationOverviewHelpers";
 
 type EmptyRunWarningPanelProps = {
   optimization: Optimization;
   /**
+   * Why the run has nothing usable to show, see {@link EMPTY_RUN_CAUSE}. Drives
+   * both the copy and the severity: a run that generated no candidates is not an
+   * error, so it must not read like one.
+   */
+  cause: EmptyRunCause;
+  /**
    * Exact scoring-health counts from the backend (OPIK-7159 Wave 2). When
    * present and `total_count > 0`, the panel body shows the exact failed/total
-   * numbers. When absent, falls back to the Wave-1 heuristic copy.
+   * numbers. When absent, falls back to the Wave-1 heuristic copy. Only
+   * consulted for the SCORING_FAILED cause.
    */
   scoringHealth?: OptimizationScoringHealth;
 };
 
+type EmptyRunAppearance = {
+  Icon: typeof Info;
+  container: string;
+  iconColor: string;
+  title: string;
+  body: string;
+};
+
 /**
- * Shown when a run ends in COMPLETED but produced no usable scores (the
- * heuristic in {@link ./optimizationOverviewHelpers}.computeEmptyRunWarning).
- * This is the FE half of the OPIK-7029 "silent COMPLETED" gap: without it the
- * run looks like a plain empty run with no explanation.
+ * Appearance per cause, in one place so the icon and every class stay in sync.
+ * SCORING_FAILED uses the amber warning-box tokens, not the destructive scale:
+ * the run did complete, the scores are just unusable. NO_CANDIDATES uses the
+ * neutral surface, so a normal outcome does not look like a failure.
+ */
+const APPEARANCE: Record<
+  Exclude<EmptyRunCause, typeof EMPTY_RUN_CAUSE.NONE>,
+  EmptyRunAppearance
+> = {
+  [EMPTY_RUN_CAUSE.NO_CANDIDATES]: {
+    Icon: Info,
+    container: "border-border bg-soft-background",
+    iconColor: "text-muted-slate",
+    title: "text-foreground",
+    body: "text-muted-slate",
+  },
+  [EMPTY_RUN_CAUSE.SCORING_FAILED]: {
+    Icon: TriangleAlert,
+    container: "border-warning-box-icon-bg/40 bg-warning-box-bg",
+    iconColor: "text-warning-box-icon-text",
+    title: "text-warning-box-text",
+    body: "text-warning-box-text",
+  },
+};
+
+/**
+ * Shown when a run ends in COMPLETED with nothing usable on screen, per
+ * computeEmptyRunCause. This is the FE half of the OPIK-7029 "silent COMPLETED"
+ * gap: without it the run looks empty with no explanation.
  *
- * It mirrors the ERROR-gated {@link ./RunErrorPanel} markup but reads as a
- * WARNING (amber) rather than a failure (destructive), because the run did
- * technically complete — the scores are simply unusable.
- *
- * When `scoringHealth` is provided (OPIK-7159 Wave 2), the body shows the
- * exact failed/total item count. Otherwise, the Wave-1 heuristic copy is used.
+ * Severity follows the cause (OPIK-7458). SCORING_FAILED is a warning and earns
+ * the "check the metric and re-run" call to action. NO_CANDIDATES is an
+ * informational note: the metric worked and the baseline was kept.
  */
 const EmptyRunWarningPanel: React.FC<EmptyRunWarningPanelProps> = ({
   optimization,
+  cause,
   scoringHealth,
 }) => {
-  // Body message: exact count when scoring_health is present, else the heuristic
-  // copy. Returns null ONLY when the backend explicitly says nothing failed
-  // (failed_count === 0) — in that case we must NOT contradict it with a warning,
-  // so the panel renders nothing (the client heuristic and the item-level count
-  // can legitimately diverge).
-  const warningMessage = getEmptyRunWarningMessage(scoringHealth);
+  // Null when the cause is NONE, or when the backend reports no failed item. In
+  // the latter case the panel renders nothing rather than contradicting the
+  // backend, since the client classifier and the item counts can diverge.
+  const message = getEmptyRunMessage(cause, scoringHealth);
   const [open, setOpen] = useState(false);
   const { data, dataUpdatedAt } = useOptimizationStudioLogs(
     { optimizationId: optimization.id },
@@ -53,23 +94,23 @@ const EmptyRunWarningPanel: React.FC<EmptyRunWarningPanelProps> = ({
     [logContent],
   );
 
-  if (warningMessage === null) {
+  if (message === null || cause === EMPTY_RUN_CAUSE.NONE) {
     return null;
   }
 
+  const { Icon, container, iconColor, title, body } = APPEARANCE[cause];
+
   return (
     <>
-      {/* Amber (warning-box tokens), not the red `--warning`/destructive scale:
-          the run completed, the scores are just unusable — see the FE-1 card. */}
-      <div className="rounded-lg border border-warning-box-icon-bg/40 bg-warning-box-bg p-4">
+      <div className={`rounded-lg border p-4 ${container}`}>
         <div className="mb-1 flex items-center gap-2">
-          <TriangleAlert className="size-4 shrink-0 text-warning-box-icon-text" />
-          <h3 className="comet-body-s-accented text-warning-box-text">
-            No usable scores
+          <Icon className={`size-4 shrink-0 ${iconColor}`} />
+          <h3 className={`comet-body-s-accented ${title}`}>
+            {getEmptyRunTitle(cause)}
           </h3>
         </div>
-        <p className="comet-body-xs whitespace-pre-wrap break-words text-warning-box-text">
-          {warningMessage}
+        <p className={`comet-body-xs whitespace-pre-wrap break-words ${body}`}>
+          {message}
         </p>
         {logContent && (
           <Button

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/EmptyRunWarningPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/EmptyRunWarningPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { Info, TriangleAlert } from "lucide-react";
+import { Info, LucideIcon, TriangleAlert } from "lucide-react";
 
 import { Button } from "@/ui/button";
 import { Optimization, OptimizationScoringHealth } from "@/types/optimizations";
@@ -31,7 +31,7 @@ type EmptyRunWarningPanelProps = {
 };
 
 type EmptyRunAppearance = {
-  Icon: typeof Info;
+  Icon: LucideIcon;
   container: string;
   iconColor: string;
   title: string;

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/EmptyRunWarningPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/EmptyRunWarningPanel.tsx
@@ -15,17 +15,11 @@ import {
 
 type EmptyRunWarningPanelProps = {
   optimization: Optimization;
-  /**
-   * Why the run has nothing usable to show, see {@link EMPTY_RUN_CAUSE}. Drives
-   * both the copy and the severity: a run that generated no candidates is not an
-   * error, so it must not read like one.
-   */
+  /** Drives both the copy and the severity, see {@link EMPTY_RUN_CAUSE}. */
   cause: EmptyRunCause;
   /**
-   * Exact scoring-health counts from the backend (OPIK-7159 Wave 2). When
-   * present and `total_count > 0`, the panel body shows the exact failed/total
-   * numbers. When absent, falls back to the Wave-1 heuristic copy. Only
-   * consulted for the SCORING_FAILED cause.
+   * Exact failed/total counts from the backend (OPIK-7159 Wave 2), falling back
+   * to the Wave-1 copy when absent. Only consulted for SCORING_FAILED.
    */
   scoringHealth?: OptimizationScoringHealth;
 };
@@ -39,10 +33,8 @@ type EmptyRunAppearance = {
 };
 
 /**
- * Appearance per cause, in one place so the icon and every class stay in sync.
- * SCORING_FAILED uses the amber warning-box tokens, not the destructive scale:
- * the run did complete, the scores are just unusable. NO_CANDIDATES uses the
- * neutral surface, so a normal outcome does not look like a failure.
+ * SCORING_FAILED uses the amber warning-box tokens rather than the destructive
+ * scale: the run did complete, the scores are just unusable.
  */
 const APPEARANCE: Record<
   Exclude<EmptyRunCause, typeof EMPTY_RUN_CAUSE.NONE>,
@@ -66,21 +58,17 @@ const APPEARANCE: Record<
 
 /**
  * Shown when a run ends in COMPLETED with nothing usable on screen, per
- * computeEmptyRunCause. This is the FE half of the OPIK-7029 "silent COMPLETED"
- * gap: without it the run looks empty with no explanation.
- *
- * Severity follows the cause (OPIK-7458). SCORING_FAILED is a warning and earns
- * the "check the metric and re-run" call to action. NO_CANDIDATES is an
- * informational note: the metric worked and the baseline was kept.
+ * computeEmptyRunCause, which would otherwise look empty with no explanation
+ * (the OPIK-7029 "silent COMPLETED" gap). Severity follows the cause: a warning
+ * with a re-run call to action for SCORING_FAILED, a neutral note otherwise.
  */
 const EmptyRunWarningPanel: React.FC<EmptyRunWarningPanelProps> = ({
   optimization,
   cause,
   scoringHealth,
 }) => {
-  // Null when the cause is NONE, or when the backend reports no failed item. In
-  // the latter case the panel renders nothing rather than contradicting the
-  // backend, since the client classifier and the item counts can diverge.
+  // Null when the backend reports no failed item: it wins over the client
+  // classifier, so the panel stays silent rather than contradicting it.
   const message = getEmptyRunMessage(cause, scoringHealth);
   const [open, setOpen] = useState(false);
   const { data, dataUpdatedAt } = useOptimizationStudioLogs(

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationKPICards.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationKPICards.tsx
@@ -18,6 +18,8 @@ import {
   OptimizationScoringHealth,
 } from "@/types/optimizations";
 import {
+  EMPTY_RUN_CAUSE,
+  EmptyRunCause,
   getCompletedRunDurationSeconds,
   getEmptyRunKPICaption,
 } from "./optimizationOverviewHelpers";
@@ -65,15 +67,17 @@ type OptimizationKPICardsProps = {
   optimizationLastUpdatedAt?: string;
   isInProgress?: boolean;
   /**
-   * Heuristic flag: the run COMPLETED but scored nothing usable (OPIK-7029). When
-   * set, the score card shows a caption so a degenerate run isn't a bare 0%/-.
+   * Why the COMPLETED run has nothing usable to show (OPIK-7029, OPIK-7458).
+   * When it is not `NONE`, the score card shows a caption so a degenerate run is
+   * not a bare 0%/-. The caption names the actual cause, since a run that
+   * generated no candidates did not suffer a scoring failure.
    */
-  scoringFailed?: boolean;
+  emptyRunCause?: EmptyRunCause;
   /**
    * Exact scoring-health counts from the backend (OPIK-7159 Wave 2). When
    * present and `total_count > 0`, the score card caption shows the exact
    * failed/total numbers. When absent, falls back to the Wave-1 heuristic copy.
-   * Only used when `scoringFailed` is true.
+   * Only consulted for the SCORING_FAILED cause.
    */
   scoringHealth?: OptimizationScoringHealth;
 };
@@ -89,7 +93,7 @@ const OptimizationKPICards: React.FunctionComponent<
   optimizationCreatedAt,
   optimizationLastUpdatedAt,
   isInProgress,
-  scoringFailed,
+  emptyRunCause = EMPTY_RUN_CAUSE.NONE,
   scoringHealth,
 }) => {
   const kpiData = useMemo(
@@ -119,13 +123,13 @@ const OptimizationKPICards: React.FunctionComponent<
     <div className="grid grid-cols-4 gap-4">
       {configs.map((config) => {
         const field = CANDIDATE_KEY_MAP[config.key];
-        // Caption the score card when the run scored nothing usable, so the
-        // 0%/- reads as "scoring failed" rather than a genuine result.
-        // When scoringHealth is present, show exact counts; otherwise fall back
-        // to the Wave-1 heuristic copy.
+        // Caption the score card when the run has nothing usable to show, so a
+        // 0%/- is explained rather than read as a real result. The copy follows
+        // the cause: a scoring failure earns the "check the logs" framing, a run
+        // with no candidates just says the baseline was kept.
         const caption =
           config.key === "score"
-            ? getEmptyRunKPICaption(!!scoringFailed, scoringHealth) ?? undefined
+            ? getEmptyRunKPICaption(emptyRunCause, scoringHealth) ?? undefined
             : undefined;
         return (
           <MetricKPICard

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationKPICards.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationKPICards.tsx
@@ -67,17 +67,13 @@ type OptimizationKPICardsProps = {
   optimizationLastUpdatedAt?: string;
   isInProgress?: boolean;
   /**
-   * Why the COMPLETED run has nothing usable to show (OPIK-7029, OPIK-7458).
-   * When it is not `NONE`, the score card shows a caption so a degenerate run is
-   * not a bare 0%/-. The caption names the actual cause, since a run that
-   * generated no candidates did not suffer a scoring failure.
+   * When not `NONE`, the score card shows a caption naming the cause, so a
+   * degenerate run is not a bare 0%/- (OPIK-7029, OPIK-7458).
    */
   emptyRunCause?: EmptyRunCause;
   /**
-   * Exact scoring-health counts from the backend (OPIK-7159 Wave 2). When
-   * present and `total_count > 0`, the score card caption shows the exact
-   * failed/total numbers. When absent, falls back to the Wave-1 heuristic copy.
-   * Only consulted for the SCORING_FAILED cause.
+   * Exact failed/total counts from the backend (OPIK-7159 Wave 2), falling back
+   * to the Wave-1 copy when absent. Only consulted for SCORING_FAILED.
    */
   scoringHealth?: OptimizationScoringHealth;
 };
@@ -123,10 +119,8 @@ const OptimizationKPICards: React.FunctionComponent<
     <div className="grid grid-cols-4 gap-4">
       {configs.map((config) => {
         const field = CANDIDATE_KEY_MAP[config.key];
-        // Caption the score card when the run has nothing usable to show, so a
-        // 0%/- is explained rather than read as a real result. The copy follows
-        // the cause: a scoring failure earns the "check the logs" framing, a run
-        // with no candidates just says the baseline was kept.
+        // Caption the score card so a 0%/- is explained rather than read as a
+        // real result.
         const caption =
           config.key === "score"
             ? getEmptyRunKPICaption(emptyRunCause, scoringHealth) ?? undefined

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationPage.tsx
@@ -19,7 +19,10 @@ import OptimizationTrialsTable from "./OptimizationTrialsTable";
 import OptimizationKPICards from "./OptimizationKPICards";
 import RunErrorPanel from "./RunErrorPanel";
 import EmptyRunWarningPanel from "./EmptyRunWarningPanel";
-import { computeEmptyRunWarning } from "./optimizationOverviewHelpers";
+import {
+  EMPTY_RUN_CAUSE,
+  computeEmptyRunCause,
+} from "./optimizationOverviewHelpers";
 import TrialSidebar from "./TrialSidebar/TrialSidebar";
 import TrialSidebarContent from "./TrialSidebar/TrialSidebarContent";
 import { computeCandidateStatuses } from "@/v2/pages-shared/experiments/OptimizationProgressChart/optimizationChartUtils";
@@ -133,12 +136,10 @@ const OptimizationPage: React.FC = () => {
     ? baselineCandidate ?? bestCandidate
     : bestCandidate;
 
-  // Heuristic: a COMPLETED run that produced no usable scores (OPIK-7029). Drives
-  // both the amber warning panel and the KPI score-card caption below.
-  const isEmptyCompletedRun = useMemo(
-    () => computeEmptyRunWarning(candidates, optimization?.status),
-    [candidates, optimization?.status],
-  );
+  // Why a COMPLETED run has nothing usable to show (OPIK-7029, OPIK-7458).
+  // Drives the panel copy, its severity, and the KPI score-card caption, so that
+  // "the optimizer generated nothing" does not read as "the metric failed".
+  const emptyRunCause = computeEmptyRunCause(candidates, optimization?.status);
 
   // Single status source for the chart, the trials table, and the sidebar's
   // status card.
@@ -240,10 +241,11 @@ const OptimizationPage: React.FC = () => {
                   <RunErrorPanel optimization={optimization} />
                 </div>
               )}
-            {optimization && isEmptyCompletedRun && (
+            {optimization && emptyRunCause !== EMPTY_RUN_CAUSE.NONE && (
               <div className="shrink-0">
                 <EmptyRunWarningPanel
                   optimization={optimization}
+                  cause={emptyRunCause}
                   scoringHealth={optimization.metadata?.scoring_health}
                 />
               </div>
@@ -257,7 +259,7 @@ const OptimizationPage: React.FC = () => {
                 objectiveName={optimization?.objective_name}
                 optimizationCreatedAt={optimization?.created_at}
                 optimizationLastUpdatedAt={optimization?.last_updated_at}
-                scoringFailed={isEmptyCompletedRun}
+                emptyRunCause={emptyRunCause}
                 scoringHealth={optimization?.metadata?.scoring_health}
                 isInProgress={
                   !!optimization?.status &&

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationPage.tsx
@@ -136,9 +136,7 @@ const OptimizationPage: React.FC = () => {
     ? baselineCandidate ?? bestCandidate
     : bestCandidate;
 
-  // Why a COMPLETED run has nothing usable to show (OPIK-7029, OPIK-7458).
-  // Drives the panel copy, its severity, and the KPI score-card caption, so that
-  // "the optimizer generated nothing" does not read as "the metric failed".
+  // Drives the panel copy, its severity, and the KPI score-card caption.
   const emptyRunCause = computeEmptyRunCause(candidates, optimization?.status);
 
   // Single status source for the chart, the trials table, and the sidebar's

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/optimizationOverviewHelpers.test.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/optimizationOverviewHelpers.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from "vitest";
 
 import {
-  computeEmptyRunWarning,
+  EMPTY_RUN_CAUSE,
+  computeEmptyRunCause,
   getCompletedRunDurationSeconds,
   getEmptyRunKPICaption,
-  getEmptyRunWarningMessage,
+  getEmptyRunMessage,
+  getEmptyRunTitle,
   getOptimizationDurationSeconds,
   getOptimizationRefetchInterval,
 } from "./optimizationOverviewHelpers";
@@ -111,24 +113,26 @@ describe("getCompletedRunDurationSeconds", () => {
   });
 });
 
-describe("computeEmptyRunWarning", () => {
-  it("does not warn while the run is unfinished or errored", () => {
+describe("computeEmptyRunCause", () => {
+  it("stays NONE while the run is unfinished or errored", () => {
     const candidates = [makeCandidate({ candidateId: "a", stepIndex: 0 })];
-    expect(
-      computeEmptyRunWarning(candidates, OPTIMIZATION_STATUS.RUNNING),
-    ).toBe(false);
-    expect(
-      computeEmptyRunWarning(candidates, OPTIMIZATION_STATUS.INITIALIZED),
-    ).toBe(false);
-    expect(computeEmptyRunWarning(candidates, OPTIMIZATION_STATUS.ERROR)).toBe(
-      false,
+    expect(computeEmptyRunCause(candidates, OPTIMIZATION_STATUS.RUNNING)).toBe(
+      EMPTY_RUN_CAUSE.NONE,
     );
-    expect(computeEmptyRunWarning(candidates, undefined)).toBe(false);
+    expect(
+      computeEmptyRunCause(candidates, OPTIMIZATION_STATUS.INITIALIZED),
+    ).toBe(EMPTY_RUN_CAUSE.NONE);
+    expect(computeEmptyRunCause(candidates, OPTIMIZATION_STATUS.ERROR)).toBe(
+      EMPTY_RUN_CAUSE.NONE,
+    );
+    expect(computeEmptyRunCause(candidates, undefined)).toBe(
+      EMPTY_RUN_CAUSE.NONE,
+    );
   });
 
-  it("warns on a COMPLETED run where no non-baseline trial scored", () => {
+  it("reports SCORING_FAILED when candidates ran but none scored", () => {
     const candidates = [
-      // A scored baseline does not count — it is expected on every run.
+      // A scored baseline does not count; it is expected on every run.
       makeCandidate({ candidateId: "base", stepIndex: 0, score: 0.5 }),
       makeCandidate({
         candidateId: "a",
@@ -144,20 +148,38 @@ describe("computeEmptyRunWarning", () => {
       }),
     ];
     expect(
-      computeEmptyRunWarning(candidates, OPTIMIZATION_STATUS.COMPLETED),
-    ).toBe(true);
+      computeEmptyRunCause(candidates, OPTIMIZATION_STATUS.COMPLETED),
+    ).toBe(EMPTY_RUN_CAUSE.SCORING_FAILED);
   });
 
-  it("warns on a COMPLETED run that produced no non-baseline trials at all", () => {
+  it("reports NO_CANDIDATES when the baseline scored but nothing else was generated", () => {
+    // The OPIK-7458 case: a strong seed prompt, zero non-baseline candidates.
+    // The metric demonstrably worked, so this must NOT read as a scoring failure.
     const candidates = [
-      makeCandidate({ candidateId: "base", stepIndex: 0, score: 0.5 }),
+      makeCandidate({ candidateId: "base", stepIndex: 0, score: 1 }),
     ];
     expect(
-      computeEmptyRunWarning(candidates, OPTIMIZATION_STATUS.COMPLETED),
-    ).toBe(true);
+      computeEmptyRunCause(candidates, OPTIMIZATION_STATUS.COMPLETED),
+    ).toBe(EMPTY_RUN_CAUSE.NO_CANDIDATES);
   });
 
-  it("does not warn when at least one non-baseline trial scored", () => {
+  it("reports SCORING_FAILED when nothing was generated AND the baseline never scored", () => {
+    // Nothing was evaluated at all, so scoring is the cause, not the optimizer.
+    const candidates = [
+      makeCandidate({ candidateId: "base", stepIndex: 0, score: undefined }),
+    ];
+    expect(
+      computeEmptyRunCause(candidates, OPTIMIZATION_STATUS.COMPLETED),
+    ).toBe(EMPTY_RUN_CAUSE.SCORING_FAILED);
+  });
+
+  it("reports SCORING_FAILED for a COMPLETED run with no candidate rows at all", () => {
+    expect(computeEmptyRunCause([], OPTIMIZATION_STATUS.COMPLETED)).toBe(
+      EMPTY_RUN_CAUSE.SCORING_FAILED,
+    );
+  });
+
+  it("stays NONE when at least one non-baseline trial scored", () => {
     const candidates = [
       makeCandidate({ candidateId: "base", stepIndex: 0, score: 0.5 }),
       makeCandidate({
@@ -174,8 +196,19 @@ describe("computeEmptyRunWarning", () => {
       }),
     ];
     expect(
-      computeEmptyRunWarning(candidates, OPTIMIZATION_STATUS.COMPLETED),
-    ).toBe(false);
+      computeEmptyRunCause(candidates, OPTIMIZATION_STATUS.COMPLETED),
+    ).toBe(EMPTY_RUN_CAUSE.NONE);
+  });
+});
+
+describe("getEmptyRunTitle", () => {
+  it("names the cause instead of always claiming there are no scores", () => {
+    expect(getEmptyRunTitle(EMPTY_RUN_CAUSE.NO_CANDIDATES)).toBe(
+      "No candidates generated",
+    );
+    expect(getEmptyRunTitle(EMPTY_RUN_CAUSE.SCORING_FAILED)).toBe(
+      "No usable scores",
+    );
   });
 });
 
@@ -201,10 +234,54 @@ describe("getOptimizationRefetchInterval", () => {
 });
 
 // ---------------------------------------------------------------------------
-// getEmptyRunWarningMessage — Wave 2 exact-count path + Wave-1 fallback
+// getEmptyRunMessage: Wave 2 exact-count path + Wave-1 fallback
 // ---------------------------------------------------------------------------
 
-describe("getEmptyRunWarningMessage", () => {
+describe("getEmptyRunMessage", () => {
+  const FAILED = EMPTY_RUN_CAUSE.SCORING_FAILED;
+
+  it("says nothing when there is no empty-run cause", () => {
+    expect(getEmptyRunMessage(EMPTY_RUN_CAUSE.NONE)).toBeNull();
+    expect(
+      getEmptyRunMessage(EMPTY_RUN_CAUSE.NONE, {
+        failed_count: 5,
+        total_count: 5,
+      }),
+    ).toBeNull();
+  });
+
+  // --- NO_CANDIDATES (OPIK-7458) ---
+
+  it("names the optimizer, not the metric, when no candidates were generated", () => {
+    const msg = getEmptyRunMessage(EMPTY_RUN_CAUSE.NO_CANDIDATES);
+    expect(msg).toContain("produced no prompt variants to score");
+    expect(msg).toContain("the baseline prompt was kept");
+    // Nothing is wrong with this outcome, so the copy must not imply the metric
+    // broke or ask the user to re-run.
+    expect(msg).not.toContain("failed");
+    expect(msg).not.toContain("run it again");
+  });
+
+  it("ignores scoring_health for NO_CANDIDATES (the baseline scored, so counts can't explain it)", () => {
+    // The regression from OPIK-7458: a degenerate {0, 0} health object used to
+    // route this run into the metric-failure copy via the `total_count > 0` guard.
+    const degenerate: OptimizationScoringHealth = {
+      failed_count: 0,
+      total_count: 0,
+    };
+    const populated: OptimizationScoringHealth = {
+      failed_count: 0,
+      total_count: 30,
+    };
+    const expected = getEmptyRunMessage(EMPTY_RUN_CAUSE.NO_CANDIDATES);
+    expect(getEmptyRunMessage(EMPTY_RUN_CAUSE.NO_CANDIDATES, degenerate)).toBe(
+      expected,
+    );
+    expect(getEmptyRunMessage(EMPTY_RUN_CAUSE.NO_CANDIDATES, populated)).toBe(
+      expected,
+    );
+  });
+
   // --- Exact-count path (scoring_health present) ---
 
   it("uses all-failed framing when every item failed (plural)", () => {
@@ -212,7 +289,7 @@ describe("getEmptyRunWarningMessage", () => {
       failed_count: 5,
       total_count: 5,
     };
-    const msg = getEmptyRunWarningMessage(health);
+    const msg = getEmptyRunMessage(FAILED, health);
     expect(msg).toContain("All 5 items failed to score");
   });
 
@@ -221,7 +298,7 @@ describe("getEmptyRunWarningMessage", () => {
       failed_count: 1,
       total_count: 1,
     };
-    const msg = getEmptyRunWarningMessage(health);
+    const msg = getEmptyRunMessage(FAILED, health);
     // A one-item dataset reads "The item failed …", never "All 1 item …".
     expect(msg).toContain("The item failed to score");
     expect(msg).not.toContain("All 1");
@@ -233,7 +310,7 @@ describe("getEmptyRunWarningMessage", () => {
       failed_count: 3,
       total_count: 10,
     };
-    const msg = getEmptyRunWarningMessage(health);
+    const msg = getEmptyRunMessage(FAILED, health);
     expect(msg).toContain("3 of 10 items failed to score");
     // Partial framing should NOT say "All"
     expect(msg).not.toMatch(/^All /);
@@ -244,7 +321,7 @@ describe("getEmptyRunWarningMessage", () => {
       failed_count: 1,
       total_count: 10,
     };
-    const msg = getEmptyRunWarningMessage(health);
+    const msg = getEmptyRunMessage(FAILED, health);
     // "1 of 10 items" — the noun agrees with the total, not the failed count.
     expect(msg).toContain("1 of 10 items failed to score");
   });
@@ -254,7 +331,7 @@ describe("getEmptyRunWarningMessage", () => {
       failed_count: 0,
       total_count: 10,
     };
-    expect(getEmptyRunWarningMessage(health)).toBeNull();
+    expect(getEmptyRunMessage(FAILED, health)).toBeNull();
   });
 
   it("falls back to the heuristic message when total_count is 0 (degenerate health object)", () => {
@@ -265,7 +342,7 @@ describe("getEmptyRunWarningMessage", () => {
     };
     // With total_count === 0, the guard `total_count > 0` is false, so we
     // return the heuristic fallback (non-null).
-    const msg = getEmptyRunWarningMessage(health);
+    const msg = getEmptyRunMessage(FAILED, health);
     expect(msg).not.toBeNull();
     expect(msg).toContain("no usable scores");
   });
@@ -273,7 +350,7 @@ describe("getEmptyRunWarningMessage", () => {
   // --- Heuristic fallback (absent scoring_health) ---
 
   it("returns the Wave-1 heuristic copy when scoring_health is absent", () => {
-    const msg = getEmptyRunWarningMessage(undefined);
+    const msg = getEmptyRunMessage(FAILED, undefined);
     // The static Wave-1 message must be returned unchanged.
     expect(msg).toBe(
       "This run finished but produced no usable scores — the metric may have failed on every item. Open the logs, check the metric and model, then run it again.",
@@ -282,22 +359,30 @@ describe("getEmptyRunWarningMessage", () => {
 });
 
 // ---------------------------------------------------------------------------
-// getEmptyRunKPICaption — compact caption for the KPI score card
+// getEmptyRunKPICaption: compact caption for the KPI score card
 // ---------------------------------------------------------------------------
 
 describe("getEmptyRunKPICaption", () => {
-  it("returns null when the run is not empty (isEmptyRun=false)", () => {
-    expect(getEmptyRunKPICaption(false)).toBeNull();
+  const FAILED = EMPTY_RUN_CAUSE.SCORING_FAILED;
+
+  it("returns null when the run has no empty-run cause", () => {
+    expect(getEmptyRunKPICaption(EMPTY_RUN_CAUSE.NONE)).toBeNull();
     expect(
-      getEmptyRunKPICaption(false, {
+      getEmptyRunKPICaption(EMPTY_RUN_CAUSE.NONE, {
         failed_count: 5,
         total_count: 5,
       }),
     ).toBeNull();
   });
 
+  it("captions a no-candidates run neutrally, since the score shown is the baseline's", () => {
+    const caption = getEmptyRunKPICaption(EMPTY_RUN_CAUSE.NO_CANDIDATES);
+    expect(caption).toBe("No candidates generated. Baseline prompt kept.");
+    expect(caption).not.toContain("failed");
+  });
+
   it("all-failed exact count caption (plural)", () => {
-    const caption = getEmptyRunKPICaption(true, {
+    const caption = getEmptyRunKPICaption(FAILED, {
       failed_count: 8,
       total_count: 8,
     });
@@ -306,7 +391,7 @@ describe("getEmptyRunKPICaption", () => {
   });
 
   it("all-failed exact count caption (singular)", () => {
-    const caption = getEmptyRunKPICaption(true, {
+    const caption = getEmptyRunKPICaption(FAILED, {
       failed_count: 1,
       total_count: 1,
     });
@@ -316,7 +401,7 @@ describe("getEmptyRunKPICaption", () => {
   });
 
   it("partial failure exact count caption", () => {
-    const caption = getEmptyRunKPICaption(true, {
+    const caption = getEmptyRunKPICaption(FAILED, {
       failed_count: 4,
       total_count: 12,
     });
@@ -326,12 +411,12 @@ describe("getEmptyRunKPICaption", () => {
 
   it("returns null when failed_count is 0", () => {
     expect(
-      getEmptyRunKPICaption(true, { failed_count: 0, total_count: 10 }),
+      getEmptyRunKPICaption(FAILED, { failed_count: 0, total_count: 10 }),
     ).toBeNull();
   });
 
   it("falls back to Wave-1 heuristic copy when scoring_health is absent", () => {
-    const caption = getEmptyRunKPICaption(true, undefined);
+    const caption = getEmptyRunKPICaption(FAILED, undefined);
     expect(caption).toBe("No usable scores — check the logs.");
   });
 });

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/optimizationOverviewHelpers.test.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/optimizationOverviewHelpers.test.ts
@@ -153,8 +153,7 @@ describe("computeEmptyRunCause", () => {
   });
 
   it("reports NO_CANDIDATES when the baseline scored but nothing else was generated", () => {
-    // The OPIK-7458 case: a strong seed prompt, zero non-baseline candidates.
-    // The metric demonstrably worked, so this must NOT read as a scoring failure.
+    // The OPIK-7458 case: a strong seed prompt, so the metric demonstrably worked.
     const candidates = [
       makeCandidate({ candidateId: "base", stepIndex: 0, score: 1 }),
     ];
@@ -164,7 +163,6 @@ describe("computeEmptyRunCause", () => {
   });
 
   it("reports SCORING_FAILED when nothing was generated AND the baseline never scored", () => {
-    // Nothing was evaluated at all, so scoring is the cause, not the optimizer.
     const candidates = [
       makeCandidate({ candidateId: "base", stepIndex: 0, score: undefined }),
     ];
@@ -256,8 +254,6 @@ describe("getEmptyRunMessage", () => {
     const msg = getEmptyRunMessage(EMPTY_RUN_CAUSE.NO_CANDIDATES);
     expect(msg).toContain("produced no prompt variants to score");
     expect(msg).toContain("the baseline prompt was kept");
-    // Nothing is wrong with this outcome, so the copy must not imply the metric
-    // broke or ask the user to re-run.
     expect(msg).not.toContain("failed");
     expect(msg).not.toContain("run it again");
   });

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/optimizationOverviewHelpers.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/optimizationOverviewHelpers.ts
@@ -66,19 +66,10 @@ export const getCompletedRunDurationSeconds = ({
   );
 };
 
-/**
- * Why a COMPLETED run has nothing usable to show. Previously a single boolean,
- * which made the panel blame the metric even when the metric worked (OPIK-7458).
- */
+/** Why a COMPLETED run has nothing usable to show (OPIK-7029, OPIK-7458). */
 export const EMPTY_RUN_CAUSE = {
-  /** Nothing to surface: the run is unfinished or errored, or something scored. */
   NONE: "none",
-  /** Nothing was generated beyond the baseline, and the baseline scored. */
   NO_CANDIDATES: "no-candidates",
-  /**
-   * Nothing produced a usable score: every non-baseline candidate is unscored,
-   * or nothing scored at all. The OPIK-7029 "silent COMPLETED" gap.
-   */
   SCORING_FAILED: "scoring-failed",
 } as const;
 
@@ -86,26 +77,15 @@ export type EmptyRunCause =
   (typeof EMPTY_RUN_CAUSE)[keyof typeof EMPTY_RUN_CAUSE];
 
 /**
- * Classifies a run that finished with nothing usable on screen, so the copy can
- * name the real cause.
+ * Classifies a COMPLETED run that shows nothing usable, so the copy can name the
+ * real cause. ERROR is RunErrorPanel's job, and in-progress runs legitimately
+ * have unscored candidates. The baseline (stepIndex 0) never counts as optimizer
+ * output, since a scored baseline is expected on every run.
  *
- * Order matters, because the checks overlap:
- *  1. Only COMPLETED runs qualify. ERROR is handled by RunErrorPanel, and
- *     in-progress runs legitimately have unscored candidates.
- *  2. No non-baseline candidates, baseline scored: NO_CANDIDATES.
- *  3. No non-baseline candidates, baseline unscored: SCORING_FAILED, since
- *     nothing was evaluated at all.
- *  4. Candidates exist but none scored: SCORING_FAILED.
- *
- * The baseline (stepIndex 0) never counts as optimizer output; a scored baseline
- * is expected on every run.
- *
- * `candidates` is the page-1 load capped at MAX_EXPERIMENTS_LOADED, sorted by
- * created_at ascending, so the baseline is always present and only trials past
- * the cap can be missing. Classifying from `scoring_health` instead is not an
- * option: those counts are per dataset item, so they cannot tell "the optimizer
- * generated nothing" from "the candidates failed to score", which is the whole
- * distinction here.
+ * `candidates` is the page-1 load capped at MAX_EXPERIMENTS_LOADED and sorted by
+ * created_at, so the baseline is always present. `scoring_health` cannot replace
+ * it: those counts are per dataset item, so they cannot separate "generated
+ * nothing" from "candidates failed to score" — the distinction this draws.
  */
 export const computeEmptyRunCause = (
   candidates: AggregatedCandidate[],
@@ -129,28 +109,20 @@ export const computeEmptyRunCause = (
     : EMPTY_RUN_CAUSE.NONE;
 };
 
-/** Panel heading. Names the cause instead of always reporting missing scores. */
 export const getEmptyRunTitle = (cause: EmptyRunCause): string =>
   cause === EMPTY_RUN_CAUSE.NO_CANDIDATES
     ? "No candidates generated"
     : "No usable scores";
 
-/**
- * Body copy for NO_CANDIDATES. Carries no call to action on purpose: the metric
- * worked and the baseline was kept, so there is nothing to fix or retry.
- */
+/** No call to action on purpose: nothing is broken, so there is nothing to retry. */
 const NO_CANDIDATES_MESSAGE =
   "The optimizer produced no prompt variants to score, so the baseline prompt was kept. " +
   "This is common when the original prompt already scores well.";
 
 /**
- * The scoring-failure lead sentence, single-sourced so the panel body and the
- * KPI caption cannot drift apart (they only differ in the tail they append).
- *
- * - `suppressed`: backend health data says nothing failed — say nothing.
- * - `all-failed` / `partial`: exact-count copy (OPIK-7159 Wave 2). `lead` has
- *   no trailing punctuation; callers append their own tail.
- * - `unknown`: no usable health data — callers fall back to static Wave-1 copy.
+ * Single-sourced lead sentence for a scoring failure (OPIK-7159 Wave 2), so the
+ * panel body and the KPI caption cannot drift apart. `lead` carries no trailing
+ * punctuation: callers append their own tail.
  */
 type ScoringFailureSummary =
   | { kind: "suppressed" | "unknown"; lead?: never }
@@ -167,8 +139,8 @@ const summarizeScoringFailure = (
   if (failed_count === 0) return { kind: "suppressed" };
 
   if (failed_count >= total_count) {
-    // Every item failed — stronger framing. The noun agrees with total_count,
-    // so a one-item dataset reads "The item …" not "All 1 item …".
+    // The noun agrees with total_count, so one item reads "The item …" not
+    // "All 1 item …".
     return {
       kind: "all-failed",
       lead:
@@ -178,8 +150,7 @@ const summarizeScoringFailure = (
     };
   }
 
-  // Partial failure. It always has total_count >= 2 (failed_count is >= 1 and
-  // strictly less than total), so the noun is always plural ("1 of 5 items").
+  // total_count >= 2 always holds here, so the noun is always plural.
   return {
     kind: "partial",
     lead: `${failed_count} of ${total_count} items failed to score`,
@@ -187,16 +158,8 @@ const summarizeScoringFailure = (
 };
 
 /**
- * Body copy for the empty-run panel.
- *
- * NO_CANDIDATES has its own copy and ignores `scoring_health`: the baseline
- * scored, so per-item failure counts cannot explain it.
- *
- * SCORING_FAILED copy comes from {@link summarizeScoringFailure}: exact-count
- * framing when backend health data exists, static Wave-1 message otherwise.
- *
- * Returns null when there is nothing to say: cause NONE, or health data
- * reporting no failures.
+ * Body copy for the empty-run panel. Returns null when there is nothing to say:
+ * cause NONE, or health data reporting no failures.
  */
 export const getEmptyRunMessage = (
   cause: EmptyRunCause,
@@ -230,12 +193,9 @@ export const getEmptyRunMessage = (
 };
 
 /**
- * Shortened version of {@link getEmptyRunMessage} for the KPI score-card
- * caption, where space is tight. Returns null under the same conditions: cause
- * NONE, or health data reporting no failures.
- *
- * The NO_CANDIDATES caption stays neutral, because the score on the card is the
- * baseline's real score rather than a failure.
+ * Shortened {@link getEmptyRunMessage} for the KPI score card, where space is
+ * tight. Same null conditions. The NO_CANDIDATES caption stays neutral because
+ * the score on the card is the baseline's real score, not a failure.
  */
 export const getEmptyRunKPICaption = (
   cause: EmptyRunCause,

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/optimizationOverviewHelpers.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/optimizationOverviewHelpers.ts
@@ -99,6 +99,13 @@ export type EmptyRunCause =
  *
  * The baseline (stepIndex 0) never counts as optimizer output; a scored baseline
  * is expected on every run.
+ *
+ * `candidates` is the page-1 load capped at MAX_EXPERIMENTS_LOADED, sorted by
+ * created_at ascending, so the baseline is always present and only trials past
+ * the cap can be missing. Classifying from `scoring_health` instead is not an
+ * option: those counts are per dataset item, so they cannot tell "the optimizer
+ * generated nothing" from "the candidates failed to score", which is the whole
+ * distinction here.
  */
 export const computeEmptyRunCause = (
   candidates: AggregatedCandidate[],

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/optimizationOverviewHelpers.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/optimizationOverviewHelpers.ts
@@ -144,15 +144,56 @@ const NO_CANDIDATES_MESSAGE =
   "This is common when the original prompt already scores well.";
 
 /**
- * Body copy for the empty-run panel and the KPI score-card caption.
+ * The scoring-failure lead sentence, single-sourced so the panel body and the
+ * KPI caption cannot drift apart (they only differ in the tail they append).
+ *
+ * - `suppressed`: backend health data says nothing failed — say nothing.
+ * - `all-failed` / `partial`: exact-count copy (OPIK-7159 Wave 2). `lead` has
+ *   no trailing punctuation; callers append their own tail.
+ * - `unknown`: no usable health data — callers fall back to static Wave-1 copy.
+ */
+type ScoringFailureSummary =
+  | { kind: "suppressed" | "unknown"; lead?: never }
+  | { kind: "all-failed" | "partial"; lead: string };
+
+const summarizeScoringFailure = (
+  scoringHealth?: OptimizationScoringHealth,
+): ScoringFailureSummary => {
+  if (!scoringHealth || scoringHealth.total_count <= 0)
+    return { kind: "unknown" };
+
+  const { failed_count, total_count } = scoringHealth;
+
+  if (failed_count === 0) return { kind: "suppressed" };
+
+  if (failed_count >= total_count) {
+    // Every item failed — stronger framing. The noun agrees with total_count,
+    // so a one-item dataset reads "The item …" not "All 1 item …".
+    return {
+      kind: "all-failed",
+      lead:
+        total_count === 1
+          ? "The item failed to score"
+          : `All ${total_count} items failed to score`,
+    };
+  }
+
+  // Partial failure. It always has total_count >= 2 (failed_count is >= 1 and
+  // strictly less than total), so the noun is always plural ("1 of 5 items").
+  return {
+    kind: "partial",
+    lead: `${failed_count} of ${total_count} items failed to score`,
+  };
+};
+
+/**
+ * Body copy for the empty-run panel.
  *
  * NO_CANDIDATES has its own copy and ignores `scoring_health`: the baseline
  * scored, so per-item failure counts cannot explain it.
  *
- * SCORING_FAILED has two paths. When `scoring_health` is present with
- * `total_count > 0`, use the backend's exact counts (OPIK-7159 Wave 2),
- * distinguishing all-failed from partial and keeping the noun in agreement with
- * total_count. Otherwise return the static Wave-1 message unchanged.
+ * SCORING_FAILED copy comes from {@link summarizeScoringFailure}: exact-count
+ * framing when backend health data exists, static Wave-1 message otherwise.
  *
  * Returns null when there is nothing to say: cause NONE, or health data
  * reporting no failures.
@@ -165,41 +206,27 @@ export const getEmptyRunMessage = (
 
   if (cause === EMPTY_RUN_CAUSE.NO_CANDIDATES) return NO_CANDIDATES_MESSAGE;
 
-  // --- Exact-count path (backend-provided, OPIK-7159 Wave 2) ---
-  if (scoringHealth && scoringHealth.total_count > 0) {
-    const { failed_count, total_count } = scoringHealth;
+  const failure = summarizeScoringFailure(scoringHealth);
 
-    if (failed_count === 0) {
-      // Backend says nothing failed — suppress the warning.
+  switch (failure.kind) {
+    case "suppressed":
       return null;
-    }
-
-    if (failed_count >= total_count) {
-      // Every item failed — use the stronger framing. The noun agrees with
-      // total_count, so a one-item dataset reads "The item …" not "All 1 item …".
-      const lead =
-        total_count === 1
-          ? "The item failed to score."
-          : `All ${total_count} items failed to score.`;
+    case "all-failed":
       return (
-        `${lead} ` +
+        `${failure.lead}. ` +
         "The metric may have errored on every evaluation. " +
         "Open the logs, check the metric and model, then run it again."
       );
-    }
-
-    // Partial failure — softer framing. A partial failure always has
-    // total_count >= 2 (failed_count is >= 1 and strictly less than total),
-    // so the noun is always plural ("1 of 5 items", never "1 of 5 item").
-    return (
-      `${failed_count} of ${total_count} items failed to score. ` +
-      "Some evaluations did not produce a usable result. " +
-      "Open the logs to see which items failed, then run it again."
-    );
+    case "partial":
+      return (
+        `${failure.lead}. ` +
+        "Some evaluations did not produce a usable result. " +
+        "Open the logs to see which items failed, then run it again."
+      );
+    case "unknown":
+      // Heuristic fallback (Wave 1, no backend data).
+      return "This run finished but produced no usable scores — the metric may have failed on every item. Open the logs, check the metric and model, then run it again.";
   }
-
-  // --- Heuristic fallback (Wave 1, no backend data) ---
-  return "This run finished but produced no usable scores — the metric may have failed on every item. Open the logs, check the metric and model, then run it again.";
 };
 
 /**
@@ -220,20 +247,18 @@ export const getEmptyRunKPICaption = (
     return "No candidates generated. Baseline prompt kept.";
   }
 
-  if (scoringHealth && scoringHealth.total_count > 0) {
-    const { failed_count, total_count } = scoringHealth;
-    if (failed_count === 0) return null;
+  const failure = summarizeScoringFailure(scoringHealth);
 
-    if (failed_count >= total_count) {
-      return total_count === 1
-        ? "The item failed to score — check the logs."
-        : `All ${total_count} items failed to score — check the logs.`;
-    }
-    return `${failed_count} of ${total_count} items failed to score — check the logs.`;
+  switch (failure.kind) {
+    case "suppressed":
+      return null;
+    case "all-failed":
+    case "partial":
+      return `${failure.lead} — check the logs.`;
+    case "unknown":
+      // Heuristic fallback (Wave 1).
+      return "No usable scores — check the logs.";
   }
-
-  // Heuristic fallback (Wave 1).
-  return "No usable scores — check the logs.";
 };
 
 /**

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/optimizationOverviewHelpers.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/optimizationOverviewHelpers.ts
@@ -67,54 +67,97 @@ export const getCompletedRunDurationSeconds = ({
 };
 
 /**
- * Heuristic detector for a "silent COMPLETED" run — the OPIK-7029 gap where a
- * run finishes normally but every evaluation failed to score, so it looks like
- * a plain empty run (dashes, "No data to show") with no error or warning.
- *
- * The rule: the run is terminal-COMPLETED **and** no candidate that actually
- * ran an optimization step produced a usable score. The baseline (stepIndex 0)
- * is deliberately excluded from the "did anything score?" check — a scored
- * baseline is expected on every run and does not mean the optimizer produced
- * anything, so a run whose only score is the baseline is still degenerate.
- * A run with zero non-baseline candidates counts as empty too (the optimizer
- * generated nothing to evaluate).
- *
- * This is a client-only heuristic; it can't tell a genuine all-zero run from an
- * all-failed one (Wave 2 threads exact scoring-health counts from the backend).
- * It only fires on COMPLETED — ERROR runs are already handled by RunErrorPanel,
- * and in-progress runs legitimately have unscored candidates.
+ * Why a COMPLETED run has nothing usable to show. Previously a single boolean,
+ * which made the panel blame the metric even when the metric worked (OPIK-7458).
  */
-export const computeEmptyRunWarning = (
-  candidates: AggregatedCandidate[],
-  status?: OPTIMIZATION_STATUS,
-): boolean => {
-  if (status !== OPTIMIZATION_STATUS.COMPLETED) return false;
+export const EMPTY_RUN_CAUSE = {
+  /** Nothing to surface: the run is unfinished or errored, or something scored. */
+  NONE: "none",
+  /** Nothing was generated beyond the baseline, and the baseline scored. */
+  NO_CANDIDATES: "no-candidates",
+  /**
+   * Nothing produced a usable score: every non-baseline candidate is unscored,
+   * or nothing scored at all. The OPIK-7029 "silent COMPLETED" gap.
+   */
+  SCORING_FAILED: "scoring-failed",
+} as const;
 
-  const nonBaselineCandidates = candidates.filter((c) => c.stepIndex !== 0);
-  // No trials at all, or none of the trials scored → no usable optimization result.
-  return nonBaselineCandidates.every((c) => c.score == null);
-};
+export type EmptyRunCause =
+  (typeof EMPTY_RUN_CAUSE)[keyof typeof EMPTY_RUN_CAUSE];
 
 /**
- * Produces the user-facing body message for the empty-run warning panel and the
- * KPI score-card caption. Two code paths:
+ * Classifies a run that finished with nothing usable on screen, so the copy can
+ * name the real cause.
  *
- *  1. **Exact count** (Wave 2, OPIK-7159): when `scoring_health` is present
- *     and `total_count > 0`, the backend persisted the real numbers. The copy
- *     uses `failed_count` / `total_count` directly and distinguishes:
- *       - all failed  → "All N items failed to score …"
- *       - partial     → "N of M items failed to score …"
- *       - singular    → "1 item" not "1 items"
+ * Order matters, because the checks overlap:
+ *  1. Only COMPLETED runs qualify. ERROR is handled by RunErrorPanel, and
+ *     in-progress runs legitimately have unscored candidates.
+ *  2. No non-baseline candidates, baseline scored: NO_CANDIDATES.
+ *  3. No non-baseline candidates, baseline unscored: SCORING_FAILED, since
+ *     nothing was evaluated at all.
+ *  4. Candidates exist but none scored: SCORING_FAILED.
  *
- *  2. **Heuristic fallback** (Wave 1, no backend data): returns the static
- *     message that was already shown before Wave 2 — exact backward compat.
- *
- * Returns `null` when the health data says nothing failed (failed_count === 0),
- * which lets the caller skip rendering the warning entirely.
+ * The baseline (stepIndex 0) never counts as optimizer output; a scored baseline
+ * is expected on every run.
  */
-export const getEmptyRunWarningMessage = (
+export const computeEmptyRunCause = (
+  candidates: AggregatedCandidate[],
+  status?: OPTIMIZATION_STATUS,
+): EmptyRunCause => {
+  if (status !== OPTIMIZATION_STATUS.COMPLETED) return EMPTY_RUN_CAUSE.NONE;
+
+  const nonBaselineCandidates = candidates.filter((c) => c.stepIndex !== 0);
+
+  if (nonBaselineCandidates.length === 0) {
+    const baselineScored = candidates.some(
+      (c) => c.stepIndex === 0 && c.score != null,
+    );
+    return baselineScored
+      ? EMPTY_RUN_CAUSE.NO_CANDIDATES
+      : EMPTY_RUN_CAUSE.SCORING_FAILED;
+  }
+
+  return nonBaselineCandidates.every((c) => c.score == null)
+    ? EMPTY_RUN_CAUSE.SCORING_FAILED
+    : EMPTY_RUN_CAUSE.NONE;
+};
+
+/** Panel heading. Names the cause instead of always reporting missing scores. */
+export const getEmptyRunTitle = (cause: EmptyRunCause): string =>
+  cause === EMPTY_RUN_CAUSE.NO_CANDIDATES
+    ? "No candidates generated"
+    : "No usable scores";
+
+/**
+ * Body copy for NO_CANDIDATES. Carries no call to action on purpose: the metric
+ * worked and the baseline was kept, so there is nothing to fix or retry.
+ */
+const NO_CANDIDATES_MESSAGE =
+  "The optimizer produced no prompt variants to score, so the baseline prompt was kept. " +
+  "This is common when the original prompt already scores well.";
+
+/**
+ * Body copy for the empty-run panel and the KPI score-card caption.
+ *
+ * NO_CANDIDATES has its own copy and ignores `scoring_health`: the baseline
+ * scored, so per-item failure counts cannot explain it.
+ *
+ * SCORING_FAILED has two paths. When `scoring_health` is present with
+ * `total_count > 0`, use the backend's exact counts (OPIK-7159 Wave 2),
+ * distinguishing all-failed from partial and keeping the noun in agreement with
+ * total_count. Otherwise return the static Wave-1 message unchanged.
+ *
+ * Returns null when there is nothing to say: cause NONE, or health data
+ * reporting no failures.
+ */
+export const getEmptyRunMessage = (
+  cause: EmptyRunCause,
   scoringHealth?: OptimizationScoringHealth,
 ): string | null => {
+  if (cause === EMPTY_RUN_CAUSE.NONE) return null;
+
+  if (cause === EMPTY_RUN_CAUSE.NO_CANDIDATES) return NO_CANDIDATES_MESSAGE;
+
   // --- Exact-count path (backend-provided, OPIK-7159 Wave 2) ---
   if (scoringHealth && scoringHealth.total_count > 0) {
     const { failed_count, total_count } = scoringHealth;
@@ -153,19 +196,22 @@ export const getEmptyRunWarningMessage = (
 };
 
 /**
- * Shortened version of {@link getEmptyRunWarningMessage} for the KPI score-card
- * caption, where space is tight. Returns `null` for the same conditions
- * (nothing failed, or scoring_health absent but `isEmptyRun` is false).
+ * Shortened version of {@link getEmptyRunMessage} for the KPI score-card
+ * caption, where space is tight. Returns null under the same conditions: cause
+ * NONE, or health data reporting no failures.
  *
- * When `isEmptyRun` is false and `scoring_health` is absent, returns null —
- * callers gate on `isEmptyRun` already, so this helper is only called when a
- * warning is appropriate.
+ * The NO_CANDIDATES caption stays neutral, because the score on the card is the
+ * baseline's real score rather than a failure.
  */
 export const getEmptyRunKPICaption = (
-  isEmptyRun: boolean,
+  cause: EmptyRunCause,
   scoringHealth?: OptimizationScoringHealth,
 ): string | null => {
-  if (!isEmptyRun) return null;
+  if (cause === EMPTY_RUN_CAUSE.NONE) return null;
+
+  if (cause === EMPTY_RUN_CAUSE.NO_CANDIDATES) {
+    return "No candidates generated. Baseline prompt kept.";
+  }
 
   if (scoringHealth && scoringHealth.total_count > 0) {
     const { failed_count, total_count } = scoringHealth;


### PR DESCRIPTION
## Details

A COMPLETED run whose optimizer produced no candidates beyond the baseline showed **"No usable scores, the metric may have failed on every item"**, even though the metric worked and the baseline was scored. That is the common "already-good prompt" outcome, not an error, so the copy was misleading. One boolean was carrying two causes; it is now an explicit classifier, and the panel's severity follows the cause.

- `computeEmptyRunCause()` replaces `computeEmptyRunWarning()`. `NO_CANDIDATES` when nothing was generated but the baseline scored; `SCORING_FAILED` when candidates ran without scoring, or when nothing scored at all (the old vacuous `every()` could not tell those apart); `NONE` otherwise.
- `scoring_health` keeps its exact-count precedence for `SCORING_FAILED` only. For `NO_CANDIDATES` it is ignored, since the baseline scored and per-item failure counts cannot explain the outcome. This is what removes the `total_count === 0` fall-through that routed candidate-less runs into the metric-failure copy.
- The panel takes the cause and picks severity from a single cause-keyed appearance map: warning styling plus the re-run call to action for `SCORING_FAILED`, neutral note with no call to action for `NO_CANDIDATES`. The heading comes from `getEmptyRunTitle()` instead of a hardcoded string.
- The KPI score-card caption gets the same split so both surfaces agree. `OptimizationKPICards`' `scoringFailed` boolean becomes `emptyRunCause`, since the old name was untrue for a candidate-less run.

Wave-2 exact-count strings and the `failed_count === 0` suppression are unchanged, and pinned by tests.

FE only: no backend or API change. `v1` has no `EmptyRunWarningPanel` or `optimizationOverviewHelpers`, so this is v2 only.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7458

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Cause classifier, panel and KPI copy, severity split, call-site threading, and the tests for all of it.
- Human verification: Author reviewed the diff. Both panel states were rendered in a running frontend, see screenshots, and the no-false-positive case was checked against a real completed run.

## Testing

```
cd apps/opik-frontend
npx vitest run src/v2/pages/OptimizationPage   # 15 files, 109 tests pass
npm run typecheck                              # clean
npx eslint src/v2/pages/OptimizationPage --max-warnings=0   # clean
```

New and extended coverage in `optimizationOverviewHelpers.test.ts` plus a new `EmptyRunWarningPanel.test.tsx`:

- baseline scored, zero candidates: `NO_CANDIDATES`, the reported bug
- baseline unscored, zero candidates: `SCORING_FAILED`, the case the old boolean could not express
- no candidate rows at all: `SCORING_FAILED`
- candidates all unscored: `SCORING_FAILED`; one scored: `NONE`; RUNNING, INITIALIZED, ERROR: `NONE`
- `NO_CANDIDATES` with `{failed: 0, total: 30}` and with `{0, 0}`: still the no-candidates copy, not suppressed and not the metric-failure text
- `SCORING_FAILED` regression pins: `{5,5}` gives "All 5 items failed to score", `{1,10}` gives "1 of 10 items", `{0,10}` gives `null`, absent health gives the exact Wave-1 string
- panel: heading per cause, "run it again" absent for `NO_CANDIDATES`, `View logs` present on both, renders nothing when the backend reports no failed item

Manual verification: frontend run locally in `--mode comet` against a real environment. A pre-existing completed run with three scored candidates correctly shows no panel (`NONE`), confirming no false positive. Both empty-run states were then forced in the running app to capture the screenshots above.

Not run: the Playwright `@optimization-studio` e2e spec, which needs cloud test credentials I did not have. Worth flagging for whoever picks that up: the `dev` environment currently cannot execute optimization runs at all. `opik-redis-master` is absent from `cometml-development`, the python-backend logs `Redis client initialization failed ... Error -3`, and no RQ worker listens on `opik:optimizer-cloud`, so Studio runs there sit at `Initialized` until the stall reaper errors them. `staging` is healthy.

## Documentation

No documentation change. User-facing copy only, no new concepts or configuration.
