### PR TITLE
[NA] [CI] test: verify actions/labeler v7 (throwaway)

### DIFF
--- a/.github/LABELER_V7_TEST.md
+++ b/.github/LABELER_V7_TEST.md
@@ -1,0 +1,5 @@
+# Throwaway: actions/labeler v7 verification
+
+Temporary file to give the labeler something to match while verifying the
+v6 -> v7 bump on a scratch PR. Delete this file and revert the temporary
+`pull_request` trigger in `labeler.yml` before closing the test.

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,7 +11,10 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # TEMPORARY: include github.event_name so the temporary pull_request (v7) run
+  # doesn't share a group with pull_request_target and get cancelled. Revert with
+  # the rest of the scratch changes.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,6 +3,11 @@ name: 🗂️ Auto Label PR
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
+  # TEMPORARY (danield/NA-test-labeler-v7): runs the workflow from the PR HEAD so the
+  # @v7 bump actually executes pre-merge. pull_request_target can't self-test action
+  # bumps because it always runs the base-branch workflow. REVERT before any merge.
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
 
 
 concurrency:
@@ -24,7 +29,7 @@ jobs:
 
     steps:
       - name: Apply and Sync Labels
-        uses: actions/labeler@v6
+        uses: actions/labeler@v7
         with:
           sync-labels: true # Remove labels if the file paths no longer match
           configuration-path: .github/labeler.yml


### PR DESCRIPTION
## Details
Throwaway PR to verify the \`actions/labeler\` v6 -> v7 bump (#7639) actually runs before merging it.

\`pull_request_target\` can't self-test an action bump — it always runs the base-branch workflow, so #7639's own CI still logs \`Run actions/labeler@v6\`. This branch adds a **temporary** \`pull_request\` trigger so the workflow runs from the PR head with \`@v7\`.

**Do not merge.** Close after verifying labels apply.

## Change checklist
- [x] Bump \`actions/labeler@v6\` -> \`@v7\`
- [x] Temporary \`pull_request\` trigger (revert before merge)
- [x] Trivial \`.md\` file so the labeler has something to match

## Issues
NA

## Testing
Watch the "🗂️ Auto Label PR" run on this PR and confirm \`Infrastructure\` + \`documentation\` labels get applied by v7.

## Documentation
NA