### PR TITLE
[NA] test: fix Ollie explain E2E test flakiness in production

### DIFF
--- a/tests_end_to_end/e2e/tests/ollie/ollie-explain.spec.ts
+++ b/tests_end_to_end/e2e/tests/ollie/ollie-explain.spec.ts
@@ -21,7 +21,7 @@ function skipIfOllieDisabled(envConfig: { features: { ollie: boolean } }): void 
 // reliably references even when the surrounding phrasing differs.
 const KEYWORD_PATTERN: Record<'cost' | 'duration', RegExp> = {
   cost: /cost/i,
-  duration: /duration|second|end time|running/i,
+  duration: /duration|second|end time|running|\bms\b|millisecond/i,
 };
 
 // The popover and the sidebar chat bubble render the same markdown through
@@ -42,11 +42,16 @@ test.describe('Ollie — explain cells', { tag: ['@t3-nightly', '@ollie'] }, () 
   }) => {
     test.setTimeout(600_000);
     const logs = new LogsPage(page);
+    const ollie = new OlliePage(page, project.id);
 
     await test.step('Open Logs and wait for the seeded traces to render', async () => {
       await logs.goto(project.id);
       await logs.waitForReady();
       expect(await logs.countTraces()).toBe(explainTraces.length);
+      // The explain popover shares the same on-demand Ollie pod/bridge as the
+      // sidebar; opening it before the pod is ready fails instantly with
+      // "unavailable" rather than waiting, so wait for the bridge here.
+      await ollie.waitForSidebarReady();
     });
 
     for (const trace of explainTraces) {
@@ -93,6 +98,7 @@ test.describe('Ollie — explain cells', { tag: ['@t3-nightly', '@ollie'] }, () 
     await test.step('Open Logs and wait for the seeded traces to render', async () => {
       await logs.goto(project.id);
       await logs.waitForReady();
+      await ollie.waitForSidebarReady();
     });
 
     await test.step('Open Explain on the Errors cell and read its settled text', async () => {


### PR DESCRIPTION
## Details
Fix flaky/failing Ollie explain E2E test in production by waiting for the sidebar's on-demand Ollie pod/bridge to be ready before opening the explain popover, and by broadening the duration keyword pattern to also match millisecond-based durations (e.g. "ms", "millisecond").

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA (no ticket — internal test-flake fix)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Sonnet 5
- Scope: full implementation
- Human verification: code review

## Testing
- No automated command run locally (Playwright E2E suite requires a running Opik environment); change verified by inspection against the existing `ollie-explain.spec.ts` test structure and `OlliePage.waitForSidebarReady` helper.
- Ran `python3 -m pre_commit run --files tests_end_to_end/e2e/tests/ollie/ollie-explain.spec.ts` — no applicable hooks reported issues.

## Documentation
N/A
