### PR TITLE
[OPIK-7460] [BE] chore: bump opik-optimizer pin to 3.1.1

### DIFF
--- a/apps/opik-python-backend/requirements.txt
+++ b/apps/opik-python-backend/requirements.txt
@@ -27,7 +27,7 @@ schedule==1.2.1
 tiktoken==0.9.0
 redis==6.4.0
 rq==2.6.0
-opik-optimizer==3.1.0
+opik-optimizer==3.1.1
 gepa==0.0.17
 pyrate-limiter>=3.0.0,<4.0.0
 python-jsonpath>=2.0.0,<3.0.0


### PR DESCRIPTION
## Details

Bumps the `opik-optimizer` pin in `apps/opik-python-backend/requirements.txt` from 3.1.0 to 3.1.1, so Optimization Studio actually runs the fixes merged in #7591. Single-line change.

- 3.1.1 picks up GEPA stop conditions (`ScoreThresholdStopper` on a perfect **full-eval** score, `NoImprovementStopper`) and a surfaced `finish_reason`, so a run no longer looks like a silent budget burn.
- It also picks up `adapter.py::_classify_experiment_type`, which tags reflection batches as `mini-batch` instead of `trial`. The frontend filter (`useOptimizationExperiments.ts:61`, `types: [TRIAL]`) and the `OptimizationDAO.java:496` best-score exclusion were always correct — the SDK was mislabelling the rows, so there was nothing for them to exclude.
- The pin was stuck at 3.1.0 because 3.1.1 was never published until today: the version had been in `pyproject.toml` since April, but its publish run failed on a PyPI token scope problem and was never retried. Fixed by #7653; 3.1.1 is now on PyPI.

## Change checklist
- [x] User facing
- [ ] Documentation update

User facing: it is the change that makes the trials chart and table stop mixing mini-batch scores with full evaluations, and makes early-stopped runs report why they stopped.

## Issues

- OPIK-7460

Related but not resolved here: OPIK_7461 keeps its remaining defect after this merge — it has been retitled to the `max_trials` semantics problem (`max_trials * n_samples` means a 10-trial budget still produces 57 trial rows), which #7591 did not change. OPIK_7521 tracks reflection-LLM spend sitting outside the budget, also untouched by this. OPIK_7265 is the trusted-publishing migration that unblocked the 3.1.1 release.

## AI-WATERMARK

AI-WATERMARK: [yes]

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 5
  - Scope: Established that 3.1.1 was unpublished rather than merely un-pinned, authored the one-line bump and this description.
  - Human verification: Pending review. See the honest limits in Testing below — the behavioural verification has not been done yet and this should not be treated as verified until it is.

## Testing

Verified that the pin resolves, which is the specific failure this change could cause:

- `opik-optimizer` 3.1.1 exists on PyPI (both wheel and sdist, uploaded 2026-07-28T13:34:31Z), so `pip install -r requirements.txt` can satisfy it. This is worth stating explicitly because the earlier CI run on this branch failed precisely because 3.1.1 did not yet exist; those checks need a re-run against the published version.
- Relying on CI for the rest: `run-python-backend-tests` and `Python BE E2E` exercise the python backend against the new pin.

Not run, and deliberately called out rather than glossed:

- No behavioural verification of the Studio fixes. The end-to-end check that belongs with OPIK-7460 is a GEPA run on staging (30-item dataset, weak seed prompt) confirming the trials table shows only full evaluations and that a 100% run reports `finish_reason = perfect_score`. That needs the rebuilt `opik-python-backend` image, so it can only happen after this merges. **OPIK-7460 should not be closed on this merge alone.**
- No local test run; I have read-only access to the environments involved and no local python-backend stack.

## Documentation

No documentation change. Version pins are not user-documented, and the behavioural changes were documented with #7591.
